### PR TITLE
Release v0.9.0-beta.3: Fix GPG fingerprint + version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,7 +357,7 @@ jobs:
         run: |
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
           echo "Imported GPG key: F94266795DCA259D"
-          echo "F94266795DCA259D:6:" | gpg --import-ownertrust
+          echo "D3B274C5F3344FD4DCC969F9F94266795DCA259D:6:" | gpg --import-ownertrust
 
       - name: Download native libraries
         uses: actions/download-artifact@v4

--- a/cmd/meshctl/templates/java/basic/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/basic/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/typescript/basic/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/cmd/meshctl/templates/typescript/llm-agent/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/cmd/meshctl/templates/typescript/llm-provider/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/docs/00-why-mcp-mesh/index.md
+++ b/docs/00-why-mcp-mesh/index.md
@@ -113,7 +113,7 @@ meshctl scaffold --compose --observability
 
 # Or deploy to Kubernetes (OCI registry)
 helm install my-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.9.0-beta.2 -n mcp-mesh --create-namespace
+  --version 0.9.0-beta.3 -n mcp-mesh --create-namespace
 ```
 
 ### 4. Built-in Observability

--- a/docs/04-kubernetes-basics.md
+++ b/docs/04-kubernetes-basics.md
@@ -21,7 +21,7 @@ kubectl create namespace mcp-mesh
 
 # Deploy core (OCI registry - no "helm repo add" needed)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   --namespace mcp-mesh
 
 # Wait for registry
@@ -65,7 +65,7 @@ Build the image:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=my-agent \
@@ -76,7 +76,7 @@ For cloud deployments, use your full registry path:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
@@ -138,7 +138,7 @@ resources:
 ```bash
 # Core without Grafana/Tempo (lighter footprint)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   --namespace mcp-mesh \
   --set grafana.enabled=false \
   --set tempo.enabled=false
@@ -149,7 +149,7 @@ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
 ```bash
 # Just the registry, no database or observability
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   --namespace mcp-mesh
 ```
 
@@ -161,13 +161,13 @@ helm list -n mcp-mesh
 
 # Upgrade an agent
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   --namespace mcp-mesh \
   --set image.tag=v2
 
 # Scale replicas
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   --namespace mcp-mesh \
   --reuse-values \
   --set replicaCount=3

--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -19,7 +19,7 @@ The data flows: **Agents → Redis → Registry → Tempo → Grafana**
 ```bash
 # Deploy core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   --namespace mcp-mesh \
   --set redis.enabled=true \
   --set tempo.enabled=true \

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,7 +44,7 @@ docker-compose up
 ```bash
 # Quick start (OCI registry - no helm repo add needed)
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 0.9.0-beta.2 -n mcp-mesh --create-namespace
+  --version 0.9.0-beta.3 -n mcp-mesh --create-namespace
 ```
 
 [:material-arrow-right: Kubernetes Guide](04-kubernetes-basics.md){ .md-button .md-button--primary }

--- a/docs/index.md
+++ b/docs/index.md
@@ -238,7 +238,7 @@ Graceful failure handling, auto-reconnection, RBAC support, and real-time monito
 
 ## :star: Project Status
 
-- **Latest Release**: v0.9.0-beta.2 (February 2026)
+- **Latest Release**: v0.9.0-beta.3 (February 2026)
 - **License**: MIT
 - **Languages**: Python 3.11+ and TypeScript/Node.js 18+ (runtime), Go 1.23+ (registry)
 - **Status**: Production-ready, actively developed

--- a/docs/python/getting-started/prerequisites.md
+++ b/docs/python/getting-started/prerequisites.md
@@ -177,12 +177,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/docs/typescript/getting-started/prerequisites.md
+++ b/docs/typescript/getting-started/prerequisites.md
@@ -177,12 +177,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/examples/docker-examples/agents/claude-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/claude-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying claude-provider with mcp-mesh-agent chart
 # Usage: helm install claude-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 0.9.0-beta.2 -f helm-values.yaml
+#        --version 0.9.0-beta.3 -f helm-values.yaml
 
 image:
   repository: your-registry/claude-provider

--- a/examples/docker-examples/agents/claude-provider/requirements.txt
+++ b/examples/docker-examples/agents/claude-provider/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Mesh SDK
-mcp-mesh>=0.9.0-beta.2
+mcp-mesh>=0.9.0-beta.3
 
 # FastMCP for MCP server
 fastmcp

--- a/examples/docker-examples/agents/openai-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/openai-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying openai-provider with mcp-mesh-agent chart
 # Usage: helm install openai-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 0.9.0-beta.2 -f helm-values.yaml
+#        --version 0.9.0-beta.3 -f helm-values.yaml
 
 image:
   repository: your-registry/openai-provider

--- a/examples/docker-examples/agents/openai-provider/requirements.txt
+++ b/examples/docker-examples/agents/openai-provider/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Mesh SDK
-mcp-mesh>=0.9.0-beta.2
+mcp-mesh>=0.9.0-beta.3
 
 # FastMCP for MCP server
 fastmcp

--- a/examples/java/basic-tool-agent/pom.xml
+++ b/examples/java/basic-tool-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/dependency-agent/pom.xml
+++ b/examples/java/dependency-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/employee-service/pom.xml
+++ b/examples/java/employee-service/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/gemini-provider-agent/pom.xml
+++ b/examples/java/gemini-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/java/gpt-provider-agent/pom.xml
+++ b/examples/java/gpt-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/java/java-calculator/pom.xml
+++ b/examples/java/java-calculator/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/java-math-agent/pom.xml
+++ b/examples/java/java-math-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/java-weather-agent/pom.xml
+++ b/examples/java/java-weather-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/llm-direct-agent/pom.xml
+++ b/examples/java/llm-direct-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/java/llm-mesh-agent/pom.xml
+++ b/examples/java/llm-mesh-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/llm-provider-agent/pom.xml
+++ b/examples/java/llm-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/java/rest-api-consumer/pom.xml
+++ b/examples/java/rest-api-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/toolcalls/analyst-java/pom.xml
+++ b/examples/toolcalls/analyst-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/toolcalls/analyst-ts/package-lock.json
+++ b/examples/toolcalls/analyst-ts/package-lock.json
@@ -8,7 +8,7 @@
       "name": "analyst-ts",
       "version": "1.0.0",
       "dependencies": {
-        "@mcpmesh/sdk": "^0.9.0-beta.2"
+        "@mcpmesh/sdk": "^0.9.0-beta.3"
       },
       "devDependencies": {
         "@types/node": "^22.18.0",
@@ -578,21 +578,21 @@
       }
     },
     "node_modules/@mcpmesh/core": {
-      "version": "0.9.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@mcpmesh/core/-/core-0.9.0-beta.2.tgz",
+      "version": "0.9.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@mcpmesh/core/-/core-0.9.0-beta.3.tgz",
       "integrity": "sha512-C9Aamem1FchC2z9giGiSdwUSOx3dTumNA24+GtktNWBkfUJMj9PR5JM5SemDUW2WhP+pXRGwSBCgY9MOnDUutA==",
       "license": "MIT"
     },
     "node_modules/@mcpmesh/sdk": {
-      "version": "0.9.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@mcpmesh/sdk/-/sdk-0.9.0-beta.2.tgz",
+      "version": "0.9.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@mcpmesh/sdk/-/sdk-0.9.0-beta.3.tgz",
       "integrity": "sha512-O8yVp3UIbO+P25XL/kyoVmV8b5SllW3FTcFMAldoVaVJVtWjvESe0bBae0OlmT6kpThzc1JEpn/NMaja2N01Ow==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/google": "^3.0.0",
         "@ai-sdk/openai": "^3.0.0",
-        "@mcpmesh/core": "0.9.0-beta.2",
+        "@mcpmesh/core": "0.9.0-beta.3",
         "ai": "^6.0.0",
         "fastmcp": "^3.26.8",
         "handlebars": "^4.7.8",

--- a/examples/toolcalls/analyst-ts/package.json
+++ b/examples/toolcalls/analyst-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/claude-provider-ts/package-lock.json
+++ b/examples/toolcalls/claude-provider-ts/package-lock.json
@@ -8,7 +8,7 @@
       "name": "claude-provider-ts",
       "version": "1.0.0",
       "dependencies": {
-        "@mcpmesh/sdk": "^0.9.0-beta.2"
+        "@mcpmesh/sdk": "^0.9.0-beta.3"
       },
       "devDependencies": {
         "@types/node": "^22.18.0",
@@ -578,21 +578,21 @@
       }
     },
     "node_modules/@mcpmesh/core": {
-      "version": "0.9.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@mcpmesh/core/-/core-0.9.0-beta.2.tgz",
+      "version": "0.9.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@mcpmesh/core/-/core-0.9.0-beta.3.tgz",
       "integrity": "sha512-C9Aamem1FchC2z9giGiSdwUSOx3dTumNA24+GtktNWBkfUJMj9PR5JM5SemDUW2WhP+pXRGwSBCgY9MOnDUutA==",
       "license": "MIT"
     },
     "node_modules/@mcpmesh/sdk": {
-      "version": "0.9.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@mcpmesh/sdk/-/sdk-0.9.0-beta.2.tgz",
+      "version": "0.9.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@mcpmesh/sdk/-/sdk-0.9.0-beta.3.tgz",
       "integrity": "sha512-O8yVp3UIbO+P25XL/kyoVmV8b5SllW3FTcFMAldoVaVJVtWjvESe0bBae0OlmT6kpThzc1JEpn/NMaja2N01Ow==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/google": "^3.0.0",
         "@ai-sdk/openai": "^3.0.0",
-        "@mcpmesh/core": "0.9.0-beta.2",
+        "@mcpmesh/core": "0.9.0-beta.3",
         "ai": "^6.0.0",
         "fastmcp": "^3.26.8",
         "handlebars": "^4.7.8",

--- a/examples/toolcalls/claude-provider-ts/package.json
+++ b/examples/toolcalls/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/gemini-provider-ts/package-lock.json
+++ b/examples/toolcalls/gemini-provider-ts/package-lock.json
@@ -8,7 +8,7 @@
       "name": "gemini-provider-ts",
       "version": "1.0.0",
       "dependencies": {
-        "@mcpmesh/sdk": "^0.9.0-beta.2"
+        "@mcpmesh/sdk": "^0.9.0-beta.3"
       },
       "devDependencies": {
         "@types/node": "^22.18.0",
@@ -578,21 +578,21 @@
       }
     },
     "node_modules/@mcpmesh/core": {
-      "version": "0.9.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@mcpmesh/core/-/core-0.9.0-beta.2.tgz",
+      "version": "0.9.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@mcpmesh/core/-/core-0.9.0-beta.3.tgz",
       "integrity": "sha512-C9Aamem1FchC2z9giGiSdwUSOx3dTumNA24+GtktNWBkfUJMj9PR5JM5SemDUW2WhP+pXRGwSBCgY9MOnDUutA==",
       "license": "MIT"
     },
     "node_modules/@mcpmesh/sdk": {
-      "version": "0.9.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@mcpmesh/sdk/-/sdk-0.9.0-beta.2.tgz",
+      "version": "0.9.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@mcpmesh/sdk/-/sdk-0.9.0-beta.3.tgz",
       "integrity": "sha512-O8yVp3UIbO+P25XL/kyoVmV8b5SllW3FTcFMAldoVaVJVtWjvESe0bBae0OlmT6kpThzc1JEpn/NMaja2N01Ow==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/google": "^3.0.0",
         "@ai-sdk/openai": "^3.0.0",
-        "@mcpmesh/core": "0.9.0-beta.2",
+        "@mcpmesh/core": "0.9.0-beta.3",
         "ai": "^6.0.0",
         "fastmcp": "^3.26.8",
         "handlebars": "^4.7.8",

--- a/examples/toolcalls/gemini-provider-ts/package.json
+++ b/examples/toolcalls/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/openai-provider-ts/package-lock.json
+++ b/examples/toolcalls/openai-provider-ts/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openai-provider-ts",
       "version": "1.0.0",
       "dependencies": {
-        "@mcpmesh/sdk": "^0.9.0-beta.2"
+        "@mcpmesh/sdk": "^0.9.0-beta.3"
       },
       "devDependencies": {
         "@types/node": "^22.18.0",
@@ -578,21 +578,21 @@
       }
     },
     "node_modules/@mcpmesh/core": {
-      "version": "0.9.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@mcpmesh/core/-/core-0.9.0-beta.2.tgz",
+      "version": "0.9.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@mcpmesh/core/-/core-0.9.0-beta.3.tgz",
       "integrity": "sha512-C9Aamem1FchC2z9giGiSdwUSOx3dTumNA24+GtktNWBkfUJMj9PR5JM5SemDUW2WhP+pXRGwSBCgY9MOnDUutA==",
       "license": "MIT"
     },
     "node_modules/@mcpmesh/sdk": {
-      "version": "0.9.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@mcpmesh/sdk/-/sdk-0.9.0-beta.2.tgz",
+      "version": "0.9.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@mcpmesh/sdk/-/sdk-0.9.0-beta.3.tgz",
       "integrity": "sha512-O8yVp3UIbO+P25XL/kyoVmV8b5SllW3FTcFMAldoVaVJVtWjvESe0bBae0OlmT6kpThzc1JEpn/NMaja2N01Ow==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/google": "^3.0.0",
         "@ai-sdk/openai": "^3.0.0",
-        "@mcpmesh/core": "0.9.0-beta.2",
+        "@mcpmesh/core": "0.9.0-beta.3",
         "ai": "^6.0.0",
         "fastmcp": "^3.26.8",
         "handlebars": "^4.7.8",

--- a/examples/toolcalls/openai-provider-ts/package.json
+++ b/examples/toolcalls/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/weather-tool-java/pom.xml
+++ b/examples/toolcalls/weather-tool-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>0.9.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>0.9.0-beta.3</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/toolcalls/weather-tool-ts/package-lock.json
+++ b/examples/toolcalls/weather-tool-ts/package-lock.json
@@ -8,7 +8,7 @@
       "name": "weather-tool-ts",
       "version": "1.0.0",
       "dependencies": {
-        "@mcpmesh/sdk": "^0.9.0-beta.2"
+        "@mcpmesh/sdk": "^0.9.0-beta.3"
       },
       "devDependencies": {
         "@types/node": "^22.18.0",
@@ -578,21 +578,21 @@
       }
     },
     "node_modules/@mcpmesh/core": {
-      "version": "0.9.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@mcpmesh/core/-/core-0.9.0-beta.2.tgz",
+      "version": "0.9.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@mcpmesh/core/-/core-0.9.0-beta.3.tgz",
       "integrity": "sha512-C9Aamem1FchC2z9giGiSdwUSOx3dTumNA24+GtktNWBkfUJMj9PR5JM5SemDUW2WhP+pXRGwSBCgY9MOnDUutA==",
       "license": "MIT"
     },
     "node_modules/@mcpmesh/sdk": {
-      "version": "0.9.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@mcpmesh/sdk/-/sdk-0.9.0-beta.2.tgz",
+      "version": "0.9.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@mcpmesh/sdk/-/sdk-0.9.0-beta.3.tgz",
       "integrity": "sha512-O8yVp3UIbO+P25XL/kyoVmV8b5SllW3FTcFMAldoVaVJVtWjvESe0bBae0OlmT6kpThzc1JEpn/NMaja2N01Ow==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/google": "^3.0.0",
         "@ai-sdk/openai": "^3.0.0",
-        "@mcpmesh/core": "0.9.0-beta.2",
+        "@mcpmesh/core": "0.9.0-beta.3",
         "ai": "^6.0.0",
         "fastmcp": "^3.26.8",
         "handlebars": "^4.7.8",

--- a/examples/toolcalls/weather-tool-ts/package.json
+++ b/examples/toolcalls/weather-tool-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/express-api/package-lock.json
+++ b/examples/typescript/express-api/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../../../src/runtime/typescript": {
       "name": "@mcpmesh/sdk",
-      "version": "0.9.0-beta.2",
+      "version": "0.9.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",

--- a/helm/mcp-mesh-agent/Chart.yaml
+++ b/helm/mcp-mesh-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-agent
 description: MCP Mesh Agent - Python runtime for MCP agents with mesh capabilities
 type: application
-version: 0.9.0-beta.2
-appVersion: "0.9.0-beta.2"
+version: 0.9.0-beta.3
+appVersion: "0.9.0-beta.3"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-core/Chart.lock
+++ b/helm/mcp-mesh-core/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: mcp-mesh-postgres
   repository: file://../mcp-mesh-postgres
-  version: 0.9.0-beta.2
+  version: 0.9.0-beta.3
 - name: mcp-mesh-redis
   repository: file://../mcp-mesh-redis
-  version: 0.9.0-beta.2
+  version: 0.9.0-beta.3
 - name: mcp-mesh-registry
   repository: file://../mcp-mesh-registry
-  version: 0.9.0-beta.2
+  version: 0.9.0-beta.3
 - name: mcp-mesh-grafana
   repository: file://../mcp-mesh-grafana
-  version: 0.9.0-beta.2
+  version: 0.9.0-beta.3
 - name: mcp-mesh-tempo
   repository: file://../mcp-mesh-tempo
-  version: 0.9.0-beta.2
+  version: 0.9.0-beta.3
 digest: sha256:ea586eae084429c3d4db4d93c4170cc4deb7d01c652b9402e7d71e774040d2e1
 generated: "2026-01-27T00:00:00.000000-05:00"

--- a/helm/mcp-mesh-core/Chart.yaml
+++ b/helm/mcp-mesh-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-core
 description: MCP Mesh Core Infrastructure - Registry, PostgreSQL, Redis, and Observability
 type: application
-version: 0.9.0-beta.2
-appVersion: "0.9.0-beta.2"
+version: 0.9.0-beta.3
+appVersion: "0.9.0-beta.3"
 keywords:
   - mcp
   - mesh
@@ -28,22 +28,22 @@ annotations:
   "artifacthub.io/containsSecurityUpdates": "false"
 dependencies:
   - name: mcp-mesh-postgres
-    version: "0.9.0-beta.2"
+    version: "0.9.0-beta.3"
     repository: "file://../mcp-mesh-postgres"
     condition: postgres.enabled
   - name: mcp-mesh-redis
-    version: "0.9.0-beta.2"
+    version: "0.9.0-beta.3"
     repository: "file://../mcp-mesh-redis"
     condition: redis.enabled
   - name: mcp-mesh-registry
-    version: "0.9.0-beta.2"
+    version: "0.9.0-beta.3"
     repository: "file://../mcp-mesh-registry"
     condition: registry.enabled
   - name: mcp-mesh-grafana
-    version: "0.9.0-beta.2"
+    version: "0.9.0-beta.3"
     repository: "file://../mcp-mesh-grafana"
     condition: grafana.enabled
   - name: mcp-mesh-tempo
-    version: "0.9.0-beta.2"
+    version: "0.9.0-beta.3"
     repository: "file://../mcp-mesh-tempo"
     condition: tempo.enabled

--- a/helm/mcp-mesh-grafana/Chart.yaml
+++ b/helm/mcp-mesh-grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-grafana
 description: Grafana observability component for MCP Mesh
 type: application
-version: 0.9.0-beta.2
+version: 0.9.0-beta.3
 appVersion: "12.3.1"
 keywords:
   - grafana

--- a/helm/mcp-mesh-ingress/Chart.yaml
+++ b/helm/mcp-mesh-ingress/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ingress
 description: Ingress configuration for MCP Mesh services with flexible DNS routing
 type: application
-version: 0.9.0-beta.2
-appVersion: "0.9.0-beta.2"
+version: 0.9.0-beta.3
+appVersion: "0.9.0-beta.3"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-postgres/Chart.yaml
+++ b/helm/mcp-mesh-postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-postgres
 description: PostgreSQL database for MCP Mesh Registry
 type: application
-version: 0.9.0-beta.2
+version: 0.9.0-beta.3
 appVersion: "15"
 keywords:
   - mcp

--- a/helm/mcp-mesh-redis/Chart.yaml
+++ b/helm/mcp-mesh-redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-redis
 description: Redis cache for MCP Mesh session storage
 type: application
-version: 0.9.0-beta.2
+version: 0.9.0-beta.3
 appVersion: "7"
 keywords:
   - mcp

--- a/helm/mcp-mesh-registry/Chart.yaml
+++ b/helm/mcp-mesh-registry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-registry
 description: MCP Mesh Registry Service - Central service registry for MCP agents
 type: application
-version: 0.9.0-beta.2
-appVersion: "0.9.0-beta.2"
+version: 0.9.0-beta.3
+appVersion: "0.9.0-beta.3"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-tempo/Chart.yaml
+++ b/helm/mcp-mesh-tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-tempo
 description: Tempo distributed tracing component for MCP Mesh
 type: application
-version: 0.9.0-beta.2
+version: 0.9.0-beta.3
 appVersion: "2.9.0"
 keywords:
   - tempo

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/cli",
-  "version": "0.9.0-beta.2",
+  "version": "0.9.0-beta.3",
   "description": "CLI for MCP Mesh - Enterprise-Grade Distributed Service Mesh for AI Agents",
   "license": "MIT",
   "repository": {
@@ -22,10 +22,10 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@mcpmesh/cli-linux-x64": "0.9.0-beta.2",
-    "@mcpmesh/cli-linux-arm64": "0.9.0-beta.2",
-    "@mcpmesh/cli-darwin-x64": "0.9.0-beta.2",
-    "@mcpmesh/cli-darwin-arm64": "0.9.0-beta.2"
+    "@mcpmesh/cli-linux-x64": "0.9.0-beta.3",
+    "@mcpmesh/cli-linux-arm64": "0.9.0-beta.3",
+    "@mcpmesh/cli-darwin-x64": "0.9.0-beta.3",
+    "@mcpmesh/cli-darwin-arm64": "0.9.0-beta.3"
   },
   "keywords": [
     "mcp",

--- a/packaging/homebrew/mcp-mesh.rb
+++ b/packaging/homebrew/mcp-mesh.rb
@@ -2,7 +2,7 @@
 class McpMesh < Formula
   desc "Kubernetes-native platform for distributed MCP applications"
   homepage "https://github.com/dhyansraj/mcp-mesh"
-  version "0.9.0-beta.2"  # Will be updated by release automation
+  version "0.9.0-beta.3"  # Will be updated by release automation
 
   if OS.mac?
     if Hardware::CPU.arm?

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "0.9.0b2"
+version = "0.9.0b3"
 description = "Kubernetes-native platform for distributed MCP applications"
 readme = "README.md"
 license = { text = "MIT" }
@@ -39,7 +39,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     # Rust core runtime (required - no Python fallback)
-    "mcp-mesh-core>=0.9.0b2",
+    "mcp-mesh-core>=0.9.0b3",
     "fastapi>=0.104.0,<1.0.0",
     "uvicorn>=0.24.0,<1.0.0",
     "httpx>=0.25.0,<1.0.0",

--- a/packaging/scoop/mcp-mesh.json
+++ b/packaging/scoop/mcp-mesh.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.0-beta.2",
+  "version": "0.9.0-beta.3",
   "description": "Kubernetes-native platform for distributed MCP applications",
   "homepage": "https://github.com/dhyansraj/mcp-mesh",
   "license": "MIT",

--- a/src/core/cli/handlers/java_handler.go
+++ b/src/core/cli/handlers/java_handler.go
@@ -300,7 +300,7 @@ const javaPomTemplate = `<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>0.9.0-beta.2</version>
+            <version>0.9.0-beta.3</version>
         </dependency>
     </dependencies>
 

--- a/src/core/cli/handlers/language_test.go
+++ b/src/core/cli/handlers/language_test.go
@@ -202,7 +202,7 @@ func TestDetectLanguage_PythonDirectoryRequirements(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Create requirements.txt
-	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("mcp-mesh==0.9.0-beta.2"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("mcp-mesh==0.9.0-beta.3"), 0644); err != nil {
 		t.Fatalf("Failed to create requirements.txt: %v", err)
 	}
 

--- a/src/core/cli/handlers/python_handler.go
+++ b/src/core/cli/handlers/python_handler.go
@@ -248,5 +248,5 @@ const pythonInitTemplate = `# {{.Name}} MCP Mesh Agent
 const pythonMainModuleTemplate = `from .main import *
 `
 
-const pythonRequirementsTemplate = `mcp-mesh>=0.9.0-beta.2
+const pythonRequirementsTemplate = `mcp-mesh>=0.9.0-beta.3
 `

--- a/src/core/cli/handlers/typescript_handler.go
+++ b/src/core/cli/handlers/typescript_handler.go
@@ -269,7 +269,7 @@ const typescriptPackageTemplate = `{
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2",
+    "@mcpmesh/sdk": "^0.9.0-beta.3",
     "fastmcp": "^3.26.0",
     "zod": "^3.23.0"
   },

--- a/src/core/cli/man/content/capabilities.md
+++ b/src/core/cli/man/content/capabilities.md
@@ -69,7 +69,7 @@ dependencies=[
 | `tags: [["a"], ["b"]]`         | a OR b (full OR)                         |
 | `[{tags:["a"]}, {tags:["b"]}]` | a OR b (multiple selectors - LLM filter) |
 
-**Tag-Level OR** (v0.9.0-beta.2+):
+**Tag-Level OR** (v0.9.0-beta.3+):
 
 Use nested arrays in tags for OR alternatives with fallback behavior:
 

--- a/src/core/cli/man/content/capabilities_typescript.md
+++ b/src/core/cli/man/content/capabilities_typescript.md
@@ -67,7 +67,7 @@ dependencies: [
 | `tags: [["a"], ["b"]]`         | a OR b (full OR)                         |
 | `[{tags:["a"]}, {tags:["b"]}]` | a OR b (multiple selectors - LLM filter) |
 
-**Tag-Level OR** (v0.9.0-beta.2+):
+**Tag-Level OR** (v0.9.0-beta.3+):
 
 Use nested arrays in tags for OR alternatives with fallback behavior:
 

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -152,12 +152,12 @@ For production Kubernetes deployment, use the official Helm charts from the MCP 
 # Install core infrastructure (registry + database + observability)
 # No "helm repo add" needed - uses OCI registry directly
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh --create-namespace
 
 # Deploy agent using scaffold-generated helm-values.yaml
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -210,7 +210,7 @@ docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.0.0 --pu
 # 3. Update helm-values.yaml with your image repository
 # 4. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
@@ -222,14 +222,14 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 ```bash
 # Core without observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh --create-namespace \
   --set grafana.enabled=false \
   --set tempo.enabled=false
 
 # Core without PostgreSQL (in-memory registry)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh --create-namespace \
   --set postgres.enabled=false
 ```

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -16,7 +16,7 @@ MCP Mesh supports multiple deployment patterns for Java/Spring Boot agents. The 
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>0.9.0-beta.2</version>
+    <version>0.9.0-beta.3</version>
 </dependency>
 ```
 
@@ -204,12 +204,12 @@ For production Kubernetes deployment:
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh --create-namespace
 
 # Deploy Java agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -246,7 +246,7 @@ docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.0.0 --pu
 
 # 2. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -145,12 +145,12 @@ For production Kubernetes deployment:
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh --create-namespace
 
 # Deploy TypeScript agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -196,7 +196,7 @@ docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.0.0 --pu
 
 # 3. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -65,12 +65,12 @@ docker compose up -d
 ```bash
 # Install core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh --create-namespace
 
 # Or disable observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh --create-namespace \
   --set tempo.enabled=false \
   --set grafana.enabled=false

--- a/src/core/cli/man/content/prerequisites.md
+++ b/src/core/cli/man/content/prerequisites.md
@@ -130,7 +130,7 @@ sudo apt install openjdk-17-jdk maven   # Ubuntu/Debian
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>0.9.0-beta.2</version>
+    <version>0.9.0-beta.3</version>
 </dependency>
 ```
 
@@ -210,12 +210,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 0.9.0-beta.2 \
+  --version 0.9.0-beta.3 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/src/core/cli/man/content/quickstart_java.md
+++ b/src/core/cli/man/content/quickstart_java.md
@@ -81,7 +81,7 @@ Create `pom.xml`:
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>0.9.0-beta.2</version>
+            <version>0.9.0-beta.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/runtime/core/Cargo.toml
+++ b/src/runtime/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-mesh-core"
-version = "0.9.0-beta.2"
+version = "0.9.0-beta.3"
 edition = "2021"
 description = "Rust core runtime for MCP Mesh agents"
 license = "MIT"

--- a/src/runtime/core/pyproject.toml
+++ b/src/runtime/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mcp-mesh-core"
-version = "0.9.0b2"
+version = "0.9.0b3"
 description = "Rust core runtime for MCP Mesh agents"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/core/typescript/package.json
+++ b/src/runtime/core/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/core",
-  "version": "0.9.0-beta.2",
+  "version": "0.9.0-beta.3",
   "description": "MCP Mesh Rust core bindings for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/runtime/java/mcp-mesh-bom/pom.xml
+++ b/src/runtime/java/mcp-mesh-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-bom</artifactId>
-    <version>0.9.0-beta.2-SNAPSHOT</version>
+    <version>0.9.0-beta.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>MCP Mesh BOM</name>

--- a/src/runtime/java/mcp-mesh-core/pom.xml
+++ b/src/runtime/java/mcp-mesh-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>0.9.0-beta.2-SNAPSHOT</version>
+        <version>0.9.0-beta.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>mcp-mesh-core</artifactId>

--- a/src/runtime/java/mcp-mesh-native/pom.xml
+++ b/src/runtime/java/mcp-mesh-native/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>0.9.0-beta.2-SNAPSHOT</version>
+        <version>0.9.0-beta.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>mcp-mesh-native</artifactId>

--- a/src/runtime/java/mcp-mesh-sdk/pom.xml
+++ b/src/runtime/java/mcp-mesh-sdk/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>0.9.0-beta.2-SNAPSHOT</version>
+        <version>0.9.0-beta.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>mcp-mesh-sdk</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-ai/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-ai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>0.9.0-beta.2-SNAPSHOT</version>
+        <version>0.9.0-beta.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>mcp-mesh-spring-ai</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>0.9.0-beta.2-SNAPSHOT</version>
+        <version>0.9.0-beta.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>

--- a/src/runtime/java/pom.xml
+++ b/src/runtime/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-parent</artifactId>
-    <version>0.9.0-beta.2-SNAPSHOT</version>
+    <version>0.9.0-beta.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>MCP Mesh Java SDK</name>

--- a/src/runtime/python/_mcp_mesh/__init__.py
+++ b/src/runtime/python/_mcp_mesh/__init__.py
@@ -31,7 +31,7 @@ from .engine.decorator_registry import (
     get_decorator_stats,
 )
 
-__version__ = "0.9.0b2"
+__version__ = "0.9.0b3"
 
 # Store reference to runtime processor if initialized
 _runtime_processor = None

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "0.9.0b2"
+version = "0.9.0b3"
 description = "Kubernetes-native platform for distributed MCP applications"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/typescript/package.json
+++ b/src/runtime/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/sdk",
-  "version": "0.9.0-beta.2",
+  "version": "0.9.0-beta.3",
   "description": "MCP Mesh SDK for TypeScript - Build distributed MCP agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -102,12 +102,12 @@ Edit `config.yaml` to set versions:
 
 ```yaml
 packages:
-  cli_version: "0.9.0-beta.2" # @mcpmesh/cli
-  sdk_python_version: "0.9.0-beta.2" # mcp-mesh (pip) - PEP 440 format
-  sdk_typescript_version: "0.9.0-beta.2" # @mcpmesh/sdk
+  cli_version: "0.9.0-beta.3" # @mcpmesh/cli
+  sdk_python_version: "0.9.0-beta.3" # mcp-mesh (pip) - PEP 440 format
+  sdk_typescript_version: "0.9.0-beta.3" # @mcpmesh/sdk
 
 docker:
-  base_image: "tsuite-mesh:0.9.0-beta.2"
+  base_image: "tsuite-mesh:0.9.0-beta.3"
 ```
 
 ## Environment Variables

--- a/tests/integration/config.yaml
+++ b/tests/integration/config.yaml
@@ -25,7 +25,7 @@ docker:
   # Use tsuite-mesh:local (from src-tests) or tsuite-mesh:X.Y.Z (from lib-tests)
   # Both images have meshctl, mesh module, and node pre-installed
   # - tsuite-mesh:local     -> local mode (packages from /wheels, /packages)
-  # - tsuite-mesh:0.9.0-beta.2 -> published mode (packages from PyPI/npm)
+  # - tsuite-mesh:0.9.0-beta.3 -> published mode (packages from PyPI/npm)
   base_image: tsuite-mesh:local
   network: bridge
   # No mounts needed - packages are baked into the image

--- a/tests/integration/suites/README.md
+++ b/tests/integration/suites/README.md
@@ -108,7 +108,7 @@ const agent = mesh(server, {
 ```bash
 docker run --rm -it \
   -v $(pwd)/suites/uc01_registry/artifacts:/uc-artifacts:ro \
-  tsuite-mesh:0.9.0-beta.2 bash
+  tsuite-mesh:0.9.0-beta.3 bash
 ```
 
 ### Common issues:
@@ -123,9 +123,9 @@ Available in test.yaml via `${config.X}`:
 
 | Variable                                 | Example      |
 | ---------------------------------------- | ------------ |
-| `config.packages.cli_version`            | 0.9.0-beta.2 |
-| `config.packages.sdk_python_version`     | 0.9.0-beta.2 |
-| `config.packages.sdk_typescript_version` | 0.9.0-beta.2 |
+| `config.packages.cli_version`            | 0.9.0-beta.3 |
+| `config.packages.sdk_python_version`     | 0.9.0-beta.3 |
+| `config.packages.sdk_typescript_version` | 0.9.0-beta.3 |
 
 ## Issue Reporting Policy
 

--- a/tests/integration/suites/uc01_registry/artifacts/ts-multi-agent/package.json
+++ b/tests/integration/suites/uc01_registry/artifacts/ts-multi-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "0.9.0-beta.2",
+    "@mcpmesh/sdk": "0.9.0-beta.3",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc01_registry/artifacts/ts-simple-agent/package.json
+++ b/tests/integration/suites/uc01_registry/artifacts/ts-simple-agent/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "0.9.0-beta.2",
+    "@mcpmesh/sdk": "0.9.0-beta.3",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-accurate-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-accurate-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "0.9.0-beta.2",
+    "@mcpmesh/sdk": "0.9.0-beta.3",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-deprecated-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-deprecated-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "0.9.0-beta.2",
+    "@mcpmesh/sdk": "0.9.0-beta.3",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-fast-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-fast-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "0.9.0-beta.2",
+    "@mcpmesh/sdk": "0.9.0-beta.3",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-tag-consumer/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-tag-consumer/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "0.9.0-beta.2",
+    "@mcpmesh/sdk": "0.9.0-beta.3",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "0.9.0-beta.2",
+    "@mcpmesh/sdk": "0.9.0-beta.3",
     "@ai-sdk/anthropic": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "0.9.0-beta.2",
+    "@mcpmesh/sdk": "0.9.0-beta.3",
     "@ai-sdk/google": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "0.9.0-beta.2",
+    "@mcpmesh/sdk": "0.9.0-beta.3",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "0.9.0-beta.2",
+    "@mcpmesh/sdk": "0.9.0-beta.3",
     "@ai-sdk/anthropic": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "0.9.0-beta.2",
+    "@mcpmesh/sdk": "0.9.0-beta.3",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "0.9.0-beta.2",
+    "@mcpmesh/sdk": "0.9.0-beta.3",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "0.9.0-beta.2",
+    "@mcpmesh/sdk": "0.9.0-beta.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "0.9.0-beta.2",
+    "@mcpmesh/sdk": "0.9.0-beta.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2"
+    "@mcpmesh/sdk": "^0.9.0-beta.3"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^0.9.0-beta.2",
+    "@mcpmesh/sdk": "^0.9.0-beta.3",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/lib-tests/README.md
+++ b/tests/lib-tests/README.md
@@ -62,7 +62,7 @@ tsuite --uc uc03_build_image
 
 After successful run, you'll have:
 
-- `tsuite-mesh:0.9.0-beta.2` (or current version) Docker image
+- `tsuite-mesh:0.9.0-beta.3` (or current version) Docker image
 
 Verify with:
 
@@ -76,10 +76,10 @@ Edit `config.yaml` to update versions:
 
 ```yaml
 packages:
-  cli_version: "0.9.0-beta.2"
-  sdk_python_version: "0.9.0-beta.2" # PEP 440 format for Python
-  sdk_typescript_version: "0.9.0-beta.2"
-  core_version: "0.9.0-beta.2"
+  cli_version: "0.9.0-beta.3"
+  sdk_python_version: "0.9.0-beta.3" # PEP 440 format for Python
+  sdk_typescript_version: "0.9.0-beta.3"
+  core_version: "0.9.0-beta.3"
 ```
 
 ## Next Steps

--- a/tests/lib-tests/config.yaml
+++ b/tests/lib-tests/config.yaml
@@ -10,10 +10,10 @@ suite:
 
 packages:
   # Version to test - update this for each release
-  cli_version: "0.9.0-beta.2"
-  sdk_python_version: "0.9.0-beta.2" # PEP 440 format for pip
-  sdk_typescript_version: "0.9.0-beta.2"
-  core_version: "0.9.0-beta.2"
+  cli_version: "0.9.0-beta.3"
+  sdk_python_version: "0.9.0-beta.3" # PEP 440 format for pip
+  sdk_typescript_version: "0.9.0-beta.3"
+  core_version: "0.9.0-beta.3"
 
 # Docker settings for the base image build
 docker:


### PR DESCRIPTION
## Summary

- **Fix GPG `--import-ownertrust`** in `release.yml` — was using short 16-char key ID (`F94266795DCA259D`), now uses full 40-char fingerprint (`D3B274C5F3344FD4DCC969F9F94266795DCA259D`). This caused the `publish-java-sdk` job to fail in v0.9.0-beta.2.
- **Version bump** from `0.9.0-beta.2` → `0.9.0-beta.3` across 108 files (all runtimes, examples, Helm charts, docs, tests, packaging configs)

## Context

The v0.9.0-beta.2 release partially succeeded — Python (PyPI), TypeScript (npm), Rust core, and CLI packages were published, but the Java SDK publish failed at the GPG key trust step. Docker images were skipped as a result. Since published packages are immutable, a new version is required.

## What failed in beta.2
| Job | Status |
|-----|--------|
| publish-rust-core (PyPI) | ✅ Published |
| publish-node-core (npm) | ✅ Published |
| publish-typescript-sdk (npm) | ✅ Published |
| publish-python (PyPI) | ✅ Published |
| publish-npm / CLI (npm) | ✅ Published |
| **publish-java-sdk (Maven)** | **❌ GPG fingerprint error** |
| build-docker | ⏭️ Skipped (depends on Java) |

## Test plan
- [x] Go build passes (`go build ./...`)
- [x] Handler tests pass (37/37)
- [x] Zero remaining `0.9.0-beta.2` references in codebase (verified by grep)
- [ ] Trigger release workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Release**
  * Version bump from 0.9.0-beta.2 to 0.9.0-beta.3
  * All SDKs, dependencies, Helm charts, and project templates updated to the latest beta version
  * Documentation and deployment examples updated with current version references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->