### PR TITLE
Fix: meshctl scaffold --compose generates correct command (#222)

### DIFF
--- a/src/core/cli/scaffold/compose.go
+++ b/src/core/cli/scaffold/compose.go
@@ -314,7 +314,7 @@ services:
     volumes:
       - ./{{ .Dir }}:/app:ro
     working_dir: /app
-    command: ["python", "main.py"]
+    command: ["main.py"]
     environment:
       MCP_MESH_REGISTRY_URL: http://registry:8000
       AGENT_NAME: {{ .Name }}


### PR DESCRIPTION
## Summary
- Fixes incorrect command in generated docker-compose.yml
- Changed from `["python", "main.py"]` to `["main.py"]`
- The `mcpmesh/python-runtime` image has `ENTRYPOINT ["python"]`, so specifying python again was redundant

## Changes
- `src/core/cli/scaffold/compose.go`: Line 317

## Test plan
- [x] Run `meshctl scaffold --compose` and verify the generated command is `["main.py"]`

Fixes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated script execution configuration in container deployment setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->