### PR TITLE
fix: generate tutorial download artifacts in docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.11'
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -42,8 +42,42 @@ jobs:
           pip install mkdocs-minify-plugin
           pip install mkdocs-git-revision-date-localized-plugin
 
+      - name: Install pandoc
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+
       - name: Generate tutorial download artifacts
         run: bash scripts/generate_tutorial_artifacts.sh
+
+      - name: Verify tutorial artifacts exist
+        run: |
+          set -e
+          REQUIRED=(
+            docs/downloads/day-01-scaffold.zip
+            docs/downloads/day-02-dependency-injection.zip
+            docs/downloads/day-03-llm-provider.zip
+            docs/downloads/day-04-provider-tiers.zip
+            docs/downloads/day-05-http-gateway.zip
+            docs/downloads/day-06-chat-history.zip
+            docs/downloads/day-07-committee.zip
+            docs/downloads/day-08-docker-compose.zip
+            docs/downloads/day-09-kubernetes.zip
+            docs/downloads/day-10-whats-next.zip
+            docs/downloads/final-product.zip
+            docs/downloads/tutorial-complete.html
+            docs/downloads/tutorial-complete.txt
+          )
+          MISSING=()
+          for f in "${REQUIRED[@]}"; do
+            if [ ! -s "$f" ]; then
+              MISSING+=("$f")
+            fi
+          done
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "ERROR: Missing tutorial artifacts:"
+            printf '  - %s\n' "${MISSING[@]}"
+            exit 1
+          fi
+          echo "All tutorial artifacts present."
 
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,8 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
+      - 'examples/tutorial/**'
+      - 'scripts/generate_tutorial_artifacts.sh'
   workflow_dispatch:
 
 permissions:
@@ -20,12 +22,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      
+
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -33,12 +35,15 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      
+
       - name: Install dependencies
         run: |
           pip install mkdocs-material
           pip install mkdocs-minify-plugin
           pip install mkdocs-git-revision-date-localized-plugin
-      
+
+      - name: Generate tutorial download artifacts
+        run: bash scripts/generate_tutorial_artifacts.sh
+
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary
- Added `Generate tutorial download artifacts` step to `.github/workflows/docs.yml`, runs before `mkdocs gh-deploy`
- Added `examples/tutorial/**` and `scripts/generate_tutorial_artifacts.sh` to path triggers so docs redeploy when tutorial source changes
- Generator produces 10 day-NN zips, final-product.zip, and tutorial-complete.{html,txt} into `docs/downloads/` (which is gitignored — never tracked, must be built in CI)

## Review Notes
- Single-file diff, 9 insertions / 4 deletions (4 are trailing-whitespace cleanup from pre-commit)
- Generator script verified working locally (53MB total output)
- ubuntu-latest has `zip` available by default

Closes #775

## Test plan
- [ ] After merge, verify https://mcp-mesh.ai/tutorial/downloads/day-01-scaffold.zip downloads
- [ ] Verify https://mcp-mesh.ai/tutorial/downloads/tutorial-complete.html loads
- [ ] Verify https://mcp-mesh.ai/tutorial/downloads/tutorial-complete.txt loads
- [ ] Verify https://mcp-mesh.ai/tutorial/downloads/final-product.zip downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation deployment workflow now automatically generates tutorial artifacts during the deployment process.
  * Expanded deployment trigger to include tutorial-related file changes for more frequent documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->