### PR TITLE
Fix Helm chart docs: remove redundant python from command (#225)

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -46,7 +46,7 @@ helm install mcp-core helm/mcp-mesh-core -n mcp-mesh
 # 2. Install agents (repeat for each agent)
 helm install hello-world helm/mcp-mesh-agent -n mcp-mesh \
   --set agent.name=hello-world \
-  --set agent.command='["python","/app/agent.py"]'
+  --set agent.command='["/app/agent.py"]'
 
 # 3. (Optional) Install ingress for external access
 helm install mcp-ingress helm/mcp-mesh-ingress -n mcp-mesh

--- a/helm/mcp-mesh-agent/README.md
+++ b/helm/mcp-mesh-agent/README.md
@@ -18,7 +18,7 @@ For simple agents with a single Python file:
 ```bash
 helm install hello-world ./helm/mcp-mesh-agent -n mcp-mesh \
   --set agent.name=hello-world \
-  --set agent.command='["python","/app/agent.py"]'
+  --set agent.command='["/app/agent.py"]'
 ```
 
 ### Method 2: Multi-File Agent (Custom Docker Image)

--- a/helm/mcp-mesh-agent/values.yaml
+++ b/helm/mcp-mesh-agent/values.yaml
@@ -104,8 +104,9 @@ agent:
 
   # Container command override (optional)
   # If empty, uses Docker image's CMD (recommended for multi-file agents)
-  # For single-file agents: ["python", "/app/agent.py"]
-  # For multi-file agents: [] (uses Docker CMD like "python -m myagent")
+  # For single-file agents: ["/app/agent.py"]
+  # For multi-file agents: [] (uses Docker CMD)
+  # Note: Don't include "python" - the mcpmesh/python-runtime image ENTRYPOINT provides it
   command: []
 
   # Hostname advertised to registry for service discovery


### PR DESCRIPTION
## Summary
Fixes incorrect command examples in Helm chart documentation that caused double python execution.

## Changes
| File | Change |
|------|--------|
| `helm/README.md` | `["python","/app/agent.py"]` → `["/app/agent.py"]` |
| `helm/mcp-mesh-agent/README.md` | `["python","/app/agent.py"]` → `["/app/agent.py"]` |
| `helm/mcp-mesh-agent/values.yaml` | Updated comment + added clarifying note |

## Root Cause
The `mcpmesh/python-runtime` image has `ENTRYPOINT ["python"]`, so including `python` in the command causes double execution.

## Test plan
- [x] Documentation examples now show correct command format

Fixes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm installation guidance for agent command configuration, clarifying that single-file agents should specify only the script path without explicit Python interpreter invocation.
  * Added clarification that the Python runtime is provided by the container's ENTRYPOINT.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->