### PR TITLE
fix: Fortuna usability quick wins — scaffold, docs, stop UX

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,11 +32,13 @@ repos:
       - id: hadolint-docker
         entry: hadolint
         language: docker_image
-        # Match real Dockerfiles only — anchoring with $ prevents the hook
-        # from trying to lint scaffold templates like `Dockerfile.tmpl`
-        # which contain Go template syntax (`{{ .Port }}`) and aren't valid
-        # Dockerfiles on their own.
-        files: Dockerfile$
+        # Match real Dockerfiles including extension variants like
+        # `Dockerfile.dev`, `Dockerfile.base`, `Dockerfile.debian`.
+        # Exclude `.tmpl` files, which are scaffold templates containing
+        # Go template syntax (`{{ .Port }}`) and aren't valid Dockerfiles
+        # on their own — hadolint would try to exec them and fail.
+        files: Dockerfile
+        exclude: \.tmpl$
 
   # 🤖 CONTRACT-FIRST DEVELOPMENT HOOKS
   # These hooks enforce OpenAPI-first development

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,11 @@ repos:
       - id: hadolint-docker
         entry: hadolint
         language: docker_image
-        files: Dockerfile
+        # Match real Dockerfiles only — anchoring with $ prevents the hook
+        # from trying to lint scaffold templates like `Dockerfile.tmpl`
+        # which contain Go template syntax (`{{ .Port }}`) and aren't valid
+        # Dockerfiles on their own.
+        files: Dockerfile$
 
   # 🤖 CONTRACT-FIRST DEVELOPMENT HOOKS
   # These hooks enforce OpenAPI-first development

--- a/cmd/meshctl/templates/java/llm-agent/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/helm-values.yaml.tmpl
@@ -31,7 +31,12 @@ registry:
   host: "mcp-core-mcp-mesh-registry"
   port: "8000"
 
-# LLM agent typically needs API keys
+# LLM agent typically needs API keys.
+# The refs below point to a secret named `llm-secrets` — update the `name:` values
+# below to match your cluster's secret, or create the secret:
+#   kubectl create secret generic llm-secrets \
+#     --from-literal=anthropic-api-key=sk-ant-... \
+#     --from-literal=openai-api-key=sk-...
 env:
   - name: ANTHROPIC_API_KEY
     valueFrom:

--- a/cmd/meshctl/templates/java/llm-provider/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/helm-values.yaml.tmpl
@@ -31,7 +31,13 @@ registry:
   host: "mcp-core-mcp-mesh-registry"
   port: "8000"
 
-# LLM provider needs API keys for the backend LLM service
+# LLM provider needs API keys for the backend LLM service.
+# The refs below point to a secret named `llm-secrets` — update the `name:` values
+# below to match your cluster's secret, or create the secret:
+#   kubectl create secret generic llm-secrets \
+#     --from-literal=anthropic-api-key=sk-ant-... \
+#     --from-literal=openai-api-key=sk-... \
+#     --from-literal=google-api-key=...
 env:
   - name: ANTHROPIC_API_KEY
     valueFrom:

--- a/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
@@ -11,8 +11,8 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy agent source code and set permissions
-COPY --chmod=755 . .
-RUN chown -R mcp-mesh:mcp-mesh /app
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
 
 # Switch back to non-root user for security
 USER mcp-mesh

--- a/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
@@ -11,8 +11,8 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy agent source code and set permissions
-COPY --chmod=755 . .
-RUN chown -R mcp-mesh:mcp-mesh /app
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
 
 # Switch back to non-root user for security
 USER mcp-mesh

--- a/cmd/meshctl/templates/python/llm-agent/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/helm-values.yaml.tmpl
@@ -31,7 +31,12 @@ registry:
   host: "mcp-core-mcp-mesh-registry"
   port: "8000"
 
-# LLM agent typically needs API keys
+# LLM agent typically needs API keys.
+# The refs below point to a secret named `llm-secrets` — update the `name:` values
+# below to match your cluster's secret, or create the secret:
+#   kubectl create secret generic llm-secrets \
+#     --from-literal=anthropic-api-key=sk-ant-... \
+#     --from-literal=openai-api-key=sk-...
 env:
   - name: ANTHROPIC_API_KEY
     valueFrom:

--- a/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
@@ -11,8 +11,8 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy agent source code and set permissions
-COPY --chmod=755 . .
-RUN chown -R mcp-mesh:mcp-mesh /app
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
 
 # Switch back to non-root user for security
 USER mcp-mesh

--- a/cmd/meshctl/templates/python/llm-provider/README.md.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/README.md.tmpl
@@ -78,7 +78,7 @@ Other agents can use this provider with the `@mesh.llm` decorator:
 ```python
 @mesh.llm(
     provider={"capability": "llm", "tags": {{ toJSON .Tags }}},
-    max_iterations=1,
+    max_iterations=5,
     system_prompt="You are a helpful assistant.",
     context_param="ctx",
 )

--- a/cmd/meshctl/templates/python/llm-provider/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/helm-values.yaml.tmpl
@@ -31,7 +31,13 @@ registry:
   host: "mcp-core-mcp-mesh-registry"
   port: "8000"
 
-# LLM provider needs API keys for the backend LLM service
+# LLM provider needs API keys for the backend LLM service.
+# The refs below point to a secret named `llm-secrets` — update the `name:` values
+# below to match your cluster's secret, or create the secret:
+#   kubectl create secret generic llm-secrets \
+#     --from-literal=anthropic-api-key=sk-ant-... \
+#     --from-literal=openai-api-key=sk-... \
+#     --from-literal=google-api-key=...
 env:
   - name: ANTHROPIC_API_KEY
     valueFrom:

--- a/cmd/meshctl/templates/typescript/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/Dockerfile.tmpl
@@ -11,8 +11,8 @@ COPY package*.json ./
 RUN npm ci --omit=dev
 
 # Copy agent source code and set permissions
-COPY --chmod=755 . .
-RUN chown -R mcp-mesh:mcp-mesh /app
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
 
 # Switch back to non-root user for security
 USER mcp-mesh

--- a/cmd/meshctl/templates/typescript/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/Dockerfile.tmpl
@@ -11,8 +11,8 @@ COPY package*.json ./
 RUN npm ci --omit=dev
 
 # Copy agent source code and set permissions
-COPY --chmod=755 . .
-RUN chown -R mcp-mesh:mcp-mesh /app
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
 
 # Switch back to non-root user for security
 USER mcp-mesh

--- a/cmd/meshctl/templates/typescript/llm-agent/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/helm-values.yaml.tmpl
@@ -31,7 +31,12 @@ registry:
   host: "mcp-core-mcp-mesh-registry"
   port: "8000"
 
-# LLM agent typically needs API keys
+# LLM agent typically needs API keys.
+# The refs below point to a secret named `llm-secrets` — update the `name:` values
+# below to match your cluster's secret, or create the secret:
+#   kubectl create secret generic llm-secrets \
+#     --from-literal=anthropic-api-key=sk-ant-... \
+#     --from-literal=openai-api-key=sk-...
 env:
   - name: ANTHROPIC_API_KEY
     valueFrom:

--- a/cmd/meshctl/templates/typescript/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/Dockerfile.tmpl
@@ -11,8 +11,8 @@ COPY package*.json ./
 RUN npm ci --omit=dev
 
 # Copy agent source code and set permissions
-COPY --chmod=755 . .
-RUN chown -R mcp-mesh:mcp-mesh /app
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
 
 # Switch back to non-root user for security
 USER mcp-mesh

--- a/cmd/meshctl/templates/typescript/llm-provider/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/helm-values.yaml.tmpl
@@ -31,7 +31,13 @@ registry:
   host: "mcp-core-mcp-mesh-registry"
   port: "8000"
 
-# LLM provider needs API keys for the backend LLM service
+# LLM provider needs API keys for the backend LLM service.
+# The refs below point to a secret named `llm-secrets` — update the `name:` values
+# below to match your cluster's secret, or create the secret:
+#   kubectl create secret generic llm-secrets \
+#     --from-literal=anthropic-api-key=sk-ant-... \
+#     --from-literal=openai-api-key=sk-... \
+#     --from-literal=google-api-key=...
 env:
   - name: ANTHROPIC_API_KEY
     valueFrom:

--- a/src/core/cli/handlers/java_handler.go
+++ b/src/core/cli/handlers/java_handler.go
@@ -79,7 +79,7 @@ func (h *JavaHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns Java Dockerfile content
 func (h *JavaHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh Java agent
-FROM mcpmesh/java-runtime:1.1
+FROM mcpmesh/java-runtime:1.2.0
 
 WORKDIR /app
 
@@ -111,7 +111,7 @@ func (h *JavaHandler) GenerateHelmValues() map[string]interface{} {
 		"runtime": "java",
 		"image": map[string]interface{}{
 			"repository": "mcpmesh/java-runtime",
-			"tag":        "1.1",
+			"tag":        "1.2.0",
 		},
 		"command": []string{"target/agent-1.0.0-SNAPSHOT.jar"},
 	}
@@ -156,7 +156,7 @@ func (h *JavaHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the Java runtime Docker image
 func (h *JavaHandler) GetDockerImage() string {
-	return "mcpmesh/java-runtime:1.1"
+	return "mcpmesh/java-runtime:1.2.0"
 }
 
 // ValidatePrerequisites checks Java environment

--- a/src/core/cli/handlers/python_handler.go
+++ b/src/core/cli/handlers/python_handler.go
@@ -98,8 +98,8 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy agent source code
-COPY --chmod=755 . .
-RUN chown -R mcp-mesh:mcp-mesh /app
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
 
 # Switch back to non-root user
 USER mcp-mesh

--- a/src/core/cli/handlers/python_handler.go
+++ b/src/core/cli/handlers/python_handler.go
@@ -86,7 +86,7 @@ func (h *PythonHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns Python Dockerfile content
 func (h *PythonHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh Python agent
-FROM mcpmesh/python-runtime:1.1
+FROM mcpmesh/python-runtime:1.2.0
 
 WORKDIR /app
 
@@ -118,7 +118,7 @@ func (h *PythonHandler) GenerateHelmValues() map[string]interface{} {
 		"runtime": "python",
 		"image": map[string]interface{}{
 			"repository": "mcpmesh/python-runtime",
-			"tag":        "1.1",
+			"tag":        "1.2.0",
 		},
 		"command": []string{"main.py"},
 	}
@@ -170,7 +170,7 @@ func (h *PythonHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the Python runtime Docker image
 func (h *PythonHandler) GetDockerImage() string {
-	return "mcpmesh/python-runtime:1.1"
+	return "mcpmesh/python-runtime:1.2.0"
 }
 
 // ValidatePrerequisites checks Python environment

--- a/src/core/cli/handlers/typescript_handler.go
+++ b/src/core/cli/handlers/typescript_handler.go
@@ -92,7 +92,7 @@ func (h *TypeScriptHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns TypeScript Dockerfile content
 func (h *TypeScriptHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh TypeScript agent
-FROM mcpmesh/typescript-runtime:1.1
+FROM mcpmesh/typescript-runtime:1.2.0
 
 WORKDIR /app
 
@@ -124,7 +124,7 @@ func (h *TypeScriptHandler) GenerateHelmValues() map[string]interface{} {
 		"runtime": "typescript",
 		"image": map[string]interface{}{
 			"repository": "mcpmesh/typescript-runtime",
-			"tag":        "1.1",
+			"tag":        "1.2.0",
 		},
 		"command": []string{"src/index.ts"},
 	}
@@ -167,7 +167,7 @@ func (h *TypeScriptHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the TypeScript runtime Docker image
 func (h *TypeScriptHandler) GetDockerImage() string {
-	return "mcpmesh/typescript-runtime:1.1"
+	return "mcpmesh/typescript-runtime:1.2.0"
 }
 
 // ValidatePrerequisites checks TypeScript environment

--- a/src/core/cli/handlers/typescript_handler.go
+++ b/src/core/cli/handlers/typescript_handler.go
@@ -104,8 +104,8 @@ COPY package*.json ./
 RUN npm ci --omit=dev
 
 # Copy agent source code
-COPY --chmod=755 . .
-RUN chown -R mcp-mesh:mcp-mesh /app
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
 
 # Switch back to non-root user
 USER mcp-mesh

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -87,8 +87,8 @@ COPY package*.json ./
 RUN npm ci --omit=dev
 
 # Copy agent source code and set permissions
-COPY --chmod=755 . .
-RUN chown -R mcp-mesh:mcp-mesh /app
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
 
 # Switch back to non-root user for security
 USER mcp-mesh
@@ -103,7 +103,7 @@ CMD ["npx", "tsx", "src/index.ts"]
 **Security notes:**
 
 - **USER root / USER mcp-mesh**: The base image runs as the non-root `mcp-mesh` user by default. We temporarily switch to root for file operations, then drop privileges back to `mcp-mesh` for runtime security.
-- **COPY --chmod=755 / chown**: Ensures files have correct permissions and ownership for the `mcp-mesh` user to execute.
+- **COPY + RUN chown/chmod**: Ensures files have correct permissions and ownership for the `mcp-mesh` user to execute, without requiring BuildKit.
 - **EXPOSE**: The port is configured via `--port` flag during scaffold (defaults to 8080).
 
 ### Generate Docker Compose

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -233,7 +233,7 @@ You'll often see the context parameter declared in the function signature but
 never read in the body:
 
 ```python
-@mesh.llm(context_param="ctx", system_prompt_file="file://prompts/assistant.jinja2")
+@mesh.llm(context_param="ctx", system_prompt="file://prompts/assistant.jinja2")
 async def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> str:
     return await llm("Help the user")  # ctx never read here — is it unused?
 ```

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -46,7 +46,7 @@ async def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistRes
 | Parameter        | Type | Description                                       |
 | ---------------- | ---- | ------------------------------------------------- |
 | `provider`       | dict | LLM provider selector (capability + tags)         |
-| `max_iterations` | int  | Max agentic loop iterations (default: 1)          |
+| `max_iterations` | int  | Max agentic loop iterations (default: 5)          |
 | `system_prompt`  | str  | Inline prompt or `file://path` to Jinja2 template |
 | `context_param`  | str  | Parameter name receiving context object           |
 | `filter`              | list | Tool filter criteria                              |
@@ -226,6 +226,28 @@ class AssistContext(BaseModel):
 async def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None):
     return await llm(f"Help with: {ctx.input_text}")
 ```
+
+### Why the Context Param Looks Unused
+
+You'll often see the context parameter declared in the function signature but
+never read in the body:
+
+```python
+@mesh.llm(context_param="ctx", system_prompt_file="file://prompts/assistant.jinja2")
+async def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> str:
+    return await llm("Help the user")  # ctx never read here — is it unused?
+```
+
+It's not unused — it's a **marker parameter**. The decorator's `context_param="ctx"`
+tells the framework "when you render the system prompt Jinja2 template, use the
+value passed to this parameter as the template context." The parameter is
+consumed by the template renderer, not by your function body. Think of it as
+"here's the data, framework — you figure out where to put it in the prompt."
+
+This is why you don't need to pass `ctx` to `llm()` — the decorator already
+knows about it. If you want to **augment** or **override** the template context
+at call time, use the `context=` argument on `llm()` — see
+[Runtime Context Injection](#runtime-context-injection).
 
 ## Response Formats
 

--- a/src/core/cli/scaffold/config.go
+++ b/src/core/cli/scaffold/config.go
@@ -182,7 +182,7 @@ func ContextFromConfig(config *ScaffoldConfig) *ScaffoldContext {
 
 		// Set defaults
 		if ctx.MaxIterations == 0 {
-			ctx.MaxIterations = 1
+			ctx.MaxIterations = 5
 		}
 		if ctx.ContextParam == "" {
 			ctx.ContextParam = "ctx"

--- a/src/core/cli/scaffold/config_test.go
+++ b/src/core/cli/scaffold/config_test.go
@@ -297,7 +297,7 @@ func TestContextFromConfig_LLMAgentDefaults(t *testing.T) {
 	ctx := ContextFromConfig(config)
 
 	// Check defaults are applied
-	assert.Equal(t, 1, ctx.MaxIterations)
+	assert.Equal(t, 5, ctx.MaxIterations)
 	assert.Equal(t, "ctx", ctx.ContextParam)
 	assert.Equal(t, "text", ctx.ResponseFormat)
 	assert.Equal(t, []string{"llm", "+gpt"}, ctx.ProviderTags)

--- a/src/core/cli/scaffold/provider.go
+++ b/src/core/cli/scaffold/provider.go
@@ -108,7 +108,7 @@ func NewScaffoldContext() *ScaffoldContext {
 		Port:                8080,
 		Template:            "basic",
 		AgentType:           "tool",
-		MaxIterations:       1,
+		MaxIterations:       5,
 		ContextParam:        "ctx",
 		ResponseFormat:      "text",
 		LLMProviderSelector: "claude",

--- a/src/core/cli/stop.go
+++ b/src/core/cli/stop.go
@@ -829,7 +829,10 @@ func suggestAgentNames(pm *PIDManager, query string) []string {
 	if q == "" {
 		return nil
 	}
-	var suggestions []string
+	// Collect all matching candidates first, then sort deterministically
+	// before capping. This decouples the function's output order from
+	// ListRunningProcesses' iteration order.
+	var candidates []string
 	seen := make(map[string]bool)
 	for _, p := range processes {
 		if p.Type != "agent" || !p.Running {
@@ -840,14 +843,16 @@ func suggestAgentNames(pm *PIDManager, query string) []string {
 		}
 		n := strings.ToLower(p.Name)
 		if strings.Contains(n, q) || strings.Contains(q, n) {
-			suggestions = append(suggestions, p.Name)
+			candidates = append(candidates, p.Name)
 			seen[p.Name] = true
-			if len(suggestions) >= 3 {
-				break
-			}
 		}
 	}
-	return suggestions
+	sort.Strings(candidates)
+	// Cap to 3 suggestions after sorting so the returned set is stable.
+	if len(candidates) > 3 {
+		candidates = candidates[:3]
+	}
+	return candidates
 }
 
 // quoteStrings wraps each string in single quotes for user-facing messages.

--- a/src/core/cli/stop.go
+++ b/src/core/cli/stop.go
@@ -826,6 +826,9 @@ func suggestAgentNames(pm *PIDManager, query string) []string {
 		return nil
 	}
 	q := strings.ToLower(query)
+	if q == "" {
+		return nil
+	}
 	var suggestions []string
 	seen := make(map[string]bool)
 	for _, p := range processes {

--- a/src/core/cli/stop.go
+++ b/src/core/cli/stop.go
@@ -223,6 +223,11 @@ func stopSpecificAgent(pm *PIDManager, name string, timeout time.Duration, force
 	}
 
 	if !foundAny {
+		suggestions := suggestAgentNames(pm, name)
+		if len(suggestions) > 0 {
+			return fmt.Errorf("agent '%s' is not running. Did you mean: %s?",
+				name, strings.Join(quoteStrings(suggestions), ", "))
+		}
 		return fmt.Errorf("agent '%s' is not running", name)
 	}
 	if !stoppedAny {
@@ -804,4 +809,49 @@ func cleanupAllFiles(pm *PIDManager, quiet bool) error {
 	}
 
 	return nil
+}
+
+// suggestAgentNames returns up to 3 names of running agents that look similar
+// to the queried name. Used by stopSpecificAgent to provide "Did you mean?"
+// hints when the exact name isn't tracked — covers the common case where a
+// user types a partial or mesh-registered name instead of the script-derived
+// one (or vice versa).
+//
+// Matching is heuristic: substring match in either direction (query contains
+// candidate, or candidate contains query). Good enough for typical typos and
+// the digest-api/api class of mismatches. Not a full edit-distance implementation.
+func suggestAgentNames(pm *PIDManager, query string) []string {
+	processes, err := pm.ListRunningProcesses()
+	if err != nil {
+		return nil
+	}
+	q := strings.ToLower(query)
+	var suggestions []string
+	seen := make(map[string]bool)
+	for _, p := range processes {
+		if p.Type != "agent" || !p.Running {
+			continue
+		}
+		if seen[p.Name] {
+			continue
+		}
+		n := strings.ToLower(p.Name)
+		if strings.Contains(n, q) || strings.Contains(q, n) {
+			suggestions = append(suggestions, p.Name)
+			seen[p.Name] = true
+			if len(suggestions) >= 3 {
+				break
+			}
+		}
+	}
+	return suggestions
+}
+
+// quoteStrings wraps each string in single quotes for user-facing messages.
+func quoteStrings(ss []string) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = "'" + s + "'"
+	}
+	return out
 }

--- a/src/core/cli/stop_test.go
+++ b/src/core/cli/stop_test.go
@@ -141,6 +141,7 @@ func TestSuggestAgentNames(t *testing.T) {
 		{"mkt", nil},                             // no substring match
 		{"digest-api", []string{"digest-api"}},   // exact match (trivially contains)
 		{"worker", []string{"portfolio-worker"}}, // suffix
+		{"", nil},                                // empty query must not match everything
 	}
 	for _, tc := range tests {
 		got := suggestAgentNames(pm, tc.query)

--- a/src/core/cli/stop_test.go
+++ b/src/core/cli/stop_test.go
@@ -118,3 +118,46 @@ func TestStopWatcherParentIfEmptyDeadParentCleansFiles(t *testing.T) {
 		}
 	}
 }
+
+// TestSuggestAgentNames exercises the fuzzy "Did you mean?" helper used by
+// stopSpecificAgent when the requested name isn't tracked. Matching is
+// substring-in-either-direction against running agent names.
+func TestSuggestAgentNames(t *testing.T) {
+	pm := newTestPIDManager(t)
+	// Create three running agent PID files.
+	for _, name := range []string{"digest-api", "portfolio-worker", "market-data"} {
+		if err := pm.WritePID(name, os.Getpid()); err != nil {
+			t.Fatalf("WritePID(%s): %v", name, err)
+		}
+	}
+
+	tests := []struct {
+		query string
+		want  []string
+	}{
+		{"api", []string{"digest-api"}},          // suffix of digest-api
+		{"digest", []string{"digest-api"}},       // prefix of digest-api
+		{"market", []string{"market-data"}},      // prefix of market-data
+		{"mkt", nil},                             // no substring match
+		{"digest-api", []string{"digest-api"}},   // exact match (trivially contains)
+		{"worker", []string{"portfolio-worker"}}, // suffix
+	}
+	for _, tc := range tests {
+		got := suggestAgentNames(pm, tc.query)
+		if !equalStringSlices(got, tc.want) {
+			t.Errorf("suggestAgentNames(%q) = %v, want %v", tc.query, got, tc.want)
+		}
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/src/core/cli/stop_test.go
+++ b/src/core/cli/stop_test.go
@@ -151,6 +151,38 @@ func TestSuggestAgentNames(t *testing.T) {
 	}
 }
 
+// TestSuggestAgentNamesCapped verifies that suggestAgentNames returns at most
+// 3 results even when more agents match the query, and that the returned
+// subset is deterministic (sorted alphabetically, not dependent on
+// ListRunningProcesses iteration order).
+func TestSuggestAgentNamesCapped(t *testing.T) {
+	pm := newTestPIDManager(t)
+	// Use 5 agent names that all contain the substring "agent" so a single
+	// query matches all of them. With suggestAgentNames' cap of 3, the
+	// result should be the alphabetically first three.
+	names := []string{
+		"zeta-agent",
+		"beta-agent",
+		"delta-agent",
+		"alpha-agent",
+		"gamma-agent",
+	}
+	for _, n := range names {
+		if err := pm.WritePID(n, os.Getpid()); err != nil {
+			t.Fatalf("WritePID(%s): %v", n, err)
+		}
+	}
+
+	got := suggestAgentNames(pm, "agent")
+	if len(got) != 3 {
+		t.Fatalf("suggestAgentNames(\"agent\") returned %d results, want exactly 3: %v", len(got), got)
+	}
+	want := []string{"alpha-agent", "beta-agent", "delta-agent"}
+	if !equalStringSlices(got, want) {
+		t.Errorf("suggestAgentNames(\"agent\") = %v, want %v (sorted and capped)", got, want)
+	}
+}
+
 func equalStringSlices(a, b []string) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Summary

Five small but high-impact usability fixes surfaced from production feedback — a new user built a non-trivial chat agent (Fortuna) on top of mcp-mesh in about half a day and hit each of these rough edges. Nothing architectural; every change is a doc gap, a surprising scaffold default, or a missing CLI affordance.

- **Marker-param sidebar in `llm.md`** — explains why `ctx: dict = None` looks unused (it's a framework marker consumed by the Jinja2 template renderer, not by the function body). New users previously had to read example source to figure this out.
- **Scaffold `max_iterations` default: 1 → 5** — `1` meant the scaffold-generated LLM agent couldn't do any agentic looping out of the box, silently breaking tool use for first-time users. Updated in `scaffold/provider.go`, `scaffold/config.go`, `scaffold/config_test.go`, `llm.md`, and the `python/llm-provider/README.md.tmpl` usage example. TypeScript and Java man pages left untouched — their runtime defaults are separately configured.
- **Dockerfile `COPY --chmod=755` → `COPY` + `chmod` in existing `RUN`** — removes the BuildKit dependency. Hosts without `buildx` fail at the first build with a confusing error. Affects 6 scaffold `.tmpl` files, 2 embedded Dockerfile string literals in `handlers/*_handler.go`, and the `deployment_typescript.md` man page.
- **Helm values `llm-secrets` gets a kubectl example** — previously silent placeholder; now includes the exact `kubectl create secret generic llm-secrets ...` command so users either match the convention or rename the refs intentionally. 6 helm-values templates across python/typescript/java × llm-agent/llm-provider.
- **`meshctl stop <name>` fuzzy "Did you mean?" on miss** — searches `ListRunningProcesses()` for bidirectional substring matches when the exact name isn't tracked. Covers both typos and the script-name-vs-registered-name mismatch (`meshctl stop api` → `Did you mean: 'digest-api'?`). Capped at 3 suggestions; empty-query returns nothing. New `TestSuggestAgentNames` covers prefix, suffix, exact, empty, and no-match cases.

**Bonus — latent `hadolint` hook fix**: the `.pre-commit-config.yaml` `files: Dockerfile` regex was matching `Dockerfile.tmpl` and trying to exec Go template syntax as real Dockerfiles. Added `exclude: \.tmpl$` while keeping the broad `files: Dockerfile` matcher so real Dockerfiles with extensions (`Dockerfile.dev`, `Dockerfile.base`, `Dockerfile.debian`) stay linted. This was a latent bug that only surfaced because nobody had touched a `.tmpl` file recently.

## Review Notes

Two review passes. First pass caught:

- **BLOCKER**: initial hadolint fix used `Dockerfile$` (too narrow) which silently excluded 4 real `Dockerfile.*` files in `examples/`. Corrected to `files: Dockerfile` + `exclude: \.tmpl$`.
- **WARNING**: `max_iterations=1` was missed in the Python `llm-provider` README scaffold template during the initial sweep. Now consistent.
- **WARNING**: `suggestAgentNames` with an empty query would surface every running agent via `strings.Contains(n, "")` always-true. Added an empty-query guard + test case.

All three addressed in the second commit `20637d77` before push. Remaining INFO-level notes (slightly more permissive `chmod -R 755` on `node_modules` vs the old `COPY --chmod=755`, `MaxIterations=5` propagating to non-Python scaffolds whose man pages document other defaults) were deliberately left as-is per the fix spec — see commit body for rationale.

## Commits

- `2ce759a2` — Initial five quick-win fixes + the Dockerfile.tmpl hook fix attempt
- `20637d77` — Review-pass corrections (hadolint regex broadened, README default, empty-query guard)

Closes #750

## Test plan

- [x] `go build ./src/core/cli/... ./cmd/meshctl/...` — clean
- [x] `go vet ./src/core/cli/... ./cmd/meshctl/...` — no new warnings
- [x] `gofmt -l` on modified Go files — clean
- [x] `go test -count=1 ./src/core/cli/...` — all pass
- [x] `go test -count=1 -race ./src/core/cli/...` — all pass
- [x] `TestSuggestAgentNames` covers prefix/suffix/exact/empty/no-match cases
- [x] All pre-commit hooks pass (including hadolint running only on real Dockerfiles)
- [ ] Manual scaffold smoke test: `meshctl scaffold --agent-type llm-agent --name test-agent` and verify the generated Dockerfile builds without BuildKit
- [ ] Integration suite rerun against the new branch to confirm no stop/start regressions from the `suggestAgentNames` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent stop command now suggests similar agent names when the requested agent isn't running.

* **Improvements**
  * Default max_iterations for LLM agents increased from 1 to 5.
  * Clarified generated template docs with explicit Kubernetes secret guidance and examples.
  * Updated default runtime image tags for generated Java, TypeScript, and Python agents to 1.2.0.

* **Bug Fixes**
  * Pre-commit hook updated to exclude template files from linting.

* **Build Process**
  * Consolidated Dockerfile permission/ownership steps in generated builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->