### PR TITLE
fix: prevent SQLite corruption from connection pool PRAGMA loss

### DIFF
--- a/src/core/database/ent_database.go
+++ b/src/core/database/ent_database.go
@@ -83,17 +83,30 @@ func InitializeEnt(config *Config, enableDebugLogging bool) (*EntDatabase, error
 		// Build DSN with PRAGMAs as query parameters so they apply to every
 		// new connection (go-sqlite3 executes _pragma params on connect).
 		// This prevents corruption from connection pool recycling losing PRAGMAs.
-		fk := 0
-		if config.EnableForeignKeys {
-			fk = 1
+		// Apply defaults for zero-valued PRAGMA fields (e.g., partial Config from tests)
+		journalMode := config.JournalMode
+		if journalMode == "" {
+			journalMode = "WAL"
 		}
-		dataSourceName = fmt.Sprintf("%s?_fk=%d&_journal_mode=%s&_busy_timeout=%d&_synchronous=%s&_cache_size=-%d",
+		busyTimeout := config.BusyTimeout
+		if busyTimeout == 0 {
+			busyTimeout = 5000
+		}
+		synchronous := config.Synchronous
+		if synchronous == "" {
+			synchronous = "NORMAL"
+		}
+		cacheSize := config.CacheSize
+		if cacheSize == 0 {
+			cacheSize = 10000
+		}
+		// Foreign keys are always enabled for SQLite — Ent requires _fk=1 for schema migration.
+		dataSourceName = fmt.Sprintf("%s?_fk=1&_journal_mode=%s&_busy_timeout=%d&_synchronous=%s&_cache_size=-%d",
 			sqlitePath,
-			fk,
-			config.JournalMode,
-			config.BusyTimeout,
-			config.Synchronous,
-			config.CacheSize,
+			journalMode,
+			busyTimeout,
+			synchronous,
+			cacheSize,
 		)
 	}
 


### PR DESCRIPTION
## Summary

- Move SQLite PRAGMAs from post-connect `ExecContext` calls into DSN query parameters so they apply to every new connection
- Set `ConnMaxLifetime(0)` for SQLite to prevent connection recycling entirely
- Remove redundant post-connect PRAGMA block (now handled by DSN)

## Root Cause

PRAGMAs (`journal_mode=WAL`, `busy_timeout=5000`, etc.) were set via `ExecContext` on the initial connection but lost when the pool recycled after `ConnMaxLifetime` (300s). The new connection defaulted to `journal_mode=DELETE`, causing a journal mode mismatch and database corruption under concurrent agent heartbeat load.

## Test plan

- [x] `go build ./cmd/mcp-mesh-registry/` passes
- [x] `go build ./cmd/mcp-mesh-ui/` passes
- [x] `go vet ./src/core/database/...` passes
- [ ] Run 7+ agents with `meshctl start -d -w` for 10+ minutes, verify no DB corruption
- [ ] Verify `meshctl list` and `meshctl call` work consistently after extended runtime

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * SQLite connection string now embeds PRAGMA-style settings to ensure consistent runtime options.
  * Removed the separate post-connection PRAGMA execution step for SQLite.
  * Connection pooling tightened to maintain a single persistent SQLite connection, improving stability and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->