### PR TITLE
fix: Java tracing span orphans and header propagation regressions

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpHttpClient.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpHttpClient.java
@@ -104,10 +104,12 @@ public class McpHttpClient {
             Map<String, Object> argsWithTrace = params != null ? new LinkedHashMap<>(params) : new LinkedHashMap<>();
             if (traceInfo != null) {
                 argsWithTrace.put("_trace_id", traceInfo.getTraceId());
-                argsWithTrace.put("_parent_span", traceInfo.getSpanId());
+                if (traceInfo.getSpanId() != null) {
+                    argsWithTrace.put("_parent_span", traceInfo.getSpanId());
+                }
                 log.trace("Injecting trace context into args: trace={}, parent={}",
                     traceInfo.getTraceId().substring(0, 8),
-                    traceInfo.getSpanId().substring(0, 8));
+                    traceInfo.getSpanId() != null ? traceInfo.getSpanId().substring(0, 8) : "null");
             }
 
             // Build merged headers: session propagated + per-call (per-call wins, filtered by allowlist)
@@ -148,10 +150,12 @@ public class McpHttpClient {
             // Inject trace context into HTTP headers
             if (traceInfo != null) {
                 requestBuilder.header("X-Trace-ID", traceInfo.getTraceId());
-                requestBuilder.header("X-Parent-Span", traceInfo.getSpanId());
+                if (traceInfo.getSpanId() != null) {
+                    requestBuilder.header("X-Parent-Span", traceInfo.getSpanId());
+                }
                 log.trace("Injecting trace headers: X-Trace-ID={}, X-Parent-Span={}",
                     traceInfo.getTraceId().substring(0, 8),
-                    traceInfo.getSpanId().substring(0, 8));
+                    traceInfo.getSpanId() != null ? traceInfo.getSpanId().substring(0, 8) : "null");
             }
 
             // Inject merged headers as HTTP headers (propagated + per-call)

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshMcpServerConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshMcpServerConfiguration.java
@@ -99,6 +99,7 @@ public class MeshMcpServerConfiguration {
             .capabilities(ServerCapabilities.builder()
                 .tools(true)
                 .build())
+            .immediateExecution(true)
             .build();
 
         // Register all tools from wrapper registry (includes both @MeshTool and @MeshLlmProvider)

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TraceInfo.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TraceInfo.java
@@ -96,15 +96,14 @@ public class TraceInfo {
      * Instead, the incoming parent span becomes the current span_id so that
      * {@link #createChild()} correctly parents to the actual caller.
      * If {@code incomingParentSpan} is null (root calls with no parent),
-     * a new span ID is generated to avoid null span IDs downstream.
+     * the span ID will be null, causing {@link #createChild()} to produce a root span with no parent.
      *
      * @param traceId Trace ID from X-Trace-ID header
      * @param incomingParentSpan Parent span from X-Parent-Span header (may be null for root calls)
      * @return TraceInfo suitable for use in TraceContext propagation
      */
     public static TraceInfo forPropagation(String traceId, String incomingParentSpan) {
-        String spanId = (incomingParentSpan != null) ? incomingParentSpan : generateSpanId();
-        return new TraceInfo(traceId, spanId, null, System.currentTimeMillis());
+        return new TraceInfo(traceId, incomingParentSpan, null, System.currentTimeMillis());
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TracingFilter.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TracingFilter.java
@@ -83,7 +83,9 @@ public class TracingFilter implements Filter {
                 // Add trace headers to response for debugging (only when tracing enabled)
                 if (enabled) {
                     httpResponse.setHeader(TRACE_ID_HEADER, traceInfo.getTraceId());
-                    httpResponse.setHeader(PARENT_SPAN_HEADER, traceInfo.getSpanId());
+                    if (traceInfo.getSpanId() != null) {
+                        httpResponse.setHeader(PARENT_SPAN_HEADER, traceInfo.getSpanId());
+                    }
                 }
             } else {
                 // No trace headers - don't create root trace here


### PR DESCRIPTION
## Summary
- Fix orphan spans in trace graph by removing phantom spanId generation in `TraceInfo.forPropagation()` — CLI calls without `_parent_span` now correctly produce a root span
- Fix header propagation returning empty `{}` by setting `immediateExecution(true)` on the MCP stateless server — tool handlers now run on the servlet thread where `TracingFilter` sets ThreadLocal context
- Add null guards on `getSpanId()` in `McpHttpClient`, `TracingFilter` for consistency

## Review Notes
- WARNING: `ExecutionTracer.startSpan()` has an implicit nullable contract on parentSpan — works correctly but could benefit from explicit documentation in a future PR

Closes #589

## Test plan
- [ ] `tc09_span_completeness` (uc06_observability) — validates ORPHAN_COUNT=0, ROOT_COUNT=1, GRAPH_VALID=true
- [ ] `tc03_java_header_chain` (uc11_header_propagation) — validates custom headers propagated through Java relay→echo chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace propagation robustness by properly handling scenarios where parent span information is absent.
  * Enhanced HTTP header handling to prevent sending empty or null span identifiers.
  * Enabled immediate execution for tools to optimize performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->