### PR TITLE
Add meshctl man command for embedded documentation (#184)

### DIFF
--- a/cmd/meshctl/main.go
+++ b/cmd/meshctl/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"mcp-mesh/src/core/cli"
+	"mcp-mesh/src/core/cli/man"
 	"mcp-mesh/src/core/cli/scaffold"
 )
 
@@ -35,6 +36,7 @@ func main() {
 	rootCmd.AddCommand(cli.NewStatusCommand())
 	rootCmd.AddCommand(cli.NewConfigCommand())
 	rootCmd.AddCommand(cli.NewScaffoldCommand())
+	rootCmd.AddCommand(man.NewManCommand())
 
 	// Execute the root command
 	if err := rootCmd.Execute(); err != nil {

--- a/src/core/cli/man/content.go
+++ b/src/core/cli/man/content.go
@@ -1,0 +1,216 @@
+package man
+
+import (
+	"embed"
+	"fmt"
+	"strings"
+)
+
+//go:embed content/*.md
+var guideContent embed.FS
+
+// Guide represents a documentation guide topic.
+type Guide struct {
+	Name        string
+	Aliases     []string
+	Title       string
+	Description string
+}
+
+// guideRegistry maps guide names to their metadata.
+var guideRegistry = map[string]*Guide{
+	"overview": {
+		Name:        "overview",
+		Aliases:     []string{"architecture", "arch"},
+		Title:       "MCP Mesh Architecture",
+		Description: "Core architecture, agent coordination, and design philosophy",
+	},
+	"capabilities": {
+		Name:        "capabilities",
+		Aliases:     []string{"caps"},
+		Title:       "Capabilities System",
+		Description: "Named services that agents provide",
+	},
+	"tags": {
+		Name:        "tags",
+		Aliases:     []string{"tag-matching"},
+		Title:       "Tag Matching System",
+		Description: "Tag system with +/- operators for smart service selection",
+	},
+	"decorators": {
+		Name:        "decorators",
+		Aliases:     []string{"decorator"},
+		Title:       "MCP Mesh Decorators",
+		Description: "@mesh.tool, @mesh.llm, @mesh.llm_provider, @mesh.agent, @mesh.route",
+	},
+	"dependency-injection": {
+		Name:        "dependency-injection",
+		Aliases:     []string{"di", "injection"},
+		Title:       "Dependency Injection",
+		Description: "How DI works, proxy creation, and automatic wiring",
+	},
+	"health": {
+		Name:        "health",
+		Aliases:     []string{"health-checks", "heartbeat"},
+		Title:       "Health Monitoring & Auto-Rewiring",
+		Description: "Heartbeat system, health checks, and automatic topology updates",
+	},
+	"registry": {
+		Name:        "registry",
+		Aliases:     []string{"reg"},
+		Title:       "Registry Operations",
+		Description: "Registry role, agent registration, and dependency resolution",
+	},
+	"llm": {
+		Name:        "llm",
+		Aliases:     []string{"llm-integration"},
+		Title:       "LLM Integration",
+		Description: "LLM agents, @mesh.llm decorator, and tool filtering",
+	},
+	"proxies": {
+		Name:        "proxies",
+		Aliases:     []string{"proxy", "communication"},
+		Title:       "Proxy System & Communication",
+		Description: "Inter-agent communication, proxy types, and configuration",
+	},
+	"environment": {
+		Name:        "environment",
+		Aliases:     []string{"env", "config"},
+		Title:       "Environment Variables",
+		Description: "Configuration via environment variables",
+	},
+	"deployment": {
+		Name:        "deployment",
+		Aliases:     []string{"deploy"},
+		Title:       "Deployment Patterns",
+		Description: "Local, Docker, and Kubernetes deployment",
+	},
+	"testing": {
+		Name:        "testing",
+		Aliases:     []string{"curl", "mcp-api"},
+		Title:       "Testing MCP Agents",
+		Description: "Testing agents with curl, MCP JSON-RPC syntax",
+	},
+	"fastapi": {
+		Name:        "fastapi",
+		Aliases:     []string{"route", "routes", "backend"},
+		Title:       "FastAPI Integration",
+		Description: "@mesh.route for FastAPI backends consuming mesh capabilities",
+	},
+}
+
+// aliasMap maps aliases to canonical guide names.
+var aliasMap map[string]string
+
+func init() {
+	aliasMap = make(map[string]string)
+	for name, guide := range guideRegistry {
+		aliasMap[name] = name
+		for _, alias := range guide.Aliases {
+			aliasMap[alias] = name
+		}
+	}
+}
+
+// GetGuide retrieves a guide by name or alias.
+func GetGuide(name string) (*Guide, string, error) {
+	name = strings.ToLower(strings.TrimSpace(name))
+
+	canonicalName, ok := aliasMap[name]
+	if !ok {
+		return nil, "", fmt.Errorf("guide '%s' not found", name)
+	}
+
+	guide := guideRegistry[canonicalName]
+
+	// Load content from embedded filesystem
+	content, err := guideContent.ReadFile(fmt.Sprintf("content/%s.md", canonicalName))
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to load guide content: %w", err)
+	}
+
+	return guide, string(content), nil
+}
+
+// ListGuides returns all available guides sorted by name.
+func ListGuides() []*Guide {
+	guides := make([]*Guide, 0, len(guideRegistry))
+	// Return in a consistent order
+	order := []string{
+		"overview", "capabilities", "tags", "decorators",
+		"dependency-injection", "health", "registry", "llm",
+		"proxies", "fastapi", "environment", "deployment", "testing",
+	}
+	for _, name := range order {
+		if guide, ok := guideRegistry[name]; ok {
+			guides = append(guides, guide)
+		}
+	}
+	return guides
+}
+
+// SearchResult represents a search match in guides.
+type SearchResult struct {
+	Guide   *Guide
+	Matches []string // Lines containing the search term
+}
+
+// SearchGuides searches across all guide content for a query string.
+func SearchGuides(query string) ([]*SearchResult, error) {
+	query = strings.ToLower(query)
+	var results []*SearchResult
+
+	for name, guide := range guideRegistry {
+		content, err := guideContent.ReadFile(fmt.Sprintf("content/%s.md", name))
+		if err != nil {
+			continue
+		}
+
+		contentStr := string(content)
+		if strings.Contains(strings.ToLower(contentStr), query) {
+			// Find matching lines
+			var matches []string
+			lines := strings.Split(contentStr, "\n")
+			for _, line := range lines {
+				if strings.Contains(strings.ToLower(line), query) {
+					matches = append(matches, strings.TrimSpace(line))
+					if len(matches) >= 3 { // Limit to 3 matches per guide
+						break
+					}
+				}
+			}
+			results = append(results, &SearchResult{
+				Guide:   guide,
+				Matches: matches,
+			})
+		}
+	}
+
+	return results, nil
+}
+
+// SuggestSimilarTopics returns topic suggestions for a failed lookup.
+func SuggestSimilarTopics(query string) []string {
+	query = strings.ToLower(query)
+	var suggestions []string
+
+	for name, guide := range guideRegistry {
+		// Check if query is a substring of name or aliases
+		if strings.Contains(name, query) {
+			suggestions = append(suggestions, name)
+			continue
+		}
+		for _, alias := range guide.Aliases {
+			if strings.Contains(alias, query) {
+				suggestions = append(suggestions, name)
+				break
+			}
+		}
+		// Check if query matches part of description
+		if strings.Contains(strings.ToLower(guide.Description), query) {
+			suggestions = append(suggestions, name)
+		}
+	}
+
+	return suggestions
+}

--- a/src/core/cli/man/content/decorators.md
+++ b/src/core/cli/man/content/decorators.md
@@ -1,0 +1,168 @@
+# MCP Mesh Decorators
+
+> Core decorators for building distributed agent systems
+
+## Overview
+
+MCP Mesh provides five core decorators that transform regular Python functions and classes into mesh-aware distributed services. These decorators handle registration, dependency injection, and communication automatically.
+
+| Decorator            | Purpose                         |
+| -------------------- | ------------------------------- |
+| `@mesh.agent`        | Configure agent server settings |
+| `@mesh.tool`         | Register capability with DI     |
+| `@mesh.llm`          | Enable LLM-powered tools        |
+| `@mesh.llm_provider` | Create LLM provider (zero-code) |
+| `@mesh.route`        | FastAPI route with mesh DI      |
+
+## Decorator Order (Critical!)
+
+When using multiple decorators, order matters:
+
+```python
+@app.tool()           # 1. FastMCP protocol handler (outermost)
+@mesh.llm(...)        # 2. LLM integration (if using)
+@mesh.tool(...)       # 3. Mesh capability registration (innermost)
+def my_function():
+    pass
+```
+
+## @mesh.agent
+
+Configures the agent server settings. Applied to a class.
+
+```python
+@mesh.agent(
+    name="my-service",           # Required: unique agent identifier
+    version="1.0.0",             # Semantic version
+    description="Service desc",  # Human-readable description
+    http_port=8080,              # HTTP server port (0 = auto-assign)
+    http_host="localhost",       # Host announced to registry
+    namespace="default",         # Namespace for isolation
+    auto_run=True,               # Start automatically (no main() needed)
+    auto_run_interval=30,        # Heartbeat interval in seconds
+    health_check=health_fn,      # Optional health check function
+    health_check_ttl=30,         # Health check cache TTL
+)
+class MyAgent:
+    pass
+```
+
+## @mesh.tool
+
+Registers a function as a mesh capability with dependency injection.
+
+```python
+@app.tool()
+@mesh.tool(
+    capability="greeting",              # Capability name for discovery
+    description="Greets users",         # Human-readable description
+    version="1.0.0",                    # Capability version
+    tags=["greeting", "utility"],       # Tags for filtering
+    dependencies=["date_service"],      # Required capabilities
+)
+async def greet(name: str, date_svc: mesh.McpMeshAgent = None) -> str:
+    if date_svc:
+        today = await date_svc()  # Must use await for proxy calls!
+        return f"Hello {name}! Today is {today}"
+    return f"Hello {name}!"  # Graceful degradation
+```
+
+**Note**: Functions with dependencies must be `async def` and proxy calls require `await`.
+
+### Dependency Injection Types
+
+| Type                | Use Case                               |
+| ------------------- | -------------------------------------- |
+| `mesh.McpMeshAgent` | Tool calls via proxy                   |
+| `mesh.MeshLlmAgent` | LLM agent injection (with `@mesh.llm`) |
+
+## @mesh.llm
+
+Enables LLM-powered tools with automatic tool discovery.
+
+```python
+@app.tool()
+@mesh.llm(
+    provider={"capability": "llm", "tags": ["+claude"]},  # LLM provider selector
+    max_iterations=5,                    # Max agentic loop iterations
+    system_prompt="file://prompts/agent.jinja2",  # Jinja2 template
+    context_param="ctx",                 # Parameter name for context
+    response_format="json",              # "text" or "json"
+    filter=[{"tags": ["tools"]}],        # Tool filter for discovery
+    filter_mode="all",                   # "all", "best_match", or "*"
+)
+@mesh.tool(
+    capability="smart_assistant",
+    description="LLM-powered assistant",
+)
+def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None):
+    return llm("Help the user with their request")
+```
+
+### Filter Modes
+
+| Mode         | Description                              |
+| ------------ | ---------------------------------------- |
+| `all`        | Include all tools matching any filter    |
+| `best_match` | One tool per capability (best tag match) |
+| `*`          | All available tools (wildcard)           |
+
+## @mesh.llm_provider
+
+Creates a zero-code LLM provider wrapping LiteLLM.
+
+```python
+@mesh.llm_provider(
+    model="anthropic/claude-sonnet-4-5",  # LiteLLM model string
+    capability="llm",                      # Capability name
+    tags=["llm", "claude", "provider"],    # Discovery tags
+    version="1.0.0",                       # Provider version
+)
+def claude_provider():
+    pass  # No implementation needed
+```
+
+## @mesh.route
+
+Enables mesh dependency injection in FastAPI route handlers. Use this when building REST APIs that consume mesh capabilities.
+
+```python
+from fastapi import APIRouter, Request
+import mesh
+from mesh.types import McpMeshAgent
+
+router = APIRouter()
+
+@router.post("/chat")
+@mesh.route(dependencies=["avatar_chat"])
+async def chat_endpoint(
+    request: Request,
+    message: str,
+    avatar_agent: McpMeshAgent = None,  # Injected by mesh
+):
+    result = await avatar_agent(message=message, user_email="user@example.com")
+    return {"response": result.get("message")}
+```
+
+**Note**: `@mesh.route` is for FastAPI backends that _consume_ mesh capabilities. Use `@mesh.tool` for MCP agents that _provide_ capabilities.
+
+See `meshctl man fastapi` for complete FastAPI integration guide.
+
+## Environment Variable Overrides
+
+All decorator parameters can be overridden via environment variables:
+
+```bash
+export MCP_MESH_AGENT_NAME=custom-name
+export MCP_MESH_HTTP_PORT=9090
+export MCP_MESH_NAMESPACE=production
+export MCP_MESH_AUTO_RUN=false
+```
+
+## See Also
+
+- `meshctl man dependency-injection` - DI details
+- `meshctl man llm` - LLM integration guide
+- `meshctl man tags` - Tag matching system
+- `meshctl man capabilities` - Capabilities system
+- `meshctl man fastapi` - FastAPI integration with @mesh.route

--- a/src/core/cli/man/content/dependency-injection.md
+++ b/src/core/cli/man/content/dependency-injection.md
@@ -1,0 +1,151 @@
+# Dependency Injection
+
+> Automatic wiring of capabilities between agents
+
+## Overview
+
+MCP Mesh provides automatic dependency injection (DI) that connects agents based on their declared capabilities and dependencies. When a function declares a dependency, the mesh automatically creates a callable proxy that routes to the providing agent.
+
+## How It Works
+
+1. **Declaration**: Function declares dependencies via `@mesh.tool` decorator
+2. **Registration**: Agent registers with registry, advertising capabilities
+3. **Resolution**: Registry matches dependencies to providers
+4. **Injection**: Mesh creates proxy objects for each dependency
+5. **Invocation**: Calling the proxy routes to the remote agent
+
+## Declaring Dependencies
+
+### Simple Dependencies
+
+```python
+@app.tool()
+@mesh.tool(
+    capability="greeting",
+    dependencies=["date_service"],  # Request by capability name
+)
+async def greet(name: str, date_service: mesh.McpMeshAgent = None) -> str:
+    if date_service:
+        today = await date_service()  # Must use await!
+        return f"Hello {name}! Today is {today}"
+    return f"Hello {name}!"
+```
+
+**Important**: Functions with dependencies must be `async def` and calls must use `await`.
+
+### Dependencies with Filters
+
+```python
+@app.tool()
+@mesh.tool(
+    capability="report",
+    dependencies=[
+        {"capability": "data_service", "tags": ["+fast"]},
+        {"capability": "formatter", "tags": ["-deprecated"]},
+    ],
+)
+async def generate_report(
+    data_svc: mesh.McpMeshAgent = None,
+    formatter: mesh.McpMeshAgent = None,
+) -> str:
+    data = await data_svc(query="sales")
+    return await formatter(data=data)
+```
+
+## Injection Types
+
+### mesh.McpMeshAgent
+
+Callable proxy for tool invocations:
+
+```python
+async def my_tool(helper: mesh.McpMeshAgent = None):
+    result = await helper(arg1="value")  # Direct call
+    result = await helper.call_tool("tool_name", {"arg": "value"})  # Named tool
+```
+
+### mesh.MeshLlmAgent
+
+For LLM agent injection in `@mesh.llm` decorated functions:
+
+```python
+@mesh.llm(...)
+def smart_tool(ctx: Context, llm: mesh.MeshLlmAgent = None):
+    response = llm("Process this request")
+```
+
+## Graceful Degradation
+
+Dependencies may be unavailable. Always handle `None`:
+
+```python
+async def my_tool(helper: mesh.McpMeshAgent = None):
+    if helper is None:
+        return "Service temporarily unavailable"
+    return await helper()
+```
+
+Or use default values:
+
+```python
+async def get_time(date_service: mesh.McpMeshAgent = None):
+    if date_service:
+        return await date_service()
+    return datetime.now().isoformat()  # Fallback
+```
+
+## Proxy Configuration
+
+Configure proxy behavior via `dependency_kwargs`:
+
+```python
+@mesh.tool(
+    dependencies=["slow_service"],
+    dependency_kwargs={
+        "slow_service": {
+            "timeout": 60,           # Request timeout (seconds)
+            "retry_count": 3,        # Retry attempts
+            "streaming": True,       # Enable streaming
+            "session_required": True, # Require session affinity
+        }
+    },
+)
+async def my_tool(slow_service: mesh.McpMeshAgent = None):
+    result = await slow_service(data="large_payload")
+    ...
+```
+
+## Proxy Types (Auto-Selected)
+
+The mesh automatically selects the appropriate proxy:
+
+| Proxy Type               | Use Case                 |
+| ------------------------ | ------------------------ |
+| `SelfDependencyProxy`    | Same agent (direct call) |
+| `MCPClientProxy`         | Simple tool calls        |
+| `EnhancedMCPClientProxy` | Timeout/retry config     |
+| `EnhancedFullMCPProxy`   | Streaming/sessions       |
+
+## Function vs Capability Names
+
+- **Capability name**: Used for dependency resolution (`date_service`)
+- **Function name**: Used in MCP tool calls (`get_current_time`)
+
+The mesh maps capabilities to their implementing functions automatically.
+
+## Auto-Rewiring
+
+When topology changes (agents join/leave), the mesh:
+
+1. Detects change via heartbeat response
+2. Refreshes dependency proxies
+3. Routes to new providers automatically
+
+No code changes needed - happens transparently.
+
+## See Also
+
+- `meshctl man capabilities` - Declaring capabilities
+- `meshctl man tags` - Tag-based selection
+- `meshctl man health` - Health monitoring
+- `meshctl man proxies` - Proxy details

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -1,0 +1,282 @@
+# Deployment Patterns
+
+> Local, Docker, and Kubernetes deployment options
+
+## Overview
+
+MCP Mesh supports multiple deployment patterns from local development to production Kubernetes clusters. This guide covers common deployment scenarios.
+
+## Local Development
+
+### Quick Start
+
+```bash
+# Terminal 1: Start registry
+meshctl start --registry-only --debug
+
+# Terminal 2: Start agent
+meshctl start my_agent.py --debug --auto-restart
+
+# Terminal 3: Monitor
+watch 'meshctl list'
+```
+
+### Multiple Agents
+
+```bash
+# Start multiple agents
+meshctl start agent1.py agent2.py agent3.py
+
+# Or with specific ports
+MCP_MESH_HTTP_PORT=8081 python agent1.py &
+MCP_MESH_HTTP_PORT=8082 python agent2.py &
+MCP_MESH_HTTP_PORT=8083 python agent3.py &
+```
+
+### Hot Reload
+
+```bash
+# Auto-restart on file changes
+meshctl start my_agent.py --auto-restart --watch-pattern "*.py,*.json"
+```
+
+## Docker Deployment
+
+### Single Agent Dockerfile
+
+```dockerfile
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . .
+
+ENV HOST=0.0.0.0
+ENV MCP_MESH_HTTP_HOST=my-agent
+ENV MCP_MESH_REGISTRY_URL=http://registry:8000
+
+CMD ["python", "main.py"]
+```
+
+### Docker Compose
+
+```yaml
+version: "3.8"
+
+services:
+  registry:
+    image: ghcr.io/dhyansraj/mcp-mesh-registry:latest
+    ports:
+      - "8000:8000"
+    environment:
+      - HOST=0.0.0.0
+      - PORT=8000
+      - MCP_MESH_LOG_LEVEL=INFO
+
+  system-agent:
+    build: ./agents/system
+    environment:
+      - HOST=0.0.0.0
+      - MCP_MESH_HTTP_HOST=system-agent
+      - MCP_MESH_REGISTRY_URL=http://registry:8000
+    depends_on:
+      - registry
+
+  hello-agent:
+    build: ./agents/hello
+    environment:
+      - HOST=0.0.0.0
+      - MCP_MESH_HTTP_HOST=hello-agent
+      - MCP_MESH_REGISTRY_URL=http://registry:8000
+    depends_on:
+      - registry
+      - system-agent
+```
+
+### Running
+
+```bash
+docker-compose up -d
+docker-compose logs -f
+docker-compose ps
+```
+
+## Kubernetes Deployment
+
+### Registry Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-mesh-registry
+  namespace: mcp-mesh
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-mesh-registry
+  template:
+    metadata:
+      labels:
+        app: mcp-mesh-registry
+    spec:
+      containers:
+        - name: registry
+          image: ghcr.io/dhyansraj/mcp-mesh-registry:latest
+          ports:
+            - containerPort: 8000
+          env:
+            - name: HOST
+              value: "0.0.0.0"
+            - name: PORT
+              value: "8000"
+            - name: MCP_MESH_LOG_LEVEL
+              value: "INFO"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-mesh-registry
+  namespace: mcp-mesh
+spec:
+  selector:
+    app: mcp-mesh-registry
+  ports:
+    - port: 8000
+      targetPort: 8000
+```
+
+### Agent Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-agent
+  namespace: mcp-mesh
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: my-agent
+  template:
+    metadata:
+      labels:
+        app: my-agent
+    spec:
+      containers:
+        - name: agent
+          image: my-registry/my-agent:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: HOST
+              value: "0.0.0.0"
+            - name: MCP_MESH_HTTP_PORT
+              value: "8080"
+            - name: MCP_MESH_HTTP_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MCP_MESH_REGISTRY_URL
+              value: "http://mcp-mesh-registry:8000"
+            - name: MCP_MESH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+```
+
+### Service Discovery
+
+In Kubernetes, agents can discover each other via:
+
+1. **Registry**: Standard MCP Mesh discovery
+2. **K8s DNS**: `service-name.namespace.svc.cluster.local`
+3. **Environment**: Injected service endpoints
+
+## Helm Deployment
+
+```bash
+# Add MCP Mesh Helm repo
+helm repo add mcp-mesh https://dhyansraj.github.io/mcp-mesh/charts
+
+# Install registry
+helm install registry mcp-mesh/registry -n mcp-mesh
+
+# Install agent
+helm install my-agent mcp-mesh/agent \
+  --set image.repository=my-registry/my-agent \
+  --set image.tag=latest \
+  --set registryUrl=http://registry:8000
+```
+
+## Best Practices
+
+### Health Checks
+
+Always configure health checks:
+
+```python
+async def health_check() -> dict:
+    return {
+        "status": "healthy",
+        "checks": {"database": True},
+        "errors": [],
+    }
+
+@mesh.agent(
+    name="my-service",
+    health_check=health_check,
+    health_check_ttl=30,
+)
+class MyAgent:
+    pass
+```
+
+### Resource Limits
+
+```yaml
+resources:
+  requests:
+    memory: "128Mi"
+    cpu: "100m"
+  limits:
+    memory: "512Mi"
+    cpu: "500m"
+```
+
+### Graceful Shutdown
+
+```bash
+# Configure shutdown timeout
+meshctl start my_agent.py --shutdown-timeout 60
+```
+
+### Logging
+
+```bash
+# Structured logging for production
+export MCP_MESH_LOG_LEVEL=INFO
+export MCP_MESH_DEBUG_MODE=false
+```
+
+## See Also
+
+- `meshctl man environment` - Configuration options
+- `meshctl man health` - Health monitoring
+- `meshctl man registry` - Registry setup

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -1,0 +1,271 @@
+# Environment Variables
+
+> Configure MCP Mesh via environment variables
+
+## Overview
+
+MCP Mesh can be configured using environment variables. They override `@mesh.agent` decorator parameters and provide flexibility for different deployment environments.
+
+## Configuration Hierarchy
+
+Environment variables are applied in this order (last wins):
+
+1. System environment variables
+2. Environment files (`.env`)
+3. meshctl `--env` flags
+4. `@mesh.agent` decorator parameters
+
+## Agent Configuration
+
+### Core Settings
+
+```bash
+# Agent identity
+export MCP_MESH_AGENT_NAME=my-service
+export MCP_MESH_NAMESPACE=production
+
+# HTTP server
+export HOST=0.0.0.0              # Bind address
+export MCP_MESH_HTTP_PORT=8080   # Server port
+export MCP_MESH_HTTP_HOST=my-service  # Announced hostname
+
+# Auto-run behavior
+export MCP_MESH_AUTO_RUN=true
+export MCP_MESH_AUTO_RUN_INTERVAL=30  # Heartbeat interval (seconds)
+
+# Health monitoring
+export MCP_MESH_HEALTH_INTERVAL=30
+
+# Global toggle
+export MCP_MESH_ENABLED=true
+```
+
+### Registry Connection
+
+```bash
+# Full URL
+export MCP_MESH_REGISTRY_URL=http://localhost:8000
+
+# Or separate host/port
+export MCP_MESH_REGISTRY_HOST=localhost
+export MCP_MESH_REGISTRY_PORT=8000
+```
+
+### Logging
+
+```bash
+# Log levels: DEBUG, INFO, WARNING, ERROR, CRITICAL
+export MCP_MESH_LOG_LEVEL=INFO
+
+# Debug mode (forces DEBUG level)
+export MCP_MESH_DEBUG_MODE=true
+```
+
+### Advanced Settings
+
+```bash
+# HTTP server toggle
+export MCP_MESH_HTTP_ENABLED=true
+
+# External endpoint (for proxies/load balancers)
+export MCP_MESH_HTTP_ENDPOINT=https://api.example.com:443
+
+# Authentication token for secure communication
+export MCP_MESH_AUTH_TOKEN=secret-token
+
+# Startup debounce delay (seconds)
+export MCP_MESH_DEBOUNCE_DELAY=1.0
+```
+
+## LLM Provider Configuration
+
+Required for `@mesh.llm_provider` agents:
+
+```bash
+# Anthropic Claude
+export ANTHROPIC_API_KEY=sk-ant-your-key-here
+
+# OpenAI
+export OPENAI_API_KEY=sk-your-key-here
+```
+
+## Observability
+
+```bash
+# Telemetry
+export MCP_MESH_TELEMETRY_ENABLED=true
+
+# Distributed tracing
+export MCP_MESH_DISTRIBUTED_TRACING_ENABLED=false
+
+# Redis trace publishing
+export MCP_MESH_REDIS_TRACE_PUBLISHING=true
+export REDIS_URL=redis://localhost:6379
+```
+
+## Registry Configuration
+
+```bash
+# Server binding
+export HOST=0.0.0.0
+export PORT=8000
+
+# Database
+export DATABASE_URL=mcp_mesh_registry.db  # SQLite
+export DATABASE_URL=postgresql://user:pass@host:5432/db  # PostgreSQL
+
+# Health monitoring
+export DEFAULT_TIMEOUT_THRESHOLD=20   # Mark unhealthy (seconds)
+export HEALTH_CHECK_INTERVAL=10       # Scan frequency (seconds)
+export DEFAULT_EVICTION_THRESHOLD=60  # Evict stale agents (seconds)
+
+# Caching
+export CACHE_TTL=30
+export ENABLE_RESPONSE_CACHE=true
+
+# CORS
+export ENABLE_CORS=true
+export ALLOWED_ORIGINS="*"
+
+# Features
+export ENABLE_METRICS=true
+export ENABLE_PROMETHEUS=true
+```
+
+## Environment Profiles
+
+### Development
+
+```bash
+# .env.development
+MCP_MESH_LOG_LEVEL=DEBUG
+MCP_MESH_DEBUG_MODE=true
+MCP_MESH_REGISTRY_URL=http://localhost:8000
+MCP_MESH_NAMESPACE=development
+MCP_MESH_AUTO_RUN_INTERVAL=10
+MCP_MESH_HEALTH_INTERVAL=15
+HOST=0.0.0.0
+```
+
+### Production
+
+```bash
+# .env.production
+MCP_MESH_LOG_LEVEL=INFO
+MCP_MESH_DEBUG_MODE=false
+MCP_MESH_REGISTRY_URL=https://registry.company.com
+MCP_MESH_NAMESPACE=production
+MCP_MESH_AUTO_RUN_INTERVAL=30
+MCP_MESH_HEALTH_INTERVAL=30
+HOST=0.0.0.0
+```
+
+### Testing
+
+```bash
+# .env.testing
+MCP_MESH_LOG_LEVEL=WARNING
+MCP_MESH_AUTO_RUN=false
+MCP_MESH_REGISTRY_URL=http://test-registry:8000
+MCP_MESH_NAMESPACE=testing
+```
+
+## Using Environment Files
+
+### With meshctl
+
+```bash
+meshctl start my_agent.py --env-file .env.development
+
+# Individual variables
+meshctl start my_agent.py --env MCP_MESH_LOG_LEVEL=DEBUG
+```
+
+### With Python
+
+```bash
+source .env.development
+python my_agent.py
+
+# Or use python-dotenv
+pip install python-dotenv
+```
+
+```python
+from dotenv import load_dotenv
+load_dotenv('.env.development')
+```
+
+## Docker Configuration
+
+```yaml
+# docker-compose.yml
+services:
+  my-agent:
+    environment:
+      - HOST=0.0.0.0
+      - MCP_MESH_HTTP_HOST=my-agent
+      - MCP_MESH_HTTP_PORT=8080
+      - MCP_MESH_REGISTRY_URL=http://registry:8000
+      - MCP_MESH_LOG_LEVEL=INFO
+      - MCP_MESH_NAMESPACE=docker
+```
+
+## Kubernetes Configuration
+
+```yaml
+# deployment.yaml
+env:
+  - name: MCP_MESH_REGISTRY_URL
+    value: "http://registry.mcp-mesh:8000"
+  - name: MCP_MESH_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  - name: MCP_MESH_AGENT_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+```
+
+## Debugging
+
+```bash
+# Show all MCP Mesh environment variables
+env | grep MCP_MESH
+
+# Test specific variable
+echo $MCP_MESH_LOG_LEVEL
+
+# Verify with meshctl
+meshctl start my_agent.py --env-file .env.dev --debug
+```
+
+## Common Issues
+
+### Port Already in Use
+
+```bash
+lsof -i :8080
+export MCP_MESH_HTTP_PORT=8081
+```
+
+### Registry Connection Failed
+
+```bash
+curl -s http://localhost:8000/health
+export MCP_MESH_REGISTRY_URL=http://backup-registry:8000
+```
+
+### Agent Name Conflicts
+
+```bash
+export MCP_MESH_AGENT_NAME=my-unique-agent-$(date +%s)
+meshctl list
+```
+
+## See Also
+
+- `meshctl man deployment` - Deployment patterns
+- `meshctl man registry` - Registry configuration
+- `meshctl man health` - Health monitoring settings

--- a/src/core/cli/man/content/fastapi.md
+++ b/src/core/cli/man/content/fastapi.md
@@ -1,0 +1,178 @@
+# FastAPI Integration
+
+> Use mesh dependency injection in FastAPI backends with @mesh.route
+
+## Overview
+
+MCP Mesh provides `@mesh.route` decorator for FastAPI applications that need to consume mesh capabilities without being MCP agents themselves. This enables traditional REST APIs to leverage the mesh service layer.
+
+## Two Architectures
+
+| Pattern         | Decorator                    | Use Case                              |
+| --------------- | ---------------------------- | ------------------------------------- |
+| MCP Agent       | `@mesh.tool` + `@mesh.agent` | Service that _provides_ capabilities  |
+| FastAPI Backend | `@mesh.route`                | REST API that _consumes_ capabilities |
+
+```
+[Frontend] → [FastAPI Backend] → [MCP Mesh] → [Agents]
+                   ↑
+            @mesh.route
+```
+
+## @mesh.route Decorator
+
+```python
+from fastapi import APIRouter, Request
+import mesh
+from mesh.types import McpMeshAgent
+
+router = APIRouter()
+
+@router.post("/chat")
+@mesh.route(dependencies=["avatar_chat"])
+async def chat(
+    request: Request,
+    message: str,
+    avatar_agent: McpMeshAgent = None,  # Injected by mesh
+):
+    result = await avatar_agent(
+        message=message,
+        user_email="user@example.com",
+    )
+    return {"response": result.get("message")}
+```
+
+## Dependency Declaration
+
+### Simple (by capability name)
+
+```python
+@mesh.route(dependencies=["user_service", "notification_service"])
+async def handler(
+    user_svc: McpMeshAgent = None,
+    notif_svc: McpMeshAgent = None,
+):
+    ...
+```
+
+### With Tag Filtering
+
+```python
+@mesh.route(dependencies=[
+    {"capability": "llm", "tags": ["+claude"]},
+    {"capability": "storage", "tags": ["-deprecated"]},
+])
+async def handler(
+    llm_agent: McpMeshAgent = None,
+    storage_agent: McpMeshAgent = None,
+):
+    ...
+```
+
+## Complete Example
+
+```python
+from fastapi import FastAPI, APIRouter, Request, HTTPException
+import mesh
+from mesh.types import McpMeshAgent
+from pydantic import BaseModel
+
+app = FastAPI(title="My Backend")
+router = APIRouter(prefix="/api", tags=["api"])
+
+class ChatRequest(BaseModel):
+    message: str
+    avatar_id: str = "default"
+
+class ChatResponse(BaseModel):
+    response: str
+    avatar_id: str
+
+@router.post("/chat", response_model=ChatResponse)
+@mesh.route(dependencies=["avatar_chat"])
+async def chat_endpoint(
+    request: Request,
+    chat_req: ChatRequest,
+    avatar_agent: McpMeshAgent = None,
+):
+    """Chat endpoint that delegates to mesh avatar agent."""
+    if avatar_agent is None:
+        raise HTTPException(503, "Avatar service unavailable")
+
+    result = await avatar_agent(
+        message=chat_req.message,
+        avatar_id=chat_req.avatar_id,
+        user_email="user@example.com",
+    )
+
+    return ChatResponse(
+        response=result.get("message", ""),
+        avatar_id=chat_req.avatar_id,
+    )
+
+@router.get("/history")
+@mesh.route(dependencies=["conversation_history_get"])
+async def get_history(
+    request: Request,
+    avatar_id: str = "default",
+    limit: int = 50,
+    history_agent: McpMeshAgent = None,
+):
+    """Get conversation history from mesh agent."""
+    result = await history_agent(
+        avatar_id=avatar_id,
+        limit=limit,
+    )
+    return {"messages": result.get("messages", [])}
+
+app.include_router(router)
+```
+
+## Running the Backend
+
+```bash
+# Set registry URL
+export MCP_MESH_REGISTRY_URL=http://localhost:8000
+
+# Run with uvicorn
+uvicorn main:app --host 0.0.0.0 --port 8080
+```
+
+The backend will:
+
+1. Connect to the mesh registry on startup
+2. Resolve dependencies declared in `@mesh.route`
+3. Inject `McpMeshAgent` proxies into route handlers
+4. Re-resolve on topology changes (auto-rewiring)
+
+## Key Differences from @mesh.tool
+
+| Aspect                | @mesh.tool   | @mesh.route                     |
+| --------------------- | ------------ | ------------------------------- |
+| Registers with mesh   | Yes          | No                              |
+| Provides capabilities | Yes          | No                              |
+| Consumes capabilities | Yes          | Yes                             |
+| Has heartbeat         | Yes          | Yes (for dependency resolution) |
+| Protocol              | MCP JSON-RPC | REST/HTTP                       |
+| Use case              | Microservice | API Gateway/Backend             |
+
+## When to Use @mesh.route
+
+- Building a REST API that fronts mesh services
+- API gateway pattern
+- Backend-for-Frontend (BFF) services
+- Adding REST endpoints to existing FastAPI apps
+- When you need traditional HTTP semantics (REST, OpenAPI docs)
+
+## When to Use @mesh.tool Instead
+
+- Building reusable mesh capabilities
+- Service-to-service communication
+- LLM tool providers
+- When other agents need to discover and call your service
+
+## See Also
+
+- `meshctl man decorators` - All mesh decorators
+- `meshctl man dependency-injection` - How DI works
+- `meshctl man proxies` - Proxy configuration

--- a/src/core/cli/man/content/health.md
+++ b/src/core/cli/man/content/health.md
@@ -1,0 +1,170 @@
+# Health Monitoring & Auto-Rewiring
+
+> Fast heartbeat system and automatic topology updates
+
+## Overview
+
+MCP Mesh uses a dual-heartbeat system for fast failure detection and automatic topology updates. Agents maintain connectivity with the registry, and the mesh automatically rewires dependencies when agents join or leave.
+
+## Heartbeat System
+
+### Dual-Heartbeat Design
+
+| Type | Frequency  | Size  | Purpose                  |
+| ---- | ---------- | ----- | ------------------------ |
+| HEAD | ~5 seconds | ~200B | Lightweight keep-alive   |
+| POST | On change  | ~2KB  | Full registration update |
+
+### How It Works
+
+1. Agent sends HEAD request every 5 seconds
+2. Registry responds with status:
+   - `200 OK`: No changes
+   - `202 Accepted`: Topology changed, refresh needed
+   - `410 Gone`: Agent unknown, re-register
+3. On `202`, agent sends POST with full registration
+4. Registry returns updated dependency topology
+
+### Failure Detection
+
+- Registry marks agents unhealthy after missed heartbeats
+- Default threshold: 20 seconds (4 missed 5-second heartbeats)
+- Configurable via environment variables
+
+## Registry Health Monitor
+
+Background process that:
+
+- Scans for agents past timeout threshold
+- Marks unhealthy agents in database
+- Generates audit events for topology changes
+- Triggers `202` responses to notify other agents
+
+## Configuration
+
+### Agent Settings
+
+```bash
+# Heartbeat interval (seconds)
+export MCP_MESH_AUTO_RUN_INTERVAL=30
+
+# Health check interval (seconds)
+export MCP_MESH_HEALTH_INTERVAL=30
+```
+
+### Registry Settings
+
+```bash
+# When to mark agents unhealthy (seconds)
+export DEFAULT_TIMEOUT_THRESHOLD=20
+
+# How often to scan for unhealthy agents (seconds)
+export HEALTH_CHECK_INTERVAL=10
+
+# When to evict stale agents (seconds)
+export DEFAULT_EVICTION_THRESHOLD=60
+```
+
+### Performance Profiles
+
+**Development (fast feedback)**:
+
+```bash
+DEFAULT_TIMEOUT_THRESHOLD=10
+HEALTH_CHECK_INTERVAL=5
+```
+
+**Production (balanced)**:
+
+```bash
+DEFAULT_TIMEOUT_THRESHOLD=20
+HEALTH_CHECK_INTERVAL=10
+```
+
+**High-Performance (sub-5s detection)**:
+
+```bash
+DEFAULT_TIMEOUT_THRESHOLD=5
+HEALTH_CHECK_INTERVAL=2
+```
+
+## Auto-Rewiring
+
+When topology changes, the mesh automatically:
+
+1. **Detects change**: Via heartbeat response (`202`)
+2. **Fetches new topology**: Registry returns updated dependencies
+3. **Compares hashes**: Prevents unnecessary updates
+4. **Refreshes proxies**: Creates new proxy objects
+5. **Routes traffic**: New calls go to updated providers
+
+### Code Impact
+
+None! Auto-rewiring is transparent:
+
+```python
+@mesh.tool(dependencies=["date_service"])
+def my_tool(date_svc: mesh.McpMeshAgent = None):
+    # If date_service agent restarts or is replaced,
+    # the proxy automatically points to new instance
+    return date_svc()
+```
+
+## Custom Health Checks
+
+Add custom health checks to your agent:
+
+```python
+async def my_health_check() -> dict:
+    # Check your dependencies
+    db_ok = await check_database()
+    api_ok = await check_external_api()
+
+    return {
+        "status": "healthy" if (db_ok and api_ok) else "unhealthy",
+        "checks": {
+            "database": db_ok,
+            "external_api": api_ok,
+        },
+        "errors": [] if (db_ok and api_ok) else ["Some checks failed"],
+    }
+
+@mesh.agent(
+    name="my-service",
+    health_check=my_health_check,
+    health_check_ttl=30,  # Cache health for 30 seconds
+)
+class MyAgent:
+    pass
+```
+
+## Graceful Failure
+
+The mesh handles failures gracefully:
+
+- **Registry down**: Existing agent-to-agent communication continues
+- **Agent down**: Dependencies return `None`, code handles gracefully
+- **Network partition**: Agents continue with cached topology
+- **Recovery**: Automatic reconnection and topology refresh
+
+## Monitoring
+
+```bash
+# Check overall mesh health
+meshctl status
+
+# Verbose status with heartbeat info
+meshctl status --verbose
+
+# List agents with health status
+meshctl list
+
+# JSON output for automation
+meshctl status --json
+```
+
+## See Also
+
+- `meshctl man registry` - Registry operations
+- `meshctl man dependency-injection` - How DI handles failures
+- `meshctl man environment` - Configuration options

--- a/src/core/cli/man/content/overview.md
+++ b/src/core/cli/man/content/overview.md
@@ -1,0 +1,82 @@
+# MCP Mesh Architecture
+
+> Enterprise-grade distributed service mesh for MCP agents with zero-boilerplate dependency injection
+
+## Overview
+
+MCP Mesh is a distributed service mesh that enables MCP (Model Context Protocol) agents to discover each other, share capabilities, and collaborate through automatic dependency injection. The system follows a "background coordination" philosophy where agents operate autonomously while the registry facilitates discovery.
+
+## Core Philosophy
+
+- **Agents are autonomous**: Each agent runs independently and communicates directly with other agents
+- **Registry is a facilitator**: The registry helps agents find each other but doesn't proxy communication
+- **Graceful degradation**: If a dependency is unavailable, agents continue operating with reduced functionality
+- **Zero boilerplate**: Decorators handle all the complex wiring automatically
+
+## Key Components
+
+### 1. Registry
+
+The central coordination service that:
+
+- Accepts agent registrations via heartbeat
+- Stores capability metadata in database (SQLite or PostgreSQL)
+- Resolves dependencies when agents request them
+- Monitors agent health and marks unhealthy agents
+- Never calls agents directly - agents always initiate communication
+
+### 2. Agents
+
+Python services decorated with `@mesh.agent` that:
+
+- Register capabilities with the registry on startup
+- Send periodic heartbeats to maintain registration
+- Receive dependency topology from registry
+- Communicate directly with other agents via FastMCP
+
+### 3. Capabilities
+
+Named services that agents provide:
+
+- Identified by capability name (e.g., "date_service", "weather_data")
+- Can have multiple implementations with different tags
+- Resolved by registry based on name, tags, and version constraints
+
+### 4. Dependencies
+
+Capabilities that an agent needs from other agents:
+
+- Declared in `@mesh.tool` decorator via `dependencies` parameter
+- Automatically injected as callable proxies at runtime
+- Gracefully handle unavailability (injected as `None`)
+
+## Communication Flow
+
+```
+┌─────────┐     Heartbeat/Register     ┌──────────┐
+│  Agent  │ ─────────────────────────► │ Registry │
+│    A    │ ◄───────────────────────── │          │
+└─────────┘   Topology (dependencies)  └──────────┘
+     │
+     │ Direct MCP Call (tool invocation)
+     ▼
+┌─────────┐
+│  Agent  │
+│    B    │
+└─────────┘
+```
+
+## Heartbeat System
+
+MCP Mesh uses a dual-heartbeat system for fast topology detection:
+
+- **HEAD requests** every ~5 seconds (lightweight, ~200 bytes)
+- **POST requests** when topology changes (full registration, ~2KB)
+- Registry detects failures in sub-20 seconds (4 missed heartbeats)
+
+## See Also
+
+- `meshctl man capabilities` - Capabilities system details
+- `meshctl man dependency-injection` - How DI works
+- `meshctl man health` - Health monitoring and auto-rewiring
+- `meshctl man registry` - Registry operations

--- a/src/core/cli/man/content/proxies.md
+++ b/src/core/cli/man/content/proxies.md
@@ -1,0 +1,171 @@
+# Proxy System & Communication
+
+> Inter-agent communication and proxy configuration
+
+## Overview
+
+MCP Mesh uses proxy objects to enable seamless communication between agents. When you call an injected dependency, you're actually calling a proxy that routes to the remote agent via MCP JSON-RPC.
+
+## How Proxies Work
+
+```
+┌─────────────┐     Proxy Call      ┌─────────────┐
+│   Agent A   │ ────────────────►   │   Agent B   │
+│             │   MCP JSON-RPC      │             │
+│  date_svc() │ ◄────────────────   │ get_time()  │
+└─────────────┘     Response        └─────────────┘
+```
+
+1. Agent A calls `date_svc()` (the proxy)
+2. Proxy serializes call to MCP JSON-RPC
+3. HTTP POST to Agent B's `/mcp` endpoint
+4. Agent B executes `get_time()` function
+5. Response returned to Agent A
+
+## Proxy Types
+
+MCP Mesh automatically selects the appropriate proxy:
+
+| Proxy                    | Use Case     | Features             |
+| ------------------------ | ------------ | -------------------- |
+| `SelfDependencyProxy`    | Same agent   | Direct function call |
+| `MCPClientProxy`         | Simple tools | Basic MCP calls      |
+| `EnhancedMCPClientProxy` | Configured   | Timeout, retry       |
+| `EnhancedFullMCPProxy`   | Advanced     | Streaming, sessions  |
+
+## Using Proxies
+
+**Important**: All proxy calls are async and require `await`.
+
+### Simple Call
+
+```python
+async def my_tool(helper: mesh.McpMeshAgent = None):
+    if helper:
+        result = await helper()  # Call default tool
+```
+
+### Named Tool Call
+
+```python
+async def my_tool(helper: mesh.McpMeshAgent = None):
+    if helper:
+        result = await helper.call_tool("specific_tool", {"arg": "value"})
+```
+
+### With Arguments
+
+```python
+async def my_tool(helper: mesh.McpMeshAgent = None):
+    if helper:
+        result = await helper(city="London", units="metric")
+```
+
+## Proxy Configuration
+
+Configure via `dependency_kwargs` in the decorator:
+
+```python
+@mesh.tool(
+    dependencies=["slow_service"],
+    dependency_kwargs={
+        "slow_service": {
+            "timeout": 60,              # Request timeout (seconds)
+            "retry_count": 3,           # Retry attempts on failure
+            "custom_headers": {         # Custom HTTP headers
+                "X-Request-ID": "...",
+            },
+            "streaming": True,          # Enable streaming responses
+            "session_required": True,   # Require session affinity
+            "auth_required": True,      # Require authentication
+            "stateful": True,           # Mark as stateful
+            "auto_session_management": True,  # Auto session lifecycle
+        }
+    },
+)
+async def my_tool(slow_service: mesh.McpMeshAgent = None):
+    result = await slow_service(data="payload")
+    ...
+```
+
+## Configuration Options
+
+| Option                    | Type | Default | Description                 |
+| ------------------------- | ---- | ------- | --------------------------- |
+| `timeout`                 | int  | 30      | Request timeout in seconds  |
+| `retry_count`             | int  | 0       | Number of retry attempts    |
+| `streaming`               | bool | False   | Enable streaming responses  |
+| `session_required`        | bool | False   | Require session affinity    |
+| `auth_required`           | bool | False   | Require authentication      |
+| `stateful`                | bool | False   | Mark capability as stateful |
+| `auto_session_management` | bool | False   | Auto manage sessions        |
+| `custom_headers`          | dict | {}      | Additional HTTP headers     |
+
+## Streaming
+
+Enable streaming for real-time data:
+
+```python
+@mesh.tool(
+    dependencies=["stream_service"],
+    dependency_kwargs={
+        "stream_service": {"streaming": True}
+    },
+)
+async def process_stream(stream_svc: mesh.McpMeshAgent = None):
+    async for chunk in stream_svc.stream("data"):
+        process(chunk)
+```
+
+## Session Affinity
+
+For stateful services, ensure requests go to the same instance:
+
+```python
+@mesh.tool(
+    dependencies=["stateful_service"],
+    dependency_kwargs={
+        "stateful_service": {
+            "session_required": True,
+            "auto_session_management": True,
+        }
+    },
+)
+async def stateful_operation(svc: mesh.McpMeshAgent = None):
+    # All calls routed to same instance
+    await svc.initialize()
+    result = await svc.process()
+    await svc.cleanup()
+```
+
+## Error Handling
+
+Proxies handle errors gracefully:
+
+```python
+async def my_tool(helper: mesh.McpMeshAgent = None):
+    if helper is None:
+        return "Service unavailable"
+
+    try:
+        return await helper()
+    except TimeoutError:
+        return "Service timed out"
+    except ConnectionError:
+        return "Cannot reach service"
+```
+
+## Direct Communication
+
+Agents communicate directly - no proxy server:
+
+- Registry provides endpoint information
+- Agents call each other via HTTP
+- Minimal latency (no intermediary)
+- Continues working if registry is down
+
+## See Also
+
+- `meshctl man dependency-injection` - DI overview
+- `meshctl man health` - Auto-rewiring on failure
+- `meshctl man testing` - Testing agent communication

--- a/src/core/cli/man/content/registry.md
+++ b/src/core/cli/man/content/registry.md
@@ -1,0 +1,169 @@
+# Registry Operations
+
+> Central coordination service for agent discovery and dependency resolution
+
+## Overview
+
+The registry is the central coordination service in MCP Mesh. It facilitates agent discovery and dependency resolution but never proxies communication - agents communicate directly with each other.
+
+## Registry Role
+
+The registry is a **facilitator, not a controller**:
+
+- Accepts agent registrations via heartbeat
+- Stores capability metadata in database
+- Resolves dependencies on request
+- Monitors health and marks unhealthy agents
+- Never calls agents - agents always initiate
+
+## Starting the Registry
+
+### With meshctl (Recommended)
+
+```bash
+# Start registry only
+meshctl start --registry-only
+
+# Start registry on custom port
+meshctl start --registry-only --registry-port 9000
+
+# Start registry with debug logging
+meshctl start --registry-only --debug
+```
+
+### With Go Binary
+
+```bash
+# Download registry binary
+curl -sSL https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh | bash -s -- --registry-only
+
+# Start registry
+mcp-mesh-registry --host 0.0.0.0 --port 8000
+```
+
+## Configuration
+
+### Environment Variables
+
+```bash
+# Server binding
+export HOST=0.0.0.0
+export PORT=8000
+
+# Database
+export DATABASE_URL=mcp_mesh_registry.db  # SQLite
+export DATABASE_URL=postgresql://user:pass@host:5432/db  # PostgreSQL
+
+# Health monitoring
+export DEFAULT_TIMEOUT_THRESHOLD=20  # Mark unhealthy after (seconds)
+export HEALTH_CHECK_INTERVAL=10      # Scan frequency (seconds)
+export DEFAULT_EVICTION_THRESHOLD=60 # Remove stale agents (seconds)
+
+# Caching
+export CACHE_TTL=30
+export ENABLE_RESPONSE_CACHE=true
+
+# Logging
+export MCP_MESH_LOG_LEVEL=INFO
+export MCP_MESH_DEBUG_MODE=false
+```
+
+## API Endpoints
+
+| Endpoint        | Method    | Description            |
+| --------------- | --------- | ---------------------- |
+| `/health`       | GET       | Registry health check  |
+| `/agents`       | GET       | List registered agents |
+| `/agents/{id}`  | GET       | Get agent details      |
+| `/capabilities` | GET       | List all capabilities  |
+| `/register`     | POST      | Register/update agent  |
+| `/heartbeat`    | HEAD/POST | Agent heartbeat        |
+
+## Dependency Resolution
+
+When an agent requests dependencies, the registry:
+
+1. **Finds providers**: Agents with matching capability
+2. **Applies filters**: Tag and version constraints
+3. **Scores matches**: Preferred tags add points
+4. **Returns topology**: Selected providers for each dependency
+
+### Resolution Request
+
+```json
+{
+  "agent_id": "hello-world",
+  "dependencies": [
+    { "capability": "date_service" },
+    { "capability": "weather", "tags": ["+fast"] }
+  ]
+}
+```
+
+### Resolution Response
+
+```json
+{
+  "dependencies": {
+    "date_service": {
+      "agent_id": "system-agent",
+      "endpoint": "http://localhost:8081",
+      "capability": "date_service"
+    },
+    "weather": {
+      "agent_id": "weather-premium",
+      "endpoint": "http://localhost:8082",
+      "capability": "weather"
+    }
+  }
+}
+```
+
+## Database Storage
+
+### SQLite (Development)
+
+```bash
+export DATABASE_URL=mcp_mesh_registry.db
+```
+
+Simple, no setup, good for development and single-node.
+
+### PostgreSQL (Production)
+
+```bash
+export DATABASE_URL=postgresql://user:password@localhost:5432/mcp_mesh
+```
+
+Better for production: concurrent access, persistence, replication.
+
+## Monitoring
+
+```bash
+# Check registry health
+curl http://localhost:8000/health
+
+# List all agents
+curl http://localhost:8000/agents | jq .
+
+# Get specific agent
+curl http://localhost:8000/agents/hello-world | jq .
+
+# Using meshctl
+meshctl status
+meshctl list
+```
+
+## High Availability (Future)
+
+Planned features:
+
+- Multi-registry federation
+- Cross-cluster discovery
+- Leader election
+
+## See Also
+
+- `meshctl man health` - Health monitoring details
+- `meshctl man capabilities` - Capability registration
+- `meshctl man environment` - All configuration options

--- a/src/core/cli/man/content/tags.md
+++ b/src/core/cli/man/content/tags.md
@@ -1,0 +1,132 @@
+# Tag Matching System
+
+> Smart service selection using tags with +/- operators
+
+## Overview
+
+Tags are metadata labels attached to capabilities that enable intelligent service selection. MCP Mesh supports "smart matching" with operators that express preferences and exclusions.
+
+## Tag Operators
+
+| Prefix | Meaning   | Example                                 |
+| ------ | --------- | --------------------------------------- |
+| (none) | Required  | `"api"` - must have this tag            |
+| `+`    | Preferred | `"+fast"` - bonus if present            |
+| `-`    | Excluded  | `"-deprecated"` - hard failure if found |
+
+## Declaring Tags
+
+```python
+@mesh.tool(
+    capability="weather_data",
+    tags=["weather", "current", "api", "free"],
+)
+def get_weather(city: str): ...
+```
+
+## Using Tags in Dependencies
+
+### Simple Tag Filter
+
+```python
+@mesh.tool(
+    dependencies=[
+        {"capability": "weather_data", "tags": ["api"]},
+    ],
+)
+def my_tool(weather: mesh.McpMeshAgent = None): ...
+```
+
+### Smart Matching with Operators
+
+```python
+@mesh.tool(
+    dependencies=[
+        {
+            "capability": "weather_data",
+            "tags": [
+                "api",           # Required: must have "api" tag
+                "+accurate",     # Preferred: bonus if "accurate"
+                "+fast",         # Preferred: bonus if "fast"
+                "-deprecated",   # Excluded: fail if "deprecated"
+            ],
+        },
+    ],
+)
+def my_tool(weather: mesh.McpMeshAgent = None): ...
+```
+
+## Matching Algorithm
+
+1. **Filter**: Remove candidates with excluded tags (`-`)
+2. **Require**: Keep only candidates with required tags (no prefix)
+3. **Score**: Add points for preferred tags (`+`)
+4. **Select**: Choose highest-scoring candidate
+
+### Example
+
+Available providers:
+
+- Provider A: `["weather", "api", "accurate"]`
+- Provider B: `["weather", "api", "fast", "deprecated"]`
+- Provider C: `["weather", "api", "fast", "accurate"]`
+
+Filter: `["api", "+accurate", "+fast", "-deprecated"]`
+
+Result:
+
+1. Provider B eliminated (has `-deprecated`)
+2. Remaining: A and C (both have required `api`)
+3. Scores: A=1 (accurate), C=2 (accurate+fast)
+4. Winner: Provider C
+
+## Tag Naming Conventions
+
+| Category    | Examples                       |
+| ----------- | ------------------------------ |
+| Type        | `api`, `service`, `provider`   |
+| Quality     | `fast`, `accurate`, `reliable` |
+| Status      | `beta`, `stable`, `deprecated` |
+| Provider    | `openai`, `claude`, `local`    |
+| Environment | `production`, `staging`, `dev` |
+
+## LLM Provider Selection
+
+Common pattern for selecting LLM providers:
+
+```python
+@mesh.llm(
+    provider={"capability": "llm", "tags": ["+claude"]},
+)
+def my_llm_tool(): ...
+```
+
+Or for multiple provider fallback:
+
+```python
+@mesh.llm(
+    provider={"capability": "llm", "tags": ["+claude", "+gpt4"]},
+)
+def my_llm_tool(): ...
+```
+
+## Tool Filtering in @mesh.llm
+
+Filter which tools an LLM agent can access:
+
+```python
+@mesh.llm(
+    filter=[
+        {"tags": ["executor", "tools"]},      # Tools with these tags
+        {"capability": "calculator"},          # Or this specific capability
+    ],
+    filter_mode="all",  # Include all matching
+)
+def smart_assistant(): ...
+```
+
+## See Also
+
+- `meshctl man capabilities` - Capabilities system
+- `meshctl man llm` - LLM integration
+- `meshctl man dependency-injection` - How DI works

--- a/src/core/cli/man/content/testing.md
+++ b/src/core/cli/man/content/testing.md
@@ -1,0 +1,125 @@
+# Testing MCP Agents
+
+> How to test MCP Mesh agents using curl and the MCP JSON-RPC protocol
+
+## Overview
+
+MCP agents expose a JSON-RPC 2.0 API over HTTP with Server-Sent Events (SSE) responses. This guide shows the correct curl syntax for testing agents - a common source of errors when working with MCP.
+
+## Key Points
+
+- **Endpoint**: Always POST to `/mcp` (not REST-style paths like `/tools/list`)
+- **Method**: Always `POST`
+- **Headers**: Must include both `Content-Type` AND `Accept` headers
+- **Body**: JSON-RPC 2.0 format with `jsonrpc`, `id`, `method`, `params`
+- **Response**: Server-Sent Events format, requires parsing
+
+## List Available Tools
+
+```bash
+curl -s -X POST http://localhost:PORT/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/list",
+    "params": {}
+  }'
+```
+
+## Call a Tool (No Arguments)
+
+```bash
+curl -s -X POST http://localhost:PORT/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "get_current_time",
+      "arguments": {}
+    }
+  }'
+```
+
+## Call a Tool (With Arguments)
+
+```bash
+curl -s -X POST http://localhost:PORT/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "generate_report",
+      "arguments": {"title": "Test Report", "format": "markdown"}
+    }
+  }'
+```
+
+## Available MCP Methods
+
+| Method           | Description                  |
+| ---------------- | ---------------------------- |
+| `tools/list`     | List all available tools     |
+| `tools/call`     | Invoke a tool with arguments |
+| `prompts/list`   | List available prompts       |
+| `resources/list` | List available resources     |
+| `resources/read` | Read a resource              |
+
+## Response Format
+
+MCP responses use Server-Sent Events (SSE) format:
+
+```
+data: {"jsonrpc":"2.0","id":1,"result":{"tools":[...]}}
+```
+
+To parse the response, you can pipe through:
+
+```bash
+| grep "^data:" | sed 's/^data: //' | jq .
+```
+
+## Common Errors
+
+### Missing Accept Header
+
+```
+Error: Response not in expected format
+Fix: Add -H "Accept: application/json, text/event-stream"
+```
+
+### Wrong Endpoint
+
+```
+Error: 404 Not Found
+Fix: Use /mcp endpoint, not /tools/list or similar
+```
+
+### Invalid JSON-RPC Format
+
+```
+Error: Invalid request
+Fix: Ensure body has jsonrpc, id, method, and params fields
+```
+
+## Testing with meshctl
+
+```bash
+# Find agent ports
+meshctl list
+
+# Check agent status
+meshctl status --verbose
+```
+
+## See Also
+
+- `meshctl man decorators` - How to create tools
+- `meshctl man capabilities` - Understanding capabilities

--- a/src/core/cli/man/man.go
+++ b/src/core/cli/man/man.go
@@ -1,0 +1,106 @@
+package man
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// NewManCommand creates the man command for meshctl.
+func NewManCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "man [topic]",
+		Short: "Show MCP Mesh manual pages",
+		Long: `Show comprehensive MCP Mesh manual pages.
+
+Use this command to learn about MCP Mesh concepts, decorators,
+configuration, and best practices. Manual pages are embedded in the
+binary and work offline.
+
+The --raw flag outputs plain markdown, which is useful for:
+- LLM assistants that need to understand MCP Mesh concepts
+- Piping to other tools (grep, less, etc.)
+- Copying to documentation
+
+Examples:
+  meshctl man                    # Show architecture overview
+  meshctl man decorators         # Learn about mesh decorators
+  meshctl man tags               # Understand tag matching system
+  meshctl man di                 # Dependency injection (alias)
+  meshctl man testing            # MCP curl syntax for testing
+  meshctl man --list             # List all available topics
+  meshctl man --raw decorators   # Raw markdown output (LLM-friendly)
+  meshctl man --search "health"  # Search across all topics`,
+		RunE:              runManCommand,
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completeManTopics,
+	}
+
+	cmd.Flags().BoolP("list", "l", false, "List all available topics")
+	cmd.Flags().BoolP("raw", "r", false, "Output raw markdown (LLM-friendly)")
+	cmd.Flags().StringP("search", "s", "", "Search across all topics")
+
+	return cmd
+}
+
+// runManCommand executes the man command.
+func runManCommand(cmd *cobra.Command, args []string) error {
+	raw, _ := cmd.Flags().GetBool("raw")
+	list, _ := cmd.Flags().GetBool("list")
+	search, _ := cmd.Flags().GetString("search")
+
+	renderer := NewRenderer(raw)
+
+	// Handle --list flag
+	if list {
+		guides := ListGuides()
+		fmt.Print(renderer.RenderList(guides))
+		return nil
+	}
+
+	// Handle --search flag
+	if search != "" {
+		results, err := SearchGuides(search)
+		if err != nil {
+			return fmt.Errorf("search failed: %w", err)
+		}
+		fmt.Print(renderer.RenderSearchResults(search, results))
+		return nil
+	}
+
+	// Get topic (default to "overview")
+	topic := "overview"
+	if len(args) > 0 {
+		topic = args[0]
+	}
+
+	// Get and render guide
+	guide, content, err := GetGuide(topic)
+	if err != nil {
+		// Show suggestions for similar topics
+		suggestions := SuggestSimilarTopics(topic)
+		fmt.Print(renderer.RenderSuggestions(topic, suggestions))
+		return nil
+	}
+
+	fmt.Print(renderer.Render(guide, content))
+	return nil
+}
+
+// completeManTopics provides shell completion for man topics.
+func completeManTopics(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var completions []string
+	guides := ListGuides()
+	for _, guide := range guides {
+		completions = append(completions, guide.Name+"\t"+guide.Description)
+		for _, alias := range guide.Aliases {
+			completions = append(completions, alias+"\t"+guide.Description)
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/src/core/cli/man/renderer.go
+++ b/src/core/cli/man/renderer.go
@@ -1,0 +1,282 @@
+package man
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ANSI color codes for terminal styling
+const (
+	bold      = "\033[1m"
+	dim       = "\033[2m"
+	italic    = "\033[3m"
+	underline = "\033[4m"
+	reset     = "\033[0m"
+
+	black   = "\033[30m"
+	red     = "\033[31m"
+	green   = "\033[32m"
+	yellow  = "\033[33m"
+	blue    = "\033[34m"
+	magenta = "\033[35m"
+	cyan    = "\033[36m"
+	white   = "\033[37m"
+	gray    = "\033[90m"
+
+	bgBlack   = "\033[40m"
+	bgRed     = "\033[41m"
+	bgGreen   = "\033[42m"
+	bgYellow  = "\033[43m"
+	bgBlue    = "\033[44m"
+	bgMagenta = "\033[45m"
+	bgCyan    = "\033[46m"
+	bgWhite   = "\033[47m"
+	bgGray    = "\033[100m"
+)
+
+// Renderer handles guide content rendering.
+type Renderer struct {
+	Raw bool // Output raw markdown instead of styled
+}
+
+// NewRenderer creates a new renderer with the given options.
+func NewRenderer(raw bool) *Renderer {
+	return &Renderer{Raw: raw}
+}
+
+// Render renders guide content for terminal display.
+func (r *Renderer) Render(guide *Guide, content string) string {
+	if r.Raw {
+		return content
+	}
+	return r.renderStyled(guide, content)
+}
+
+// renderStyled applies terminal styling to markdown content.
+func (r *Renderer) renderStyled(guide *Guide, content string) string {
+	var sb strings.Builder
+
+	// Add title header
+	sb.WriteString(cyan + bold)
+	sb.WriteString("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
+	sb.WriteString("  " + guide.Title + "\n")
+	sb.WriteString("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
+	sb.WriteString(reset)
+
+	lines := strings.Split(content, "\n")
+	inCodeBlock := false
+	codeBlockLang := ""
+
+	for _, line := range lines {
+		// Handle code blocks
+		if strings.HasPrefix(line, "```") {
+			if !inCodeBlock {
+				inCodeBlock = true
+				codeBlockLang = strings.TrimPrefix(line, "```")
+				sb.WriteString(gray + "┌─")
+				if codeBlockLang != "" {
+					sb.WriteString("[" + codeBlockLang + "]")
+				}
+				sb.WriteString("─────────────────────────────────────────────────────────────────\n")
+				continue
+			} else {
+				inCodeBlock = false
+				codeBlockLang = ""
+				sb.WriteString("└──────────────────────────────────────────────────────────────────────────\n" + reset)
+				continue
+			}
+		}
+
+		if inCodeBlock {
+			sb.WriteString(gray + "│ " + green + line + reset + "\n")
+			continue
+		}
+
+		// Handle headers
+		if strings.HasPrefix(line, "# ") {
+			// Skip h1 since we already have a title
+			continue
+		}
+		if strings.HasPrefix(line, "## ") {
+			sb.WriteString("\n" + cyan + bold + strings.TrimPrefix(line, "## ") + reset + "\n")
+			sb.WriteString(cyan + "────────────────────────────────────────────────────────────────────────────\n" + reset)
+			continue
+		}
+		if strings.HasPrefix(line, "### ") {
+			sb.WriteString("\n" + yellow + bold + strings.TrimPrefix(line, "### ") + reset + "\n")
+			continue
+		}
+		if strings.HasPrefix(line, "#### ") {
+			sb.WriteString("\n" + magenta + strings.TrimPrefix(line, "#### ") + reset + "\n")
+			continue
+		}
+
+		// Handle blockquotes (summary lines)
+		if strings.HasPrefix(line, "> ") {
+			sb.WriteString(italic + gray + "  " + strings.TrimPrefix(line, "> ") + reset + "\n\n")
+			continue
+		}
+
+		// Handle bullet points
+		if strings.HasPrefix(line, "- ") {
+			sb.WriteString(yellow + "  • " + reset + strings.TrimPrefix(line, "- ") + "\n")
+			continue
+		}
+		if strings.HasPrefix(line, "  - ") {
+			sb.WriteString(yellow + "    ◦ " + reset + strings.TrimPrefix(line, "  - ") + "\n")
+			continue
+		}
+
+		// Handle numbered lists
+		if matched, _ := regexp.MatchString(`^\d+\. `, line); matched {
+			sb.WriteString(yellow + "  " + reset + line + "\n")
+			continue
+		}
+
+		// Handle tables (simple pass-through with dim color)
+		if strings.HasPrefix(line, "|") {
+			sb.WriteString(dim + line + reset + "\n")
+			continue
+		}
+
+		// Handle inline formatting
+		styled := r.styleInline(line)
+		sb.WriteString(styled + "\n")
+	}
+
+	return sb.String()
+}
+
+// styleInline applies inline styling for bold, italic, code, etc.
+func (r *Renderer) styleInline(line string) string {
+	// Inline code: `code`
+	codeRe := regexp.MustCompile("`([^`]+)`")
+	line = codeRe.ReplaceAllString(line, green+"$1"+reset)
+
+	// Bold: **text** or __text__
+	boldRe := regexp.MustCompile(`\*\*([^*]+)\*\*|__([^_]+)__`)
+	line = boldRe.ReplaceAllString(line, bold+"$1$2"+reset)
+
+	// Italic: *text* or _text_
+	italicRe := regexp.MustCompile(`\*([^*]+)\*|_([^_]+)_`)
+	line = italicRe.ReplaceAllString(line, italic+"$1$2"+reset)
+
+	// Links: [text](url) - show as underlined text
+	linkRe := regexp.MustCompile(`\[([^\]]+)\]\([^)]+\)`)
+	line = linkRe.ReplaceAllString(line, underline+cyan+"$1"+reset)
+
+	return line
+}
+
+// RenderList renders the list of available guides.
+func (r *Renderer) RenderList(guides []*Guide) string {
+	var sb strings.Builder
+
+	if r.Raw {
+		sb.WriteString("# Available Topics\n\n")
+		for _, guide := range guides {
+			sb.WriteString("- **" + guide.Name + "**")
+			if len(guide.Aliases) > 0 {
+				sb.WriteString(" (aliases: " + strings.Join(guide.Aliases, ", ") + ")")
+			}
+			sb.WriteString(" - " + guide.Description + "\n")
+		}
+		return sb.String()
+	}
+
+	// Styled output
+	sb.WriteString(cyan + bold + "Available Topics" + reset + "\n")
+	sb.WriteString(cyan + "────────────────────────────────────────────────────────────────────────────\n" + reset)
+	sb.WriteString("\n")
+
+	for _, guide := range guides {
+		sb.WriteString(yellow + bold + "  " + guide.Name + reset)
+		if len(guide.Aliases) > 0 {
+			sb.WriteString(gray + " (" + strings.Join(guide.Aliases, ", ") + ")" + reset)
+		}
+		sb.WriteString("\n")
+		sb.WriteString("    " + guide.Description + "\n\n")
+	}
+
+	sb.WriteString(gray + "Use 'meshctl man <topic>' to view a topic.\n")
+	sb.WriteString("Use 'meshctl man <topic> --raw' for LLM-friendly markdown output." + reset + "\n")
+
+	return sb.String()
+}
+
+// RenderSearchResults renders search results.
+func (r *Renderer) RenderSearchResults(query string, results []*SearchResult) string {
+	var sb strings.Builder
+
+	if len(results) == 0 {
+		if r.Raw {
+			return "No results found for: " + query + "\n"
+		}
+		return yellow + "No results found for: " + reset + query + "\n"
+	}
+
+	if r.Raw {
+		sb.WriteString("# Search Results for: " + query + "\n\n")
+		for _, result := range results {
+			sb.WriteString("## " + result.Guide.Title + " (" + result.Guide.Name + ")\n")
+			for _, match := range result.Matches {
+				sb.WriteString("  - " + match + "\n")
+			}
+			sb.WriteString("\n")
+		}
+		return sb.String()
+	}
+
+	// Styled output
+	sb.WriteString(cyan + bold + "Search Results for: " + reset + yellow + query + reset + "\n")
+	sb.WriteString(cyan + "────────────────────────────────────────────────────────────────────────────\n" + reset)
+	sb.WriteString("\n")
+
+	for _, result := range results {
+		sb.WriteString(yellow + bold + "  " + result.Guide.Name + reset)
+		sb.WriteString(" - " + result.Guide.Title + "\n")
+		for _, match := range result.Matches {
+			// Highlight query in match
+			highlighted := strings.ReplaceAll(
+				strings.ToLower(match),
+				strings.ToLower(query),
+				green+bold+query+reset+gray,
+			)
+			sb.WriteString(gray + "    " + highlighted + reset + "\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString(gray + "Use 'meshctl man <topic>' to view full topic." + reset + "\n")
+
+	return sb.String()
+}
+
+// RenderSuggestions renders topic suggestions when a guide is not found.
+func (r *Renderer) RenderSuggestions(query string, suggestions []string) string {
+	var sb strings.Builder
+
+	if r.Raw {
+		sb.WriteString("Topic '" + query + "' not found.\n\n")
+		if len(suggestions) > 0 {
+			sb.WriteString("Did you mean:\n")
+			for _, s := range suggestions {
+				sb.WriteString("  - " + s + "\n")
+			}
+		}
+		sb.WriteString("\nUse 'meshctl man --list' to see all available topics.\n")
+		return sb.String()
+	}
+
+	sb.WriteString(red + "Topic '" + query + "' not found." + reset + "\n\n")
+	if len(suggestions) > 0 {
+		sb.WriteString(yellow + "Did you mean:" + reset + "\n")
+		for _, s := range suggestions {
+			sb.WriteString("  " + cyan + s + reset + "\n")
+		}
+		sb.WriteString("\n")
+	}
+	sb.WriteString(gray + "Use 'meshctl man --list' to see all available topics." + reset + "\n")
+
+	return sb.String()
+}


### PR DESCRIPTION
## Summary

- Adds `meshctl man` command with 13 embedded documentation topics
- Styled terminal output + raw markdown mode for LLM consumption
- Topic search, aliases, and tab completion

## Features

| Feature | Description |
|---------|-------------|
| `meshctl man <topic>` | View styled documentation |
| `meshctl man --raw <topic>` | Raw markdown (LLM-friendly) |
| `meshctl man --list` | List all topics |
| `meshctl man --search <term>` | Search across topics |

## Topics (13)

overview, capabilities, tags, decorators, dependency-injection, health, registry, llm, proxies, fastapi, environment, deployment, testing

## Key Content

- Correct MCP curl syntax for testing agents
- All decorators: `@mesh.tool`, `@mesh.llm`, `@mesh.llm_provider`, `@mesh.agent`, `@mesh.route`
- FastAPI integration with `@mesh.route`
- Async/await patterns for proxy calls
- Environment variables including `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`

## Test plan

- [x] `meshctl man --list` shows all 13 topics
- [x] `meshctl man decorators` renders styled output
- [x] `meshctl man --raw di` outputs clean markdown
- [x] `meshctl man --search health` finds matches
- [x] Aliases work (di → dependency-injection, route → fastapi)
- [x] `go build ./cmd/meshctl` succeeds

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive offline CLI documentation system with guides covering deployment patterns, configuration, decorators, dependency injection, LLM integration, and architecture.
  * Supports listing all available guides, searching by content, and tab-completion for quick topic lookup.
  * Includes styled terminal rendering with proper formatting for code blocks and headers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->