### PR TITLE
fix(cli): meshctl status resolves to healthy agent when only one is healthy

### DIFF
--- a/src/core/cli/status.go
+++ b/src/core/cli/status.go
@@ -117,7 +117,7 @@ func runStatusCommand(cmd *cobra.Command, args []string) error {
 
 	// If agent ID/prefix provided as positional argument, show details for that specific agent
 	if len(args) > 0 {
-		matchResult := ResolveAgentByPrefix(agents, args[0], false) // include all agents for status
+		matchResult := ResolveAgentByPrefix(agents, args[0], true) // prefer healthy agents, same as call.go
 		if err := matchResult.FormattedError(); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- When multiple agents match a name prefix but only one is healthy, `meshctl status` now auto-resolves to the healthy agent
- Makes `meshctl status` consistent with `meshctl call` behavior

Closes #460

## Test plan
- [x] `meshctl status py-claude-provider` resolves to the healthy agent instead of showing disambiguation error
- [x] `meshctl status <full-agent-id>` still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent selection in the status command to prioritize healthy agents when resolving a specific agent by prefix, improving the reliability of targeted status queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->