### PR TITLE
TypeScript SDK: Vercel AI SDK v6 Compatibility

### DIFF
--- a/src/runtime/typescript/package-lock.json
+++ b/src/runtime/typescript/package-lock.json
@@ -9,20 +9,20 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
         "@mcpmesh/core": "file:../core/typescript",
+        "ai": "^6.0.0",
         "fastmcp": "^3.26.8",
         "handlebars": "^4.7.8",
         "zod": "^3.24.1",
         "zod-to-json-schema": "^3.24.1"
       },
       "devDependencies": {
-        "@ai-sdk/anthropic": "^1.0.0",
-        "@ai-sdk/google": "^1.0.0",
-        "@ai-sdk/openai": "^1.0.0",
+        "@ai-sdk/google": "^3.0.0",
         "@types/express": "^4.17.0",
         "@types/express-v5": "npm:@types/express@^5.0.0",
         "@types/node": "^22.0.0",
-        "ai": "^4.0.0",
         "express": "^4.18.0",
         "express-v5": "npm:express@^5.0.0",
         "typescript": "^5.7.0",
@@ -32,25 +32,9 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@ai-sdk/anthropic": "^1.0.0",
-        "@ai-sdk/google": "^1.0.0",
-        "@ai-sdk/openai": "^1.0.0",
-        "ai": "^4.0.0",
         "express": "^4.18.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
-        "@ai-sdk/anthropic": {
-          "optional": true
-        },
-        "@ai-sdk/google": {
-          "optional": true
-        },
-        "@ai-sdk/openai": {
-          "optional": true
-        },
-        "ai": {
-          "optional": true
-        },
         "express": {
           "optional": true
         }
@@ -65,61 +49,75 @@
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-1.2.12.tgz",
-      "integrity": "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==",
-      "dev": true,
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.14.tgz",
+      "integrity": "sha512-71BaVg60FM6tN0JaRY7kRb/6qZtHi5R9PFF3NES+kqonY3nVD4PCPP8DoMb/tqxC7f/XezlCqsHrveT2mGfi3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8"
+        "@ai-sdk/provider": "3.0.3",
+        "@ai-sdk/provider-utils": "4.0.7"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.15.tgz",
+      "integrity": "sha512-OsWcXMfkF9U38YhU7926rYt4IAtJuZlnM1e8STN8hHb4qbiTaORBSXcFaJuOEZ1kYOf3DqqP7CxbmM543ePzIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.3",
+        "@ai-sdk/provider-utils": "4.0.7",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "1.2.22",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-1.2.22.tgz",
-      "integrity": "sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.9.tgz",
+      "integrity": "sha512-whRdK0gCZL92UbEHdmQ6edm3cp5ZZSqwE79AIvTEaJR+BeaMUJchTxz/I5w9l3EHGOiDxrKYssklqO3z45KGXg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8"
+        "@ai-sdk/provider": "3.0.3",
+        "@ai-sdk/provider-utils": "4.0.7"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "1.3.24",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.24.tgz",
-      "integrity": "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==",
-      "dev": true,
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.11.tgz",
+      "integrity": "sha512-nX7Egt9EJtvImiq1D88sZCOlfAIJgKJGa987ptp40hJRp7CQ4snBLnEHt344m2tqB0LIpzdc53l02o+LlYsM2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8"
+        "@ai-sdk/provider": "3.0.3",
+        "@ai-sdk/provider-utils": "4.0.7"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
-      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
-      "dev": true,
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.3.tgz",
+      "integrity": "sha512-qGPYdoAuECaUXPrrz0BPX1SacZQuJ6zky0aakxpW89QW1hrY0eF4gcFm/3L9Pk8C5Fwe+RvBf2z7ZjDhaPjnlg==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -129,64 +127,20 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
-      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
-      "dev": true,
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.7.tgz",
+      "integrity": "sha512-ItzTdBxRLieGz1GHPwl9X3+HKfwTfFd9MdIa91aXRnOjUVRw68ENjAGKm3FcXGsBLkXDLaFWgjbTVdXe2igs2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "nanoid": "^3.3.8",
-        "secure-json-parse": "^2.7.0"
+        "@ai-sdk/provider": "3.0.3",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@ai-sdk/react": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
-      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@ai-sdk/ui-utils": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
-      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "zod-to-json-schema": "^3.24.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.23.8"
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@borewit/text-codec": {
@@ -962,7 +916,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -1404,13 +1357,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/diff-match-patch": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
-      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1552,6 +1498,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1681,30 +1636,21 @@
       }
     },
     "node_modules/ai": {
-      "version": "4.3.19",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
-      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
-      "dev": true,
+      "version": "6.0.37",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.37.tgz",
+      "integrity": "sha512-GUMBYx0TXKxXRcWy6DY3ryHJZ7cATxc99WPT7WCD8hGCYkdhFVItKPTtINeTlK+FlUomDqzjPGtiDcVftcw//w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/react": "1.2.12",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "@opentelemetry/api": "1.9.0",
-        "jsondiffpatch": "0.6.0"
+        "@ai-sdk/gateway": "3.0.15",
+        "@ai-sdk/provider": "3.0.3",
+        "@ai-sdk/provider-utils": "4.0.7",
+        "@opentelemetry/api": "1.9.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -1911,19 +1857,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -2047,16 +1980,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -2066,13 +1989,6 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
-    },
-    "node_modules/diff-match-patch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3106,7 +3022,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
@@ -3120,24 +3035,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/jsondiffpatch": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
-      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/diff-match-patch": "^1.0.36",
-        "chalk": "^5.3.0",
-        "diff-match-patch": "^1.0.5"
-      },
-      "bin": {
-        "jsondiffpatch": "bin/jsondiffpatch.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -3531,17 +3428,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3647,13 +3533,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
-    },
-    "node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/send": {
       "version": "0.19.2",
@@ -3948,33 +3827,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/swr": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.8.tgz",
-      "integrity": "sha512-gaCPRVoMq8WGDcWj9p4YWzCMPHzE0WNl6W8ADIx9c3JBEIdMkJGMzW+uzXvxHMltwcYACr9jP+32H8/hgwMR7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/throttleit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -4157,16 +4009,6 @@
       "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.2.0.tgz",
       "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==",
       "license": "http://geraintluff.github.io/tv4/LICENSE.txt"
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/src/runtime/typescript/package.json
+++ b/src/runtime/typescript/package.json
@@ -31,10 +31,10 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^1.0.0",
-    "@ai-sdk/openai": "^1.0.0",
+    "@ai-sdk/anthropic": "^3.0.0",
+    "@ai-sdk/openai": "^3.0.0",
     "@mcpmesh/core": "file:../core/typescript",
-    "ai": "^4.0.0",
+    "ai": "^6.0.0",
     "fastmcp": "^3.26.8",
     "handlebars": "^4.7.8",
     "zod": "^3.24.1",
@@ -49,7 +49,7 @@
     }
   },
   "devDependencies": {
-    "@ai-sdk/google": "^1.0.0",
+    "@ai-sdk/google": "^3.0.0",
     "@types/express": "^4.17.0",
     "@types/express-v5": "npm:@types/express@^5.0.0",
     "@types/node": "^22.0.0",

--- a/src/runtime/typescript/src/__tests__/generic-handler.test.ts
+++ b/src/runtime/typescript/src/__tests__/generic-handler.test.ts
@@ -150,17 +150,17 @@ describe("GenericHandler", () => {
       expect(request.responseFormat).toBeUndefined();
     });
 
-    it("should pass through temperature, maxTokens, and topP", () => {
+    it("should pass through temperature, maxOutputTokens, and topP", () => {
       const messages: LlmMessage[] = [{ role: "user", content: "Hello" }];
 
       const request = handler.prepareRequest(messages, null, null, {
         temperature: 0.8,
-        maxTokens: 500,
+        maxOutputTokens: 500,
         topP: 0.9,
       });
 
       expect(request.temperature).toBe(0.8);
-      expect(request.maxTokens).toBe(500);
+      expect(request.maxOutputTokens).toBe(500);
       expect(request.topP).toBe(0.9);
     });
 

--- a/src/runtime/typescript/src/__tests__/llm-provider.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-provider.test.ts
@@ -210,7 +210,7 @@ describe("getLlmProviderMeta", () => {
     const fakeTool = {
       name: "test",
       execute: () => Promise.resolve(""),
-      parameters: {},
+      inputSchema: {},
     } as unknown as ReturnType<typeof llmProvider>;
 
     const meta = getLlmProviderMeta(fakeTool);
@@ -220,14 +220,14 @@ describe("getLlmProviderMeta", () => {
 });
 
 describe("LLM provider configurations", () => {
-  it("should accept maxTokens configuration", () => {
+  it("should accept maxOutputTokens configuration", () => {
     const tool = llmProvider({
       model: "anthropic/claude-sonnet-4-5",
-      maxTokens: 4096,
+      maxOutputTokens: 4096,
     });
 
     expect(tool).toBeDefined();
-    // maxTokens is used internally in execute, verified via integration tests
+    // maxOutputTokens is used internally in execute, verified via integration tests
   });
 
   it("should accept temperature configuration", () => {
@@ -256,7 +256,7 @@ describe("LLM provider configurations", () => {
       version: "3.0.0",
       name: "production_chat",
       description: "Production LLM endpoint with Claude",
-      maxTokens: 8192,
+      maxOutputTokens: 8192,
       temperature: 0.5,
       topP: 0.95,
     });

--- a/src/runtime/typescript/src/__tests__/openai-handler.test.ts
+++ b/src/runtime/typescript/src/__tests__/openai-handler.test.ts
@@ -137,17 +137,17 @@ describe("OpenAIHandler", () => {
       expect(request.responseFormat).toBeUndefined();
     });
 
-    it("should pass through temperature, maxTokens, and topP", () => {
+    it("should pass through temperature, maxOutputTokens, and topP", () => {
       const messages: LlmMessage[] = [{ role: "user", content: "Hello" }];
 
       const request = handler.prepareRequest(messages, null, null, {
         temperature: 0.5,
-        maxTokens: 2000,
+        maxOutputTokens: 2000,
         topP: 0.95,
       });
 
       expect(request.temperature).toBe(0.5);
-      expect(request.maxTokens).toBe(2000);
+      expect(request.maxOutputTokens).toBe(2000);
       expect(request.topP).toBe(0.95);
     });
 

--- a/src/runtime/typescript/src/__tests__/route.test.ts
+++ b/src/runtime/typescript/src/__tests__/route.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Unit tests for route.ts
+ *
+ * Tests mesh.route() Express middleware and RouteRegistry.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+import { route, routeWithConfig, RouteRegistry } from "../route.js";
+import type { McpMeshAgent } from "../types.js";
+
+// Mock createProxy from proxy.ts
+vi.mock("../proxy.js", () => ({
+  normalizeDependency: vi.fn((dep) => {
+    if (typeof dep === "string") {
+      return { capability: dep, tags: [] };
+    }
+    return {
+      capability: dep.capability,
+      tags: dep.tags ?? [],
+      version: dep.version,
+    };
+  }),
+  createProxy: vi.fn((endpoint, capability, functionName) => {
+    // Create mock McpMeshAgent
+    const mockProxy = async (args?: Record<string, unknown>) => {
+      return JSON.stringify({ result: "mock", args });
+    };
+    Object.defineProperties(mockProxy, {
+      endpoint: { value: endpoint },
+      capability: { value: capability },
+      functionName: { value: functionName },
+      isAvailable: { value: true },
+      callTool: { value: async () => "mock" },
+    });
+    return mockProxy as McpMeshAgent;
+  }),
+}));
+
+describe("RouteRegistry", () => {
+  beforeEach(() => {
+    // Reset registry before each test
+    RouteRegistry.reset();
+  });
+
+  describe("getInstance", () => {
+    it("should return singleton instance", () => {
+      const instance1 = RouteRegistry.getInstance();
+      const instance2 = RouteRegistry.getInstance();
+
+      expect(instance1).toBe(instance2);
+    });
+  });
+
+  describe("registerRoute", () => {
+    it("should register a route with dependencies", () => {
+      const registry = RouteRegistry.getInstance();
+
+      const routeId = registry.registerRoute("POST", "/compute", [
+        { capability: "calculator" },
+        { capability: "logger", tags: ["async"] },
+      ]);
+
+      expect(routeId).toMatch(/^route_\d+_POST:\/compute$/);
+
+      const route = registry.getRoute(routeId);
+      expect(route).toBeDefined();
+      expect(route?.method).toBe("POST");
+      expect(route?.path).toBe("/compute");
+      expect(route?.dependencies).toHaveLength(2);
+      expect(route?.dependencies[0].capability).toBe("calculator");
+      expect(route?.dependencies[1].capability).toBe("logger");
+      expect(route?.dependencies[1].tags).toEqual(["async"]);
+    });
+
+    it("should generate unique route IDs", () => {
+      const registry = RouteRegistry.getInstance();
+
+      const id1 = registry.registerRoute("GET", "/a", []);
+      const id2 = registry.registerRoute("GET", "/b", []);
+      const id3 = registry.registerRoute("POST", "/a", []);
+
+      expect(id1).not.toBe(id2);
+      expect(id2).not.toBe(id3);
+      expect(id1).not.toBe(id3);
+    });
+
+    it("should handle string dependencies", () => {
+      const registry = RouteRegistry.getInstance();
+
+      const routeId = registry.registerRoute("GET", "/test", [
+        "service-a",
+        "service-b",
+      ]);
+
+      const route = registry.getRoute(routeId);
+      expect(route?.dependencies[0].capability).toBe("service-a");
+      expect(route?.dependencies[1].capability).toBe("service-b");
+    });
+  });
+
+  describe("getRoutes", () => {
+    it("should return all registered routes", () => {
+      const registry = RouteRegistry.getInstance();
+
+      registry.registerRoute("GET", "/a", ["svc1"]);
+      registry.registerRoute("POST", "/b", ["svc2"]);
+
+      const routes = registry.getRoutes();
+      expect(routes).toHaveLength(2);
+    });
+  });
+
+  describe("dependency management", () => {
+    it("should set and get dependencies", () => {
+      const registry = RouteRegistry.getInstance();
+      const routeId = registry.registerRoute("GET", "/test", ["calculator"]);
+
+      // Create mock proxy
+      const mockProxy = (() => Promise.resolve("test")) as unknown as McpMeshAgent;
+      Object.defineProperties(mockProxy, {
+        endpoint: { value: "http://localhost:8000" },
+        capability: { value: "calculator" },
+        functionName: { value: "add" },
+        isAvailable: { value: true },
+      });
+
+      // Set dependency
+      registry.setDependency(routeId, 0, mockProxy);
+
+      // Get dependency
+      const dep = registry.getDependency(routeId, 0);
+      expect(dep).toBe(mockProxy);
+    });
+
+    it("should return null for unset dependencies", () => {
+      const registry = RouteRegistry.getInstance();
+      const routeId = registry.registerRoute("GET", "/test", ["calculator"]);
+
+      const dep = registry.getDependency(routeId, 0);
+      expect(dep).toBeNull();
+    });
+
+    it("should remove dependencies", () => {
+      const registry = RouteRegistry.getInstance();
+      const routeId = registry.registerRoute("GET", "/test", ["calculator"]);
+
+      const mockProxy = (() => Promise.resolve("test")) as unknown as McpMeshAgent;
+      registry.setDependency(routeId, 0, mockProxy);
+      registry.removeDependency(routeId, 0);
+
+      const dep = registry.getDependency(routeId, 0);
+      expect(dep).toBeNull();
+    });
+
+    it("should get dependencies for route as object", () => {
+      const registry = RouteRegistry.getInstance();
+      const routeId = registry.registerRoute("GET", "/test", [
+        "calculator",
+        "logger",
+      ]);
+
+      const mockCalc = (() => Promise.resolve("calc")) as unknown as McpMeshAgent;
+      Object.defineProperties(mockCalc, { capability: { value: "calculator" } });
+
+      registry.setDependency(routeId, 0, mockCalc);
+      // Leave logger unset
+
+      const deps = registry.getDependenciesForRoute(routeId);
+      expect(deps.calculator).toBe(mockCalc);
+      expect(deps.logger).toBeNull();
+    });
+
+    it("should clear all dependencies", () => {
+      const registry = RouteRegistry.getInstance();
+      const routeId = registry.registerRoute("GET", "/test", ["calculator"]);
+
+      const mockProxy = (() => Promise.resolve("test")) as unknown as McpMeshAgent;
+      registry.setDependency(routeId, 0, mockProxy);
+      registry.clearAllDependencies();
+
+      const dep = registry.getDependency(routeId, 0);
+      expect(dep).toBeNull();
+    });
+  });
+});
+
+describe("route()", () => {
+  beforeEach(() => {
+    RouteRegistry.reset();
+  });
+
+  it("should create Express middleware", () => {
+    const handler = vi.fn();
+    const middleware = route([{ capability: "calculator" }], handler);
+
+    expect(typeof middleware).toBe("function");
+    expect(middleware.length).toBe(3); // (req, res, next)
+  });
+
+  it("should attach mesh metadata to middleware", () => {
+    const handler = vi.fn();
+    const middleware = route([{ capability: "calculator" }], handler) as ReturnType<typeof route> & {
+      _meshRouteId: string;
+      _meshDependencies: Array<{ capability: string; tags: string[] }>;
+    };
+
+    expect(middleware._meshRouteId).toBeDefined();
+    expect(middleware._meshDependencies).toBeDefined();
+    expect(middleware._meshDependencies[0].capability).toBe("calculator");
+  });
+
+  it("should call handler with dependencies", async () => {
+    const handler = vi.fn();
+    const middleware = route(["calculator"], handler);
+
+    // Create mock request/response/next
+    const mockReq = {} as Request;
+    const mockRes = {} as Response;
+    const mockNext = vi.fn() as NextFunction;
+
+    // Call middleware
+    await middleware(mockReq, mockRes, mockNext);
+
+    // Handler should be called with req, res, and deps object
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      mockReq,
+      mockRes,
+      expect.objectContaining({ calculator: null }) // No deps resolved yet
+    );
+  });
+
+  it("should inject resolved dependencies", async () => {
+    const registry = RouteRegistry.getInstance();
+    const handler = vi.fn();
+    const middleware = route(["calculator"], handler) as ReturnType<typeof route> & {
+      _meshRouteId: string;
+    };
+
+    // Set up resolved dependency
+    const mockCalc = (async () => "result") as unknown as McpMeshAgent;
+    registry.setDependency(middleware._meshRouteId, 0, mockCalc);
+
+    // Create mock request/response/next
+    const mockReq = {} as Request;
+    const mockRes = {} as Response;
+    const mockNext = vi.fn() as NextFunction;
+
+    // Call middleware
+    await middleware(mockReq, mockRes, mockNext);
+
+    // Handler should receive the resolved dependency
+    expect(handler).toHaveBeenCalledWith(
+      mockReq,
+      mockRes,
+      expect.objectContaining({ calculator: mockCalc })
+    );
+  });
+
+  it("should call next() on error", async () => {
+    const error = new Error("Test error");
+    const handler = vi.fn().mockRejectedValue(error);
+    const middleware = route(["calculator"], handler);
+
+    const mockReq = {} as Request;
+    const mockRes = {} as Response;
+    const mockNext = vi.fn() as NextFunction;
+
+    await middleware(mockReq, mockRes, mockNext);
+
+    expect(mockNext).toHaveBeenCalledWith(error);
+  });
+
+  it("should support handler with next function", async () => {
+    const handler = vi.fn((_req, _res, _deps, next) => {
+      next();
+    });
+    const middleware = route(["calculator"], handler);
+
+    const mockReq = {} as Request;
+    const mockRes = {} as Response;
+    const mockNext = vi.fn() as NextFunction;
+
+    await middleware(mockReq, mockRes, mockNext);
+
+    expect(handler).toHaveBeenCalledWith(
+      mockReq,
+      mockRes,
+      expect.any(Object),
+      mockNext
+    );
+  });
+});
+
+describe("routeWithConfig()", () => {
+  beforeEach(() => {
+    RouteRegistry.reset();
+  });
+
+  it("should create middleware from config object", () => {
+    const handler = vi.fn();
+    const middleware = routeWithConfig(
+      {
+        dependencies: [{ capability: "calculator" }],
+        dependencyKwargs: [{ timeout: 60 }],
+      },
+      handler
+    );
+
+    expect(typeof middleware).toBe("function");
+  });
+
+  it("should register route with kwargs", () => {
+    const handler = vi.fn();
+    const middleware = routeWithConfig(
+      {
+        dependencies: ["calculator"],
+        dependencyKwargs: [{ timeout: 60, maxAttempts: 3 }],
+      },
+      handler
+    ) as ReturnType<typeof routeWithConfig> & { _meshRouteId: string };
+
+    const registry = RouteRegistry.getInstance();
+    const route = registry.getRoute(middleware._meshRouteId);
+
+    expect(route?.dependencyKwargs).toEqual([{ timeout: 60, maxAttempts: 3 }]);
+  });
+});
+
+describe("mesh.route integration", () => {
+  beforeEach(() => {
+    RouteRegistry.reset();
+  });
+
+  it("should work with multiple dependencies", async () => {
+    const registry = RouteRegistry.getInstance();
+    const handler = vi.fn();
+
+    const middleware = route(
+      [
+        { capability: "calculator" },
+        { capability: "logger", tags: ["async"] },
+        "formatter",
+      ],
+      handler
+    ) as ReturnType<typeof route> & { _meshRouteId: string };
+
+    // Set up some dependencies
+    const mockCalc = (async () => "calc") as unknown as McpMeshAgent;
+    const mockLogger = (async () => "log") as unknown as McpMeshAgent;
+    registry.setDependency(middleware._meshRouteId, 0, mockCalc);
+    registry.setDependency(middleware._meshRouteId, 1, mockLogger);
+    // formatter left unresolved
+
+    const mockReq = {} as Request;
+    const mockRes = {} as Response;
+    const mockNext = vi.fn() as NextFunction;
+
+    await middleware(mockReq, mockRes, mockNext);
+
+    expect(handler).toHaveBeenCalledWith(
+      mockReq,
+      mockRes,
+      expect.objectContaining({
+        calculator: mockCalc,
+        logger: mockLogger,
+        formatter: null,
+      })
+    );
+  });
+
+  it("should handle empty dependencies", async () => {
+    const handler = vi.fn();
+    const middleware = route([], handler);
+
+    const mockReq = {} as Request;
+    const mockRes = {} as Response;
+    const mockNext = vi.fn() as NextFunction;
+
+    await middleware(mockReq, mockRes, mockNext);
+
+    expect(handler).toHaveBeenCalledWith(mockReq, mockRes, {});
+  });
+});

--- a/src/runtime/typescript/src/llm-agent.ts
+++ b/src/runtime/typescript/src/llm-agent.ts
@@ -67,7 +67,7 @@ export interface MeshLlmAgentConfig {
   /** Max agentic loop iterations */
   maxIterations: number;
   /** Max tokens */
-  maxTokens?: number;
+  maxOutputTokens?: number;
   /** Temperature */
   temperature?: number;
   /** Top-p */
@@ -107,7 +107,7 @@ export interface LlmProvider {
     messages: LlmMessage[],
     tools?: LlmToolDefinition[],
     options?: {
-      maxTokens?: number;
+      maxOutputTokens?: number;
       temperature?: number;
       topP?: number;
       stop?: string[];
@@ -131,7 +131,7 @@ export class LiteLLMProvider implements LlmProvider {
     messages: LlmMessage[],
     tools?: LlmToolDefinition[],
     options?: {
-      maxTokens?: number;
+      maxOutputTokens?: number;
       temperature?: number;
       topP?: number;
       stop?: string[];
@@ -147,7 +147,7 @@ export class LiteLLMProvider implements LlmProvider {
       body.tool_choice = "auto";
     }
 
-    if (options?.maxTokens) body.max_tokens = options.maxTokens;
+    if (options?.maxOutputTokens) body.max_tokens = options.maxOutputTokens;
     if (options?.temperature !== undefined) body.temperature = options.temperature;
     if (options?.topP !== undefined) body.top_p = options.topP;
     if (options?.stop) body.stop = options.stop;
@@ -202,7 +202,7 @@ export class MeshDelegatedProvider implements LlmProvider {
     messages: LlmMessage[],
     tools?: LlmToolDefinition[],
     options?: {
-      maxTokens?: number;
+      maxOutputTokens?: number;
       temperature?: number;
       topP?: number;
       stop?: string[];
@@ -214,7 +214,7 @@ export class MeshDelegatedProvider implements LlmProvider {
     if (model && model !== "default") {
       modelParams.model = model;
     }
-    if (options?.maxTokens) modelParams.max_tokens = options.maxTokens;
+    if (options?.maxOutputTokens) modelParams.max_tokens = options.maxOutputTokens;
     if (options?.temperature !== undefined) modelParams.temperature = options.temperature;
     if (options?.topP !== undefined) modelParams.top_p = options.topP;
     if (options?.stop) modelParams.stop = options.stop;
@@ -444,7 +444,7 @@ export class MeshLlmAgent<T = string> {
 
     // Get effective options
     const maxIterations = context.options?.maxIterations ?? this.config.maxIterations;
-    const maxTokens = context.options?.maxTokens ?? this.config.maxTokens;
+    const maxTokens = context.options?.maxOutputTokens ?? this.config.maxOutputTokens;
     const temperature = context.options?.temperature ?? this.config.temperature;
 
     // Determine model
@@ -462,7 +462,7 @@ export class MeshLlmAgent<T = string> {
         model,
         messages,
         toolDefs.length > 0 ? toolDefs : undefined,
-        { maxTokens, temperature, topP: this.config.topP, stop: this.config.stop }
+        { maxOutputTokens: maxTokens, temperature, topP: this.config.topP, stop: this.config.stop }
       );
 
       // Track tokens

--- a/src/runtime/typescript/src/llm.ts
+++ b/src/runtime/typescript/src/llm.ts
@@ -162,7 +162,7 @@ export interface LlmToolConfig {
   contextParam?: string;
   filter?: LlmFilterSpec[];
   filterMode: LlmFilterMode;
-  maxTokens?: number;
+  maxOutputTokens?: number;
   temperature?: number;
   topP?: number;
   stop?: string[];
@@ -229,7 +229,7 @@ export function llm<
     contextParam: config.contextParam,
     filter: config.filter,
     filterMode: config.filterMode ?? "all",
-    maxTokens: config.maxTokens,
+    maxOutputTokens: config.maxOutputTokens,
     temperature: config.temperature,
     topP: config.topP,
     stop: config.stop,
@@ -250,7 +250,7 @@ export function llm<
     systemPrompt: llmConfig.systemPrompt,
     contextParam: llmConfig.contextParam,
     maxIterations: llmConfig.maxIterations,
-    maxTokens: llmConfig.maxTokens,
+    maxOutputTokens: llmConfig.maxOutputTokens,
     temperature: llmConfig.temperature,
     topP: llmConfig.topP,
     stop: llmConfig.stop,

--- a/src/runtime/typescript/src/provider-handlers/generic-handler.ts
+++ b/src/runtime/typescript/src/provider-handlers/generic-handler.ts
@@ -62,12 +62,12 @@ export class GenericHandler implements ProviderHandler {
     options?: {
       outputMode?: OutputMode;
       temperature?: number;
-      maxTokens?: number;
+      maxOutputTokens?: number;
       topP?: number;
       [key: string]: unknown;
     }
   ): PreparedRequest {
-    const { outputMode, temperature, maxTokens, topP, ...rest } = options ?? {};
+    const { outputMode, temperature, maxOutputTokens: maxTokens, topP, ...rest } = options ?? {};
 
     const request: PreparedRequest = {
       messages: [...messages],
@@ -84,7 +84,7 @@ export class GenericHandler implements ProviderHandler {
       request.temperature = temperature;
     }
     if (maxTokens !== undefined) {
-      request.maxTokens = maxTokens;
+      request.maxOutputTokens = maxTokens;
     }
     if (topP !== undefined) {
       request.topP = topP;

--- a/src/runtime/typescript/src/provider-handlers/openai-handler.ts
+++ b/src/runtime/typescript/src/provider-handlers/openai-handler.ts
@@ -71,12 +71,12 @@ export class OpenAIHandler implements ProviderHandler {
     options?: {
       outputMode?: OutputMode;
       temperature?: number;
-      maxTokens?: number;
+      maxOutputTokens?: number;
       topP?: number;
       [key: string]: unknown;
     }
   ): PreparedRequest {
-    const { outputMode, temperature, maxTokens, topP, ...rest } = options ?? {};
+    const { outputMode, temperature, maxOutputTokens: maxTokens, topP, ...rest } = options ?? {};
     const determinedMode = this.determineOutputMode(outputSchema, outputMode);
 
     // Convert messages to Vercel AI SDK format (shared utility)
@@ -97,7 +97,7 @@ export class OpenAIHandler implements ProviderHandler {
       request.temperature = temperature;
     }
     if (maxTokens !== undefined) {
-      request.maxTokens = maxTokens;
+      request.maxOutputTokens = maxTokens;
     }
     if (topP !== undefined) {
       request.topP = topP;

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -446,7 +446,7 @@ export interface MeshLlmConfig<TParams extends z.ZodType, TReturns extends z.Zod
 
   // LiteLLM parameters
   /** Maximum tokens to generate */
-  maxTokens?: number;
+  maxOutputTokens?: number;
   /** Sampling temperature */
   temperature?: number;
   /** Top-p sampling */
@@ -551,7 +551,7 @@ export interface LlmCallOptions {
   /** Context merge mode: "merge" (default) adds to base context, "replace" overrides entirely */
   contextMode?: LlmContextMode;
   /** Override max tokens */
-  maxTokens?: number;
+  maxOutputTokens?: number;
   /** Override temperature */
   temperature?: number;
   /** Override max iterations */
@@ -662,7 +662,7 @@ export interface MeshLlmResponse {
  *   model: "anthropic/claude-sonnet-4-5",
  *   capability: "llm",
  *   tags: ["llm", "claude", "anthropic", "provider"],
- *   maxTokens: 4096,
+ *   maxOutputTokens: 4096,
  *   temperature: 0.7,
  * }));
  * ```
@@ -677,7 +677,7 @@ export interface LlmProviderConfig {
   /** Version string for mesh registration. Defaults to "1.0.0" */
   version?: string;
   /** Maximum tokens to generate. Passed to Vercel AI SDK */
-  maxTokens?: number;
+  maxOutputTokens?: number;
   /** Sampling temperature. Passed to Vercel AI SDK */
   temperature?: number;
   /** Top-p sampling. Passed to Vercel AI SDK */


### PR DESCRIPTION
## Summary

Fixes #411 - Upgrade TypeScript SDK to Vercel AI SDK v6

- Update tool schema to use `inputSchema` instead of `parameters`
- Change tool call property from `args` to `input` (AI SDK v6 format)
- Update tool result output to use `{ type: 'text'|'json', value }` format
- Disable prompt caching (AI SDK v6 requires string content for system messages)
- Extract `wrapToolResultOutput()` helper with `ToolResultOutput` interface
- Add `VercelToolCall` interface for type safety
- Standardize `maxOutputTokens` naming in docs and tests

## Test plan

- [x] All 284 unit tests pass
- [x] Tested with Claude provider (ts-openai-provider with OpenAI)
- [x] Tested with scaffold agents (ts-smart-assistant, ts-math-agent)
- [x] Verified LLM agentic loop works with tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Vercel AI SDK to v6 with associated library updates
  * Expanded test coverage for new SDK behavior

* **Breaking Changes**
  * LLM configuration parameter renamed: `maxTokens` to `maxOutputTokens`
  * Prompt caching disabled for improved SDK compatibility
  * Tool call structures updated: `args` → `input`, `result` → `output`
  * Token usage metrics restructured to align with new SDK format

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->