### PR TITLE
fix: Docker registry build for v0.1.3 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,8 +138,6 @@ jobs:
           context: .
           file: ./packaging/docker/registry.Dockerfile
           platforms: linux/amd64,linux/arm64
-          build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
           push: >
             ${{ github.event_name == 'release' ||
             (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production') }}

--- a/packaging/docker/registry.Dockerfile
+++ b/packaging/docker/registry.Dockerfile
@@ -21,14 +21,12 @@ RUN apk add --no-cache \
     sqlite-dev \
     build-base
 
-# Download source from GitHub release
-RUN if [ -n "$VERSION" ]; then \
-        wget -O source.tar.gz "https://github.com/dhyansraj/mcp-mesh/archive/v${VERSION}.tar.gz" && \
-        tar --strip-components=1 -xzf source.tar.gz && \
-        rm source.tar.gz; \
-    else \
-        echo "VERSION build arg is required" && exit 1; \
-    fi
+# Copy go mod files first for better caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . ./
 
 # Build for target architecture with SQLite support
 ENV CGO_ENABLED=1


### PR DESCRIPTION
## Summary
Fix Docker registry build failures preventing v0.1.3 release completion by reverting to the proven v0.1.2 approach.

## Problem
- v0.1.3 release workflow failed during Docker registry image build
- Multi-platform builds failed with VERSION build-arg and GitHub source download approach
- Error: "VERSION build arg is required" followed by cross-compilation issues

## Root Cause Analysis
- **v0.1.2 worked**: Used local source with `COPY . ./` 
- **v0.1.3 failed**: Changed to GitHub source download during build
- Multi-platform CGO builds more complex with remote source downloads

## Solution
Revert to the working v0.1.2 Dockerfile approach:
- ✅ **Local source copy**: `COPY . ./` instead of GitHub downloads
- ✅ **Remove VERSION dependency**: No longer need VERSION build-arg
- ✅ **Proven approach**: Same method that built v0.1.2 multi-platform images successfully
- ✅ **Verified locally**: Single-platform build tested and working

## Changes Made
- **Dockerfile**: Replace GitHub download with local source copy
- **Release workflow**: Remove unused VERSION build-arg

## Testing
- ✅ Local Docker build succeeds
- ✅ Same approach successfully built v0.1.2 multi-platform images
- 🔄 CI will verify unit tests pass

## Impact
Enables successful completion of v0.1.3 release with working Docker registry images.

🤖 Generated with [Claude Code](https://claude.ai/code)