### PR TITLE
Add meshctl stop command with per-agent PID tracking (#364)

### DIFF
--- a/cmd/meshctl/main.go
+++ b/cmd/meshctl/main.go
@@ -33,6 +33,7 @@ func main() {
 
 	// Add all subcommands
 	rootCmd.AddCommand(cli.NewStartCommand())
+	rootCmd.AddCommand(cli.NewStopCommand()) // Issue #364
 	rootCmd.AddCommand(cli.NewListCommand())
 	rootCmd.AddCommand(cli.NewCallCommand())
 	rootCmd.AddCommand(cli.NewStatusCommand())

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -60,6 +60,24 @@ MCP_MESH_HTTP_PORT=8082 python agent2.py &
 MCP_MESH_HTTP_PORT=8083 python agent3.py &
 ```
 
+### Development Workflow
+
+For fast iterative development:
+
+```bash
+# Watch mode: auto-restart on file changes
+meshctl start my_agent.py --watch --debug
+
+# Or run in background
+meshctl start my_agent.py --detach
+
+# Stop when done
+meshctl stop my_agent      # Stop specific agent
+meshctl stop               # Stop all
+```
+
+See `meshctl start --help` and `meshctl stop --help` for options.
+
 ## Docker Deployment
 
 ### Generate Dockerfile (Recommended)

--- a/src/core/cli/pid_manager.go
+++ b/src/core/cli/pid_manager.go
@@ -1,0 +1,229 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// PIDManager handles PID file operations for detached processes
+type PIDManager struct {
+	pidsDir string
+}
+
+// PIDInfo represents information about a tracked process
+type PIDInfo struct {
+	Name     string
+	PID      int
+	PIDFile  string
+	Running  bool
+	Type     string // "agent" or "registry"
+}
+
+// NewPIDManager creates a new PID manager with the default pids directory
+func NewPIDManager() (*PIDManager, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	pidsDir := filepath.Join(homeDir, ".mcp-mesh", "pids")
+
+	// Ensure pids directory exists
+	if err := os.MkdirAll(pidsDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create pids directory: %w", err)
+	}
+
+	return &PIDManager{pidsDir: pidsDir}, nil
+}
+
+// GetPIDsDir returns the pids directory path
+func (pm *PIDManager) GetPIDsDir() string {
+	return pm.pidsDir
+}
+
+// GetPIDFile returns the path to the PID file for a given name
+func (pm *PIDManager) GetPIDFile(name string) string {
+	// Sanitize name to be filesystem safe
+	safeName := sanitizeName(name)
+	return filepath.Join(pm.pidsDir, safeName+".pid")
+}
+
+// WritePID writes a PID to the appropriate PID file
+func (pm *PIDManager) WritePID(name string, pid int) error {
+	pidFile := pm.GetPIDFile(name)
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", pid)), 0644); err != nil {
+		return fmt.Errorf("failed to write PID file %s: %w", pidFile, err)
+	}
+	return nil
+}
+
+// ReadPID reads the PID from a PID file for a given name
+func (pm *PIDManager) ReadPID(name string) (int, error) {
+	pidFile := pm.GetPIDFile(name)
+	return pm.ReadPIDFromFile(pidFile)
+}
+
+// ReadPIDFromFile reads the PID from a specific PID file
+func (pm *PIDManager) ReadPIDFromFile(pidFile string) (int, error) {
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		return 0, err
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("invalid PID in file %s: %w", pidFile, err)
+	}
+
+	return pid, nil
+}
+
+// RemovePID removes the PID file for a given name
+func (pm *PIDManager) RemovePID(name string) error {
+	pidFile := pm.GetPIDFile(name)
+	return pm.RemovePIDFile(pidFile)
+}
+
+// RemovePIDFile removes a specific PID file
+func (pm *PIDManager) RemovePIDFile(pidFile string) error {
+	if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove PID file %s: %w", pidFile, err)
+	}
+	return nil
+}
+
+// IsProcessRunning checks if a process with the given name is running
+func (pm *PIDManager) IsProcessRunning(name string) bool {
+	pid, err := pm.ReadPID(name)
+	if err != nil {
+		return false
+	}
+	return IsProcessAlive(pid)
+}
+
+// Note: IsProcessAlive is defined in utils.go
+
+// ListRunningProcesses returns all running processes tracked by PID files
+func (pm *PIDManager) ListRunningProcesses() ([]PIDInfo, error) {
+	entries, err := os.ReadDir(pm.pidsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []PIDInfo{}, nil
+		}
+		return nil, fmt.Errorf("failed to read pids directory: %w", err)
+	}
+
+	var processes []PIDInfo
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".pid") {
+			continue
+		}
+
+		name := strings.TrimSuffix(entry.Name(), ".pid")
+		pidFile := filepath.Join(pm.pidsDir, entry.Name())
+
+		pid, err := pm.ReadPIDFromFile(pidFile)
+		if err != nil {
+			continue
+		}
+
+		running := IsProcessAlive(pid)
+		procType := "agent"
+		if name == "registry" {
+			procType = "registry"
+		}
+
+		processes = append(processes, PIDInfo{
+			Name:    name,
+			PID:     pid,
+			PIDFile: pidFile,
+			Running: running,
+			Type:    procType,
+		})
+	}
+
+	return processes, nil
+}
+
+// ListAllPIDFiles returns all PID files (including stale ones)
+func (pm *PIDManager) ListAllPIDFiles() ([]PIDInfo, error) {
+	return pm.ListRunningProcesses() // Same implementation, includes running status
+}
+
+// CleanStalePIDFiles removes PID files for processes that are no longer running
+func (pm *PIDManager) CleanStalePIDFiles() ([]string, error) {
+	processes, err := pm.ListAllPIDFiles()
+	if err != nil {
+		return nil, err
+	}
+
+	var cleaned []string
+	for _, proc := range processes {
+		if !proc.Running {
+			if err := pm.RemovePIDFile(proc.PIDFile); err == nil {
+				cleaned = append(cleaned, proc.Name)
+			}
+		}
+	}
+
+	return cleaned, nil
+}
+
+// GetRunningAgents returns only running agent processes (excludes registry)
+func (pm *PIDManager) GetRunningAgents() ([]PIDInfo, error) {
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		return nil, err
+	}
+
+	var agents []PIDInfo
+	for _, proc := range processes {
+		if proc.Running && proc.Type == "agent" {
+			agents = append(agents, proc)
+		}
+	}
+
+	return agents, nil
+}
+
+// GetRegistry returns the registry process info if running
+func (pm *PIDManager) GetRegistry() (*PIDInfo, error) {
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, proc := range processes {
+		if proc.Name == "registry" && proc.Running {
+			return &proc, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// sanitizeName converts a name to a filesystem-safe string
+func sanitizeName(name string) string {
+	// Remove path components, keep only the base name
+	name = filepath.Base(name)
+
+	// Remove .py extension if present
+	name = strings.TrimSuffix(name, ".py")
+
+	// Replace any remaining problematic characters
+	name = strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			return r
+		}
+		return '_'
+	}, name)
+
+	if name == "" {
+		name = "unknown"
+	}
+
+	return name
+}

--- a/src/core/cli/stop.go
+++ b/src/core/cli/stop.go
@@ -1,0 +1,381 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// NewStopCommand creates the stop command
+func NewStopCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stop [name]",
+		Short: "Stop detached agents and registry",
+		Long: `Stop agents and/or registry running in detached mode.
+
+Without arguments, stops all agents and the registry.
+With a name argument, stops only that specific agent.
+
+Examples:
+  meshctl stop                    # Stop all agents + registry
+  meshctl stop my-agent           # Stop specific agent
+  meshctl stop --registry         # Stop only registry
+  meshctl stop --agents           # Stop all agents, keep registry
+  meshctl stop --keep-registry    # Stop all agents, keep registry (alias)`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runStopCommand,
+	}
+
+	cmd.Flags().Bool("registry", false, "Stop only the registry")
+	cmd.Flags().Bool("agents", false, "Stop all agents, keep registry running")
+	cmd.Flags().Bool("keep-registry", false, "Stop all agents, keep registry running (alias for --agents)")
+	cmd.Flags().Int("timeout", 10, "Shutdown timeout in seconds per process")
+	cmd.Flags().Bool("force", false, "Force kill without graceful shutdown")
+	cmd.Flags().Bool("quiet", false, "Suppress output messages")
+
+	return cmd
+}
+
+func runStopCommand(cmd *cobra.Command, args []string) error {
+	registryOnly, _ := cmd.Flags().GetBool("registry")
+	agentsOnly, _ := cmd.Flags().GetBool("agents")
+	keepRegistry, _ := cmd.Flags().GetBool("keep-registry")
+	timeout, _ := cmd.Flags().GetInt("timeout")
+	force, _ := cmd.Flags().GetBool("force")
+	quiet, _ := cmd.Flags().GetBool("quiet")
+
+	// --keep-registry is alias for --agents
+	if keepRegistry {
+		agentsOnly = true
+	}
+
+	// Validate flag combinations
+	if registryOnly && agentsOnly {
+		return fmt.Errorf("cannot use --registry and --agents together")
+	}
+
+	// Create PID manager
+	pm, err := NewPIDManager()
+	if err != nil {
+		return fmt.Errorf("failed to initialize PID manager: %w", err)
+	}
+
+	// Clean stale PID files first
+	cleaned, _ := pm.CleanStalePIDFiles()
+	if len(cleaned) > 0 && !quiet {
+		for _, name := range cleaned {
+			fmt.Printf("Cleaned stale PID file for: %s\n", name)
+		}
+	}
+
+	shutdownTimeout := time.Duration(timeout) * time.Second
+
+	// Handle specific agent stop
+	if len(args) == 1 {
+		agentName := args[0]
+		return stopSpecificAgent(pm, agentName, shutdownTimeout, force, quiet)
+	}
+
+	// Handle --registry flag
+	if registryOnly {
+		return stopRegistry(pm, shutdownTimeout, force, quiet)
+	}
+
+	// Handle --agents flag (stop agents, keep registry)
+	if agentsOnly {
+		return stopAllAgents(pm, shutdownTimeout, force, quiet)
+	}
+
+	// Default: stop all (agents + registry)
+	return stopAll(pm, shutdownTimeout, force, quiet)
+}
+
+// stopSpecificAgent stops a single agent by name
+func stopSpecificAgent(pm *PIDManager, name string, timeout time.Duration, force, quiet bool) error {
+	pid, err := pm.ReadPID(name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("agent '%s' is not running in background", name)
+		}
+		return fmt.Errorf("failed to read PID for %s: %w", name, err)
+	}
+
+	if !IsProcessAlive(pid) {
+		// Process is dead, clean up PID file
+		pm.RemovePID(name)
+		if !quiet {
+			fmt.Printf("Agent '%s' is not running (cleaned stale PID file)\n", name)
+		}
+		return nil
+	}
+
+	if !quiet {
+		fmt.Printf("Stopping agent '%s' (PID: %d)...\n", name, pid)
+	}
+
+	if err := stopProcess(pid, timeout, force); err != nil {
+		return fmt.Errorf("failed to stop agent '%s': %w", name, err)
+	}
+
+	pm.RemovePID(name)
+
+	if !quiet {
+		fmt.Printf("Agent '%s' stopped\n", name)
+	}
+
+	return nil
+}
+
+// stopRegistry stops only the registry
+func stopRegistry(pm *PIDManager, timeout time.Duration, force, quiet bool) error {
+	registry, err := pm.GetRegistry()
+	if err != nil {
+		return fmt.Errorf("failed to check registry status: %w", err)
+	}
+
+	if registry == nil {
+		if !quiet {
+			fmt.Println("Registry is not running in background")
+		}
+		return nil
+	}
+
+	if !quiet {
+		fmt.Printf("Stopping registry (PID: %d)...\n", registry.PID)
+	}
+
+	if err := stopProcess(registry.PID, timeout, force); err != nil {
+		return fmt.Errorf("failed to stop registry: %w", err)
+	}
+
+	pm.RemovePID("registry")
+
+	if !quiet {
+		fmt.Println("Registry stopped")
+	}
+
+	return nil
+}
+
+// stopAllAgents stops all agents but keeps the registry running (parallel)
+func stopAllAgents(pm *PIDManager, timeout time.Duration, force, quiet bool) error {
+	agents, err := pm.GetRunningAgents()
+	if err != nil {
+		return fmt.Errorf("failed to list agents: %w", err)
+	}
+
+	if len(agents) == 0 {
+		if !quiet {
+			fmt.Println("No agents running in background")
+		}
+		return nil
+	}
+
+	if !quiet {
+		fmt.Printf("Stopping %d agent(s) in parallel...\n", len(agents))
+	}
+
+	// Stop agents in parallel
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var stopped, failed int
+
+	for _, agent := range agents {
+		wg.Add(1)
+		go func(agent PIDInfo) {
+			defer wg.Done()
+
+			if !quiet {
+				fmt.Printf("Stopping agent '%s' (PID: %d)...\n", agent.Name, agent.PID)
+			}
+
+			if err := stopProcess(agent.PID, timeout, force); err != nil {
+				mu.Lock()
+				if !quiet {
+					fmt.Printf("Failed to stop agent '%s': %v\n", agent.Name, err)
+				}
+				failed++
+				mu.Unlock()
+				return
+			}
+
+			pm.RemovePIDFile(agent.PIDFile)
+
+			mu.Lock()
+			stopped++
+			if !quiet {
+				fmt.Printf("Agent '%s' stopped\n", agent.Name)
+			}
+			mu.Unlock()
+		}(agent)
+	}
+
+	wg.Wait()
+
+	if !quiet {
+		fmt.Printf("\nStopped %d agent(s)", stopped)
+		if failed > 0 {
+			fmt.Printf(", %d failed", failed)
+		}
+		fmt.Println()
+	}
+
+	if failed > 0 {
+		return fmt.Errorf("%d agent(s) failed to stop", failed)
+	}
+
+	return nil
+}
+
+// stopAll stops all agents and the registry (agents in parallel, registry last)
+func stopAll(pm *PIDManager, timeout time.Duration, force, quiet bool) error {
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		return fmt.Errorf("failed to list processes: %w", err)
+	}
+
+	// Separate agents and registry
+	var agents []PIDInfo
+	var registry *PIDInfo
+	for _, proc := range processes {
+		if !proc.Running {
+			continue
+		}
+		if proc.Type == "registry" {
+			registry = &proc
+		} else {
+			agents = append(agents, proc)
+		}
+	}
+
+	if len(agents) == 0 && registry == nil {
+		if !quiet {
+			fmt.Println("No agents running in background. Use 'meshctl start --detach' to run agents in background.")
+		}
+		return nil
+	}
+
+	var stopped, failed int
+	var mu sync.Mutex
+
+	// Stop agents in parallel
+	if len(agents) > 0 {
+		if !quiet {
+			fmt.Printf("Stopping %d agent(s) in parallel...\n", len(agents))
+		}
+
+		var wg sync.WaitGroup
+		for _, agent := range agents {
+			wg.Add(1)
+			go func(proc PIDInfo) {
+				defer wg.Done()
+
+				if !quiet {
+					fmt.Printf("Stopping agent '%s' (PID: %d)...\n", proc.Name, proc.PID)
+				}
+
+				if err := stopProcess(proc.PID, timeout, force); err != nil {
+					mu.Lock()
+					if !quiet {
+						fmt.Printf("Failed to stop agent '%s': %v\n", proc.Name, err)
+					}
+					failed++
+					mu.Unlock()
+					return
+				}
+
+				pm.RemovePIDFile(proc.PIDFile)
+
+				mu.Lock()
+				stopped++
+				if !quiet {
+					fmt.Printf("Agent '%s' stopped\n", proc.Name)
+				}
+				mu.Unlock()
+			}(agent)
+		}
+		wg.Wait()
+	}
+
+	// Stop registry last (sequential)
+	if registry != nil {
+		if !quiet {
+			fmt.Printf("Stopping registry (PID: %d)...\n", registry.PID)
+		}
+
+		if err := stopProcess(registry.PID, timeout, force); err != nil {
+			if !quiet {
+				fmt.Printf("Failed to stop registry: %v\n", err)
+			}
+			failed++
+		} else {
+			pm.RemovePIDFile(registry.PIDFile)
+			stopped++
+			if !quiet {
+				fmt.Println("Registry stopped")
+			}
+		}
+	}
+
+	if !quiet {
+		fmt.Printf("\nStopped %d process(es)", stopped)
+		if failed > 0 {
+			fmt.Printf(", %d failed", failed)
+		}
+		fmt.Println()
+	}
+
+	if failed > 0 {
+		return fmt.Errorf("%d process(es) failed to stop", failed)
+	}
+
+	return nil
+}
+
+// stopProcess gracefully stops a process (SIGTERM, then SIGKILL after timeout)
+func stopProcess(pid int, timeout time.Duration, force bool) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("process not found: %w", err)
+	}
+
+	// If force, skip graceful shutdown
+	if force {
+		if err := process.Kill(); err != nil {
+			return fmt.Errorf("failed to kill process: %w", err)
+		}
+		return nil
+	}
+
+	// Send SIGTERM for graceful shutdown
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		// Process might already be dead
+		if !IsProcessAlive(pid) {
+			return nil
+		}
+		return fmt.Errorf("failed to send SIGTERM: %w", err)
+	}
+
+	// Wait for process to exit
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !IsProcessAlive(pid) {
+			return nil // Process exited gracefully
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Timeout reached, force kill
+	if err := process.Kill(); err != nil {
+		if !IsProcessAlive(pid) {
+			return nil // Process already dead
+		}
+		return fmt.Errorf("failed to kill process after timeout: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

- Add `meshctl stop [name]` command to stop detached agents and registry
- Implement per-agent PID files in `~/.mcp-mesh/pids/` (replaces single global PID file)
- Support parallel agent shutdown with configurable timeout (10s default)
- Add flags: `--registry`, `--agents`, `--keep-registry`, `--force`, `--timeout`, `--quiet`
- Deprecate `--pid-file` flag (PID files now managed automatically per-agent)
- Clean stale PID files automatically on stop
- Update deployment docs with dev workflow (`--watch`, `--detach`, `meshctl stop`)

## Usage

```bash
# Start agents in background
meshctl start agent1.py --detach
meshctl start agent2.py --detach

# Stop specific agent
meshctl stop agent1

# Stop all agents + registry
meshctl stop

# Stop only agents, keep registry
meshctl stop --agents

# Force kill without graceful shutdown
meshctl stop --force
```

## Test plan

- [x] Build passes
- [x] Tests pass
- [ ] Manual test: `meshctl start agent.py --detach` creates PID file in `~/.mcp-mesh/pids/`
- [ ] Manual test: Multiple `meshctl start --detach` commands work (no blocking)
- [ ] Manual test: `meshctl stop agent` stops specific agent
- [ ] Manual test: `meshctl stop` stops all agents + registry
- [ ] Manual test: `meshctl stop --agents` keeps registry running

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `stop` subcommand to gracefully or forcefully terminate agents and/or the registry, with configurable timeout and force options for flexible process management.

* **Deprecations**
  * The global `--pid-file` flag is deprecated in favor of per-agent PID file tracking for improved process management.

* **Documentation**
  * Added development workflow section documenting iterative development with watch, detach, and stop processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->