### PR TITLE
Fix npm packages to include mcp-mesh-registry for all platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,9 +210,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Publish npm packages
+  # Downloads pre-built binaries from GitHub releases instead of building
   publish-npm:
     runs-on: ubuntu-latest
-    needs: [build-binaries, build-macos-binaries]
+    needs: [build-binaries, build-macos-binaries, combine-checksums]
     if: >
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
@@ -221,17 +222,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: false
-
-      - name: Install cross-compilation toolchain
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-x86-64-linux-gnu
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -255,7 +245,7 @@ jobs:
 
       - name: Build npm packages
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: v${{ steps.version.outputs.version }}
         run: ./packaging/scripts/build-npm-packages.sh
 
       - name: Publish platform packages to npm


### PR DESCRIPTION
## Summary

Fix npm packages to include `mcp-mesh-registry` for macOS platforms by downloading pre-built binaries from GitHub releases instead of building from source.

## Problem

- v0.7.3 npm packages missing `mcp-mesh-registry` on macOS
- CGO cross-compilation from Linux to macOS not possible without macOS SDK

## Solution

Download pre-built binaries from GitHub releases (which are built natively on `macos-latest`) instead of cross-compiling.

## Changes

- **build-npm-packages.sh**: Download release tarballs and extract binaries
- **release.yml**: Remove Go/CGO setup from `publish-npm`, depend on `combine-checksums`

## Test plan

- [x] Verified locally all 4 platforms have both binaries
- [ ] Release v0.7.4 to test in CI

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined npm package build process to download and use pre-built binaries instead of in-source compilation.
  * Enhanced CI/CD workflow efficiency by restructuring job dependencies and removing redundant build steps.
  * Updated package metadata and added improved logging for better build transparency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->