### PR TITLE
Add meshctl trace command for distributed call tracing (#310)

### DIFF
--- a/cmd/meshctl/main.go
+++ b/cmd/meshctl/main.go
@@ -38,6 +38,7 @@ func main() {
 	rootCmd.AddCommand(cli.NewStatusCommand())
 	rootCmd.AddCommand(cli.NewConfigCommand())
 	rootCmd.AddCommand(cli.NewScaffoldCommand())
+	rootCmd.AddCommand(cli.NewTraceCommand()) // Issue #310
 	rootCmd.AddCommand(man.NewManCommand())
 
 	// Execute the root command

--- a/examples/docker-examples/docker-compose.yml
+++ b/examples/docker-examples/docker-compose.yml
@@ -90,6 +90,8 @@ services:
       - TRACE_EXPORTER_TYPE=otlp
       - TELEMETRY_ENDPOINT=tempo:4317
       - TELEMETRY_PROTOCOL=grpc
+      # Tempo HTTP API for trace querying (Issue #310 - meshctl trace)
+      - TEMPO_URL=http://tempo:3200
     networks:
       - mcp-mesh
     depends_on:

--- a/src/core/cli/man/content/cli.md
+++ b/src/core/cli/man/content/cli.md
@@ -4,12 +4,13 @@
 
 ## Quick Reference
 
-| Command                | Purpose                    |
-| ---------------------- | -------------------------- |
-| `meshctl call`         | Invoke a tool on any agent |
-| `meshctl list`         | Show healthy agents        |
-| `meshctl list --tools` | List all available tools   |
-| `meshctl status`       | Show agent wiring details  |
+| Command                | Purpose                      |
+| ---------------------- | ---------------------------- |
+| `meshctl call`         | Invoke a tool on any agent   |
+| `meshctl list`         | Show healthy agents          |
+| `meshctl list --tools` | List all available tools     |
+| `meshctl status`       | Show agent wiring details    |
+| `meshctl trace`        | View distributed call traces |
 
 ## Calling Tools
 
@@ -28,6 +29,30 @@ meshctl call analyzer:process --file data.json
 
 # Direct agent call (skip registry)
 meshctl call hello_mesh --agent-url http://localhost:8080
+```
+
+## Distributed Tracing
+
+Track calls across multiple agents with `--trace`:
+
+```bash
+# Call with tracing enabled
+meshctl call smart_analyze '{"query": "test"}' --trace
+# Output includes: Trace ID: abc123...
+
+# View the call tree
+meshctl trace abc123
+
+# Example output:
+# └─ smart_analyze (llm-agent) [120ms] ✓
+#    ├─ get_current_time (time-agent) [5ms] ✓
+#    └─ fetch_data (data-agent) [15ms] ✓
+
+# Show internal wrapper spans
+meshctl trace abc123 --show-internal
+
+# Output as JSON
+meshctl trace abc123 --json
 ```
 
 ## Listing Agents and Tools

--- a/src/core/cli/man/content/testing.md
+++ b/src/core/cli/man/content/testing.md
@@ -121,17 +121,14 @@ Fix: Ensure body has jsonrpc, id, method, and params fields
 
 ## Testing in Docker Compose
 
-When agents run in Docker Compose, they register with container hostnames (e.g., `agent-one:9001`) which aren't resolvable from your host machine.
-
-Use `--agent-url` with the mapped localhost port:
+Calls route through the registry proxy by default:
 
 ```bash
-# Find mapped ports
-docker compose ps
+meshctl call greet
+meshctl call calculator:add '{"a": 1, "b": 2}'
 
-# Call using localhost with mapped port
-meshctl call greet --agent-url http://localhost:9001
-meshctl call calculator:add '{"a": 1, "b": 2}' --agent-url http://localhost:9002
+# Bypass proxy (requires mapped ports)
+meshctl call greet --use-proxy=false --agent-url http://localhost:9001
 ```
 
 ## Testing in Kubernetes

--- a/src/core/cli/trace.go
+++ b/src/core/cli/trace.go
@@ -1,0 +1,347 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// TraceSpan represents a span in the trace tree
+type TraceSpan struct {
+	TraceID      string  `json:"TraceID"`
+	SpanID       string  `json:"SpanID"`
+	ParentSpan   *string `json:"ParentSpan,omitempty"`
+	AgentName    string  `json:"AgentName"`
+	AgentID      string  `json:"AgentID"`
+	IPAddress    string  `json:"IPAddress"`
+	Operation    string  `json:"Operation"`
+	StartTime    string  `json:"StartTime"`
+	EndTime      *string `json:"EndTime,omitempty"`
+	DurationMS   *int64  `json:"DurationMS,omitempty"`
+	Success      *bool   `json:"Success,omitempty"`
+	ErrorMessage *string `json:"ErrorMessage,omitempty"`
+	Capability   *string `json:"Capability,omitempty"`
+	TargetAgent  *string `json:"TargetAgent,omitempty"`
+	Runtime      string  `json:"Runtime,omitempty"`
+}
+
+// CompletedTraceResponse represents the registry's trace response
+type CompletedTraceResponse struct {
+	TraceID    string       `json:"TraceID"`
+	Spans      []*TraceSpan `json:"Spans"`
+	StartTime  string       `json:"StartTime"`
+	EndTime    string       `json:"EndTime"`
+	Duration   int64        `json:"Duration"`
+	Success    bool         `json:"Success"`
+	SpanCount  int          `json:"SpanCount"`
+	AgentCount int          `json:"AgentCount"`
+	Agents     []string     `json:"Agents"`
+}
+
+// TraceTreeNode represents a node in the trace tree for display
+type TraceTreeNode struct {
+	Span     *TraceSpan
+	Children []*TraceTreeNode
+}
+
+// NewTraceCommand creates the trace command
+func NewTraceCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "trace <trace_id>",
+		Short: "Display distributed call trace",
+		Long: `Query and display the call tree for a distributed trace.
+
+Use with 'meshctl call --trace' to get trace IDs, then view the full
+call tree with this command.
+
+Examples:
+  meshctl trace abc123def456789                    # View trace by ID
+  meshctl trace abc123def456789 --json             # Output as JSON
+  meshctl trace abc123def456789 --registry-url http://remote:8000  # Remote registry`,
+		Args: cobra.ExactArgs(1),
+		RunE: runTraceCommand,
+	}
+
+	// Registry connection flags
+	cmd.Flags().String("registry-url", "", "Registry URL (overrides host/port)")
+	cmd.Flags().String("registry-host", "", "Registry host (default: localhost)")
+	cmd.Flags().Int("registry-port", 0, "Registry port (default: 8000)")
+	cmd.Flags().String("registry-scheme", "http", "Registry URL scheme (http/https)")
+	cmd.Flags().Bool("insecure", false, "Skip TLS certificate verification")
+	cmd.Flags().Int("timeout", 30, "Request timeout in seconds")
+
+	// Output options
+	cmd.Flags().Bool("json", false, "Output as JSON")
+	cmd.Flags().Bool("show-internal", false, "Show internal wrapper spans (proxy_call_wrapper, etc.)")
+
+	return cmd
+}
+
+func runTraceCommand(cmd *cobra.Command, args []string) error {
+	traceID := args[0]
+
+	// Load configuration
+	config, err := LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	// Get registry connection flags
+	registryURL, _ := cmd.Flags().GetString("registry-url")
+	registryHost, _ := cmd.Flags().GetString("registry-host")
+	registryPort, _ := cmd.Flags().GetInt("registry-port")
+	registryScheme, _ := cmd.Flags().GetString("registry-scheme")
+	insecure, _ := cmd.Flags().GetBool("insecure")
+	timeout, _ := cmd.Flags().GetInt("timeout")
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	showInternal, _ := cmd.Flags().GetBool("show-internal")
+
+	// Determine final registry URL
+	finalRegistryURL := determineRegistryURL(config, registryURL, registryHost, registryPort, registryScheme)
+
+	// Create HTTP client
+	httpClient := createHTTPClient(timeout, insecure)
+
+	// Query trace from registry
+	trace, err := queryTrace(httpClient, finalRegistryURL, traceID)
+	if err != nil {
+		return fmt.Errorf("failed to query trace: %w", err)
+	}
+
+	if trace == nil {
+		return fmt.Errorf("trace '%s' not found", traceID)
+	}
+
+	// Output result
+	if jsonOutput {
+		output, _ := json.MarshalIndent(trace, "", "  ")
+		fmt.Println(string(output))
+	} else {
+		printTraceTree(trace, showInternal)
+	}
+
+	return nil
+}
+
+// queryTrace queries the registry for a trace by ID
+func queryTrace(client *http.Client, registryURL, traceID string) (*CompletedTraceResponse, error) {
+	url := fmt.Sprintf("%s/trace/%s", registryURL, traceID)
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to registry: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("registry returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var trace CompletedTraceResponse
+	if err := json.NewDecoder(resp.Body).Decode(&trace); err != nil {
+		return nil, fmt.Errorf("failed to parse trace response: %w", err)
+	}
+
+	return &trace, nil
+}
+
+// printTraceTree prints the trace as a formatted tree
+func printTraceTree(trace *CompletedTraceResponse, showInternal bool) {
+	// Header
+	fmt.Printf("Call Tree for trace %s\n", trace.TraceID)
+	fmt.Println(strings.Repeat("═", 60))
+	fmt.Println()
+
+	// Build tree structure
+	tree := buildTraceTree(trace.Spans, showInternal)
+
+	// Print tree
+	for i, root := range tree {
+		isLast := i == len(tree)-1
+		printTreeNode(root, "", isLast)
+	}
+
+	// Summary
+	fmt.Println()
+	fmt.Println(strings.Repeat("─", 60))
+
+	// Parse duration from nanoseconds
+	durationStr := formatTraceDuration(trace.Duration)
+
+	statusIcon := "✓"
+	if !trace.Success {
+		statusIcon = "✗"
+	}
+
+	fmt.Printf("Summary: %d spans across %d agents | %s | %s\n",
+		trace.SpanCount, trace.AgentCount, durationStr, statusIcon)
+	fmt.Printf("Agents: %s\n", strings.Join(trace.Agents, ", "))
+}
+
+// buildTraceTree builds a tree structure from flat span list
+func buildTraceTree(spans []*TraceSpan, showInternal bool) []*TraceTreeNode {
+	// Create nodes for all spans
+	nodeMap := make(map[string]*TraceTreeNode)
+	for _, span := range spans {
+		nodeMap[span.SpanID] = &TraceTreeNode{
+			Span:     span,
+			Children: make([]*TraceTreeNode, 0),
+		}
+	}
+
+	// Build parent-child relationships
+	var roots []*TraceTreeNode
+	for _, span := range spans {
+		node := nodeMap[span.SpanID]
+		if span.ParentSpan != nil && *span.ParentSpan != "" {
+			if parent, exists := nodeMap[*span.ParentSpan]; exists {
+				parent.Children = append(parent.Children, node)
+			} else {
+				// Parent not found, treat as root
+				roots = append(roots, node)
+			}
+		} else {
+			// No parent, this is a root
+			roots = append(roots, node)
+		}
+	}
+
+	// Sort children by start time
+	for _, node := range nodeMap {
+		sort.Slice(node.Children, func(i, j int) bool {
+			return node.Children[i].Span.StartTime < node.Children[j].Span.StartTime
+		})
+	}
+
+	// Sort roots by start time
+	sort.Slice(roots, func(i, j int) bool {
+		return roots[i].Span.StartTime < roots[j].Span.StartTime
+	})
+
+	// Collapse internal wrapper spans unless --show-internal is set
+	if !showInternal {
+		roots = collapseWrapperSpans(roots)
+	}
+
+	return roots
+}
+
+// collapseWrapperSpans removes internal wrapper spans and re-parents their children
+// This makes the trace tree cleaner by hiding implementation details
+func collapseWrapperSpans(nodes []*TraceTreeNode) []*TraceTreeNode {
+	var result []*TraceTreeNode
+
+	for _, node := range nodes {
+		// Recursively process children first
+		node.Children = collapseWrapperSpans(node.Children)
+
+		// Check if this is a wrapper span that should be collapsed
+		if isWrapperSpan(node.Span.Operation) {
+			// Skip this node, promote its children to the parent level
+			result = append(result, node.Children...)
+		} else {
+			result = append(result, node)
+		}
+	}
+
+	// Re-sort by start time after collapsing
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Span.StartTime < result[j].Span.StartTime
+	})
+
+	return result
+}
+
+// isWrapperSpan returns true if the operation is an internal wrapper that should be hidden
+func isWrapperSpan(operation string) bool {
+	// Prefixes of internal wrapper operations to hide from trace display
+	// Using prefix matching for flexibility (e.g., proxy_call_wrapper_v2)
+	wrapperPrefixes := []string{
+		"proxy_call_wrapper",
+		"_internal_",
+	}
+
+	for _, prefix := range wrapperPrefixes {
+		if strings.HasPrefix(operation, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// printTreeNode prints a single node and its children
+func printTreeNode(node *TraceTreeNode, prefix string, isLast bool) {
+	// Determine connector
+	connector := "├─"
+	if isLast {
+		connector = "└─"
+	}
+
+	// Format duration
+	durationStr := ""
+	if node.Span.DurationMS != nil {
+		durationStr = fmt.Sprintf("[%dms]", *node.Span.DurationMS)
+	}
+
+	// Format status
+	statusIcon := "✓"
+	if node.Span.Success != nil && !*node.Span.Success {
+		statusIcon = "✗"
+	}
+
+	// Print node
+	fmt.Printf("%s%s %s (%s) %s %s\n",
+		prefix, connector,
+		node.Span.Operation,
+		node.Span.AgentName,
+		durationStr,
+		statusIcon)
+
+	// Print error message if present
+	if node.Span.ErrorMessage != nil && *node.Span.ErrorMessage != "" {
+		childPrefix := prefix
+		if isLast {
+			childPrefix += "   "
+		} else {
+			childPrefix += "│  "
+		}
+		fmt.Fprintf(os.Stderr, "%s   Error: %s\n", childPrefix, *node.Span.ErrorMessage)
+	}
+
+	// Print children
+	childPrefix := prefix
+	if isLast {
+		childPrefix += "   "
+	} else {
+		childPrefix += "│  "
+	}
+
+	for i, child := range node.Children {
+		childIsLast := i == len(node.Children)-1
+		printTreeNode(child, childPrefix, childIsLast)
+	}
+}
+
+// formatTraceDuration formats nanoseconds as human readable duration
+func formatTraceDuration(nanos int64) string {
+	d := time.Duration(nanos)
+	if d < time.Millisecond {
+		return fmt.Sprintf("%dµs", d.Microseconds())
+	}
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	return fmt.Sprintf("%.2fs", d.Seconds())
+}

--- a/src/core/cli/trace_test.go
+++ b/src/core/cli/trace_test.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsWrapperSpan(t *testing.T) {
+	tests := []struct {
+		operation string
+		expected  bool
+	}{
+		// Wrapper spans that should be hidden
+		{"proxy_call_wrapper", true},
+		{"proxy_call_wrapper_v2", true},
+		{"_internal_span", true},
+		{"_internal_", true},
+
+		// Regular operations that should be shown
+		{"smart_analyze", false},
+		{"get_current_time", false},
+		{"fetch_system_overview", false},
+		{"process_chat", false},
+		{"GET /api/tools", false},
+		{"POST /mcp", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.operation, func(t *testing.T) {
+			result := isWrapperSpan(tt.operation)
+			if result != tt.expected {
+				t.Errorf("isWrapperSpan(%q) = %v, expected %v", tt.operation, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFormatTraceDuration(t *testing.T) {
+	tests := []struct {
+		nanos    int64
+		expected string
+	}{
+		// Microseconds
+		{500, "0µs"},
+		{500000, "500µs"},
+		{999999, "999µs"},
+
+		// Milliseconds
+		{int64(time.Millisecond), "1ms"},
+		{int64(50 * time.Millisecond), "50ms"},
+		{int64(999 * time.Millisecond), "999ms"},
+
+		// Seconds
+		{int64(time.Second), "1.00s"},
+		{int64(2500 * time.Millisecond), "2.50s"},
+		{int64(10 * time.Second), "10.00s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := formatTraceDuration(tt.nanos)
+			if result != tt.expected {
+				t.Errorf("formatTraceDuration(%d) = %q, expected %q", tt.nanos, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildTraceTree(t *testing.T) {
+	// Test basic tree building with wrapper span collapse
+	parentSpan := "parent123"
+	spans := []*TraceSpan{
+		{SpanID: "root", ParentSpan: nil, Operation: "smart_analyze", AgentName: "llm-agent", StartTime: "2024-01-01T00:00:00Z"},
+		{SpanID: "wrapper1", ParentSpan: &parentSpan, Operation: "proxy_call_wrapper", AgentName: "llm-agent", StartTime: "2024-01-01T00:00:01Z"},
+		{SpanID: "child1", ParentSpan: &parentSpan, Operation: "get_time", AgentName: "time-agent", StartTime: "2024-01-01T00:00:02Z"},
+	}
+
+	// Test with showInternal=false (default behavior)
+	tree := buildTraceTree(spans, false)
+
+	// Wrapper span should be collapsed
+	wrapperFound := false
+	for _, node := range tree {
+		if node.Span.Operation == "proxy_call_wrapper" {
+			wrapperFound = true
+		}
+	}
+	if wrapperFound {
+		t.Error("Wrapper span should be collapsed when showInternal=false")
+	}
+
+	// Test with showInternal=true
+	treeWithInternal := buildTraceTree(spans, true)
+
+	// Wrapper span should be present
+	wrapperFoundWithInternal := false
+	var checkNodes func([]*TraceTreeNode)
+	checkNodes = func(nodes []*TraceTreeNode) {
+		for _, node := range nodes {
+			if node.Span.Operation == "proxy_call_wrapper" {
+				wrapperFoundWithInternal = true
+			}
+			checkNodes(node.Children)
+		}
+	}
+	checkNodes(treeWithInternal)
+
+	if !wrapperFoundWithInternal {
+		t.Error("Wrapper span should be present when showInternal=true")
+	}
+}

--- a/src/core/registry/ent_handlers.go
+++ b/src/core/registry/ent_handlers.go
@@ -704,6 +704,14 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 		proxyReq.Header.Set("Accept", accept)
 	}
 
+	// Forward trace headers for distributed tracing (Issue #310)
+	if traceID := c.Request.Header.Get("X-Trace-ID"); traceID != "" {
+		proxyReq.Header.Set("X-Trace-ID", traceID)
+	}
+	if parentSpan := c.Request.Header.Get("X-Parent-Span"); parentSpan != "" {
+		proxyReq.Header.Set("X-Parent-Span", parentSpan)
+	}
+
 	// Execute the request
 	client := &http.Client{
 		Timeout: 60 * time.Second, // Reasonable timeout for MCP calls

--- a/src/core/registry/tracing/tempo_client.go
+++ b/src/core/registry/tracing/tempo_client.go
@@ -1,0 +1,312 @@
+package tracing
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// TempoClient queries traces from Grafana Tempo
+type TempoClient struct {
+	endpoint   string
+	httpClient *http.Client
+}
+
+// TempoTraceResponse represents the response from Tempo's trace API
+type TempoTraceResponse struct {
+	Batches []TempoBatch `json:"batches"`
+}
+
+// TempoBatch represents a batch of spans from Tempo
+type TempoBatch struct {
+	Resource   TempoResource    `json:"resource"`
+	ScopeSpans []TempoScopeSpan `json:"scopeSpans"`
+}
+
+// TempoResource represents the resource attributes
+type TempoResource struct {
+	Attributes []TempoAttribute `json:"attributes"`
+}
+
+// TempoScopeSpan represents instrumentation scope spans
+type TempoScopeSpan struct {
+	Scope TempoScope  `json:"scope"`
+	Spans []TempoSpan `json:"spans"`
+}
+
+// TempoScope represents the instrumentation scope
+type TempoScope struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// TempoSpan represents a single span from Tempo
+type TempoSpan struct {
+	TraceID           string           `json:"traceId"`
+	SpanID            string           `json:"spanId"`
+	ParentSpanID      string           `json:"parentSpanId,omitempty"`
+	Name              string           `json:"name"`
+	Kind              string           `json:"kind"` // e.g., "SPAN_KIND_INTERNAL"
+	StartTimeUnixNano string           `json:"startTimeUnixNano"`
+	EndTimeUnixNano   string           `json:"endTimeUnixNano"`
+	Attributes        []TempoAttribute `json:"attributes"`
+	Status            TempoStatus      `json:"status"`
+}
+
+// TempoAttribute represents a key-value attribute
+type TempoAttribute struct {
+	Key   string     `json:"key"`
+	Value TempoValue `json:"value"`
+}
+
+// TempoValue represents an attribute value
+type TempoValue struct {
+	StringValue string `json:"stringValue,omitempty"`
+	IntValue    string `json:"intValue,omitempty"`
+	BoolValue   *bool  `json:"boolValue,omitempty"`
+}
+
+// TempoStatus represents span status
+type TempoStatus struct {
+	Code    string `json:"code"` // e.g., "STATUS_CODE_OK", "STATUS_CODE_ERROR"
+	Message string `json:"message,omitempty"`
+}
+
+// NewTempoClient creates a new Tempo client
+func NewTempoClient(endpoint string) *TempoClient {
+	// Ensure endpoint doesn't have trailing slash
+	endpoint = strings.TrimSuffix(endpoint, "/")
+
+	return &TempoClient{
+		endpoint: endpoint,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// GetTempoURLFromEnv returns the Tempo query URL from environment variables
+func GetTempoURLFromEnv() string {
+	// Check for TEMPO_URL first (preferred for querying)
+	tempoURL := os.Getenv("TEMPO_URL")
+	if tempoURL != "" {
+		return tempoURL
+	}
+
+	// Fallback: construct from TELEMETRY_ENDPOINT (replace gRPC port with HTTP port)
+	telemetryEndpoint := os.Getenv("TELEMETRY_ENDPOINT")
+	if telemetryEndpoint != "" {
+		// Convert tempo:4317 (gRPC) to http://tempo:3200 (HTTP API)
+		host := strings.Split(telemetryEndpoint, ":")[0]
+		return fmt.Sprintf("http://%s:3200", host)
+	}
+
+	return ""
+}
+
+// GetTrace retrieves a trace by ID from Tempo
+func (tc *TempoClient) GetTrace(traceID string) (*CompletedTrace, error) {
+	// Normalize trace ID (remove dashes if present)
+	normalizedID := strings.ReplaceAll(traceID, "-", "")
+
+	// Query Tempo API
+	url := fmt.Sprintf("%s/api/traces/%s", tc.endpoint, normalizedID)
+
+	resp, err := tc.httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query Tempo: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil // Trace not found
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Tempo returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Tempo response: %w", err)
+	}
+
+	var tempoResp TempoTraceResponse
+	if err := json.Unmarshal(body, &tempoResp); err != nil {
+		return nil, fmt.Errorf("failed to parse Tempo response: %w", err)
+	}
+
+	// Convert Tempo response to CompletedTrace
+	return tc.convertTempoToCompletedTrace(traceID, &tempoResp)
+}
+
+// convertTempoToCompletedTrace converts Tempo's response format to CompletedTrace
+func (tc *TempoClient) convertTempoToCompletedTrace(traceID string, tempoResp *TempoTraceResponse) (*CompletedTrace, error) {
+	var spans []*TraceSpan
+	agentSet := make(map[string]bool)
+
+	for _, batch := range tempoResp.Batches {
+		// Extract service name from resource attributes
+		serviceName := tc.getServiceName(batch.Resource.Attributes)
+
+		for _, scopeSpan := range batch.ScopeSpans {
+			for _, span := range scopeSpan.Spans {
+				traceSpan := tc.convertTempoSpan(&span, serviceName)
+				spans = append(spans, traceSpan)
+				agentSet[traceSpan.AgentName] = true
+			}
+		}
+	}
+
+	if len(spans) == 0 {
+		return nil, nil
+	}
+
+	// Sort spans by start time
+	sort.Slice(spans, func(i, j int) bool {
+		return spans[i].StartTime.Before(spans[j].StartTime)
+	})
+
+	// Calculate trace timing
+	startTime := spans[0].StartTime
+	endTime := spans[0].StartTime
+	success := true
+
+	for _, span := range spans {
+		if span.StartTime.Before(startTime) {
+			startTime = span.StartTime
+		}
+		if span.EndTime != nil && span.EndTime.After(endTime) {
+			endTime = *span.EndTime
+		}
+		if span.Success != nil && !*span.Success {
+			success = false
+		}
+	}
+
+	// Build agent list
+	agents := make([]string, 0, len(agentSet))
+	for agent := range agentSet {
+		agents = append(agents, agent)
+	}
+	sort.Strings(agents)
+
+	return &CompletedTrace{
+		TraceID:    traceID,
+		Spans:      spans,
+		StartTime:  startTime,
+		EndTime:    endTime,
+		Duration:   endTime.Sub(startTime),
+		Success:    success,
+		SpanCount:  len(spans),
+		AgentCount: len(agents),
+		Agents:     agents,
+	}, nil
+}
+
+// convertTempoSpan converts a Tempo span to TraceSpan
+func (tc *TempoClient) convertTempoSpan(span *TempoSpan, serviceName string) *TraceSpan {
+	// Parse timestamps (nanoseconds since epoch as string)
+	startNano := parseNanoTimestamp(span.StartTimeUnixNano)
+	endNano := parseNanoTimestamp(span.EndTimeUnixNano)
+
+	startTime := time.Unix(0, startNano)
+	endTime := time.Unix(0, endNano)
+
+	// Calculate duration
+	durationMS := (endNano - startNano) / 1e6
+
+	// Extract attributes
+	agentID := ""
+	operation := span.Name
+	capability := ""
+	targetAgent := ""
+	runtime := ""
+	ipAddress := ""
+
+	for _, attr := range span.Attributes {
+		switch attr.Key {
+		case "mcp.agent.id":
+			agentID = attr.Value.StringValue
+		case "mcp.operation":
+			operation = attr.Value.StringValue
+		case "mcp.capability":
+			capability = attr.Value.StringValue
+		case "mcp.target.agent", "mcp.target_agent":
+			targetAgent = attr.Value.StringValue
+		case "mcp.runtime":
+			runtime = attr.Value.StringValue
+		case "mcp.ip.address", "mcp.agent.ip":
+			ipAddress = attr.Value.StringValue
+		}
+	}
+
+	// Determine success from status code string
+	// STATUS_CODE_OK = success, STATUS_CODE_ERROR = failure, others = unknown (treat as success)
+	success := span.Status.Code != "STATUS_CODE_ERROR"
+	var errorMessage *string
+	if span.Status.Message != "" {
+		errorMessage = &span.Status.Message
+	}
+
+	// Handle parent span
+	var parentSpan *string
+	if span.ParentSpanID != "" {
+		parentSpan = &span.ParentSpanID
+	}
+
+	return &TraceSpan{
+		TraceID:      span.TraceID,
+		SpanID:       span.SpanID,
+		ParentSpan:   parentSpan,
+		AgentName:    serviceName,
+		AgentID:      agentID,
+		IPAddress:    ipAddress,
+		Operation:    operation,
+		StartTime:    startTime,
+		EndTime:      &endTime,
+		DurationMS:   &durationMS,
+		Success:      &success,
+		ErrorMessage: errorMessage,
+		Capability:   stringPtrIfNotEmpty(capability),
+		TargetAgent:  stringPtrIfNotEmpty(targetAgent),
+		Runtime:      runtime,
+	}
+}
+
+// getServiceName extracts service.name from resource attributes
+func (tc *TempoClient) getServiceName(attrs []TempoAttribute) string {
+	for _, attr := range attrs {
+		if attr.Key == "service.name" {
+			return attr.Value.StringValue
+		}
+	}
+	return "unknown"
+}
+
+// parseNanoTimestamp parses a nanosecond timestamp string
+func parseNanoTimestamp(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	nano, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0 // Return epoch time on parse error
+	}
+	return nano
+}
+
+// stringPtrIfNotEmpty returns a pointer to s if not empty, nil otherwise
+func stringPtrIfNotEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/src/runtime/python/_mcp_mesh/tracing/fastapi_tracing_middleware.py
+++ b/src/runtime/python/_mcp_mesh/tracing/fastapi_tracing_middleware.py
@@ -40,6 +40,9 @@ class FastAPITracingMiddleware(BaseHTTPMiddleware):
         if not is_tracing_enabled():
             return await call_next(request)
 
+        self.logger.debug(
+            f"[TRACE] Processing request {request.method} {request.url.path}"
+        )
 
         # Setup distributed tracing context from request headers
         try:
@@ -49,7 +52,6 @@ class FastAPITracingMiddleware(BaseHTTPMiddleware):
             trace_context = await TraceContextHelper.extract_trace_context_from_request(
                 request
             )
-
 
             # Setup trace context for this request lifecycle
             TraceContextHelper.setup_request_trace_context(trace_context, self.logger)
@@ -61,7 +63,6 @@ class FastAPITracingMiddleware(BaseHTTPMiddleware):
         # Extract route information for tracing
         route_name = self._extract_route_name(request)
         start_time = time.time()
-
 
         try:
             # Process the request
@@ -83,7 +84,6 @@ class FastAPITracingMiddleware(BaseHTTPMiddleware):
                 status_code=response.status_code,
             )
 
-
             return response
 
         except Exception as e:
@@ -102,7 +102,6 @@ class FastAPITracingMiddleware(BaseHTTPMiddleware):
                 success=False,
                 error=str(e),
             )
-
 
             raise  # Re-raise the original exception
 


### PR DESCRIPTION
## Summary

Add distributed tracing support with trace visualization:

- Add `meshctl call --trace` flag to display trace ID in response
- Add `meshctl trace <trace_id>` command to display call tree
- Inject X-Trace-Id/X-Span-Id response headers from Python agents
- Add Tempo client in registry to query traces by ID
- Add /trace/{id} endpoint in registry to serve trace data

## Example Usage

```bash
# Call with tracing enabled
meshctl call smart_analyze '{"query": "test"}' --trace
# Output includes: Trace ID: abc123...

# View the call tree
meshctl trace abc123

# Example output:
# └─ smart_analyze (llm-agent) [120ms] ✓
#    ├─ get_current_time (time-agent) [5ms] ✓
#    └─ fetch_data (data-agent) [15ms] ✓

# Show internal wrapper spans
meshctl trace abc123 --show-internal
```

## Changes

| File | Change |
|------|--------|
| `src/core/cli/call.go` | Add `--trace` flag, inject trace headers |
| `src/core/cli/trace.go` | New trace command with tree display |
| `src/core/cli/trace_test.go` | Unit tests for trace functionality |
| `src/core/registry/tracing/tempo_client.go` | Query traces from Tempo |
| `src/core/registry/ent_handlers.go` | Forward trace headers through proxy |
| `src/runtime/python/.../fastapi_tracing_middleware.py` | Inject response headers |
| `src/runtime/python/.../trace_context_helper.py` | Shared header utilities |
| `src/runtime/python/mesh/decorators.py` | ASGI middleware for SSE support |
| `src/core/cli/man/content/cli.md` | Document trace command |
| `src/core/cli/man/content/testing.md` | Update Docker Compose section |

## Test plan

- [x] Unit tests for `isWrapperSpan`, `formatTraceDuration`, `buildTraceTree`
- [x] Tested multi-hop LLM agent call with 4 agents
- [x] Verified `--show-internal` flag shows wrapper spans
- [x] Verified trace ID propagation through registry proxy

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added meshctl trace command (tree or JSON) and a --trace option for call tracing; show trace IDs when enabled
  * Optional Grafana Tempo integration for fetching traces

* **Documentation**
  * Updated CLI docs and testing guides with tracing examples and usage notes

* **Bug Fixes**
  * Forward trace headers through proxy paths and include trace headers in HTTP responses

* **Chores**
  * Docker examples expose TEMPO_URL for local Tempo queries

* **Tests**
  * Added unit tests for trace utilities and tree building

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->