### PR TITLE
Release v0.5.2 - macOS Support & Platform Improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "Version (e.g., v0.5.0)"
         required: true
-        default: "v0.5.1"
+        default: "v0.5.2"
       environment:
         description: "Environment"
         type: choice
@@ -572,7 +572,14 @@ jobs:
   # Discord notification for successful releases
   notify-discord:
     runs-on: ubuntu-latest
-    needs: [build-binaries, build-macos-binaries, publish-python, build-docker, update-packages]
+    needs:
+      [
+        build-binaries,
+        build-macos-binaries,
+        publish-python,
+        build-docker,
+        update-packages,
+      ]
     if: >
       ${{ success() && (github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')) }}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Variables
 REGISTRY_NAME = mcp-mesh-registry
 DEV_NAME = meshctl
-VERSION = 0.5.1
+VERSION = 0.5.2
 BUILD_DIR = bin
 REGISTRY_CMD_DIR = cmd/mcp-mesh-registry
 DEV_CMD_DIR = cmd/meshctl

--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ pip install "mcp-mesh>=0.5,<0.6"
 
 ### CLI Tools
 
+**macOS (Homebrew)**
+
+```bash
+# Add the official tap and install
+brew tap dhyansraj/mcp-mesh
+brew install mcp-mesh
+```
+
+**Linux/macOS (Install Script)**
+
 ```bash
 # Install meshctl and registry binaries
 curl -sSL https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh | bash
@@ -196,11 +206,12 @@ docker pull mcpmesh/cli:0.5
 
 ### Quick Setup Options
 
-| Method             | Best For                | Command                                            |
-| ------------------ | ----------------------- | -------------------------------------------------- |
-| **Docker Compose** | Getting started quickly | `cd examples/docker-examples && docker-compose up` |
-| **Python Package** | Agent development       | `pip install "mcp-mesh>=0.5,<0.6"`                 |
-| **Kubernetes**     | Production deployment   | `kubectl apply -k examples/k8s/base/`              |
+| Method             | Best For                | Command                                                |
+| ------------------ | ----------------------- | ------------------------------------------------------ |
+| **Homebrew**       | macOS users             | `brew tap dhyansraj/mcp-mesh && brew install mcp-mesh` |
+| **Docker Compose** | Getting started quickly | `cd examples/docker-examples && docker-compose up`     |
+| **Python Package** | Agent development       | `pip install "mcp-mesh>=0.5,<0.6"`                     |
+| **Kubernetes**     | Production deployment   | `kubectl apply -k examples/k8s/base/`                  |
 
 > **🔧 For Development**: See [Local Development Guide](docs/02-local-development.md) to build from source.
 
@@ -307,6 +318,10 @@ curl -sSL https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh |
 ### Package Manager Installation
 
 ```bash
+# macOS with Homebrew (recommended)
+brew tap dhyansraj/mcp-mesh
+brew install mcp-mesh
+
 # Python package from PyPI (allows patch updates)
 pip install "mcp-mesh>=0.5,<0.6"
 
@@ -316,7 +331,7 @@ docker pull mcpmesh/python-runtime:0.5
 docker pull mcpmesh/cli:0.5
 
 # Download CLI binary directly (specific version)
-curl -L https://github.com/dhyansraj/mcp-mesh/releases/download/v0.5.1/mcp-mesh_v0.5.1_linux_amd64.tar.gz | tar xz
+curl -L https://github.com/dhyansraj/mcp-mesh/releases/download/v0.5.2/mcp-mesh_v0.5.2_linux_amd64.tar.gz | tar xz
 sudo mv meshctl /usr/local/bin/
 ```
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,51 @@
 # MCP Mesh Release Notes
 
+## v0.5.2 (2025-08-16)
+
+### 🍎 macOS Support & Platform Improvements
+
+**Native macOS Binary Distribution**
+
+- Added native macOS builds for both Intel (`darwin/amd64`) and Apple Silicon (`darwin/arm64`) architectures
+- Implemented automated Homebrew tap distribution via `dhyansraj/homebrew-mcp-mesh`
+- Fixed binary naming consistency: standardized on `mcp-mesh-registry` across all platforms
+- Enhanced GitHub Actions pipeline with cross-platform build support and automated package manager updates
+
+**Enhanced Installation Experience**
+
+- **Homebrew Support**: `brew tap dhyansraj/mcp-mesh && brew install mcp-mesh`
+- **PATH Resolution**: Improved binary discovery for both development and system installations using `exec.LookPath()`
+- **Cross-Platform Install Script**: Updated `install.sh` to handle macOS/Linux differences seamlessly
+
+**Distributed Tracing Reliability**
+
+- Fixed silent tracing failures that were preventing proper observability data collection
+- Enhanced FastAPI middleware integration for more robust trace capture
+- Improved context handling and metadata publishing to Redis streams
+- Updated Grafana dashboards with better trace visualization
+
+### 🏷️ Migration Guide
+
+**Upgrading from v0.5.1:**
+
+- **Python Package**: Update to `pip install "mcp-mesh>=0.5.2,<0.6"`
+- **macOS Users**: Install via Homebrew: `brew tap dhyansraj/mcp-mesh && brew install mcp-mesh`
+- **Docker Images**: Use `mcpmesh/registry:0.5.2` and `mcpmesh/python-runtime:0.5.2`
+- **Helm Charts**: All charts now use v0.5.2 for consistent dependency management
+
+**Breaking Changes:**
+
+- None - this release maintains full backward compatibility with v0.5.1
+- Binary names are now consistent (`mcp-mesh-registry`) but old references will continue to work
+
+### 📦 Distribution Improvements
+
+- **GitHub Actions**: Native macOS builds with proper Gatekeeper signing preparation
+- **Homebrew Automation**: Automatic formula updates with cross-platform checksum verification
+- **Enhanced CI/CD**: Improved reliability with disabled Go cache and proper dependency management
+
+---
+
 ## v0.5.1 (2025-08-14)
 
 ### 🔧 Major Enhancement Release - Unified Telemetry Architecture

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -91,9 +91,36 @@ curl -s -X POST http://localhost:8081/mcp \
 
 That's it! You now have a working distributed MCP service mesh! 🎉
 
-## Alternative: Python Package (3 Minutes)
+## Alternative: macOS with Homebrew (2 Minutes)
 
-**For Python development with published packages:**
+**For macOS users with Homebrew:**
+
+```bash
+# 1. Install MCP Mesh CLI tools
+brew tap dhyansraj/mcp-mesh
+brew install mcp-mesh
+
+# 2. Install Python package with semantic versioning
+pip install "mcp-mesh>=0.5,<0.6"
+
+# 3. Download example agents
+git clone https://github.com/dhyansraj/mcp-mesh.git
+cd mcp-mesh/examples/simple
+
+# 4. Start registry and agents
+mcp-mesh-registry --host 0.0.0.0 --port 8000 &
+python system_agent.py &
+python hello_world.py &
+
+# 5. Test it
+curl -s -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"method": "tools/call", "params": {"name": "hello_mesh_simple", "arguments": {}}}' | jq .
+```
+
+## Alternative: Linux/macOS Install Script (3 Minutes)
+
+**For Linux or manual macOS installation:**
 
 ```bash
 # 1. Install MCP Mesh with semantic versioning (allows patch updates)
@@ -101,7 +128,7 @@ pip install "mcp-mesh>=0.5,<0.6"
 
 # 2. Download and start registry (use minor version for latest patches)
 curl -sSL https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh | bash -s -- --registry-only --version v0.5
-registry --host 0.0.0.0 --port 8000 &
+mcp-mesh-registry --host 0.0.0.0 --port 8000 &
 
 # 3. Download example agents
 git clone https://github.com/dhyansraj/mcp-mesh.git

--- a/docs/01-getting-started/02-installation.md
+++ b/docs/01-getting-started/02-installation.md
@@ -4,7 +4,22 @@
 
 ## Quick Install (Recommended)
 
-Install MCP Mesh using published packages:
+### macOS with Homebrew
+
+```bash
+# Install CLI tools (includes meshctl and mcp-mesh-registry)
+brew tap dhyansraj/mcp-mesh
+brew install mcp-mesh
+
+# Install Python package with semantic versioning
+pip install "mcp-mesh>=0.5,<0.6"
+
+# Verify installation
+meshctl --version
+mcp-mesh-registry --version
+```
+
+### Linux/macOS with Install Script
 
 ```bash
 # Install MCP Mesh from PyPI with semantic versioning (allows patch updates)
@@ -15,14 +30,14 @@ curl -sSL https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh |
 
 # Verify installation
 meshctl --version
-registry --version
+mcp-mesh-registry --version
 ```
 
 **What this installs:**
 
 - 📦 **Python package**: MCP Mesh runtime for building agents
 - 🔧 **meshctl**: CLI tool for managing the mesh
-- 🏗️ **registry**: Service discovery and coordination server
+- 🏗️ **mcp-mesh-registry**: Service discovery and coordination server
 
 ## Alternative: Build from Source
 
@@ -273,8 +288,8 @@ For comprehensive solutions, see our [Troubleshooting Guide](./troubleshooting.m
 
 ## 📝 TODO
 
-- [ ] Create one-line installer script
-- [ ] Add Homebrew formula for macOS
+- [x] Create one-line installer script
+- [x] Add Homebrew formula for macOS
 - [ ] Create snap package for Linux
 - [ ] Add Windows installer (.exe)
 - [ ] Support poetry and pipenv

--- a/helm/mcp-mesh-agent/Chart.yaml
+++ b/helm/mcp-mesh-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-agent
 description: MCP Mesh Agent - Python runtime for MCP agents with mesh capabilities
 type: application
-version: 0.5.1
-appVersion: "0.5.1"
+version: 0.5.2
+appVersion: "0.5.2"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-core/Chart.yaml
+++ b/helm/mcp-mesh-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-core
 description: MCP Mesh Core Infrastructure - Registry, PostgreSQL, Redis, and Observability
 type: application
-version: 0.5.1
-appVersion: "0.5.1"
+version: 0.5.2
+appVersion: "0.5.2"
 keywords:
   - mcp
   - mesh
@@ -28,22 +28,22 @@ annotations:
   "artifacthub.io/containsSecurityUpdates": "false"
 dependencies:
   - name: mcp-mesh-postgres
-    version: "0.5.1"
+    version: "0.5.2"
     repository: "file://../mcp-mesh-postgres"
     condition: postgres.enabled
   - name: mcp-mesh-redis
-    version: "0.5.1"
+    version: "0.5.2"
     repository: "file://../mcp-mesh-redis"
     condition: redis.enabled
   - name: mcp-mesh-registry
-    version: "0.5.1"
+    version: "0.5.2"
     repository: "file://../mcp-mesh-registry"
     condition: registry.enabled
   - name: mcp-mesh-grafana
-    version: "0.5.1"
+    version: "0.5.2"
     repository: "file://../mcp-mesh-grafana"
     condition: grafana.enabled
   - name: mcp-mesh-tempo
-    version: "0.5.1"
+    version: "0.5.2"
     repository: "file://../mcp-mesh-tempo"
     condition: tempo.enabled

--- a/helm/mcp-mesh-grafana/Chart.yaml
+++ b/helm/mcp-mesh-grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-grafana
 description: Grafana observability component for MCP Mesh
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: "11.4.0"
 keywords:
   - grafana

--- a/helm/mcp-mesh-ingress/Chart.yaml
+++ b/helm/mcp-mesh-ingress/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ingress
 description: Ingress configuration for MCP Mesh services with flexible DNS routing
 type: application
-version: 0.5.1
-appVersion: "0.5.1"
+version: 0.5.2
+appVersion: "0.5.2"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-postgres/Chart.yaml
+++ b/helm/mcp-mesh-postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-postgres
 description: PostgreSQL database for MCP Mesh Registry
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: "15"
 keywords:
   - mcp

--- a/helm/mcp-mesh-redis/Chart.yaml
+++ b/helm/mcp-mesh-redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-redis
 description: Redis cache for MCP Mesh session storage
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: "7"
 keywords:
   - mcp

--- a/helm/mcp-mesh-tempo/Chart.yaml
+++ b/helm/mcp-mesh-tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-tempo
 description: Tempo distributed tracing component for MCP Mesh
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: "2.8.1"
 keywords:
   - tempo

--- a/packaging/homebrew/mcp-mesh.rb
+++ b/packaging/homebrew/mcp-mesh.rb
@@ -2,7 +2,7 @@
 class McpMesh < Formula
   desc "Kubernetes-native platform for distributed MCP applications"
   homepage "https://github.com/dhyansraj/mcp-mesh"
-  version "0.5.1"  # Will be updated by release automation
+  version "0.5.2"  # Will be updated by release automation
 
   if OS.mac?
     if Hardware::CPU.arm?

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "0.5.1"
+version = "0.5.2"
 description = "Kubernetes-native platform for distributed MCP applications"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packaging/scoop/mcp-mesh.json
+++ b/packaging/scoop/mcp-mesh.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Kubernetes-native platform for distributed MCP applications",
   "homepage": "https://github.com/dhyansraj/mcp-mesh",
   "license": "MIT",

--- a/src/runtime/python/_mcp_mesh/__init__.py
+++ b/src/runtime/python/_mcp_mesh/__init__.py
@@ -31,7 +31,7 @@ from .engine.decorator_registry import (
     get_decorator_stats,
 )
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 # Store reference to runtime processor if initialized
 _runtime_processor = None

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "0.5.1"
+version = "0.5.2"
 description = "Kubernetes-native platform for distributed MCP applications"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

This release brings native macOS support and enhanced platform distribution for MCP Mesh.

### 🍎 macOS Support & Platform Improvements

- **Native macOS Binary Distribution**: Added Intel and Apple Silicon builds with automated Homebrew tap
- **Enhanced Installation Experience**: Homebrew support with improved PATH resolution 
- **Distributed Tracing Reliability**: Fixed silent tracing failures and enhanced FastAPI middleware integration

### 📦 Key Changes

- Added native macOS builds for both `darwin/amd64` and `darwin/arm64` architectures
- Implemented automated Homebrew tap distribution via `dhyansraj/homebrew-mcp-mesh`
- Fixed binary naming consistency: standardized on `mcp-mesh-registry` across all platforms
- Enhanced GitHub Actions pipeline with cross-platform build support
- Fixed distributed tracing silent failures preventing proper observability data collection
- Updated all version references across 18 files to v0.5.2

### 🏷️ Migration Notes

- **Homebrew Support**: `brew tap dhyansraj/mcp-mesh && brew install mcp-mesh`
- **Full backward compatibility** with v0.5.1 - no breaking changes
- **Docker Images**: Use `mcpmesh/registry:0.5.2` and `mcpmesh/python-runtime:0.5.2`

## Test plan

- [x] All version numbers updated consistently across 18 files
- [x] Release notes created with comprehensive v0.5.2 documentation
- [x] GitHub issue #122 created for release tracking
- [x] Feature branch created with all changes applied
- [ ] CI/CD pipeline validation after merge
- [ ] Homebrew formula update verification
- [ ] Docker image builds and publications
- [ ] Documentation deployment validation

🤖 Generated with [Claude Code](https://claude.ai/code)