### PR TITLE
fix: apply review-agent feedback from PR #808 (4 items)

### DIFF
--- a/src/core/cli/signal_handler.go
+++ b/src/core/cli/signal_handler.go
@@ -61,16 +61,22 @@ func (sh *SignalHandler) SetShutdownTimeout(timeout time.Duration) {
 
 // StartSignalHandling starts listening for system signals
 func (sh *SignalHandler) StartSignalHandling() {
-	sh.signalChan = make(chan os.Signal, 1)
+	signalChan := make(chan os.Signal, 1)
 
 	// Register for interrupt signals
-	signal.Notify(sh.signalChan,
+	signal.Notify(signalChan,
 		os.Interrupt,    // SIGINT (Ctrl+C)
 		syscall.SIGTERM, // SIGTERM (termination request)
 		syscall.SIGHUP,  // SIGHUP (hangup)
 	)
 
-	go sh.handleSignals(sh.signalChan)
+	// Publish the channel under the mutex so gracefulShutdown's
+	// snapshot read sees a fully-initialized value.
+	sh.mutex.Lock()
+	sh.signalChan = signalChan
+	sh.mutex.Unlock()
+
+	go sh.handleSignals(signalChan)
 	sh.logger.Println("Started signal handling")
 }
 
@@ -97,9 +103,19 @@ func (sh *SignalHandler) gracefulShutdown() {
 		// Stop receiving signals and close the channel so the
 		// handleSignals goroutine exits cleanly (prevents goroutine leak,
 		// notably for SIGHUP which loops in handleSignals).
-		if sh.signalChan != nil {
-			signal.Stop(sh.signalChan)
-			close(sh.signalChan)
+		//
+		// Snapshot the channel under the mutex (writers go through the
+		// same lock in StartSignalHandling), then perform signal.Stop +
+		// close outside the critical section to avoid holding the lock
+		// across a potentially blocking call. Nil out sh.signalChan so
+		// any future caller observes "already torn down".
+		sh.mutex.Lock()
+		ch := sh.signalChan
+		sh.signalChan = nil
+		sh.mutex.Unlock()
+		if ch != nil {
+			signal.Stop(ch)
+			close(ch)
 		}
 
 		close(sh.shutdownChan)

--- a/src/runtime/python/_mcp_mesh/engine/signature_analyzer.py
+++ b/src/runtime/python/_mcp_mesh/engine/signature_analyzer.py
@@ -3,9 +3,12 @@ Function signature analysis for MCP Mesh dependency injection.
 """
 
 import inspect
+import logging
 from typing import Any, get_type_hints
 
 from mesh.types import McpMeshTool, MeshLlmAgent
+
+logger = logging.getLogger(__name__)
 
 # Also support deprecated McpMeshAgent for backwards compatibility
 try:
@@ -126,9 +129,6 @@ def get_mesh_agent_positions(func: Any) -> list[int]:
 
     except Exception as e:
         # If we can't analyze the signature, return empty list
-        import logging
-
-        logger = logging.getLogger(__name__)
         logger.warning(f"Failed to analyze signature for {func}: {e}")
         return []
 
@@ -158,9 +158,6 @@ def get_mesh_agent_parameter_names(func: Any) -> list[str]:
         return mesh_param_names
 
     except Exception as e:
-        import logging
-
-        logger = logging.getLogger(__name__)
         logger.warning(f"Failed to analyze signature for {func}: {e}")
         return []
 
@@ -227,9 +224,6 @@ def get_llm_agent_positions(func: Any) -> list[int]:
 
     except Exception as e:
         # If we can't analyze the signature, return empty list
-        import logging
-
-        logger = logging.getLogger(__name__)
         logger.warning(f"Failed to analyze signature for {func}: {e}")
         return []
 
@@ -271,9 +265,6 @@ def get_llm_agent_parameter_names(func: Any) -> list[str]:
 
         return llm_param_names
     except Exception as e:
-        import logging
-
-        logger = logging.getLogger(__name__)
         logger.warning(f"Failed to analyze signature for {func}: {e}")
         return []
 
@@ -389,8 +380,5 @@ def get_context_parameter_name(
         # Re-raise ValueError for explicit name validation errors
         raise
     except Exception as e:
-        import logging
-
-        logger = logging.getLogger(__name__)
         logger.debug(f"Failed to detect context parameter for {func.__name__}: {e}")
         return None

--- a/tests/integration/suites/uc02_tools/tc24_invalid_type_hint_warning_py/test.yaml
+++ b/tests/integration/suites/uc02_tools/tc24_invalid_type_hint_warning_py/test.yaml
@@ -51,7 +51,18 @@ test:
     workdir: /workspace
     capture: list_output
 
-  # Inspect log file for the warning we emit from signature_analyzer
+  # Verify the agent reached 'healthy' status — a registration that
+  # crashes immediately after registering would still appear in
+  # `meshctl list`, but would not show up as healthy.
+  - name: "Verify agent is healthy"
+    handler: shell
+    command: "meshctl status py-bad-hints-agent"
+    workdir: /workspace
+    capture: status_output
+
+  # Inspect log file for the warning we emit from signature_analyzer.
+  # We grep for the WARNING-level prefix together with the message so
+  # a future downgrade to DEBUG/INFO would surface as a test failure.
   - name: "Inspect agent log for signature warning"
     handler: shell
     command: |
@@ -62,11 +73,11 @@ test:
         exit 1
       fi
       echo "=== Matching warning lines ==="
-      grep "Failed to analyze signature for" "$LOG_FILE" || true
-      if grep -q "Failed to analyze signature for" "$LOG_FILE"; then
-        echo "PASS: Warning was logged"
+      grep -E "WARNING.*Failed to analyze signature for" "$LOG_FILE" || true
+      if grep -Eq "WARNING.*Failed to analyze signature for" "$LOG_FILE"; then
+        echo "PASS: WARNING-level signature analyzer log was emitted"
       else
-        echo "FAIL: Expected warning 'Failed to analyze signature for' not found in log"
+        echo "FAIL: Expected 'WARNING ... Failed to analyze signature for' not found in log"
         echo "=== Last 50 log lines ==="
         tail -50 "$LOG_FILE"
         exit 1
@@ -79,9 +90,23 @@ assertions:
   - expr: "${captured.list_output} contains 'py-bad-hints-agent'"
     message: "Agent should still register despite unresolvable type hint"
 
-  # Warning was emitted (no silent swallow)
-  - expr: "${captured.log_check} contains 'PASS: Warning was logged'"
-    message: "signature_analyzer should log a warning instead of silently swallowing"
+  # Status command should succeed for the registered agent
+  - expr: ${steps.status_output.exit_code} == 0
+    message: "meshctl status should succeed for the bad-hints agent"
+
+  # Tightened: agent must reach 'healthy' status, not just be present
+  # in the registry. A crash-on-registration would not satisfy this.
+  # Word-boundary regex avoids a false-positive match on 'unhealthy'.
+  - expr: "${captured.status_output} matches '(^|[^a-zA-Z])healthy([^a-zA-Z]|$)'"
+    message: "Agent should reach healthy status (word-boundary; not 'unhealthy')"
+
+  # Tightened: assert the WARNING level prefix is present together
+  # with the message — a downgrade to DEBUG/INFO would now fail.
+  - expr: "${captured.log_check} matches 'WARNING.*Failed to analyze signature for'"
+    message: "signature_analyzer should emit a WARNING-level log (not silently swallow or downgrade)"
+
+  - expr: "${captured.log_check} contains 'PASS: WARNING-level signature analyzer log was emitted'"
+    message: "Inspection step should report PASS for the WARNING-level grep"
 
 post_run:
   - handler: shell

--- a/tests/integration/suites/uc05_meshctl/tc40_repeated_start_stop_lifecycle/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc40_repeated_start_stop_lifecycle/test.yaml
@@ -1,37 +1,37 @@
-# Test Case: tc40_repeated_start_stop_no_goroutine_leak
-# Verifies meshctl can be started and stopped repeatedly without resource leaks.
+# Test Case: tc40_repeated_start_stop_lifecycle
+# Smoke test: 20-iteration meshctl start/stop lifecycle stays healthy.
 # Related Issue: https://github.com/dhyansraj/mcp-mesh/issues/801
 #
-# Background:
-# In src/core/cli/signal_handler.go, the SIGHUP-handling goroutine spawned by
-# StartSignalHandling() never exited cleanly because:
-#   1. signal.Stop() was never called for the signal channel.
-#   2. The signal channel was never closed.
-# SIGINT/SIGTERM exited via an explicit `return`, but on a normal graceful
-# shutdown the goroutine could remain blocked on `range signalChan`.
+# Scope of this test:
+# Each `meshctl start ... -d` invocation spawns a fresh meshctl process,
+# and `gracefulShutdown` ends that process via os.Exit(0) — so any
+# in-process goroutine state is reaped by the OS at exit. As a result,
+# this loop test cannot directly observe a goroutine leak inside
+# meshctl; it would pass even with the pre-fix signal_handler code.
 #
-# Fix:
-# gracefulShutdown() now calls signal.Stop(sh.signalChan) and closes the
-# channel so the handleSignals goroutine exits when the channel is drained.
+# What this test DOES verify:
+#   - meshctl can complete 20 back-to-back start/stop cycles without
+#     hanging, crashing, or accumulating user-visible failures.
+#   - meshctl remains responsive (`meshctl list` succeeds) after the
+#     loop, so the lifecycle plumbing is healthy end-to-end.
 #
-# Test approach:
-# Goroutine state inside the meshctl process is not directly observable from
-# the outside. As a pragmatic check, we exercise the full start/stop lifecycle
-# many times in a loop and confirm:
-#   - The loop completes without hanging or crashing.
-#   - meshctl remains responsive after the iterations.
-# A real leak typically surfaces as cumulative resource pressure (slowdown,
-# OOM, or a hang), so a clean run is meaningful evidence the lifecycle is
-# healthy. The actual goroutine-leak fix is verified at code-review time and
-# by Go's static guarantees about closed channels.
+# How the actual goroutine-leak fix is verified:
+#   - Code review of src/core/cli/signal_handler.go (signal.Stop +
+#     close of the signal channel inside gracefulShutdown, guarded by
+#     sync.Once).
+#   - Go's static guarantees about closed-channel semantics: a `range`
+#     loop over a closed channel terminates after draining buffered
+#     values, allowing the handleSignals goroutine to exit cleanly.
+#   - The inline comment in signal_handler.go documenting the
+#     sync.Once + signal.Stop ordering.
 
-name: "Repeated start/stop has no goroutine leak"
-description: "Run meshctl start/stop many times to exercise SignalHandler lifecycle (issue #801)"
+name: "Repeated start/stop lifecycle smoke test"
+description: "Smoke test: 20-iteration meshctl start/stop lifecycle stays healthy (issue #801)"
 tags:
   - meshctl
   - python
   - lifecycle
-  - regression
+  - smoke
   - signal-handler
 timeout: 600
 
@@ -65,7 +65,7 @@ test:
   - name: "Verify meshctl still responsive after loop"
     handler: shell
     workdir: /workspace
-    command: "meshctl list 2>&1 || true"
+    command: "meshctl list 2>&1"
     capture: post_loop_list
 
 assertions:


### PR DESCRIPTION
## Summary

PR #808 was merged with the **pre-review-feedback** version of the commit due to a `git add` path mishap during amend (a renamed-test-directory path failed atomically, the amend silently used the prior staged state). This PR lands the 4 review items that didn't make it into the merged commit.

**None are bugs in merged code** — all are review-feedback improvements:

1. **Hoist Python logger to module scope** (`signature_analyzer.py`) — replace inline `import logging` in 4 except blocks with a single module-level logger.

2. **Mutex-guard `signalChan` access in `gracefulShutdown`** (`signal_handler.go`) — snapshot under `sh.mutex` + nil-out, then perform `signal.Stop` + `close` outside the critical section. Defense-in-depth (current code is safe via happens-before, but unguarded reads are bad practice).

3. **Reframe tc40 as honest smoke test** — the directory was renamed `_no_goroutine_leak` → `_lifecycle` in PR #808, but the `test.yaml` content still claimed regression coverage it doesn't have. Per-process `os.Exit(0)` cleans up regardless of leaked goroutines, so the 20-iter loop test cannot detect the bug. Updated name/description/header to be honest about this.

4. **Tighten tc24 assertions** — added `meshctl status` healthy check + tightened log-grep to regex `WARNING.*Failed to analyze signature for` so a future log-level downgrade fails the test.

## Review Notes

These exact 4 changes were verified clean by review-agent during PR #808's amend cycle (commit `b03e2683` locally) before the merge:

> 0 BLOCKERS, 0 WARNINGS, 1 INFO. All previous BLOCKER/WARNING findings from prior review correctly closed. No new regressions.

The single INFO (residual inline logger in `get_context_parameter_name`) remains explicitly out of scope.

Closes #809

## Test plan

- [x] `go build ./...` clean
- [x] Patch applied cleanly from saved diff (`/tmp/review-fixes.patch`, 244 lines)
- [x] Code path identical to what review-agent already approved
- [ ] tsuite uc02_tools/tc24 passes with tightened assertions
- [ ] tsuite uc05_meshctl/tc40_repeated_start_stop_lifecycle passes
- [ ] No regression in existing uc02/uc05 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved internal signal handling stability and synchronization.
  * Optimized logging configuration in Python analyzer module.

* **Tests**
  * Enhanced test suite coverage for Python type hint validation.
  * Added lifecycle and health status verification tests for command-line tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->