### PR TITLE
fix: meshctl call falls back to capability name for tool lookup (#680)

### DIFF
--- a/src/core/cli/call.go
+++ b/src/core/cli/call.go
@@ -89,12 +89,16 @@ func NewCallCommand() *cobra.Command {
 The command discovers the agent endpoint via the registry and makes the MCP call
 with proper headers. Arguments can be provided as JSON string or via --file flag.
 
+Tool lookup matches by MCP tool name first, then falls back to capability name.
+This allows calling tools by either name (e.g., 'get_weather' or 'weather.get_weather').
+
 By default, calls are routed through the registry proxy. This allows external access
 to agents running in Docker/Kubernetes without exposing individual agent ports.
 
 Examples:
   # Most common - auto-discover agent by tool name
   meshctl call get_weather                                # Tool name only (recommended)
+  meshctl call weather.get_weather                        # By capability name
   meshctl call add '{"a": 1, "b": 2}'                     # With JSON arguments
   meshctl call process --file data.json                   # Arguments from file
 


### PR DESCRIPTION
## Summary
- `meshctl call` now matches tools by MCP tool name first, then falls back to capability name on the same registry response (no extra network call)
- Fixes Java agent interop where `FunctionName` is camelCase (`getWeather`) but capability `Name` is snake_case (`get_weather`)
- The resolved `FunctionName` is always used for the actual MCP `tools/call` request, ensuring the call succeeds at the agent level
- Updated help text with capability name example
- Both `findAgentWithTool` and `findAgentWithToolIngress` paths updated

## Verified manually
```
meshctl call list_accounts '{}'              # Pass 1: matches FunctionName
meshctl call portfolio.list_accounts '{}'    # Pass 2: matches capability Name, resolves to FunctionName
```

Closes #680

## Test plan
- [x] `go build ./...` — compiles
- [x] `go test ./cli/...` — passes
- [x] Manual: `meshctl call list_accounts` works (function_name match)
- [x] Manual: `meshctl call portfolio.list_accounts` works (capability fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured tool discovery and invocation mechanism to improve MCP function name resolution with a two-stage matching approach for more reliable tool lookup.

* **Bug Fixes**
  * Enhanced error handling in tool discovery with more specific diagnostic messages for better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->