### PR TITLE
feat(cli): Add --java flag to meshctl man pages

### DIFF
--- a/src/core/cli/man/content/capabilities.md
+++ b/src/core/cli/man/content/capabilities.md
@@ -2,6 +2,8 @@
 
 > Named services that agents provide for discovery and dependency injection
 
+**Note:** This page shows Python examples. See `meshctl man capabilities --typescript` for TypeScript or `meshctl man capabilities --java` for Java/Spring Boot examples.
+
 ## Overview
 
 Capabilities are named services that agents register with the mesh. When an agent declares a capability, other agents can discover and use it through dependency injection. Multiple agents can provide the same capability with different implementations.

--- a/src/core/cli/man/content/capabilities_java.md
+++ b/src/core/cli/man/content/capabilities_java.md
@@ -1,0 +1,183 @@
+# Capabilities System (Java/Spring Boot)
+
+> Named services that agents provide for discovery and dependency injection
+
+## Overview
+
+Capabilities are named services that agents register with the mesh. When an agent declares a capability, other agents can discover and use it through dependency injection. Multiple agents can provide the same capability with different implementations.
+
+## Declaring Capabilities
+
+Use `@MeshTool` to declare a capability on any method in your Spring Boot application:
+
+```java
+@MeshTool(capability = "weather_data",
+          description = "Provides weather info",
+          version = "1.0.0",
+          tags = {"weather", "current", "api"})
+public WeatherResponse getWeather(
+        @Param(value = "city", description = "City name") String city) {
+    return new WeatherResponse(city, 72, "sunny");
+}
+
+record WeatherResponse(String city, int temp, String conditions) {}
+```
+
+## Capability Selector Syntax
+
+MCP Mesh uses the `@Selector` annotation for selecting capabilities. This same pattern appears in `dependencies`, `@MeshLlm` provider/filter, and `@MeshRoute`.
+
+### Selector Fields
+
+| Field        | Required | Description                                   |
+| ------------ | -------- | --------------------------------------------- |
+| `capability` | Yes\*    | Capability name to match                      |
+| `tags`       | No       | Tag filters with +/- operators                |
+| `version`    | No       | Semantic version constraint (e.g., `>=2.0.0`) |
+
+\*When filtering by tags only (e.g., LLM tool filter), `capability` can be omitted.
+
+### Selector Usage
+
+**By capability name:**
+
+```java
+dependencies = @Selector(capability = "date_service")
+```
+
+**With tag filters:**
+
+```java
+dependencies = @Selector(capability = "weather_data",
+                          tags = {"+fast", "-deprecated"})
+```
+
+**With version constraint:**
+
+```java
+dependencies = @Selector(capability = "api_client", version = ">=2.0.0")
+```
+
+### Where Selectors Are Used
+
+| Context                   | Example                                                        |
+| ------------------------- | -------------------------------------------------------------- |
+| `@MeshTool` dependencies  | `dependencies = @Selector(capability = "svc")`                 |
+| `@MeshLlm` provider       | `providerSelector = @Selector(capability = "llm")`             |
+| `@MeshLlm` filter         | `filter = @Selector(tags = {"tools"})`                         |
+| `@MeshRoute` dependencies | `dependencies = @Selector(capability = "api", tags = {"+v2"})` |
+
+### Tag Operators
+
+| Prefix | Meaning   | Example         |
+| ------ | --------- | --------------- |
+| (none) | Required  | `"api"`         |
+| `+`    | Preferred | `"+fast"`       |
+| `-`    | Excluded  | `"-deprecated"` |
+
+## Multiple Capabilities on One Agent
+
+A single agent class can declare multiple capabilities:
+
+```java
+@MeshAgent(name = "math-service", version = "1.0.0",
+           description = "Math operations", port = 9000)
+@SpringBootApplication
+public class MathAgentApplication {
+
+    @MeshTool(capability = "add",
+              description = "Add two numbers",
+              tags = {"math", "addition", "java"})
+    public int add(@Param(value = "a", description = "First number") int a,
+                   @Param(value = "b", description = "Second number") int b) {
+        return a + b;
+    }
+
+    @MeshTool(capability = "multiply",
+              description = "Multiply two numbers",
+              tags = {"math", "multiplication", "java"})
+    public int multiply(@Param(value = "a", description = "First number") int a,
+                        @Param(value = "b", description = "Second number") int b) {
+        return a * b;
+    }
+}
+```
+
+## Multiple Implementations
+
+Multiple agents can provide the same capability:
+
+```java
+// Agent 1: Free weather provider
+@MeshTool(capability = "weather_data",
+          tags = {"weather", "openweather", "free"})
+public WeatherResponse freeWeather(
+        @Param(value = "city", description = "City name") String city) { /* ... */ }
+
+// Agent 2: Premium weather provider
+@MeshTool(capability = "weather_data",
+          tags = {"weather", "premium", "accurate"})
+public WeatherResponse premiumWeather(
+        @Param(value = "city", description = "City name") String city) { /* ... */ }
+```
+
+Consumers select implementations using tag filters in `@Selector`:
+
+```java
+@MeshTool(capability = "forecast",
+          description = "Get forecast using premium weather",
+          dependencies = @Selector(capability = "weather_data",
+                                    tags = {"+premium"}))
+public ForecastResponse getForecast(
+        @Param(value = "city", description = "City name") String city,
+        McpMeshTool<WeatherResponse> weatherData) {
+    if (weatherData != null && weatherData.isAvailable()) {
+        WeatherResponse weather = weatherData.call("city", city);
+        return new ForecastResponse(weather);
+    }
+    return new ForecastResponse("Weather service unavailable");
+}
+```
+
+## Capability Resolution
+
+When an agent requests a dependency, the registry resolves it by:
+
+1. **Name matching**: Find agents providing the requested capability
+2. **Tag filtering**: Apply tag constraints (if specified)
+3. **Version constraints**: Check semantic version compatibility
+4. **Load balancing**: Select from multiple matching providers
+
+## Capability Naming Conventions
+
+| Pattern         | Example         | Use Case         |
+| --------------- | --------------- | ---------------- |
+| `noun_noun`     | `weather_data`  | Data providers   |
+| `verb_noun`     | `get_time`      | Action services  |
+| `domain_action` | `auth_validate` | Domain-specific  |
+| `service`       | `llm`           | Generic services |
+
+## Versioning
+
+Capabilities support semantic versioning:
+
+```java
+@MeshTool(capability = "api_client", version = "2.1.0",
+          description = "API client v2", tags = {"api", "v2"})
+public ApiResponse callApi(
+        @Param(value = "endpoint", description = "API endpoint") String endpoint) {
+    /* ... */
+}
+```
+
+Consumers can specify version constraints:
+
+```java
+dependencies = @Selector(capability = "api_client", version = ">=2.0.0")
+```
+
+## See Also
+
+- `meshctl man tags --java` - Tag matching system
+- `meshctl man dependency-injection --java` - How DI works
+- `meshctl man decorators --java` - All Java annotations

--- a/src/core/cli/man/content/decorators.md
+++ b/src/core/cli/man/content/decorators.md
@@ -2,7 +2,7 @@
 
 > Core decorators for building distributed agent systems
 
-**Note:** This page shows Python examples. TypeScript uses equivalent function-based APIs (`mesh()`, `mesh.llm()`, `mesh.route()`). See `meshctl man decorators --typescript` for TypeScript examples.
+**Note:** This page shows Python examples. See `meshctl man decorators --typescript` for TypeScript or `meshctl man decorators --java` for Java/Spring Boot examples.
 
 ## Overview
 
@@ -75,7 +75,7 @@ async def greet(name: str, date_svc: mesh.McpMeshTool = None) -> str:
 
 | Type                | Use Case                               |
 | ------------------- | -------------------------------------- |
-| `mesh.McpMeshTool` | Tool calls via proxy                   |
+| `mesh.McpMeshTool`  | Tool calls via proxy                   |
 | `mesh.MeshLlmAgent` | LLM agent injection (with `@mesh.llm`) |
 
 ## @mesh.llm

--- a/src/core/cli/man/content/decorators_java.md
+++ b/src/core/cli/man/content/decorators_java.md
@@ -1,0 +1,338 @@
+# MCP Mesh Annotations (Java/Spring Boot)
+
+> Core annotations for building distributed agent systems
+
+## Overview
+
+MCP Mesh provides annotations that transform regular Spring Boot methods into mesh-aware distributed services. These annotations handle registration, dependency injection, and communication automatically.
+
+| Annotation         | Purpose                                   |
+| ------------------ | ----------------------------------------- |
+| `@MeshAgent`       | Agent configuration (name, version, port) |
+| `@MeshTool`        | Register capability with DI               |
+| `@Param`           | Document tool parameters                  |
+| `@Selector`        | Capability/tag selection for dependencies |
+| `@MeshLlm`         | Enable LLM-powered tools                  |
+| `@MeshLlmProvider` | Create zero-code LLM provider             |
+| `@MeshRoute`       | REST endpoint with mesh DI                |
+
+## @MeshAgent
+
+Configures the agent identity. Applied to your `@SpringBootApplication` class.
+
+```java
+@MeshAgent(
+    name = "my-service",          // Required: unique agent identifier
+    version = "1.0.0",            // Semantic version
+    description = "Service desc", // Human-readable description
+    port = 9000                   // HTTP server port
+)
+@SpringBootApplication
+public class MyAgentApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MyAgentApplication.class, args);
+    }
+}
+```
+
+| Attribute     | Required | Default   | Description                |
+| ------------- | -------- | --------- | -------------------------- |
+| `name`        | Yes      |           | Unique agent identifier    |
+| `version`     | No       | `"1.0.0"` | Semantic version           |
+| `description` | No       | `""`      | Human-readable description |
+| `port`        | No       | `8080`    | HTTP server port           |
+
+## @MeshTool
+
+Registers a method as a mesh capability with dependency injection.
+
+```java
+@MeshTool(
+    capability = "greeting",              // Capability name for discovery
+    description = "Greets users",         // Human-readable description
+    version = "1.0.0",                    // Capability version
+    tags = {"greeting", "utility"},       // Tags for filtering
+    dependencies = @Selector(             // Required capabilities
+        capability = "date_service")
+)
+public GreetingResponse greet(
+        @Param(value = "name", description = "The name") String name,
+        McpMeshTool<String> dateService) {       // Injected dependency
+    if (dateService != null && dateService.isAvailable()) {
+        String today = dateService.call();
+        return new GreetingResponse("Hello " + name + "! Today is " + today);
+    }
+    return new GreetingResponse("Hello " + name + "!");
+}
+```
+
+| Attribute      | Required | Default | Description                   |
+| -------------- | -------- | ------- | ----------------------------- |
+| `capability`   | Yes      |         | Capability name for discovery |
+| `description`  | No       | `""`    | Human-readable description    |
+| `version`      | No       | `""`    | Capability version            |
+| `tags`         | No       | `{}`    | Tags for filtering            |
+| `dependencies` | No       |         | `@Selector` for required caps |
+
+**Note**: Dependencies are injected as `McpMeshTool<T>` parameters on the method. They may be `null` if unavailable.
+
+## @Param
+
+Documents tool parameters. Applied to method parameters.
+
+```java
+@MeshTool(capability = "search", description = "Search documents")
+public SearchResult search(
+        @Param(value = "query", description = "Search query") String query,
+        @Param(value = "limit", description = "Max results") int limit) {
+    /* ... */
+}
+```
+
+| Attribute     | Required | Description                |
+| ------------- | -------- | -------------------------- |
+| `value`       | Yes      | Parameter name             |
+| `description` | No       | Human-readable description |
+
+## @Selector
+
+Specifies capability and tag selection for dependencies, LLM providers, and filters.
+
+```java
+// By capability name
+@Selector(capability = "date_service")
+
+// With tag filters
+@Selector(capability = "weather_data", tags = {"+fast", "-deprecated"})
+
+// With version constraint
+@Selector(capability = "api_client", version = ">=2.0.0")
+
+// Tags only (for LLM tool filtering)
+@Selector(tags = {"data", "tools"})
+```
+
+| Attribute    | Required | Description                    |
+| ------------ | -------- | ------------------------------ |
+| `capability` | No\*     | Capability name to match       |
+| `tags`       | No       | Tag filters with +/- operators |
+| `version`    | No       | Semantic version constraint    |
+
+\*Required for dependencies; optional for LLM tool filters.
+
+## @MeshLlm
+
+Enables LLM-powered tools. Applied alongside `@MeshTool` on the method.
+
+### Via Mesh (providerSelector)
+
+Route LLM requests through a mesh provider agent:
+
+```java
+@MeshLlm(
+    providerSelector = @Selector(capability = "llm"),  // Find LLM via mesh
+    maxIterations = 5,                                  // Max agentic loops
+    systemPrompt = "classpath:prompts/analyst.ftl",     // FreeMarker template
+    contextParam = "ctx",                               // Parameter for context
+    filter = @Selector(tags = {"data", "tools"}),       // Tool filter
+    filterMode = FilterMode.ALL,                        // Filter mode
+    maxTokens = 4096,                                   // Max output tokens
+    temperature = 0.7                                   // Sampling temperature
+)
+@MeshTool(capability = "analyze",
+          description = "AI-powered analysis",
+          tags = {"analysis", "llm", "java"})
+public AnalysisResult analyze(
+        @Param(value = "ctx", description = "Analysis context") AnalysisContext ctx,
+        MeshLlmAgent llm) {
+    return llm.request()
+              .user(ctx.query())
+              .maxTokens(4096)
+              .temperature(0.7)
+              .generate(AnalysisResult.class);
+}
+```
+
+### Direct Provider (provider)
+
+Use a specific LLM provider by name:
+
+```java
+@MeshLlm(
+    provider = "claude",                    // Direct provider name
+    maxIterations = 1,                      // Single generation
+    systemPrompt = "You are a helpful assistant.",
+    maxTokens = 1024,
+    temperature = 0.7
+)
+@MeshTool(capability = "chat",
+          description = "Chat with Claude",
+          tags = {"chat", "llm", "java", "direct"})
+public ChatResponse chat(
+        @Param(value = "message", description = "User message") String message,
+        MeshLlmAgent llm) {
+    if (llm != null && llm.isAvailable()) {
+        String response = llm.generate(message);
+        return new ChatResponse(response);
+    }
+    return new ChatResponse("LLM unavailable");
+}
+```
+
+| Attribute          | Required | Default | Description                          |
+| ------------------ | -------- | ------- | ------------------------------------ |
+| `provider`         | No\*     |         | Direct provider name                 |
+| `providerSelector` | No\*     |         | `@Selector` for mesh LLM discovery   |
+| `maxIterations`    | No       | `1`     | Max agentic loop iterations          |
+| `systemPrompt`     | No       | `""`    | System prompt or template path       |
+| `contextParam`     | No       | `""`    | Parameter name for template context  |
+| `filter`           | No       |         | `@Selector` for tool filtering       |
+| `filterMode`       | No       | `ALL`   | `FilterMode.ALL` or `BEST_MATCH`     |
+| `maxTokens`        | No       | `0`     | Max output tokens (0 = default)      |
+| `temperature`      | No       | `0.0`   | Sampling temperature (0.0 = default) |
+
+\*Specify either `provider` (direct) or `providerSelector` (mesh discovery), not both.
+
+### MeshLlmAgent API
+
+```java
+// Simple text generation
+String response = llm.generate(message);
+
+// Builder pattern with structured output
+AnalysisResult result = llm.request()
+    .system("Custom system prompt")
+    .user("Analyze this data")
+    .maxTokens(4096)
+    .temperature(0.7)
+    .generate(AnalysisResult.class);
+
+// With message history
+String response = llm.request()
+    .messages(conversationHistory)
+    .user("Follow-up question")
+    .generate();
+
+// Check availability
+if (llm != null && llm.isAvailable()) { /* ... */ }
+
+// Get generation metadata
+llm.request().lastMeta();
+```
+
+## @MeshLlmProvider
+
+Creates a zero-code LLM provider. No implementation needed - the annotation handles everything.
+
+```java
+@MeshAgent(name = "claude-provider", version = "1.0.0",
+           description = "Claude LLM provider for mesh", port = 9110)
+@MeshLlmProvider(
+    model = "anthropic/claude-sonnet-4-5",            // LiteLLM model string
+    capability = "llm",                                // Capability name
+    tags = {"llm", "claude", "anthropic", "provider"}, // Discovery tags
+    version = "1.0.0"                                  // Provider version
+)
+@SpringBootApplication
+public class ClaudeProviderApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(ClaudeProviderApplication.class, args);
+    }
+    // No implementation needed - annotation handles everything
+}
+```
+
+| Attribute    | Required | Default | Description          |
+| ------------ | -------- | ------- | -------------------- |
+| `model`      | Yes      |         | LiteLLM model string |
+| `capability` | Yes      |         | Capability name      |
+| `tags`       | No       | `{}`    | Discovery tags       |
+| `version`    | No       | `""`    | Provider version     |
+
+## @MeshRoute
+
+Enables mesh dependency injection in REST endpoint handlers.
+
+```java
+@MeshRoute(dependencies = @Selector(capability = "avatar_chat"))
+@PostMapping("/chat")
+public ResponseEntity<ChatResponse> chat(
+        @RequestBody ChatRequest request,
+        McpMeshTool<String> avatarChat) {
+    if (avatarChat == null || !avatarChat.isAvailable()) {
+        return ResponseEntity.status(503)
+            .body(new ChatResponse("Service unavailable"));
+    }
+    String result = avatarChat.call("message", request.message());
+    return ResponseEntity.ok(new ChatResponse(result));
+}
+```
+
+## Environment Variable Overrides
+
+All configuration can be overridden via environment variables:
+
+```bash
+export MCP_MESH_AGENT_NAME=custom-name
+export MCP_MESH_HTTP_PORT=9090
+export MCP_MESH_NAMESPACE=production
+export MCP_MESH_REGISTRY_URL=http://registry:8000
+```
+
+## Complete Example
+
+```java
+package com.example.calculator;
+
+import io.mcpmesh.*;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@MeshAgent(name = "calculator", version = "1.0.0",
+           description = "Calculator with logging", port = 9000)
+@SpringBootApplication
+public class CalculatorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CalculatorApplication.class, args);
+    }
+
+    // Basic tool - no dependencies
+    @MeshTool(capability = "add",
+              description = "Add two numbers",
+              tags = {"math", "calculator", "java"})
+    public int add(@Param(value = "a", description = "First number") int a,
+                   @Param(value = "b", description = "Second number") int b) {
+        return a + b;
+    }
+
+    // Tool with dependency
+    @MeshTool(capability = "calculator_logged",
+              description = "Calculate with audit logging",
+              tags = {"math", "calculator", "audit", "java"},
+              dependencies = @Selector(capability = "audit_log"))
+    public CalculationResult calculateWithLogging(
+            @Param(value = "operation", description = "Operation") String operation,
+            @Param(value = "a", description = "First number") int a,
+            @Param(value = "b", description = "Second number") int b,
+            McpMeshTool<String> auditLog) {
+
+        int result = operation.equals("add") ? a + b : a - b;
+
+        if (auditLog != null && auditLog.isAvailable()) {
+            auditLog.call("action", "calculation",
+                          "operation", operation, "result", result);
+        }
+
+        return new CalculationResult(operation, a, b, result);
+    }
+
+    record CalculationResult(String operation, int a, int b, int result) {}
+}
+```
+
+## See Also
+
+- `meshctl man dependency-injection --java` - DI details
+- `meshctl man capabilities --java` - Capabilities system
+- `meshctl man tags --java` - Tag matching system

--- a/src/core/cli/man/content/dependency-injection.md
+++ b/src/core/cli/man/content/dependency-injection.md
@@ -2,6 +2,8 @@
 
 > Automatic wiring of capabilities between agents
 
+**Note:** This page shows Python examples. See `meshctl man dependency-injection --typescript` for TypeScript or `meshctl man dependency-injection --java` for Java/Spring Boot examples.
+
 ## Overview
 
 MCP Mesh provides automatic dependency injection (DI) that connects agents based on their declared capabilities and dependencies. When a function declares a dependency, the mesh automatically creates a callable proxy that routes to the providing agent.

--- a/src/core/cli/man/content/dependency-injection_java.md
+++ b/src/core/cli/man/content/dependency-injection_java.md
@@ -1,0 +1,297 @@
+# Dependency Injection (Java/Spring Boot)
+
+> Automatic wiring of capabilities between agents
+
+## Overview
+
+MCP Mesh provides automatic dependency injection (DI) that connects agents based on their declared capabilities and dependencies. When a tool declares a dependency via `@Selector`, the mesh automatically injects a `McpMeshTool<T>` proxy that routes to the providing agent.
+
+## How It Works
+
+1. **Declaration**: Tool declares dependencies via `@MeshTool(dependencies = @Selector(...))`
+2. **Registration**: Agent registers with registry, advertising capabilities
+3. **Resolution**: Registry matches dependencies to providers
+4. **Injection**: Mesh injects `McpMeshTool<T>` instances as method parameters
+5. **Invocation**: Calling the proxy routes to the remote agent
+
+## Declaring Dependencies
+
+### Simple Dependency
+
+```java
+@MeshTool(capability = "smart_greeting",
+          description = "Greet with current date",
+          dependencies = @Selector(capability = "date_service"))
+public GreetingResponse smartGreet(
+        @Param(value = "name", description = "The name to greet") String name,
+        McpMeshTool<String> dateService) {
+
+    if (dateService != null && dateService.isAvailable()) {
+        String today = dateService.call();
+        return new GreetingResponse("Hello " + name + "! Today is " + today);
+    }
+    return new GreetingResponse("Hello " + name + "!");
+}
+```
+
+**Important**: Dependencies are injected as `McpMeshTool<T>` parameters on the method. They may be `null` if unavailable.
+
+### Dependencies with Filters
+
+Use the `@Selector` annotation with tags or version to filter providers:
+
+```java
+@MeshTool(capability = "report",
+          description = "Generate report with formatted data",
+          dependencies = @Selector(capability = "data_service",
+                                    tags = {"+fast", "-deprecated"}))
+public String generateReport(
+        @Param(value = "query", description = "Report query") String query,
+        McpMeshTool<String> dataService) {
+
+    if (dataService == null || !dataService.isAvailable()) {
+        return "Data service unavailable";
+    }
+    return dataService.call("query", query);
+}
+```
+
+## `McpMeshTool<T>` API Reference
+
+The `McpMeshTool<T>` interface is the primary way to interact with remote capabilities. The type parameter `T` indicates the expected return type.
+
+### call() - No Arguments
+
+Invoke the remote tool with no parameters:
+
+```java
+McpMeshTool<String> dateService;
+String today = dateService.call();
+```
+
+### call(Record) - Structured Parameters
+
+Pass a Java record whose field names become parameter names:
+
+```java
+McpMeshTool<Integer> calculator;
+
+record AddParams(int a, int b) {}
+Integer sum = calculator.call(new AddParams(3, 5));  // sum = 8
+```
+
+### call(key, value, ...) - Varargs
+
+Pass parameters as key-value pairs:
+
+```java
+McpMeshTool<String> greeting;
+String result = greeting.call("name", "Alice", "language", "en");
+```
+
+### isAvailable()
+
+Check if the remote capability is currently reachable:
+
+```java
+if (dateService != null && dateService.isAvailable()) {
+    // Safe to call
+}
+```
+
+### getEndpoint()
+
+Get the remote endpoint URL:
+
+```java
+String url = dateService.getEndpoint();
+// e.g., "http://localhost:9001"
+```
+
+### getCapability()
+
+Get the capability name this proxy represents:
+
+```java
+String cap = dateService.getCapability();
+// e.g., "date_service"
+```
+
+### API Summary
+
+| Method            | Description                        | Return Type |
+| ----------------- | ---------------------------------- | ----------- |
+| `call()`          | No-arg invocation                  | `T`         |
+| `call(record)`    | Call with record fields as params  | `T`         |
+| `call(k, v, ...)` | Call with key-value pairs          | `T`         |
+| `isAvailable()`   | Check provider reachability        | `boolean`   |
+| `getEndpoint()`   | Remote agent endpoint URL          | `String`    |
+| `getCapability()` | Capability name of this dependency | `String`    |
+
+## Type-Safe Responses
+
+The generic type parameter `T` on `McpMeshTool<T>` controls response deserialization. The SDK automatically converts the remote JSON response to the specified type.
+
+```java
+// Primitive types
+McpMeshTool<Integer> calculator;
+Integer sum = calculator.call(new AddParams(3, 5));
+
+// String responses
+McpMeshTool<String> dateService;
+String today = dateService.call();
+
+// Complex record types
+McpMeshTool<Employee> employeeService;
+Employee emp = employeeService.call("id", 42);
+// Employee record is auto-deserialized from JSON
+
+record Employee(int id, String name, String department) {}
+```
+
+## Graceful Degradation
+
+Dependencies may be unavailable if the providing agent is down or not yet started. Always handle `null` and check availability:
+
+```java
+@MeshTool(capability = "agent_status",
+          description = "Get status with dependency info",
+          dependencies = @Selector(capability = "date_service"))
+public AgentStatus getStatus(McpMeshTool<String> dateService) {
+    boolean depAvailable = dateService != null && dateService.isAvailable();
+
+    if (depAvailable) {
+        String date = dateService.call();
+        return new AgentStatus("operational", date);
+    }
+    return new AgentStatus("degraded", "date service unavailable");
+}
+
+record AgentStatus(String status, String info) {}
+```
+
+Or provide fallback values:
+
+```java
+@MeshTool(capability = "time_service",
+          description = "Get current time",
+          dependencies = @Selector(capability = "date_service"))
+public TimeResponse getTime(McpMeshTool<String> dateService) {
+    if (dateService != null && dateService.isAvailable()) {
+        return new TimeResponse(dateService.call());
+    }
+    // Fallback to local time
+    return new TimeResponse(java.time.LocalDateTime.now().toString());
+}
+```
+
+## Auto-Rewiring
+
+When topology changes (agents join/leave), the mesh:
+
+1. Detects change via heartbeat response
+2. Refreshes dependency proxies
+3. Routes to new providers automatically
+
+No code changes needed - happens transparently.
+
+## Multiple Dependencies
+
+A single tool can depend on multiple capabilities. Each dependency gets its own `McpMeshTool<T>` parameter:
+
+```java
+@MeshTool(capability = "add_via_mesh",
+          description = "Add two numbers using remote calculator",
+          tags = {"math", "cross-agent", "java"},
+          dependencies = @Selector(capability = "add"))
+public CalculationResult addViaMesh(
+        @Param(value = "a", description = "First number") int a,
+        @Param(value = "b", description = "Second number") int b,
+        McpMeshTool<Integer> calculator) {
+
+    Integer sum = calculator.call(new AddParams(a, b));
+    return new CalculationResult("add", a, b, sum);
+}
+
+record AddParams(int a, int b) {}
+record CalculationResult(String op, int a, int b, int result) {}
+```
+
+### LLM Injection
+
+For `@MeshLlm` annotated tools, the LLM is injected as a `MeshLlmAgent` parameter:
+
+```java
+@MeshLlm(providerSelector = @Selector(capability = "llm"),
+         maxIterations = 5, systemPrompt = "You are a helpful analyst.")
+@MeshTool(capability = "analyze",
+          description = "AI-powered analysis",
+          tags = {"analysis", "llm", "java"})
+public AnalysisResult analyze(
+        @Param(value = "query", description = "Analysis query") String query,
+        MeshLlmAgent llm) {
+
+    return llm.request()
+              .user(query)
+              .generate(AnalysisResult.class);
+}
+```
+
+## Complete Example
+
+```java
+package com.example.assistant;
+
+import io.mcpmesh.*;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@MeshAgent(name = "assistant", version = "1.0.0",
+           description = "Assistant with mesh dependencies", port = 9001)
+@SpringBootApplication
+public class AssistantAgentApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AssistantAgentApplication.class, args);
+    }
+
+    @MeshTool(capability = "smart_greeting",
+              description = "Greet with current date from mesh",
+              tags = {"greeting", "assistant", "java"},
+              dependencies = @Selector(capability = "date_service"))
+    public GreetingResponse smartGreet(
+            @Param(value = "name", description = "The name to greet") String name,
+            McpMeshTool<String> dateService) {
+
+        if (dateService != null && dateService.isAvailable()) {
+            String dateString = dateService.call();
+            return new GreetingResponse(
+                "Hello, " + name + "! Today is " + dateString);
+        }
+        return new GreetingResponse(
+            "Hello, " + name + "! (date service unavailable)");
+    }
+
+    @MeshTool(capability = "agent_status",
+              description = "Get agent status with dependency info",
+              tags = {"status", "info", "java"},
+              dependencies = @Selector(capability = "date_service"))
+    public AgentStatus getStatus(McpMeshTool<String> dateService) {
+        boolean available = dateService != null && dateService.isAvailable();
+        String endpoint = available ? dateService.getEndpoint() : "N/A";
+        String capability = available ? dateService.getCapability() : "N/A";
+
+        return new AgentStatus("assistant", available, endpoint, capability);
+    }
+
+    record GreetingResponse(String message) {}
+    record AgentStatus(String agent, boolean depAvailable,
+                       String depEndpoint, String depCapability) {}
+}
+```
+
+## See Also
+
+- `meshctl man capabilities --java` - Declaring capabilities
+- `meshctl man tags --java` - Tag-based selection
+- `meshctl man decorators --java` - All Java annotations

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-MCP Mesh supports multiple deployment patterns from local development to production Kubernetes clusters. Both Python and TypeScript agents can be deployed using the same patterns. Use `meshctl scaffold` to generate deployment-ready files automatically.
+MCP Mesh supports multiple deployment patterns from local development to production Kubernetes clusters. Python, TypeScript, and Java agents can be deployed using the same patterns. Use `meshctl scaffold` to generate deployment-ready files automatically.
 
 ## Official Docker Images
 

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -1,0 +1,304 @@
+# Deployment Patterns (Java/Spring Boot)
+
+> Local, Docker, and Kubernetes deployment for Java agents
+
+## Overview
+
+MCP Mesh supports multiple deployment patterns for Java/Spring Boot agents. The `meshctl start` command auto-detects `pom.xml` in directories and handles Maven builds automatically.
+
+## Prerequisites
+
+- Java 17+ (`java -version`)
+- Maven 3.8+ (`mvn -version`)
+- MCP Mesh Spring Boot Starter in `pom.xml`
+
+```xml
+<dependency>
+    <groupId>io.mcpmesh</groupId>
+    <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+    <version>0.8.0-SNAPSHOT</version>
+</dependency>
+```
+
+## Local Development
+
+### Quick Start
+
+```bash
+# Terminal 1: Start registry
+meshctl start --registry-only --debug
+
+# Terminal 2: Start Java agent (auto-detects pom.xml)
+meshctl start examples/java/basic-tool-agent --debug
+
+# Terminal 3: Monitor
+watch 'meshctl list'
+```
+
+`meshctl start` detects the `pom.xml` in the directory, builds the project with Maven, and starts the Spring Boot application.
+
+### Running Directly with Maven
+
+```bash
+cd examples/java/basic-tool-agent
+mvn spring-boot:run
+
+# With environment overrides
+MCP_MESH_HTTP_PORT=9001 mvn spring-boot:run
+```
+
+### Multiple Agents
+
+```bash
+# Start multiple Java agents
+meshctl start examples/java/basic-tool-agent examples/java/dependency-agent
+
+# Or run directly with different ports
+MCP_MESH_HTTP_PORT=9000 mvn -f agent1/pom.xml spring-boot:run &
+MCP_MESH_HTTP_PORT=9001 mvn -f agent2/pom.xml spring-boot:run &
+```
+
+### Development Workflow
+
+```bash
+# Start agent (detaches automatically for Java)
+meshctl start examples/java/basic-tool-agent --debug
+
+# Check running agents
+meshctl list
+
+# Stop specific agent
+meshctl stop greeter
+
+# Stop all agents
+meshctl stop
+```
+
+## Spring Boot Configuration
+
+### application.yml
+
+```yaml
+# src/main/resources/application.yml
+server:
+  port: ${MCP_MESH_HTTP_PORT:9000}
+
+spring:
+  application:
+    name: ${MCP_MESH_AGENT_NAME:my-agent}
+
+logging:
+  level:
+    io.mcpmesh: ${MCP_MESH_LOG_LEVEL:INFO}
+```
+
+### Environment Variables
+
+All `@MeshAgent` parameters can be overridden via environment variables:
+
+```bash
+export MCP_MESH_AGENT_NAME=custom-name
+export MCP_MESH_HTTP_PORT=9090
+export MCP_MESH_REGISTRY_URL=http://localhost:8000
+export MCP_MESH_NAMESPACE=production
+```
+
+## Docker Deployment
+
+### Dockerfile (Multi-Stage Build)
+
+```dockerfile
+FROM eclipse-temurin:17-jdk-jammy AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src/ src/
+RUN mvn package -DskipTests -q
+
+FROM eclipse-temurin:17-jre-jammy
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 9000
+CMD ["java", "-jar", "app.jar"]
+```
+
+### Build and Run
+
+```bash
+cd examples/java/basic-tool-agent
+
+# Build image
+docker build -t my-java-agent:latest .
+
+# Run with registry
+docker run -e MCP_MESH_REGISTRY_URL=http://host.docker.internal:8000 \
+    -p 9000:9000 my-java-agent:latest
+```
+
+### Docker Compose
+
+```yaml
+# docker-compose.yml
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: mesh
+      POSTGRES_PASSWORD: mesh
+      POSTGRES_DB: mesh
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mesh"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  registry:
+    image: mcpmesh/registry:0.8
+    ports:
+      - "8000:8000"
+    environment:
+      DATABASE_URL: postgres://mesh:mesh@postgres:5432/mesh
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8000/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  greeter:
+    build: ./examples/java/basic-tool-agent
+    ports:
+      - "9000:9000"
+    environment:
+      MCP_MESH_REGISTRY_URL: http://registry:8000
+      MCP_MESH_HTTP_PORT: 9000
+    depends_on:
+      registry:
+        condition: service_healthy
+
+  assistant:
+    build: ./examples/java/dependency-agent
+    ports:
+      - "9001:9001"
+    environment:
+      MCP_MESH_REGISTRY_URL: http://registry:8000
+      MCP_MESH_HTTP_PORT: 9001
+    depends_on:
+      registry:
+        condition: service_healthy
+```
+
+```bash
+docker compose up -d
+docker compose logs -f
+docker compose ps
+```
+
+## Kubernetes Deployment
+
+### Helm Charts
+
+For production Kubernetes deployment:
+
+```bash
+# Install core infrastructure
+helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
+  --version 0.8.1 \
+  -n mcp-mesh --create-namespace
+
+# Deploy Java agent
+helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
+  --version 0.8.1 \
+  -n mcp-mesh \
+  -f my-agent/helm-values.yaml
+```
+
+### helm-values.yaml for Java
+
+```yaml
+image:
+  repository: your-registry/my-java-agent
+  tag: latest
+
+agent:
+  name: my-agent
+  command: [] # Empty = use Docker image's CMD (recommended)
+
+mesh:
+  enabled: true
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 200m
+    memory: 256Mi
+```
+
+### Deployment Workflow
+
+```bash
+# 1. Build and push Docker image
+cd my-agent
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.0.0 --push .
+
+# 2. Deploy with Helm
+helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
+  --version 0.8.1 \
+  -n mcp-mesh \
+  -f helm-values.yaml \
+  --set image.repository=your-registry/my-agent \
+  --set image.tag=v1.0.0
+```
+
+## Port Strategy
+
+| Environment            | Port Strategy                | Why                                   |
+| ---------------------- | ---------------------------- | ------------------------------------- |
+| Local / docker-compose | Unique ports (9000, 9001...) | All containers share host network     |
+| Kubernetes             | All agents use 8080          | Each pod has its own IP, no conflicts |
+
+The Helm chart sets `MCP_MESH_HTTP_PORT=8080` which overrides `@MeshAgent(port = 9000)`. Your code does not need to change between environments.
+
+## Best Practices
+
+### Health Checks
+
+Spring Boot agents automatically expose `/actuator/health`. The MCP Mesh starter integrates with Spring Boot's health system.
+
+### Graceful Shutdown
+
+Spring Boot handles `SIGINT`/`SIGTERM` automatically. Agents deregister from the registry on shutdown.
+
+### Logging
+
+```bash
+# Structured logging for production
+export MCP_MESH_LOG_LEVEL=INFO
+export MCP_MESH_DEBUG_MODE=false
+
+# Enable debug logging
+export MCP_MESH_LOG_LEVEL=DEBUG
+```
+
+### Resource Limits (Kubernetes)
+
+Java agents typically need more memory than Python/TypeScript:
+
+```yaml
+resources:
+  requests:
+    memory: "256Mi"
+    cpu: "200m"
+  limits:
+    memory: "512Mi"
+    cpu: "500m"
+```
+
+## See Also
+
+- `meshctl man environment` - Configuration options
+- `meshctl man health --java` - Health monitoring
+- `meshctl man testing --java` - Testing Java agents

--- a/src/core/cli/man/content/health.md
+++ b/src/core/cli/man/content/health.md
@@ -2,6 +2,8 @@
 
 > Fast heartbeat system and automatic topology updates
 
+**Note:** This page shows Python examples. See `meshctl man health --typescript` for TypeScript or `meshctl man health --java` for Java/Spring Boot examples.
+
 ## Overview
 
 MCP Mesh uses a dual-heartbeat system for fast failure detection and automatic topology updates. Agents maintain connectivity with the registry, and the mesh automatically rewires dependencies when agents join or leave.

--- a/src/core/cli/man/content/health_java.md
+++ b/src/core/cli/man/content/health_java.md
@@ -1,0 +1,183 @@
+# Health Monitoring & Auto-Rewiring (Java/Spring Boot)
+
+> Fast heartbeat system and automatic topology updates
+
+## Overview
+
+MCP Mesh uses a dual-heartbeat system for fast failure detection and automatic topology updates. Java/Spring Boot agents participate in the same health monitoring system as Python and TypeScript agents. The Spring Boot starter handles heartbeat, registration, and auto-rewiring automatically.
+
+## Heartbeat System
+
+### Dual-Heartbeat Design
+
+| Type | Frequency  | Size  | Purpose                  |
+| ---- | ---------- | ----- | ------------------------ |
+| HEAD | ~5 seconds | ~200B | Lightweight keep-alive   |
+| POST | On change  | ~2KB  | Full registration update |
+
+### How It Works
+
+1. Agent sends HEAD request every 5 seconds
+2. Registry responds with status:
+   - `200 OK`: No changes
+   - `202 Accepted`: Topology changed, refresh needed
+   - `410 Gone`: Agent unknown, re-register
+3. On `202`, agent sends POST with full registration
+4. Registry returns updated dependency topology
+
+### Failure Detection
+
+- Registry marks agents unhealthy after missed heartbeats
+- Default threshold: 20 seconds (4 missed 5-second heartbeats)
+- Configurable via environment variables
+
+## Checking Dependency Health
+
+Use `isAvailable()` on `McpMeshTool` to check if a dependency is reachable:
+
+```java
+@MeshTool(
+    capability = "smart_greeting",
+    description = "Greet with current date from mesh",
+    dependencies = @Selector(capability = "date_service")
+)
+public GreetingResponse smartGreet(
+    @Param(value = "name", description = "Name to greet") String name,
+    McpMeshTool<String> dateService
+) {
+    if (dateService != null && dateService.isAvailable()) {
+        String date = dateService.call();
+        return new GreetingResponse("Hello, " + name + "! Today is " + date, "mesh");
+    }
+    // Graceful degradation
+    return new GreetingResponse("Hello, " + name + "!", "fallback");
+}
+```
+
+## The agent_status Tool Pattern
+
+Expose a tool that reports dependency health to the mesh:
+
+```java
+@MeshTool(
+    capability = "agent_status",
+    description = "Get agent status with dependency info",
+    tags = {"status", "info", "java"},
+    dependencies = @Selector(capability = "date_service")
+)
+public AgentStatus getStatus(McpMeshTool<String> dateService) {
+    boolean dateServiceAvailable = dateService != null && dateService.isAvailable();
+    String dateServiceEndpoint = dateServiceAvailable ? dateService.getEndpoint() : null;
+
+    return new AgentStatus(
+        "assistant",
+        "1.0.0",
+        "Java " + System.getProperty("java.version"),
+        dateServiceAvailable,
+        dateServiceEndpoint
+    );
+}
+
+public record AgentStatus(
+    String name,
+    String version,
+    String runtime,
+    boolean dateServiceAvailable,
+    String dateServiceEndpoint
+) {}
+```
+
+This pattern lets other agents (or operators) query dependency health programmatically via `meshctl call agent_status`.
+
+## Auto-Rewiring
+
+When topology changes, the mesh automatically:
+
+1. **Detects change**: Via heartbeat response (`202`)
+2. **Fetches new topology**: Registry returns updated dependencies
+3. **Compares hashes**: Prevents unnecessary updates
+4. **Refreshes proxies**: McpMeshTool proxies update automatically
+5. **Routes traffic**: New calls go to updated providers
+
+### Code Impact
+
+None! Auto-rewiring is transparent:
+
+```java
+@MeshTool(
+    capability = "my_tool",
+    dependencies = @Selector(capability = "date_service")
+)
+public String myTool(McpMeshTool<String> dateService) {
+    // If date_service agent restarts or is replaced,
+    // the proxy automatically points to the new instance
+    if (dateService != null && dateService.isAvailable()) {
+        return dateService.call();
+    }
+    return "Service unavailable";
+}
+```
+
+## Spring Boot Health Actuator
+
+The MCP Mesh Spring Boot starter automatically integrates with Spring Boot's health actuator. The `/actuator/health` endpoint includes mesh status:
+
+```bash
+curl http://localhost:9000/actuator/health
+```
+
+## Configuration
+
+### Agent Settings
+
+```bash
+# Heartbeat interval (seconds)
+export MCP_MESH_AUTO_RUN_INTERVAL=30
+
+# Health check interval (seconds)
+export MCP_MESH_HEALTH_INTERVAL=30
+```
+
+### Registry Settings
+
+```bash
+# When to mark agents unhealthy (seconds)
+export DEFAULT_TIMEOUT_THRESHOLD=20
+
+# How often to scan for unhealthy agents (seconds)
+export HEALTH_CHECK_INTERVAL=10
+
+# When to evict stale agents (seconds)
+export DEFAULT_EVICTION_THRESHOLD=60
+```
+
+## Graceful Failure
+
+The mesh handles failures gracefully:
+
+- **Registry down**: Existing agent-to-agent communication continues
+- **Agent down**: Dependencies are `null`, code handles gracefully
+- **Network partition**: Agents continue with cached topology
+- **Recovery**: Automatic reconnection and topology refresh
+
+## Monitoring
+
+```bash
+# Check overall mesh health
+meshctl status
+
+# Verbose status with heartbeat info
+meshctl status --verbose
+
+# List agents with health status
+meshctl list
+
+# JSON output for automation
+meshctl status --json
+```
+
+## See Also
+
+- `meshctl man registry` - Registry operations
+- `meshctl man dependency-injection --java` - How DI handles failures
+- `meshctl man environment` - Configuration options

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -2,7 +2,7 @@
 
 > Building LLM-powered agents with @mesh.llm decorator
 
-**Note:** This page shows Python examples. TypeScript uses equivalent `mesh.llm()` function wrapper. See `meshctl man llm --typescript` for TypeScript examples.
+**Note:** This page shows Python examples. See `meshctl man llm --typescript` for TypeScript or `meshctl man llm --java` for Java/Spring Boot examples.
 
 ## Overview
 

--- a/src/core/cli/man/content/llm_java.md
+++ b/src/core/cli/man/content/llm_java.md
@@ -1,0 +1,348 @@
+# LLM Integration (Java/Spring Boot)
+
+> Building LLM-powered agents with @MeshLlm annotation
+
+## Overview
+
+MCP Mesh provides first-class LLM support for Java/Spring Boot agents through the `@MeshLlm` annotation. Two modes are available:
+
+| Mode              | Annotation                          | API Key Location | Use Case                         |
+| ----------------- | ----------------------------------- | ---------------- | -------------------------------- |
+| **Direct**        | `@MeshLlm(provider = "claude")`     | Local agent      | Single agent, simpler setup      |
+| **Mesh Delegate** | `@MeshLlm(providerSelector = @...)` | Provider agent   | Shared LLM, centralized key mgmt |
+
+## Architecture
+
+### Direct Mode
+
+```
+User -> Agent -> Spring AI -> Claude API (direct)
+                 (local API key)
+```
+
+### Mesh Delegation Mode
+
+```
+User -> Agent -> Mesh -> LLM Provider Agent -> Claude API
+                         (API key here only)
+```
+
+## Direct LLM (@MeshLlm with provider)
+
+Use `provider = "claude"` or `provider = "openai"` for direct API calls. Requires the API key set locally.
+
+```java
+import io.mcpmesh.*;
+import io.mcpmesh.types.MeshLlmAgent;
+
+@MeshLlm(
+    provider = "claude",
+    maxIterations = 1,
+    systemPrompt = "You are a helpful, friendly assistant. Keep responses concise.",
+    maxTokens = 1024,
+    temperature = 0.7
+)
+@MeshTool(
+    capability = "chat",
+    description = "Interactive chat with Claude",
+    tags = {"chat", "llm", "java", "direct"}
+)
+public ChatResponse chat(
+    @Param(value = "message", description = "User message") String message,
+    MeshLlmAgent llm
+) {
+    if (llm != null && llm.isAvailable()) {
+        String response = llm.generate(message);
+        return new ChatResponse(message, response, "direct:claude");
+    }
+    return new ChatResponse(message, "LLM unavailable", "fallback");
+}
+```
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+# or
+export OPENAI_API_KEY=sk-...
+```
+
+## Mesh Delegation (@MeshLlm with providerSelector)
+
+Use `providerSelector` to delegate LLM calls to a provider agent in the mesh. No local API key needed.
+
+```java
+@MeshLlm(
+    providerSelector = @Selector(capability = "llm"),
+    maxIterations = 5,
+    systemPrompt = "classpath:prompts/analyst.ftl",
+    contextParam = "ctx",
+    filter = @Selector(tags = {"data", "tools"}),
+    filterMode = FilterMode.ALL,
+    maxTokens = 4096,
+    temperature = 0.7
+)
+@MeshTool(
+    capability = "analyze",
+    description = "AI-powered data analysis",
+    tags = {"analysis", "llm", "java"}
+)
+public AnalysisResult analyze(
+    @Param(value = "ctx", description = "Analysis context") AnalysisContext ctx,
+    MeshLlmAgent llm
+) {
+    if (llm == null || !llm.isAvailable()) {
+        return fallbackAnalysis(ctx);
+    }
+    return llm.request()
+        .user(ctx.query())
+        .generate(AnalysisResult.class);
+}
+```
+
+## Fluent Builder API
+
+The `MeshLlmAgent` provides a fluent builder for clean, readable LLM calls:
+
+### Simple Text Generation
+
+```java
+String response = llm.request()
+    .user("What is the capital of France?")
+    .temperature(0.7)
+    .generate();
+```
+
+### Structured Output
+
+Return a Java record or class by passing the type to `generate()`:
+
+```java
+public record AnalysisResult(
+    String summary,
+    List<String> insights,
+    double confidence,
+    String source
+) {}
+
+AnalysisResult result = llm.request()
+    .user("Analyze Q4 sales trends")
+    .maxTokens(4096)
+    .temperature(0.7)
+    .generate(AnalysisResult.class);
+```
+
+### With System Prompt Override
+
+```java
+String response = llm.request()
+    .system("You are a code review expert.")
+    .user("Review this function for bugs")
+    .maxTokens(2048)
+    .generate();
+```
+
+## Multi-Turn Conversations
+
+Use `messages()` with `Message` helpers to pass conversation history:
+
+```java
+import io.mcpmesh.types.MeshLlmAgent.Message;
+
+// Build history (typically loaded from Redis/database)
+List<Message> history = new ArrayList<>();
+history.add(Message.user("Hello, I'm interested in data analysis."));
+history.add(Message.assistant("What kind of data are you working with?"));
+history.add(Message.user("I have sales data from Q4 2024."));
+history.add(Message.assistant("What insights are you looking for?"));
+
+// Continue conversation with history
+String response = llm.request()
+    .system("You are a helpful assistant. Remember the conversation context.")
+    .messages(history)
+    .user("Show me the top trends")
+    .maxTokens(2048)
+    .temperature(0.7)
+    .generate();
+```
+
+### Loading History from Database
+
+```java
+// Load from Redis/PostgreSQL as List<Map<String, String>>
+List<Map<String, String>> rawHistory = redis.lrange("chat:" + sessionId, 0, -1);
+List<Message> history = Message.fromMaps(rawHistory);
+
+String response = llm.request()
+    .messages(history)
+    .user(currentMessage)
+    .generate();
+```
+
+## Tool Filtering
+
+Control which mesh tools the LLM can discover and call:
+
+```java
+// Filter by tags
+filter = @Selector(tags = {"data", "tools"})
+
+// Filter by capability
+filter = @Selector(capability = "calculator")
+
+// FilterMode controls selection
+filterMode = FilterMode.ALL          // All tools matching filter
+filterMode = FilterMode.BEST_MATCH   // One tool per capability (best tag match)
+```
+
+## System Prompts
+
+### Inline String
+
+```java
+@MeshLlm(
+    providerSelector = @Selector(capability = "llm"),
+    systemPrompt = "You are a helpful assistant. Analyze the input and respond."
+)
+```
+
+### Freemarker Template File
+
+```java
+@MeshLlm(
+    providerSelector = @Selector(capability = "llm"),
+    systemPrompt = "classpath:prompts/analyst.ftl",
+    contextParam = "ctx"
+)
+```
+
+Template file (`src/main/resources/prompts/analyst.ftl`):
+
+```ftl
+You are a data analyst assistant.
+
+## Query
+${ctx.query}
+
+## Instructions
+Analyze the data and provide structured insights.
+```
+
+The `contextParam` value maps to the parameter name in the tool method. Template variables are populated from that parameter's fields.
+
+## @MeshLlmProvider - Zero-Code Provider
+
+Create an LLM provider agent with zero implementation code:
+
+```java
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshLlmProvider;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@MeshAgent(
+    name = "claude-provider",
+    version = "1.0.0",
+    description = "Claude LLM provider for mesh",
+    port = 9110
+)
+@MeshLlmProvider(
+    model = "anthropic/claude-sonnet-4-5",
+    capability = "llm",
+    tags = {"llm", "claude", "anthropic", "provider"},
+    version = "1.0.0"
+)
+@SpringBootApplication
+public class ClaudeProviderApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(ClaudeProviderApplication.class, args);
+    }
+    // No implementation needed - @MeshLlmProvider handles everything!
+}
+```
+
+The provider automatically:
+
+1. Creates a tool with `capability = "llm"`
+2. Registers with the mesh registry
+3. Handles incoming generate requests
+4. Forwards to Spring AI ChatClient
+5. Returns responses through the mesh
+
+## Provider Pattern Benefits
+
+- **Centralized API keys**: Only the provider agent needs the key
+- **Rate limiting**: Apply limits at the provider level
+- **Swap providers**: Switch LLM vendors without redeploying consumers
+- **Shared access**: Multiple consumer agents share a single provider
+- **Monitoring**: Centralized logging and cost tracking
+
+## Supported Models
+
+Uses LiteLLM model format in `@MeshLlmProvider`:
+
+| Provider  | Model Format                   |
+| --------- | ------------------------------ |
+| Anthropic | `anthropic/claude-sonnet-4-5`  |
+| OpenAI    | `openai/gpt-4o`                |
+| Mistral   | `mistral/mistral-large-latest` |
+| Google    | `gemini/gemini-pro`            |
+
+## Complete Example
+
+```java
+// 1. Provider Agent (claude-provider, port 9110)
+@MeshAgent(name = "claude-provider", port = 9110)
+@MeshLlmProvider(
+    model = "anthropic/claude-sonnet-4-5",
+    capability = "llm",
+    tags = {"llm", "claude", "provider"}
+)
+@SpringBootApplication
+public class ProviderApp {
+    public static void main(String[] args) {
+        SpringApplication.run(ProviderApp.class, args);
+    }
+}
+
+// 2. Consumer Agent (analyst, port 9002)
+@MeshAgent(name = "analyst", port = 9002)
+@SpringBootApplication
+public class AnalystApp {
+    public static void main(String[] args) {
+        SpringApplication.run(AnalystApp.class, args);
+    }
+
+    @MeshLlm(
+        providerSelector = @Selector(capability = "llm"),
+        maxIterations = 5,
+        systemPrompt = "You are a data analyst.",
+        filter = @Selector(tags = {"data", "tools"}),
+        filterMode = FilterMode.ALL
+    )
+    @MeshTool(
+        capability = "analyze",
+        description = "AI-powered analysis",
+        tags = {"analysis", "llm"}
+    )
+    public AnalysisResult analyze(
+        @Param(value = "query", description = "Analysis query") String query,
+        MeshLlmAgent llm
+    ) {
+        return llm.request()
+            .user(query)
+            .maxTokens(4096)
+            .generate(AnalysisResult.class);
+    }
+
+    public record AnalysisResult(
+        String summary,
+        List<String> insights,
+        double confidence
+    ) {}
+}
+```
+
+## See Also
+
+- `meshctl man decorators --java` - All annotations reference
+- `meshctl man tags` - Tag matching for provider selection
+- `meshctl man capabilities` - Capability discovery

--- a/src/core/cli/man/content/overview.md
+++ b/src/core/cli/man/content/overview.md
@@ -2,7 +2,7 @@
 
 > Production-grade distributed mesh for intelligent agents
 
-**Supported Languages:** Python and TypeScript
+**Supported Languages:** Python, TypeScript, and Java
 
 ## Why MCP Mesh?
 
@@ -34,7 +34,7 @@ The central coordination service that:
 
 ### 2. Agents
 
-Python or TypeScript services using the MCP Mesh SDK that:
+Python, TypeScript, or Java services using the MCP Mesh SDK that:
 
 - Register capabilities with the registry on startup
 - Send periodic heartbeats to maintain registration

--- a/src/core/cli/man/content/prerequisites.md
+++ b/src/core/cli/man/content/prerequisites.md
@@ -2,7 +2,7 @@
 
 > What you need before building MCP Mesh agents
 
-**MCP Mesh supports both Python and TypeScript.** Choose the language that fits your needs—or use both in the same mesh.
+**MCP Mesh supports Python, TypeScript, and Java.** Choose the language that fits your needs—or use multiple languages in the same mesh.
 
 ## Windows Users
 
@@ -110,6 +110,44 @@ npm install
 meshctl start src/index.ts --debug
 ```
 
+### Java 17+ / Maven
+
+```bash
+# Check versions
+java -version    # Need 17+
+mvn -version     # Apache Maven 3.8+
+
+# Install if needed
+brew install openjdk@17      # macOS
+brew install maven           # macOS
+sudo apt install openjdk-17-jdk maven   # Ubuntu/Debian
+```
+
+### MCP Mesh Spring Boot Starter
+
+```xml
+<!-- In your pom.xml -->
+<dependency>
+    <groupId>io.mcpmesh</groupId>
+    <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+    <version>0.8.0-SNAPSHOT</version>
+</dependency>
+```
+
+### Quick Start (Java)
+
+```bash
+# 1. Use an example as template
+cp -r examples/java/basic-tool-agent my-agent
+cd my-agent
+
+# 2. Build and run
+mvn spring-boot:run
+
+# 3. Or use meshctl (auto-detects pom.xml)
+meshctl start my-agent --debug
+```
+
 ## Docker Deployment
 
 For containerized deployments.
@@ -194,6 +232,8 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 | ---------- | ------- | ----------- |
 | Python     | 3.11    | 3.12        |
 | Node.js    | 18      | 20+         |
+| Java       | 17      | 17+         |
+| Maven      | 3.8     | 3.9+        |
 | Docker     | 20.10   | Latest      |
 | Kubernetes | 1.25    | 1.28+       |
 | Helm       | 3.10    | 3.14+       |

--- a/src/core/cli/man/content/proxies.md
+++ b/src/core/cli/man/content/proxies.md
@@ -2,6 +2,8 @@
 
 > Inter-agent communication and proxy configuration
 
+**Note:** This page shows Python examples. See `meshctl man proxies --typescript` for TypeScript or `meshctl man proxies --java` for Java/Spring Boot examples.
+
 ## Overview
 
 MCP Mesh uses proxy objects to enable seamless communication between agents. When you call an injected dependency, you're actually calling a proxy that routes to the remote agent via MCP JSON-RPC.

--- a/src/core/cli/man/content/proxies_java.md
+++ b/src/core/cli/man/content/proxies_java.md
@@ -1,0 +1,222 @@
+# Proxy System & Communication (Java/Spring Boot)
+
+> Inter-agent communication via McpMeshTool proxies
+
+## Overview
+
+In Java/Spring Boot, `McpMeshTool<T>` is the proxy type for inter-agent communication. When you declare a dependency via `@Selector`, the mesh automatically injects a `McpMeshTool<T>` proxy that routes calls to the remote agent via MCP JSON-RPC.
+
+## How Proxies Work
+
+```
+┌─────────────┐     Proxy Call      ┌─────────────┐
+│   Agent A   │ ────────────────►   │   Agent B   │
+│             │   MCP JSON-RPC      │             │
+│  calc.call()│ ◄────────────────   │ add(a, b)   │
+└─────────────┘     Response        └─────────────┘
+```
+
+1. Agent A calls `calculator.call(new AddParams(1, 2))`
+2. Proxy serializes call to MCP JSON-RPC
+3. HTTP POST to Agent B's `/mcp` endpoint
+4. Agent B executes the `add` tool
+5. Response deserialized into type `T` and returned
+
+## Declaring Dependencies
+
+Dependencies are declared via `@Selector` in `@MeshTool` and injected as method parameters:
+
+```java
+@MeshTool(
+    capability = "smart_greeting",
+    dependencies = @Selector(capability = "date_service")
+)
+public String smartGreet(
+    @Param(value = "name", description = "Name") String name,
+    McpMeshTool<String> dateService
+) {
+    if (dateService != null && dateService.isAvailable()) {
+        String date = dateService.call();
+        return "Hello, " + name + "! Today is " + date;
+    }
+    return "Hello, " + name + "!";
+}
+```
+
+## McpMeshTool<T> API Reference
+
+### call() - No Parameters
+
+Call the remote tool with no arguments:
+
+```java
+McpMeshTool<String> dateService;
+
+String today = dateService.call();
+```
+
+### call(record) - Record-Based Parameters
+
+Use a Java record where field names map to MCP parameter names:
+
+```java
+record AddParams(int a, int b) {}
+
+McpMeshTool<Integer> calculator;
+
+Integer sum = calculator.call(new AddParams(3, 4));  // sum = 7
+```
+
+### call("key", value, ...) - Varargs Parameters
+
+For simple parameter passing without defining a record:
+
+```java
+McpMeshTool<Employee> employeeService;
+
+Employee emp = employeeService.call("id", 42);
+```
+
+Multiple key-value pairs:
+
+```java
+String result = service.call("city", "London", "units", "metric");
+```
+
+### isAvailable() - Check Reachability
+
+Returns `true` if the remote agent is registered and reachable:
+
+```java
+if (dateService != null && dateService.isAvailable()) {
+    // Safe to call
+    String date = dateService.call();
+}
+```
+
+### getEndpoint() - Remote URL
+
+Get the HTTP endpoint of the remote agent:
+
+```java
+String url = dateService.getEndpoint();
+// e.g., "http://localhost:9001"
+```
+
+### getCapability() - Capability Name
+
+Get the capability name this proxy resolves to:
+
+```java
+String cap = dateService.getCapability();
+// e.g., "date_service"
+```
+
+## Type-Safe Responses
+
+The type parameter `T` in `McpMeshTool<T>` controls automatic deserialization:
+
+### Primitive Types
+
+```java
+McpMeshTool<Integer> calculator;
+Integer result = calculator.call(new AddParams(1, 2));
+
+McpMeshTool<String> dateService;
+String date = dateService.call();
+```
+
+### Complex Types (Records)
+
+```java
+public record Employee(
+    int id,
+    String firstName,
+    String lastName,
+    String department,
+    double salary
+) {}
+
+McpMeshTool<Employee> employeeService;
+Employee emp = employeeService.call("id", 42);
+// emp.firstName() -> "Alice"
+// emp.department() -> "Engineering"
+```
+
+The SDK automatically deserializes the remote agent's JSON response into the specified type. No manual parsing needed.
+
+## Proxy Lifecycle
+
+1. **Created on registration**: When the agent registers with the registry, proxies are created for resolved dependencies
+2. **Updated on topology change**: When agents join or leave, the registry notifies via `202` heartbeat response, and proxies are refreshed
+3. **Null if unavailable**: If no provider matches the dependency selector, the proxy parameter is `null`
+
+Always check for `null` before calling:
+
+```java
+if (dateService != null && dateService.isAvailable()) {
+    return dateService.call();
+}
+return "Fallback value";
+```
+
+## Cross-Language Calls
+
+McpMeshTool proxies work across languages. A Java agent can call Python or TypeScript agents and vice versa:
+
+```java
+// Java agent calling a TypeScript calculator
+@MeshTool(
+    capability = "add_via_mesh",
+    description = "Add via remote calculator (cross-agent)",
+    dependencies = @Selector(capability = "add")
+)
+public CalculationResult addViaMesh(
+    @Param(value = "a", description = "First number") int a,
+    @Param(value = "b", description = "Second number") int b,
+    McpMeshTool<Integer> calculator
+) {
+    Integer sum = calculator.call(new AddParams(a, b));
+    return new CalculationResult(a, b, sum, calculator.getEndpoint());
+}
+
+record AddParams(int a, int b) {}
+record CalculationResult(int a, int b, int result, String remoteEndpoint) {}
+```
+
+All agents speak the same MCP JSON-RPC protocol, so language is transparent.
+
+## Error Handling
+
+```java
+@MeshTool(
+    capability = "resilient_tool",
+    dependencies = @Selector(capability = "helper")
+)
+public String resilientTool(McpMeshTool<String> helper) {
+    if (helper == null) {
+        return "Service unavailable";
+    }
+
+    try {
+        return helper.call();
+    } catch (Exception e) {
+        return "Error: " + e.getMessage();
+    }
+}
+```
+
+## Direct Communication
+
+Agents communicate directly with no proxy server:
+
+- Registry provides endpoint information
+- Agents call each other via HTTP
+- Minimal latency (no intermediary)
+- Continues working if registry is down
+
+## See Also
+
+- `meshctl man dependency-injection --java` - DI overview
+- `meshctl man health --java` - Auto-rewiring on failure
+- `meshctl man testing --java` - Testing agent communication

--- a/src/core/cli/man/content/quickstart.md
+++ b/src/core/cli/man/content/quickstart.md
@@ -2,6 +2,8 @@
 
 > Get started with MCP Mesh in minutes (Python)
 
+**Note:** This page shows Python examples. See `meshctl man quickstart --typescript` for TypeScript or `meshctl man quickstart --java` for Java/Spring Boot examples.
+
 ## Prerequisites
 
 ```bash

--- a/src/core/cli/man/content/quickstart_java.md
+++ b/src/core/cli/man/content/quickstart_java.md
@@ -1,0 +1,172 @@
+# Quick Start
+
+> Get started with MCP Mesh in minutes (Java/Spring Boot)
+
+## Prerequisites
+
+```bash
+# Java 17+
+java --version
+
+# Maven
+mvn --version
+
+# Create project directory
+mkdir my-mesh-project && cd my-mesh-project
+```
+
+## 1. Start the Registry
+
+```bash
+# Terminal 1: Start registry
+meshctl start --registry-only --debug
+```
+
+## 2. Create Your First Agent
+
+Create `GreeterAgentApplication.java`:
+
+```java
+package com.example.greeter;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@MeshAgent(name = "greeter", version = "1.0.0",
+           description = "Simple greeting service", port = 9000)
+@SpringBootApplication
+public class GreeterAgentApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(GreeterAgentApplication.class, args);
+    }
+
+    @MeshTool(capability = "greeting",
+              description = "Greet a user by name",
+              tags = {"greeting", "utility", "java"})
+    public GreetingResponse greet(
+            @Param(value = "name", description = "The name to greet") String name) {
+        return new GreetingResponse("Hello, " + name + "!");
+    }
+
+    record GreetingResponse(String message) {}
+}
+```
+
+## 3. Add the Maven Dependency
+
+Create `pom.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.2</version>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>greeter-agent</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcpmesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>0.8.1</version>
+        </dependency>
+    </dependencies>
+</project>
+```
+
+## 4. Build and Run
+
+```bash
+# Option A: Run directly with Maven
+cd greeter
+mvn spring-boot:run
+
+# Option B: Use meshctl (auto-detects pom.xml)
+meshctl start examples/java/basic-tool-agent --debug
+```
+
+`meshctl start` can start Java agents by pointing at a directory containing a `pom.xml`, a `.java` file, or a `.jar` file. For Maven projects, it runs `mvn spring-boot:run -q` under the hood.
+
+## 5. Test the Agent
+
+```bash
+# Terminal 3: Call the agent
+meshctl call greeter greeting --params '{"name": "World"}'
+# Output: {"message": "Hello, World!"}
+
+# List running agents
+meshctl list
+```
+
+## 6. Add a Dependency
+
+Create a second agent that depends on the greeter:
+
+```java
+package com.example.assistant;
+
+import io.mcpmesh.*;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@MeshAgent(name = "assistant", version = "1.0.0",
+           description = "Assistant with mesh dependencies", port = 9001)
+@SpringBootApplication
+public class AssistantAgentApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AssistantAgentApplication.class, args);
+    }
+
+    @MeshTool(capability = "smart_greeting",
+              description = "Enhanced greeting via mesh",
+              tags = {"greeting", "assistant", "java"},
+              dependencies = @Selector(capability = "greeting"))
+    public GreetingResponse smartGreet(
+            @Param(value = "name", description = "The name to greet") String name,
+            McpMeshTool<String> greeting) {
+
+        if (greeting != null && greeting.isAvailable()) {
+            String baseGreeting = greeting.call("name", name);
+            return new GreetingResponse(baseGreeting + " Welcome to MCP Mesh!");
+        }
+        return new GreetingResponse("Hello, " + name + "! (greeter unavailable)");
+    }
+
+    record GreetingResponse(String message) {}
+}
+```
+
+```bash
+# Start the assistant
+meshctl start examples/java/dependency-agent --debug
+
+# Call the smart greeting
+meshctl call assistant smart_greeting --params '{"name": "Developer"}'
+# Output: {"message": "Hello, Developer! Welcome to MCP Mesh!"}
+```
+
+## Next Steps
+
+- `meshctl man decorators --java` - Learn all mesh annotations
+- `meshctl man llm --java` - Add LLM capabilities
+- `meshctl man capabilities --java` - Capabilities system
+- `meshctl man dependency-injection --java` - How DI works
+
+## See Also
+
+- `meshctl scaffold --help` - All scaffold options
+- `meshctl man prerequisites` - Full setup guide

--- a/src/core/cli/man/content/scaffold.md
+++ b/src/core/cli/man/content/scaffold.md
@@ -2,7 +2,7 @@
 
 > Generate MCP Mesh agents from templates
 
-Scaffold supports both **Python** and **TypeScript** agents. Use `--lang typescript` for TypeScript.
+Scaffold supports **Python**, **TypeScript**, and **Java** agents. Use `--lang typescript` for TypeScript or `--lang java` for Java/Spring Boot.
 
 ## Input Modes
 
@@ -28,6 +28,9 @@ meshctl scaffold --name my-agent --agent-type tool
 
 # Basic tool agent (TypeScript)
 meshctl scaffold --name my-agent --agent-type tool --lang typescript
+
+# Basic tool agent (Java/Spring Boot)
+meshctl scaffold --name my-agent --agent-type tool --lang java
 
 # LLM agent using Claude
 meshctl scaffold --name analyzer --agent-type llm-agent --llm-selector claude
@@ -67,20 +70,20 @@ meshctl scaffold --compose --project-name my-project
 
 ## Key Flags
 
-| Flag               | Description                                          |
-| ------------------ | ---------------------------------------------------- |
-| `--name`           | Agent name (required for non-interactive)            |
-| `--agent-type`     | `tool`, `llm-agent`, or `llm-provider`               |
-| `--lang`           | Language: `python` (default) or `typescript`         |
-| `--dry-run`        | Preview generated code                               |
-| `--no-interactive` | Disable prompts (for scripting)                      |
-| `--output`         | Output directory (default: `.`)                      |
-| `--port`           | HTTP port (default: 9000)                            |
-| `--model`          | LiteLLM model for llm-provider                       |
-| `--llm-selector`   | LLM provider for llm-agent: `claude`, `openai`       |
-| `--filter`         | Tool filter for llm-agent (capability selector JSON) |
-| `--compose`        | Generate docker-compose.yml                          |
-| `--observability`  | Add Redis/Tempo/Grafana to compose                   |
+| Flag               | Description                                           |
+| ------------------ | ----------------------------------------------------- |
+| `--name`           | Agent name (required for non-interactive)             |
+| `--agent-type`     | `tool`, `llm-agent`, or `llm-provider`                |
+| `--lang`           | Language: `python` (default), `typescript`, or `java` |
+| `--dry-run`        | Preview generated code                                |
+| `--no-interactive` | Disable prompts (for scripting)                       |
+| `--output`         | Output directory (default: `.`)                       |
+| `--port`           | HTTP port (default: 9000)                             |
+| `--model`          | LiteLLM model for llm-provider                        |
+| `--llm-selector`   | LLM provider for llm-agent: `claude`, `openai`        |
+| `--filter`         | Tool filter for llm-agent (capability selector JSON)  |
+| `--compose`        | Generate docker-compose.yml                           |
+| `--observability`  | Add Redis/Tempo/Grafana to compose                    |
 
 The `--filter` flag uses capability selector syntax. See `meshctl man capabilities` for details.
 
@@ -114,6 +117,7 @@ meshctl start agent.py --watch --env-file .env
 ```
 
 Benefits:
+
 - Fast local development (edit code, auto-reload with `--watch`)
 - Full observability (traces in Grafana at http://localhost:3000)
 - Shared registry (all agents discover each other)

--- a/src/core/cli/man/content/tags.md
+++ b/src/core/cli/man/content/tags.md
@@ -2,6 +2,8 @@
 
 > Smart service selection using tags with +/- operators
 
+**Note:** This page shows Python examples. See `meshctl man tags --typescript` for TypeScript or `meshctl man tags --java` for Java/Spring Boot examples.
+
 ## Overview
 
 Tags are metadata labels attached to capabilities that enable intelligent service selection. MCP Mesh supports "smart matching" with operators that express preferences and exclusions.

--- a/src/core/cli/man/content/tags_java.md
+++ b/src/core/cli/man/content/tags_java.md
@@ -1,0 +1,239 @@
+# Tag Matching System (Java/Spring Boot)
+
+> Smart service selection using tags with +/- operators
+
+## Overview
+
+Tags are metadata labels attached to capabilities that enable intelligent service selection. MCP Mesh supports "smart matching" with operators that express preferences and exclusions.
+
+Tags are part of the **Capability Selector** syntax used throughout MCP Mesh. See `meshctl man capabilities --java` for the complete selector reference.
+
+## Tag Operators (Consumer Side)
+
+Use these operators when **selecting** capabilities (dependencies, providers, filters):
+
+| Prefix | Meaning   | Example                                 |
+| ------ | --------- | --------------------------------------- |
+| (none) | Required  | `"api"` - must have this tag            |
+| `+`    | Preferred | `"+fast"` - bonus if present            |
+| `-`    | Excluded  | `"-deprecated"` - hard failure if found |
+
+**Note:** Operators are for consumers only. When declaring tags on your tool, use plain strings without +/- prefixes.
+
+## Declaring Tags (Provider Side)
+
+```java
+@MeshTool(capability = "weather_data",
+          description = "Provides weather info",
+          tags = {"weather", "current", "api", "free"})  // Plain strings
+public WeatherResponse getWeather(
+        @Param(value = "city", description = "City name") String city) {
+    return new WeatherResponse(city, 72);
+}
+
+record WeatherResponse(String city, int temp) {}
+```
+
+## Using Tags in Dependencies
+
+### Simple Tag Filter
+
+```java
+@MeshTool(capability = "my_capability",
+          description = "Tool using weather data",
+          dependencies = @Selector(capability = "weather_data",
+                                    tags = {"api"}))
+public String getInfo(McpMeshTool<String> weatherData) {
+    if (weatherData != null && weatherData.isAvailable()) {
+        return weatherData.call("city", "NYC");
+    }
+    return "Weather service unavailable";
+}
+```
+
+### Smart Matching with Operators
+
+```java
+@MeshTool(capability = "smart_weather",
+          description = "Smart weather lookup",
+          dependencies = @Selector(
+              capability = "weather_data",
+              tags = {
+                  "api",          // Required: must have "api" tag
+                  "+accurate",    // Preferred: bonus if "accurate"
+                  "+fast",        // Preferred: bonus if "fast"
+                  "-deprecated"   // Excluded: fail if "deprecated"
+              }))
+public String smartWeather(McpMeshTool<String> weatherData) {
+    if (weatherData != null && weatherData.isAvailable()) {
+        return weatherData.call("city", "NYC");
+    }
+    return "No suitable weather service found";
+}
+```
+
+## Matching Algorithm
+
+1. **Filter**: Remove candidates with excluded tags (`-`)
+2. **Require**: Keep only candidates with required tags (no prefix)
+3. **Score**: Add points for preferred tags (`+`)
+4. **Select**: Choose highest-scoring candidate
+
+### Example
+
+Available providers:
+
+- Provider A: `["weather", "api", "accurate"]`
+- Provider B: `["weather", "api", "fast", "deprecated"]`
+- Provider C: `["weather", "api", "fast", "accurate"]`
+
+Filter: `{"api", "+accurate", "+fast", "-deprecated"}`
+
+Result:
+
+1. Provider B eliminated (has `-deprecated`)
+2. Remaining: A and C (both have required `api`)
+3. Scores: A=1 (accurate), C=2 (accurate+fast)
+4. Winner: Provider C
+
+## Tag Naming Conventions
+
+| Category    | Examples                       |
+| ----------- | ------------------------------ |
+| Type        | `api`, `service`, `provider`   |
+| Quality     | `fast`, `accurate`, `reliable` |
+| Status      | `beta`, `stable`, `deprecated` |
+| Provider    | `openai`, `claude`, `local`    |
+| Environment | `production`, `staging`, `dev` |
+
+## Priority Scoring with Preferences
+
+Stack multiple `+` tags to create priority ordering. The provider matching the most preferred tags wins.
+
+```java
+@MeshLlm(providerSelector = @Selector(
+             capability = "llm",
+             tags = {"+claude", "+anthropic", "+gpt"}),
+         systemPrompt = "You are helpful.",
+         maxIterations = 1)
+@MeshTool(capability = "chat",
+          description = "Chat with best available LLM",
+          tags = {"chat", "llm", "java"})
+public String chat(
+        @Param(value = "message", description = "User message") String message,
+        MeshLlmAgent llm) {
+    return llm.generate(message);
+}
+```
+
+| Provider | Its Tags                         | Matches             | Score  |
+| -------- | -------------------------------- | ------------------- | ------ |
+| Claude   | `["llm", "claude", "anthropic"]` | +claude, +anthropic | **+2** |
+| GPT      | `["llm", "gpt", "openai"]`       | +gpt                | **+1** |
+| Llama    | `["llm", "llama"]`               | (none)              | **+0** |
+
+Result: Claude (+2) > GPT (+1) > Llama (+0)
+
+## Tool Filtering in @MeshLlm
+
+Filter which tools an LLM agent can access using the `filter` and `filterMode` attributes:
+
+```java
+@MeshLlm(providerSelector = @Selector(capability = "llm"),
+         filter = @Selector(tags = {"executor", "tools"}),
+         filterMode = FilterMode.ALL,
+         systemPrompt = "You are a helpful assistant.",
+         maxIterations = 5)
+@MeshTool(capability = "assistant",
+          description = "LLM-powered assistant",
+          tags = {"assistant", "llm", "java"})
+public String assist(
+        @Param(value = "query", description = "User query") String query,
+        MeshLlmAgent llm) {
+    return llm.generate(query);
+}
+```
+
+## Filter Modes
+
+| Mode                    | Description                              |
+| ----------------------- | ---------------------------------------- |
+| `FilterMode.ALL`        | Include all tools matching any filter    |
+| `FilterMode.BEST_MATCH` | One tool per capability (best tag match) |
+
+## Tag OR Alternatives
+
+Use nested arrays in tags to express OR conditions with fallback behavior. In Java `@Selector`, tag-level OR alternatives follow the same convention as other SDKs:
+
+```java
+// Prefer python implementation, fallback to typescript
+dependencies = @Selector(capability = "math",
+                          tags = {"addition", "python|typescript"})
+```
+
+### Fallback Behavior
+
+When using tag-level OR, alternatives are tried in order:
+
+1. First, try to find provider with `addition` AND `python`
+2. If not found, try provider with `addition` AND `typescript`
+3. If neither found, dependency is injected as `null`
+
+This is useful when you have multiple implementations and want to prefer
+one but gracefully fallback to another when your preferred is unavailable.
+
+## Complete Example
+
+```java
+package com.example.weather;
+
+import io.mcpmesh.*;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@MeshAgent(name = "weather-consumer", version = "1.0.0",
+           description = "Weather consumer with smart selection", port = 9000)
+@SpringBootApplication
+public class WeatherConsumerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(WeatherConsumerApplication.class, args);
+    }
+
+    @MeshTool(capability = "forecast",
+              description = "Get forecast using best available weather provider",
+              tags = {"weather", "forecast", "java"},
+              dependencies = @Selector(
+                  capability = "weather_data",
+                  tags = {
+                      "api",          // Must have API access
+                      "+accurate",    // Prefer accurate
+                      "+fast",        // Prefer fast
+                      "+premium",     // Prefer premium
+                      "-deprecated",  // Never use deprecated
+                      "-beta"         // Avoid beta services
+                  }))
+    public ForecastResponse getForecast(
+            @Param(value = "city", description = "City name") String city,
+            @Param(value = "days", description = "Forecast days") int days,
+            McpMeshTool<WeatherData> weatherData) {
+
+        if (weatherData == null || !weatherData.isAvailable()) {
+            return new ForecastResponse("error",
+                "No weather service available. Check mesh status with 'meshctl list'");
+        }
+
+        WeatherData data = weatherData.call("city", city, "days", days);
+        return new ForecastResponse("ok", data.toString());
+    }
+
+    record ForecastResponse(String status, String data) {}
+    record WeatherData(String city, int temp, String conditions) {}
+}
+```
+
+## See Also
+
+- `meshctl man capabilities --java` - Capabilities system
+- `meshctl man dependency-injection --java` - How DI works
+- `meshctl man decorators --java` - All Java annotations

--- a/src/core/cli/man/content/testing.md
+++ b/src/core/cli/man/content/testing.md
@@ -2,6 +2,8 @@
 
 > How to test MCP Mesh agents using meshctl and curl
 
+**Note:** This page shows Python examples. See `meshctl man testing --typescript` for TypeScript or `meshctl man testing --java` for Java/Spring Boot examples.
+
 ## Quick Way: meshctl call
 
 ```bash

--- a/src/core/cli/man/content/testing_java.md
+++ b/src/core/cli/man/content/testing_java.md
@@ -1,0 +1,250 @@
+# Testing MCP Agents (Java/Spring Boot)
+
+> How to test Java/Spring Boot MCP Mesh agents
+
+## Quick Way: meshctl call
+
+```bash
+meshctl call greeting '{"name": "World"}'        # Call tool by name
+meshctl call add '{"a": 1, "b": 2}'              # With arguments
+meshctl list --tools                              # List all available tools
+```
+
+See `meshctl man cli` for more CLI commands.
+
+## Starting Java Agents
+
+### With meshctl (auto-detects pom.xml)
+
+```bash
+# Start registry
+meshctl start --registry-only --debug
+
+# Start Java agent - meshctl detects pom.xml in the directory
+meshctl start examples/java/basic-tool-agent --debug
+
+# Verify
+meshctl list
+meshctl list --tools
+```
+
+### With Maven directly
+
+```bash
+cd examples/java/basic-tool-agent
+mvn spring-boot:run
+
+# With custom port
+MCP_MESH_HTTP_PORT=9001 mvn spring-boot:run
+```
+
+## Integration Testing with meshctl
+
+End-to-end testing using the CLI:
+
+```bash
+# 1. Start registry
+meshctl start --registry-only
+
+# 2. Start agent under test
+meshctl start examples/java/basic-tool-agent
+
+# 3. Wait for registration
+sleep 5
+
+# 4. Verify agent is registered
+meshctl list | grep greeter
+
+# 5. Call tools and verify responses
+meshctl call greeting '{"name": "Test"}'
+meshctl call agent_info
+
+# 6. Cleanup
+meshctl stop
+```
+
+## JUnit Testing with Spring Boot Test
+
+Use `@SpringBootTest` to test agents with the full Spring context:
+
+```java
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class GreeterAgentTest {
+
+    @Autowired
+    private GreeterAgentApplication agent;
+
+    @Test
+    void testGreet() {
+        var response = agent.greet("World");
+        assertNotNull(response);
+        assertTrue(response.message().contains("Hello, World!"));
+        assertEquals("greeter-java", response.source());
+    }
+
+    @Test
+    void testAgentInfo() {
+        var info = agent.getInfo();
+        assertEquals("greeter", info.name());
+        assertEquals("1.0.0", info.version());
+    }
+}
+```
+
+### Testing with Dependencies (Graceful Degradation)
+
+```java
+@SpringBootTest(properties = {
+    "mcp.mesh.registry-url="  // Disable registry for unit tests
+})
+class AssistantAgentTest {
+
+    @Autowired
+    private AssistantAgentApplication agent;
+
+    @Test
+    void testSmartGreetWithoutDependency() {
+        // With no registry, dateService will be null (graceful degradation)
+        var response = agent.smartGreet("Test", null);
+        assertNotNull(response);
+        assertTrue(response.message().contains("Hello, Test!"));
+        assertEquals("local fallback", response.source());
+    }
+}
+```
+
+## Testing with Docker Compose
+
+```yaml
+# docker-compose.test.yml
+services:
+  registry:
+    image: mcpmesh/registry:0.8
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8000/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  agent-under-test:
+    build: .
+    depends_on:
+      registry:
+        condition: service_healthy
+    environment:
+      MCP_MESH_REGISTRY_URL: http://registry:8000
+```
+
+```bash
+# Run integration tests
+docker compose -f docker-compose.test.yml up -d
+sleep 10  # Wait for Spring Boot startup
+
+# Test via meshctl
+meshctl call greeting '{"name": "Docker"}'
+
+# Cleanup
+docker compose -f docker-compose.test.yml down
+```
+
+## Protocol Details: curl
+
+MCP agents expose a JSON-RPC 2.0 API over HTTP. Java agents use the same protocol as Python and TypeScript:
+
+### List Available Tools
+
+```bash
+curl -s -X POST http://localhost:9000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/list",
+    "params": {}
+  }'
+```
+
+### Call a Tool
+
+```bash
+curl -s -X POST http://localhost:9000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "greeting",
+      "arguments": {"name": "World"}
+    }
+  }'
+```
+
+### Parse SSE Response
+
+```bash
+| grep "^data:" | sed 's/^data: //' | jq .
+```
+
+## Testing Dependencies and Graceful Degradation
+
+Test that your agent handles unavailable dependencies properly:
+
+```java
+@Test
+void testWithUnavailableDependency() {
+    // Pass null to simulate unavailable dependency
+    var response = agent.smartGreet("Test", null);
+
+    // Should use fallback, not throw
+    assertNotNull(response);
+    assertTrue(response.source().contains("fallback"));
+}
+
+@Test
+void testAgentStatusWithNoDependencies() {
+    var status = agent.getStatus(null);
+
+    assertEquals("assistant", status.name());
+    assertFalse(status.dateServiceAvailable());
+    assertNull(status.dateServiceEndpoint());
+}
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+cd examples/java/basic-tool-agent
+mvn test
+
+# Run specific test class
+mvn test -Dtest=GreeterAgentTest
+
+# Run with verbose output
+mvn test -Dsurefire.useFile=false
+```
+
+## Available MCP Methods
+
+| Method           | Description                  |
+| ---------------- | ---------------------------- |
+| `tools/list`     | List all available tools     |
+| `tools/call`     | Invoke a tool with arguments |
+| `prompts/list`   | List available prompts       |
+| `resources/list` | List available resources     |
+
+## See Also
+
+- `meshctl man cli` - CLI commands reference
+- `meshctl man decorators --java` - Java annotations
+- `meshctl man deployment --java` - Deployment patterns

--- a/src/core/cli/man/man.go
+++ b/src/core/cli/man/man.go
@@ -25,12 +25,18 @@ The --raw flag outputs plain markdown, which is useful for:
 The --typescript flag shows TypeScript examples for topics that have
 TypeScript variants (decorators, deployment, llm, testing, etc.).
 
+The --java flag shows Java/Spring Boot examples for topics that have
+Java variants (decorators, deployment, llm, testing, etc.).
+
 Examples:
   meshctl man                       # Show architecture overview
   meshctl man decorators            # Learn about mesh decorators (Python)
   meshctl man decorators -t         # TypeScript decorator examples
+  meshctl man decorators -j         # Java annotation examples
   meshctl man deployment --typescript  # TypeScript deployment guide
+  meshctl man deployment --java     # Java/Spring Boot deployment guide
   meshctl man llm -t                # TypeScript LLM integration
+  meshctl man llm -j                # Java LLM integration
   meshctl man --list                # List all available topics
   meshctl man --raw decorators      # Raw markdown output (LLM-friendly)
   meshctl man --search "health"     # Search across all topics
@@ -49,6 +55,7 @@ Code Generation:
 	cmd.Flags().BoolP("raw", "r", false, "Output raw markdown (LLM-friendly)")
 	cmd.Flags().StringP("search", "s", "", "Search across all topics")
 	cmd.Flags().BoolP("typescript", "t", false, "Show TypeScript examples (for topics with TypeScript variants)")
+	cmd.Flags().BoolP("java", "j", false, "Show Java/Spring Boot examples (for topics with Java variants)")
 
 	return cmd
 }
@@ -59,6 +66,7 @@ func runManCommand(cmd *cobra.Command, args []string) error {
 	list, _ := cmd.Flags().GetBool("list")
 	search, _ := cmd.Flags().GetString("search")
 	typescript, _ := cmd.Flags().GetBool("typescript")
+	java, _ := cmd.Flags().GetBool("java")
 
 	renderer := NewRenderer(raw)
 
@@ -85,8 +93,19 @@ func runManCommand(cmd *cobra.Command, args []string) error {
 		topic = args[0]
 	}
 
-	// Get and render guide (with optional TypeScript variant)
-	guide, content, err := GetGuideWithVariant(topic, typescript)
+	// Determine language variant
+	var variant string
+	if typescript && java {
+		return fmt.Errorf("cannot use both --typescript and --java flags; choose one language variant")
+	}
+	if typescript {
+		variant = "typescript"
+	} else if java {
+		variant = "java"
+	}
+
+	// Get and render guide (with optional language variant)
+	guide, content, err := GetGuideWithVariant(topic, variant)
 	if err != nil {
 		// Show suggestions for similar topics
 		suggestions := SuggestSimilarTopics(topic)


### PR DESCRIPTION
## Summary

- Add `--java` / `-j` flag to `meshctl man` for Java/Spring Boot documentation, mirroring the existing `--typescript` / `-t` pattern
- Create 10 new Java man pages covering all topics that have TypeScript variants
- Add cross-language "See also" footers between Python, TypeScript, and Java pages
- Update existing pages to reference Java alongside Python and TypeScript

Closes #494

## Test plan

- [ ] `meshctl man decorators --java` shows Java annotations page
- [ ] `meshctl man llm -j` shows Java LLM integration
- [ ] `meshctl man decorators` footer shows both `--typescript` and `--java`
- [ ] `meshctl man decorators -t` footer shows `--java`
- [ ] `meshctl man decorators -j` footer shows `--typescript`
- [ ] `meshctl man decorators -t -j` errors with "cannot use both"
- [ ] `meshctl man overview --java` falls back to default (no Java variant)
- [ ] `meshctl man --search "Spring"` finds Java pages
- [ ] `meshctl man --list` unchanged
- [ ] `go build ./cmd/meshctl` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)