### PR TITLE
hotfix: Fix version update paths - _mcp_mesh not mcp_mesh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,14 +312,14 @@ jobs:
           echo "Event name: ${{ github.event_name }}"
           echo "Ref name: ${{ github.ref_name }}"
           echo "Detected version: ${VERSION}"
-          echo "Current version in file: $(grep '__version__' src/mcp_mesh/__init__.py)"
+          echo "Current version in file: $(grep '__version__' _mcp_mesh/__init__.py)"
 
           # Update version in both __init__.py and pyproject.toml
-          sed -i "s/__version__ = \".*\"/__version__ = \"${VERSION}\"/" src/mcp_mesh/__init__.py
+          sed -i "s/__version__ = \".*\"/__version__ = \"${VERSION}\"/" _mcp_mesh/__init__.py
           sed -i "s/version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
 
           # Verify the versions were updated
-          echo "Updated __init__.py version to: $(grep '__version__' src/mcp_mesh/__init__.py)"
+          echo "Updated __init__.py version to: $(grep '__version__' _mcp_mesh/__init__.py)"
           echo "Updated pyproject.toml version to: $(grep 'version = ' pyproject.toml)"
 
       - name: Build package


### PR DESCRIPTION
Fixes path error in release workflow. The correct path is _mcp_mesh/__init__.py (with underscore) not mcp_mesh/__init__.py. This was causing 'No such file' errors in the v0.2.0 release.