### PR TITLE
Add meshctl call command and --tools flag for tool discovery

### DIFF
--- a/cmd/meshctl/main.go
+++ b/cmd/meshctl/main.go
@@ -33,6 +33,7 @@ func main() {
 	// Add all subcommands
 	rootCmd.AddCommand(cli.NewStartCommand())
 	rootCmd.AddCommand(cli.NewListCommand())
+	rootCmd.AddCommand(cli.NewCallCommand())
 	rootCmd.AddCommand(cli.NewStatusCommand())
 	rootCmd.AddCommand(cli.NewConfigCommand())
 	rootCmd.AddCommand(cli.NewScaffoldCommand())

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -220,17 +220,20 @@ cd mcp-mesh/examples/docker-examples
 docker-compose up
 
 # 3. Test it (in another terminal)
-curl -s -X POST http://localhost:8081/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hello_mesh_simple","arguments":{}}}' | jq .
+meshctl call hello_mesh_simple --agent-url http://localhost:8081
 ```
 
 **Expected response:**
 
 ```json
 {
-  "result": "Hello from MCP Mesh! Today is 2025-06-19 15:30:42"
+  "content": [
+    {
+      "type": "text",
+      "text": "👋 Hello from MCP Mesh! Today is December 11, 2025 at 03:30 PM"
+    }
+  ],
+  "isError": false
 }
 ```
 
@@ -253,11 +256,7 @@ meshctl start system_agent.py     # Terminal 1
 meshctl start hello_world.py      # Terminal 2
 
 # 4. Test it
-curl -s -X POST http://localhost:8080/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hello_mesh_simple","arguments":{}}}' \
-  | grep "^data:" | sed 's/^data: //' | jq '.result.content[0].text'
+meshctl call hello_mesh_simple
 ```
 
 !!! tip "Auto-Registry"

--- a/docs/01-getting-started/03-hello-world.md
+++ b/docs/01-getting-started/03-hello-world.md
@@ -16,17 +16,21 @@ meshctl start examples/simple/system_agent.py
 meshctl start examples/simple/hello_world.py
 
 # 3. Test it
-curl -s -X POST http://localhost:9090/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hello_mesh_simple","arguments":{}}}' \
-  | grep "^data:" | sed 's/^data: //' | jq '.result.content[0].text'
+meshctl call hello_mesh_simple
 ```
 
 **Expected response:**
 
-```
-"Hello from MCP Mesh! Today is December 10, 2025 at 03:30 PM"
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "👋 Hello from MCP Mesh! Today is December 10, 2025 at 03:30 PM"
+    }
+  ],
+  "isError": false
+}
 ```
 
 ## Understanding the Code
@@ -108,14 +112,20 @@ MCP Mesh automatically:
 
 ## Testing Your Setup
 
-### List Available Tools
+### List Registered Agents
 
 ```bash
-curl -s -X POST http://localhost:9090/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
-  | grep "^data:" | sed 's/^data: //' | jq '.result.tools[].name'
+meshctl list
+```
+
+### Call a Tool
+
+```bash
+# Call hello_mesh_simple on any agent that provides it
+meshctl call hello_mesh_simple
+
+# Call get_current_time from system agent
+meshctl call get_current_time
 ```
 
 ### Check Agent Status
@@ -124,11 +134,21 @@ curl -s -X POST http://localhost:9090/mcp \
 meshctl status
 ```
 
-### View Registry
+<details>
+<summary>Alternative: Using curl directly</summary>
 
 ```bash
+# List tools from an agent
+curl -s -X POST http://localhost:9090/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+
+# View registry
 curl -s http://localhost:8000/agents | jq '.agents[] | {name, capabilities}'
 ```
+
+</details>
 
 ## Troubleshooting
 

--- a/docs/01-getting-started/04-dependency-injection.md
+++ b/docs/01-getting-started/04-dependency-injection.md
@@ -312,28 +312,42 @@ def date_service_proxy():
 ### Check Service Registration
 
 ```bash
-# See what services are registered
-curl -s http://localhost:8000/agents | \
-  jq '.agents[] | {name: .name, capabilities: (.capabilities | keys)}'
+# See what agents are registered
+meshctl list
 ```
 
 ### Test Individual Services
 
 ```bash
 # Test date service directly
+meshctl call get_current_time
+
+# Test dependency injection (hello_mesh_simple calls date_service internally)
+meshctl call hello_mesh_simple
+```
+
+<details>
+<summary>Alternative: Using curl directly</summary>
+
+```bash
+# View registry
+curl -s http://localhost:8000/agents | \
+  jq '.agents[] | {name: .name, capabilities: (.capabilities | keys)}'
+
+# Test date service directly
 curl -s -X POST http://localhost:8080/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_current_time","arguments":{}}}' \
-  | grep "^data:" | sed 's/^data: //' | jq '.result.content[0].text'
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_current_time","arguments":{}}}'
 
 # Test dependency injection
 curl -s -X POST http://localhost:9090/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hello_mesh_simple","arguments":{}}}' \
-  | grep "^data:" | sed 's/^data: //' | jq '.result.content[0].text'
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hello_mesh_simple","arguments":{}}}'
 ```
+
+</details>
 
 ## Benefits of the New Pattern
 

--- a/docs/01-getting-started/05-first-agent.md
+++ b/docs/01-getting-started/05-first-agent.md
@@ -379,18 +379,10 @@ python ../examples/simple/system_agent.py
 
 ```bash
 # Test weather data
-curl -s -X POST http://localhost:9091/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather","arguments":{"city":"tokyo"}}}' \
-  | grep "^data:" | sed 's/^data: //' | jq '.result.content[0].text'
+meshctl call get_weather '{"city":"tokyo"}'
 
 # Test forecast with dependencies
-curl -s -X POST http://localhost:9091/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_forecast","arguments":{"city":"london","days":5}}}' \
-  | grep "^data:" | sed 's/^data: //' | jq '.result.content[0].text'
+meshctl call get_forecast '{"city":"london","days":5}'
 ```
 
 ````
@@ -411,33 +403,30 @@ python weather_agent.py
 
 ```bash
 # 1. Test basic weather data (self-dependency)
-curl -s -X POST http://localhost:9091/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather","arguments":{"city":"tokyo"}}}' \
-  | grep "^data:" | sed 's/^data: //' | jq '.result.content[0].text'
+meshctl call get_weather '{"city":"tokyo"}'
 
 # 2. Test forecast (self + external dependencies)
-curl -s -X POST http://localhost:9091/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_forecast","arguments":{"city":"london","days":3}}}' \
-  | grep "^data:" | sed 's/^data: //' | jq '.result.content[0].text'
+meshctl call get_forecast '{"city":"london","days":3}'
+```
 
+<details>
+<summary>Testing prompts and resources (requires curl)</summary>
+
+```bash
 # 3. Test prompt generation
 curl -s -X POST http://localhost:9091/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"weather_analysis_prompt","arguments":{"city":"paris","analysis_type":"detailed"}}}' \
-  | grep "^data:" | sed 's/^data: //' | jq '.result'
+  -d '{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"weather_analysis_prompt","arguments":{"city":"paris","analysis_type":"detailed"}}}'
 
 # 4. Test resource access
 curl -s -X POST http://localhost:9091/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"weather://config/sydney"}}' \
-  | grep "^data:" | sed 's/^data: //' | jq '.result'
+  -d '{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"weather://config/sydney"}}'
 ```
+
+</details>
 
 ### Verify Service Integration
 

--- a/docs/02-local-development.md
+++ b/docs/02-local-development.md
@@ -102,26 +102,37 @@ class MyAgent:
 meshctl start main.py
 ```
 
-### 6. Test with curl
+### 6. Test Your Agent
+
+```bash
+# List registered agents
+meshctl list
+
+# Call your tool
+meshctl call my_function '{"data":"hello"}'
+```
+
+<details>
+<summary>Alternative: Using curl directly</summary>
 
 ```bash
 # List available tools
 curl -s -X POST http://localhost:8080/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
-  | grep "^data:" | sed 's/^data: //' | jq '.result.tools[].name'
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
 
 # Call your tool
 curl -s -X POST http://localhost:8080/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"my_function","arguments":{"data":"hello"}}}' \
-  | grep "^data:" | sed 's/^data: //' | jq '.result.content[0].text'
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"my_function","arguments":{"data":"hello"}}}'
 ```
 
 !!! note "SSE Response Format"
-MCP Mesh uses Server-Sent Events (SSE) format. The `grep "^data:" | sed 's/^data: //'` extracts the JSON from the SSE stream.
+MCP Mesh uses Server-Sent Events (SSE) format. `meshctl call` handles this automatically.
+
+</details>
 
 ## Multi-Agent Development
 
@@ -135,11 +146,7 @@ meshctl start agents/auth_agent.py
 meshctl start agents/api_agent.py
 
 # Test dependency injection
-curl -s -X POST http://localhost:8081/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"secure_operation","arguments":{}}}' \
-  | grep "^data:" | sed 's/^data: //' | jq '.result.content[0].text'
+meshctl call secure_operation
 ```
 
 ## Project Structure

--- a/docs/architecture-and-design.md
+++ b/docs/architecture-and-design.md
@@ -42,21 +42,37 @@ MCP Mesh uses [FastMCP](https://github.com/jlowin/fastmcp) under the hood to han
 
 **MCP Compatibility:**
 
-MCP Mesh tools are standard MCP tools. They can be invoked by any MCP client using JSON-RPC:
+MCP Mesh tools are standard MCP tools. They can be invoked using the meshctl CLI or any MCP client:
+
+```bash
+# List registered agents
+meshctl list
+
+# Call a tool (discovers agent via registry)
+meshctl call my_tool '{"param":"value"}'
+
+# Call with explicit agent
+meshctl call my-agent:my_tool '{"param":"value"}'
+```
+
+<details>
+<summary>Using curl directly (JSON-RPC)</summary>
 
 ```bash
 # List available tools
-curl -s -X POST http://agent:8080/mcp \
+curl -s -X POST http://localhost:8080/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
 
 # Call a tool
-curl -s -X POST http://agent:8080/mcp \
+curl -s -X POST http://localhost:8080/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"my_tool","arguments":{"param":"value"}}}'
 ```
+
+</details>
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -110,22 +110,16 @@ Once you have any example running, test the core functionality:
 
 ```bash
 # 1. Install meshctl CLI (optional, use minor version for latest patches)
-curl -sSL https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh | bash -s -- --meshctl-only --version v0.3
+curl -sSL https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh | bash -s -- --meshctl-only --version v0.7
 
 # 2. Check agent registration
-meshctl list agents
+meshctl list
 
 # 3. Test basic functionality
-curl -s -X POST http://localhost:8081/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hello_mesh_simple","arguments":{}}}' | jq .
+meshctl call hello_mesh_simple
 
 # 4. Test dependency injection
-curl -s -X POST http://localhost:8082/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_current_time","arguments":{}}}' | jq .
+meshctl call get_current_time
 ```
 
 **Expected Results**:

--- a/examples/complex/README.md
+++ b/examples/complex/README.md
@@ -19,6 +19,7 @@ While the `examples/simple/` directory shows basic MCP Mesh functionality, this 
 A comprehensive multi-file agent demonstrating advanced data processing capabilities with **real dependency injection** from weather and LLM services.
 
 **Features:**
+
 - **Multi-format data parsing**: CSV, JSON, Excel, Parquet, TSV
 - **Statistical analysis**: Descriptive statistics, correlation analysis, outlier detection
 - **Data transformation**: Filtering, sorting, aggregation, cleaning operations
@@ -30,6 +31,7 @@ A comprehensive multi-file agent demonstrating advanced data processing capabili
 - **Proper Python packaging**: `pyproject.toml` with dependencies and scripts
 
 **Structure:**
+
 ```
 data_processor_agent/
 ├── __init__.py              # Package initialization
@@ -85,18 +87,21 @@ The data processor agent depends on two service agents from `examples/advanced/`
 ### 1. Start Required Services
 
 **Terminal 1 - Weather Service:**
+
 ```bash
 cd examples/advanced
 python weather_agent.py
 ```
 
 **Terminal 2 - LLM Service:**
+
 ```bash
 cd examples/advanced
 python llm_chat_agent.py
 ```
 
 **Terminal 3 - Data Processor (with dependencies):**
+
 ```bash
 cd examples/complex/data_processor_agent
 python main.py
@@ -110,6 +115,7 @@ curl -s http://localhost:8000/agents | jq '.agents[] | {name: .name, endpoint: .
 ```
 
 Expected output:
+
 ```json
 {
   "name": "weather-agent-472dbc15",
@@ -117,7 +123,7 @@ Expected output:
   "dependencies_resolved": 0
 }
 {
-  "name": "llm-chat-agent-ce2b56ad", 
+  "name": "llm-chat-agent-ce2b56ad",
   "endpoint": "http://10.211.55.3:9093",
   "dependencies_resolved": 0
 }
@@ -131,7 +137,12 @@ Expected output:
 ### 3. Test Service Integration
 
 **Test Weather Service:**
+
 ```bash
+# Using meshctl
+meshctl call --agent-url http://localhost:9094 get_local_weather
+
+# Or using curl
 curl -s -X POST http://localhost:9094/mcp/ \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
@@ -147,7 +158,12 @@ curl -s -X POST http://localhost:9094/mcp/ \
 ```
 
 **Test LLM Service:**
+
 ```bash
+# Using meshctl
+meshctl call --agent-url http://localhost:9093 process_text_with_llm '{"text": "Weather data shows 70°F temperature with overcast conditions", "task": "analyze"}'
+
+# Or using curl
 curl -s -X POST http://localhost:9093/mcp/ \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
@@ -166,7 +182,12 @@ curl -s -X POST http://localhost:9093/mcp/ \
 ```
 
 **Test Data Processor (with dependency injection):**
+
 ```bash
+# Using meshctl
+meshctl call --agent-url http://localhost:9090 get_agent_status
+
+# Or using curl
 curl -s -X POST http://localhost:9090/mcp/ \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
@@ -184,6 +205,7 @@ curl -s -X POST http://localhost:9090/mcp/ \
 ### 4. Alternative Execution Methods
 
 **Local Development:**
+
 ```bash
 cd data_processor_agent
 python -m venv venv
@@ -193,12 +215,14 @@ python -m data_processor_agent
 ```
 
 **Docker Deployment:**
+
 ```bash
 docker build -t data-processor-agent .
 docker run -p 9092:9092 data-processor-agent
 ```
 
 **Docker Compose (full stack with registry):**
+
 ```bash
 docker-compose up -d
 ```
@@ -206,11 +230,13 @@ docker-compose up -d
 ## Architecture Patterns Demonstrated
 
 ### 1. **Dual Decorator Pattern**
+
 All tools use FastMCP + MCP Mesh dual decorators:
+
 ```python
 @app.tool()                    # FastMCP decorator FIRST
 @mesh.tool(                    # MCP Mesh decorator SECOND
-    capability="data_processing", 
+    capability="data_processing",
     dependencies=["weather-service", "llm-service"],
     # Enhanced proxy configuration
     timeout=300,
@@ -222,7 +248,7 @@ All tools use FastMCP + MCP Mesh dual decorators:
     }
 )
 def parse_data_file(
-    file_path: str, 
+    file_path: str,
     file_format: Optional[str] = None,
     weather_service: mesh.McpMeshAgent = None,  # Dependency injection
     llm_service: mesh.McpMeshAgent = None       # Dependency injection
@@ -232,13 +258,15 @@ def parse_data_file(
 ```
 
 ### 2. **Enhanced Proxy Configuration (v0.3+)**
+
 Direct kwargs for advanced proxy features:
+
 ```python
 @mesh.tool(
     capability="data_processing",
     # Enhanced proxy configuration as direct kwargs
     timeout=300,              # 5-minute timeout
-    retry_count=3,           # 3 retry attempts  
+    retry_count=3,           # 3 retry attempts
     streaming=True,          # Enable streaming
     custom_headers={         # Custom HTTP headers
         "X-Service-Type": "data-processor",
@@ -248,11 +276,13 @@ Direct kwargs for advanced proxy features:
 ```
 
 ### 3. **Auto-Run Pattern**
+
 All agents use `auto_run=True` for zero-boilerplate startup:
+
 ```python
 @mesh.agent(
     name="data-processor",
-    version="1.0.0", 
+    version="1.0.0",
     http_port=9092,
     auto_run=True    # MCP Mesh handles everything automatically
 )
@@ -261,11 +291,13 @@ class DataProcessorAgent:
 ```
 
 ### 4. **Modular Package Structure**
+
 - Clear separation of concerns with `config/`, `tools/`, `utils/` modules
 - Proper Python package initialization and exports
 - Flexible import strategies for both package and standalone execution
 
 ### 5. **Service Discovery & Dependency Injection**
+
 - Automatic service discovery through MCP Mesh registry
 - Type-safe dependency injection with `mesh.McpMeshAgent` parameters
 - Graceful degradation when dependencies are unavailable
@@ -288,7 +320,7 @@ source .venv/bin/activate       # Shared virtual environment
 cd examples/complex/data_processor_agent
 python main.py
 
-cd examples/advanced  
+cd examples/advanced
 python weather_agent.py
 python llm_chat_agent.py
 ```
@@ -333,10 +365,11 @@ python -m data_processor_agent
 These examples demonstrate advanced MCP Mesh features:
 
 ### 1. **Real Dependency Injection**
+
 ```python
 @app.tool()
 @mesh.tool(
-    capability="data_processing", 
+    capability="data_processing",
     dependencies=["weather-service", "llm-service"]
 )
 def analyze_data_with_context(
@@ -346,18 +379,19 @@ def analyze_data_with_context(
 ) -> Dict[str, Any]:
     # Get weather context
     weather_data = weather_service() if weather_service else None
-    
+
     # Use LLM for analysis
     analysis = llm_service({
-        "text": data, 
+        "text": data,
         "task": "analyze",
         "context": f"Weather: {weather_data}"
     }) if llm_service else None
-    
+
     return {"data": data, "weather": weather_data, "analysis": analysis}
 ```
 
 ### 2. **Enhanced Proxy Configuration (v0.3+)**
+
 ```python
 @app.tool()
 @mesh.tool(
@@ -378,6 +412,7 @@ def process_large_dataset(data: str) -> Dict[str, Any]:
 ```
 
 ### 3. **FastMCP Compatibility**
+
 ```python
 # ✅ CORRECT: No **kwargs in function signatures
 def parse_data_file(file_path: str, file_format: Optional[str] = None) -> Dict[str, Any]:
@@ -393,43 +428,51 @@ def parse_data_file(file_path: str, **options) -> Dict[str, Any]:
 This example demonstrates a complete service ecosystem:
 
 ### Service Providers
+
 - **Weather Service**: Real weather data with auto-location detection
 - **LLM Service**: Text processing and data interpretation
 - **Data Processor**: Complex multi-file agent consuming both services
 
 ### Capability Names
+
 - `weather-service` → Provided by weather agent
-- `llm-service` → Provided by LLM agent  
+- `llm-service` → Provided by LLM agent
 - `data_processing` → Provided by data processor agent (multiple tools)
 - `statistical_analysis` → Provided by data processor agent
 - `data_interpretation` → Provided by LLM agent
 
 ### Service Discovery
+
 All agents automatically register with the MCP Mesh registry and dependencies are resolved via capability names and tags.
 
 ## Best Practices Demonstrated
 
 ### 1. **Code Organization**
+
 - Single responsibility principle for each module
 - Clear interfaces between components
 - Separation of business logic from infrastructure
 
 ### 2. **Configuration Management**
+
 - All configuration via environment variables
 - Type-safe configuration with validation
 - Hierarchical configuration with defaults
 
 ### 3. **Error Handling**
+
 - Structured error responses for MCP tools
 - Graceful degradation for partial failures
 - Comprehensive logging for debugging
 
 ### 4. **Testing Strategy**
+
 - Unit tests for individual components
 - Integration tests for MCP tools
 - Multi-agent testing with real dependencies
 
 ### 5. **Deployment Flexibility**
+
 - Multiple execution methods
 - Docker containerization with multi-stage builds
 - Kubernetes-ready configuration
@@ -438,21 +481,25 @@ All agents automatically register with the MCP Mesh registry and dependencies ar
 ## Deployment Options
 
 ### 1. **Local Development**
+
 - Direct Python execution for rapid iteration
 - Virtual environment with editable installation
 - Environment variable configuration
 
 ### 2. **Docker Containerization**
+
 - Multi-stage builds for optimization
 - Non-root user for security
 - Health checks and monitoring
 
 ### 3. **Kubernetes Deployment**
+
 - Production-ready manifests
 - ConfigMap and Secret integration
 - Service discovery and load balancing
 
 ### 4. **Package Distribution**
+
 - PyPI-compatible packages
 - Command-line scripts installation
 - Dependency management
@@ -467,7 +514,7 @@ All agents automatically register with the MCP Mesh registry and dependencies ar
 
 ## Related Documentation
 
-- [Simple Examples](../simple/README.md) - Basic MCP Mesh functionality  
+- [Simple Examples](../simple/README.md) - Basic MCP Mesh functionality
 - [Advanced Examples](../advanced/README.md) - Weather and LLM service agents
 - [Mesh Decorators Guide](../../docs/mesh-decorators.md) - Complete decorator reference
 - [Development Guide](../../docs/02-local-development.md) - Comprehensive best practices
@@ -475,6 +522,7 @@ All agents automatically register with the MCP Mesh registry and dependencies ar
 ## Support
 
 For questions about complex agent development:
+
 1. Review the development guide and example code
 2. Check the main MCP Mesh documentation
 3. Test the multi-agent setup to understand service dependencies

--- a/examples/docker-examples/README.md
+++ b/examples/docker-examples/README.md
@@ -152,6 +152,17 @@ curl -s -X POST http://localhost:8084/mcp \
 
 ```bash
 # Simple greeting
+meshctl call hello_mesh_simple
+
+# Typed greeting with dependency resolution
+meshctl call hello_mesh_typed
+```
+
+<details>
+<summary>Alternative: Using curl directly</summary>
+
+```bash
+# Simple greeting
 curl -s -X POST http://localhost:8081/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
@@ -180,6 +191,8 @@ curl -s -X POST http://localhost:8081/mcp \
   }' | grep "^data:" | sed 's/^data: //' | jq -r '.result.content[0].text'
 ```
 
+</details>
+
 ### FastMCP Agent
 
 **Available Tools:**
@@ -187,6 +200,20 @@ curl -s -X POST http://localhost:8081/mcp \
 - `get_current_time` - Get the current system time
 - `calculate_with_timestamp` - Perform math operation with timestamp from time service
 - `process_data` - Process and format data
+
+```bash
+# Get current time
+meshctl call get_current_time
+
+# Math calculation with timestamp
+meshctl call calculate_with_timestamp '{"operation": "add", "a": 10, "b": 5}'
+
+# Process data
+meshctl call process_data '{"input": "sample data to process"}'
+```
+
+<details>
+<summary>Alternative: Using curl directly</summary>
 
 ```bash
 # Get current time
@@ -238,6 +265,8 @@ curl -s -X POST http://localhost:8083/mcp \
   }' | grep "^data:" | sed 's/^data: //' | jq -r '.result.content[0].text'
 ```
 
+</details>
+
 ### System Agent
 
 **Available Tools:**
@@ -247,6 +276,20 @@ curl -s -X POST http://localhost:8083/mcp \
 - `check_how_long_running` - Get system uptime information
 - `analyze_storage_and_os` - Get disk and OS information
 - `perform_health_diagnostic` - Get system status including current time
+
+```bash
+# Get current time
+meshctl call get_current_time
+
+# Get system overview
+meshctl call fetch_system_overview
+
+# Check system uptime
+meshctl call check_how_long_running
+```
+
+<details>
+<summary>Alternative: Using curl directly</summary>
 
 ```bash
 # Get current time
@@ -292,6 +335,8 @@ curl -s -X POST http://localhost:8082/mcp \
   }' | grep "^data:" | sed 's/^data: //' | jq -r '.result.content[0].text'
 ```
 
+</details>
+
 ### Dependent Agent (3-Agent Dependency Injection Demo)
 
 **Available Tools:**
@@ -301,9 +346,23 @@ curl -s -X POST http://localhost:8082/mcp \
 - `analyze_data` - Analyze data with timestamp from time service
 
 ```bash
-# 🔥 NEW: 3-Agent Dependency Chain with Distributed Tracing
+# 🔥 3-Agent Dependency Chain with Distributed Tracing
 # This demonstrates the complete dependency injection flow:
 # Dependent Agent → FastMCP Agent → System Agent
+meshctl call generate_comprehensive_report '{"report_title": "Multi-Agent System Report", "include_system_data": true}'
+
+# Generate report (uses FastMCP agent's time service)
+meshctl call generate_report '{"title": "System Status Report", "content": "All systems operational"}'
+
+# Analyze data (uses dependency injection for timestamps)
+meshctl call analyze_data '{"data": ["value1", "value2", "value3", "value4", "value5"]}'
+```
+
+<details>
+<summary>Alternative: Using curl directly</summary>
+
+```bash
+# 3-Agent Dependency Chain with Distributed Tracing
 curl -s -X POST http://localhost:8084/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
@@ -353,6 +412,8 @@ curl -s -X POST http://localhost:8084/mcp \
     }
   }' | grep "^data:" | sed 's/^data: //' | jq -r '.result.content[0].text' | jq .
 ```
+
+</details>
 
 #### 🔍 **Distributed Tracing Verification**
 

--- a/examples/k8s/README.md
+++ b/examples/k8s/README.md
@@ -206,6 +206,21 @@ curl -s -X POST http://enhanced-fastmcp-agent.mcp-mesh.local/mcp/ \
 - `test_dependencies` - Test function showing hybrid dependency resolution
 
 ```bash
+# Using meshctl with Kubernetes ingress
+# Note: Use --ingress-url with minikube IP if DNS is not configured
+meshctl call --ingress-domain mcp-mesh.local --ingress-url http://$(minikube ip) hello_mesh_simple
+
+# Simple greeting
+meshctl call --ingress-domain mcp-mesh.local hello_mesh_simple
+
+# Typed greeting with dependency resolution
+meshctl call --ingress-domain mcp-mesh.local hello_mesh_typed
+```
+
+<details>
+<summary>Alternative: Using curl directly</summary>
+
+```bash
 # Simple greeting
 curl -s -X POST http://hello-world.mcp-mesh.local/mcp/ \
   -H "Content-Type: application/json" \
@@ -235,6 +250,8 @@ curl -s -X POST http://hello-world.mcp-mesh.local/mcp/ \
   }' | grep "^data:" | sed 's/^data: //' | jq -r '.result.content[0].text'
 ```
 
+</details>
+
 ### FastMCP Agent
 
 **Available Tools:**
@@ -244,6 +261,23 @@ curl -s -X POST http://hello-world.mcp-mesh.local/mcp/ \
 - `process_data` - Process and format data
 - `get_enriched_system_info` - Get enriched system information by calling system agent
 - `increment_session_counter` - Increment a counter for a specific session
+
+```bash
+# Get current time
+meshctl call --ingress-domain mcp-mesh.local get_current_time
+
+# Math calculation with timestamp
+meshctl call --ingress-domain mcp-mesh.local calculate_with_timestamp '{"operation": "add", "a": 10, "b": 5}'
+
+# Process data
+meshctl call --ingress-domain mcp-mesh.local process_data '{"data": "sample data to process"}'
+
+# Get enriched system info (dependency chain: FastMCP → System)
+meshctl call --ingress-domain mcp-mesh.local get_enriched_system_info
+```
+
+<details>
+<summary>Alternative: Using curl directly</summary>
 
 ```bash
 # Get current time
@@ -309,6 +343,8 @@ curl -s -X POST http://fastmcp-agent.mcp-mesh.local/mcp/ \
   }' | grep "^data:" | sed 's/^data: //' | jq -r '.result.content[0].text'
 ```
 
+</details>
+
 ### System Agent
 
 **Available Tools:**
@@ -318,6 +354,23 @@ curl -s -X POST http://fastmcp-agent.mcp-mesh.local/mcp/ \
 - `check_how_long_running` - Get system uptime information
 - `analyze_storage_and_os` - Get disk and OS information
 - `perform_health_diagnostic` - Get system status including current time
+
+```bash
+# Get current time
+meshctl call --ingress-domain mcp-mesh.local get_current_time
+
+# Get system overview
+meshctl call --ingress-domain mcp-mesh.local fetch_system_overview
+
+# Check system uptime
+meshctl call --ingress-domain mcp-mesh.local check_how_long_running
+
+# Health diagnostic with dependency injection
+meshctl call --ingress-domain mcp-mesh.local perform_health_diagnostic
+```
+
+<details>
+<summary>Alternative: Using curl directly</summary>
 
 ```bash
 # Get current time
@@ -377,6 +430,8 @@ curl -s -X POST http://system-agent.mcp-mesh.local/mcp/ \
   }' | grep "^data:" | sed 's/^data: //' | jq -r '.result.content[0].text' | jq .
 ```
 
+</details>
+
 ### Enhanced FastMCP Agent
 
 **Available Tools:**
@@ -386,6 +441,20 @@ curl -s -X POST http://system-agent.mcp-mesh.local/mcp/ \
 - `stream_data_processing` - Streaming data processing with auto-configured streaming
 - `get_secure_config` - Secure configuration with authentication handling
 - `enhanced_session_increment` - Enhanced session management with auto-session handling
+
+```bash
+# Get enhanced time with metadata
+meshctl call --ingress-domain mcp-mesh.local get_enhanced_time
+
+# Enhanced calculation with auto-retry
+meshctl call --ingress-domain mcp-mesh.local calculate_enhanced '{"operation": "power", "a": 2, "b": 8}'
+
+# Enhanced session management
+meshctl call --ingress-domain mcp-mesh.local enhanced_session_increment
+```
+
+<details>
+<summary>Alternative: Using curl directly</summary>
 
 ```bash
 # Get enhanced time with metadata
@@ -435,6 +504,8 @@ curl -s -X POST http://enhanced-fastmcp-agent.mcp-mesh.local/mcp/ \
   }' | grep "^data:" | sed 's/^data: //' | jq -r '.result.content[0].text'
 ```
 
+</details>
+
 ### Dependent Agent (Multi-Agent Dependency Injection Demo)
 
 **Available Tools:**
@@ -447,6 +518,20 @@ curl -s -X POST http://enhanced-fastmcp-agent.mcp-mesh.local/mcp/ \
 # 🔥 3-Agent Dependency Chain with Distributed Tracing
 # This demonstrates the complete dependency injection flow:
 # Dependent Agent → FastMCP Agent → System Agent
+meshctl call --ingress-domain mcp-mesh.local generate_comprehensive_report '{"report_title": "Multi-Agent K8s System Report", "include_system_data": true}'
+
+# Generate report (uses FastMCP agent's time service)
+meshctl call --ingress-domain mcp-mesh.local generate_report '{"title": "K8s System Status Report", "content": "All K8s systems operational"}'
+
+# Analyze data (uses dependency injection for timestamps)
+meshctl call --ingress-domain mcp-mesh.local analyze_data '{"data": ["k8s-pod1", "k8s-pod2", "k8s-service", "k8s-ingress", "k8s-configmap"]}'
+```
+
+<details>
+<summary>Alternative: Using curl directly</summary>
+
+```bash
+# 3-Agent Dependency Chain with Distributed Tracing
 curl -s -X POST http://dependent-agent.mcp-mesh.local/mcp/ \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
@@ -496,6 +581,8 @@ curl -s -X POST http://dependent-agent.mcp-mesh.local/mcp/ \
     }
   }' | grep "^data:" | sed 's/^data: //' | jq -r '.result.content[0].text' | jq .
 ```
+
+</details>
 
 #### 🔍 **Distributed Tracing Verification**
 

--- a/examples/multi-agent-poc/README.md
+++ b/examples/multi-agent-poc/README.md
@@ -83,6 +83,10 @@ EOF
 Send the request:
 
 ```bash
+# Using meshctl (reads JSON arguments from file)
+meshctl call --registry http://localhost:8003 --agent-url http://localhost:9200 chat "$(cat test-prime-request.json | jq -c '.params.arguments')"
+
+# Or using curl directly
 curl -s -X POST http://localhost:9200/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
@@ -125,6 +129,10 @@ meshctl list --registry-port 8003
 3. **Send the Same Request Again**:
 
 ```bash
+# Using meshctl
+meshctl call --registry http://localhost:8003 --agent-url http://localhost:9200 chat "$(cat test-prime-request.json | jq -c '.params.arguments')"
+
+# Or using curl
 curl -s -X POST http://localhost:9200/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
@@ -151,6 +159,10 @@ meshctl list --registry-port 8003 --healthy-only
 5. **Next Request Uses Claude Again** (automatic recovery):
 
 ```bash
+# Using meshctl
+meshctl call --registry http://localhost:8003 --agent-url http://localhost:9200 chat "$(cat test-prime-request.json | jq -c '.params.arguments')"
+
+# Or using curl
 curl -s -X POST http://localhost:9200/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \

--- a/src/core/cli/call.go
+++ b/src/core/cli/call.go
@@ -1,0 +1,560 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// MCPRequest represents an MCP JSON-RPC request
+type MCPRequest struct {
+	JSONRPC string                 `json:"jsonrpc"`
+	ID      int                    `json:"id"`
+	Method  string                 `json:"method"`
+	Params  map[string]interface{} `json:"params"`
+}
+
+// MCPResponse represents an MCP JSON-RPC response
+type MCPResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *MCPError       `json:"error,omitempty"`
+}
+
+// MCPError represents an MCP JSON-RPC error
+type MCPError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// NewCallCommand creates the call command
+func NewCallCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "call [agent:]tool_name [arguments]",
+		Short: "Call an MCP tool on an agent",
+		Long: `Call an MCP tool on a registered agent.
+
+The command discovers the agent endpoint via the registry and makes the MCP call
+with proper headers. Arguments can be provided as JSON string or via --file flag.
+
+Examples:
+  meshctl call hello_mesh_simple                          # Call tool, discover agent via registry
+  meshctl call weather-agent:get_weather                  # Specify agent explicitly
+  meshctl call calculator:add '{"a": 1, "b": 2}'          # With JSON arguments
+  meshctl call analyzer:process --file data.json          # Arguments from file
+  meshctl call hello_mesh --registry-url http://remote:8000  # Remote registry
+  meshctl call hello_mesh --registry-scheme https --insecure # HTTPS with self-signed cert
+  meshctl call hello_mesh --agent-url http://localhost:8080  # Direct agent call (skip registry)
+
+Ingress mode (for Kubernetes clusters with ingress configured):
+  meshctl call hello_mesh_simple --ingress-domain mcp-mesh.local                    # With DNS configured
+  meshctl call hello_mesh_simple --ingress-domain mcp-mesh.local --ingress-url http://192.168.58.2  # Without DNS
+  meshctl call hello_mesh_simple --ingress-domain mcp-mesh.local --ingress-url http://localhost:9080  # Port-forwarded ingress`,
+		Args: cobra.RangeArgs(1, 2),
+		RunE: runCallCommand,
+	}
+
+	// Registry connection flags (same as list command)
+	cmd.Flags().String("registry-url", "", "Registry URL (overrides host/port)")
+	cmd.Flags().String("registry-host", "", "Registry host (default: localhost)")
+	cmd.Flags().Int("registry-port", 0, "Registry port (default: 8000)")
+	cmd.Flags().String("registry-scheme", "http", "Registry URL scheme (http/https)")
+	cmd.Flags().Bool("insecure", false, "Skip TLS certificate verification")
+	cmd.Flags().Int("timeout", 30, "Request timeout in seconds")
+
+	// Output options
+	cmd.Flags().Bool("raw", false, "Output raw JSON without formatting")
+	cmd.Flags().Bool("pretty", true, "Pretty print JSON output")
+
+	// Input options
+	cmd.Flags().String("file", "", "Read arguments from JSON file")
+
+	// Direct agent connection (bypasses registry lookup for agent endpoint)
+	cmd.Flags().String("agent-url", "", "Agent URL to call directly (bypasses registry endpoint lookup)")
+
+	// Ingress mode flags (for Kubernetes clusters with ingress)
+	cmd.Flags().String("ingress-domain", "", "Ingress domain (e.g., mcp-mesh.local) - enables ingress mode")
+	cmd.Flags().String("ingress-url", "", "Ingress base URL (e.g., http://192.168.58.2) - required if DNS not configured")
+
+	return cmd
+}
+
+func runCallCommand(cmd *cobra.Command, args []string) error {
+	// Load configuration
+	config, err := LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	// Parse tool specifier (agent:tool or just tool)
+	toolSpec := args[0]
+	agentName, toolName := parseToolSpecifier(toolSpec)
+
+	// Get arguments
+	var toolArgs map[string]interface{}
+	fileFlag, _ := cmd.Flags().GetString("file")
+
+	if fileFlag != "" {
+		// Read arguments from file
+		data, err := os.ReadFile(fileFlag)
+		if err != nil {
+			return fmt.Errorf("failed to read arguments file: %w", err)
+		}
+		if err := json.Unmarshal(data, &toolArgs); err != nil {
+			return fmt.Errorf("invalid JSON in arguments file: %w", err)
+		}
+	} else if len(args) > 1 {
+		// Parse arguments from command line
+		if err := json.Unmarshal([]byte(args[1]), &toolArgs); err != nil {
+			return fmt.Errorf("invalid JSON arguments: %w", err)
+		}
+	} else {
+		toolArgs = make(map[string]interface{})
+	}
+
+	// Get registry connection flags
+	registryURL, _ := cmd.Flags().GetString("registry-url")
+	registryHost, _ := cmd.Flags().GetString("registry-host")
+	registryPort, _ := cmd.Flags().GetInt("registry-port")
+	registryScheme, _ := cmd.Flags().GetString("registry-scheme")
+	insecure, _ := cmd.Flags().GetBool("insecure")
+	timeout, _ := cmd.Flags().GetInt("timeout")
+	raw, _ := cmd.Flags().GetBool("raw")
+	agentURL, _ := cmd.Flags().GetString("agent-url")
+	ingressDomain, _ := cmd.Flags().GetString("ingress-domain")
+	ingressURL, _ := cmd.Flags().GetString("ingress-url")
+
+	// Create HTTP client with TLS config
+	httpClient := createHTTPClient(timeout, insecure)
+
+	// Determine agent endpoint and host header (for ingress mode)
+	var agentEndpoint string
+	var agentHostHeader string
+
+	if agentURL != "" {
+		// Use provided agent URL directly
+		agentEndpoint = agentURL
+	} else if ingressDomain != "" {
+		// Ingress mode: use Host headers for routing
+		extractedAgentName, hostHeader, err := findAgentWithToolIngress(httpClient, ingressURL, ingressDomain, agentName, toolName)
+		if err != nil {
+			return fmt.Errorf("failed to find agent: %w", err)
+		}
+		agentHostHeader = hostHeader
+		// In ingress mode, endpoint is the ingress URL, routing done via Host header
+		if ingressURL != "" {
+			agentEndpoint = ingressURL
+		} else {
+			agentEndpoint = fmt.Sprintf("http://%s.%s", extractedAgentName, ingressDomain)
+		}
+	} else {
+		// Direct mode: discover agent via registry
+		finalRegistryURL := determineRegistryURL(config, registryURL, registryHost, registryPort, registryScheme)
+		var err error
+		agentEndpoint, err = findAgentWithTool(httpClient, finalRegistryURL, agentName, toolName)
+		if err != nil {
+			return fmt.Errorf("failed to find agent: %w", err)
+		}
+	}
+
+	// Make MCP call
+	var result json.RawMessage
+	if ingressDomain != "" && agentURL == "" {
+		// Ingress mode: need Host header
+		result, err = callMCPToolWithHost(httpClient, agentEndpoint, agentHostHeader, toolName, toolArgs)
+	} else {
+		result, err = callMCPTool(httpClient, agentEndpoint, toolName, toolArgs)
+	}
+	if err != nil {
+		return fmt.Errorf("MCP call failed: %w", err)
+	}
+
+	// Output result
+	if raw {
+		fmt.Println(string(result))
+	} else {
+		var prettyJSON bytes.Buffer
+		if err := json.Indent(&prettyJSON, result, "", "  "); err != nil {
+			fmt.Println(string(result))
+		} else {
+			fmt.Println(prettyJSON.String())
+		}
+	}
+
+	return nil
+}
+
+// parseToolSpecifier parses "agent:tool" or "tool" format
+func parseToolSpecifier(spec string) (agentName, toolName string) {
+	parts := strings.SplitN(spec, ":", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", parts[0]
+}
+
+// createHTTPClient creates an HTTP client with optional TLS skip
+func createHTTPClient(timeoutSeconds int, insecure bool) *http.Client {
+	transport := &http.Transport{}
+
+	if insecure {
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+
+	return &http.Client{
+		Timeout:   time.Duration(timeoutSeconds) * time.Second,
+		Transport: transport,
+	}
+}
+
+// AgentWithCapabilities represents an agent from the registry with capabilities
+type AgentWithCapabilities struct {
+	ID           string     `json:"id"`
+	Name         string     `json:"name"`
+	Endpoint     string     `json:"endpoint"`
+	Status       string     `json:"status"`
+	Capabilities []ToolInfo `json:"capabilities"`
+}
+
+// findAgentWithTool queries the registry to find an agent with the specified tool
+func findAgentWithTool(client *http.Client, registryURL, agentName, toolName string) (string, error) {
+	// Get all agents from registry
+	resp, err := client.Get(registryURL + "/agents")
+	if err != nil {
+		return "", fmt.Errorf("failed to connect to registry at %s: %w", registryURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("registry returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var agentsResp struct {
+		Agents []AgentWithCapabilities `json:"agents"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&agentsResp); err != nil {
+		return "", fmt.Errorf("failed to parse registry response: %w", err)
+	}
+
+	// Find agent with matching tool (prefer healthy agents)
+	for _, agent := range agentsResp.Agents {
+		// Skip unhealthy agents
+		if agent.Status != "healthy" {
+			continue
+		}
+
+		// If agent name is specified, filter by it
+		if agentName != "" && agent.Name != agentName && agent.ID != agentName {
+			continue
+		}
+
+		// Check if agent has the tool (function_name is the MCP tool name)
+		for _, cap := range agent.Capabilities {
+			if cap.FunctionName == toolName {
+				if agent.Endpoint == "" {
+					return "", fmt.Errorf("agent '%s' has tool '%s' but no endpoint", agent.Name, toolName)
+				}
+				return agent.Endpoint, nil
+			}
+		}
+	}
+
+	if agentName != "" {
+		return "", fmt.Errorf("tool '%s' not found on agent '%s'", toolName, agentName)
+	}
+	return "", fmt.Errorf("no agent found with tool '%s'", toolName)
+}
+
+// findAgentWithToolIngress queries the registry via ingress to find an agent with the specified tool
+// Returns: extracted agent name (for ingress routing), host header for the agent, error
+func findAgentWithToolIngress(client *http.Client, ingressURL, ingressDomain, agentName, toolName string) (string, string, error) {
+	// Build registry URL and host header
+	var registryRequestURL string
+	registryHost := "registry." + ingressDomain
+
+	if ingressURL != "" {
+		registryRequestURL = strings.TrimSuffix(ingressURL, "/") + "/agents"
+	} else {
+		registryRequestURL = "http://" + registryHost + "/agents"
+	}
+
+	// Create request with Host header
+	req, err := http.NewRequest("GET", registryRequestURL, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set Host header for ingress routing (only needed if using ingressURL)
+	if ingressURL != "" {
+		req.Host = registryHost
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to connect to registry via ingress at %s: %w", registryRequestURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", "", fmt.Errorf("registry returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var agentsResp struct {
+		Agents []AgentWithCapabilities `json:"agents"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&agentsResp); err != nil {
+		return "", "", fmt.Errorf("failed to parse registry response: %w", err)
+	}
+
+	// Find agent with matching tool (prefer healthy agents)
+	for _, agent := range agentsResp.Agents {
+		// Skip unhealthy agents
+		if agent.Status != "healthy" {
+			continue
+		}
+
+		// If agent name is specified, filter by it
+		if agentName != "" && agent.Name != agentName && agent.ID != agentName {
+			continue
+		}
+
+		// Check if agent has the tool (function_name is the MCP tool name)
+		for _, cap := range agent.Capabilities {
+			if cap.FunctionName == toolName {
+				if agent.Endpoint == "" {
+					return "", "", fmt.Errorf("agent '%s' has tool '%s' but no endpoint", agent.Name, toolName)
+				}
+				// Extract agent name from endpoint for ingress routing
+				// Pattern: {agent-name}-mcp-mesh-agent.{namespace}:{port} -> {agent-name}
+				extractedName := extractAgentNameFromEndpoint(agent.Endpoint)
+				agentHost := extractedName + "." + ingressDomain
+				return extractedName, agentHost, nil
+			}
+		}
+	}
+
+	if agentName != "" {
+		return "", "", fmt.Errorf("tool '%s' not found on agent '%s'", toolName, agentName)
+	}
+	return "", "", fmt.Errorf("no agent found with tool '%s'", toolName)
+}
+
+// extractAgentNameFromEndpoint extracts the agent name from a K8s service endpoint
+// Examples:
+//   - "http://hello-world-mcp-mesh-agent.mcp-mesh:8080" -> "hello-world"
+//   - "http://system-agent-mcp-mesh-agent.mcp-mesh:8080" -> "system-agent"
+//   - "http://10.244.0.64:8080" -> "" (IP address, can't extract)
+func extractAgentNameFromEndpoint(endpoint string) string {
+	// Remove protocol prefix
+	endpoint = strings.TrimPrefix(endpoint, "http://")
+	endpoint = strings.TrimPrefix(endpoint, "https://")
+
+	// Get host part (before port)
+	host := strings.Split(endpoint, ":")[0]
+
+	// Check if it's an IP address (skip extraction)
+	if isIPAddress(host) {
+		return ""
+	}
+
+	// Get service name (before namespace dot)
+	serviceName := strings.Split(host, ".")[0]
+
+	// Remove "-mcp-mesh-agent" suffix to get agent name
+	agentName := strings.TrimSuffix(serviceName, "-mcp-mesh-agent")
+
+	return agentName
+}
+
+// isIPAddress checks if the string looks like an IP address
+func isIPAddress(s string) bool {
+	parts := strings.Split(s, ".")
+	if len(parts) != 4 {
+		return false
+	}
+	for _, part := range parts {
+		if len(part) == 0 || len(part) > 3 {
+			return false
+		}
+		for _, c := range part {
+			if c < '0' || c > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// callMCPToolWithHost makes an MCP tools/call request with a custom Host header (for ingress)
+func callMCPToolWithHost(client *http.Client, endpoint, hostHeader, toolName string, args map[string]interface{}) (json.RawMessage, error) {
+	// Build MCP request
+	mcpReq := MCPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+		Params: map[string]interface{}{
+			"name":      toolName,
+			"arguments": args,
+		},
+	}
+
+	reqBody, err := json.Marshal(mcpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Make request to agent's /mcp endpoint
+	mcpURL := strings.TrimSuffix(endpoint, "/") + "/mcp"
+	req, err := http.NewRequest("POST", mcpURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	// Set Host header for ingress routing
+	if hostHeader != "" {
+		req.Host = hostHeader
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call agent at %s (Host: %s): %w", mcpURL, hostHeader, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("agent returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Check if response is SSE format and extract JSON data
+	bodyStr := string(body)
+	jsonData := body
+
+	// SSE format: "event: message\ndata: {json}\n\n"
+	if strings.HasPrefix(bodyStr, "event:") || strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+		// Extract JSON from SSE data line
+		for _, line := range strings.Split(bodyStr, "\n") {
+			if strings.HasPrefix(line, "data:") {
+				jsonData = []byte(strings.TrimPrefix(line, "data:"))
+				jsonData = []byte(strings.TrimSpace(string(jsonData)))
+				break
+			}
+		}
+	}
+
+	// Parse MCP response
+	var mcpResp MCPResponse
+	if err := json.Unmarshal(jsonData, &mcpResp); err != nil {
+		// Return raw body if not valid JSON-RPC
+		return body, nil
+	}
+
+	if mcpResp.Error != nil {
+		return nil, fmt.Errorf("MCP error %d: %s", mcpResp.Error.Code, mcpResp.Error.Message)
+	}
+
+	if mcpResp.Result != nil {
+		return mcpResp.Result, nil
+	}
+
+	return body, nil
+}
+
+// callMCPTool makes an MCP tools/call request to the agent
+func callMCPTool(client *http.Client, endpoint, toolName string, args map[string]interface{}) (json.RawMessage, error) {
+	// Build MCP request
+	mcpReq := MCPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+		Params: map[string]interface{}{
+			"name":      toolName,
+			"arguments": args,
+		},
+	}
+
+	reqBody, err := json.Marshal(mcpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Make request to agent's /mcp endpoint
+	mcpURL := strings.TrimSuffix(endpoint, "/") + "/mcp"
+	req, err := http.NewRequest("POST", mcpURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call agent at %s: %w", mcpURL, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("agent returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Check if response is SSE format and extract JSON data
+	bodyStr := string(body)
+	jsonData := body
+
+	// SSE format: "event: message\ndata: {json}\n\n"
+	if strings.HasPrefix(bodyStr, "event:") || strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+		// Extract JSON from SSE data line
+		for _, line := range strings.Split(bodyStr, "\n") {
+			if strings.HasPrefix(line, "data:") {
+				jsonData = []byte(strings.TrimPrefix(line, "data:"))
+				jsonData = []byte(strings.TrimSpace(string(jsonData)))
+				break
+			}
+		}
+	}
+
+	// Parse MCP response
+	var mcpResp MCPResponse
+	if err := json.Unmarshal(jsonData, &mcpResp); err != nil {
+		// Return raw body if not valid JSON-RPC
+		return body, nil
+	}
+
+	if mcpResp.Error != nil {
+		return nil, fmt.Errorf("MCP error %d: %s", mcpResp.Error.Code, mcpResp.Error.Message)
+	}
+
+	if mcpResp.Result != nil {
+		return mcpResp.Result, nil
+	}
+
+	return body, nil
+}


### PR DESCRIPTION
## Summary
Add CLI commands for invoking MCP tools and discovering available tools across agents.

Closes #202

## Features

### meshctl call
- `meshctl call <tool_name> '{"arg": "value"}'` - invoke any MCP tool directly
- Automatic agent discovery - finds which agent provides the tool
- Support for `agent:tool` syntax to target specific agents

### meshctl list --tools
- `meshctl list --tools` - list all tools across all agents
- `meshctl list --tools=<tool>` - show tool details with input schema

## Usage
```bash
# Call a tool
meshctl call get_current_time
meshctl call add '{"a": 5, "b": 3}'

# List all tools
meshctl list --tools

# Get tool details
meshctl list --tools=get_current_time
```

## Test plan
- [x] Go unit tests pass
- [x] Python unit tests pass
- [ ] Manual testing of meshctl call
- [ ] Manual testing of meshctl list --tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `meshctl call` subcommand to directly invoke MCP tools on agents from the CLI with support for registry discovery and Kubernetes ingress routing.
  * Enhanced `meshctl list` with `--tools` flag to inspect available tools and view detailed tool information including schemas and examples.

* **Documentation**
  * Comprehensively updated getting-started guides, examples, and architecture documentation to showcase meshctl CLI workflows with curl alternatives provided for advanced users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->