### PR TITLE
Fix CI/CD Pipeline Directory Structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
   lint-and-format:
     name: Code Quality Checks
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/runtime/python
     steps:
       - uses: actions/checkout@v4
 
@@ -30,20 +33,23 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Run ruff linting
-        run: ruff check packages tests
+        run: ruff check src/mcp_mesh tests
 
       - name: Run ruff formatting check
-        run: ruff format --check packages tests
+        run: ruff format --check src/mcp_mesh tests
 
       - name: Run black formatting check
-        run: black --check packages tests
+        run: black --check src/mcp_mesh tests
 
       - name: Run isort import sorting check
-        run: isort --check-only packages tests
+        run: isort --check-only src/mcp_mesh tests
 
   type-check:
     name: Type Checking
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/runtime/python
     steps:
       - uses: actions/checkout@v4
 
@@ -59,11 +65,14 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Run mypy type checking
-        run: mypy packages
+        run: mypy src/mcp_mesh
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/runtime/python
     strategy:
       fail-fast: false
       matrix:
@@ -89,8 +98,7 @@ jobs:
         if: matrix.test-group == 'unit'
         run: |
           pytest tests/unit/ -v \
-            --cov=packages/mcp_mesh/src/mcp_mesh \
-            --cov=packages/mcp_mesh_runtime/src/mcp_mesh_runtime \
+            --cov=src/mcp_mesh \
             --cov-report=xml \
             --cov-report=term-missing \
             --junit-xml=test-results-unit-${{ matrix.python-version }}.xml
@@ -99,8 +107,7 @@ jobs:
         if: matrix.test-group == 'integration'
         run: |
           pytest tests/integration/ -v \
-            --cov=packages/mcp_mesh/src/mcp_mesh \
-            --cov=packages/mcp_mesh_runtime/src/mcp_mesh_runtime \
+            --cov=src/mcp_mesh \
             --cov-report=xml \
             --cov-report=term-missing \
             --junit-xml=test-results-integration-${{ matrix.python-version }}.xml
@@ -109,8 +116,7 @@ jobs:
         if: matrix.test-group == 'e2e'
         run: |
           pytest tests/e2e/ -v \
-            --cov=packages/mcp_mesh/src/mcp_mesh \
-            --cov=packages/mcp_mesh_runtime/src/mcp_mesh_runtime \
+            --cov=src/mcp_mesh \
             --cov-report=xml \
             --cov-report=term-missing \
             --junit-xml=test-results-e2e-${{ matrix.python-version }}.xml


### PR DESCRIPTION
## Summary
- Fix CI/CD pipeline directory structure and path references
- Add working-directory: src/runtime/python to all Python jobs  
- Update tool commands to use correct paths (src/mcp_mesh instead of packages)
- Fix coverage paths and remove non-existent package references

## Problem Solved
CI/CD pipeline was failing with "No such file or directory" errors because:
- ❌ Looking for `packages` directory (doesn't exist)
- ❌ Looking for `tests` in wrong location
- ❌ Wrong coverage paths referencing non-existent packages
- ❌ Missing working directory context

## Changes Made
**Working Directory**: Set `working-directory: src/runtime/python` for all Python jobs

**Path Updates**:
- `packages` → `src/mcp_mesh` (actual source location)
- `tests` → `tests` (correct within working directory)
- Coverage paths updated to `src/mcp_mesh`
- Removed non-existent `mcp_mesh_runtime` package references

**Tool Commands Fixed**:
- `ruff check packages tests` → `ruff check src/mcp_mesh tests`
- `mypy packages` → `mypy src/mcp_mesh`  
- `black --check packages tests` → `black --check src/mcp_mesh tests`
- `isort --check-only packages tests` → `isort --check-only src/mcp_mesh tests`

## Impact
- ✅ Fixes "No such file or directory" errors in CI
- ✅ Unit tests should now run successfully in CI environment
- ✅ Code quality checks will work with correct paths
- ✅ Type checking will find the actual source code
- ✅ Unblocks PR merge workflow (no more CI blocking)

## Evidence
**Before**: 
```
packages:1:1: E902 No such file or directory (os error 2)
tests:1:1: E902 No such file or directory (os error 2)
mypy: can't read file 'packages': No such file or directory
```

**After**: CI should find correct directories and run successfully.

Closes #9

## Test plan
- [x] YAML syntax is valid (pre-commit hooks passed)
- [x] Working directory structure aligns with actual codebase
- [x] Tool commands reference existing directories
- [ ] Verify CI checks pass after merge
- [ ] Confirm unit tests run successfully in CI

🤖 Generated with [Claude Code](https://claude.ai/code)