### PR TITLE
Docs: Fix response_format and venv location documentation

### DIFF
--- a/src/core/cli/man/content/decorators.md
+++ b/src/core/cli/man/content/decorators.md
@@ -87,7 +87,6 @@ Enables LLM-powered tools with automatic tool discovery.
     max_iterations=5,                    # Max agentic loop iterations
     system_prompt="file://prompts/agent.jinja2",  # Jinja2 template
     context_param="ctx",                 # Parameter name for context
-    response_format="json",              # "text" or "json"
     filter=[{"tags": ["tools"]}],        # Tool filter for discovery
     filter_mode="all",                   # "all", "best_match", or "*"
 )
@@ -95,9 +94,11 @@ Enables LLM-powered tools with automatic tool discovery.
     capability="smart_assistant",
     description="LLM-powered assistant",
 )
-def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None):
+def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
     return llm("Help the user with their request")
 ```
+
+**Note**: Response format is determined by return type: `-> str` for text, `-> PydanticModel` for JSON.
 
 ### Filter Modes
 

--- a/src/core/cli/man/content/prerequisites.md
+++ b/src/core/cli/man/content/prerequisites.md
@@ -28,8 +28,11 @@ sudo apt install python3.11       # Ubuntu/Debian
 
 ### Virtual Environment (Recommended)
 
+Create a virtual environment at your **project root** (where you run `meshctl`).
+All agents share this single venv - do not create separate venvs inside agent folders.
+
 ```bash
-# Create and activate
+# At project root
 python3.11 -m venv .venv
 source .venv/bin/activate         # macOS/Linux
 .venv\Scripts\activate            # Windows
@@ -50,15 +53,17 @@ python -c "import mesh; print('Ready!')"
 ### Quick Start
 
 ```bash
-# Create project
-mkdir my-agent && cd my-agent
+# Setup venv at project root
 python3.11 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
 pip install "mcp-mesh>=0.7,<0.8"
 
-# Scaffold and run
+# Scaffold agents (creates subfolders)
 meshctl scaffold --name hello --agent-type basic
+meshctl scaffold --name assistant --agent-type llm-agent
+
+# Run (from project root)
 meshctl start hello/main.py --debug
 ```
 


### PR DESCRIPTION
## Summary

### Issue #254: Clarify response_format is determined by return type
- Remove `response_format` from decorator examples and parameter tables
- Add note explaining return type determines format (`-> str` vs `-> PydanticModel`)
- Update Response Formats section with clear examples

### Issue #256: Clarify venv should be at project root
- Add explicit note that venv goes at project root
- Clarify agents share single venv, not separate ones per agent folder
- Simplify Quick Start (users are already in their project)

## Files Changed

- `src/core/cli/man/content/llm.md`
- `src/core/cli/man/content/decorators.md`
- `src/core/cli/man/content/prerequisites.md`

Closes #254
Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that response format is determined by function return type annotations rather than decorator parameters.
  * Updated setup instructions for virtual environment management at the project root.
  * Revised Quick Start guide with updated scaffolding steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->