### PR TITLE
Add workflow_dispatch environment parameter for release re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,14 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to release (e.g., v1.0.0)"
+        description: "Version (e.g., v0.1.1)"
         required: true
-        type: string
+        default: "v0.1.1"
+      environment:
+        description: "Environment"
+        type: choice
+        options: [production, test]
+        default: test
 
 env:
   REGISTRY: mcpmesh
@@ -88,14 +93,18 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        if: >
+          github.event_name == 'release' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Log in to GitHub Container Registry
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        if: >
+          github.event_name == 'release' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -125,7 +134,9 @@ jobs:
           context: .
           file: ./packaging/docker/registry.Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
+          push: >
+            ${{ github.event_name == 'release' ||
+            (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production') }}
           tags: |
             ${{ env.REGISTRY }}/registry:latest
             ${{ env.REGISTRY }}/registry:${{ steps.meta.outputs.version }}
@@ -140,7 +151,9 @@ jobs:
           context: .
           file: ./packaging/docker/python-runtime.Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
+          push: >
+            ${{ github.event_name == 'release' ||
+            (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production') }}
           tags: |
             ${{ env.REGISTRY }}/python-runtime:latest
             ${{ env.REGISTRY }}/python-runtime:${{ steps.meta.outputs.version }}
@@ -155,7 +168,9 @@ jobs:
           context: .
           file: ./packaging/docker/cli.Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
+          push: >
+            ${{ github.event_name == 'release' ||
+            (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production') }}
           tags: |
             ${{ env.REGISTRY }}/cli:latest
             ${{ env.REGISTRY }}/cli:${{ steps.meta.outputs.version }}
@@ -167,7 +182,9 @@ jobs:
   # Publish Python package to PyPI
   publish-python:
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: >
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
     permissions:
       contents: read
       id-token: write # For trusted publishing
@@ -214,11 +231,11 @@ jobs:
           echo "Ref name: ${{ github.ref_name }}"
           echo "Detected version: ${VERSION}"
           echo "Current version in file: $(grep '__version__' src/mcp_mesh/__init__.py)"
-          
+
           # Update version in both __init__.py and pyproject.toml
           sed -i "s/__version__ = \".*\"/__version__ = \"${VERSION}\"/" src/mcp_mesh/__init__.py
           sed -i "s/version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
-          
+
           # Verify the versions were updated
           echo "Updated __init__.py version to: $(grep '__version__' src/mcp_mesh/__init__.py)"
           echo "Updated pyproject.toml version to: $(grep 'version = ' pyproject.toml)"
@@ -242,7 +259,9 @@ jobs:
   # Update package manager manifests
   update-packages:
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: >
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
     needs: [build-binaries]
     permissions:
       contents: write
@@ -296,7 +315,9 @@ jobs:
   # Security scan
   security-scan:
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: >
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
     needs: [build-docker]
     permissions:
       contents: read

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -143,6 +143,24 @@ twine check dist/*
 gh workflow run release.yml -f version=v1.0.0
 ```
 
+### Release Re-runs:
+
+When a release workflow fails (e.g., PyPI conflicts, Docker registry issues), you can re-run the workflow without recreating the GitHub release:
+
+```bash
+# Re-run for production deployment (pushes to registries and PyPI)
+gh workflow run release.yml -f version=v1.0.1 -f environment=production
+
+# Re-run for testing (builds only, no publishing)
+gh workflow run release.yml -f version=v1.0.1 -f environment=test
+```
+
+**Benefits:**
+- Preserves original release timestamp and history
+- No need to delete and recreate GitHub releases
+- Allows iterative fixes without losing release context
+- Supports both production deploys and test builds
+
 ## 📋 Supported Architectures
 
 ### Docker Images:


### PR DESCRIPTION
## Summary
- Added `environment` parameter to release workflow with workflow_dispatch trigger
- Allows re-running releases in different environments (staging, prod, etc.)
- Maintains backward compatibility with existing automated releases

## Test plan
- [ ] Verify workflow_dispatch trigger works with environment parameter
- [ ] Test manual release runs in different environments
- [ ] Confirm automated releases still work without changes

🤖 Generated with [Claude Code](https://claude.ai/code)