### PR TITLE
fix(py-sdk): Auto-assigned port detection filters by PID on macOS

### DIFF
--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -386,10 +386,11 @@ def _start_uvicorn_immediately(http_host: str, http_port: int):
                     text=True,
                     timeout=5,
                 )
+                current_pid = str(os.getpid())
                 for line in result.stdout.split("\n"):
-                    if "LISTEN" in line and "python" in line.lower():
-                        # Parse port from line like "python  1234  user  5u  IPv4 ... TCP *:54321 (LISTEN)"
-                        parts = line.split()
+                    parts = line.split()
+                    # Check PID matches current process (lsof returns all network connections on macOS)
+                    if len(parts) > 1 and parts[1] == current_pid and "LISTEN" in line:
                         for part in parts:
                             if ":" in part and "(LISTEN)" not in part:
                                 try:


### PR DESCRIPTION
## Summary
- Fix port detection when multiple Python agents start simultaneously with `http_port=0`
- On macOS, `lsof -i` returns ALL network connections, not just for the specified PID
- The code was matching the first Python LISTEN entry, which could be from a different agent process
- Fix: Filter lsof output by checking that the PID column matches `os.getpid()`

Closes #457

## Root Cause
When 5 agents start with `http_port=0`:
1. Agent 1 starts, binds to port 61781
2. Agent 2 runs `lsof -i -P -n -p{pid}`, sees ALL Python processes including Agent 1's port
3. Agent 2 matches first LISTEN entry (Agent 1's port 61781), registers with wrong port
4. All agents end up registered with Agent 1's port

## Test plan
- [x] Start 5 py-math-agents with `http_port=0` simultaneously
- [x] Verify each agent registers with unique auto-assigned port
- [x] Verify `meshctl call` works to each agent independently
- [x] Verify TypeScript SDK doesn't have this issue (uses different port detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced port detection mechanism during service startup to improve reliability, particularly on macOS systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->