### PR TITLE
Fix nested braces in Grafana dashboards Python code

### DIFF
--- a/docs/07-observability/02-grafana-dashboards.md
+++ b/docs/07-observability/02-grafana-dashboards.md
@@ -847,7 +847,7 @@ data:
                 "type": "graph",
                 "targets": [
                     {
-                        "expr": f'rate(mcp_mesh_requests_total{{agent="{agent}"}}[5m])',
+                        "expr": f'rate(mcp_mesh_requests_total{% raw %}{{agent="{agent}"}}{% endraw %}[5m])',
                         "refId": "A"
                     }
                 ]


### PR DESCRIPTION
## 🐛 Fix
Manually wraps the nested braces pattern on line 850 that was missed by the regex.

## 📋 Issue
Line 850 has nested braces and quotes that the sed regex couldn't handle:
```python
"expr": f'rate(mcp_mesh_requests_total{{agent="{agent}"}}[5m])'
```

## 🔧 Solution
Manually wrapped the problematic pattern with `{% raw %}` tags:
```python
"expr": f'rate(mcp_mesh_requests_total{% raw %}{{agent="{agent}"}}{% endraw %}[5m])'
```

## 🔗 Context
- Follow-up to PR #145
- The sed pattern `{{[^}]*}}` doesn't handle nested braces
- This is the only instance with this complex nesting pattern

## ✅ Checklist
- [x] Line 850 manually fixed
- [x] Verified no other nested brace patterns exist
- [x] Committed and force pushed
- [ ] PR merged
- [ ] GitHub Pages builds successfully