### PR TITLE
Docs: Clarify meshctl auto-detects .venv without activation

### DIFF
--- a/src/core/cli/man/content/prerequisites.md
+++ b/src/core/cli/man/content/prerequisites.md
@@ -31,13 +31,16 @@ sudo apt install python3.11       # Ubuntu/Debian
 Create a virtual environment at your **project root** (where you run `meshctl`).
 All agents share this single venv - do not create separate venvs inside agent folders.
 
+> **Note:** `meshctl` is a Go binary that auto-detects `.venv` in the current directory.
+> You only need to activate the venv for `pip` commands - meshctl commands work without activation.
+
 ```bash
-# At project root
+# At project root - create venv (one-time setup)
 python3.11 -m venv .venv
+
+# Activate only when using pip
 source .venv/bin/activate         # macOS/Linux
 .venv\Scripts\activate            # Windows
-
-# Upgrade pip
 pip install --upgrade pip
 ```
 
@@ -53,17 +56,18 @@ python -c "import mesh; print('Ready!')"
 ### Quick Start
 
 ```bash
-# Setup venv at project root
+# 1. Create venv and install SDK (one-time setup)
 python3.11 -m venv .venv
-source .venv/bin/activate
+source .venv/bin/activate    # Only needed for pip
 pip install --upgrade pip
 pip install "mcp-mesh>=0.7,<0.8"
+deactivate                   # Can deactivate after pip install
 
-# Scaffold agents (creates subfolders)
+# 2. Scaffold agents - meshctl auto-detects .venv (no activation needed)
 meshctl scaffold --name hello --agent-type basic
 meshctl scaffold --name assistant --agent-type llm-agent
 
-# Run (from project root)
+# 3. Run agent - meshctl uses .venv/bin/python automatically
 meshctl start hello/main.py --debug
 ```
 
@@ -81,9 +85,9 @@ docker compose version
 
 ### MCP Mesh Images
 
-| Image | Description |
-|-------|-------------|
-| `mcpmesh/registry:0.7` | Registry service |
+| Image                        | Description             |
+| ---------------------------- | ----------------------- |
+| `mcpmesh/registry:0.7`       | Registry service        |
 | `mcpmesh/python-runtime:0.7` | Python runtime with SDK |
 
 ```bash
@@ -119,10 +123,10 @@ helm version
 
 Available from OCI registry (no `helm repo add` needed):
 
-| Chart | Description |
-|-------|-------------|
-| `oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core` | Registry + DB + Observability |
-| `oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent` | Deploy agents |
+| Chart                                             | Description                   |
+| ------------------------------------------------- | ----------------------------- |
+| `oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core`  | Registry + DB + Observability |
+| `oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent` | Deploy agents                 |
 
 ```bash
 # Install core infrastructure
@@ -145,12 +149,12 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 
 ## Version Compatibility
 
-| Component | Minimum | Recommended |
-|-----------|---------|-------------|
-| Python | 3.11 | 3.12 |
-| Docker | 20.10 | Latest |
-| Kubernetes | 1.25 | 1.28+ |
-| Helm | 3.10 | 3.14+ |
+| Component  | Minimum | Recommended |
+| ---------- | ------- | ----------- |
+| Python     | 3.11    | 3.12        |
+| Docker     | 20.10   | Latest      |
+| Kubernetes | 1.25    | 1.28+       |
+| Helm       | 3.10    | 3.14+       |
 
 ## See Also
 


### PR DESCRIPTION
## Summary

- Clarify that `meshctl` is a Go binary that auto-detects `.venv` in the current directory
- Users only need to activate venv for `pip` commands, not for meshctl commands
- meshctl uses `.venv/bin/python` automatically when running agents

This helps LLMs (and users) understand the venv activation is only needed for pip install commands.

## Test plan

- [ ] Verify `meshctl man prerequisites` shows updated documentation
- [ ] Confirm documentation renders correctly in terminal

Fixes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified virtual environment setup instructions, specifying when activation is required for different commands.
  * Enhanced table formatting and readability for MCP Mesh Images, Helm Charts, and Version Compatibility sections.
  * Improved guidance on meshctl's auto-detection of virtual environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->