### PR TITLE
Add pre-flight validation to meshctl start

### DIFF
--- a/src/core/cli/package_manager.go
+++ b/src/core/cli/package_manager.go
@@ -99,6 +99,18 @@ func InstallPackage(pythonExec, packageName string) error {
 	return nil
 }
 
+// findSystemPython finds a Python executable in the system PATH.
+// Used for creating new virtual environments.
+func findSystemPython() (string, error) {
+	candidates := []string{"python3", "python"}
+	for _, candidate := range candidates {
+		if path, err := exec.LookPath(candidate); err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("no Python executable found in PATH")
+}
+
 // CreateVirtualEnvironment creates a new virtual environment
 func CreateVirtualEnvironment(venvPath string) error {
 	fmt.Printf("🔧 Creating virtual environment at %s...\n", venvPath)


### PR DESCRIPTION
## Summary

Closes #337

- Add `--skip-checks` flag to bypass prerequisite validation
- Strictly require `.venv` in current directory (no fallback to system Python)
- Check Python version >= 3.11 (per pyproject.toml)
- Check mcp-mesh package is installed
- Validate agent files exist before spawning
- Provide clear error messages with remediation steps

## Behavior

**Before:** `meshctl start` spawns agents and users have to check logs to find failures like missing Python or mcp-mesh package.

**After:** Validates all prerequisites upfront with clear errors:

```
$ meshctl start agent.py   # from directory without .venv

❌ Prerequisite check failed: Python environment

Python environment check failed: virtual environment not found at /tmp/.venv

MCP Mesh requires a .venv directory in your current working directory.

Current directory: /tmp

To fix this issue:
  1. Navigate to your project directory (where your agents are)
  2. Create a virtual environment: python3.11 -m venv .venv
  3. Activate it: source .venv/bin/activate
  4. Install mcp-mesh: pip install mcp-mesh
  5. Run meshctl start from this directory
```

## Test plan

- [ ] Run `meshctl start agent.py` from directory without `.venv` - should fail with clear error
- [ ] Run `meshctl start agent.py` from directory with proper `.venv` - should pass validation
- [ ] Run `meshctl start --skip-checks agent.py` - should bypass validation
- [ ] Run `meshctl start nonexistent.py` - should fail with "agent file not found" error

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prerequisites validation runs before agent startup, checking Python environment, version (3.11+), required package availability (mcp-mesh), and configuration paths
  * Added --skip-checks flag to bypass validation with warnings
  * Improved, actionable error and remediation guidance when checks fail
  * Enforced local .venv usage and support for applying environment files before checks

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->