### PR TITLE
security: hardening pass — registry auth, header propagation, TLS, error sanitization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,10 +357,20 @@ jobs:
         env:
           GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         run: |
-          # Defense-in-depth: explicit mask (GitHub already auto-masks secrets.*)
-          echo "::add-mask::$GPG_KEY"
-          # Pass via env var + printf to avoid shell-quoting risks of inline template substitution
-          printf '%s' "$GPG_KEY" | gpg --batch --import
+          # Mask each non-empty line of the multi-line PEM individually.
+          # GitHub's auto-mask only catches exact full-string matches; per-line
+          # masking ensures fragments that surface in error output are also redacted.
+          while IFS= read -r line; do
+            if [ -n "$line" ]; then
+              echo "::add-mask::$line"
+            fi
+          done <<< "$GPG_KEY"
+          # Import; filter gpg output to suppress any incidental PEM markers
+          # (defense-in-depth — gpg --batch normally doesn't echo key material,
+          # but error paths could).
+          printf '%s\n' "$GPG_KEY" | gpg --batch --import 2>&1 \
+              | grep -vE '(BEGIN PGP|END PGP|^\s*[A-Za-z0-9+/]{40,}={0,2}\s*$)' \
+              || true
           echo "Imported GPG key: F94266795DCA259D"
           echo "D3B274C5F3344FD4DCC969F9F94266795DCA259D:6:" | gpg --import-ownertrust
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,8 +354,13 @@ jobs:
           echo "Publishing Java SDK version: ${VERSION}"
 
       - name: Import GPG key
+        env:
+          GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
+          # Defense-in-depth: explicit mask (GitHub already auto-masks secrets.*)
+          echo "::add-mask::$GPG_KEY"
+          # Pass via env var + printf to avoid shell-quoting risks of inline template substitution
+          printf '%s' "$GPG_KEY" | gpg --batch --import
           echo "Imported GPG key: F94266795DCA259D"
           echo "D3B274C5F3344FD4DCC969F9F94266795DCA259D:6:" | gpg --import-ownertrust
 

--- a/src/core/cli/man/content/headers.md
+++ b/src/core/cli/man/content/headers.md
@@ -65,6 +65,10 @@ export MCP_MESH_PROPAGATE_HEADERS=authorization        # exact
 export MCP_MESH_PROPAGATE_HEADERS=auth-*               # prefix family
 ```
 
+> **Note**: `auth-*` matches `auth-token`, `auth-secret`, etc. — but **NOT**
+> `authorization`. If you previously relied on `auth` matching `authorization`,
+> the correct replacement is the exact entry `authorization`.
+
 > **Note**: A bare `*` (or any entry that becomes empty after stripping the
 > trailing `*`) is rejected at parse time. Such entries would be a
 > zero-length prefix that matches every header — including credentials —
@@ -211,7 +215,7 @@ SDK combination is in the chain.
 
 | Variable                     | Description                                       | Default  |
 | ---------------------------- | ------------------------------------------------- | -------- |
-| `MCP_MESH_PROPAGATE_HEADERS` | Comma-separated allowlist (exact or `prefix-*`)   | _(none)_ |
+| `MCP_MESH_PROPAGATE_HEADERS` | Comma-separated allowlist (exact `name` or `prefix*`) | _(none)_ |
 
 ## See Also
 

--- a/src/core/cli/man/content/headers.md
+++ b/src/core/cli/man/content/headers.md
@@ -18,15 +18,60 @@ Set the allowlist via environment variable on every agent in the chain:
 export MCP_MESH_PROPAGATE_HEADERS=authorization,x-request-id,x-tenant-id
 ```
 
-- Comma-separated header name **prefixes**
+- Comma-separated header names
 - Case-insensitive (normalized to lowercase internally)
-- Prefix matching: `x-audit` matches `x-audit-id`, `x-audit-source`, etc.
 - Whitespace around names is trimmed
 - Parsed once at startup — restart to change
 - Must be set on **every agent** in the chain that should participate
 
 With no value set, no custom headers are propagated. Trace headers
 (`X-Trace-ID`, `X-Parent-Span`) are always propagated independently.
+
+### Matching semantics (as of v1.4)
+
+Each entry in the allowlist is one of:
+
+- **Exact match** (plain token): `authorization` matches only `authorization`.
+- **Prefix match** (trailing `*`): `x-trace-*` matches `x-trace-id`,
+  `x-trace-parent`, etc.
+
+Matching is case-insensitive for both modes.
+
+```bash
+# Exact: only "authorization" is forwarded. "authorization-extra" is dropped.
+export MCP_MESH_PROPAGATE_HEADERS=authorization
+
+# Prefix: all x-trace-* headers are forwarded.
+export MCP_MESH_PROPAGATE_HEADERS=x-trace-*
+
+# Mixed: exact for auth tokens, prefix for trace/audit families.
+export MCP_MESH_PROPAGATE_HEADERS=authorization,x-trace-*,x-audit-*
+```
+
+### Migration note (v1.3 → v1.4)
+
+Prior to v1.4, **all** entries used prefix matching. Setting
+`MCP_MESH_PROPAGATE_HEADERS=auth` would silently match `authorization`,
+`auth-token`, and anything else starting with `auth` — a credential-leakage
+risk. Starting in v1.4, plain tokens are exact-only.
+
+If you previously relied on a short token to match longer header names,
+update your allowlist to either the exact name or an explicit prefix:
+
+```bash
+# Before (v1.3):                    After (v1.4, pick one):
+export MCP_MESH_PROPAGATE_HEADERS=auth    # matched "authorization"
+export MCP_MESH_PROPAGATE_HEADERS=authorization        # exact
+export MCP_MESH_PROPAGATE_HEADERS=auth-*               # prefix family
+```
+
+> **Note**: A bare `*` (or any entry that becomes empty after stripping the
+> trailing `*`) is rejected at parse time. Such entries would be a
+> zero-length prefix that matches every header — including credentials —
+> re-introducing the leakage class this allowlist exists to prevent. To
+> propagate a wide set of headers, list them explicitly
+> (`x-trace-id, x-tenant-id, ...`) or use prefix matching with a non-empty
+> prefix (`x-app-*`).
 
 ## How It Works
 
@@ -114,7 +159,7 @@ Session propagated headers (from incoming request)
 ```
 
 Per-call headers **win** on conflict. All headers (session and per-call)
-are filtered by the `MCP_MESH_PROPAGATE_HEADERS` prefix allowlist — agents
+are filtered by the `MCP_MESH_PROPAGATE_HEADERS` allowlist — agents
 cannot inject arbitrary headers unless the operator explicitly allows them.
 
 ## Example: Auth Token Forwarding
@@ -166,7 +211,7 @@ SDK combination is in the chain.
 
 | Variable                     | Description                                       | Default  |
 | ---------------------------- | ------------------------------------------------- | -------- |
-| `MCP_MESH_PROPAGATE_HEADERS` | Comma-separated header name prefixes to forward   | _(none)_ |
+| `MCP_MESH_PROPAGATE_HEADERS` | Comma-separated allowlist (exact or `prefix-*`)   | _(none)_ |
 
 ## See Also
 

--- a/src/core/cli/tls_auto.go
+++ b/src/core/cli/tls_auto.go
@@ -141,7 +141,7 @@ func (tc *TLSAutoConfig) GenerateAgentCert(agentName string) (certPath string, k
 func (tc *TLSAutoConfig) GetRegistryTLSEnv() []string {
 	return []string{
 		"MCP_MESH_TLS_MODE=auto",
-		"MCP_MESH_TRUST_BACKEND=localca",
+		"MCP_MESH_TRUST_BACKEND=localca,filestore",
 		fmt.Sprintf("MCP_MESH_TRUST_DIR=%s", tc.TLSDir),
 		fmt.Sprintf("MCP_MESH_TLS_CERT=%s", tc.RegistryCert),
 		fmt.Sprintf("MCP_MESH_TLS_KEY=%s", tc.RegistryKey),
@@ -150,6 +150,11 @@ func (tc *TLSAutoConfig) GetRegistryTLSEnv() []string {
 }
 
 // GetAgentTLSEnv returns environment variables for an agent process when TLS auto is enabled.
+//
+// Agents trust localca only — the filestore backend is registry-scoped (#805).
+// Propagating filestore to agents would mean every agent implicitly trusts
+// every entity an operator registers via `meshctl entity register`, which
+// broadens the trust surface beyond what the #805 fix intended.
 func (tc *TLSAutoConfig) GetAgentTLSEnv(agentCertPath, agentKeyPath string) []string {
 	return []string{
 		"MCP_MESH_TLS_MODE=auto",

--- a/src/core/registry/ent_handlers.go
+++ b/src/core/registry/ent_handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -30,18 +31,29 @@ type resolvedDependency = struct {
 
 // Package-level proxy configuration parsed once at init (#769)
 var (
-	proxyPropagateHeaderPrefixes []string
-	proxyDefaultTimeout          = 60 * time.Second
+	proxyPropagateHeaderEntries []string
+	proxyDefaultTimeout         = 60 * time.Second
 )
 
 func init() {
+	// Parse MCP_MESH_PROPAGATE_HEADERS. Each comma-separated entry is either an
+	// exact header name (e.g., "authorization") or a prefix with trailing "*"
+	// (e.g., "x-trace-*"). Matching is performed in proxyRequest below.
 	if raw := os.Getenv("MCP_MESH_PROPAGATE_HEADERS"); raw != "" {
-		prefixes := strings.Split(raw, ",")
-		for _, p := range prefixes {
-			p = strings.TrimSpace(strings.ToLower(p))
-			if p != "" {
-				proxyPropagateHeaderPrefixes = append(proxyPropagateHeaderPrefixes, p)
+		entries := strings.Split(raw, ",")
+		for _, e := range entries {
+			e = strings.TrimSpace(strings.ToLower(e))
+			if e == "" {
+				continue
 			}
+			// Reject zero-length prefix matchers (e.g. "*" alone) which would match
+			// every header and re-introduce the credential leakage class #790 was
+			// meant to prevent.
+			if strings.TrimSuffix(e, "*") == "" {
+				log.Printf("[propagate-headers] ignoring entry %q: zero-length prefix would match all headers", e)
+				continue
+			}
+			proxyPropagateHeaderEntries = append(proxyPropagateHeaderEntries, e)
 		}
 	}
 	if envTimeout := os.Getenv("MCP_MESH_PROXY_TIMEOUT"); envTimeout != "" {
@@ -140,8 +152,14 @@ func (h *EntBusinessLogicHandlers) SendHeartbeat(c *gin.Context) {
 	// Call lightweight heartbeat service method using EntService
 	serviceResp, err := h.entService.UpdateHeartbeat(heartbeatReq)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, generated.ErrorResponse{
-			Error:     err.Error(),
+		status := http.StatusBadRequest
+		msg := err.Error()
+		if errors.Is(err, ErrEntityIDMismatch) {
+			status = http.StatusForbidden
+			msg = "entity_id mismatch: agent owned by another entity" // sanitized — full detail in server log
+		}
+		c.JSON(status, generated.ErrorResponse{
+			Error:     msg,
 			Timestamp: time.Now().UTC(),
 		})
 		return
@@ -521,12 +539,19 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 		proxyReq.Header.Set("X-Mesh-Timeout", meshTimeout)
 	}
 
-	// Forward headers matching MCP_MESH_PROPAGATE_HEADERS prefixes (#769)
-	if len(proxyPropagateHeaderPrefixes) > 0 {
+	// Forward headers matching MCP_MESH_PROPAGATE_HEADERS allowlist (#769, #790).
+	// Entries are exact matches by default; a trailing "*" denotes a prefix.
+	if len(proxyPropagateHeaderEntries) > 0 {
 		for headerName, values := range c.Request.Header {
 			lowerName := strings.ToLower(headerName)
-			for _, prefix := range proxyPropagateHeaderPrefixes {
-				if strings.HasPrefix(lowerName, prefix) {
+			for _, entry := range proxyPropagateHeaderEntries {
+				matches := false
+				if strings.HasSuffix(entry, "*") {
+					matches = strings.HasPrefix(lowerName, strings.TrimSuffix(entry, "*"))
+				} else {
+					matches = lowerName == entry
+				}
+				if matches {
 					for _, v := range values {
 						proxyReq.Header.Add(headerName, v)
 					}
@@ -573,8 +598,9 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 		caCert, err := os.ReadFile(caPath)
 		if err != nil {
 			log.Printf("ERROR: failed to read CA cert %s: %v", caPath, err)
+			// Sanitize response: full detail (paths, OS errors) stays in server log only (#794).
 			c.JSON(http.StatusInternalServerError, generated.ErrorResponse{
-				Error:     fmt.Sprintf("Proxy TLS misconfiguration: failed to read CA cert: %v", err),
+				Error:     "Proxy TLS misconfiguration",
 				Timestamp: time.Now().UTC(),
 			})
 			return
@@ -585,8 +611,9 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 		clientCert, err := tls.LoadX509KeyPair(certPath, keyPath)
 		if err != nil {
 			log.Printf("ERROR: failed to load client cert/key (%s, %s): %v", certPath, keyPath, err)
+			// Sanitize response: full detail (paths, OS errors) stays in server log only (#794).
 			c.JSON(http.StatusInternalServerError, generated.ErrorResponse{
-				Error:     fmt.Sprintf("Proxy TLS misconfiguration: failed to load client certificate: %v", err),
+				Error:     "Proxy TLS misconfiguration",
 				Timestamp: time.Now().UTC(),
 			})
 			return

--- a/src/core/registry/ent_handlers.go
+++ b/src/core/registry/ent_handlers.go
@@ -539,11 +539,23 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 		proxyReq.Header.Set("X-Mesh-Timeout", meshTimeout)
 	}
 
+	// Names already set explicitly above — don't duplicate via propagation
+	explicitlySet := map[string]bool{
+		"content-type":   true,
+		"accept":         true,
+		"x-trace-id":     true,
+		"x-parent-span":  true,
+		"x-mesh-timeout": true,
+	}
+
 	// Forward headers matching MCP_MESH_PROPAGATE_HEADERS allowlist (#769, #790).
 	// Entries are exact matches by default; a trailing "*" denotes a prefix.
 	if len(proxyPropagateHeaderEntries) > 0 {
 		for headerName, values := range c.Request.Header {
 			lowerName := strings.ToLower(headerName)
+			if explicitlySet[lowerName] {
+				continue
+			}
 			for _, entry := range proxyPropagateHeaderEntries {
 				matches := false
 				if strings.HasSuffix(entry, "*") {
@@ -606,7 +618,15 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 			return
 		}
 		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(caCert)
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			log.Printf("ERROR: failed to parse CA cert from %s (empty or malformed PEM)", caPath)
+			// Sanitize response: full detail stays in server log only (#794).
+			c.JSON(http.StatusInternalServerError, generated.ErrorResponse{
+				Error:     "Proxy TLS misconfiguration",
+				Timestamp: time.Now().UTC(),
+			})
+			return
+		}
 
 		clientCert, err := tls.LoadX509KeyPair(certPath, keyPath)
 		if err != nil {

--- a/src/core/registry/ent_service.go
+++ b/src/core/registry/ent_service.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -21,6 +22,15 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 )
+
+// ErrEntityIDMismatch is returned when a heartbeat or registration update is
+// attempted by an entity that does not own the target agent. The mesh enforces
+// "first-claim wins": once an agent_id is registered with a TLS-verified
+// entity_id, only heartbeats from that same entity can update it. Empty
+// entity_id requests are rejected when the existing agent has been claimed
+// (prevents downgrade attacks where TLS-off heartbeats modify TLS-claimed
+// agents).
+var ErrEntityIDMismatch = errors.New("entity_id mismatch")
 
 // Dependency represents a tool dependency with constraints
 // Replaces the old database.Dependency from GORM models
@@ -348,6 +358,18 @@ func (s *EntService) RegisterAgent(req *AgentRegistrationRequest) (*AgentRegistr
 				return fmt.Errorf("failed to check existing agent: %w", err)
 			}
 		} else {
+			// Enforce entity ownership on register-update path. Mirrors the check in
+			// UpdateHeartbeat — protects against the race where a heartbeat for a
+			// non-existent agent_id escalates into RegisterAgent and an entity
+			// concurrently claims that agent_id; without this check, the rogue
+			// register would silently overwrite EntityID.
+			if existingAgent.EntityID != nil && *existingAgent.EntityID != "" && *existingAgent.EntityID != req.EntityID {
+				s.logger.Warning("entity_id mismatch in RegisterAgent: agent %q owned by %q, rejected register from %q",
+					req.AgentID, *existingAgent.EntityID, req.EntityID)
+				return fmt.Errorf("%w: agent %q owned by another entity",
+					ErrEntityIDMismatch, req.AgentID)
+			}
+
 			// Update existing agent
 			updateBuilder := existingAgent.Update().
 				SetAgentType(agent.AgentType(meta.agentType)).
@@ -972,6 +994,12 @@ func (s *EntService) UpdateHeartbeat(req *HeartbeatRequest) (*HeartbeatResponse,
 				}
 				regResp, err := s.RegisterAgent(fullReq)
 				if err != nil {
+					// Propagate ErrEntityIDMismatch as a real error so the HTTP
+					// handler can map it to 403 (otherwise it'd be swallowed into
+					// a 200 response with status="error").
+					if errors.Is(err, ErrEntityIDMismatch) {
+						return nil, err
+					}
 					return &HeartbeatResponse{
 						Status:    "error",
 						Timestamp:    now.Format(time.RFC3339),
@@ -1009,6 +1037,17 @@ func (s *EntService) UpdateHeartbeat(req *HeartbeatRequest) (*HeartbeatResponse,
 			}, nil
 		}
 		return nil, fmt.Errorf("failed to check agent existence: %w", err)
+	}
+
+	// Enforce entity ownership. Once an agent has been claimed by an entity
+	// (via TLS-verified registration), subsequent heartbeats must come from the
+	// same entity. Empty req.EntityID is rejected if the existing agent is
+	// claimed — this prevents downgrade attacks.
+	if existingAgent.EntityID != nil && *existingAgent.EntityID != "" && *existingAgent.EntityID != req.EntityID {
+		s.logger.Warning("entity_id mismatch: agent %q owned by %q, rejected heartbeat from %q",
+			req.AgentID, *existingAgent.EntityID, req.EntityID)
+		return nil, fmt.Errorf("%w: agent %q owned by another entity",
+			ErrEntityIDMismatch, req.AgentID)
 	}
 
 	// Check for status transitions and handle accordingly

--- a/src/core/registry/ent_service.go
+++ b/src/core/registry/ent_service.go
@@ -300,6 +300,22 @@ func extractAgentMetadata(agentID string, metadata map[string]interface{}) agent
 	return m
 }
 
+// checkEntityOwnership verifies that req's entity_id matches the existing
+// agent's owner. Returns ErrEntityIDMismatch (wrapped) if claimed != stored
+// and stored is non-empty. op is a short caller name for log context.
+func (s *EntService) checkEntityOwnership(op, agentID, reqEntityID string, storedEntityID *string) error {
+	if storedEntityID == nil || *storedEntityID == "" {
+		return nil
+	}
+	if *storedEntityID == reqEntityID {
+		return nil
+	}
+	s.logger.Warning("entity_id mismatch in %s: agent %q owned by %q, rejected request from %q",
+		op, agentID, *storedEntityID, reqEntityID)
+	return fmt.Errorf("%w: agent %q owned by another entity",
+		ErrEntityIDMismatch, agentID)
+}
+
 // RegisterAgent handles agent registration using Ent queries
 func (s *EntService) RegisterAgent(req *AgentRegistrationRequest) (*AgentRegistrationResponse, error) {
 	ctx := context.Background()
@@ -363,11 +379,8 @@ func (s *EntService) RegisterAgent(req *AgentRegistrationRequest) (*AgentRegistr
 			// non-existent agent_id escalates into RegisterAgent and an entity
 			// concurrently claims that agent_id; without this check, the rogue
 			// register would silently overwrite EntityID.
-			if existingAgent.EntityID != nil && *existingAgent.EntityID != "" && *existingAgent.EntityID != req.EntityID {
-				s.logger.Warning("entity_id mismatch in RegisterAgent: agent %q owned by %q, rejected register from %q",
-					req.AgentID, *existingAgent.EntityID, req.EntityID)
-				return fmt.Errorf("%w: agent %q owned by another entity",
-					ErrEntityIDMismatch, req.AgentID)
+			if err := s.checkEntityOwnership("RegisterAgent", req.AgentID, req.EntityID, existingAgent.EntityID); err != nil {
+				return err
 			}
 
 			// Update existing agent
@@ -1043,11 +1056,8 @@ func (s *EntService) UpdateHeartbeat(req *HeartbeatRequest) (*HeartbeatResponse,
 	// (via TLS-verified registration), subsequent heartbeats must come from the
 	// same entity. Empty req.EntityID is rejected if the existing agent is
 	// claimed — this prevents downgrade attacks.
-	if existingAgent.EntityID != nil && *existingAgent.EntityID != "" && *existingAgent.EntityID != req.EntityID {
-		s.logger.Warning("entity_id mismatch: agent %q owned by %q, rejected heartbeat from %q",
-			req.AgentID, *existingAgent.EntityID, req.EntityID)
-		return nil, fmt.Errorf("%w: agent %q owned by another entity",
-			ErrEntityIDMismatch, req.AgentID)
+	if err := s.checkEntityOwnership("UpdateHeartbeat", req.AgentID, req.EntityID, existingAgent.EntityID); err != nil {
+		return nil, err
 	}
 
 	// Check for status transitions and handle accordingly

--- a/src/core/registry/server.go
+++ b/src/core/registry/server.go
@@ -136,13 +136,9 @@ func (s *Server) Run(addr string) error {
 	// Use TLS listener when TLS mode is enabled
 	if s.config.TlsMode != "" && s.config.TlsMode != "off" {
 		if s.config.TlsCertFile == "" || s.config.TlsKeyFile == "" {
-			if s.config.TlsMode == "strict" {
-				return fmt.Errorf("TLS mode is 'strict' but TLS cert/key not configured (set MCP_MESH_TLS_CERT and MCP_MESH_TLS_KEY)")
-			}
-			log.Printf("[server] WARNING: TLS mode '%s' but cert/key not configured, falling back to plaintext", s.config.TlsMode)
-		} else {
-			return s.runWithTLS(addr)
+			return fmt.Errorf("TLS mode %q requires MCP_MESH_TLS_CERT and MCP_MESH_TLS_KEY to be set; use MCP_MESH_TLS_MODE=off to run plaintext", s.config.TlsMode)
 		}
+		return s.runWithTLS(addr)
 	}
 	return s.engine.Run(addr)
 }

--- a/src/core/registry/trust/filestore.go
+++ b/src/core/registry/trust/filestore.go
@@ -289,6 +289,13 @@ func (fs *FileStore) startWatcher() error {
 							log.Printf("[trust/filestore] warning: cannot watch new entities dir: %v", err)
 						}
 						log.Printf("[trust/filestore] now watching entities directory: %s", event.Name)
+						// Reload to catch any PEM files written before the watch was set up
+						// (race: meshctl entity register MkdirAll's the dir AND writes the file
+						// in rapid succession; fsnotify may fire entities/ Create before we add
+						// a watch on it, missing the subsequent .pem write).
+						if err := fs.loadAll(); err != nil {
+							log.Printf("[trust/filestore] reload error after entities dir creation: %v", err)
+						}
 					}
 				}
 				if !strings.HasSuffix(event.Name, ".pem") {

--- a/src/runtime/core/Cargo.lock
+++ b/src/runtime/core/Cargo.lock
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-mesh-core"
-version = "1.3.1"
+version = "1.3.3"
 dependencies = [
  "async-trait",
  "base64",

--- a/src/runtime/core/src/trace_context.rs
+++ b/src/runtime/core/src/trace_context.rs
@@ -98,7 +98,13 @@ pub fn extract_trace_context(headers_json: &str, body_json: Option<&str>) -> Str
     .to_string()
 }
 
-/// Filter headers by propagation allowlist with prefix matching.
+/// Filter headers by propagation allowlist.
+///
+/// Allowlist entries are comma-separated and case-insensitive. Each entry is
+/// either:
+/// - Exact match (plain token): `authorization` matches only `authorization`.
+/// - Prefix match (trailing `*`): `x-trace-*` matches `x-trace-id`,
+///   `x-trace-parent`, etc.
 pub fn filter_propagation_headers(
     headers_json: &str,
     allowlist_csv: &str,
@@ -114,7 +120,13 @@ pub fn filter_propagation_headers(
     let mut result = serde_json::Map::new();
     for (key, value) in obj {
         let lower_key = key.to_lowercase();
-        if allowlist.iter().any(|prefix| lower_key.starts_with(prefix)) {
+        if allowlist.iter().any(|entry| {
+            if let Some(prefix) = entry.strip_suffix('*') {
+                lower_key.starts_with(prefix)
+            } else {
+                lower_key == entry.as_str()
+            }
+        }) {
             result.insert(lower_key, value.clone());
         }
     }
@@ -124,16 +136,32 @@ pub fn filter_propagation_headers(
 }
 
 /// Check if a header matches the propagation allowlist.
+///
+/// See [`filter_propagation_headers`] for allowlist syntax: plain tokens are
+/// exact matches; tokens with a trailing `*` are prefix matches.
 pub fn matches_propagate_header(header_name: &str, allowlist_csv: &str) -> bool {
     let allowlist = parse_allowlist(allowlist_csv);
     let lower = header_name.to_lowercase();
-    allowlist.iter().any(|prefix| lower.starts_with(prefix))
+    allowlist.iter().any(|entry| {
+        if let Some(prefix) = entry.strip_suffix('*') {
+            lower.starts_with(prefix)
+        } else {
+            lower == entry.as_str()
+        }
+    })
 }
 
 fn parse_allowlist(csv: &str) -> Vec<String> {
     csv.split(',')
         .map(|s| s.trim().to_lowercase())
         .filter(|s| !s.is_empty())
+        .filter(|s| {
+            // Reject zero-length prefix matchers (e.g. "*" alone) which would
+            // match every header and re-introduce the credential leakage class
+            // #790 was meant to prevent.
+            let core = s.strip_suffix('*').unwrap_or(s);
+            !core.is_empty()
+        })
         .collect()
 }
 
@@ -286,7 +314,7 @@ mod tests {
     fn test_filter_prefix_matching() {
         let result = filter_propagation_headers(
             r#"{"X-Audit-Id": "123", "X-Request-Id": "456", "Content-Type": "json"}"#,
-            "x-audit, x-request",
+            "x-audit-*, x-request-*",
         )
         .unwrap();
         let v: Value = serde_json::from_str(&result).unwrap();
@@ -299,7 +327,7 @@ mod tests {
     fn test_filter_no_matches() {
         let result = filter_propagation_headers(
             r#"{"Content-Type": "json"}"#,
-            "x-audit",
+            "x-audit-*",
         )
         .unwrap();
         let v: Value = serde_json::from_str(&result).unwrap();
@@ -321,13 +349,39 @@ mod tests {
     fn test_filter_multiple_prefixes() {
         let result = filter_propagation_headers(
             r#"{"X-A-One": "1", "X-B-Two": "2", "X-C-Three": "3"}"#,
-            "x-a, x-c",
+            "x-a-*, x-c-*",
         )
         .unwrap();
         let v: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(v["x-a-one"], "1");
         assert!(v.get("x-b-two").is_none());
         assert_eq!(v["x-c-three"], "3");
+    }
+
+    #[test]
+    fn test_filter_exact_match_only() {
+        // Exact token must match exactly, not as a prefix.
+        let result = filter_propagation_headers(
+            r#"{"Authorization": "bearer", "Authorization-Extra": "leak"}"#,
+            "authorization",
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["authorization"], "bearer");
+        assert!(v.get("authorization-extra").is_none());
+    }
+
+    #[test]
+    fn test_filter_mixed_exact_and_prefix() {
+        let result = filter_propagation_headers(
+            r#"{"X-Auth-Exact": "ok", "X-Auth-Exact-Longer": "nope", "X-Trace-Id": "t1"}"#,
+            "x-auth-exact, x-trace-*",
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["x-auth-exact"], "ok");
+        assert!(v.get("x-auth-exact-longer").is_none());
+        assert_eq!(v["x-trace-id"], "t1");
     }
 
     // =========================================================================
@@ -340,17 +394,55 @@ mod tests {
     }
 
     #[test]
-    fn test_matches_prefix() {
-        assert!(matches_propagate_header("X-Audit-Id", "x-audit"));
+    fn test_matches_exact_rejects_prefix() {
+        // Plain token is exact-only; longer header must not match.
+        assert!(!matches_propagate_header("X-Audit-Id", "x-audit"));
+    }
+
+    #[test]
+    fn test_matches_prefix_with_star() {
+        assert!(matches_propagate_header("X-Audit-Id", "x-audit-*"));
     }
 
     #[test]
     fn test_matches_no_match() {
-        assert!(!matches_propagate_header("Content-Type", "x-audit"));
+        assert!(!matches_propagate_header("Content-Type", "x-audit-*"));
     }
 
     #[test]
     fn test_matches_empty_allowlist() {
         assert!(!matches_propagate_header("X-Audit-Id", ""));
+    }
+
+    // =========================================================================
+    // bare "*" rejection — guards against credential leakage class #790
+    // =========================================================================
+
+    #[test]
+    fn test_bare_star_rejected_in_matches() {
+        // A bare "*" must NOT match anything — it's a zero-length prefix and
+        // would otherwise propagate every header (including auth).
+        assert!(!matches_propagate_header("authorization", "*"));
+        assert!(!matches_propagate_header("x-audit-id", "*"));
+        assert!(!matches_propagate_header("cookie", "*"));
+    }
+
+    #[test]
+    fn test_bare_star_rejected_in_filter() {
+        let result = filter_propagation_headers(
+            r#"{"authorization": "Bearer secret", "x-audit-id": "123"}"#,
+            "*",
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        // Empty result — bare "*" rejected, no headers propagate.
+        assert_eq!(v.as_object().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_bare_star_rejected_among_other_entries() {
+        // Other valid entries should still work; only the bare "*" is dropped.
+        assert!(matches_propagate_header("x-audit-id", "*, x-audit-id"));
+        assert!(!matches_propagate_header("authorization", "*, x-audit-id"));
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TraceContext.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TraceContext.java
@@ -37,7 +37,7 @@ public class TraceContext {
 
     static final List<String> PROPAGATE_HEADERS;
 
-    /** Pre-built CSV of propagate header prefixes for Rust core calls. */
+    /** Pre-built CSV of propagate header allowlist entries for Rust core calls. */
     private static final String PROPAGATE_HEADERS_CSV;
 
     static {
@@ -141,14 +141,19 @@ public class TraceContext {
     }
 
     /**
-     * Check if a header name matches any prefix in the propagate headers allowlist.
-     * Uses prefix matching: if PROPAGATE_HEADERS contains "x-audit", it will match
-     * "x-audit", "x-audit-id", "x-audit-source", etc.
+     * Check if a header name matches the propagate headers allowlist.
+     *
+     * <p>Each allowlist entry is either an exact match (plain token) or a
+     * prefix match (trailing {@code *}). Matching is case-insensitive.
+     * <ul>
+     *   <li>{@code authorization} matches only {@code authorization}.</li>
+     *   <li>{@code x-trace-*} matches {@code x-trace-id}, {@code x-trace-parent}, etc.</li>
+     * </ul>
      *
      * <p>Delegates to Rust core for consistent cross-SDK behavior.
      *
      * @param name Header name to check
-     * @return true if the name matches any prefix in the allowlist
+     * @return true if the name matches any entry in the allowlist
      */
     public static boolean matchesPropagateHeader(String name) {
         if (PROPAGATE_HEADERS.isEmpty()) return false;

--- a/src/runtime/python/_mcp_mesh/tracing/context.py
+++ b/src/runtime/python/_mcp_mesh/tracing/context.py
@@ -21,10 +21,15 @@ PROPAGATE_HEADERS_CSV: str = ",".join(PROPAGATE_HEADERS)
 
 
 def matches_propagate_header(name: str) -> bool:
-    """Check if a header name matches any prefix in the propagate headers allowlist.
+    """Check if a header name matches the propagate headers allowlist.
 
-    Uses prefix matching: if PROPAGATE_HEADERS contains 'x-audit', it will match
-    'x-audit', 'x-audit-id', 'x-audit-source', etc.
+    Each allowlist entry is either an exact match (plain token) or a prefix
+    match (trailing ``*``). Matching is case-insensitive and is delegated to
+    the Rust core so all SDKs behave identically.
+
+    Examples:
+        - ``authorization`` matches only ``authorization``.
+        - ``x-trace-*`` matches ``x-trace-id``, ``x-trace-parent``, etc.
     """
     if not PROPAGATE_HEADERS:
         return False

--- a/src/runtime/python/mesh/types.py
+++ b/src/runtime/python/mesh/types.py
@@ -109,8 +109,9 @@ class McpMeshTool(Protocol):
         Args:
             arguments: Arguments to pass to the remote function (optional)
             headers: Per-call headers to inject into the downstream request (optional).
-                     Filtered by MCP_MESH_PROPAGATE_HEADERS prefix allowlist
-                     (e.g., allowlist "x-audit" permits "x-audit-id").
+                     Filtered by the MCP_MESH_PROPAGATE_HEADERS allowlist
+                     (exact match by default; trailing "*" for prefix match —
+                     e.g., "x-audit-*" permits "x-audit-id").
                      Merges with session-level propagated headers (per-call wins).
 
         Returns:

--- a/src/runtime/typescript/src/tracing.ts
+++ b/src/runtime/typescript/src/tracing.ts
@@ -36,11 +36,14 @@ function parsePropagateHeaders(): string[] {
 export const PROPAGATE_HEADERS: string[] = parsePropagateHeaders();
 
 /**
- * Check if a header name matches any prefix in the propagate headers allowlist.
- * Uses prefix matching: if PROPAGATE_HEADERS contains 'x-audit', it will match
- * 'x-audit', 'x-audit-id', 'x-audit-source', etc.
+ * Check if a header name matches the propagate headers allowlist.
  *
- * Delegates to Rust core for matching logic.
+ * Each allowlist entry is either an exact match (plain token) or a prefix
+ * match (trailing `*`). Matching is case-insensitive.
+ * - `authorization` matches only `authorization`.
+ * - `x-trace-*` matches `x-trace-id`, `x-trace-parent`, etc.
+ *
+ * Delegates to Rust core so all SDKs behave identically.
  */
 export function matchesPropagateHeader(name: string): boolean {
   if (PROPAGATE_HEADERS.length === 0) return false;

--- a/tests/integration/suites/uc01_registry/tc15_error_message_no_internal_paths/test.yaml
+++ b/tests/integration/suites/uc01_registry/tc15_error_message_no_internal_paths/test.yaml
@@ -1,0 +1,173 @@
+# Test Case: Error Messages Do Not Leak Internal File Paths (#794)
+# Regression test for proxy TLS error responses that previously echoed
+# err.Error() — which included the CA/cert/key file paths — directly into
+# the HTTP response body. After the fix, the body is a fixed sanitized
+# string ("Proxy TLS misconfiguration"); full detail stays in server logs.
+#
+# Scenario:
+#   1. Start the registry + system agent with --tls-auto (everything HTTPS).
+#   2. Move the CA file out of the way so os.ReadFile(caPath) in the proxy
+#      path fails when a proxy call is attempted.
+#   3. Issue a proxy call (https://localhost:8000/proxy/<agent>/mcp).
+#   4. Assert the response body has NO file paths, cert extensions or
+#      internal directory tokens — only the sanitized message.
+
+name: "Proxy Error Messages Do Not Leak Paths"
+description: "Regression test for #794 — proxy TLS failures must not echo file paths"
+tags:
+  - registry
+  - proxy
+  - security
+  - tls
+  - issue_794
+timeout: 300
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy system agent to workspace"
+    handler: shell
+    command: |
+      cp /uc-artifacts/py-system-agent.py /workspace/system_agent.py
+      ls -la /workspace/
+    capture: copy_output
+
+  - name: "Start system agent with TLS auto (brings up mTLS registry)"
+    handler: shell
+    command: "meshctl start system_agent.py --tls-auto -d"
+    workdir: /workspace
+    capture: system_start
+
+  - name: "Wait for system agent to register"
+    handler: wait
+    seconds: 10
+
+  - name: "Confirm agent registered with HTTPS endpoint"
+    handler: shell
+    command: |
+      curl -sk https://localhost:8000/agents 2>&1
+    capture: agents_api
+
+  - name: "Extract agent host:port from registry"
+    handler: shell
+    command: |
+      AGENT_HP=$(curl -sk https://localhost:8000/agents | python3 -c "
+      import sys, json
+      data = json.load(sys.stdin)
+      for a in data.get('agents', []):
+          ep = a.get('endpoint', '')
+          if 'system-agent' in a.get('name', '') and ep.startswith('https://'):
+              print(ep.replace('https://', ''))
+              break
+      ")
+      echo "AGENT_HP=$AGENT_HP"
+    workdir: /workspace
+    capture: agent_hp
+
+  - name: "Move CA file out of registry's reach"
+    handler: shell
+    command: |
+      CA_PATH="$HOME/.mcp-mesh/tls/ca.pem"
+      if [ -f "$CA_PATH" ]; then
+        mv "$CA_PATH" "$CA_PATH.bak"
+        echo "CA_MOVED=true"
+      else
+        echo "CA file not at expected path, searching..."
+        find "$HOME/.mcp-mesh" -name "ca*.pem" 2>/dev/null || true
+        # Try alternate locations used by tls_auto
+        for p in $HOME/.mcp-mesh/tls/local-dev/ca.pem $HOME/.mcp-mesh/tls/local-dev/root-ca.pem; do
+          if [ -f "$p" ]; then
+            mv "$p" "$p.bak"
+            echo "CA_MOVED=true (from $p)"
+            break
+          fi
+        done
+      fi
+    workdir: /workspace
+    capture: ca_move
+    ignore_errors: true
+
+  - name: "Call /proxy/<agent>/mcp and capture response body"
+    handler: shell
+    command: |
+      AGENT_HP=$(echo "${captured.agent_hp}" | grep "AGENT_HP=" | cut -d= -f2)
+      echo "Calling proxy for AGENT_HP=$AGENT_HP"
+      # Use -k to skip registry cert verification (its cert is still fine),
+      # and capture the response body for assertion.
+      BODY=$(curl -sk -X POST \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json, text/event-stream" \
+        -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_current_time","arguments":{}}}' \
+        "https://localhost:8000/proxy/${AGENT_HP}/mcp")
+      echo "PROXY_BODY_START"
+      echo "$BODY"
+      echo "PROXY_BODY_END"
+    workdir: /workspace
+    capture: proxy_body
+    timeout: 30
+
+  - name: "Capture registry logs (full detail should be here, not in body)"
+    handler: shell
+    command: |
+      meshctl logs registry 2>&1 | tail -40 || echo "no registry logs"
+    workdir: /workspace
+    capture: registry_logs
+    ignore_errors: true
+
+  - name: "Restore CA file for clean teardown"
+    handler: shell
+    command: |
+      CA_PATH="$HOME/.mcp-mesh/tls/ca.pem"
+      if [ -f "$CA_PATH.bak" ]; then mv "$CA_PATH.bak" "$CA_PATH"; fi
+      for p in $HOME/.mcp-mesh/tls/local-dev/ca.pem.bak $HOME/.mcp-mesh/tls/local-dev/root-ca.pem.bak; do
+        if [ -f "$p" ]; then
+          mv "$p" "${p%.bak}"
+        fi
+      done
+    workdir: /workspace
+    ignore_errors: true
+
+  - name: "Stop all"
+    handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+
+assertions:
+  # Sanitized message must be present in the response body.
+  - expr: "${captured.proxy_body} contains 'Proxy TLS misconfiguration'"
+    message: "Response body should contain the sanitized TLS-misconfig message"
+
+  # No filesystem path tokens may appear in the response body.
+  - expr: "${captured.proxy_body} not contains '/etc/'"
+    message: "Response body must not contain absolute /etc/ paths"
+
+  - expr: "${captured.proxy_body} not contains '.pem'"
+    message: "Response body must not contain .pem file extensions"
+
+  - expr: "${captured.proxy_body} not contains '.mcp-mesh/tls'"
+    message: "Response body must not contain registry TLS directory paths"
+
+  - expr: "${captured.proxy_body} not contains 'no such file'"
+    message: "Response body must not contain OS error strings like 'no such file'"
+
+  - expr: "${captured.proxy_body} not contains 'open '"
+    message: "Response body must not contain Go's 'open <path>:' error prefix"
+
+post_run:
+  - handler: shell
+    command: |
+      # Safety net: always restore CA if the step above did not run.
+      CA_PATH="$HOME/.mcp-mesh/tls/ca.pem"
+      if [ -f "$CA_PATH.bak" ]; then mv "$CA_PATH.bak" "$CA_PATH"; fi
+      for p in $HOME/.mcp-mesh/tls/local-dev/ca.pem.bak $HOME/.mcp-mesh/tls/local-dev/root-ca.pem.bak; do
+        if [ -f "$p" ]; then mv "$p" "${p%.bak}"; fi
+      done
+      meshctl stop 2>/dev/null || true
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc11_header_propagation/tc08_python_per_call_headers/test.yaml
+++ b/tests/integration/suites/uc11_header_propagation/tc08_python_per_call_headers/test.yaml
@@ -33,7 +33,7 @@ test:
   - name: "Start header-echo agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-echo-py/main.py --env MCP_MESH_HTTP_PORT=3040 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
+    command: "meshctl start header-echo-py/main.py --env MCP_MESH_HTTP_PORT=3040 --env 'MCP_MESH_PROPAGATE_HEADERS=x-audit-*' -d"
     capture: start_echo
 
   # Wait for echo agent to register
@@ -58,7 +58,7 @@ test:
   - name: "Start header-relay agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-relay-py/main.py --env MCP_MESH_HTTP_PORT=3041 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
+    command: "meshctl start header-relay-py/main.py --env MCP_MESH_HTTP_PORT=3041 --env 'MCP_MESH_PROPAGATE_HEADERS=x-audit-*' -d"
     capture: start_relay
 
   # Wait for relay agent to register

--- a/tests/integration/suites/uc11_header_propagation/tc08_python_per_call_headers/test.yaml
+++ b/tests/integration/suites/uc11_header_propagation/tc08_python_per_call_headers/test.yaml
@@ -33,7 +33,7 @@ test:
   - name: "Start header-echo agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-echo-py/main.py --env MCP_MESH_HTTP_PORT=3040 --env MCP_MESH_PROPAGATE_HEADERS=x-audit -d"
+    command: "meshctl start header-echo-py/main.py --env MCP_MESH_HTTP_PORT=3040 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
     capture: start_echo
 
   # Wait for echo agent to register
@@ -58,7 +58,7 @@ test:
   - name: "Start header-relay agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-relay-py/main.py --env MCP_MESH_HTTP_PORT=3041 --env MCP_MESH_PROPAGATE_HEADERS=x-audit -d"
+    command: "meshctl start header-relay-py/main.py --env MCP_MESH_HTTP_PORT=3041 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
     capture: start_relay
 
   # Wait for relay agent to register

--- a/tests/integration/suites/uc11_header_propagation/tc09_typescript_per_call_headers/test.yaml
+++ b/tests/integration/suites/uc11_header_propagation/tc09_typescript_per_call_headers/test.yaml
@@ -42,7 +42,7 @@ test:
   - name: "Start header-echo-ts agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-echo-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3042 --env MCP_MESH_PROPAGATE_HEADERS=x-audit -d"
+    command: "meshctl start header-echo-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3042 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
     capture: start_echo
 
   # Wait for echo agent to register
@@ -67,7 +67,7 @@ test:
   - name: "Start header-relay-ts agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-relay-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3043 --env MCP_MESH_PROPAGATE_HEADERS=x-audit -d"
+    command: "meshctl start header-relay-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3043 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
     capture: start_relay
 
   # Wait for relay agent to register

--- a/tests/integration/suites/uc11_header_propagation/tc09_typescript_per_call_headers/test.yaml
+++ b/tests/integration/suites/uc11_header_propagation/tc09_typescript_per_call_headers/test.yaml
@@ -42,7 +42,7 @@ test:
   - name: "Start header-echo-ts agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-echo-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3042 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
+    command: "meshctl start header-echo-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3042 --env 'MCP_MESH_PROPAGATE_HEADERS=x-audit-*' -d"
     capture: start_echo
 
   # Wait for echo agent to register
@@ -67,7 +67,7 @@ test:
   - name: "Start header-relay-ts agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-relay-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3043 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
+    command: "meshctl start header-relay-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3043 --env 'MCP_MESH_PROPAGATE_HEADERS=x-audit-*' -d"
     capture: start_relay
 
   # Wait for relay agent to register

--- a/tests/integration/suites/uc11_header_propagation/tc10_java_per_call_headers/test.yaml
+++ b/tests/integration/suites/uc11_header_propagation/tc10_java_per_call_headers/test.yaml
@@ -44,7 +44,7 @@ test:
   - name: "Start header-echo-java agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start /workspace/header-echo-java --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
+    command: "meshctl start /workspace/header-echo-java --env 'MCP_MESH_PROPAGATE_HEADERS=x-audit-*' -d"
     capture: start_echo
 
   # Wait for echo agent to register (Java is slow to start)
@@ -69,7 +69,7 @@ test:
   - name: "Start header-relay-java agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start /workspace/header-relay-java --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
+    command: "meshctl start /workspace/header-relay-java --env 'MCP_MESH_PROPAGATE_HEADERS=x-audit-*' -d"
     capture: start_relay
 
   # Wait for relay agent to register

--- a/tests/integration/suites/uc11_header_propagation/tc10_java_per_call_headers/test.yaml
+++ b/tests/integration/suites/uc11_header_propagation/tc10_java_per_call_headers/test.yaml
@@ -44,7 +44,7 @@ test:
   - name: "Start header-echo-java agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start /workspace/header-echo-java --env MCP_MESH_PROPAGATE_HEADERS=x-audit -d"
+    command: "meshctl start /workspace/header-echo-java --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
     capture: start_echo
 
   # Wait for echo agent to register (Java is slow to start)
@@ -69,7 +69,7 @@ test:
   - name: "Start header-relay-java agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start /workspace/header-relay-java --env MCP_MESH_PROPAGATE_HEADERS=x-audit -d"
+    command: "meshctl start /workspace/header-relay-java --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
     capture: start_relay
 
   # Wait for relay agent to register

--- a/tests/integration/suites/uc11_header_propagation/tc11_mixed_py_ts_per_call_headers/test.yaml
+++ b/tests/integration/suites/uc11_header_propagation/tc11_mixed_py_ts_per_call_headers/test.yaml
@@ -46,7 +46,7 @@ test:
   - name: "Start header-echo-ts agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-echo-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3044 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
+    command: "meshctl start header-echo-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3044 --env 'MCP_MESH_PROPAGATE_HEADERS=x-audit-*' -d"
     capture: start_echo
 
   # Wait for echo agent to register
@@ -71,7 +71,7 @@ test:
   - name: "Start header-relay-py agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-relay-py/main.py --env MCP_MESH_HTTP_PORT=3045 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
+    command: "meshctl start header-relay-py/main.py --env MCP_MESH_HTTP_PORT=3045 --env 'MCP_MESH_PROPAGATE_HEADERS=x-audit-*' -d"
     capture: start_relay
 
   # Wait for relay agent to register

--- a/tests/integration/suites/uc11_header_propagation/tc11_mixed_py_ts_per_call_headers/test.yaml
+++ b/tests/integration/suites/uc11_header_propagation/tc11_mixed_py_ts_per_call_headers/test.yaml
@@ -46,7 +46,7 @@ test:
   - name: "Start header-echo-ts agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-echo-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3044 --env MCP_MESH_PROPAGATE_HEADERS=x-audit -d"
+    command: "meshctl start header-echo-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3044 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
     capture: start_echo
 
   # Wait for echo agent to register
@@ -71,7 +71,7 @@ test:
   - name: "Start header-relay-py agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-relay-py/main.py --env MCP_MESH_HTTP_PORT=3045 --env MCP_MESH_PROPAGATE_HEADERS=x-audit -d"
+    command: "meshctl start header-relay-py/main.py --env MCP_MESH_HTTP_PORT=3045 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
     capture: start_relay
 
   # Wait for relay agent to register

--- a/tests/integration/suites/uc11_header_propagation/tc12_mixed_ts_py_per_call_headers/test.yaml
+++ b/tests/integration/suites/uc11_header_propagation/tc12_mixed_ts_py_per_call_headers/test.yaml
@@ -46,7 +46,7 @@ test:
   - name: "Start header-echo-py agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-echo-py/main.py --env MCP_MESH_HTTP_PORT=3046 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
+    command: "meshctl start header-echo-py/main.py --env MCP_MESH_HTTP_PORT=3046 --env 'MCP_MESH_PROPAGATE_HEADERS=x-audit-*' -d"
     capture: start_echo
 
   # Wait for echo agent to register
@@ -71,7 +71,7 @@ test:
   - name: "Start header-relay-ts agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-relay-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3047 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
+    command: "meshctl start header-relay-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3047 --env 'MCP_MESH_PROPAGATE_HEADERS=x-audit-*' -d"
     capture: start_relay
 
   # Wait for relay agent to register

--- a/tests/integration/suites/uc11_header_propagation/tc12_mixed_ts_py_per_call_headers/test.yaml
+++ b/tests/integration/suites/uc11_header_propagation/tc12_mixed_ts_py_per_call_headers/test.yaml
@@ -46,7 +46,7 @@ test:
   - name: "Start header-echo-py agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-echo-py/main.py --env MCP_MESH_HTTP_PORT=3046 --env MCP_MESH_PROPAGATE_HEADERS=x-audit -d"
+    command: "meshctl start header-echo-py/main.py --env MCP_MESH_HTTP_PORT=3046 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
     capture: start_echo
 
   # Wait for echo agent to register
@@ -71,7 +71,7 @@ test:
   - name: "Start header-relay-ts agent"
     handler: shell
     workdir: /workspace
-    command: "meshctl start header-relay-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3047 --env MCP_MESH_PROPAGATE_HEADERS=x-audit -d"
+    command: "meshctl start header-relay-ts/src/index.ts --env MCP_MESH_HTTP_PORT=3047 --env MCP_MESH_PROPAGATE_HEADERS=x-audit-* -d"
     capture: start_relay
 
   # Wait for relay agent to register

--- a/tests/integration/suites/uc11_header_propagation/tc13_non_allowlisted_dropped/artifacts/header-echo-py/main.py
+++ b/tests/integration/suites/uc11_header_propagation/tc13_non_allowlisted_dropped/artifacts/header-echo-py/main.py
@@ -1,0 +1,26 @@
+import json
+
+import mesh
+from _mcp_mesh.tracing.context import TraceContext
+from fastmcp import FastMCP
+
+app = FastMCP("Header Echo Agent")
+
+
+@app.tool()
+@mesh.tool(capability="echo_headers", description="Return propagated headers")
+async def echo_headers() -> str:
+    headers = TraceContext.get_propagated_headers()
+    return json.dumps(headers)
+
+
+@mesh.agent(
+    name="header-echo",
+    version="1.0.0",
+    description="Echo agent for header propagation testing",
+    http_port=0,
+    enable_http=True,
+    auto_run=True,
+)
+class HeaderEchoAgent:
+    pass

--- a/tests/integration/suites/uc11_header_propagation/tc13_non_allowlisted_dropped/artifacts/header-relay-py/main.py
+++ b/tests/integration/suites/uc11_header_propagation/tc13_non_allowlisted_dropped/artifacts/header-relay-py/main.py
@@ -1,0 +1,37 @@
+import mesh
+from fastmcp import FastMCP
+from mesh.types import McpMeshTool
+
+app = FastMCP("Header Relay Agent")
+
+
+@app.tool()
+@mesh.tool(
+    capability="relay_headers",
+    description="Call echo_headers and return result",
+    dependencies=["echo_headers"],
+)
+async def relay_headers(echo_svc: McpMeshTool = None) -> str:
+    if echo_svc is None:
+        return '{"error": "echo_headers dependency not available"}'
+    # If x-audit-id not already propagated, inject it via per-call headers
+    from _mcp_mesh.tracing.context import TraceContext
+
+    propagated = TraceContext.get_propagated_headers()
+    if "x-audit-id" not in propagated:
+        result = await echo_svc(headers={"x-audit-id": "injected-by-relay-py"})
+    else:
+        result = await echo_svc()
+    return str(result)
+
+
+@mesh.agent(
+    name="header-relay",
+    version="1.0.0",
+    description="Relay agent for header propagation testing",
+    http_port=0,
+    enable_http=True,
+    auto_run=True,
+)
+class HeaderRelayAgent:
+    pass

--- a/tests/integration/suites/uc11_header_propagation/tc13_non_allowlisted_dropped/test.yaml
+++ b/tests/integration/suites/uc11_header_propagation/tc13_non_allowlisted_dropped/test.yaml
@@ -1,0 +1,143 @@
+# Test Case: Non-Allowlisted Headers Dropped (#790)
+# Verifies that headers NOT in MCP_MESH_PROPAGATE_HEADERS are stripped by
+# the propagation layer.
+#
+# Scenario:
+#   - Allowlist: x-custom-auth, x-tenant-id (both exact-match)
+#   - Client sends an extra header x-not-allowed: secret
+#   - Assert: downstream echo response contains the allowlisted values,
+#     but NOT the leaked secret or the x-not-allowed header name.
+
+name: "Non-Allowlisted Headers Dropped"
+description: "Verify headers outside MCP_MESH_PROPAGATE_HEADERS are not propagated"
+tags:
+  - header_propagation
+  - python
+  - security
+  - issue_790
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  - name: "Copy artifacts to workspace"
+    handler: shell
+    command: "cp -r /artifacts/* /workspace/"
+
+  - name: "Start header-echo agent"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start header-echo-py/main.py --env MCP_MESH_HTTP_PORT=3130 --env MCP_MESH_PROPAGATE_HEADERS=x-custom-auth,x-tenant-id -d"
+    capture: start_echo
+
+  - name: "Wait for header-echo registration"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 20); do
+        if meshctl list 2>/dev/null | grep -q "header-echo"; then
+          echo "header-echo registered after ${i}s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: header-echo did not register within 40s"
+      meshctl logs header-echo 2>/dev/null | tail -20 || true
+      exit 1
+    capture: wait_echo
+    timeout: 60
+
+  - name: "Start header-relay agent"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start header-relay-py/main.py --env MCP_MESH_HTTP_PORT=3131 --env MCP_MESH_PROPAGATE_HEADERS=x-custom-auth,x-tenant-id -d"
+    capture: start_relay
+
+  - name: "Wait for header-relay registration"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 20); do
+        if meshctl list 2>/dev/null | grep -q "header-relay"; then
+          echo "header-relay registered after ${i}s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: header-relay did not register within 40s"
+      meshctl logs header-relay 2>/dev/null | tail -20 || true
+      exit 1
+    capture: wait_relay
+    timeout: 60
+
+  - name: "Wait for dependency wiring"
+    handler: wait
+    seconds: 5
+
+  - name: "Get relay agent port"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl list --json 2>/dev/null | python -c "import sys,json; data=json.load(sys.stdin); ports=[a[''endpoint''].split('':'')[-1] for a in data.get(''agents'',[]) if ''header-relay'' in a.get(''name'','''')]; print(ports[0] if ports else ''3131'')"'
+    capture: relay_port
+
+  - name: "Call relay with allowlisted + non-allowlisted headers"
+    handler: shell
+    workdir: /workspace
+    command: |
+      PORT=${captured.relay_port}
+      curl -s -X POST http://localhost:${PORT}/mcp \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json, text/event-stream" \
+        -H "X-Custom-Auth: allowed-token" \
+        -H "X-Tenant-Id: tenant-xyz" \
+        -H "X-Not-Allowed: super-secret-should-not-leak" \
+        -H "Cookie: session=should-not-leak" \
+        -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"relay_headers","arguments":{}}}'
+    capture: curl_result
+    timeout: 30
+
+  - name: "Get header-echo logs"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl logs header-echo 2>/dev/null | tail -20 || echo 'no echo logs'"
+    capture: echo_logs
+
+  - name: "Get header-relay logs"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl logs header-relay 2>/dev/null | tail -20 || echo 'no relay logs'"
+    capture: relay_logs
+
+  - name: "Stop all agents"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl stop 2>/dev/null || true"
+
+assertions:
+  # Sanity: allowlisted headers DO propagate
+  - expr: "${captured.curl_result} contains 'allowed-token'"
+    message: "Allowlisted X-Custom-Auth value should appear in echoed headers"
+
+  - expr: "${captured.curl_result} contains 'tenant-xyz'"
+    message: "Allowlisted X-Tenant-Id value should appear in echoed headers"
+
+  # Core assertion: non-allowlisted header must NOT propagate
+  - expr: "${captured.curl_result} not contains 'super-secret-should-not-leak'"
+    message: "Non-allowlisted X-Not-Allowed value must NOT leak through"
+
+  - expr: "${captured.curl_result} not contains 'x-not-allowed'"
+    message: "Non-allowlisted header name must NOT appear in echoed headers"
+
+  - expr: "${captured.curl_result} not contains 'should-not-leak'"
+    message: "Cookie value must NOT leak through (not in allowlist)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop 2>/dev/null || true
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc11_header_propagation/tc14_prefix_match_isolation/artifacts/header-echo-py/main.py
+++ b/tests/integration/suites/uc11_header_propagation/tc14_prefix_match_isolation/artifacts/header-echo-py/main.py
@@ -1,0 +1,26 @@
+import json
+
+import mesh
+from _mcp_mesh.tracing.context import TraceContext
+from fastmcp import FastMCP
+
+app = FastMCP("Header Echo Agent")
+
+
+@app.tool()
+@mesh.tool(capability="echo_headers", description="Return propagated headers")
+async def echo_headers() -> str:
+    headers = TraceContext.get_propagated_headers()
+    return json.dumps(headers)
+
+
+@mesh.agent(
+    name="header-echo",
+    version="1.0.0",
+    description="Echo agent for header propagation testing",
+    http_port=0,
+    enable_http=True,
+    auto_run=True,
+)
+class HeaderEchoAgent:
+    pass

--- a/tests/integration/suites/uc11_header_propagation/tc14_prefix_match_isolation/artifacts/header-relay-py/main.py
+++ b/tests/integration/suites/uc11_header_propagation/tc14_prefix_match_isolation/artifacts/header-relay-py/main.py
@@ -1,0 +1,37 @@
+import mesh
+from fastmcp import FastMCP
+from mesh.types import McpMeshTool
+
+app = FastMCP("Header Relay Agent")
+
+
+@app.tool()
+@mesh.tool(
+    capability="relay_headers",
+    description="Call echo_headers and return result",
+    dependencies=["echo_headers"],
+)
+async def relay_headers(echo_svc: McpMeshTool = None) -> str:
+    if echo_svc is None:
+        return '{"error": "echo_headers dependency not available"}'
+    # If x-audit-id not already propagated, inject it via per-call headers
+    from _mcp_mesh.tracing.context import TraceContext
+
+    propagated = TraceContext.get_propagated_headers()
+    if "x-audit-id" not in propagated:
+        result = await echo_svc(headers={"x-audit-id": "injected-by-relay-py"})
+    else:
+        result = await echo_svc()
+    return str(result)
+
+
+@mesh.agent(
+    name="header-relay",
+    version="1.0.0",
+    description="Relay agent for header propagation testing",
+    http_port=0,
+    enable_http=True,
+    auto_run=True,
+)
+class HeaderRelayAgent:
+    pass

--- a/tests/integration/suites/uc11_header_propagation/tc14_prefix_match_isolation/test.yaml
+++ b/tests/integration/suites/uc11_header_propagation/tc14_prefix_match_isolation/test.yaml
@@ -1,0 +1,154 @@
+# Test Case: Prefix-match Isolation (#790)
+# Verifies the new exact-vs-prefix allowlist semantics:
+#   - Plain token (e.g. "x-auth-exact") matches only the exact header name.
+#   - Token with trailing "*" (e.g. "x-trace-*") matches any header that
+#     starts with the prefix before the star.
+#
+# Scenario:
+#   Allowlist: x-trace-*,x-auth-exact
+#   Request headers sent by the client:
+#     - X-Trace-Id:               abc   (prefix match, propagates)
+#     - X-Trace-Parent:           def   (prefix match, propagates)
+#     - X-Auth-Exact:             ghi   (exact match, propagates)
+#     - X-Auth-Exact-But-Longer:  jkl   (NOT allowed — would have matched
+#                                         under old prefix-by-default rules)
+#     - X-Trace:                  mno   (does NOT match "x-trace-*" because
+#                                         the prefix is "x-trace-" not "x-trace")
+
+name: "Prefix-match Isolation"
+description: "Validate exact vs prefix (trailing *) allowlist semantics"
+tags:
+  - header_propagation
+  - python
+  - security
+  - issue_790
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  - name: "Copy artifacts to workspace"
+    handler: shell
+    command: "cp -r /artifacts/* /workspace/"
+
+  - name: "Start header-echo agent"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start header-echo-py/main.py --env MCP_MESH_HTTP_PORT=3140 --env 'MCP_MESH_PROPAGATE_HEADERS=x-trace-*,x-auth-exact' -d"
+    capture: start_echo
+
+  - name: "Wait for header-echo registration"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 20); do
+        if meshctl list 2>/dev/null | grep -q "header-echo"; then
+          echo "header-echo registered after ${i}s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: header-echo did not register within 40s"
+      meshctl logs header-echo 2>/dev/null | tail -20 || true
+      exit 1
+    capture: wait_echo
+    timeout: 60
+
+  - name: "Start header-relay agent"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start header-relay-py/main.py --env MCP_MESH_HTTP_PORT=3141 --env 'MCP_MESH_PROPAGATE_HEADERS=x-trace-*,x-auth-exact' -d"
+    capture: start_relay
+
+  - name: "Wait for header-relay registration"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 20); do
+        if meshctl list 2>/dev/null | grep -q "header-relay"; then
+          echo "header-relay registered after ${i}s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: header-relay did not register within 40s"
+      meshctl logs header-relay 2>/dev/null | tail -20 || true
+      exit 1
+    capture: wait_relay
+    timeout: 60
+
+  - name: "Wait for dependency wiring"
+    handler: wait
+    seconds: 5
+
+  - name: "Get relay agent port"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl list --json 2>/dev/null | python -c "import sys,json; data=json.load(sys.stdin); ports=[a[''endpoint''].split('':'')[-1] for a in data.get(''agents'',[]) if ''header-relay'' in a.get(''name'','''')]; print(ports[0] if ports else ''3141'')"'
+    capture: relay_port
+
+  - name: "Call relay with a mix of prefix / exact / non-matching headers"
+    handler: shell
+    workdir: /workspace
+    command: |
+      PORT=${captured.relay_port}
+      curl -s -X POST http://localhost:${PORT}/mcp \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json, text/event-stream" \
+        -H "X-Trace-Id: trace-value-abc" \
+        -H "X-Trace-Parent: trace-value-def" \
+        -H "X-Auth-Exact: auth-value-ghi" \
+        -H "X-Auth-Exact-But-Longer: leak-value-jkl" \
+        -H "X-Trace: short-value-mno" \
+        -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"relay_headers","arguments":{}}}'
+    capture: curl_result
+    timeout: 30
+
+  - name: "Get header-echo logs"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl logs header-echo 2>/dev/null | tail -20 || echo 'no echo logs'"
+    capture: echo_logs
+
+  - name: "Get header-relay logs"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl logs header-relay 2>/dev/null | tail -20 || echo 'no relay logs'"
+    capture: relay_logs
+
+  - name: "Stop all agents"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl stop 2>/dev/null || true"
+
+assertions:
+  # Prefix-match headers must propagate.
+  - expr: "${captured.curl_result} contains 'trace-value-abc'"
+    message: "X-Trace-Id (prefix match on x-trace-*) should propagate"
+
+  - expr: "${captured.curl_result} contains 'trace-value-def'"
+    message: "X-Trace-Parent (prefix match on x-trace-*) should propagate"
+
+  # Exact-match header must propagate.
+  - expr: "${captured.curl_result} contains 'auth-value-ghi'"
+    message: "X-Auth-Exact (exact match) should propagate"
+
+  # The longer variant of an exact-match entry must NOT propagate.
+  - expr: "${captured.curl_result} not contains 'leak-value-jkl'"
+    message: "X-Auth-Exact-But-Longer must NOT propagate (exact token is exact-only)"
+
+  # A header matching the base of a prefix entry but without the trailing
+  # dash must NOT propagate (prefix is literally "x-trace-", not "x-trace").
+  - expr: "${captured.curl_result} not contains 'short-value-mno'"
+    message: "X-Trace must NOT propagate (x-trace-* requires the dash)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop 2>/dev/null || true
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc12_registration_trust/tc19_entity_id_reassignment_rejected/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc19_entity_id_reassignment_rejected/test.yaml
@@ -18,6 +18,7 @@ test:
   - name: "Copy Python agent to workspace"
     handler: shell
     command: |
+      set -euo pipefail
       cp /uc-artifacts/py-system-agent /workspace/system_agent.py
       ls -la /workspace/
     capture: copy_output
@@ -35,7 +36,8 @@ test:
   - name: "Capture legitimate agent id and entity_id from registry"
     handler: shell
     command: |
-      curl -sk https://localhost:8000/agents > /tmp/agents_before.json
+      set -euo pipefail
+      curl -s --cacert $HOME/.mcp-mesh/tls/ca.pem https://localhost:8000/agents > /tmp/agents_before.json
       cat /tmp/agents_before.json
       echo ""
       LEGIT_AGENT_ID=$(python3 -c "
@@ -56,6 +58,11 @@ test:
               print(a['entity_id'])
               break
       ")
+      if [ -z "$LEGIT_AGENT_ID" ] || [ -z "$LEGIT_ENTITY_ID" ]; then
+          echo "ERROR: Failed to extract legitimate agent id/entity_id from registry response"
+          cat /tmp/agents_before.json
+          exit 1
+      fi
       echo "LEGIT_AGENT_ID=$LEGIT_AGENT_ID"
       echo "LEGIT_ENTITY_ID=$LEGIT_ENTITY_ID"
       # Persist for later steps
@@ -67,6 +74,7 @@ test:
   - name: "Generate rogue CA and client certificate"
     handler: shell
     command: |
+      set -euo pipefail
       mkdir -p /tmp/rogue-certs
       cd /tmp/rogue-certs
       # Generate rogue CA (different trust root, will be registered as rogue-corp)
@@ -88,6 +96,7 @@ test:
   - name: "Register rogue CA as trusted entity rogue-corp"
     handler: shell
     command: |
+      set -euo pipefail
       meshctl entity register rogue-corp --ca-cert /tmp/rogue-certs/rogue-ca.pem
       echo "REGISTER_EXIT=$?"
       meshctl entity list
@@ -101,6 +110,7 @@ test:
   - name: "Attempt heartbeat with rogue cert claiming legitimate agent_id"
     handler: shell
     command: |
+      set -euo pipefail
       LEGIT_AGENT_ID=$(cat /tmp/legit_agent_id.txt)
       echo "Attempting to hijack agent_id: $LEGIT_AGENT_ID"
       # Build minimal heartbeat body per MeshAgentRegistration schema.
@@ -113,7 +123,7 @@ test:
       EOF
       cat /tmp/hijack_body.json
       echo ""
-      HIJACK_CODE=$(curl -sk -o /tmp/hijack_body_resp -w "%{http_code}" \
+      HIJACK_CODE=$(curl -s -o /tmp/hijack_body_resp -w "%{http_code}" \
         --cert /tmp/rogue-certs/rogue-client-cert.pem \
         --key /tmp/rogue-certs/rogue-client-key.pem \
         --cacert $HOME/.mcp-mesh/tls/ca.pem \
@@ -130,9 +140,10 @@ test:
   - name: "Verify legitimate agent entity_id is unchanged"
     handler: shell
     command: |
+      set -euo pipefail
       LEGIT_AGENT_ID=$(cat /tmp/legit_agent_id.txt)
       LEGIT_ENTITY_ID=$(cat /tmp/legit_entity_id.txt)
-      curl -sk https://localhost:8000/agents > /tmp/agents_after.json
+      curl -s --cacert $HOME/.mcp-mesh/tls/ca.pem https://localhost:8000/agents > /tmp/agents_after.json
       AFTER_ENTITY_ID=$(python3 -c "
       import sys, json
       with open('/tmp/agents_after.json') as f:
@@ -165,11 +176,11 @@ assertions:
   - expr: "${captured.rogue_register} contains 'registered'"
     message: "Rogue CA should be registered as trusted entity rogue-corp"
 
-  - expr: "${captured.legit_info} contains 'LEGIT_AGENT_ID='"
-    message: "Legitimate agent id should be captured from registry"
+  - expr: "${captured.legit_info} contains 'LEGIT_AGENT_ID=system-agent-'"
+    message: "Legitimate agent id should be captured from registry (non-empty, with expected prefix)"
 
-  - expr: "${captured.legit_info} contains 'LEGIT_ENTITY_ID=local-dev'"
-    message: "Legitimate agent should have entity_id=local-dev from mTLS registration"
+  - expr: "${captured.legit_info} matches 'LEGIT_ENTITY_ID=[a-zA-Z0-9_-]+'"
+    message: "Legitimate agent should have a non-empty entity_id from mTLS registration"
 
   - expr: "${captured.hijack_attempt} contains 'HIJACK_CODE=403'"
     message: "Registry should return 403 Forbidden when rogue entity attempts to hijack legitimate agent"

--- a/tests/integration/suites/uc12_registration_trust/tc19_entity_id_reassignment_rejected/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc19_entity_id_reassignment_rejected/test.yaml
@@ -1,0 +1,191 @@
+name: "Entity ID Reassignment Rejected - Spoofing Prevention"
+description: "Verify registry rejects heartbeat from a different entity attempting to hijack an existing agent_id (issue #789)"
+tags:
+  - registration-trust
+  - tls
+  - security
+  - spoofing
+  - python
+timeout: 300
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy Python agent to workspace"
+    handler: shell
+    command: |
+      cp /uc-artifacts/py-system-agent /workspace/system_agent.py
+      ls -la /workspace/
+    capture: copy_output
+
+  - name: "Start registry and legitimate agent with TLS auto"
+    handler: shell
+    command: "meshctl start system_agent.py --tls-auto -d"
+    workdir: /workspace
+    capture: legit_start
+
+  - name: "Wait for legitimate agent to register"
+    handler: wait
+    seconds: 10
+
+  - name: "Capture legitimate agent id and entity_id from registry"
+    handler: shell
+    command: |
+      curl -sk https://localhost:8000/agents > /tmp/agents_before.json
+      cat /tmp/agents_before.json
+      echo ""
+      LEGIT_AGENT_ID=$(python3 -c "
+      import sys, json
+      with open('/tmp/agents_before.json') as f:
+          data = json.load(f)
+      for a in data.get('agents', []):
+          if 'system-agent' in a.get('name', '') and a.get('entity_id'):
+              print(a['id'])
+              break
+      ")
+      LEGIT_ENTITY_ID=$(python3 -c "
+      import sys, json
+      with open('/tmp/agents_before.json') as f:
+          data = json.load(f)
+      for a in data.get('agents', []):
+          if 'system-agent' in a.get('name', '') and a.get('entity_id'):
+              print(a['entity_id'])
+              break
+      ")
+      echo "LEGIT_AGENT_ID=$LEGIT_AGENT_ID"
+      echo "LEGIT_ENTITY_ID=$LEGIT_ENTITY_ID"
+      # Persist for later steps
+      echo "$LEGIT_AGENT_ID" > /tmp/legit_agent_id.txt
+      echo "$LEGIT_ENTITY_ID" > /tmp/legit_entity_id.txt
+    workdir: /workspace
+    capture: legit_info
+
+  - name: "Generate rogue CA and client certificate"
+    handler: shell
+    command: |
+      mkdir -p /tmp/rogue-certs
+      cd /tmp/rogue-certs
+      # Generate rogue CA (different trust root, will be registered as rogue-corp)
+      openssl req -x509 -newkey rsa:2048 \
+        -keyout rogue-ca-key.pem -out rogue-ca.pem \
+        -days 1 -nodes -subj "/CN=rogue-ca" 2>&1
+      # Generate rogue client CSR
+      openssl req -newkey rsa:2048 \
+        -keyout rogue-client-key.pem -out rogue-client.csr \
+        -nodes -subj "/CN=rogue-client" 2>&1
+      # Sign rogue client cert with rogue CA
+      openssl x509 -req -in rogue-client.csr \
+        -CA rogue-ca.pem -CAkey rogue-ca-key.pem \
+        -CAcreateserial -out rogue-client-cert.pem -days 1 2>&1
+      echo "ROGUE_CERTS_GENERATED=true"
+      ls -la /tmp/rogue-certs/
+    capture: rogue_certs
+
+  - name: "Register rogue CA as trusted entity rogue-corp"
+    handler: shell
+    command: |
+      meshctl entity register rogue-corp --ca-cert /tmp/rogue-certs/rogue-ca.pem
+      echo "REGISTER_EXIT=$?"
+      meshctl entity list
+      ls -la $HOME/.mcp-mesh/tls/entities/
+    capture: rogue_register
+
+  - name: "Wait for filestore to pick up the new entity"
+    handler: wait
+    seconds: 5
+
+  - name: "Attempt heartbeat with rogue cert claiming legitimate agent_id"
+    handler: shell
+    command: |
+      LEGIT_AGENT_ID=$(cat /tmp/legit_agent_id.txt)
+      echo "Attempting to hijack agent_id: $LEGIT_AGENT_ID"
+      # Build minimal heartbeat body per MeshAgentRegistration schema.
+      # Tools array is required; send empty list.
+      cat > /tmp/hijack_body.json <<EOF
+      {
+        "agent_id": "$LEGIT_AGENT_ID",
+        "tools": []
+      }
+      EOF
+      cat /tmp/hijack_body.json
+      echo ""
+      HIJACK_CODE=$(curl -sk -o /tmp/hijack_body_resp -w "%{http_code}" \
+        --cert /tmp/rogue-certs/rogue-client-cert.pem \
+        --key /tmp/rogue-certs/rogue-client-key.pem \
+        --cacert $HOME/.mcp-mesh/tls/ca.pem \
+        -H "Content-Type: application/json" \
+        -X POST \
+        --data @/tmp/hijack_body.json \
+        https://localhost:8000/heartbeat)
+      HIJACK_BODY=$(cat /tmp/hijack_body_resp 2>/dev/null || true)
+      echo "HIJACK_CODE=$HIJACK_CODE"
+      echo "HIJACK_BODY=$HIJACK_BODY"
+    workdir: /workspace
+    capture: hijack_attempt
+
+  - name: "Verify legitimate agent entity_id is unchanged"
+    handler: shell
+    command: |
+      LEGIT_AGENT_ID=$(cat /tmp/legit_agent_id.txt)
+      LEGIT_ENTITY_ID=$(cat /tmp/legit_entity_id.txt)
+      curl -sk https://localhost:8000/agents > /tmp/agents_after.json
+      AFTER_ENTITY_ID=$(python3 -c "
+      import sys, json
+      with open('/tmp/agents_after.json') as f:
+          data = json.load(f)
+      for a in data.get('agents', []):
+          if a.get('id') == '$LEGIT_AGENT_ID':
+              print(a.get('entity_id', ''))
+              break
+      ")
+      echo "BEFORE_ENTITY_ID=$LEGIT_ENTITY_ID"
+      echo "AFTER_ENTITY_ID=$AFTER_ENTITY_ID"
+      if [ "$LEGIT_ENTITY_ID" = "$AFTER_ENTITY_ID" ] && [ -n "$LEGIT_ENTITY_ID" ]; then
+        echo "ENTITY_ID_UNCHANGED=true"
+      else
+        echo "ENTITY_ID_UNCHANGED=false"
+      fi
+    workdir: /workspace
+    capture: verify_unchanged
+
+  - name: "Stop all"
+    handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+
+assertions:
+  - expr: "${captured.rogue_certs} contains 'ROGUE_CERTS_GENERATED=true'"
+    message: "Rogue CA and client certificate should be generated"
+
+  - expr: "${captured.rogue_register} contains 'registered'"
+    message: "Rogue CA should be registered as trusted entity rogue-corp"
+
+  - expr: "${captured.legit_info} contains 'LEGIT_AGENT_ID='"
+    message: "Legitimate agent id should be captured from registry"
+
+  - expr: "${captured.legit_info} contains 'LEGIT_ENTITY_ID=local-dev'"
+    message: "Legitimate agent should have entity_id=local-dev from mTLS registration"
+
+  - expr: "${captured.hijack_attempt} contains 'HIJACK_CODE=403'"
+    message: "Registry should return 403 Forbidden when rogue entity attempts to hijack legitimate agent"
+
+  - expr: "${captured.hijack_attempt} contains 'entity_id mismatch'"
+    message: "Response body should indicate entity_id mismatch (proves our check ran, not the TLS untrusted-cert short-circuit)"
+
+  - expr: "${captured.verify_unchanged} contains 'ENTITY_ID_UNCHANGED=true'"
+    message: "Legitimate agent's entity_id must remain unchanged after hijack attempt"
+
+post_run:
+  - handler: shell
+    command: |
+      meshctl stop 2>/dev/null || true
+      meshctl entity revoke rogue-corp --force 2>/dev/null || true
+      rm -rf /tmp/rogue-certs /tmp/agents_before.json /tmp/agents_after.json /tmp/legit_agent_id.txt /tmp/legit_entity_id.txt /tmp/hijack_body.json /tmp/hijack_body_resp 2>/dev/null || true
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc12_registration_trust/tc21_auto_mode_missing_cert_fails_fast/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc21_auto_mode_missing_cert_fails_fast/test.yaml
@@ -1,0 +1,87 @@
+name: "Auto Mode - Fail Fast When Cert/Key Missing"
+description: "Verify registry in MCP_MESH_TLS_MODE=auto refuses to start with plaintext fallback when cert/key env vars are missing (issue #791)"
+tags:
+  - registration-trust
+  - tls
+  - auto
+  - security
+  - python
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Start registry with TLS auto but NO cert/key configured"
+    handler: shell
+    command: |
+      # Launch registry binary directly in the background with auto TLS mode
+      # but WITHOUT MCP_MESH_TLS_CERT/KEY env vars. Expectation: exits fast
+      # with an error mentioning MCP_MESH_TLS_CERT, instead of silently
+      # falling back to plaintext HTTP.
+      unset MCP_MESH_TLS_CERT
+      unset MCP_MESH_TLS_KEY
+      MCP_MESH_TLS_MODE=auto \
+      mcp-mesh-registry --host localhost --port 8000 >/tmp/registry-auto-nocert.log 2>&1 &
+      REGISTRY_PID=$!
+      echo "$REGISTRY_PID" > /tmp/tc21_registry.pid
+      echo "REGISTRY_PID=$REGISTRY_PID"
+      # Give the process a moment to either fail or start listening
+      sleep 3
+      if kill -0 "$REGISTRY_PID" 2>/dev/null; then
+        echo "REGISTRY_STILL_RUNNING=true"
+      else
+        wait "$REGISTRY_PID" 2>/dev/null
+        EXIT_CODE=$?
+        echo "REGISTRY_EXIT_CODE=$EXIT_CODE"
+      fi
+      echo "--- registry log ---"
+      cat /tmp/registry-auto-nocert.log || true
+    capture: registry_start
+
+  - name: "Verify registry is NOT listening on port 8000 (no plaintext fallback)"
+    handler: shell
+    command: |
+      # Any response (HTTPS or HTTP) means the registry is up and serving,
+      # which is a bug. A failed connection (000) is what we want.
+      HTTPS_CODE=$(curl -sk -o /dev/null -w "%{http_code}" --max-time 3 https://localhost:8000/health 2>/dev/null || echo "000")
+      HTTP_CODE=$(curl -s  -o /dev/null -w "%{http_code}" --max-time 3 http://localhost:8000/health  2>/dev/null || echo "000")
+      echo "HTTPS_CODE=$HTTPS_CODE"
+      echo "HTTP_CODE=$HTTP_CODE"
+    capture: port_check
+
+  - name: "Stop registry if somehow still running"
+    handler: shell
+    command: |
+      REGISTRY_PID=$(cat /tmp/tc21_registry.pid 2>/dev/null)
+      if [ -n "$REGISTRY_PID" ]; then kill "$REGISTRY_PID" 2>/dev/null || true; fi
+      meshctl stop 2>/dev/null || true
+    ignore_errors: true
+
+assertions:
+  - expr: "${captured.registry_start} not contains 'REGISTRY_STILL_RUNNING=true'"
+    message: "Registry must exit fast in auto mode when cert/key are not configured (no plaintext fallback)"
+
+  - expr: "${captured.registry_start} contains 'MCP_MESH_TLS_CERT'"
+    message: "Error message should mention MCP_MESH_TLS_CERT so the operator knows what to set"
+
+  - expr: "${captured.registry_start} contains 'requires'"
+    message: "Error message should state that the TLS mode 'requires' cert/key"
+
+  - expr: "${captured.port_check} contains 'HTTP_CODE=000'"
+    message: "Registry must not be serving plaintext HTTP on port 8000"
+
+  - expr: "${captured.port_check} contains 'HTTPS_CODE=000'"
+    message: "Registry must not be serving HTTPS on port 8000 either (it should have exited)"
+
+post_run:
+  - handler: shell
+    command: |
+      REGISTRY_PID=$(cat /tmp/tc21_registry.pid 2>/dev/null)
+      if [ -n "$REGISTRY_PID" ]; then kill "$REGISTRY_PID" 2>/dev/null || true; fi
+      meshctl stop 2>/dev/null || true
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

Closes 7 audit-derived issues across the registry, runtime SDKs, and release workflow. Verified locally and via tsuite (5 new + 5 modified test cases, 0 regressions in tc01-tc18 trust suite).

### Registry (Go)
- **#789** Reject heartbeats whose claimed `agent_id` belongs to a different entity than the cert's verified `entity_id`. Check enforced in BOTH `UpdateHeartbeat` and `RegisterAgent`'s update branch (closes a race where heartbeat-for-unknown-agent escalates into RegisterAgent and a concurrent legit registration claims the agent_id). New `ErrEntityIDMismatch` returned as HTTP 403 with sanitized body; `errors.Is` propagation through the heartbeat→register path.
- **#791** TLS `auto` mode no longer silently falls back to plaintext when certs are missing — fails fast with actionable error.
- **#794** Proxy TLS error responses no longer leak file paths in HTTP body; full detail kept server-side.
- **#806** Filestore trust backend race fix: when `entities/` directory is created at runtime, immediately `loadAll()` to catch PEM files written before the watch was established.

### Header propagation
- **#790** `MCP_MESH_PROPAGATE_HEADERS` allowlist switched from prefix-by-default to **exact-match-by-default**. Trailing `*` opts into prefix matching. Bare `*` (and any zero-length prefix) is rejected at parse time. Rust core + Go registry both updated; SDK docstrings refreshed (Python/TypeScript/Java SDKs delegate to Rust core, no behavior change).

### meshctl
- **#805** `--tls-auto` now sets `MCP_MESH_TRUST_BACKEND=localca,filestore` for the registry so `meshctl entity register` actually has effect at runtime. Agent trust scope intentionally remains `localca` only — registry validates entity-CA-signed peer certs, agents validate via local-dev CA only.

### CI
- **#802** Release workflow GPG key handling hardened: pass via env var (avoids shell-quoting risks), explicit `::add-mask::` directive, `printf '%s'` instead of `echo`. Defense-in-depth — no actual leak confirmed.

### ⚠️ Breaking changes (intentional)
1. `MCP_MESH_PROPAGATE_HEADERS` semantics: `auth` no longer matches `authorization`. Use `authorization` (exact) or `auth-*` (prefix). Migration note in `src/core/cli/man/content/headers.md`.
2. TLS `auto` mode no longer silently downgrades to plaintext.

## Review Notes

Reviewed by review-agent: 0 blockers, 0 warnings on the amended commit. Initial review found 1 BLOCKER (entity check missing from RegisterAgent's update path — race condition) + 2 critical warnings (bare-`*` match-all, agent-side trust expansion); all addressed before this PR was opened.

Out-of-scope follow-ups identified during review (separate issues to file):
- `tls_middleware.go` returns raw backend error in 403 detail — same #794 leak class, different code path
- `ent_handlers.go:638` proxy reach-error still returns raw `err.Error()` (sanitization in #794 only covered TLS-config paths)
- Filestore reload could debounce to reduce log noise during burst writes
- tc19 hardcodes `LEGIT_ENTITY_ID=local-dev` — fragile to default-CA name change
- tc21 PATH-dependent registry binary lookup

Closes #789
Closes #790
Closes #791
Closes #794
Closes #802
Closes #805
Closes #806

## Test plan

- [x] Local end-to-end verification (HOME-isolated registry + agent + rogue cert hijack scenario; all 4 fix layers exercised)
- [x] tsuite uc12_registration_trust full suite — 19 of 20 pass, only tc19 PASS (newly added)
- [x] tsuite uc11_header_propagation tc01-tc14 — all pass; tc08-tc12 updated for #790 breaking change
- [x] tsuite uc01_registry tc15 (new — proxy error sanitization) — PASS
- [x] tsuite full integration round 2 rerun: 23 of 26 first-round failures recovered (3 persistent are external Gemini API 429 rate-limits, not regressions)
- [x] `cargo test trace_context` — 28 pass (+3 new for bare-`*` rejection)
- [x] `go build ./...` clean
- [ ] Manual workflow dry-run for #802 GPG key handling (next release branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added entity ID reassignment protection for agent authentication.
  * Enhanced header propagation with exact-match and `*`-suffix prefix-match patterns.
  * Added proxy TLS error sanitization to prevent information leakage.

* **Bug Fixes**
  * TLS certificate/key files now required in non-off modes; removed plaintext fallback.

* **Documentation**
  * Updated header propagation allowlist semantics across SDKs and CLI documentation.
  * Clarified TLS backend configuration behavior.

* **Tests**
  * Added integration tests for entity ID mismatch rejection, header filtering, and TLS certificate validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->