### PR TITLE
Add scaffold topic to meshctl man (#223)

### DIFF
--- a/src/core/cli/man/content.go
+++ b/src/core/cli/man/content.go
@@ -97,6 +97,12 @@ var guideRegistry = map[string]*Guide{
 		Title:       "FastAPI Integration",
 		Description: "@mesh.route for FastAPI backends consuming mesh capabilities",
 	},
+	"scaffold": {
+		Name:        "scaffold",
+		Aliases:     []string{"scaffolding", "generate", "gen", "new"},
+		Title:       "Agent Scaffolding",
+		Description: "Generate agents with meshctl scaffold command",
+	},
 }
 
 // aliasMap maps aliases to canonical guide names.
@@ -140,6 +146,7 @@ func ListGuides() []*Guide {
 		"overview", "capabilities", "tags", "decorators",
 		"dependency-injection", "health", "registry", "llm",
 		"proxies", "fastapi", "environment", "deployment", "testing",
+		"scaffold",
 	}
 	for _, name := range order {
 		if guide, ok := guideRegistry[name]; ok {

--- a/src/core/cli/man/content/scaffold.md
+++ b/src/core/cli/man/content/scaffold.md
@@ -1,0 +1,82 @@
+# Agent Scaffolding
+
+> Generate MCP Mesh agents from templates
+
+## Input Modes
+
+| Mode | Usage | Best For |
+|------|-------|----------|
+| Interactive | `meshctl scaffold` | First-time users |
+| CLI flags | `meshctl scaffold --name my-agent --agent-type tool` | Scripting |
+| Config file | `meshctl scaffold --config scaffold.yaml` | Complex agents |
+
+## Agent Types
+
+| Type | Decorator | Description |
+|------|-----------|-------------|
+| `tool` | `@mesh.tool` | Basic capability agent |
+| `llm-agent` | `@mesh.llm` | LLM-powered agent that consumes providers |
+| `llm-provider` | `@mesh.llm_provider` | Zero-code LLM provider |
+
+## Quick Examples
+
+```bash
+# Basic tool agent
+meshctl scaffold --name my-agent --agent-type tool
+
+# LLM agent using Claude
+meshctl scaffold --name analyzer --agent-type llm-agent --llm-selector claude
+
+# LLM provider exposing GPT-4
+meshctl scaffold --name gpt-provider --agent-type llm-provider --model openai/gpt-4
+
+# Preview without creating files
+meshctl scaffold --name my-agent --agent-type tool --dry-run
+
+# Non-interactive mode (for CI/scripts)
+meshctl scaffold --name my-agent --agent-type tool --no-interactive
+```
+
+## Adding Tools to Existing Agents
+
+```bash
+# Add a basic tool
+meshctl scaffold --name my-agent --add-tool new_function --tool-type mesh.tool
+
+# Add an LLM-powered tool
+meshctl scaffold --name my-agent --add-tool smart_function --tool-type mesh.llm
+```
+
+## Docker Compose Generation
+
+```bash
+# Generate docker-compose.yml for all agents in current directory
+meshctl scaffold --compose
+
+# Include observability stack (Redis, Tempo, Grafana)
+meshctl scaffold --compose --observability
+
+# Custom project name
+meshctl scaffold --compose --project-name my-project
+```
+
+## Key Flags
+
+| Flag | Description |
+|------|-------------|
+| `--name` | Agent name (required for non-interactive) |
+| `--agent-type` | `tool`, `llm-agent`, or `llm-provider` |
+| `--dry-run` | Preview generated code |
+| `--no-interactive` | Disable prompts (for scripting) |
+| `--output` | Output directory (default: `.`) |
+| `--port` | HTTP port (default: 9000) |
+| `--model` | LiteLLM model for llm-provider |
+| `--llm-selector` | LLM provider for llm-agent: `claude`, `openai` |
+| `--compose` | Generate docker-compose.yml |
+| `--observability` | Add Redis/Tempo/Grafana to compose |
+
+## See Also
+
+- `meshctl man decorators` - Decorator reference
+- `meshctl man llm` - LLM integration guide
+- `meshctl man deployment` - Docker and Kubernetes deployment


### PR DESCRIPTION
## Summary
Adds `meshctl man scaffold` documentation covering agent scaffolding.

## Topics Covered
- Input modes: interactive, CLI flags, config file
- Agent types: `tool`, `llm-agent`, `llm-provider`
- Quick examples for common use cases
- Adding tools to existing agents (`--add-tool`)
- Docker compose generation (`--compose`, `--observability`)
- Key flags reference table

## Aliases
`scaffolding`, `generate`, `gen`, `new`

## Test plan
- [x] `meshctl man --list` shows scaffold topic
- [x] `meshctl man scaffold` displays the documentation
- [x] Aliases work (`meshctl man gen`, `meshctl man new`)

Fixes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Agent Scaffolding guide covering input modes, agent type options, quick setup examples, Docker Compose generation with observability features, and key configuration flags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->