### PR TITLE
Add CLI commands topic to meshctl man

### DIFF
--- a/src/core/cli/man/content.go
+++ b/src/core/cli/man/content.go
@@ -103,6 +103,12 @@ var guideRegistry = map[string]*Guide{
 		Title:       "Agent Scaffolding",
 		Description: "Generate agents with meshctl scaffold command",
 	},
+	"cli": {
+		Name:        "cli",
+		Aliases:     []string{"commands", "call", "list", "status"},
+		Title:       "CLI Commands",
+		Description: "meshctl call, list, status for development and testing",
+	},
 }
 
 // aliasMap maps aliases to canonical guide names.
@@ -146,7 +152,7 @@ func ListGuides() []*Guide {
 		"overview", "capabilities", "tags", "decorators",
 		"dependency-injection", "health", "registry", "llm",
 		"proxies", "fastapi", "environment", "deployment", "testing",
-		"scaffold",
+		"scaffold", "cli",
 	}
 	for _, name := range order {
 		if guide, ok := guideRegistry[name]; ok {

--- a/src/core/cli/man/content/cli.md
+++ b/src/core/cli/man/content/cli.md
@@ -1,0 +1,78 @@
+# CLI Commands for Development
+
+> Essential meshctl commands for developing and testing agents
+
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `meshctl call` | Invoke a tool on any agent |
+| `meshctl list` | Show running agents |
+| `meshctl list --tools` | List all available tools |
+| `meshctl status` | Check mesh health |
+
+## Calling Tools
+
+```bash
+# Call a tool (auto-discovers agent via registry)
+meshctl call hello_mesh_simple
+
+# Specify agent explicitly
+meshctl call weather-agent:get_weather
+
+# Pass arguments as JSON
+meshctl call calculator:add '{"a": 1, "b": 2}'
+
+# Arguments from file
+meshctl call analyzer:process --file data.json
+
+# Direct agent call (skip registry)
+meshctl call hello_mesh --agent-url http://localhost:8080
+```
+
+## Listing Agents and Tools
+
+```bash
+# Show all running agents
+meshctl list
+
+# Wide view with endpoints and tool counts
+meshctl list --wide
+
+# Filter by name
+meshctl list --filter hello
+
+# List all tools across all agents
+meshctl list --tools
+
+# Show specific tool's schema
+meshctl list --tools=get_current_time
+```
+
+## Checking Status
+
+```bash
+# Basic status
+meshctl status
+
+# Detailed information
+meshctl status --verbose
+
+# JSON output for scripting
+meshctl status --json
+```
+
+## Remote Registry
+
+All commands support connecting to remote registries:
+
+```bash
+meshctl call hello_mesh --registry-url http://remote:8000
+meshctl list --registry-url http://remote:8000
+meshctl status --registry-url http://remote:8000
+```
+
+## See Also
+
+- `meshctl man testing` - MCP JSON-RPC protocol details
+- `meshctl man scaffold` - Creating new agents

--- a/src/core/cli/man/content/testing.md
+++ b/src/core/cli/man/content/testing.md
@@ -1,10 +1,20 @@
 # Testing MCP Agents
 
-> How to test MCP Mesh agents using curl and the MCP JSON-RPC protocol
+> How to test MCP Mesh agents using meshctl and curl
 
-## Overview
+## Quick Way: meshctl call
 
-MCP agents expose a JSON-RPC 2.0 API over HTTP with Server-Sent Events (SSE) responses. This guide shows the correct curl syntax for testing agents - a common source of errors when working with MCP.
+```bash
+meshctl call hello_mesh_simple                    # Call tool by name
+meshctl call calculator:add '{"a": 1, "b": 2}'    # With arguments
+meshctl list --tools                              # List all available tools
+```
+
+See `meshctl man cli` for more CLI commands.
+
+## Protocol Details: curl
+
+MCP agents expose a JSON-RPC 2.0 API over HTTP with Server-Sent Events (SSE) responses. This section shows the correct curl syntax - useful for understanding the underlying protocol.
 
 ## Key Points
 
@@ -121,5 +131,6 @@ meshctl status --verbose
 
 ## See Also
 
+- `meshctl man cli` - CLI commands for development
 - `meshctl man decorators` - How to create tools
 - `meshctl man capabilities` - Understanding capabilities


### PR DESCRIPTION
## Summary
- Add new `cli` topic covering `meshctl call`, `list`, `status` commands for development
- Update `testing` topic to show `meshctl call` as the quick/easy way first
- Keep curl examples for protocol understanding

## Changes
- New `src/core/cli/man/content/cli.md` with concise command reference
- Updated `testing.md` to reference cli topic in See Also
- Registered cli topic with aliases: commands, call, list, status

## Test plan
- [ ] `meshctl man cli` shows the new topic
- [ ] `meshctl man call` works via alias
- [ ] `meshctl man testing` shows quick meshctl call section at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive CLI commands guide featuring quick reference examples for calling tools, listing agents, and checking status.
  * Updated testing documentation to include meshctl usage examples alongside curl-based testing methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->