### PR TITLE
fix: parent_span linkage in Python tracing + total calls metric

### DIFF
--- a/src/core/registry/tracing/accumulator.go
+++ b/src/core/registry/tracing/accumulator.go
@@ -60,6 +60,12 @@ type TraceAccumulator struct {
 	// Per-agent activity count (spans seen per agent)
 	agentActivity map[string]int
 
+	// Total number of finalized traces (never resets)
+	totalFinalized int
+
+	// Total number of finalized traces that had errors (never resets)
+	totalErrors int
+
 	// Live subscribers for SSE streaming
 	liveMu      sync.RWMutex
 	liveClients map[chan *LiveTraceEvent]struct{}
@@ -236,6 +242,11 @@ func (ta *TraceAccumulator) finalizeTrace(at *activeTrace, rootSpan *TraceEvent)
 		AgentCount:    len(at.Agents),
 		Success:       !at.HasError,
 		Agents:        agents,
+	}
+
+	ta.totalFinalized++
+	if !summary.Success {
+		ta.totalErrors++
 	}
 
 	// Push to ring buffer
@@ -427,6 +438,20 @@ func (ta *TraceAccumulator) GetEdgeStats() []EdgeStats {
 	})
 
 	return edges
+}
+
+// GetTotalFinalized returns the total number of finalized traces.
+func (ta *TraceAccumulator) GetTotalFinalized() int {
+	ta.mu.RLock()
+	defer ta.mu.RUnlock()
+	return ta.totalFinalized
+}
+
+// GetTotalErrors returns the total number of finalized traces that had errors.
+func (ta *TraceAccumulator) GetTotalErrors() int {
+	ta.mu.RLock()
+	defer ta.mu.RUnlock()
+	return ta.totalErrors
 }
 
 // GetAgentActivity returns a copy of the agent activity map.

--- a/src/core/registry/tracing/manager.go
+++ b/src/core/registry/tracing/manager.go
@@ -732,6 +732,22 @@ func (tm *TracingManager) GetAccumulator() *TraceAccumulator {
 	return tm.accumulator
 }
 
+// GetTotalFinalized returns the total number of finalized traces from the accumulator.
+func (tm *TracingManager) GetTotalFinalized() int {
+	if tm.accumulator != nil {
+		return tm.accumulator.GetTotalFinalized()
+	}
+	return 0
+}
+
+// GetTotalErrors returns the total number of error traces from the accumulator.
+func (tm *TracingManager) GetTotalErrors() int {
+	if tm.accumulator != nil {
+		return tm.accumulator.GetTotalErrors()
+	}
+	return 0
+}
+
 // GetAgentActivity returns per-agent span counts from the accumulator.
 func (tm *TracingManager) GetAgentActivity() map[string]int {
 	if tm.accumulator != nil {

--- a/src/core/ui/trace_poller.go
+++ b/src/core/ui/trace_poller.go
@@ -102,8 +102,10 @@ func (p *TracePoller) poll() {
 		p.hub.Publish(DashboardEvent{
 			Type: "trace_activity",
 			Data: map[string]interface{}{
-				"agents":      agentCounts,
-				"trace_count": totalSpans,
+				"agents":       agentCounts,
+				"trace_count":  totalSpans,
+				"total_calls":  p.tracingManager.GetTotalFinalized(),
+				"total_errors": p.tracingManager.GetTotalErrors(),
 			},
 			Timestamp: now,
 		})
@@ -119,11 +121,19 @@ func (p *TracePoller) poll() {
 					fallbackCounts[agent]++
 				}
 			}
+			fallbackErrors := 0
+			for _, t := range traces {
+				if !t.Success {
+					fallbackErrors++
+				}
+			}
 			p.hub.Publish(DashboardEvent{
 				Type: "trace_activity",
 				Data: map[string]interface{}{
-					"agents":      fallbackCounts,
-					"trace_count": len(traces),
+					"agents":       fallbackCounts,
+					"trace_count":  len(traces),
+					"total_calls":  len(traces),
+					"total_errors": fallbackErrors,
 				},
 				Timestamp: now,
 			})

--- a/src/runtime/python/_mcp_mesh/tracing/execution_tracer.py
+++ b/src/runtime/python/_mcp_mesh/tracing/execution_tracer.py
@@ -68,15 +68,15 @@ class ExecutionTracer:
 
             if self.trace_context:
                 # Have trace context - use existing trace_id, create child span
-                # Published parent is the CALLER's span (from X-Parent-Span header),
-                # not the local request span. This ensures root spans from meshctl
-                # (which sends no X-Parent-Span) have parent_span=None, enabling
-                # immediate trace finalization in the accumulator.
+                # Published parent is the caller's span_id (from X-Parent-Span header
+                # or the containing function's span). For root spans (meshctl with no
+                # X-Parent-Span), span_id is empty → or None ensures parent_span=None,
+                # enabling immediate trace finalization in the accumulator.
                 self.execution_metadata.update(
                     {
                         "trace_id": self.trace_context.trace_id,
                         "span_id": function_span_id,
-                        "parent_span": self.trace_context.parent_span,
+                        "parent_span": self.trace_context.span_id or None,
                     }
                 )
 

--- a/src/ui/app/traffic/page.tsx
+++ b/src/ui/app/traffic/page.tsx
@@ -87,7 +87,7 @@ function Sparkline({
 }
 
 export default function TrafficPage() {
-  const { edgeStats, agentStats, modelStats, loading, error, refresh } = useMesh();
+  const { edgeStats, agentStats, modelStats, loading, error, refresh, totalCalls: totalCallsFromContext, totalErrors: totalErrorsFromContext } = useMesh();
 
   // Sparkline history ring buffer
   const historyRef = useRef<Map<string, number[]>>(new Map());
@@ -107,8 +107,8 @@ export default function TrafficPage() {
 
   // Aggregated stats for overview cards
   const overview = useMemo(() => {
-    const totalCalls = edgeStats.reduce((sum, e) => sum + (e.call_count || 0), 0);
-    const totalErrors = edgeStats.reduce((sum, e) => sum + (e.error_count || 0), 0);
+    const totalCalls = totalCallsFromContext;
+    const totalErrors = totalErrorsFromContext;
     const successRate = totalCalls > 0 ? ((1 - totalErrors / totalCalls) * 100) : 100;
 
     const totalTokens = agentStats.reduce(
@@ -122,7 +122,7 @@ export default function TrafficPage() {
     );
 
     return { totalCalls, successRate, totalTokens, totalData };
-  }, [edgeStats, agentStats]);
+  }, [edgeStats, agentStats, totalCallsFromContext, totalErrorsFromContext]);
 
   // Sorted edges by route name
   const sortedEdges = useMemo(() => {

--- a/src/ui/lib/mesh-context.tsx
+++ b/src/ui/lib/mesh-context.tsx
@@ -15,6 +15,8 @@ export interface MeshContextValue {
   setPaused: (paused: boolean) => void;
   refresh: () => Promise<void>;
   traceActivity: Record<string, number>;
+  totalCalls: number;
+  totalErrors: number;
   edgeStats: EdgeStat[];
   agentStats: AgentStat[];
   modelStats: ModelStat[];
@@ -30,6 +32,8 @@ export function MeshProvider({ children }: { children: React.ReactNode }) {
   const [showAll, setShowAll] = useState(false);
   const [paused, setPaused] = useState(false);
   const [traceActivity, setTraceActivity] = useState<Record<string, number>>({});
+  const [totalCalls, setTotalCalls] = useState<number>(0);
+  const [totalErrors, setTotalErrors] = useState<number>(0);
   const [edgeStats, setEdgeStats] = useState<EdgeStat[]>([]);
   const [agentStats, setAgentStats] = useState<AgentStat[]>([]);
   const [modelStats, setModelStats] = useState<ModelStat[]>([]);
@@ -58,6 +62,10 @@ export function MeshProvider({ children }: { children: React.ReactNode }) {
       if (event.type === "trace_activity") {
         const agents = event.data?.agents as Record<string, number> | undefined;
         if (agents) setTraceActivity(agents);
+        const total = event.data?.total_calls as number | undefined;
+        if (total !== undefined) setTotalCalls(total);
+        const errors = event.data?.total_errors as number | undefined;
+        if (errors !== undefined) setTotalErrors(errors);
         return;
       }
       if (event.type === "edge_stats") {
@@ -155,6 +163,8 @@ export function MeshProvider({ children }: { children: React.ReactNode }) {
         setPaused,
         refresh: fetchAgents,
         traceActivity,
+        totalCalls,
+        totalErrors,
         edgeStats,
         agentStats,
         modelStats,


### PR DESCRIPTION
## Summary
- Fix Python `ExecutionTracer` publishing `trace_context.parent_span` (always None) instead of `trace_context.span_id` (caller's span ID from X-Parent-Span header), which caused all spans to appear as root spans and prevented cross-agent edge detection
- Add `totalFinalized` and `totalErrors` counters to `TraceAccumulator`, exposed through SSE `trace_activity` events to the dashboard
- Traffic page "Total Calls" now counts every finalized trace once (not just cross-agent edges), and "Success Rate" uses consistent trace-level populations for both numerator and denominator

## Review Notes
- TypeScript and Java runtimes are not affected — they already use the correct field for parent_span
- The `totalFinalized`/`totalErrors` counters are in-memory and reset on UI server restart (same as all other accumulator state)

Closes #744

## Test plan
- [x] Verified parent_span values in Redis stream after fix (cross-agent + single-agent calls)
- [x] Verified edge stats populate on dashboard traffic page
- [x] Verified Total Calls increments for both cross-agent and single-agent calls
- [x] Verified Total Calls counts each top-level invocation exactly once (no double-counting)
- [ ] Run uc06_observability integration suite
- [ ] Run uc17_ui_server integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent tracking of total trace calls and total errors across the system.
  * Traffic/Activity dashboard now displays total calls and total errors and updates dynamically.
  * UI context exposes these metrics so overview pages and components consume live totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->