### PR TITLE
Extract vendor from model name for direct LiteLLM calls

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -219,9 +219,10 @@ docker run -d \
   mcp-mesh-base:latest
 
 # Test the weather agent
-curl -X POST http://localhost:8083/mcp \
+curl -s -X POST http://localhost:8083/mcp \
   -H "Content-Type: application/json" \
-  -d '{"method": "tools/list", "params": {}}'
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
 ```
 
 ### Debug Mode

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -78,7 +78,8 @@ docker-compose up
 # 3. Test it (in another terminal)
 curl -s -X POST http://localhost:8081/mcp \
   -H "Content-Type: application/json" \
-  -d '{"method": "tools/call", "params": {"name": "hello_mesh_simple", "arguments": {}}}' | jq .
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hello_mesh_simple","arguments":{}}}' | jq .
 ```
 
 **Expected response:**
@@ -115,7 +116,8 @@ python hello_world.py &
 # 5. Test it
 curl -s -X POST http://localhost:8080/mcp \
   -H "Content-Type: application/json" \
-  -d '{"method": "tools/call", "params": {"name": "hello_mesh_simple", "arguments": {}}}' | jq .
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hello_mesh_simple","arguments":{}}}' | jq .
 ```
 
 ## Alternative: Linux/macOS Install Script (3 Minutes)
@@ -141,7 +143,8 @@ python hello_world.py &
 # 5. Test it
 curl -s -X POST http://localhost:8080/mcp \
   -H "Content-Type: application/json" \
-  -d '{"method": "tools/call", "params": {"name": "hello_mesh_simple", "arguments": {}}}' | jq .
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hello_mesh_simple","arguments":{}}}' | jq .
 ```
 
 ## Alternative: Local Development (5 Minutes)

--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -87,17 +87,10 @@ Python agents automatically participate in distributed tracing when the registry
 curl http://localhost:8000/trace/status
 
 # Make a test call to generate traces
-curl -X POST http://localhost:9093/mcp \
+curl -s -X POST http://localhost:9093/mcp \
   -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "tools/call",
-    "params": {
-      "name": "generate_report",
-      "arguments": {"title": "Test Report"}
-    }
-  }'
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"generate_report","arguments":{"title":"Test Report"}}}'
 
 # Check completed traces (after ~1 minute)
 curl http://localhost:8000/trace/list | jq .

--- a/examples/README.md
+++ b/examples/README.md
@@ -118,12 +118,14 @@ meshctl list agents
 # 3. Test basic functionality
 curl -s -X POST http://localhost:8081/mcp \
   -H "Content-Type: application/json" \
-  -d '{"method": "tools/call", "params": {"name": "hello_mesh_simple", "arguments": {}}}' | jq .
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hello_mesh_simple","arguments":{}}}' | jq .
 
 # 4. Test dependency injection
 curl -s -X POST http://localhost:8082/mcp \
   -H "Content-Type: application/json" \
-  -d '{"method": "tools/call", "params": {"name": "get_current_time", "arguments": {}}}' | jq .
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_current_time","arguments":{}}}' | jq .
 ```
 
 **Expected Results**:

--- a/examples/llm-examples/prompt-templates/test_006_orchestrator.py
+++ b/examples/llm-examples/prompt-templates/test_006_orchestrator.py
@@ -19,6 +19,16 @@ class OrchestratorResult(BaseModel):
     analysis_details: str
 
 
+class SelfDepTestResult(BaseModel):
+    """Result from self-dependency test."""
+
+    test_name: str
+    self_dep_target: str
+    orchestration_result: str
+    test_passed: bool
+    diagnosis: str
+
+
 @app.tool()
 @mesh.llm(
     system_prompt="file://prompts/orchestrator_chain.jinja2",
@@ -40,6 +50,87 @@ def orchestrate_analysis(
     for AnalysisContext, helping it construct proper context objects.
     """
     return llm(request)
+
+
+# ===== SELF-DEPENDENCY TEST =====
+# Tests that self-dependencies work with @mesh.llm decorated functions
+
+
+@app.tool()
+@mesh.tool(
+    capability="self_dep_llm_test",
+    dependencies=["orchestration"],  # Self-dependency: same agent!
+    description="Test self-dependency with @mesh.llm decorated function",
+)
+async def test_self_dependency_llm(
+    orchestrate_analysis: mesh.McpMeshAgent | None = None,
+) -> SelfDepTestResult:
+    """
+    Test self-dependency injection with @mesh.llm decorated functions.
+
+    This tool depends on 'orchestrate_analysis' which is in the SAME agent.
+    'orchestrate_analysis' is decorated with @mesh.llm and needs MeshLlmAgent injected.
+
+    Test chain:
+        test_self_dependency_llm (orchestrator)
+            → [SELF-DEP via wrapper] orchestrate_analysis (orchestrator)
+                → [LLM call with tools] analyze_document (analyzer agent)
+
+    If self-dependency uses the WRAPPER:
+    - orchestrate_analysis's 'llm' parameter will be injected
+    - The LLM call will work and return structured result
+
+    If self-dependency uses the ORIGINAL function:
+    - orchestrate_analysis's 'llm' parameter will be None
+    - Will raise an error when trying to call llm(request)
+    """
+    result = SelfDepTestResult(
+        test_name="self_dependency_with_mesh_llm",
+        self_dep_target="orchestrate_analysis",
+        orchestration_result="not_available",
+        test_passed=False,
+        diagnosis="",
+    )
+
+    if orchestrate_analysis is None:
+        result.diagnosis = "FAIL: orchestrate_analysis not injected (self-dep failed)"
+        return result
+
+    try:
+        # Call orchestrate_analysis - this goes through SelfDependencyProxy
+        # If wrapper is used: llm will be injected, we get orchestration result
+        # If original is used: llm will be None, we get an error
+        orch_result = await orchestrate_analysis(
+            request="Briefly analyze: Self-dependency test for MCP Mesh."
+        )
+        result.orchestration_result = str(orch_result)
+
+        # Check if the LLM call worked (nested dependency)
+        if (
+            "status" in str(orch_result).lower()
+            or "analysis" in str(orch_result).lower()
+        ):
+            result.test_passed = True
+            result.diagnosis = (
+                "PASS: Self-dependency with @mesh.llm worked! "
+                "LLM agent was properly injected via wrapper."
+            )
+        else:
+            result.test_passed = False
+            result.diagnosis = f"UNKNOWN: Unexpected response format: {orch_result}"
+
+    except TypeError as e:
+        if "NoneType" in str(e) or "llm" in str(e):
+            result.diagnosis = (
+                "FAIL: LLM agent was not injected. "
+                "SelfDependencyProxy may be using original function instead of wrapper."
+            )
+        else:
+            result.diagnosis = f"FAIL: TypeError - {e}"
+    except Exception as e:
+        result.diagnosis = f"FAIL: Exception during self-dep call: {e}"
+
+    return result
 
 
 @mesh.agent(

--- a/examples/prompt-template-examples/test_006_orchestrator.py
+++ b/examples/prompt-template-examples/test_006_orchestrator.py
@@ -17,6 +17,16 @@ class OrchestratorResult(BaseModel):
     analysis: str
 
 
+class SelfDepTestResult(BaseModel):
+    """Result from self-dependency test."""
+
+    test_name: str
+    self_dep_target: str
+    orchestration_result: str
+    test_passed: bool
+    diagnosis: str
+
+
 @app.tool()
 @mesh.llm(
     system_prompt="file://prompts/orchestrator_chain.jinja2",
@@ -33,6 +43,87 @@ def orchestrate_analysis(
     # Calling LLM should see enhanced schema with Field descriptions
     # for AnalysisContext, helping it construct proper context
     return llm(request)
+
+
+# ===== SELF-DEPENDENCY TEST =====
+# Tests that self-dependencies work with @mesh.llm decorated functions
+
+
+@app.tool()
+@mesh.tool(
+    capability="self_dep_llm_test",
+    dependencies=["orchestration"],  # Self-dependency: same agent!
+    description="Test self-dependency with @mesh.llm decorated function",
+)
+async def test_self_dependency_llm(
+    orchestrate_analysis: mesh.McpMeshAgent | None = None,
+) -> SelfDepTestResult:
+    """
+    Test self-dependency injection with @mesh.llm decorated functions.
+
+    This tool depends on 'orchestrate_analysis' which is in the SAME agent.
+    'orchestrate_analysis' is decorated with @mesh.llm and needs MeshLlmAgent injected.
+
+    Test chain:
+        test_self_dependency_llm (orchestrator-chain)
+            → [SELF-DEP via wrapper] orchestrate_analysis (orchestrator-chain)
+                → [LLM call with tools] analyze_document (analyzer agent)
+
+    If self-dependency uses the WRAPPER:
+    - orchestrate_analysis's 'llm' parameter will be injected
+    - The LLM call will work and return structured result
+
+    If self-dependency uses the ORIGINAL function:
+    - orchestrate_analysis's 'llm' parameter will be None
+    - Will raise an error when trying to call llm(request)
+    """
+    result = SelfDepTestResult(
+        test_name="self_dependency_with_mesh_llm",
+        self_dep_target="orchestrate_analysis",
+        orchestration_result="not_available",
+        test_passed=False,
+        diagnosis="",
+    )
+
+    if orchestrate_analysis is None:
+        result.diagnosis = "FAIL: orchestrate_analysis not injected (self-dep failed)"
+        return result
+
+    try:
+        # Call orchestrate_analysis - this goes through SelfDependencyProxy
+        # If wrapper is used: llm will be injected, we get orchestration result
+        # If original is used: llm will be None, we get an error
+        orch_result = await orchestrate_analysis(
+            request="Briefly analyze: Self-dependency test for MCP Mesh."
+        )
+        result.orchestration_result = str(orch_result)
+
+        # Check if the LLM call worked (nested dependency)
+        if (
+            "status" in str(orch_result).lower()
+            or "analysis" in str(orch_result).lower()
+        ):
+            result.test_passed = True
+            result.diagnosis = (
+                "PASS: Self-dependency with @mesh.llm worked! "
+                "LLM agent was properly injected via wrapper."
+            )
+        else:
+            result.test_passed = False
+            result.diagnosis = f"UNKNOWN: Unexpected response format: {orch_result}"
+
+    except TypeError as e:
+        if "NoneType" in str(e) or "llm" in str(e):
+            result.diagnosis = (
+                "FAIL: LLM agent was not injected. "
+                "SelfDependencyProxy may be using original function instead of wrapper."
+            )
+        else:
+            result.diagnosis = f"FAIL: TypeError - {e}"
+    except Exception as e:
+        result.diagnosis = f"FAIL: Exception during self-dep call: {e}"
+
+    return result
 
 
 # Agent configuration for HTTP transport


### PR DESCRIPTION
## Summary
- Extract vendor from LiteLLM model strings (e.g., `anthropic/claude-sonnet-4-5` → `anthropic`) for proper provider handler selection
- Add self-dependency test for `@mesh.llm` decorated functions
- Fix curl syntax in documentation to include proper MCP headers

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated examples and API documentation with standardized JSON-RPC 2.0 request format and explicit Accept headers.

* **Tests**
  * Added self-dependency validation tests for orchestrator flow with enhanced diagnostic reporting.

* **Improvements**
  * Enhanced LLM model vendor detection and resolution in agent initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->