### PR TITLE
Fix registry version output (double v and outdated description)

### DIFF
--- a/cmd/mcp-mesh-registry/main.go
+++ b/cmd/mcp-mesh-registry/main.go
@@ -62,9 +62,8 @@ func main() {
 	}
 
 	if *showVersion {
-		fmt.Printf("MCP Mesh Registry Service v%s\n", version)
-		fmt.Println("Built with Go and Kubernetes API Server patterns")
-		fmt.Println("Compatible with Python MCP Mesh Registry API")
+		fmt.Printf("MCP Mesh Registry %s\n", version)
+		fmt.Println("Central service discovery and agent coordination for MCP Mesh")
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Fix double 'v' in version output (`vv0.7.5` → `v0.7.5`)
- Update description to reflect current purpose
- Remove legacy Python compatibility mention

## Before
```
MCP Mesh Registry Service vv0.7.5
Built with Go and Kubernetes API Server patterns
Compatible with Python MCP Mesh Registry API
```

## After
```
MCP Mesh Registry v0.7.5
Central service discovery and agent coordination for MCP Mesh
```

## Test plan
- [ ] `mcp-mesh-registry --version` shows correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated version display format and service description text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->