### PR TITLE
fix(release): Fix npm version and maturin cross-compilation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,13 +228,18 @@ jobs:
           echo "Updated pyproject.toml version to: ${VERSION_PYPI}"
           grep "^version" pyproject.toml
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Build wheels with maturin
         uses: PyO3/maturin-action@v1
         with:
           working-directory: src/runtime/core
           target: ${{ matrix.target }}
           manylinux: auto
-          args: --release --out dist
+          args: --release --out dist -i python3.11
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4
@@ -347,7 +352,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           cd src/runtime/core/typescript
-          npm version ${VERSION} --no-git-tag-version --allow-same-version
+          npm version ${VERSION} --no-git-tag-version --allow-same-version --ignore-scripts
           echo "Updated package.json version to: ${VERSION}"
           cat package.json
 
@@ -511,7 +516,7 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
 
           # Update version
-          npm version ${VERSION} --no-git-tag-version --allow-same-version
+          npm version ${VERSION} --no-git-tag-version --allow-same-version --ignore-scripts
 
           # Update @mcpmesh/core dependency from file: to npm version
           sed -i 's|"@mcpmesh/core": "file:../core/typescript"|"@mcpmesh/core": "'"${VERSION}"'"|' package.json


### PR DESCRIPTION
## Summary

Fixes two issues that caused the v0.8.0-beta.1 release workflow to fail.

## Failures

### 1. build-node-bindings: `napi: command not found`

```
npm error command sh -c napi version
```

The `npm version` command triggers the `"version": "napi version"` script in package.json, but `napi` (a devDependency) isn't installed yet at that point.

**Fix:** Add `--ignore-scripts` flag to skip lifecycle scripts during version update.

### 2. build-rust-wheels: `Couldn't find any python interpreters`

```
💥 maturin failed
  Caused by: Couldn't find any python interpreters. Please specify at least one with -i
```

Cross-compilation with maturin in Docker containers needs an explicit Python interpreter.

**Fix:** 
- Add `actions/setup-python@v5` step before maturin-action
- Pass `-i python3.11` to explicitly specify interpreter

## Test plan

- [ ] Re-run release workflow after merge
- [ ] Verify all build jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow and build infrastructure to support Python 3.11 and improve build consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->