### PR TITLE
chore: Bump version to 0.2.1 to avoid PyPI conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ docker pull mcpmesh/python-runtime:0.2
 docker pull mcpmesh/cli:0.2
 
 # Download CLI binary directly (specific version)
-curl -L https://github.com/dhyansraj/mcp-mesh/releases/download/v0.2.0/mcp-mesh_v0.2.0_linux_amd64.tar.gz | tar xz
+curl -L https://github.com/dhyansraj/mcp-mesh/releases/download/v0.2.1/mcp-mesh_v0.2.1_linux_amd64.tar.gz | tar xz
 sudo mv meshctl /usr/local/bin/
 ```
 

--- a/helm/mcp-mesh-agent/Chart.yaml
+++ b/helm/mcp-mesh-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-agent
 description: MCP Mesh Agent - Python runtime for MCP agents with mesh capabilities
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.2.1
+appVersion: "0.2.1"
 keywords:
   - mcp
   - mesh

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "0.2.0"
+version = "0.2.1"
 description = "Kubernetes-native platform for distributed MCP applications"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "0.2.0"
+version = "0.2.1"
 description = "Kubernetes-native platform for distributed MCP applications"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
PyPI rejected 0.2.0 as it was previously uploaded. Bumping to 0.2.1 for successful package publishing. Version ranges >=0.2.0 will still work and automatically get 0.2.1.