### PR TITLE
fix: meshctl stop cascade-kill across independent watchers

### DIFF
--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -58,6 +58,24 @@ async def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistRes
 
 **Note**: Response format is determined by the function's return type annotation, not a parameter. See [Response Formats](#response-formats).
 
+## Calling llm()
+
+The injected `llm` is an async callable. All arguments after `message` are keyword-only.
+
+| Parameter      | Type                                 | Description                                                         |
+| -------------- | ------------------------------------ | ------------------------------------------------------------------- |
+| `message`      | `str` \| `list[dict]`                | User text, or OpenAI-format messages array for multi-turn history   |
+| `media`        | `list`                               | Images/files to attach — see `meshctl man multimodal`               |
+| `context`      | `dict`                               | Runtime context merged with `context_param` for template rendering  |
+| `context_mode` | `"append"` \| `"prepend"` \| `"replace"` | How `context` merges with auto-populated (default: `append`)    |
+| `**kwargs`     | any                                  | LiteLLM call-time params (`max_tokens`, `temperature`, …)           |
+
+**Multi-turn chat**: pass `message` as a list of `{"role": "user"\|"assistant"\|"system"\|"tool", "content": ...}` dicts. The decorator's `system_prompt` is auto-inserted at `messages[0]` (or replaces an existing system message).
+
+**Context vs. messages**: `context=` feeds the Jinja2 system prompt template — use it for background knowledge, user profile, per-call config. The `messages` list is the conversation — use it for turn-by-turn history. See [Runtime Context Injection](#runtime-context-injection) below for merge semantics.
+
+**LiteLLM overrides**: call-time `**kwargs` override decorator defaults. See [LLM Model Parameters](#llm-model-parameters) below.
+
 ## LLM Model Parameters
 
 Pass any LiteLLM parameter in the decorator as defaults:

--- a/src/core/cli/man/content/llm_typescript.md
+++ b/src/core/cli/man/content/llm_typescript.md
@@ -65,6 +65,24 @@ agent.addTool({
 | `filterMode`    | `string`          | How to select tools: "all", "best_match", "\*"   |
 | `returns`       | `ZodType`         | Optional: Schema for structured output           |
 
+## Calling llm()
+
+The injected `llm` is an async callable: `llm(message, options?)`.
+
+| Parameter           | Type                                         | Description                                                        |
+| ------------------- | -------------------------------------------- | ------------------------------------------------------------------ |
+| `message`           | `string` \| `Array<{role, content}>`         | User text, or message array for multi-turn history                 |
+| `options.context`   | `Record<string, unknown>`                    | Runtime context merged with `contextParam` for template rendering  |
+| `options.contextMode` | `"merge"` \| `"replace"`                   | How `context` merges with auto-populated (default: `merge`)        |
+| `options.media`     | `Array<string \| {data, mimeType}>`          | Images/files to attach — see `meshctl man multimodal`              |
+| `options.maxOutputTokens` | `number`                               | Override decorator `maxOutputTokens`                               |
+| `options.temperature`     | `number`                               | Override decorator `temperature`                                   |
+| `options.maxIterations`   | `number`                               | Override decorator `maxIterations`                                 |
+
+**Multi-turn chat**: pass `message` as an array of `{role: "user" | "assistant", content: string}` objects. The decorator's `systemPrompt` is auto-prepended.
+
+**Context vs. messages**: `options.context` feeds the Handlebars system prompt template — use it for background knowledge, user profile, per-call config. The `message` array is the conversation — use it for turn-by-turn history.
+
 ## Provider Selector
 
 Select LLM providers using capability and tag matching:

--- a/src/core/cli/pid_manager.go
+++ b/src/core/cli/pid_manager.go
@@ -377,7 +377,13 @@ func (pm *PIDManager) GetRunningAgents() ([]PIDInfo, error) {
 	return agents, nil
 }
 
-// GetRegistry returns the registry process info if running
+// GetRegistry returns the registry process info if running.
+//
+// Matches on BOTH Name=="registry" and Type=="registry" to avoid confusing a
+// watch-mode agent named "registry" (e.g. "registry.12345.pid") with the real
+// flat registry.pid. Under the current parser, only the flat "registry.pid"
+// file produces Type="registry"; any dotted "registry.<ppid>.pid" file is
+// parsed as Type="agent".
 func (pm *PIDManager) GetRegistry() (*PIDInfo, error) {
 	processes, err := pm.ListRunningProcesses()
 	if err != nil {
@@ -385,7 +391,7 @@ func (pm *PIDManager) GetRegistry() (*PIDInfo, error) {
 	}
 
 	for _, proc := range processes {
-		if proc.Name == "registry" && proc.Running {
+		if proc.Name == "registry" && proc.Type == "registry" && proc.Running {
 			return &proc, nil
 		}
 	}

--- a/src/core/cli/pid_manager.go
+++ b/src/core/cli/pid_manager.go
@@ -147,14 +147,22 @@ func (pm *PIDManager) RemoveWatchParentPID(name string, parentPID int) error {
 
 // FindWatchAgentsByName returns all watch-mode agent entries for a given name
 // (one per distinct parent_pid). Returns only entries whose agent process is alive.
+//
+// The lookup name is normalized via sanitizeName before comparison, matching the
+// normalization applied by the write path (GetWatchAgentPIDFile). This means
+// callers can pass the original unsanitized agent name (e.g., "my agent") and
+// it will match the on-disk sanitized form ("my_agent"). Passing an already
+// sanitized name also works, because sanitizeName is idempotent for names that
+// only contain characters it allows.
 func (pm *PIDManager) FindWatchAgentsByName(name string) ([]PIDInfo, error) {
 	all, err := pm.ListRunningProcesses()
 	if err != nil {
 		return nil, err
 	}
+	sanitized := sanitizeName(name)
 	var matches []PIDInfo
 	for _, p := range all {
-		if p.Type == "agent" && p.Name == name && p.ParentPID > 0 && p.Running {
+		if p.Type == "agent" && p.Name == sanitized && p.ParentPID > 0 && p.Running {
 			matches = append(matches, p)
 		}
 	}

--- a/src/core/cli/pid_manager.go
+++ b/src/core/cli/pid_manager.go
@@ -163,7 +163,15 @@ func (pm *PIDManager) FindWatchAgentsByName(name string) ([]PIDInfo, error) {
 
 // FindWatchAgentsByParent returns all watch-mode agent entries under a given parent meshctl PID.
 // Returns only entries whose agent process is alive.
+//
+// parentPID must be > 0. Passing 0 or negative returns nil (no matches) — the
+// method's semantic is "agents under a watch-mode parent", and parent 0 is
+// not a valid watch-mode parent (flat entries also have ParentPID == 0, and
+// they are not watch-mode agents).
 func (pm *PIDManager) FindWatchAgentsByParent(parentPID int) ([]PIDInfo, error) {
+	if parentPID <= 0 {
+		return nil, nil
+	}
 	all, err := pm.ListRunningProcesses()
 	if err != nil {
 		return nil, err
@@ -171,6 +179,30 @@ func (pm *PIDManager) FindWatchAgentsByParent(parentPID int) ([]PIDInfo, error) 
 	var matches []PIDInfo
 	for _, p := range all {
 		if p.Type == "agent" && p.ParentPID == parentPID && p.Running {
+			matches = append(matches, p)
+		}
+	}
+	return matches, nil
+}
+
+// FindWatchParentsByPID returns all watcher-parent tracking entries whose
+// parent meshctl PID matches. Unlike FindWatchAgentsByParent, this returns
+// tracking file metadata regardless of whether the parent process itself
+// is still alive — used by stop to clean up stale tracking files when the
+// parent has already exited.
+//
+// parentPID must be > 0; passing 0 or negative returns nil.
+func (pm *PIDManager) FindWatchParentsByPID(parentPID int) ([]PIDInfo, error) {
+	if parentPID <= 0 {
+		return nil, nil
+	}
+	all, err := pm.ListRunningProcesses()
+	if err != nil {
+		return nil, err
+	}
+	var matches []PIDInfo
+	for _, p := range all {
+		if p.Type == "watcher-parent" && p.ParentPID == parentPID {
 			matches = append(matches, p)
 		}
 	}
@@ -215,6 +247,11 @@ func (pm *PIDManager) ListRunningProcesses() ([]PIDInfo, error) {
 
 		base := strings.TrimSuffix(entry.Name(), ".pid")
 
+		// Skip empty base (filename was just ".pid").
+		if base == "" {
+			continue
+		}
+
 		// Legacy watcher-parent format: "<name>_watcher-parent.pid" (underscore separator).
 		// Pre-namespacing versions of meshctl wrote these; they're unparseable in the
 		// current scheme and would otherwise be mis-parsed as flat agents. Skip them.
@@ -245,25 +282,35 @@ func (pm *PIDManager) ListRunningProcesses() ([]PIDInfo, error) {
 				continue
 			}
 			parsedPID, perr := strconv.Atoi(rest[idx+1:])
-			if perr != nil {
+			if perr != nil || parsedPID <= 0 {
 				continue
 			}
 			name = rest[:idx]
 			parentPID = parsedPID
 			procType = "watcher-parent"
 		} else {
-			// Case 2 or 3: has a trailing .<parent_pid> (watch-mode agent) or not (flat/legacy)
+			// Case 2 or 3: has a trailing .<parent_pid> (watch-mode agent) or not (flat/legacy).
+			//
+			// Invariant: sanitizeName strips dots from legitimate agent names, so any
+			// dot in the base must come from one of the documented <name>.<parent_pid>
+			// or <name>.<parent_pid>.watcher-parent patterns. If a dot is present but
+			// the trailing segment isn't a positive integer parent PID, the file was
+			// not written by a current meshctl version — skip rather than fall back to
+			// flat, because "flat fallback with a dotted name" would yield a name that
+			// no other code path can ever re-derive (sanitizeName would never produce
+			// it), leaving a permanent stale entry.
 			idx := strings.LastIndex(base, ".")
 			if idx > 0 {
-				// Try to parse as <name>.<parent_pid>
-				if parsedPID, perr := strconv.Atoi(base[idx+1:]); perr == nil {
-					name = base[:idx]
-					parentPID = parsedPID
-					procType = "agent"
+				parsedPID, perr := strconv.Atoi(base[idx+1:])
+				if perr != nil || parsedPID <= 0 {
+					// Dotted but unparseable — skip.
+					continue
 				}
-			}
-			if procType == "" {
-				// Case 3: flat — <name>.pid
+				name = base[:idx]
+				parentPID = parsedPID
+				procType = "agent"
+			} else {
+				// No dot: flat — <name>.pid
 				name = base
 				parentPID = 0
 				switch name {

--- a/src/core/cli/pid_manager.go
+++ b/src/core/cli/pid_manager.go
@@ -40,6 +40,15 @@ func NewPIDManager() (*PIDManager, error) {
 	return &PIDManager{pidsDir: pidsDir}, nil
 }
 
+// newPIDManagerWithDir creates a PIDManager rooted at a specific directory.
+// Used primarily for testing to avoid touching ~/.mcp-mesh/pids.
+func newPIDManagerWithDir(pidsDir string) (*PIDManager, error) {
+	if err := os.MkdirAll(pidsDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create pids directory: %w", err)
+	}
+	return &PIDManager{pidsDir: pidsDir}, nil
+}
+
 // GetPIDsDir returns the pids directory path
 func (pm *PIDManager) GetPIDsDir() string {
 	return pm.pidsDir
@@ -205,6 +214,15 @@ func (pm *PIDManager) ListRunningProcesses() ([]PIDInfo, error) {
 		}
 
 		base := strings.TrimSuffix(entry.Name(), ".pid")
+
+		// Legacy watcher-parent format: "<name>_watcher-parent.pid" (underscore separator).
+		// Pre-namespacing versions of meshctl wrote these; they're unparseable in the
+		// current scheme and would otherwise be mis-parsed as flat agents. Skip them.
+		// Users can clean them up with `meshctl stop --clean`.
+		if strings.HasSuffix(base, "_watcher-parent") {
+			continue
+		}
+
 		pidFile := filepath.Join(pm.pidsDir, entry.Name())
 
 		pid, err := pm.ReadPIDFromFile(pidFile)

--- a/src/core/cli/pid_manager.go
+++ b/src/core/cli/pid_manager.go
@@ -15,11 +15,12 @@ type PIDManager struct {
 
 // PIDInfo represents information about a tracked process
 type PIDInfo struct {
-	Name     string
-	PID      int
-	PIDFile  string
-	Running  bool
-	Type     string // "agent" or "registry"
+	Name      string
+	PID       int
+	PIDFile   string
+	Running   bool
+	Type      string // "agent", "registry", "ui", "watcher-parent"
+	ParentPID int    // 0 for flat/non-watch entries; otherwise the watcher parent meshctl PID that owns this entry
 }
 
 // NewPIDManager creates a new PID manager with the default pids directory
@@ -95,6 +96,78 @@ func (pm *PIDManager) RemovePIDFile(pidFile string) error {
 	return nil
 }
 
+// GetWatchAgentPIDFile returns <name>.<parentPID>.pid
+func (pm *PIDManager) GetWatchAgentPIDFile(name string, parentPID int) string {
+	safeName := sanitizeName(name)
+	return filepath.Join(pm.pidsDir, fmt.Sprintf("%s.%d.pid", safeName, parentPID))
+}
+
+// GetWatchParentPIDFile returns <name>.<parentPID>.watcher-parent.pid
+func (pm *PIDManager) GetWatchParentPIDFile(name string, parentPID int) string {
+	safeName := sanitizeName(name)
+	return filepath.Join(pm.pidsDir, fmt.Sprintf("%s.%d.watcher-parent.pid", safeName, parentPID))
+}
+
+// WriteWatchAgentPID writes the agent process PID to <name>.<parentPID>.pid
+func (pm *PIDManager) WriteWatchAgentPID(name string, parentPID int, agentPID int) error {
+	pidFile := pm.GetWatchAgentPIDFile(name, parentPID)
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", agentPID)), 0644); err != nil {
+		return fmt.Errorf("failed to write watch agent PID file %s: %w", pidFile, err)
+	}
+	return nil
+}
+
+// WriteWatchParentPID writes the parent meshctl PID to <name>.<parentPID>.watcher-parent.pid
+func (pm *PIDManager) WriteWatchParentPID(name string, parentPID int) error {
+	pidFile := pm.GetWatchParentPIDFile(name, parentPID)
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", parentPID)), 0644); err != nil {
+		return fmt.Errorf("failed to write watch parent PID file %s: %w", pidFile, err)
+	}
+	return nil
+}
+
+// RemoveWatchAgentPID removes <name>.<parentPID>.pid
+func (pm *PIDManager) RemoveWatchAgentPID(name string, parentPID int) error {
+	return pm.RemovePIDFile(pm.GetWatchAgentPIDFile(name, parentPID))
+}
+
+// RemoveWatchParentPID removes <name>.<parentPID>.watcher-parent.pid
+func (pm *PIDManager) RemoveWatchParentPID(name string, parentPID int) error {
+	return pm.RemovePIDFile(pm.GetWatchParentPIDFile(name, parentPID))
+}
+
+// FindWatchAgentsByName returns all watch-mode agent entries for a given name
+// (one per distinct parent_pid). Returns only entries whose agent process is alive.
+func (pm *PIDManager) FindWatchAgentsByName(name string) ([]PIDInfo, error) {
+	all, err := pm.ListRunningProcesses()
+	if err != nil {
+		return nil, err
+	}
+	var matches []PIDInfo
+	for _, p := range all {
+		if p.Type == "agent" && p.Name == name && p.ParentPID > 0 && p.Running {
+			matches = append(matches, p)
+		}
+	}
+	return matches, nil
+}
+
+// FindWatchAgentsByParent returns all watch-mode agent entries under a given parent meshctl PID.
+// Returns only entries whose agent process is alive.
+func (pm *PIDManager) FindWatchAgentsByParent(parentPID int) ([]PIDInfo, error) {
+	all, err := pm.ListRunningProcesses()
+	if err != nil {
+		return nil, err
+	}
+	var matches []PIDInfo
+	for _, p := range all {
+		if p.Type == "agent" && p.ParentPID == parentPID && p.Running {
+			matches = append(matches, p)
+		}
+	}
+	return matches, nil
+}
+
 // IsProcessRunning checks if a process with the given name is running
 func (pm *PIDManager) IsProcessRunning(name string) bool {
 	pid, err := pm.ReadPID(name)
@@ -106,7 +179,16 @@ func (pm *PIDManager) IsProcessRunning(name string) bool {
 
 // Note: IsProcessAlive is defined in utils.go
 
-// ListRunningProcesses returns all running processes tracked by PID files
+// ListRunningProcesses returns all running processes tracked by PID files.
+//
+// Supported filename layouts (base = filename without the ".pid" suffix):
+//  1. Flat/legacy: "<name>"                        -> Type=agent|registry|ui, ParentPID=0
+//  2. Watch-mode agent: "<name>.<parent_pid>"      -> Type=agent, ParentPID=<parent_pid>
+//  3. Watch-mode parent: "<name>.<parent_pid>.watcher-parent" -> Type=watcher-parent, ParentPID=<parent_pid>
+//
+// Note: older meshctl versions wrote watcher-parent files as "<name>_watcher-parent.pid".
+// Those files won't match any of the cases above and will be silently ignored by this
+// parser. Use `meshctl stop --clean` or delete them by hand after upgrading.
 func (pm *PIDManager) ListRunningProcesses() ([]PIDInfo, error) {
 	entries, err := os.ReadDir(pm.pidsDir)
 	if err != nil {
@@ -122,7 +204,7 @@ func (pm *PIDManager) ListRunningProcesses() ([]PIDInfo, error) {
 			continue
 		}
 
-		name := strings.TrimSuffix(entry.Name(), ".pid")
+		base := strings.TrimSuffix(entry.Name(), ".pid")
 		pidFile := filepath.Join(pm.pidsDir, entry.Name())
 
 		pid, err := pm.ReadPIDFromFile(pidFile)
@@ -130,22 +212,60 @@ func (pm *PIDManager) ListRunningProcesses() ([]PIDInfo, error) {
 			continue
 		}
 
-		running := IsProcessAlive(pid)
-		procType := "agent"
-		if name == "registry" {
-			procType = "registry"
-		} else if name == "ui" {
-			procType = "ui"
-		} else if strings.HasSuffix(name, "_watcher-parent") {
+		var (
+			name      string
+			parentPID int
+			procType  string
+		)
+
+		// Case 1: watcher-parent file — <name>.<parent_pid>.watcher-parent
+		if strings.HasSuffix(base, ".watcher-parent") {
+			rest := strings.TrimSuffix(base, ".watcher-parent")
+			idx := strings.LastIndex(rest, ".")
+			if idx <= 0 {
+				// Malformed — skip
+				continue
+			}
+			parsedPID, perr := strconv.Atoi(rest[idx+1:])
+			if perr != nil {
+				continue
+			}
+			name = rest[:idx]
+			parentPID = parsedPID
 			procType = "watcher-parent"
+		} else {
+			// Case 2 or 3: has a trailing .<parent_pid> (watch-mode agent) or not (flat/legacy)
+			idx := strings.LastIndex(base, ".")
+			if idx > 0 {
+				// Try to parse as <name>.<parent_pid>
+				if parsedPID, perr := strconv.Atoi(base[idx+1:]); perr == nil {
+					name = base[:idx]
+					parentPID = parsedPID
+					procType = "agent"
+				}
+			}
+			if procType == "" {
+				// Case 3: flat — <name>.pid
+				name = base
+				parentPID = 0
+				switch name {
+				case "registry":
+					procType = "registry"
+				case "ui":
+					procType = "ui"
+				default:
+					procType = "agent"
+				}
+			}
 		}
 
 		processes = append(processes, PIDInfo{
-			Name:    name,
-			PID:     pid,
-			PIDFile: pidFile,
-			Running: running,
-			Type:    procType,
+			Name:      name,
+			PID:       pid,
+			PIDFile:   pidFile,
+			Running:   IsProcessAlive(pid),
+			Type:      procType,
+			ParentPID: parentPID,
 		})
 	}
 
@@ -185,11 +305,10 @@ func (pm *PIDManager) GetRunningAgents() ([]PIDInfo, error) {
 
 	var agents []PIDInfo
 	for _, proc := range processes {
-		if proc.Running && proc.Type == "agent" && !strings.HasSuffix(proc.Name, "_watcher-parent") {
+		if proc.Running && proc.Type == "agent" {
 			agents = append(agents, proc)
 		}
 	}
-
 	return agents, nil
 }
 

--- a/src/core/cli/pid_manager_test.go
+++ b/src/core/cli/pid_manager_test.go
@@ -564,6 +564,9 @@ func TestWriteReadRemoveWatchParent(t *testing.T) {
 // PID reuse in the microseconds after Wait returns is extraordinarily unlikely,
 // but we still poll IsProcessAlive briefly to confirm the kernel has actually
 // reflected the exit before the caller uses the value.
+//
+// Uses waitForProcessDeath (from stop.go) as the single source of truth for
+// polling logic.
 func reapedPID(t *testing.T) int {
 	t.Helper()
 	cmd := exec.Command("sh", "-c", "exit 0")
@@ -572,15 +575,10 @@ func reapedPID(t *testing.T) int {
 	}
 	pid := cmd.Process.Pid
 	_ = cmd.Wait() // reap
-	deadline := time.Now().Add(200 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		if !IsProcessAlive(pid) {
-			return pid
-		}
-		time.Sleep(5 * time.Millisecond)
+	if !waitForProcessDeath(pid, 500*time.Millisecond) {
+		t.Fatalf("reaped PID %d still reports as alive after 500ms", pid)
 	}
-	t.Fatalf("reaped PID %d still reports as alive after 200ms", pid)
-	return 0
+	return pid
 }
 
 // --- Dead-PID filter tests (F1) ---
@@ -805,5 +803,95 @@ func TestListRunningProcessesMalformedWatcherParent(t *testing.T) {
 	}
 	if p := findByFile(processes, "good.42.watcher-parent.pid"); p == nil || p.Type != "watcher-parent" || p.ParentPID != 42 {
 		t.Errorf("good watcher-parent entry wrong or missing: %+v", p)
+	}
+}
+
+// --- GetRegistry edge cases ---
+
+// TestGetRegistryPrefersFlatOverWatchMode verifies that GetRegistry returns
+// the flat "registry.pid" entry and NOT a watch-mode entry that happens to
+// carry the same agent name. Under the current parser, a file literally named
+// "registry.12345.pid" is parsed as Type="agent" with Name="registry", so the
+// tightened match on BOTH Name AND Type is what prevents a false positive.
+func TestGetRegistryPrefersFlatOverWatchMode(t *testing.T) {
+	pm := newTestPIDManager(t)
+	pid := os.Getpid()
+
+	// Flat registry — the legitimate entry.
+	writePIDFile(t, pm, "registry.pid", pid)
+	// Watch-mode entry whose name also happens to be "registry". This is
+	// contrived but the parser treats it as Type="agent", ParentPID=12345,
+	// Name="registry" — and the old GetRegistry (Name-only match) would
+	// surface it as the registry process on systems where the flat file
+	// was missing.
+	writePIDFile(t, pm, "registry.12345.pid", pid)
+
+	reg, err := pm.GetRegistry()
+	if err != nil {
+		t.Fatalf("GetRegistry: %v", err)
+	}
+	if reg == nil {
+		t.Fatal("expected flat registry to be returned")
+	}
+	if reg.Type != "registry" {
+		t.Errorf("expected Type=registry, got %q", reg.Type)
+	}
+	if filepath.Base(reg.PIDFile) != "registry.pid" {
+		t.Errorf("expected flat registry.pid, got %s", filepath.Base(reg.PIDFile))
+	}
+}
+
+// TestGetRegistryWatchModeOnlyReturnsNil verifies that when ONLY a watch-mode
+// entry named "registry" exists (and no flat registry.pid), GetRegistry
+// returns nil rather than mistakenly surfacing the watch-mode agent.
+func TestGetRegistryWatchModeOnlyReturnsNil(t *testing.T) {
+	pm := newTestPIDManager(t)
+	pid := os.Getpid()
+
+	writePIDFile(t, pm, "registry.12345.pid", pid)
+
+	reg, err := pm.GetRegistry()
+	if err != nil {
+		t.Fatalf("GetRegistry: %v", err)
+	}
+	if reg != nil {
+		t.Errorf("expected nil (no flat registry.pid), got %+v", reg)
+	}
+}
+
+// --- waitForProcessDeath (stop.go helper) ---
+
+// TestWaitForProcessDeathDeadPIDReturnsTrue verifies that waitForProcessDeath
+// returns true quickly for a PID that is already reaped before the call.
+func TestWaitForProcessDeathDeadPIDReturnsTrue(t *testing.T) {
+	dead := reapedPID(t)
+	start := time.Now()
+	if !waitForProcessDeath(dead, 500*time.Millisecond) {
+		t.Errorf("waitForProcessDeath(%d) returned false for a reaped PID", dead)
+	}
+	// Fast path: should return almost immediately because the first poll
+	// already sees the process as dead. 100ms is a generous ceiling.
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("waitForProcessDeath fast path took %v, expected under 100ms", elapsed)
+	}
+}
+
+// TestWaitForProcessDeathLivePIDReturnsFalse verifies that waitForProcessDeath
+// exhausts its polling window and returns false for a PID that stays alive.
+// We use os.Getpid() (the test process itself) which is guaranteed to outlive
+// the polling window.
+func TestWaitForProcessDeathLivePIDReturnsFalse(t *testing.T) {
+	alive := os.Getpid()
+	limit := 100 * time.Millisecond
+	start := time.Now()
+	if waitForProcessDeath(alive, limit) {
+		t.Errorf("waitForProcessDeath(%d) returned true for a live PID", alive)
+	}
+	// Sanity check: the call should have actually waited for approximately
+	// the limit before giving up (polling at 20ms intervals means it might
+	// be slightly less than limit on the last iteration, so allow a small
+	// grace window).
+	if elapsed := time.Since(start); elapsed < limit-30*time.Millisecond {
+		t.Errorf("waitForProcessDeath returned too quickly: %v (limit was %v)", elapsed, limit)
 	}
 }

--- a/src/core/cli/pid_manager_test.go
+++ b/src/core/cli/pid_manager_test.go
@@ -416,6 +416,62 @@ func TestFindWatchAgentsByNameFlatOnly(t *testing.T) {
 	}
 }
 
+// TestFindWatchAgentsByNameNormalizesLookup verifies that FindWatchAgentsByName
+// applies the same sanitizeName normalization to its lookup input that the
+// write path (GetWatchAgentPIDFile) applies to the on-disk filename. Without
+// this, looking up an agent whose original name contained characters
+// sanitizeName rewrites (e.g., a space) would silently return no matches even
+// when the agent is running.
+func TestFindWatchAgentsByNameNormalizesLookup(t *testing.T) {
+	pm := newTestPIDManager(t)
+	pid := os.Getpid()
+
+	// Write a watch-mode entry using WriteWatchAgentPID with the original
+	// unsanitized name — this mirrors what actually happens at runtime when
+	// a watcher writes its PID file. The file on disk will be
+	// "foo_bar.12345.pid" because GetWatchAgentPIDFile sanitizes the name.
+	const parent = 12345
+	if err := pm.WriteWatchAgentPID("foo bar", parent, pid); err != nil {
+		t.Fatalf("WriteWatchAgentPID: %v", err)
+	}
+
+	// Sanity check that the file is on disk under the sanitized name.
+	expectedPath := filepath.Join(pm.pidsDir, fmt.Sprintf("foo_bar.%d.pid", parent))
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Fatalf("expected sanitized file %s to exist: %v", expectedPath, err)
+	}
+
+	// Lookup with the ORIGINAL unsanitized name must resolve to the sanitized
+	// on-disk entry. This is the bug fix: the lookup name is normalized before
+	// comparison with PIDInfo.Name (which holds the sanitized form).
+	matches, err := pm.FindWatchAgentsByName("foo bar")
+	if err != nil {
+		t.Fatalf("FindWatchAgentsByName(%q): %v", "foo bar", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match for unsanitized lookup %q, got %d: %+v",
+			"foo bar", len(matches), matches)
+	}
+	if matches[0].Name != "foo_bar" || matches[0].ParentPID != parent {
+		t.Errorf("unexpected entry: %+v", matches[0])
+	}
+
+	// Lookup with the ALREADY-SANITIZED name must also resolve to the same
+	// entry — both spellings collapse to the same sanitized key, and
+	// sanitizeName is idempotent for already-safe inputs.
+	matches, err = pm.FindWatchAgentsByName("foo_bar")
+	if err != nil {
+		t.Fatalf("FindWatchAgentsByName(%q): %v", "foo_bar", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match for sanitized lookup %q, got %d: %+v",
+			"foo_bar", len(matches), matches)
+	}
+	if matches[0].Name != "foo_bar" || matches[0].ParentPID != parent {
+		t.Errorf("unexpected entry: %+v", matches[0])
+	}
+}
+
 func TestFindWatchAgentsByParent(t *testing.T) {
 	pm := newTestPIDManager(t)
 	pid := os.Getpid()
@@ -712,8 +768,7 @@ func TestFindWatchParentsByPIDReturnsDeadParent(t *testing.T) {
 			len(matches), matches)
 	}
 	if matches[0].Running {
-		// Expected: p.Running reports false for a dead PID, but the helper
-		// still surfaces the entry.
+		t.Errorf("expected dead parent entry to report Running=false, got Running=true for %+v", matches[0])
 	}
 	if matches[0].Name != "alpha" || matches[0].ParentPID != dead {
 		t.Errorf("unexpected entry: %+v", matches[0])

--- a/src/core/cli/pid_manager_test.go
+++ b/src/core/cli/pid_manager_test.go
@@ -3,10 +3,12 @@ package cli
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 )
 
 // newTestPIDManager returns a PIDManager rooted at a fresh per-test temp directory.
@@ -442,22 +444,28 @@ func TestFindWatchAgentsByParent(t *testing.T) {
 
 func TestFindWatchAgentsByParentZero(t *testing.T) {
 	pm := newTestPIDManager(t)
-	// Flat entries have ParentPID=0; FindWatchAgentsByParent(0) should return
-	// nothing (the method only finds watch-mode entries, which have parent>0 in
-	// practice, and a flat entry's ParentPID==0 matches the filter but then the
-	// "watch-mode agent" semantics aren't meaningful — current behavior returns
-	// them because the implementation filters on parent PID equality).
+	// FindWatchAgentsByParent(0) must return no matches. The method's semantic
+	// is "agents under a watch-mode parent"; parent 0 is not a valid watch-mode
+	// parent, even though flat entries internally carry ParentPID == 0. The
+	// guard at the top of the method short-circuits parentPID <= 0 to prevent
+	// flat entries from being mistakenly surfaced as watch-mode agents.
 	writePIDFile(t, pm, "flat.pid", os.Getpid())
 
 	matches, err := pm.FindWatchAgentsByParent(0)
 	if err != nil {
-		t.Fatalf("FindWatchAgentsByParent: %v", err)
+		t.Fatalf("FindWatchAgentsByParent(0): %v", err)
 	}
-	// Current behavior: the filter p.ParentPID == parentPID matches flat entries
-	// when parentPID == 0. Assert what the code actually does so future changes
-	// are flagged.
-	if len(matches) != 1 {
-		t.Errorf("expected 1 match (flat entry, ParentPID=0), got %d: %+v", len(matches), matches)
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches for parent 0, got %d: %+v", len(matches), matches)
+	}
+
+	// Also verify the guard handles negative PIDs.
+	matches, err = pm.FindWatchAgentsByParent(-1)
+	if err != nil {
+		t.Fatalf("FindWatchAgentsByParent(-1): %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches for parent -1, got %d: %+v", len(matches), matches)
 	}
 }
 
@@ -546,5 +554,256 @@ func TestWriteReadRemoveWatchParent(t *testing.T) {
 	}
 	if _, err := os.Stat(expectedPath); !os.IsNotExist(err) {
 		t.Errorf("expected file %s to be gone, got err=%v", expectedPath, err)
+	}
+}
+
+// --- Dead PID helper (F1) ---
+
+// reapedPID returns a PID that was just reaped and is (with very high probability)
+// no longer alive. Used to test the `p.Running` filter in enumeration helpers.
+// PID reuse in the microseconds after Wait returns is extraordinarily unlikely,
+// but we still poll IsProcessAlive briefly to confirm the kernel has actually
+// reflected the exit before the caller uses the value.
+func reapedPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("sh", "-c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start throwaway process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	_ = cmd.Wait() // reap
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !IsProcessAlive(pid) {
+			return pid
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("reaped PID %d still reports as alive after 200ms", pid)
+	return 0
+}
+
+// --- Dead-PID filter tests (F1) ---
+
+func TestFindWatchAgentsByNameFiltersDeadAgent(t *testing.T) {
+	pm := newTestPIDManager(t)
+	dead := reapedPID(t)
+	// Write a watch-mode entry referring to the dead PID under parent 111.
+	writePIDFile(t, pm, "ghost.111.pid", dead)
+
+	matches, err := pm.FindWatchAgentsByName("ghost")
+	if err != nil {
+		t.Fatalf("FindWatchAgentsByName: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches (agent dead), got %d: %+v", len(matches), matches)
+	}
+}
+
+func TestFindWatchAgentsByParentFiltersDeadAgent(t *testing.T) {
+	pm := newTestPIDManager(t)
+	dead := reapedPID(t)
+	writePIDFile(t, pm, "ghost.222.pid", dead)
+	// Mix in a live agent under the same parent so we can verify the filter is
+	// selective (alive pass through, dead filtered out).
+	writePIDFile(t, pm, "alive.222.pid", os.Getpid())
+
+	matches, err := pm.FindWatchAgentsByParent(222)
+	if err != nil {
+		t.Fatalf("FindWatchAgentsByParent: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match (only the live agent), got %d: %+v", len(matches), matches)
+	}
+	if matches[0].Name != "alive" {
+		t.Errorf("expected alive agent, got %+v", matches[0])
+	}
+}
+
+// --- FindWatchParentsByPID tests (F3) ---
+
+func TestFindWatchParentsByPID(t *testing.T) {
+	pm := newTestPIDManager(t)
+	pid := os.Getpid()
+
+	// Two watcher-parent entries under parent 111, one under 222.
+	writePIDFile(t, pm, "alpha.111.watcher-parent.pid", 111)
+	writePIDFile(t, pm, "beta.111.watcher-parent.pid", 111)
+	writePIDFile(t, pm, "gamma.222.watcher-parent.pid", 222)
+	// Plus some watch-mode agent entries under the same parents (must NOT be returned).
+	writePIDFile(t, pm, "alpha.111.pid", pid)
+	writePIDFile(t, pm, "gamma.222.pid", pid)
+
+	matches, err := pm.FindWatchParentsByPID(111)
+	if err != nil {
+		t.Fatalf("FindWatchParentsByPID(111): %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 watcher-parent entries under 111, got %d: %+v", len(matches), matches)
+	}
+	names := []string{}
+	for _, m := range matches {
+		if m.Type != "watcher-parent" {
+			t.Errorf("non-watcher-parent returned: %+v", m)
+		}
+		if m.ParentPID != 111 {
+			t.Errorf("wrong ParentPID: %+v", m)
+		}
+		names = append(names, m.Name)
+	}
+	sort.Strings(names)
+	if names[0] != "alpha" || names[1] != "beta" {
+		t.Errorf("expected [alpha beta], got %v", names)
+	}
+}
+
+func TestFindWatchParentsByPIDNoMatch(t *testing.T) {
+	pm := newTestPIDManager(t)
+	writePIDFile(t, pm, "alpha.111.watcher-parent.pid", 111)
+
+	matches, err := pm.FindWatchParentsByPID(999)
+	if err != nil {
+		t.Fatalf("FindWatchParentsByPID: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches, got %d: %+v", len(matches), matches)
+	}
+}
+
+func TestFindWatchParentsByPIDZero(t *testing.T) {
+	pm := newTestPIDManager(t)
+	// Even if we had a watcher-parent entry with ParentPID 0 (which is not a
+	// legitimate shape), the guard should short-circuit and return nothing.
+	writePIDFile(t, pm, "alpha.111.watcher-parent.pid", 111)
+
+	matches, err := pm.FindWatchParentsByPID(0)
+	if err != nil {
+		t.Fatalf("FindWatchParentsByPID(0): %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches for parent 0, got %d: %+v", len(matches), matches)
+	}
+	matches, err = pm.FindWatchParentsByPID(-1)
+	if err != nil {
+		t.Fatalf("FindWatchParentsByPID(-1): %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches for parent -1, got %d", len(matches))
+	}
+}
+
+// TestFindWatchParentsByPIDReturnsDeadParent pins the intentional non-filtering
+// behavior: unlike FindWatchAgentsByParent (which excludes dead PIDs),
+// FindWatchParentsByPID returns tracking file metadata regardless of whether the
+// parent is alive, because it is used to clean up stale files after a parent has
+// already exited.
+func TestFindWatchParentsByPIDReturnsDeadParent(t *testing.T) {
+	pm := newTestPIDManager(t)
+	dead := reapedPID(t)
+	// Use the dead PID both as the parent PID in the filename AND as the file
+	// contents so ListRunningProcesses reads the same dead PID.
+	filename := fmt.Sprintf("alpha.%d.watcher-parent.pid", dead)
+	writePIDFile(t, pm, filename, dead)
+
+	matches, err := pm.FindWatchParentsByPID(dead)
+	if err != nil {
+		t.Fatalf("FindWatchParentsByPID: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match (dead parent still returned for cleanup), got %d: %+v",
+			len(matches), matches)
+	}
+	if matches[0].Running {
+		// Expected: p.Running reports false for a dead PID, but the helper
+		// still surfaces the entry.
+	}
+	if matches[0].Name != "alpha" || matches[0].ParentPID != dead {
+		t.Errorf("unexpected entry: %+v", matches[0])
+	}
+}
+
+// --- Parser malformed-filename edge cases (F2) ---
+
+// TestListRunningProcessesMalformedFilenames documents and pins the parser's
+// behavior for edge-case filenames. The goal is to prevent accidental resurfacing
+// of malformed entries as "flat agents with dotted names", which would be
+// un-recreatable by any code path (sanitizeName strips dots).
+func TestListRunningProcessesMalformedFilenames(t *testing.T) {
+	pm := newTestPIDManager(t)
+	pid := os.Getpid()
+
+	// Case A: empty base — ".pid" — skipped.
+	if err := os.WriteFile(filepath.Join(pm.pidsDir, ".pid"), []byte(fmt.Sprintf("%d", pid)), 0644); err != nil {
+		t.Fatalf("write .pid: %v", err)
+	}
+	// Case B: double dot — "foo..pid" — base "foo.", trailing segment empty,
+	// Atoi fails, dotted-unparseable → skipped (not flat fallback).
+	writePIDFile(t, pm, "foo..pid", pid)
+	// Case C: non-numeric trailing segment — "foo.bar.pid" — base "foo.bar",
+	// trailing "bar" not a number, dotted-unparseable → skipped.
+	writePIDFile(t, pm, "foo.bar.pid", pid)
+	// Case D: zero parent — "foo.0.pid" — base "foo.0", parsed parent 0 which
+	// is not a valid watch-mode parent → skipped (not flat fallback).
+	writePIDFile(t, pm, "foo.0.pid", pid)
+	// Case E: negative parent — "foo.-1.pid" — Atoi returns -1, <= 0 → skipped.
+	writePIDFile(t, pm, "foo.-1.pid", pid)
+	// Case F: purely numeric name — "123.pid" — no dot → flat agent "123".
+	writePIDFile(t, pm, "123.pid", pid)
+	// Case G: valid watch-mode alongside the malformed ones, as a sanity check
+	// that the parser still processes the good files.
+	writePIDFile(t, pm, "ok-agent.999.pid", pid)
+
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		t.Fatalf("ListRunningProcesses: %v", err)
+	}
+
+	// Expected survivors: "123.pid" (flat, name "123") and "ok-agent.999.pid"
+	// (watch-mode, parent 999). All dotted-but-unparseable files are skipped.
+	if len(processes) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(processes), processes)
+	}
+
+	if p := findByFile(processes, "123.pid"); p == nil || p.Name != "123" || p.Type != "agent" || p.ParentPID != 0 {
+		t.Errorf("123.pid entry wrong or missing: %+v", p)
+	}
+	if p := findByFile(processes, "ok-agent.999.pid"); p == nil || p.Name != "ok-agent" || p.Type != "agent" || p.ParentPID != 999 {
+		t.Errorf("ok-agent.999.pid entry wrong or missing: %+v", p)
+	}
+
+	// Explicitly assert the skipped files are NOT present.
+	for _, skipped := range []string{".pid", "foo..pid", "foo.bar.pid", "foo.0.pid", "foo.-1.pid"} {
+		if p := findByFile(processes, skipped); p != nil {
+			t.Errorf("expected %s to be skipped, got entry: %+v", skipped, p)
+		}
+	}
+}
+
+// TestListRunningProcessesMalformedWatcherParent pins parser behavior for
+// watcher-parent files whose parent PID segment is malformed.
+func TestListRunningProcessesMalformedWatcherParent(t *testing.T) {
+	pm := newTestPIDManager(t)
+	pid := os.Getpid()
+
+	// "foo.watcher-parent.pid" — missing parent PID segment → rest = "foo",
+	// LastIndex returns -1 → skipped.
+	writePIDFile(t, pm, "foo.watcher-parent.pid", pid)
+	// "foo.0.watcher-parent.pid" — parent PID is 0 → skipped.
+	writePIDFile(t, pm, "foo.0.watcher-parent.pid", pid)
+	// "foo.bar.watcher-parent.pid" — non-numeric parent PID → skipped.
+	writePIDFile(t, pm, "foo.bar.watcher-parent.pid", pid)
+	// Sanity check: one valid watcher-parent file.
+	writePIDFile(t, pm, "good.42.watcher-parent.pid", 42)
+
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		t.Fatalf("ListRunningProcesses: %v", err)
+	}
+
+	if len(processes) != 1 {
+		t.Fatalf("expected 1 valid entry, got %d: %+v", len(processes), processes)
+	}
+	if p := findByFile(processes, "good.42.watcher-parent.pid"); p == nil || p.Type != "watcher-parent" || p.ParentPID != 42 {
+		t.Errorf("good watcher-parent entry wrong or missing: %+v", p)
 	}
 }

--- a/src/core/cli/pid_manager_test.go
+++ b/src/core/cli/pid_manager_test.go
@@ -1,0 +1,550 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// newTestPIDManager returns a PIDManager rooted at a fresh per-test temp directory.
+func newTestPIDManager(t *testing.T) *PIDManager {
+	t.Helper()
+	pm, err := newPIDManagerWithDir(t.TempDir())
+	if err != nil {
+		t.Fatalf("newPIDManagerWithDir: %v", err)
+	}
+	return pm
+}
+
+// writePIDFile is a small helper that writes a file containing a PID string into
+// a PIDManager's pids directory with the given filename.
+func writePIDFile(t *testing.T, pm *PIDManager, filename string, pid int) {
+	t.Helper()
+	path := filepath.Join(pm.pidsDir, filename)
+	if err := os.WriteFile(path, []byte(fmt.Sprintf("%d", pid)), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// findByFile returns the PIDInfo whose PIDFile basename matches filename, or nil.
+func findByFile(processes []PIDInfo, filename string) *PIDInfo {
+	for i := range processes {
+		if filepath.Base(processes[i].PIDFile) == filename {
+			return &processes[i]
+		}
+	}
+	return nil
+}
+
+// --- sanitizeName ---
+
+func TestSanitizeName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"foo.py", "foo"},
+		{"market-data-massive", "market-data-massive"},
+		// filepath.Base strips directories, then .py is trimmed.
+		{"agent/with/slashes.py", "slashes"},
+		// filepath.Base("") returns ".", which becomes "_" after the rune map.
+		// The name != "" fallback to "unknown" only fires for a truly empty string.
+		{"", "_"},
+		// Dots inside the base become underscores (after trimming .py).
+		{"weird.name.py", "weird_name"},
+		// Spaces and other specials are replaced with _.
+		{"has spaces", "has_spaces"},
+		{"a@b#c", "a_b_c"},
+	}
+	for _, tc := range cases {
+		got := sanitizeName(tc.in)
+		if got != tc.want {
+			t.Errorf("sanitizeName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestSanitizeNameNoDotInvariant asserts the invariant the per-parent-PID
+// filename scheme relies on: a sanitized name must never contain '.',
+// otherwise the "<name>.<parent_pid>.pid" parser could be confused.
+func TestSanitizeNameNoDotInvariant(t *testing.T) {
+	inputs := []string{
+		"foo.py",
+		"weird.name.py",
+		"a.b.c.d",
+		"market-data-massive",
+		"/abs/path/to/agent.py",
+		"agent-v1.2.3.py",
+		"",
+		"unknown",
+		"my_agent",
+		"numbers123",
+	}
+	for _, in := range inputs {
+		out := sanitizeName(in)
+		if strings.Contains(out, ".") {
+			t.Errorf("sanitizeName(%q) = %q contains '.' — violates filename invariant", in, out)
+		}
+	}
+}
+
+// --- ListRunningProcesses parser ---
+
+func TestListRunningProcessesEmptyDirectory(t *testing.T) {
+	pm := newTestPIDManager(t)
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		t.Fatalf("ListRunningProcesses: %v", err)
+	}
+	if len(processes) != 0 {
+		t.Errorf("expected empty slice, got %d entries: %+v", len(processes), processes)
+	}
+}
+
+func TestListRunningProcessesMissingDirectory(t *testing.T) {
+	// Construct a PIDManager pointing at a dir that doesn't exist, bypassing
+	// newPIDManagerWithDir (which mkdirs). We remove the dir after construction.
+	pm := newTestPIDManager(t)
+	if err := os.RemoveAll(pm.pidsDir); err != nil {
+		t.Fatalf("rm tempdir: %v", err)
+	}
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		t.Fatalf("ListRunningProcesses: %v", err)
+	}
+	if len(processes) != 0 {
+		t.Errorf("expected empty slice for missing dir, got %d entries", len(processes))
+	}
+}
+
+func TestListRunningProcessesRegistry(t *testing.T) {
+	pm := newTestPIDManager(t)
+	writePIDFile(t, pm, "registry.pid", os.Getpid())
+
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		t.Fatalf("ListRunningProcesses: %v", err)
+	}
+	if len(processes) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(processes))
+	}
+	p := processes[0]
+	if p.Name != "registry" || p.Type != "registry" || p.ParentPID != 0 {
+		t.Errorf("registry entry wrong: %+v", p)
+	}
+	if p.PID != os.Getpid() {
+		t.Errorf("registry PID = %d, want %d", p.PID, os.Getpid())
+	}
+}
+
+func TestListRunningProcessesUI(t *testing.T) {
+	pm := newTestPIDManager(t)
+	writePIDFile(t, pm, "ui.pid", os.Getpid())
+
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		t.Fatalf("ListRunningProcesses: %v", err)
+	}
+	if len(processes) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(processes))
+	}
+	p := processes[0]
+	if p.Name != "ui" || p.Type != "ui" || p.ParentPID != 0 {
+		t.Errorf("ui entry wrong: %+v", p)
+	}
+}
+
+func TestListRunningProcessesFlatAgent(t *testing.T) {
+	pm := newTestPIDManager(t)
+	writePIDFile(t, pm, "foo.pid", os.Getpid())
+
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		t.Fatalf("ListRunningProcesses: %v", err)
+	}
+	if len(processes) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(processes))
+	}
+	p := processes[0]
+	if p.Name != "foo" || p.Type != "agent" || p.ParentPID != 0 {
+		t.Errorf("flat agent entry wrong: %+v", p)
+	}
+}
+
+func TestListRunningProcessesWatchModeAgent(t *testing.T) {
+	pm := newTestPIDManager(t)
+	writePIDFile(t, pm, "market-data-massive.12345.pid", os.Getpid())
+
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		t.Fatalf("ListRunningProcesses: %v", err)
+	}
+	if len(processes) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(processes))
+	}
+	p := processes[0]
+	if p.Name != "market-data-massive" || p.Type != "agent" || p.ParentPID != 12345 {
+		t.Errorf("watch-mode agent wrong: %+v", p)
+	}
+}
+
+func TestListRunningProcessesWatcherParent(t *testing.T) {
+	pm := newTestPIDManager(t)
+	writePIDFile(t, pm, "market-data-massive.12345.watcher-parent.pid", 12345)
+
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		t.Fatalf("ListRunningProcesses: %v", err)
+	}
+	if len(processes) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(processes))
+	}
+	p := processes[0]
+	if p.Name != "market-data-massive" || p.Type != "watcher-parent" || p.ParentPID != 12345 {
+		t.Errorf("watcher-parent wrong: %+v", p)
+	}
+}
+
+func TestListRunningProcessesAgentNameEdgeCases(t *testing.T) {
+	pm := newTestPIDManager(t)
+	// Digits in the name — parser must not greedy-consume them as parent_pid.
+	writePIDFile(t, pm, "agent123.99999.pid", os.Getpid())
+	// Underscore in the name.
+	writePIDFile(t, pm, "my_agent.77777.pid", os.Getpid())
+	// Dashes in the name.
+	writePIDFile(t, pm, "market-data-v2.55555.pid", os.Getpid())
+
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		t.Fatalf("ListRunningProcesses: %v", err)
+	}
+
+	cases := []struct {
+		file     string
+		wantName string
+		wantPPID int
+		wantType string
+	}{
+		{"agent123.99999.pid", "agent123", 99999, "agent"},
+		{"my_agent.77777.pid", "my_agent", 77777, "agent"},
+		{"market-data-v2.55555.pid", "market-data-v2", 55555, "agent"},
+	}
+	for _, tc := range cases {
+		p := findByFile(processes, tc.file)
+		if p == nil {
+			t.Errorf("%s: not parsed", tc.file)
+			continue
+		}
+		if p.Name != tc.wantName || p.ParentPID != tc.wantPPID || p.Type != tc.wantType {
+			t.Errorf("%s: got name=%q ppid=%d type=%q, want name=%q ppid=%d type=%q",
+				tc.file, p.Name, p.ParentPID, p.Type, tc.wantName, tc.wantPPID, tc.wantType)
+		}
+	}
+}
+
+func TestListRunningProcessesLegacyWatcherParentIgnored(t *testing.T) {
+	pm := newTestPIDManager(t)
+	// Legacy format (underscore separator) written by pre-namespacing meshctl versions.
+	writePIDFile(t, pm, "market-data-massive_watcher-parent.pid", os.Getpid())
+
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		t.Fatalf("ListRunningProcesses: %v", err)
+	}
+	if len(processes) != 0 {
+		t.Errorf("legacy watcher-parent file should be silently ignored, got: %+v", processes)
+	}
+}
+
+func TestListRunningProcessesNonPIDFilesIgnored(t *testing.T) {
+	pm := newTestPIDManager(t)
+	// Non-.pid files should be ignored.
+	for _, f := range []string{".DS_Store", "README.md", "random.txt", "stale.log"} {
+		if err := os.WriteFile(filepath.Join(pm.pidsDir, f), []byte("garbage"), 0644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+	// A subdirectory should be ignored.
+	if err := os.MkdirAll(filepath.Join(pm.pidsDir, "subdir"), 0755); err != nil {
+		t.Fatalf("mkdir subdir: %v", err)
+	}
+	// One valid file to make sure the scan actually runs.
+	writePIDFile(t, pm, "foo.pid", os.Getpid())
+
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		t.Fatalf("ListRunningProcesses: %v", err)
+	}
+	if len(processes) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %+v", len(processes), processes)
+	}
+	if processes[0].Name != "foo" {
+		t.Errorf("unexpected entry: %+v", processes[0])
+	}
+}
+
+func TestListRunningProcessesInvalidPIDContent(t *testing.T) {
+	pm := newTestPIDManager(t)
+	// Non-numeric content.
+	if err := os.WriteFile(filepath.Join(pm.pidsDir, "bad.pid"), []byte("not-a-number"), 0644); err != nil {
+		t.Fatalf("write bad.pid: %v", err)
+	}
+	// One valid file alongside.
+	writePIDFile(t, pm, "good.pid", os.Getpid())
+
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		t.Fatalf("ListRunningProcesses returned error: %v", err)
+	}
+	if len(processes) != 1 {
+		t.Fatalf("expected 1 entry (bad file skipped), got %d: %+v", len(processes), processes)
+	}
+	if processes[0].Name != "good" {
+		t.Errorf("unexpected entry: %+v", processes[0])
+	}
+}
+
+func TestListRunningProcessesMixedDirectory(t *testing.T) {
+	pm := newTestPIDManager(t)
+	pid := os.Getpid()
+
+	// Registry + UI + flat agent + two watch-mode agents under different parents + two watcher-parent entries
+	writePIDFile(t, pm, "registry.pid", pid)
+	writePIDFile(t, pm, "ui.pid", pid)
+	writePIDFile(t, pm, "flat-agent.pid", pid)
+	writePIDFile(t, pm, "market-data.111.pid", pid)
+	writePIDFile(t, pm, "market-data.222.pid", pid)
+	writePIDFile(t, pm, "market-data.111.watcher-parent.pid", 111)
+	writePIDFile(t, pm, "market-data.222.watcher-parent.pid", 222)
+	// Junk entries
+	writePIDFile(t, pm, "legacy_watcher-parent.pid", pid) // legacy, should be skipped
+	if err := os.WriteFile(filepath.Join(pm.pidsDir, "README.md"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		t.Fatalf("ListRunningProcesses: %v", err)
+	}
+	// Expect: registry, ui, flat-agent, market-data.111, market-data.222,
+	//         market-data.111.watcher-parent, market-data.222.watcher-parent = 7 entries.
+	if len(processes) != 7 {
+		t.Fatalf("expected 7 entries, got %d: %+v", len(processes), processes)
+	}
+
+	// Spot-check a couple of specific entries.
+	if p := findByFile(processes, "registry.pid"); p == nil || p.Type != "registry" {
+		t.Errorf("registry entry missing or wrong: %+v", p)
+	}
+	if p := findByFile(processes, "market-data.111.pid"); p == nil || p.Type != "agent" || p.ParentPID != 111 {
+		t.Errorf("market-data.111 entry wrong: %+v", p)
+	}
+	if p := findByFile(processes, "market-data.222.watcher-parent.pid"); p == nil || p.Type != "watcher-parent" || p.ParentPID != 222 {
+		t.Errorf("market-data.222 watcher-parent entry wrong: %+v", p)
+	}
+}
+
+// --- FindWatchAgentsByName / FindWatchAgentsByParent ---
+
+func TestFindWatchAgentsByName(t *testing.T) {
+	pm := newTestPIDManager(t)
+	pid := os.Getpid()
+
+	// Same agent name under two different parent PIDs.
+	writePIDFile(t, pm, "market-data.111.pid", pid)
+	writePIDFile(t, pm, "market-data.222.pid", pid)
+	// A flat entry for the same name — FindWatchAgentsByName should NOT return it.
+	writePIDFile(t, pm, "market-data.pid", pid)
+	// A different-named watch-mode entry — should not appear.
+	writePIDFile(t, pm, "other.333.pid", pid)
+
+	matches, err := pm.FindWatchAgentsByName("market-data")
+	if err != nil {
+		t.Fatalf("FindWatchAgentsByName: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 watch-mode matches for 'market-data', got %d: %+v", len(matches), matches)
+	}
+
+	// Extract parent PIDs as a set and verify.
+	gotParents := []int{}
+	for _, m := range matches {
+		if m.Type != "agent" {
+			t.Errorf("match has wrong type: %+v", m)
+		}
+		if m.Name != "market-data" {
+			t.Errorf("match has wrong name: %+v", m)
+		}
+		gotParents = append(gotParents, m.ParentPID)
+	}
+	sort.Ints(gotParents)
+	if gotParents[0] != 111 || gotParents[1] != 222 {
+		t.Errorf("expected parents [111 222], got %v", gotParents)
+	}
+}
+
+func TestFindWatchAgentsByNameNoMatch(t *testing.T) {
+	pm := newTestPIDManager(t)
+	writePIDFile(t, pm, "other.111.pid", os.Getpid())
+
+	matches, err := pm.FindWatchAgentsByName("nonexistent")
+	if err != nil {
+		t.Fatalf("FindWatchAgentsByName: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches, got %d", len(matches))
+	}
+}
+
+func TestFindWatchAgentsByNameFlatOnly(t *testing.T) {
+	pm := newTestPIDManager(t)
+	// Only a flat entry exists for this name.
+	writePIDFile(t, pm, "flat-agent.pid", os.Getpid())
+
+	matches, err := pm.FindWatchAgentsByName("flat-agent")
+	if err != nil {
+		t.Fatalf("FindWatchAgentsByName: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("flat entries must not be returned by FindWatchAgentsByName, got %d: %+v",
+			len(matches), matches)
+	}
+}
+
+func TestFindWatchAgentsByParent(t *testing.T) {
+	pm := newTestPIDManager(t)
+	pid := os.Getpid()
+
+	writePIDFile(t, pm, "agent-a.111.pid", pid)
+	writePIDFile(t, pm, "agent-b.111.pid", pid)
+	writePIDFile(t, pm, "agent-c.222.pid", pid)
+	writePIDFile(t, pm, "flat.pid", pid) // ParentPID=0, must not match parent 111
+
+	matches, err := pm.FindWatchAgentsByParent(111)
+	if err != nil {
+		t.Fatalf("FindWatchAgentsByParent: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 matches under parent 111, got %d: %+v", len(matches), matches)
+	}
+	names := []string{}
+	for _, m := range matches {
+		names = append(names, m.Name)
+	}
+	sort.Strings(names)
+	if names[0] != "agent-a" || names[1] != "agent-b" {
+		t.Errorf("expected [agent-a agent-b], got %v", names)
+	}
+}
+
+func TestFindWatchAgentsByParentZero(t *testing.T) {
+	pm := newTestPIDManager(t)
+	// Flat entries have ParentPID=0; FindWatchAgentsByParent(0) should return
+	// nothing (the method only finds watch-mode entries, which have parent>0 in
+	// practice, and a flat entry's ParentPID==0 matches the filter but then the
+	// "watch-mode agent" semantics aren't meaningful — current behavior returns
+	// them because the implementation filters on parent PID equality).
+	writePIDFile(t, pm, "flat.pid", os.Getpid())
+
+	matches, err := pm.FindWatchAgentsByParent(0)
+	if err != nil {
+		t.Fatalf("FindWatchAgentsByParent: %v", err)
+	}
+	// Current behavior: the filter p.ParentPID == parentPID matches flat entries
+	// when parentPID == 0. Assert what the code actually does so future changes
+	// are flagged.
+	if len(matches) != 1 {
+		t.Errorf("expected 1 match (flat entry, ParentPID=0), got %d: %+v", len(matches), matches)
+	}
+}
+
+// --- Write / Read / Remove round-trips ---
+
+func TestWriteReadRemoveFlat(t *testing.T) {
+	pm := newTestPIDManager(t)
+	pid := os.Getpid()
+
+	if err := pm.WritePID("foo", pid); err != nil {
+		t.Fatalf("WritePID: %v", err)
+	}
+	got, err := pm.ReadPID("foo")
+	if err != nil {
+		t.Fatalf("ReadPID: %v", err)
+	}
+	if got != pid {
+		t.Errorf("ReadPID = %d, want %d", got, pid)
+	}
+	expectedPath := filepath.Join(pm.pidsDir, "foo.pid")
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Errorf("expected file %s to exist: %v", expectedPath, err)
+	}
+
+	if err := pm.RemovePID("foo"); err != nil {
+		t.Fatalf("RemovePID: %v", err)
+	}
+	if _, err := os.Stat(expectedPath); !os.IsNotExist(err) {
+		t.Errorf("expected file %s to be gone, got err=%v", expectedPath, err)
+	}
+}
+
+func TestWriteReadRemoveWatchAgent(t *testing.T) {
+	pm := newTestPIDManager(t)
+	const parent = 1234
+	const agent = 5678
+
+	if err := pm.WriteWatchAgentPID("foo", parent, agent); err != nil {
+		t.Fatalf("WriteWatchAgentPID: %v", err)
+	}
+	expectedPath := filepath.Join(pm.pidsDir, "foo.1234.pid")
+	if pm.GetWatchAgentPIDFile("foo", parent) != expectedPath {
+		t.Errorf("GetWatchAgentPIDFile = %q, want %q",
+			pm.GetWatchAgentPIDFile("foo", parent), expectedPath)
+	}
+
+	data, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "5678" {
+		t.Errorf("file content = %q, want %q", string(data), "5678")
+	}
+
+	if err := pm.RemoveWatchAgentPID("foo", parent); err != nil {
+		t.Fatalf("RemoveWatchAgentPID: %v", err)
+	}
+	if _, err := os.Stat(expectedPath); !os.IsNotExist(err) {
+		t.Errorf("expected file %s to be gone, got err=%v", expectedPath, err)
+	}
+}
+
+func TestWriteReadRemoveWatchParent(t *testing.T) {
+	pm := newTestPIDManager(t)
+	const parent = 1234
+
+	if err := pm.WriteWatchParentPID("foo", parent); err != nil {
+		t.Fatalf("WriteWatchParentPID: %v", err)
+	}
+	expectedPath := filepath.Join(pm.pidsDir, "foo.1234.watcher-parent.pid")
+	if pm.GetWatchParentPIDFile("foo", parent) != expectedPath {
+		t.Errorf("GetWatchParentPIDFile = %q, want %q",
+			pm.GetWatchParentPIDFile("foo", parent), expectedPath)
+	}
+
+	data, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "1234" {
+		t.Errorf("file content = %q, want %q", string(data), "1234")
+	}
+
+	if err := pm.RemoveWatchParentPID("foo", parent); err != nil {
+		t.Fatalf("RemoveWatchParentPID: %v", err)
+	}
+	if _, err := os.Stat(expectedPath); !os.IsNotExist(err) {
+		t.Errorf("expected file %s to be gone, got err=%v", expectedPath, err)
+	}
+}

--- a/src/core/cli/start_execution.go
+++ b/src/core/cli/start_execution.go
@@ -24,6 +24,12 @@ import (
 // Uses sync.Map for thread-safe concurrent access when starting multiple agents
 var agentNameCache sync.Map
 
+// locallyStartedRegistryPID records the PID of a registry that was started by this meshctl
+// invocation. Set by startStandardMode when it started the registry itself, read by
+// runAgentsInForeground at shutdown to decide whether to kill it. 0 means this meshctl
+// did not start a registry (e.g., it was already running, started by another meshctl).
+var locallyStartedRegistryPID int
+
 // Standard mode
 func startStandardMode(cmd *cobra.Command, args []string, config *CLIConfig) error {
 	quiet, _ := cmd.Flags().GetBool("quiet")
@@ -62,6 +68,17 @@ func startStandardMode(cmd *cobra.Command, args []string, config *CLIConfig) err
 			}
 			if err := WaitForRegistry(registryURL, time.Duration(startupTimeout)*time.Second); err != nil {
 				return fmt.Errorf("registry startup timeout: %w", err)
+			}
+
+			// Capture the PID of the registry we just started so that runAgentsInForeground
+			// can clean it up at shutdown. We deliberately only set this when this meshctl
+			// instance started the registry itself — if an existing registry was already
+			// running, locallyStartedRegistryPID stays 0 and shutdown will leave it alone
+			// (another meshctl instance likely owns it).
+			if pm, err := NewPIDManager(); err == nil {
+				if rpid, err := pm.ReadPID("registry"); err == nil && IsProcessAlive(rpid) {
+					locallyStartedRegistryPID = rpid
+				}
 			}
 		} else {
 			// Remote registry - cannot start, must connect to existing
@@ -466,8 +483,20 @@ func runAgentsInForeground(agentCmds []*exec.Cmd, watchers []*AgentWatcher, cmd 
 	// Initialize PID manager for tracking
 	pm, pmErr := NewPIDManager()
 
-	// Track agent names for cleanup
-	var agentNames []string
+	// Capture parent meshctl PID once — used for watch-mode PID file namespacing.
+	parentPID := os.Getpid()
+
+	// Track agent names for cleanup, split by flow:
+	//   nonWatchNames -> flat <name>.pid files written via pm.WritePID
+	//   watchNames    -> watch-mode <name>.<parentPID>.pid + watcher-parent files
+	var nonWatchNames []string
+	var watchNames []string
+
+	// localNonWatchAgentPIDs tracks the PIDs of non-watch agents started by THIS runAgentsInForeground
+	// invocation. Used at shutdown to kill only our own children — we deliberately do NOT use
+	// GetRunningProcesses() for cleanup, because ~/.mcp_mesh/processes.json is a globally shared
+	// file across all meshctl instances, and reading it would cause cross-instance cascade kills.
+	var localNonWatchAgentPIDs []int
 
 	// Start all agents
 	for i, agentCmd := range agentCmds {
@@ -485,9 +514,10 @@ func runAgentsInForeground(agentCmds []*exec.Cmd, watchers []*AgentWatcher, cmd 
 				break
 			}
 		}
-		agentNames = append(agentNames, agentName)
+		nonWatchNames = append(nonWatchNames, agentName)
+		localNonWatchAgentPIDs = append(localNonWatchAgentPIDs, agentCmd.Process.Pid)
 
-		// Write PID file for this agent
+		// Write PID file for this agent (non-watch: flat layout)
 		if pmErr == nil {
 			if err := pm.WritePID(agentName, agentCmd.Process.Pid); err != nil && !quiet {
 				fmt.Printf("Warning: failed to write PID file for %s: %v\n", agentName, err)
@@ -522,11 +552,14 @@ func runAgentsInForeground(agentCmds []*exec.Cmd, watchers []*AgentWatcher, cmd 
 
 	// Set PID update callbacks for watchers so PID files track the actual agent process.
 	// The callback fires on initial start and on every file-change restart.
+	// Watch-mode PID files are namespaced per parent meshctl PID to avoid collisions
+	// between independent `meshctl start -d -w` invocations that track agents with the
+	// same name (see #706 cascading-shutdown bug).
 	for _, w := range watchers {
 		name := w.config.AgentName // capture for closure
 		w.config.PIDUpdateCallback = func(pid int) {
 			if pmErr == nil {
-				if err := pm.WritePID(name, pid); err != nil && !quiet {
+				if err := pm.WriteWatchAgentPID(name, parentPID, pid); err != nil && !quiet {
 					fmt.Printf("Warning: failed to update PID file for %s: %v\n", name, err)
 				}
 			}
@@ -549,11 +582,11 @@ func runAgentsInForeground(agentCmds []*exec.Cmd, watchers []*AgentWatcher, cmd 
 	// The callback is the primary mechanism; this is best-effort for the initial startup window.
 	for _, w := range watchers {
 		agentName := w.config.AgentName
-		agentNames = append(agentNames, agentName)
+		watchNames = append(watchNames, agentName)
 
 		pid := w.GetPID()
 		if pmErr == nil && pid > 0 {
-			if err := pm.WritePID(agentName, pid); err != nil && !quiet {
+			if err := pm.WriteWatchAgentPID(agentName, parentPID, pid); err != nil && !quiet {
 				fmt.Printf("Warning: failed to write PID file for %s: %v\n", agentName, err)
 			}
 		}
@@ -575,11 +608,11 @@ func runAgentsInForeground(agentCmds []*exec.Cmd, watchers []*AgentWatcher, cmd 
 	// Track the watcher parent process (this meshctl CLI process) so meshctl stop can kill it.
 	// Without this, stopping a watched agent kills only the agent subprocess, leaving
 	// the watcher parent alive to potentially respawn or hold resources (#706).
+	// Files are namespaced per parent PID so independent `meshctl start -d -w` invocations
+	// that track same-named agents don't collide.
 	if len(watchers) > 0 && pmErr == nil {
-		parentPID := os.Getpid()
 		for _, w := range watchers {
-			watcherPIDName := w.config.AgentName + "_watcher-parent"
-			if err := pm.WritePID(watcherPIDName, parentPID); err != nil && !quiet {
+			if err := pm.WriteWatchParentPID(w.config.AgentName, parentPID); err != nil && !quiet {
 				fmt.Printf("Warning: failed to write watcher parent PID for %s: %v\n", w.config.AgentName, err)
 			}
 		}
@@ -602,69 +635,67 @@ func runAgentsInForeground(agentCmds []*exec.Cmd, watchers []*AgentWatcher, cmd 
 	// Clean up watcher PID files and watcher-parent PID files
 	if pmErr == nil {
 		for _, w := range watchers {
-			pm.RemovePID(w.config.AgentName)
-			pm.RemovePID(w.config.AgentName + "_watcher-parent")
+			pm.RemoveWatchAgentPID(w.config.AgentName, parentPID)
+			pm.RemoveWatchParentPID(w.config.AgentName, parentPID)
 		}
 	}
 
-	// Stop all processes - agents first, registry last (issue #442)
-	processes, err := GetRunningProcesses()
-	if err == nil {
-		shutdownTimeout, _ := cmd.Flags().GetInt("shutdown-timeout")
-		if shutdownTimeout == 0 {
-			shutdownTimeout = config.ShutdownTimeout
-		}
+	// Stop non-watch agents started by this meshctl invocation.
+	// We intentionally do NOT call GetRunningProcesses() here — that reads
+	// ~/.mcp_mesh/processes.json which is globally shared across all meshctl
+	// instances, and killing entries from it would cascade into unrelated
+	// instances' agents and registries (the #706-related cascading-shutdown bug).
+	shutdownTimeout, _ := cmd.Flags().GetInt("shutdown-timeout")
+	if shutdownTimeout == 0 {
+		shutdownTimeout = config.ShutdownTimeout
+	}
+	shutdownDuration := time.Duration(shutdownTimeout) * time.Second
 
-		// Separate agents from registry
-		var agents []ProcessInfo
-		var registry *ProcessInfo
-		for i := range processes {
-			if processes[i].Type == "registry" {
-				registry = &processes[i]
-			} else {
-				agents = append(agents, processes[i])
-			}
+	if len(localNonWatchAgentPIDs) > 0 {
+		var wg sync.WaitGroup
+		for _, pid := range localNonWatchAgentPIDs {
+			wg.Add(1)
+			go func(agentPID int) {
+				defer wg.Done()
+				if !quiet {
+					fmt.Printf("Stopping non-watch agent (PID: %d)\n", agentPID)
+				}
+				if err := KillProcess(agentPID, shutdownDuration); err != nil && !quiet {
+					fmt.Printf("Failed to stop agent (PID %d): %v\n", agentPID, err)
+				}
+				RemoveRunningProcess(agentPID)
+			}(pid)
 		}
+		wg.Wait()
 
-		// Stop agents first (in parallel)
-		if len(agents) > 0 {
-			var wg sync.WaitGroup
-			for _, proc := range agents {
-				wg.Add(1)
-				go func(p ProcessInfo) {
-					defer wg.Done()
-					if !quiet {
-						fmt.Printf("Stopping %s (PID: %d)\n", p.Name, p.PID)
-					}
-					if err := KillProcess(p.PID, time.Duration(shutdownTimeout)*time.Second); err != nil && !quiet {
-						fmt.Printf("Failed to stop %s: %v\n", p.Name, err)
-					}
-					RemoveRunningProcess(p.PID)
-				}(proc)
-			}
-			wg.Wait()
-
-			// Grace period for agents to complete unregister HTTP calls
-			time.Sleep(500 * time.Millisecond)
-		}
-
-		// Stop registry last
-		if registry != nil {
-			if !quiet {
-				fmt.Printf("Stopping %s (PID: %d)\n", registry.Name, registry.PID)
-			}
-			if err := KillProcess(registry.PID, time.Duration(shutdownTimeout)*time.Second); err != nil && !quiet {
-				fmt.Printf("Failed to stop %s: %v\n", registry.Name, err)
-			}
-			RemoveRunningProcess(registry.PID)
-		}
+		// Grace period for agents to complete unregister HTTP calls before the
+		// registry goes away (matches the existing behavior).
+		time.Sleep(500 * time.Millisecond)
 	}
 
-	// Clean up all PID files for tracked agents (including watcher-parent PID files)
+	// Stop the registry ONLY if this meshctl instance started it.
+	// If locallyStartedRegistryPID is 0, the registry was either already running
+	// when we started or was started by a different meshctl instance — leaving
+	// it alone is correct because stopping it would break other instances.
+	if locallyStartedRegistryPID > 0 && IsProcessAlive(locallyStartedRegistryPID) {
+		if !quiet {
+			fmt.Printf("Stopping registry (PID: %d)\n", locallyStartedRegistryPID)
+		}
+		if err := KillProcess(locallyStartedRegistryPID, shutdownDuration); err != nil && !quiet {
+			fmt.Printf("Failed to stop registry: %v\n", err)
+		}
+		RemoveRunningProcess(locallyStartedRegistryPID)
+	}
+
+	// Clean up all PID files for tracked agents.
+	// Non-watch agents use flat layout; watch agents use per-parent-PID namespacing.
 	if pmErr == nil {
-		for _, name := range agentNames {
+		for _, name := range nonWatchNames {
 			pm.RemovePID(name)
-			pm.RemovePID(name + "_watcher-parent")
+		}
+		for _, name := range watchNames {
+			pm.RemoveWatchAgentPID(name, parentPID)
+			pm.RemoveWatchParentPID(name, parentPID)
 		}
 	}
 

--- a/src/core/cli/start_execution.go
+++ b/src/core/cli/start_execution.go
@@ -15,20 +15,14 @@ import (
 	"syscall"
 	"time"
 
-	"mcp-mesh/src/core/cli/handlers"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"mcp-mesh/src/core/cli/handlers"
 )
 
 // agentNameCache caches extracted agent names to avoid repeated parsing
 // Uses sync.Map for thread-safe concurrent access when starting multiple agents
 var agentNameCache sync.Map
-
-// locallyStartedRegistryPID records the PID of a registry that was started by this meshctl
-// invocation. Set by startStandardMode when it started the registry itself, read by
-// runAgentsInForeground at shutdown to decide whether to kill it. 0 means this meshctl
-// did not start a registry (e.g., it was already running, started by another meshctl).
-var locallyStartedRegistryPID int
 
 // Standard mode
 func startStandardMode(cmd *cobra.Command, args []string, config *CLIConfig) error {
@@ -38,6 +32,13 @@ func startStandardMode(cmd *cobra.Command, args []string, config *CLIConfig) err
 
 	// Determine registry URL from flags or config
 	registryURL := determineStartRegistryURL(cmd, config)
+
+	// locallyStartedRegistryPID records the PID of a registry that was started by
+	// THIS meshctl invocation. It's threaded through to runAgentsInForeground via
+	// startAgentsWithEnv so shutdown can decide whether to kill the registry.
+	// 0 means this meshctl did not start a registry (e.g., it was already running,
+	// started by another meshctl) and shutdown will leave it alone.
+	var locallyStartedRegistryPID int
 
 	// Check if registry is running
 	if !IsRegistryRunning(registryURL) {
@@ -73,8 +74,8 @@ func startStandardMode(cmd *cobra.Command, args []string, config *CLIConfig) err
 			// Capture the PID of the registry we just started so that runAgentsInForeground
 			// can clean it up at shutdown. We deliberately only set this when this meshctl
 			// instance started the registry itself — if an existing registry was already
-			// running, locallyStartedRegistryPID stays 0 and shutdown will leave it alone
-			// (another meshctl instance likely owns it).
+			// running, the PID stays 0 and shutdown will leave it alone (another meshctl
+			// instance likely owns it).
 			if pm, err := NewPIDManager(); err == nil {
 				if rpid, err := pm.ReadPID("registry"); err == nil && IsProcessAlive(rpid) {
 					locallyStartedRegistryPID = rpid
@@ -92,7 +93,7 @@ func startStandardMode(cmd *cobra.Command, args []string, config *CLIConfig) err
 	// Build environment for agents
 	agentEnv := buildAgentEnvironment(cmd, registryURL, config)
 
-	return startAgentsWithEnv(args, agentEnv, cmd, config)
+	return startAgentsWithEnv(args, agentEnv, cmd, config, locallyStartedRegistryPID)
 }
 
 // Connect-only mode
@@ -117,8 +118,10 @@ func startConnectOnlyMode(cmd *cobra.Command, args []string, registryURL string,
 	// Build environment for agents
 	agentEnv := buildAgentEnvironment(cmd, registryURL, config)
 
-	// Start agents with external registry
-	return startAgentsWithEnv(args, agentEnv, cmd, config)
+	// Start agents with external registry. Pass 0 for locallyStartedRegistryPID
+	// because connect-only mode never starts a registry — the external one must
+	// remain running after this meshctl exits.
+	return startAgentsWithEnv(args, agentEnv, cmd, config, 0)
 }
 
 // Background mode
@@ -129,137 +132,6 @@ func startBackgroundMode(cmd *cobra.Command, args []string, config *CLIConfig) e
 
 	// Fork to detach
 	return forkToBackground(cmd, args, config)
-}
-
-func startAgents(agentPaths []string, config *CLIConfig, detach bool) error {
-	// Ensure registry is running
-	if !IsRegistryRunning(config.GetRegistryURL()) {
-		fmt.Printf("Registry not found, starting local registry on %s:%d\n", config.RegistryHost, config.RegistryPort)
-
-		// Find available port if needed
-		if !IsPortAvailable(config.RegistryHost, config.RegistryPort) {
-			availablePort, err := FindAvailablePort(config.RegistryHost, config.RegistryPort)
-			if err != nil {
-				return fmt.Errorf("no available port found: %w", err)
-			}
-			fmt.Printf("Port %d in use, using port %d instead\n", config.RegistryPort, availablePort)
-			config.RegistryPort = availablePort
-		}
-
-		// Start registry in detach
-		registryCmd, err := startRegistryService(config)
-		if err != nil {
-			return fmt.Errorf("failed to start registry: %w", err)
-		}
-
-		if err := registryCmd.Start(); err != nil {
-			return fmt.Errorf("failed to start registry: %w", err)
-		}
-
-		// Record registry process
-		registryProc := ProcessInfo{
-			PID:       registryCmd.Process.Pid,
-			Name:      "mcp-mesh-registry",
-			Type:      "registry",
-			Command:   registryCmd.String(),
-			StartTime: time.Now(),
-			Status:    "running",
-		}
-		if err := AddRunningProcess(registryProc); err != nil {
-			fmt.Printf("Warning: failed to record registry process: %v\n", err)
-		}
-
-		// Wait for registry to be ready
-		fmt.Print("Waiting for registry to be ready...")
-		if err := WaitForRegistry(config.GetRegistryURL(), time.Duration(config.StartupTimeout)*time.Second); err != nil {
-			return fmt.Errorf("registry failed to start: %w", err)
-		}
-		fmt.Println(" ✓")
-	}
-
-	// Start all agents
-	var agentCmds []*exec.Cmd
-	for _, agentPath := range agentPaths {
-		// Convert to absolute path
-		absPath, err := AbsolutePath(agentPath)
-		if err != nil {
-			return fmt.Errorf("invalid agent path %s: %w", agentPath, err)
-		}
-
-		fmt.Printf("Starting agent: %s\n", absPath)
-
-		cmd, err := StartPythonAgent(absPath, config)
-		if err != nil {
-			return fmt.Errorf("failed to prepare agent %s: %w", agentPath, err)
-		}
-
-		if detach {
-			if err := cmd.Start(); err != nil {
-				return fmt.Errorf("failed to start agent %s: %w", agentPath, err)
-			}
-
-			// Record agent process (only after Start so cmd.Process is available)
-			agentProc := ProcessInfo{
-				PID:       cmd.Process.Pid,
-				Name:      filepath.Base(agentPath),
-				Type:      "agent",
-				Command:   cmd.String(),
-				StartTime: time.Now(),
-				Status:    "running",
-				FilePath:  absPath,
-			}
-			if err := AddRunningProcess(agentProc); err != nil {
-				fmt.Printf("Warning: failed to record agent process: %v\n", err)
-			}
-
-			fmt.Printf("Agent %s started (PID: %d)\n", filepath.Base(agentPath), cmd.Process.Pid)
-		} else {
-			agentCmds = append(agentCmds, cmd)
-			fmt.Printf("Agent %s prepared for foreground\n", filepath.Base(agentPath))
-		}
-	}
-
-	if detach {
-		fmt.Printf("All agents started in detach\n")
-		fmt.Printf("Registry URL: %s\n", config.GetRegistryURL())
-		return nil
-	}
-
-	// If running in foreground, start agents and wait
-	if len(agentCmds) > 0 {
-		// Setup signal handling
-		sigChan := make(chan os.Signal, 1)
-		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-
-		fmt.Println("Agents are running. Press Ctrl+C to stop all services.")
-
-		// Start all agents
-		for _, cmd := range agentCmds {
-			go func(c *exec.Cmd) {
-				if err := c.Run(); err != nil {
-					fmt.Printf("Agent exited with error: %v\n", err)
-				}
-			}(cmd)
-		}
-
-		// Wait for signal
-		<-sigChan
-		fmt.Println("\nShutting down all services...")
-
-		// Stop all processes
-		processes, err := GetRunningProcesses()
-		if err == nil {
-			for _, proc := range processes {
-				fmt.Printf("Stopping %s (PID: %d)\n", proc.Name, proc.PID)
-				if err := KillProcess(proc.PID, time.Duration(config.ShutdownTimeout)*time.Second); err != nil {
-					fmt.Printf("Failed to stop %s: %v\n", proc.Name, err)
-				}
-				RemoveRunningProcess(proc.PID)
-			}
-		}
-	}
-
-	return nil
 }
 
 // Build agent environment with all flag support
@@ -304,8 +176,11 @@ func buildAgentEnvironment(cmd *cobra.Command, registryURL string, config *CLICo
 	return env
 }
 
-// Start agents with environment
-func startAgentsWithEnv(agentPaths []string, env []string, cmd *cobra.Command, config *CLIConfig) error {
+// Start agents with environment.
+// locallyStartedRegistryPID is the PID of a registry that this meshctl invocation
+// started itself (0 if it did not start one); it's threaded through to
+// runAgentsInForeground so shutdown can decide whether to kill the registry.
+func startAgentsWithEnv(agentPaths []string, env []string, cmd *cobra.Command, config *CLIConfig, locallyStartedRegistryPID int) error {
 	var agentCmds []*exec.Cmd
 	var watchers []*AgentWatcher
 	workingDir, _ := cmd.Flags().GetString("working-dir")
@@ -464,13 +339,13 @@ func startAgentsWithEnv(agentPaths []string, env []string, cmd *cobra.Command, c
 
 	// If running in foreground, start agents and wait
 	if len(agentCmds) > 0 || len(watchers) > 0 {
-		return runAgentsInForeground(agentCmds, watchers, cmd, config)
+		return runAgentsInForeground(agentCmds, watchers, cmd, config, locallyStartedRegistryPID)
 	}
 
 	return nil
 }
 
-func runAgentsInForeground(agentCmds []*exec.Cmd, watchers []*AgentWatcher, cmd *cobra.Command, config *CLIConfig) error {
+func runAgentsInForeground(agentCmds []*exec.Cmd, watchers []*AgentWatcher, cmd *cobra.Command, config *CLIConfig, locallyStartedRegistryPID int) error {
 	// Setup signal handling
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)

--- a/src/core/cli/start_execution.go
+++ b/src/core/cli/start_execution.go
@@ -55,12 +55,16 @@ func startStandardMode(cmd *cobra.Command, args []string, config *CLIConfig) err
 				return fmt.Errorf("cannot start registry: port %d is already in use on %s", registryPort, registryHost)
 			}
 
-			// Start registry in detach
-			go func() {
-				if err := startRegistryWithOptions(config, true, cmd); err != nil {
-					fmt.Printf("Registry startup failed: %v\n", err)
-				}
-			}()
+			// Start registry in detach. startRegistryWithOptions returns the child
+			// PID directly once registryCmd.Start() succeeds, so we don't need a
+			// goroutine wrapper here — and deriving ownership from the explicit
+			// return value is safer than re-reading the globally shared
+			// registry.pid file (which is vulnerable to cross-instance races and
+			// stale entries from unrelated meshctl processes).
+			registryPID, err := startRegistryWithOptions(config, true, cmd)
+			if err != nil {
+				return fmt.Errorf("failed to start registry: %w", err)
+			}
 
 			// Wait for registry to be ready
 			startupTimeout, _ := cmd.Flags().GetInt("startup-timeout")
@@ -71,16 +75,13 @@ func startStandardMode(cmd *cobra.Command, args []string, config *CLIConfig) err
 				return fmt.Errorf("registry startup timeout: %w", err)
 			}
 
-			// Capture the PID of the registry we just started so that runAgentsInForeground
-			// can clean it up at shutdown. We deliberately only set this when this meshctl
-			// instance started the registry itself — if an existing registry was already
-			// running, the PID stays 0 and shutdown will leave it alone (another meshctl
-			// instance likely owns it).
-			if pm, err := NewPIDManager(); err == nil {
-				if rpid, err := pm.ReadPID("registry"); err == nil && IsProcessAlive(rpid) {
-					locallyStartedRegistryPID = rpid
-				}
-			}
+			// This meshctl instance started the registry — capture ownership
+			// directly from the explicit return value so shutdown can clean it up.
+			// We deliberately avoid pm.ReadPID("registry") here: registry.pid is a
+			// globally shared file and reading it would let a stale or racing
+			// entry from another meshctl instance look like ownership, which is
+			// exactly the cross-instance tracking bug this PR fixes for agents.
+			locallyStartedRegistryPID = registryPID
 		} else {
 			// Remote registry - cannot start, must connect to existing
 			return fmt.Errorf("cannot connect to remote registry at %s - please ensure the registry is running", registryURL)
@@ -367,11 +368,22 @@ func runAgentsInForeground(agentCmds []*exec.Cmd, watchers []*AgentWatcher, cmd 
 	var nonWatchNames []string
 	var watchNames []string
 
-	// localNonWatchAgentPIDs tracks the PIDs of non-watch agents started by THIS runAgentsInForeground
-	// invocation. Used at shutdown to kill only our own children — we deliberately do NOT use
-	// GetRunningProcesses() for cleanup, because ~/.mcp_mesh/processes.json is a globally shared
-	// file across all meshctl instances, and reading it would cause cross-instance cascade kills.
-	var localNonWatchAgentPIDs []int
+	// localNonWatchAgentPIDs tracks the PIDs of non-watch agents started by THIS
+	// runAgentsInForeground invocation. Used at shutdown to kill only our own
+	// children — we deliberately do NOT use GetRunningProcesses() for cleanup,
+	// because ~/.mcp_mesh/processes.json is a globally shared file across all
+	// meshctl instances, and reading it would cause cross-instance cascade kills.
+	//
+	// A set (map[int]struct{}) is used rather than a slice so entries can be
+	// REMOVED when a child exits naturally (via the c.Wait() goroutine below).
+	// Without removal, a child that dies before shutdown would leave its PID in
+	// the slice, and shutdown's KillProcess loop would target a PID the OS may
+	// have since reused for an unrelated process — killing the wrong thing.
+	//
+	// The mutex guards all reads and writes because the Wait goroutine runs on a
+	// different goroutine from the signal-driven shutdown path.
+	var localNonWatchAgentPIDsMu sync.Mutex
+	localNonWatchAgentPIDs := make(map[int]struct{})
 
 	// Start all agents
 	for i, agentCmd := range agentCmds {
@@ -390,7 +402,9 @@ func runAgentsInForeground(agentCmds []*exec.Cmd, watchers []*AgentWatcher, cmd 
 			}
 		}
 		nonWatchNames = append(nonWatchNames, agentName)
-		localNonWatchAgentPIDs = append(localNonWatchAgentPIDs, agentCmd.Process.Pid)
+		localNonWatchAgentPIDsMu.Lock()
+		localNonWatchAgentPIDs[agentCmd.Process.Pid] = struct{}{}
+		localNonWatchAgentPIDsMu.Unlock()
 
 		// Write PID file for this agent (non-watch: flat layout)
 		if pmErr == nil {
@@ -417,6 +431,11 @@ func runAgentsInForeground(agentCmds []*exec.Cmd, watchers []*AgentWatcher, cmd 
 			if err := c.Wait(); err != nil && !quiet {
 				fmt.Printf("Agent exited with error: %v\n", err)
 			}
+			// Drop this PID from the live shutdown set so the shutdown loop
+			// doesn't target a PID the OS may have since reused.
+			localNonWatchAgentPIDsMu.Lock()
+			delete(localNonWatchAgentPIDs, c.Process.Pid)
+			localNonWatchAgentPIDsMu.Unlock()
 			RemoveRunningProcess(c.Process.Pid)
 			// Clean up PID file when agent exits
 			if pmErr == nil {
@@ -526,9 +545,18 @@ func runAgentsInForeground(agentCmds []*exec.Cmd, watchers []*AgentWatcher, cmd 
 	}
 	shutdownDuration := time.Duration(shutdownTimeout) * time.Second
 
-	if len(localNonWatchAgentPIDs) > 0 {
+	// Snapshot the live PID set under the mutex. Iterating the map directly
+	// while the Wait goroutine may still be deleting entries would race.
+	localNonWatchAgentPIDsMu.Lock()
+	pidsToKill := make([]int, 0, len(localNonWatchAgentPIDs))
+	for pid := range localNonWatchAgentPIDs {
+		pidsToKill = append(pidsToKill, pid)
+	}
+	localNonWatchAgentPIDsMu.Unlock()
+
+	if len(pidsToKill) > 0 {
 		var wg sync.WaitGroup
-		for _, pid := range localNonWatchAgentPIDs {
+		for _, pid := range pidsToKill {
 			wg.Add(1)
 			go func(agentPID int) {
 				defer wg.Done()

--- a/src/core/cli/start_registry.go
+++ b/src/core/cli/start_registry.go
@@ -126,18 +126,29 @@ func startRegistryOnlyMode(cmd *cobra.Command, config *CLIConfig) error {
 	return nil
 }
 
-func startRegistryWithOptions(config *CLIConfig, detach bool, cmd *cobra.Command) error {
+// startRegistryWithOptions starts the registry service and returns its PID.
+//
+// In detach mode it returns immediately after registryCmd.Start() with the
+// child's PID; the caller can use this PID directly to track ownership instead
+// of re-reading the globally shared registry.pid file (which is vulnerable to
+// cross-instance races or stale files from unrelated meshctl processes).
+//
+// In foreground mode it owns the full signal lifecycle and only returns after
+// the user sends SIGINT/SIGTERM and the child has been killed. The returned
+// PID in that mode isn't meaningful to the caller (the function already cleaned
+// up) — it is returned only for signature consistency with the detach path.
+func startRegistryWithOptions(config *CLIConfig, detach bool, cmd *cobra.Command) (int, error) {
 	// Start the registry service
 	registryCmd, err := startRegistryService(config)
 	if err != nil {
-		return fmt.Errorf("failed to start registry: %w", err)
+		return 0, fmt.Errorf("failed to start registry: %w", err)
 	}
 
 	if detach {
 		// Set up log file for detached registry
 		lm, err := NewLogManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize log manager: %w", err)
+			return 0, fmt.Errorf("failed to initialize log manager: %w", err)
 		}
 
 		// Rotate existing logs
@@ -149,7 +160,7 @@ func startRegistryWithOptions(config *CLIConfig, detach bool, cmd *cobra.Command
 		// Create log file and redirect output
 		logFile, err := lm.CreateLogFile("registry")
 		if err != nil {
-			return fmt.Errorf("failed to create log file for registry: %w", err)
+			return 0, fmt.Errorf("failed to create log file for registry: %w", err)
 		}
 		registryCmd.Stdout = logFile
 		registryCmd.Stderr = logFile
@@ -157,7 +168,7 @@ func startRegistryWithOptions(config *CLIConfig, detach bool, cmd *cobra.Command
 		// Start in detach
 		if err := registryCmd.Start(); err != nil {
 			logFile.Close()
-			return fmt.Errorf("failed to start registry in detach: %w", err)
+			return 0, fmt.Errorf("failed to start registry in detach: %w", err)
 		}
 		// Close parent's copy of log file — child process has its own file descriptor
 		logFile.Close()
@@ -188,12 +199,12 @@ func startRegistryWithOptions(config *CLIConfig, detach bool, cmd *cobra.Command
 			fmt.Printf("Registry URL: %s\n", config.GetRegistryURL())
 			fmt.Printf("Logs: ~/.mcp-mesh/logs/registry.log\n")
 		}
-		return nil
+		return registryCmd.Process.Pid, nil
 	}
 
 	// Start in foreground
 	if err := registryCmd.Start(); err != nil {
-		return fmt.Errorf("failed to start registry: %w", err)
+		return 0, fmt.Errorf("failed to start registry: %w", err)
 	}
 
 	// Record the process
@@ -218,7 +229,7 @@ func startRegistryWithOptions(config *CLIConfig, detach bool, cmd *cobra.Command
 
 	// Wait for registry to be ready
 	if err := WaitForRegistry(config.GetRegistryURL(), time.Duration(config.StartupTimeout)*time.Second); err != nil {
-		return fmt.Errorf("registry failed to start: %w", err)
+		return registryCmd.Process.Pid, fmt.Errorf("registry failed to start: %w", err)
 	}
 
 	if !quiet {
@@ -244,7 +255,7 @@ func startRegistryWithOptions(config *CLIConfig, detach bool, cmd *cobra.Command
 	if shutdownTimeout == 0 {
 		shutdownTimeout = config.ShutdownTimeout
 	}
-	return KillProcess(registryCmd.Process.Pid, time.Duration(shutdownTimeout)*time.Second)
+	return registryCmd.Process.Pid, KillProcess(registryCmd.Process.Pid, time.Duration(shutdownTimeout)*time.Second)
 }
 
 func startRegistryService(config *CLIConfig) (*exec.Cmd, error) {

--- a/src/core/cli/stop.go
+++ b/src/core/cli/stop.go
@@ -147,11 +147,15 @@ func stopSpecificAgent(pm *PIDManager, name string, timeout time.Duration, force
 	if pid, err := pm.ReadPID(name); err == nil {
 		foundAny = true
 		if !IsProcessAlive(pid) {
-			// Already dead at enumeration time — safe to remove the stale PID file.
+			// Already dead at enumeration time — safe to remove the stale PID
+			// file. Treat this as a successful no-op: the user's intent was
+			// "stop this agent" and the agent is confirmed not running, so the
+			// outer "could not be stopped" error would actively mislead them.
 			if !quiet {
 				fmt.Printf("Agent '%s' is not running (cleaning stale PID file)\n", name)
 			}
 			pm.RemovePID(name)
+			stoppedAny = true
 		} else {
 			if !quiet {
 				fmt.Printf("Stopping agent '%s' (PID: %d)...\n", name, pid)

--- a/src/core/cli/stop.go
+++ b/src/core/cli/stop.go
@@ -127,120 +127,136 @@ func runStopCommand(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// stopSpecificAgent stops a single agent by name
+// stopSpecificAgent stops all instances (flat and/or watch-mode) of an agent by name.
+// Returns an error if no running instances were found.
+//
+// Under the per-parent-PID namespacing scheme, the same agent name may have:
+//   - one flat (non-watch) instance, tracked as <name>.pid
+//   - zero or more watch-mode instances, each tracked as <name>.<parent_pid>.pid
+//     under a different watcher-parent meshctl process
+//
+// We stop all of them and then, for each distinct watcher-parent we touched,
+// decide whether to kill the parent process based on whether any watch-mode
+// agents still live under it.
 func stopSpecificAgent(pm *PIDManager, name string, timeout time.Duration, force, quiet bool) error {
-	pid, err := pm.ReadPID(name)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("agent '%s' is not running in background", name)
-		}
-		return fmt.Errorf("failed to read PID for %s: %w", name, err)
-	}
+	stoppedAny := false
 
-	if !IsProcessAlive(pid) {
-		// Process is dead, clean up PID file
+	// 1. Flat/non-watch mode instance (if any)
+	if pid, err := pm.ReadPID(name); err == nil {
+		if IsProcessAlive(pid) {
+			if !quiet {
+				fmt.Printf("Stopping agent '%s' (PID: %d)...\n", name, pid)
+			}
+			if err := stopProcess(pid, timeout, force); err != nil {
+				if !quiet {
+					fmt.Printf("Warning: failed to stop agent '%s' (PID %d): %v\n", name, pid, err)
+				}
+			} else {
+				if !quiet {
+					fmt.Printf("Agent '%s' stopped\n", name)
+				}
+				stoppedAny = true
+			}
+		} else if !quiet {
+			fmt.Printf("Agent '%s' is not running (cleaning stale PID file)\n", name)
+		}
 		pm.RemovePID(name)
+	}
+
+	// 2. All watch-mode instances of this name (may be multiple across different parent PIDs)
+	watchMatches, err := pm.FindWatchAgentsByName(name)
+	if err != nil {
+		return fmt.Errorf("failed to enumerate watch-mode instances: %w", err)
+	}
+
+	// Track which parents we touched so we can run shared-watcher cleanup once per parent afterwards.
+	touchedParents := make(map[int]bool)
+
+	for _, match := range watchMatches {
 		if !quiet {
-			fmt.Printf("Agent '%s' is not running (cleaned stale PID file)\n", name)
+			fmt.Printf("Stopping agent '%s' (PID: %d, watcher parent: %d)...\n", name, match.PID, match.ParentPID)
 		}
-		// Still try to clean up watcher parent if it exists
-		stopWatcherParent(pm, name, timeout, force, quiet)
-		return nil
+		if err := stopProcess(match.PID, timeout, force); err != nil {
+			if !quiet {
+				fmt.Printf("Warning: failed to stop agent '%s' (PID %d): %v\n", name, match.PID, err)
+			}
+		} else {
+			if !quiet {
+				fmt.Printf("Agent '%s' stopped\n", name)
+			}
+			stoppedAny = true
+		}
+		pm.RemoveWatchAgentPID(name, match.ParentPID)
+		touchedParents[match.ParentPID] = true
 	}
 
-	if !quiet {
-		fmt.Printf("Stopping agent '%s' (PID: %d)...\n", name, pid)
+	// 3. For each parent we touched, decide whether to stop its watcher process.
+	//    Rule: if the parent has no remaining watch-mode agents alive, stop it.
+	for parentPID := range touchedParents {
+		stopWatcherParentIfEmpty(pm, name, parentPID, timeout, force, quiet)
 	}
 
-	if err := stopProcess(pid, timeout, force); err != nil {
-		return fmt.Errorf("failed to stop agent '%s': %w", name, err)
+	if !stoppedAny {
+		return fmt.Errorf("agent '%s' is not running", name)
 	}
-
-	pm.RemovePID(name)
-
-	if !quiet {
-		fmt.Printf("Agent '%s' stopped\n", name)
-	}
-
-	// Also stop the watcher parent process if this agent was running in watch mode
-	stopWatcherParent(pm, name, timeout, force, quiet)
-
 	return nil
 }
 
-// stopWatcherParent stops the watcher parent process for a watched agent.
-// This kills the meshctl CLI process that hosts the watcher goroutine,
-// preventing it from respawning the agent or holding resources (#706).
+// stopWatcherParentIfEmpty stops the watcher-parent meshctl process with the given PID
+// only if it has no remaining live watch-mode agents under it. The name argument is used
+// purely for log messages.
 //
-// When multiple agents share the same watcher parent (e.g. meshctl start a b c -w),
-// the parent is only killed when the last agent using it is stopped.
-func stopWatcherParent(pm *PIDManager, agentName string, timeout time.Duration, force, quiet bool) {
-	watcherPIDName := agentName + "_watcher-parent"
-	watcherPID, err := pm.ReadPID(watcherPIDName)
-	if err != nil {
-		return // No watcher parent PID file — agent was not in watch mode
-	}
-
-	// Always remove this agent's watcher-parent PID file first
-	pm.RemovePID(watcherPIDName)
-
-	if !IsProcessAlive(watcherPID) {
+// This replaces the old countWatcherParentsWithPID-based approach: instead of counting
+// sibling watcher-parent PID files (which collided under the old naming scheme), we now
+// enumerate the actual agent entries that reference this parent_pid in their filename,
+// which is the authoritative source of truth.
+func stopWatcherParentIfEmpty(pm *PIDManager, name string, parentPID int, timeout time.Duration, force, quiet bool) {
+	// Count remaining live agents under this parent.
+	remaining, err := pm.FindWatchAgentsByParent(parentPID)
+	if err == nil && len(remaining) > 0 {
+		if !quiet {
+			fmt.Printf("Watcher parent (PID: %d) still has %d other agent(s), keeping alive\n", parentPID, len(remaining))
+		}
 		return
 	}
 
-	// Check if other agents still share the same watcher parent PID.
-	// Only kill the parent if no other watcher-parent PID files reference it.
-	otherWatchers := countWatcherParentsWithPID(pm, watcherPID)
-	if otherWatchers > 0 {
-		if !quiet {
-			fmt.Printf("Watcher parent (PID: %d) still has %d other agent(s), keeping alive\n", watcherPID, otherWatchers)
-		}
+	// No remaining agents — safe to remove this name's watcher-parent tracking file and kill the parent.
+	pm.RemoveWatchParentPID(name, parentPID)
+
+	if !IsProcessAlive(parentPID) {
 		return
 	}
 
 	if !quiet {
-		fmt.Printf("Stopping watcher for '%s' (PID: %d)...\n", agentName, watcherPID)
+		fmt.Printf("Stopping watcher for '%s' (PID: %d)...\n", name, parentPID)
 	}
 
-	// Send SIGTERM to the watcher parent process only (not its process group).
-	// The watcher parent may share a process group with the registry or other
-	// components started in the same meshctl session. Using stopProcess() would
-	// kill the entire group, taking down unrelated services.
-	if proc, err := os.FindProcess(watcherPID); err == nil {
+	// Signal the parent meshctl process directly — NOT its process group — so we don't
+	// take down unrelated siblings sharing the same group (registry, UI, etc).
+	if proc, err := os.FindProcess(parentPID); err == nil {
 		if err := proc.Signal(syscall.SIGTERM); err != nil && !quiet {
-			fmt.Printf("Warning: failed to signal watcher for '%s': %v\n", agentName, err)
+			fmt.Printf("Warning: failed to signal watcher for '%s': %v\n", name, err)
 		}
-		// Wait briefly for graceful exit
-		time.Sleep(500 * time.Millisecond)
-		if IsProcessAlive(watcherPID) {
+		// Wait briefly for graceful exit, then force kill.
+		deadline := time.Now().Add(timeout)
+		for time.Now().Before(deadline) {
+			if !IsProcessAlive(parentPID) {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		if IsProcessAlive(parentPID) {
 			proc.Kill()
 		}
 	}
 
-	if !IsProcessAlive(watcherPID) {
+	if IsProcessAlive(parentPID) {
 		if !quiet {
-			fmt.Printf("Watcher for '%s' stopped\n", agentName)
+			fmt.Printf("Warning: watcher for '%s' (PID: %d) may still be running\n", name, parentPID)
 		}
 	} else if !quiet {
-		fmt.Printf("Warning: watcher for '%s' (PID: %d) may still be running\n", agentName, watcherPID)
+		fmt.Printf("Watcher for '%s' stopped\n", name)
 	}
-}
-
-// countWatcherParentsWithPID counts how many remaining watcher-parent PID files
-// reference the given PID. Used to avoid killing a shared parent process when
-// other watched agents are still running.
-func countWatcherParentsWithPID(pm *PIDManager, targetPID int) int {
-	procs, err := pm.ListRunningProcesses()
-	if err != nil {
-		return 0
-	}
-	count := 0
-	for _, proc := range procs {
-		if proc.Type == "watcher-parent" && proc.PID == targetPID {
-			count++
-		}
-	}
-	return count
 }
 
 // stopRegistry stops only the registry
@@ -330,9 +346,19 @@ func stopAllAgents(pm *PIDManager, timeout time.Duration, force, quiet bool) err
 	wg.Wait()
 
 	// Stop watcher parent processes sequentially after all agents are stopped.
-	// This avoids races when multiple agents share a watcher parent (#706).
+	// Build the set of distinct parent PIDs from the killed watch-mode agents,
+	// then call stopWatcherParentIfEmpty once per parent. This avoids double-
+	// signalling the same parent when multiple agents share it (#706).
+	parentPIDs := make(map[int]string) // parentPID -> representative name (for log messages)
 	for _, agent := range agents {
-		stopWatcherParent(pm, agent.Name, timeout, force, quiet)
+		if agent.ParentPID > 0 {
+			if _, ok := parentPIDs[agent.ParentPID]; !ok {
+				parentPIDs[agent.ParentPID] = agent.Name
+			}
+		}
+	}
+	for parentPID, repName := range parentPIDs {
+		stopWatcherParentIfEmpty(pm, repName, parentPID, timeout, force, quiet)
 	}
 
 	if !quiet {

--- a/src/core/cli/stop.go
+++ b/src/core/cli/stop.go
@@ -229,19 +229,23 @@ func stopSpecificAgent(pm *PIDManager, name string, timeout time.Duration, force
 	return nil
 }
 
-// stopWatcherParentIfEmpty stops the watcher-parent meshctl process with the given PID
-// only if it has no remaining live watch-mode agents under it. The name argument is used
-// purely for log messages.
+// stopWatcherParentIfEmpty stops the watcher-parent meshctl process with the
+// given PID only if it has no remaining live watch-mode agents under it.
 //
-// This replaces the old countWatcherParentsWithPID-based approach: instead of counting
-// sibling watcher-parent PID files (which collided under the old naming scheme), we now
-// enumerate the actual agent entries that reference this parent_pid in their filename,
-// which is the authoritative source of truth.
+// Tracking file cleanup is driven by enumeration and invariant-safe:
+//   - Case 1 (live agents remain): prune stale tracking files whose agents
+//     are gone, keep the parent alive, return.
+//   - Case 2 (no live agents, parent already dead): prune all tracking files.
+//   - Case 3 (no live agents, parent still alive, kill succeeds): prune after
+//     kill is confirmed.
+//   - Case 4 (no live agents, parent still alive, kill FAILS): preserve ALL
+//     tracking files so `meshctl stop` can retry later.
 //
-// File cleanup is driven by enumeration, not by the specific name the caller passed:
-// the function prunes every stale `<x>.<parent_pid>.watcher-parent.pid` whose `<x>` no
-// longer has a live agent file, regardless of whether the caller targeted that name.
-// This means multiple agents sharing one parent are all cleaned up on a single call.
+// The invariant is: tracking files for a parent are pruned ONLY when we can
+// prove the parent either didn't need killing (keep-alive) or was successfully
+// killed. A failed kill must leave tracking intact for retry.
+//
+// The `name` argument is used purely for log messages.
 func stopWatcherParentIfEmpty(pm *PIDManager, name string, parentPID int, timeout time.Duration, force, quiet bool) {
 	// Enumerate all watcher-parent tracking entries for this parent PID. Unlike
 	// FindWatchAgentsByParent, this returns entries regardless of whether the
@@ -264,34 +268,38 @@ func stopWatcherParentIfEmpty(pm *PIDManager, name string, parentPID int, timeou
 		return
 	}
 
-	// Build the set of names whose agent is still live.
-	liveNames := make(map[string]bool, len(remaining))
-	for _, r := range remaining {
-		liveNames[r.Name] = true
-	}
-
-	// Prune watcher-parent tracking files whose agent is no longer live.
-	// This handles both the stopAllAgents "multiple agents share one parent"
-	// case and the stopSpecificAgent "keep alive" case — in both, the caller
-	// has already removed the dead agents' <name>.<parent_pid>.pid files, so
-	// any watcher-parent file whose name is not in liveNames is stale.
-	for _, wp := range allParents {
-		if !liveNames[wp.Name] {
-			pm.RemovePIDFile(wp.PIDFile)
-		}
-	}
-
-	// If any live agents remain under this parent, keep it alive.
+	// Case 1: live agents remain under this parent — keep it alive and
+	// prune any stale watcher-parent tracking files whose agents are gone.
+	// Safe to prune here because we are NOT attempting to kill the parent;
+	// the parent stays alive and the remaining live agents are tracked by
+	// their own entries.
 	if len(remaining) > 0 {
+		liveNames := make(map[string]bool, len(remaining))
+		for _, r := range remaining {
+			liveNames[r.Name] = true
+		}
+		for _, wp := range allParents {
+			if !liveNames[wp.Name] {
+				pm.RemovePIDFile(wp.PIDFile)
+			}
+		}
 		if !quiet {
 			fmt.Printf("Watcher parent (PID: %d) still has %d agent(s), keeping alive\n", parentPID, len(remaining))
 		}
 		return
 	}
 
-	// No live agents under this parent — stop it.
+	// Case 2: no live agents under this parent — attempt to kill it.
+	// CRITICAL: do NOT prune tracking files yet. If the kill fails, the
+	// user needs those files intact to retry `meshctl stop`. We prune
+	// ONLY after confirming the parent is dead.
+
 	if !IsProcessAlive(parentPID) {
-		// Already dead; nothing to kill. Tracking files were cleaned above.
+		// Parent is already dead (e.g., exited on its own between
+		// enumeration and now). Safe to prune all its tracking files.
+		for _, wp := range allParents {
+			pm.RemovePIDFile(wp.PIDFile)
+		}
 		return
 	}
 
@@ -316,24 +324,26 @@ func stopWatcherParentIfEmpty(pm *PIDManager, name string, parentPID int, timeou
 		}
 		if IsProcessAlive(parentPID) {
 			proc.Kill()
-			time.Sleep(50 * time.Millisecond) // let SIGKILL propagate
+			// Bounded poll for zombie reap — see waitForProcessDeath.
+			waitForProcessDeath(parentPID, 500*time.Millisecond)
 		}
 	}
 
 	if IsProcessAlive(parentPID) {
+		// Kill failed — PRESERVE all tracking files so the user can retry.
 		if !quiet {
 			fmt.Printf("Warning: watcher for '%s' (PID: %d) may still be running — tracking files preserved\n", name, parentPID)
 		}
-		return // DO NOT clean up tracking files; the parent is still running.
+		return
 	}
 
 	if !quiet {
 		fmt.Printf("Watcher for '%s' stopped\n", name)
 	}
 
-	// Parent confirmed dead. Re-enumerate and clean up any remaining tracking
-	// files (there shouldn't be any after the prune above unless a race
-	// occurred between the enumeration and the kill, but be defensive).
+	// Parent confirmed dead. Now safe to prune every watcher-parent tracking
+	// file for it. Re-enumerate to catch any file that may have appeared since
+	// the first enumeration (rare but defensive).
 	leftovers, _ := pm.FindWatchParentsByPID(parentPID)
 	for _, wp := range leftovers {
 		pm.RemovePIDFile(wp.PIDFile)
@@ -443,8 +453,15 @@ func stopAllAgents(pm *PIDManager, timeout time.Duration, force, quiet bool) err
 			}
 		}
 	}
-	for parentPID, repName := range parentPIDs {
-		stopWatcherParentIfEmpty(pm, repName, parentPID, timeout, force, quiet)
+	// Sort parent PIDs before iterating so log output is deterministic across
+	// runs (matches the pattern in stopSpecificAgent).
+	sortedParents := make([]int, 0, len(parentPIDs))
+	for pid := range parentPIDs {
+		sortedParents = append(sortedParents, pid)
+	}
+	sort.Ints(sortedParents)
+	for _, parentPID := range sortedParents {
+		stopWatcherParentIfEmpty(pm, parentPIDs[parentPID], parentPID, timeout, force, quiet)
 	}
 
 	if !quiet {
@@ -633,6 +650,25 @@ func stopAll(pm *PIDManager, timeout time.Duration, force, quiet bool) error {
 	return nil
 }
 
+// waitForProcessDeath polls IsProcessAlive for up to `limit` after a kill
+// signal, returning true if the process died within the window. Used to let
+// zombies be reaped across process boundaries — IsProcessAlive returns true
+// for unreaped zombies because signal 0 only fails with ESRCH after the
+// kernel fully reclaims the PID. A fixed short sleep is not enough when the
+// killing meshctl is not the agent's parent: reaping depends on the spawning
+// meshctl's exec.Cmd.Wait goroutine being scheduled, which may take longer
+// than a handful of milliseconds on a loaded system.
+func waitForProcessDeath(pid int, limit time.Duration) bool {
+	deadline := time.Now().Add(limit)
+	for time.Now().Before(deadline) {
+		if !IsProcessAlive(pid) {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return !IsProcessAlive(pid)
+}
+
 // stopProcess gracefully stops a process and its entire process group
 // (SIGTERM to process group, then SIGKILL after timeout).
 // This ensures child processes (e.g., npx -> tsx -> node) are also terminated.
@@ -656,8 +692,7 @@ func stopProcess(pid int, timeout time.Duration, force bool) error {
 			}
 		}
 		// Let the kernel propagate the SIGKILL before the final liveness check.
-		time.Sleep(50 * time.Millisecond)
-		if IsProcessAlive(pid) {
+		if !waitForProcessDeath(pid, 500*time.Millisecond) {
 			return fmt.Errorf("process %d still alive after SIGKILL", pid)
 		}
 		return nil
@@ -693,14 +728,13 @@ func stopProcess(pid int, timeout time.Duration, force bool) error {
 		}
 	}
 
-	// Give the kernel a brief moment to propagate SIGKILL and tear the
-	// process down. Then verify. SIGKILL usually succeeds, but there are
-	// edge cases (D-state uninterruptible sleep, unreaped zombie with a
-	// hung parent, permission denial, PID reuse, etc.) where the process
-	// may still appear alive; we must report that to the caller so it can
-	// preserve tracking files for a retry instead of silently losing them.
-	time.Sleep(50 * time.Millisecond)
-	if IsProcessAlive(pid) {
+	// Give the kernel a brief window to propagate SIGKILL and tear the
+	// process down. SIGKILL usually succeeds, but there are edge cases
+	// (D-state uninterruptible sleep, unreaped zombie with a hung parent,
+	// permission denial, PID reuse, etc.) where the process may still
+	// appear alive; we must report that to the caller so it can preserve
+	// tracking files for a retry instead of silently losing them.
+	if !waitForProcessDeath(pid, 500*time.Millisecond) {
 		return fmt.Errorf("process %d still alive after SIGKILL", pid)
 	}
 

--- a/src/core/cli/stop.go
+++ b/src/core/cli/stop.go
@@ -156,25 +156,18 @@ func stopSpecificAgent(pm *PIDManager, name string, timeout time.Duration, force
 			if !quiet {
 				fmt.Printf("Stopping agent '%s' (PID: %d)...\n", name, pid)
 			}
-			stopErr := stopProcess(pid, timeout, force)
-			// Re-check liveness after stopProcess regardless of its return value — the
-			// SIGKILL path can succeed even when the graceful path returned an error.
-			if !IsProcessAlive(pid) {
+			if err := stopProcess(pid, timeout, force); err != nil {
+				// Process is still alive — preserve the PID file so the user can
+				// retry with `meshctl stop <name>`.
+				if !quiet {
+					fmt.Printf("Warning: failed to stop agent '%s' (PID %d): %v (tracking preserved for retry)\n", name, pid, err)
+				}
+			} else {
 				if !quiet {
 					fmt.Printf("Agent '%s' stopped\n", name)
 				}
 				stoppedAny = true
 				pm.RemovePID(name)
-			} else {
-				// Process survived — preserve the PID file so the user can retry with
-				// `meshctl stop <name>` (otherwise name-based lookup would fail).
-				if !quiet {
-					if stopErr != nil {
-						fmt.Printf("Warning: agent '%s' (PID %d) is still running after stop attempt (%v); tracking file preserved for retry\n", name, pid, stopErr)
-					} else {
-						fmt.Printf("Warning: agent '%s' (PID %d) is still running after stop attempt; tracking file preserved for retry\n", name, pid)
-					}
-				}
 			}
 		}
 	}
@@ -197,25 +190,19 @@ func stopSpecificAgent(pm *PIDManager, name string, timeout time.Duration, force
 		if !quiet {
 			fmt.Printf("Stopping agent '%s' (PID: %d, watcher parent: %d)...\n", name, match.PID, match.ParentPID)
 		}
-		stopErr := stopProcess(match.PID, timeout, force)
-		// Re-check liveness after stopProcess regardless of its return value.
-		if !IsProcessAlive(match.PID) {
+		if err := stopProcess(match.PID, timeout, force); err != nil {
+			// Process survived — do NOT remove the watch-mode PID file, and do NOT
+			// add this parent to touchedParents (so the watcher parent is not killed).
+			if !quiet {
+				fmt.Printf("Warning: failed to stop agent '%s' (PID %d): %v (tracking preserved for retry)\n", name, match.PID, err)
+			}
+		} else {
 			if !quiet {
 				fmt.Printf("Agent '%s' stopped\n", name)
 			}
 			stoppedAny = true
 			pm.RemoveWatchAgentPID(name, match.ParentPID)
 			touchedParents[match.ParentPID] = true
-		} else {
-			// Process survived — do NOT remove the watch-mode PID file, and do NOT
-			// add this parent to touchedParents (so the watcher parent is not killed).
-			if !quiet {
-				if stopErr != nil {
-					fmt.Printf("Warning: agent '%s' (PID %d) is still running after stop attempt (%v); tracking file preserved for retry\n", name, match.PID, stopErr)
-				} else {
-					fmt.Printf("Warning: agent '%s' (PID %d) is still running after stop attempt; tracking file preserved for retry\n", name, match.PID)
-				}
-			}
 		}
 	}
 
@@ -250,20 +237,61 @@ func stopSpecificAgent(pm *PIDManager, name string, timeout time.Duration, force
 // sibling watcher-parent PID files (which collided under the old naming scheme), we now
 // enumerate the actual agent entries that reference this parent_pid in their filename,
 // which is the authoritative source of truth.
+//
+// File cleanup is driven by enumeration, not by the specific name the caller passed:
+// the function prunes every stale `<x>.<parent_pid>.watcher-parent.pid` whose `<x>` no
+// longer has a live agent file, regardless of whether the caller targeted that name.
+// This means multiple agents sharing one parent are all cleaned up on a single call.
 func stopWatcherParentIfEmpty(pm *PIDManager, name string, parentPID int, timeout time.Duration, force, quiet bool) {
-	// Count remaining live agents under this parent.
-	remaining, err := pm.FindWatchAgentsByParent(parentPID)
-	if err == nil && len(remaining) > 0 {
+	// Enumerate all watcher-parent tracking entries for this parent PID. Unlike
+	// FindWatchAgentsByParent, this returns entries regardless of whether the
+	// parent process is alive — used to drive stale-file cleanup.
+	allParents, err := pm.FindWatchParentsByPID(parentPID)
+	if err != nil {
+		// Conservative: a transient enumeration error should not cause us to
+		// kill a potentially-healthy parent or touch any tracking files.
 		if !quiet {
-			fmt.Printf("Watcher parent (PID: %d) still has %d other agent(s), keeping alive\n", parentPID, len(remaining))
+			fmt.Printf("Warning: failed to enumerate watcher-parent tracking for PID %d: %v (keeping alive)\n", parentPID, err)
 		}
 		return
 	}
 
-	// No remaining agents — safe to remove this name's watcher-parent tracking file and kill the parent.
-	pm.RemoveWatchParentPID(name, parentPID)
+	remaining, err := pm.FindWatchAgentsByParent(parentPID)
+	if err != nil {
+		if !quiet {
+			fmt.Printf("Warning: failed to enumerate live agents under PID %d: %v (keeping alive)\n", parentPID, err)
+		}
+		return
+	}
 
+	// Build the set of names whose agent is still live.
+	liveNames := make(map[string]bool, len(remaining))
+	for _, r := range remaining {
+		liveNames[r.Name] = true
+	}
+
+	// Prune watcher-parent tracking files whose agent is no longer live.
+	// This handles both the stopAllAgents "multiple agents share one parent"
+	// case and the stopSpecificAgent "keep alive" case — in both, the caller
+	// has already removed the dead agents' <name>.<parent_pid>.pid files, so
+	// any watcher-parent file whose name is not in liveNames is stale.
+	for _, wp := range allParents {
+		if !liveNames[wp.Name] {
+			pm.RemovePIDFile(wp.PIDFile)
+		}
+	}
+
+	// If any live agents remain under this parent, keep it alive.
+	if len(remaining) > 0 {
+		if !quiet {
+			fmt.Printf("Watcher parent (PID: %d) still has %d agent(s), keeping alive\n", parentPID, len(remaining))
+		}
+		return
+	}
+
+	// No live agents under this parent — stop it.
 	if !IsProcessAlive(parentPID) {
+		// Already dead; nothing to kill. Tracking files were cleaned above.
 		return
 	}
 
@@ -273,9 +301,10 @@ func stopWatcherParentIfEmpty(pm *PIDManager, name string, parentPID int, timeou
 
 	// Signal the parent meshctl process directly — NOT its process group — so we don't
 	// take down unrelated siblings sharing the same group (registry, UI, etc).
-	if proc, err := os.FindProcess(parentPID); err == nil {
-		if err := proc.Signal(syscall.SIGTERM); err != nil && !quiet {
-			fmt.Printf("Warning: failed to signal watcher for '%s': %v\n", name, err)
+	proc, perr := os.FindProcess(parentPID)
+	if perr == nil {
+		if sigErr := proc.Signal(syscall.SIGTERM); sigErr != nil && !quiet {
+			fmt.Printf("Warning: failed to signal watcher for '%s': %v\n", name, sigErr)
 		}
 		// Wait briefly for graceful exit, then force kill.
 		deadline := time.Now().Add(timeout)
@@ -287,15 +316,27 @@ func stopWatcherParentIfEmpty(pm *PIDManager, name string, parentPID int, timeou
 		}
 		if IsProcessAlive(parentPID) {
 			proc.Kill()
+			time.Sleep(50 * time.Millisecond) // let SIGKILL propagate
 		}
 	}
 
 	if IsProcessAlive(parentPID) {
 		if !quiet {
-			fmt.Printf("Warning: watcher for '%s' (PID: %d) may still be running\n", name, parentPID)
+			fmt.Printf("Warning: watcher for '%s' (PID: %d) may still be running — tracking files preserved\n", name, parentPID)
 		}
-	} else if !quiet {
+		return // DO NOT clean up tracking files; the parent is still running.
+	}
+
+	if !quiet {
 		fmt.Printf("Watcher for '%s' stopped\n", name)
+	}
+
+	// Parent confirmed dead. Re-enumerate and clean up any remaining tracking
+	// files (there shouldn't be any after the prune above unless a race
+	// occurred between the enumeration and the kill, but be defensive).
+	leftovers, _ := pm.FindWatchParentsByPID(parentPID)
+	for _, wp := range leftovers {
+		pm.RemovePIDFile(wp.PIDFile)
 	}
 }
 
@@ -389,6 +430,11 @@ func stopAllAgents(pm *PIDManager, timeout time.Duration, force, quiet bool) err
 	// Build the set of distinct parent PIDs from the killed watch-mode agents,
 	// then call stopWatcherParentIfEmpty once per parent. This avoids double-
 	// signalling the same parent when multiple agents share it (#706).
+	//
+	// The representative name is used only for log output inside
+	// stopWatcherParentIfEmpty; file cleanup is driven by enumeration, so
+	// watcher-parent tracking files for all agents sharing the parent are
+	// pruned even though we only call the function once per parent.
 	parentPIDs := make(map[int]string) // parentPID -> representative name (for log messages)
 	for _, agent := range agents {
 		if agent.ParentPID > 0 {
@@ -588,8 +634,13 @@ func stopAll(pm *PIDManager, timeout time.Duration, force, quiet bool) error {
 }
 
 // stopProcess gracefully stops a process and its entire process group
-// (SIGTERM to process group, then SIGKILL after timeout)
-// This ensures child processes (e.g., npx -> tsx -> node) are also terminated
+// (SIGTERM to process group, then SIGKILL after timeout).
+// This ensures child processes (e.g., npx -> tsx -> node) are also terminated.
+//
+// Returns nil only if the process is confirmed dead. Returns an error if the
+// process is still alive after the SIGKILL path (D-state, hung zombie parent,
+// permission issue, pid reuse, etc.). Callers rely on this return value to
+// decide whether to remove tracking files or preserve them for retry.
 func stopProcess(pid int, timeout time.Duration, force bool) error {
 	// Verify process exists
 	if !IsProcessAlive(pid) {
@@ -603,6 +654,11 @@ func stopProcess(pid int, timeout time.Duration, force bool) error {
 			if process, err := os.FindProcess(pid); err == nil {
 				process.Kill()
 			}
+		}
+		// Let the kernel propagate the SIGKILL before the final liveness check.
+		time.Sleep(50 * time.Millisecond)
+		if IsProcessAlive(pid) {
+			return fmt.Errorf("process %d still alive after SIGKILL", pid)
 		}
 		return nil
 	}
@@ -637,11 +693,16 @@ func stopProcess(pid int, timeout time.Duration, force bool) error {
 		}
 	}
 
-	// Note: We don't do a final IsProcessAlive check here because:
-	// 1. SIGKILL cannot be caught/ignored, so the process will die
-	// 2. There may be a brief window where the process is a zombie
-	//    before being reaped, and IsProcessAlive returns true for zombies
-	// 3. The old code didn't have this check and worked fine
+	// Give the kernel a brief moment to propagate SIGKILL and tear the
+	// process down. Then verify. SIGKILL usually succeeds, but there are
+	// edge cases (D-state uninterruptible sleep, unreaped zombie with a
+	// hung parent, permission denial, PID reuse, etc.) where the process
+	// may still appear alive; we must report that to the caller so it can
+	// preserve tracking files for a retry instead of silently losing them.
+	time.Sleep(50 * time.Millisecond)
+	if IsProcessAlive(pid) {
+		return fmt.Errorf("process %d still alive after SIGKILL", pid)
+	}
 
 	return nil
 }

--- a/src/core/cli/stop.go
+++ b/src/core/cli/stop.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -139,28 +140,43 @@ func runStopCommand(cmd *cobra.Command, args []string) error {
 // decide whether to kill the parent process based on whether any watch-mode
 // agents still live under it.
 func stopSpecificAgent(pm *PIDManager, name string, timeout time.Duration, force, quiet bool) error {
+	foundAny := false
 	stoppedAny := false
 
 	// 1. Flat/non-watch mode instance (if any)
 	if pid, err := pm.ReadPID(name); err == nil {
-		if IsProcessAlive(pid) {
+		foundAny = true
+		if !IsProcessAlive(pid) {
+			// Already dead at enumeration time — safe to remove the stale PID file.
+			if !quiet {
+				fmt.Printf("Agent '%s' is not running (cleaning stale PID file)\n", name)
+			}
+			pm.RemovePID(name)
+		} else {
 			if !quiet {
 				fmt.Printf("Stopping agent '%s' (PID: %d)...\n", name, pid)
 			}
-			if err := stopProcess(pid, timeout, force); err != nil {
-				if !quiet {
-					fmt.Printf("Warning: failed to stop agent '%s' (PID %d): %v\n", name, pid, err)
-				}
-			} else {
+			stopErr := stopProcess(pid, timeout, force)
+			// Re-check liveness after stopProcess regardless of its return value — the
+			// SIGKILL path can succeed even when the graceful path returned an error.
+			if !IsProcessAlive(pid) {
 				if !quiet {
 					fmt.Printf("Agent '%s' stopped\n", name)
 				}
 				stoppedAny = true
+				pm.RemovePID(name)
+			} else {
+				// Process survived — preserve the PID file so the user can retry with
+				// `meshctl stop <name>` (otherwise name-based lookup would fail).
+				if !quiet {
+					if stopErr != nil {
+						fmt.Printf("Warning: agent '%s' (PID %d) is still running after stop attempt (%v); tracking file preserved for retry\n", name, pid, stopErr)
+					} else {
+						fmt.Printf("Warning: agent '%s' (PID %d) is still running after stop attempt; tracking file preserved for retry\n", name, pid)
+					}
+				}
 			}
-		} else if !quiet {
-			fmt.Printf("Agent '%s' is not running (cleaning stale PID file)\n", name)
 		}
-		pm.RemovePID(name)
 	}
 
 	// 2. All watch-mode instances of this name (may be multiple across different parent PIDs)
@@ -169,36 +185,60 @@ func stopSpecificAgent(pm *PIDManager, name string, timeout time.Duration, force
 		return fmt.Errorf("failed to enumerate watch-mode instances: %w", err)
 	}
 
-	// Track which parents we touched so we can run shared-watcher cleanup once per parent afterwards.
+	// Track which parents we successfully cleaned up so we can run shared-watcher
+	// cleanup once per parent afterwards. We deliberately only add a parent here
+	// after the agent under it dies — if ANY agent under a parent failed to die,
+	// the parent should NOT be considered for stopWatcherParentIfEmpty so the
+	// watcher stays alive to potentially recover or report the state.
 	touchedParents := make(map[int]bool)
 
 	for _, match := range watchMatches {
+		foundAny = true
 		if !quiet {
 			fmt.Printf("Stopping agent '%s' (PID: %d, watcher parent: %d)...\n", name, match.PID, match.ParentPID)
 		}
-		if err := stopProcess(match.PID, timeout, force); err != nil {
-			if !quiet {
-				fmt.Printf("Warning: failed to stop agent '%s' (PID %d): %v\n", name, match.PID, err)
-			}
-		} else {
+		stopErr := stopProcess(match.PID, timeout, force)
+		// Re-check liveness after stopProcess regardless of its return value.
+		if !IsProcessAlive(match.PID) {
 			if !quiet {
 				fmt.Printf("Agent '%s' stopped\n", name)
 			}
 			stoppedAny = true
+			pm.RemoveWatchAgentPID(name, match.ParentPID)
+			touchedParents[match.ParentPID] = true
+		} else {
+			// Process survived — do NOT remove the watch-mode PID file, and do NOT
+			// add this parent to touchedParents (so the watcher parent is not killed).
+			if !quiet {
+				if stopErr != nil {
+					fmt.Printf("Warning: agent '%s' (PID %d) is still running after stop attempt (%v); tracking file preserved for retry\n", name, match.PID, stopErr)
+				} else {
+					fmt.Printf("Warning: agent '%s' (PID %d) is still running after stop attempt; tracking file preserved for retry\n", name, match.PID)
+				}
+			}
 		}
-		pm.RemoveWatchAgentPID(name, match.ParentPID)
-		touchedParents[match.ParentPID] = true
 	}
 
 	// 3. For each parent we touched, decide whether to stop its watcher process.
 	//    Rule: if the parent has no remaining watch-mode agents alive, stop it.
+	//    Sort parent PIDs before iterating so log output is deterministic across runs.
+	sortedParents := make([]int, 0, len(touchedParents))
 	for parentPID := range touchedParents {
+		sortedParents = append(sortedParents, parentPID)
+	}
+	sort.Ints(sortedParents)
+	for _, parentPID := range sortedParents {
 		stopWatcherParentIfEmpty(pm, name, parentPID, timeout, force, quiet)
 	}
 
-	if !stoppedAny {
+	if !foundAny {
 		return fmt.Errorf("agent '%s' is not running", name)
 	}
+	if !stoppedAny {
+		return fmt.Errorf("agent '%s' could not be stopped (still running, tracking preserved for retry)", name)
+	}
+	// Partial success (some instances died, others survived) is reported via the
+	// per-instance warnings above and returns nil so the overall CLI flow continues.
 	return nil
 }
 

--- a/src/core/cli/stop_test.go
+++ b/src/core/cli/stop_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStopWatcherParentIfEmptyKeepAlive exercises the keep-alive branch of
+// stopWatcherParentIfEmpty: when some agents under a parent have been killed
+// but others remain live, the function must:
+//  1. leave the parent process alone (we verify this by using os.Getpid() as
+//     the parent — if the function signalled it, the test would terminate),
+//  2. prune stale watcher-parent tracking files whose agent is no longer live,
+//  3. preserve watcher-parent tracking files for agents that are still live.
+//
+// The kill branch is NOT exercised here because unit tests can't safely kill
+// processes; it is covered by integration tests.
+func TestStopWatcherParentIfEmptyKeepAlive(t *testing.T) {
+	pm := newTestPIDManager(t)
+	parent := os.Getpid() // use our own PID — we're alive, keep-alive must win.
+	livePID := os.Getpid()
+
+	// Three agent names under the same parent, all writing live PIDs.
+	names := []string{"dead-agent", "alive-one", "alive-two"}
+	for _, n := range names {
+		if err := pm.WriteWatchAgentPID(n, parent, livePID); err != nil {
+			t.Fatalf("WriteWatchAgentPID(%s): %v", n, err)
+		}
+		if err := pm.WriteWatchParentPID(n, parent); err != nil {
+			t.Fatalf("WriteWatchParentPID(%s): %v", n, err)
+		}
+	}
+
+	// Simulate stopSpecificAgent having already removed dead-agent's agent file.
+	// The corresponding watcher-parent file is still present (that's exactly the
+	// stale-file scenario stopWatcherParentIfEmpty is supposed to clean up).
+	if err := pm.RemoveWatchAgentPID("dead-agent", parent); err != nil {
+		t.Fatalf("RemoveWatchAgentPID: %v", err)
+	}
+
+	// Action under test. quiet=true to suppress log noise.
+	stopWatcherParentIfEmpty(pm, "dead-agent", parent, 1*time.Second, false, true)
+
+	// 1. Test process (the "parent") is still alive — i.e., we did NOT signal ourselves.
+	if !IsProcessAlive(parent) {
+		t.Fatalf("test process PID %d is not alive — stopWatcherParentIfEmpty should not have killed it", parent)
+	}
+
+	// 2. The dead agent's watcher-parent file is removed.
+	deadWPFile := pm.GetWatchParentPIDFile("dead-agent", parent)
+	if _, err := os.Stat(deadWPFile); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be removed, stat err=%v", filepath.Base(deadWPFile), err)
+	}
+
+	// 3. Both alive agents' watcher-parent files are preserved.
+	for _, n := range []string{"alive-one", "alive-two"} {
+		wpFile := pm.GetWatchParentPIDFile(n, parent)
+		if _, err := os.Stat(wpFile); err != nil {
+			t.Errorf("expected %s to still exist, stat err=%v", filepath.Base(wpFile), err)
+		}
+	}
+
+	// 4. Exactly 2 watcher-parent files remain.
+	entries, err := os.ReadDir(pm.pidsDir)
+	if err != nil {
+		t.Fatalf("read pids dir: %v", err)
+	}
+	var wpCount int
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(e.Name(), ".watcher-parent.pid") {
+			wpCount++
+		}
+	}
+	if wpCount != 2 {
+		t.Errorf("expected 2 watcher-parent files remaining, got %d", wpCount)
+	}
+}
+
+// TestStopWatcherParentIfEmptyDeadParentCleansFiles exercises the
+// already-dead-parent branch: when the parent process has already exited,
+// the function should still prune all watcher-parent tracking files belonging
+// to it (after removing the stale <name>.<parent_pid>.pid files, the agent
+// enumeration returns empty, and the "not alive" short-circuit runs the
+// cleanup loop above the kill path).
+//
+// We construct this scenario by using a reaped PID as the parent PID and
+// writing all files referencing it. Because there are no live agent files
+// associated with the parent, FindWatchAgentsByParent returns empty and the
+// function takes the "no live agents" path. Since IsProcessAlive(dead) is
+// false, it returns early — and the prune loop above must have cleaned up
+// the stale watcher-parent files.
+func TestStopWatcherParentIfEmptyDeadParentCleansFiles(t *testing.T) {
+	pm := newTestPIDManager(t)
+	dead := reapedPID(t)
+
+	// Two watcher-parent tracking files referring to the dead parent, but no
+	// live agent files under it (simulating a crashed parent whose agents are
+	// gone but left stale watcher-parent files behind).
+	for _, n := range []string{"alpha", "beta"} {
+		if err := pm.WriteWatchParentPID(n, dead); err != nil {
+			t.Fatalf("WriteWatchParentPID(%s): %v", n, err)
+		}
+	}
+
+	stopWatcherParentIfEmpty(pm, "alpha", dead, 1*time.Second, false, true)
+
+	// Both stale watcher-parent files should have been pruned.
+	for _, n := range []string{"alpha", "beta"} {
+		wpFile := pm.GetWatchParentPIDFile(n, dead)
+		if _, err := os.Stat(wpFile); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be pruned, stat err=%v", filepath.Base(wpFile), err)
+		}
+	}
+}

--- a/src/core/cli/utils.go
+++ b/src/core/cli/utils.go
@@ -263,7 +263,13 @@ func RemoveRunningProcess(pid int) error {
 	return SaveRunningProcesses(filtered)
 }
 
-// IsProcessAlive checks if a process is still running
+// IsProcessAlive checks if a process is still running.
+//
+// signal(0) returns nil for any process the kernel still has an entry for —
+// including zombies that have been killed but not yet reaped by their parent.
+// For meshctl's purposes a zombie is "effectively dead" (the process cannot
+// do any more work and is only waiting to be reaped), so we filter them out
+// via a platform-specific check. See utils_linux.go / utils_other.go.
 func IsProcessAlive(pid int) bool {
 	if pid <= 0 {
 		return false
@@ -275,8 +281,10 @@ func IsProcessAlive(pid int) bool {
 	}
 
 	// On Unix-like systems, we can send signal 0 to check if process exists
-	err = process.Signal(syscall.Signal(0))
-	return err == nil
+	if err := process.Signal(syscall.Signal(0)); err != nil {
+		return false
+	}
+	return !isProcessZombie(pid)
 }
 
 // KillProcess attempts to gracefully kill a process

--- a/src/core/cli/utils_linux.go
+++ b/src/core/cli/utils_linux.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+package cli
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// isProcessZombie returns true if the given PID is a zombie (state Z) or
+// dead-pending (state X) on Linux. Reads /proc/<pid>/stat and parses the
+// state field.
+//
+// The stat format is:
+//
+//	pid (comm) state ppid pgrp ...
+//
+// where (comm) may contain spaces and parentheses. To parse robustly, we
+// find the LAST ")" in the line and read the character after the following
+// space — that's the state field.
+//
+// Returns false on any error (file missing, permission denied, parse
+// failure) — the caller will fall back to the signal(0) answer. A missing
+// file is the common case when the kernel has already fully reaped the
+// process, in which case signal(0) will also return ESRCH and the caller
+// already treats that as "not alive".
+func isProcessZombie(pid int) bool {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return false
+	}
+	s := string(data)
+	// Find the last ")" to skip past the comm field which can contain
+	// arbitrary characters including parens and spaces.
+	lastParen := strings.LastIndex(s, ")")
+	if lastParen < 0 || lastParen+2 >= len(s) {
+		return false
+	}
+	// After the ")", there's a space, then the single-character state.
+	rest := strings.TrimLeft(s[lastParen+1:], " ")
+	if len(rest) == 0 {
+		return false
+	}
+	state := rest[0]
+	return state == 'Z' || state == 'X'
+}

--- a/src/core/cli/utils_linux_test.go
+++ b/src/core/cli/utils_linux_test.go
@@ -1,0 +1,74 @@
+//go:build linux
+
+package cli
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestIsProcessAliveFiltersZombies verifies that a zombie child (a process
+// that has exited but not been reaped) is reported as not-alive by
+// IsProcessAlive. This is the Linux-specific path that was missing prior
+// to the tsuite regression fix for #748.
+func TestIsProcessAliveFiltersZombies(t *testing.T) {
+	// Spawn a short-lived subprocess that exits immediately. Do NOT call
+	// Wait() on it, so it becomes a zombie until this test process reaps
+	// it at the end of the test.
+	cmd := exec.Command("sh", "-c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start zombie candidate: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	// Wait until the kernel has marked the process as exited (zombie) —
+	// signal(0) still succeeds but /proc/<pid>/stat should show state Z.
+	// Poll for up to 1 second.
+	deadline := time.Now().Add(1 * time.Second)
+	foundZombie := false
+	for time.Now().Before(deadline) {
+		if isProcessZombie(pid) {
+			foundZombie = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !foundZombie {
+		// If we can't reproduce the zombie state on this kernel (e.g.,
+		// running under a reaper init like `tini` which reaps immediately),
+		// skip.
+		_ = cmd.Wait()
+		t.Skip("could not reproduce zombie state — test kernel reaps too aggressively")
+	}
+
+	// IsProcessAlive should now return false for the zombie.
+	if IsProcessAlive(pid) {
+		t.Errorf("IsProcessAlive returned true for zombie PID %d, want false", pid)
+	}
+
+	// Reap the zombie so we don't leak it.
+	_ = cmd.Wait()
+}
+
+// TestIsProcessZombieReturnsFalseForLiveProcess verifies that an ordinary
+// running process (our own test process) is NOT reported as a zombie.
+func TestIsProcessZombieReturnsFalseForLiveProcess(t *testing.T) {
+	if isProcessZombie(1) {
+		t.Errorf("isProcessZombie(1) = true, want false (init is not a zombie)")
+	}
+}
+
+// TestIsProcessZombieReturnsFalseForMissingPID verifies that a PID with no
+// /proc entry is not reported as a zombie. The caller's signal(0) check
+// will catch the missing process as "not alive" first anyway.
+func TestIsProcessZombieReturnsFalseForMissingPID(t *testing.T) {
+	// PID 0 has no /proc/0 entry.
+	if isProcessZombie(0) {
+		t.Errorf("isProcessZombie(0) = true, want false")
+	}
+	// A very high PID that almost certainly doesn't exist.
+	if isProcessZombie(2147483646) {
+		t.Errorf("isProcessZombie(2147483646) = true, want false")
+	}
+}

--- a/src/core/cli/utils_other.go
+++ b/src/core/cli/utils_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package cli
+
+// isProcessZombie is a no-op on non-Linux platforms. macOS reaping is
+// aggressive enough that the zombie window is effectively zero for
+// meshctl's use case, and the main environments where this check matters
+// (tsuite Linux containers) are covered by utils_linux.go.
+func isProcessZombie(pid int) bool {
+	return false
+}


### PR DESCRIPTION
## Summary

Fixes a cascade-kill bug where `meshctl stop <name>` could tear down unrelated agents and the registry when two independent `meshctl start -d -w` invocations existed. Two distinct bugs contributed, both now fixed, plus a polish round to align every `stop` path on the same invariants.

- **PID file collision**: tracking files were keyed by agent name alone, so a second `meshctl start -d -w` for an already-tracked agent silently overwrote the first watcher's entries. Fixed by namespacing watch-mode PID files per parent meshctl PID: `<name>.<parent_pid>.pid` and `<name>.<parent_pid>.watcher-parent.pid`. Non-watch/legacy layout (`<name>.pid`, `registry.pid`, `ui.pid`) unchanged.
- **Shared `~/.mcp_mesh/processes.json`**: `runAgentsInForeground` shutdown cleanup called `GetRunningProcesses()` on a globally shared file, so watcher B's SIGTERM handler killed every entry it saw — including watcher A's 12 agents and the registry. Fixed by tracking local `localNonWatchAgentPIDs` and threading `locallyStartedRegistryPID` through as a parameter, so each meshctl instance only touches processes it owns.
- **Stop flow invariants unified**: `stopProcess` now returns real errors when SIGKILL leaves a process alive (bounded polling via new `waitForProcessDeath` helper), so `stopSpecificAgent`, `stopAllAgents`, and `stopAll` all correctly preserve tracking files on kill failure. `stopWatcherParentIfEmpty` rewritten with an explicit case split (keep-alive / already-dead / kill-success / kill-fail) so tracking cleanup is invariant-safe: files are pruned only when safe, preserved for retry otherwise.
- **Cleanup**: deleted dead `startAgents` function (~130 LOC, no callers, contained the same broken `GetRunningProcesses()` cleanup pattern — a hazard waiting to be revived). Tightened parser to skip malformed filenames. Added `parentPID > 0` guard to `FindWatchAgentsByParent`. Tightened `GetRegistry` to match `Type == "registry"` alongside name.
- **34 new unit tests** in `pid_manager_test.go` + `stop_test.go` covering the parser, the new helpers, dead-PID filtering, malformed-filename edges, and the keep-alive / dead-parent branches of `stopWatcherParentIfEmpty`.

## User-facing behavior preserved

- `meshctl stop` (no args) still stops everything including the registry — `stopAll` reads the PID directory directly and kills the registry in its own step, independent of `locallyStartedRegistryPID`.
- `meshctl stop <agent>` only touches that agent and its owning watcher's resources. Independent watchers are never disturbed.
- Ctrl+C in foreground `meshctl start` still cleans up the registry when that instance is the one that started it.
- `meshctl list` / `meshctl status` retain cross-instance visibility — `AddRunningProcess` / `RemoveRunningProcess` still write to the shared file.

## Review Notes

Four review passes on this PR. Each pass caught items fixed in the next commit:

- **Pass 1** (758063af): found 1 BLOCKER + 4 WARNINGs (package-level mutable state, dead function, non-deterministic iteration, missing tests).
- **Pass 2** (fc3619d3): confirmed the 5 items fixed, found 3 new WARNINGs (watcher-parent file leak in `stopAllAgents`, keep-alive cleanup miss, `stopProcess` always-nil error propagation) + 6 INFO items.
- **Pass 3** (c5374006): confirmed fixes, found 2 new WARNINGs (prune-before-kill ordering bug in `stopWatcherParentIfEmpty`, 50ms post-SIGKILL window too short for cross-instance zombie reaps) + 2 INFO items.
- **Pass 4** (924db807): **0 BLOCKERs, 0 WARNINGs, 2 minor INFO items** — reviewer flagged `os.FindProcess` dead branch on Unix (left as-is) and mild test circularity where `reapedPID(t)` and `waitForProcessDeath` reference each other (cross-checked via the live-PID test).

## Commits

- `758063af` — initial cascade fix (PID namespacing + local shutdown tracking)
- `fc3619d3` — first review round (re-check before remove, sort iteration, dead code deletion, 22 parser tests, package-level state → parameter)
- `c5374006` — second review round (enumeration-driven `stopWatcherParentIfEmpty`, `FindWatchParentsByPID`, parser malformed-filename tightening, 7 more tests + `stop_test.go`)
- `924db807` — third review round (prune-before-kill ordering fix, `waitForProcessDeath` bounded polling, `GetRegistry` type check, 4 more tests)

Closes #748

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./src/core/cli/...` — no new warnings (one pre-existing `utils.go:113` IPv6 format string, unrelated)
- [x] `gofmt -l` on all modified files — clean
- [x] `go test -count=1 ./src/core/cli/...` — all pass (34 new unit tests + existing suite)
- [x] `go test -count=1 -race ./src/core/cli/` — all pass
- [x] Manual reproduction of the original 5-step bug scenario with the dev build — verified step 5 stops only the targeted second-instance agent, leaves all 12 unrelated agents and the registry alive (dogfooded from a separate Claude Code session)
- [ ] Run `tests/src-tests` integration suite to confirm no regression in tsuite-mesh image behavior
- [ ] Run `tests/integration --parallel 8` to exercise stop/restart scenarios across runtimes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable process liveness checks (zombie filtering) and bounded wait-after-kill to ensure processes are actually gone.
  * Registry shutdown only occurs when the launcher started it and it's still alive.
  * Stop preserves tracking files on kill failures and avoids killing unrelated processes.

* **New Features**
  * Namespaced PID tracking for watch-mode with parent-aware cleanup and per-run local PID tracking.
  * Registry startup now returns the started PID for better lifecycle control.

* **Documentation**
  * Added guidance for calling the built-in llm helper (usage and options).

* **Tests**
  * Expanded tests for PID parsing, watch-mode behavior, zombie detection, and stop/cleanup logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->