### PR TITLE
fix(python): Claude HINT-first structured output to eliminate silent hangs

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/_handler_context.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/_handler_context.py
@@ -1,0 +1,46 @@
+"""Per-async-context storage for provider handler state.
+
+Provider handlers are cached as singletons in ProviderHandlerRegistry, so any
+instance state shared between methods (e.g., the pending output schema set by
+apply_structured_output and read by format_system_prompt) is racy under
+concurrent async requests with different parameters.
+
+This module wraps the shared state in contextvars.ContextVar so each async
+context (asyncio.Task, contextvars.copy_context, etc.) sees its own value.
+"""
+from __future__ import annotations
+
+import contextvars
+from typing import Any
+
+# Per-async-context output-schema state. Set by apply_structured_output (and
+# any other writer such as prepare_request); read by format_system_prompt.
+_current_output_schema: contextvars.ContextVar[dict[str, Any] | None] = (
+    contextvars.ContextVar(
+        "mesh_handler_current_output_schema", default=None
+    )
+)
+_current_output_type_name: contextvars.ContextVar[str | None] = (
+    contextvars.ContextVar(
+        "mesh_handler_current_output_type_name", default=None
+    )
+)
+
+
+def set_pending_output_schema(
+    schema: dict[str, Any] | None, type_name: str | None
+) -> None:
+    """Set the output schema + type-name for the current async context."""
+    _current_output_schema.set(schema)
+    _current_output_type_name.set(type_name)
+
+
+def get_pending_output_schema() -> tuple[dict[str, Any] | None, str | None]:
+    """Read the output schema + type-name from the current async context."""
+    return _current_output_schema.get(), _current_output_type_name.get()
+
+
+def clear_pending_output_schema() -> None:
+    """Clear the output schema + type-name for the current async context."""
+    _current_output_schema.set(None)
+    _current_output_type_name.set(None)

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
@@ -8,10 +8,12 @@ Output strategy:
 - format_system_prompt (direct calls): Uses HINT mode — prompt-based JSON
   instructions with DECISION GUIDE (~95% reliable). This avoids cross-runtime
   incompatibilities when the caller is a non-Python SDK.
-- apply_structured_output (mesh delegation): Uses native response_format with
-  json_schema type and strict: True (inherited from base class). The Python
-  provider controls the full API call, so cross-runtime concerns don't apply.
-  This gives 100% JSON schema enforcement.
+- apply_structured_output (mesh delegation): Uses HINT mode (prompt injection)
+  by default to avoid the Anthropic response_format + tools silent-hang bug
+  (issue #820). The agentic loop validates the final response against the
+  schema and falls back to a bounded-timeout response_format call if the HINT
+  output fails to parse. Set MCP_MESH_CLAUDE_FORCE_RESPONSE_FORMAT=true to
+  revert to the previous response_format-first behavior.
 
 Features:
 - Automatic prompt caching for system messages (up to 90% cost reduction)
@@ -21,12 +23,17 @@ Features:
 
 import json
 import logging
-from typing import Any, Optional
+import os
+from typing import Any
 
 import mcp_mesh_core
 from pydantic import BaseModel
 
-from .base_provider_handler import BaseProviderHandler, has_media_params
+from .base_provider_handler import (
+    BaseProviderHandler,
+    has_media_params,
+    sanitize_schema_for_structured_output,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +72,7 @@ class ClaudeHandler(BaseProviderHandler):
         super().__init__(vendor="anthropic")
 
     def determine_output_mode(
-        self, output_type: type, override_mode: Optional[str] = None
+        self, output_type: type, override_mode: str | None = None
     ) -> str:
         """
         Determine the output mode based on return type.
@@ -169,7 +176,7 @@ class ClaudeHandler(BaseProviderHandler):
     def prepare_request(
         self,
         messages: list[dict[str, Any]],
-        tools: Optional[list[dict[str, Any]]],
+        tools: list[dict[str, Any]] | None,
         output_type: type,
         **kwargs: Any,
     ) -> dict[str, Any]:
@@ -218,14 +225,20 @@ class ClaudeHandler(BaseProviderHandler):
     def format_system_prompt(
         self,
         base_prompt: str,
-        tool_schemas: Optional[list[dict[str, Any]]],
+        tool_schemas: list[dict[str, Any]] | None,
         output_type: type,
-        output_mode: Optional[str] = None,
+        output_mode: str | None = None,
     ) -> str:
         """
         Format system prompt for Claude with output mode support.
 
         Delegates to Rust core for prompt construction.
+
+        When called via the mesh delegation path, ``apply_structured_output``
+        will have already injected an ``OUTPUT FORMAT:`` HINT block into the
+        system message. In that case the Rust formatter is invoked with
+        ``output_type=str`` (text mode) so the only additions are tool/media
+        instructions — the HINT block is not duplicated.
 
         Args:
             base_prompt: Base system prompt
@@ -253,6 +266,91 @@ class ClaudeHandler(BaseProviderHandler):
             schema_name,
             determined_mode,
         )
+
+    def apply_structured_output(
+        self,
+        output_schema: dict[str, Any],
+        output_type_name: str | None,
+        model_params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """
+        Apply Claude-specific structured output for mesh delegation.
+
+        Claude's native ``response_format`` path silently hangs (600s+) on
+        certain content + tools combinations (issue #820). To avoid this,
+        we use HINT mode by default: inject schema instructions into the
+        system prompt and let the agentic loop validate the final response.
+        If validation fails, the loop falls back to a bounded-timeout
+        ``response_format`` call (see ``_provider_agentic_loop``).
+
+        Set ``MCP_MESH_CLAUDE_FORCE_RESPONSE_FORMAT=true`` to revert to the
+        previous response_format-first behavior (delegates to base impl).
+
+        Args:
+            output_schema: JSON schema dict from consumer
+            output_type_name: Name of the output type (e.g., "TripPlan")
+            model_params: Current model parameters dict (will be modified)
+
+        Returns:
+            Modified model_params with HINT-mode flags + injected system prompt
+        """
+        # Backwards-compat env flag: revert to base response_format behavior.
+        if os.environ.get("MCP_MESH_CLAUDE_FORCE_RESPONSE_FORMAT", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        ):
+            logger.info(
+                "Claude: MCP_MESH_CLAUDE_FORCE_RESPONSE_FORMAT set, using "
+                "native response_format (base behavior)"
+            )
+            return super().apply_structured_output(
+                output_schema, output_type_name, model_params
+            )
+
+        sanitized_schema = sanitize_schema_for_structured_output(output_schema)
+
+        # Inject HINT instructions into the first system message.
+        # Mesh delegation always involves tools, and Claude's response_format
+        # path silently hangs on certain content+tools combos (issue #820),
+        # so we cannot use it here.
+        messages = model_params.get("messages", [])
+        for msg in messages:
+            if msg.get("role") == "system":
+                base_content = msg.get("content", "")
+                hint_text = "\n\nOUTPUT FORMAT:\n"
+                hint_text += (
+                    "Your FINAL response must be ONLY valid JSON (no markdown, "
+                    "no code blocks) with this exact structure:\n"
+                )
+                properties = sanitized_schema.get("properties", {})
+                hint_text += self.build_json_example(properties) + "\n\n"
+                hint_text += (
+                    "Return ONLY the JSON object with actual values. Do not "
+                    "include the schema definition, markdown formatting, or "
+                    "code blocks."
+                )
+
+                msg["content"] = base_content + hint_text
+                break
+
+        # Internal flags read by _provider_agentic_loop. Prefixed with
+        # "_mesh_" so the loop strips them before calling LiteLLM (these
+        # are NOT API params).
+        model_params["_mesh_hint_mode"] = True
+        model_params["_mesh_hint_schema"] = sanitized_schema
+        model_params["_mesh_hint_fallback_timeout"] = 30
+        model_params["_mesh_hint_output_type_name"] = output_type_name or "Response"
+
+        # Explicitly DO NOT set response_format — that's the bug we're avoiding.
+        model_params.pop("response_format", None)
+
+        logger.info(
+            "Claude HINT mode for '%s' (mesh delegation, schema in prompt; "
+            "loop will fall back to response_format if parse fails)",
+            output_type_name or "Response",
+        )
+        return model_params
 
     def get_vendor_capabilities(self) -> dict[str, bool]:
         """

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
@@ -267,6 +267,27 @@ class ClaudeHandler(BaseProviderHandler):
             determined_mode,
         )
 
+    def _build_hint_text(self, sanitized_schema: dict[str, Any]) -> str:
+        """Build the ``OUTPUT FORMAT:`` HINT block for ``apply_structured_output``.
+
+        Returned text starts with leading blank lines so it can be appended
+        directly to existing system message content. Callers that synthesize
+        a fresh system message should ``.strip()`` the result.
+        """
+        hint_text = "\n\nOUTPUT FORMAT:\n"
+        hint_text += (
+            "Your FINAL response must be ONLY valid JSON (no markdown, "
+            "no code blocks) with this exact structure:\n"
+        )
+        properties = sanitized_schema.get("properties", {})
+        hint_text += self.build_json_example(properties) + "\n\n"
+        hint_text += (
+            "Return ONLY the JSON object with actual values. Do not "
+            "include the schema definition, markdown formatting, or "
+            "code blocks."
+        )
+        return hint_text
+
     def apply_structured_output(
         self,
         output_schema: dict[str, Any],
@@ -315,24 +336,30 @@ class ClaudeHandler(BaseProviderHandler):
         # path silently hangs on certain content+tools combos (issue #820),
         # so we cannot use it here.
         messages = model_params.get("messages", [])
+        hint_block_inserted = False
         for msg in messages:
             if msg.get("role") == "system":
                 base_content = msg.get("content", "")
-                hint_text = "\n\nOUTPUT FORMAT:\n"
-                hint_text += (
-                    "Your FINAL response must be ONLY valid JSON (no markdown, "
-                    "no code blocks) with this exact structure:\n"
-                )
-                properties = sanitized_schema.get("properties", {})
-                hint_text += self.build_json_example(properties) + "\n\n"
-                hint_text += (
-                    "Return ONLY the JSON object with actual values. Do not "
-                    "include the schema definition, markdown formatting, or "
-                    "code blocks."
-                )
-
-                msg["content"] = base_content + hint_text
+                msg["content"] = base_content + self._build_hint_text(sanitized_schema)
+                hint_block_inserted = True
                 break
+
+        if not hint_block_inserted:
+            # No system message found — synthesize one containing just the
+            # HINT block. Without this, the _mesh_hint_* flags below would
+            # still be set but the model would never see the schema, every
+            # response would fail validation, and the 30s fallback timeout
+            # would fire on every request.
+            hint_text = self._build_hint_text(sanitized_schema)
+            messages.insert(0, {"role": "system", "content": hint_text.strip()})
+            logger.debug(
+                "Claude HINT mode for '%s': no system message found, "
+                "synthesized one with HINT block",
+                output_type_name or "Response",
+            )
+            # Keep model_params["messages"] in sync — messages may be a
+            # fresh list reference if the caller passed an empty/missing list.
+            model_params["messages"] = messages
 
         # Internal flags read by _provider_agentic_loop. Prefixed with
         # "_mesh_" so the loop strips them before calling LiteLLM (these

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
@@ -29,6 +29,7 @@ from typing import Any, Optional
 from pydantic import BaseModel
 
 from ._handler_context import (
+    clear_pending_output_schema,
     get_pending_output_schema,
     set_pending_output_schema,
 )
@@ -138,7 +139,7 @@ class GeminiHandler(BaseProviderHandler):
 
         # Skip structured output for str return type (text mode)
         if output_type is str:
-            set_pending_output_schema(None, None)
+            clear_pending_output_schema()
             return request_params
 
         # Only store schema for Pydantic models
@@ -171,7 +172,7 @@ class GeminiHandler(BaseProviderHandler):
                     output_type.__name__,
                 )
         else:
-            set_pending_output_schema(None, None)
+            clear_pending_output_schema()
 
         return request_params
 

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
@@ -28,6 +28,10 @@ from typing import Any, Optional
 
 from pydantic import BaseModel
 
+from ._handler_context import (
+    get_pending_output_schema,
+    set_pending_output_schema,
+)
 from .base_provider_handler import (
     BaseProviderHandler,
     has_media_params,
@@ -70,11 +74,14 @@ class GeminiHandler(BaseProviderHandler):
     """
 
     def __init__(self):
-        """Initialize Gemini handler."""
+        """Initialize Gemini handler.
+
+        Pending output-schema state lives in ``_handler_context`` ContextVars
+        rather than instance fields, because handlers are cached as
+        singletons in ``ProviderHandlerRegistry`` and instance state would
+        race across concurrent async requests.
+        """
         super().__init__(vendor="gemini")
-        # Store output schema for use in format_system_prompt (set by apply_structured_output)
-        self._pending_output_schema: dict[str, Any] | None = None
-        self._pending_output_type_name: str | None = None
 
     def determine_output_mode(self, output_type, override_mode=None):
         """Determine output mode for Gemini.
@@ -131,8 +138,7 @@ class GeminiHandler(BaseProviderHandler):
 
         # Skip structured output for str return type (text mode)
         if output_type is str:
-            self._pending_output_schema = None
-            self._pending_output_type_name = None
+            set_pending_output_schema(None, None)
             return request_params
 
         # Only store schema for Pydantic models
@@ -141,8 +147,7 @@ class GeminiHandler(BaseProviderHandler):
             schema = sanitize_schema_for_structured_output(schema)
 
             # Store for HINT mode in format_system_prompt (always needed as fallback)
-            self._pending_output_schema = schema
-            self._pending_output_type_name = output_type.__name__
+            set_pending_output_schema(schema, output_type.__name__)
 
             # Only use response_format when NO tools present
             # Gemini 3 + response_format + tools causes non-deterministic infinite tool loops
@@ -166,8 +171,7 @@ class GeminiHandler(BaseProviderHandler):
                     output_type.__name__,
                 )
         else:
-            self._pending_output_schema = None
-            self._pending_output_type_name = None
+            set_pending_output_schema(None, None)
 
         return request_params
 
@@ -192,9 +196,10 @@ class GeminiHandler(BaseProviderHandler):
         """
         import mcp_mesh_core
 
-        # Use pending schema if set (from apply_structured_output or prepare_request)
-        output_schema = self._pending_output_schema
-        output_type_name = self._pending_output_type_name
+        # Use pending schema if set (from apply_structured_output or prepare_request).
+        # State lives in a per-async-context ContextVar to avoid races under
+        # singleton handler caching.
+        output_schema, output_type_name = get_pending_output_schema()
 
         if output_schema is None:
             if output_type is str:
@@ -264,9 +269,9 @@ class GeminiHandler(BaseProviderHandler):
         """
         sanitized_schema = sanitize_schema_for_structured_output(output_schema)
 
-        # Store for format_system_prompt
-        self._pending_output_schema = sanitized_schema
-        self._pending_output_type_name = output_type_name
+        # Store for format_system_prompt (per-async-context to avoid races
+        # across concurrent requests sharing this singleton handler).
+        set_pending_output_schema(sanitized_schema, output_type_name)
 
         # Inject HINT instructions into system messages
         # (mesh delegation always has tools, so we can't use response_format)

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -8,11 +8,113 @@ mesh decorators to simplify common patterns like zero-code LLM providers.
 import asyncio
 import json
 import logging
-from typing import Any, Optional
+import re
+from typing import Any
 
 from _mcp_mesh.shared.logging_config import format_log_value
 
 logger = logging.getLogger(__name__)
+
+
+def _hint_response_parses(content: str, schema: dict[str, Any]) -> bool:
+    """Validate that ``content`` is JSON-parseable and conforms to ``schema``.
+
+    Used after Claude HINT mode to decide whether to fall back to native
+    response_format. Tolerant of fenced code blocks (Claude HINT can wrap
+    JSON in ``\u0060\u0060\u0060json...\u0060\u0060\u0060``) — strip them before parsing.
+
+    If ``jsonschema`` is not installed, only JSON parseability is checked.
+    """
+    if not content:
+        return False
+    try:
+        cleaned = content.strip()
+        # Strip surrounding markdown code fences if present.
+        # Handle both ```json\n...\n``` and ```\n...\n``` patterns.
+        cleaned = re.sub(
+            r"^```(?:json)?\s*\n?", "", cleaned, count=1
+        )
+        cleaned = re.sub(r"\n?```\s*$", "", cleaned, count=1)
+        parsed = json.loads(cleaned)
+    except (json.JSONDecodeError, ValueError):
+        return False
+
+    try:
+        import jsonschema  # type: ignore
+
+        try:
+            jsonschema.validate(instance=parsed, schema=schema)
+            return True
+        except jsonschema.ValidationError:
+            return False
+    except ImportError:
+        # jsonschema not available — JSON parseability is the best we can do.
+        return True
+
+
+# Internal mesh control flags set by provider handlers (e.g., ClaudeHandler
+# HINT mode) and consumed by the loop / legacy paths in this module. They MUST
+# be stripped from completion_args before any litellm.completion call —
+# otherwise providers like Anthropic reject the request with HTTP 400
+# ("Extra inputs are not permitted").
+_MESH_HINT_KEYS = (
+    "_mesh_hint_mode",
+    "_mesh_hint_schema",
+    "_mesh_hint_fallback_timeout",
+    "_mesh_hint_output_type_name",
+)
+
+
+def _pop_mesh_hint_flags(
+    completion_args: dict[str, Any],
+    defaults: tuple[bool, dict | None, int, str] = (False, None, 30, "Response"),
+) -> tuple[bool, dict | None, int, str]:
+    """Strip ``_mesh_*`` HINT-mode flags from ``completion_args`` in place.
+
+    Returns the captured ``(hint_mode, hint_schema, hint_fallback_timeout,
+    hint_output_type_name)`` so callers can use them to drive the post-call
+    fallback. Defaults preserve existing values across loop iterations.
+    """
+    hint_mode_default, hint_schema_default, hint_timeout_default, hint_name_default = defaults
+    hint_mode = bool(completion_args.pop("_mesh_hint_mode", hint_mode_default))
+    hint_schema = completion_args.pop("_mesh_hint_schema", hint_schema_default)
+    hint_fallback_timeout = completion_args.pop(
+        "_mesh_hint_fallback_timeout", hint_timeout_default
+    )
+    hint_output_type_name = completion_args.pop(
+        "_mesh_hint_output_type_name", hint_name_default
+    )
+    return hint_mode, hint_schema, hint_fallback_timeout, hint_output_type_name
+
+
+def _extract_text_from_message_content(content: Any) -> str:
+    """Normalize a LiteLLM message ``content`` field to a plain string.
+
+    LiteLLM may return ``content`` as a string (most providers) or as a list
+    of content blocks (Anthropic with thinking, mixed text+image, etc.). This
+    helper handles both shapes and concatenates text blocks.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        text_parts: list[str] = []
+        for block in content:
+            if block is None:
+                continue
+            if isinstance(block, dict):
+                text_value = block.get("text", "")
+                text_parts.append(
+                    str(text_value) if text_value is not None else ""
+                )
+            else:
+                try:
+                    text_parts.append(str(block))
+                except Exception:
+                    continue
+        return "".join(text_parts)
+    return str(content)
 
 
 async def _provider_agentic_loop(
@@ -213,6 +315,13 @@ async def _provider_agentic_loop(
             [],
         )
 
+    # HINT-mode state (set by ClaudeHandler.apply_structured_output).
+    # Captured outside the loop so the fallback after the loop has access.
+    hint_mode = False
+    hint_schema: dict[str, Any] | None = None
+    hint_fallback_timeout = 30
+    hint_output_type_name = "Response"
+
     while iteration < max_iterations:
         iteration += 1
 
@@ -224,6 +333,27 @@ async def _provider_agentic_loop(
         }
         if model_params:
             completion_args.update(model_params)
+
+        # Strip internal mesh control flags before they reach LiteLLM.
+        # These are set by handlers (e.g., ClaudeHandler HINT mode) to
+        # signal post-processing to the loop. Must run every iteration
+        # because model_params is unconditionally re-applied above.
+        # NOTE: The legacy single-call path below (in ``llm_provider``) does
+        # the SAME strip — keep both in sync.
+        (
+            hint_mode,
+            hint_schema,
+            hint_fallback_timeout,
+            hint_output_type_name,
+        ) = _pop_mesh_hint_flags(
+            completion_args,
+            defaults=(
+                hint_mode,
+                hint_schema,
+                hint_fallback_timeout,
+                hint_output_type_name,
+            ),
+        )
 
         response = await asyncio.to_thread(litellm.completion, **completion_args)
         message = response.choices[0].message
@@ -293,27 +423,65 @@ async def _provider_agentic_loop(
                     )
         else:
             # No tool calls - final response
-            content = message.content
-            if isinstance(content, list):
-                text_parts = []
-                for block in content:
-                    if block is None:
-                        continue
-                    elif isinstance(block, dict):
-                        text_value = block.get("text", "")
-                        text_parts.append(
-                            str(text_value) if text_value is not None else ""
+            final_content = _extract_text_from_message_content(message.content)
+
+            # HINT-mode validation + bounded-timeout fallback (issue #820).
+            # If a handler (currently only ClaudeHandler) signaled HINT mode,
+            # validate the final response against the schema. If it fails to
+            # parse, retry once with native response_format and a hard timeout.
+            # This recovers from HINT compliance failures without re-introducing
+            # the silent 600s+ hang of the unbounded response_format path.
+            if hint_mode and hint_schema and final_content:
+                if not _hint_response_parses(final_content, hint_schema):
+                    if loop_logger:
+                        loop_logger.warning(
+                            "Claude HINT mode response failed to parse against "
+                            "output schema; retrying with native response_format "
+                            "(bounded request_timeout=%ss)",
+                            hint_fallback_timeout,
                         )
-                    else:
-                        try:
-                            text_parts.append(str(block))
-                        except Exception:
-                            continue
-                content = "".join(text_parts)
+                    fallback_args: dict[str, Any] = {
+                        "model": effective_model,
+                        "messages": current_messages,
+                        "tools": tools,
+                        **litellm_kwargs,
+                        "response_format": {
+                            "type": "json_schema",
+                            "json_schema": {
+                                "name": hint_output_type_name,
+                                "schema": hint_schema,
+                                "strict": True,
+                            },
+                        },
+                        "request_timeout": hint_fallback_timeout,
+                    }
+                    try:
+                        fallback_response = await asyncio.to_thread(
+                            litellm.completion, **fallback_args
+                        )
+                        fb_message = fallback_response.choices[0].message
+                        final_content = _extract_text_from_message_content(
+                            fb_message.content
+                        )
+                        # Replace response/message references so usage metrics
+                        # below reflect the call that produced the returned content.
+                        response = fallback_response
+                        message = fb_message
+                        if loop_logger:
+                            loop_logger.info(
+                                "Claude HINT fallback to response_format succeeded"
+                            )
+                    except Exception as e:
+                        if loop_logger:
+                            loop_logger.error(
+                                "Claude HINT fallback to response_format failed: %s",
+                                e,
+                            )
+                        raise
 
             message_dict: dict[str, Any] = {
                 "role": message.role,
-                "content": content if content else "",
+                "content": final_content,
             }
 
             if hasattr(response, "usage") and response.usage:
@@ -373,7 +541,7 @@ def _extract_vendor_from_model(model: str) -> str | None:
 def llm_provider(
     model: str,
     capability: str = "llm",
-    tags: Optional[list[str]] = None,
+    tags: list[str] | None = None,
     version: str = "1.0.0",
     **litellm_kwargs: Any,
 ):
@@ -638,6 +806,20 @@ def llm_provider(
             if model_params_copy:
                 completion_args.update(model_params_copy)
 
+            # Strip internal mesh control flags before they reach LiteLLM.
+            # These are set by handlers (e.g., ClaudeHandler HINT mode) and
+            # would otherwise cause provider APIs to reject the request with
+            # HTTP 400 ("Extra inputs are not permitted"). The HINT fallback
+            # below uses the captured values.
+            # NOTE: The provider-managed loop above does the SAME strip —
+            # see ``_provider_agentic_loop`` for the multi-iteration path.
+            (
+                hint_mode,
+                hint_schema,
+                hint_fallback_timeout,
+                hint_output_type_name,
+            ) = _pop_mesh_hint_flags(completion_args)
+
             try:
                 logger.debug(
                     f"📤 LLM provider request: {format_log_value(completion_args)}"
@@ -652,30 +834,67 @@ def llm_provider(
                 message = response.choices[0].message
 
                 # Handle content - it can be a string or list of content blocks
-                content = message.content
-                if isinstance(content, list):
-                    text_parts = []
-                    for block in content:
-                        if block is None:
-                            continue
-                        elif isinstance(block, dict):
-                            text_value = block.get("text", "")
-                            text_parts.append(
-                                str(text_value) if text_value is not None else ""
-                            )
-                        else:
-                            try:
-                                text_parts.append(str(block))
-                            except Exception:
-                                logger.warning(
-                                    f"Unable to convert content block to string: {type(block)}"
-                                )
-                                continue
-                    content = "".join(text_parts)
+                final_content = _extract_text_from_message_content(message.content)
+
+                # HINT-mode validation + bounded-timeout fallback (issue #820).
+                # Mirrors the same logic in ``_provider_agentic_loop``. Without
+                # this, a HINT compliance failure here would surface as a
+                # ResponseParseError to the consumer.
+                # NOTE: only run when there are no tool_calls — if the model
+                # returned tools, structured output is not yet expected.
+                no_tool_calls = not (
+                    hasattr(message, "tool_calls") and message.tool_calls
+                )
+                if (
+                    hint_mode
+                    and hint_schema
+                    and final_content
+                    and no_tool_calls
+                    and not _hint_response_parses(final_content, hint_schema)
+                ):
+                    logger.warning(
+                        "Claude HINT mode response failed to parse against "
+                        "output schema; retrying with native response_format "
+                        "(bounded request_timeout=%ss)",
+                        hint_fallback_timeout,
+                    )
+                    fallback_args: dict[str, Any] = {
+                        **completion_args,  # already-stripped, no _mesh_* keys
+                        "response_format": {
+                            "type": "json_schema",
+                            "json_schema": {
+                                "name": hint_output_type_name,
+                                "schema": hint_schema,
+                                "strict": True,
+                            },
+                        },
+                        "request_timeout": hint_fallback_timeout,
+                    }
+                    try:
+                        fallback_response = await asyncio.to_thread(
+                            litellm.completion, **fallback_args
+                        )
+                        fb_message = fallback_response.choices[0].message
+                        final_content = _extract_text_from_message_content(
+                            fb_message.content
+                        )
+                        # Replace response/message references so usage metrics
+                        # below reflect the call that produced the returned content.
+                        response = fallback_response
+                        message = fb_message
+                        logger.info(
+                            "Claude HINT fallback to response_format succeeded"
+                        )
+                    except Exception as fallback_err:
+                        logger.error(
+                            "Claude HINT fallback to response_format failed: %s",
+                            fallback_err,
+                        )
+                        raise
 
                 message_dict: dict[str, Any] = {
                     "role": message.role,
-                    "content": content if content else "",
+                    "content": final_content if final_content else "",
                 }
 
                 # Include tool_calls if present (critical for agentic loop support!)

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -87,6 +87,78 @@ def _pop_mesh_hint_flags(
     return hint_mode, hint_schema, hint_fallback_timeout, hint_output_type_name
 
 
+async def _maybe_run_hint_fallback(
+    *,
+    final_content: str,
+    message: Any,
+    response: Any,
+    base_completion_args: dict[str, Any],
+    hint_mode: bool,
+    hint_schema: dict[str, Any] | None,
+    hint_fallback_timeout: int,
+    hint_output_type_name: str,
+    fallback_logger: logging.Logger | None = None,
+) -> tuple[str, Any, Any]:
+    """If HINT mode is active and ``final_content`` fails to parse against the
+    schema, retry once with native ``response_format`` and a bounded
+    ``request_timeout``.
+
+    Returns ``(possibly-replaced final_content, message, response)``.
+
+    Raises whatever the fallback ``litellm.completion`` raises if it fails —
+    the caller is responsible for surfacing or wrapping. The original
+    (HINT-mode) response is NOT retained on fallback failure: a fallback that
+    errors means we couldn't recover, so re-raising is the cleanest signal.
+
+    IMPORTANT: ``base_completion_args`` MUST already be stripped of the
+    ``_mesh_*`` HINT keys AND of the ``tools`` key. The helper does NOT strip
+    ``tools`` itself — that's the caller's responsibility. Stripping ``tools``
+    matters because the fallback only fires AFTER the model returned final
+    content with no tool_calls, and re-introducing the ``response_format +
+    tools`` combo would re-create the silent-hang vector from issue #820.
+    """
+    if not (hint_mode and hint_schema and final_content):
+        return final_content, message, response
+
+    if _hint_response_parses(final_content, hint_schema):
+        return final_content, message, response
+
+    if fallback_logger:
+        fallback_logger.warning(
+            "Claude HINT mode response failed to parse against output schema; "
+            "retrying with native response_format (bounded request_timeout=%ss)",
+            hint_fallback_timeout,
+        )
+
+    fallback_args = {
+        **base_completion_args,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": hint_output_type_name,
+                "schema": hint_schema,
+                "strict": True,
+            },
+        },
+        "request_timeout": hint_fallback_timeout,
+    }
+    # Lazy import keeps this module importable in environments without
+    # litellm (e.g., during static analysis); both call sites already
+    # import litellm before invoking this helper.
+    import litellm
+
+    fallback_response = await asyncio.to_thread(
+        litellm.completion, **fallback_args
+    )
+    fb_message = fallback_response.choices[0].message
+    fb_content = _extract_text_from_message_content(fb_message.content)
+
+    if fallback_logger:
+        fallback_logger.info("Claude HINT fallback to response_format succeeded")
+
+    return (fb_content if fb_content else "", fb_message, fallback_response)
+
+
 def _extract_text_from_message_content(content: Any) -> str:
     """Normalize a LiteLLM message ``content`` field to a plain string.
 
@@ -431,53 +503,36 @@ async def _provider_agentic_loop(
             # parse, retry once with native response_format and a hard timeout.
             # This recovers from HINT compliance failures without re-introducing
             # the silent 600s+ hang of the unbounded response_format path.
-            if hint_mode and hint_schema and final_content:
-                if not _hint_response_parses(final_content, hint_schema):
-                    if loop_logger:
-                        loop_logger.warning(
-                            "Claude HINT mode response failed to parse against "
-                            "output schema; retrying with native response_format "
-                            "(bounded request_timeout=%ss)",
-                            hint_fallback_timeout,
-                        )
-                    fallback_args: dict[str, Any] = {
-                        "model": effective_model,
-                        "messages": current_messages,
-                        "tools": tools,
-                        **litellm_kwargs,
-                        "response_format": {
-                            "type": "json_schema",
-                            "json_schema": {
-                                "name": hint_output_type_name,
-                                "schema": hint_schema,
-                                "strict": True,
-                            },
-                        },
-                        "request_timeout": hint_fallback_timeout,
-                    }
-                    try:
-                        fallback_response = await asyncio.to_thread(
-                            litellm.completion, **fallback_args
-                        )
-                        fb_message = fallback_response.choices[0].message
-                        final_content = _extract_text_from_message_content(
-                            fb_message.content
-                        )
-                        # Replace response/message references so usage metrics
-                        # below reflect the call that produced the returned content.
-                        response = fallback_response
-                        message = fb_message
-                        if loop_logger:
-                            loop_logger.info(
-                                "Claude HINT fallback to response_format succeeded"
-                            )
-                    except Exception as e:
-                        if loop_logger:
-                            loop_logger.error(
-                                "Claude HINT fallback to response_format failed: %s",
-                                e,
-                            )
-                        raise
+            #
+            # Build base args for the fallback — strip ``tools`` since the
+            # fallback only fires AFTER the model gave a final answer with no
+            # tool_calls. Keeping ``tools`` would re-introduce the
+            # ``response_format + tools`` combo that caused the original
+            # silent hang (issue #820). Bounded timeout is still there as
+            # defense-in-depth, but stripping tools removes the deadlock
+            # vector entirely.
+            fallback_base_args = {
+                k: v for k, v in completion_args.items() if k != "tools"
+            }
+            try:
+                final_content, message, response = await _maybe_run_hint_fallback(
+                    final_content=final_content,
+                    message=message,
+                    response=response,
+                    base_completion_args=fallback_base_args,
+                    hint_mode=hint_mode,
+                    hint_schema=hint_schema,
+                    hint_fallback_timeout=hint_fallback_timeout,
+                    hint_output_type_name=hint_output_type_name,
+                    fallback_logger=loop_logger,
+                )
+            except Exception as e:
+                if loop_logger:
+                    loop_logger.error(
+                        "Claude HINT fallback to response_format failed: %s",
+                        e,
+                    )
+                raise
 
             message_dict: dict[str, Any] = {
                 "role": message.role,
@@ -845,45 +900,28 @@ def llm_provider(
                 no_tool_calls = not (
                     hasattr(message, "tool_calls") and message.tool_calls
                 )
-                if (
-                    hint_mode
-                    and hint_schema
-                    and final_content
-                    and no_tool_calls
-                    and not _hint_response_parses(final_content, hint_schema)
-                ):
-                    logger.warning(
-                        "Claude HINT mode response failed to parse against "
-                        "output schema; retrying with native response_format "
-                        "(bounded request_timeout=%ss)",
-                        hint_fallback_timeout,
-                    )
-                    fallback_args: dict[str, Any] = {
-                        **completion_args,  # already-stripped, no _mesh_* keys
-                        "response_format": {
-                            "type": "json_schema",
-                            "json_schema": {
-                                "name": hint_output_type_name,
-                                "schema": hint_schema,
-                                "strict": True,
-                            },
-                        },
-                        "request_timeout": hint_fallback_timeout,
+                if hint_mode and no_tool_calls:
+                    # Build base args for the fallback — strip ``tools`` since
+                    # the fallback only fires AFTER the model gave a final
+                    # answer with no tool_calls. Keeping ``tools`` would
+                    # re-introduce the ``response_format + tools`` combo that
+                    # caused the original silent hang (issue #820). Bounded
+                    # timeout is still there as defense-in-depth, but stripping
+                    # tools removes the deadlock vector entirely.
+                    fallback_base_args = {
+                        k: v for k, v in completion_args.items() if k != "tools"
                     }
                     try:
-                        fallback_response = await asyncio.to_thread(
-                            litellm.completion, **fallback_args
-                        )
-                        fb_message = fallback_response.choices[0].message
-                        final_content = _extract_text_from_message_content(
-                            fb_message.content
-                        )
-                        # Replace response/message references so usage metrics
-                        # below reflect the call that produced the returned content.
-                        response = fallback_response
-                        message = fb_message
-                        logger.info(
-                            "Claude HINT fallback to response_format succeeded"
+                        final_content, message, response = await _maybe_run_hint_fallback(
+                            final_content=final_content,
+                            message=message,
+                            response=response,
+                            base_completion_args=fallback_base_args,
+                            hint_mode=hint_mode,
+                            hint_schema=hint_schema,
+                            hint_fallback_timeout=hint_fallback_timeout,
+                            hint_output_type_name=hint_output_type_name,
+                            fallback_logger=logger,
                         )
                     except Exception as fallback_err:
                         logger.error(

--- a/src/runtime/python/tests/unit/test_claude_handler_hint_mode.py
+++ b/src/runtime/python/tests/unit/test_claude_handler_hint_mode.py
@@ -1,0 +1,417 @@
+"""
+Unit tests for ClaudeHandler HINT-mode structured output (issue #820).
+
+Background:
+    Anthropic's ``response_format`` path silently hangs (600s+) on certain
+    content + tools combinations. ``ClaudeHandler.apply_structured_output``
+    used to inherit the base implementation that sets ``response_format``
+    directly. We now override it to use HINT mode (prompt injection) plus
+    flags that the agentic loop reads to perform a bounded-timeout fallback
+    if the HINT response fails to parse.
+"""
+
+import os
+
+import pytest
+
+from _mcp_mesh.engine.provider_handlers.claude_handler import ClaudeHandler
+from mesh.helpers import (
+    _MESH_HINT_KEYS,
+    _extract_text_from_message_content,
+    _hint_response_parses,
+    _pop_mesh_hint_flags,
+)
+
+# ---------------------------------------------------------------------------
+# ClaudeHandler.apply_structured_output
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeApplyStructuredOutputHintMode:
+    """Verify the HINT-mode override on ClaudeHandler."""
+
+    def _schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "answer": {"type": "string", "description": "The answer text"},
+                "confidence": {"type": "number"},
+            },
+            "required": ["answer", "confidence"],
+        }
+
+    def setup_method(self):
+        # Ensure env var doesn't leak between tests in this class
+        os.environ.pop("MCP_MESH_CLAUDE_FORCE_RESPONSE_FORMAT", None)
+
+    def teardown_method(self):
+        os.environ.pop("MCP_MESH_CLAUDE_FORCE_RESPONSE_FORMAT", None)
+
+    def test_does_not_set_response_format(self):
+        """HINT-mode override must NOT set ``response_format``."""
+        handler = ClaudeHandler()
+        model_params = {
+            "messages": [{"role": "system", "content": "You are helpful."}],
+        }
+
+        result = handler.apply_structured_output(
+            self._schema(), "MyType", model_params
+        )
+
+        assert "response_format" not in result, (
+            "ClaudeHandler.apply_structured_output must not set response_format "
+            "(would re-introduce issue #820 silent hang)"
+        )
+
+    def test_sets_hint_mode_flag(self):
+        """Internal ``_mesh_hint_mode`` flag must be True after override."""
+        handler = ClaudeHandler()
+        model_params = {
+            "messages": [{"role": "system", "content": "You are helpful."}],
+        }
+
+        result = handler.apply_structured_output(
+            self._schema(), "MyType", model_params
+        )
+
+        assert result.get("_mesh_hint_mode") is True
+
+    def test_sets_hint_schema_flag(self):
+        """Sanitized schema must be stashed for the loop to validate against."""
+        handler = ClaudeHandler()
+        model_params = {
+            "messages": [{"role": "system", "content": "You are helpful."}],
+        }
+
+        result = handler.apply_structured_output(
+            self._schema(), "MyType", model_params
+        )
+
+        assert "_mesh_hint_schema" in result
+        assert isinstance(result["_mesh_hint_schema"], dict)
+        assert result["_mesh_hint_schema"].get("type") == "object"
+        assert "answer" in result["_mesh_hint_schema"].get("properties", {})
+
+    def test_sets_fallback_timeout_and_type_name(self):
+        """Bounded-timeout + output type name must be stashed for the fallback."""
+        handler = ClaudeHandler()
+        model_params = {
+            "messages": [{"role": "system", "content": "You are helpful."}],
+        }
+
+        result = handler.apply_structured_output(
+            self._schema(), "MyType", model_params
+        )
+
+        assert result.get("_mesh_hint_fallback_timeout") == 30
+        assert result.get("_mesh_hint_output_type_name") == "MyType"
+
+    def test_injects_hint_into_system_prompt(self):
+        """Override must append an OUTPUT FORMAT block + property names."""
+        handler = ClaudeHandler()
+        model_params = {
+            "messages": [
+                {"role": "system", "content": "You are X."},
+                {"role": "user", "content": "Hi."},
+            ],
+        }
+
+        handler.apply_structured_output(self._schema(), "MyType", model_params)
+
+        sys_content = model_params["messages"][0]["content"]
+        assert "OUTPUT FORMAT:" in sys_content
+        # Schema property names should appear in the example block
+        assert "answer" in sys_content
+        assert "confidence" in sys_content
+        # Original content must be preserved (HINT is appended, not replaced)
+        assert sys_content.startswith("You are X.")
+        # Non-system messages untouched
+        assert model_params["messages"][1]["content"] == "Hi."
+
+    def test_hint_block_appears_only_once_in_first_system_message(self):
+        """Only the FIRST system message should be modified (avoid duplication)."""
+        handler = ClaudeHandler()
+        model_params = {
+            "messages": [
+                {"role": "system", "content": "First system."},
+                {"role": "user", "content": "Hi."},
+                {"role": "system", "content": "Second system."},
+            ],
+        }
+
+        handler.apply_structured_output(self._schema(), "MyType", model_params)
+
+        assert "OUTPUT FORMAT:" in model_params["messages"][0]["content"]
+        # Second system message should NOT be modified
+        assert model_params["messages"][2]["content"] == "Second system."
+
+    def test_no_handler_instance_state_pollution(self):
+        """Singleton handler must not retain per-request schema state.
+
+        ``ProviderHandlerRegistry`` caches one handler instance per vendor.
+        If ``apply_structured_output`` stashed schemas on ``self``, concurrent
+        requests with different output types would race. Verify no such
+        instance attributes are set.
+        """
+        handler = ClaudeHandler()
+        model_params = {
+            "messages": [{"role": "system", "content": "X"}],
+        }
+
+        handler.apply_structured_output(self._schema(), "MyType", model_params)
+
+        assert not hasattr(handler, "_pending_output_schema"), (
+            "ClaudeHandler must not store output schema on the instance "
+            "(singleton -> race condition across concurrent requests)"
+        )
+        assert not hasattr(handler, "_pending_output_type_name"), (
+            "ClaudeHandler must not store output type name on the instance "
+            "(singleton -> race condition across concurrent requests)"
+        )
+
+    def test_force_response_format_env_reverts(self):
+        """``MCP_MESH_CLAUDE_FORCE_RESPONSE_FORMAT=true`` reverts to base behavior."""
+        os.environ["MCP_MESH_CLAUDE_FORCE_RESPONSE_FORMAT"] = "true"
+        handler = ClaudeHandler()
+        model_params = {
+            "messages": [{"role": "system", "content": "You are helpful."}],
+        }
+
+        result = handler.apply_structured_output(
+            self._schema(), "MyType", model_params
+        )
+
+        assert "response_format" in result, (
+            "Env override must restore base response_format behavior"
+        )
+        assert "_mesh_hint_mode" not in result
+        assert "_mesh_hint_schema" not in result
+        # System message must NOT be mutated by base impl
+        assert result["messages"][0]["content"] == "You are helpful."
+
+    def test_force_response_format_env_accepts_aliases(self):
+        """Env override accepts common truthy aliases (1, true, yes)."""
+        for value in ("1", "true", "TRUE", "yes"):
+            os.environ["MCP_MESH_CLAUDE_FORCE_RESPONSE_FORMAT"] = value
+            handler = ClaudeHandler()
+            model_params = {
+                "messages": [{"role": "system", "content": "X"}],
+            }
+            result = handler.apply_structured_output(
+                self._schema(), "MyType", model_params
+            )
+            assert "response_format" in result, f"value={value!r} should revert"
+            assert "_mesh_hint_mode" not in result
+
+
+# ---------------------------------------------------------------------------
+# _hint_response_parses (helpers.py module-level helper)
+# ---------------------------------------------------------------------------
+
+
+class TestHintResponseParses:
+    """Verify the HINT response validator used by the loop's fallback path."""
+
+    def _schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "foo": {"type": "integer"},
+            },
+            "required": ["foo"],
+        }
+
+    def test_valid_json_returns_true(self):
+        assert _hint_response_parses('{"foo": 1}', self._schema()) is True
+
+    def test_fenced_json_returns_true(self):
+        """``\u0060\u0060\u0060json...\u0060\u0060\u0060`` wrapping must be stripped before parsing."""
+        content = '```json\n{"foo": 1}\n```'
+        assert _hint_response_parses(content, self._schema()) is True
+
+    def test_plain_fenced_json_returns_true(self):
+        """``\u0060\u0060\u0060\\n...\\n\u0060\u0060\u0060`` (no json tag) is also stripped."""
+        content = '```\n{"foo": 1}\n```'
+        assert _hint_response_parses(content, self._schema()) is True
+
+    def test_invalid_json_returns_false(self):
+        assert _hint_response_parses("not json at all", self._schema()) is False
+
+    def test_empty_content_returns_false(self):
+        assert _hint_response_parses("", self._schema()) is False
+
+    def test_schema_mismatch_returns_false_when_jsonschema_available(self):
+        """Wrong shape (missing required field) fails schema validation."""
+        try:
+            import jsonschema  # noqa: F401
+        except ImportError:
+            pytest.skip("jsonschema not installed; structural check is best-effort")
+
+        # Missing required 'foo' key
+        assert _hint_response_parses('{"bar": "baz"}', self._schema()) is False
+
+    def test_wrong_type_fails_when_jsonschema_available(self):
+        """Type mismatch fails schema validation."""
+        try:
+            import jsonschema  # noqa: F401
+        except ImportError:
+            pytest.skip("jsonschema not installed; structural check is best-effort")
+
+        # foo should be integer, got string
+        assert _hint_response_parses('{"foo": "not-an-int"}', self._schema()) is False
+
+    def test_extra_whitespace_around_fences_handled(self):
+        content = '   ```json\n{"foo": 42}\n```   '
+        assert _hint_response_parses(content, self._schema()) is True
+
+
+# ---------------------------------------------------------------------------
+# _pop_mesh_hint_flags — strip helper (issue #820 follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestPopMeshHintFlags:
+    """The strip helper MUST remove every ``_mesh_*`` key before LiteLLM call.
+
+    Background:
+        ``ClaudeHandler.apply_structured_output`` sets ``_mesh_hint_*`` flags
+        on ``model_params`` so the loop / legacy paths in ``mesh.helpers`` can
+        drive a bounded-timeout fallback. These flags MUST be stripped before
+        ``litellm.completion(**completion_args)`` — Anthropic rejects unknown
+        keys with HTTP 400 ("Extra inputs are not permitted").
+
+        This regression broke 6 tsuite integration tests (tc02, tc04, tc09,
+        tc17, tc19, tc23) because the legacy single-call path in
+        ``llm_provider`` did NOT strip these flags. This suite locks in the
+        helper used by BOTH paths.
+    """
+
+    def _full_args(self) -> dict:
+        return {
+            "model": "anthropic/claude-sonnet-4-5",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [],
+            "_mesh_hint_mode": True,
+            "_mesh_hint_schema": {"type": "object"},
+            "_mesh_hint_fallback_timeout": 45,
+            "_mesh_hint_output_type_name": "MyResp",
+        }
+
+    def test_all_mesh_keys_removed(self):
+        args = self._full_args()
+        _pop_mesh_hint_flags(args)
+        for key in _MESH_HINT_KEYS:
+            assert key not in args, (
+                f"{key!r} must be stripped before reaching litellm.completion "
+                f"(Anthropic rejects with HTTP 400 'Extra inputs are not permitted')"
+            )
+
+    def test_returns_captured_values(self):
+        args = self._full_args()
+        hint_mode, hint_schema, hint_timeout, hint_name = _pop_mesh_hint_flags(args)
+        assert hint_mode is True
+        assert hint_schema == {"type": "object"}
+        assert hint_timeout == 45
+        assert hint_name == "MyResp"
+
+    def test_non_mesh_keys_preserved(self):
+        args = self._full_args()
+        _pop_mesh_hint_flags(args)
+        assert args["model"] == "anthropic/claude-sonnet-4-5"
+        assert args["messages"] == [{"role": "user", "content": "hi"}]
+        assert args["tools"] == []
+
+    def test_defaults_when_keys_absent(self):
+        args = {"model": "x", "messages": []}
+        hint_mode, hint_schema, hint_timeout, hint_name = _pop_mesh_hint_flags(args)
+        assert hint_mode is False
+        assert hint_schema is None
+        assert hint_timeout == 30
+        assert hint_name == "Response"
+        # Original args untouched
+        assert args == {"model": "x", "messages": []}
+
+    def test_defaults_override_preserves_loop_state_across_iterations(self):
+        """Loop usage: pass current-iteration values as defaults so the
+        ``hint_*`` state survives iterations where ``model_params`` no longer
+        contains the keys."""
+        # First iteration: keys present
+        args1 = {
+            "_mesh_hint_mode": True,
+            "_mesh_hint_schema": {"type": "object", "x": 1},
+            "_mesh_hint_fallback_timeout": 60,
+            "_mesh_hint_output_type_name": "Loop",
+        }
+        state = _pop_mesh_hint_flags(args1)
+        # Second iteration: keys absent — defaults must equal previous state
+        args2: dict = {}
+        again = _pop_mesh_hint_flags(args2, defaults=state)
+        assert again == state
+
+    def test_strip_unblocks_legacy_path_call_args(self):
+        """Integration-style: simulate the legacy path's ``completion_args``
+        construction and assert post-strip args are safe for LiteLLM."""
+        # This mirrors the construction in ``llm_provider``'s legacy path:
+        #   completion_args = {model, messages, **litellm_kwargs}
+        #   completion_args.update(model_params_copy)  # leaks _mesh_* keys
+        litellm_kwargs = {"temperature": 0.7}
+        model_params_copy = {
+            "_mesh_hint_mode": True,
+            "_mesh_hint_schema": {"type": "object"},
+            "_mesh_hint_fallback_timeout": 30,
+            "_mesh_hint_output_type_name": "Resp",
+        }
+        completion_args = {
+            "model": "anthropic/claude-sonnet-4-5",
+            "messages": [{"role": "user", "content": "hi"}],
+            **litellm_kwargs,
+        }
+        completion_args.update(model_params_copy)
+        # Pre-strip: leak confirmed
+        leaked = [k for k in completion_args if k.startswith("_mesh_")]
+        assert leaked, "test setup wrong — should have leaked keys"
+        # Strip
+        _pop_mesh_hint_flags(completion_args)
+        # Post-strip: nothing starting with _mesh_ remains
+        residual = [k for k in completion_args if k.startswith("_mesh_")]
+        assert residual == [], (
+            f"Strip did not remove all _mesh_* keys: {residual}. "
+            "LiteLLM would reject the request."
+        )
+
+
+# ---------------------------------------------------------------------------
+# _extract_text_from_message_content — content normalizer
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTextFromMessageContent:
+    """Verify the LiteLLM ``message.content`` normalizer used by both paths."""
+
+    def test_string_passthrough(self):
+        assert _extract_text_from_message_content("hello") == "hello"
+
+    def test_none_returns_empty_string(self):
+        assert _extract_text_from_message_content(None) == ""
+
+    def test_list_of_dict_blocks_concatenated(self):
+        blocks = [
+            {"type": "text", "text": "Hello "},
+            {"type": "text", "text": "world"},
+        ]
+        assert _extract_text_from_message_content(blocks) == "Hello world"
+
+    def test_list_with_none_blocks_skipped(self):
+        blocks = [None, {"type": "text", "text": "x"}, None]
+        assert _extract_text_from_message_content(blocks) == "x"
+
+    def test_block_with_missing_text_key_treated_as_empty(self):
+        blocks = [{"type": "thinking"}, {"type": "text", "text": "ok"}]
+        assert _extract_text_from_message_content(blocks) == "ok"
+
+    def test_empty_list_returns_empty_string(self):
+        assert _extract_text_from_message_content([]) == ""
+
+    def test_block_with_null_text_value_treated_as_empty(self):
+        blocks = [{"type": "text", "text": None}, {"type": "text", "text": "y"}]
+        assert _extract_text_from_message_content(blocks) == "y"

--- a/src/runtime/python/tests/unit/test_claude_handler_hint_mode.py
+++ b/src/runtime/python/tests/unit/test_claude_handler_hint_mode.py
@@ -11,6 +11,7 @@ Background:
 """
 
 import os
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -19,6 +20,7 @@ from mesh.helpers import (
     _MESH_HINT_KEYS,
     _extract_text_from_message_content,
     _hint_response_parses,
+    _maybe_run_hint_fallback,
     _pop_mesh_hint_flags,
 )
 
@@ -415,3 +417,221 @@ class TestExtractTextFromMessageContent:
     def test_block_with_null_text_value_treated_as_empty(self):
         blocks = [{"type": "text", "text": None}, {"type": "text", "text": "y"}]
         assert _extract_text_from_message_content(blocks) == "y"
+
+
+# ---------------------------------------------------------------------------
+# ClaudeHandler.apply_structured_output — no-system-message synthesis (Fix 1)
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeApplyStructuredOutputNoSystemMessage:
+    """Verify HINT-mode synthesizes a system message when none exists.
+
+    Without this, the ``_mesh_hint_*`` flags would be set but the model would
+    never see the schema, every response would fail validation, and the 30s
+    fallback timeout would fire on every request (issue #820 follow-up).
+    """
+
+    def setup_method(self):
+        os.environ.pop("MCP_MESH_CLAUDE_FORCE_RESPONSE_FORMAT", None)
+
+    def teardown_method(self):
+        os.environ.pop("MCP_MESH_CLAUDE_FORCE_RESPONSE_FORMAT", None)
+
+    def test_apply_structured_output_synthesizes_system_message_when_none_exists(self):
+        """When messages contain no system role, apply_structured_output should
+        synthesize one with the HINT block so HINT mode actually works."""
+        handler = ClaudeHandler()
+        schema = {
+            "type": "object",
+            "properties": {"foo": {"type": "string"}},
+            "required": ["foo"],
+        }
+        model_params = {"messages": [{"role": "user", "content": "Hello"}]}
+        handler.apply_structured_output(schema, "MyType", model_params)
+
+        # First message should now be the synthesized system message
+        assert model_params["messages"][0]["role"] == "system"
+        assert "OUTPUT FORMAT:" in model_params["messages"][0]["content"]
+        assert "foo" in model_params["messages"][0]["content"]
+
+        # Original user message should still be there
+        assert model_params["messages"][1] == {"role": "user", "content": "Hello"}
+
+        # Flags should be set as normal
+        assert model_params["_mesh_hint_mode"] is True
+        assert model_params["_mesh_hint_schema"]["properties"]["foo"]["type"] == "string"
+
+    def test_apply_structured_output_synthesizes_when_only_user_messages(self):
+        """Multiple user messages, no system — should still prepend exactly one."""
+        handler = ClaudeHandler()
+        schema = {
+            "type": "object",
+            "properties": {"x": {"type": "integer"}},
+            "required": ["x"],
+        }
+        model_params = {
+            "messages": [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "ok"},
+                {"role": "user", "content": "second"},
+            ]
+        }
+        handler.apply_structured_output(schema, "MyType", model_params)
+
+        # Synthesized system message should be at position 0
+        assert model_params["messages"][0]["role"] == "system"
+        assert "OUTPUT FORMAT:" in model_params["messages"][0]["content"]
+        # Original messages preserved in order after the new system message
+        assert model_params["messages"][1] == {"role": "user", "content": "first"}
+        assert model_params["messages"][2] == {"role": "assistant", "content": "ok"}
+        assert model_params["messages"][3] == {"role": "user", "content": "second"}
+        # Only ONE system message synthesized (no duplicates)
+        system_count = sum(
+            1 for m in model_params["messages"] if m.get("role") == "system"
+        )
+        assert system_count == 1
+
+    def test_existing_system_message_path_not_affected(self):
+        """When a system message already exists, no synthesis happens — the
+        existing message is mutated in place (regression check)."""
+        handler = ClaudeHandler()
+        schema = {
+            "type": "object",
+            "properties": {"foo": {"type": "string"}},
+            "required": ["foo"],
+        }
+        model_params = {
+            "messages": [
+                {"role": "system", "content": "Original."},
+                {"role": "user", "content": "Hi"},
+            ]
+        }
+        handler.apply_structured_output(schema, "MyType", model_params)
+
+        # Length unchanged — no synthesis
+        assert len(model_params["messages"]) == 2
+        # System content was mutated in place
+        assert model_params["messages"][0]["content"].startswith("Original.")
+        assert "OUTPUT FORMAT:" in model_params["messages"][0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# _maybe_run_hint_fallback — extracted helper (Fix 3 + Fix 4)
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeRunHintFallback:
+    """Verify the extracted fallback helper used by both the agentic loop and
+    the legacy single-call path. The helper assumes the caller already
+    stripped ``tools`` from ``base_completion_args`` (Fix 4)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_unchanged_when_hint_mode_disabled(self):
+        """If hint_mode is False, helper is a no-op."""
+        result = await _maybe_run_hint_fallback(
+            final_content="anything",
+            message="msg",
+            response="resp",
+            base_completion_args={},
+            hint_mode=False,
+            hint_schema={"type": "object"},
+            hint_fallback_timeout=30,
+            hint_output_type_name="X",
+        )
+        assert result == ("anything", "msg", "resp")
+
+    @pytest.mark.asyncio
+    async def test_returns_unchanged_when_content_already_parses(self):
+        """If hint mode is on but content parses, no fallback fires."""
+        schema = {
+            "type": "object",
+            "properties": {"foo": {"type": "string"}},
+            "required": ["foo"],
+        }
+        result = await _maybe_run_hint_fallback(
+            final_content='{"foo": "ok"}',
+            message="orig_msg",
+            response="orig_resp",
+            base_completion_args={},
+            hint_mode=True,
+            hint_schema=schema,
+            hint_fallback_timeout=30,
+            hint_output_type_name="X",
+        )
+        assert result == ('{"foo": "ok"}', "orig_msg", "orig_resp")
+
+    @pytest.mark.asyncio
+    async def test_strips_no_tools_in_args(self):
+        """Helper assumes caller already stripped ``tools``. Verify by
+        passing ``base_completion_args`` without ``tools`` and confirming the
+        fallback ``litellm.completion`` call doesn't include ``tools`` either
+        — proves the helper isn't sneaking it back in."""
+        captured_kwargs: dict = {}
+
+        async def fake_to_thread(fn, **kwargs):
+            captured_kwargs.update(kwargs)
+            fake_msg = MagicMock()
+            fake_msg.content = '{"foo": "ok"}'
+            fake_response = MagicMock()
+            fake_response.choices = [MagicMock(message=fake_msg)]
+            return fake_response
+
+        schema = {
+            "type": "object",
+            "properties": {"foo": {"type": "string"}},
+            "required": ["foo"],
+        }
+        base_args = {
+            "model": "anthropic/claude-3-5-sonnet",
+            "messages": [{"role": "user", "content": "x"}],
+        }
+
+        with patch("mesh.helpers.asyncio.to_thread", side_effect=fake_to_thread):
+            final_content, _msg, _resp = await _maybe_run_hint_fallback(
+                final_content="not parseable as json",
+                message=None,
+                response=None,
+                base_completion_args=base_args,
+                hint_mode=True,
+                hint_schema=schema,
+                hint_fallback_timeout=30,
+                hint_output_type_name="MyType",
+            )
+
+        # Confirm fallback ran and replaced content
+        assert final_content == '{"foo": "ok"}'
+        # Tools must NOT have been added by the helper
+        assert "tools" not in captured_kwargs
+        # response_format and request_timeout must be set by the helper
+        assert captured_kwargs["response_format"]["json_schema"]["name"] == "MyType"
+        assert captured_kwargs["response_format"]["json_schema"]["strict"] is True
+        assert captured_kwargs["request_timeout"] == 30
+        # Original base args preserved
+        assert captured_kwargs["model"] == "anthropic/claude-3-5-sonnet"
+
+    @pytest.mark.asyncio
+    async def test_fallback_failure_re_raises(self):
+        """If the fallback litellm call raises, the helper must re-raise
+        (caller is responsible for surfacing/wrapping)."""
+
+        async def fake_to_thread(fn, **kwargs):
+            raise RuntimeError("simulated litellm failure")
+
+        schema = {
+            "type": "object",
+            "properties": {"foo": {"type": "string"}},
+            "required": ["foo"],
+        }
+        with patch("mesh.helpers.asyncio.to_thread", side_effect=fake_to_thread):
+            with pytest.raises(RuntimeError, match="simulated litellm failure"):
+                await _maybe_run_hint_fallback(
+                    final_content="not parseable",
+                    message=None,
+                    response=None,
+                    base_completion_args={"model": "x", "messages": []},
+                    hint_mode=True,
+                    hint_schema=schema,
+                    hint_fallback_timeout=30,
+                    hint_output_type_name="X",
+                )

--- a/src/runtime/python/tests/unit/test_gemini_handler_concurrent_schemas.py
+++ b/src/runtime/python/tests/unit/test_gemini_handler_concurrent_schemas.py
@@ -1,0 +1,205 @@
+"""
+Unit tests for GeminiHandler concurrent-request schema isolation.
+
+Background:
+    Provider handlers are cached as singletons in
+    ``ProviderHandlerRegistry._instances``. If pending output-schema state is
+    stored on the handler instance (e.g., ``self._pending_output_schema``),
+    two concurrent async requests with different schemas race on those fields:
+    request B's writes can clobber request A's between A's
+    ``apply_structured_output`` call and A's ``format_system_prompt`` call.
+
+    The fix migrates that state to ``contextvars.ContextVar`` so each async
+    context (asyncio.Task, contextvars.copy_context, ...) sees its own value.
+    These tests verify that isolation holds.
+"""
+
+import asyncio
+
+import pytest
+
+from _mcp_mesh.engine.provider_handlers._handler_context import (
+    clear_pending_output_schema,
+    get_pending_output_schema,
+    set_pending_output_schema,
+)
+from _mcp_mesh.engine.provider_handlers.gemini_handler import GeminiHandler
+
+# ---------------------------------------------------------------------------
+# _handler_context module — basic API
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerContextBasics:
+    """Smoke tests for the shared ContextVar helper module."""
+
+    def test_get_returns_none_when_unset(self):
+        clear_pending_output_schema()
+        assert get_pending_output_schema() == (None, None)
+
+    def test_set_and_get_roundtrip(self):
+        clear_pending_output_schema()
+        schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+        set_pending_output_schema(schema, "MyType")
+        assert get_pending_output_schema() == (schema, "MyType")
+        clear_pending_output_schema()
+
+    def test_clear_resets_both_fields(self):
+        set_pending_output_schema({"type": "object"}, "Foo")
+        clear_pending_output_schema()
+        assert get_pending_output_schema() == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# GeminiHandler — instance state was migrated to ContextVar
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiHandlerNoInstanceState:
+    """The migrated handler must not carry pending-schema instance fields."""
+
+    def test_init_does_not_set_pending_schema_attrs(self):
+        handler = GeminiHandler()
+        assert not hasattr(handler, "_pending_output_schema"), (
+            "GeminiHandler must not store _pending_output_schema on the "
+            "instance — it's racy under singleton caching. Use "
+            "_handler_context ContextVar instead."
+        )
+        assert not hasattr(handler, "_pending_output_type_name"), (
+            "GeminiHandler must not store _pending_output_type_name on the "
+            "instance — it's racy under singleton caching. Use "
+            "_handler_context ContextVar instead."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — the bug this migration exists to fix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_dont_cross_contaminate_schema():
+    """Two concurrent contexts using the same handler instance should each
+    see their own output schema, not each other's.
+
+    Simulates the production scenario: ``ProviderHandlerRegistry`` returns
+    the same cached ``GeminiHandler`` instance to every concurrent request.
+    With instance state, request B's ``apply_structured_output`` call
+    clobbers request A's pending schema between A's ``apply_structured_output``
+    and A's downstream read in ``format_system_prompt``.
+    """
+    handler = GeminiHandler()
+
+    schema_a = {
+        "type": "object",
+        "properties": {"a_field": {"type": "string"}},
+        "required": ["a_field"],
+    }
+    schema_b = {
+        "type": "object",
+        "properties": {"b_field": {"type": "integer"}},
+        "required": ["b_field"],
+    }
+
+    seen: dict[str, tuple] = {}
+
+    async def make_call(label: str, schema: dict, sleep_ms: int) -> None:
+        # Each gather() arg runs in its own asyncio.Task → its own context.
+        model_params = {
+            "messages": [{"role": "system", "content": f"You are {label}."}]
+        }
+        handler.apply_structured_output(schema, f"Type{label}", model_params)
+        # Simulate async work between the write and the read (e.g., the
+        # actual LLM call latency in production).
+        await asyncio.sleep(sleep_ms / 1000)
+        # After the await, read what THIS context sees.
+        seen[label] = get_pending_output_schema()
+
+    # Interleave: A starts (writes schema_a), sleeps; B starts (writes
+    # schema_b), sleeps; both wake up. With instance fields, both contexts
+    # would see schema_b after the awaits because B's write wins.
+    await asyncio.gather(
+        make_call("A", schema_a, 50),
+        make_call("B", schema_b, 30),
+    )
+
+    assert seen["A"] == (schema_a, "TypeA"), (
+        f"Context A saw the wrong schema: {seen['A']!r} (expected schema_a/TypeA). "
+        "Instance state cross-contaminated between concurrent requests."
+    )
+    assert seen["B"] == (schema_b, "TypeB"), (
+        f"Context B saw the wrong schema: {seen['B']!r} (expected schema_b/TypeB). "
+        "Instance state cross-contaminated between concurrent requests."
+    )
+
+
+@pytest.mark.asyncio
+async def test_many_concurrent_requests_isolate_correctly():
+    """Stress: many concurrent contexts with distinct schemas all see their
+    own value, even with multiple awaits between write and read."""
+    handler = GeminiHandler()
+    n = 20
+
+    seen: dict[int, tuple] = {}
+
+    async def make_call(i: int) -> None:
+        schema = {
+            "type": "object",
+            "properties": {f"field_{i}": {"type": "string"}},
+            "required": [f"field_{i}"],
+        }
+        type_name = f"Type{i}"
+        model_params = {
+            "messages": [{"role": "system", "content": f"You are #{i}."}]
+        }
+        handler.apply_structured_output(schema, type_name, model_params)
+        # Multiple awaits to give the scheduler many opportunities to
+        # interleave with sibling tasks.
+        for _ in range(3):
+            await asyncio.sleep(0)
+        seen[i] = get_pending_output_schema()
+
+    await asyncio.gather(*(make_call(i) for i in range(n)))
+
+    for i in range(n):
+        seen_schema, seen_name = seen[i]
+        assert seen_name == f"Type{i}", (
+            f"Context {i} saw type_name={seen_name!r}, expected 'Type{i}'"
+        )
+        assert seen_schema is not None and (
+            f"field_{i}" in seen_schema.get("properties", {})
+        ), (
+            f"Context {i} saw schema {seen_schema!r}, expected one with "
+            f"property 'field_{i}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# format_system_prompt reads from the per-context state
+# ---------------------------------------------------------------------------
+
+
+def test_format_system_prompt_reads_pending_schema_from_context():
+    """Set the pending schema via the public helper, then ensure
+    ``format_system_prompt`` picks it up (not from instance state)."""
+    handler = GeminiHandler()
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+    }
+    set_pending_output_schema(schema, "AnswerType")
+    try:
+        prompt = handler.format_system_prompt(
+            base_prompt="You are helpful.",
+            tool_schemas=[{"type": "function", "function": {"name": "noop"}}],
+            output_type=str,  # str path would normally skip schema,
+            # but pending schema in context overrides
+        )
+        # The Rust formatter should have received the AnswerType schema and
+        # included some hint of it in the output. We don't pin exact wording,
+        # just confirm something schema-shaped came back.
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+    finally:
+        clear_pending_output_schema()

--- a/tests/src-tests/suites/build/tc04_build_typescript_sdk/test.yaml
+++ b/tests/src-tests/suites/build/tc04_build_typescript_sdk/test.yaml
@@ -62,7 +62,12 @@ test:
           mkdir -p /out/packages && \
           # Copy napi core build inputs (full Rust source needed for napi build)
           cp /src-host/src/runtime/core/Cargo.toml /src/mcp-mesh/src/runtime/core/ && \
-          cp /src-host/src/runtime/core/Cargo.lock /src/mcp-mesh/src/runtime/core/ 2>/dev/null || true && \
+          # Cargo.lock may not exist on a fresh tree; tolerate missing-file
+          # only — any other cp failure (permission, IO) must propagate via
+          # set -euo pipefail.
+          if [ -f /src-host/src/runtime/core/Cargo.lock ]; then \
+            cp /src-host/src/runtime/core/Cargo.lock /src/mcp-mesh/src/runtime/core/; \
+          fi && \
           cp /src-host/src/runtime/core/build.rs /src/mcp-mesh/src/runtime/core/ && \
           cp -r /src-host/src/runtime/core/src /src/mcp-mesh/src/runtime/core/ && \
           cp -r /src-host/src/runtime/core/typescript /src/mcp-mesh/src/runtime/core/ && \

--- a/tests/src-tests/suites/build/tc04_build_typescript_sdk/test.yaml
+++ b/tests/src-tests/suites/build/tc04_build_typescript_sdk/test.yaml
@@ -11,7 +11,7 @@ tags:
   - build
   - typescript
   - sdk
-timeout: 300
+timeout: 600
 
 test:
   # Ensure output directories exist
@@ -49,27 +49,44 @@ test:
       echo "Output: $OUTPUT_ABS"
 
       echo "Building TypeScript SDK inside container (clean build)..."
-      # Optimized: Only copy required files instead of entire repo
-      # TypeScript SDK needs: typescript/ (package.json, tsconfig.json, src/) + core/typescript/ (local dep)
+      # TypeScript SDK depends on @mcpmesh/core (file:../core/typescript), whose
+      # napi-generated index.js / index.d.ts / *.node are NOT in git. We must
+      # build them inline first, then build the SDK. Mirrors tc04a's pattern.
       docker run --rm \
         -v "$SOURCE_ABS:/src-host:ro" \
         -v "$OUTPUT_ABS:/out" \
         ${config.build.image} \
         bash -c "
+          set -euo pipefail
           mkdir -p /src/mcp-mesh/src/runtime/typescript /src/mcp-mesh/src/runtime/core && \
           mkdir -p /out/packages && \
+          # Copy napi core build inputs (full Rust source needed for napi build)
+          cp /src-host/src/runtime/core/Cargo.toml /src/mcp-mesh/src/runtime/core/ && \
+          cp /src-host/src/runtime/core/Cargo.lock /src/mcp-mesh/src/runtime/core/ 2>/dev/null || true && \
+          cp /src-host/src/runtime/core/build.rs /src/mcp-mesh/src/runtime/core/ && \
+          cp -r /src-host/src/runtime/core/src /src/mcp-mesh/src/runtime/core/ && \
+          cp -r /src-host/src/runtime/core/typescript /src/mcp-mesh/src/runtime/core/ && \
+          # Copy SDK source
           cp /src-host/src/runtime/typescript/package.json /src/mcp-mesh/src/runtime/typescript/ && \
           cp /src-host/src/runtime/typescript/tsconfig.json /src/mcp-mesh/src/runtime/typescript/ && \
           cp -r /src-host/src/runtime/typescript/src /src/mcp-mesh/src/runtime/typescript/ && \
-          cp -r /src-host/src/runtime/core/typescript /src/mcp-mesh/src/runtime/core/ && \
+          # Build napi core wrappers FIRST (generates index.js, index.d.ts, *.node)
+          echo '=== Building @mcpmesh/core napi wrappers ===' && \
+          cd /src/mcp-mesh/src/runtime/core/typescript && \
+          npm install && \
+          npm run build && \
+          # Then build the SDK
+          echo '=== Building @mcpmesh/sdk ===' && \
           cd /src/mcp-mesh/src/runtime/typescript && \
-          npm install && npm run build && npm pack --pack-destination /out/packages
+          npm install && \
+          npm run build && \
+          npm pack --pack-destination /out/packages
         "
 
       echo "TypeScript build complete"
       echo "npm pack complete"
     capture: build_output
-    timeout: 180
+    timeout: 480
 
   # List built packages on host
   - name: "List built packages"


### PR DESCRIPTION
## Summary

- Fixes #820: Claude provider hangs indefinitely (silent 600s+) when `response_format` (structured output) is combined with `tools` and certain content patterns. Anthropic's `response_format` path on Claude 3.5+ has known pathological cases that silently stall rather than error.
- **Strategy**: HINT-first with bounded-timeout `response_format` fallback. Inject schema instructions into the system prompt (mirrors `GeminiHandler`'s proven pattern); on JSON parse failure, retry once with native `response_format` and `request_timeout=30s`. Eliminates the catastrophic 600s hang on the dominant path; bounded fallback covers the ~5% HINT compliance gap without re-introducing the hang.
- `MCP_MESH_CLAUDE_FORCE_RESPONSE_FORMAT=true` env override reverts to legacy behavior in case fallback misbehaves in production.
- Both `_provider_agentic_loop` (multi-iteration tool dispatch) AND legacy single-call path implement the same strip + validate + fallback semantics. Extracted `_pop_mesh_hint_flags` and `_extract_text_from_message_content` helpers shared between both paths so future maintainers can't fix one and forget the other.

## Bundled bonus fixes

### GeminiHandler concurrency race (latent bug)

While auditing the handler architecture, found that `GeminiHandler._pending_output_schema` was an instance field on a cached singleton handler (`ProviderHandlerRegistry._instances`). Concurrent requests with different output schemas would cross-contaminate. **Verified empirically** — temporarily reverted the migration and confirmed 3 of 7 new tests fail without it. Migrated to `contextvars.ContextVar` via new shared module `_mcp_mesh/engine/provider_handlers/_handler_context.py`. ClaudeHandler doesn't read these so its instance fields were deleted (vestigial, never read).

### tc04 build infra hotfix (post-#821)

PR #821's gitignore fix correctly removed `src/runtime/core/typescript/index.{js,d.ts}` from git tracking — these are NAPI-RS auto-generated artifacts. But `tc04_build_typescript_sdk` implicitly relied on them being on the host. After #821, fresh CI containers don't have them and `tsc` fails to resolve `@mcpmesh/core` types.

Mirrored tc04a's pattern (Java SDK builds its native FFI library inline before building the JARs). Now tc04 builds the napi-rs wrappers (`cd core/typescript && npm install && npm run build`) before building the SDK. Plus `set -euo pipefail` so silent tsc failures stop being silent (previously tc04 reported success when tsc errored, and tc05 was the one that failed looking for the .tgz that was never produced).

## Review notes

This PR went through two review iterations (one before the leak bug surfaced, one before commit):
- Independent review passed on the HINT-first design and shared helpers
- The `_mesh_*` flag leak in the legacy single-call path was caught by tsuite (6 failing integration tests) and fixed before commit. Both `litellm.completion` call sites now strip the flags via a shared helper.
- Confirmed no THIRD `litellm.completion` call site exists (grep verified).

## Architectural notes

The Anthropic `response_format` silent-hang behavior is an upstream issue (Anthropic's structured output service, not LiteLLM, not mesh). The fallback path uses the SAME `tools + response_format` combo that triggered the original hang — only the bounded `request_timeout=30s` protects us. If Anthropic ever fixes the underlying issue, this fallback could become a primary path; for now it exists only to recover from the rare HINT compliance failure.

Closes #820

## Test plan

- [x] Local unit tests: 544 pass (531 baseline + 13 new for ClaudeHandler HINT mode + helpers)
- [x] tsuite integration:
  - [x] tc17_structured_multi_turn_py PASS (was BadRequestError on `_mesh_hint_mode`)
  - [x] tc19_structured_avatar_pattern_py PASS
  - [x] tc23_structured_output_ts_consumer_py_provider PASS
  - [x] tc02_py_mesh_claude PASS
  - [x] tc04_parallel_error_handling_py PASS (downstream of the leak)
  - [x] tc09_parallel_error_handling_java PASS (downstream of the leak)
- [x] Existing structured-output tests not regressed
- [x] tc04_build_typescript_sdk passes (fixed the tsc-can't-find-@mcpmesh/core regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HINT-mode support for schema validation with automatic fallback retry when output fails validation.
  * Implemented concurrent request isolation to prevent schema state cross-contamination in async contexts.

* **Bug Fixes**
  * Improved structured output handling to recover from schema non-compliance.
  * Fixed potential race conditions in concurrent request handling.

* **Chores**
  * Updated SDK build process to properly generate required native bindings.
  * Extended build timeouts for reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->