### PR TITLE
Release v0.7.4

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -9,7 +9,7 @@ on:
       version:
         description: "Version tag (e.g., v0.7.1)"
         required: true
-        default: "v0.7.3"
+        default: "v0.7.4"
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "Version (e.g., v0.7.0)"
         required: true
-        default: "v0.7.3"
+        default: "v0.7.4"
       environment:
         description: "Environment"
         type: choice

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,20 @@
 # MCP Mesh Release Notes
 
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v0.7.3...v0.7.4)
+
+## v0.7.4 (2025-12-12)
+
+### 🐛 Bug Fixes
+
+- **npm packages**: Fixed `mcp-mesh-registry` missing from macOS npm packages
+  - Now downloads pre-built binaries from GitHub releases instead of cross-compiling
+  - All platforms (Linux x64/arm64, macOS x64/arm64) include both `meshctl` and `mcp-mesh-registry`
+
+### 📦 Infrastructure
+
+- Simplified npm build process by reusing release assets
+- Removed CGO cross-compilation dependency from npm publish workflow
+
 [Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v0.7.2...v0.7.3)
 
 ## v0.7.3 (2025-12-11)

--- a/helm/mcp-mesh-agent/Chart.yaml
+++ b/helm/mcp-mesh-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-agent
 description: MCP Mesh Agent - Python runtime for MCP agents with mesh capabilities
 type: application
-version: 0.7.3
-appVersion: "0.7.3"
+version: 0.7.4
+appVersion: "0.7.4"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-core/Chart.yaml
+++ b/helm/mcp-mesh-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-core
 description: MCP Mesh Core Infrastructure - Registry, PostgreSQL, Redis, and Observability
 type: application
-version: 0.7.3
-appVersion: "0.7.3"
+version: 0.7.4
+appVersion: "0.7.4"
 keywords:
   - mcp
   - mesh
@@ -28,22 +28,22 @@ annotations:
   "artifacthub.io/containsSecurityUpdates": "false"
 dependencies:
   - name: mcp-mesh-postgres
-    version: "0.7.3"
+    version: "0.7.4"
     repository: "file://../mcp-mesh-postgres"
     condition: postgres.enabled
   - name: mcp-mesh-redis
-    version: "0.7.3"
+    version: "0.7.4"
     repository: "file://../mcp-mesh-redis"
     condition: redis.enabled
   - name: mcp-mesh-registry
-    version: "0.7.3"
+    version: "0.7.4"
     repository: "file://../mcp-mesh-registry"
     condition: registry.enabled
   - name: mcp-mesh-grafana
-    version: "0.7.3"
+    version: "0.7.4"
     repository: "file://../mcp-mesh-grafana"
     condition: grafana.enabled
   - name: mcp-mesh-tempo
-    version: "0.7.3"
+    version: "0.7.4"
     repository: "file://../mcp-mesh-tempo"
     condition: tempo.enabled

--- a/helm/mcp-mesh-grafana/Chart.yaml
+++ b/helm/mcp-mesh-grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-grafana
 description: Grafana observability component for MCP Mesh
 type: application
-version: 0.7.3
+version: 0.7.4
 appVersion: "11.4.0"
 keywords:
   - grafana

--- a/helm/mcp-mesh-ingress/Chart.yaml
+++ b/helm/mcp-mesh-ingress/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ingress
 description: Ingress configuration for MCP Mesh services with flexible DNS routing
 type: application
-version: 0.7.3
-appVersion: "0.7.3"
+version: 0.7.4
+appVersion: "0.7.4"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-postgres/Chart.yaml
+++ b/helm/mcp-mesh-postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-postgres
 description: PostgreSQL database for MCP Mesh Registry
 type: application
-version: 0.7.3
+version: 0.7.4
 appVersion: "15"
 keywords:
   - mcp

--- a/helm/mcp-mesh-redis/Chart.yaml
+++ b/helm/mcp-mesh-redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-redis
 description: Redis cache for MCP Mesh session storage
 type: application
-version: 0.7.3
+version: 0.7.4
 appVersion: "7"
 keywords:
   - mcp

--- a/helm/mcp-mesh-registry/Chart.yaml
+++ b/helm/mcp-mesh-registry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-registry
 description: MCP Mesh Registry Service - Central service registry for MCP agents
 type: application
-version: 0.7.3
-appVersion: "0.7.3"
+version: 0.7.4
+appVersion: "0.7.4"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-tempo/Chart.yaml
+++ b/helm/mcp-mesh-tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-tempo
 description: Tempo distributed tracing component for MCP Mesh
 type: application
-version: 0.7.3
+version: 0.7.4
 appVersion: "2.8.1"
 keywords:
   - tempo

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/cli",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "CLI for MCP Mesh - Enterprise-Grade Distributed Service Mesh for AI Agents",
   "license": "MIT",
   "repository": {
@@ -22,10 +22,10 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@mcpmesh/cli-linux-x64": "0.7.3",
-    "@mcpmesh/cli-linux-arm64": "0.7.3",
-    "@mcpmesh/cli-darwin-x64": "0.7.3",
-    "@mcpmesh/cli-darwin-arm64": "0.7.3"
+    "@mcpmesh/cli-linux-x64": "0.7.4",
+    "@mcpmesh/cli-linux-arm64": "0.7.4",
+    "@mcpmesh/cli-darwin-x64": "0.7.4",
+    "@mcpmesh/cli-darwin-arm64": "0.7.4"
   },
   "keywords": [
     "mcp",

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "0.7.3"
+version = "0.7.4"
 description = "Kubernetes-native platform for distributed MCP applications"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packaging/scoop/mcp-mesh.json
+++ b/packaging/scoop/mcp-mesh.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Kubernetes-native platform for distributed MCP applications",
   "homepage": "https://github.com/dhyansraj/mcp-mesh",
   "license": "MIT",

--- a/src/runtime/python/_mcp_mesh/__init__.py
+++ b/src/runtime/python/_mcp_mesh/__init__.py
@@ -31,7 +31,7 @@ from .engine.decorator_registry import (
     get_decorator_stats,
 )
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"
 
 # Store reference to runtime processor if initialized
 _runtime_processor = None

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "0.7.3"
+version = "0.7.4"
 description = "Kubernetes-native platform for distributed MCP applications"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

- Fix npm packages to include `mcp-mesh-registry` for all platforms
- Version bumps to 0.7.4

## Changes

### 🐛 Bug Fixes

- **npm packages**: Fixed `mcp-mesh-registry` missing from macOS npm packages
  - Downloads pre-built binaries from GitHub releases instead of cross-compiling
  - All platforms now include both `meshctl` and `mcp-mesh-registry`

### 📦 Infrastructure

- Simplified npm build process by reusing release assets
- Removed CGO cross-compilation dependency from npm publish workflow

## Test plan

- [ ] Verify all version files updated to 0.7.4
- [ ] Tag and release after merge
- [ ] Verify npm packages include both binaries on all platforms

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mcp-mesh-registry unavailability on macOS
  * meshctl and mcp-mesh-registry now available on all supported platforms
  * Improved binary distribution using pre-built GitHub releases

* **Infrastructure**
  * Streamlined npm package build process using release assets
  * Optimized cross-platform compilation workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->