### PR TITLE
fix: Correct return code capture in build script

### DIFF
--- a/packaging/scripts/build-binaries.sh
+++ b/packaging/scripts/build-binaries.sh
@@ -250,7 +250,8 @@ build_all_binaries() {
         # Build meshctl
         if build_binary "meshctl" "$goos" "$goarch" "meshctl"; then
             # Build registry
-            registry_result=$(build_binary "registry" "$goos" "$goarch" "registry"; echo $?)
+            build_binary "registry" "$goos" "$goarch" "registry"
+            registry_result=$?
             if [[ $registry_result -eq 0 ]]; then
                 built_platforms+=("${goos}_${goarch}")
             elif [[ $registry_result -eq 2 ]]; then


### PR DESCRIPTION
## Issue Fixed
The build script was failing with bash syntax errors due to incorrect return code capture.

### Problem
```bash
# This was capturing both output AND return code
registry_result=$(build_binary "registry" "$goos" "$goarch" "registry"; echo $?)

# Result: registry_result contained log output + return code
# Causing: [[: [2025-06-22...] 0: syntax error: operand expected
```

### Solution
```bash
# Standard approach: run command then capture return code
build_binary "registry" "$goos" "$goarch" "registry"
registry_result=$?
```

### Root Cause
The `$(command; echo $?)` pattern captures both:
1. All stdout from the `build_binary` function (log messages)
2. The return code from `echo $?`

This created a multi-line string that couldn't be compared with `[[ $registry_result -eq 0 ]]`.

### Testing
- [x] Syntax is now correct
- [x] Return codes will be properly captured
- [x] Darwin skips will work as intended
- [x] Linux builds will proceed normally

## Files Changed
- `packaging/scripts/build-binaries.sh` - Fixed return code capture logic

This is a critical fix needed for the v0.1.5 release to complete successfully.