### PR TITLE
Add LLM response metadata via _mesh_meta for cost tracking (#311)

### DIFF
--- a/src/runtime/python/mesh/__init__.py
+++ b/src/runtime/python/mesh/__init__.py
@@ -19,7 +19,7 @@ Use 'import mesh' and then '@mesh.tool()' for consistency with MCP patterns.
 """
 
 from . import decorators
-from .types import McpMeshAgent, MeshContextModel, MeshLlmAgent, MeshLlmRequest
+from .types import LlmMeta, McpMeshAgent, MeshContextModel, MeshLlmAgent, MeshLlmRequest
 
 # Note: helpers.llm_provider is imported lazily in __getattr__ to avoid
 # initialization timing issues with @mesh.agent auto_run in tests
@@ -113,6 +113,8 @@ def __getattr__(name):
         return MeshLlmAgent
     elif name == "MeshLlmRequest":
         return MeshLlmRequest
+    elif name == "LlmMeta":
+        return LlmMeta
     elif name == "create_server":
         return create_server
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -277,6 +277,16 @@ def llm_provider(
                         for tc in message.tool_calls
                     ]
 
+                # Issue #311: Include usage metadata for cost tracking
+                if hasattr(response, "usage") and response.usage:
+                    usage = response.usage
+                    message_dict["_mesh_usage"] = {
+                        "prompt_tokens": getattr(usage, "prompt_tokens", 0) or 0,
+                        "completion_tokens": getattr(usage, "completion_tokens", 0)
+                        or 0,
+                        "model": effective_model,
+                    }
+
                 logger.info(
                     f"LLM provider {func.__name__} processed request "
                     f"(model={effective_model}, messages={len(request.messages)}, "

--- a/src/runtime/python/mesh/types.py
+++ b/src/runtime/python/mesh/types.py
@@ -387,6 +387,50 @@ except ImportError:
 
 
 @dataclass
+class LlmMeta:
+    """
+    Metadata from LLM response for cost tracking and debugging.
+
+    This is attached to results from @mesh.llm calls as `_mesh_meta` attribute,
+    providing access to token counts, latency, and model information.
+
+    Attributes:
+        provider: LLM provider name (e.g., "anthropic", "openai")
+        model: Full model identifier (e.g., "anthropic/claude-3-5-haiku-20241022")
+        input_tokens: Number of tokens in the prompt
+        output_tokens: Number of tokens in the response
+        total_tokens: Total tokens used (input + output)
+        latency_ms: Request latency in milliseconds
+
+    Usage:
+        @mesh.llm(provider="anthropic/claude-3-5-haiku-20241022")
+        async def ask(question: str, llm: MeshLlmAgent) -> Answer:
+            result = await llm(question)
+
+            # Access result normally
+            print(result.answer)
+
+            # Access metadata
+            print(result._mesh_meta.model)          # "anthropic/claude-3-5-haiku-20241022"
+            print(result._mesh_meta.output_tokens)  # 85
+            print(result._mesh_meta.latency_ms)     # 125.5
+
+            return result
+
+    Note:
+        For primitive return types (str, int, etc.) and frozen Pydantic models,
+        _mesh_meta cannot be attached. This is a Python limitation.
+    """
+
+    provider: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    latency_ms: float
+
+
+@dataclass
 class MeshLlmRequest:
     """
     Standard LLM request format for mesh-delegated LLM calls.
@@ -414,9 +458,9 @@ class MeshLlmRequest:
         caller_agent: Optional agent name that initiated the request
     """
 
-    messages: List[Dict[str, Any]]  # Changed from Dict[str, str] to allow tool_calls
-    tools: Optional[List[Dict]] = None
-    model_params: Optional[Dict] = None
-    context: Optional[Dict] = None
+    messages: list[dict[str, Any]]  # Changed from Dict[str, str] to allow tool_calls
+    tools: Optional[list[dict]] = None
+    model_params: Optional[dict] = None
+    context: Optional[dict] = None
     request_id: Optional[str] = None
     caller_agent: Optional[str] = None


### PR DESCRIPTION
## Summary

- Add `LlmMeta` dataclass with provider, model, token counts, and latency
- Attach `_mesh_meta` to LLM results for cost tracking and debugging
- Support both direct LiteLLM calls and mesh delegation
- Backward compatible - existing code works unchanged

## Usage

```python
result = await llm(question)
print(result._mesh_meta.model)          # "openai/gpt-4o"
print(result._mesh_meta.input_tokens)   # 100
print(result._mesh_meta.output_tokens)  # 50
print(result._mesh_meta.latency_ms)     # 125.5
```

## Changes

| File | Change |
|------|--------|
| `mesh/types.py` | Added `LlmMeta` dataclass |
| `mesh/__init__.py` | Exported `LlmMeta` |
| `_mcp_mesh/engine/mesh_llm_agent.py` | Track timing, accumulate tokens, attach `_mesh_meta` |
| `mesh/helpers.py` | Include `_mesh_usage` in provider response |
| `tests/unit/test_mesh_llm_agent_proxy.py` | Added 8 new tests |

## Test plan

- [x] 71 unit tests pass
- [x] Docker integration tested with `meshctl call smart_analyze`
- [x] Verified `_mesh_meta` attached in logs: `model=openai/gpt-4o, tokens=2034+203=2237, latency=4564.2ms`
- [x] Backward compatibility confirmed - existing `llm_with_deps_agent.py` works unchanged

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `LlmMeta` metadata object that automatically attaches to LLM results, capturing provider, model, token usage (input/output/total), and latency.
  * Implemented automatic token tracking and latency measurement for LLM operations.
  * Exposed `LlmMeta` type in public API for user access.

* **Tests**
  * Added unit tests for metadata attachment and token accumulation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->