### PR TITLE
docs: clean up stale version refs, fix mismatches and broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ This project is open source. License details will be provided in the LICENSE fil
 ## 📚 Learn More
 
 1. **[📚 Full Documentation](https://mcp-mesh.ai/)** - Complete guides and reference
-2. **[⚡ Quick Tutorial](https://mcp-mesh.ai/01-getting-started/)** - Build your first distributed MCP agent
+2. **[⚡ Quick Tutorial](https://mcp-mesh.ai/python/getting-started/)** - Build your first distributed MCP agent
 3. **[💬 Join Discord](https://discord.gg/KDFDREphWn)** - Connect with the community
 4. **[🔧 Contribute](https://mcp-mesh.ai/contributing/)** - Help build the future of AI orchestration
 

--- a/docs/01-getting-started/06-llm-integration.md
+++ b/docs/01-getting-started/06-llm-integration.md
@@ -4,7 +4,7 @@
 
 ## What is @mesh.llm?
 
-**New in v0.7**: MCP Mesh treats LLMs as first-class agents in the mesh. With `@mesh.llm()`, you can:
+MCP Mesh treats LLMs as first-class agents in the mesh. With `@mesh.llm()`, you can:
 
 - 🤖 **Inject LLM agents** like any other dependency
 - 🔍 **Auto-discover tools** based on capability filters
@@ -197,7 +197,7 @@ async def chat(
 
 ## Advanced: Dual Injection (LLM + MCP Agent)
 
-**New in v0.7**: Inject both LLM agents AND MCP agents into the same function:
+Inject both LLM agents AND MCP agents into the same function:
 
 ```python
 from pydantic import BaseModel

--- a/docs/enhanced-tag-matching-migration.md
+++ b/docs/enhanced-tag-matching-migration.md
@@ -2,11 +2,11 @@
 
 > Upgrading from exact tag matching to smart `+`/`-` operators
 
-This guide helps you migrate existing MCP Mesh applications to take advantage of enhanced tag matching with preference and exclusion operators introduced in v0.4+.
+This guide helps you migrate existing MCP Mesh applications to take advantage of enhanced tag matching with preference and exclusion operators.
 
 ## What Changed
 
-### Before v0.4 - Exact Matching Only
+### Legacy: Exact Matching Only
 
 ```python
 @mesh.tool(
@@ -19,7 +19,7 @@ This guide helps you migrate existing MCP Mesh applications to take advantage of
 
 **Problem**: Rigid matching - either exact match or total failure. No fallback options.
 
-### After v0.4 - Smart Matching
+### Now: Smart Matching
 
 ```python
 @mesh.tool(

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -68,17 +68,16 @@ export MCP_MESH_SESSION_TTL=3600
 ### HTTP Server Settings
 
 ```bash
-# Server binding address (what interface to bind to)
-export HOST=0.0.0.0
+# External hostname announced to registry (also used as bind hint)
+# In K8s/production, set to the externally reachable hostname (e.g., service name).
+# Agents bind to 0.0.0.0 internally regardless.
+export MCP_MESH_HTTP_HOST=0.0.0.0
 
 # Agent HTTP port
 export MCP_MESH_HTTP_PORT=8080
 
 # Enable/disable HTTP transport
 export MCP_MESH_HTTP_ENABLED=true
-
-# External hostname announced to registry
-export MCP_MESH_HTTP_HOST=my-agent
 ```
 
 ### Health and Monitoring
@@ -534,7 +533,6 @@ MCP_MESH_REGISTRY_URL=http://registry.company.com:8000
 MCP_MESH_NAMESPACE=production
 MCP_MESH_AUTO_RUN_INTERVAL=30
 MCP_MESH_HEALTH_INTERVAL=30
-HOST=0.0.0.0
 MCP_MESH_HTTP_HOST=api-service.company.com
 ```
 
@@ -657,7 +655,6 @@ export HOSTNAME=my-agent-pod-abc123
 services:
   my-agent:
     environment:
-      - HOST=0.0.0.0 # Bind to all interfaces
       - MCP_MESH_HTTP_HOST=my-agent # Service name for inter-container communication
       - MCP_MESH_HTTP_PORT=8080
       - MCP_MESH_REGISTRY_URL=http://registry:8000
@@ -889,7 +886,7 @@ MCP_MESH_REGISTRY_URL=http://localhost:8000
 MCP_MESH_NAMESPACE=development
 MCP_MESH_AUTO_RUN_INTERVAL=10
 MCP_MESH_HEALTH_INTERVAL=15
-HOST=0.0.0.0
+MCP_MESH_HTTP_HOST=0.0.0.0
 ```
 
 ### Production Template
@@ -904,14 +901,13 @@ MCP_MESH_AUTO_RUN_INTERVAL=30
 MCP_MESH_HEALTH_INTERVAL=30
 MCP_MESH_UPDATE_STRATEGY=graceful
 MCP_MESH_UPDATE_GRACE_PERIOD=60
-HOST=0.0.0.0
+MCP_MESH_HTTP_HOST=0.0.0.0
 ```
 
 ### Docker Template
 
 ```bash
 # .env.docker
-HOST=0.0.0.0
 MCP_MESH_HTTP_HOST=my-service
 MCP_MESH_REGISTRY_URL=http://registry:8000
 MCP_MESH_NAMESPACE=docker
@@ -940,7 +936,7 @@ export MCP_MESH_REGISTRY_URL=$(vault kv get -field=url secret/mesh/registry)
 # Use secure URLs in production
 export MCP_MESH_REGISTRY_URL=https://registry.company.com  # ✅ HTTPS
 
-# Bind to specific interfaces when needed
+# Bind the registry server to specific interfaces when needed
 export HOST=127.0.0.1  # ✅ Localhost only
 export HOST=0.0.0.0    # ⚠️ All interfaces (use carefully)
 ```

--- a/docs/mesh-decorators.md
+++ b/docs/mesh-decorators.md
@@ -915,7 +915,7 @@ async def process_pipeline(
 
 ## @mesh.llm - LLM Agent Injection
 
-> **New in v0.7**: Inject LLM agents as dependencies with automatic tool discovery and type-safe prompt templates
+> Inject LLM agents as dependencies with automatic tool discovery and type-safe prompt templates
 
 The `@mesh.llm` decorator enables LLM integration as first-class mesh capabilities, treating LLMs as injectable dependencies like any other agent.
 

--- a/docs/python/capabilities-tags.md
+++ b/docs/python/capabilities-tags.md
@@ -77,7 +77,7 @@ dependencies=[
 | `tags: [["a"], ["b"]]`         | a OR b (full OR)                         |
 | `[{tags:["a"]}, {tags:["b"]}]` | a OR b (multiple selectors - LLM filter) |
 
-**Tag-Level OR** (v0.9.1+):
+**Tag-Level OR**:
 
 Use nested arrays in tags for OR alternatives with fallback behavior:
 

--- a/docs/typescript/capabilities-tags.md
+++ b/docs/typescript/capabilities-tags.md
@@ -75,7 +75,7 @@ dependencies: [
 | `tags: [["a"], ["b"]]`         | a OR b (full OR)                         |
 | `[{tags:["a"]}, {tags:["b"]}]` | a OR b (multiple selectors - LLM filter) |
 
-**Tag-Level OR** (v0.9.1+):
+**Tag-Level OR**:
 
 Use nested arrays in tags for OR alternatives with fallback behavior:
 

--- a/src/core/cli/man/content/decorators.md
+++ b/src/core/cli/man/content/decorators.md
@@ -39,7 +39,7 @@ Configures the agent server settings. Applied to a class.
     http_host="localhost",       # Host announced to registry
     namespace="default",         # Namespace for isolation
     auto_run=True,               # Start automatically (no main() needed)
-    auto_run_interval=30,        # Heartbeat interval in seconds
+    auto_run_interval=10,        # Heartbeat interval in seconds
     health_check=health_fn,      # Optional health check function
     health_check_ttl=30,         # Health check cache TTL
 )


### PR DESCRIPTION
## Summary

Five docs issues from the audit pass. All small, all verified against current code.

| # | Issue | Action |
|---|---|---|
| #796 | Stale v0.x version refs | **Fixed** — 7 stale annotations removed (audit cited 3, verification found 4 more) |
| #797 | `auto_run_interval` default mismatch | **Fixed** — verified ground truth = 10, fixed the man-page example showing 30 |
| #798 | Stale `tutorial-complete.{txt,html}` | **Won't-fix here** — files are gitignored generated artifacts; needs publish-pipeline hook, not bump_version.py HANDLER. Will close with explanation. |
| #799 | README link mismatch | **Fixed** — `/01-getting-started/` → `/python/getting-started/` |
| #800 | env-vars `HOST` naming | **Fixed** — replaced agent-context `HOST=0.0.0.0` with `MCP_MESH_HTTP_HOST=0.0.0.0`; left registry-context `HOST` intact (Go server uses generic name) |

## Verification notes

- **#796**: Audit cited `mesh-decorators.md:589` but the v0.x annotation had drifted to `:918`. Found and removed 4 additional stale refs in `docs/python/capabilities-tags.md`, `docs/typescript/capabilities-tags.md`, and `docs/01-getting-started/06-llm-integration.md`.
- **#797**: Verified default in `src/runtime/python/mesh/decorators.py:873` + `_mcp_mesh/shared/defaults.py` + unit tests. The `docs/mesh-decorators.md` was already correct — only `src/core/cli/man/content/decorators.md` was wrong.
- **#798**: `docs/downloads/` is in `.gitignore`. Files are generated by `scripts/generate_tutorial_artifacts.sh` and the audit was based on stale local generated files. The right fix is a publish-pipeline / release-time hook to regenerate. Skipping here; will close issue with a recommendation.
- **#800**: Per `src/runtime/python/_mcp_mesh/shared/host_resolver.py`, `MCP_MESH_HTTP_HOST` controls the externally-advertised hostname (agents always bind internally to `0.0.0.0`). The Go registry server uses generic `HOST`/`PORT`. Fix applied to agent-context references; left registry-context refs alone.

## Stats

8 files changed, +17/-21 (net negative — removing stale annotations).

Closes #796
Closes #797
Closes #799
Closes #800

## Test plan

- [x] All affected `.md` files parse cleanly (markdown sanity check)
- [x] `git diff --stat` shows only intended files
- [ ] Built mkdocs site for visual sanity (deferred — purely text edits, low risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)