### PR TITLE
Fix: UnregisterAgent creates wrong event type and duplicate events (Closes #81)

### DIFF
--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -107,6 +107,20 @@ curl -s -X POST http://localhost:PORT/mcp/ \
       "arguments": {}
     }
   }' | grep "^data:" | sed 's/^data: //' | jq -r '.result.content[0].text'
+
+# Test tools with required arguments (example: generate_report on dependent agent)
+curl -s -X POST http://localhost:9093/mcp/ \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "generate_report",
+      "arguments": {"title": "Test Report"}
+    }
+  }' | grep "^data:" | sed 's/^data: //' | jq -r '.result.content[0].text'
 ```
 
 ### 3. Test Dependency Injection


### PR DESCRIPTION
## Summary

Fixes the unregister functionality that was broken by the status change hooks implementation in #79. The `DELETE /agents/{agent_id}` endpoint was creating incorrect event types and causing duplicate events.

## Problem Addressed

- **Wrong Event Type**: DELETE endpoint was creating `EventTypeUnhealthy` instead of `EventTypeUnregister` events
- **Duplicate Events**: Status hooks couldn't distinguish graceful shutdown from health timeout
- **Timestamp Issues**: Agent timestamps weren't updated correctly during unregistration
- **API Contract Violation**: Tests expect `EventTypeUnregister` but implementation created `EventTypeUnhealthy`

## Solution Implemented

### 🔧 Core Fixes

1. **Modified UnregisterAgent Method** (`src/core/registry/ent_service.go`):
   - Create explicit `EventTypeUnregister` events before status update
   - Use UTC timestamps and update agent timestamp correctly
   - Include proper event metadata (agent_type, name, version, reason, source)
   - Follow same transaction pattern as RegisterAgent

2. **Enhanced Status Change Hooks** (`src/core/registry/status_hooks.go`):
   - Check for recent unregister events (within 5 seconds) before creating unhealthy events
   - Skip hook-based event creation if explicit unregister event already exists
   - Prevents duplicate events while preserving health monitor functionality

3. **Documentation Improvements** (`examples/simple/README.md`):
   - Added example for tools with required arguments (`generate_report`)
   - Use hardcoded port 9093 consistent with agent examples
   - Show proper JSON-RPC 2.0 format with required parameters

## Changes Made

```diff
src/core/registry/ent_service.go       < /dev/null |  25 +++++++++++++++++++++++--
src/core/registry/status_hooks.go     | 18 ++++++++++++++++++
examples/simple/README.md             | 14 ++++++++++++++
```

## Expected Behavior

✅ **DELETE `/agents/{agent_id}`** → Creates `EventTypeUnregister` event  
✅ **Health monitor timeout** → Creates `EventTypeUnhealthy` event  
✅ **No duplicate events** for graceful shutdowns  
✅ **Proper UTC timestamps** throughout the system  
✅ **API contract compliance** with OpenAPI spec and tests

## Test Results

### Unit Tests
```bash
go test ./src/core/registry/... -v -run "TestUnregisterAgent"
# PASS: All tests passing including TestUnregisterAgent
```

### Manual Verification
```sql
-- Correct unregister events now created
SELECT event_type, timestamp, data FROM registry_events 
WHERE event_type = 'unregister' ORDER BY timestamp DESC LIMIT 1;

unregister|2025-07-06 01:18:23.523287101+00:00|{
  "agent_type":"mcp_agent",
  "name":"dependent-service-fa7f41ef", 
  "reason":"graceful_shutdown",
  "source":"delete_endpoint",
  "version":"1.0.0"
}
```

### Tool Call Testing
```bash
# New README example works correctly
curl -s -X POST http://localhost:9093/mcp/ \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", 
       "params": {"name": "generate_report", "arguments": {"title": "Test Report"}}}'
# ✅ Returns proper JSON response
```

## Breaking Changes

None - this is a backward-compatible fix that restores expected functionality.

## Impact

This fix ensures proper event tracking for topology change detection, which is critical for:
- **Service discovery** - Other agents can detect when dependencies are removed
- **Dependency resolution** - Mesh can update dependency graphs correctly  
- **Monitoring/alerting** - Distinguish between graceful shutdown vs failure
- **Audit compliance** - Accurate event logs for operations

## Testing Checklist

- [x] Unit tests pass (`TestUnregisterAgent`)
- [x] Manual DELETE endpoint testing
- [x] Event creation verification in database
- [x] No duplicate events during graceful shutdown
- [x] Health monitor still creates unhealthy events for timeouts
- [x] Documentation examples work correctly
- [x] No regressions in other functionality

Closes #81

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>