### PR TITLE
Add Google Search Console verification to Jekyll theme

### DIFF
--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,0 +1,1 @@
+<meta name="google-site-verification" content="EtV7XZPdw0d9azFHor7Zq2BeuVZVnwSwD0zzGNMOUoM" />


### PR DESCRIPTION
## ✅ Fix
Adds Google Search Console verification meta tag to the Jekyll theme.

## 📋 Changes
Created `docs/_includes/head-custom.html` with the Google verification meta tag.

## 🔧 How It Works
Jekyll's Leap Day theme automatically includes `_includes/head-custom.html` in the `<head>` section if it exists. This is the standard way to add custom head content to Jekyll themes.

## 🎯 Result
The verification meta tag will now appear in the HTML head:
```html
<meta name="google-site-verification" content="EtV7XZPdw0d9azFHor7Zq2BeuVZVnwSwD0zzGNMOUoM" />
```

## 🔗 Context
- Google Search Console verification was missing after Jekyll theme setup
- Previous attempt to add it via _config.yml didn't work
- Using Jekyll's standard custom head include pattern

## ✅ Checklist
- [x] Created _includes/head-custom.html
- [x] Added Google verification meta tag
- [x] Committed and pushed
- [ ] PR merged
- [ ] Verified meta tag appears in HTML
- [ ] Google Search Console verification confirmed