### PR TITLE
Sequential Pipeline: Docker Images After PyPI/CLI Publishing (Issue #2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
   # Build and push Docker images
   build-docker:
     runs-on: ubuntu-latest
+    needs: [publish-python, build-binaries]
     permissions:
       contents: read
       packages: write
@@ -134,6 +135,8 @@ jobs:
           context: .
           file: ./packaging/docker/registry.Dockerfile
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           push: >
             ${{ github.event_name == 'release' ||
             (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production') }}
@@ -151,6 +154,8 @@ jobs:
           context: .
           file: ./packaging/docker/python-runtime.Dockerfile
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           push: >
             ${{ github.event_name == 'release' ||
             (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production') }}
@@ -168,6 +173,8 @@ jobs:
           context: .
           file: ./packaging/docker/cli.Dockerfile
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           push: >
             ${{ github.event_name == 'release' ||
             (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production') }}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+# MCP Mesh Binary Installer
+# Downloads and installs MCP Mesh binaries from GitHub releases
+
+set -e
+
+# Default values
+VERSION="latest"
+INSTALL_DIR="/usr/local/bin"
+REPO="dhyansraj/mcp-mesh"
+INSTALL_MESHCTL="true"
+INSTALL_REGISTRY="true"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Print functions
+print_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Help function
+show_help() {
+    cat << EOF
+MCP Mesh Binary Installer
+
+Usage: $0 [OPTIONS]
+
+Options:
+    --meshctl-only       Install only meshctl CLI binary
+    --registry-only      Install only mcp-mesh-registry binary
+    --all                Install both binaries (default)
+    --version VERSION    Install specific version (default: latest)
+    --install-dir DIR    Install directory (default: /usr/local/bin)
+    --help              Show this help message
+
+Examples:
+    # Install both binaries (default)
+    curl -sSL https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh | bash
+
+    # Install only meshctl CLI
+    curl -sSL https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh | bash -s -- --meshctl-only
+
+    # Install only registry (useful for Docker)
+    curl -sSL https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh | bash -s -- --registry-only
+
+    # Install specific version of both
+    curl -sSL https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh | bash -s -- --version v0.1.1
+
+    # Install to custom directory
+    curl -sSL https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh | bash -s -- --install-dir /usr/bin
+
+EOF
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --meshctl-only)
+            INSTALL_MESHCTL="true"
+            INSTALL_REGISTRY="false"
+            shift
+            ;;
+        --registry-only)
+            INSTALL_MESHCTL="false"
+            INSTALL_REGISTRY="true"
+            shift
+            ;;
+        --all)
+            INSTALL_MESHCTL="true"
+            INSTALL_REGISTRY="true"
+            shift
+            ;;
+        --version)
+            VERSION="$2"
+            shift 2
+            ;;
+        --install-dir)
+            INSTALL_DIR="$2"
+            shift 2
+            ;;
+        --help)
+            show_help
+            exit 0
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Detect platform
+detect_platform() {
+    local os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    local arch=$(uname -m)
+    
+    case $os in
+        linux)
+            OS="linux"
+            ;;
+        darwin)
+            OS="darwin"
+            ;;
+        *)
+            print_error "Unsupported OS: $os"
+            exit 1
+            ;;
+    esac
+    
+    case $arch in
+        x86_64|amd64)
+            ARCH="amd64"
+            ;;
+        arm64|aarch64)
+            ARCH="arm64"
+            ;;
+        *)
+            print_error "Unsupported architecture: $arch"
+            exit 1
+            ;;
+    esac
+    
+    PLATFORM="${OS}-${ARCH}"
+    print_info "Detected platform: $PLATFORM"
+}
+
+# Get the latest version from GitHub
+get_latest_version() {
+    print_info "Fetching latest version from GitHub..."
+    VERSION=$(curl -sSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name":' | cut -d'"' -f4)
+    if [[ -z "$VERSION" ]]; then
+        print_error "Failed to fetch latest version"
+        exit 1
+    fi
+    print_info "Latest version: $VERSION"
+}
+
+# Generic function to download and install a binary
+install_binary() {
+    local binary_name="$1"
+    local download_url="https://github.com/$REPO/releases/download/$VERSION/mcp-mesh_${VERSION}_$PLATFORM.tar.gz"
+    local temp_dir=$(mktemp -d)
+    
+    print_info "Downloading $binary_name $VERSION for $PLATFORM..."
+    print_info "URL: $download_url"
+    
+    # Download the archive
+    if ! curl -sSL "$download_url" -o "$temp_dir/mcp-mesh.tar.gz"; then
+        print_error "Failed to download from $download_url"
+        print_error "Please check if the version and platform are correct"
+        exit 1
+    fi
+    
+    # Extract the binary
+    print_info "Extracting $binary_name..."
+    if ! tar -xzf "$temp_dir/mcp-mesh.tar.gz" -C "$temp_dir"; then
+        print_error "Failed to extract archive"
+        exit 1
+    fi
+    
+    # Create install directory if it doesn't exist
+    if [[ ! -d "$INSTALL_DIR" ]]; then
+        print_info "Creating install directory: $INSTALL_DIR"
+        sudo mkdir -p "$INSTALL_DIR"
+    fi
+    
+    # Install the binary
+    print_info "Installing $binary_name to $INSTALL_DIR..."
+    local extracted_binary
+    if [[ "$binary_name" == "registry" ]]; then
+        extracted_binary="$temp_dir/$PLATFORM/registry"
+    else
+        extracted_binary="$temp_dir/$PLATFORM/$binary_name"
+    fi
+    
+    if [[ -w "$INSTALL_DIR" ]]; then
+        cp "$extracted_binary" "$INSTALL_DIR/$binary_name"
+        chmod +x "$INSTALL_DIR/$binary_name"
+    else
+        sudo cp "$extracted_binary" "$INSTALL_DIR/$binary_name"
+        sudo chmod +x "$INSTALL_DIR/$binary_name"
+    fi
+    
+    # Cleanup
+    rm -rf "$temp_dir"
+    
+    print_info "✅ $binary_name installed successfully!"
+}
+
+# Install meshctl
+install_meshctl() {
+    install_binary "meshctl"
+    
+    # Verify installation
+    if command -v meshctl >/dev/null 2>&1; then
+        print_info "Verification: $(meshctl version 2>/dev/null || echo 'meshctl is installed')"
+    else
+        print_warn "meshctl was installed to $INSTALL_DIR but is not in PATH"
+        print_warn "Add $INSTALL_DIR to your PATH or use the full path: $INSTALL_DIR/meshctl"
+    fi
+}
+
+# Install mcp-mesh-registry
+install_registry() {
+    install_binary "registry"
+    
+    # Verify installation
+    if command -v registry >/dev/null 2>&1; then
+        print_info "Verification: registry installed to $INSTALL_DIR/registry"
+    else
+        print_warn "registry was installed to $INSTALL_DIR but is not in PATH"
+        print_warn "Add $INSTALL_DIR to your PATH or use the full path: $INSTALL_DIR/registry"
+    fi
+}
+
+# Main execution
+main() {
+    print_info "MCP Mesh Binary Installer"
+    print_info "========================="
+    
+    detect_platform
+    
+    # Get latest version if not specified
+    if [[ "$VERSION" == "latest" ]]; then
+        get_latest_version
+    fi
+    
+    # Install selected binaries
+    local installed_count=0
+    if [[ "$INSTALL_MESHCTL" == "true" ]]; then
+        install_meshctl
+        installed_count=$((installed_count + 1))
+    fi
+    
+    if [[ "$INSTALL_REGISTRY" == "true" ]]; then
+        install_registry
+        installed_count=$((installed_count + 1))
+    fi
+    
+    # Final message
+    print_info ""
+    if [[ $installed_count -eq 0 ]]; then
+        print_warn "No binaries were selected for installation"
+        print_info "Use --help to see available options"
+    else
+        print_info "🎉 Installation completed!"
+        if [[ "$INSTALL_MESHCTL" == "true" ]]; then
+            print_info "Run 'meshctl --help' to get started with the CLI"
+        fi
+        if [[ "$INSTALL_REGISTRY" == "true" ]]; then
+            print_info "Run 'registry --help' to get started with the registry"
+        fi
+    fi
+}
+
+# Run main function
+main "$@"# Updated Sat Jun 21 09:51:42 EDT 2025


### PR DESCRIPTION
## Summary
Implements the sequential pipeline solution for Docker images after PyPI/CLI publishing, with an enhanced install.sh script that follows the "easy but with control" philosophy.

## Problem Solved
- **Race Conditions**: Docker images previously built in parallel with PyPI/CLI publishing, causing inconsistency
- **Artifact Mismatch**: Docker images contained different code than published packages
- **Complex Installation**: Manual platform detection and binary installation in Dockerfiles

## Sequential Pipeline Changes
- ✅ Added `needs: [publish-python, build-binaries]` to `build-docker` job
- ✅ Added VERSION build arguments to all Docker builds
- ✅ Creates proper dependency chain: **PyPI/CLI → Docker**
- ✅ Eliminates race conditions between parallel builds

## Enhanced install.sh Script
- ✅ **Binary Selection**: `--meshctl-only`, `--registry-only`, `--all` (default)
- ✅ **Version Support**: `--version` parameter for specific releases  
- ✅ **Platform Detection**: Auto-detects linux/darwin, amd64/arm64
- ✅ **Enhanced Help**: Clear usage examples and documentation
- ✅ **Generic Design**: Reusable `install_binary()` function

## Simplified Dockerfiles
- ✅ **registry.Dockerfile**: Use `install.sh --registry-only` 
- ✅ **python-runtime.Dockerfile**: Simple `pip install mcp-mesh==${VERSION}`
- ✅ **cli.Dockerfile**: Use `install.sh --all` for both binaries
- ✅ Removed all complex platform detection and tar extraction code

## Benefits Achieved
- **Consistency**: Docker images use exact same artifacts that users install
- **Reliability**: Docker builds fail if PyPI/GitHub releases fail (proper dependency chain) 
- **Separation of Concerns**: install.sh for binaries, pip for Python, docker pull for images
- **User Control**: Choose exactly what to install with clear options
- **Maintainability**: Single script handles all binary installation logic
- **Real Testing**: If published packages are broken, Docker build fails

## Usage Examples
```bash
# Install both binaries (default)
curl -sSL https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh  < /dev/null |  bash

# Install only CLI  
curl -sSL .../install.sh | bash -s -- --meshctl-only

# Install only registry (Docker use case)
curl -sSL .../install.sh | bash -s -- --registry-only

# Install Python package
pip install mcp-mesh

# Get Docker images
docker pull mcpmesh/...
```

## Test Plan
- [ ] Verify install.sh works for all binary selection options
- [ ] Test Docker builds with the new pipeline dependencies
- [ ] Ensure VERSION argument validation works correctly
- [ ] Confirm Docker images use published artifacts (not source builds)

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)