### PR TITLE
Add observability docs, improve trace errors, and enable full LLM logging

### DIFF
--- a/src/core/cli/man/content.go
+++ b/src/core/cli/man/content.go
@@ -109,6 +109,12 @@ var guideRegistry = map[string]*Guide{
 		Title:       "CLI Commands",
 		Description: "meshctl call, list, status for development and testing",
 	},
+	"observability": {
+		Name:        "observability",
+		Aliases:     []string{"tracing", "monitoring", "tempo", "grafana"},
+		Title:       "Observability",
+		Description: "Distributed tracing, Grafana dashboards, and monitoring setup",
+	},
 	"prerequisites": {
 		Name:        "prerequisites",
 		Aliases:     []string{"prereq", "setup", "install"},
@@ -157,8 +163,8 @@ func ListGuides() []*Guide {
 	order := []string{
 		"prerequisites", "overview", "capabilities", "tags", "decorators",
 		"dependency-injection", "health", "registry", "llm",
-		"proxies", "fastapi", "environment", "deployment", "testing",
-		"scaffold", "cli",
+		"proxies", "fastapi", "environment", "deployment", "observability",
+		"testing", "scaffold", "cli",
 	}
 	for _, name := range order {
 		if guide, ok := guideRegistry[name]; ok {

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -1,0 +1,124 @@
+# Observability
+
+> Distributed tracing and monitoring for MCP Mesh agents
+
+## Overview
+
+MCP Mesh provides built-in observability through:
+
+- **CLI tracing**: Quick debugging with `meshctl call --trace`
+- **Grafana dashboards**: Production monitoring with Tempo backend
+
+## CLI Tracing
+
+### Get trace IDs
+
+```bash
+# Add --trace flag to any call
+meshctl call my-agent:my_tool --trace
+# Output includes: Trace ID: abc123def456...
+```
+
+### View trace tree
+
+```bash
+# View the full call tree
+meshctl trace abc123def456
+
+# Output as JSON
+meshctl trace abc123def456 --json
+
+# Show internal spans (usually hidden)
+meshctl trace abc123def456 --show-internal
+```
+
+### Example output
+
+```
+Call Tree for trace abc123def456
+════════════════════════════════════════════════════════════
+
+└─ process_request (orchestrator) [45ms] ✓
+   ├─ validate_input (validator) [5ms] ✓
+   └─ execute_task (worker) [38ms] ✓
+      └─ fetch_data (data-service) [30ms] ✓
+
+────────────────────────────────────────────────────────────
+Summary: 4 spans across 4 agents | 45ms | ✓
+Agents: orchestrator, validator, worker, data-service
+```
+
+## Production Monitoring (Grafana)
+
+### Setup with Docker Compose
+
+```bash
+# Generate docker-compose with observability stack
+meshctl scaffold --compose --observability
+
+# Starts: Redis, Tempo, Grafana
+docker compose up -d
+```
+
+### Setup with Kubernetes
+
+```bash
+# Install core with observability enabled (default)
+helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
+  --version 0.7.18 \
+  -n mcp-mesh --create-namespace
+
+# Or disable observability
+helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
+  --version 0.7.18 \
+  -n mcp-mesh --create-namespace \
+  --set tempo.enabled=false \
+  --set grafana.enabled=false
+```
+
+### Access Grafana
+
+| Deployment     | URL                                                      |
+| -------------- | -------------------------------------------------------- |
+| Docker Compose | http://localhost:3000                                    |
+| Kubernetes     | `kubectl port-forward svc/grafana 3000:3000 -n mcp-mesh` |
+
+Default credentials: `admin` / `admin`
+
+### Pre-built Dashboards
+
+- **MCP Mesh Overview**: Agent health, request rates, error rates
+- **Trace Explorer**: Search and visualize distributed traces
+- **Agent Details**: Per-agent metrics and traces
+
+## Environment Variables
+
+| Variable                               | Description     | Default             |
+| -------------------------------------- | --------------- | ------------------- |
+| `MCP_MESH_DISTRIBUTED_TRACING_ENABLED` | Enable tracing  | `false`             |
+| `TRACE_EXPORTER_TYPE`                  | Exporter type   | `otlp`              |
+| `TELEMETRY_ENDPOINT`                   | Tempo endpoint  | `tempo:4317`        |
+| `TELEMETRY_PROTOCOL`                   | Protocol        | `grpc`              |
+| `TEMPO_URL`                            | Tempo query URL | `http://tempo:3200` |
+
+## Troubleshooting
+
+### "Trace not found"
+
+Possible reasons:
+
+- Trace ID incorrect or expired (traces expire after ~1 hour by default)
+- Distributed tracing not enabled (`MCP_MESH_DISTRIBUTED_TRACING_ENABLED=true`)
+- Observability stack not deployed
+
+### Traces not appearing in Grafana
+
+1. Check Tempo is running: `docker compose ps tempo`
+2. Check agent has tracing enabled in environment
+3. Verify network connectivity between agents and Tempo
+
+## See Also
+
+- `meshctl man deployment` - Setup Docker/Kubernetes
+- `meshctl man scaffold` - Generate observability stack
+- `meshctl trace --help` - Trace command options

--- a/src/core/cli/trace.go
+++ b/src/core/cli/trace.go
@@ -116,7 +116,12 @@ func runTraceCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	if trace == nil {
-		return fmt.Errorf("trace '%s' not found", traceID)
+		return fmt.Errorf("trace '%s' not found\n\n"+
+			"Possible reasons:\n"+
+			"  - Trace ID may be incorrect or expired\n"+
+			"  - Distributed tracing may not be enabled\n"+
+			"  - Observability stack (Tempo) may not be deployed\n\n"+
+			"Run 'meshctl man observability' for setup instructions.", traceID)
 	}
 
 	// Output result
@@ -136,7 +141,10 @@ func queryTrace(client *http.Client, registryURL, traceID string) (*CompletedTra
 
 	resp, err := client.Get(url)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to registry: %w", err)
+		return nil, fmt.Errorf("failed to connect to registry: %w\n\n"+
+			"Hint: Ensure the registry and observability stack are running.\n"+
+			"      Run 'meshctl scaffold --compose --observability' to generate docker-compose with Tempo.\n"+
+			"      See 'meshctl man observability' for details.", err)
 	}
 	defer resp.Body.Close()
 

--- a/src/runtime/python/_mcp_mesh/shared/logging_config.py
+++ b/src/runtime/python/_mcp_mesh/shared/logging_config.py
@@ -169,15 +169,16 @@ def get_trace_prefix() -> str:
     return ""
 
 
-def format_log_value(value, max_len: int = 1000) -> str:
-    """Format a value for logging with truncation.
+def format_log_value(value, max_len: int = 0) -> str:
+    """Format a value for logging.
 
-    Provides a readable representation of values with size info and truncation
-    for large payloads. Suitable for DEBUG level logging.
+    Provides a readable representation of values with size info.
+    By default, no truncation is applied (max_len=0) to enable full
+    request/response logging at DEBUG/TRACE levels.
 
     Args:
         value: Any value to format
-        max_len: Maximum length before truncation (default 1000)
+        max_len: Maximum length before truncation (0 = no truncation)
 
     Returns:
         Formatted string representation
@@ -190,18 +191,18 @@ def format_log_value(value, max_len: int = 1000) -> str:
     try:
         if isinstance(value, dict):
             content = str(value)
-            if len(content) > max_len:
+            if max_len > 0 and len(content) > max_len:
                 return f"{type_name}({len(value)} keys): {content[:max_len]}..."
             return content
 
         elif isinstance(value, (list, tuple)):
             content = str(value)
-            if len(content) > max_len:
+            if max_len > 0 and len(content) > max_len:
                 return f"{type_name}({len(value)} items): {content[:max_len]}..."
             return content
 
         elif isinstance(value, str):
-            if len(value) > max_len:
+            if max_len > 0 and len(value) > max_len:
                 return f'"{value[:max_len]}..." ({len(value)} chars)'
             return f'"{value}"'
 
@@ -211,13 +212,13 @@ def format_log_value(value, max_len: int = 1000) -> str:
         elif hasattr(value, "__dict__"):
             # Object with attributes - show class name and key attributes
             content = str(value)
-            if len(content) > max_len:
+            if max_len > 0 and len(content) > max_len:
                 return f"{type_name}: {content[:max_len]}..."
             return f"{type_name}: {content}"
 
         else:
             content = str(value)
-            if len(content) > max_len:
+            if max_len > 0 and len(content) > max_len:
                 return f"{type_name}: {content[:max_len]}..."
             return content
 

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -8,6 +8,8 @@ mesh decorators to simplify common patterns like zero-code LLM providers.
 import logging
 from typing import Any, Dict, List, Optional
 
+from _mcp_mesh.shared.logging_config import format_log_value
+
 logger = logging.getLogger(__name__)
 
 
@@ -228,7 +230,16 @@ def llm_provider(
 
             # Call LiteLLM
             try:
+                # Log full request
+                logger.debug(
+                    f"📤 LLM provider request: {format_log_value(completion_args)}"
+                )
+
                 response = litellm.completion(**completion_args)
+
+                # Log full response
+                logger.debug(f"📥 LLM provider response: {format_log_value(response)}")
+
                 message = response.choices[0].message
 
                 # Build message dict with all necessary fields for agentic loop


### PR DESCRIPTION
## Summary

- Add `meshctl man observability` page with CLI tracing and Grafana setup docs (#366)
- Improve trace error messages with helpful hints when trace not found (#365)
- Remove default truncation in `format_log_value()` to enable full debug logging (#363)
- Add LLM provider request/response logging at the provider level (last leg)

## Changes

| File | Description |
|------|-------------|
| `observability.md` | New man page for CLI tracing and Grafana setup |
| `content.go` | Register observability page in guide registry |
| `trace.go` | Better error hints for "trace not found" |
| `logging_config.py` | Change `max_len=1000` to `max_len=0` (no truncation) |
| `helpers.py` | Add full LLM request/response logging at provider level |

## Test plan

- [x] `meshctl man observability` displays correctly
- [x] `meshctl trace <invalid>` shows helpful hints
- [x] LLM provider logs show full request/response without truncation
- [x] Tested with long system prompt (~2700 chars) and multi-turn conversation

Fixes #363, #365, #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observability guide with distributed tracing and Grafana monitoring setup
  * Enhanced error messages with troubleshooting guidance
  * Improved request and response logging

* **Documentation**
  * Comprehensive observability guide including setup instructions, configuration options, and troubleshooting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->