### PR TITLE
build: Add Python 3.12 and 3.13 wheel builds for mcp-mesh-core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,10 +229,13 @@ jobs:
           echo "Updated pyproject.toml version to: ${VERSION_PYPI}"
           grep "^version" pyproject.toml
 
-      - name: Set up Python
+      - name: Set up Python versions
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: |
+            3.11
+            3.12
+            3.13
 
       - name: Install Zig
         if: matrix.use-zig
@@ -253,7 +256,7 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: auto
           container: ${{ matrix.use-zig && 'off' || '' }}
-          args: --release --out dist -i python3.11 ${{ matrix.use-zig && '--zig' || '' }}
+          args: --release --out dist -i python3.11 python3.12 python3.13 ${{ matrix.use-zig && '--zig' || '' }}
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Distributed Computing",
     "Topic :: Scientific/Engineering :: Artificial Intelligence"

--- a/src/runtime/core/pyproject.toml
+++ b/src/runtime/core/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Distributed Computing",


### PR DESCRIPTION
## Summary
- Build mcp-mesh-core wheels for Python 3.11, 3.12, and 3.13
- Update classifiers to include Python 3.13 support

## Changes
- `.github/workflows/release.yml`: Set up Python 3.11, 3.12, 3.13 and build wheels for all versions
- `packaging/pypi/pyproject.toml`: Add Python 3.13 classifier
- `src/runtime/core/pyproject.toml`: Add Python 3.13 classifier

## Result
- 15 wheels total (5 platforms × 3 Python versions)
- Users on Python 3.12 and 3.13 can now install mcp-mesh-core

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and packaging configurations to support Python 3.11, 3.12, and 3.13 in the release process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->