### PR TITLE
Fix Liquid raw tag syntax with proper spacing

### DIFF
--- a/docs/03-docker-deployment/01-building-images.md
+++ b/docs/03-docker-deployment/01-building-images.md
@@ -343,7 +343,7 @@ docker run --rm test-agent:latest whoami | grep -q "mcp" || exit 1
 # Test health check
 docker run -d --name test-health test-agent:latest
 sleep 5
-docker inspect test-health --format='{%raw%}{{.State.Health.Status}}{%endraw%}' | grep -q "healthy" || exit 1
+docker inspect test-health --format='{% raw %}{{.State.Health.Status}}{% endraw %}' | grep -q "healthy" || exit 1
 docker rm -f test-health
 ```
 

--- a/docs/03-docker-deployment/04-networking.md
+++ b/docs/03-docker-deployment/04-networking.md
@@ -517,7 +517,7 @@ nc -zv registry 8000
 
 ```bash
 # Monitor network usage
-docker stats --format "table {%raw%}{{.Container}}{%endraw%}\t{%raw%}{{.NetIO}}{%endraw%}"
+docker stats --format "table {% raw %}{{.Container}}{% endraw %}\t{% raw %}{{.NetIO}}{% endraw %}"
 
 # Check network interfaces
 docker exec weather-agent ip addr

--- a/docs/03-docker-deployment/troubleshooting.md
+++ b/docs/03-docker-deployment/troubleshooting.md
@@ -25,7 +25,7 @@ docker-compose version > /dev/null 2>&1 && echo "INSTALLED" || echo "NOT FOUND"
 
 # Check running containers
 echo -e "\nRunning containers:"
-docker ps --format "table {%raw%}{{.Names}}{%endraw%}\t{%raw%}{{.Status}}{%endraw%}\t{%raw%}{{.Ports}}{%endraw%}"
+docker ps --format "table {% raw %}{{.Names}}{% endraw %}\t{% raw %}{{.Status}}{% endraw %}\t{% raw %}{{.Ports}}{% endraw %}"
 
 # Check networks
 echo -e "\nDocker networks:"
@@ -41,7 +41,7 @@ docker system df
 
 # Check container health
 echo -e "\nContainer health:"
-docker ps --format "table {%raw%}{{.Names}}{%endraw%}\t{%raw%}{{.Status}}{%endraw%}" | grep -E "(healthy|unhealthy|starting)"
+docker ps --format "table {% raw %}{{.Names}}{% endraw %}\t{% raw %}{{.Status}}{% endraw %}" | grep -E "(healthy|unhealthy|starting)"
 
 # Check registry connectivity
 echo -e "\nRegistry status:"
@@ -477,7 +477,7 @@ Invalid compose file
 
 ```bash
 # Find CPU-hungry containers
-docker stats --no-stream --format "table {%raw%}{{.Container}}{%endraw%}\t{%raw%}{{.CPUPerc}}{%endraw%}"
+docker stats --no-stream --format "table {% raw %}{{.Container}}{% endraw %}\t{% raw %}{{.CPUPerc}}{% endraw %}"
 
 # Limit CPU usage
 services:

--- a/docs/06-helm-deployment.md
+++ b/docs/06-helm-deployment.md
@@ -167,7 +167,7 @@ spec:
     spec:
       containers:
         - name: registry-init
-          image: "{%raw%}{{ .Values.image.repository }}{%endraw%}:{%raw%}{{ .Values.image.tag }}{%endraw%}"
+          image: "{% raw %}{{ .Values.image.repository }}{% endraw %}:{% raw %}{{ .Values.image.tag }}{% endraw %}"
           command: ["sh", "-c", "echo 'Initializing MCP Mesh Registry...'"]
       restartPolicy: Never
 ```

--- a/docs/06-helm-deployment/01-understanding-charts.md
+++ b/docs/06-helm-deployment/01-understanding-charts.md
@@ -51,38 +51,38 @@ mcp-mesh-registry/
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {%raw%}{{ include "mcp-mesh-registry.fullname" . }}{%endraw%}
+  name: {% raw %}{{ include "mcp-mesh-registry.fullname" . }}{% endraw %}
   labels:
-    {%raw%}{{- include "mcp-mesh-registry.labels" . | nindent 4 }}{%endraw%}
+    {% raw %}{{- include "mcp-mesh-registry.labels" . | nindent 4 }}{% endraw %}
 spec:
-  serviceName: {%raw%}{{ include "mcp-mesh-registry.fullname" . }}{%endraw%}-headless
-  replicas: {%raw%}{{ .Values.replicaCount }}{%endraw%}
+  serviceName: {% raw %}{{ include "mcp-mesh-registry.fullname" . }}{% endraw %}-headless
+  replicas: {% raw %}{{ .Values.replicaCount }}{% endraw %}
   selector:
     matchLabels:
-      {%raw%}{{- include "mcp-mesh-registry.selectorLabels" . | nindent 6 }}{%endraw%}
+      {% raw %}{{- include "mcp-mesh-registry.selectorLabels" . | nindent 6 }}{% endraw %}
   template:
     metadata:
       annotations:
-        checksum/config: {%raw%}{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}{%endraw%}
-        {%raw%}{{- with .Values.podAnnotations }}{%endraw%}
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
+        checksum/config: {% raw %}{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}{% endraw %}
+        {% raw %}{{- with .Values.podAnnotations }}{% endraw %}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
       labels:
-        {%raw%}{{- include "mcp-mesh-registry.selectorLabels" . | nindent 8 }}{%endraw%}
+        {% raw %}{{- include "mcp-mesh-registry.selectorLabels" . | nindent 8 }}{% endraw %}
     spec:
-      serviceAccountName: {%raw%}{{ include "mcp-mesh-registry.serviceAccountName" . }}{%endraw%}
+      serviceAccountName: {% raw %}{{ include "mcp-mesh-registry.serviceAccountName" . }}{% endraw %}
       securityContext:
-        {%raw%}{{- toYaml .Values.podSecurityContext | nindent 8 }}{%endraw%}
+        {% raw %}{{- toYaml .Values.podSecurityContext | nindent 8 }}{% endraw %}
       containers:
-      - name: {%raw%}{{ .Chart.Name }}{%endraw%}
+      - name: {% raw %}{{ .Chart.Name }}{% endraw %}
         securityContext:
-          {%raw%}{{- toYaml .Values.securityContext | nindent 12 }}{%endraw%}
-        image: "{%raw%}{{ .Values.image.repository }}{%endraw%}:{%raw%}{{ .Values.image.tag | default .Chart.AppVersion }}{%endraw%}"
-        imagePullPolicy: {%raw%}{{ .Values.image.pullPolicy }}{%endraw%}
+          {% raw %}{{- toYaml .Values.securityContext | nindent 12 }}{% endraw %}
+        image: "{% raw %}{{ .Values.image.repository }}{% endraw %}:{% raw %}{{ .Values.image.tag | default .Chart.AppVersion }}{% endraw %}"
+        imagePullPolicy: {% raw %}{{ .Values.image.pullPolicy }}{% endraw %}
         command: ["/app/bin/registry"]  # 🎯 Matches working examples
         ports:
         - name: http
-          containerPort: {%raw%}{{ .Values.registry.port }}{%endraw%}  # 🎯 Default 8000
+          containerPort: {% raw %}{{ .Values.registry.port }}{% endraw %}  # 🎯 Default 8000
           protocol: TCP
         - name: metrics
           containerPort: 9090
@@ -101,16 +101,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {%raw%}{{- if ne .Values.registry.database.type "sqlite" }}{%endraw%}
+        {% raw %}{{- if ne .Values.registry.database.type "sqlite" }}{% endraw %}
         - name: DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {%raw%}{{ include "mcp-mesh-registry.fullname" . }}{%endraw%}-secret
+              name: {% raw %}{{ include "mcp-mesh-registry.fullname" . }}{% endraw %}-secret
               key: database-password
-        {%raw%}{{- end }}{%endraw%}
+        {% raw %}{{- end }}{% endraw %}
         envFrom:
         - configMapRef:
-            name: {%raw%}{{ include "mcp-mesh-registry.fullname" . }}{%endraw%}-config  # 🎯 Updated naming
+            name: {% raw %}{{ include "mcp-mesh-registry.fullname" . }}{% endraw %}-config  # 🎯 Updated naming
         livenessProbe:
           httpGet:
             path: /health  # 🎯 Consistent health endpoint
@@ -136,36 +136,36 @@ spec:
           timeoutSeconds: 5
           failureThreshold: 30
         resources:
-          {%raw%}{{- toYaml .Values.resources | nindent 12 }}{%endraw%}
+          {% raw %}{{- toYaml .Values.resources | nindent 12 }}{% endraw %}
         volumeMounts:
         - name: data
           mountPath: /data
-        {%raw%}{{- if .Values.extraVolumeMounts }}{%endraw%}
-        {%raw%}{{- toYaml .Values.extraVolumeMounts | nindent 8 }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- with .Values.nodeSelector }}{%endraw%}
+        {% raw %}{{- if .Values.extraVolumeMounts }}{% endraw %}
+        {% raw %}{{- toYaml .Values.extraVolumeMounts | nindent 8 }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- with .Values.nodeSelector }}{% endraw %}
       nodeSelector:
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- with .Values.affinity }}{%endraw%}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- with .Values.affinity }}{% endraw %}
       affinity:
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- with .Values.tolerations }}{%endraw%}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- with .Values.tolerations }}{% endraw %}
       tolerations:
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-  {%raw%}{{- if .Values.persistence.enabled }}{%endraw%}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+  {% raw %}{{- if .Values.persistence.enabled }}{% endraw %}
   volumeClaimTemplates:
   - metadata:
       name: data
     spec:
-      accessModes: {%raw%}{{ .Values.persistence.accessModes }}{%endraw%}
-      storageClassName: {%raw%}{{ .Values.persistence.storageClassName }}{%endraw%}
+      accessModes: {% raw %}{{ .Values.persistence.accessModes }}{% endraw %}
+      storageClassName: {% raw %}{{ .Values.persistence.storageClassName }}{% endraw %}
       resources:
         requests:
-          storage: {%raw%}{{ .Values.persistence.size }}{%endraw%}
-  {%raw%}{{- end }}{%endraw%}
+          storage: {% raw %}{{ .Values.persistence.size }}{% endraw %}
+  {% raw %}{{- end }}{% endraw %}
 ```
 
 ### Step 3: Agent Chart Deep Dive
@@ -177,55 +177,55 @@ The agent chart is more flexible, supporting various agent configurations:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {%raw%}{{ include "mcp-mesh-agent.fullname" . }}{%endraw%}
+  name: {% raw %}{{ include "mcp-mesh-agent.fullname" . }}{% endraw %}
   labels:
-    {%raw%}{{- include "mcp-mesh-agent.labels" . | nindent 4 }}{%endraw%}
+    {% raw %}{{- include "mcp-mesh-agent.labels" . | nindent 4 }}{% endraw %}
 spec:
-  replicas: {%raw%}{{ .Values.replicaCount }}{%endraw%}
+  replicas: {% raw %}{{ .Values.replicaCount }}{% endraw %}
   selector:
     matchLabels:
-      {%raw%}{{- include "mcp-mesh-agent.selectorLabels" . | nindent 6 }}{%endraw%}
+      {% raw %}{{- include "mcp-mesh-agent.selectorLabels" . | nindent 6 }}{% endraw %}
   template:
     metadata:
       annotations:
-        {%raw%}{{- if .Values.agent.configMap }}{%endraw%}
-        checksum/config: {%raw%}{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
-        {%raw%}{{- with .Values.podAnnotations }}{%endraw%}
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
+        {% raw %}{{- if .Values.agent.configMap }}{% endraw %}
+        checksum/config: {% raw %}{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
+        {% raw %}{{- with .Values.podAnnotations }}{% endraw %}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
       labels:
-        {%raw%}{{- include "mcp-mesh-agent.selectorLabels" . | nindent 8 }}{%endraw%}
-        {%raw%}{{- with .Values.agent.labels }}{%endraw%}
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
+        {% raw %}{{- include "mcp-mesh-agent.selectorLabels" . | nindent 8 }}{% endraw %}
+        {% raw %}{{- with .Values.agent.labels }}{% endraw %}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
     spec:
-      serviceAccountName: {%raw%}{{ include "mcp-mesh-agent.serviceAccountName" . }}{%endraw%}
+      serviceAccountName: {% raw %}{{ include "mcp-mesh-agent.serviceAccountName" . }}{% endraw %}
       securityContext:
-        {%raw%}{{- toYaml .Values.podSecurityContext | nindent 8 }}{%endraw%}
-      {%raw%}{{- if .Values.agent.initContainers }}{%endraw%}
+        {% raw %}{{- toYaml .Values.podSecurityContext | nindent 8 }}{% endraw %}
+      {% raw %}{{- if .Values.agent.initContainers }}{% endraw %}
       initContainers:
-        {%raw%}{{- toYaml .Values.agent.initContainers | nindent 8 }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
+        {% raw %}{{- toYaml .Values.agent.initContainers | nindent 8 }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
       containers:
-      - name: {%raw%}{{ .Chart.Name }}{%endraw%}
+      - name: {% raw %}{{ .Chart.Name }}{% endraw %}
         securityContext:
-          {%raw%}{{- toYaml .Values.securityContext | nindent 12 }}{%endraw%}
-        image: "{%raw%}{{ .Values.image.repository }}{%endraw%}:{%raw%}{{ .Values.image.tag | default .Chart.AppVersion }}{%endraw%}"
-        imagePullPolicy: {%raw%}{{ .Values.image.pullPolicy }}{%endraw%}
+          {% raw %}{{- toYaml .Values.securityContext | nindent 12 }}{% endraw %}
+        image: "{% raw %}{{ .Values.image.repository }}{% endraw %}:{% raw %}{{ .Values.image.tag | default .Chart.AppVersion }}{% endraw %}"
+        imagePullPolicy: {% raw %}{{ .Values.image.pullPolicy }}{% endraw %}
         command: ["python", "/app/agent.py"]  # 🎯 Matches working examples
         ports:
         - name: http
-          containerPort: {%raw%}{{ .Values.agent.http.port | default 8080 }}{%endraw%}  # 🎯 Standard port 8080
+          containerPort: {% raw %}{{ .Values.agent.http.port | default 8080 }}{% endraw %}  # 🎯 Standard port 8080
           protocol: TCP
-        {%raw%}{{- if .Values.metrics.enabled }}{%endraw%}
+        {% raw %}{{- if .Values.metrics.enabled }}{% endraw %}
         - name: metrics
           containerPort: 9090
           protocol: TCP
-        {%raw%}{{- end }}{%endraw%}
+        {% raw %}{{- end }}{% endraw %}
         env:
         - name: AGENT_NAME
-          value: {%raw%}{{ .Values.agent.name | quote }}{%endraw%}
+          value: {% raw %}{{ .Values.agent.name | quote }}{% endraw %}
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -235,48 +235,48 @@ spec:
             fieldRef:
               fieldPath: status.podIP
         - name: MCP_MESH_REGISTRY_URL
-          value: {%raw%}{{ .Values.agent.registryUrl | quote }}{%endraw%}
-        {%raw%}{{- if .Values.agent.capabilities }}{%endraw%}
+          value: {% raw %}{{ .Values.agent.registryUrl | quote }}{% endraw %}
+        {% raw %}{{- if .Values.agent.capabilities }}{% endraw %}
         - name: MCP_MESH_CAPABILITIES
-          value: {%raw%}{{ .Values.agent.capabilities | join "," | quote }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
-        {%raw%}{{- if .Values.agent.dependencies }}{%endraw%}
+          value: {% raw %}{{ .Values.agent.capabilities | join "," | quote }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
+        {% raw %}{{- if .Values.agent.dependencies }}{% endraw %}
         - name: MCP_MESH_DEPENDENCIES
-          value: {%raw%}{{ .Values.agent.dependencies | join "," | quote }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
-        {%raw%}{{- range $key, $value := .Values.agent.env }}{%endraw%}
-        - name: {%raw%}{{ $key }}{%endraw%}
-          value: {%raw%}{{ $value | quote }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
-        {%raw%}{{- if or .Values.agent.configMap .Values.agent.secret }}{%endraw%}
+          value: {% raw %}{{ .Values.agent.dependencies | join "," | quote }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
+        {% raw %}{{- range $key, $value := .Values.agent.env }}{% endraw %}
+        - name: {% raw %}{{ $key }}{% endraw %}
+          value: {% raw %}{{ $value | quote }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
+        {% raw %}{{- if or .Values.agent.configMap .Values.agent.secret }}{% endraw %}
         envFrom:
-        {%raw%}{{- if .Values.agent.configMap }}{%endraw%}
+        {% raw %}{{- if .Values.agent.configMap }}{% endraw %}
         - configMapRef:
-            name: {%raw%}{{ include "mcp-mesh-agent.fullname" . }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
-        {%raw%}{{- if .Values.agent.secret }}{%endraw%}
+            name: {% raw %}{{ include "mcp-mesh-agent.fullname" . }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
+        {% raw %}{{- if .Values.agent.secret }}{% endraw %}
         - secretRef:
-            name: {%raw%}{{ include "mcp-mesh-agent.fullname" . }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
-        {%raw%}{{- if .Values.agent.livenessProbe }}{%endraw%}
+            name: {% raw %}{{ include "mcp-mesh-agent.fullname" . }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
+        {% raw %}{{- if .Values.agent.livenessProbe }}{% endraw %}
         livenessProbe:
-          {%raw%}{{- toYaml .Values.agent.livenessProbe | nindent 10 }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
-        {%raw%}{{- if .Values.agent.readinessProbe }}{%endraw%}
+          {% raw %}{{- toYaml .Values.agent.livenessProbe | nindent 10 }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
+        {% raw %}{{- if .Values.agent.readinessProbe }}{% endraw %}
         readinessProbe:
-          {%raw%}{{- toYaml .Values.agent.readinessProbe | nindent 10 }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
+          {% raw %}{{- toYaml .Values.agent.readinessProbe | nindent 10 }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
         resources:
-          {%raw%}{{- toYaml .Values.resources | nindent 12 }}{%endraw%}
-        {%raw%}{{- if .Values.agent.volumeMounts }}{%endraw%}
+          {% raw %}{{- toYaml .Values.resources | nindent 12 }}{% endraw %}
+        {% raw %}{{- if .Values.agent.volumeMounts }}{% endraw %}
         volumeMounts:
-          {%raw%}{{- toYaml .Values.agent.volumeMounts | nindent 10 }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- if .Values.agent.volumes }}{%endraw%}
+          {% raw %}{{- toYaml .Values.agent.volumeMounts | nindent 10 }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- if .Values.agent.volumes }}{% endraw %}
       volumes:
-        {%raw%}{{- toYaml .Values.agent.volumes | nindent 8 }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
+        {% raw %}{{- toYaml .Values.agent.volumes | nindent 8 }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
 ```
 
 ### Step 4: Understanding Template Helpers
@@ -288,45 +288,45 @@ Helper functions provide consistency across templates:
 {{/*
 Expand the name of the chart.
 */}}
-{%raw%}{{- define "mcp-mesh-registry.name" -}}{%endraw%}
-{%raw%}{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- define "mcp-mesh-registry.name" -}}{% endraw %}
+{% raw %}{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 
 {{/*
 Create a default fully qualified app name.
 */}}
-{%raw%}{{- define "mcp-mesh-registry.fullname" -}}{%endraw%}
-{%raw%}{{- if .Values.fullnameOverride }}{%endraw%}
-{%raw%}{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}{%endraw%}
-{%raw%}{{- else }}{%endraw%}
-{%raw%}{{- $name := default .Chart.Name .Values.nameOverride }}{%endraw%}
-{%raw%}{{- if contains $name .Release.Name }}{%endraw%}
-{%raw%}{{- .Release.Name | trunc 63 | trimSuffix "-" }}{%endraw%}
-{%raw%}{{- else }}{%endraw%}
-{%raw%}{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- define "mcp-mesh-registry.fullname" -}}{% endraw %}
+{% raw %}{{- if .Values.fullnameOverride }}{% endraw %}
+{% raw %}{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}{% endraw %}
+{% raw %}{{- else }}{% endraw %}
+{% raw %}{{- $name := default .Chart.Name .Values.nameOverride }}{% endraw %}
+{% raw %}{{- if contains $name .Release.Name }}{% endraw %}
+{% raw %}{{- .Release.Name | trunc 63 | trimSuffix "-" }}{% endraw %}
+{% raw %}{{- else }}{% endraw %}
+{% raw %}{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 
 {{/*
 Common labels
 */}}
-{%raw%}{{- define "mcp-mesh-registry.labels" -}}{%endraw%}
-helm.sh/chart: {%raw%}{{ include "mcp-mesh-registry.chart" . }}{%endraw%}
-{%raw%}{{ include "mcp-mesh-registry.selectorLabels" . }}{%endraw%}
-{%raw%}{{- if .Chart.AppVersion }}{%endraw%}
-app.kubernetes.io/version: {%raw%}{{ .Chart.AppVersion | quote }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
-app.kubernetes.io/managed-by: {%raw%}{{ .Release.Service }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- define "mcp-mesh-registry.labels" -}}{% endraw %}
+helm.sh/chart: {% raw %}{{ include "mcp-mesh-registry.chart" . }}{% endraw %}
+{% raw %}{{ include "mcp-mesh-registry.selectorLabels" . }}{% endraw %}
+{% raw %}{{- if .Chart.AppVersion }}{% endraw %}
+app.kubernetes.io/version: {% raw %}{{ .Chart.AppVersion | quote }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
+app.kubernetes.io/managed-by: {% raw %}{{ .Release.Service }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 
 {{/*
 Selector labels
 */}}
-{%raw%}{{- define "mcp-mesh-registry.selectorLabels" -}}{%endraw%}
-app.kubernetes.io/name: {%raw%}{{ include "mcp-mesh-registry.name" . }}{%endraw%}
-app.kubernetes.io/instance: {%raw%}{{ .Release.Name }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- define "mcp-mesh-registry.selectorLabels" -}}{% endraw %}
+app.kubernetes.io/name: {% raw %}{{ include "mcp-mesh-registry.name" . }}{% endraw %}
+app.kubernetes.io/instance: {% raw %}{{ .Release.Name }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 ```
 
 ### Step 5: Values File Structure
@@ -505,11 +505,11 @@ Add custom templates to extend functionality:
 
 ```yaml
 # templates/custom-job.yaml
-{%raw%}{{- if .Values.agent.migrations.enabled }}{%endraw%}
+{% raw %}{{- if .Values.agent.migrations.enabled }}{% endraw %}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {%raw%}{{ include "mcp-mesh-agent.fullname" . }}{%endraw%}-migrate
+  name: {% raw %}{{ include "mcp-mesh-agent.fullname" . }}{% endraw %}-migrate
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-1"
@@ -519,15 +519,15 @@ spec:
       restartPolicy: Never
       containers:
       - name: migrate
-        image: "{%raw%}{{ .Values.image.repository }}{%endraw%}:{%raw%}{{ .Values.image.tag }}{%endraw%}"
+        image: "{% raw %}{{ .Values.image.repository }}{% endraw %}:{% raw %}{{ .Values.image.tag }}{% endraw %}"
         command: ["python", "-m", "migrations.run"]
         env:
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
-              name: {%raw%}{{ include "mcp-mesh-agent.fullname" . }}{%endraw%}
+              name: {% raw %}{{ include "mcp-mesh-agent.fullname" . }}{% endraw %}
               key: database-url
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- end }}{% endraw %}
 ```
 
 ## Best Practices
@@ -648,12 +648,12 @@ helm status my-release -n mcp-mesh
 
 ```yaml
 # Ensure helper is defined in _helpers.tpl
-{%raw%}{{- define "mcp-mesh-agent.name" -}}{%endraw%}
-{%raw%}{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- define "mcp-mesh-agent.name" -}}{% endraw %}
+{% raw %}{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 
 # Use correct name in template
-{%raw%}{{ include "mcp-mesh-agent.name" . }}{%endraw%}
+{% raw %}{{ include "mcp-mesh-agent.name" . }}{% endraw %}
 ```
 
 ### Issue 2: Values Not Propagating
@@ -666,7 +666,7 @@ helm status my-release -n mcp-mesh
 
 ```yaml
 # Use default function
-value: {%raw%}{{ .Values.agent.port | default 8080 }}{%endraw%}
+value: {% raw %}{{ .Values.agent.port | default 8080 }}{% endraw %}
 
 # Check values path
 helm get values my-release -n mcp-mesh

--- a/docs/06-helm-deployment/02-umbrella-chart.md
+++ b/docs/06-helm-deployment/02-umbrella-chart.md
@@ -340,33 +340,33 @@ helm install mcp-platform ./mcp-mesh-platform \
 
 Platform-wide labels
 \*/}}
-{%raw%}{{- define "mcp-mesh-platform.labels" -}}{%endraw%}
+{% raw %}{{- define "mcp-mesh-platform.labels" -}}{% endraw %}
 app.kubernetes.io/part-of: mcp-mesh-platform
-app.kubernetes.io/managed-by: {%raw%}{{ .Release.Service }}{%endraw%}
-helm.sh/chart: {%raw%}{{ include "mcp-mesh-platform.chart" . }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+app.kubernetes.io/managed-by: {% raw %}{{ .Release.Service }}{% endraw %}
+helm.sh/chart: {% raw %}{{ include "mcp-mesh-platform.chart" . }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 
 {{/*
 Registry URL for agents
 */}}
-{%raw%}{{- define "mcp-mesh-platform.registryUrl" -}}{%endraw%}
-{%raw%}{{- if .Values.registry.externalUrl -}}{%endraw%}
-{%raw%}{{- .Values.registry.externalUrl -}}{%endraw%}
-{%raw%}{{- else -}}{%endraw%}
-http://{%raw%}{{ .Release.Name }}{%endraw%}-mcp-mesh-registry:{%raw%}{{ .Values.registry.service.port | default 8080 }}{%endraw%}
-{%raw%}{{- end -}}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- define "mcp-mesh-platform.registryUrl" -}}{% endraw %}
+{% raw %}{{- if .Values.registry.externalUrl -}}{% endraw %}
+{% raw %}{{- .Values.registry.externalUrl -}}{% endraw %}
+{% raw %}{{- else -}}{% endraw %}
+http://{% raw %}{{ .Release.Name }}{% endraw %}-mcp-mesh-registry:{% raw %}{{ .Values.registry.service.port | default 8080 }}{% endraw %}
+{% raw %}{{- end -}}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 
 {{/*
 Database connection string
 */}}
-{%raw%}{{- define "mcp-mesh-platform.databaseUrl" -}}{%endraw%}
-{%raw%}{{- if .Values.postgresql.enabled -}}{%endraw%}
-postgresql://{%raw%}{{ .Values.global.postgresql.auth.username | default "postgres" }}{%endraw%}:{%raw%}{{ .Values.global.postgresql.auth.postgresPassword }}{%endraw%}@{%raw%}{{ .Release.Name }}{%endraw%}-postgresql:5432/{%raw%}{{ .Values.global.postgresql.auth.database }}{%endraw%}
-{%raw%}{{- else -}}{%endraw%}
-{%raw%}{{- required "External database URL required when postgresql.enabled=false" .Values.registry.database.externalUrl -}}{%endraw%}
-{%raw%}{{- end -}}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- define "mcp-mesh-platform.databaseUrl" -}}{% endraw %}
+{% raw %}{{- if .Values.postgresql.enabled -}}{% endraw %}
+postgresql://{% raw %}{{ .Values.global.postgresql.auth.username | default "postgres" }}{% endraw %}:{% raw %}{{ .Values.global.postgresql.auth.postgresPassword }}{% endraw %}@{% raw %}{{ .Release.Name }}{% endraw %}-postgresql:5432/{% raw %}{{ .Values.global.postgresql.auth.database }}{% endraw %}
+{% raw %}{{- else -}}{% endraw %}
+{% raw %}{{- required "External database URL required when postgresql.enabled=false" .Values.registry.database.externalUrl -}}{% endraw %}
+{% raw %}{{- end -}}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 
 ````
 
@@ -376,36 +376,36 @@ Create additional resources for the platform:
 
 ```yaml
 # templates/namespace.yaml
-{%raw%}{{- if .Values.createNamespace }}{%endraw%}
+{% raw %}{{- if .Values.createNamespace }}{% endraw %}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {%raw%}{{ .Release.Namespace }}{%endraw%}
+  name: {% raw %}{{ .Release.Namespace }}{% endraw %}
   labels:
-    {%raw%}{{- include "mcp-mesh-platform.labels" . | nindent 4 }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+    {% raw %}{{- include "mcp-mesh-platform.labels" . | nindent 4 }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 
 ---
 # templates/resourcequota.yaml
-{%raw%}{{- if .Values.resourceQuota.enabled }}{%endraw%}
+{% raw %}{{- if .Values.resourceQuota.enabled }}{% endraw %}
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name: {%raw%}{{ .Release.Name }}{%endraw%}-quota
-  namespace: {%raw%}{{ .Release.Namespace }}{%endraw%}
+  name: {% raw %}{{ .Release.Name }}{% endraw %}-quota
+  namespace: {% raw %}{{ .Release.Namespace }}{% endraw %}
 spec:
   hard:
-    {%raw%}{{- toYaml .Values.resourceQuota.hard | nindent 4 }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+    {% raw %}{{- toYaml .Values.resourceQuota.hard | nindent 4 }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 
 ---
 # templates/networkpolicy.yaml
-{%raw%}{{- if .Values.networkPolicies.enabled }}{%endraw%}
+{% raw %}{{- if .Values.networkPolicies.enabled }}{% endraw %}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {%raw%}{{ .Release.Name }}{%endraw%}-default-deny
-  namespace: {%raw%}{{ .Release.Namespace }}{%endraw%}
+  name: {% raw %}{{ .Release.Name }}{% endraw %}-default-deny
+  namespace: {% raw %}{{ .Release.Namespace }}{% endraw %}
 spec:
   podSelector: {}
   policyTypes:
@@ -422,24 +422,24 @@ spec:
     - protocol: UDP
       port: 53
   # Allow intra-namespace
-  {%raw%}{{- if .Values.networkPolicies.allowIntraNamespace }}{%endraw%}
+  {% raw %}{{- if .Values.networkPolicies.allowIntraNamespace }}{% endraw %}
   - to:
     - podSelector: {}
-  {%raw%}{{- end }}{%endraw%}
+  {% raw %}{{- end }}{% endraw %}
   ingress:
   # Allow from allowed namespaces
-  {%raw%}{{- range .Values.networkPolicies.allowedNamespaces }}{%endraw%}
+  {% raw %}{{- range .Values.networkPolicies.allowedNamespaces }}{% endraw %}
   - from:
     - namespaceSelector:
         matchLabels:
-          name: {%raw%}{{ . }}{%endraw%}
-  {%raw%}{{- end }}{%endraw%}
+          name: {% raw %}{{ . }}{% endraw %}
+  {% raw %}{{- end }}{% endraw %}
   # Allow intra-namespace
-  {%raw%}{{- if .Values.networkPolicies.allowIntraNamespace }}{%endraw%}
+  {% raw %}{{- if .Values.networkPolicies.allowIntraNamespace }}{% endraw %}
   - from:
     - podSelector: {}
-  {%raw%}{{- end }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+  {% raw %}{{- end }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 ````
 
 ### Step 5: Create Deployment Scripts
@@ -448,48 +448,48 @@ Add convenient deployment scripts:
 
 ```yaml
 # templates/NOTES.txt
-{%raw%}{{- $registryUrl := include "mcp-mesh-platform.registryUrl" . -}}{%endraw%}
+{% raw %}{{- $registryUrl := include "mcp-mesh-platform.registryUrl" . -}}{% endraw %}
 MCP Mesh Platform has been deployed!
 
-Registry URL: {%raw%}{{ $registryUrl }}{%endraw%}
+Registry URL: {% raw %}{{ $registryUrl }}{% endraw %}
 
 To access the services:
 
 1. Registry:
-   {%raw%}{{- if .Values.registry.ingress.enabled }}{%endraw%}
-   URL: http://{%raw%}{{ (index .Values.registry.ingress.hosts 0).host }}{%endraw%}
-   {%raw%}{{- else }}{%endraw%}
-   kubectl port-forward -n {%raw%}{{ .Release.Namespace }}{%endraw%} svc/{%raw%}{{ .Release.Name }}{%endraw%}-mcp-mesh-registry 8080:8080
-   {%raw%}{{- end }}{%endraw%}
+   {% raw %}{{- if .Values.registry.ingress.enabled }}{% endraw %}
+   URL: http://{% raw %}{{ (index .Values.registry.ingress.hosts 0).host }}{% endraw %}
+   {% raw %}{{- else }}{% endraw %}
+   kubectl port-forward -n {% raw %}{{ .Release.Namespace }}{% endraw %} svc/{% raw %}{{ .Release.Name }}{% endraw %}-mcp-mesh-registry 8080:8080
+   {% raw %}{{- end }}{% endraw %}
 
 2. Grafana Dashboard:
-   {%raw%}{{- if .Values.monitoring.grafana.enabled }}{%endraw%}
-   kubectl port-forward -n {%raw%}{{ .Release.Namespace }}{%endraw%} svc/{%raw%}{{ .Release.Name }}{%endraw%}-grafana 3000:80
+   {% raw %}{{- if .Values.monitoring.grafana.enabled }}{% endraw %}
+   kubectl port-forward -n {% raw %}{{ .Release.Namespace }}{% endraw %} svc/{% raw %}{{ .Release.Name }}{% endraw %}-grafana 3000:80
    Username: admin
-   Password: {%raw%}{{ .Values.monitoring.grafana.adminPassword }}{%endraw%}
-   {%raw%}{{- end }}{%endraw%}
+   Password: {% raw %}{{ .Values.monitoring.grafana.adminPassword }}{% endraw %}
+   {% raw %}{{- end }}{% endraw %}
 
 3. Prometheus:
-   {%raw%}{{- if .Values.monitoring.prometheus.enabled }}{%endraw%}
-   kubectl port-forward -n {%raw%}{{ .Release.Namespace }}{%endraw%} svc/{%raw%}{{ .Release.Name }}{%endraw%}-prometheus-server 9090:80
-   {%raw%}{{- end }}{%endraw%}
+   {% raw %}{{- if .Values.monitoring.prometheus.enabled }}{% endraw %}
+   kubectl port-forward -n {% raw %}{{ .Release.Namespace }}{% endraw %} svc/{% raw %}{{ .Release.Name }}{% endraw %}-prometheus-server 9090:80
+   {% raw %}{{- end }}{% endraw %}
 
 Deployed Agents:
-{%raw%}{{- if .Values.agents.weather.enabled }}{%endraw%}
-- Weather Agent: {%raw%}{{ .Values.agents.weather.replicaCount }}{%endraw%} replicas
-{%raw%}{{- end }}{%endraw%}
-{%raw%}{{- if .Values.agents.analytics.enabled }}{%endraw%}
-- Analytics Agent: {%raw%}{{ .Values.agents.analytics.replicaCount }}{%endraw%} replicas
-{%raw%}{{- end }}{%endraw%}
-{%raw%}{{- if .Values.agents.notification.enabled }}{%endraw%}
-- Notification Agent: {%raw%}{{ .Values.agents.notification.replicaCount }}{%endraw%} replicas
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- if .Values.agents.weather.enabled }}{% endraw %}
+- Weather Agent: {% raw %}{{ .Values.agents.weather.replicaCount }}{% endraw %} replicas
+{% raw %}{{- end }}{% endraw %}
+{% raw %}{{- if .Values.agents.analytics.enabled }}{% endraw %}
+- Analytics Agent: {% raw %}{{ .Values.agents.analytics.replicaCount }}{% endraw %} replicas
+{% raw %}{{- end }}{% endraw %}
+{% raw %}{{- if .Values.agents.notification.enabled }}{% endraw %}
+- Notification Agent: {% raw %}{{ .Values.agents.notification.replicaCount }}{% endraw %} replicas
+{% raw %}{{- end }}{% endraw %}
 
 To check platform status:
-  helm status {%raw%}{{ .Release.Name }}{%endraw%} -n {%raw%}{{ .Release.Namespace }}{%endraw%}
+  helm status {% raw %}{{ .Release.Name }}{% endraw %} -n {% raw %}{{ .Release.Namespace }}{% endraw %}
 
 To view all platform resources:
-  kubectl get all -n {%raw%}{{ .Release.Namespace }}{%endraw%} -l app.kubernetes.io/part-of=mcp-mesh-platform
+  kubectl get all -n {% raw %}{{ .Release.Namespace }}{% endraw %} -l app.kubernetes.io/part-of=mcp-mesh-platform
 ```
 
 ## Configuration Options

--- a/docs/06-helm-deployment/03-customizing-values.md
+++ b/docs/06-helm-deployment/03-customizing-values.md
@@ -334,48 +334,48 @@ Use Go templates for dynamic values:
 # values/templates/dynamic-values.yaml
 # Dynamic value generation
 
-{%raw%}{{- $environment := .Values.global.environment | default "development" -}}{%endraw%}
-{%raw%}{{- $domain := .Values.global.domain | default "local" -}}{%endraw%}
+{% raw %}{{- $environment := .Values.global.environment | default "development" -}}{% endraw %}
+{% raw %}{{- $domain := .Values.global.domain | default "local" -}}{% endraw %}
 
 # Generate URLs based on environment
 urls:
   registry:
-    internal: "http://{%raw%}{{ .Release.Name }}{%endraw%}-registry.{%raw%}{{ .Release.Namespace }}{%endraw%}.svc.cluster.local:8080"
-    external: "https://registry.{%raw%}{{ $environment }}{%endraw%}.{%raw%}{{ $domain }}{%endraw%}"
+    internal: "http://{% raw %}{{ .Release.Name }}{% endraw %}-registry.{% raw %}{{ .Release.Namespace }}{% endraw %}.svc.cluster.local:8080"
+    external: "https://registry.{% raw %}{{ $environment }}{% endraw %}.{% raw %}{{ $domain }}{% endraw %}"
 
   agents:
-    {%raw%}{{- range $name, $agent := .Values.agents }}{%endraw%}
-    {%raw%}{{ $name }}{%endraw%}:
-      internal: "http://{%raw%}{{ $.Release.Name }}{%endraw%}-{%raw%}{{ $name }}{%endraw%}.{%raw%}{{ $.Release.Namespace }}{%endraw%}.svc.cluster.local:8080"
-      external: "https://{%raw%}{{ $name }}{%endraw%}.{%raw%}{{ $environment }}{%endraw%}.{%raw%}{{ $domain }}{%endraw%}"
-    {%raw%}{{- end }}{%endraw%}
+    {% raw %}{{- range $name, $agent := .Values.agents }}{% endraw %}
+    {% raw %}{{ $name }}{% endraw %}:
+      internal: "http://{% raw %}{{ $.Release.Name }}{% endraw %}-{% raw %}{{ $name }}{% endraw %}.{% raw %}{{ $.Release.Namespace }}{% endraw %}.svc.cluster.local:8080"
+      external: "https://{% raw %}{{ $name }}{% endraw %}.{% raw %}{{ $environment }}{% endraw %}.{% raw %}{{ $domain }}{% endraw %}"
+    {% raw %}{{- end }}{% endraw %}
 
 # Environment-specific features
 features:
-  debugMode: {%raw%}{{ eq $environment "development" }}{%endraw%}
-  tracing: {%raw%}{{ has $environment (list "staging" "production") }}{%endraw%}
-  profiling: {%raw%}{{ eq $environment "development" }}{%endraw%}
+  debugMode: {% raw %}{{ eq $environment "development" }}{% endraw %}
+  tracing: {% raw %}{{ has $environment (list "staging" "production") }}{% endraw %}
+  profiling: {% raw %}{{ eq $environment "development" }}{% endraw %}
 
 # Resource multipliers by environment
 resourceMultipliers:
-  {%raw%}{{- if eq $environment "production" }}{%endraw%}
+  {% raw %}{{- if eq $environment "production" }}{% endraw %}
   cpu: 2.0
   memory: 2.0
-  {%raw%}{{- else if eq $environment "staging" }}{%endraw%}
+  {% raw %}{{- else if eq $environment "staging" }}{% endraw %}
   cpu: 1.5
   memory: 1.5
-  {%raw%}{{- else }}{%endraw%}
+  {% raw %}{{- else }}{% endraw %}
   cpu: 0.5
   memory: 0.5
-  {%raw%}{{- end }}{%endraw%}
+  {% raw %}{{- end }}{% endraw %}
 
 # Conditional configurations
-{%raw%}{{- if eq $environment "production" }}{%endraw%}
+{% raw %}{{- if eq $environment "production" }}{% endraw %}
 backup:
   enabled: true
   schedule: "0 2 * * *"
   retention: 30
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- end }}{% endraw %}
 ```
 
 ### Step 5: Secrets Management
@@ -498,22 +498,22 @@ featureFlags:
   # Core features
   core:
     newAuthSystem:
-      enabled: {%raw%}{{ eq .Values.global.environment "development" }}{%endraw%}
+      enabled: {% raw %}{{ eq .Values.global.environment "development" }}{% endraw %}
       rolloutPercentage: 10
 
     improvedCaching:
       enabled: true
-      rolloutPercentage: {%raw%}{{ .Values.global.featureRollout.improvedCaching | default 50 }}{%endraw%}
+      rolloutPercentage: {% raw %}{{ .Values.global.featureRollout.improvedCaching | default 50 }}{% endraw %}
 
   # Agent-specific features
   agents:
     weather:
       mlPredictions:
-        enabled: {%raw%}{{ has .Values.global.environment (list "staging" "production") }}{%endraw%}
+        enabled: {% raw %}{{ has .Values.global.environment (list "staging" "production") }}{% endraw %}
         modelVersion: "2.1.0"
 
       premiumApi:
-        enabled: {%raw%}{{ .Values.global.environment | eq "production" }}{%endraw%}
+        enabled: {% raw %}{{ .Values.global.environment | eq "production" }}{% endraw %}
         rateLimit: 1000
 
     analytics:
@@ -524,17 +524,17 @@ featureFlags:
           - "customer-456"
 
 # Apply feature flags to agents
-{%raw%}{{- range $agent, $features := .Values.featureFlags.agents }}{%endraw%}
+{% raw %}{{- range $agent, $features := .Values.featureFlags.agents }}{% endraw %}
 agents:
-  {%raw%}{{ $agent }}{%endraw%}:
+  {% raw %}{{ $agent }}{% endraw %}:
     env:
-      {%raw%}{{- range $feature, $config := $features }}{%endraw%}
-      FEATURE_{%raw%}{{ $feature | upper }}{%endraw%}_ENABLED: {%raw%}{{ $config.enabled | quote }}{%endraw%}
-      {%raw%}{{- if $config.rolloutPercentage }}{%endraw%}
-      FEATURE_{%raw%}{{ $feature | upper }}{%endraw%}_ROLLOUT: {%raw%}{{ $config.rolloutPercentage | quote }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+      {% raw %}{{- range $feature, $config := $features }}{% endraw %}
+      FEATURE_{% raw %}{{ $feature | upper }}{% endraw %}_ENABLED: {% raw %}{{ $config.enabled | quote }}{% endraw %}
+      {% raw %}{{- if $config.rolloutPercentage }}{% endraw %}
+      FEATURE_{% raw %}{{ $feature | upper }}{% endraw %}_ROLLOUT: {% raw %}{{ $config.rolloutPercentage | quote }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 ```
 
 ## Best Practices
@@ -723,13 +723,13 @@ helm upgrade my-release ./chart \
 # Move templates to tpl files:
 
 # templates/values-helper.tpl
-{%raw%}{{- define "dynamic.values" -}}{%endraw%}
-environment: {%raw%}{{ .Values.global.environment }}{%endraw%}
-url: https://{%raw%}{{ .Values.global.environment }}{%endraw%}.example.com
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- define "dynamic.values" -}}{% endraw %}
+environment: {% raw %}{{ .Values.global.environment }}{% endraw %}
+url: https://{% raw %}{{ .Values.global.environment }}{% endraw %}.example.com
+{% raw %}{{- end }}{% endraw %}
 
 # Use in templates
-{%raw%}{{- $dynamicValues := include "dynamic.values" . | fromYaml }}{%endraw%}
+{% raw %}{{- $dynamicValues := include "dynamic.values" . | fromYaml }}{% endraw %}
 ```
 
 For more issues, see the [section troubleshooting guide](./troubleshooting.md).

--- a/docs/06-helm-deployment/04-multi-environment.md
+++ b/docs/06-helm-deployment/04-multi-environment.md
@@ -814,30 +814,30 @@ Enable features per environment:
 
 ```yaml
 # Feature flags template
-{%raw%}{{- define "features" -}}{%endraw%}
-{%raw%}{{- $env := .Values.global.environment | default "development" -}}{%endraw%}
+{% raw %}{{- define "features" -}}{% endraw %}
+{% raw %}{{- $env := .Values.global.environment | default "development" -}}{% endraw %}
 features:
   # Development features
-  {%raw%}{{- if eq $env "development" }}{%endraw%}
+  {% raw %}{{- if eq $env "development" }}{% endraw %}
   debugEndpoints: true
   mockExternalServices: true
   unlimitedRateLimit: true
-  {%raw%}{{- end }}{%endraw%}
+  {% raw %}{{- end }}{% endraw %}
 
   # Staging features
-  {%raw%}{{- if eq $env "staging" }}{%endraw%}
+  {% raw %}{{- if eq $env "staging" }}{% endraw %}
   canaryDeployment: true
   abTesting: true
   syntheticMonitoring: true
-  {%raw%}{{- end }}{%endraw%}
+  {% raw %}{{- end }}{% endraw %}
 
   # Production features
-  {%raw%}{{- if eq $env "production" }}{%endraw%}
+  {% raw %}{{- if eq $env "production" }}{% endraw %}
   auditLogging: true
   complianceMode: true
   disasterRecovery: true
-  {%raw%}{{- end }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+  {% raw %}{{- end }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 ```
 
 ## Best Practices

--- a/docs/06-helm-deployment/05-best-practices.md
+++ b/docs/06-helm-deployment/05-best-practices.md
@@ -165,78 +165,78 @@ Write maintainable and efficient templates:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {%raw%}{{ include "mcp-mesh-agent.fullname" . }}{%endraw%}
-  namespace: {%raw%}{{ .Release.Namespace }}{%endraw%}
+  name: {% raw %}{{ include "mcp-mesh-agent.fullname" . }}{% endraw %}
+  namespace: {% raw %}{{ .Release.Namespace }}{% endraw %}
   labels:
-    {%raw%}{{- include "mcp-mesh-agent.labels" . | nindent 4 }}{%endraw%}
-    {%raw%}{{- with .Values.commonLabels }}{%endraw%}
-    {%raw%}{{- toYaml . | nindent 4 }}{%endraw%}
-    {%raw%}{{- end }}{%endraw%}
+    {% raw %}{{- include "mcp-mesh-agent.labels" . | nindent 4 }}{% endraw %}
+    {% raw %}{{- with .Values.commonLabels }}{% endraw %}
+    {% raw %}{{- toYaml . | nindent 4 }}{% endraw %}
+    {% raw %}{{- end }}{% endraw %}
   annotations:
-    {%raw%}{{- include "mcp-mesh-agent.annotations" . | nindent 4 }}{%endraw%}
-    {%raw%}{{- with .Values.commonAnnotations }}{%endraw%}
-    {%raw%}{{- toYaml . | nindent 4 }}{%endraw%}
-    {%raw%}{{- end }}{%endraw%}
+    {% raw %}{{- include "mcp-mesh-agent.annotations" . | nindent 4 }}{% endraw %}
+    {% raw %}{{- with .Values.commonAnnotations }}{% endraw %}
+    {% raw %}{{- toYaml . | nindent 4 }}{% endraw %}
+    {% raw %}{{- end }}{% endraw %}
 spec:
-  {%raw%}{{- if not .Values.autoscaling.enabled }}{%endraw%}
-  replicas: {%raw%}{{ .Values.replicaCount }}{%endraw%}
-  {%raw%}{{- end }}{%endraw%}
-  revisionHistoryLimit: {%raw%}{{ .Values.revisionHistoryLimit | default 10 }}{%endraw%}
+  {% raw %}{{- if not .Values.autoscaling.enabled }}{% endraw %}
+  replicas: {% raw %}{{ .Values.replicaCount }}{% endraw %}
+  {% raw %}{{- end }}{% endraw %}
+  revisionHistoryLimit: {% raw %}{{ .Values.revisionHistoryLimit | default 10 }}{% endraw %}
   selector:
     matchLabels:
-      {%raw%}{{- include "mcp-mesh-agent.selectorLabels" . | nindent 6 }}{%endraw%}
-  {%raw%}{{- with .Values.updateStrategy }}{%endraw%}
+      {% raw %}{{- include "mcp-mesh-agent.selectorLabels" . | nindent 6 }}{% endraw %}
+  {% raw %}{{- with .Values.updateStrategy }}{% endraw %}
   strategy:
-    {%raw%}{{- toYaml . | nindent 4 }}{%endraw%}
-  {%raw%}{{- end }}{%endraw%}
+    {% raw %}{{- toYaml . | nindent 4 }}{% endraw %}
+  {% raw %}{{- end }}{% endraw %}
   template:
     metadata:
       annotations:
         # Force pod restart on config change
-        checksum/config: {%raw%}{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}{%endraw%}
-        checksum/secret: {%raw%}{{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}{%endraw%}
-        {%raw%}{{- with .Values.podAnnotations }}{%endraw%}
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
+        checksum/config: {% raw %}{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}{% endraw %}
+        checksum/secret: {% raw %}{{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}{% endraw %}
+        {% raw %}{{- with .Values.podAnnotations }}{% endraw %}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
       labels:
-        {%raw%}{{- include "mcp-mesh-agent.selectorLabels" . | nindent 8 }}{%endraw%}
-        {%raw%}{{- with .Values.podLabels }}{%endraw%}
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
+        {% raw %}{{- include "mcp-mesh-agent.selectorLabels" . | nindent 8 }}{% endraw %}
+        {% raw %}{{- with .Values.podLabels }}{% endraw %}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
     spec:
-      {%raw%}{{- with .Values.imagePullSecrets }}{%endraw%}
+      {% raw %}{{- with .Values.imagePullSecrets }}{% endraw %}
       imagePullSecrets:
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-      serviceAccountName: {%raw%}{{ include "mcp-mesh-agent.serviceAccountName" . }}{%endraw%}
-      automountServiceAccountToken: {%raw%}{{ .Values.serviceAccount.automountToken | default false }}{%endraw%}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+      serviceAccountName: {% raw %}{{ include "mcp-mesh-agent.serviceAccountName" . }}{% endraw %}
+      automountServiceAccountToken: {% raw %}{{ .Values.serviceAccount.automountToken | default false }}{% endraw %}
       securityContext:
-        {%raw%}{{- toYaml .Values.podSecurityContext | nindent 8 }}{%endraw%}
-      {%raw%}{{- with .Values.priorityClassName }}{%endraw%}
-      priorityClassName: {%raw%}{{ . }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- with .Values.hostAliases }}{%endraw%}
+        {% raw %}{{- toYaml .Values.podSecurityContext | nindent 8 }}{% endraw %}
+      {% raw %}{{- with .Values.priorityClassName }}{% endraw %}
+      priorityClassName: {% raw %}{{ . }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- with .Values.hostAliases }}{% endraw %}
       hostAliases:
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- if .Values.initContainers }}{%endraw%}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- if .Values.initContainers }}{% endraw %}
       initContainers:
-        {%raw%}{{- include "mcp-mesh-agent.renderTpl" (dict "value" .Values.initContainers "context" $) | nindent 8 }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
+        {% raw %}{{- include "mcp-mesh-agent.renderTpl" (dict "value" .Values.initContainers "context" $) | nindent 8 }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
       containers:
-        - name: {%raw%}{{ .Chart.Name }}{%endraw%}
+        - name: {% raw %}{{ .Chart.Name }}{% endraw %}
           securityContext:
-            {%raw%}{{- toYaml .Values.securityContext | nindent 12 }}{%endraw%}
-          image: "{%raw%}{{ .Values.image.repository }}{%endraw%}:{%raw%}{{ .Values.image.tag | default .Chart.AppVersion }}{%endraw%}"
-          imagePullPolicy: {%raw%}{{ .Values.image.pullPolicy }}{%endraw%}
-          {%raw%}{{- with .Values.command }}{%endraw%}
+            {% raw %}{{- toYaml .Values.securityContext | nindent 12 }}{% endraw %}
+          image: "{% raw %}{{ .Values.image.repository }}{% endraw %}:{% raw %}{{ .Values.image.tag | default .Chart.AppVersion }}{% endraw %}"
+          imagePullPolicy: {% raw %}{{ .Values.image.pullPolicy }}{% endraw %}
+          {% raw %}{{- with .Values.command }}{% endraw %}
           command:
-            {%raw%}{{- toYaml . | nindent 12 }}{%endraw%}
-          {%raw%}{{- end }}{%endraw%}
-          {%raw%}{{- with .Values.args }}{%endraw%}
+            {% raw %}{{- toYaml . | nindent 12 }}{% endraw %}
+          {% raw %}{{- end }}{% endraw %}
+          {% raw %}{{- with .Values.args }}{% endraw %}
           args:
-            {%raw%}{{- toYaml . | nindent 12 }}{%endraw%}
-          {%raw%}{{- end }}{%endraw%}
+            {% raw %}{{- toYaml . | nindent 12 }}{% endraw %}
+          {% raw %}{{- end }}{% endraw %}
           env:
             - name: POD_NAME
               valueFrom:
@@ -254,92 +254,92 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            {%raw%}{{- if .Values.env }}{%endraw%}
-            {%raw%}{{- include "mcp-mesh-agent.renderTpl" (dict "value" .Values.env "context" $) | nindent 12 }}{%endraw%}
-            {%raw%}{{- end }}{%endraw%}
-          {%raw%}{{- if or .Values.envFrom .Values.agent.configMap .Values.agent.secret }}{%endraw%}
+            {% raw %}{{- if .Values.env }}{% endraw %}
+            {% raw %}{{- include "mcp-mesh-agent.renderTpl" (dict "value" .Values.env "context" $) | nindent 12 }}{% endraw %}
+            {% raw %}{{- end }}{% endraw %}
+          {% raw %}{{- if or .Values.envFrom .Values.agent.configMap .Values.agent.secret }}{% endraw %}
           envFrom:
-            {%raw%}{{- with .Values.envFrom }}{%endraw%}
-            {%raw%}{{- toYaml . | nindent 12 }}{%endraw%}
-            {%raw%}{{- end }}{%endraw%}
-            {%raw%}{{- if .Values.agent.configMap }}{%endraw%}
+            {% raw %}{{- with .Values.envFrom }}{% endraw %}
+            {% raw %}{{- toYaml . | nindent 12 }}{% endraw %}
+            {% raw %}{{- end }}{% endraw %}
+            {% raw %}{{- if .Values.agent.configMap }}{% endraw %}
             - configMapRef:
-                name: {%raw%}{{ include "mcp-mesh-agent.fullname" . }}{%endraw%}
-            {%raw%}{{- end }}{%endraw%}
-            {%raw%}{{- if .Values.agent.secret }}{%endraw%}
+                name: {% raw %}{{ include "mcp-mesh-agent.fullname" . }}{% endraw %}
+            {% raw %}{{- end }}{% endraw %}
+            {% raw %}{{- if .Values.agent.secret }}{% endraw %}
             - secretRef:
-                name: {%raw%}{{ include "mcp-mesh-agent.fullname" . }}{%endraw%}
-            {%raw%}{{- end }}{%endraw%}
-          {%raw%}{{- end }}{%endraw%}
+                name: {% raw %}{{ include "mcp-mesh-agent.fullname" . }}{% endraw %}
+            {% raw %}{{- end }}{% endraw %}
+          {% raw %}{{- end }}{% endraw %}
           ports:
             - name: http
-              containerPort: {%raw%}{{ .Values.agent.port | default 8080 }}{%endraw%}
+              containerPort: {% raw %}{{ .Values.agent.port | default 8080 }}{% endraw %}
               protocol: TCP
-            {%raw%}{{- if .Values.metrics.enabled }}{%endraw%}
+            {% raw %}{{- if .Values.metrics.enabled }}{% endraw %}
             - name: metrics
-              containerPort: {%raw%}{{ .Values.metrics.port | default 9090 }}{%endraw%}
+              containerPort: {% raw %}{{ .Values.metrics.port | default 9090 }}{% endraw %}
               protocol: TCP
-            {%raw%}{{- end }}{%endraw%}
-            {%raw%}{{- range .Values.extraPorts }}{%endraw%}
-            - name: {%raw%}{{ .name }}{%endraw%}
-              containerPort: {%raw%}{{ .port }}{%endraw%}
-              protocol: {%raw%}{{ .protocol | default "TCP" }}{%endraw%}
-            {%raw%}{{- end }}{%endraw%}
-          {%raw%}{{- with .Values.livenessProbe }}{%endraw%}
+            {% raw %}{{- end }}{% endraw %}
+            {% raw %}{{- range .Values.extraPorts }}{% endraw %}
+            - name: {% raw %}{{ .name }}{% endraw %}
+              containerPort: {% raw %}{{ .port }}{% endraw %}
+              protocol: {% raw %}{{ .protocol | default "TCP" }}{% endraw %}
+            {% raw %}{{- end }}{% endraw %}
+          {% raw %}{{- with .Values.livenessProbe }}{% endraw %}
           livenessProbe:
-            {%raw%}{{- toYaml . | nindent 12 }}{%endraw%}
-          {%raw%}{{- end }}{%endraw%}
-          {%raw%}{{- with .Values.readinessProbe }}{%endraw%}
+            {% raw %}{{- toYaml . | nindent 12 }}{% endraw %}
+          {% raw %}{{- end }}{% endraw %}
+          {% raw %}{{- with .Values.readinessProbe }}{% endraw %}
           readinessProbe:
-            {%raw%}{{- toYaml . | nindent 12 }}{%endraw%}
-          {%raw%}{{- end }}{%endraw%}
-          {%raw%}{{- with .Values.startupProbe }}{%endraw%}
+            {% raw %}{{- toYaml . | nindent 12 }}{% endraw %}
+          {% raw %}{{- end }}{% endraw %}
+          {% raw %}{{- with .Values.startupProbe }}{% endraw %}
           startupProbe:
-            {%raw%}{{- toYaml . | nindent 12 }}{%endraw%}
-          {%raw%}{{- end }}{%endraw%}
+            {% raw %}{{- toYaml . | nindent 12 }}{% endraw %}
+          {% raw %}{{- end }}{% endraw %}
           resources:
-            {%raw%}{{- toYaml .Values.resources | nindent 12 }}{%endraw%}
-          {%raw%}{{- with .Values.volumeMounts }}{%endraw%}
+            {% raw %}{{- toYaml .Values.resources | nindent 12 }}{% endraw %}
+          {% raw %}{{- with .Values.volumeMounts }}{% endraw %}
           volumeMounts:
-            {%raw%}{{- toYaml . | nindent 12 }}{%endraw%}
-          {%raw%}{{- end }}{%endraw%}
-          {%raw%}{{- with .Values.lifecycle }}{%endraw%}
+            {% raw %}{{- toYaml . | nindent 12 }}{% endraw %}
+          {% raw %}{{- end }}{% endraw %}
+          {% raw %}{{- with .Values.lifecycle }}{% endraw %}
           lifecycle:
-            {%raw%}{{- toYaml . | nindent 12 }}{%endraw%}
-          {%raw%}{{- end }}{%endraw%}
-        {%raw%}{{- with .Values.sidecars }}{%endraw%}
-        {%raw%}{{- include "mcp-mesh-agent.renderTpl" (dict "value" . "context" $) | nindent 8 }}{%endraw%}
-        {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- with .Values.volumes }}{%endraw%}
+            {% raw %}{{- toYaml . | nindent 12 }}{% endraw %}
+          {% raw %}{{- end }}{% endraw %}
+        {% raw %}{{- with .Values.sidecars }}{% endraw %}
+        {% raw %}{{- include "mcp-mesh-agent.renderTpl" (dict "value" . "context" $) | nindent 8 }}{% endraw %}
+        {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- with .Values.volumes }}{% endraw %}
       volumes:
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- with .Values.nodeSelector }}{%endraw%}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- with .Values.nodeSelector }}{% endraw %}
       nodeSelector:
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- with .Values.affinity }}{%endraw%}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- with .Values.affinity }}{% endraw %}
       affinity:
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- with .Values.tolerations }}{%endraw%}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- with .Values.tolerations }}{% endraw %}
       tolerations:
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- with .Values.topologySpreadConstraints }}{%endraw%}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- with .Values.topologySpreadConstraints }}{% endraw %}
       topologySpreadConstraints:
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- with .Values.terminationGracePeriodSeconds }}{%endraw%}
-      terminationGracePeriodSeconds: {%raw%}{{ . }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- with .Values.dnsPolicy }}{%endraw%}
-      dnsPolicy: {%raw%}{{ . }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
-      {%raw%}{{- with .Values.dnsConfig }}{%endraw%}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- with .Values.terminationGracePeriodSeconds }}{% endraw %}
+      terminationGracePeriodSeconds: {% raw %}{{ . }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- with .Values.dnsPolicy }}{% endraw %}
+      dnsPolicy: {% raw %}{{ . }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
+      {% raw %}{{- with .Values.dnsConfig }}{% endraw %}
       dnsConfig:
-        {%raw%}{{- toYaml . | nindent 8 }}{%endraw%}
-      {%raw%}{{- end }}{%endraw%}
+        {% raw %}{{- toYaml . | nindent 8 }}{% endraw %}
+      {% raw %}{{- end }}{% endraw %}
 ```
 
 ### Step 4: Security Best Practices
@@ -348,13 +348,13 @@ Implement comprehensive security measures:
 
 ```yaml
 # templates/podsecuritypolicy.yaml
-{%raw%}{{- if .Values.podSecurityPolicy.enabled }}{%endraw%}
+{% raw %}{{- if .Values.podSecurityPolicy.enabled }}{% endraw %}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {%raw%}{{ include "mcp-mesh-agent.fullname" . }}{%endraw%}
+  name: {% raw %}{{ include "mcp-mesh-agent.fullname" . }}{% endraw %}
   labels:
-    {%raw%}{{- include "mcp-mesh-agent.labels" . | nindent 4 }}{%endraw%}
+    {% raw %}{{- include "mcp-mesh-agent.labels" . | nindent 4 }}{% endraw %}
 spec:
   privileged: false
   allowPrivilegeEscalation: false
@@ -379,21 +379,21 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: true
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- end }}{% endraw %}
 
 ---
 # templates/networkpolicy.yaml
-{%raw%}{{- if .Values.networkPolicy.enabled }}{%endraw%}
+{% raw %}{{- if .Values.networkPolicy.enabled }}{% endraw %}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {%raw%}{{ include "mcp-mesh-agent.fullname" . }}{%endraw%}
+  name: {% raw %}{{ include "mcp-mesh-agent.fullname" . }}{% endraw %}
   labels:
-    {%raw%}{{- include "mcp-mesh-agent.labels" . | nindent 4 }}{%endraw%}
+    {% raw %}{{- include "mcp-mesh-agent.labels" . | nindent 4 }}{% endraw %}
 spec:
   podSelector:
     matchLabels:
-      {%raw%}{{- include "mcp-mesh-agent.selectorLabels" . | nindent 6 }}{%endraw%}
+      {% raw %}{{- include "mcp-mesh-agent.selectorLabels" . | nindent 6 }}{% endraw %}
   policyTypes:
     - Ingress
     - Egress
@@ -405,17 +405,17 @@ spec:
               app.kubernetes.io/name: mcp-mesh-registry
       ports:
         - protocol: TCP
-          port: {%raw%}{{ .Values.agent.port | default 8080 }}{%endraw%}
+          port: {% raw %}{{ .Values.agent.port | default 8080 }}{% endraw %}
     # Allow metrics scraping
-    {%raw%}{{- if .Values.metrics.enabled }}{%endraw%}
+    {% raw %}{{- if .Values.metrics.enabled }}{% endraw %}
     - from:
         - namespaceSelector:
             matchLabels:
               name: monitoring
       ports:
         - protocol: TCP
-          port: {%raw%}{{ .Values.metrics.port | default 9090 }}{%endraw%}
-    {%raw%}{{- end }}{%endraw%}
+          port: {% raw %}{{ .Values.metrics.port | default 9090 }}{% endraw %}
+    {% raw %}{{- end }}{% endraw %}
   egress:
     # Allow DNS
     - to:
@@ -440,7 +440,7 @@ spec:
       ports:
         - protocol: TCP
           port: 443
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- end }}{% endraw %}
 ```
 
 ### Step 5: Performance Optimization
@@ -457,37 +457,37 @@ Efficient helper functions with caching
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{%raw%}{{- define "mcp-mesh-agent.fullname" -}}{%endraw%}
-{%raw%}{{- if .Values.fullnameOverride }}{%endraw%}
-{%raw%}{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}{%endraw%}
-{%raw%}{{- else }}{%endraw%}
-{%raw%}{{- $name := default .Chart.Name .Values.nameOverride }}{%endraw%}
-{%raw%}{{- if contains $name .Release.Name }}{%endraw%}
-{%raw%}{{- .Release.Name | trunc 63 | trimSuffix "-" }}{%endraw%}
-{%raw%}{{- else }}{%endraw%}
-{%raw%}{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- define "mcp-mesh-agent.fullname" -}}{% endraw %}
+{% raw %}{{- if .Values.fullnameOverride }}{% endraw %}
+{% raw %}{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}{% endraw %}
+{% raw %}{{- else }}{% endraw %}
+{% raw %}{{- $name := default .Chart.Name .Values.nameOverride }}{% endraw %}
+{% raw %}{{- if contains $name .Release.Name }}{% endraw %}
+{% raw %}{{- .Release.Name | trunc 63 | trimSuffix "-" }}{% endraw %}
+{% raw %}{{- else }}{% endraw %}
+{% raw %}{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 
 {{/*
 Render template with caching for performance
 */}}
-{%raw%}{{- define "mcp-mesh-agent.renderTpl" -}}{%endraw%}
-{%raw%}{{- $value := .value -}}{%endraw%}
-{%raw%}{{- $context := .context -}}{%endraw%}
-{%raw%}{{- if typeIs "string" $value -}}{%endraw%}
-{%raw%}{{- tpl $value $context -}}{%endraw%}
-{%raw%}{{- else -}}{%endraw%}
-{%raw%}{{- tpl ($value | toYaml) $context -}}{%endraw%}
-{%raw%}{{- end -}}{%endraw%}
-{%raw%}{{- end -}}{%endraw%}
+{% raw %}{{- define "mcp-mesh-agent.renderTpl" -}}{% endraw %}
+{% raw %}{{- $value := .value -}}{% endraw %}
+{% raw %}{{- $context := .context -}}{% endraw %}
+{% raw %}{{- if typeIs "string" $value -}}{% endraw %}
+{% raw %}{{- tpl $value $context -}}{% endraw %}
+{% raw %}{{- else -}}{% endraw %}
+{% raw %}{{- tpl ($value | toYaml) $context -}}{% endraw %}
+{% raw %}{{- end -}}{% endraw %}
+{% raw %}{{- end -}}{% endraw %}
 
 {{/*
 Common labels with minimal computation
 */}}
-{%raw%}{{- define "mcp-mesh-agent.labels" -}}{%endraw%}
-{%raw%}{{- if not .labels_cached }}{%endraw%}
+{% raw %}{{- define "mcp-mesh-agent.labels" -}}{% endraw %}
+{% raw %}{{- if not .labels_cached }}{% endraw %}
 {{- $_ := set . "labels_cached" (dict
   "helm.sh/chart" (include "mcp-mesh-agent.chart" .)
   "app.kubernetes.io/name" (include "mcp-mesh-agent.name" .)
@@ -495,11 +495,11 @@ Common labels with minimal computation
   "app.kubernetes.io/version" (.Chart.AppVersion | default "0.3" | quote)
   "app.kubernetes.io/managed-by" .Release.Service
 ) }}
-{%raw%}{{- end }}{%endraw%}
-{%raw%}{{- range $key, $value := .labels_cached }}{%endraw%}
-{%raw%}{{ $key }}{%endraw%}: {%raw%}{{ $value }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- end }}{% endraw %}
+{% raw %}{{- range $key, $value := .labels_cached }}{% endraw %}
+{% raw %}{{ $key }}{% endraw %}: {% raw %}{{ $value }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 ```
 
 ### Step 6: Operational Excellence
@@ -512,9 +512,9 @@ Implement comprehensive operational practices:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{%raw%}{{ include "mcp-mesh-agent.fullname" . }}{%endraw%}-test-connection"
+  name: "{% raw %}{{ include "mcp-mesh-agent.fullname" . }}{% endraw %}-test-connection"
   labels:
-    {%raw%}{{- include "mcp-mesh-agent.labels" . | nindent 4 }}{%endraw%}
+    {% raw %}{{- include "mcp-mesh-agent.labels" . | nindent 4 }}{% endraw %}
   annotations:
     "helm.sh/hook": test
 spec:
@@ -525,13 +525,13 @@ spec:
       args:
         - |
           echo "Testing agent health endpoint..."
-          curl -f http://{%raw%}{{ include "mcp-mesh-agent.fullname" . }}{%endraw%}:{%raw%}{{ .Values.agent.port | default 8080 }}{%endraw%}/health
+          curl -f http://{% raw %}{{ include "mcp-mesh-agent.fullname" . }}{% endraw %}:{% raw %}{{ .Values.agent.port | default 8080 }}{% endraw %}/health
           echo "Testing agent readiness..."
-          curl -f http://{%raw%}{{ include "mcp-mesh-agent.fullname" . }}{%endraw%}:{%raw%}{{ .Values.agent.port | default 8080 }}{%endraw%}/ready
+          curl -f http://{% raw %}{{ include "mcp-mesh-agent.fullname" . }}{% endraw %}:{% raw %}{{ .Values.agent.port | default 8080 }}{% endraw %}/ready
           echo "Testing metrics endpoint..."
-          {%raw%}{{- if .Values.metrics.enabled }}{%endraw%}
-          curl -f http://{%raw%}{{ include "mcp-mesh-agent.fullname" . }}{%endraw%}:{%raw%}{{ .Values.metrics.port | default 9090 }}{%endraw%}/metrics
-          {%raw%}{{- end }}{%endraw%}
+          {% raw %}{{- if .Values.metrics.enabled }}{% endraw %}
+          curl -f http://{% raw %}{{ include "mcp-mesh-agent.fullname" . }}{% endraw %}:{% raw %}{{ .Values.metrics.port | default 9090 }}{% endraw %}/metrics
+          {% raw %}{{- end }}{% endraw %}
           echo "All tests passed!"
   restartPolicy: Never
 ```
@@ -541,78 +541,78 @@ Create comprehensive documentation:
 ```markdown
 # templates/NOTES.txt
 
-{%raw%}{{- $fullName := include "mcp-mesh-agent.fullname" . -}}{%endraw%}
-✨ MCP Mesh Agent {%raw%}{{ .Values.agent.name }}{%endraw%} has been deployed!
+{% raw %}{{- $fullName := include "mcp-mesh-agent.fullname" . -}}{% endraw %}
+✨ MCP Mesh Agent {% raw %}{{ .Values.agent.name }}{% endraw %} has been deployed!
 
 📋 Release Information:
-Name: {%raw%}{{ .Release.Name }}{%endraw%}
-Namespace: {%raw%}{{ .Release.Namespace }}{%endraw%}
-Version: {%raw%}{{ .Chart.Version }}{%endraw%}
-Revision: {%raw%}{{ .Release.Revision }}{%endraw%}
+Name: {% raw %}{{ .Release.Name }}{% endraw %}
+Namespace: {% raw %}{{ .Release.Namespace }}{% endraw %}
+Version: {% raw %}{{ .Chart.Version }}{% endraw %}
+Revision: {% raw %}{{ .Release.Revision }}{% endraw %}
 
 🚀 Application Details:
-Agent Name: {%raw%}{{ .Values.agent.name }}{%endraw%}
-Replicas: {%raw%}{{ .Values.replicaCount }}{%endraw%}
-Image: {%raw%}{{ .Values.image.repository }}{%endraw%}:{%raw%}{{ .Values.image.tag | default .Chart.AppVersion }}{%endraw%}
-{%raw%}{{- if .Values.agent.capabilities }}{%endraw%}
-Capabilities: {%raw%}{{ .Values.agent.capabilities | join ", " }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+Agent Name: {% raw %}{{ .Values.agent.name }}{% endraw %}
+Replicas: {% raw %}{{ .Values.replicaCount }}{% endraw %}
+Image: {% raw %}{{ .Values.image.repository }}{% endraw %}:{% raw %}{{ .Values.image.tag | default .Chart.AppVersion }}{% endraw %}
+{% raw %}{{- if .Values.agent.capabilities }}{% endraw %}
+Capabilities: {% raw %}{{ .Values.agent.capabilities | join ", " }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 
 📊 Resources:
-CPU Request: {%raw%}{{ .Values.resources.requests.cpu | default "not set" }}{%endraw%}
-Memory Request: {%raw%}{{ .Values.resources.requests.memory | default "not set" }}{%endraw%}
-CPU Limit: {%raw%}{{ .Values.resources.limits.cpu | default "not set" }}{%endraw%}
-Memory Limit: {%raw%}{{ .Values.resources.limits.memory | default "not set" }}{%endraw%}
+CPU Request: {% raw %}{{ .Values.resources.requests.cpu | default "not set" }}{% endraw %}
+Memory Request: {% raw %}{{ .Values.resources.requests.memory | default "not set" }}{% endraw %}
+CPU Limit: {% raw %}{{ .Values.resources.limits.cpu | default "not set" }}{% endraw %}
+Memory Limit: {% raw %}{{ .Values.resources.limits.memory | default "not set" }}{% endraw %}
 
 🔍 Service Discovery:
-Internal DNS: {%raw%}{{ $fullName }}{%endraw%}.{%raw%}{{ .Release.Namespace }}{%endraw%}.svc.cluster.local
-Service Port: {%raw%}{{ .Values.service.port | default 8080 }}{%endraw%}
+Internal DNS: {% raw %}{{ $fullName }}{% endraw %}.{% raw %}{{ .Release.Namespace }}{% endraw %}.svc.cluster.local
+Service Port: {% raw %}{{ .Values.service.port | default 8080 }}{% endraw %}
 
-{%raw%}{{- if .Values.ingress.enabled }}{%endraw%}
+{% raw %}{{- if .Values.ingress.enabled }}{% endraw %}
 🌐 External Access:
-{%raw%}{{- range $host := .Values.ingress.hosts }}{%endraw%}
-{%raw%}{{- range .paths }}{%endraw%}
-URL: http{%raw%}{{ if $.Values.ingress.tls }}{%endraw%}s{%raw%}{{ end }}{%endraw%}://{%raw%}{{ $host.host }}{%endraw%}{%raw%}{{ .path }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
-{%raw%}{{- else }}{%endraw%}
+{% raw %}{{- range $host := .Values.ingress.hosts }}{% endraw %}
+{% raw %}{{- range .paths }}{% endraw %}
+URL: http{% raw %}{{ if $.Values.ingress.tls }}{% endraw %}s{% raw %}{{ end }}{% endraw %}://{% raw %}{{ $host.host }}{% endraw %}{% raw %}{{ .path }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
+{% raw %}{{- else }}{% endraw %}
 🔒 External Access: Disabled (ingress.enabled=false)
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- end }}{% endraw %}
 
-{%raw%}{{- if .Values.autoscaling.enabled }}{%endraw%}
+{% raw %}{{- if .Values.autoscaling.enabled }}{% endraw %}
 📈 Autoscaling:
-Min Replicas: {%raw%}{{ .Values.autoscaling.minReplicas }}{%endraw%}
-Max Replicas: {%raw%}{{ .Values.autoscaling.maxReplicas }}{%endraw%}
-Target CPU: {%raw%}{{ .Values.autoscaling.targetCPUUtilizationPercentage }}{%endraw%}%
-{%raw%}{{- end }}{%endraw%}
+Min Replicas: {% raw %}{{ .Values.autoscaling.minReplicas }}{% endraw %}
+Max Replicas: {% raw %}{{ .Values.autoscaling.maxReplicas }}{% endraw %}
+Target CPU: {% raw %}{{ .Values.autoscaling.targetCPUUtilizationPercentage }}{% endraw %}%
+{% raw %}{{- end }}{% endraw %}
 
 🏥 Health Checks:
-Liveness: curl http://{%raw%}{{ $fullName }}{%endraw%}:{%raw%}{{ .Values.agent.port | default 8080 }}{%endraw%}/health
-Readiness: curl http://{%raw%}{{ $fullName }}{%endraw%}:{%raw%}{{ .Values.agent.port | default 8080 }}{%endraw%}/ready
-{%raw%}{{- if .Values.metrics.enabled }}{%endraw%}
-Metrics: curl http://{%raw%}{{ $fullName }}{%endraw%}:{%raw%}{{ .Values.metrics.port | default 9090 }}{%endraw%}/metrics
-{%raw%}{{- end }}{%endraw%}
+Liveness: curl http://{% raw %}{{ $fullName }}{% endraw %}:{% raw %}{{ .Values.agent.port | default 8080 }}{% endraw %}/health
+Readiness: curl http://{% raw %}{{ $fullName }}{% endraw %}:{% raw %}{{ .Values.agent.port | default 8080 }}{% endraw %}/ready
+{% raw %}{{- if .Values.metrics.enabled }}{% endraw %}
+Metrics: curl http://{% raw %}{{ $fullName }}{% endraw %}:{% raw %}{{ .Values.metrics.port | default 9090 }}{% endraw %}/metrics
+{% raw %}{{- end }}{% endraw %}
 
 📝 Common Operations:
 
 1. Check deployment status:
-   kubectl rollout status deployment/{%raw%}{{ $fullName }}{%endraw%} -n {%raw%}{{ .Release.Namespace }}{%endraw%}
+   kubectl rollout status deployment/{% raw %}{{ $fullName }}{% endraw %} -n {% raw %}{{ .Release.Namespace }}{% endraw %}
 
 2. View logs:
-   kubectl logs -f deployment/{%raw%}{{ $fullName }}{%endraw%} -n {%raw%}{{ .Release.Namespace }}{%endraw%}
+   kubectl logs -f deployment/{% raw %}{{ $fullName }}{% endraw %} -n {% raw %}{{ .Release.Namespace }}{% endraw %}
 
 3. Scale deployment:
-   kubectl scale deployment/{%raw%}{{ $fullName }}{%endraw%} --replicas=5 -n {%raw%}{{ .Release.Namespace }}{%endraw%}
+   kubectl scale deployment/{% raw %}{{ $fullName }}{% endraw %} --replicas=5 -n {% raw %}{{ .Release.Namespace }}{% endraw %}
 
 4. Port forward for local access:
-   kubectl port-forward deployment/{%raw%}{{ $fullName }}{%endraw%} 8080:{%raw%}{{ .Values.agent.port | default 8080 }}{%endraw%} -n {%raw%}{{ .Release.Namespace }}{%endraw%}
+   kubectl port-forward deployment/{% raw %}{{ $fullName }}{% endraw %} 8080:{% raw %}{{ .Values.agent.port | default 8080 }}{% endraw %} -n {% raw %}{{ .Release.Namespace }}{% endraw %}
 
 5. Run tests:
-   helm test {%raw%}{{ .Release.Name }}{%endraw%} -n {%raw%}{{ .Release.Namespace }}{%endraw%}
+   helm test {% raw %}{{ .Release.Name }}{% endraw %} -n {% raw %}{{ .Release.Namespace }}{% endraw %}
 
-{%raw%}{{- if .Values.debug.enabled }}{%endraw%}
+{% raw %}{{- if .Values.debug.enabled }}{% endraw %}
 ⚠️ DEBUG MODE IS ENABLED - Not recommended for production!
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- end }}{% endraw %}
 
 For more information, visit: https://docs.mcp-mesh.io
 ```
@@ -821,7 +821,7 @@ helm push mcp-mesh-agent-*.tgz oci://registry.mcp-mesh.io/charts
 image: mcp-mesh/agent:1.0.0
 
 # Good
-image: "{%raw%}{{ .Values.image.repository }}{%endraw%}:{%raw%}{{ .Values.image.tag | default .Chart.AppVersion }}{%endraw%}"
+image: "{% raw %}{{ .Values.image.repository }}{% endraw %}:{% raw %}{{ .Values.image.tag | default .Chart.AppVersion }}{% endraw %}"
 ```
 
 ### Pitfall 2: Missing Resource Limits
@@ -994,13 +994,13 @@ helm template ./mcp-mesh-agent \
 
 ```yaml
 # Cache computed values
-{%raw%}{{- $fullname := include "chart.fullname" . -}}{%endraw%}
-{%raw%}{{- $labels := include "chart.labels" . -}}{%endraw%}
+{% raw %}{{- $fullname := include "chart.fullname" . -}}{% endraw %}
+{% raw %}{{- $labels := include "chart.labels" . -}}{% endraw %}
 
 # Reuse throughout template
-name: {%raw%}{{ $fullname }}{%endraw%}
+name: {% raw %}{{ $fullname }}{% endraw %}
 labels:
-  {%raw%}{{- $labels | nindent 4 }}{%endraw%}
+  {% raw %}{{- $labels | nindent 4 }}{% endraw %}
 ```
 
 For more issues, see the [section troubleshooting guide](./troubleshooting.md).

--- a/docs/06-helm-deployment/troubleshooting.md
+++ b/docs/06-helm-deployment/troubleshooting.md
@@ -242,17 +242,17 @@ Error: template: mcp-mesh-agent/templates/deployment.yaml:12:20: executing "..."
 
 ```yaml
 # Add defaults in templates
-image: "{%raw%}{{ .Values.image.repository }}{%endraw%}:{%raw%}{{ .Values.image.tag | default .Chart.AppVersion }}{%endraw%}"
+image: "{% raw %}{{ .Values.image.repository }}{% endraw %}:{% raw %}{{ .Values.image.tag | default .Chart.AppVersion }}{% endraw %}"
 
 # Check for nil values
-{%raw%}{{- if .Values.agent }}{%endraw%}
-{%raw%}{{- if .Values.agent.config }}{%endraw%}
-config: {%raw%}{{ .Values.agent.config }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
-{%raw%}{{- end }}{%endraw%}
+{% raw %}{{- if .Values.agent }}{% endraw %}
+{% raw %}{{- if .Values.agent.config }}{% endraw %}
+config: {% raw %}{{ .Values.agent.config }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
+{% raw %}{{- end }}{% endraw %}
 
 # Use required function
-namespace: {%raw%}{{ required "A namespace is required!" .Values.namespace }}{%endraw%}
+namespace: {% raw %}{{ required "A namespace is required!" .Values.namespace }}{% endraw %}
 ```
 
 ### 🏃 Runtime Issues

--- a/docs/07-observability/01-prometheus-integration.md
+++ b/docs/07-observability/01-prometheus-integration.md
@@ -761,7 +761,7 @@ spec:
             severity: warning
           annotations:
             summary: "Prometheus high memory usage"
-            description: "Prometheus {%raw%}{{ $labels.instance }}{%endraw%} memory usage is high"
+            description: "Prometheus {% raw %}{{ $labels.instance }}{% endraw %} memory usage is high"
 
         - alert: PrometheusTargetDown
           expr: up{job=~"mcp-mesh.*"} == 0
@@ -770,7 +770,7 @@ spec:
             severity: critical
           annotations:
             summary: "MCP Mesh target down"
-            description: "Target {%raw%}{{ $labels.instance }}{%endraw%} is down"
+            description: "Target {% raw %}{{ $labels.instance }}{% endraw %} is down"
 ```
 
 ### Debug Metrics Issues

--- a/docs/07-observability/02-grafana-dashboards.md
+++ b/docs/07-observability/02-grafana-dashboards.md
@@ -225,7 +225,7 @@ Create a comprehensive overview dashboard:
         "targets": [
           {
             "expr": "sum by (agent) (rate(mcp_mesh_requests_total{namespace=~\"$namespace\", agent=~\"$agent\"}[$interval]))",
-            "legendFormat": "{%raw%}{%raw%}{{agent}}{%endraw%}{%endraw%}",
+            "legendFormat": "{% raw %}{{agent}}{% endraw %}",
             "refId": "A"
           }
         ],
@@ -362,7 +362,7 @@ Build detailed dashboards for individual agents:
         "targets": [
           {
             "expr": "sum by (method) (increase(mcp_mesh_requests_total{agent=\"$agent\"}[$interval]))",
-            "legendFormat": "{%raw%}{%raw%}{{method}}{%endraw%}{%endraw%}",
+            "legendFormat": "{% raw %}{{method}}{% endraw %}",
             "refId": "A"
           }
         ],
@@ -385,7 +385,7 @@ Build detailed dashboards for individual agents:
         "targets": [
           {
             "expr": "mcp_mesh_connections_active{agent=\"$agent\"}",
-            "legendFormat": "{%raw%}{%raw%}{{type}}{%endraw%}{%endraw%}",
+            "legendFormat": "{% raw %}{{type}}{% endraw %}",
             "refId": "A"
           }
         ],
@@ -464,7 +464,7 @@ Visualize business-specific KPIs:
         "targets": [
           {
             "expr": "sum by (agent) (increase(mcp_mesh_business_revenue_total[$__range]))",
-            "legendFormat": "{%raw%}{%raw%}{{agent}}{%endraw%}{%endraw%}",
+            "legendFormat": "{% raw %}{{agent}}{% endraw %}",
             "refId": "A"
           }
         ],
@@ -495,7 +495,7 @@ Visualize business-specific KPIs:
         "targets": [
           {
             "expr": "sum by (api_provider) (increase(mcp_mesh_business_api_calls_total[$interval]) * 0.001)",
-            "legendFormat": "{%raw%}{%raw%}{{api_provider}}{%endraw%}{%endraw%} ($0.001/call)",
+            "legendFormat": "{% raw %}{{api_provider}}{% endraw %} ($0.001/call)",
             "refId": "A"
           }
         ],
@@ -702,7 +702,7 @@ data:
             "targets": [
               {
                 "expr": "histogram_quantile($percentile, sum by (agent, le) (rate(mcp_mesh_request_duration_seconds_bucket{agent=~\"$agent_regex\"}[$interval])))",
-                "legendFormat": "{%raw%}{%raw%}{{agent}}{%endraw%}{%endraw%} - p${percentile:raw}",
+                "legendFormat": "{% raw %}{{agent}}{% endraw %} - p${percentile:raw}",
                 "refId": "A"
               }
             ],
@@ -723,17 +723,17 @@ data:
             "targets": [
               {
                 "expr": "mcp_mesh:request_rate{agent=~\"$agent_regex\"}",
-                "legendFormat": "{%raw%}{%raw%}{{agent}}{%endraw%}{%endraw%} - actual",
+                "legendFormat": "{% raw %}{{agent}}{% endraw %} - actual",
                 "refId": "A"
               },
               {
                 "expr": "predict_linear(mcp_mesh:request_rate{agent=~\"$agent_regex\"}[1h], 3600)",
-                "legendFormat": "{%raw%}{%raw%}{{agent}}{%endraw%}{%endraw%} - predicted",
+                "legendFormat": "{% raw %}{{agent}}{% endraw %} - predicted",
                 "refId": "B"
               },
               {
                 "expr": "mcp_mesh:request_rate{agent=~\"$agent_regex\"} + 2 * stddev_over_time(mcp_mesh:request_rate{agent=~\"$agent_regex\"}[1h])",
-                "legendFormat": "{%raw%}{%raw%}{{agent}}{%endraw%}{%endraw%} - upper bound",
+                "legendFormat": "{% raw %}{{agent}}{% endraw %} - upper bound",
                 "refId": "C"
               }
             ],
@@ -847,7 +847,7 @@ data:
                 "type": "graph",
                 "targets": [
                     {
-                        "expr": f'rate(mcp_mesh_requests_total{%raw%}{{agent="{agent}"}}{%endraw%}[5m])',
+                        "expr": f'rate(mcp_mesh_requests_total{{agent="{agent}"}}[5m])',
                         "refId": "A"
                     }
                 ]

--- a/docs/07-observability/04-centralized-logging.md
+++ b/docs/07-observability/04-centralized-logging.md
@@ -1561,7 +1561,7 @@ data:
           severity: warning
         annotations:
           summary: "Low log ingestion rate"
-          description: "Log ingestion rate is {%raw%}{{ $value }}{%endraw%} logs/sec"
+          description: "Log ingestion rate is {% raw %}{{ $value }}{% endraw %} logs/sec"
 
       - alert: ElasticsearchDiskSpace
         expr: |

--- a/docs/07-observability/05-alerting-slos.md
+++ b/docs/07-observability/05-alerting-slos.md
@@ -137,9 +137,9 @@ spec:
       sli:
         raw:
           error_ratio_query: |
-            sum(rate(mcp_mesh_requests_total{status="error"}[{%raw%}{{.window}}{%endraw%}]))
+            sum(rate(mcp_mesh_requests_total{status="error"}[{% raw %}{{.window}}{% endraw %}]))
             /
-            sum(rate(mcp_mesh_requests_total[{%raw%}{{.window}}{%endraw%}]))
+            sum(rate(mcp_mesh_requests_total[{% raw %}{{.window}}{% endraw %}]))
 
       alerting:
         name: MCP_Mesh_HighErrorRate
@@ -161,9 +161,9 @@ spec:
         raw:
           error_ratio_query: |
             (
-              sum(rate(mcp_mesh_request_duration_seconds_bucket{le="0.5"}[{%raw%}{{.window}}{%endraw%}]))
+              sum(rate(mcp_mesh_request_duration_seconds_bucket{le="0.5"}[{% raw %}{{.window}}{% endraw %}]))
               /
-              sum(rate(mcp_mesh_request_duration_seconds_count[{%raw%}{{.window}}{%endraw%}]))
+              sum(rate(mcp_mesh_request_duration_seconds_count[{% raw %}{{.window}}{% endraw %}]))
             )
 
       alerting:
@@ -251,7 +251,7 @@ spec:
             team: platform
           annotations:
             summary: "MCP Mesh Registry is down"
-            description: "Registry {%raw%}{{ $labels.instance }}{%endraw%} has been down for more than 2 minutes"
+            description: "Registry {% raw %}{{ $labels.instance }}{% endraw %} has been down for more than 2 minutes"
             runbook_url: "https://wiki.mcp-mesh.io/runbooks/registry-down"
             dashboard_url: "https://grafana.mcp-mesh.io/d/registry/overview"
 
@@ -268,7 +268,7 @@ spec:
             team: platform
           annotations:
             summary: "High error rate detected"
-            description: "Error rate is {%raw%}{{ $value | humanizePercentage }}{%endraw%} (threshold: 5%)"
+            description: "Error rate is {% raw %}{{ $value | humanizePercentage }}{% endraw %} (threshold: 5%)"
             runbook_url: "https://wiki.mcp-mesh.io/runbooks/high-error-rate"
 
         - alert: MCP_Mesh_SLO_BurnRate_High
@@ -289,7 +289,7 @@ spec:
             team: platform
           annotations:
             summary: "SLO burn rate is critically high"
-            description: "At this rate, the error budget will be exhausted in {%raw%}{{ $value | humanizeDuration }}{%endraw%}"
+            description: "At this rate, the error budget will be exhausted in {% raw %}{{ $value | humanizeDuration }}{% endraw %}"
             runbook_url: "https://wiki.mcp-mesh.io/runbooks/slo-burn-rate"
 
     # Warning Alerts - Create ticket
@@ -308,9 +308,9 @@ spec:
             severity: warning
             team: platform
           annotations:
-            summary: "High latency on {%raw%}{{ $labels.agent }}{%endraw%}"
-            description: "P95 latency is {%raw%}{{ $value }}{%endraw%}s (threshold: 0.5s)"
-            dashboard_url: "https://grafana.mcp-mesh.io/d/agents/{%raw%}{{ $labels.agent }}{%endraw%}"
+            summary: "High latency on {% raw %}{{ $labels.agent }}{% endraw %}"
+            description: "P95 latency is {% raw %}{{ $value }}{% endraw %}s (threshold: 0.5s)"
+            dashboard_url: "https://grafana.mcp-mesh.io/d/agents/{% raw %}{{ $labels.agent }}{% endraw %}"
 
         - alert: MCP_Mesh_HighMemoryUsage
           expr: |
@@ -324,8 +324,8 @@ spec:
             severity: warning
             team: platform
           annotations:
-            summary: "High memory usage in {%raw%}{{ $labels.pod }}{%endraw%}"
-            description: "Memory usage is {%raw%}{{ $value | humanizePercentage }}{%endraw%} of limit"
+            summary: "High memory usage in {% raw %}{{ $labels.pod }}{% endraw %}"
+            description: "Memory usage is {% raw %}{{ $value | humanizePercentage }}{% endraw %} of limit"
 
         - alert: MCP_Mesh_PodRestarts
           expr: |
@@ -334,8 +334,8 @@ spec:
             severity: warning
             team: platform
           annotations:
-            summary: "Pod {%raw%}{{ $labels.pod }}{%endraw%} is restarting frequently"
-            description: "{%raw%}{{ $value }}{%endraw%} restarts in the last hour"
+            summary: "Pod {% raw %}{{ $labels.pod }}{% endraw %} is restarting frequently"
+            description: "{% raw %}{{ $value }}{% endraw %} restarts in the last hour"
 
     # Info Alerts - Dashboard only
     - name: mcp-mesh.info
@@ -350,8 +350,8 @@ spec:
             severity: info
             team: platform
           annotations:
-            summary: "Deployment in progress for {%raw%}{{ $labels.deployment }}{%endraw%}"
-            description: "{%raw%}{{ $labels.deployment }}{%endraw%} has {%raw%}{{ $value }}{%endraw%} replicas updating"
+            summary: "Deployment in progress for {% raw %}{{ $labels.deployment }}{% endraw %}"
+            description: "{% raw %}{{ $labels.deployment }}{% endraw %} has {% raw %}{{ $value }}{% endraw %} replicas updating"
 
         - alert: MCP_Mesh_CertificateExpiring
           expr: |
@@ -361,7 +361,7 @@ spec:
             team: platform
           annotations:
             summary: "Certificate expiring soon"
-            description: "Certificate {%raw%}{{ $labels.name }}{%endraw%} expires in {%raw%}{{ $value }}{%endraw%} days"
+            description: "Certificate {% raw %}{{ $labels.name }}{% endraw %} expires in {% raw %}{{ $value }}{% endraw %} days"
 ```
 
 ### Step 4: Create Runbooks
@@ -661,42 +661,42 @@ stringData:
       slack_configs:
       - channel: '#alerts-default'
         title: 'MCP Mesh Alert'
-        text: '{%raw%}{{ range .Alerts }}{%endraw%}{%raw%}{{ .Annotations.summary }}{%endraw%}{%raw%}{{ end }}{%endraw%}'
+        text: '{% raw %}{{ range .Alerts }}{% endraw %}{% raw %}{{ .Annotations.summary }}{% endraw %}{% raw %}{{ end }}{% endraw %}'
 
     - name: 'pagerduty-critical'
       pagerduty_configs:
       - service_key: ${PAGERDUTY_SERVICE_KEY}
-        description: '{%raw%}{{ .GroupLabels.alertname }}{%endraw%}: {%raw%}{{ .CommonAnnotations.summary }}{%endraw%}'
+        description: '{% raw %}{{ .GroupLabels.alertname }}{% endraw %}: {% raw %}{{ .CommonAnnotations.summary }}{% endraw %}'
         details:
-          firing: '{%raw%}{{ .Alerts.Firing | len }}{%endraw%}'
-          resolved: '{%raw%}{{ .Alerts.Resolved | len }}{%endraw%}'
-          labels: '{%raw%}{{ .CommonLabels }}{%endraw%}'
+          firing: '{% raw %}{{ .Alerts.Firing | len }}{% endraw %}'
+          resolved: '{% raw %}{{ .Alerts.Resolved | len }}{% endraw %}'
+          labels: '{% raw %}{{ .CommonLabels }}{% endraw %}'
         links:
-        - href: '{%raw%}{{ .CommonAnnotations.dashboard_url }}{%endraw%}'
+        - href: '{% raw %}{{ .CommonAnnotations.dashboard_url }}{% endraw %}'
           text: 'Dashboard'
-        - href: '{%raw%}{{ .CommonAnnotations.runbook_url }}{%endraw%}'
+        - href: '{% raw %}{{ .CommonAnnotations.runbook_url }}{% endraw %}'
           text: 'Runbook'
 
     - name: 'slack-critical'
       slack_configs:
       - channel: '#alerts-critical'
         color: 'danger'
-        title: '🚨 CRITICAL: {%raw%}{{ .GroupLabels.alertname }}{%endraw%}'
+        title: '🚨 CRITICAL: {% raw %}{{ .GroupLabels.alertname }}{% endraw %}'
         text: |
-          {%raw%}{{ range .Alerts.Firing }}{%endraw%}
-          *Alert:* {%raw%}{{ .Annotations.summary }}{%endraw%}
-          *Description:* {%raw%}{{ .Annotations.description }}{%endraw%}
-          *Runbook:* <{%raw%}{{ .Annotations.runbook_url }}{%endraw%}|View Runbook>
-          *Dashboard:* <{%raw%}{{ .Annotations.dashboard_url }}{%endraw%}|View Dashboard>
-          {%raw%}{{ end }}{%endraw%}
+          {% raw %}{{ range .Alerts.Firing }}{% endraw %}
+          *Alert:* {% raw %}{{ .Annotations.summary }}{% endraw %}
+          *Description:* {% raw %}{{ .Annotations.description }}{% endraw %}
+          *Runbook:* <{% raw %}{{ .Annotations.runbook_url }}{% endraw %}|View Runbook>
+          *Dashboard:* <{% raw %}{{ .Annotations.dashboard_url }}{% endraw %}|View Dashboard>
+          {% raw %}{{ end }}{% endraw %}
         send_resolved: true
 
     - name: 'slack-warnings'
       slack_configs:
       - channel: '#alerts-warning'
         color: 'warning'
-        title: '⚠️ Warning: {%raw%}{{ .GroupLabels.alertname }}{%endraw%}'
-        text: '{%raw%}{{ .CommonAnnotations.summary }}{%endraw%}'
+        title: '⚠️ Warning: {% raw %}{{ .GroupLabels.alertname }}{% endraw %}'
+        text: '{% raw %}{{ .CommonAnnotations.summary }}{% endraw %}'
         send_resolved: true
 
     - name: 'platform-team'
@@ -735,9 +735,9 @@ spec:
       sli:
         raw:
           error_ratio_query: |
-            sum(rate(mcp_mesh_business_transactions_total{status="failed"}[{%raw%}{{.window}}{%endraw%}]))
+            sum(rate(mcp_mesh_business_transactions_total{status="failed"}[{% raw %}{{.window}}{% endraw %}]))
             /
-            sum(rate(mcp_mesh_business_transactions_total[{%raw%}{{.window}}{%endraw%}]))
+            sum(rate(mcp_mesh_business_transactions_total[{% raw %}{{.window}}{% endraw %}]))
 
       alerting:
         name: BusinessTransactionFailures
@@ -754,9 +754,9 @@ spec:
         raw:
           error_ratio_query: |
             (
-              sum(rate(mcp_mesh_api_calls_total{cost_exceeded="true"}[{%raw%}{{.window}}{%endraw%}]))
+              sum(rate(mcp_mesh_api_calls_total{cost_exceeded="true"}[{% raw %}{{.window}}{% endraw %}]))
               /
-              sum(rate(mcp_mesh_api_calls_total[{%raw%}{{.window}}{%endraw%}]))
+              sum(rate(mcp_mesh_api_calls_total[{% raw %}{{.window}}{% endraw %}]))
             )
 ```
 
@@ -838,7 +838,7 @@ class AdaptiveAlerting:
           annotations:
             summary: "{metric_name} exceeds dynamic threshold"
             description: |
-              Current value: {%raw%}{{{{ $value }}{%endraw%}}}
+              Current value: {% raw %}{{{{ $value }}{% endraw %}}}
               Dynamic threshold: {threshold_info['threshold']:.2f}
               Based on mean: {threshold_info['mean']:.2f} (±{threshold_info['std']:.2f})
               P95: {threshold_info['p95']:.2f}, P99: {threshold_info['p99']:.2f}
@@ -884,8 +884,8 @@ print(f"Based on historical mean: {threshold['mean']:.2f} (±{threshold['std']:.
 - alert: AlertQualityLow
   expr: alerts:quality:actionable_ratio < 0.5
   annotations:
-    summary: "Alert {%raw%}{{ $labels.alertname }}{%endraw%} has low actionable ratio"
-    description: "Only {%raw%}{{ $value | humanizePercentage }}{%endraw%} of alerts were actionable"
+    summary: "Alert {% raw %}{{ $labels.alertname }}{% endraw %} has low actionable ratio"
+    description: "Only {% raw %}{{ $value | humanizePercentage }}{% endraw %} of alerts were actionable"
 ```
 
 ### Pitfall 2: Unrealistic SLOs


### PR DESCRIPTION
## 🐛 Fix
Corrects Liquid raw tag syntax by adding required spaces.

## �� Issue
Jekyll was throwing error:
```
Liquid syntax error (line 224): Unknown tag 'endraw'
```

## 🔧 Root Cause
Liquid tags require spaces: `{% raw %}` not `{%raw%}`

## ✅ Solution
1. Removed all existing raw tags (both formats)
2. Re-applied with correct syntax: `{% raw %}` and `{% endraw %}`
3. Applied to all 14 files with 523 pattern replacements

## 📚 Reference
- [Jekyll Liquid Tags Documentation](https://jekyllrb.com/docs/liquid/tags/)
- [Stack Overflow: Jekyll raw tag syntax](https://stackoverflow.com/questions/19352368/show-raw-tags-in-post-generated-by-jekyll)

## 🔗 Context
- Follow-up to PR #144
- Previous PR had tags without spaces
- Jekyll requires proper spacing in all Liquid tags

## ✅ Checklist
- [x] All raw tags have proper spacing
- [x] 14 files modified
- [x] Tested syntax with web search
- [x] Committed and force pushed
- [ ] PR merged
- [ ] GitHub Pages builds successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized templating tag spacing to {% raw %}...{% endraw %} across Docker deployment and troubleshooting guides.
  * Normalized Helm docs (deployment, charts, values, multi-environment, best practices, troubleshooting) for consistent raw tag usage and formatting.
  * Updated Observability content (Prometheus, Grafana dashboards, centralized logging, alerting/SLOs) with consistent raw wrappers and cleaned examples.
  * Minor whitespace/indentation adjustments for readability. No changes to command behavior, rendered templates, or logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->