### PR TITLE
Use GET /v1/models for Anthropic health check

### DIFF
--- a/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
@@ -42,20 +42,20 @@ async def health_check() -> dict:
         errors.append("ANTHROPIC_API_KEY not set")
         status = "unhealthy"
 
-    # Check API connectivity
+    # Check API connectivity (uses /v1/models - free, no tokens consumed)
     if api_key:
         try:
             import httpx
 
             async with httpx.AsyncClient(timeout=5.0) as client:
-                response = await client.head(
-                    "https://api.anthropic.com/v1/messages",
+                response = await client.get(
+                    "https://api.anthropic.com/v1/models",
                     headers={
                         "anthropic-version": "2023-06-01",
                         "x-api-key": api_key,
                     },
                 )
-                if response.status_code in [400, 405]:
+                if response.status_code == 200:
                     checks["anthropic_api_reachable"] = True
                     checks["anthropic_api_key_valid"] = True
                 elif response.status_code == 401:


### PR DESCRIPTION
## Summary

- Replace `HEAD /v1/messages` (returns 405) with `GET /v1/models` (returns 200)
- Same approach as OpenAI health check
- Free endpoint (no tokens consumed)
- Validates API key and confirms API reachability

## Before
```python
response = await client.head("https://api.anthropic.com/v1/messages")
if response.status_code in [400, 405]:  # Hacky workaround
```

## After
```python
response = await client.get("https://api.anthropic.com/v1/models")
if response.status_code == 200:  # Clean, consistent with OpenAI
```

## Test plan

- [x] Verified `GET /v1/models` returns 200 with valid API key
- [x] Template updated

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Anthropic connectivity verification to better validate API key validity and endpoint reachability through updated health check mechanisms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->