### PR TITLE
Remove redundant mcp-mesh from scaffolded requirements.txt

### DIFF
--- a/cmd/meshctl/templates/python/basic/requirements.txt.tmpl
+++ b/cmd/meshctl/templates/python/basic/requirements.txt.tmpl
@@ -1,3 +1,3 @@
 # {{ .Name }} dependencies
-mcp-mesh>=0.7.0
-fastmcp>=0.1.0
+# Add your third-party dependencies here
+# Note: mcp-mesh is provided by the runtime environment (local venv or Docker base image)

--- a/cmd/meshctl/templates/python/llm-agent/requirements.txt.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/requirements.txt.tmpl
@@ -1,8 +1,3 @@
-# MCP Mesh SDK
-mcp-mesh>=0.7.0
-
-# FastMCP for MCP server
-fastmcp
-
-# Pydantic for data validation
-pydantic>=2.0.0
+# {{ .Name }} dependencies
+# Add your third-party dependencies here
+# Note: mcp-mesh is provided by the runtime environment (local venv or Docker base image)

--- a/cmd/meshctl/templates/python/llm-provider/requirements.txt.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/requirements.txt.tmpl
@@ -1,11 +1,3 @@
-# MCP Mesh SDK
-mcp-mesh>=0.7.0
-
-# FastMCP for MCP server
-fastmcp
-
-# LiteLLM for LLM provider
-litellm
-
-# HTTP client for health checks
-httpx
+# {{ .Name }} dependencies
+# Add your third-party dependencies here
+# Note: mcp-mesh is provided by the runtime environment (local venv or Docker base image)


### PR DESCRIPTION
## Summary
- Removes `mcp-mesh` and its transitive dependencies from scaffolded `requirements.txt.tmpl` files
- Adds clarifying comment that mcp-mesh is provided by the runtime environment

## Rationale
The `mcp-mesh` package in scaffolded requirements.txt is redundant because:
- **Local development**: Users must already have `pip install mcp-mesh` as a prerequisite
- **Docker/Kubernetes**: The base image `mcpmesh/python-runtime:0.7` pre-installs mcp-mesh from PyPI

Including it causes confusion and potential version conflicts.

## Changes
- `cmd/meshctl/templates/python/basic/requirements.txt.tmpl`
- `cmd/meshctl/templates/python/llm-agent/requirements.txt.tmpl`
- `cmd/meshctl/templates/python/llm-provider/requirements.txt.tmpl`

Fixes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Replaced hard-coded Python dependencies in project templates with customizable placeholders, enabling users to specify their own third-party packages.
  * Added inline notes indicating which libraries are provided by the runtime environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->