### PR TITLE
fix(release): Use zig for Linux ARM64 cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,10 +162,11 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact-name: wheels-linux-x86_64
-          # Linux aarch64
+          # Linux aarch64 (use zig for cross-compilation to avoid ring crate issues)
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact-name: wheels-linux-aarch64
+            use-zig: true
           # macOS x86_64 (cross-compile from ARM64 runner)
           - os: macos-14
             target: x86_64-apple-darwin
@@ -233,13 +234,26 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install Zig
+        if: matrix.use-zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: "0.14.0"
+
+      - name: Install auditwheel and patchelf (for host builds)
+        if: matrix.use-zig
+        run: |
+          pip install auditwheel
+          sudo apt-get update && sudo apt-get install -y patchelf
+
       - name: Build wheels with maturin
         uses: PyO3/maturin-action@v1
         with:
           working-directory: src/runtime/core
           target: ${{ matrix.target }}
           manylinux: auto
-          args: --release --out dist -i python3.11
+          container: ${{ matrix.use-zig && 'off' || '' }}
+          args: --release --out dist -i python3.11 ${{ matrix.use-zig && '--zig' || '' }}
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Fixes the `ring` crate cross-compilation failure on Linux ARM64.

## Problem

```
error: #error "ARM assembler must define __ARM_ARCH"
failed to run custom build command for `ring v0.17.14`
```

The default manylinux Docker container's cross-compiler doesn't properly handle ARM assembly for the `ring` crate.

## Solution

Use `zig` as the cross-compiler for Linux ARM64 builds. Zig's toolchain handles ARM assembly correctly without special environment setup.

Changes:
- Add `use-zig: true` matrix variable for Linux aarch64
- Use `--zig` flag and disable manylinux container when use-zig is set

## Test plan

- [ ] Re-run release workflow after merge
- [ ] Verify Linux ARM64 wheel builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds support for building Linux aarch64 (ARM64) packages via Zig-enabled cross-compilation.

* **Documentation**
  * Clarifies the Zig-based cross-compilation path in CI so aarch64 builds are prepared and run reliably.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->