### PR TITLE
Add registry proxy for external meshctl access (#306)

### DIFF
--- a/api/mcp-mesh-registry.openapi.yaml
+++ b/api/mcp-mesh-registry.openapi.yaml
@@ -271,6 +271,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  # Note: /proxy/{target} endpoint is implemented as an operational endpoint
+  # (not in OpenAPI) because it requires wildcard path matching which OpenAPI
+  # path parameters don't support. See server.go setupOperationalEndpoints().
+
 components:
   schemas:
     # New flattened mesh agent schemas

--- a/tools/detection/detect_endpoints.py
+++ b/tools/detection/detect_endpoints.py
@@ -39,6 +39,7 @@ class DualContractEndpointDetector:
     }
     EXCLUDED_PATH_PREFIXES = [
         "/trace/",  # Individual trace lookups like /trace/{trace_id}
+        "/proxy/",  # Reverse proxy for MCP calls (requires wildcard routing not supported by OpenAPI)
     ]
 
     def __init__(


### PR DESCRIPTION
## Summary
- Adds reverse proxy endpoint to registry for external meshctl access
- Enables calling agents from outside Docker/K8s without exposing individual ports
- Routes calls through registry by default (`--use-proxy=true`)

## Changes
- **Registry**: Add `/proxy/*target` wildcard endpoint with security validation
  - Only proxies to registered agents
  - Only allows `/mcp/*` paths
- **meshctl**: Add `--use-proxy` flag (default: true) to route calls through registry
- **OpenAPI**: Document proxy as operational endpoint (requires wildcard routing)

## Test plan
- [x] Tested with docker-compose: `meshctl call hello_mesh_simple` works from host
- [x] Verified security: non-registered agents return 403
- [x] Verified path restriction: non-/mcp paths return 400

## Usage
```bash
# From outside Docker (now works without --agent-url):
meshctl call hello_mesh_simple

# To bypass proxy (requires direct network access):
meshctl call tool_name --use-proxy=false --agent-url http://localhost:8081
```

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --use-proxy flag (enabled by default) to route MCP calls through the registry proxy.
  * Registry now proxies MCP GET/POST requests to registered agents with target validation, header/body forwarding, and clearer proxy-mode error messages and guidance.

* **Documentation**
  * Non-functional notes added to the API spec clarifying the /proxy/{target} operational endpoint.

* **Chores**
  * Endpoint detection now excludes /proxy/ from discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->