### PR TITLE
Fix Dockerfile templates for non-root user permissions (#226)

### DIFF
--- a/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
@@ -3,15 +3,22 @@ FROM mcpmesh/python-runtime:0.7
 
 WORKDIR /app
 
+# Switch to root to copy files (base image runs as non-root mcp-mesh user)
+USER root
+
 # Copy requirements and install dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy agent source code
-COPY . .
+# Copy agent source code and set permissions
+COPY --chmod=755 . .
+RUN chown -R mcp-mesh:mcp-mesh /app
+
+# Switch back to non-root user for security
+USER mcp-mesh
 
 # Expose the agent port
 EXPOSE {{ .Port }}
 
-# Run as module
-CMD ["python", "-m", "{{ .Name }}"]
+# Run the agent
+CMD ["main.py"]

--- a/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
@@ -3,15 +3,22 @@ FROM mcpmesh/python-runtime:0.7
 
 WORKDIR /app
 
+# Switch to root to copy files (base image runs as non-root mcp-mesh user)
+USER root
+
 # Copy requirements and install dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy agent source code
-COPY . .
+# Copy agent source code and set permissions
+COPY --chmod=755 . .
+RUN chown -R mcp-mesh:mcp-mesh /app
+
+# Switch back to non-root user for security
+USER mcp-mesh
 
 # Expose the agent port
 EXPOSE {{ .Port }}
 
-# Run as module
-CMD ["python", "-m", "{{ .Name }}"]
+# Run the agent
+CMD ["main.py"]

--- a/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
@@ -3,15 +3,22 @@ FROM mcpmesh/python-runtime:0.7
 
 WORKDIR /app
 
+# Switch to root to copy files (base image runs as non-root mcp-mesh user)
+USER root
+
 # Copy requirements and install dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy agent source code
-COPY . .
+# Copy agent source code and set permissions
+COPY --chmod=755 . .
+RUN chown -R mcp-mesh:mcp-mesh /app
+
+# Switch back to non-root user for security
+USER mcp-mesh
 
 # Expose the agent port
 EXPOSE {{ .Port }}
 
-# Run as module
-CMD ["python", "-m", "{{ .Name }}"]
+# Run the agent
+CMD ["main.py"]


### PR DESCRIPTION
## Summary
- Fix scaffolded Dockerfile templates to work out of the box with mcpmesh/python-runtime base image
- The base image runs as non-root user (mcp-mesh), which caused permission errors during COPY
- Templates now switch to root, copy files with proper permissions, then switch back to mcp-mesh

## Changes
- Switch to `USER root` before copying files
- Use `COPY --chmod=755` for proper permissions
- Set ownership with `chown -R mcp-mesh:mcp-mesh /app`
- Switch back to `USER mcp-mesh` for runtime security
- Update CMD from `["python", "-m", "name"]` to `["main.py"]` (consistent with #222 fix)

## Files Changed
- `cmd/meshctl/templates/python/basic/Dockerfile.tmpl`
- `cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl`
- `cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl`

## Test plan
- [ ] Run `meshctl scaffold basic test-agent` and verify Dockerfile looks correct
- [ ] Build the generated Dockerfile with Docker
- [ ] Verify container runs successfully as non-root user

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Enhanced security posture of generated Python service containers with improved user privilege and permission management during container initialization phases
  * Modified service startup method from module-based Python execution to direct entry script invocation for improved runtime behavior
  * Updates applied to all Python service templates including basic, LLM agent, and LLM provider services

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->