### PR TITLE
Update Grafana to 12.3.1 and Tempo to 2.9.0

### DIFF
--- a/examples/docker-examples/docker-compose.yml
+++ b/examples/docker-examples/docker-compose.yml
@@ -613,7 +613,7 @@ services:
 
   # Tempo - Distributed tracing backend
   tempo:
-    image: grafana/tempo:2.8.1
+    image: grafana/tempo:2.9.0
     container_name: mcp-mesh-tempo
     command: ["-config.file=/etc/tempo.yaml"]
     volumes:
@@ -643,7 +643,7 @@ services:
 
   # Grafana - Observability and visualization
   grafana:
-    image: grafana/grafana:11.4.0
+    image: grafana/grafana:12.3.1
     container_name: mcp-mesh-grafana
     environment:
       - GF_SECURITY_ADMIN_USER=admin

--- a/examples/k8s/base/observability/grafana/deployment.yaml
+++ b/examples/k8s/base/observability/grafana/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: grafana/grafana:11.4.0
+          image: grafana/grafana:12.3.1
           ports:
             - containerPort: 3000
               name: http

--- a/examples/k8s/base/observability/tempo/deployment.yaml
+++ b/examples/k8s/base/observability/tempo/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: tempo
-          image: grafana/tempo:2.8.1
+          image: grafana/tempo:2.9.0
           args:
             - -config.file=/etc/tempo.yaml
           ports:

--- a/examples/observability-test/docker-compose.yml
+++ b/examples/observability-test/docker-compose.yml
@@ -282,7 +282,7 @@ services:
 
   # Tempo - Distributed tracing backend
   tempo:
-    image: grafana/tempo:2.8.1
+    image: grafana/tempo:2.9.0
     container_name: trace-test-tempo
     hostname: tempo
     command: ["-config.file=/etc/tempo.yaml"]
@@ -313,7 +313,7 @@ services:
 
   # Grafana - Observability and visualization
   grafana:
-    image: grafana/grafana:11.4.0
+    image: grafana/grafana:12.3.1
     container_name: trace-test-grafana
     hostname: grafana
     environment:

--- a/helm/mcp-mesh-grafana/Chart.yaml
+++ b/helm/mcp-mesh-grafana/Chart.yaml
@@ -3,7 +3,7 @@ name: mcp-mesh-grafana
 description: Grafana observability component for MCP Mesh
 type: application
 version: 0.7.14
-appVersion: "11.4.0"
+appVersion: "12.3.1"
 keywords:
   - grafana
   - observability

--- a/helm/mcp-mesh-grafana/values.yaml
+++ b/helm/mcp-mesh-grafana/values.yaml
@@ -2,7 +2,7 @@ grafana:
   enabled: true
   image:
     repository: grafana/grafana
-    tag: "11.4.0"
+    tag: "12.3.1"
     pullPolicy: IfNotPresent
 
   resources:

--- a/helm/mcp-mesh-tempo/Chart.yaml
+++ b/helm/mcp-mesh-tempo/Chart.yaml
@@ -3,7 +3,7 @@ name: mcp-mesh-tempo
 description: Tempo distributed tracing component for MCP Mesh
 type: application
 version: 0.7.14
-appVersion: "2.8.1"
+appVersion: "2.9.0"
 keywords:
   - tempo
   - tracing

--- a/helm/mcp-mesh-tempo/values.yaml
+++ b/helm/mcp-mesh-tempo/values.yaml
@@ -2,7 +2,7 @@ tempo:
   enabled: true
   image:
     repository: grafana/tempo
-    tag: "2.8.1"
+    tag: "2.9.0"
     pullPolicy: IfNotPresent
 
   resources:

--- a/src/core/cli/scaffold/compose.go
+++ b/src/core/cli/scaffold/compose.go
@@ -594,7 +594,7 @@ func generateObservabilityServicesYAML(config *ComposeConfig, needsRedis, needsT
 
 	if needsTempo {
 		sb.WriteString(fmt.Sprintf(`tempo:
-  image: grafana/tempo:2.8.1
+  image: grafana/tempo:2.9.0
   container_name: %s-tempo
   hostname: tempo
   command: ["-config.file=/etc/tempo.yaml"]
@@ -616,7 +616,7 @@ func generateObservabilityServicesYAML(config *ComposeConfig, needsRedis, needsT
 
 	if needsGrafana {
 		sb.WriteString(fmt.Sprintf(`grafana:
-  image: grafana/grafana:10.2.0
+  image: grafana/grafana:12.3.1
   container_name: %s-grafana
   hostname: grafana
   environment:
@@ -977,7 +977,7 @@ services:
       - {{ .NetworkName }}
 
   tempo:
-    image: grafana/tempo:2.8.1
+    image: grafana/tempo:2.9.0
     container_name: {{ .ProjectName }}-tempo
     hostname: tempo
     command: ["-config.file=/etc/tempo.yaml"]
@@ -996,7 +996,7 @@ services:
       - {{ .NetworkName }}
 
   grafana:
-    image: grafana/grafana:10.2.0
+    image: grafana/grafana:12.3.1
     container_name: {{ .ProjectName }}-grafana
     hostname: grafana
     environment:


### PR DESCRIPTION
## Summary

- Update Grafana from 11.4.0 to 12.3.1
- Update Tempo from 2.8.1 to 2.9.0

## Test plan

- [x] Tested with `examples/observability-test/` docker-compose
- [x] All 4 agents healthy and registered
- [x] Distributed tracing working correctly
- [x] Trace hierarchy verified with `meshctl trace`

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Updated observability stack versions: Grafana to v12.3.1 and Tempo to v2.9.0 across Docker Compose examples, Kubernetes deployments, and Helm configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->