### PR TITLE
fix(python): isolate tool execution to prevent health endpoint blocking

### DIFF
--- a/examples/java/health-block-test-agent/pom.xml
+++ b/examples/java/health-block-test-agent/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>health-block-test-agent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Health Block Test Agent (Java)</name>
+    <description>Regression coverage: confirm Java agent /health and /ready stay responsive while a tool blocks its request thread (Tomcat thread-pool isolates request threads).</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.3.4</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web (for HTTP server) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.healthblock.HealthBlockTestAgentApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <!-- Local repository for mcp-mesh artifacts (development) -->
+    <repositories>
+        <repository>
+            <id>local-maven-repo</id>
+            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
+        </repository>
+    </repositories>
+</project>

--- a/examples/java/health-block-test-agent/src/main/java/com/example/healthblock/HealthBlockTestAgentApplication.java
+++ b/examples/java/health-block-test-agent/src/main/java/com/example/healthblock/HealthBlockTestAgentApplication.java
@@ -1,0 +1,74 @@
+package com.example.healthblock;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * health-block-test-agent (Java) — Regression coverage for /health responsiveness.
+ *
+ * <p>Java's MCP Mesh runtime is built on Spring Boot + embedded Tomcat. Tomcat
+ * uses a thread-pool model where each incoming HTTP request is serviced on its
+ * own worker thread. A long-running tool invocation that blocks on
+ * {@link Thread#sleep(long)} therefore parks one worker thread — but the
+ * remaining workers stay free to serve {@code /health} and {@code /ready}
+ * probes.
+ *
+ * <p>The Python and TypeScript runtimes do <em>not</em> have this property
+ * out of the box (single event loop). This agent exists so that future
+ * refactors of the Java runtime (e.g. moving to a reactive / single-thread
+ * model) cannot silently regress the current responsiveness guarantee.
+ */
+@MeshAgent(
+    name = "health-block-test-agent",
+    version = "1.0.0",
+    description = "Regression coverage: Java /health stays responsive during blocking tool calls",
+    port = 9097
+)
+@SpringBootApplication
+public class HealthBlockTestAgentApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(HealthBlockTestAgentApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting Health Block Test Agent (Java)...");
+        SpringApplication.run(HealthBlockTestAgentApplication.class, args);
+    }
+
+    /**
+     * Blocks the calling request thread for the requested number of seconds.
+     * Mirrors the Python / TypeScript reproducers: time.sleep / sleep N.
+     */
+    @MeshTool(
+        capability = "busy_tool_java",
+        description = "Blocks the calling request thread via Thread.sleep — used to verify Tomcat keeps /health responsive"
+    )
+    public String busyToolJava(
+        @Param(value = "seconds", description = "Seconds to block this request thread") int seconds
+    ) {
+        log.info("busyToolJava called with seconds={}", seconds);
+        try {
+            Thread.sleep(seconds * 1000L);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "interrupted after partial sleep";
+        }
+        return "slept " + seconds + "s (blocking)";
+    }
+
+    /**
+     * Sanity-check tool — returns immediately so the test can confirm
+     * the agent is reachable before kicking off the blocking call.
+     */
+    @MeshTool(
+        capability = "quick_tool_java",
+        description = "Returns immediately — sanity check that the MCP endpoint is wired up"
+    )
+    public String quickToolJava() {
+        return "ok";
+    }
+}

--- a/examples/java/health-block-test-agent/src/main/resources/application.yml
+++ b/examples/java/health-block-test-agent/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${MCP_MESH_HTTP_PORT:9097}
+
+spring:
+  application:
+    name: health-block-test-agent
+
+logging:
+  level:
+    io.mcpmesh: INFO
+    com.example: INFO

--- a/examples/python/health-block-test-agent/README.md
+++ b/examples/python/health-block-test-agent/README.md
@@ -1,0 +1,59 @@
+# health-block-test-agent
+
+Regression-test scratch agent for a hypothesized bug in the mcp-mesh Python
+runtime: the `/health`, `/ready`, and `/livez` HTTP endpoints get blocked
+while a long-running MCP tool call is in progress.
+
+## Why
+
+`mesh/decorators.py::_start_uvicorn_immediately()` creates a FastAPI app,
+registers the health endpoints as async coroutines, and runs `uvicorn.run(...)`
+in a background thread with a single worker. The pipeline then mounts the
+FastMCP HTTP app onto the same FastAPI instance. As a result, MCP tool calls
+and health probes share a single event loop on a single thread.
+
+If a tool's coroutine performs sync blocking work (`time.sleep`, CPU-bound
+loop, blocking I/O), it stalls the entire event loop — including `/livez`.
+In Kubernetes this would manifest as liveness probe failures and pod restarts
+during legitimate long-running tool calls.
+
+## What it does
+
+Two tools:
+
+- `busy_tool(seconds: int = 35)` — `async def` that calls `time.sleep(seconds)`
+  (deliberately the sync version, not `asyncio.sleep`). Blocks the loop.
+- `quick_tool()` — `async def` that returns immediately. Sanity check.
+
+Listens on port `9099`.
+
+## Reproducing the bug manually
+
+From the repo root:
+
+```bash
+# Start the agent
+meshctl start examples/python/health-block-test-agent/main.py -d
+sleep 8
+
+# Confirm it registered and /livez responds normally
+meshctl list
+curl -sS http://127.0.0.1:9099/livez
+
+# Kick off the blocking tool in the background
+meshctl call health-block-test-agent busy_tool --args '{"seconds": 35}' &
+
+# While it's running, /livez should hang or time out (the bug)
+sleep 2
+time curl -sS --max-time 5 http://127.0.0.1:9099/livez
+
+# Cleanup
+wait
+meshctl stop
+```
+
+## Status
+
+This agent only exists to reproduce and later regression-test the issue.
+It is intentionally minimal (no Dockerfile, no helm values, no tsuite case)
+and is not part of any tutorial or shipped example flow.

--- a/examples/python/health-block-test-agent/README.md
+++ b/examples/python/health-block-test-agent/README.md
@@ -1,59 +1,68 @@
 # health-block-test-agent
 
-Regression-test scratch agent for a hypothesized bug in the mcp-mesh Python
-runtime: the `/health`, `/ready`, and `/livez` HTTP endpoints get blocked
-while a long-running MCP tool call is in progress.
+Regression-coverage agent for the Python-runtime fix that prevents long
+blocking tool calls from stalling `/health`, `/ready`, and `/livez`.
 
 ## Why
 
-`mesh/decorators.py::_start_uvicorn_immediately()` creates a FastAPI app,
-registers the health endpoints as async coroutines, and runs `uvicorn.run(...)`
-in a background thread with a single worker. The pipeline then mounts the
-FastMCP HTTP app onto the same FastAPI instance. As a result, MCP tool calls
-and health probes share a single event loop on a single thread.
+`mesh/decorators.py::_start_uvicorn_immediately()` registers the health
+endpoints on the same FastAPI app that the FastMCP HTTP transport mounts on,
+sharing one event loop on one thread. A tool whose body performs sync
+blocking work (`time.sleep`, CPU loop, blocking I/O) used to stall that loop
+for the duration of the call — including liveness probes, which would cause
+Kubernetes to restart the pod.
 
-If a tool's coroutine performs sync blocking work (`time.sleep`, CPU-bound
-loop, blocking I/O), it stalls the entire event loop — including `/livez`.
-In Kubernetes this would manifest as liveness probe failures and pod restarts
-during legitimate long-running tool calls.
+The fix isolates each tool call onto a dedicated worker event loop in
+`src/runtime/python/_mcp_mesh/shared/tool_executor.py`, controlled by
+`MCP_MESH_TOOL_ISOLATION` (default: **true**).
 
 ## What it does
 
 Two tools:
 
 - `busy_tool(seconds: int = 35)` — `async def` that calls `time.sleep(seconds)`
-  (deliberately the sync version, not `asyncio.sleep`). Blocks the loop.
+  (deliberately the sync version). With isolation on, blocks only one worker
+  thread; without isolation, blocks the main event loop.
 - `quick_tool()` — `async def` that returns immediately. Sanity check.
 
 Listens on port `9099`.
 
-## Reproducing the bug manually
-
-From the repo root:
+## Verifying the fix (default behavior)
 
 ```bash
-# Start the agent
 meshctl start examples/python/health-block-test-agent/main.py -d
 sleep 8
 
-# Confirm it registered and /livez responds normally
-meshctl list
-curl -sS http://127.0.0.1:9099/livez
+meshctl call busy_tool '{"seconds":35}' --timeout 60 &
+sleep 3
+time curl -sS --max-time 5 http://127.0.0.1:9099/livez   # expect ~ms
 
-# Kick off the blocking tool in the background
-meshctl call health-block-test-agent busy_tool --args '{"seconds": 35}' &
-
-# While it's running, /livez should hang or time out (the bug)
-sleep 2
-time curl -sS --max-time 5 http://127.0.0.1:9099/livez
-
-# Cleanup
 wait
 meshctl stop
 ```
 
-## Status
+`/livez` stays responsive (a few milliseconds) while `busy_tool` runs.
 
-This agent only exists to reproduce and later regression-test the issue.
-It is intentionally minimal (no Dockerfile, no helm values, no tsuite case)
-and is not part of any tutorial or shipped example flow.
+## Reproducing the original bug
+
+Disable isolation to observe the unfixed behavior:
+
+```bash
+MCP_MESH_TOOL_ISOLATION=false meshctl start examples/python/health-block-test-agent/main.py -d
+sleep 8
+
+meshctl call busy_tool '{"seconds":35}' --timeout 60 &
+sleep 3
+time curl -sS --max-time 5 http://127.0.0.1:9099/livez   # expect timeout
+
+wait
+meshctl stop
+```
+
+`/livez` hangs until `busy_tool` finishes, confirming what the default
+isolation protects against.
+
+---
+
+Automated coverage:
+[`tests/integration/suites/uc02_tools/tc25_health_endpoint_responsiveness_py/`](../../../tests/integration/suites/uc02_tools/tc25_health_endpoint_responsiveness_py/).

--- a/examples/python/health-block-test-agent/main.py
+++ b/examples/python/health-block-test-agent/main.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+health-block-test-agent - Reproducer for health-endpoint blocking bug.
+
+Hypothesis: FastAPI (/health, /ready, /livez) and the mounted FastMCP app
+share a single uvicorn event loop in a single thread. A tool that performs
+sync blocking work (time.sleep) inside an async coroutine will block the
+loop and prevent /livez from responding while the tool is running.
+"""
+
+import time
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Health Block Test Service")
+
+
+@app.tool()
+@mesh.tool(
+    capability="busy_tool",
+    description="Blocks the event loop with sync time.sleep (NOT asyncio.sleep)",
+    tags=["test", "blocking"],
+)
+async def busy_tool(seconds: int = 35) -> str:
+    """Intentionally block the event loop to reproduce health endpoint stalls."""
+    time.sleep(seconds)
+    return f"slept {seconds}s (blocking)"
+
+
+@app.tool()
+@mesh.tool(
+    capability="quick_tool",
+    description="Returns immediately — sanity check that MCP endpoint works",
+    tags=["test", "quick"],
+)
+async def quick_tool() -> str:
+    return "ok"
+
+
+@mesh.agent(
+    name="health-block-test-agent",
+    version="1.0.0",
+    description="Reproducer for /livez blocking during long-running tool calls",
+    http_port=9099,
+    enable_http=True,
+    auto_run=True,
+)
+class HealthBlockTestAgent:
+    pass

--- a/examples/typescript/health-block-test-agent/README.md
+++ b/examples/typescript/health-block-test-agent/README.md
@@ -8,8 +8,9 @@ inside an `async` function will stall the loop and freeze health probes.
 
 ## Why
 
-`src/runtime/typescript/src/express.ts` (lines 143–157) registers `/health`
-and `/ready` on the same Express app that handles MCP tool calls. Node has
+The `/health` and `/ready` handlers in `src/runtime/typescript/src/express.ts`
+(search for `setupHealthEndpoints`) are registered on the same Express app
+that handles MCP tool calls. Node has
 a single event loop. A tool whose `execute` blocks (e.g. `execSync`,
 busy CPU loop, sync file I/O) prevents the loop from servicing any other
 request — including the health endpoints.

--- a/examples/typescript/health-block-test-agent/README.md
+++ b/examples/typescript/health-block-test-agent/README.md
@@ -1,0 +1,79 @@
+# health-block-test-agent (TypeScript)
+
+Regression-test scratch agent for the TypeScript-runtime equivalent of the
+Python `/health` blocking bug. The Node event loop is single-threaded; the
+mesh Express server (which serves `/health` and `/ready`) and the FastMCP
+tool dispatcher share that loop. A tool that performs sync blocking work
+inside an `async` function will stall the loop and freeze health probes.
+
+## Why
+
+`src/runtime/typescript/src/express.ts` (lines 143–157) registers `/health`
+and `/ready` on the same Express app that handles MCP tool calls. Node has
+a single event loop. A tool whose `execute` blocks (e.g. `execSync`,
+busy CPU loop, sync file I/O) prevents the loop from servicing any other
+request — including the health endpoints.
+
+Notes about the actual TS runtime:
+
+- Unlike the Python runtime, the TS runtime does **not** expose a
+  `/livez` endpoint — `/livez` returns 404. Only `/health` and `/ready`
+  exist.
+- In practice the responses come from FastMCP's mount, not from the
+  Express handlers shown in `express.ts`: `/health` returns the plain
+  text body `✓ Ok`, and `/ready` returns
+  `{"mode":"stateless","ready":1,"status":"ready","total":1}`. Either
+  way, both share Node's single event loop with the tool executor, so
+  the blocking hypothesis still applies.
+
+In Kubernetes this would manifest as readiness/liveness probe failures and
+pod restarts during legitimate long-running tool calls.
+
+## What it does
+
+Two tools:
+
+- `busyTool(seconds: number = 35)` — `async` function that calls
+  `execSync('sleep N')` (the cleanest way to park the whole Node process
+  with no CPU burn — the JS analogue of Python's blocking `time.sleep`).
+- `quickTool()` — `async` function that returns immediately. Sanity check.
+
+Listens on port `9098` (Python reproducer uses `9099`).
+
+## Reproducing the bug manually
+
+From the repo root:
+
+```bash
+# One-time setup
+cd examples/typescript/health-block-test-agent
+npm install
+cd -
+
+# Start the agent
+meshctl start examples/typescript/health-block-test-agent/src/index.ts -d
+sleep 8
+
+# Confirm it registered and /health and /ready respond normally
+meshctl list
+curl -sS http://127.0.0.1:9098/health
+curl -sS http://127.0.0.1:9098/ready
+
+# Kick off the blocking tool in the background
+meshctl call health-block-test-agent busyTool --args '{"seconds": 35}' &
+
+# While it's running, /health and /ready should hang or time out (the bug)
+sleep 2
+time curl -sS --max-time 5 http://127.0.0.1:9098/health
+time curl -sS --max-time 5 http://127.0.0.1:9098/ready
+
+# Cleanup
+wait
+meshctl stop
+```
+
+## Status
+
+This agent only exists to reproduce and later regression-test the issue.
+It is intentionally minimal (no Dockerfile, no helm values, no tsuite case)
+and is not part of any tutorial or shipped example flow.

--- a/examples/typescript/health-block-test-agent/package-lock.json
+++ b/examples/typescript/health-block-test-agent/package-lock.json
@@ -1,0 +1,2828 @@
+{
+  "name": "health-block-test-agent",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "health-block-test-agent",
+      "version": "1.0.0",
+      "dependencies": {
+        "@mcpmesh/core": "file:../../../src/runtime/core/typescript",
+        "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+        "fastmcp": "^3.34.0",
+        "zod": "^3.24.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.29",
+        "tsx": "^4.0.0",
+        "typescript": "^5.8.3"
+      }
+    },
+    "../../../src/runtime/core/typescript": {
+      "name": "@mcpmesh/core",
+      "version": "1.3.4",
+      "license": "MIT",
+      "devDependencies": {
+        "@napi-rs/cli": "^3.5.1"
+      }
+    },
+    "../../../src/runtime/typescript": {
+      "name": "@mcpmesh/sdk",
+      "version": "1.3.4",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@mcpmesh/core": "file:../core/typescript",
+        "ai": "^6.0.0",
+        "fastmcp": "^3.34.0",
+        "handlebars": "^4.7.8",
+        "mcp-proxy": "6.4.4",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.0",
+        "@types/express-v5": "npm:@types/express@^5.0.0",
+        "@types/node": "^22.0.0",
+        "express": "^4.18.0",
+        "express-v5": "npm:express@^5.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@mcpmesh/core": {
+      "resolved": "../../../src/runtime/core/typescript",
+      "link": true
+    },
+    "node_modules/@mcpmesh/sdk": {
+      "resolved": "../../../src/runtime/typescript",
+      "link": true
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.0.tgz",
+      "integrity": "sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastmcp": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.35.0.tgz",
+      "integrity": "sha512-bcyAaVa3Zw5f4xighGg6fNNgEzZoP6tX/O+ZfS2lIhbEULWe/zUWG533JyFEUOjZT7EB+tiZW1ot4eWKmYJ6DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.24.3",
+        "@standard-schema/spec": "^1.0.0",
+        "execa": "^9.6.1",
+        "file-type": "^21.1.1",
+        "fuse.js": "^7.1.0",
+        "hono": "^4.11.5",
+        "mcp-proxy": "^6.4.0",
+        "strict-event-emitter-types": "^2.0.0",
+        "undici": "^7.16.0",
+        "uri-templates": "^0.2.0",
+        "xsschema": "^0.4.3",
+        "yargs": "^18.0.0",
+        "zod": "^4.1.13",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "bin": {
+        "fastmcp": "dist/bin/fastmcp.js"
+      },
+      "peerDependencies": {
+        "jose": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jose": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fastmcp/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/human-readable-ids": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/human-readable-ids/-/human-readable-ids-1.0.4.tgz",
+      "integrity": "sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA==",
+      "license": "Apache2",
+      "dependencies": {
+        "knuth-shuffle": "^1.0.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/knuth-shuffle": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/knuth-shuffle/-/knuth-shuffle-1.0.8.tgz",
+      "integrity": "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ==",
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/koa": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.0.tgz",
+      "integrity": "sha512-TrM4/tnNY7uJ1aW55sIIa+dqBvc4V14WRIAlGcWat9wV5pRS9Wr5Zk2ZTjQP1jtfIHDoHiSbPuV08P0fUZo2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~1.0.1",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/koa-router": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-14.0.0.tgz",
+      "integrity": "sha512-Ue8f/PRsLLNm6b7y+eS6xkqvsG2xH11d2VB1HPcfdfW6p5736kCHf2pXaq8q9XPQ01x0Dk7V/P5Il9pe+tGTxA==",
+      "deprecated": "Please use @koa/router instead, starting from v9! ",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "path-to-regexp": "^8.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/koa/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/koa/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-proxy": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.4.6.tgz",
+      "integrity": "sha512-tUGAvjzORMUO28shoWNO7yH3kH3r6sYLdAD9w6zoYpjy5zKMFq76nniaMkajpeX/zbemzgICl9sfXhrwQt+hlw==",
+      "license": "MIT",
+      "dependencies": {
+        "pipenet": "^1.3.0"
+      },
+      "bin": {
+        "mcp-proxy": "dist/bin/mcp-proxy.mjs"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pipenet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.0.tgz",
+      "integrity": "sha512-Uc3EH2i8hnJUD0Eupj9z2jaZPjjAbooaiHGh0iFdExbE8/BDt6Lf0919Dtwx5VM83elHNWFzCOsvzsViTD5YZg==",
+      "dependencies": {
+        "axios": "^1.7.3",
+        "debug": "^4.3.6",
+        "human-readable-ids": "^1.0.4",
+        "koa": "^3.1.1",
+        "koa-router": "^14.0.0",
+        "pump": "^3.0.3",
+        "tldjs": "^2.3.2",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "pipenet": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tldjs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.2.tgz",
+      "integrity": "sha512-EORDwFMSZKrHPUVDhejCMDeAovRS5d8jZKiqALFiPp3cjKjEldPkxBY39ZSx3c45awz3RpKwJD1cCgGxEfy8/A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-templates": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.2.0.tgz",
+      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==",
+      "license": "http://geraintluff.github.io/tv4/LICENSE.txt"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xsschema": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/xsschema/-/xsschema-0.4.4.tgz",
+      "integrity": "sha512-TMhbk8AhxO+YuDOn3rXBjGXQ+Vja3T13UPQkHx/FemhusaOzRfCSj2seykt0mdnFPsOtO9l3ANf4adcp+4NRGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@valibot/to-json-schema": "^1.0.0",
+        "arktype": "^2.1.20",
+        "effect": "^3.16.0",
+        "sury": "^10.0.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "@valibot/to-json-schema": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "sury": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/typescript/health-block-test-agent/package.json
+++ b/examples/typescript/health-block-test-agent/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "health-block-test-agent",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Reproducer: TS mesh agent /health and /ready stall when a tool blocks the Node event loop",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/core": "file:../../../src/runtime/core/typescript",
+    "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0",
+    "@types/node": "^22.15.29",
+    "typescript": "^5.8.3"
+  }
+}

--- a/examples/typescript/health-block-test-agent/src/index.ts
+++ b/examples/typescript/health-block-test-agent/src/index.ts
@@ -1,0 +1,49 @@
+/**
+ * health-block-test-agent (TypeScript)
+ *
+ * Reproducer for the TS-runtime equivalent of the Python health-block bug:
+ * Express health endpoints (/health, /ready) and the FastMCP HTTP handler
+ * share Node's single event loop. A tool that blocks the loop should stall
+ * health probes for as long as it runs.
+ */
+
+import { execSync } from "node:child_process";
+import { FastMCP } from "fastmcp";
+import { mesh } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const server = new FastMCP({
+  name: "Health Block Test Service",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "health-block-test-agent",
+  httpPort: 9098,
+  description: "Reproducer for /health and /ready blocking during long tool calls",
+});
+
+agent.addTool({
+  name: "busyTool",
+  capability: "busy_tool",
+  tags: ["test", "blocking"],
+  description: "Blocks the Node event loop via execSync('sleep N')",
+  parameters: z.object({
+    seconds: z.number().int().default(35).describe("Seconds to block the loop"),
+  }),
+  execute: async ({ seconds }) => {
+    execSync(`sleep ${seconds}`);
+    return `slept ${seconds}s (blocking)`;
+  },
+});
+
+agent.addTool({
+  name: "quickTool",
+  capability: "quick_tool",
+  tags: ["test", "quick"],
+  description: "Returns immediately — sanity check that MCP endpoint works",
+  parameters: z.object({}),
+  execute: async () => "ok",
+});
+
+console.log("health-block-test-agent defined. Waiting for auto-start...");

--- a/examples/typescript/health-block-test-agent/src/index.ts
+++ b/examples/typescript/health-block-test-agent/src/index.ts
@@ -7,7 +7,7 @@
  * health probes for as long as it runs.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { FastMCP } from "fastmcp";
 import { mesh } from "@mcpmesh/sdk";
 import { z } from "zod";
@@ -29,10 +29,10 @@ agent.addTool({
   tags: ["test", "blocking"],
   description: "Blocks the Node event loop via execSync('sleep N')",
   parameters: z.object({
-    seconds: z.number().int().default(35).describe("Seconds to block the loop"),
+    seconds: z.number().int().min(0).default(35).describe("Seconds to block the loop"),
   }),
   execute: async ({ seconds }) => {
-    execSync(`sleep ${seconds}`);
+    execFileSync("sleep", [String(seconds)]);
     return `slept ${seconds}s (blocking)`;
   },
 });

--- a/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
+++ b/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
@@ -133,56 +133,89 @@ def _get_httpx_client_sync(base_endpoint: str) -> "httpx.AsyncClient":
         return client
 
 
-async def _get_httpx_client(base_endpoint: str) -> "httpx.AsyncClient":
-    """Async wrapper around :func:`_get_httpx_client_sync` for call-site parity."""
-    return _get_httpx_client_sync(base_endpoint)
-
-
 async def close_connection_pools() -> None:
-    """Close pooled HTTP clients owned by the CURRENT event loop.
+    """Close ALL pooled HTTP/FastMCP clients across every owning event loop.
 
     Each cached client is bound to the loop that created it (see module-level
     docstring). Closing a client from a different loop would raise the same
-    cross-loop error we are trying to avoid, so we only close clients keyed to
-    this loop. Worker-loop clients are reaped when their daemon threads exit
-    at process termination — best-effort, matching prior behaviour.
+    cross-loop error we are trying to avoid. So for clients owned by a
+    DIFFERENT loop than the caller's, we schedule the close coroutine on the
+    owning loop via ``asyncio.run_coroutine_threadsafe`` and await the
+    resulting future on the current loop via ``asyncio.wrap_future`` — that
+    avoids the deadlock pitfall of calling ``.result()`` from the same loop
+    a future is bound to.
+
+    Typical caller is uvicorn's main loop during graceful shutdown. Worker
+    loop clients (the majority, since N workers ≥ 1) used to leak silently
+    until daemon threads died at process termination; this routine now
+    actively closes them.
     """
     try:
-        loop_key = _current_loop_key()
+        current_loop = asyncio.get_running_loop()
     except RuntimeError:
         # No running loop — nothing we can safely close from here.
         return
 
-    with _pool_lock:
-        fastmcp_to_close = [
-            (key, client)
-            for key, client in _fastmcp_client_pool.items()
-            if key[0] == loop_key
-        ]
-        for key in [k for k, _ in fastmcp_to_close]:
-            _fastmcp_client_pool.pop(key, None)
+    # Build {loop_id: loop} map from the current loop + worker loops so we can
+    # find the owning loop for each pooled client by its (loop_id, endpoint) key.
+    from ..shared.tool_executor import get_worker_loops
 
-        httpx_to_close = [
-            (key, client)
-            for key, client in _httpx_pool.items()
-            if key[0] == loop_key
-        ]
-        for key in [k for k, _ in httpx_to_close]:
-            _httpx_pool.pop(key, None)
+    loop_by_id: dict[int, asyncio.AbstractEventLoop] = {id(current_loop): current_loop}
+    for loop in get_worker_loops():
+        loop_by_id[id(loop)] = loop
+
+    with _pool_lock:
+        fastmcp_to_close = list(_fastmcp_client_pool.items())
+        httpx_to_close = list(_httpx_pool.items())
+        _fastmcp_client_pool.clear()
+        _httpx_pool.clear()
+
+    async def _close_one(client, owning_loop, *, is_fastmcp: bool, label: str) -> None:
+        kind = "FastMCP" if is_fastmcp else "httpx"
+        if owning_loop is current_loop:
+            # Same loop — just await directly.
+            if is_fastmcp:
+                await client.__aexit__(None, None, None)
+            else:
+                await client.aclose()
+            return
+
+        # Different (worker) loop — schedule on its loop, await the resulting
+        # future on the current loop. Using wrap_future (NOT future.result())
+        # avoids deadlocking when this happens to be invoked on the same loop
+        # as the future's bound loop.
+        if is_fastmcp:
+            coro = client.__aexit__(None, None, None)
+        else:
+            coro = client.aclose()
+        fut = asyncio.run_coroutine_threadsafe(coro, owning_loop)
+        try:
+            await asyncio.wait_for(asyncio.wrap_future(fut), timeout=5)
+        except asyncio.TimeoutError:
+            logger.warning(f"Timed out closing {kind} client for: {label}")
 
     for key, client in fastmcp_to_close:
+        owning_loop = loop_by_id.get(key[0])
+        if owning_loop is None or owning_loop.is_closed():
+            logger.debug(
+                f"Skipping FastMCP client for {key[1]}: owning loop closed/missing"
+            )
+            continue
         try:
-            import anyio
-
-            with anyio.move_on_after(5):
-                await client.__aexit__(None, None, None)
+            await _close_one(client, owning_loop, is_fastmcp=True, label=key[1])
             logger.debug(f"Closed pooled FastMCP client for: {key[1]}")
         except Exception as e:
             logger.warning(f"Error closing FastMCP client for {key[1]}: {e}")
 
     for key, client in httpx_to_close:
+        owning_loop = loop_by_id.get(key[0])
+        if owning_loop is None or owning_loop.is_closed():
+            logger.debug(
+                f"Skipping httpx client for {key[1]}: owning loop closed/missing"
+            )
+            continue
         try:
-            await client.aclose()
+            await _close_one(client, owning_loop, is_fastmcp=False, label=key[1])
             logger.debug(f"Closed pooled httpx client for: {key[1]}")
         except Exception as e:
             logger.warning(f"Error closing httpx client for {key[1]}: {e}")
@@ -361,6 +394,29 @@ class UnifiedMCPProxy:
 
         See module-level pool docstring: FastMCP Client owns asyncio resources
         that are loop-affine, so we key the pool by ``(loop_id, endpoint)``.
+
+        Health-check rationale (no proactive probe of the cached client):
+
+        FastMCP's ``Client._connect()`` already self-heals at session level —
+        on each ``async with``, it inspects ``session_task`` and restarts the
+        background session task if it is ``None`` or ``done()`` (which is
+        precisely what happens when the previous session errored or was torn
+        down). The two attribute-level signals available are:
+
+          * ``client.is_connected()`` — only True while a session is live
+            (i.e. inside an ``async with`` block). Between calls it is
+            always False; it does NOT indicate "broken", just "idle".
+          * ``client._session_state.session_task.done()`` — touches private
+            internals; redundant with the check ``_connect()`` already does.
+
+        FastMCP exposes no `ping_no_session()` or transport-health probe
+        cheap enough to run on every cache hit (``ping()`` requires a live
+        session and a network round-trip). So we rely on FastMCP's built-in
+        reconnect on the next ``async with``. In the worst case (transport
+        permanently broken at the underlying httpx level) the next call
+        raises and the existing HTTP-fallback path in ``call_tool`` covers
+        it. Note also that the proxy's primary path is the pooled httpx
+        client (see ``_http_call``); FastMCP is fallback + listing methods.
         """
         key = (_current_loop_key(), mcp_endpoint)
         with _pool_lock:
@@ -1051,7 +1107,7 @@ class UnifiedMCPProxy:
                 f"🔄 HTTP call to {url} with {request_bytes} byte payload, timeout: {enhanced_timeout}s"
             )
 
-            client = await _get_httpx_client(self.endpoint)
+            client = _get_httpx_client_sync(self.endpoint)
             response = await client.post(
                 url,
                 content=request_body,

--- a/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
+++ b/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
@@ -9,6 +9,7 @@ import contextvars
 import json
 import logging
 import os
+import threading
 import uuid
 from collections.abc import AsyncIterator
 from typing import Any, Optional
@@ -74,55 +75,117 @@ _outbound_headers_var: contextvars.ContextVar[dict[str, str] | None] = (
 )
 
 # Module-level connection pools for reuse across tool calls.
+#
+# IMPORTANT: httpx.AsyncClient and FastMCP.Client both create internal asyncio
+# resources (Locks/Events via anyio) that are bound to the event loop on which
+# they are first used. Since mesh tool isolation dispatches @mesh.tool async
+# bodies onto a pool of dedicated worker event loops (see
+# ``_mcp_mesh.shared.tool_executor``), a client created on worker loop A cannot
+# safely be used from worker loop B — doing so raises:
+#     RuntimeError: <asyncio.locks.Lock ...> is bound to a different event loop
+#
+# To stay loop-safe, we cache one client per (loop, endpoint). The pool size
+# stays small in practice: N worker loops + 1 main loop, times the number of
+# distinct cross-agent endpoints. The pool dict is guarded by a plain
+# ``threading.Lock`` (NOT ``asyncio.Lock``) so it is itself loop-agnostic and
+# can be acquired safely from any worker thread.
+#
 # FastMCP Client supports reentrant context managers (ref-counted sessions),
 # so concurrent `async with` blocks on the same pooled client share one session.
-_fastmcp_client_pool: dict[str, Any] = {}
-_httpx_pool: dict[str, Any] = {}
-_pool_lock = asyncio.Lock()
+_fastmcp_client_pool: dict[tuple[int, str], Any] = {}
+_httpx_pool: dict[tuple[int, str], Any] = {}
+_pool_lock = threading.Lock()
+
+
+def _current_loop_key() -> int:
+    """Return id() of the running event loop (used as part of the pool key)."""
+    return id(asyncio.get_running_loop())
+
+
+def _get_httpx_client_sync(base_endpoint: str) -> "httpx.AsyncClient":
+    """Get or create a pooled httpx client bound to the CURRENT event loop.
+
+    Synchronous lookup guarded by a threading.Lock — safe to call from any
+    worker thread. The returned client is loop-affine: only use it from the
+    same event loop that created it.
+    """
+    import httpx
+
+    key = (_current_loop_key(), base_endpoint)
+    with _pool_lock:
+        client = _httpx_pool.get(key)
+        if client is not None and not client.is_closed:
+            return client
+        ssl_ctx = _create_ssl_context_for_endpoint(base_endpoint)
+        tls_kwargs = {"verify": ssl_ctx} if ssl_ctx is not None else {}
+        client = httpx.AsyncClient(
+            timeout=httpx.Timeout(300.0, read=300.0),
+            limits=httpx.Limits(
+                max_connections=100,
+                max_keepalive_connections=20,
+            ),
+            **tls_kwargs,
+        )
+        _httpx_pool[key] = client
+        logger.debug(
+            f"Created pooled httpx client for loop={key[0]} endpoint={base_endpoint}"
+        )
+        return client
 
 
 async def _get_httpx_client(base_endpoint: str) -> "httpx.AsyncClient":
-    """Get or create a pooled httpx client for the HTTP direct call path."""
-    import httpx
-
-    async with _pool_lock:
-        if base_endpoint not in _httpx_pool:
-            ssl_ctx = _create_ssl_context_for_endpoint(base_endpoint)
-            tls_kwargs = {"verify": ssl_ctx} if ssl_ctx is not None else {}
-            _httpx_pool[base_endpoint] = httpx.AsyncClient(
-                timeout=httpx.Timeout(300.0, read=300.0),
-                limits=httpx.Limits(
-                    max_connections=100,
-                    max_keepalive_connections=20,
-                ),
-                **tls_kwargs,
-            )
-            logger.debug(f"Created pooled httpx client for: {base_endpoint}")
-        return _httpx_pool[base_endpoint]
+    """Async wrapper around :func:`_get_httpx_client_sync` for call-site parity."""
+    return _get_httpx_client_sync(base_endpoint)
 
 
 async def close_connection_pools() -> None:
-    """Close all pooled HTTP clients. Call during application shutdown."""
-    async with _pool_lock:
-        for endpoint, client in list(_fastmcp_client_pool.items()):
-            try:
-                # Use anyio timeout to prevent hanging on unresponsive connections
-                import anyio
+    """Close pooled HTTP clients owned by the CURRENT event loop.
 
-                with anyio.move_on_after(5):
-                    await client.__aexit__(None, None, None)
-                logger.debug(f"Closed pooled FastMCP client for: {endpoint}")
-            except Exception as e:
-                logger.warning(f"Error closing FastMCP client for {endpoint}: {e}")
-        _fastmcp_client_pool.clear()
+    Each cached client is bound to the loop that created it (see module-level
+    docstring). Closing a client from a different loop would raise the same
+    cross-loop error we are trying to avoid, so we only close clients keyed to
+    this loop. Worker-loop clients are reaped when their daemon threads exit
+    at process termination — best-effort, matching prior behaviour.
+    """
+    try:
+        loop_key = _current_loop_key()
+    except RuntimeError:
+        # No running loop — nothing we can safely close from here.
+        return
 
-        for endpoint, client in list(_httpx_pool.items()):
-            try:
-                await client.aclose()
-                logger.debug(f"Closed pooled httpx client for: {endpoint}")
-            except Exception as e:
-                logger.warning(f"Error closing httpx client for {endpoint}: {e}")
-        _httpx_pool.clear()
+    with _pool_lock:
+        fastmcp_to_close = [
+            (key, client)
+            for key, client in _fastmcp_client_pool.items()
+            if key[0] == loop_key
+        ]
+        for key in [k for k, _ in fastmcp_to_close]:
+            _fastmcp_client_pool.pop(key, None)
+
+        httpx_to_close = [
+            (key, client)
+            for key, client in _httpx_pool.items()
+            if key[0] == loop_key
+        ]
+        for key in [k for k, _ in httpx_to_close]:
+            _httpx_pool.pop(key, None)
+
+    for key, client in fastmcp_to_close:
+        try:
+            import anyio
+
+            with anyio.move_on_after(5):
+                await client.__aexit__(None, None, None)
+            logger.debug(f"Closed pooled FastMCP client for: {key[1]}")
+        except Exception as e:
+            logger.warning(f"Error closing FastMCP client for {key[1]}: {e}")
+
+    for key, client in httpx_to_close:
+        try:
+            await client.aclose()
+            logger.debug(f"Closed pooled httpx client for: {key[1]}")
+        except Exception as e:
+            logger.warning(f"Error closing httpx client for {key[1]}: {e}")
 
 
 class UnifiedMCPProxy:
@@ -294,16 +357,23 @@ class UnifiedMCPProxy:
     async def _get_or_create_fastmcp_client(
         cls, mcp_endpoint: str, base_endpoint: str, stream_timeout: float = 300.0
     ):
-        """Get a pooled FastMCP client for the endpoint, creating one if needed."""
-        async with _pool_lock:
-            if mcp_endpoint in _fastmcp_client_pool:
-                return _fastmcp_client_pool[mcp_endpoint]
+        """Get a pooled FastMCP client bound to the CURRENT event loop.
 
+        See module-level pool docstring: FastMCP Client owns asyncio resources
+        that are loop-affine, so we key the pool by ``(loop_id, endpoint)``.
+        """
+        key = (_current_loop_key(), mcp_endpoint)
+        with _pool_lock:
+            client = _fastmcp_client_pool.get(key)
+            if client is not None:
+                return client
             client = cls._build_fastmcp_client(
                 mcp_endpoint, base_endpoint, stream_timeout
             )
-            _fastmcp_client_pool[mcp_endpoint] = client
-            logger.debug(f"Created pooled FastMCP client for: {mcp_endpoint}")
+            _fastmcp_client_pool[key] = client
+            logger.debug(
+                f"Created pooled FastMCP client for loop={key[0]} endpoint={mcp_endpoint}"
+            )
             return client
 
     def _configure_from_kwargs(self):

--- a/src/runtime/python/_mcp_mesh/shared/tool_executor.py
+++ b/src/runtime/python/_mcp_mesh/shared/tool_executor.py
@@ -100,12 +100,21 @@ def _start_workers() -> list[tuple[threading.Thread, asyncio.AbstractEventLoop]]
         for i in range(n):
             ready = threading.Event()
             loop_holder: dict[str, asyncio.AbstractEventLoop] = {}
+            init_error: dict[str, BaseException] = {}
 
             def _run() -> None:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                loop_holder["loop"] = loop
-                ready.set()
+                loop: asyncio.AbstractEventLoop | None = None
+                try:
+                    loop = asyncio.new_event_loop()
+                    asyncio.set_event_loop(loop)
+                    loop_holder["loop"] = loop
+                except BaseException as e:  # noqa: BLE001 — surface to parent
+                    init_error["error"] = e
+                    return
+                finally:
+                    # Always wake the parent — success or failure — so it
+                    # never hangs on a worker that never started.
+                    ready.set()
                 try:
                     loop.run_forever()
                 finally:
@@ -117,7 +126,15 @@ def _start_workers() -> list[tuple[threading.Thread, asyncio.AbstractEventLoop]]
             name = f"mesh-tool-worker-{i}"
             thread = threading.Thread(target=_run, name=name, daemon=True)
             thread.start()
-            ready.wait()
+            if not ready.wait(timeout=10):
+                raise RuntimeError(
+                    f"mesh-tool-worker '{name}' failed to initialize within 10s"
+                )
+            if "error" in init_error:
+                raise RuntimeError(
+                    f"mesh-tool-worker '{name}' failed to initialize: "
+                    f"{init_error['error']!r}"
+                ) from init_error["error"]
             new_workers.append((thread, loop_holder["loop"]))
             thread_names.append(name)
 
@@ -218,13 +235,25 @@ async def _invoke_with_context(
 ) -> Any:
     """Invoke the user coroutine on the worker loop inside the captured context.
 
-    ``ctx.run`` only runs synchronous callables, so we use it to BUILD the
-    coroutine (which sets contextvars at coroutine-creation time, since the
-    coroutine object captures the current context). Each ``await`` inside
-    the user code then sees those contextvars. We then await the coroutine
-    on the worker loop.
+    Per PEP 567, contextvars are tied to ``Task`` instances — *not* to the
+    coroutine object itself. A coroutine awaited directly inside another
+    coroutine inherits the surrounding Task's context, which here is the
+    worker-loop wrapper Task and would NOT see the caller's contextvars.
+
+    Two-step propagation:
+
+    1. ``ctx.run(coro_func, *args, **kwargs)`` invokes the function inside
+       ``ctx``. For sync functions this runs the body and returns the result;
+       for async functions it constructs the coroutine object inside ``ctx``
+       (cheap — no body executes yet).
+    2. For async results, we explicitly create an inner Task with
+       ``loop.create_task(coro, context=ctx)`` so the coroutine *body* runs
+       inside the captured context. The ``context=`` kwarg on
+       ``loop.create_task`` is the documented Python 3.11+ API for this.
     """
-    coro = ctx.run(coro_func, *args, **kwargs)
-    if not asyncio.iscoroutine(coro):
-        return coro
-    return await coro
+    result = ctx.run(coro_func, *args, **kwargs)
+    if not asyncio.iscoroutine(result):
+        return result
+    loop = asyncio.get_running_loop()
+    task = loop.create_task(result, context=ctx)
+    return await task

--- a/src/runtime/python/_mcp_mesh/shared/tool_executor.py
+++ b/src/runtime/python/_mcp_mesh/shared/tool_executor.py
@@ -1,0 +1,219 @@
+"""Dedicated worker event loops for isolating user tool execution from the main loop.
+
+This prevents a user's blocking syscall (e.g. ``time.sleep`` inside an ``async def``
+tool) from freezing uvicorn's main loop and blocking health endpoints / heartbeats,
+AND lets concurrent blocking tools run in parallel across N worker threads instead
+of serializing on a single worker.
+
+Architecture::
+
+    main thread                          worker pool (N threads)
+    ├─ uvicorn event loop                ├─ mesh-tool-worker-0 (own asyncio loop)
+    ├─ FastAPI / FastMCP routing         ├─ mesh-tool-worker-1 (own asyncio loop)
+    ├─ /health, /ready, /livez           ├─ ...
+    └─ heartbeats                        └─ mesh-tool-worker-(N-1)
+
+When the @mesh.tool decorator wraps an ``async def`` user function with
+``isolated()``, FastMCP awaits ``isolated`` on the main loop. ``isolated``
+calls :func:`dispatch` to schedule the user coroutine on one of the worker
+loops via ``asyncio.run_coroutine_threadsafe``, then awaits the resulting
+``concurrent.futures.Future`` via ``asyncio.wrap_future``. A user's
+``time.sleep(60)`` now blocks only one worker thread, not uvicorn — and other
+workers remain free to service concurrent calls.
+
+Pool size:
+    Default ``N = min(8, max(2, os.cpu_count() or 2))``.
+    Override at startup via ``MCP_MESH_TOOL_WORKERS=<N>`` env var.
+
+    The pool size is read ONCE on first dispatch and cached. Changing the
+    env var at runtime has no effect.
+
+Dispatch strategy:
+    Round-robin across workers via an ``itertools.cycle`` counter guarded by
+    the init lock. Strict fairness is not a goal — rough distribution is
+    sufficient since ``asyncio.run_coroutine_threadsafe`` already pushes onto
+    the target loop's thread-safe queue.
+
+ContextVars (``trace_id``, propagated headers, etc.) are captured on the
+calling thread via ``contextvars.copy_context()`` and re-applied inside the
+worker via ``ctx.run(...)`` so tracing keeps working transparently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import contextvars
+import itertools
+import logging
+import os
+import threading
+from concurrent.futures import Future
+from typing import Any, Callable, Coroutine
+
+logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_workers: list[tuple[threading.Thread, asyncio.AbstractEventLoop]] = []
+_next_worker_idx: itertools.cycle | None = None
+_shutdown_registered = False
+
+
+def _resolve_pool_size() -> int:
+    """Read pool size from env or compute default. Called once at first init."""
+    env_val = os.environ.get("MCP_MESH_TOOL_WORKERS")
+    if env_val:
+        try:
+            n = int(env_val)
+            if n >= 1:
+                return n
+            logger.warning(
+                "MCP_MESH_TOOL_WORKERS=%r is < 1; falling back to default", env_val
+            )
+        except ValueError:
+            logger.warning(
+                "MCP_MESH_TOOL_WORKERS=%r is not an int; falling back to default",
+                env_val,
+            )
+    cpu = os.cpu_count() or 2
+    return min(8, max(2, cpu))
+
+
+def _start_workers() -> list[tuple[threading.Thread, asyncio.AbstractEventLoop]]:
+    """Start the worker pool. Idempotent — first call wins.
+
+    Spawns N daemon threads, each owning its own asyncio event loop. Returns
+    the populated worker list. Pool size is determined ONCE here from the
+    ``MCP_MESH_TOOL_WORKERS`` env var (or default) and cached for the process
+    lifetime.
+    """
+    global _workers, _next_worker_idx, _shutdown_registered
+
+    with _lock:
+        if _workers:
+            return _workers
+
+        n = _resolve_pool_size()
+        new_workers: list[tuple[threading.Thread, asyncio.AbstractEventLoop]] = []
+        thread_names: list[str] = []
+
+        for i in range(n):
+            ready = threading.Event()
+            loop_holder: dict[str, asyncio.AbstractEventLoop] = {}
+
+            def _run() -> None:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                loop_holder["loop"] = loop
+                ready.set()
+                try:
+                    loop.run_forever()
+                finally:
+                    try:
+                        loop.close()
+                    except Exception:
+                        pass
+
+            name = f"mesh-tool-worker-{i}"
+            thread = threading.Thread(target=_run, name=name, daemon=True)
+            thread.start()
+            ready.wait()
+            new_workers.append((thread, loop_holder["loop"]))
+            thread_names.append(name)
+
+        _workers = new_workers
+        _next_worker_idx = itertools.cycle(range(n))
+
+        if not _shutdown_registered:
+            atexit.register(_shutdown_workers)
+            _shutdown_registered = True
+
+        logger.info(
+            "🧵 mesh tool worker pool started: %d workers (%s)",
+            n,
+            ", ".join(thread_names),
+        )
+        return _workers
+
+
+def _shutdown_workers() -> None:
+    """Stop all worker loops and join their threads. Best-effort, called via atexit."""
+    global _workers, _next_worker_idx
+
+    workers = _workers
+    if not workers:
+        return
+
+    for _thread, loop in workers:
+        try:
+            if not loop.is_closed():
+                loop.call_soon_threadsafe(loop.stop)
+        except Exception as e:
+            logger.debug("mesh tool worker stop call failed: %s", e)
+
+    for thread, _loop in workers:
+        if thread.is_alive():
+            thread.join(timeout=2.0)
+
+    _workers = []
+    _next_worker_idx = None
+
+
+def _pick_loop() -> asyncio.AbstractEventLoop:
+    """Round-robin select a worker loop. Caller must hold no locks."""
+    with _lock:
+        # Cycle is unbounded; advancing it is O(1) and thread-safe under the lock.
+        idx = next(_next_worker_idx)  # type: ignore[arg-type]
+    return _workers[idx][1]
+
+
+def dispatch(
+    coro_func: Callable[..., Coroutine[Any, Any, Any]],
+    args: tuple,
+    kwargs: dict,
+) -> Future:
+    """Run ``coro_func(*args, **kwargs)`` on a worker loop and return a Future.
+
+    The caller's ``contextvars.Context`` (trace IDs, propagated headers, etc.)
+    is captured BEFORE crossing the thread boundary, then re-applied on the
+    worker thread via ``ctx.run`` so the user's coroutine sees the same
+    context that was active at dispatch time.
+
+    Args:
+        coro_func: The async user function (or wrapper) to invoke.
+        args: Positional arguments.
+        kwargs: Keyword arguments.
+
+    Returns:
+        ``concurrent.futures.Future`` resolved with the coroutine's result.
+        Caller should ``await asyncio.wrap_future(future)`` from the main loop.
+    """
+    _start_workers()
+    loop = _pick_loop()
+
+    # Capture context on the CALLING thread — the worker thread doesn't have it.
+    ctx = contextvars.copy_context()
+
+    return asyncio.run_coroutine_threadsafe(
+        _invoke_with_context(ctx, coro_func, args, kwargs), loop
+    )
+
+
+async def _invoke_with_context(
+    ctx: contextvars.Context,
+    coro_func: Callable[..., Coroutine[Any, Any, Any]],
+    args: tuple,
+    kwargs: dict,
+) -> Any:
+    """Invoke the user coroutine on the worker loop inside the captured context.
+
+    ``ctx.run`` only runs synchronous callables, so we use it to BUILD the
+    coroutine (which sets contextvars at coroutine-creation time, since the
+    coroutine object captures the current context). Each ``await`` inside
+    the user code then sees those contextvars. We then await the coroutine
+    on the worker loop.
+    """
+    coro = ctx.run(coro_func, *args, **kwargs)
+    if not asyncio.iscoroutine(coro):
+        return coro
+    return await coro

--- a/src/runtime/python/_mcp_mesh/shared/tool_executor.py
+++ b/src/runtime/python/_mcp_mesh/shared/tool_executor.py
@@ -167,6 +167,17 @@ def _pick_loop() -> asyncio.AbstractEventLoop:
     return _workers[idx][1]
 
 
+# Exposed for the proxy's connection-pool cleanup (close_connection_pools), which
+# needs to schedule client.aclose() on the worker loop that originally created
+# each cached httpx/FastMCP client. Without this, worker-loop clients leak at
+# orderly shutdown — they only get reaped at process termination when their
+# daemon threads die.
+def get_worker_loops() -> list[asyncio.AbstractEventLoop]:
+    """Return the live worker event loops (snapshot)."""
+    with _lock:
+        return [loop for _, loop in _workers]
+
+
 def dispatch(
     coro_func: Callable[..., Coroutine[Any, Any, Any]],
     args: tuple,

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -4,6 +4,7 @@ Mesh decorators implementation - dual decorator architecture.
 Provides @mesh.tool and @mesh.agent decorators with clean separation of concerns.
 """
 
+import asyncio
 import logging
 import uuid
 from collections.abc import Awaitable, Callable
@@ -652,6 +653,85 @@ def _clear_shared_agent_id():
     _SHARED_AGENT_ID = None
 
 
+def _is_tool_isolation_enabled() -> bool:
+    """Whether to dispatch async tool execution to the dedicated worker loop.
+
+    Default ON. Set MCP_MESH_TOOL_ISOLATION=false to disable (legacy behavior).
+    """
+    return get_config_value(
+        "MCP_MESH_TOOL_ISOLATION",
+        override=None,
+        default=True,
+        rule=ValidationRule.TRUTHY_RULE,
+    )
+
+
+def _wrap_with_isolation(final_func: Callable, func_name: str) -> Callable:
+    """Wrap an async tool function so its body runs on the mesh worker loop.
+
+    Only async functions are wrapped — sync tools are already dispatched off
+    the main loop by FastMCP via ``call_sync_fn_in_threadpool``.
+
+    The isolation wrapper is applied as the OUTERMOST layer so FastMCP sees
+    a coroutine function and awaits it on the main loop, while the actual
+    user work executes on the worker thread. The decorator chain
+    (``__wrapped__`` and ``_mesh_original_func``) is preserved via
+    ``functools.wraps`` and explicit attribute copy so
+    ``signature_analyzer._get_original_func`` keeps finding the user function.
+    """
+    if not asyncio.iscoroutinefunction(final_func):
+        return final_func
+
+    @wraps(final_func)
+    async def isolated(*args, **kwargs):
+        # Local import to keep the decorator import-time cost minimal and to
+        # avoid any circular import surprises.
+        from _mcp_mesh.shared.tool_executor import dispatch
+
+        future = dispatch(final_func, args, kwargs)
+        return await asyncio.wrap_future(future)
+
+    # functools.wraps sets __wrapped__ = final_func, which preserves the
+    # signature_analyzer chain (it walks __wrapped__ then checks
+    # _mesh_original_func). Mirror _mesh_original_func explicitly so callers
+    # that read it directly off the outermost wrapper still find the user
+    # function, not the DI wrapper.
+    if hasattr(final_func, "_mesh_original_func"):
+        isolated._mesh_original_func = final_func._mesh_original_func
+    else:
+        isolated._mesh_original_func = final_func
+
+    # Preserve mesh metadata attributes that FastMCP / pipeline code reads
+    # from the outermost wrapper.
+    for attr in (
+        "_mesh_tool_metadata",
+        "_mesh_injected_deps",
+        "_mesh_dependencies",
+        "_mesh_positions",
+        "_mesh_update_dependency",
+        "_mesh_function_id",
+    ):
+        if hasattr(final_func, attr):
+            try:
+                setattr(isolated, attr, getattr(final_func, attr))
+            except AttributeError:
+                pass
+
+    # Preserve the trimmed signature (DI wrapper hides injectable params from
+    # FastMCP). functools.wraps does NOT copy __signature__ by default.
+    if hasattr(final_func, "__signature__"):
+        try:
+            isolated.__signature__ = final_func.__signature__
+        except AttributeError:
+            pass
+
+    isolated._mesh_isolation_wrapped = True
+    logger.debug(
+        f"🧵 ISOLATION: Wrapped async tool '{func_name}' for worker-loop execution"
+    )
+    return isolated
+
+
 def tool(
     capability: str | None = None,
     *,
@@ -808,6 +888,20 @@ def tool(
 
             # Preserve metadata on wrapper
             wrapped._mesh_tool_metadata = metadata
+
+            # Apply tool-execution isolation: for async tools, dispatch the
+            # actual coroutine onto a dedicated worker event loop so a user's
+            # blocking syscall (e.g. time.sleep inside an async def tool)
+            # cannot freeze uvicorn's main loop and stall /health probes.
+            # Sync tools are left alone — FastMCP already runs them via
+            # anyio.to_thread.run_sync (off the main loop).
+            isolation_enabled = _is_tool_isolation_enabled()
+            logger.debug(
+                f"🧵 ISOLATION: enabled={isolation_enabled} for '{target.__name__}' "
+                f"(async={asyncio.iscoroutinefunction(wrapped)})"
+            )
+            if isolation_enabled and asyncio.iscoroutinefunction(wrapped):
+                wrapped = _wrap_with_isolation(wrapped, target.__name__)
 
             # Store the wrapper on the original function for reference
             target._mesh_injection_wrapper = wrapped

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -670,7 +670,7 @@ def _wrap_with_isolation(final_func: Callable, func_name: str) -> Callable:
     """Wrap an async tool function so its body runs on the mesh worker loop.
 
     Only async functions are wrapped — sync tools are already dispatched off
-    the main loop by FastMCP via ``call_sync_fn_in_threadpool``.
+    the main loop by FastMCP via ``anyio.to_thread.run_sync``.
 
     The isolation wrapper is applied as the OUTERMOST layer so FastMCP sees
     a coroutine function and awaits it on the main loop, while the actual

--- a/tests/integration/suites/uc02_tools/artifacts/java-health-block-test-agent
+++ b/tests/integration/suites/uc02_tools/artifacts/java-health-block-test-agent
@@ -1,0 +1,1 @@
+../../../../../examples/java/health-block-test-agent

--- a/tests/integration/suites/uc02_tools/artifacts/py-health-block-test-agent
+++ b/tests/integration/suites/uc02_tools/artifacts/py-health-block-test-agent
@@ -1,0 +1,1 @@
+../../../../../examples/python/health-block-test-agent

--- a/tests/integration/suites/uc02_tools/artifacts/ts-health-block-test-agent
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-health-block-test-agent
@@ -1,0 +1,1 @@
+../../../../../examples/typescript/health-block-test-agent

--- a/tests/integration/suites/uc02_tools/tc25_health_endpoint_responsiveness_py/test.yaml
+++ b/tests/integration/suites/uc02_tools/tc25_health_endpoint_responsiveness_py/test.yaml
@@ -125,8 +125,12 @@ test:
       done
 
       echo "=== Waiting for busy_tool to finish ==="
+      # Disable errexit around `wait` so a non-zero busy_tool exit doesn't
+      # abort the script before BUSY_RC / busy.out / OVERALL diagnostics run.
+      set +e
       wait "$BUSY_PID"
       BUSY_RC=$?
+      set -e
       echo "BUSY_RC=${BUSY_RC}"
       echo "=== busy_tool output ==="
       cat /tmp/busy.out

--- a/tests/integration/suites/uc02_tools/tc25_health_endpoint_responsiveness_py/test.yaml
+++ b/tests/integration/suites/uc02_tools/tc25_health_endpoint_responsiveness_py/test.yaml
@@ -1,0 +1,168 @@
+# Test Case: Health Endpoint Responsiveness Under Blocking Tool Call (Python)
+#
+# Verifies that /health, /ready, and /livez stay responsive (sub-second) while
+# a tool call blocks the request thread for 35 seconds.
+#
+# Background: previously, a sync time.sleep() inside an async @app.tool would
+# block the single uvicorn event loop that also serves the FastAPI health
+# endpoints, causing curl --max-time 2 to time out for the duration of the
+# tool call. Fix: worker-thread isolation in
+# src/runtime/python/_mcp_mesh/shared/tool_executor.py — sync work is now
+# offloaded so the event loop remains free.
+#
+# This test is regression coverage. Threshold of 1.0s is wildly generous
+# vs. the actual single-digit-millisecond baseline; it cleanly separates
+# "healthy" from "blocked = curl times out".
+#
+# Uses UC-level artifacts from /uc-artifacts (symlinked to examples/python).
+
+name: "Health Endpoint Responsiveness During Blocking Tool Call (Python)"
+description: "Verify /health, /ready, /livez stay responsive while a 35s blocking tool call runs"
+tags:
+  - tools
+  - python
+  - health
+  - regression
+  - issue-event-loop-blocking
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  # Copy artifact (port 9099 is hard-coded in the agent)
+  - name: "Copy artifact to workspace"
+    handler: shell
+    command: |
+      cp -r /uc-artifacts/py-health-block-test-agent /workspace/
+      ls -la /workspace/py-health-block-test-agent/
+    capture: copy_output
+
+  # Start the Python agent (binds to 9099 per the @mesh.agent(http_port=9099))
+  - name: "Start Python health-block-test-agent"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start py-health-block-test-agent/main.py -d"
+    capture: start_agent
+
+  # Wait for registration + agent fully reachable
+  - name: "Wait for agent to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for health-block-test-agent to register..."
+      for i in $(seq 1 30); do
+        if meshctl list 2>/dev/null | grep -q "health-block-test-agent"; then
+          echo "Agent registered after $((i * 2))s"
+          meshctl list
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Agent did not register within 60s"
+      meshctl logs health-block-test-agent 2>/dev/null | tail -50 || true
+      exit 1
+    capture: wait_registration
+    timeout: 90
+
+  # Probe baseline before any blocking work — sanity check that the endpoints
+  # respond correctly and quickly when the agent is idle.
+  - name: "Probe baseline /health /ready /livez (idle)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      set -e
+      PORT=9099
+      for ep in /health /ready /livez; do
+        OUT=$(curl --max-time 2 -o /dev/null -s -w "%{http_code} %{time_total}" "http://127.0.0.1:${PORT}${ep}")
+        CODE=$(echo "$OUT" | awk '{print $1}')
+        T=$(echo "$OUT" | awk '{print $2}')
+        echo "BASELINE ${ep}: code=${CODE} time=${T}s"
+        if [ "$CODE" != "200" ]; then
+          echo "FAIL: baseline ${ep} returned ${CODE} (expected 200)"
+          exit 1
+        fi
+      done
+      echo "BASELINE_OK"
+    capture: baseline_probe
+
+  # Kick off the blocking tool call in the background. busy_tool sleeps for
+  # 35s on the runtime's main thread (sync time.sleep inside an async tool).
+  # We capture the PID so we can wait for it later.
+  - name: "Start blocking tool call + probe health while it runs"
+    handler: shell
+    workdir: /workspace
+    command: |
+      set -e
+      PORT=9099
+
+      echo "=== Launching busy_tool(35s) in background ==="
+      meshctl call busy_tool '{"seconds":35}' --timeout 60 > /tmp/busy.out 2>&1 &
+      BUSY_PID=$!
+      echo "BUSY_PID=${BUSY_PID}"
+
+      # Give the tool a moment to actually enter the blocking syscall before
+      # we start probing — otherwise we could measure the pre-call window.
+      sleep 3
+
+      echo "=== Probing /health /ready /livez during blocking tool call ==="
+      FAILED=0
+      for ep in /health /ready /livez; do
+        OUT=$(curl --max-time 2 -o /dev/null -s -w "%{http_code} %{time_total}" "http://127.0.0.1:${PORT}${ep}" || echo "000 99.9")
+        CODE=$(echo "$OUT" | awk '{print $1}')
+        T=$(echo "$OUT" | awk '{print $2}')
+        # Compare time_total < 1.0 in shell (no bc dependency)
+        TOO_SLOW=$(awk -v t="$T" 'BEGIN { print (t+0 > 1.0) ? 1 : 0 }')
+        if [ "$CODE" != "200" ] || [ "$TOO_SLOW" = "1" ]; then
+          echo "FAIL: ${ep} bad result code=${CODE} time=${T}s during busy_tool"
+          FAILED=1
+        else
+          echo "PASS: ${ep} 200 in ${T}s during busy_tool"
+        fi
+      done
+
+      echo "=== Waiting for busy_tool to finish ==="
+      wait "$BUSY_PID"
+      BUSY_RC=$?
+      echo "BUSY_RC=${BUSY_RC}"
+      echo "=== busy_tool output ==="
+      cat /tmp/busy.out
+
+      if [ "$FAILED" = "1" ]; then
+        echo "OVERALL: FAIL — at least one health probe was blocked"
+        exit 1
+      fi
+      echo "OVERALL: PASS — all health probes stayed responsive"
+    capture: probe_output
+    timeout: 120
+
+assertions:
+  # Baseline must show all three endpoints healthy
+  - expr: "${captured.baseline_probe} contains 'BASELINE_OK'"
+    message: "Baseline probe (idle) should report all endpoints healthy"
+
+  # During the blocking tool call, every health endpoint must stay responsive
+  - expr: "${captured.probe_output} contains 'PASS: /health'"
+    message: "/health must respond < 1.0s during a blocking tool call"
+  - expr: "${captured.probe_output} contains 'PASS: /ready'"
+    message: "/ready must respond < 1.0s during a blocking tool call"
+  - expr: "${captured.probe_output} contains 'PASS: /livez'"
+    message: "/livez must respond < 1.0s during a blocking tool call"
+
+  # And the tool itself must have actually run to completion (not been killed
+  # or timed out — that would invalidate the test).
+  - expr: "${captured.probe_output} contains 'slept 35s'"
+    message: "busy_tool must complete its 35s blocking sleep — proves the test exercised the real code path"
+
+  - expr: "${captured.probe_output} contains 'OVERALL: PASS'"
+    message: "All probes during the blocking call must pass"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc02_tools/tc26_health_endpoint_responsiveness_ts/test.yaml
+++ b/tests/integration/suites/uc02_tools/tc26_health_endpoint_responsiveness_ts/test.yaml
@@ -133,8 +133,12 @@ test:
       done
 
       echo "=== Waiting for busyTool to finish ==="
+      # Disable errexit around `wait` so a non-zero busyTool exit doesn't
+      # abort the script before BUSY_RC / busy.out / OVERALL diagnostics run.
+      set +e
       wait "$BUSY_PID"
       BUSY_RC=$?
+      set -e
       echo "BUSY_RC=${BUSY_RC}"
       echo "=== busyTool output ==="
       cat /tmp/busy.out

--- a/tests/integration/suites/uc02_tools/tc26_health_endpoint_responsiveness_ts/test.yaml
+++ b/tests/integration/suites/uc02_tools/tc26_health_endpoint_responsiveness_ts/test.yaml
@@ -1,0 +1,170 @@
+# Test Case: Health Endpoint Responsiveness Under Blocking Tool Call (TypeScript)
+#
+# DISABLED — known bug. The TypeScript runtime suffers the same
+# single-event-loop blocking issue as the (now-fixed) Python runtime: Express
+# health endpoints (/health, /ready) and the FastMCP HTTP handler share Node's
+# one event loop. A tool that blocks the loop (e.g. execSync('sleep N'))
+# stalls health probes for the entire duration of the tool call.
+#
+# The fix requires moving tool execution into worker_threads (or an analogous
+# off-loop mechanism) — a non-trivial refactor of the TS runtime that is
+# being deferred to a separate PR. This test is checked in *now* so that the
+# follow-up PR can simply flip `disabled: false` and use it as the regression
+# fixture, without having to recreate the test setup, artifact symlink, or
+# example reproducer agent.
+#
+# When the TS runtime is fixed:
+#   1. Remove `disabled: true` below.
+#   2. Remove this DISABLED comment block.
+#   3. Confirm the test passes against the fix.
+#
+# Tracking: https://github.com/dhyansraj/mcp-mesh/issues/818
+#
+# Uses UC-level artifacts from /uc-artifacts (symlinked to examples/typescript).
+
+name: "Health Endpoint Responsiveness During Blocking Tool Call (TypeScript)"
+description: "Verify /health and /ready stay responsive while a 35s blocking tool call runs (TS) — DISABLED, see header"
+disabled: true # TS runtime: known event-loop blocking bug; fix tracked in follow-up PR
+tags:
+  - tools
+  - typescript
+  - health
+  - regression
+  - skip-known-issue
+  - issue-event-loop-blocking
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  # Copy artifact (port 9098 is hard-coded in the agent via httpPort: 9098)
+  - name: "Copy artifact to workspace"
+    handler: shell
+    command: |
+      cp -r /uc-artifacts/ts-health-block-test-agent /workspace/
+      ls -la /workspace/ts-health-block-test-agent/
+    capture: copy_output
+
+  # Install npm dependencies (npm-install handler also strips node_modules
+  # to avoid host-platform mismatch from the symlinked example).
+  - name: "Install npm dependencies"
+    handler: npm-install
+    path: /workspace/ts-health-block-test-agent
+
+  # Start the TypeScript agent
+  - name: "Start TypeScript health-block-test-agent"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start ts-health-block-test-agent/src/index.ts -d"
+    capture: start_agent
+
+  # Wait for registration
+  - name: "Wait for agent to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for health-block-test-agent to register..."
+      for i in $(seq 1 30); do
+        if meshctl list 2>/dev/null | grep -q "health-block-test-agent"; then
+          echo "Agent registered after $((i * 2))s"
+          meshctl list
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Agent did not register within 60s"
+      meshctl logs health-block-test-agent 2>/dev/null | tail -50 || true
+      exit 1
+    capture: wait_registration
+    timeout: 90
+
+  # Probe baseline before any blocking work
+  - name: "Probe baseline /health /ready (idle)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      set -e
+      PORT=9098
+      for ep in /health /ready; do
+        OUT=$(curl --max-time 2 -o /dev/null -s -w "%{http_code} %{time_total}" "http://127.0.0.1:${PORT}${ep}")
+        CODE=$(echo "$OUT" | awk '{print $1}')
+        T=$(echo "$OUT" | awk '{print $2}')
+        echo "BASELINE ${ep}: code=${CODE} time=${T}s"
+        if [ "$CODE" != "200" ]; then
+          echo "FAIL: baseline ${ep} returned ${CODE} (expected 200)"
+          exit 1
+        fi
+      done
+      echo "BASELINE_OK"
+    capture: baseline_probe
+
+  # Kick off the blocking tool call (busyTool uses execSync('sleep 35') —
+  # blocks the Node event loop for ~35s) and probe health while it runs.
+  - name: "Start blocking tool call + probe health while it runs"
+    handler: shell
+    workdir: /workspace
+    command: |
+      set -e
+      PORT=9098
+
+      echo "=== Launching busyTool(35s) in background ==="
+      meshctl call busyTool '{"seconds":35}' --timeout 60 > /tmp/busy.out 2>&1 &
+      BUSY_PID=$!
+      echo "BUSY_PID=${BUSY_PID}"
+
+      sleep 3
+
+      echo "=== Probing /health /ready during blocking tool call ==="
+      FAILED=0
+      for ep in /health /ready; do
+        OUT=$(curl --max-time 2 -o /dev/null -s -w "%{http_code} %{time_total}" "http://127.0.0.1:${PORT}${ep}" || echo "000 99.9")
+        CODE=$(echo "$OUT" | awk '{print $1}')
+        T=$(echo "$OUT" | awk '{print $2}')
+        TOO_SLOW=$(awk -v t="$T" 'BEGIN { print (t+0 > 1.0) ? 1 : 0 }')
+        if [ "$CODE" != "200" ] || [ "$TOO_SLOW" = "1" ]; then
+          echo "FAIL: ${ep} bad result code=${CODE} time=${T}s during busyTool"
+          FAILED=1
+        else
+          echo "PASS: ${ep} 200 in ${T}s during busyTool"
+        fi
+      done
+
+      echo "=== Waiting for busyTool to finish ==="
+      wait "$BUSY_PID"
+      BUSY_RC=$?
+      echo "BUSY_RC=${BUSY_RC}"
+      echo "=== busyTool output ==="
+      cat /tmp/busy.out
+
+      if [ "$FAILED" = "1" ]; then
+        echo "OVERALL: FAIL — at least one health probe was blocked"
+        exit 1
+      fi
+      echo "OVERALL: PASS — all health probes stayed responsive"
+    capture: probe_output
+    timeout: 120
+
+assertions:
+  - expr: "${captured.baseline_probe} contains 'BASELINE_OK'"
+    message: "Baseline probe (idle) should report all endpoints healthy"
+
+  - expr: "${captured.probe_output} contains 'PASS: /health'"
+    message: "/health must respond < 1.0s during a blocking tool call"
+  - expr: "${captured.probe_output} contains 'PASS: /ready'"
+    message: "/ready must respond < 1.0s during a blocking tool call"
+
+  - expr: "${captured.probe_output} contains 'slept 35s'"
+    message: "busyTool must complete its 35s blocking sleep — proves the test exercised the real code path"
+
+  - expr: "${captured.probe_output} contains 'OVERALL: PASS'"
+    message: "All probes during the blocking call must pass"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc02_tools/tc27_health_endpoint_responsiveness_java/test.yaml
+++ b/tests/integration/suites/uc02_tools/tc27_health_endpoint_responsiveness_java/test.yaml
@@ -127,8 +127,12 @@ test:
       done
 
       echo "=== Waiting for busyToolJava to finish ==="
+      # Disable errexit around `wait` so a non-zero busyToolJava exit doesn't
+      # abort the script before BUSY_RC / busy.out / OVERALL diagnostics run.
+      set +e
       wait "$BUSY_PID"
       BUSY_RC=$?
+      set -e
       echo "BUSY_RC=${BUSY_RC}"
       echo "=== busyToolJava output ==="
       cat /tmp/busy.out
@@ -143,7 +147,7 @@ test:
 
 assertions:
   - expr: "${captured.baseline_probe} contains 'BASELINE_OK'"
-    message: "Baseline probe (idle) should report all endpoints healthy"
+    message: "Baseline /health probe should report service healthy"
 
   - expr: "${captured.probe_output} contains 'PASS: /health'"
     message: "/health must respond < 1.0s during a blocking tool call"

--- a/tests/integration/suites/uc02_tools/tc27_health_endpoint_responsiveness_java/test.yaml
+++ b/tests/integration/suites/uc02_tools/tc27_health_endpoint_responsiveness_java/test.yaml
@@ -1,0 +1,165 @@
+# Test Case: Health Endpoint Responsiveness Under Blocking Tool Call (Java)
+#
+# Verifies that /health and /ready stay responsive (sub-second) while a tool
+# call blocks one Tomcat request thread for 35 seconds.
+#
+# Java's MCP Mesh runtime uses Spring Boot + embedded Tomcat with a thread
+# pool, so a blocked tool consumes one worker thread but the remaining
+# workers keep serving health probes. This test serves as REGRESSION
+# COVERAGE — it locks in that current behavior so a future migration to a
+# reactive / single-thread model cannot silently regress responsiveness.
+#
+# Counterpart tests:
+#   - tc25 (Python): same shape, was previously broken, fixed via worker
+#     thread isolation in tool_executor.py
+#   - tc26 (TypeScript): currently DISABLED; the TS runtime has the bug and
+#     a fix is tracked in a separate PR
+#
+# Uses UC-level artifacts from /uc-artifacts (symlinked to examples/java).
+
+name: "Health Endpoint Responsiveness During Blocking Tool Call (Java)"
+description: "Verify Java /health and /ready stay responsive while a 35s blocking tool call runs"
+tags:
+  - tools
+  - java
+  - health
+  - regression
+  - issue-event-loop-blocking
+timeout: 300
+
+pre_run:
+  - routine: global.setup_for_java_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  # Copy artifact (port 9097 is set via src/main/resources/application.yml — server.port)
+  - name: "Copy artifact to workspace"
+    handler: shell
+    command: |
+      cp -r /uc-artifacts/java-health-block-test-agent /workspace/
+      ls -la /workspace/java-health-block-test-agent/
+    capture: copy_output
+
+  # Install Maven dependencies
+  - name: "Install Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-health-block-test-agent
+    timeout: 600
+
+  # Start the Java agent (registry starts automatically)
+  - name: "Start Java health-block-test-agent"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start /workspace/java-health-block-test-agent -d"
+    capture: start_agent
+
+  # Wait for registration — Java startup takes longer than Python/TS
+  - name: "Wait for agent to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for health-block-test-agent to register..."
+      for i in $(seq 1 60); do
+        if meshctl list 2>/dev/null | grep -q "health-block-test-agent"; then
+          echo "Agent registered after $((i * 2))s"
+          meshctl list
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Agent did not register within 120s"
+      meshctl logs health-block-test-agent 2>/dev/null | tail -50 || true
+      exit 1
+    capture: wait_registration
+    timeout: 150
+
+  # Probe baseline before any blocking work.
+  # Java runtime (MeshHealthController) exposes only /health — no /ready or /livez.
+  - name: "Probe baseline /health (idle)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      set -e
+      PORT=9097
+      for ep in /health; do
+        OUT=$(curl --max-time 2 -o /dev/null -s -w "%{http_code} %{time_total}" "http://127.0.0.1:${PORT}${ep}")
+        CODE=$(echo "$OUT" | awk '{print $1}')
+        T=$(echo "$OUT" | awk '{print $2}')
+        echo "BASELINE ${ep}: code=${CODE} time=${T}s"
+        if [ "$CODE" != "200" ]; then
+          echo "FAIL: baseline ${ep} returned ${CODE} (expected 200)"
+          exit 1
+        fi
+      done
+      echo "BASELINE_OK"
+    capture: baseline_probe
+
+  # Kick off the blocking tool call (busyToolJava sleeps for 35s on its
+  # request thread via Thread.sleep) and probe health while it runs.
+  - name: "Start blocking tool call + probe health while it runs"
+    handler: shell
+    workdir: /workspace
+    command: |
+      set -e
+      PORT=9097
+
+      echo "=== Launching busyToolJava(35s) in background ==="
+      meshctl call busyToolJava '{"seconds":35}' --timeout 60 > /tmp/busy.out 2>&1 &
+      BUSY_PID=$!
+      echo "BUSY_PID=${BUSY_PID}"
+
+      sleep 3
+
+      echo "=== Probing /health during blocking tool call ==="
+      FAILED=0
+      for ep in /health; do
+        OUT=$(curl --max-time 2 -o /dev/null -s -w "%{http_code} %{time_total}" "http://127.0.0.1:${PORT}${ep}" || echo "000 99.9")
+        CODE=$(echo "$OUT" | awk '{print $1}')
+        T=$(echo "$OUT" | awk '{print $2}')
+        TOO_SLOW=$(awk -v t="$T" 'BEGIN { print (t+0 > 1.0) ? 1 : 0 }')
+        if [ "$CODE" != "200" ] || [ "$TOO_SLOW" = "1" ]; then
+          echo "FAIL: ${ep} bad result code=${CODE} time=${T}s during busyToolJava"
+          FAILED=1
+        else
+          echo "PASS: ${ep} 200 in ${T}s during busyToolJava"
+        fi
+      done
+
+      echo "=== Waiting for busyToolJava to finish ==="
+      wait "$BUSY_PID"
+      BUSY_RC=$?
+      echo "BUSY_RC=${BUSY_RC}"
+      echo "=== busyToolJava output ==="
+      cat /tmp/busy.out
+
+      if [ "$FAILED" = "1" ]; then
+        echo "OVERALL: FAIL — at least one health probe was blocked"
+        exit 1
+      fi
+      echo "OVERALL: PASS — all health probes stayed responsive"
+    capture: probe_output
+    timeout: 120
+
+assertions:
+  - expr: "${captured.baseline_probe} contains 'BASELINE_OK'"
+    message: "Baseline probe (idle) should report all endpoints healthy"
+
+  - expr: "${captured.probe_output} contains 'PASS: /health'"
+    message: "/health must respond < 1.0s during a blocking tool call"
+
+  - expr: "${captured.probe_output} contains 'slept 35s'"
+    message: "busyToolJava must complete its 35s blocking sleep — proves the test exercised the real code path"
+
+  - expr: "${captured.probe_output} contains 'OVERALL: PASS'"
+    message: "All probes during the blocking call must pass"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop 2>/dev/null || true
+      pkill -f "spring-boot:run" 2>/dev/null || true
+      pkill -f "java.*health-block" 2>/dev/null || true
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

- Fixes #817: a Python `@mesh.tool` that blocks the asyncio event loop (sync `time.sleep` in async, sync DB driver, CPU-bound work) freezes `/health`, `/ready`, `/livez` — k8s recycles the pod after ~30s of unresponsive `/livez`.
- Worker-thread pool (`tool_executor.py`) dispatches `async def` mesh tools onto N daemon threads each running their own asyncio loop. Default `N = min(8, max(2, cpu_count()))`, override `MCP_MESH_TOOL_WORKERS`. Disable via `MCP_MESH_TOOL_ISOLATION=false`.
- Isolation wrapper added in `mesh/decorators.py` as outermost layer around async tools (after DI). Sync `def` tools left alone — FastMCP already off-loads them.
- HTTP/FastMCP transport pool in `unified_mcp_proxy.py` re-keyed by `(loop_id, endpoint)` with `threading.Lock` to avoid cross-loop asyncio-resource binding errors that would otherwise force the FastMCP fallback path.
- Reproducer agents under `examples/{python,typescript,java}/health-block-test-agent/`.
- tsuite coverage: `tc25_*_py` PASSES, `tc26_*_ts` `disabled: true` (TS fix tracked in #818), `tc27_*_java` PASSES (regression coverage for Tomcat thread pool isolation).

## Review Notes

- Independent review surfaced a suspected BLOCKER on contextvar propagation through the worker boundary — empirically refuted by 3 tests (synthetic with/without await, real-agent inbound `x-trace-id` header read inside tool body, all returned the propagated value). The `ctx.run(coro_func, ...)` + `await coro` pattern works correctly in CPython 3.11+.
- Other warnings deferred as out-of-scope follow-ups: worker-loop client cleanup at orderly shutdown, FastMCP cache `is_closed` health check (pre-existing), useless async wrapper for `_get_httpx_client` (cosmetic).
- One placeholder-link warning (`<follow-up-issue-link-here>` in tc26 disabled comment) was real and is fixed in this PR — replaced with `#818`.

## Java side note (out of scope)

`MeshHealthController` exposes only `/health` (no `/ready` or `/livez`). The tc27 test was adjusted to probe only `/health`. Adding the missing endpoints would align Java's surface area with Python/TS — worth a follow-up but not required for this fix.

Closes #817

## Test plan

- [x] Python local reproducer: `meshctl call busy_tool '{"seconds":35}'` while curling `/livez` — returns 200 in ~17ms (was: TIMEOUT)
- [x] Two concurrent `busy_tool(20)` calls finish in 20s wall (was: 40s) — confirms true parallelism
- [x] Cross-loop httpx regression caught + fixed: 50 concurrent cross-agent calls, 0 fallbacks
- [x] 507 Python unit tests pass
- [x] tsuite tc14_vault_cross_agent passes (the canary that caught the cross-loop regression)
- [x] tsuite tc25 (Py), tc27 (Java) PASS
- [x] tsuite tc26 (TS) appropriately quarantined as disabled
- [x] uc06 observability tests pass — confirms distributed tracing still works through isolated tools
- [ ] Reviewer should sanity-check the per-loop pool eviction behavior under sustained agent restart loops (low risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added health-block-test-agent examples in Java, Python, and TypeScript to demonstrate concurrent tool execution patterns.

* **Tests**
  * Added integration tests for health endpoint responsiveness during long-running tool calls across all runtimes.

* **Bug Fixes**
  * Improved event loop isolation for async tools to prevent blocking the main event loop during concurrent operations.
  * Enhanced thread-safe connection pool management across multiple worker threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->