### PR TITLE
Fix CI/CD Pipeline Requirements and Security Scan Paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
   lint-and-format:
     name: Code Quality Checks
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/runtime/python
     steps:
       - uses: actions/checkout@v4
 
@@ -30,20 +33,23 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Run ruff linting
-        run: ruff check packages tests
+        run: ruff check src/mcp_mesh tests
 
       - name: Run ruff formatting check
-        run: ruff format --check packages tests
+        run: ruff format --check src/mcp_mesh tests
 
       - name: Run black formatting check
-        run: black --check packages tests
+        run: black --check src/mcp_mesh tests
 
       - name: Run isort import sorting check
-        run: isort --check-only packages tests
+        run: isort --check-only src/mcp_mesh tests
 
   type-check:
     name: Type Checking
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/runtime/python
     steps:
       - uses: actions/checkout@v4
 
@@ -59,11 +65,14 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Run mypy type checking
-        run: mypy packages
+        run: mypy src/mcp_mesh
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/runtime/python
     strategy:
       fail-fast: false
       matrix:
@@ -89,8 +98,7 @@ jobs:
         if: matrix.test-group == 'unit'
         run: |
           pytest tests/unit/ -v \
-            --cov=packages/mcp_mesh/src/mcp_mesh \
-            --cov=packages/mcp_mesh_runtime/src/mcp_mesh_runtime \
+            --cov=src/mcp_mesh \
             --cov-report=xml \
             --cov-report=term-missing \
             --junit-xml=test-results-unit-${{ matrix.python-version }}.xml
@@ -99,8 +107,7 @@ jobs:
         if: matrix.test-group == 'integration'
         run: |
           pytest tests/integration/ -v \
-            --cov=packages/mcp_mesh/src/mcp_mesh \
-            --cov=packages/mcp_mesh_runtime/src/mcp_mesh_runtime \
+            --cov=src/mcp_mesh \
             --cov-report=xml \
             --cov-report=term-missing \
             --junit-xml=test-results-integration-${{ matrix.python-version }}.xml
@@ -109,8 +116,7 @@ jobs:
         if: matrix.test-group == 'e2e'
         run: |
           pytest tests/e2e/ -v \
-            --cov=packages/mcp_mesh/src/mcp_mesh \
-            --cov=packages/mcp_mesh_runtime/src/mcp_mesh_runtime \
+            --cov=src/mcp_mesh \
             --cov-report=xml \
             --cov-report=term-missing \
             --junit-xml=test-results-e2e-${{ matrix.python-version }}.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,9 @@ jobs:
     name: MCP Protocol Compliance
     runs-on: ubuntu-latest
     needs: [lint-and-format, type-check]
+    defaults:
+      run:
+        working-directory: src/runtime/python
 
     steps:
       - uses: actions/checkout@v4
@@ -186,6 +189,9 @@ jobs:
     name: Security Scanning
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    defaults:
+      run:
+        working-directory: src/runtime/python
 
     steps:
       - uses: actions/checkout@v4
@@ -201,8 +207,8 @@ jobs:
 
       - name: Run bandit security scan
         run: |
-          bandit -r packages/ -f json -o bandit-report.json || true
-          bandit -r packages/ -f txt
+          bandit -r src/mcp_mesh/ -f json -o bandit-report.json || true
+          bandit -r src/mcp_mesh/ -f txt
 
       - name: Upload security scan results
         uses: actions/upload-artifact@v4
@@ -215,6 +221,9 @@ jobs:
     name: Build and Package
     runs-on: ubuntu-latest
     needs: [test, mcp-compliance]
+    defaults:
+      run:
+        working-directory: src/runtime/python
 
     steps:
       - uses: actions/checkout@v4
@@ -248,6 +257,9 @@ jobs:
     name: Performance Benchmarks
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    defaults:
+      run:
+        working-directory: src/runtime/python
 
     steps:
       - uses: actions/checkout@v4

--- a/src/runtime/python/requirements-dev.txt
+++ b/src/runtime/python/requirements-dev.txt
@@ -1,0 +1,22 @@
+# Development dependencies for MCP Mesh
+# Install with: pip install -r requirements-dev.txt
+
+# Core MCP SDK
+mcp>=1.9.0
+
+# Development Tools
+pytest>=8.0.0
+pytest-asyncio>=1.0.0
+pytest-cov>=6.0.0
+black>=25.0.0
+isort>=6.0.0
+mypy>=1.16.0
+ruff>=0.11.0
+pre-commit>=4.0.0
+
+# Security scanning
+bandit[toml]>=1.7.0
+
+# Additional development utilities
+ipython
+jupyter


### PR DESCRIPTION
## Summary
- Fix missing requirements-dev.txt causing 'No such file or directory' errors  
- Fix security scan paths from packages/ to src/mcp_mesh/
- Add consistent working-directory to all Python jobs

## Test plan
- [x] Push to PR branch to test CI pipeline 
- [ ] Verify all CI jobs pass
- [ ] Merge only after CI success

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/code)