### PR TITLE
fix(cli): replace bash watch mode with Go fsnotify watcher (#533)

### DIFF
--- a/src/core/cli/watcher.go
+++ b/src/core/cli/watcher.go
@@ -1,0 +1,369 @@
+//go:build !windows
+// +build !windows
+
+package cli
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// WatchConfig holds configuration for the AgentWatcher.
+type WatchConfig struct {
+	ProjectRoot   string        // project root (for logging)
+	WatchDir      string        // directory to watch recursively (e.g., projectRoot/src)
+	Extensions    []string      // file extensions to watch: ".java", ".yml", ".yaml", ".properties", ".xml"
+	ExcludeDirs   []string      // directories to skip: "target", ".git", ".idea", "node_modules", ".mvn"
+	DebounceDelay time.Duration // default 500ms, configurable via MCP_MESH_RELOAD_DEBOUNCE env var
+	PortDelay     time.Duration // delay after kill for port release, default 500ms, configurable via MCP_MESH_RELOAD_PORT_DELAY
+	StopTimeout   time.Duration // SIGTERM -> SIGKILL timeout, default 3s
+	AgentName     string        // for logging
+}
+
+// AgentWatcher provides event-driven file watching with process restart capability.
+type AgentWatcher struct {
+	config     WatchConfig
+	cmdFactory func() *exec.Cmd
+	watcher    *fsnotify.Watcher
+	currentCmd *exec.Cmd
+	mu         sync.Mutex
+	stopChan   chan struct{}
+	doneChan   chan struct{}
+	stopOnce   sync.Once
+	quiet      bool
+}
+
+// NewAgentWatcher creates a new AgentWatcher with the given config, command factory, and quiet flag.
+func NewAgentWatcher(config WatchConfig, cmdFactory func() *exec.Cmd, quiet bool) *AgentWatcher {
+	return &AgentWatcher{
+		config:     config,
+		cmdFactory: cmdFactory,
+		stopChan:   make(chan struct{}),
+		doneChan:   make(chan struct{}),
+		quiet:      quiet,
+	}
+}
+
+// Start begins watching for file changes and managing the agent process. It blocks until Stop is called.
+func (aw *AgentWatcher) Start() error {
+	var err error
+	aw.watcher, err = fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to create file watcher: %w", err)
+	}
+
+	// Walk the watch directory recursively, adding each qualifying subdirectory
+	err = filepath.WalkDir(aw.config.WatchDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip directories we can't read
+		}
+		if !d.IsDir() {
+			return nil
+		}
+
+		basename := filepath.Base(path)
+
+		// Skip hidden directories
+		if strings.HasPrefix(basename, ".") && path != aw.config.WatchDir {
+			return filepath.SkipDir
+		}
+
+		// Skip excluded directories
+		for _, excl := range aw.config.ExcludeDirs {
+			if basename == excl {
+				return filepath.SkipDir
+			}
+		}
+
+		if addErr := aw.watcher.Add(path); addErr != nil {
+			// Non-fatal: log and continue
+			if !aw.quiet {
+				fmt.Printf("Warning: could not watch %s: %v\n", path, addErr)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		aw.watcher.Close()
+		return fmt.Errorf("failed to walk watch directory %s: %w", aw.config.WatchDir, err)
+	}
+
+	// Start initial process
+	aw.mu.Lock()
+	cmd := aw.cmdFactory()
+	if err := cmd.Start(); err != nil {
+		aw.mu.Unlock()
+		aw.watcher.Close()
+		return fmt.Errorf("failed to start initial agent process: %w", err)
+	}
+	aw.currentCmd = cmd
+	aw.mu.Unlock()
+
+	if !aw.quiet {
+		fmt.Printf("Watch mode: watching %s for changes\n", aw.config.WatchDir)
+	}
+
+	// Debounce setup
+	var debounceTimer *time.Timer
+	restartCh := make(chan struct{}, 1)
+
+	// Process exit monitoring for the initial process
+	exitCh := make(chan struct{}, 1)
+	go func() {
+		cmd.Wait()
+		select {
+		case exitCh <- struct{}{}:
+		default:
+		}
+	}()
+
+	defer func() {
+		aw.watcher.Close()
+		close(aw.doneChan)
+	}()
+
+	for {
+		select {
+		case event, ok := <-aw.watcher.Events:
+			if !ok {
+				return nil
+			}
+			if aw.shouldWatch(event) {
+				if debounceTimer != nil {
+					debounceTimer.Stop()
+				}
+				debounceTimer = time.AfterFunc(aw.config.DebounceDelay, func() {
+					select {
+					case restartCh <- struct{}{}:
+					default:
+					}
+				})
+			}
+
+		case err, ok := <-aw.watcher.Errors:
+			if !ok {
+				return nil
+			}
+			if !aw.quiet {
+				fmt.Printf("Watch error: %v\n", err)
+			}
+
+		case <-restartCh:
+			aw.restartAgent(&exitCh)
+
+		case <-exitCh:
+			if !aw.quiet {
+				fmt.Println("Agent process exited")
+			}
+			// Do NOT auto-restart; wait for a file change
+
+		case <-aw.stopChan:
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			aw.terminateAgent()
+			return nil
+		}
+	}
+}
+
+// shouldWatch determines whether a file system event should trigger a rebuild.
+func (aw *AgentWatcher) shouldWatch(event fsnotify.Event) bool {
+	// If a new directory was created, add it to the watcher
+	if event.Has(fsnotify.Create) {
+		info, err := os.Stat(event.Name)
+		if err == nil && info.IsDir() {
+			basename := filepath.Base(event.Name)
+			// Don't watch hidden or excluded dirs
+			if !strings.HasPrefix(basename, ".") {
+				excluded := false
+				for _, excl := range aw.config.ExcludeDirs {
+					if basename == excl {
+						excluded = true
+						break
+					}
+				}
+				if !excluded {
+					aw.watcher.Add(event.Name)
+				}
+			}
+			return false
+		}
+	}
+
+	// Only pass Write, Create, Rename operations
+	if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) && !event.Has(fsnotify.Rename) {
+		return false
+	}
+
+	basename := filepath.Base(event.Name)
+
+	// Skip hidden files
+	if strings.HasPrefix(basename, ".") {
+		return false
+	}
+
+	// Skip editor temp files
+	if strings.HasSuffix(basename, "~") ||
+		strings.HasSuffix(basename, ".swp") ||
+		strings.HasSuffix(basename, ".tmp") ||
+		strings.HasSuffix(basename, ".bak") {
+		return false
+	}
+
+	// Check if any path component matches an excluded directory
+	parts := strings.Split(event.Name, string(os.PathSeparator))
+	for _, part := range parts {
+		for _, excl := range aw.config.ExcludeDirs {
+			if part == excl {
+				return false
+			}
+		}
+	}
+
+	// Check file extension
+	ext := filepath.Ext(event.Name)
+	for _, watchExt := range aw.config.Extensions {
+		if ext == watchExt {
+			return true
+		}
+	}
+
+	return false
+}
+
+// terminateAgent sends SIGTERM to the current agent's process group, then SIGKILL if it doesn't exit in time.
+func (aw *AgentWatcher) terminateAgent() {
+	aw.mu.Lock()
+	defer aw.mu.Unlock()
+
+	if aw.currentCmd == nil || aw.currentCmd.Process == nil {
+		return
+	}
+
+	pid := aw.currentCmd.Process.Pid
+	// Process group ID equals PID since we set Setpgid
+	pgid := pid
+
+	// Send SIGTERM to the process group
+	if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
+		// Process may already be dead
+		aw.currentCmd = nil
+		return
+	}
+
+	// Poll every 50ms until StopTimeout
+	deadline := time.Now().Add(aw.config.StopTimeout)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(-pgid, 0); err != nil {
+			// Process group no longer exists
+			aw.currentCmd = nil
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Force kill
+	syscall.Kill(-pgid, syscall.SIGKILL)
+	aw.currentCmd = nil
+}
+
+// restartAgent terminates the current agent and starts a new one.
+func (aw *AgentWatcher) restartAgent(exitCh *chan struct{}) {
+	if !aw.quiet {
+		fmt.Println("Restarting agent...")
+	}
+
+	aw.terminateAgent()
+
+	// Let port free up
+	time.Sleep(aw.config.PortDelay)
+
+	aw.mu.Lock()
+	cmd := aw.cmdFactory()
+	if err := cmd.Start(); err != nil {
+		aw.mu.Unlock()
+		if !aw.quiet {
+			fmt.Printf("Failed to restart agent: %v\n", err)
+		}
+		return
+	}
+	aw.currentCmd = cmd
+	aw.mu.Unlock()
+
+	if !aw.quiet {
+		fmt.Printf("Agent restarted (PID: %d)\n", cmd.Process.Pid)
+	}
+
+	// Start new exit monitoring goroutine with a fresh channel
+	newExitCh := make(chan struct{}, 1)
+	*exitCh = newExitCh
+	go func() {
+		cmd.Wait()
+		select {
+		case newExitCh <- struct{}{}:
+		default:
+		}
+	}()
+}
+
+// Stop signals the watcher to shut down. Safe to call multiple times.
+func (aw *AgentWatcher) Stop() {
+	aw.stopOnce.Do(func() {
+		close(aw.stopChan)
+	})
+}
+
+// Wait blocks until the watcher has fully stopped.
+func (aw *AgentWatcher) Wait() {
+	<-aw.doneChan
+}
+
+// GetPID returns the PID of the currently running agent process, or 0 if none.
+func (aw *AgentWatcher) GetPID() int {
+	aw.mu.Lock()
+	defer aw.mu.Unlock()
+
+	if aw.currentCmd != nil && aw.currentCmd.Process != nil {
+		return aw.currentCmd.Process.Pid
+	}
+	return 0
+}
+
+// getWatchDebounceDelay reads the MCP_MESH_RELOAD_DEBOUNCE env var and returns the debounce delay.
+// Falls back to 500ms if not set or invalid.
+func getWatchDebounceDelay() time.Duration {
+	val := os.Getenv("MCP_MESH_RELOAD_DEBOUNCE")
+	if val == "" {
+		return 500 * time.Millisecond
+	}
+	seconds, err := strconv.ParseFloat(val, 64)
+	if err != nil || seconds <= 0 {
+		return 500 * time.Millisecond
+	}
+	return time.Duration(seconds * float64(time.Second))
+}
+
+// getWatchPortDelay reads the MCP_MESH_RELOAD_PORT_DELAY env var and returns the port release delay.
+// Falls back to 500ms if not set or invalid.
+func getWatchPortDelay() time.Duration {
+	val := os.Getenv("MCP_MESH_RELOAD_PORT_DELAY")
+	if val == "" {
+		return 500 * time.Millisecond
+	}
+	seconds, err := strconv.ParseFloat(val, 64)
+	if err != nil || seconds <= 0 {
+		return 500 * time.Millisecond
+	}
+	return time.Duration(seconds * float64(time.Second))
+}

--- a/tests/integration/suites/uc05_meshctl/tc20_watch_py_simple/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc20_watch_py_simple/test.yaml
@@ -1,0 +1,83 @@
+# Test Case: tc20_watch_py_simple
+# Tests watch mode hot reload for py-simple-agent
+# Verifies that modifying the greeting message triggers a reload
+
+name: "Watch Mode: Python Simple Agent"
+description: "Test meshctl start -w watch mode with py-simple-agent - verify hot reload updates greeting message"
+tags:
+  - meshctl
+  - python
+  - watch
+  - hot-reload
+timeout: 300
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy py-simple-agent to workspace"
+    handler: shell
+    command: |
+      cp -r /uc-artifacts/py-simple-agent /workspace/
+    capture: copy_output
+
+  - name: "Start py-simple-agent with watch flag"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start py-simple-agent/main.py -d -w"
+    capture: start_output
+
+  - name: "Wait for py-simple-agent to register"
+    handler: wait
+    seconds: 8
+
+  - name: "Verify py-simple-agent registered"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: agent_list
+
+  - name: "Call greet before modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call py-simple-agent:greet ''{"name": "WatchTest"}'''
+    capture: greet_before
+
+  - name: "Modify py-simple-agent source with sed"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/Hello, {name}!/WATCH_RELOAD: Hello, {name}!/g' py-simple-agent/main.py
+
+  - name: "Wait for watch to detect change and reload"
+    handler: wait
+    seconds: 8
+
+  - name: "Call greet after modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call py-simple-agent:greet ''{"name": "WatchTest"}'''
+    capture: greet_after
+
+assertions:
+  - expr: "${captured.agent_list} contains 'py-simple-agent'"
+    message: "py-simple-agent should be registered"
+
+  - expr: "${captured.greet_before} contains 'Hello, WatchTest!'"
+    message: "Greet before modification should return original greeting"
+
+  - expr: "${captured.greet_before} not contains 'WATCH_RELOAD'"
+    message: "Greet before modification should NOT contain WATCH_RELOAD"
+
+  - expr: "${captured.greet_after} contains 'WATCH_RELOAD'"
+    message: "Greet after modification should contain WATCH_RELOAD (hot reload worked)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop --agents 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc05_meshctl/tc21_watch_py_math/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc21_watch_py_math/test.yaml
@@ -1,0 +1,83 @@
+# Test Case: tc21_watch_py_math
+# Tests watch mode hot reload for py-math-agent
+# Verifies that modifying the add function triggers a reload with updated result
+
+name: "Watch Mode: Python Math Agent"
+description: "Test meshctl start -w watch mode with py-math-agent - verify hot reload updates add tool result"
+tags:
+  - meshctl
+  - python
+  - watch
+  - hot-reload
+timeout: 300
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy py-math-agent to workspace"
+    handler: shell
+    command: |
+      cp -r /uc-artifacts/py-math-agent /workspace/
+    capture: copy_output
+
+  - name: "Start py-math-agent with watch flag"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start py-math-agent/main.py -d -w"
+    capture: start_output
+
+  - name: "Wait for py-math-agent to register"
+    handler: wait
+    seconds: 8
+
+  - name: "Verify py-math-agent registered"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: agent_list
+
+  - name: "Call add before modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call py-math-agent:add ''{"a": 10, "b": 20}'''
+    capture: add_before
+
+  - name: "Modify py-math-agent add function with sed"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/return a + b/return a + b + 1000/g' py-math-agent/main.py
+
+  - name: "Wait for watch to detect change and reload"
+    handler: wait
+    seconds: 8
+
+  - name: "Call add after modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call py-math-agent:add ''{"a": 10, "b": 20}'''
+    capture: add_after
+
+assertions:
+  - expr: "${captured.agent_list} contains 'py-math-agent'"
+    message: "py-math-agent should be registered"
+
+  - expr: "${captured.add_before} contains '30'"
+    message: "Add before modification should return 30 (10+20)"
+
+  - expr: "${captured.add_before} not contains '1030'"
+    message: "Add before modification should NOT return 1030"
+
+  - expr: "${captured.add_after} contains '1030'"
+    message: "Add after modification should return 1030 (10+20+1000, hot reload worked)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop --agents 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc05_meshctl/tc22_watch_py_calc/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc22_watch_py_calc/test.yaml
@@ -1,0 +1,83 @@
+# Test Case: tc22_watch_py_calc
+# Tests watch mode hot reload for py-calculator-agent
+# Verifies that modifying the calc_add function triggers a reload with updated result
+
+name: "Watch Mode: Python Calculator Agent"
+description: "Test meshctl start -w watch mode with py-calculator-agent - verify hot reload updates calc_add tool result"
+tags:
+  - meshctl
+  - python
+  - watch
+  - hot-reload
+timeout: 300
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy py-calculator-agent to workspace"
+    handler: shell
+    command: |
+      cp -r /uc-artifacts/py-calculator-agent /workspace/
+    capture: copy_output
+
+  - name: "Start py-calculator-agent with watch flag"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start py-calculator-agent/main.py -d -w"
+    capture: start_output
+
+  - name: "Wait for py-calculator-agent to register"
+    handler: wait
+    seconds: 8
+
+  - name: "Verify py-calculator-agent registered"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: agent_list
+
+  - name: "Call calc_add before modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call py-calculator-agent:calc_add ''{"a": 5, "b": 7}'''
+    capture: calc_add_before
+
+  - name: "Modify py-calculator-agent calc_add function with sed"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/return a + b/return a + b + 2000/g' py-calculator-agent/main.py
+
+  - name: "Wait for watch to detect change and reload"
+    handler: wait
+    seconds: 8
+
+  - name: "Call calc_add after modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call py-calculator-agent:calc_add ''{"a": 5, "b": 7}'''
+    capture: calc_add_after
+
+assertions:
+  - expr: "${captured.agent_list} contains 'py-calculator-agent'"
+    message: "py-calculator-agent should be registered"
+
+  - expr: "${captured.calc_add_before} contains '12'"
+    message: "calc_add before modification should return 12 (5+7)"
+
+  - expr: "${captured.calc_add_before} not contains '2012'"
+    message: "calc_add before modification should NOT return 2012"
+
+  - expr: "${captured.calc_add_after} contains '2012'"
+    message: "calc_add after modification should return 2012 (5+7+2000, hot reload worked)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop --agents 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc05_meshctl/tc23_watch_java_greet/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc23_watch_java_greet/test.yaml
@@ -1,0 +1,107 @@
+# Test Case: tc23_watch_java_greet
+# Tests watch mode hot reload for Java greeter agent greet tool
+# Verifies that modifying the greeting message triggers a recompile and reload
+
+name: "Watch Mode: Java Greeter Greet Tool"
+description: "Test meshctl start -w watch mode with Java greeter agent - verify hot reload updates greet tool response"
+tags:
+  - meshctl
+  - java
+  - watch
+  - hot-reload
+timeout: 600
+
+pre_run:
+  - routine: global.setup_for_java_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  - name: "Copy java-greeter-agent to workspace"
+    handler: shell
+    command: |
+      cp -r /uc-artifacts/java-greeter-agent /workspace/
+    capture: copy_output
+
+  - name: "Install Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-greeter-agent
+    timeout: 600
+
+  - name: "Start java-greeter-agent with watch flag"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start /workspace/java-greeter-agent -d -w"
+    capture: start_output
+
+  - name: "Wait for greeter registration"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for Java greeter to register..."
+      for i in $(seq 1 45); do
+        if meshctl list 2>/dev/null | grep -q "greeter"; then
+          echo "Greeter registered after $((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Greeter did not register within 90s"
+      meshctl logs greeter 2>/dev/null | tail -30 || true
+      exit 1
+    capture: wait_registration
+    timeout: 120
+
+  - name: "Call greet before modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call greet ''{"name": "WatchTest"}'''
+    capture: greet_before
+
+  - name: "Modify greeting message with sed"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/Hello, %s! Welcome to MCP Mesh./WATCH_RELOAD: Hello, %s!/g' java-greeter-agent/src/main/java/com/example/greeter/GreeterAgentApplication.java
+
+  - name: "Wait for Java watch to recompile and reload"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for Java agent to reload after source change..."
+      sleep 10
+      for i in $(seq 1 30); do
+        if meshctl list 2>/dev/null | grep -q "greeter"; then
+          echo "Greeter re-registered after $((i*2 + 10))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Greeter did not re-register within 70s after modification"
+      meshctl logs greeter 2>/dev/null | tail -30 || true
+      exit 1
+    capture: wait_reload
+    timeout: 120
+
+  - name: "Call greet after modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call greet ''{"name": "WatchTest"}'''
+    capture: greet_after
+
+assertions:
+  - expr: "${captured.greet_before} contains 'Hello, WatchTest'"
+    message: "Greet before modification should contain Hello, WatchTest"
+
+  - expr: "${captured.greet_before} not contains 'WATCH_RELOAD'"
+    message: "Greet before modification should NOT contain WATCH_RELOAD"
+
+  - expr: "${captured.greet_after} contains 'WATCH_RELOAD'"
+    message: "Greet after modification should contain WATCH_RELOAD (hot reload worked)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop --agents 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc05_meshctl/tc24_watch_java_info/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc24_watch_java_info/test.yaml
@@ -1,0 +1,107 @@
+# Test Case: tc24_watch_java_info
+# Tests watch mode hot reload for Java greeter agent getInfo tool
+# Verifies that modifying the version string triggers a recompile and reload
+
+name: "Watch Mode: Java Greeter GetInfo Tool"
+description: "Test meshctl start -w watch mode with Java greeter agent - verify hot reload updates getInfo tool version"
+tags:
+  - meshctl
+  - java
+  - watch
+  - hot-reload
+timeout: 600
+
+pre_run:
+  - routine: global.setup_for_java_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  - name: "Copy java-greeter-agent to workspace"
+    handler: shell
+    command: |
+      cp -r /uc-artifacts/java-greeter-agent /workspace/
+    capture: copy_output
+
+  - name: "Install Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-greeter-agent
+    timeout: 600
+
+  - name: "Start java-greeter-agent with watch flag"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start /workspace/java-greeter-agent -d -w"
+    capture: start_output
+
+  - name: "Wait for greeter registration"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for Java greeter to register..."
+      for i in $(seq 1 45); do
+        if meshctl list 2>/dev/null | grep -q "greeter"; then
+          echo "Greeter registered after $((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Greeter did not register within 90s"
+      meshctl logs greeter 2>/dev/null | tail -30 || true
+      exit 1
+    capture: wait_registration
+    timeout: 120
+
+  - name: "Call getInfo before modification"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl call getInfo '{}'"
+    capture: info_before
+
+  - name: "Modify version string with sed"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/"1.0.0"/"2.0.0-watch"/g' java-greeter-agent/src/main/java/com/example/greeter/GreeterAgentApplication.java
+
+  - name: "Wait for Java watch to recompile and reload"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for Java agent to reload after source change..."
+      sleep 10
+      for i in $(seq 1 30); do
+        if meshctl list 2>/dev/null | grep -q "greeter"; then
+          echo "Greeter re-registered after $((i*2 + 10))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Greeter did not re-register within 70s after modification"
+      meshctl logs greeter 2>/dev/null | tail -30 || true
+      exit 1
+    capture: wait_reload
+    timeout: 120
+
+  - name: "Call getInfo after modification"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl call getInfo '{}'"
+    capture: info_after
+
+assertions:
+  - expr: "${jq:captured.info_before:.content[0].text | fromjson | .version} == '1.0.0'"
+    message: "getInfo before modification should return version 1.0.0"
+
+  - expr: "${captured.info_before} not contains '2.0.0-watch'"
+    message: "getInfo before modification should NOT contain 2.0.0-watch"
+
+  - expr: "${jq:captured.info_after:.content[0].text | fromjson | .version} == '2.0.0-watch'"
+    message: "getInfo after modification should return version 2.0.0-watch (hot reload worked)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop --agents 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc05_meshctl/tc25_watch_java_multi_tool/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc25_watch_java_multi_tool/test.yaml
@@ -1,0 +1,132 @@
+# Test Case: tc25_watch_java_multi_tool
+# Tests watch mode hot reload for Java greeter agent with multiple tools
+# Verifies that greet changes after modification AND getInfo still works
+
+name: "Watch Mode: Java Greeter Multiple Tools After Reload"
+description: "Test meshctl start -w watch mode with Java greeter agent - verify both greet and getInfo work after hot reload"
+tags:
+  - meshctl
+  - java
+  - watch
+  - hot-reload
+timeout: 600
+
+pre_run:
+  - routine: global.setup_for_java_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  - name: "Copy java-greeter-agent to workspace"
+    handler: shell
+    command: |
+      cp -r /uc-artifacts/java-greeter-agent /workspace/
+    capture: copy_output
+
+  - name: "Install Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-greeter-agent
+    timeout: 600
+
+  - name: "Start java-greeter-agent with watch flag"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start /workspace/java-greeter-agent -d -w"
+    capture: start_output
+
+  - name: "Wait for greeter registration"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for Java greeter to register..."
+      for i in $(seq 1 45); do
+        if meshctl list 2>/dev/null | grep -q "greeter"; then
+          echo "Greeter registered after $((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Greeter did not register within 90s"
+      meshctl logs greeter 2>/dev/null | tail -30 || true
+      exit 1
+    capture: wait_registration
+    timeout: 120
+
+  - name: "Call greet before modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call greet ''{"name": "WatchTest"}'''
+    capture: greet_before
+
+  - name: "Call getInfo before modification"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl call getInfo '{}'"
+    capture: info_before
+
+  - name: "Modify greeting message with sed"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/Hello, %s! Welcome to MCP Mesh./WATCH_RELOAD: Hello, %s!/g' java-greeter-agent/src/main/java/com/example/greeter/GreeterAgentApplication.java
+
+  - name: "Wait for Java watch to recompile and reload"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for Java agent to reload after source change..."
+      sleep 10
+      for i in $(seq 1 30); do
+        if meshctl list 2>/dev/null | grep -q "greeter"; then
+          echo "Greeter re-registered after $((i*2 + 10))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Greeter did not re-register within 70s after modification"
+      meshctl logs greeter 2>/dev/null | tail -30 || true
+      exit 1
+    capture: wait_reload
+    timeout: 120
+
+  - name: "Call greet after modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call greet ''{"name": "WatchTest"}'''
+    capture: greet_after
+
+  - name: "Call getInfo after modification"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl call getInfo '{}'"
+    capture: info_after
+
+assertions:
+  # Greet before modification
+  - expr: "${captured.greet_before} contains 'Hello, WatchTest'"
+    message: "Greet before modification should contain Hello, WatchTest"
+
+  - expr: "${captured.greet_before} not contains 'WATCH_RELOAD'"
+    message: "Greet before modification should NOT contain WATCH_RELOAD"
+
+  # getInfo before modification
+  - expr: "${jq:captured.info_before:.content[0].text | fromjson | .name} == 'greeter'"
+    message: "getInfo before modification should return agent name greeter"
+
+  # Greet after modification
+  - expr: "${captured.greet_after} contains 'WATCH_RELOAD'"
+    message: "Greet after modification should contain WATCH_RELOAD (hot reload worked)"
+
+  # getInfo still works after reload
+  - expr: "${jq:captured.info_after:.content[0].text | fromjson | .name} == 'greeter'"
+    message: "getInfo after modification should still return agent name greeter"
+
+  - expr: "${jq:captured.info_after:.content[0].text | fromjson | .runtime} contains 'Java'"
+    message: "getInfo after modification should still report Java runtime"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop --agents 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc05_meshctl/tc26_watch_ts_add/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc26_watch_ts_add/test.yaml
@@ -1,0 +1,86 @@
+# Test Case: tc26_watch_ts_add
+# Tests watch mode hot reload for ts-math-agent add tool
+# Verifies that modifying the add function triggers a reload with updated result
+
+name: "Watch Mode: TypeScript Math Agent Add Tool"
+description: "Test meshctl start -w watch mode with ts-math-agent - verify hot reload updates add tool result"
+tags:
+  - meshctl
+  - typescript
+  - watch
+  - hot-reload
+timeout: 300
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  - name: "Copy ts-math-agent to workspace"
+    handler: shell
+    command: |
+      cp -r /uc-artifacts/ts-math-agent /workspace/
+    capture: copy_output
+
+  - name: "Install ts-math-agent dependencies"
+    handler: npm-install
+    path: /workspace/ts-math-agent
+
+  - name: "Start ts-math-agent with watch flag"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start ts-math-agent/src/index.ts -d -w"
+    capture: start_output
+
+  - name: "Wait for ts-math-agent to register"
+    handler: wait
+    seconds: 10
+
+  - name: "Verify ts-math-agent registered"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: agent_list
+
+  - name: "Call add before modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call ts-math-agent:add ''{"a": 5, "b": 3}'''
+    capture: add_before
+
+  - name: "Modify ts-math-agent add function with sed"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/return a + b;/return a + b + 1000;/g' ts-math-agent/src/index.ts
+
+  - name: "Wait for watch to detect change and reload"
+    handler: wait
+    seconds: 10
+
+  - name: "Call add after modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call ts-math-agent:add ''{"a": 5, "b": 3}'''
+    capture: add_after
+
+assertions:
+  - expr: "${captured.agent_list} contains 'ts-math-agent'"
+    message: "ts-math-agent should be registered"
+
+  - expr: "${captured.add_before} contains '8'"
+    message: "Add before modification should return 8 (5+3)"
+
+  - expr: "${captured.add_before} not contains '1008'"
+    message: "Add before modification should NOT return 1008"
+
+  - expr: "${captured.add_after} contains '1008'"
+    message: "Add after modification should return 1008 (5+3+1000, hot reload worked)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop --agents 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc05_meshctl/tc27_watch_ts_multiply/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc27_watch_ts_multiply/test.yaml
@@ -1,0 +1,86 @@
+# Test Case: tc27_watch_ts_multiply
+# Tests watch mode hot reload for ts-math-agent multiply tool
+# Verifies that modifying the multiply function triggers a reload with updated result
+
+name: "Watch Mode: TypeScript Math Agent Multiply Tool"
+description: "Test meshctl start -w watch mode with ts-math-agent - verify hot reload updates multiply tool result"
+tags:
+  - meshctl
+  - typescript
+  - watch
+  - hot-reload
+timeout: 300
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  - name: "Copy ts-math-agent to workspace"
+    handler: shell
+    command: |
+      cp -r /uc-artifacts/ts-math-agent /workspace/
+    capture: copy_output
+
+  - name: "Install ts-math-agent dependencies"
+    handler: npm-install
+    path: /workspace/ts-math-agent
+
+  - name: "Start ts-math-agent with watch flag"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start ts-math-agent/src/index.ts -d -w"
+    capture: start_output
+
+  - name: "Wait for ts-math-agent to register"
+    handler: wait
+    seconds: 10
+
+  - name: "Verify ts-math-agent registered"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: agent_list
+
+  - name: "Call multiply before modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call ts-math-agent:multiply ''{"a": 4, "b": 5}'''
+    capture: multiply_before
+
+  - name: "Modify ts-math-agent multiply function with sed"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/return a \* b;/return a * b + 5000;/g' ts-math-agent/src/index.ts
+
+  - name: "Wait for watch to detect change and reload"
+    handler: wait
+    seconds: 10
+
+  - name: "Call multiply after modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call ts-math-agent:multiply ''{"a": 4, "b": 5}'''
+    capture: multiply_after
+
+assertions:
+  - expr: "${captured.agent_list} contains 'ts-math-agent'"
+    message: "ts-math-agent should be registered"
+
+  - expr: "${captured.multiply_before} contains '20'"
+    message: "Multiply before modification should return 20 (4*5)"
+
+  - expr: "${captured.multiply_before} not contains '5020'"
+    message: "Multiply before modification should NOT return 5020"
+
+  - expr: "${captured.multiply_after} contains '5020'"
+    message: "Multiply after modification should return 5020 (4*5+5000, hot reload worked)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop --agents 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc05_meshctl/tc28_watch_ts_calc/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc28_watch_ts_calc/test.yaml
@@ -1,0 +1,86 @@
+# Test Case: tc28_watch_ts_calc
+# Tests watch mode hot reload for ts-calculator-agent calc_add tool
+# Verifies that modifying the calc_add function triggers a reload with updated result
+
+name: "Watch Mode: TypeScript Calculator Agent"
+description: "Test meshctl start -w watch mode with ts-calculator-agent - verify hot reload updates calc_add tool result"
+tags:
+  - meshctl
+  - typescript
+  - watch
+  - hot-reload
+timeout: 300
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  - name: "Copy ts-calculator-agent to workspace"
+    handler: shell
+    command: |
+      cp -r /uc-artifacts/ts-calculator-agent /workspace/
+    capture: copy_output
+
+  - name: "Install ts-calculator-agent dependencies"
+    handler: npm-install
+    path: /workspace/ts-calculator-agent
+
+  - name: "Start ts-calculator-agent with watch flag"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start ts-calculator-agent/src/index.ts -d -w"
+    capture: start_output
+
+  - name: "Wait for ts-calculator-agent to register"
+    handler: wait
+    seconds: 10
+
+  - name: "Verify ts-calculator-agent registered"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: agent_list
+
+  - name: "Call calc_add before modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call ts-calculator-agent:calc_add ''{"a": 6, "b": 9}'''
+    capture: calc_add_before
+
+  - name: "Modify ts-calculator-agent calc_add function with sed"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/return a + b;/return a + b + 3000;/g' ts-calculator-agent/src/index.ts
+
+  - name: "Wait for watch to detect change and reload"
+    handler: wait
+    seconds: 10
+
+  - name: "Call calc_add after modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call ts-calculator-agent:calc_add ''{"a": 6, "b": 9}'''
+    capture: calc_add_after
+
+assertions:
+  - expr: "${captured.agent_list} contains 'ts-calculator-agent'"
+    message: "ts-calculator-agent should be registered"
+
+  - expr: "${captured.calc_add_before} contains '15'"
+    message: "calc_add before modification should return 15 (6+9)"
+
+  - expr: "${captured.calc_add_before} not contains '3015'"
+    message: "calc_add before modification should NOT return 3015"
+
+  - expr: "${captured.calc_add_after} contains '3015'"
+    message: "calc_add after modification should return 3015 (6+9+3000, hot reload worked)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop --agents 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc05_meshctl/tc29_watch_mixed/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc29_watch_mixed/test.yaml
@@ -1,0 +1,227 @@
+# Test Case: tc29_watch_mixed
+# Tests watch mode hot reload with all 3 languages simultaneously
+# Python (py-math-agent:9010), TypeScript (ts-math-agent:9011), Java (java-greeter-agent:9000)
+# Each agent is started separately with meshctl start <path> -d -w
+
+name: "Watch Mode: Mixed Languages (Python + TypeScript + Java)"
+description: "Test meshctl start -w watch mode with all 3 language agents - verify hot reload works for each independently"
+tags:
+  - meshctl
+  - python
+  - typescript
+  - java
+  - watch
+  - hot-reload
+  - mixed
+timeout: 600
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+  - routine: global.setup_for_typescript_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+  - routine: global.setup_for_java_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  # ========== COPY ALL ARTIFACTS ==========
+
+  - name: "Copy all agents to workspace"
+    handler: shell
+    command: |
+      cp -r /uc-artifacts/py-math-agent /workspace/
+      cp -r /uc-artifacts/ts-math-agent /workspace/
+      cp -r /uc-artifacts/java-greeter-agent /workspace/
+    capture: copy_output
+
+  # ========== INSTALL DEPENDENCIES ==========
+
+  - name: "Install ts-math-agent dependencies"
+    handler: npm-install
+    path: /workspace/ts-math-agent
+
+  - name: "Install java-greeter-agent Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-greeter-agent
+    timeout: 600
+
+  # ========== START ALL AGENTS WITH WATCH ==========
+
+  - name: "Start py-math-agent with watch flag"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start py-math-agent/main.py -d -w"
+    capture: py_start
+
+  - name: "Start ts-math-agent with watch flag"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start ts-math-agent/src/index.ts -d -w"
+    capture: ts_start
+
+  - name: "Start java-greeter-agent with watch flag"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start /workspace/java-greeter-agent -d -w"
+    capture: java_start
+
+  # ========== WAIT FOR REGISTRATION ==========
+
+  - name: "Wait for Python and TypeScript agents"
+    handler: wait
+    seconds: 10
+
+  - name: "Wait for Java greeter registration"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for Java greeter to register..."
+      for i in $(seq 1 45); do
+        if meshctl list 2>/dev/null | grep -q "greeter"; then
+          echo "Greeter registered after $((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Greeter did not register within 90s"
+      meshctl logs greeter 2>/dev/null | tail -30 || true
+      exit 1
+    capture: wait_java
+    timeout: 120
+
+  - name: "Verify all agents registered"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: agent_list
+
+  # ========== CALL TOOLS BEFORE MODIFICATION ==========
+
+  - name: "Call Python add before modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call py-math-agent:add ''{"a": 10, "b": 20}'''
+    capture: py_add_before
+
+  - name: "Call TypeScript add before modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call ts-math-agent:add ''{"a": 5, "b": 3}'''
+    capture: ts_add_before
+
+  - name: "Call Java greet before modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call greet ''{"name": "WatchTest"}'''
+    capture: java_greet_before
+
+  # ========== MODIFY ALL SOURCES ==========
+
+  - name: "Modify Python source"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/return a + b/return a + b + 1000/g' py-math-agent/main.py
+
+  - name: "Modify TypeScript source"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/return a + b;/return a + b + 1000;/g' ts-math-agent/src/index.ts
+
+  - name: "Modify Java source"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/Hello, %s! Welcome to MCP Mesh./WATCH_RELOAD: Hello, %s!/g' java-greeter-agent/src/main/java/com/example/greeter/GreeterAgentApplication.java
+
+  # ========== WAIT FOR RELOADS ==========
+
+  - name: "Wait for Python and TypeScript reload"
+    handler: wait
+    seconds: 10
+
+  - name: "Wait for Java watch to recompile and reload"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for Java agent to reload after source change..."
+      sleep 10
+      for i in $(seq 1 30); do
+        if meshctl list 2>/dev/null | grep -q "greeter"; then
+          echo "Greeter re-registered after $((i*2 + 10))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Greeter did not re-register within 70s after modification"
+      meshctl logs greeter 2>/dev/null | tail -30 || true
+      exit 1
+    capture: wait_java_reload
+    timeout: 120
+
+  # ========== CALL TOOLS AFTER MODIFICATION ==========
+
+  - name: "Call Python add after modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call py-math-agent:add ''{"a": 10, "b": 20}'''
+    capture: py_add_after
+
+  - name: "Call TypeScript add after modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call ts-math-agent:add ''{"a": 5, "b": 3}'''
+    capture: ts_add_after
+
+  - name: "Call Java greet after modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call greet ''{"name": "WatchTest"}'''
+    capture: java_greet_after
+
+assertions:
+  # All agents registered
+  - expr: "${captured.agent_list} contains 'py-math-agent'"
+    message: "py-math-agent should be registered"
+
+  - expr: "${captured.agent_list} contains 'ts-math-agent'"
+    message: "ts-math-agent should be registered"
+
+  - expr: "${captured.agent_list} contains 'greeter'"
+    message: "Java greeter should be registered"
+
+  # Python before/after
+  - expr: "${captured.py_add_before} contains '30'"
+    message: "Python add before modification should return 30 (10+20)"
+
+  - expr: "${captured.py_add_after} contains '1030'"
+    message: "Python add after modification should return 1030 (10+20+1000, hot reload worked)"
+
+  # TypeScript before/after
+  - expr: "${captured.ts_add_before} contains '8'"
+    message: "TypeScript add before modification should return 8 (5+3)"
+
+  - expr: "${captured.ts_add_after} contains '1008'"
+    message: "TypeScript add after modification should return 1008 (5+3+1000, hot reload worked)"
+
+  # Java before/after
+  - expr: "${captured.java_greet_before} contains 'Hello, WatchTest'"
+    message: "Java greet before modification should contain Hello, WatchTest"
+
+  - expr: "${captured.java_greet_before} not contains 'WATCH_RELOAD'"
+    message: "Java greet before modification should NOT contain WATCH_RELOAD"
+
+  - expr: "${captured.java_greet_after} contains 'WATCH_RELOAD'"
+    message: "Java greet after modification should contain WATCH_RELOAD (hot reload worked)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop --agents 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc05_meshctl/tc30_watch_mixed_single_start/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc30_watch_mixed_single_start/test.yaml
@@ -1,0 +1,215 @@
+# Test Case: tc30_watch_mixed_single_start
+# Tests watch mode hot reload with all 3 languages started via a single meshctl start command
+# Python (py-math-agent:9010), TypeScript (ts-math-agent:9011), Java (java-greeter-agent:9000)
+# All agents started together: meshctl start <py> <ts> <java> -d -w
+
+name: "Watch Mode: Mixed Languages Single Start Command"
+description: "Test meshctl start -w with multiple agents in a single command - verify hot reload works for all 3 languages"
+tags:
+  - meshctl
+  - python
+  - typescript
+  - java
+  - watch
+  - hot-reload
+  - mixed
+timeout: 600
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+  - routine: global.setup_for_typescript_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+  - routine: global.setup_for_java_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  # ========== COPY ALL ARTIFACTS ==========
+
+  - name: "Copy all agents to workspace"
+    handler: shell
+    command: |
+      cp -r /uc-artifacts/py-math-agent /workspace/
+      cp -r /uc-artifacts/ts-math-agent /workspace/
+      cp -r /uc-artifacts/java-greeter-agent /workspace/
+    capture: copy_output
+
+  # ========== INSTALL DEPENDENCIES ==========
+
+  - name: "Install ts-math-agent dependencies"
+    handler: npm-install
+    path: /workspace/ts-math-agent
+
+  - name: "Install java-greeter-agent Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-greeter-agent
+    timeout: 600
+
+  # ========== START ALL AGENTS WITH SINGLE COMMAND ==========
+
+  - name: "Start all agents with single meshctl start command"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start py-math-agent/main.py ts-math-agent/src/index.ts /workspace/java-greeter-agent -d -w"
+    capture: start_output
+
+  # ========== WAIT FOR REGISTRATION ==========
+
+  - name: "Wait for Python and TypeScript agents"
+    handler: wait
+    seconds: 10
+
+  - name: "Wait for Java greeter registration"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for Java greeter to register..."
+      for i in $(seq 1 45); do
+        if meshctl list 2>/dev/null | grep -q "greeter"; then
+          echo "Greeter registered after $((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Greeter did not register within 90s"
+      meshctl logs greeter 2>/dev/null | tail -30 || true
+      exit 1
+    capture: wait_java
+    timeout: 120
+
+  - name: "Verify all agents registered"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: agent_list
+
+  # ========== CALL TOOLS BEFORE MODIFICATION ==========
+
+  - name: "Call Python add before modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call py-math-agent:add ''{"a": 10, "b": 20}'''
+    capture: py_add_before
+
+  - name: "Call TypeScript add before modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call ts-math-agent:add ''{"a": 5, "b": 3}'''
+    capture: ts_add_before
+
+  - name: "Call Java greet before modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call greet ''{"name": "WatchTest"}'''
+    capture: java_greet_before
+
+  # ========== MODIFY ALL SOURCES ==========
+
+  - name: "Modify Python source"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/return a + b/return a + b + 1000/g' py-math-agent/main.py
+
+  - name: "Modify TypeScript source"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/return a + b;/return a + b + 1000;/g' ts-math-agent/src/index.ts
+
+  - name: "Modify Java source"
+    handler: shell
+    workdir: /workspace
+    command: |
+      sed -i 's/Hello, %s! Welcome to MCP Mesh./WATCH_RELOAD: Hello, %s!/g' java-greeter-agent/src/main/java/com/example/greeter/GreeterAgentApplication.java
+
+  # ========== WAIT FOR RELOADS ==========
+
+  - name: "Wait for Python and TypeScript reload"
+    handler: wait
+    seconds: 10
+
+  - name: "Wait for Java watch to recompile and reload"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for Java agent to reload after source change..."
+      sleep 10
+      for i in $(seq 1 30); do
+        if meshctl list 2>/dev/null | grep -q "greeter"; then
+          echo "Greeter re-registered after $((i*2 + 10))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Greeter did not re-register within 70s after modification"
+      meshctl logs greeter 2>/dev/null | tail -30 || true
+      exit 1
+    capture: wait_java_reload
+    timeout: 120
+
+  # ========== CALL TOOLS AFTER MODIFICATION ==========
+
+  - name: "Call Python add after modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call py-math-agent:add ''{"a": 10, "b": 20}'''
+    capture: py_add_after
+
+  - name: "Call TypeScript add after modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call ts-math-agent:add ''{"a": 5, "b": 3}'''
+    capture: ts_add_after
+
+  - name: "Call Java greet after modification"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call greet ''{"name": "WatchTest"}'''
+    capture: java_greet_after
+
+assertions:
+  # All agents registered
+  - expr: "${captured.agent_list} contains 'py-math-agent'"
+    message: "py-math-agent should be registered"
+
+  - expr: "${captured.agent_list} contains 'ts-math-agent'"
+    message: "ts-math-agent should be registered"
+
+  - expr: "${captured.agent_list} contains 'greeter'"
+    message: "Java greeter should be registered"
+
+  # Python before/after
+  - expr: "${captured.py_add_before} contains '30'"
+    message: "Python add before modification should return 30 (10+20)"
+
+  - expr: "${captured.py_add_after} contains '1030'"
+    message: "Python add after modification should return 1030 (10+20+1000, hot reload worked)"
+
+  # TypeScript before/after
+  - expr: "${captured.ts_add_before} contains '8'"
+    message: "TypeScript add before modification should return 8 (5+3)"
+
+  - expr: "${captured.ts_add_after} contains '1008'"
+    message: "TypeScript add after modification should return 1008 (5+3+1000, hot reload worked)"
+
+  # Java before/after
+  - expr: "${captured.java_greet_before} contains 'Hello, WatchTest'"
+    message: "Java greet before modification should contain Hello, WatchTest"
+
+  - expr: "${captured.java_greet_before} not contains 'WATCH_RELOAD'"
+    message: "Java greet before modification should NOT contain WATCH_RELOAD"
+
+  - expr: "${captured.java_greet_after} contains 'WATCH_RELOAD'"
+    message: "Java greet after modification should contain WATCH_RELOAD (hot reload worked)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop --agents 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

- Replace buggy bash-based watch mode (infinite restart cycles for Java, `watchfiles` pip dependency for Python) with a Go-based `AgentWatcher` using fsnotify
- New `watcher.go`: event-driven file watching, debounce, process group termination, automatic subdirectory watching — language-agnostic and compiled into meshctl with zero runtime dependencies
- Route Java and Python agents through `AgentWatcher` when `-w` flag is set; TypeScript unchanged (`tsx --watch` / `node --watch` works fine)
- Add 11 integration tests (tc20-tc30) covering Python, Java, TypeScript, and mixed-language watch mode with hot reload verification

## Test plan

- [x] `meshctl start examples/java/basic-tool-agent -w` — starts without infinite restart cycle
- [x] Edit `.java` file in `src/` — agent restarts within ~1s
- [x] Edit file in `target/` — no restart (excluded directory)
- [x] `meshctl start examples/java/basic-tool-agent -d -w` — detach mode works, `meshctl stop` cleans up
- [x] Python watch mode works with fsnotify (no `watchfiles` dependency)
- [x] All 11 new integration tests pass (tc20-tc30)
- [x] All existing uc05_meshctl tests pass (tc01-tc19)

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added hot-reload watch mode for Python agents with file watching and automatic restarts.
  * Added hot-reload watch mode for Java agents with Maven project support.
  * Implemented file watcher system with configurable debounce and port-release delays.
  * Enabled simultaneous watch mode support for mixed-language agent environments.

* **Tests**
  * Added comprehensive integration tests validating hot-reload functionality across Python, Java, and TypeScript agents in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->