### PR TITLE
Add missing PyPI dependencies: litellm, jinja2, cachetools

### DIFF
--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -48,9 +48,12 @@ dependencies = [
     "typer>=0.9.0,<1.0.0",
     "mcp>=1.9.0,<2.0.0",
     "fastmcp>=2.8.0,<3.0.0",
+    "litellm>=1.30.0",
     "prometheus-client>=0.19.0,<1.0.0",
     "pyyaml>=6.0,<7.0",
-    "redis>=4.0.0,<7.0.0"
+    "jinja2>=3.1.0",
+    "redis>=4.0.0,<7.0.0",
+    "cachetools>=5.3.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Syncs `packaging/pypi/pyproject.toml` with `src/runtime/python/pyproject.toml` by adding missing dependencies
- Adds `litellm>=1.30.0`, `jinja2>=3.1.0`, `cachetools>=5.3.0`

## Test plan

- [ ] Verify PyPI package includes these dependencies after release
- [ ] Test `@mesh.llm` decorator works in Docker container

Fixes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->