### PR TITLE
release: v1.1.0 (#732)

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version tag (e.g., v1.1.0-beta.6)"
+        description: "Version tag (e.g., v1.1.0)"
         required: true
-        default: "v1.1.0-beta.6"
+        default: "v1.1.0"
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version (e.g., v1.1.0-beta.6)"
+        description: "Version (e.g., v1.1.0)"
         required: true
-        default: "v1.1.0-beta.6"
+        default: "v1.1.0"
       environment:
         description: "Environment"
         type: choice

--- a/.gitignore
+++ b/.gitignore
@@ -291,3 +291,4 @@ src/ui/out/
 src/ui/node_modules/
 .next/
 mcp-mesh-ui
+uisample/

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,57 @@
 # MCP Mesh Release Notes
 
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v1.0.1...v1.1.0)
+
+## v1.1.0 (2026-04-05)
+
+The dashboard release. Real-time monitoring, parallel tool execution, per-service TLS, and production-grade Kubernetes deployment with Helm charts.
+
+### 🖥️ Web Dashboard
+
+- **Dashboard UI** (#665, #668, #669, #673, #677, #695): Real-time agent monitoring with 5 pages — Dashboard overview (stats, traffic, events), Agents (table with capabilities), Topology (dependency graph), Traffic (per-edge metrics, token usage, latency), and Live (trace streaming)
+- **Docker image** (`mcpmesh/ui`) (#722, #723, #727, #731): Published to Docker Hub and GHCR, serves at `/ops/dashboard` by default for Kubernetes ingress routing
+- **basePath support** (#711, #717): Configurable path prefix for ingress routing. Custom paths via `ui-custom.Dockerfile`
+- **`meshctl start --ui`**: Embedded UI server for local development with auto-open via `--dashboard`
+
+### ⚡ Performance
+
+- **Parallel tool execution** (#672, #715): Provider-side parallel tool calls across all 3 runtimes — Python (`asyncio.gather`), TypeScript (`Promise.all`), Java (`CompletableFuture.allOf`)
+- **HTTP-first transport** (#697): orjson + simd-json for faster serialization across Python and Rust runtimes
+- **Connection pooling** (#674, #676): Shared HTTP clients for inter-agent calls in Python and TypeScript SDKs
+
+### 🔒 Security & TLS
+
+- **Per-service TLS** (#704, #716): Independent TLS configuration for Redis, Tempo, OTLP, and UI-to-Registry connections via `{SERVICE}_TLS_CA/CERT/KEY` environment variables
+- **CLI TLS hardening** (#719): Auto-detect TLS auto CA, `--insecure` flag wired up, MinVersion TLS 1.2
+- **SPIRE in published wheel** (#719): `pip install mcp-mesh-core` now includes SPIRE workload identity support
+- **Reproducible Rust builds** (#719): Cargo.lock tracked in git to prevent dependency drift
+
+### 🏗️ Helm & Infrastructure
+
+- **mcp-mesh-ui chart**: Optional dependency in mcp-mesh-core with basePath-aware health probes
+- **Ingress chart**: UI + Grafana routing (host-based and path-based), ops NetworkPolicy template
+- **Grafana sub-path**: `serve_from_sub_path` support for basePath-based ingress
+- **Per-service TLS secrets**: Conditional cert/key env vars and volume mounts in registry and UI charts
+
+### 🛠️ SDK & Runtime
+
+- **Rust core extraction** (#679): Duplicated SDK logic (TLS, config, heartbeat) moved to shared Rust core
+- **DependencyKwargs parity** (#689): Schema filtering fix across all runtimes
+- **Pydantic serialization** (#700): Model serialization fix in HTTP direct path
+
+### 🐛 Bug Fixes
+
+- **Detach mode** (#719): StringArray/StringSlice flags and TLS env vars properly forwarded to forked processes
+- **meshctl stability** (#714): SQLite locking, watch mode stop, process management fixes
+- **meshctl call** (#686): Falls back to capability name for tool lookup
+- **Ingress NOTES.txt**: Fixed nil pointer in `range` loop
+
+### 📚 Documentation
+
+- **Dashboard docs**: Production screenshots, deployment guide, architecture overview
+- **Environment variables** (#705): 50+ missing vars added to docs page, man page updated with key vars and footer link
+- **UI deployment** in `meshctl man deployment`: Local dev, Kubernetes, ingress routing, custom basePath, beta tag overrides
+
 [Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v1.0.0...v1.0.1)
 
 ## v1.0.1 (2026-03-28)

--- a/cmd/meshctl/templates/java/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:1.1.0-beta.6
+FROM mcpmesh/java-runtime:1.1
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/basic/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/basic/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:1.1.0-beta.6
+FROM mcpmesh/java-runtime:1.1
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:1.1.0-beta.6
+FROM mcpmesh/java-runtime:1.1
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent
-FROM mcpmesh/python-runtime:1.1.0-beta.6
+FROM mcpmesh/python-runtime:1.1
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:1.1.0-beta.6
+FROM mcpmesh/python-runtime:1.1
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:1.1.0-beta.6
+FROM mcpmesh/python-runtime:1.1
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent
-FROM mcpmesh/typescript-runtime:1.1.0-beta.6
+FROM mcpmesh/typescript-runtime:1.1
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/basic/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/cmd/meshctl/templates/typescript/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:1.1.0-beta.6
+FROM mcpmesh/typescript-runtime:1.1
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/llm-agent/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/cmd/meshctl/templates/typescript/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:1.1.0-beta.6
+FROM mcpmesh/typescript-runtime:1.1
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/llm-provider/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/docs/00-why-mcp-mesh/index.md
+++ b/docs/00-why-mcp-mesh/index.md
@@ -111,7 +111,7 @@ meshctl scaffold --compose --observability
 
 # Or deploy to Kubernetes (OCI registry)
 helm install my-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 -n mcp-mesh --create-namespace
+  --version 1.1.0 -n mcp-mesh --create-namespace
 ```
 
 ### 5. Built-in Observability

--- a/docs/02-local-development.md
+++ b/docs/02-local-development.md
@@ -97,7 +97,7 @@ graph LR
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>1.1.0-beta.6</version>
+        <version>1.1.0</version>
     </dependency>
     ```
 

--- a/docs/04-kubernetes-basics.md
+++ b/docs/04-kubernetes-basics.md
@@ -21,7 +21,7 @@ kubectl create namespace mcp-mesh
 
 # Deploy core (OCI registry - no "helm repo add" needed)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   --namespace mcp-mesh
 
 # Wait for registry
@@ -65,7 +65,7 @@ Build the image:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=my-agent \
@@ -76,7 +76,7 @@ For cloud deployments, use your full registry path:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
@@ -138,7 +138,7 @@ resources:
 ```bash
 # Core without Grafana/Tempo (lighter footprint)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   --namespace mcp-mesh \
   --set grafana.enabled=false \
   --set tempo.enabled=false
@@ -149,7 +149,7 @@ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
 ```bash
 # Just the registry, no database or observability
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   --namespace mcp-mesh
 ```
 
@@ -161,13 +161,13 @@ just match `-n` with `--set global.namespace`:
 ```bash
 # Deploy core to a custom namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n my-namespace --create-namespace \
   --set global.namespace=my-namespace
 
 # Deploy agent to the same namespace
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n my-namespace \
   -f helm-values.yaml
 ```
@@ -180,12 +180,12 @@ For **multi-tenant** clusters (separate core per team), deploy each core to its 
 ```bash
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n team-a --create-namespace --set global.namespace=team-a
 
 # Team B — same values, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n team-b --create-namespace --set global.namespace=team-b
 ```
 
@@ -193,7 +193,7 @@ For **cross-namespace** access (agent in one namespace, core in another), use FQ
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 -n other-ns \
+  --version 1.1.0 -n other-ns \
   --set mesh.registryUrl=http://mcp-core-mcp-mesh-registry.team-a.svc.cluster.local:8000
 ```
 
@@ -205,13 +205,13 @@ helm list -n mcp-mesh
 
 # Upgrade an agent
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   --namespace mcp-mesh \
   --set image.tag=v2
 
 # Scale replicas
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   --namespace mcp-mesh \
   --reuse-values \
   --set replicaCount=3

--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -19,7 +19,7 @@ The data flows: **Agents → Redis → Registry → Tempo → Grafana**
 ```bash
 # Deploy core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   --namespace mcp-mesh \
   --set redis.enabled=true \
   --set tempo.enabled=true \

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -201,7 +201,7 @@ Designed for containers and Kubernetes.
 
 ## Multimodal Pipeline
 
-MCP Mesh v1.1.0-beta.6 adds a media pipeline that lets tools produce and LLMs consume binary content:
+MCP Mesh v1.1.0 adds a media pipeline that lets tools produce and LLMs consume binary content:
 
 ```
 Tool produces media

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,7 +44,7 @@ docker-compose up
 ```bash
 # Quick start (OCI registry - no helm repo add needed)
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 1.1.0-beta.6 -n mcp-mesh --create-namespace
+  --version 1.1.0 -n mcp-mesh --create-namespace
 ```
 
 [:material-arrow-right: Kubernetes Guide](04-kubernetes-basics.md){ .md-button .md-button--primary }
@@ -117,7 +117,7 @@ For Kubernetes, configure TLS via Helm values:
 
 ```bash
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 1.1.0-beta.6 -n mcp-mesh --create-namespace \
+  --version 1.1.0 -n mcp-mesh --create-namespace \
   --set registry.security.tls.mode=strict \
   --set registry.security.trust.backend=k8s-secrets
 ```

--- a/docs/dev-to-production.md
+++ b/docs/dev-to-production.md
@@ -85,10 +85,10 @@ The [TSuite](https://github.com/dhyansraj/mcp-mesh-test-suite) integration testi
 
     ```bash
     helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-      --version 1.1.0-beta.6 -n mcp-mesh --create-namespace
+      --version 1.1.0 -n mcp-mesh --create-namespace
 
     helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 1.1.0-beta.6 -n mcp-mesh -f helm-values.yaml
+      --version 1.1.0 -n mcp-mesh -f helm-values.yaml
     ```
 
 Same agent code runs locally, in Docker, and in Kubernetes — no changes needed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ MCP Mesh is a complete platform for **building and deploying AI agents to produc
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>1.1.0-beta.6</version>
+        <version>1.1.0</version>
     </dependency>
     ```
 
@@ -271,7 +271,7 @@ Pass images, PDFs, and files between agents and LLMs. Claude, OpenAI, and Gemini
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>1.1.0-beta.6</version>
+        <version>1.1.0</version>
     </dependency>
     ```
 
@@ -319,7 +319,7 @@ Pass images, PDFs, and files between agents and LLMs. Claude, OpenAI, and Gemini
 
 ## :star: Project Status
 
-- **Latest Release**: v1.1.0-beta.6 (March 2026)
+- **Latest Release**: v1.1.0 (March 2026)
 - **License**: MIT
 - **Languages**: Python 3.11+, TypeScript/Node.js 18+, and Java 17+ (runtime), Go 1.23+ (registry)
 - **Status**: Production-ready, actively developed

--- a/docs/java/getting-started/index.md
+++ b/docs/java/getting-started/index.md
@@ -83,13 +83,13 @@ Create `pom.xml`:
 
     <groupId>com.example</groupId>
     <artifactId>greeter-agent</artifactId>
-    <version>1.1.0-beta.6</version>
+    <version>1.1.0</version>
 
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>1.1.0-beta.6</version>
+            <version>1.1.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/docs/java/getting-started/prerequisites.md
+++ b/docs/java/getting-started/prerequisites.md
@@ -60,7 +60,7 @@ Add the Spring Boot starter to your `pom.xml`:
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>1.1.0-beta.6</version>
+        <version>1.1.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/docs/java/local-development/01-getting-started.md
+++ b/docs/java/local-development/01-getting-started.md
@@ -45,7 +45,7 @@ The recommended way is to use `meshctl scaffold` (see next page). If you prefer 
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>1.1.0-beta.6</version>
+        <version>1.1.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/docs/java/local-development/troubleshooting.md
+++ b/docs/java/local-development/troubleshooting.md
@@ -38,7 +38,7 @@ Ensure the dependency version matches an available release:
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>1.1.0-beta.6</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 

--- a/docs/java/spring-boot-integration.md
+++ b/docs/java/spring-boot-integration.md
@@ -23,7 +23,7 @@ MCP Mesh provides `@MeshRoute` and `@MeshInject` annotations for Spring Boot RES
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>1.1.0-beta.6</version>
+        <version>1.1.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/docs/python/getting-started/prerequisites.md
+++ b/docs/python/getting-started/prerequisites.md
@@ -145,12 +145,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/examples/docker-examples/agents/claude-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/claude-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying claude-provider with mcp-mesh-agent chart
 # Usage: helm install claude-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 1.1.0-beta.6 -f helm-values.yaml
+#        --version 1.1.0 -f helm-values.yaml
 
 image:
   repository: your-registry/claude-provider

--- a/examples/docker-examples/agents/claude-provider/requirements.txt
+++ b/examples/docker-examples/agents/claude-provider/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Mesh SDK
-mcp-mesh>=1.1.0b6
+mcp-mesh>=1.1.0
 
 # FastMCP for MCP server
 fastmcp>=3.0.0,<4.0.0

--- a/examples/docker-examples/agents/openai-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/openai-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying openai-provider with mcp-mesh-agent chart
 # Usage: helm install openai-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 1.1.0-beta.6 -f helm-values.yaml
+#        --version 1.1.0 -f helm-values.yaml
 
 image:
   repository: your-registry/openai-provider

--- a/examples/docker-examples/agents/openai-provider/requirements.txt
+++ b/examples/docker-examples/agents/openai-provider/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Mesh SDK
-mcp-mesh>=1.1.0b6
+mcp-mesh>=1.1.0
 
 # FastMCP for MCP server
 fastmcp>=3.0.0,<4.0.0

--- a/examples/java/basic-tool-agent/pom.xml
+++ b/examples/java/basic-tool-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-a/pom.xml
+++ b/examples/java/benchmark-chain/svc-a/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-b/pom.xml
+++ b/examples/java/benchmark-chain/svc-b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-c/pom.xml
+++ b/examples/java/benchmark-chain/svc-c/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-d/pom.xml
+++ b/examples/java/benchmark-chain/svc-d/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-e/pom.xml
+++ b/examples/java/benchmark-chain/svc-e/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.2</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/dependency-agent/pom.xml
+++ b/examples/java/dependency-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/direct-openai-agent/pom.xml
+++ b/examples/java/direct-openai-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/java/employee-service/pom.xml
+++ b/examples/java/employee-service/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/gemini-provider-agent/pom.xml
+++ b/examples/java/gemini-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/java/gpt-provider-agent/pom.xml
+++ b/examples/java/gpt-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/java/header-api/pom.xml
+++ b/examples/java/header-api/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/java-accurate-provider/pom.xml
+++ b/examples/java/java-accurate-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/java-alpha-provider/pom.xml
+++ b/examples/java/java-alpha-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/java-beta-provider/pom.xml
+++ b/examples/java/java-beta-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/java-booking-consumer/pom.xml
+++ b/examples/java/java-booking-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/java-calculator/pom.xml
+++ b/examples/java/java-calculator/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/java-deprecated-provider/pom.xml
+++ b/examples/java/java-deprecated-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/java-dual-consumer/pom.xml
+++ b/examples/java/java-dual-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/java-fast-provider/pom.xml
+++ b/examples/java/java-fast-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/java-math-agent/pom.xml
+++ b/examples/java/java-math-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/java-schedule-agent/pom.xml
+++ b/examples/java/java-schedule-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/java-tag-consumer/pom.xml
+++ b/examples/java/java-tag-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/java-weather-agent/pom.xml
+++ b/examples/java/java-weather-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/llm-direct-agent/pom.xml
+++ b/examples/java/llm-direct-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/java/llm-mesh-agent/pom.xml
+++ b/examples/java/llm-mesh-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/llm-provider-agent/pom.xml
+++ b/examples/java/llm-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/java/media-consumer-agent/pom.xml
+++ b/examples/java/media-consumer-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/media-producer-agent/pom.xml
+++ b/examples/java/media-producer-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/multijar-api-gateway/pom.xml
+++ b/examples/java/multijar-api-gateway/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/multijar-payment-service/pom.xml
+++ b/examples/java/multijar-payment-service/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/rest-api-consumer/pom.xml
+++ b/examples/java/rest-api-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/parallel-tools/direct-consumer-claude-java/pom.xml
+++ b/examples/parallel-tools/direct-consumer-claude-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/parallel-tools/direct-consumer-claude-ts/package.json
+++ b/examples/parallel-tools/direct-consumer-claude-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/direct-consumer-gemini-java/pom.xml
+++ b/examples/parallel-tools/direct-consumer-gemini-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/parallel-tools/direct-consumer-gemini-ts/package.json
+++ b/examples/parallel-tools/direct-consumer-gemini-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/direct-consumer-openai-java/pom.xml
+++ b/examples/parallel-tools/direct-consumer-openai-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/parallel-tools/direct-consumer-openai-ts/package.json
+++ b/examples/parallel-tools/direct-consumer-openai-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/parallel-consumer-java/pom.xml
+++ b/examples/parallel-tools/parallel-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/parallel-tools/parallel-consumer-ts/package.json
+++ b/examples/parallel-tools/parallel-consumer-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/slow-tool-java/pom.xml
+++ b/examples/parallel-tools/slow-tool-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/parallel-tools/slow-tool-ts/package.json
+++ b/examples/parallel-tools/slow-tool-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/analyst-java/pom.xml
+++ b/examples/toolcalls/analyst-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/toolcalls/analyst-ts/package.json
+++ b/examples/toolcalls/analyst-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/claude-provider-java/pom.xml
+++ b/examples/toolcalls/claude-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/claude-provider-ts/package.json
+++ b/examples/toolcalls/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/gemini-provider-java/pom.xml
+++ b/examples/toolcalls/gemini-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/gemini-provider-ts/package.json
+++ b/examples/toolcalls/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/openai-provider-java/pom.xml
+++ b/examples/toolcalls/openai-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M2</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/openai-provider-ts/package.json
+++ b/examples/toolcalls/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/weather-tool-java/pom.xml
+++ b/examples/toolcalls/weather-tool-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/toolcalls/weather-tool-ts/package.json
+++ b/examples/toolcalls/weather-tool-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-a/package.json
+++ b/examples/typescript/benchmark-chain/svc-a/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.2"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-b/package.json
+++ b/examples/typescript/benchmark-chain/svc-b/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.2"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-c/package.json
+++ b/examples/typescript/benchmark-chain/svc-c/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.2"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-d/package.json
+++ b/examples/typescript/benchmark-chain/svc-d/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.2"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-e/package.json
+++ b/examples/typescript/benchmark-chain/svc-e/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.2"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/header-api/package.json
+++ b/examples/typescript/header-api/package.json
@@ -11,7 +11,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6",
+    "@mcpmesh/sdk": "^1.1.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/examples/typescript/llm-consumer/package.json
+++ b/examples/typescript/llm-consumer/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6",
+    "@mcpmesh/sdk": "^1.1.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/examples/typescript/llm-provider/package.json
+++ b/examples/typescript/llm-provider/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6",
+    "@mcpmesh/sdk": "^1.1.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/helm/mcp-mesh-agent/Chart.yaml
+++ b/helm/mcp-mesh-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-agent
 description: MCP Mesh Agent - Python runtime for MCP agents with mesh capabilities
 type: application
-version: 1.1.0-beta.6
-appVersion: "1.1.0-beta.6"
+version: 1.1.0
+appVersion: "1.1.0"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-core/Chart.lock
+++ b/helm/mcp-mesh-core/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: mcp-mesh-postgres
   repository: file://../mcp-mesh-postgres
-  version: 1.1.0-beta.6
+  version: 1.1.0
 - name: mcp-mesh-redis
   repository: file://../mcp-mesh-redis
-  version: 1.1.0-beta.6
+  version: 1.1.0
 - name: mcp-mesh-registry
   repository: file://../mcp-mesh-registry
-  version: 1.1.0-beta.6
+  version: 1.1.0
 - name: mcp-mesh-grafana
   repository: file://../mcp-mesh-grafana
-  version: 1.1.0-beta.6
+  version: 1.1.0
 - name: mcp-mesh-tempo
   repository: file://../mcp-mesh-tempo
-  version: 1.1.0-beta.6
+  version: 1.1.0
 - name: mcp-mesh-ui
   repository: file://../mcp-mesh-ui
-  version: 1.1.0-beta.6
-digest: sha256:6ad541000a940e7bbfe769f0e0fd029ae84b46e705785f29723ef2ac33b7e025
-generated: "2026-04-05T10:59:11.040243-04:00"
+  version: 1.1.0
+digest: sha256:df46db057ed57559c4979e68a9088bb48d1739cbe44d7cb4f20f3cd903e92d97
+generated: "2026-04-05T14:49:35.628823-04:00"

--- a/helm/mcp-mesh-core/Chart.yaml
+++ b/helm/mcp-mesh-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-core
 description: MCP Mesh Core Infrastructure - Registry, PostgreSQL, Redis, and Observability
 type: application
-version: 1.1.0-beta.6
-appVersion: "1.1.0-beta.6"
+version: 1.1.0
+appVersion: "1.1.0"
 keywords:
   - mcp
   - mesh
@@ -28,26 +28,26 @@ annotations:
   "artifacthub.io/containsSecurityUpdates": "false"
 dependencies:
   - name: mcp-mesh-postgres
-    version: "1.1.0-beta.6"
+    version: "1.1.0"
     repository: "file://../mcp-mesh-postgres"
     condition: postgres.enabled
   - name: mcp-mesh-redis
-    version: "1.1.0-beta.6"
+    version: "1.1.0"
     repository: "file://../mcp-mesh-redis"
     condition: redis.enabled
   - name: mcp-mesh-registry
-    version: "1.1.0-beta.6"
+    version: "1.1.0"
     repository: "file://../mcp-mesh-registry"
     condition: registry.enabled
   - name: mcp-mesh-grafana
-    version: "1.1.0-beta.6"
+    version: "1.1.0"
     repository: "file://../mcp-mesh-grafana"
     condition: grafana.enabled
   - name: mcp-mesh-tempo
-    version: "1.1.0-beta.6"
+    version: "1.1.0"
     repository: "file://../mcp-mesh-tempo"
     condition: tempo.enabled
   - name: mcp-mesh-ui
-    version: "1.1.0-beta.6"
+    version: "1.1.0"
     repository: "file://../mcp-mesh-ui"
     condition: ui.enabled

--- a/helm/mcp-mesh-grafana/Chart.yaml
+++ b/helm/mcp-mesh-grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-grafana
 description: Grafana observability component for MCP Mesh
 type: application
-version: 1.1.0-beta.6
+version: 1.1.0
 appVersion: "12.3.1"
 keywords:
   - grafana

--- a/helm/mcp-mesh-ingress/Chart.yaml
+++ b/helm/mcp-mesh-ingress/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ingress
 description: Ingress configuration for MCP Mesh services with flexible DNS routing
 type: application
-version: 1.1.0-beta.6
-appVersion: "1.1.0-beta.6"
+version: 1.1.0
+appVersion: "1.1.0"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-postgres/Chart.yaml
+++ b/helm/mcp-mesh-postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-postgres
 description: PostgreSQL database for MCP Mesh Registry
 type: application
-version: 1.1.0-beta.6
+version: 1.1.0
 appVersion: "15"
 keywords:
   - mcp

--- a/helm/mcp-mesh-redis/Chart.yaml
+++ b/helm/mcp-mesh-redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-redis
 description: Redis cache for MCP Mesh session storage
 type: application
-version: 1.1.0-beta.6
+version: 1.1.0
 appVersion: "7"
 keywords:
   - mcp

--- a/helm/mcp-mesh-registry/Chart.yaml
+++ b/helm/mcp-mesh-registry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-registry
 description: MCP Mesh Registry Service - Central service registry for MCP agents
 type: application
-version: 1.1.0-beta.6
-appVersion: "1.1.0-beta.6"
+version: 1.1.0
+appVersion: "1.1.0"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-tempo/Chart.yaml
+++ b/helm/mcp-mesh-tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-tempo
 description: Tempo distributed tracing component for MCP Mesh
 type: application
-version: 1.1.0-beta.6
+version: 1.1.0
 appVersion: "2.9.0"
 keywords:
   - tempo

--- a/helm/mcp-mesh-ui/Chart.yaml
+++ b/helm/mcp-mesh-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ui
 description: MCP Mesh Dashboard UI Server - Web dashboard for monitoring MCP agents
 type: application
-version: 1.1.0-beta.6
-appVersion: "1.1.0-beta.6"
+version: 1.1.0
+appVersion: "1.1.0"
 keywords:
   - mcp
   - mesh

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/cli",
-  "version": "1.1.0-beta.6",
+  "version": "1.1.0",
   "description": "CLI for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration",
   "license": "MIT",
   "repository": {
@@ -23,10 +23,10 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@mcpmesh/cli-linux-x64": "1.1.0-beta.6",
-    "@mcpmesh/cli-linux-arm64": "1.1.0-beta.6",
-    "@mcpmesh/cli-darwin-x64": "1.1.0-beta.6",
-    "@mcpmesh/cli-darwin-arm64": "1.1.0-beta.6"
+    "@mcpmesh/cli-linux-x64": "1.1.0",
+    "@mcpmesh/cli-linux-arm64": "1.1.0",
+    "@mcpmesh/cli-darwin-x64": "1.1.0",
+    "@mcpmesh/cli-darwin-arm64": "1.1.0"
   },
   "keywords": [
     "mcp",

--- a/packaging/homebrew/mcp-mesh.rb
+++ b/packaging/homebrew/mcp-mesh.rb
@@ -2,7 +2,7 @@
 class McpMesh < Formula
   desc "Kubernetes-native platform for distributed MCP applications"
   homepage "https://github.com/dhyansraj/mcp-mesh"
-  version "1.1.0-beta.6"  # Will be updated by release automation
+  version "1.1.0"  # Will be updated by release automation
 
   if OS.mac?
     if Hardware::CPU.arm?

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "1.1.0b6"
+version = "1.1.0"
 description = "Python SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration"
 readme = "README.md"
 license = { text = "MIT" }
@@ -39,7 +39,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     # Rust core runtime (required - no Python fallback)
-    "mcp-mesh-core>=1.1.0b6",
+    "mcp-mesh-core>=1.1.0",
     "fastapi>=0.104.0,<1.0.0",
     "uvicorn>=0.24.0,<1.0.0",
     "httpx>=0.25.0,<1.0.0",

--- a/packaging/scoop/mcp-mesh.json
+++ b/packaging/scoop/mcp-mesh.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0-beta.6",
+  "version": "1.1.0",
   "description": "Kubernetes-native platform for distributed MCP applications",
   "homepage": "https://github.com/dhyansraj/mcp-mesh",
   "license": "MIT",

--- a/src/core/cli/handlers/java_handler.go
+++ b/src/core/cli/handlers/java_handler.go
@@ -304,7 +304,7 @@ const javaPomTemplate = `<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>1.1.0-beta.6</version>
+            <version>1.1.0</version>
         </dependency>
     </dependencies>
 

--- a/src/core/cli/handlers/language_test.go
+++ b/src/core/cli/handlers/language_test.go
@@ -202,7 +202,7 @@ func TestDetectLanguage_PythonDirectoryRequirements(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Create requirements.txt
-	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("mcp-mesh==1.1.0b6"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("mcp-mesh==1.1.0"), 0644); err != nil {
 		t.Fatalf("Failed to create requirements.txt: %v", err)
 	}
 

--- a/src/core/cli/handlers/python_handler.go
+++ b/src/core/cli/handlers/python_handler.go
@@ -248,5 +248,5 @@ const pythonInitTemplate = `# {{.Name}} MCP Mesh Agent
 const pythonMainModuleTemplate = `from .main import *
 `
 
-const pythonRequirementsTemplate = `mcp-mesh>=1.1.0b6
+const pythonRequirementsTemplate = `mcp-mesh>=1.1.0
 `

--- a/src/core/cli/handlers/typescript_handler.go
+++ b/src/core/cli/handlers/typescript_handler.go
@@ -269,7 +269,7 @@ const typescriptPackageTemplate = `{
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6",
+    "@mcpmesh/sdk": "^1.1.0",
     "fastmcp": "^3.26.0",
     "zod": "^3.23.0"
   },

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -155,12 +155,12 @@ For production Kubernetes deployment, use the official Helm charts from the MCP 
 # Install core infrastructure (registry + database + observability)
 # No "helm repo add" needed - uses OCI registry directly
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy agent using scaffold-generated helm-values.yaml
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -171,12 +171,12 @@ Deploy into any namespace — just match `-n` with `--set global.namespace`:
 
 ```bash
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n my-namespace --create-namespace \
   --set global.namespace=my-namespace
 
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n my-namespace \
   -f helm-values.yaml
 ```
@@ -195,19 +195,19 @@ its own namespace. Short service names resolve independently within each namespa
 ```bash
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n team-a --create-namespace --set global.namespace=team-a
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 -n team-a -f greeter/helm-values.yaml
+  --version 1.1.0 -n team-a -f greeter/helm-values.yaml
 
 # Team B — same helm-values.yaml, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n team-b --create-namespace --set global.namespace=team-b
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 -n team-b -f greeter/helm-values.yaml
+  --version 1.1.0 -n team-b -f greeter/helm-values.yaml
 ```
 
 ### Available Helm Charts
@@ -256,16 +256,16 @@ meshctl scaffold --name my-agent --agent-type tool
 
 # 2. Build and push Docker image (works on all platforms)
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.1.0-beta.6 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.1.0 --push .
 
 # 3. Update helm-values.yaml with your image repository
 # 4. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v1.1.0-beta.6
+  --set image.tag=v1.1.0
 ```
 
 ### Disable Optional Components
@@ -273,14 +273,14 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 ```bash
 # Core without observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh --create-namespace \
   --set grafana.enabled=false \
   --set tempo.enabled=false
 
 # Core without PostgreSQL (in-memory registry)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh --create-namespace \
   --set postgres.enabled=false
 ```

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -16,7 +16,7 @@ MCP Mesh supports multiple deployment patterns for Java/Spring Boot agents. The 
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>1.1.0-beta.6</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
@@ -204,12 +204,12 @@ For production Kubernetes deployment:
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy Java agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -242,15 +242,15 @@ resources:
 ```bash
 # 1. Build and push Docker image
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.1.0-beta.6 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.1.0 --push .
 
 # 2. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v1.1.0-beta.6
+  --set image.tag=v1.1.0
 ```
 
 ## Port Strategy

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -145,12 +145,12 @@ For production Kubernetes deployment:
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy TypeScript agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -192,15 +192,15 @@ meshctl scaffold --name my-agent --agent-type tool --lang typescript
 
 # 2. Build and push Docker image
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.1.0-beta.6 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.1.0 --push .
 
 # 3. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v1.1.0-beta.6
+  --set image.tag=v1.1.0
 ```
 
 ## Port Strategy

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -65,12 +65,12 @@ docker compose up -d
 ```bash
 # Install core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh --create-namespace
 
 # Or disable observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh --create-namespace \
   --set tempo.enabled=false \
   --set grafana.enabled=false

--- a/src/core/cli/man/content/prerequisites.md
+++ b/src/core/cli/man/content/prerequisites.md
@@ -137,12 +137,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/src/core/cli/man/content/prerequisites_java.md
+++ b/src/core/cli/man/content/prerequisites_java.md
@@ -52,7 +52,7 @@ Add the Spring Boot starter to your `pom.xml`:
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>1.1.0-beta.6</version>
+        <version>1.1.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/src/core/cli/man/content/quickstart_java.md
+++ b/src/core/cli/man/content/quickstart_java.md
@@ -75,13 +75,13 @@ Create `pom.xml`:
 
     <groupId>com.example</groupId>
     <artifactId>greeter-agent</artifactId>
-    <version>1.1.0-beta.6</version>
+    <version>1.1.0</version>
 
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>1.1.0-beta.6</version>
+            <version>1.1.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/core/cli/man/content/registry.md
+++ b/src/core/cli/man/content/registry.md
@@ -171,7 +171,7 @@ The registry supports multiple replicas for high availability. All replicas shar
 ```bash
 # Scale registry replicas
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 1.1.0-beta.6 \
+  --version 1.1.0 \
   -n mcp-mesh --create-namespace \
   --set registry.replicas=3
 ```

--- a/src/runtime/core/Cargo.toml
+++ b/src/runtime/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-mesh-core"
-version = "1.1.0-beta.6"
+version = "1.1.0"
 edition = "2021"
 description = "Rust core runtime for MCP Mesh agents"
 license = "MIT"

--- a/src/runtime/core/pyproject.toml
+++ b/src/runtime/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mcp-mesh-core"
-version = "1.1.0b6"
+version = "1.1.0"
 description = "Rust core runtime for MCP Mesh agents"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/core/typescript/package.json
+++ b/src/runtime/core/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/core",
-  "version": "1.1.0-beta.6",
+  "version": "1.1.0",
   "description": "MCP Mesh Rust core bindings for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/runtime/java/mcp-mesh-bom/pom.xml
+++ b/src/runtime/java/mcp-mesh-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-bom</artifactId>
-    <version>1.1.0-beta.6</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
 
     <name>MCP Mesh BOM</name>

--- a/src/runtime/java/mcp-mesh-core/pom.xml
+++ b/src/runtime/java/mcp-mesh-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>1.1.0-beta.6</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>mcp-mesh-core</artifactId>

--- a/src/runtime/java/mcp-mesh-native/pom.xml
+++ b/src/runtime/java/mcp-mesh-native/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>1.1.0-beta.6</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>mcp-mesh-native</artifactId>

--- a/src/runtime/java/mcp-mesh-sdk/pom.xml
+++ b/src/runtime/java/mcp-mesh-sdk/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>1.1.0-beta.6</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>mcp-mesh-sdk</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-ai/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-ai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>1.1.0-beta.6</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>mcp-mesh-spring-ai</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>1.1.0-beta.6</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>

--- a/src/runtime/java/pom.xml
+++ b/src/runtime/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-parent</artifactId>
-    <version>1.1.0-beta.6</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
 
     <name>MCP Mesh Java SDK</name>

--- a/src/runtime/python/_mcp_mesh/__init__.py
+++ b/src/runtime/python/_mcp_mesh/__init__.py
@@ -31,7 +31,7 @@ from .engine.decorator_registry import (
     get_decorator_stats,
 )
 
-__version__ = "1.1.0b6"
+__version__ = "1.1.0"
 
 # Store reference to runtime processor if initialized
 _runtime_processor = None

--- a/src/runtime/python/mesh/__init__.py
+++ b/src/runtime/python/mesh/__init__.py
@@ -31,7 +31,7 @@ from .types import (
 # Note: helpers.llm_provider is imported lazily in __getattr__ to avoid
 # initialization timing issues with @mesh.agent auto_run in tests
 
-__version__ = "1.1.0b6"
+__version__ = "1.1.0"
 
 
 # Helper function to create FastMCP server with proper naming

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "1.1.0b6"
+version = "1.1.0"
 description = "Python SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/typescript/package.json
+++ b/src/runtime/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/sdk",
-  "version": "1.1.0-beta.6",
+  "version": "1.1.0",
   "description": "TypeScript SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -102,12 +102,12 @@ Edit `config.yaml` to set versions:
 
 ```yaml
 packages:
-  cli_version: "1.1.0-beta.6" # @mcpmesh/cli
-  sdk_python_version: "1.1.0-beta.6" # mcp-mesh (pip) - PEP 440 format
-  sdk_typescript_version: "1.1.0-beta.6" # @mcpmesh/sdk
+  cli_version: "1.1.0" # @mcpmesh/cli
+  sdk_python_version: "1.1.0" # mcp-mesh (pip) - PEP 440 format
+  sdk_typescript_version: "1.1.0" # @mcpmesh/sdk
 
 docker:
-  base_image: "tsuite-mesh:1.1.0-beta.6"
+  base_image: "tsuite-mesh:1.1.0"
 ```
 
 ## Environment Variables

--- a/tests/integration/suites/README.md
+++ b/tests/integration/suites/README.md
@@ -108,7 +108,7 @@ const agent = mesh(server, {
 ```bash
 docker run --rm -it \
   -v $(pwd)/suites/uc01_registry/artifacts:/uc-artifacts:ro \
-  tsuite-mesh:1.1.0-beta.6 bash
+  tsuite-mesh:1.1.0 bash
 ```
 
 ### Common issues:
@@ -123,9 +123,9 @@ Available in test.yaml via `${config.X}`:
 
 | Variable                                 | Example      |
 | ---------------------------------------- | ------------ |
-| `config.packages.cli_version`            | 1.1.0-beta.6 |
-| `config.packages.sdk_python_version`     | 1.1.0-beta.6 |
-| `config.packages.sdk_typescript_version` | 1.1.0-beta.6 |
+| `config.packages.cli_version`            | 1.1.0 |
+| `config.packages.sdk_python_version`     | 1.1.0 |
+| `config.packages.sdk_typescript_version` | 1.1.0 |
 
 ## Issue Reporting Policy
 

--- a/tests/integration/suites/uc01_registry/artifacts/ts-multi-agent/package.json
+++ b/tests/integration/suites/uc01_registry/artifacts/ts-multi-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc01_registry/artifacts/ts-simple-agent/package.json
+++ b/tests/integration/suites/uc01_registry/artifacts/ts-simple-agent/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-accurate-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-accurate-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-deprecated-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-deprecated-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-fast-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-fast-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-tag-consumer/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-tag-consumer/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-alpha-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-alpha-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-beta-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-beta-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-dual-consumer/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-dual-consumer/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-caller/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-caller/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-provider/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-provider/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-caller/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-caller/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-provider/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "@ai-sdk/anthropic": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "@ai-sdk/google": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "@ai-sdk/anthropic": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "@ai-sdk/google": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc23_structured_output_ts_consumer_py_provider/artifacts/structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc23_structured_output_ts_consumer_py_provider/artifacts/structured-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6",
+    "@mcpmesh/sdk": "^1.1.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc28_structured_output_ts_consumer_java_provider/artifacts/structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc28_structured_output_ts_consumer_java_provider/artifacts/structured-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6",
+    "@mcpmesh/sdk": "^1.1.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc32_structured_output_ts_consumer_py_openai_provider/artifacts/structured-consumer-openai-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc32_structured_output_ts_consumer_py_openai_provider/artifacts/structured-consumer-openai-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6",
+    "@mcpmesh/sdk": "^1.1.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/artifacts/java-non-mesh-app/pom.xml
+++ b/tests/integration/suites/uc05_meshctl/artifacts/java-non-mesh-app/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc05_meshctl/tc33_ts_api_port_isolation/artifacts/ts-api-app/package.json
+++ b/tests/integration/suites/uc05_meshctl/tc33_ts_api_port_isolation/artifacts/ts-api-app/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "1.1.0-beta.6",
+    "@mcpmesh/sdk": "1.1.0",
     "express": "^4.21.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc06_observability/artifacts/express-api/package.json
+++ b/tests/integration/suites/uc06_observability/artifacts/express-api/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6",
+    "@mcpmesh/sdk": "^1.1.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6",
+    "@mcpmesh/sdk": "^1.1.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-echo-ts/package.json
+++ b/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-echo-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-relay-ts/package.json
+++ b/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-relay-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-echo-java/pom.xml
+++ b/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-echo-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-relay-java/pom.xml
+++ b/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-relay-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc14_multimedia/tc30_download_media_typescript/artifacts/ts-download-agent/package.json
+++ b/tests/integration/suites/uc14_multimedia/tc30_download_media_typescript/artifacts/ts-download-agent/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6",
+    "@mcpmesh/sdk": "^1.1.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc14_multimedia/tc31_download_media_java/artifacts/java-download-agent/pom.xml
+++ b/tests/integration/suites/uc14_multimedia/tc31_download_media_java/artifacts/java-download-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc16_schema_filtering/artifacts/java-schema-agent/pom.xml
+++ b/tests/integration/suites/uc16_schema_filtering/artifacts/java-schema-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0-beta.6</mcp-mesh.version>
+        <mcp-mesh.version>1.1.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc16_schema_filtering/artifacts/ts-schema-agent/package.json
+++ b/tests/integration/suites/uc16_schema_filtering/artifacts/ts-schema-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0-beta.6"
+    "@mcpmesh/sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/lib-tests/README.md
+++ b/tests/lib-tests/README.md
@@ -68,7 +68,7 @@ tsuite --uc uc04_build_image
 
 After successful run, you'll have:
 
-- `tsuite-mesh:1.1.0-beta.6` (or current version) Docker image
+- `tsuite-mesh:1.1.0` (or current version) Docker image
 
 Verify with:
 
@@ -82,11 +82,11 @@ Edit `config.yaml` to update versions:
 
 ```yaml
 packages:
-  cli_version: "1.1.0-beta.6"
-  sdk_python_version: "1.1.0-beta.6" # PEP 440 format for Python
-  sdk_typescript_version: "1.1.0-beta.6"
-  core_version: "1.1.0-beta.6"
-  sdk_java_version: "1.1.0-beta.6"
+  cli_version: "1.1.0"
+  sdk_python_version: "1.1.0" # PEP 440 format for Python
+  sdk_typescript_version: "1.1.0"
+  core_version: "1.1.0"
+  sdk_java_version: "1.1.0"
 ```
 
 ## Next Steps

--- a/tests/lib-tests/config.yaml
+++ b/tests/lib-tests/config.yaml
@@ -10,11 +10,11 @@ suite:
 
 packages:
   # Version to test - update this for each release
-  cli_version: "1.1.0-beta.6"
-  sdk_python_version: "1.1.0b6" # PEP 440 format for pip
-  sdk_typescript_version: "1.1.0-beta.6"
-  core_version: "1.1.0-beta.6"
-  sdk_java_version: "1.1.0-beta.6"
+  cli_version: "1.1.0"
+  sdk_python_version: "1.1.0" # PEP 440 format for pip
+  sdk_typescript_version: "1.1.0"
+  core_version: "1.1.0"
+  sdk_java_version: "1.1.0"
 
 # Docker settings for the base image build
 docker:


### PR DESCRIPTION
## Summary
Version bump 1.1.0-beta.6 → 1.1.0 (184 files).

The dashboard release — real-time monitoring, parallel tool execution, per-service TLS, and production-grade Kubernetes deployment.

### Key changes in this PR
- Version bump across all packages, charts, templates, docs, and tests
- Release notes added to RELEASE_NOTES.md
- Benchmark-chain examples updated from stale beta versions
- Scaffold template Docker tags fixed to use `1.1` minor tag (matching Go handlers)
- `uisample/` added to .gitignore (source screenshots, not for repo)

### Full changelog (since v1.0.1)
See RELEASE_NOTES.md for complete list of features, fixes, and improvements.

Closes #732

## Test plan
- [x] `go build ./...` passes
- [x] `helm dependency update helm/mcp-mesh-core` succeeds
- [x] All pre-commit hooks pass
- [x] No stale beta or old version references (verified via grep)
- [x] Scaffold templates use `1.1` minor Docker tags
- [x] 15/15 TLS/SPIRE integration tests passing (verified in beta.6)