### PR TITLE
Fix registry port default docs and add Capability Selector documentation

### DIFF
--- a/src/core/cli/config.go
+++ b/src/core/cli/config.go
@@ -19,7 +19,7 @@ import (
 // MUST match Python CLI configuration behavior exactly
 type CLIConfig struct {
 	// Registry settings
-	RegistryPort int    `json:"registry_port"` // default: 8080
+	RegistryPort int    `json:"registry_port"` // default: 8000
 	RegistryHost string `json:"registry_host"` // default: "localhost"
 
 	// Database settings

--- a/src/core/cli/man/content/capabilities.md
+++ b/src/core/cli/man/content/capabilities.md
@@ -6,6 +6,67 @@
 
 Capabilities are named services that agents register with the mesh. When an agent declares a capability, other agents can discover and use it through dependency injection. Multiple agents can provide the same capability with different implementations.
 
+## Capability Selector Syntax
+
+MCP Mesh uses a unified syntax for selecting capabilities throughout the framework. This same pattern appears in `dependencies`, `@mesh.llm` provider/filter, `@mesh.route`, and `meshctl scaffold --filter`.
+
+### Selector Fields
+
+| Field        | Required | Description                                   |
+| ------------ | -------- | --------------------------------------------- |
+| `capability` | Yes\*    | Capability name to match                      |
+| `tags`       | No       | Tag filters with +/- operators                |
+| `version`    | No       | Semantic version constraint (e.g., `>=2.0.0`) |
+
+\*When filtering by tags only (e.g., LLM tool filter), `capability` can be omitted.
+
+### Syntax Forms
+
+**Shorthand** (capability name only):
+
+```python
+dependencies=["date_service", "weather_data"]
+```
+
+**Full form** (with filters):
+
+```python
+dependencies=[
+    {"capability": "date_service"},
+    {"capability": "weather_data", "tags": ["+fast", "-deprecated"]},
+    {"capability": "api_client", "version": ">=2.0.0"},
+]
+```
+
+### Where This Syntax Is Used
+
+| Context                     | Example                                                 |
+| --------------------------- | ------------------------------------------------------- |
+| `@mesh.tool` dependencies   | `dependencies=["svc"]` or `[{"capability": "svc"}]`     |
+| `@mesh.llm` provider        | `provider={"capability": "llm", "tags": ["+claude"]}`   |
+| `@mesh.llm` filter          | `filter=[{"capability": "calc"}, {"tags": ["tools"]}]`  |
+| `@mesh.route` dependencies  | `dependencies=[{"capability": "api", "tags": ["+v2"]}]` |
+| `meshctl scaffold --filter` | `--filter '[{"capability": "x"}]'`                      |
+
+### Tag Operators
+
+| Prefix | Meaning   | Example         |
+| ------ | --------- | --------------- |
+| (none) | Required  | `"api"`         |
+| `+`    | Preferred | `"+fast"`       |
+| `-`    | Excluded  | `"-deprecated"` |
+
+### Selector Logic (AND/OR)
+
+| Syntax                         | Semantics                             |
+| ------------------------------ | ------------------------------------- |
+| `tags: ["a", "b", "c"]`        | a AND b AND c (all required)          |
+| `tags: ["+a", "+b"]`           | Prefer a, prefer b (neither required) |
+| `tags: ["a", "-x"]`            | Must have a, must NOT have x          |
+| `[{tags:["a"]}, {tags:["b"]}]` | a OR b (multiple selectors)           |
+
+See `meshctl man tags` for detailed tag matching behavior.
+
 ## Declaring Capabilities
 
 ```python

--- a/src/core/cli/man/content/dependency-injection.md
+++ b/src/core/cli/man/content/dependency-injection.md
@@ -35,6 +35,8 @@ async def greet(name: str, date_service: mesh.McpMeshAgent = None) -> str:
 
 ### Dependencies with Filters
 
+Use the capability selector syntax (see `meshctl man capabilities`) to filter by tags or version:
+
 ```python
 @app.tool()
 @mesh.tool(

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -38,6 +38,8 @@ def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
 | `filter_mode`    | str  | `"all"`, `"best_match"`, or `"*"`                 |
 | `<llm_params>`   | any  | LiteLLM params (max_tokens, temperature, etc.)    |
 
+**Note**: `provider` and `filter` use the capability selector syntax (`capability`, `tags`, `version`). See `meshctl man capabilities` for details.
+
 **Note**: Response format is determined by the function's return type annotation, not a parameter. See [Response Formats](#response-formats).
 
 ## LLM Model Parameters

--- a/src/core/cli/man/content/scaffold.md
+++ b/src/core/cli/man/content/scaffold.md
@@ -4,19 +4,19 @@
 
 ## Input Modes
 
-| Mode | Usage | Best For |
-|------|-------|----------|
-| Interactive | `meshctl scaffold` | First-time users |
-| CLI flags | `meshctl scaffold --name my-agent --agent-type tool` | Scripting |
-| Config file | `meshctl scaffold --config scaffold.yaml` | Complex agents |
+| Mode        | Usage                                                | Best For         |
+| ----------- | ---------------------------------------------------- | ---------------- |
+| Interactive | `meshctl scaffold`                                   | First-time users |
+| CLI flags   | `meshctl scaffold --name my-agent --agent-type tool` | Scripting        |
+| Config file | `meshctl scaffold --config scaffold.yaml`            | Complex agents   |
 
 ## Agent Types
 
-| Type | Decorator | Description |
-|------|-----------|-------------|
-| `tool` | `@mesh.tool` | Basic capability agent |
-| `llm-agent` | `@mesh.llm` | LLM-powered agent that consumes providers |
-| `llm-provider` | `@mesh.llm_provider` | Zero-code LLM provider |
+| Type           | Decorator            | Description                               |
+| -------------- | -------------------- | ----------------------------------------- |
+| `tool`         | `@mesh.tool`         | Basic capability agent                    |
+| `llm-agent`    | `@mesh.llm`          | LLM-powered agent that consumes providers |
+| `llm-provider` | `@mesh.llm_provider` | Zero-code LLM provider                    |
 
 ## Quick Examples
 
@@ -62,18 +62,29 @@ meshctl scaffold --compose --project-name my-project
 
 ## Key Flags
 
-| Flag | Description |
-|------|-------------|
-| `--name` | Agent name (required for non-interactive) |
-| `--agent-type` | `tool`, `llm-agent`, or `llm-provider` |
-| `--dry-run` | Preview generated code |
-| `--no-interactive` | Disable prompts (for scripting) |
-| `--output` | Output directory (default: `.`) |
-| `--port` | HTTP port (default: 9000) |
-| `--model` | LiteLLM model for llm-provider |
-| `--llm-selector` | LLM provider for llm-agent: `claude`, `openai` |
-| `--compose` | Generate docker-compose.yml |
-| `--observability` | Add Redis/Tempo/Grafana to compose |
+| Flag               | Description                                          |
+| ------------------ | ---------------------------------------------------- |
+| `--name`           | Agent name (required for non-interactive)            |
+| `--agent-type`     | `tool`, `llm-agent`, or `llm-provider`               |
+| `--dry-run`        | Preview generated code                               |
+| `--no-interactive` | Disable prompts (for scripting)                      |
+| `--output`         | Output directory (default: `.`)                      |
+| `--port`           | HTTP port (default: 9000)                            |
+| `--model`          | LiteLLM model for llm-provider                       |
+| `--llm-selector`   | LLM provider for llm-agent: `claude`, `openai`       |
+| `--filter`         | Tool filter for llm-agent (capability selector JSON) |
+| `--compose`        | Generate docker-compose.yml                          |
+| `--observability`  | Add Redis/Tempo/Grafana to compose                   |
+
+The `--filter` flag uses capability selector syntax. See `meshctl man capabilities` for details.
+
+```bash
+# Filter tools by capability
+meshctl scaffold --name analyzer --agent-type llm-agent --filter '[{"capability": "calculator"}]'
+
+# Filter tools by tags
+meshctl scaffold --name analyzer --agent-type llm-agent --filter '[{"tags": ["tools"]}]'
+```
 
 ## See Also
 

--- a/src/core/cli/man/content/tags.md
+++ b/src/core/cli/man/content/tags.md
@@ -6,6 +6,8 @@
 
 Tags are metadata labels attached to capabilities that enable intelligent service selection. MCP Mesh supports "smart matching" with operators that express preferences and exclusions.
 
+Tags are part of the **Capability Selector** syntax used throughout MCP Mesh. See `meshctl man capabilities` for the complete selector reference.
+
 ## Tag Operators
 
 | Prefix | Meaning   | Example                                 |

--- a/src/core/cli/start.go
+++ b/src/core/cli/start.go
@@ -43,7 +43,7 @@ Examples:
 
 	// Registry configuration flags
 	cmd.Flags().String("registry-host", "", "Registry host address (default: localhost)")
-	cmd.Flags().Int("registry-port", 0, "Registry port number (default: 8080)")
+	cmd.Flags().Int("registry-port", 0, "Registry port number (default: 8000)")
 	cmd.Flags().String("db-path", "", "Database file path (default: ./dev_registry.db)")
 
 	// Logging and debug flags


### PR DESCRIPTION
## Summary

- Fix incorrect `--registry-port` default documentation (8080 → 8000)
- Add unified Capability Selector Syntax section to `meshctl man capabilities`
- Document AND/OR semantics for tag matching
- Add cross-references across man pages

Closes #321

## Test plan

- [ ] Run `meshctl start --help` and verify registry-port shows default 8000
- [ ] Run `meshctl man capabilities` and verify new Capability Selector section
- [ ] Verify cross-references work in `meshctl man di`, `meshctl man llm`, `meshctl man tags`, `meshctl man scaffold`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--filter` flag for selecting tools by capability, tags, or version during scaffolding operations.

* **Documentation**
  * Introduced unified Capability Selector Syntax documentation with complete selector reference.
  * Updated dependency injection, LLM, and tags documentation to reference capability selector syntax.
  * Enhanced scaffold documentation with improved formatting, new filtering examples, and clearer flag descriptions.

* **Changes**
  * Updated default registry port from 8080 to 8000.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->