### PR TITLE
feat(ts-sdk): Auto-serialize execute return values like Python SDK

### DIFF
--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -182,7 +182,17 @@ export class MeshAgent {
         const result = await runWithTraceContext(traceContext, async () => {
           return await execute(cleanArgs, ...depsArray);
         });
-        return result;
+
+        // Auto-serialize non-string results (like Python SDK does)
+        // This allows users to return natural types (numbers, objects, arrays)
+        // without manually calling JSON.stringify() or String()
+        if (typeof result === "string") {
+          return result;
+        } else if (result === undefined || result === null) {
+          return "";
+        } else {
+          return JSON.stringify(result);
+        }
       } catch (err) {
         success = false;
         error = err instanceof Error ? err.message : String(err);

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -165,11 +165,24 @@ export interface MeshToolDef<T extends z.ZodType = z.ZodType> {
   /**
    * Tool implementation.
    *
+   * Returns any serializable value - the SDK auto-converts to string:
+   * - string: returned as-is
+   * - number/boolean: converted via JSON.stringify
+   * - object/array: converted via JSON.stringify
+   * - null/undefined: converted to empty string
+   *
    * @param args - Parsed arguments matching the Zod schema
    * @param deps - Dependency proxies injected positionally (McpMeshTool | null)
    *
    * @example
    * ```typescript
+   * // Return number - auto-serialized
+   * execute: async ({ a, b }) => a + b
+   *
+   * // Return object - auto-serialized to JSON
+   * execute: async ({ a, b }) => ({ result: a + b, source: "local" })
+   *
+   * // With dependencies
    * execute: async (
    *   { query },
    *   timeTool: McpMeshTool | null = null,
@@ -178,14 +191,14 @@ export interface MeshToolDef<T extends z.ZodType = z.ZodType> {
    *   if (timeTool) {
    *     const time = await timeTool();
    *   }
-   *   return "result";
+   *   return { result: time };
    * }
    * ```
    */
   execute: (
     args: z.infer<T>,
     ...deps: (McpMeshTool | null)[]
-  ) => Promise<string> | string;
+  ) => Promise<unknown> | unknown;
 }
 
 /**


### PR DESCRIPTION
## Summary

- TS SDK now auto-serializes execute return values
- Users can return natural types (numbers, objects, arrays) without manual `JSON.stringify()`
- Aligns TS SDK behavior with Python SDK

## Changes

| Return Type | Serialization |
|-------------|---------------|
| `string` | Returned as-is |
| `number` / `boolean` | `JSON.stringify()` |
| `object` / `array` | `JSON.stringify()` |
| `null` / `undefined` | Empty string `""` |

## Test plan

- [x] Tested with `ts-calculator-agent` - all operations work
- [x] Tested with `ts-math-agent` - returns numbers correctly
- [x] Verified string returns unchanged
- [x] Verified object/array returns serialized

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tools can now return structured data objects instead of just strings—results are automatically serialized for processing.
  * Improved handling of null and undefined returns as empty strings.

* **Documentation**
  * Updated documentation and examples to showcase auto-serialization behavior for various return types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->