### PR TITLE
fix(release): add --ignore-scripts to @mcpmesh/core npm publish

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -9,7 +9,7 @@ on:
       version:
         description: "Version tag (e.g., v0.8.0)"
         required: true
-        default: "v0.8.0-beta.5"
+        default: "v0.8.0-beta.6"
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "Version (e.g., v0.8.0)"
         required: true
-        default: "v0.8.0-beta.5"
+        default: "v0.8.0-beta.6"
       environment:
         description: "Environment"
         type: choice
@@ -494,7 +494,8 @@ jobs:
           NPM_TAG: ${{ steps.version.outputs.npm_tag }}
         run: |
           echo "Publishing @mcpmesh/core with tag ${NPM_TAG}..."
-          npm publish --access public --tag "${NPM_TAG}"
+          # Use --ignore-scripts since prepublishOnly runs napi which isn't in the artifact
+          npm publish --access public --tag "${NPM_TAG}" --ignore-scripts
 
       - name: Wait for npm to index @mcpmesh/core
         env:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Variables
 REGISTRY_NAME = mcp-mesh-registry
 DEV_NAME = meshctl
-VERSION = 0.8.0-beta.5
+VERSION = 0.8.0-beta.6
 BUILD_DIR = bin
 REGISTRY_CMD_DIR = cmd/mcp-mesh-registry
 DEV_CMD_DIR = cmd/meshctl

--- a/docs/00-why-mcp-mesh/index.md
+++ b/docs/00-why-mcp-mesh/index.md
@@ -113,7 +113,7 @@ meshctl scaffold --compose --observability
 
 # Or deploy to Kubernetes (OCI registry)
 helm install my-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.8.0-beta.5 -n mcp-mesh --create-namespace
+  --version 0.8.0-beta.6 -n mcp-mesh --create-namespace
 ```
 
 ### 4. Built-in Observability

--- a/docs/04-kubernetes-basics.md
+++ b/docs/04-kubernetes-basics.md
@@ -21,7 +21,7 @@ kubectl create namespace mcp-mesh
 
 # Deploy core (OCI registry - no "helm repo add" needed)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   --namespace mcp-mesh
 
 # Wait for registry
@@ -65,7 +65,7 @@ Build the image:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=my-agent \
@@ -76,7 +76,7 @@ For cloud deployments, use your full registry path:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
@@ -138,7 +138,7 @@ resources:
 ```bash
 # Core without Grafana/Tempo (lighter footprint)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   --namespace mcp-mesh \
   --set grafana.enabled=false \
   --set tempo.enabled=false
@@ -149,7 +149,7 @@ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
 ```bash
 # Just the registry, no database or observability
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   --namespace mcp-mesh
 ```
 
@@ -161,13 +161,13 @@ helm list -n mcp-mesh
 
 # Upgrade an agent
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   --namespace mcp-mesh \
   --set image.tag=v2
 
 # Scale replicas
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   --namespace mcp-mesh \
   --reuse-values \
   --set replicaCount=3

--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -19,7 +19,7 @@ The data flows: **Agents → Redis → Registry → Tempo → Grafana**
 ```bash
 # Deploy core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   --namespace mcp-mesh \
   --set redis.enabled=true \
   --set tempo.enabled=true \

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,7 +44,7 @@ docker-compose up
 ```bash
 # Quick start (OCI registry - no helm repo add needed)
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 0.8.0-beta.5 -n mcp-mesh --create-namespace
+  --version 0.8.0-beta.6 -n mcp-mesh --create-namespace
 ```
 
 [:material-arrow-right: Kubernetes Guide](04-kubernetes-basics.md){ .md-button .md-button--primary }

--- a/docs/index.md
+++ b/docs/index.md
@@ -238,7 +238,7 @@ Graceful failure handling, auto-reconnection, RBAC support, and real-time monito
 
 ## :star: Project Status
 
-- **Latest Release**: v0.8.0-beta.5 (January 2026)
+- **Latest Release**: v0.8.0-beta.6 (January 2026)
 - **License**: MIT
 - **Languages**: Python 3.11+ and TypeScript/Node.js 18+ (runtime), Go 1.23+ (registry)
 - **Status**: Production-ready, actively developed

--- a/docs/python/getting-started/prerequisites.md
+++ b/docs/python/getting-started/prerequisites.md
@@ -177,12 +177,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/docs/typescript/getting-started/prerequisites.md
+++ b/docs/typescript/getting-started/prerequisites.md
@@ -177,12 +177,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/examples/docker-examples/agents/claude-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/claude-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying claude-provider with mcp-mesh-agent chart
 # Usage: helm install claude-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 0.8.0-beta.5 -f helm-values.yaml
+#        --version 0.8.0-beta.6 -f helm-values.yaml
 
 image:
   repository: your-registry/claude-provider

--- a/examples/docker-examples/agents/openai-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/openai-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying openai-provider with mcp-mesh-agent chart
 # Usage: helm install openai-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 0.8.0-beta.5 -f helm-values.yaml
+#        --version 0.8.0-beta.6 -f helm-values.yaml
 
 image:
   repository: your-registry/openai-provider

--- a/helm/mcp-mesh-agent/Chart.yaml
+++ b/helm/mcp-mesh-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-agent
 description: MCP Mesh Agent - Python runtime for MCP agents with mesh capabilities
 type: application
-version: 0.8.0-beta.5
-appVersion: "0.8.0-beta.5"
+version: 0.8.0-beta.6
+appVersion: "0.8.0-beta.6"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-core/Chart.yaml
+++ b/helm/mcp-mesh-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-core
 description: MCP Mesh Core Infrastructure - Registry, PostgreSQL, Redis, and Observability
 type: application
-version: 0.8.0-beta.5
-appVersion: "0.8.0-beta.5"
+version: 0.8.0-beta.6
+appVersion: "0.8.0-beta.6"
 keywords:
   - mcp
   - mesh
@@ -28,22 +28,22 @@ annotations:
   "artifacthub.io/containsSecurityUpdates": "false"
 dependencies:
   - name: mcp-mesh-postgres
-    version: "0.8.0-beta.5"
+    version: "0.8.0-beta.6"
     repository: "file://../mcp-mesh-postgres"
     condition: postgres.enabled
   - name: mcp-mesh-redis
-    version: "0.8.0-beta.5"
+    version: "0.8.0-beta.6"
     repository: "file://../mcp-mesh-redis"
     condition: redis.enabled
   - name: mcp-mesh-registry
-    version: "0.8.0-beta.5"
+    version: "0.8.0-beta.6"
     repository: "file://../mcp-mesh-registry"
     condition: registry.enabled
   - name: mcp-mesh-grafana
-    version: "0.8.0-beta.5"
+    version: "0.8.0-beta.6"
     repository: "file://../mcp-mesh-grafana"
     condition: grafana.enabled
   - name: mcp-mesh-tempo
-    version: "0.8.0-beta.5"
+    version: "0.8.0-beta.6"
     repository: "file://../mcp-mesh-tempo"
     condition: tempo.enabled

--- a/helm/mcp-mesh-grafana/Chart.yaml
+++ b/helm/mcp-mesh-grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-grafana
 description: Grafana observability component for MCP Mesh
 type: application
-version: 0.8.0-beta.5
+version: 0.8.0-beta.6
 appVersion: "12.3.1"
 keywords:
   - grafana

--- a/helm/mcp-mesh-ingress/Chart.yaml
+++ b/helm/mcp-mesh-ingress/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ingress
 description: Ingress configuration for MCP Mesh services with flexible DNS routing
 type: application
-version: 0.8.0-beta.5
-appVersion: "0.8.0-beta.5"
+version: 0.8.0-beta.6
+appVersion: "0.8.0-beta.6"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-postgres/Chart.yaml
+++ b/helm/mcp-mesh-postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-postgres
 description: PostgreSQL database for MCP Mesh Registry
 type: application
-version: 0.8.0-beta.5
+version: 0.8.0-beta.6
 appVersion: "15"
 keywords:
   - mcp

--- a/helm/mcp-mesh-redis/Chart.yaml
+++ b/helm/mcp-mesh-redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-redis
 description: Redis cache for MCP Mesh session storage
 type: application
-version: 0.8.0-beta.5
+version: 0.8.0-beta.6
 appVersion: "7"
 keywords:
   - mcp

--- a/helm/mcp-mesh-registry/Chart.yaml
+++ b/helm/mcp-mesh-registry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-registry
 description: MCP Mesh Registry Service - Central service registry for MCP agents
 type: application
-version: 0.8.0-beta.5
-appVersion: "0.8.0-beta.5"
+version: 0.8.0-beta.6
+appVersion: "0.8.0-beta.6"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-tempo/Chart.yaml
+++ b/helm/mcp-mesh-tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-tempo
 description: Tempo distributed tracing component for MCP Mesh
 type: application
-version: 0.8.0-beta.5
+version: 0.8.0-beta.6
 appVersion: "2.9.0"
 keywords:
   - tempo

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/cli",
-  "version": "0.8.0-beta.5",
+  "version": "0.8.0-beta.6",
   "description": "CLI for MCP Mesh - Enterprise-Grade Distributed Service Mesh for AI Agents",
   "license": "MIT",
   "repository": {
@@ -22,10 +22,10 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@mcpmesh/cli-linux-x64": "0.8.0-beta.5",
-    "@mcpmesh/cli-linux-arm64": "0.8.0-beta.5",
-    "@mcpmesh/cli-darwin-x64": "0.8.0-beta.5",
-    "@mcpmesh/cli-darwin-arm64": "0.8.0-beta.5"
+    "@mcpmesh/cli-linux-x64": "0.8.0-beta.6",
+    "@mcpmesh/cli-linux-arm64": "0.8.0-beta.6",
+    "@mcpmesh/cli-darwin-x64": "0.8.0-beta.6",
+    "@mcpmesh/cli-darwin-arm64": "0.8.0-beta.6"
   },
   "keywords": [
     "mcp",

--- a/packaging/homebrew/mcp-mesh.rb
+++ b/packaging/homebrew/mcp-mesh.rb
@@ -2,7 +2,7 @@
 class McpMesh < Formula
   desc "Kubernetes-native platform for distributed MCP applications"
   homepage "https://github.com/dhyansraj/mcp-mesh"
-  version "0.8.0-beta.5"  # Will be updated by release automation
+  version "0.8.0-beta.6"  # Will be updated by release automation
 
   if OS.mac?
     if Hardware::CPU.arm?

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "0.8.0b5"
+version = "0.8.0b6"
 description = "Kubernetes-native platform for distributed MCP applications"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packaging/scoop/mcp-mesh.json
+++ b/packaging/scoop/mcp-mesh.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0-beta.5",
+  "version": "0.8.0-beta.6",
   "description": "Kubernetes-native platform for distributed MCP applications",
   "homepage": "https://github.com/dhyansraj/mcp-mesh",
   "license": "MIT",

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -152,12 +152,12 @@ For production Kubernetes deployment, use the official Helm charts from the MCP 
 # Install core infrastructure (registry + database + observability)
 # No "helm repo add" needed - uses OCI registry directly
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh --create-namespace
 
 # Deploy agent using scaffold-generated helm-values.yaml
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -210,7 +210,7 @@ docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.0.0 --pu
 # 3. Update helm-values.yaml with your image repository
 # 4. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
@@ -222,14 +222,14 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 ```bash
 # Core without observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh --create-namespace \
   --set grafana.enabled=false \
   --set tempo.enabled=false
 
 # Core without PostgreSQL (in-memory registry)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh --create-namespace \
   --set postgres.enabled=false
 ```

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -145,12 +145,12 @@ For production Kubernetes deployment:
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh --create-namespace
 
 # Deploy TypeScript agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -196,7 +196,7 @@ docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.0.0 --pu
 
 # 3. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -65,12 +65,12 @@ docker compose up -d
 ```bash
 # Install core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh --create-namespace
 
 # Or disable observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh --create-namespace \
   --set tempo.enabled=false \
   --set grafana.enabled=false

--- a/src/core/cli/man/content/prerequisites.md
+++ b/src/core/cli/man/content/prerequisites.md
@@ -172,12 +172,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.8.0-beta.5 \
+  --version 0.8.0-beta.6 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/src/runtime/core/Cargo.toml
+++ b/src/runtime/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-mesh-core"
-version = "0.8.0-beta.5"
+version = "0.8.0-beta.6"
 edition = "2021"
 description = "Rust core runtime for MCP Mesh agents"
 license = "MIT"

--- a/src/runtime/core/pyproject.toml
+++ b/src/runtime/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mcp-mesh-core"
-version = "0.8.0b5"
+version = "0.8.0b6"
 description = "Rust core runtime for MCP Mesh agents"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/core/typescript/package.json
+++ b/src/runtime/core/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/core",
-  "version": "0.8.0-beta.5",
+  "version": "0.8.0-beta.6",
   "description": "MCP Mesh Rust core bindings for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/runtime/python/_mcp_mesh/__init__.py
+++ b/src/runtime/python/_mcp_mesh/__init__.py
@@ -31,7 +31,7 @@ from .engine.decorator_registry import (
     get_decorator_stats,
 )
 
-__version__ = "0.8.0b5"
+__version__ = "0.8.0b6"
 
 # Store reference to runtime processor if initialized
 _runtime_processor = None

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "0.8.0b5"
+version = "0.8.0b6"
 description = "Kubernetes-native platform for distributed MCP applications"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/typescript/package.json
+++ b/src/runtime/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/sdk",
-  "version": "0.8.0-beta.5",
+  "version": "0.8.0-beta.6",
   "description": "MCP Mesh SDK for TypeScript - Build distributed MCP agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` flag to npm publish for `@mcpmesh/core` to fix "napi: not found" error
- Bump version to v0.8.0-beta.6

## Problem
The `@mcpmesh/core` package has a `prepublishOnly` script that runs `napi prepublish -t npm`. When publishing from the release workflow, napi CLI isn't available in the dist folder since binaries are already built by the matrix jobs. This causes:
```
> @mcpmesh/core@0.8.0-beta.5 prepublishOnly
> napi prepublish -t npm

sh: 1: napi: not found
npm error code 127
```

## Solution
Add `--ignore-scripts` to the npm publish command since the package is already built and ready to publish.

## Test plan
- [ ] Merge this PR
- [ ] Tag v0.8.0-beta.6 and push to trigger release workflow
- [ ] Verify @mcpmesh/core publishes successfully to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Bumped version from 0.8.0-beta.5 to 0.8.0-beta.6 across the project:
  * Build and deployment workflows
  * Helm charts for all services and dependencies
  * Package manifests across multiple ecosystems (npm, Python, Homebrew, Scoop)
  * Runtime packages and SDKs
  * Documentation and CLI guidance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->