### PR TITLE
Allow model override in @mesh.llm with mesh delegation (#308)

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
@@ -611,7 +611,7 @@ IMPORTANT TOOL CALLING RULES:
 
                     if self._is_mesh_delegated:
                         # Mesh delegation: extract model_params to send to provider
-                        # Exclude messages/tools (separate params), model/api_key (provider has them),
+                        # Exclude messages/tools (separate params), api_key (provider has it),
                         # and output_mode (only used locally by prepare_request)
                         model_params = {
                             k: v
@@ -620,11 +620,17 @@ IMPORTANT TOOL CALLING RULES:
                             not in [
                                 "messages",
                                 "tools",
-                                "model",
                                 "api_key",
                                 "output_mode",
+                                "model",  # Model handled separately below
                             ]
                         }
+
+                        # Issue #308: Include model override if explicitly set by consumer
+                        # This allows consumer to request a specific model from the provider
+                        # (e.g., use haiku instead of provider's default sonnet)
+                        if self.model:
+                            model_params["model"] = self.model
 
                         logger.debug(
                             f"📤 Delegating to mesh provider with handler-prepared params: "


### PR DESCRIPTION
## Summary

Enables consumers to specify a model override when using mesh delegation, allowing them to request a specific model variant from the provider (e.g., use haiku instead of provider's default sonnet).

## Changes

- `mesh_llm_agent.py`: Include model in model_params when explicitly set
- `helpers.py`: Handle model override with vendor mismatch validation
  - Extract vendor from model string for compatibility check
  - Log warning and fall back to provider default on vendor mismatch
  - Log effective model used (not decorator default)
- Added 8 unit tests for model override functionality

## Behavior

| Scenario | Result |
|----------|--------|
| Consumer specifies `model="anthropic/claude-haiku"` with Claude provider | Uses haiku |
| Consumer specifies `model="openai/gpt-4o"` with Claude provider | Warns, uses provider default |
| Consumer specifies no model | Uses provider default (existing behavior) |

## Test plan

- [x] Unit tests added (8 new tests)
- [x] Tested with docker-examples multi-agent setup

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added explicit model override capability for mesh-delegated LLM configurations, enabling users to request specific models from providers
  - Intelligent vendor validation for model overrides with comprehensive logging and fallback handling
  - Enhanced response content handling for improved message processing

* **Tests**
  - Comprehensive test coverage for model override scenarios and vendor matching validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->