### PR TITLE
Fix version not embedded correctly in binaries

### DIFF
--- a/packaging/scripts/build-binaries.sh
+++ b/packaging/scripts/build-binaries.sh
@@ -112,7 +112,7 @@ build_binary() {
     local ldflags=(
         "-w"                                    # Omit debug info
         "-s"                                    # Omit symbol table
-        "-X main.Version=$VERSION"              # Set version
+        "-X main.version=$VERSION"              # Set version (lowercase 'v' to match Go source)
         "-X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)"  # Set build time
         "-X main.GitCommit=$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')"  # Set git commit
     )


### PR DESCRIPTION
## Summary
- Fix ldflags to use lowercase `main.version` to match Go source code
- Go's `-X` linker flag is case-sensitive

## Test plan
- [ ] Verify binaries show correct version after release

Fixes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to properly align version assignment with source code conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->