### PR TITLE
Fix LLM tool resolutions not stored for tags-only filters

### DIFF
--- a/src/core/registry/ent_service.go
+++ b/src/core/registry/ent_service.go
@@ -717,17 +717,25 @@ func (s *EntService) StoreLLMToolResolutions(
 				filterTags = getStringSlice(f, "tags")
 			}
 
-			if filterCapability == "" {
+			// Skip only if BOTH capability AND tags are empty
+			if filterCapability == "" && len(filterTags) == 0 {
 				continue
 			}
 
 			// Find matching resolved tools
 			var matchedTools []LLMToolInfo
 			if hasResolved {
-				for _, tool := range resolvedTools {
-					if tool.Capability == filterCapability {
-						matchedTools = append(matchedTools, tool)
+				if filterCapability != "" {
+					// Capability-based filter: match by capability name
+					for _, tool := range resolvedTools {
+						if tool.Capability == filterCapability {
+							matchedTools = append(matchedTools, tool)
+						}
 					}
+				} else {
+					// Tags-only filter: all resolved tools are matches
+					// (FilterToolsForLLM already filtered by tags)
+					matchedTools = resolvedTools
 				}
 			}
 


### PR DESCRIPTION
## Summary

Fixes #255

The `StoreLLMToolResolutions` function was skipping storage when the filter had no `capability` field, even when tags were present. This caused `meshctl status` to show no LLM tool resolutions for the common tags-only filter pattern.

## Changes

- Skip storage only when BOTH capability AND tags are empty
- For tags-only filters, use all resolved tools (already filtered by `FilterToolsForLLM`)

## Before/After

| Metric | Before | After |
|--------|--------|-------|
| `llm_tool_resolutions` rows | 1 (capability-only) | 9 (all filters) |
| `meshctl status` LLM Tool Resolutions | 1 | 8 |

## Test plan

- [x] Verified tags-only filters now stored in PostgreSQL
- [x] Verified `meshctl status` displays all LLM tool resolutions
- [x] Tested with demo docker-compose (built registry from source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool resolution behavior when filtering by tags without specifying capabilities. Tools are now properly matched when tag filters are applied.
  * Improved handling of tool resolution logic when combining different filter configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->