### PR TITLE
feat(cli): Allow agent name prefix matching for call, status, list

### DIFF
--- a/src/core/cli/list.go
+++ b/src/core/cli/list.go
@@ -1867,11 +1867,22 @@ func runToolsListCommand(registryURL, toolSpec string, jsonOutput, healthyOnly b
 	// Parse tool specifier (agent:tool or just tool)
 	agentName, toolName := parseToolSpec(toolSpec)
 
+	// If agent name specified, resolve with prefix matching
+	var targetAgentID string
+	if agentName != "" {
+		matchResult := ResolveAgentByPrefix(enhancedAgents, agentName, healthyOnly)
+		if err := matchResult.FormattedError(); err != nil {
+			return err
+		}
+		targetAgentID = matchResult.Agent.ID
+	}
+
 	// Find the specific tool
 	var matchedTool *ToolListItem
 	var matchedAgent *EnhancedAgent
 	for _, agent := range enhancedAgents {
-		if agentName != "" && agent.Name != agentName && agent.ID != agentName {
+		// If agent was resolved via prefix, use that specific agent
+		if targetAgentID != "" && agent.ID != targetAgentID {
 			continue
 		}
 		for _, tool := range agent.Tools {

--- a/src/core/cli/prefix_match_test.go
+++ b/src/core/cli/prefix_match_test.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestResolveAgentByPrefix(t *testing.T) {
+	agents := []EnhancedAgent{
+		{ID: "calc-agent-1234", Name: "calc-agent", Status: "healthy"},
+		{ID: "calculator-5678", Name: "calculator", Status: "healthy"},
+		{ID: "weather-agent-9abc", Name: "weather-agent", Status: "healthy"},
+		{ID: "unhealthy-agent-def0", Name: "unhealthy-agent", Status: "unhealthy"},
+	}
+
+	testCases := []struct {
+		name        string
+		prefix      string
+		healthyOnly bool
+		expectMatch bool
+		expectMulti bool
+		expectName  string
+		expectExact bool
+	}{
+		// Exact match tests
+		{"exact name match", "calc-agent", true, true, false, "calc-agent", true},
+		{"exact id match", "calc-agent-1234", true, true, false, "calc-agent", true},
+
+		// Prefix match tests
+		{"unique prefix", "wea", true, true, false, "weather-agent", false},
+		{"ambiguous prefix", "calc", true, false, true, "", false},
+
+		// No match tests
+		{"no match prefix", "xyz", true, false, false, "", false},
+
+		// Health filtering tests
+		{"unhealthy exact match with filter", "unhealthy-agent", true, false, false, "", false},
+		{"unhealthy exact match without filter", "unhealthy-agent", false, true, false, "unhealthy-agent", true},
+
+		// Case insensitivity
+		{"case insensitive prefix", "WEATH", true, true, false, "weather-agent", false},
+		{"case insensitive exact", "CALC-AGENT", true, true, false, "calc-agent", false}, // prefix match, not exact
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ResolveAgentByPrefix(agents, tc.prefix, tc.healthyOnly)
+
+			if tc.expectMulti {
+				if len(result.Matches) <= 1 {
+					t.Errorf("expected multiple matches, got %d", len(result.Matches))
+				}
+				if result.Error == nil {
+					t.Error("expected error for multiple matches")
+				}
+				return
+			}
+
+			if tc.expectMatch {
+				if result.Agent == nil {
+					t.Errorf("expected match but got nil, error: %v", result.Error)
+					return
+				}
+				if result.Agent.Name != tc.expectName {
+					t.Errorf("expected agent name %s, got %s", tc.expectName, result.Agent.Name)
+				}
+				if tc.expectExact && !result.IsExact {
+					t.Error("expected exact match but got prefix match")
+				}
+				if !tc.expectExact && result.IsExact {
+					t.Error("expected prefix match but got exact match")
+				}
+			} else {
+				if result.Agent != nil && len(result.Matches) <= 1 {
+					t.Errorf("expected no match but got %s", result.Agent.Name)
+				}
+				if result.Error == nil {
+					t.Error("expected error for no match")
+				}
+			}
+		})
+	}
+}
+
+func TestResolveAgentByPrefix_EmptyList(t *testing.T) {
+	result := ResolveAgentByPrefix([]EnhancedAgent{}, "test", false)
+	if result.Agent != nil {
+		t.Error("expected no match for empty agent list")
+	}
+	if result.Error == nil {
+		t.Error("expected error for empty agent list")
+	}
+}
+
+func TestResolveAgentByPrefix_AllUnhealthy(t *testing.T) {
+	agents := []EnhancedAgent{
+		{ID: "agent-1", Name: "agent-one", Status: "unhealthy"},
+		{ID: "agent-2", Name: "agent-two", Status: "degraded"},
+	}
+
+	result := ResolveAgentByPrefix(agents, "agent", true)
+	if result.Agent != nil {
+		t.Error("expected no match when all agents are unhealthy and healthyOnly=true")
+	}
+	if result.Error == nil || !strings.Contains(result.Error.Error(), "no healthy agent") {
+		t.Errorf("expected 'no healthy agent' error, got: %v", result.Error)
+	}
+}
+
+func TestAgentMatchResult_FormattedError(t *testing.T) {
+	t.Run("no error returns nil", func(t *testing.T) {
+		result := &AgentMatchResult{
+			Agent: &EnhancedAgent{ID: "test", Name: "test"},
+		}
+		if result.FormattedError() != nil {
+			t.Error("expected nil error")
+		}
+	})
+
+	t.Run("single match error returns simple error", func(t *testing.T) {
+		result := &AgentMatchResult{
+			Error: fmt.Errorf("no agent found"),
+		}
+		err := result.FormattedError()
+		if err == nil || err.Error() != "no agent found" {
+			t.Errorf("expected simple error, got: %v", err)
+		}
+	})
+
+	t.Run("multiple matches returns formatted error", func(t *testing.T) {
+		result := &AgentMatchResult{
+			Error: fmt.Errorf("multiple agents match"),
+			Matches: []EnhancedAgent{
+				{ID: "a-1", Name: "agent-a", Status: "healthy"},
+				{ID: "a-2", Name: "agent-b", Status: "healthy"},
+			},
+		}
+		err := result.FormattedError()
+		if err == nil {
+			t.Error("expected error")
+			return
+		}
+		errStr := err.Error()
+		if !strings.Contains(errStr, "agent-a") || !strings.Contains(errStr, "agent-b") {
+			t.Errorf("expected formatted error with agent names, got: %s", errStr)
+		}
+	})
+}
+
+func TestFormatAgentMatchOptions(t *testing.T) {
+	matches := []EnhancedAgent{
+		{ID: "agent-1234", Name: "agent-one", Status: "healthy"},
+		{ID: "agent-5678", Name: "agent-two", Status: "unhealthy"},
+	}
+
+	output := FormatAgentMatchOptions(matches)
+
+	// Check that output contains expected elements
+	if !strings.Contains(output, "agent-one") {
+		t.Error("output should contain agent-one")
+	}
+	if !strings.Contains(output, "agent-two") {
+		t.Error("output should contain agent-two")
+	}
+	if !strings.Contains(output, "agent-1234") {
+		t.Error("output should contain agent ID")
+	}
+	if !strings.Contains(output, "Matching agents:") {
+		t.Error("output should contain header")
+	}
+	if !strings.Contains(output, "Please specify") {
+		t.Error("output should contain instruction")
+	}
+}

--- a/src/core/cli/status.go
+++ b/src/core/cli/status.go
@@ -115,10 +115,13 @@ func runStatusCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get agents: %w", err)
 	}
 
-	// If agent ID provided as positional argument, show details for that specific agent
+	// If agent ID/prefix provided as positional argument, show details for that specific agent
 	if len(args) > 0 {
-		agentID := args[0]
-		return outputAgentDetails(agents, agentID, jsonOutput)
+		matchResult := ResolveAgentByPrefix(agents, args[0], false) // include all agents for status
+		if err := matchResult.FormattedError(); err != nil {
+			return err
+		}
+		return outputAgentDetails(agents, matchResult.Agent.ID, jsonOutput)
 	}
 
 	// Filter to only healthy agents


### PR DESCRIPTION
## Summary

- Add prefix matching support for agent names/IDs in `meshctl call`, `meshctl status`, and `meshctl list --tools` commands
- Reduces friction when agent IDs include runtime-generated suffixes (e.g., `ts-smart-assistant-964a2cca`)
- Users can now use partial names like `ts-smart` instead of full IDs

## Changes

- Add `ResolveAgentByPrefix()` and `FormatAgentMatchOptions()` utilities in `utils.go`
- Add `FormattedError()` method on `AgentMatchResult` for cleaner error handling
- Add `resolveAgentPrefix()` helper in `call.go` to eliminate duplication
- Update `findAgentWithTool()` and `findAgentWithToolIngress()` in `call.go`
- Update `runStatusCommand()` in `status.go`
- Update `runToolsListCommand()` in `list.go`
- Add comprehensive unit tests

## Behavior

| Input | Result |
|-------|--------|
| Unique prefix (e.g., `ts-smart`) | Auto-resolves to matching agent |
| Ambiguous prefix (e.g., `ts`) | Shows all matching agents with IDs and status |
| No match | Clear error message |
| Exact match | Works as before (backwards compatible) |

## Test plan

- [x] Unit tests for `ResolveAgentByPrefix()` pass
- [x] Unit tests for `FormattedError()` pass
- [x] Manual testing with real agents confirms prefix matching works
- [x] Exact matches still work (backwards compatible)
- [x] `go build` succeeds
- [x] All existing CLI tests pass

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent selection now supports flexible prefix matching, allowing partial names or IDs instead of requiring exact matches.
  * Improved error messages when a prefix matches multiple agents, with clear guidance and matching options displayed.

* **Tests**
  * Added comprehensive unit tests covering agent prefix resolution, matching scenarios, health filtering, and error conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->