### PR TITLE
Fix meshctl scaffold --observability missing Grafana provisioning

### DIFF
--- a/src/core/cli/scaffold/compose.go
+++ b/src/core/cli/scaffold/compose.go
@@ -338,9 +338,9 @@ func addObservabilityToExisting(doc *yaml.Node, servicesNode *yaml.Node, existin
 		}
 	}
 
-	// Add tempo-data volume if tempo is being added or exists
+	// Add observability volumes if tempo is being added or exists
 	if needsTempo || existingServices["tempo"] {
-		addTempoVolume(doc)
+		addObservabilityVolumes(doc)
 	}
 
 	// Update existing registry with tracing env vars
@@ -517,8 +517,8 @@ func addDependencyToService(servicesNode *yaml.Node, serviceName string, depende
 	}
 }
 
-// addTempoVolume adds the tempo-data and grafana-data volumes to the document
-func addTempoVolume(doc *yaml.Node) {
+// addObservabilityVolumes adds the tempo-data and grafana-data volumes to the document
+func addObservabilityVolumes(doc *yaml.Node) {
 	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
 		return
 	}


### PR DESCRIPTION
## Summary
- Add embedded Grafana configuration templates to scaffold command
- Generate Grafana config files when using `--observability` flag
- Update Grafana service in docker-compose to mount provisioning volumes

## Changes
When running `meshctl scaffold --compose --observability`, now generates:
- `grafana/grafana.ini` - Main Grafana configuration
- `grafana/provisioning/datasources/datasources.yaml` - Tempo datasource
- `grafana/provisioning/dashboards/dashboards.yaml` - Dashboard provider config
- `grafana/dashboards/mcp-mesh-overview.json` - MCP Mesh overview dashboard

Updates Grafana service with proper volume mounts:
```yaml
volumes:
  - ./grafana/grafana.ini:/etc/grafana/grafana.ini:ro
  - ./grafana/provisioning:/etc/grafana/provisioning:ro
  - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
  - grafana-data:/var/lib/grafana
```

Also adds `GF_FEATURE_TOGGLES_ENABLE=traceqlEditor` environment variable.

## Test plan
- [x] Build meshctl successfully
- [x] All scaffold tests pass
- [x] `meshctl scaffold --compose --observability` generates grafana/ directory with all config files
- [x] Docker-compose Grafana service has correct volume mounts
- [x] Merge flow (adding observability to existing compose) works correctly

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Grafana observability: automatic generation of Grafana config, datasources, and pre-configured dashboards when observability is enabled.
  * Docker Compose now wires Grafana into the stack with data volumes and feature toggles for enhanced monitoring.
  * Observability volume handling extended to include both tracing and Grafana data, plus agent-specific volumes for provisioning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->