### PR TITLE
Release v0.6.4 - Missing PyPI Dependencies Fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "Version (e.g., v0.6.0)"
         required: true
-        default: "v0.6.3"
+        default: "v0.6.4"
       environment:
         description: "Environment"
         type: choice

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Variables
 REGISTRY_NAME = mcp-mesh-registry
 DEV_NAME = meshctl
-VERSION = 0.6.3
+VERSION = 0.6.4
 BUILD_DIR = bin
 REGISTRY_CMD_DIR = cmd/mcp-mesh-registry
 DEV_CMD_DIR = cmd/meshctl

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # MCP Mesh Release Notes
 
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v0.6.3...v0.6.4)
+
+## v0.6.4 (2025-11-30)
+
+### 🐛 Bug Fixes
+
+- **Missing PyPI Dependencies**: Added missing `litellm`, `jinja2`, and `cachetools` dependencies to PyPI package configuration
+  - Fixes `jinja2 is required for template rendering` error
+  - Fixes `litellm is required for MeshLlmAgent` error
+  - Root cause: `packaging/pypi/pyproject.toml` was out of sync with `src/runtime/python/pyproject.toml`
+
 [Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v0.6.2...v0.6.3)
 
 ## v0.6.3 (2025-11-30)

--- a/docs/06-helm-deployment/01-understanding-charts.md
+++ b/docs/06-helm-deployment/01-understanding-charts.md
@@ -343,7 +343,7 @@ global:
 # Image configuration (updated to match working examples)
 image:
   repository: mcp-mesh-base  # 🎯 Updated from mcp-mesh/registry
-  tag: "0.6.3"  # 🎯 Updated for local development
+  tag: "0.6.4"  # 🎯 Updated for local development
   pullPolicy: Never  # 🎯 For local development
 
 # Deployment settings
@@ -469,7 +469,7 @@ version: 1.0.0
 appVersion: "1.0.0"
 dependencies:
   - name: mcp-mesh-agent
-    version: "0.6.3"
+    version: "0.6.4"
     repository: "https://charts.mcp-mesh.io"
 ```
 

--- a/docs/06-helm-deployment/02-umbrella-chart.md
+++ b/docs/06-helm-deployment/02-umbrella-chart.md
@@ -221,25 +221,25 @@ keywords:
 dependencies:
   # Core registry
   - name: mcp-mesh-registry
-    version: "0.6.3"
+    version: "0.6.4"
     repository: "file://../mcp-mesh-registry"
     condition: registry.enabled
 
   # Agents using aliases for multiple instances
   - name: mcp-mesh-agent
-    version: "0.6.3"
+    version: "0.6.4"
     repository: "file://../mcp-mesh-agent"
     alias: hello-world-agent
     condition: agents.helloWorld.enabled
 
   - name: mcp-mesh-agent
-    version: "0.6.3"
+    version: "0.6.4"
     repository: "file://../mcp-mesh-agent"
     alias: system-agent
     condition: agents.system.enabled
 
   - name: mcp-mesh-agent
-    version: "0.6.3"
+    version: "0.6.4"
     repository: "file://../mcp-mesh-agent"
     alias: weather-agent
     condition: agents.weather.enabled
@@ -263,7 +263,7 @@ mcp-mesh-registry:
   replicaCount: 1
   image:
     repository: mcp-mesh-base
-    tag: "0.6.3"
+    tag: "0.6.4"
     pullPolicy: Never
   service:
     port: 8000
@@ -290,7 +290,7 @@ hello-world-agent:
       - translation
   image:
     repository: mcp-mesh-base
-    tag: "0.6.3"
+    tag: "0.6.4"
     pullPolicy: Never
 
 system-agent:
@@ -303,7 +303,7 @@ system-agent:
       - system_info
   image:
     repository: mcp-mesh-base
-    tag: "0.6.3"
+    tag: "0.6.4"
     pullPolicy: Never
 
 weather-agent:
@@ -316,7 +316,7 @@ weather-agent:
       - weather_current
   image:
     repository: mcp-mesh-base
-    tag: "0.6.3"
+    tag: "0.6.4"
     pullPolicy: Never
   env:
     WEATHER_API_KEY: "your-api-key"

--- a/docs/index.md
+++ b/docs/index.md
@@ -162,8 +162,8 @@ class MyAgent:
 === "Docker"
 
     ```bash
-    docker pull mcpmesh/registry:0.6.3
-    docker pull mcpmesh/python-runtime:0.6.3
+    docker pull mcpmesh/registry:0.6.4
+    docker pull mcpmesh/python-runtime:0.6.4
     ```
 
 ---
@@ -179,7 +179,7 @@ class MyAgent:
 
 ## :star: Project Status
 
-- **Latest Release**: v0.6.3 (November 2025)
+- **Latest Release**: v0.6.4 (November 2025)
 - **License**: MIT
 - **Language**: Python 3.11+ (runtime), Go 1.23+ (registry)
 - **Status**: Production-ready, actively developed

--- a/helm/mcp-mesh-agent/Chart.yaml
+++ b/helm/mcp-mesh-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-agent
 description: MCP Mesh Agent - Python runtime for MCP agents with mesh capabilities
 type: application
-version: 0.6.3
-appVersion: "0.6.3"
+version: 0.6.4
+appVersion: "0.6.4"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-core/Chart.yaml
+++ b/helm/mcp-mesh-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-core
 description: MCP Mesh Core Infrastructure - Registry, PostgreSQL, Redis, and Observability
 type: application
-version: 0.6.3
-appVersion: "0.6.3"
+version: 0.6.4
+appVersion: "0.6.4"
 keywords:
   - mcp
   - mesh
@@ -28,22 +28,22 @@ annotations:
   "artifacthub.io/containsSecurityUpdates": "false"
 dependencies:
   - name: mcp-mesh-postgres
-    version: "0.6.3"
+    version: "0.6.4"
     repository: "file://../mcp-mesh-postgres"
     condition: postgres.enabled
   - name: mcp-mesh-redis
-    version: "0.6.3"
+    version: "0.6.4"
     repository: "file://../mcp-mesh-redis"
     condition: redis.enabled
   - name: mcp-mesh-registry
-    version: "0.6.3"
+    version: "0.6.4"
     repository: "file://../mcp-mesh-registry"
     condition: registry.enabled
   - name: mcp-mesh-grafana
-    version: "0.6.3"
+    version: "0.6.4"
     repository: "file://../mcp-mesh-grafana"
     condition: grafana.enabled
   - name: mcp-mesh-tempo
-    version: "0.6.3"
+    version: "0.6.4"
     repository: "file://../mcp-mesh-tempo"
     condition: tempo.enabled

--- a/helm/mcp-mesh-grafana/Chart.yaml
+++ b/helm/mcp-mesh-grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-grafana
 description: Grafana observability component for MCP Mesh
 type: application
-version: 0.6.3
+version: 0.6.4
 appVersion: "11.4.0"
 keywords:
   - grafana

--- a/helm/mcp-mesh-ingress/Chart.yaml
+++ b/helm/mcp-mesh-ingress/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ingress
 description: Ingress configuration for MCP Mesh services with flexible DNS routing
 type: application
-version: 0.6.3
-appVersion: "0.6.3"
+version: 0.6.4
+appVersion: "0.6.4"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-postgres/Chart.yaml
+++ b/helm/mcp-mesh-postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-postgres
 description: PostgreSQL database for MCP Mesh Registry
 type: application
-version: 0.6.3
+version: 0.6.4
 appVersion: "15"
 keywords:
   - mcp

--- a/helm/mcp-mesh-redis/Chart.yaml
+++ b/helm/mcp-mesh-redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-redis
 description: Redis cache for MCP Mesh session storage
 type: application
-version: 0.6.3
+version: 0.6.4
 appVersion: "7"
 keywords:
   - mcp

--- a/helm/mcp-mesh-registry/Chart.yaml
+++ b/helm/mcp-mesh-registry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-registry
 description: MCP Mesh Registry Service - Central service registry for MCP agents
 type: application
-version: 0.6.3
-appVersion: "0.6.3"
+version: 0.6.4
+appVersion: "0.6.4"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-tempo/Chart.yaml
+++ b/helm/mcp-mesh-tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-tempo
 description: Tempo distributed tracing component for MCP Mesh
 type: application
-version: 0.6.3
+version: 0.6.4
 appVersion: "2.8.1"
 keywords:
   - tempo

--- a/packaging/homebrew/mcp-mesh.rb
+++ b/packaging/homebrew/mcp-mesh.rb
@@ -2,7 +2,7 @@
 class McpMesh < Formula
   desc "Kubernetes-native platform for distributed MCP applications"
   homepage "https://github.com/dhyansraj/mcp-mesh"
-  version "0.6.3"  # Will be updated by release automation
+  version "0.6.4"  # Will be updated by release automation
 
   if OS.mac?
     if Hardware::CPU.arm?

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "0.6.3"
+version = "0.6.4"
 description = "Kubernetes-native platform for distributed MCP applications"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packaging/scoop/mcp-mesh.json
+++ b/packaging/scoop/mcp-mesh.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Kubernetes-native platform for distributed MCP applications",
   "homepage": "https://github.com/dhyansraj/mcp-mesh",
   "license": "MIT",

--- a/src/runtime/python/_mcp_mesh/__init__.py
+++ b/src/runtime/python/_mcp_mesh/__init__.py
@@ -31,7 +31,7 @@ from .engine.decorator_registry import (
     get_decorator_stats,
 )
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 
 # Store reference to runtime processor if initialized
 _runtime_processor = None

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "0.6.3"
+version = "0.6.4"
 description = "Kubernetes-native platform for distributed MCP applications"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

Release v0.6.4 to fix missing PyPI dependencies that were causing runtime errors with `@mesh.llm` decorator.

## Changes Since v0.6.3

### Bug Fixes

- **Missing PyPI Dependencies** (#178): Added missing `litellm`, `jinja2`, and `cachetools` dependencies to `packaging/pypi/pyproject.toml`
  - Fixes `jinja2 is required for template rendering` error
  - Fixes `litellm is required for MeshLlmAgent` error

### Version Bump

- Updated version to 0.6.4 across 19 files (Helm charts, Python packages, docs, etc.)

## Test plan

- [ ] Verify PyPI package includes litellm, jinja2, cachetools dependencies
- [ ] Test `@mesh.llm` decorator works in fresh Docker container
- [ ] Verify Maya V2 works with official `mcpmesh/python-runtime:0.6.4` image

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing PyPI package dependencies (litellm, jinja2, cachetools) required for proper template rendering and MeshLlmAgent functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->