### PR TITLE
Fix FastAPI/API heartbeat logging and main.py fallback

### DIFF
--- a/src/core/cli/start.go
+++ b/src/core/cli/start.go
@@ -1603,6 +1603,23 @@ func extractAgentName(scriptPath string) string {
 	fallback := filepath.Base(scriptPath)
 	fallback = strings.TrimSuffix(fallback, ".py")
 
+	// If filename is "main", use parent directory name instead (#382)
+	// This helps pure FastAPI apps with @mesh.route that don't have @mesh.agent
+	if fallback == "main" {
+		dir := filepath.Dir(scriptPath)
+		parentName := filepath.Base(dir)
+		// Handle edge case: if dir is "." use actual current directory name
+		if parentName == "." {
+			if cwd, err := os.Getwd(); err == nil {
+				parentName = filepath.Base(cwd)
+			}
+		}
+		// Only use parentName if it's meaningful
+		if parentName != "" && parentName != "." {
+			fallback = parentName
+		}
+	}
+
 	// Python script to extract agent name using AST
 	// Handles all valid Python decorator syntaxes:
 	//   @mesh.agent(name="hello")

--- a/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/api_fast_heartbeat_check.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/api_fast_heartbeat_check.py
@@ -73,7 +73,7 @@ class APIFastHeartbeatStep(PipelineStep):
 
             # Log status and action with API-specific messaging
             if status == FastHeartbeatStatus.NO_CHANGES:
-                self.logger.info(
+                self.logger.trace(
                     f"✅ API fast heartbeat: No changes detected for service '{service_id}'"
                 )
             elif status == FastHeartbeatStatus.TOPOLOGY_CHANGED:

--- a/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/api_health_check.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/api_health_check.py
@@ -38,7 +38,7 @@ class APIHealthCheckStep(PipelineStep):
         Returns:
             PipelineResult with health_status in context
         """
-        self.logger.info("🏥 [DEBUG] Checking FastAPI application health status")
+        self.logger.trace("🏥 Checking FastAPI application health status")
 
         try:
             # Get FastAPI app from context
@@ -66,7 +66,7 @@ class APIHealthCheckStep(PipelineStep):
             routes_with_mesh = self._count_mesh_routes(fastapi_app)
             total_routes = len(getattr(fastapi_app, "routes", []))
 
-            self.logger.debug(
+            self.logger.trace(
                 f"🔍 FastAPI app health: {app_title} v{app_version}, "
                 f"{routes_with_mesh}/{total_routes} routes with mesh injection"
             )
@@ -91,7 +91,7 @@ class APIHealthCheckStep(PipelineStep):
                 }
             }
 
-            self.logger.info(
+            self.logger.trace(
                 f"🏥 API health check passed: {app_title} v{app_version} "
                 f"({routes_with_mesh} mesh routes)"
             )

--- a/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/api_heartbeat_orchestrator.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/api_heartbeat_orchestrator.py
@@ -58,19 +58,19 @@ class APIHeartbeatOrchestrator:
             self._log_api_heartbeat_request(heartbeat_context, self._heartbeat_count)
 
             # Execute API heartbeat pipeline with timeout protection
-            self.logger.info(f"💓 Executing API heartbeat #{self._heartbeat_count} for service '{service_id}'")
+            self.logger.trace(f"💓 Executing API heartbeat #{self._heartbeat_count} for service '{service_id}'")
 
             # Add timeout to prevent hanging heartbeats (30 seconds max)
             import asyncio
 
             try:
-                self.logger.debug("Starting API heartbeat pipeline execution")
+                self.logger.trace("Starting API heartbeat pipeline execution")
                 result = await asyncio.wait_for(
                     self.pipeline.execute_api_heartbeat_cycle(heartbeat_context),
                     timeout=30.0,
                 )
                 if result.is_success():
-                    self.logger.debug("✅ API heartbeat pipeline completed successfully")
+                    self.logger.trace("✅ API heartbeat pipeline completed successfully")
                 else:
                     self.logger.error(f"❌ API heartbeat pipeline failed: {result.message}")
             except TimeoutError:
@@ -120,10 +120,6 @@ class APIHeartbeatOrchestrator:
         
         # Get API service metadata from startup context
         api_service_metadata = startup_context.get("api_service_metadata", {})
-        self.logger.debug(f"🔍 Startup context has api_service_metadata: {len(api_service_metadata) > 0}")
-        if api_service_metadata:
-            capabilities = api_service_metadata.get("capabilities", [])
-            self.logger.debug(f"🔍 API service has {len(capabilities)} route capabilities")
         
         # Build heartbeat-specific context
         heartbeat_context = {
@@ -182,7 +178,7 @@ class APIHeartbeatOrchestrator:
             }
 
         # Log heartbeat details
-        self.logger.debug(
+        self.logger.trace(
             f"🔍 API Heartbeat #{heartbeat_count} for '{service_id}': "
             f"app={app_info}, display={display_config}"
         )
@@ -197,29 +193,29 @@ class APIHeartbeatOrchestrator:
             heartbeat_response = result.context.get("heartbeat_response")
             heartbeat_success = result.context.get("heartbeat_success", False)
             
-            self.logger.debug(f"API heartbeat result - success: {heartbeat_success}")
+            self.logger.trace(f"API heartbeat result - success: {heartbeat_success}")
 
             # Check if heartbeat was skipped due to optimization
             heartbeat_skipped = result.context.get("heartbeat_skipped", False)
             skip_reason = result.context.get("skip_reason")
             
             if heartbeat_success and heartbeat_response:
-                # Log response details for debugging
+                # Log response details for tracing
                 try:
                     response_json = json.dumps(
                         heartbeat_response, indent=2, default=str
                     )
-                    self.logger.debug(
+                    self.logger.trace(
                         f"🔍 API heartbeat response #{heartbeat_count}:\n{response_json}"
                     )
                 except Exception as e:
-                    self.logger.debug(
+                    self.logger.trace(
                         f"🔍 API heartbeat response #{heartbeat_count}: {heartbeat_response} "
                         f"(json serialization failed: {e})"
                     )
 
-                self.logger.info(
-                    f"💚 API heartbeat #{heartbeat_count} sent successfully for service '{service_id}'"
+                self.logger.debug(
+                    f"🚀 API heartbeat #{heartbeat_count} sent for service '{service_id}'"
                 )
                 return True
             elif heartbeat_success and heartbeat_skipped:

--- a/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/api_heartbeat_pipeline.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/api_heartbeat_pipeline.py
@@ -208,7 +208,7 @@ class APIHeartbeatPipeline(MeshPipeline):
                 # NO_CHANGES - skip for optimization
                 should_execute_remaining = False
                 reason = "optimization (no changes detected)"
-                self.logger.info(
+                self.logger.trace(
                     f"🚀 API heartbeat: Skipping remaining steps for optimization: {reason}"
                 )
             elif FastHeartbeatStatusUtil.should_skip_for_resilience(

--- a/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/api_registry_connection.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/api_registry_connection.py
@@ -39,14 +39,14 @@ class APIRegistryConnectionStep(PipelineStep):
         Returns:
             PipelineResult with registry_wrapper in context
         """
-        self.logger.info("🔗 [DEBUG] Preparing API registry connection for heartbeat")
+        self.logger.trace("🔗 Preparing API registry connection for heartbeat")
 
         try:
             # Check if registry_wrapper already exists in context
             registry_wrapper = context.get("registry_wrapper")
             
             if registry_wrapper is not None:
-                self.logger.debug("✅ Registry wrapper already available in context")
+                self.logger.trace("✅ Registry wrapper already available in context")
                 return PipelineResult(
                     message="Registry connection already established",
                     context={"registry_wrapper": registry_wrapper}
@@ -69,7 +69,7 @@ class APIRegistryConnectionStep(PipelineStep):
                 rule=ValidationRule.URL_RULE,
             )
 
-            self.logger.debug(f"🔍 Using registry URL: {registry_url}")
+            self.logger.trace(f"🔍 Using registry URL: {registry_url}")
 
             # Create registry client wrapper
             from ...generated.mcp_mesh_registry_client.api_client import ApiClient
@@ -80,7 +80,7 @@ class APIRegistryConnectionStep(PipelineStep):
             api_client = ApiClient(configuration=config)
             registry_wrapper = RegistryClientWrapper(api_client)
 
-            self.logger.info(f"🔗 API registry connection prepared: {registry_url}")
+            self.logger.trace(f"🔗 API registry connection prepared: {registry_url}")
 
             return PipelineResult(
                 message=f"Registry connection prepared for {registry_url}",


### PR DESCRIPTION
## Summary
- Reduce API heartbeat pipeline logging verbosity (#379)
- Use parent directory name for log files when script is main.py (#382)

## #379: Reduce API heartbeat pipeline logging verbosity

Downgrade routine logs from DEBUG/INFO to TRACE for consistency with MCP pipeline:
- `api_heartbeat_orchestrator.py`: Use trace for pipeline execution, results
- `api_heartbeat_pipeline.py`: Use trace for optimization skip message
- `api_registry_connection.py`: Use trace for connection setup
- `api_health_check.py`: Use trace for health checks
- `api_fast_heartbeat_check.py`: Use trace for NO_CHANGES status

**DEBUG mode now shows only:**
```
🚀 API heartbeat #16 skipped for service 'api-xxx' - no_changes_optimization
```

**INFO mode shows:**
- Every 10th heartbeat status
- Topology changes
- Errors

## #382: Use parent directory name when script is main.py

- When filename is "main" (after stripping .py), use parent directory name
- Helps pure FastAPI apps with `@mesh.route` that don't have `@mesh.agent`
- Handles edge case where script is in current directory (`./main.py`)

**Examples:**
| Path | Log File |
|------|----------|
| `my-api/main.py` | `my-api.log` |
| `calculator/main.py` | `calculator.log` |
| `greeter.py` | `greeter.log` |

## Test plan
- [ ] Run FastAPI example with `--debug` and verify reduced log output
- [ ] Start agent from `test-dir/main.py` and verify log file is `test-dir.log`

Closes #379
Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Improved agent name resolution for FastAPI applications, now using parent directory names as fallback when appropriate.
  * Reduced log verbosity during heartbeat operations and health checks by adjusting logging levels for routine messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->