### PR TITLE
hotfix: Fix Python packaging source paths in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,8 @@ jobs:
         run: |
           cp ../../src/runtime/python/README.md .
           cp ../../LICENSE .
-          cp -r ../../src/runtime/python/src .
+          cp -r ../../src/runtime/python/_mcp_mesh .
+          cp -r ../../src/runtime/python/mesh .
 
       - name: Update version in packaging files
         working-directory: packaging/pypi


### PR DESCRIPTION
## Critical Release Fix

Fixes the failing Python packaging step in the v0.2.0 release workflow.

## Issue

The release workflow was failing because it was trying to copy from a non-existent `src` directory:
```bash
cp -r ../../src/runtime/python/src .  # ❌ This directory doesn't exist
```

## Solution

Updated to copy the actual source directories:
```bash
cp -r ../../src/runtime/python/_mcp_mesh .  # ✅ Actual source directory
cp -r ../../src/runtime/python/mesh .       # ✅ Actual source directory  
```

## Impact

- ✅ **Fixes v0.2.0 release** - Python package can now build successfully
- ✅ **Enables PyPI publishing** - Package will be available via pip install
- ✅ **Unblocks Docker builds** - Docker pipeline depends on Python package
- ✅ **No functional changes** - Only fixes the build process

## Urgency

This is a **critical hotfix** needed to complete the v0.2.0 release. The release tag exists but packages aren't being published due to this build failure.

🤖 Generated with [Claude Code](https://claude.ai/code)