### PR TITLE
Improve scaffold output to list generated files (#336)

### DIFF
--- a/src/core/cli/scaffold/static.go
+++ b/src/core/cli/scaffold/static.go
@@ -266,18 +266,21 @@ func (p *StaticProvider) Execute(ctx *ScaffoldContext) error {
 		}
 	}
 
-	// Print success message
+	// Print success message with generated files
 	if ctx.Cmd != nil {
-		ctx.Cmd.Printf("Successfully created agent '%s' in %s\n", ctx.Name, outputDir)
-		ctx.Cmd.Printf("  Language: %s\n", ctx.Language)
-		if ctx.AgentType != "" {
-			ctx.Cmd.Printf("  Agent Type: %s\n", ctx.AgentType)
-		}
-		ctx.Cmd.Printf("  Template: %s\n", ctx.Template)
-		ctx.Cmd.Printf("  Port: %d\n", ctx.Port)
-		if ctx.Model != "" {
-			ctx.Cmd.Printf("  Model: %s\n", ctx.Model)
-		}
+		ctx.Cmd.Printf("\n✅ Created agent '%s' in %s/\n\n", ctx.Name, outputDir)
+		ctx.Cmd.Printf("Generated files:\n")
+		ctx.Cmd.Printf("  %s/\n", ctx.Name)
+		ctx.Cmd.Printf("  ├── main.py             # Agent entry point\n")
+		ctx.Cmd.Printf("  ├── Dockerfile          # Container build\n")
+		ctx.Cmd.Printf("  ├── helm-values.yaml    # K8s deployment values\n")
+		ctx.Cmd.Printf("  ├── requirements.txt    # Python dependencies\n")
+		ctx.Cmd.Printf("  └── README.md\n")
+		ctx.Cmd.Printf("\n")
+		ctx.Cmd.Printf("Next steps:\n")
+		ctx.Cmd.Printf("  meshctl start %s/main.py\n", ctx.Name)
+		ctx.Cmd.Printf("\n")
+		ctx.Cmd.Printf("For Docker/K8s deployment, see: meshctl man deployment\n")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Display file tree of generated files after scaffold completes
- Show clear next steps for running the agent

## Changes
- Updated scaffold success output to show file tree structure
- Added `meshctl start` command as next step
- Referenced `meshctl man deployment` for Docker/K8s deployment

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced success messaging display when scaffolding completes. Users now receive a formatted success banner, explicit list of generated files, next steps guidance, and deployment information in a structured format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->