### PR TITLE
Suppress noisy docket task queue DEBUG logs

### DIFF
--- a/src/runtime/python/_mcp_mesh/shared/logging_config.py
+++ b/src/runtime/python/_mcp_mesh/shared/logging_config.py
@@ -73,6 +73,11 @@ def configure_logging():
     logging.getLogger("mcp_mesh").setLevel(log_level)
     logging.getLogger("_mcp_mesh").setLevel(log_level)
 
+    # Suppress noisy third-party loggers
+    # docket (task queue used by fastmcp) produces excessive DEBUG logs like
+    # "Scheduling due tasks", "Getting redeliveries", "Getting new deliveries" in tight loops
+    logging.getLogger("docket").setLevel(logging.WARNING)
+
     # Return the configured level for reference
     return log_level
 


### PR DESCRIPTION
## Summary

- Suppress excessive DEBUG logs from `docket` library (task queue used by fastmcp)
- Messages like "Scheduling due tasks", "Getting redeliveries", "Getting new deliveries" were flooding logs in tight loops
- Set `docket` logger to WARNING level while keeping mcp-mesh loggers at DEBUG

## Test plan

- [x] Tested with docker-compose demo - docket spam is gone
- [x] mcp-mesh DEBUG logs still visible

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced excessive debug logging from a third-party component, improving log clarity and readability while maintaining all existing internal logging configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->