### PR TITLE
test: add FastMCP lifespan extraction regression tests (#671)

### DIFF
--- a/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-lifespan-agent/main.py
+++ b/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-lifespan-agent/main.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Test agent that verifies FastMCP lifespan extraction.
+
+The lifespan sets a global flag on startup. The tool reports the flag's value.
+If lifespan extraction works, the flag will be True after agent startup.
+"""
+from contextlib import asynccontextmanager
+
+import mesh
+from fastmcp import FastMCP
+
+_lifespan_started = False
+
+
+@asynccontextmanager
+async def _lifespan(server):
+    global _lifespan_started
+    _lifespan_started = True
+    yield
+    _lifespan_started = False
+
+
+app = FastMCP("lifespan-agent", lifespan=_lifespan)
+
+
+@app.tool()
+@mesh.tool(capability="lifespan.status")
+def lifespan_status() -> dict:
+    """Returns whether the lifespan startup code has executed."""
+    return {"lifespan_started": _lifespan_started}
+
+
+@mesh.agent(name="lifespan-agent", auto_run=True)
+class LifespanAgent:
+    pass

--- a/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-lifespan-task-agent/main.py
+++ b/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-lifespan-task-agent/main.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Test agent with a lifespan that starts a background asyncio.Task.
+
+Mimics the real-world pattern where agents use lifespan to start
+Redis listeners or other long-running background jobs.
+"""
+import asyncio
+from contextlib import asynccontextmanager
+
+import mesh
+from fastmcp import FastMCP
+
+_lifespan_started = False
+_task_tick_count = 0
+_background_task = None
+
+
+async def _background_worker():
+    """Simulates a long-running background job (like a Redis listener)."""
+    global _task_tick_count
+    while True:
+        _task_tick_count += 1
+        await asyncio.sleep(1)
+
+
+@asynccontextmanager
+async def _lifespan(server):
+    global _lifespan_started, _background_task
+    _lifespan_started = True
+    _background_task = asyncio.create_task(_background_worker())
+    try:
+        yield
+    finally:
+        _lifespan_started = False
+        if _background_task and not _background_task.done():
+            _background_task.cancel()
+            try:
+                await _background_task
+            except asyncio.CancelledError:
+                pass
+
+
+app = FastMCP("lifespan-task-agent", lifespan=_lifespan)
+
+
+@app.tool()
+@mesh.tool(capability="lifespan.task_status")
+def task_status() -> dict:
+    """Returns lifespan and background task state."""
+    return {
+        "lifespan_started": _lifespan_started,
+        "task_running": _background_task is not None and not _background_task.done(),
+        "tick_count": _task_tick_count,
+    }
+
+
+@mesh.agent(name="lifespan-task-agent", auto_run=True)
+class LifespanTaskAgent:
+    pass

--- a/tests/integration/suites/uc02_agent_lifecycle/tc10_lifespan_extraction/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc10_lifespan_extraction/test.yaml
@@ -1,0 +1,69 @@
+# Test Case: FastMCP Lifespan Extraction
+# Verifies that a FastMCP lifespan's startup code executes when agent starts.
+# This is the TDD test for issue #671.
+
+name: "FastMCP Lifespan Extraction"
+description: "Verify that a FastMCP lifespan context manager runs on agent startup"
+tags:
+  - lifecycle
+  - lifespan
+  - fastmcp
+  - python
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy lifespan agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-lifespan-agent /workspace/"
+    capture: copy_output
+
+  - name: "Start lifespan agent"
+    handler: shell
+    command: "meshctl start py-lifespan-agent/main.py -d"
+    workdir: /workspace
+    capture: start_output
+
+  - name: "Wait for agent to start"
+    handler: wait
+    seconds: 15
+
+  - name: "Check agent is running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: list_output
+
+  - name: "Call lifespan_status tool"
+    handler: shell
+    command: "meshctl call lifespan_status '{}'"
+    workdir: /workspace
+    capture: lifespan_result
+
+  - name: "Show agent logs for debugging"
+    handler: shell
+    command: "meshctl logs lifespan-agent 2>/dev/null | tail -30 || echo 'no logs'"
+    workdir: /workspace
+    capture: agent_logs
+
+assertions:
+  - expr: ${captured.list_output} contains 'lifespan-agent'
+    message: "Agent should be registered"
+
+  - expr: ${captured.lifespan_result} contains 'lifespan_started'
+    message: "Tool should return lifespan_started field"
+
+  - expr: ${captured.lifespan_result} contains 'true'
+    message: "Lifespan startup code should have executed"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc02_agent_lifecycle/tc11_lifespan_background_task/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc11_lifespan_background_task/test.yaml
@@ -1,0 +1,75 @@
+# Test Case: FastMCP Lifespan with Background Task
+# Verifies that a lifespan which starts an asyncio.Task works correctly.
+# This mimics the real-world pattern used by wisefolio agents (issue #671).
+
+name: "FastMCP Lifespan Background Task"
+description: "Verify that a lifespan-started background asyncio.Task runs after agent startup"
+tags:
+  - lifecycle
+  - lifespan
+  - fastmcp
+  - python
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy lifespan task agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-lifespan-task-agent /workspace/"
+    capture: copy_output
+
+  - name: "Start lifespan task agent"
+    handler: shell
+    command: "meshctl start py-lifespan-task-agent/main.py -d"
+    workdir: /workspace
+    capture: start_output
+
+  - name: "Wait for agent to start"
+    handler: wait
+    seconds: 15
+
+  - name: "Check agent is running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: list_output
+
+  - name: "Call task_status tool"
+    handler: shell
+    command: "meshctl call task_status '{}'"
+    workdir: /workspace
+    capture: task_result
+
+  - name: "Show agent logs for debugging"
+    handler: shell
+    command: "meshctl logs lifespan-task-agent 2>/dev/null | tail -30 || echo 'no logs'"
+    workdir: /workspace
+    capture: agent_logs
+
+assertions:
+  - expr: ${captured.list_output} contains 'lifespan-task-agent'
+    message: "Agent should be registered"
+
+  - expr: ${captured.task_result} contains 'lifespan_started'
+    message: "Tool should return lifespan_started field"
+
+  - expr: ${captured.task_result} contains 'true'
+    message: "Lifespan startup code should have executed"
+
+  - expr: ${captured.task_result} contains 'task_running'
+    message: "Tool should return task_running field"
+
+  - expr: ${captured.task_result} contains 'tick_count'
+    message: "Tool should return tick_count field"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary
- Add two integration tests to `uc02_agent_lifecycle` verifying FastMCP lifespan extraction works on agent startup
- **tc10**: simple lifespan that sets a flag — validates basic extraction
- **tc11**: lifespan that starts a background `asyncio.Task` — mimics the real-world pattern used by wisefolio agents (Redis listeners, pipeline triggers)
- Both tests pass with current SDK, confirming the lifespan extraction mechanism works for both patterns

## Investigation Notes
- Root cause analysis found the failure path: when decorator-time extraction fails, pipeline mounts FastMCP as a Starlette sub-app whose lifespan is never invoked (Starlette doesn't run lifespans on mounted sub-apps)
- Both test patterns pass with current SDK, suggesting the original issue may have been environment-specific or resolved in a recent SDK update
- These tests serve as regression guards against future lifespan extraction breakage

Closes #671

## Test plan
- [x] `tsuite run --tc uc02_agent_lifecycle/tc10_lifespan_extraction` — passes
- [x] `tsuite run --tc uc02_agent_lifecycle/tc11_lifespan_background_task` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration test coverage for FastMCP lifespan extraction and initialization.
  * Added integration test coverage for FastMCP lifespan management with background task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->