### PR TITLE
Closes #19: Fix Docker registry CGO/SQLite build configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,42 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Test Registry image functionality
+        run: |
+          # Build test image locally to validate before pushing
+          docker build -f ./packaging/docker/registry.Dockerfile -t test-registry:validation .
+
+          # Test 1: Verify binary works and shows help
+          echo "Testing registry binary help..."
+          docker run --rm test-registry:validation --help
+
+          # Test 2: Start registry and test SQLite functionality
+          echo "Testing SQLite functionality..."
+          CONTAINER_ID=$(docker run -d -p 28000:8000 test-registry:validation)
+          sleep 5
+
+          # Test health endpoint (verifies SQLite is working)
+          HEALTH_RESPONSE=$(curl -s http://localhost:28000/health || echo "FAILED")
+          echo "Health response: $HEALTH_RESPONSE"
+
+          # Verify health response contains expected fields
+          if echo "$HEALTH_RESPONSE" | grep -q '"status":"healthy"'; then
+            echo "✅ Registry health check passed - SQLite is working"
+          else
+            echo "❌ Registry health check failed - SQLite may not be working"
+            docker logs $CONTAINER_ID
+            exit 1
+          fi
+
+          # Test 3: Verify SQLite database was created
+          docker exec $CONTAINER_ID ls -la /data/
+
+          # Clean up
+          docker stop $CONTAINER_ID
+          docker rm $CONTAINER_ID
+
+          echo "✅ All registry functionality tests passed"
+
       - name: Build and push Python Runtime image
         uses: docker/build-push-action@v5
         with:

--- a/packaging/docker/registry.Dockerfile
+++ b/packaging/docker/registry.Dockerfile
@@ -1,34 +1,64 @@
-# MCP Mesh Registry - Downloads from GitHub releases
+# MCP Mesh Registry - Multi-stage build with CGO support
 # Supports linux/amd64, linux/arm64
 
-FROM --platform=$TARGETPLATFORM alpine:3.19
+# Build stage
+FROM --platform=$TARGETPLATFORM golang:1.23-alpine AS builder
 
 ARG TARGETPLATFORM
 ARG VERSION
 ARG TARGETOS
 ARG TARGETARCH
 
-# Install runtime dependencies
+WORKDIR /build
+
+# Install build dependencies (including SQLite build tools)
+RUN apk add --no-cache \
+    git \
+    ca-certificates \
+    tzdata \
+    gcc \
+    musl-dev \
+    sqlite-dev \
+    build-base
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . ./
+
+# Build for target architecture with SQLite support
+ENV CGO_ENABLED=1
+ENV CGO_CFLAGS="-D_LARGEFILE64_SOURCE"
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+RUN go build -tags "sqlite_omit_load_extension" -ldflags="-w -s" -o registry ./cmd/mcp-mesh-registry
+
+# Final stage - minimal runtime image
+FROM --platform=$TARGETPLATFORM alpine:3.19
+
+# Install runtime dependencies (including wget for health checks)
 RUN apk add --no-cache \
     ca-certificates \
     tzdata \
     sqlite \
-    curl \
     wget \
-    bash \
     && addgroup -g 1001 -S mcp-mesh \
     && adduser -u 1001 -S mcp-mesh -G mcp-mesh
 
-# Install registry binary using install.sh script
-RUN if [ -z "$VERSION" ]; then echo "VERSION build arg is required" && exit 1; fi && \
-    echo "Installing registry ${VERSION} using install.sh..." && \
-    curl -sSL "https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh" | bash -s -- --registry-only --version ${VERSION} --install-dir /usr/local/bin
+# Copy binary from builder stage
+COPY --from=builder /build/registry /usr/local/bin/registry
 
 # Create data directory
 RUN mkdir -p /data && chown mcp-mesh:mcp-mesh /data
 
 # Switch to non-root user
 USER mcp-mesh
+
+# Set database path to use /data volume
+ENV DATABASE_URL=/data/mcp_mesh_registry.db
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
@@ -38,4 +68,4 @@ EXPOSE 8000
 VOLUME ["/data"]
 
 ENTRYPOINT ["/usr/local/bin/registry"]
-CMD ["--host", "0.0.0.0", "--port", "8000", "--data-dir", "/data"]
+CMD ["--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary

- Fix published Docker registry images that fail with CGO/SQLite build configuration mismatch
- Enable proper SQLite support in published Docker images while maintaining PostgreSQL compatibility
- Add CI validation to prevent future published image failures

## Changes Made

### Docker Registry Build
- Enable CGO with multi-stage build approach for SQLite driver support
- Add required build dependencies (gcc, musl-dev, sqlite-dev, build-base)
- Set proper CGO flags (-D_LARGEFILE64_SOURCE) for SQLite compilation
- Use golang:1.23-alpine base image with build tools in first stage
- Copy built binary to minimal Alpine runtime image

### CI/CD Pipeline
- Add comprehensive image validation tests before publishing
- Test registry binary functionality and SQLite database creation
- Verify health endpoint responds correctly with SQLite backend
- Add cleanup and error handling for test containers

### Command Configuration
- Remove unsupported --data-dir flag from CMD
- Use DATABASE_URL environment variable for SQLite file path configuration
- Maintain compatibility with existing PostgreSQL configuration patterns

## Test Plan

- [x] Tested locally with Docker build - SQLite functionality works
- [x] Verified registry starts successfully and creates SQLite database
- [x] Confirmed health endpoint responds correctly
- [x] Validated multi-architecture build (linux/amd64, linux/arm64)
- [x] Ensured PostgreSQL configuration still works via DATABASE_URL
- [x] All CI checks pass (except local hadolint Docker pull issue)
- [x] **IMPORTANT**: Verified CLAUDE.md is NOT included in commit

## Related Issues

- Closes #19 - Fix published Docker registry images that are non-functional due to CGO/SQLite build configuration mismatch

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>