### PR TITLE
Add helpful hint to meshctl call connection errors

### DIFF
--- a/src/core/cli/call.go
+++ b/src/core/cli/call.go
@@ -512,7 +512,11 @@ func callMCPTool(client *http.Client, endpoint, toolName string, args map[string
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to call agent at %s: %w", mcpURL, err)
+		return nil, fmt.Errorf("failed to call agent at %s: %w\n\n"+
+			"Hint: If you're running meshctl from outside Docker/Kubernetes, the agent\n"+
+			"hostname may not be reachable from your network.\n\n"+
+			"Try using --agent-url with the externally exposed endpoint:\n"+
+			"    meshctl call <tool_name> --agent-url http://localhost:<exposed_port>", mcpURL, err)
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
## Summary
- Adds a helpful hint when `meshctl call` fails with a connection error
- Guides users to use `--agent-url` when running from outside Docker/Kubernetes

## Problem
When running `meshctl call` from outside Docker Compose or Kubernetes, the registry returns internal hostnames (e.g., `hello-world-agent:8080`) that aren't reachable from the host machine. The error message was not helpful.

## Solution
Show a hint on connection errors:
```
Hint: If you're running meshctl from outside Docker/Kubernetes, the agent
hostname may not be reachable from your network.

Try using --agent-url with the externally exposed endpoint:
    meshctl call <tool_name> --agent-url http://localhost:<exposed_port>
```

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages when MCP tool calls fail, providing clearer guidance on troubleshooting steps and configuration options for resolving connectivity issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->