### PR TITLE
fix: Update K8s agent deployment commands to use Python interpreter (Closes #36)

### DIFF
--- a/examples/k8s/base/agents/hello-world-deployment.yaml
+++ b/examples/k8s/base/agents/hello-world-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - name: hello-world-agent
           image: mcpmesh/python-runtime:0.1
           imagePullPolicy: IfNotPresent
-          command: ["/app/agent.py"]
+          command: ["python", "/app/agent.py"]
           ports:
             - name: http
               containerPort: 8080

--- a/examples/k8s/base/agents/system-agent-deployment.yaml
+++ b/examples/k8s/base/agents/system-agent-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - name: system-agent
           image: mcpmesh/python-runtime:0.1
           imagePullPolicy: IfNotPresent
-          command: ["/app/agent.py"]
+          command: ["python", "/app/agent.py"]
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## Summary

Fixes Kubernetes agent deployment crashes by updating container commands to use Python interpreter instead of direct script execution.

## Problem

Agent pods in `examples/k8s/` were failing to start with permission denied errors:
- **Error**: `exec: "/app/agent.py": permission denied`
- **Root cause**: Container trying to execute ConfigMap-mounted script directly without execute permissions

## Changes

Updated both agent deployments in `examples/k8s/base/agents/`:

**hello-world-deployment.yaml**:
```yaml
# Before
command: ["/app/agent.py"]

# After  
command: ["python", "/app/agent.py"]
```

**system-agent-deployment.yaml**:
```yaml
# Before
command: ["/app/agent.py"]

# After
command: ["python", "/app/agent.py"]
```

## Test Plan

- [x] Deploy fresh minikube cluster
- [x] Apply K8s manifests with fixes
- [x] Verify all pods reach Running status
- [x] Set up port forwarding for testing
- [x] Test MCP function calls:
  - [x] Hello world with date dependency: ✅ Working
  - [x] Direct system agent calls: ✅ Working  
  - [x] Advanced tag-based matching: ✅ Working
  - [x] Multiple dependencies: ⚠️ Partial (edge cases exist but core functionality works)

## Verification

All pods now start successfully:
```
NAME                                     READY   STATUS    RESTARTS   AGE
mcp-mesh-hello-world-864f4cbd77-pd2rb    1/1     Running   0          20s
mcp-mesh-postgres-0                      1/1     Running   0          7m59s
mcp-mesh-registry-0                      1/1     Running   0          7m59s
mcp-mesh-system-agent-679b449bbb-fbgrt   1/1     Running   0          20s
```

MCP function calls working correctly with successful dependency injection between agents.

Closes #36

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>