### PR TITLE
Fix scaffold llm-agent template issues

### DIFF
--- a/cmd/meshctl/templates/python/llm-agent/main.py.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/main.py.tmpl
@@ -14,17 +14,8 @@ from pydantic import BaseModel, Field
 # FastMCP server instance
 app = FastMCP("{{ toPascalCase .Name }} Service")
 
-# ===== SYSTEM PROMPT =====
-{{ if .SystemPromptInline }}
-SYSTEM_PROMPT = """{{ .SystemPrompt }}"""
-{{ else if not .SystemPromptIsFile }}
-# Default system prompt - customize this for your use case
-SYSTEM_PROMPT = """You are {{ toPascalCase .Name }}, an AI assistant.
-
-{{ if .Description }}{{ .Description }}{{ else }}Process the input and provide a helpful response.{{ end }}
-
-Analyze the provided context and respond appropriately."""
-{{ end }}
+# System prompt is loaded from: prompts/{{ .Name }}.jinja2
+# Customize the prompt file to change the LLM behavior.
 
 # ===== CONTEXT MODEL =====
 
@@ -59,9 +50,8 @@ class {{ toPascalCase .Name }}Response(BaseModel):
     filter_mode="{{ .FilterMode }}",
     provider={"capability": "llm", "tags": {{ toJSON .ProviderTags }}},
     max_iterations={{ .MaxIterations }},
-    system_prompt={{ if .SystemPromptIsFile }}"{{ .SystemPrompt }}"{{ else }}SYSTEM_PROMPT{{ end }},
+    system_prompt={{ if .SystemPromptIsFile }}"{{ .SystemPrompt }}"{{ else }}"file://prompts/{{ .Name }}.jinja2"{{ end }},
     context_param="{{ .ContextParam }}",
-    response_format="{{ .ResponseFormat }}",
 )
 @mesh.tool(
     capability="{{ toSnakeCase .Name }}",


### PR DESCRIPTION
## Summary

- Remove `response_format` parameter from `@mesh.llm` decorator - causes `TypeError: Unsupported response_format type - text` with LiteLLM/OpenAI
- Use `file://prompts/<name>.jinja2` for `system_prompt` instead of inline string - makes `context_param` work correctly with Jinja2 templates
- Add dynamic file listing to show all generated files including `prompts/` directory

## Before

```python
@mesh.llm(
    system_prompt=SYSTEM_PROMPT,  # inline, context_param ignored
    context_param="ctx",
    response_format="text",  # ❌ causes TypeError
)
```

## After

```python
@mesh.llm(
    system_prompt="file://prompts/test-llm-agent.jinja2",  # ✅ uses template
    context_param="ctx",  # ✅ now works
)
```

## Test plan

- [x] Test `meshctl scaffold --name test --template basic`
- [x] Test `meshctl scaffold --name test --template llm-agent --llm-selector openai`
- [x] Test `meshctl scaffold --name test --template llm-provider`
- [x] Verify file listing shows prompts/ directory for llm-agent

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)