### PR TITLE
Fix broken --env-file flag in meshctl start

### DIFF
--- a/src/core/cli/start.go
+++ b/src/core/cli/start.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
 	"net/url"
 	"os"
@@ -186,12 +187,9 @@ func loadEnvironmentFile(envFile string) error {
 	}
 	defer file.Close()
 
-	// Read and parse .env format
-	var lines []string
-	fmt.Fscanf(file, "%s", &lines)
-
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
@@ -200,7 +198,7 @@ func loadEnvironmentFile(envFile string) error {
 		}
 	}
 
-	return nil
+	return scanner.Err()
 }
 
 // Set environment variable from KEY=VALUE format


### PR DESCRIPTION
## Summary

- Fix `loadEnvironmentFile()` which was completely non-functional
- The bug: `fmt.Fscanf(file, "%s", &lines)` expects `*string` not `*[]string`, and `%s` only reads one token
- Result: `lines` slice was always empty, env vars never loaded

## Changes

- Replace broken `fmt.Fscanf` with `bufio.Scanner` to properly read line by line
- Return `scanner.Err()` to surface any read errors

## Test plan

- [x] Verified env vars are loaded and passed to agents
- [x] Verified comments and blank lines are skipped
- [x] Verified proper error for non-existent file
- [x] Verified proper error for invalid format (missing `=`)

Fixes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved environment file parsing to process lines individually with immediate validation instead of batch processing.

* **Bug Fixes**
  * Enhanced error handling for environment file reading to catch and report issues more promptly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->