### PR TITLE
feat: Vertex AI (Gemini via IAM) support across Python, TS, Java

### DIFF
--- a/docs/01-getting-started/06-llm-integration.md
+++ b/docs/01-getting-started/06-llm-integration.md
@@ -145,6 +145,14 @@ Provide detailed analysis appropriate for {{ user_level }}-level users.
 | `context_param`  | `str`  | `None`     | Parameter name containing template context         |
 | `max_iterations` | `int`  | `5`        | Max agentic loop iterations                        |
 
+> **Vertex AI (Gemini via IAM)**: For production deployments using Google
+> Cloud IAM instead of API keys, change the model prefix to
+> `vertex_ai/gemini-2.0-flash` and install the `[vertex]` extra. The
+> TypeScript and Java runtimes have equivalent support — see the
+> [Python](../python/llm/index.md), [TypeScript](../typescript/llm/index.md),
+> and [Java](../java/llm/index.md) LLM Integration pages for runtime-specific
+> auth env vars (each follows its own ecosystem's naming convention).
+
 ### Basic Usage Patterns
 
 #### Pattern 1: Simple LLM Chat

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -358,12 +358,132 @@ export ANTHROPIC_API_KEY=sk-ant-your-key
 # OpenAI
 export OPENAI_API_KEY=sk-your-key
 
-# Google Gemini (varies by runtime)
+# Google Gemini AI Studio (API key — varies by runtime)
 export GOOGLE_API_KEY=your-key                     # Python (via LiteLLM)
 export GOOGLE_GENERATIVE_AI_API_KEY=your-key       # TypeScript (Vercel AI SDK)
 export GOOGLE_AI_GEMINI_API_KEY=your-key           # Java (Spring AI)
-export GOOGLE_PROJECT_ID=my-gcp-project            # Java (Vertex AI)
 ```
+
+For Gemini via Vertex AI (IAM auth), see the
+[Vertex AI section below](#vertex-ai-gemini-via-iam) — env var conventions
+also vary by runtime, with `GOOGLE_APPLICATION_CREDENTIALS` shared across
+all three.
+
+### Vertex AI (Gemini via IAM)
+
+For users who want to call Gemini through Google Cloud's Vertex AI instead
+of AI Studio (e.g., to use IAM service-account auth, GCP Provisioned
+Throughput, VPC-SC, or org-controlled billing). All three runtimes share
+mesh's `GeminiHandler` (same prompt-shaping, same HINT-mode behavior with
+tools); only the auth transport and env var names differ.
+
+#### Quick env var matrix
+
+| Runtime    | SDK            | Project env var                              | Location env var                             |
+| ---------- | -------------- | -------------------------------------------- | -------------------------------------------- |
+| Python     | LiteLLM        | `VERTEXAI_PROJECT`                           | `VERTEXAI_LOCATION`                          |
+| TypeScript | Vercel AI SDK  | `GOOGLE_VERTEX_PROJECT`                      | `GOOGLE_VERTEX_LOCATION`                     |
+| Java       | Spring AI      | `SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID`<br/>(or set `spring.ai.vertex.ai.gemini.project-id`) | `SPRING_AI_VERTEX_AI_GEMINI_LOCATION`<br/>(or set `spring.ai.vertex.ai.gemini.location`) |
+
+`GOOGLE_APPLICATION_CREDENTIALS` (or `gcloud auth application-default login`)
+is the same across all three.
+
+#### Python — model prefix
+
+```python
+@mesh.llm(
+    provider={"capability": "llm", "tags": ["gemini"]},
+    model="vertex_ai/gemini-2.0-flash",
+)
+async def my_tool(...): ...
+```
+
+The Python runtime routes `vertex_ai/*` through the same `GeminiHandler` as
+`gemini/*`, but LiteLLM picks the Vertex AI transport based on the prefix.
+
+Install the `vertex` extra (adds `google-auth`):
+
+```bash
+pip install 'mcp-mesh[vertex]'
+```
+
+Without it, the first Vertex call raises `ModuleNotFoundError: No module
+named 'google.auth'`. (Non-Vertex users — AI Studio, Claude, OpenAI — don't
+need this.)
+
+LiteLLM auth resolution order:
+
+1. Explicit `vertex_credentials` / `vertex_project` / `vertex_location`
+   passed in the call (mesh does not set these — your env wins).
+2. `VERTEXAI_CREDENTIALS` + `VERTEXAI_PROJECT` + `VERTEXAI_LOCATION`.
+3. `GOOGLE_APPLICATION_CREDENTIALS` (standard ADC), with project/location
+   derived from the SA JSON.
+4. Implicit ADC (e.g., `gcloud` user credentials, GCE metadata server).
+
+#### TypeScript — model prefix
+
+```typescript
+agent.addLlmProvider({
+  model: "vertex_ai/gemini-2.0-flash",
+  capability: "llm",
+  tags: ["gemini", "vertex"],
+});
+```
+
+`@ai-sdk/google-vertex` is bundled with `@mcpmesh/sdk` — no extra install.
+Auth uses Google ADC; project + location come from `GOOGLE_VERTEX_PROJECT`
+and `GOOGLE_VERTEX_LOCATION`. Location defaults to `us-central1`.
+
+#### Java — `provider = "vertex_ai"`
+
+```java
+@MeshLlm(provider = "vertex_ai", …)
+@MeshTool(capability = "…")
+public MyResult myTool(@Param("…") String input, MeshLlmAgent llm) { … }
+```
+
+Add the Vertex AI Spring AI starter to your `pom.xml` (mesh's
+`mcp-mesh-spring-ai` does not pull it in by default):
+
+```xml
+<dependency>
+  <groupId>org.springframework.ai</groupId>
+  <artifactId>spring-ai-starter-model-vertex-ai-gemini</artifactId>
+  <version>${spring-ai.version}</version>
+</dependency>
+```
+
+Spring AI's Vertex AI auto-config doesn't read any conventional `GOOGLE_*`
+env var on its own — it binds Spring Boot properties (which Spring relaxed
+binding can populate from env vars):
+
+| Spring property                                 | Env var (relaxed binding)                         |
+| ----------------------------------------------- | ------------------------------------------------- |
+| `spring.ai.vertex.ai.gemini.project-id`         | `SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID`           |
+| `spring.ai.vertex.ai.gemini.location`           | `SPRING_AI_VERTEX_AI_GEMINI_LOCATION`             |
+| `spring.ai.vertex.ai.gemini.chat.options.model` | `SPRING_AI_VERTEX_AI_GEMINI_CHAT_OPTIONS_MODEL`   |
+
+`provider = "vertex_ai"` is significant: with just `provider = "gemini"`,
+SpringAiLlmProvider prefers the AI Studio bean (`googleAiGeminiChatModel`)
+when both backends are configured; `"vertex_ai"` forces the IAM path.
+
+#### Same Code, Two Backends
+
+The same agent code works against AI Studio _or_ Vertex AI by changing only
+the model prefix / provider value and the auth config — no other code changes:
+
+|                | AI Studio                                  | Vertex AI                                                          |
+| -------------- | ------------------------------------------ | ------------------------------------------------------------------ |
+| Python         | `model="gemini/gemini-2.0-flash"`          | `model="vertex_ai/gemini-2.0-flash"`                               |
+| TypeScript     | `model: "gemini/gemini-2.0-flash"`         | `model: "vertex_ai/gemini-2.0-flash"`                              |
+| Java           | `@MeshLlm(provider = "gemini")`            | `@MeshLlm(provider = "vertex_ai")`                                 |
+| Auth env       | `GOOGLE_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY` / `GOOGLE_AI_GEMINI_API_KEY` | `GOOGLE_APPLICATION_CREDENTIALS` (ADC)        |
+
+#### Provisioned Throughput
+
+GCP Provisioned Throughput is a Vertex AI account-side feature and requires
+no mesh configuration — once your project has a PT reservation for the
+target model, Vertex routes your calls through it automatically.
 
 ### LLM Agent Overrides
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -431,8 +431,10 @@ agent.addLlmProvider({
 ```
 
 `@ai-sdk/google-vertex` is bundled with `@mcpmesh/sdk` — no extra install.
-Auth uses Google ADC; project + location come from `GOOGLE_VERTEX_PROJECT`
-and `GOOGLE_VERTEX_LOCATION`. Location defaults to `us-central1`.
+Auth uses Google ADC. Both `GOOGLE_VERTEX_PROJECT` and `GOOGLE_VERTEX_LOCATION`
+are required — the SDK throws a `LoadSettingError` on the first call if
+either is unset (no project auto-discovery from ADC, no default location).
+Common location values: `us-central1`, `global`.
 
 #### Java — `provider = "vertex_ai"`
 

--- a/docs/java/llm/index.md
+++ b/docs/java/llm/index.md
@@ -287,12 +287,109 @@ The provider automatically:
 
 Uses LiteLLM model format in `@MeshLlmProvider`:
 
-| Provider  | Model Format                   |
-| --------- | ------------------------------ |
-| Anthropic | `anthropic/claude-sonnet-4-5`  |
-| OpenAI    | `openai/gpt-4o`                |
-| Mistral   | `mistral/mistral-large-latest` |
-| Google    | `gemini/gemini-pro`            |
+| Provider                | Model Format                   |
+| ----------------------- | ------------------------------ |
+| Anthropic               | `anthropic/claude-sonnet-4-5`  |
+| OpenAI                  | `openai/gpt-4o`                |
+| Google AI Studio        | `gemini/gemini-2.0-flash`      |
+| Google Vertex AI (IAM)  | `vertex_ai/gemini-2.0-flash`   |
+| Mistral                 | `mistral/mistral-large-latest` |
+
+## Vertex AI (Gemini via IAM)
+
+The Java runtime supports Gemini via Google Cloud Vertex AI as an
+alternative to AI Studio. Same model family, same `GeminiHandler`, same
+HINT-mode prompt shaping for structured output with tools — only the
+provider value, dependency, and auth config change.
+
+### When to use Vertex AI vs AI Studio
+
+| Use case                                              | Pick                                                |
+| ----------------------------------------------------- | --------------------------------------------------- |
+| Quickstart / dev / lowest setup                       | AI Studio (`provider = "gemini"`, `GOOGLE_AI_GEMINI_API_KEY`) |
+| Production with IAM auth, GCP audit logs, VPC-SC      | Vertex AI (`provider = "vertex_ai"`, ADC)           |
+| Need Provisioned Throughput (no capacity 429s)        | Vertex AI                                           |
+| Multi-tenant org-controlled billing                   | Vertex AI                                           |
+
+### Setup
+
+1. Add the Vertex AI Spring AI starter to your `pom.xml` (mesh's
+   `mcp-mesh-spring-ai` does **not** pull it in by default — it's optional
+   so non-Vertex users don't drag in `google-cloud-aiplatform`):
+
+   ```xml
+   <dependency>
+     <groupId>org.springframework.ai</groupId>
+     <artifactId>spring-ai-starter-model-vertex-ai-gemini</artifactId>
+     <version>${spring-ai.version}</version>
+   </dependency>
+   ```
+
+2. Configure project + location in `application.yml` (or via env vars
+   through Spring Boot's relaxed binding):
+
+   ```yaml
+   spring:
+     ai:
+       vertex:
+         ai:
+           gemini:
+             project-id: ${SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID:my-gcp-project}
+             location:   ${SPRING_AI_VERTEX_AI_GEMINI_LOCATION:us-central1}
+             chat:
+               options:
+                 model: gemini-2.0-flash
+   ```
+
+3. Configure GCP Application Default Credentials:
+
+   ```bash
+   gcloud auth application-default login
+   # OR for CI/prod:
+   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+   ```
+
+4. Use `provider = "vertex_ai"` on `@MeshLlm`:
+
+   ```java
+   @MeshLlm(provider = "vertex_ai", maxTokens = 256, temperature = 0.0)
+   @MeshTool(capability = "geo")
+   public CapitalInfo capitalOf(@Param("country") String country, MeshLlmAgent llm) {
+       return llm.request().user("What is the capital of " + country + "?")
+                 .generate(CapitalInfo.class);
+   }
+   ```
+
+### Why "vertex_ai" matters
+
+`provider = "gemini"` (or `"google"`) prefers the AI Studio bean
+(`googleAiGeminiChatModel`) when both backends are configured, falling back
+to Vertex AI only if AI Studio is unavailable. This is convenient for users
+who only have one backend, but ambiguous when both are present.
+
+`provider = "vertex_ai"` (or `"vertexai"`) skips that preference and goes
+straight to `vertexAiGeminiChatModel`, throwing a clear error if it's not
+configured.
+
+### Switching backends
+
+Migrate from AI Studio to Vertex AI:
+
+```java
+// before:
+@MeshLlm(provider = "gemini", …)
+// after:
+@MeshLlm(provider = "vertex_ai", …)
+```
+
+Swap the dependency in `pom.xml`
+(`spring-ai-starter-model-google-genai` → `spring-ai-starter-model-vertex-ai-gemini`)
+and replace `GOOGLE_AI_GEMINI_API_KEY` with ADC + the
+`spring.ai.vertex.ai.gemini.*` properties shown above.
+
+### Reference example
+
+See `examples/java/vertex-ai-agent/` for a working minimal Spring Boot agent.
 
 ## Complete Example
 

--- a/docs/python/llm/index.md
+++ b/docs/python/llm/index.md
@@ -153,11 +153,105 @@ class ClaudeProviderAgent:
 
 ```
 anthropic/claude-sonnet-4-5
-anthropic/claude-sonnet-4-5
+anthropic/claude-opus-4
 openai/gpt-4o
 openai/gpt-4-turbo
 openai/gpt-3.5-turbo
+gemini/gemini-2.0-flash          # Google AI Studio (API key)
+vertex_ai/gemini-2.0-flash       # Google Vertex AI (IAM)
 ```
+
+## Vertex AI (Gemini via IAM)
+
+mcp-mesh's Python runtime supports Gemini via Google Cloud Vertex AI as an
+alternative to AI Studio. Same handler, same HINT-mode prompt shaping for
+structured output with tools — only the model prefix and auth env vars change.
+
+The TypeScript and Java runtimes have equivalent support — see
+[TypeScript LLM Integration](../../typescript/llm/index/) and
+[Java LLM Integration](../../java/llm/index/) for the runtime-specific
+auth env vars (each follows its own ecosystem's naming convention).
+
+### When to use Vertex AI vs AI Studio
+
+| Use case                                              | Pick                                            |
+| ----------------------------------------------------- | ----------------------------------------------- |
+| Quickstart / dev / lowest setup                       | AI Studio (`gemini/*`, `GOOGLE_API_KEY`)        |
+| Production with IAM auth, GCP audit logs, VPC-SC      | Vertex AI (`vertex_ai/*`, ADC)                  |
+| Need Provisioned Throughput (no capacity 429s)        | Vertex AI (Provisioned Throughput is GCP-side)  |
+| Multi-tenant org-controlled billing                   | Vertex AI                                       |
+
+### Setup
+
+1. Install the `vertex` extra:
+
+   ```bash
+   pip install 'mcp-mesh[vertex]'
+   ```
+
+   This adds `google-auth` (required by LiteLLM for ADC).
+
+2. Configure auth + project + location (pick one path):
+
+   **User ADC** (dev):
+
+   ```bash
+   gcloud auth application-default login
+   export VERTEXAI_PROJECT=my-gcp-project
+   export VERTEXAI_LOCATION=us-central1
+   ```
+
+   **Service account** (CI / prod):
+
+   ```bash
+   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+   export VERTEXAI_LOCATION=us-central1
+   ```
+
+   **Workload Identity** (GKE):
+
+   ```bash
+   export VERTEXAI_LOCATION=us-central1
+   ```
+
+3. Use the `vertex_ai/*` prefix in your decorator:
+
+   ```python
+   @mesh.llm_provider(
+       capability="llm",
+       tags=["gemini", "vertex"],
+       model="vertex_ai/gemini-2.0-flash",
+   )
+   def my_provider(): pass
+   ```
+
+That's it. Same agent code as the AI Studio path; mesh's `GeminiHandler` is
+selected automatically and applies HINT-mode prompt shaping when the call
+involves tools.
+
+### Switching backends
+
+To migrate an existing agent from AI Studio to Vertex AI:
+
+```python
+# Change one line in the decorator:
+model="gemini/gemini-2.0-flash"      # was: "gemini/gemini-2.0-flash"
+                                     # now: "vertex_ai/gemini-2.0-flash"
+```
+
+```bash
+# Switch the env vars:
+unset GOOGLE_API_KEY
+export VERTEXAI_PROJECT=my-project
+export VERTEXAI_LOCATION=us-central1
+gcloud auth application-default login
+```
+
+No other changes required.
+
+### Reference example
+
+See `examples/python/vertex-ai-agent/` for a working minimal agent.
 
 ## Tool Filtering
 

--- a/docs/python/llm/index.md
+++ b/docs/python/llm/index.md
@@ -205,12 +205,18 @@ auth env vars (each follows its own ecosystem's naming convention).
 
    ```bash
    export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+   # VERTEXAI_PROJECT is technically optional with SA JSON (LiteLLM can read
+   # the project from the JSON), but recommended for explicitness:
+   export VERTEXAI_PROJECT=my-gcp-project
    export VERTEXAI_LOCATION=us-central1
    ```
 
    **Workload Identity** (GKE):
 
    ```bash
+   # VERTEXAI_PROJECT is recommended even when ADC carries project info via
+   # the WI binding / metadata server — explicit beats implicit across envs:
+   export VERTEXAI_PROJECT=my-gcp-project
    export VERTEXAI_LOCATION=us-central1
    ```
 

--- a/docs/python/llm/index.md
+++ b/docs/python/llm/index.md
@@ -235,8 +235,7 @@ To migrate an existing agent from AI Studio to Vertex AI:
 
 ```python
 # Change one line in the decorator:
-model="gemini/gemini-2.0-flash"      # was: "gemini/gemini-2.0-flash"
-                                     # now: "vertex_ai/gemini-2.0-flash"
+model="vertex_ai/gemini-2.0-flash"   # was: "gemini/gemini-2.0-flash"
 ```
 
 ```bash

--- a/docs/typescript/llm/index.md
+++ b/docs/typescript/llm/index.md
@@ -218,12 +218,95 @@ agent.addLlmProvider({
 
 Uses LiteLLM model format:
 
-| Provider  | Model Format                   |
-| --------- | ------------------------------ |
-| Anthropic | `anthropic/claude-sonnet-4-5`  |
-| OpenAI    | `openai/gpt-4o`                |
-| Mistral   | `mistral/mistral-large-latest` |
-| Ollama    | `ollama/llama3`                |
+| Provider                | Model Format                   |
+| ----------------------- | ------------------------------ |
+| Anthropic               | `anthropic/claude-sonnet-4-5`  |
+| OpenAI                  | `openai/gpt-4o`                |
+| Google AI Studio        | `gemini/gemini-2.0-flash`      |
+| Google Vertex AI (IAM)  | `vertex_ai/gemini-2.0-flash`   |
+| Mistral                 | `mistral/mistral-large-latest` |
+| Ollama                  | `ollama/llama3`                |
+
+## Vertex AI (Gemini via IAM)
+
+The TypeScript runtime supports Gemini via Google Cloud Vertex AI as an
+alternative to AI Studio. Same model family, same `GeminiHandler`, same
+HINT-mode prompt shaping for structured output with tools — only the model
+prefix and auth env vars change.
+
+### When to use Vertex AI vs AI Studio
+
+| Use case                                              | Pick                                                  |
+| ----------------------------------------------------- | ----------------------------------------------------- |
+| Quickstart / dev / lowest setup                       | AI Studio (`gemini/*`, `GOOGLE_GENERATIVE_AI_API_KEY`) |
+| Production with IAM auth, GCP audit logs, VPC-SC      | Vertex AI (`vertex_ai/*`, ADC)                        |
+| Need Provisioned Throughput (no capacity 429s)        | Vertex AI (Provisioned Throughput is GCP-side)        |
+| Multi-tenant org-controlled billing                   | Vertex AI                                             |
+
+### Setup
+
+`@ai-sdk/google-vertex` is bundled with `@mcpmesh/sdk` — no extra install
+needed.
+
+1. Configure GCP Application Default Credentials. Pick one:
+
+   **User ADC** (dev):
+
+   ```bash
+   gcloud auth application-default login
+   export GOOGLE_VERTEX_PROJECT=my-gcp-project
+   export GOOGLE_VERTEX_LOCATION=us-central1
+   ```
+
+   **Service account** (CI / prod):
+
+   ```bash
+   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+   export GOOGLE_VERTEX_PROJECT=my-gcp-project
+   export GOOGLE_VERTEX_LOCATION=us-central1
+   ```
+
+   `GOOGLE_VERTEX_LOCATION` defaults to `us-central1` if unset.
+
+2. Use the `vertex_ai/*` model prefix:
+
+   ```typescript
+   agent.addLlmProvider({
+     model: "vertex_ai/gemini-2.0-flash",
+     capability: "llm",
+     tags: ["llm", "gemini", "vertex"],
+   });
+   ```
+
+That's it. Same agent code as the AI Studio path; mesh's `GeminiHandler` is
+selected automatically and applies HINT-mode prompt shaping when the call
+involves tools (avoiding Gemini's response_format-with-tools deadlock).
+
+### Switching backends
+
+Migrate from AI Studio to Vertex AI by changing the model prefix and env vars:
+
+```typescript
+// before:
+model: "gemini/gemini-2.0-flash";
+// after:
+model: "vertex_ai/gemini-2.0-flash";
+```
+
+```bash
+# before:
+export GOOGLE_GENERATIVE_AI_API_KEY=AIza...
+# after:
+gcloud auth application-default login
+export GOOGLE_VERTEX_PROJECT=my-gcp-project
+export GOOGLE_VERTEX_LOCATION=us-central1
+```
+
+No other code changes required.
+
+### Reference example
+
+See `examples/typescript/vertex-ai-agent/` for a working minimal agent.
 
 ## Complete Example
 

--- a/examples/java/vertex-ai-agent/README.md
+++ b/examples/java/vertex-ai-agent/README.md
@@ -27,8 +27,11 @@ path — only the `provider` value and auth config change.
 ```bash
 cd examples/java/vertex-ai-agent
 
-# Configure project + location. Either edit src/main/resources/application.yml
-# or override via env vars (Spring Boot binds them through relaxed binding):
+# Configure project + location. Both are REQUIRED — application.yml has no
+# fallback defaults, so Spring Boot fails fast at startup if these are unset
+# (rather than deferring failure to the first Vertex API call with a
+# placeholder project id). Spring Boot relaxed binding maps them onto
+# `spring.ai.vertex.ai.gemini.project-id` / `.location`.
 export SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID=my-gcp-project
 export SPRING_AI_VERTEX_AI_GEMINI_LOCATION=us-central1
 

--- a/examples/java/vertex-ai-agent/README.md
+++ b/examples/java/vertex-ai-agent/README.md
@@ -1,0 +1,90 @@
+# vertex-ai-agent (Java)
+
+Minimal Spring Boot example of calling Google Gemini through **Vertex AI**
+(IAM auth) from a mesh agent. Same Gemini model family as the AI Studio
+path — only the `provider` value and auth config change.
+
+## What it shows
+
+- `@MeshLlm(provider = "vertex_ai")` to force Vertex AI even if AI Studio is
+  also configured (otherwise `provider = "gemini"` prefers AI Studio)
+- A Java record (`CapitalInfo`) as the structured output type
+- Mesh's `GeminiHandler` routing automatically applies HINT-mode prompt
+  shaping when structured output is combined with tools
+
+## Prerequisites
+
+1. A GCP project with the **Vertex AI API** enabled
+2. An identity (user account or service account) with the
+   `roles/aiplatform.user` role
+3. Application Default Credentials configured — either:
+   - User flow: `gcloud auth application-default login`
+   - Service account: `GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json`
+4. Java 17+ and Maven 3.9+
+
+## Run locally
+
+```bash
+cd examples/java/vertex-ai-agent
+
+# Configure project + location. Either edit src/main/resources/application.yml
+# or override via env vars (Spring Boot binds them through relaxed binding):
+export SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID=my-gcp-project
+export SPRING_AI_VERTEX_AI_GEMINI_LOCATION=us-central1
+
+# Start the registry in another terminal first, then:
+mvn spring-boot:run
+```
+
+## Try it
+
+```bash
+# Once registered, call the tool through any mesh client. For a quick
+# smoke test, hit the agent's MCP HTTP endpoint directly:
+curl -s http://localhost:9042/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,"method":"tools/call",
+    "params":{"name":"capitalOf","arguments":{"country":"France"}}
+  }' | jq .
+```
+
+You should see a structured response like:
+
+```json
+{ "name": "France", "capital": "Paris" }
+```
+
+## Switching to AI Studio
+
+To run the same agent against Google AI Studio instead:
+
+1. Replace the dependency in `pom.xml`:
+   ```xml
+   <dependency>
+     <groupId>org.springframework.ai</groupId>
+     <artifactId>spring-ai-starter-model-google-genai</artifactId>
+     <version>${spring-ai.version}</version>
+   </dependency>
+   ```
+2. Change the annotation:
+   ```java
+   @MeshLlm(provider = "gemini", …)   // was: provider = "vertex_ai"
+   ```
+3. Configure the API key:
+   ```bash
+   export GOOGLE_AI_GEMINI_API_KEY=AIza…
+   ```
+
+## Env var conventions across runtimes
+
+Each runtime follows its own ecosystem's naming convention for Vertex AI:
+
+| Runtime              | SDK            | Project                                    | Location                                   |
+| -------------------- | -------------- | ------------------------------------------ | ------------------------------------------ |
+| Python               | LiteLLM        | `VERTEXAI_PROJECT`                         | `VERTEXAI_LOCATION`                        |
+| TypeScript           | Vercel AI SDK  | `GOOGLE_VERTEX_PROJECT`                    | `GOOGLE_VERTEX_LOCATION`                   |
+| **Java (this)**      | **Spring AI** | `spring.ai.vertex.ai.gemini.project-id`<br/>(or env: `SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID`) | `spring.ai.vertex.ai.gemini.location`<br/>(or env: `SPRING_AI_VERTEX_AI_GEMINI_LOCATION`) |
+
+`GOOGLE_APPLICATION_CREDENTIALS` (or `gcloud auth application-default login`)
+works for ADC across all three.

--- a/examples/java/vertex-ai-agent/pom.xml
+++ b/examples/java/vertex-ai-agent/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>vertex-ai-agent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Vertex AI Agent (Java)</name>
+    <description>Minimal Spring Boot agent: Gemini via Vertex AI (IAM auth) using Spring AI</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.3.4</mcp-mesh.version>
+        <spring-ai.version>2.0.0-M4</spring-ai.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- MCP Mesh Spring AI Integration (provides SpringAiLlmProvider, GeminiHandler) -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-ai</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring AI Vertex AI Gemini starter — IAM auth, NOT API key.
+             Auto-configures vertexAiGeminiChatModel from
+             spring.ai.vertex.ai.gemini.* properties. -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-vertex-ai-gemini</artifactId>
+            <version>${spring-ai.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.vertex.VertexAiAgentApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>local-maven-repo</id>
+            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
+        </repository>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+</project>

--- a/examples/java/vertex-ai-agent/pom.xml
+++ b/examples/java/vertex-ai-agent/pom.xml
@@ -23,6 +23,10 @@
         <java.version>17</java.version>
         <mcp-mesh.version>1.3.4</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
+        <!-- Defensive bump over Spring Boot 4.0.5's managed Tomcat 11.0.20.
+             Verified 11.0.21 exists on Maven Central. Keeps the example
+             on a CVE-free embed-tomcat without affecting SDK consumers. -->
+        <tomcat.version>11.0.21</tomcat.version>
     </properties>
 
     <dependencies>

--- a/examples/java/vertex-ai-agent/src/main/java/com/example/vertex/VertexAiAgentApplication.java
+++ b/examples/java/vertex-ai-agent/src/main/java/com/example/vertex/VertexAiAgentApplication.java
@@ -1,0 +1,113 @@
+package com.example.vertex;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshLlm;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.types.MeshLlmAgent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * vertex-ai-agent (Java) — Minimal Gemini-via-Vertex-AI Spring Boot agent.
+ *
+ * <p>Demonstrates calling Google Gemini through Vertex AI (IAM auth) instead of
+ * AI Studio, using Spring AI's {@code spring-ai-starter-model-vertex-ai-gemini}.
+ *
+ * <p>The only differences from a Gemini AI Studio agent are:
+ * <ul>
+ *   <li>{@code provider = "vertex_ai"} on {@code @MeshLlm} (vs {@code "gemini"})</li>
+ *   <li>auth: GCP ADC + {@code spring.ai.vertex.ai.gemini.project-id} +
+ *       {@code spring.ai.vertex.ai.gemini.location} (vs {@code GOOGLE_AI_GEMINI_API_KEY})</li>
+ * </ul>
+ *
+ * <p>Mesh-side prompt shaping is identical for both backends — the same
+ * {@code GeminiHandler} is selected for both {@code "gemini"} and
+ * {@code "vertex_ai"} provider strings.
+ *
+ * <p>The {@code provider = "vertex_ai"} value is significant: with just
+ * {@code provider = "gemini"}, the runtime would prefer the AI Studio
+ * ({@code googleAiGeminiChatModel}) bean if it were also configured. Setting
+ * {@code "vertex_ai"} explicitly forces the Vertex AI path.
+ *
+ * <h2>Prerequisites</h2>
+ * <ul>
+ *   <li>GCP project with the Vertex AI API enabled</li>
+ *   <li>An identity with {@code roles/aiplatform.user}</li>
+ *   <li>Application Default Credentials configured (via
+ *       {@code gcloud auth application-default login} or
+ *       {@code GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json})</li>
+ * </ul>
+ *
+ * <h2>Running</h2>
+ * <pre>
+ * # In src/main/resources/application.yml, set project + location, OR override
+ * # at runtime via env vars (Spring Boot auto-binds SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID
+ * # and SPRING_AI_VERTEX_AI_GEMINI_LOCATION):
+ * export SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID=my-gcp-project
+ * export SPRING_AI_VERTEX_AI_GEMINI_LOCATION=us-central1
+ *
+ * # Start the registry
+ * meshctl start --registry-only
+ *
+ * # Run this agent
+ * cd examples/java/vertex-ai-agent
+ * mvn spring-boot:run
+ *
+ * # Smoke-test
+ * curl -s http://localhost:9042/mcp \
+ *   -H 'Content-Type: application/json' \
+ *   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
+ *        "params":{"name":"capitalOf","arguments":{"country":"France"}}}' | jq .
+ * </pre>
+ */
+@MeshAgent(
+    name = "vertex-ai-agent-java",
+    version = "1.0.0",
+    description = "Gemini via Vertex AI (IAM auth) demo agent — Java",
+    port = 9042
+)
+@SpringBootApplication
+public class VertexAiAgentApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(VertexAiAgentApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting vertex-ai-agent (Java)…");
+        SpringApplication.run(VertexAiAgentApplication.class, args);
+    }
+
+    /** Structured response: country + capital. */
+    public record CapitalInfo(String name, String capital) {}
+
+    /**
+     * Look up a country's capital via Gemini on Vertex AI.
+     *
+     * <p>The {@code provider = "vertex_ai"} forces SpringAiLlmProvider to use
+     * {@code vertexAiGeminiChatModel} even if the AI Studio bean is also present.
+     */
+    @MeshLlm(
+        provider = "vertex_ai",
+        maxIterations = 1,
+        systemPrompt =
+            "You answer geography questions concisely. " +
+            "Return the country name and its capital as structured JSON.",
+        maxTokens = 256,
+        temperature = 0.0
+    )
+    @MeshTool(
+        capability = "capital_lookup",
+        description = "Return the capital of a country as a structured CapitalInfo object",
+        tags = {"geography", "llm", "vertex"}
+    )
+    public CapitalInfo capitalOf(
+        @Param(value = "country", description = "Country to look up") String country,
+        MeshLlmAgent llm
+    ) {
+        return llm.request()
+            .user("What is the capital of " + country + "?")
+            .generate(CapitalInfo.class);
+    }
+}

--- a/examples/java/vertex-ai-agent/src/main/resources/application.yml
+++ b/examples/java/vertex-ai-agent/src/main/resources/application.yml
@@ -8,13 +8,15 @@ spring:
     vertex:
       ai:
         gemini:
-          # GCP project + region. Override at runtime via env vars:
+          # GCP project + region. REQUIRED env vars (no defaults — startup
+          # fails fast if these are missing rather than deferring failure to
+          # the first Vertex API call with a placeholder value):
           #   SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID=my-gcp-project
           #   SPRING_AI_VERTEX_AI_GEMINI_LOCATION=us-central1
           # Auth is via Google Application Default Credentials (gcloud
           # auth application-default login, or GOOGLE_APPLICATION_CREDENTIALS).
-          project-id: ${SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID:my-gcp-project}
-          location: ${SPRING_AI_VERTEX_AI_GEMINI_LOCATION:us-central1}
+          project-id: ${SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID}
+          location: ${SPRING_AI_VERTEX_AI_GEMINI_LOCATION}
           chat:
             options:
               model: gemini-2.0-flash

--- a/examples/java/vertex-ai-agent/src/main/resources/application.yml
+++ b/examples/java/vertex-ai-agent/src/main/resources/application.yml
@@ -1,0 +1,25 @@
+server:
+  port: ${MCP_MESH_HTTP_PORT:9042}
+
+spring:
+  application:
+    name: vertex-ai-agent
+  ai:
+    vertex:
+      ai:
+        gemini:
+          # GCP project + region. Override at runtime via env vars:
+          #   SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID=my-gcp-project
+          #   SPRING_AI_VERTEX_AI_GEMINI_LOCATION=us-central1
+          # Auth is via Google Application Default Credentials (gcloud
+          # auth application-default login, or GOOGLE_APPLICATION_CREDENTIALS).
+          project-id: ${SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID:my-gcp-project}
+          location: ${SPRING_AI_VERTEX_AI_GEMINI_LOCATION:us-central1}
+          chat:
+            options:
+              model: gemini-2.0-flash
+
+logging:
+  level:
+    io.mcpmesh: INFO
+    com.example: INFO

--- a/examples/python/vertex-ai-agent/README.md
+++ b/examples/python/vertex-ai-agent/README.md
@@ -1,0 +1,71 @@
+# vertex-ai-agent
+
+Minimal example of calling Google Gemini through **Vertex AI** (IAM auth)
+from a mesh agent. Same Gemini model family as the AI Studio path — only
+the model prefix and auth env vars change.
+
+## What it shows
+
+- `model="vertex_ai/gemini-2.0-flash"` on `@mesh.llm_provider`
+- A Pydantic structured-output return type (`CapitalInfo`)
+- Mesh's HINT-mode prompt shaping is applied automatically (same as for
+  `gemini/*`), so structured output works alongside tool use without
+  triggering Gemini's response_format-with-tools deadlock.
+
+## Prerequisites
+
+1. A GCP project with the **Vertex AI API** enabled
+2. An identity (user account or service account) with the `roles/aiplatform.user` role
+3. Application Default Credentials configured — either:
+   - User flow: `gcloud auth application-default login`
+   - Service account: `GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json`
+4. **Install mesh with the `vertex` extra** — pulls in `google-auth` which LiteLLM
+   needs to read ADC for `vertex_ai/*` model strings:
+   ```bash
+   pip install 'mcp-mesh[vertex]'
+   ```
+
+## Run locally
+
+```bash
+# Project + location: required if using user ADC (gcloud auth application-default login).
+# If using a service account JSON, project is auto-derived but location is still recommended.
+export VERTEXAI_PROJECT=my-gcp-project
+export VERTEXAI_LOCATION=us-central1
+
+# Start the registry in another terminal first, then:
+meshctl start examples/python/vertex-ai-agent/main.py
+```
+
+## Try it
+
+```bash
+# Once registered, call the tool through any mesh client. For a quick
+# smoke test, hit the agent's MCP HTTP endpoint directly:
+curl -s http://localhost:9040/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,"method":"tools/call",
+    "params":{"name":"capital_of","arguments":{"country":"France"}}
+  }' | jq .
+```
+
+You should see a structured response like:
+
+```json
+{ "name": "France", "capital": "Paris" }
+```
+
+## Switching to AI Studio
+
+To run the same agent against Google AI Studio instead, change two things:
+
+```python
+model="gemini/gemini-2.0-flash"   # was: vertex_ai/gemini-2.0-flash
+```
+
+```bash
+export GOOGLE_API_KEY=...         # instead of ADC + VERTEXAI_*
+```
+
+The `mcp-mesh[vertex]` extra is not needed for the AI Studio path — `pip install mcp-mesh` is sufficient. No other code changes required.

--- a/examples/python/vertex-ai-agent/main.py
+++ b/examples/python/vertex-ai-agent/main.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+vertex-ai-agent - Minimal Gemini-via-Vertex-AI agent
+
+Demonstrates calling Google Gemini through Vertex AI (IAM auth) instead of
+AI Studio. The only differences from a Gemini AI Studio agent are:
+  - model prefix:   "vertex_ai/<model>"   (vs "gemini/<model>")
+  - auth env var:   GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+                    (vs GOOGLE_API_KEY)
+
+Mesh-side prompt shaping (HINT-mode for tool calls, STRICT-mode for tool-free
+structured output) is identical for both backends.
+"""
+
+import mesh
+from fastmcp import FastMCP
+from pydantic import BaseModel
+
+app = FastMCP("Vertex AI Agent")
+
+
+class CapitalInfo(BaseModel):
+    """Structured response describing a country and its capital."""
+
+    name: str
+    capital: str
+
+
+@mesh.llm_provider(
+    model="vertex_ai/gemini-2.0-flash",
+    capability="llm",
+    tags=["gemini", "vertex"],
+    version="1.0.0",
+)
+def vertex_gemini_provider():
+    """Zero-code Vertex AI Gemini provider — config is in the decorator."""
+    pass
+
+
+@app.tool()
+@mesh.llm(
+    provider={"capability": "llm", "tags": ["vertex"]},
+    system_prompt=(
+        "You answer geography questions concisely. "
+        "Return the country name and its capital as structured JSON."
+    ),
+)
+@mesh.tool(capability="capital_lookup", version="1.0.0")
+async def capital_of(country: str, llm: mesh.MeshLlmAgent = None) -> CapitalInfo:
+    """Return the capital of a country as a structured CapitalInfo object."""
+    return await llm(f"What is the capital of {country}?")
+
+
+@mesh.agent(
+    name="vertex-ai-agent",
+    version="1.0.0",
+    description="Gemini via Vertex AI (IAM auth) demo agent",
+    http_port=9040,
+    enable_http=True,
+    auto_run=True,
+)
+class VertexAiAgent:
+    pass

--- a/examples/python/vertex-ai-agent/requirements.txt
+++ b/examples/python/vertex-ai-agent/requirements.txt
@@ -1,5 +1,7 @@
 # vertex-ai-agent dependencies
-# Note: mcp-mesh is provided by the runtime environment.
-# LiteLLM (bundled with mcp-mesh) talks to Vertex AI directly using
-# the standard google-auth library — no extra packages required when
-# you authenticate via GOOGLE_APPLICATION_CREDENTIALS.
+# Install mcp-mesh with the [vertex] extra:
+#   pip install 'mcp-mesh[vertex]'
+# This pulls in google-auth, which LiteLLM needs for vertex_ai/* model
+# strings (to read Application Default Credentials and call the Vertex AI
+# REST endpoint). Without it, the first call raises
+# `ModuleNotFoundError: No module named 'google.auth'`.

--- a/examples/python/vertex-ai-agent/requirements.txt
+++ b/examples/python/vertex-ai-agent/requirements.txt
@@ -1,0 +1,5 @@
+# vertex-ai-agent dependencies
+# Note: mcp-mesh is provided by the runtime environment.
+# LiteLLM (bundled with mcp-mesh) talks to Vertex AI directly using
+# the standard google-auth library — no extra packages required when
+# you authenticate via GOOGLE_APPLICATION_CREDENTIALS.

--- a/examples/typescript/vertex-ai-agent/README.md
+++ b/examples/typescript/vertex-ai-agent/README.md
@@ -1,0 +1,84 @@
+# vertex-ai-agent (TypeScript)
+
+Minimal example of calling Google Gemini through **Vertex AI** (IAM auth)
+from a TypeScript mesh agent. Same Gemini model family as the AI Studio
+path — only the model prefix and auth env vars change.
+
+## What it shows
+
+- `model="vertex_ai/gemini-2.0-flash"` on `agent.addLlmProvider`
+- A Zod structured-output schema (`CapitalInfo`)
+- Mesh's HINT-mode prompt shaping is applied automatically (same as for
+  `gemini/*`), so structured output works alongside tool use without
+  triggering Gemini's response_format-with-tools deadlock.
+
+## Prerequisites
+
+1. A GCP project with the **Vertex AI API** enabled
+2. An identity (user account or service account) with the
+   `roles/aiplatform.user` role
+3. Application Default Credentials configured — either:
+   - User flow: `gcloud auth application-default login`
+   - Service account: `GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json`
+4. Node.js 18+. The `@ai-sdk/google-vertex` package is already a dep of
+   `@mcpmesh/sdk` so no extra install is needed.
+
+## Run locally
+
+```bash
+cd examples/typescript/vertex-ai-agent
+npm install
+
+# Required: project + location for Vercel SDK's @ai-sdk/google-vertex.
+export GOOGLE_VERTEX_PROJECT=my-gcp-project
+export GOOGLE_VERTEX_LOCATION=us-central1
+
+# Start the registry in another terminal first, then:
+npm start
+```
+
+## Try it
+
+```bash
+# Once registered, call the tool through any mesh client. For a quick
+# smoke test, hit the agent's MCP HTTP endpoint directly:
+curl -s http://localhost:9041/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,"method":"tools/call",
+    "params":{"name":"capital_of","arguments":{"country":"France"}}
+  }' | jq .
+```
+
+You should see a structured response like:
+
+```json
+{ "name": "France", "capital": "Paris" }
+```
+
+## Switching to AI Studio
+
+To run the same agent against Google AI Studio instead, change two things:
+
+```typescript
+model: "gemini/gemini-2.0-flash"   // was: "vertex_ai/gemini-2.0-flash"
+```
+
+```bash
+export GOOGLE_GENERATIVE_AI_API_KEY=AIza...   # instead of ADC + GOOGLE_VERTEX_*
+```
+
+No other code changes required.
+
+## Env var conventions across runtimes
+
+Each runtime follows its own ecosystem's naming convention for Vertex AI:
+
+| Runtime              | SDK            | Project                | Location               |
+| -------------------- | -------------- | ---------------------- | ---------------------- |
+| Python               | LiteLLM        | `VERTEXAI_PROJECT`     | `VERTEXAI_LOCATION`    |
+| **TypeScript (this)** | **Vercel AI SDK** | `GOOGLE_VERTEX_PROJECT`| `GOOGLE_VERTEX_LOCATION` |
+| Java                 | Spring AI      | `spring.ai.vertex.ai.gemini.project-id` | `spring.ai.vertex.ai.gemini.location` |
+
+`GOOGLE_APPLICATION_CREDENTIALS` (or `gcloud auth application-default login`)
+works for ADC across all three.

--- a/examples/typescript/vertex-ai-agent/package-lock.json
+++ b/examples/typescript/vertex-ai-agent/package-lock.json
@@ -1,0 +1,2840 @@
+{
+  "name": "vertex-ai-agent-ts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vertex-ai-agent-ts",
+      "version": "1.0.0",
+      "dependencies": {
+        "@mcpmesh/core": "file:../../../src/runtime/core/typescript",
+        "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+        "fastmcp": "^3.34.0",
+        "zod": "^3.24.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "../../../src/runtime/core/typescript": {
+      "name": "@mcpmesh/core",
+      "version": "1.3.4",
+      "license": "MIT",
+      "devDependencies": {
+        "@napi-rs/cli": "^3.5.1"
+      }
+    },
+    "../../../src/runtime/typescript": {
+      "name": "@mcpmesh/sdk",
+      "version": "1.3.4",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/google-vertex": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@mcpmesh/core": "file:../core/typescript",
+        "ai": "^6.0.0",
+        "fastmcp": "^3.34.0",
+        "handlebars": "^4.7.8",
+        "mcp-proxy": "6.4.4",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.0",
+        "@types/express-v5": "npm:@types/express@^5.0.0",
+        "@types/node": "^22.0.0",
+        "express": "^4.18.0",
+        "express-v5": "npm:express@^5.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@mcpmesh/core": {
+      "resolved": "../../../src/runtime/core/typescript",
+      "link": true
+    },
+    "node_modules/@mcpmesh/sdk": {
+      "resolved": "../../../src/runtime/typescript",
+      "link": true
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastmcp": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.35.0.tgz",
+      "integrity": "sha512-bcyAaVa3Zw5f4xighGg6fNNgEzZoP6tX/O+ZfS2lIhbEULWe/zUWG533JyFEUOjZT7EB+tiZW1ot4eWKmYJ6DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.24.3",
+        "@standard-schema/spec": "^1.0.0",
+        "execa": "^9.6.1",
+        "file-type": "^21.1.1",
+        "fuse.js": "^7.1.0",
+        "hono": "^4.11.5",
+        "mcp-proxy": "^6.4.0",
+        "strict-event-emitter-types": "^2.0.0",
+        "undici": "^7.16.0",
+        "uri-templates": "^0.2.0",
+        "xsschema": "^0.4.3",
+        "yargs": "^18.0.0",
+        "zod": "^4.1.13",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "bin": {
+        "fastmcp": "dist/bin/fastmcp.js"
+      },
+      "peerDependencies": {
+        "jose": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jose": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fastmcp/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/human-readable-ids": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/human-readable-ids/-/human-readable-ids-1.0.4.tgz",
+      "integrity": "sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA==",
+      "license": "Apache2",
+      "dependencies": {
+        "knuth-shuffle": "^1.0.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/knuth-shuffle": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/knuth-shuffle/-/knuth-shuffle-1.0.8.tgz",
+      "integrity": "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ==",
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/koa": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.0.tgz",
+      "integrity": "sha512-TrM4/tnNY7uJ1aW55sIIa+dqBvc4V14WRIAlGcWat9wV5pRS9Wr5Zk2ZTjQP1jtfIHDoHiSbPuV08P0fUZo2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~1.0.1",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/koa-router": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-14.0.0.tgz",
+      "integrity": "sha512-Ue8f/PRsLLNm6b7y+eS6xkqvsG2xH11d2VB1HPcfdfW6p5736kCHf2pXaq8q9XPQ01x0Dk7V/P5Il9pe+tGTxA==",
+      "deprecated": "Please use @koa/router instead, starting from v9! ",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "path-to-regexp": "^8.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/koa/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/koa/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-proxy": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.4.6.tgz",
+      "integrity": "sha512-tUGAvjzORMUO28shoWNO7yH3kH3r6sYLdAD9w6zoYpjy5zKMFq76nniaMkajpeX/zbemzgICl9sfXhrwQt+hlw==",
+      "license": "MIT",
+      "dependencies": {
+        "pipenet": "^1.3.0"
+      },
+      "bin": {
+        "mcp-proxy": "dist/bin/mcp-proxy.mjs"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pipenet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.0.tgz",
+      "integrity": "sha512-Uc3EH2i8hnJUD0Eupj9z2jaZPjjAbooaiHGh0iFdExbE8/BDt6Lf0919Dtwx5VM83elHNWFzCOsvzsViTD5YZg==",
+      "dependencies": {
+        "axios": "^1.7.3",
+        "debug": "^4.3.6",
+        "human-readable-ids": "^1.0.4",
+        "koa": "^3.1.1",
+        "koa-router": "^14.0.0",
+        "pump": "^3.0.3",
+        "tldjs": "^2.3.2",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "pipenet": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tldjs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.2.tgz",
+      "integrity": "sha512-EORDwFMSZKrHPUVDhejCMDeAovRS5d8jZKiqALFiPp3cjKjEldPkxBY39ZSx3c45awz3RpKwJD1cCgGxEfy8/A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-templates": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.2.0.tgz",
+      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==",
+      "license": "http://geraintluff.github.io/tv4/LICENSE.txt"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xsschema": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/xsschema/-/xsschema-0.4.4.tgz",
+      "integrity": "sha512-TMhbk8AhxO+YuDOn3rXBjGXQ+Vja3T13UPQkHx/FemhusaOzRfCSj2seykt0mdnFPsOtO9l3ANf4adcp+4NRGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@valibot/to-json-schema": "^1.0.0",
+        "arktype": "^2.1.20",
+        "effect": "^3.16.0",
+        "sury": "^10.0.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "@valibot/to-json-schema": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "sury": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/typescript/vertex-ai-agent/package.json
+++ b/examples/typescript/vertex-ai-agent/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "vertex-ai-agent-ts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Minimal TS mesh agent: Gemini via Vertex AI (IAM auth) using Vercel AI SDK",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/core": "file:../../../src/runtime/core/typescript",
+    "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/typescript/vertex-ai-agent/src/index.ts
+++ b/examples/typescript/vertex-ai-agent/src/index.ts
@@ -1,0 +1,75 @@
+/**
+ * vertex-ai-agent (TypeScript) — Minimal Gemini-via-Vertex-AI agent
+ *
+ * Demonstrates calling Google Gemini through Vertex AI (IAM auth) instead of
+ * AI Studio, using the Vercel AI SDK's @ai-sdk/google-vertex provider.
+ *
+ * The only differences from a Gemini AI Studio agent are:
+ *   - model prefix:   "vertex_ai/<model>"   (vs "gemini/<model>")
+ *   - auth env vars:  GOOGLE_VERTEX_PROJECT + GOOGLE_VERTEX_LOCATION + ADC
+ *                     (vs GOOGLE_GENERATIVE_AI_API_KEY)
+ *
+ * Mesh-side prompt shaping (HINT-mode for tool calls, STRICT-mode for
+ * tool-free structured output) is identical for both backends — the same
+ * GeminiHandler is selected for vendor "vertex_ai".
+ */
+
+import { FastMCP, mesh } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const server = new FastMCP({
+  name: "Vertex AI Agent (TS)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "vertex-ai-agent-ts",
+  version: "1.0.0",
+  description: "Gemini via Vertex AI (IAM auth) demo agent — TypeScript",
+  httpPort: 9041,
+});
+
+// Zero-code Vertex AI provider — selected via the vertex_ai/* model prefix.
+agent.addLlmProvider({
+  name: "vertex_chat",
+  model: "vertex_ai/gemini-2.0-flash",
+  capability: "llm",
+  tags: ["llm", "gemini", "vertex", "provider"],
+  version: "1.0.0",
+});
+
+// Structured-output tool: returns a CapitalInfo object.
+const CapitalInfo = z.object({
+  name: z.string().describe("The country name"),
+  capital: z.string().describe("The capital city"),
+});
+
+const capitalOfTool = mesh.llm({
+  name: "capital_of",
+  capability: "capital_lookup",
+  description: "Return the capital of a country as a structured CapitalInfo object",
+  tags: ["geography", "llm"],
+  version: "1.0.0",
+
+  // Mesh delegation — find any LLM provider tagged "vertex".
+  provider: { capability: "llm", tags: ["+vertex"] },
+  systemPrompt:
+    "You answer geography questions concisely. " +
+    "Return the country name and its capital as structured JSON.",
+
+  // Input schema for the tool.
+  parameters: z.object({
+    country: z.string().describe("Country to look up"),
+  }),
+
+  // Output schema — triggers HINT-mode prompt shaping when combined with tools.
+  returns: CapitalInfo,
+
+  execute: async ({ country }, { llm }) => {
+    return await llm(`What is the capital of ${country}?`);
+  },
+});
+
+server.addTool(capitalOfTool);
+
+console.log("vertex-ai-agent-ts initialized. Waiting for auto-start...");

--- a/examples/typescript/vertex-ai-agent/tsconfig.json
+++ b/examples/typescript/vertex-ai-agent/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -83,6 +83,13 @@ kubernetes = [
     "kubernetes>=28.1.0",
     "pykube-ng>=22.9.0"
 ]
+vertex = [
+    # google-auth is required for LiteLLM's vertex_ai/* model prefix to read
+    # Application Default Credentials. Optional because non-Vertex users (AI
+    # Studio, Claude, OpenAI) don't need it. Install via:
+    #   pip install mcp-mesh[vertex]
+    "google-auth>=2.0.0"
+]
 
 [project.urls]
 Homepage = "https://github.com/dhyansraj/mcp-mesh"

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -147,7 +147,10 @@ needed. Auth is via Google ADC.
 | Service account JSON                                | `GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json`, `GOOGLE_VERTEX_PROJECT`, `GOOGLE_VERTEX_LOCATION` |
 | Workload Identity (GKE pods)                        | `GOOGLE_VERTEX_PROJECT`, `GOOGLE_VERTEX_LOCATION`                                |
 
-If `GOOGLE_VERTEX_LOCATION` is omitted the SDK defaults to `us-central1`.
+Both `GOOGLE_VERTEX_PROJECT` and `GOOGLE_VERTEX_LOCATION` are required by
+`@ai-sdk/google-vertex` — the SDK throws a `LoadSettingError` on the first
+call if either is unset (it does not auto-discover the project from ADC and
+has no default location). Common location values: `us-central1`, `global`.
 
 #### Java (Spring AI)
 

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -95,6 +95,104 @@ export GOOGLE_GENERATIVE_AI_API_KEY=your-key       # TypeScript (Vercel AI SDK)
 export GOOGLE_AI_GEMINI_API_KEY=your-key           # Java (Spring AI)
 ```
 
+### Vertex AI (Gemini via IAM)
+
+For users who want to call Gemini through Google Cloud's Vertex AI instead of
+AI Studio (IAM auth, GCP Provisioned Throughput, VPC-SC, org-controlled billing),
+use the `vertex_ai/` model prefix (Python/TS) or `provider = "vertex_ai"` (Java).
+
+All three runtimes share the same prompt-shaping rules — the same
+GeminiHandler runs for both `gemini/*` and `vertex_ai/*`. Only the auth
+transport and env var names differ.
+
+#### Python (LiteLLM)
+
+```python
+@mesh.llm_provider(
+    capability="llm",
+    tags=["gemini", "vertex"],
+    model="vertex_ai/gemini-2.0-flash",  # vs "gemini/gemini-2.0-flash" for AI Studio
+)
+def my_provider(): pass
+```
+
+Install the optional `vertex` extra (adds `google-auth` for ADC):
+
+```bash
+pip install 'mcp-mesh[vertex]'
+```
+
+| Scenario                                            | Required env vars                                                            |
+| --------------------------------------------------- | ---------------------------------------------------------------------------- |
+| User ADC (`gcloud auth application-default login`)  | `VERTEXAI_PROJECT`, `VERTEXAI_LOCATION`                                      |
+| Service account JSON                                | `GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json`, `VERTEXAI_LOCATION`       |
+| Workload Identity (GKE pods)                        | `VERTEXAI_LOCATION` (project from WI binding)                                |
+
+#### TypeScript (Vercel AI SDK)
+
+```typescript
+agent.addLlmProvider({
+  model: "vertex_ai/gemini-2.0-flash",
+  capability: "llm",
+  tags: ["gemini", "vertex"],
+});
+```
+
+`@ai-sdk/google-vertex` is bundled with `@mcpmesh/sdk` — no extra install
+needed. Auth is via Google ADC.
+
+| Scenario                                            | Required env vars                                                                |
+| --------------------------------------------------- | -------------------------------------------------------------------------------- |
+| User ADC (`gcloud auth application-default login`)  | `GOOGLE_VERTEX_PROJECT`, `GOOGLE_VERTEX_LOCATION`                                |
+| Service account JSON                                | `GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json`, `GOOGLE_VERTEX_PROJECT`, `GOOGLE_VERTEX_LOCATION` |
+| Workload Identity (GKE pods)                        | `GOOGLE_VERTEX_PROJECT`, `GOOGLE_VERTEX_LOCATION`                                |
+
+If `GOOGLE_VERTEX_LOCATION` is omitted the SDK defaults to `us-central1`.
+
+#### Java (Spring AI)
+
+```java
+@MeshLlm(provider = "vertex_ai", …)
+@MeshTool(capability = "…")
+public MyResult myTool(@Param("…") String input, MeshLlmAgent llm) { … }
+```
+
+Add the Vertex AI starter to your `pom.xml` (mesh's `mcp-mesh-spring-ai`
+keeps it optional so you don't pull google-cloud-aiplatform unless asked):
+
+```xml
+<dependency>
+  <groupId>org.springframework.ai</groupId>
+  <artifactId>spring-ai-starter-model-vertex-ai-gemini</artifactId>
+  <version>${spring-ai.version}</version>
+</dependency>
+```
+
+Spring AI's auto-config doesn't read any conventional `GOOGLE_*` env var on
+its own — it binds Spring Boot properties:
+
+| Spring property                              | Equivalent env var (relaxed binding)         |
+| -------------------------------------------- | -------------------------------------------- |
+| `spring.ai.vertex.ai.gemini.project-id`      | `SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID`      |
+| `spring.ai.vertex.ai.gemini.location`        | `SPRING_AI_VERTEX_AI_GEMINI_LOCATION`        |
+| `spring.ai.vertex.ai.gemini.chat.options.model` | `SPRING_AI_VERTEX_AI_GEMINI_CHAT_OPTIONS_MODEL` |
+
+Auth is via Google ADC (`gcloud auth application-default login` or
+`GOOGLE_APPLICATION_CREDENTIALS`).
+
+The `provider = "vertex_ai"` value is significant. With just
+`provider = "gemini"`, the runtime prefers the AI Studio bean
+(`googleAiGeminiChatModel`) when both backends are configured;
+`"vertex_ai"` forces the IAM path.
+
+#### Common: ADC
+
+ADC is auto-discovered from the standard Google location
+(`~/.config/gcloud/application_default_credentials.json`) — no extra env
+needed if you've run `gcloud auth application-default login`. For headless
+or service-account scenarios, set `GOOGLE_APPLICATION_CREDENTIALS` to the
+JSON key file path. This is the **same** across all three runtimes.
+
 ## LLM Agent Configuration
 
 Override `@mesh.llm` decorator parameters at runtime:

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -166,7 +166,31 @@ anthropic/claude-opus-4
 openai/gpt-4o
 openai/gpt-4-turbo
 openai/gpt-3.5-turbo
+gemini/gemini-2.0-flash          # Google AI Studio (API key)
+vertex_ai/gemini-2.0-flash       # Google Vertex AI (IAM)
 ```
+
+## Gemini Backend Selection
+
+Mesh routes Gemini calls via the model prefix:
+
+| Backend                    | Model prefix                 | Auth                                            |
+| -------------------------- | ---------------------------- | ----------------------------------------------- |
+| Google AI Studio (API key) | `gemini/gemini-2.0-flash`    | `GOOGLE_API_KEY` env                            |
+| Google Vertex AI (IAM)     | `vertex_ai/gemini-2.0-flash` | ADC + `VERTEXAI_PROJECT` + `VERTEXAI_LOCATION`  |
+
+Same `GeminiHandler` runs for both — identical HINT-mode prompt shaping for
+structured output with tools. Switch backends by changing only the model
+prefix and the auth env vars; no agent code changes.
+
+For Vertex AI:
+- **Python**: install the optional extra: `pip install 'mcp-mesh[vertex]'`
+- **TypeScript**: `@mcpmesh/sdk` already depends on `@ai-sdk/google-vertex` —
+  no extra install needed
+- **Java**: add `org.springframework.ai:spring-ai-starter-model-vertex-ai-gemini`
+  to your `pom.xml` (the mesh starter only auto-wires it when present)
+
+See `meshctl man env` for the full env var matrix across runtimes.
 
 ## Tool Filtering
 

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -190,7 +190,15 @@ For Vertex AI:
 - **Java**: add `org.springframework.ai:spring-ai-starter-model-vertex-ai-gemini`
   to your `pom.xml` (the mesh starter only auto-wires it when present)
 
-See `meshctl man env` for the full env var matrix across runtimes.
+**Per-language env var names** (each runtime follows its ecosystem's convention):
+
+- **Python (LiteLLM)**: `VERTEXAI_PROJECT`, `VERTEXAI_LOCATION`
+- **TypeScript (Vercel AI SDK)**: `GOOGLE_VERTEX_PROJECT`, `GOOGLE_VERTEX_LOCATION`
+- **Java (Spring AI)**: `SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID`,
+  `SPRING_AI_VERTEX_AI_GEMINI_LOCATION`
+
+`GOOGLE_APPLICATION_CREDENTIALS` (path to SA JSON / ADC) is shared across all
+three. See `meshctl man env` for the full matrix.
 
 ## Tool Filtering
 

--- a/src/core/cli/man/content/llm_java.md
+++ b/src/core/cli/man/content/llm_java.md
@@ -279,12 +279,109 @@ The provider automatically:
 
 Uses LiteLLM model format in `@MeshLlmProvider`:
 
-| Provider  | Model Format                   |
-| --------- | ------------------------------ |
-| Anthropic | `anthropic/claude-sonnet-4-5`  |
-| OpenAI    | `openai/gpt-4o`                |
-| Mistral   | `mistral/mistral-large-latest` |
-| Google    | `gemini/gemini-pro`            |
+| Provider                | Model Format                   |
+| ----------------------- | ------------------------------ |
+| Anthropic               | `anthropic/claude-sonnet-4-5`  |
+| OpenAI                  | `openai/gpt-4o`                |
+| Google AI Studio        | `gemini/gemini-2.0-flash`      |
+| Google Vertex AI (IAM)  | `vertex_ai/gemini-2.0-flash`   |
+| Mistral                 | `mistral/mistral-large-latest` |
+
+## Vertex AI (Gemini via IAM)
+
+The Java runtime supports Gemini via Google Cloud Vertex AI as an
+alternative to AI Studio. Same model family, same `GeminiHandler`, same
+HINT-mode prompt shaping for structured output with tools — only the
+provider value, dependency, and auth config change.
+
+### When to use Vertex AI vs AI Studio
+
+| Use case                                              | Pick                                                |
+| ----------------------------------------------------- | --------------------------------------------------- |
+| Quickstart / dev / lowest setup                       | AI Studio (`provider = "gemini"`, `GOOGLE_AI_GEMINI_API_KEY`) |
+| Production with IAM auth, GCP audit logs, VPC-SC      | Vertex AI (`provider = "vertex_ai"`, ADC)           |
+| Need Provisioned Throughput (no capacity 429s)        | Vertex AI                                           |
+| Multi-tenant org-controlled billing                   | Vertex AI                                           |
+
+### Setup
+
+1. Add the Vertex AI Spring AI starter to your `pom.xml` (mesh's
+   `mcp-mesh-spring-ai` does **not** pull it in by default — it's optional
+   so non-Vertex users don't drag in `google-cloud-aiplatform`):
+
+   ```xml
+   <dependency>
+     <groupId>org.springframework.ai</groupId>
+     <artifactId>spring-ai-starter-model-vertex-ai-gemini</artifactId>
+     <version>${spring-ai.version}</version>
+   </dependency>
+   ```
+
+2. Configure project + location in `application.yml` (or via env vars
+   through Spring Boot's relaxed binding):
+
+   ```yaml
+   spring:
+     ai:
+       vertex:
+         ai:
+           gemini:
+             project-id: ${SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID:my-gcp-project}
+             location:   ${SPRING_AI_VERTEX_AI_GEMINI_LOCATION:us-central1}
+             chat:
+               options:
+                 model: gemini-2.0-flash
+   ```
+
+3. Configure GCP Application Default Credentials:
+
+   ```bash
+   gcloud auth application-default login
+   # OR for CI/prod:
+   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+   ```
+
+4. Use `provider = "vertex_ai"` on `@MeshLlm`:
+
+   ```java
+   @MeshLlm(provider = "vertex_ai", maxTokens = 256, temperature = 0.0)
+   @MeshTool(capability = "geo")
+   public CapitalInfo capitalOf(@Param("country") String country, MeshLlmAgent llm) {
+       return llm.request().user("What is the capital of " + country + "?")
+                 .generate(CapitalInfo.class);
+   }
+   ```
+
+### Why "vertex_ai" matters
+
+`provider = "gemini"` (or `"google"`) prefers the AI Studio bean
+(`googleAiGeminiChatModel`) when both backends are configured, falling back
+to Vertex AI only if AI Studio is unavailable. This is convenient for users
+who only have one backend, but ambiguous when both are present.
+
+`provider = "vertex_ai"` (or `"vertexai"`) skips that preference and goes
+straight to `vertexAiGeminiChatModel`, throwing a clear error if it's not
+configured.
+
+### Switching backends
+
+Migrate from AI Studio to Vertex AI:
+
+```java
+// before:
+@MeshLlm(provider = "gemini", …)
+// after:
+@MeshLlm(provider = "vertex_ai", …)
+```
+
+Swap the dependency in `pom.xml`
+(`spring-ai-starter-model-google-genai` → `spring-ai-starter-model-vertex-ai-gemini`)
+and replace `GOOGLE_AI_GEMINI_API_KEY` with ADC + the
+`spring.ai.vertex.ai.gemini.*` properties shown above.
+
+### Reference example
+
+See `examples/java/vertex-ai-agent/` for a working minimal Spring Boot agent.
 
 ## Complete Example
 

--- a/src/core/cli/man/content/llm_typescript.md
+++ b/src/core/cli/man/content/llm_typescript.md
@@ -228,12 +228,95 @@ agent.addLlmProvider({
 
 Uses LiteLLM model format:
 
-| Provider  | Model Format                   |
-| --------- | ------------------------------ |
-| Anthropic | `anthropic/claude-sonnet-4-5`  |
-| OpenAI    | `openai/gpt-4o`                |
-| Mistral   | `mistral/mistral-large-latest` |
-| Ollama    | `ollama/llama3`                |
+| Provider                | Model Format                   |
+| ----------------------- | ------------------------------ |
+| Anthropic               | `anthropic/claude-sonnet-4-5`  |
+| OpenAI                  | `openai/gpt-4o`                |
+| Google AI Studio        | `gemini/gemini-2.0-flash`      |
+| Google Vertex AI (IAM)  | `vertex_ai/gemini-2.0-flash`   |
+| Mistral                 | `mistral/mistral-large-latest` |
+| Ollama                  | `ollama/llama3`                |
+
+## Vertex AI (Gemini via IAM)
+
+The TypeScript runtime supports Gemini via Google Cloud Vertex AI as an
+alternative to AI Studio. Same model family, same `GeminiHandler`, same
+HINT-mode prompt shaping for structured output with tools — only the model
+prefix and auth env vars change.
+
+### When to use Vertex AI vs AI Studio
+
+| Use case                                              | Pick                                                  |
+| ----------------------------------------------------- | ----------------------------------------------------- |
+| Quickstart / dev / lowest setup                       | AI Studio (`gemini/*`, `GOOGLE_GENERATIVE_AI_API_KEY`) |
+| Production with IAM auth, GCP audit logs, VPC-SC      | Vertex AI (`vertex_ai/*`, ADC)                        |
+| Need Provisioned Throughput (no capacity 429s)        | Vertex AI (Provisioned Throughput is GCP-side)        |
+| Multi-tenant org-controlled billing                   | Vertex AI                                             |
+
+### Setup
+
+`@ai-sdk/google-vertex` is bundled with `@mcpmesh/sdk` — no extra install
+needed.
+
+1. Configure GCP Application Default Credentials. Pick one:
+
+   **User ADC** (dev):
+
+   ```bash
+   gcloud auth application-default login
+   export GOOGLE_VERTEX_PROJECT=my-gcp-project
+   export GOOGLE_VERTEX_LOCATION=us-central1
+   ```
+
+   **Service account** (CI / prod):
+
+   ```bash
+   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+   export GOOGLE_VERTEX_PROJECT=my-gcp-project
+   export GOOGLE_VERTEX_LOCATION=us-central1
+   ```
+
+   `GOOGLE_VERTEX_LOCATION` defaults to `us-central1` if unset.
+
+2. Use the `vertex_ai/*` model prefix:
+
+   ```typescript
+   agent.addLlmProvider({
+     model: "vertex_ai/gemini-2.0-flash",
+     capability: "llm",
+     tags: ["llm", "gemini", "vertex"],
+   });
+   ```
+
+That's it. Same agent code as the AI Studio path; mesh's `GeminiHandler` is
+selected automatically and applies HINT-mode prompt shaping when the call
+involves tools (avoiding Gemini's response_format-with-tools deadlock).
+
+### Switching backends
+
+Migrate from AI Studio to Vertex AI by changing the model prefix and env vars:
+
+```typescript
+// before:
+model: "gemini/gemini-2.0-flash"
+// after:
+model: "vertex_ai/gemini-2.0-flash"
+```
+
+```bash
+# before:
+export GOOGLE_GENERATIVE_AI_API_KEY=AIza...
+# after:
+gcloud auth application-default login
+export GOOGLE_VERTEX_PROJECT=my-gcp-project
+export GOOGLE_VERTEX_LOCATION=us-central1
+```
+
+No other code changes required.
+
+### Reference example
+
+See `examples/typescript/vertex-ai-agent/` for a working minimal agent.
 
 ## Complete Example
 

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlm.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlm.java
@@ -62,8 +62,19 @@ public @interface MeshLlm {
     /**
      * Direct LLM provider name for Spring AI.
      *
-     * <p>Supported values: "claude", "anthropic", "openai", "gpt".
-     * Leave empty to use {@link #providerSelector()} for mesh delegation.
+     * <p>Supported values:
+     * <ul>
+     *   <li>{@code "claude"}, {@code "anthropic"} — Claude via spring-ai-anthropic</li>
+     *   <li>{@code "openai"}, {@code "gpt"} — GPT via spring-ai-openai</li>
+     *   <li>{@code "gemini"}, {@code "google"} — Gemini, prefers AI Studio (spring-ai-google-genai)
+     *       and falls back to Vertex AI if AI Studio not configured</li>
+     *   <li>{@code "vertex_ai"} (or {@code "vertexai"}) — Force Gemini via Vertex AI
+     *       (spring-ai-vertex-ai-gemini), even if AI Studio is also configured. Use
+     *       this when you need IAM auth, Provisioned Throughput, VPC-SC, or
+     *       org-controlled billing.</li>
+     * </ul>
+     *
+     * <p>Leave empty to use {@link #providerSelector()} for mesh delegation.
      */
     String provider() default "";
 

--- a/src/runtime/java/mcp-mesh-spring-ai/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-ai/pom.xml
@@ -58,6 +58,17 @@
             <version>${spring-ai.version}</version>
             <optional>true</optional>
         </dependency>
+        <!-- Vertex AI Gemini: needed at compile time so GeminiHandler can branch on
+             VertexAiGeminiChatModel/Options. The starter is pulled in by the consuming
+             agent (e.g., examples/java/vertex-ai-agent); here we only need the core
+             module for the instanceof check and options builder. Optional, mirroring
+             spring-ai-starter-model-google-genai above. -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-vertex-ai-gemini</artifactId>
+            <version>${spring-ai.version}</version>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Testing -->
         <dependency>

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/SpringAiLlmProvider.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/SpringAiLlmProvider.java
@@ -22,7 +22,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * <ul>
  *   <li>{@code "claude"}, {@code "anthropic"} - Anthropic Claude models</li>
  *   <li>{@code "openai"}, {@code "gpt"} - OpenAI GPT models</li>
- *   <li>{@code "gemini"}, {@code "google"} - Google Gemini models</li>
+ *   <li>{@code "gemini"}, {@code "google"} - Google Gemini models (prefers AI Studio when both AI Studio + Vertex configured)</li>
+ *   <li>{@code "vertex_ai"}, {@code "vertexai"} - Google Gemini via Vertex AI (IAM auth) — forced even if AI Studio is also configured</li>
  * </ul>
  *
  * <h2>Configuration</h2>
@@ -30,7 +31,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * <ul>
  *   <li>{@code ANTHROPIC_API_KEY} - For Claude models</li>
  *   <li>{@code OPENAI_API_KEY} - For OpenAI models</li>
- *   <li>{@code GOOGLE_AI_GEMINI_API_KEY} or GCP credentials - For Gemini models</li>
+ *   <li>{@code GOOGLE_AI_GEMINI_API_KEY} - For Gemini AI Studio</li>
+ *   <li>GCP ADC + {@code spring.ai.vertex.ai.gemini.project-id} + {@code spring.ai.vertex.ai.gemini.location} - For Gemini via Vertex AI</li>
  * </ul>
  *
  * <p>Or in application.yml:
@@ -47,6 +49,15 @@ import java.util.concurrent.ConcurrentHashMap;
  *           project-id: ${GOOGLE_PROJECT_ID}
  *           location: us-central1
  * </pre>
+ *
+ * <p>Note: Spring AI's Vertex AI Gemini auto-config does not key off any
+ * fixed env var name itself — it looks at {@code spring.ai.vertex.ai.gemini.*}
+ * properties (which Spring Boot can in turn populate from env vars like
+ * {@code SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID}). The {@code GOOGLE_PROJECT_ID}
+ * shorthand only works because the example {@code application.properties}
+ * substitutes it. Authentication itself uses Google Application Default
+ * Credentials, so {@code GOOGLE_APPLICATION_CREDENTIALS} or {@code gcloud auth
+ * application-default login} are still required.
  */
 public class SpringAiLlmProvider {
 
@@ -89,6 +100,7 @@ public class SpringAiLlmProvider {
             case "claude", "anthropic" -> anthropicChatModel != null;
             case "openai", "gpt" -> openAiChatModel != null;
             case "gemini", "google" -> vertexAiGeminiChatModel != null || googleAiGeminiChatModel != null;
+            case "vertex_ai" -> vertexAiGeminiChatModel != null;
             default -> false;
         };
     }
@@ -254,6 +266,17 @@ public class SpringAiLlmProvider {
                     "Add spring-ai-google-genai dependency and set GEMINI_API_KEY, " +
                     "or add spring-ai-vertex-ai-gemini dependency and configure GCP credentials");
             }
+            case "vertex_ai" -> {
+                // Explicit Vertex AI: do NOT fall back to AI Studio even if both are configured.
+                // Use this when you specifically need IAM auth, Provisioned Throughput, VPC-SC, etc.
+                if (vertexAiGeminiChatModel != null) {
+                    yield vertexAiGeminiChatModel;
+                }
+                throw new IllegalStateException("Vertex AI Gemini ChatModel not configured. " +
+                    "Add spring-ai-starter-model-vertex-ai-gemini dependency and configure " +
+                    "spring.ai.vertex.ai.gemini.project-id + spring.ai.vertex.ai.gemini.location " +
+                    "(plus GCP Application Default Credentials).");
+            }
             default -> {
                 // Try anthropic as default fallback
                 if (anthropicChatModel != null) {
@@ -280,6 +303,11 @@ public class SpringAiLlmProvider {
     /**
      * Normalize provider string: extract vendor prefix from full model paths.
      * E.g., "anthropic/claude-sonnet-4-5" -> "anthropic", "claude" -> "claude".
+     *
+     * <p>Also normalizes the {@code vertexai} alias to {@code vertex_ai} so users
+     * can write either {@code @MeshLlm(provider = "vertex_ai")} or
+     * {@code @MeshLlm(provider = "vertexai")} or use a model string like
+     * {@code "vertex_ai/gemini-2.0-flash"}.
      */
     private static String normalizeProvider(String provider) {
         if (provider == null || provider.trim().isEmpty()) {
@@ -287,7 +315,11 @@ public class SpringAiLlmProvider {
         }
         String lower = provider.toLowerCase().trim();
         if (lower.contains("/")) {
-            return lower.substring(0, lower.indexOf('/'));
+            lower = lower.substring(0, lower.indexOf('/'));
+        }
+        // Forgiving alias: vertexai -> vertex_ai (matches LiteLLM-style "vertex_ai/" prefix)
+        if (lower.equals("vertexai")) {
+            return "vertex_ai";
         }
         return lower;
     }
@@ -319,8 +351,17 @@ public class SpringAiLlmProvider {
                 throw new IllegalStateException(
                     "Gemini ChatModel not configured. Add spring-ai-google-genai and set GEMINI_API_KEY");
             }
+            case "vertex_ai" -> {
+                if (vertexAiGeminiChatModel != null) {
+                    yield vertexAiGeminiChatModel;
+                }
+                throw new IllegalStateException(
+                    "Vertex AI Gemini ChatModel not configured. " +
+                    "Add spring-ai-starter-model-vertex-ai-gemini and configure " +
+                    "spring.ai.vertex.ai.gemini.project-id + spring.ai.vertex.ai.gemini.location.");
+            }
             default -> throw new IllegalArgumentException("Unknown LLM provider: " + provider +
-                ". Supported: claude, anthropic, openai, gpt, gemini, google");
+                ". Supported: claude, anthropic, openai, gpt, gemini, google, vertex_ai");
         };
 
         log.info("Creating ChatClient for provider: {}", provider);

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/GeminiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/GeminiHandler.java
@@ -10,10 +10,13 @@ import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
+import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatModel;
+import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatOptions;
 
 import java.util.*;
 import java.util.function.Function;
@@ -292,16 +295,15 @@ public class GeminiHandler implements LlmProviderHandler {
         // Create tool callbacks for schema only (no execution)
         List<ToolCallback> toolCallbacks = createToolCallbacksForSchema(tools);
 
-        // Build Gemini-specific chat options with tool execution DISABLED and response_format
-        GoogleGenAiChatOptions.Builder geminiOptionsBuilder = GoogleGenAiChatOptions.builder()
-            .toolCallbacks(toolCallbacks)
-            .internalToolExecutionEnabled(false);  // Don't auto-execute tools!
-
+        // Build Gemini-specific chat options with tool execution DISABLED.
+        // The concrete options class must match the underlying ChatModel: Vertex's
+        // chat model does an explicit checkcast to VertexAiGeminiChatOptions and
+        // throws ClassCastException if given GoogleGenAiChatOptions (and vice versa).
         // Don't use responseSchema - Spring AI has issues with Gemini responseSchema
         // Structured output is handled via prompt-based hints in formatSystemPrompt()
         log.debug("Using prompt-based JSON hints for structured output (not responseSchema)");
 
-        GoogleGenAiChatOptions chatOptions = geminiOptionsBuilder.build();
+        ChatOptions chatOptions = buildToolNoExecuteOptions(model, toolCallbacks);
 
         // Create prompt with options
         org.springframework.ai.chat.prompt.Prompt prompt =
@@ -340,6 +342,35 @@ public class GeminiHandler implements LlmProviderHandler {
             toolCalls.size());
 
         return new LlmResponse(content, toolCalls, extractUsage(response));
+    }
+
+    /**
+     * Build provider-specific {@link ChatOptions} for the no-tool-execution path.
+     *
+     * <p>Mesh delegation routes both {@code gemini/...} (Google AI Studio) and
+     * {@code vertex_ai/...} model strings through this {@code GeminiHandler}, but
+     * the underlying {@link ChatModel} differs:
+     * <ul>
+     *   <li>{@code GoogleGenAiChatModel} accepts {@link GoogleGenAiChatOptions}</li>
+     *   <li>{@link VertexAiGeminiChatModel} accepts {@link VertexAiGeminiChatOptions}</li>
+     * </ul>
+     * Each chat model does an explicit checkcast on the options it receives, so
+     * passing the wrong type throws {@link ClassCastException} at request time.
+     * Branch on the chat model type to pick the matching options class.
+     *
+     * <p>Package-private for testability.
+     */
+    ChatOptions buildToolNoExecuteOptions(ChatModel chatModel, List<ToolCallback> toolCallbacks) {
+        if (chatModel instanceof VertexAiGeminiChatModel) {
+            return VertexAiGeminiChatOptions.builder()
+                .toolCallbacks(toolCallbacks)
+                .internalToolExecutionEnabled(false)
+                .build();
+        }
+        return GoogleGenAiChatOptions.builder()
+            .toolCallbacks(toolCallbacks)
+            .internalToolExecutionEnabled(false)
+            .build();
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/GeminiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/GeminiHandler.java
@@ -344,6 +344,37 @@ public class GeminiHandler implements LlmProviderHandler {
         return new LlmResponse(content, toolCalls, extractUsage(response));
     }
 
+    // Reflection-based lookup of Vertex AI chat model class. The
+    // spring-ai-vertex-ai-gemini dependency is declared <optional>true</optional>
+    // in mcp-mesh-spring-ai/pom.xml, so consumers using only AI Studio
+    // (spring-ai-starter-model-google-genai) won't have these classes on their
+    // runtime classpath. Resolving via Class.forName lets us safely detect
+    // availability without an `instanceof` check that would trigger a
+    // NoClassDefFoundError on consumer classpaths missing the dep.
+    //
+    // The compile-time imports of VertexAiGeminiChatModel/VertexAiGeminiChatOptions
+    // are intentional and benign: imports are erased to fully-qualified bytecode
+    // references, and the JVM only resolves a referenced class when a method
+    // *body* mentioning it is first invoked. By isolating Vertex API calls into
+    // buildVertexOptions(), the class load is deferred until we've already
+    // verified the class is present (VERTEX_OPTIONS_CLASS != null).
+    private static final Class<?> VERTEX_CHAT_MODEL_CLASS;
+    private static final Class<?> VERTEX_OPTIONS_CLASS;
+    static {
+        Class<?> modelClass = null;
+        Class<?> optionsClass = null;
+        try {
+            modelClass = Class.forName("org.springframework.ai.vertexai.gemini.VertexAiGeminiChatModel");
+            optionsClass = Class.forName("org.springframework.ai.vertexai.gemini.VertexAiGeminiChatOptions");
+        } catch (ClassNotFoundException e) {
+            // Vertex AI starter not on classpath -- fine, AI Studio path will be used.
+            // Logged at debug level so we don't spam stdout for normal AI-Studio-only deployments.
+            log.debug("spring-ai-vertex-ai-gemini not on classpath; vertex_ai routing disabled");
+        }
+        VERTEX_CHAT_MODEL_CLASS = modelClass;
+        VERTEX_OPTIONS_CLASS = optionsClass;
+    }
+
     /**
      * Build provider-specific {@link ChatOptions} for the no-tool-execution path.
      *
@@ -352,22 +383,40 @@ public class GeminiHandler implements LlmProviderHandler {
      * the underlying {@link ChatModel} differs:
      * <ul>
      *   <li>{@code GoogleGenAiChatModel} accepts {@link GoogleGenAiChatOptions}</li>
-     *   <li>{@link VertexAiGeminiChatModel} accepts {@link VertexAiGeminiChatOptions}</li>
+     *   <li>{@code VertexAiGeminiChatModel} accepts {@code VertexAiGeminiChatOptions}</li>
      * </ul>
      * Each chat model does an explicit checkcast on the options it receives, so
      * passing the wrong type throws {@link ClassCastException} at request time.
      * Branch on the chat model type to pick the matching options class.
      *
+     * <p>The Vertex branch is guarded by {@link #VERTEX_CHAT_MODEL_CLASS} being
+     * non-null, which is only true when {@code spring-ai-vertex-ai-gemini} is on
+     * the consumer's classpath. AI-Studio-only consumers will skip the branch
+     * and never trigger a class load of the Vertex types.
+     *
      * <p>Package-private for testability.
      */
     ChatOptions buildToolNoExecuteOptions(ChatModel chatModel, List<ToolCallback> toolCallbacks) {
-        if (chatModel instanceof VertexAiGeminiChatModel) {
-            return VertexAiGeminiChatOptions.builder()
-                .toolCallbacks(toolCallbacks)
-                .internalToolExecutionEnabled(false)
-                .build();
+        if (VERTEX_CHAT_MODEL_CLASS != null && VERTEX_CHAT_MODEL_CLASS.isInstance(chatModel)) {
+            return buildVertexOptions(toolCallbacks);
         }
         return GoogleGenAiChatOptions.builder()
+            .toolCallbacks(toolCallbacks)
+            .internalToolExecutionEnabled(false)
+            .build();
+    }
+
+    /**
+     * Isolated method that touches the Vertex options class.
+     *
+     * <p>Only called when {@link #VERTEX_CHAT_MODEL_CLASS} != null (verified at
+     * the call site in {@link #buildToolNoExecuteOptions}), so the JVM's lazy
+     * class resolution of {@code VertexAiGeminiChatOptions} when this method
+     * body is first executed is guaranteed to succeed -- the class IS on the
+     * classpath by the time we get here.
+     */
+    private ChatOptions buildVertexOptions(List<ToolCallback> toolCallbacks) {
+        return VertexAiGeminiChatOptions.builder()
             .toolCallbacks(toolCallbacks)
             .internalToolExecutionEnabled(false)
             .build();

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/LlmProviderHandlerRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/LlmProviderHandlerRegistry.java
@@ -47,6 +47,11 @@ public class LlmProviderHandlerRegistry {
         register("gpt", OpenAiHandler.class);        // Alias
         register("gemini", GeminiHandler.class);
         register("google", GeminiHandler.class);     // Alias
+        // Vertex AI uses the same Gemini model family on the wire — same prompt-shaping,
+        // same HINT-mode behavior with tools; only the auth/transport differs (IAM via
+        // spring-ai-vertex-ai-gemini vs API key via spring-ai-google-genai).
+        register("vertex_ai", GeminiHandler.class);  // Alias
+        register("vertexai", GeminiHandler.class);   // Forgiving alias for "vertex_ai"
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/LlmProviderHandlerRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/LlmProviderHandlerRegistry.java
@@ -60,7 +60,20 @@ public class LlmProviderHandlerRegistry {
      * <p>Returns a cached instance if available, otherwise creates one.
      * Falls back to GenericHandler for unknown vendors.
      *
-     * @param vendor The vendor name (e.g., "anthropic", "openai")
+     * <p>Lookup order:
+     * <ol>
+     *   <li>Direct lookup of the raw provider name (covers explicit aliases like
+     *       {@code "vertex_ai"}, {@code "anthropic"}, {@code "openai"} that don't
+     *       follow the {@code "vendor/model"} form and that {@link #extractVendor}
+     *       does not recognize as substrings).</li>
+     *   <li>Fallback: extract a vendor from a model-string form
+     *       (e.g., {@code "vertex_ai/gemini-2.0-flash"} → {@code "vertex_ai"})
+     *       and look that up.</li>
+     *   <li>Final fallback: {@link GenericHandler}.</li>
+     * </ol>
+     *
+     * @param vendor The vendor name (e.g., "anthropic", "openai", "vertex_ai")
+     *               or a model string (e.g., "vertex_ai/gemini-2.0-flash")
      * @return The handler instance
      */
     public static LlmProviderHandler getHandler(String vendor) {
@@ -68,33 +81,50 @@ public class LlmProviderHandlerRegistry {
             vendor = "unknown";
         }
 
-        String normalizedVendor = extractVendor(vendor).toLowerCase().trim();
+        String normalizedRaw = vendor.toLowerCase().trim();
 
-        // Check cache first
-        LlmProviderHandler cached = instances.get(normalizedVendor);
+        // First: check direct registration (covers explicit provider names like
+        // "vertex_ai", "vertexai", "anthropic", etc. that don't follow the
+        // "vendor/model" form and that extractVendor() does not detect via
+        // substring inference).
+        LlmProviderHandler cached = instances.get(normalizedRaw);
         if (cached != null) {
             return cached;
+        }
+        Class<? extends LlmProviderHandler> handlerClass = handlers.get(normalizedRaw);
+        String cacheKey = normalizedRaw;
+
+        if (handlerClass == null) {
+            // Second: fall back to vendor extraction from model-string form
+            // ("anthropic/claude-..." -> "anthropic", "vertex_ai/gemini-..." -> "vertex_ai"
+            // via slash split).
+            String extracted = extractVendor(vendor).toLowerCase().trim();
+            cached = instances.get(extracted);
+            if (cached != null) {
+                return cached;
+            }
+            handlerClass = handlers.get(extracted);
+            cacheKey = extracted;
         }
 
         // Create new instance
         LlmProviderHandler handler;
-        Class<? extends LlmProviderHandler> handlerClass = handlers.get(normalizedVendor);
-
         if (handlerClass != null) {
             try {
                 handler = handlerClass.getDeclaredConstructor().newInstance();
-                log.debug("Created handler for vendor '{}': {}", normalizedVendor, handlerClass.getSimpleName());
+                log.debug("Created handler for vendor '{}': {}", cacheKey, handlerClass.getSimpleName());
             } catch (Exception e) {
-                log.error("Failed to instantiate handler for '{}', using GenericHandler", normalizedVendor, e);
+                log.error("Failed to instantiate handler for '{}', using GenericHandler", cacheKey, e);
                 handler = new GenericHandler();
             }
         } else {
-            log.warn("Unknown vendor '{}', using GenericHandler", normalizedVendor);
+            log.warn("Unknown vendor '{}', using GenericHandler", cacheKey);
             handler = new GenericHandler();
         }
 
-        // Cache and return
-        instances.put(normalizedVendor, handler);
+        // Cache under the resolved key (prefer extracted form when raw didn't match,
+        // so future lookups via either form still hit a cached entry).
+        instances.put(cacheKey, handler);
         return handler;
     }
 
@@ -121,6 +151,12 @@ public class LlmProviderHandlerRegistry {
     public static boolean hasHandler(String vendor) {
         if (vendor == null || vendor.isEmpty()) {
             return false;
+        }
+        String normalizedRaw = vendor.toLowerCase().trim();
+        // Mirror getHandler's two-tier lookup: direct match first (catches
+        // "vertex_ai" and other explicit aliases), then extraction fallback.
+        if (handlers.containsKey(normalizedRaw)) {
+            return true;
         }
         return handlers.containsKey(extractVendor(vendor).toLowerCase().trim());
     }

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/GeminiHandlerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/GeminiHandlerTest.java
@@ -2,7 +2,14 @@ package io.mcpmesh.ai.handlers;
 
 import io.mcpmesh.ai.handlers.LlmProviderHandler.*;
 import org.junit.jupiter.api.*;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.google.genai.GoogleGenAiChatModel;
+import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatModel;
+import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatOptions;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 import java.util.*;
 
@@ -307,6 +314,35 @@ class GeminiHandlerTest {
             String result = handler.formatSystemPrompt("Base.", List.of(), null);
             assertFalse(result.contains("TOOL CALLING RULES"),
                 "Empty tools list should not add tool instructions");
+        }
+    }
+
+    @Nested
+    @DisplayName("buildToolNoExecuteOptions")
+    class BuildToolNoExecuteOptionsTests {
+
+        @Test
+        @DisplayName("returns VertexAiGeminiChatOptions for VertexAiGeminiChatModel")
+        void returnsVertexOptionsForVertexChatModel() {
+            VertexAiGeminiChatModel mockModel = mock(VertexAiGeminiChatModel.class);
+            List<ToolCallback> callbacks = List.of();
+
+            ChatOptions opts = handler.buildToolNoExecuteOptions(mockModel, callbacks);
+
+            assertInstanceOf(VertexAiGeminiChatOptions.class, opts,
+                "Vertex chat model must receive VertexAiGeminiChatOptions to avoid ClassCastException");
+        }
+
+        @Test
+        @DisplayName("returns GoogleGenAiChatOptions for GoogleGenAiChatModel")
+        void returnsGoogleGenAiOptionsForGoogleGenAiChatModel() {
+            GoogleGenAiChatModel mockModel = mock(GoogleGenAiChatModel.class);
+            List<ToolCallback> callbacks = List.of();
+
+            ChatOptions opts = handler.buildToolNoExecuteOptions(mockModel, callbacks);
+
+            assertInstanceOf(GoogleGenAiChatOptions.class, opts,
+                "Google GenAI chat model must receive GoogleGenAiChatOptions");
         }
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/LlmProviderHandlerRegistryTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/LlmProviderHandlerRegistryTest.java
@@ -127,6 +127,36 @@ class LlmProviderHandlerRegistryTest {
             assertTrue(handler instanceof GeminiHandler);
             assertEquals("gemini", handler.getVendor());
         }
+
+        // Regression: extractVendor() does not recognize "vertex" as a Gemini
+        // substring, so the old getHandler() (which always called extractVendor
+        // first) returned GenericHandler for "vertex_ai". This dropped HINT-mode
+        // prompt shaping for the Gemini-via-Vertex-AI provider. The two-tier
+        // lookup now matches the registered alias directly.
+        // See PR #824 (issue #816).
+        @Test
+        @DisplayName("'vertex_ai' returns GeminiHandler (not GenericHandler)")
+        void vertexAi_returnsGeminiHandler() {
+            LlmProviderHandler handler = LlmProviderHandlerRegistry.getHandler("vertex_ai");
+            assertTrue(handler instanceof GeminiHandler,
+                "vertex_ai must route to GeminiHandler so HINT-mode applies with tools");
+        }
+
+        @Test
+        @DisplayName("'vertexai' returns GeminiHandler (forgiving alias)")
+        void vertexai_returnsGeminiHandler() {
+            LlmProviderHandler handler = LlmProviderHandlerRegistry.getHandler("vertexai");
+            assertTrue(handler instanceof GeminiHandler);
+        }
+
+        @Test
+        @DisplayName("'vertex_ai/gemini-2.0-flash' (model-string form) returns GeminiHandler")
+        void vertexAiModelString_returnsGeminiHandler() {
+            // Confirms the extractVendor fallback still catches the slash-form
+            // model string after the two-tier lookup change.
+            LlmProviderHandler handler = LlmProviderHandlerRegistry.getHandler("vertex_ai/gemini-2.0-flash");
+            assertTrue(handler instanceof GeminiHandler);
+        }
     }
 
     @Nested
@@ -230,6 +260,18 @@ class LlmProviderHandlerRegistryTest {
         }
 
         @Test
+        @DisplayName("true for explicit aliases: vertex_ai, vertexai, claude, gpt, google")
+        void explicitAliases_returnTrue() {
+            // Regression: hasHandler used to delegate solely to extractVendor,
+            // which doesn't recognize "vertex" as a Gemini substring.
+            assertTrue(LlmProviderHandlerRegistry.hasHandler("vertex_ai"));
+            assertTrue(LlmProviderHandlerRegistry.hasHandler("vertexai"));
+            assertTrue(LlmProviderHandlerRegistry.hasHandler("claude"));
+            assertTrue(LlmProviderHandlerRegistry.hasHandler("gpt"));
+            assertTrue(LlmProviderHandlerRegistry.hasHandler("google"));
+        }
+
+        @Test
         @DisplayName("false for unregistered vendors")
         void unregisteredVendors_returnFalse() {
             assertFalse(LlmProviderHandlerRegistry.hasHandler("unregistered"));
@@ -288,6 +330,8 @@ class LlmProviderHandlerRegistryTest {
             assertEquals("AnthropicHandler", vendors.get("claude"));
             assertEquals("OpenAiHandler", vendors.get("gpt"));
             assertEquals("GeminiHandler", vendors.get("google"));
+            assertEquals("GeminiHandler", vendors.get("vertex_ai"));
+            assertEquals("GeminiHandler", vendors.get("vertexai"));
         }
     }
 }

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/provider_handler_registry.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/provider_handler_registry.py
@@ -27,7 +27,20 @@ class ProviderHandlerRegistry:
     Vendor Mapping:
     - "anthropic" -> ClaudeHandler
     - "openai" -> OpenAIHandler
+    - "gemini" -> GeminiHandler (Google AI Studio API key auth)
+    - "vertex_ai" -> GeminiHandler (Vertex AI / IAM auth, same Gemini models)
     - "unknown" or others -> GenericHandler
+
+    Note on the gemini/vertex_ai aliasing:
+        Both ``gemini/<model>`` and ``vertex_ai/<model>`` route through the
+        same GeminiHandler because they target the same Gemini model family on
+        the other side of the wire — only the auth/transport differs (AI
+        Studio API key vs GCP IAM via service account / ADC). LiteLLM handles
+        the routing distinction internally based on the model prefix and the
+        environment variables present (``GOOGLE_API_KEY`` vs
+        ``GOOGLE_APPLICATION_CREDENTIALS`` / ``VERTEXAI_*``). Mesh-side
+        prompt-shaping behavior (HINT mode with tools, STRICT mode without)
+        is identical for both.
 
     Usage:
         handler = ProviderHandlerRegistry.get_handler("anthropic")
@@ -43,7 +56,8 @@ class ProviderHandlerRegistry:
     _handlers: dict[str, type[BaseProviderHandler]] = {
         "anthropic": ClaudeHandler,
         "openai": OpenAIHandler,
-        "gemini": GeminiHandler,
+        "gemini": GeminiHandler,        # Google AI Studio (GOOGLE_API_KEY)
+        "vertex_ai": GeminiHandler,     # Vertex AI / IAM (same Gemini family, different auth)
     }
 
     # Cache of instantiated handlers (singleton per vendor)

--- a/src/runtime/python/_mcp_mesh/media/resolver.py
+++ b/src/runtime/python/_mcp_mesh/media/resolver.py
@@ -61,6 +61,7 @@ _VENDOR_FORMATTERS = {
     "openai": _format_for_openai,
     "gemini": _format_for_gemini,
     "google": _format_for_gemini,
+    "vertex_ai": _format_for_gemini,
 }
 
 
@@ -164,7 +165,7 @@ async def _resolve_single_resource_link(resource_link: dict, vendor: str) -> dic
             b64_data = base64.b64encode(data).decode("ascii")
             if vendor in ("anthropic", "claude"):
                 return _format_pdf_for_claude(b64_data)
-            elif vendor in ("gemini", "google"):
+            elif vendor in ("gemini", "google", "vertex_ai"):
                 return _format_pdf_for_gemini(b64_data, name)
             else:
                 return _format_pdf_for_openai(b64_data, name)
@@ -240,7 +241,7 @@ async def resolve_resource_links(tool_result: Any, vendor: str) -> list[dict]:
 # For OpenAI and Gemini, images are sent in a follow-up user message using
 # OpenAI-compatible format (image_url with data URI), which LiteLLM converts
 # to the provider's native format.
-_TOOL_IMAGE_UNSUPPORTED_VENDORS = {"openai", "gemini", "google"}
+_TOOL_IMAGE_UNSUPPORTED_VENDORS = {"openai", "gemini", "google", "vertex_ai"}
 
 
 async def resolve_resource_links_for_tool_message(

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -82,6 +82,13 @@ kubernetes = [
     "kubernetes>=28.1.0",
     "pykube-ng>=22.9.0"
 ]
+vertex = [
+    # google-auth is required for LiteLLM's vertex_ai/* model prefix to read
+    # Application Default Credentials. Optional because non-Vertex users (AI
+    # Studio, Claude, OpenAI) don't need it. Install via:
+    #   pip install mcp-mesh[vertex]
+    "google-auth>=2.0.0"
+]
 
 [project.urls]
 Homepage = "https://github.com/dhyansraj/mcp-mesh"

--- a/src/runtime/python/tests/unit/test_provider_handler_registry.py
+++ b/src/runtime/python/tests/unit/test_provider_handler_registry.py
@@ -1,0 +1,104 @@
+"""
+Unit tests for ProviderHandlerRegistry vendor routing.
+
+Covers:
+- Built-in handler selection for known vendors (anthropic, openai, gemini)
+- The vertex_ai -> GeminiHandler alias added for issue #816
+- Cache behavior across the gemini/vertex_ai aliases
+- Fallback to GenericHandler for unknown vendors
+- list_vendors visibility of the alias
+"""
+
+import pytest
+
+from _mcp_mesh.engine.provider_handlers.claude_handler import ClaudeHandler
+from _mcp_mesh.engine.provider_handlers.gemini_handler import GeminiHandler
+from _mcp_mesh.engine.provider_handlers.generic_handler import GenericHandler
+from _mcp_mesh.engine.provider_handlers.openai_handler import OpenAIHandler
+from _mcp_mesh.engine.provider_handlers.provider_handler_registry import (
+    ProviderHandlerRegistry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry_cache():
+    """Each test starts with an empty handler instance cache."""
+    ProviderHandlerRegistry.clear_cache()
+    yield
+    ProviderHandlerRegistry.clear_cache()
+
+
+class TestBuiltInVendorRouting:
+    """Sanity: known vendors resolve to their dedicated handler classes."""
+
+    def test_anthropic_routes_to_claude_handler(self):
+        handler = ProviderHandlerRegistry.get_handler("anthropic")
+        assert isinstance(handler, ClaudeHandler)
+
+    def test_openai_routes_to_openai_handler(self):
+        handler = ProviderHandlerRegistry.get_handler("openai")
+        assert isinstance(handler, OpenAIHandler)
+
+    def test_gemini_routes_to_gemini_handler(self):
+        handler = ProviderHandlerRegistry.get_handler("gemini")
+        assert isinstance(handler, GeminiHandler)
+
+
+class TestVertexAiAlias:
+    """Issue #816: vertex_ai must route through GeminiHandler."""
+
+    def test_vertex_ai_alias_routes_to_gemini_handler(self):
+        handler = ProviderHandlerRegistry.get_handler("vertex_ai")
+        assert isinstance(handler, GeminiHandler)
+
+    def test_vertex_ai_alias_visible_via_list_vendors(self):
+        vendors = ProviderHandlerRegistry.list_vendors()
+        assert vendors.get("vertex_ai") == "GeminiHandler"
+        assert vendors.get("gemini") == "GeminiHandler"
+
+    def test_vertex_ai_and_gemini_cache_distinctly(self):
+        """Both vendor keys map to GeminiHandler but are cached as distinct
+        instances.
+
+        Acceptable since vendor is mostly metadata (used for logs and the
+        media/PDF formatting branch in resolver.py, where 'gemini' and
+        'google' both take the same path — vertex_ai routing is otherwise
+        identical). The minor memory cost of two cached singletons is
+        worth keeping the registry logic trivial and avoiding alias-
+        collapsing magic in get_handler.
+        """
+        h1 = ProviderHandlerRegistry.get_handler("vertex_ai")
+        h2 = ProviderHandlerRegistry.get_handler("gemini")
+
+        assert isinstance(h1, GeminiHandler)
+        assert isinstance(h2, GeminiHandler)
+        assert h1 is not h2  # distinct cache entries
+
+        # Cache hit returns the same instance for the same vendor key
+        assert ProviderHandlerRegistry.get_handler("vertex_ai") is h1
+        assert ProviderHandlerRegistry.get_handler("gemini") is h2
+
+    def test_vertex_ai_handler_reports_gemini_vendor(self):
+        """GeminiHandler hardcodes vendor='gemini' in __init__, so the
+        instance returned for 'vertex_ai' will report vendor='gemini'.
+        This is intentional — downstream vendor-based branching (e.g.,
+        resolver._VENDOR_FORMATTERS) treats both as the same Gemini
+        family. Logs may show vendor=gemini for vertex_ai calls."""
+        handler = ProviderHandlerRegistry.get_handler("vertex_ai")
+        assert handler.vendor == "gemini"
+
+
+class TestUnknownVendorFallback:
+    """Unknown / None / empty vendors fall back to GenericHandler."""
+
+    def test_unknown_vendor_returns_generic_handler(self):
+        handler = ProviderHandlerRegistry.get_handler("totally-not-a-vendor")
+        assert isinstance(handler, GenericHandler)
+
+    def test_none_vendor_returns_generic_handler(self):
+        handler = ProviderHandlerRegistry.get_handler(None)
+        assert isinstance(handler, GenericHandler)
+
+    def test_empty_vendor_returns_generic_handler(self):
+        handler = ProviderHandlerRegistry.get_handler("")
+        assert isinstance(handler, GenericHandler)

--- a/src/runtime/typescript/package-lock.json
+++ b/src/runtime/typescript/package-lock.json
@@ -1,21 +1,23 @@
 {
   "name": "@mcpmesh/sdk",
-  "version": "0.9.0",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcpmesh/sdk",
-      "version": "0.9.0",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/google-vertex": "^3.0.0",
         "@ai-sdk/openai": "^3.0.0",
         "@mcpmesh/core": "file:../core/typescript",
         "ai": "^6.0.0",
-        "fastmcp": "^3.26.8",
+        "fastmcp": "^3.34.0",
         "handlebars": "^4.7.8",
+        "mcp-proxy": "6.4.4",
         "zod": "^3.24.1",
         "zod-to-json-schema": "^3.24.1"
       },
@@ -42,7 +44,7 @@
     },
     "../core/typescript": {
       "name": "@mcpmesh/core",
-      "version": "0.9.0",
+      "version": "1.3.4",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1"
@@ -97,6 +99,87 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@ai-sdk/google-vertex": {
+      "version": "3.0.132",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google-vertex/-/google-vertex-3.0.132.tgz",
+      "integrity": "sha512-IZfAutGNrHPk7VsziwtBVsNBnXTS2y5qZpI1tT9MdN+O6z0UFv6LVBDIpAFAZcQOec9M22j+5uc4ukB6BfC/0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/anthropic": "2.0.77",
+        "@ai-sdk/google": "2.0.70",
+        "@ai-sdk/openai-compatible": "1.0.36",
+        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider-utils": "3.0.23",
+        "google-auth-library": "^10.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google-vertex/node_modules/@ai-sdk/anthropic": {
+      "version": "2.0.77",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.77.tgz",
+      "integrity": "sha512-8n7ApEzFOxqVvT3HyqLrEQlgUx/2nUmPFLTGY3fNKwUA8KVNU3Ovd2C66Qh1Y93Iq5NkHsOWuLiTyAZpRKQhgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider-utils": "3.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google-vertex/node_modules/@ai-sdk/google": {
+      "version": "2.0.70",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.70.tgz",
+      "integrity": "sha512-NDMTvMo6vnPHDTA94FBOh3YMv0lxWDohYmFSGYhg0IimHMcOcC1ZV7E2KMLjzHOz5S7uasTITW7V3X5T+ozInQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider-utils": "3.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google-vertex/node_modules/@ai-sdk/provider": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
+      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/google-vertex/node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.23.tgz",
+      "integrity": "sha512-60GYsRj5wIJQRcq5YwYJq4KhwLeStceXEJiZdecP1miiH+6FMmrnc7lZDOJoQ6m9lrudEb+uI4LEwddLz5+rPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@ai-sdk/openai": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.11.tgz",
@@ -105,6 +188,51 @@
       "dependencies": {
         "@ai-sdk/provider": "3.0.3",
         "@ai-sdk/provider-utils": "4.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai-compatible": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-1.0.36.tgz",
+      "integrity": "sha512-ePJ1nj1Wv2QcG9m8zA3zT20WBInFqEfwV17KT0JBeRyQucmiJBwIhzLkOq95O0sBwUutJJJrQNG8pEYxGf6w3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider-utils": "3.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai-compatible/node_modules/@ai-sdk/provider": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
+      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/openai-compatible/node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.23.tgz",
+      "integrity": "sha512-60GYsRj5wIJQRcq5YwYJq4KhwLeStceXEJiZdecP1miiH+6FMmrnc7lZDOJoQ6m9lrudEb+uI4LEwddLz5+rPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"
@@ -1634,6 +1762,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ai": {
       "version": "6.0.37",
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.37.tgz",
@@ -1725,6 +1862,52 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -1790,6 +1973,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1880,6 +2069,18 @@
         "node": ">=20"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -1916,6 +2117,19 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -1941,6 +2155,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -1969,6 +2192,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -2003,6 +2247,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2022,6 +2275,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -2056,6 +2318,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2532,6 +2809,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2555,9 +2838,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastmcp": {
-      "version": "3.26.8",
-      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.26.8.tgz",
-      "integrity": "sha512-DQgvEdSoQpISqPDgLZe5K2RU8ICCz3/5QcEhHmz4KiNcNSdFOo7o817mGwWxPffOLe36vypCulq22cvEwqBi/A==",
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.35.0.tgz",
+      "integrity": "sha512-bcyAaVa3Zw5f4xighGg6fNNgEzZoP6tX/O+ZfS2lIhbEULWe/zUWG533JyFEUOjZT7EB+tiZW1ot4eWKmYJ6DA==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.3",
@@ -2565,11 +2848,12 @@
         "execa": "^9.6.1",
         "file-type": "^21.1.1",
         "fuse.js": "^7.1.0",
-        "mcp-proxy": "^5.12.5",
+        "hono": "^4.11.5",
+        "mcp-proxy": "^6.4.0",
         "strict-event-emitter-types": "^2.0.0",
         "undici": "^7.16.0",
         "uri-templates": "^0.2.0",
-        "xsschema": "0.4.0-beta.5",
+        "xsschema": "^0.4.3",
         "yargs": "^18.0.0",
         "zod": "^4.1.13",
         "zod-to-json-schema": "^3.25.0"
@@ -2611,6 +2895,29 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/figures": {
@@ -2679,6 +2986,54 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2728,6 +3083,34 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-caller-file": {
@@ -2804,6 +3187,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2849,6 +3258,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2862,13 +3286,59 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
-      "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/http-errors": {
@@ -2889,6 +3359,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-readable-ids": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/human-readable-ids/-/human-readable-ids-1.0.4.tgz",
+      "integrity": "sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA==",
+      "license": "Apache2",
+      "dependencies": {
+        "knuth-shuffle": "^1.0.0"
       }
     },
     "node_modules/human-signals": {
@@ -3017,6 +3509,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -3034,6 +3535,167 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/knuth-shuffle": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/knuth-shuffle/-/knuth-shuffle-1.0.8.tgz",
+      "integrity": "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ==",
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/koa": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.0.tgz",
+      "integrity": "sha512-TrM4/tnNY7uJ1aW55sIIa+dqBvc4V14WRIAlGcWat9wV5pRS9Wr5Zk2ZTjQP1jtfIHDoHiSbPuV08P0fUZo2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~1.0.1",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/koa-router": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-14.0.0.tgz",
+      "integrity": "sha512-Ue8f/PRsLLNm6b7y+eS6xkqvsG2xH11d2VB1HPcfdfW6p5736kCHf2pXaq8q9XPQ01x0Dk7V/P5Il9pe+tGTxA==",
+      "deprecated": "Please use @koa/router instead, starting from v9! ",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "path-to-regexp": "^8.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/koa-router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/koa/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/koa/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/koa/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -3062,10 +3724,13 @@
       }
     },
     "node_modules/mcp-proxy": {
-      "version": "5.12.5",
-      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-5.12.5.tgz",
-      "integrity": "sha512-Vawdc8vi36fXxKCaDpluRvbGcmrUXJdvXcDhkh30HYsws8XqX2rWPBflZpavzeS+6SwijRFV7g+9ypQRJZlrEQ==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.4.4.tgz",
+      "integrity": "sha512-8L61e0yk/1S6pe0DkeWXDNRkb8m5yoa6ZouLpe9uOes/pkcjgYvLhfVnO7zjZUTD5R3/GljAI+KizaYBNrypBg==",
       "license": "MIT",
+      "dependencies": {
+        "pipenet": "^1.3.0"
+      },
       "bin": {
         "mcp-proxy": "dist/bin/mcp-proxy.mjs"
       }
@@ -3178,6 +3843,44 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
@@ -3322,6 +4025,27 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pipenet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.0.tgz",
+      "integrity": "sha512-Uc3EH2i8hnJUD0Eupj9z2jaZPjjAbooaiHGh0iFdExbE8/BDt6Lf0919Dtwx5VM83elHNWFzCOsvzsViTD5YZg==",
+      "dependencies": {
+        "axios": "^1.7.3",
+        "debug": "^4.3.6",
+        "human-readable-ids": "^1.0.4",
+        "koa": "^3.1.1",
+        "koa-router": "^14.0.0",
+        "pump": "^3.0.3",
+        "tldjs": "^2.3.2",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "pipenet": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -3386,6 +4110,34 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -3887,6 +4639,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldjs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.2.tgz",
+      "integrity": "sha512-EORDwFMSZKrHPUVDhejCMDeAovRS5d8jZKiqALFiPp3cjKjEldPkxBY39ZSx3c45awz3RpKwJD1cCgGxEfy8/A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3912,6 +4677,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
       }
     },
     "node_modules/type-is": {
@@ -4198,6 +4972,15 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4260,9 +5043,9 @@
       "license": "ISC"
     },
     "node_modules/xsschema": {
-      "version": "0.4.0-beta.5",
-      "resolved": "https://registry.npmjs.org/xsschema/-/xsschema-0.4.0-beta.5.tgz",
-      "integrity": "sha512-73pYwf1hMy++7SnOkghJdgdPaGi+Y5I0SaO6rIlxb1ouV6tEyDbEcXP82kyr32KQVTlUbFj6qewi9eUVEiXm+g==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/xsschema/-/xsschema-0.4.4.tgz",
+      "integrity": "sha512-TMhbk8AhxO+YuDOn3rXBjGXQ+Vja3T13UPQkHx/FemhusaOzRfCSj2seykt0mdnFPsOtO9l3ANf4adcp+4NRGw==",
       "license": "MIT",
       "peerDependencies": {
         "@valibot/to-json-schema": "^1.0.0",
@@ -4270,7 +5053,7 @@
         "effect": "^3.16.0",
         "sury": "^10.0.0",
         "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.24.5"
+        "zod-to-json-schema": "^3.25.0"
       },
       "peerDependenciesMeta": {
         "@valibot/to-json-schema": {

--- a/src/runtime/typescript/package.json
+++ b/src/runtime/typescript/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.0",
     "@ai-sdk/google": "^3.0.0",
+    "@ai-sdk/google-vertex": "^3.0.0",
     "@ai-sdk/openai": "^3.0.0",
     "@mcpmesh/core": "file:../core/typescript",
     "ai": "^6.0.0",

--- a/src/runtime/typescript/src/__tests__/llm-provider.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-provider.test.ts
@@ -11,6 +11,7 @@ import {
   llmProvider,
   isLlmProviderTool,
   getLlmProviderMeta,
+  providerOptionsKey,
 } from "../llm-provider.js";
 
 describe("extractVendorFromModel", () => {
@@ -267,5 +268,32 @@ describe("LLM provider configurations", () => {
     expect(tool._meshMeta?.tags).toEqual(["production", "fast"]);
     expect(tool._meshMeta?.version).toBe("3.0.0");
     expect(tool._meshMeta?.vendor).toBe("anthropic");
+  });
+});
+
+describe("providerOptionsKey", () => {
+  it("should map gemini to google (Vercel @ai-sdk/google key)", () => {
+    expect(providerOptionsKey("gemini")).toBe("google");
+  });
+
+  it("should map vertex_ai to vertex (Vercel @ai-sdk/google-vertex key)", () => {
+    expect(providerOptionsKey("vertex_ai")).toBe("vertex");
+  });
+
+  it("should map anthropic to anthropic (matches mesh)", () => {
+    expect(providerOptionsKey("anthropic")).toBe("anthropic");
+  });
+
+  it("should map openai to openai (matches mesh)", () => {
+    expect(providerOptionsKey("openai")).toBe("openai");
+  });
+
+  it("should return unknown vendor unchanged", () => {
+    expect(providerOptionsKey("cohere")).toBe("cohere");
+    expect(providerOptionsKey("custom-vendor")).toBe("custom-vendor");
+  });
+
+  it("should return empty string unchanged", () => {
+    expect(providerOptionsKey("")).toBe("");
   });
 });

--- a/src/runtime/typescript/src/__tests__/media-resolver.test.ts
+++ b/src/runtime/typescript/src/__tests__/media-resolver.test.ts
@@ -107,6 +107,30 @@ describe("resolveResourceLinks", () => {
       expect((result[0] as Record<string, unknown>).image_url).toBeDefined();
     });
 
+    it("resolves image resource_link for vertex_ai (uses gemini/openai format)", async () => {
+      const imageData = Buffer.from("fake-vertex-image-data");
+      mockFetch.mockResolvedValue({ data: imageData, mimeType: "image/png" });
+
+      const result = await resolveResourceLinks(
+        {
+          type: "resource_link",
+          resource: {
+            uri: "file:///tmp/vertex.png",
+            name: "vertex.png",
+            mimeType: "image/png",
+          },
+        },
+        "vertex_ai"
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe("image_url");
+      expect((result[0] as Record<string, unknown>).image_url).toEqual({
+        url: `data:image/png;base64,${imageData.toString("base64")}`,
+        detail: "high",
+      });
+    });
+
     it("resolves image resource_link with flat format (no nested resource)", async () => {
       const imageData = Buffer.from("flat-format-data");
       mockFetch.mockResolvedValue({ data: imageData, mimeType: "image/png" });
@@ -164,6 +188,35 @@ describe("resolveResourceLinks", () => {
       expect(result).toHaveLength(1);
       expect(result[0].type).toBe("text");
       expect(result[0].text).toContain("report.pdf");
+    });
+
+    it("PDF for vertex_ai uses gemini-style placeholder", async () => {
+      const pdfData = Buffer.from("%PDF-1.4 fake");
+      mockFetch.mockResolvedValue({ data: pdfData, mimeType: "application/pdf" });
+
+      const result = await resolveResourceLinks(
+        {
+          type: "resource_link",
+          resource: {
+            uri: "file:///tmp/vertex-doc.pdf",
+            name: "vertex-doc.pdf",
+            mimeType: "application/pdf",
+          },
+        },
+        "vertex_ai"
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe("text");
+      expect(result[0].text).toContain("vertex-doc.pdf");
+      expect(result[0].text).toContain("Gemini PDF support via LiteLLM may vary");
+    });
+  });
+
+  describe("vertex_ai vendor", () => {
+    it("vertex_ai is in TOOL_IMAGE_UNSUPPORTED_VENDORS (mirrors gemini)", async () => {
+      const { TOOL_IMAGE_UNSUPPORTED_VENDORS } = await import("../media/resolver.js");
+      expect(TOOL_IMAGE_UNSUPPORTED_VENDORS.has("vertex_ai")).toBe(true);
     });
   });
 

--- a/src/runtime/typescript/src/llm-provider.ts
+++ b/src/runtime/typescript/src/llm-provider.ts
@@ -50,6 +50,7 @@ const VENDOR_PROVIDERS: Record<string, string> = {
   openai: "@ai-sdk/openai",
   google: "@ai-sdk/google",
   gemini: "@ai-sdk/google", // gemini/ model prefix uses Google AI SDK
+  vertex_ai: "@ai-sdk/google-vertex", // vertex_ai/ model prefix uses Google Vertex AI (IAM auth)
   // Can extend with more providers as needed
 };
 
@@ -60,7 +61,38 @@ const VENDOR_PROVIDERS: Record<string, string> = {
  */
 const VENDOR_EXPORTS: Record<string, string> = {
   gemini: "google", // @ai-sdk/google exports 'google', not 'gemini'
+  vertex_ai: "vertex", // @ai-sdk/google-vertex exports 'vertex'
 };
+
+/**
+ * Mapping from mesh's vendor name to the key Vercel AI SDK uses inside
+ * `generateText({ providerOptions: { ... } })`.
+ *
+ * The Vercel AI SDK parses `providerOptions` under each SDK's own key, NOT
+ * under mesh's vendor name. For example, `@ai-sdk/google` looks at
+ * `providerOptions.google.*`, so passing `providerOptions.gemini.*` is
+ * silently dropped. Mapping table:
+ *   - `@ai-sdk/google`         → key `"google"`
+ *   - `@ai-sdk/google-vertex`  → key `"vertex"`
+ *   - `@ai-sdk/anthropic`      → key `"anthropic"` (matches mesh)
+ *   - `@ai-sdk/openai`         → key `"openai"`   (matches mesh)
+ */
+const PROVIDER_OPTIONS_KEY: Record<string, string> = {
+  gemini: "google",
+  vertex_ai: "vertex",
+  anthropic: "anthropic",
+  openai: "openai",
+};
+
+/**
+ * Resolve the providerOptions key for a given mesh vendor.
+ *
+ * Returns the SDK-expected key (e.g., "google" for vendor "gemini"),
+ * falling back to the vendor name unchanged for unknown vendors.
+ */
+export function providerOptionsKey(vendor: string): string {
+  return PROVIDER_OPTIONS_KEY[vendor] ?? vendor;
+}
 
 /**
  * Normalize environment variables for cross-SDK compatibility.
@@ -85,6 +117,27 @@ function normalizeEnvVars(vendor: string): void {
     } else if (vercelKey && !litellmKey) {
       process.env.GOOGLE_API_KEY = vercelKey;
       debug("Set GOOGLE_API_KEY from GOOGLE_GENERATIVE_AI_API_KEY");
+    }
+  } else if (vendor === "vertex_ai") {
+    // Vercel AI SDK's @ai-sdk/google-vertex reads:
+    //   GOOGLE_VERTEX_PROJECT  - GCP project ID
+    //   GOOGLE_VERTEX_LOCATION - GCP region (e.g., us-central1)
+    //   GOOGLE_APPLICATION_CREDENTIALS - path to service-account JSON (or rely on
+    //                                    gcloud user ADC / GCE/GKE workload identity)
+    // We don't auto-copy from any other env var because the Python (LiteLLM) and
+    // Vercel SDK conventions diverge (VERTEXAI_PROJECT vs GOOGLE_VERTEX_PROJECT) —
+    // each runtime follows its own ecosystem's naming.
+    if (!process.env.GOOGLE_VERTEX_PROJECT) {
+      debug(
+        "vertex_ai vendor selected but GOOGLE_VERTEX_PROJECT is not set — " +
+        "@ai-sdk/google-vertex will fall back to ADC project discovery"
+      );
+    }
+    if (!process.env.GOOGLE_VERTEX_LOCATION) {
+      debug(
+        "vertex_ai vendor selected but GOOGLE_VERTEX_LOCATION is not set — " +
+        "@ai-sdk/google-vertex defaults to us-central1"
+      );
     }
   }
 }
@@ -568,7 +621,8 @@ export function llmProvider(config: LlmProviderConfig): {
     // The manual loop drops Gemini's thought_signature from assistant messages,
     // causing 400 errors in multi-turn tool conversations. AI SDK preserves it.
     // Claude/OpenAI keep the manual loop (they need response_format on every call).
-    const useMaxSteps = hasToolEndpoints && (vendor === "gemini" || vendor === "google");
+    // vertex_ai is the same Gemini model on the wire, so it gets the same treatment.
+    const useMaxSteps = hasToolEndpoints && (vendor === "gemini" || vendor === "google" || vendor === "vertex_ai");
     if (hasToolEndpoints) {
       debug(`Provider-managed loop: ${Object.keys(toolEndpoints).length} tools with endpoints${useMaxSteps ? " (Gemini maxSteps mode)" : ""}`);
     }
@@ -714,14 +768,16 @@ export function llmProvider(config: LlmProviderConfig): {
     // which generateObject() doesn't support. The handler sets responseFormat when in strict mode.
     // EXCEPTION: Gemini 3 + response_format + tools causes infinite tool loops,
     // so skip responseFormat when Gemini has tools (matching Python handler guard).
-    const skipResponseFormat = (vendor === "gemini" || vendor === "google") && hasTools;
+    // vertex_ai is the same Gemini model on the wire — same restriction applies.
+    const skipResponseFormat = (vendor === "gemini" || vendor === "google" || vendor === "vertex_ai") && hasTools;
     if (preparedRequest.responseFormat && !skipResponseFormat) {
+      const optsKey = providerOptionsKey(vendor);
       requestOptions.providerOptions = {
-        [vendor]: {
+        [optsKey]: {
           response_format: preparedRequest.responseFormat,
         },
       };
-      debug(`Passing responseFormat via providerOptions for vendor: ${vendor}`);
+      debug(`Passing responseFormat via providerOptions for vendor: ${vendor} (key: ${optsKey})`);
     } else if (skipResponseFormat) {
       debug(`Skipping responseFormat for Gemini (tools present — avoids infinite loop)`);
     }

--- a/src/runtime/typescript/src/llm-provider.ts
+++ b/src/runtime/typescript/src/llm-provider.ts
@@ -130,13 +130,15 @@ function normalizeEnvVars(vendor: string): void {
     if (!process.env.GOOGLE_VERTEX_PROJECT) {
       debug(
         "vertex_ai vendor selected but GOOGLE_VERTEX_PROJECT is not set — " +
-        "@ai-sdk/google-vertex will fall back to ADC project discovery"
+        "@ai-sdk/google-vertex will throw a LoadSettingError on the first call " +
+        "(the SDK requires the env var; it does not auto-discover from ADC)"
       );
     }
     if (!process.env.GOOGLE_VERTEX_LOCATION) {
       debug(
         "vertex_ai vendor selected but GOOGLE_VERTEX_LOCATION is not set — " +
-        "@ai-sdk/google-vertex defaults to us-central1"
+        "@ai-sdk/google-vertex will throw a LoadSettingError on the first call " +
+        "(the SDK has no default location; set e.g. 'us-central1' or 'global')"
       );
     }
   }

--- a/src/runtime/typescript/src/media/resolver.ts
+++ b/src/runtime/typescript/src/media/resolver.ts
@@ -65,6 +65,7 @@ const VENDOR_FORMATTERS: Record<string, (b64: string, mimeType: string) => Resol
   openai: formatForOpenai,
   gemini: formatForGemini,
   google: formatForGemini,
+  vertex_ai: formatForGemini,
 };
 
 function formatPdfForClaude(b64: string): ResolvedContent {
@@ -157,7 +158,7 @@ async function resolveSingleResourceLink(
       const b64 = data.toString("base64");
       if (vendor === "anthropic" || vendor === "claude") {
         return formatPdfForClaude(b64);
-      } else if (vendor === "gemini" || vendor === "google") {
+      } else if (vendor === "gemini" || vendor === "google" || vendor === "vertex_ai") {
         return formatPdfForGemini(b64, name);
       } else {
         return formatPdfForOpenai(b64, name);
@@ -269,7 +270,7 @@ export async function resolveResourceLinks(
 }
 
 /** Vendors that do NOT support images in tool/function result messages. */
-export const TOOL_IMAGE_UNSUPPORTED_VENDORS = new Set(["openai", "gemini", "google"]);
+export const TOOL_IMAGE_UNSUPPORTED_VENDORS = new Set(["openai", "gemini", "google", "vertex_ai"]);
 
 /**
  * Resolve resource_links for inclusion in a tool result message.

--- a/src/runtime/typescript/src/provider-handlers/gemini-handler.ts
+++ b/src/runtime/typescript/src/provider-handlers/gemini-handler.ts
@@ -176,3 +176,9 @@ export class GeminiHandler implements ProviderHandler {
 // Use "gemini" as vendor name to match model prefix (e.g., "gemini/gemini-3-flash-preview")
 // This is consistent with Python SDK's registration
 ProviderHandlerRegistry.register("gemini", GeminiHandler);
+
+// Also register under "vertex_ai" — same Gemini model family, same prompt-shaping
+// rules (HINT mode for tool calls, STRICT mode for tool-free structured output);
+// only the auth/transport differs (IAM via @ai-sdk/google-vertex vs API key via
+// @ai-sdk/google). Mirrors Python's GeminiHandler registry alias.
+ProviderHandlerRegistry.register("vertex_ai", GeminiHandler);

--- a/tests/integration/suites/uc04_llm_integration/artifacts/java-vertex-ai-agent
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/java-vertex-ai-agent
@@ -1,0 +1,1 @@
+../../../../../examples/java/vertex-ai-agent

--- a/tests/integration/suites/uc04_llm_integration/artifacts/vertex-ai-agent
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/vertex-ai-agent
@@ -1,0 +1,1 @@
+../../../../../examples/python/vertex-ai-agent

--- a/tests/integration/suites/uc04_llm_integration/artifacts/vertex-ai-agent-ts
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/vertex-ai-agent-ts
@@ -1,0 +1,1 @@
+../../../../../examples/typescript/vertex-ai-agent

--- a/tests/integration/suites/uc04_llm_integration/tc34_vertex_provider_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc34_vertex_provider_py/test.yaml
@@ -1,0 +1,175 @@
+# Test Case: Vertex AI Provider Integration - Python
+# Verifies Gemini-via-Vertex-AI LLM provider using @mesh.llm_provider with
+# the "vertex_ai/<model>" prefix (IAM auth, NOT AI Studio API key).
+#
+# REQUIRED secrets in tsuite DB (configured via the secrets handler):
+#   - GCP_SA_JSON_B64     : base64-encoded service-account JSON (single-line — multi-line
+#                           values mangle the .env file when sourced via `set -a && . .env`).
+#                           Generate via: `base64 -i ~/.config/gcloud/application_default_credentials.json | tr -d '\n'`
+#   - VERTEXAI_PROJECT    : GCP project id (e.g., eng-cache-151909)
+#   - VERTEXAI_LOCATION   : GCP region    (e.g., us-central1)
+# Without these, the materialize step fails with a clear "secret not configured" error.
+#
+# Related: https://github.com/dhyansraj/mcp-mesh/issues/816
+
+name: "Vertex AI Provider Integration - Py"
+description: "Test Gemini via Vertex AI (IAM auth) provider end-to-end (Python)"
+tags:
+  - llm
+  - gemini
+  - vertex
+  - provider
+  - python
+  - issue-816
+timeout: 180
+# Note: Skip this test with --skip-tag llm if no GCP credentials are available
+pre_run:
+  # Setup for Python agent
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+test:
+  # Copy artifact to workspace (symlink resolves to examples/python/vertex-ai-agent)
+  - name: "Copy artifact to workspace"
+    handler: shell
+    command: "cp -rL /uc-artifacts/vertex-ai-agent /workspace/"
+    capture: copy_output
+  # Materialize all secrets (incl. multi-line GCP_SA_JSON) into .env
+  - name: "Create env file with secrets"
+    handler: secrets
+    target: /workspace/.env
+  # Materialize the SA JSON to a file, then unset the env var so it isn't
+  # leaked through GOOGLE_APPLICATION_CREDENTIALS=$GCP_SA_JSON-style mishaps.
+  - name: "Materialize service-account JSON to file"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # Defensive: detect raw-JSON secret value before sourcing it.
+      # If GCP_SA_JSON_B64 was stored as multi-line JSON instead of base64,
+      # `set -a && . .env` would crash with "account:: command not found"
+      # when bash hits the JSON content. Fail clearly here instead.
+      if grep -qE '^\{$|"account"|"client_id"' /workspace/.env; then
+        echo "ERROR: /workspace/.env contains raw JSON content — looks like GCP_SA_JSON_B64 was stored as the multi-line JSON instead of a single-line base64-encoded string."
+        echo "Fix: regenerate the secret value via:"
+        echo "  base64 -i ~/.config/gcloud/application_default_credentials.json | tr -d '\\n'"
+        echo "Then replace the GCP_SA_JSON_B64 value in tsuite DB with that single-line string."
+        exit 1
+      fi
+      set -a
+      . /workspace/.env
+      set +a
+      if [ -z "$GCP_SA_JSON_B64" ]; then
+        echo "ERROR: GCP_SA_JSON_B64 is empty — secret not configured in tsuite DB"
+        exit 1
+      fi
+      echo "$GCP_SA_JSON_B64" | base64 -d > /workspace/sa.json
+      chmod 600 /workspace/sa.json
+      # Strip GCP_SA_JSON_B64 from the env file so the agent doesn't inherit it
+      grep -v '^GCP_SA_JSON_B64=' /workspace/.env > /workspace/.env.tmp && mv /workspace/.env.tmp /workspace/.env
+      echo "sa.json bytes: $(wc -c < /workspace/sa.json)"
+      # Quick sanity: verify it parses as JSON
+      python3 -c "import json; json.load(open('/workspace/sa.json')); print('sa.json: valid JSON')"
+    capture: sa_materialize
+  # Install google-auth (required by LiteLLM's vertex_ai/* path to read ADC).
+  # In a published install this comes via `pip install 'mcp-mesh[vertex]'`; the
+  # tsuite test container has the base mcp-mesh installed without that extra,
+  # so we install the dep directly here to mirror the [vertex] extra.
+  - name: "Install google-auth (mcp-mesh[vertex] extra)"
+    handler: shell
+    command: "pip install --quiet 'google-auth>=2.0.0' && python -c 'import google.auth; print(\"google-auth:\", google.auth.__version__)'"
+    capture: install_google_auth
+    timeout: 60
+  # Verify all files copied
+  - name: "Verify workspace files"
+    handler: shell
+    command: "ls -la /workspace/"
+    capture: ls_output
+  # Start the vertex-ai-agent with env file + ADC pointing at sa.json
+  - name: "Start vertex-ai-agent"
+    handler: shell
+    command: "meshctl start vertex-ai-agent/main.py --env-file .env --env GOOGLE_APPLICATION_CREDENTIALS=/workspace/sa.json --env MCP_MESH_HTTP_PORT=3040 -d --debug"
+    workdir: /workspace
+    capture: start_output
+  # Wait for provider to register (poll up to 90s)
+  - name: "Wait for provider to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for vertex-ai-agent to register..."
+      for i in $(seq 1 45); do
+        AGENTS=$(meshctl list 2>/dev/null || echo "")
+        if echo "$AGENTS" | grep -q "vertex-ai-agent"; then
+          echo "Agent registered after $((i*2))s"
+          exit 0
+        fi
+        if [ $((i % 10)) -eq 0 ]; then
+          echo "Still waiting... ($((i*2))s)"
+        fi
+        sleep 2
+      done
+      echo "ERROR: Agent did not register within 90s"
+      meshctl logs vertex-ai-agent 2>/dev/null | tail -80 || true
+      exit 1
+    capture: wait_registration
+    timeout: 120
+  # Verify agent is running
+  - name: "Verify agent is running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: list_output
+  # List available tools
+  - name: "List available tools"
+    handler: shell
+    command: "meshctl list -t"
+    workdir: /workspace
+    capture: tools_output
+  # Call capital_of via the structured-output tool
+  - name: "Call capital_of - France"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call capital_of '{"country": "France"}'
+    capture: llm_response
+    timeout: 90
+  # Capture agent log to confirm Vertex routing (vs AI Studio fallback)
+  - name: "Capture agent log for routing assertion"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl logs vertex-ai-agent 2>/dev/null | tail -200 || true"
+    capture: agent_log
+  # Stop agent
+  - name: "Stop agent"
+    handler: shell
+    command: "meshctl stop"
+    workdir: /workspace
+assertions:
+  # Agent registered
+  - expr: "${captured.list_output} contains 'vertex-ai-agent'"
+    message: "vertex-ai-agent should appear in meshctl list"
+  # Tool registered (Python registers by function name)
+  - expr: "${captured.tools_output} contains 'capital_of'"
+    message: "capital_of tool should be listed"
+  # Capability is correct
+  - expr: "${captured.tools_output} contains 'capital_lookup'"
+    message: "Tool should expose capital_lookup capability"
+  # Structured response shape: contains the field names + the answer
+  - expr: "${captured.llm_response} contains 'name'"
+    message: "Response should contain the 'name' field"
+  - expr: "${captured.llm_response} contains 'capital'"
+    message: "Response should contain the 'capital' field"
+  - expr: "${captured.llm_response} contains 'Paris'"
+    message: "Response should contain Paris as the capital"
+  # Routing — confirm we actually went through the Vertex path, not AI Studio
+  - expr: "${captured.agent_log} contains 'vertex_ai'"
+    message: "Agent log should reference vertex_ai routing"
+  - expr: "${captured.agent_log} contains 'GeminiHandler for vendor: vertex_ai'"
+    message: "Agent log should show GeminiHandler selected for vendor: vertex_ai"
+post_run:
+  # Stop any remaining agents and clean up SA JSON
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true; rm -f /workspace/sa.json /workspace/.env 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc04_llm_integration/tc34_vertex_provider_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc34_vertex_provider_py/test.yaml
@@ -21,7 +21,7 @@ tags:
   - provider
   - python
   - issue-816
-timeout: 180
+timeout: 360
 # Note: Skip this test with --skip-tag llm if no GCP credentials are available
 pre_run:
   # Setup for Python agent

--- a/tests/integration/suites/uc04_llm_integration/tc35_vertex_provider_ts/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc35_vertex_provider_ts/test.yaml
@@ -21,7 +21,7 @@ tags:
   - provider
   - typescript
   - issue-816
-timeout: 240
+timeout: 480
 # Note: Skip this test with --skip-tag llm if no GCP credentials are available
 pre_run:
   # TypeScript test - need Node.js + meshctl

--- a/tests/integration/suites/uc04_llm_integration/tc35_vertex_provider_ts/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc35_vertex_provider_ts/test.yaml
@@ -1,0 +1,164 @@
+# Test Case: Vertex AI Provider Integration - TypeScript
+# Verifies Gemini-via-Vertex-AI LLM provider using mesh.addLlmProvider() with
+# the "vertex_ai/<model>" prefix (IAM auth via @ai-sdk/google-vertex), NOT AI Studio.
+#
+# REQUIRED secrets in tsuite DB (configured via the secrets handler):
+#   - GCP_SA_JSON_B64           : base64-encoded service-account JSON (single-line — multi-line
+#                                 values mangle the .env file when sourced via `set -a && . .env`).
+#                                 Generate via: `base64 -i ~/.config/gcloud/application_default_credentials.json | tr -d '\n'`
+#   - GOOGLE_VERTEX_PROJECT     : GCP project id (e.g., eng-cache-151909)
+#   - GOOGLE_VERTEX_LOCATION    : GCP region    (e.g., us-central1)
+# Without these, the materialize step fails with a clear "secret not configured" error.
+#
+# Related: https://github.com/dhyansraj/mcp-mesh/issues/816
+
+name: "Vertex AI Provider Integration - TS"
+description: "Test Gemini via Vertex AI (IAM auth) provider end-to-end (TypeScript)"
+tags:
+  - llm
+  - gemini
+  - vertex
+  - provider
+  - typescript
+  - issue-816
+timeout: 240
+# Note: Skip this test with --skip-tag llm if no GCP credentials are available
+pre_run:
+  # TypeScript test - need Node.js + meshctl
+  - routine: global.setup_for_typescript_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+test:
+  # Copy artifact to workspace (symlink resolves to examples/typescript/vertex-ai-agent)
+  - name: "Copy artifact to workspace"
+    handler: shell
+    command: "cp -rL /uc-artifacts/vertex-ai-agent-ts /workspace/"
+    capture: copy_output
+  # Materialize all secrets (incl. multi-line GCP_SA_JSON) into .env
+  - name: "Create env file with secrets"
+    handler: secrets
+    target: /workspace/.env
+  # Materialize the SA JSON to a file, then strip GCP_SA_JSON from .env
+  - name: "Materialize service-account JSON to file"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # Defensive: detect raw-JSON secret value before sourcing it.
+      if grep -qE '^\{$|"account"|"client_id"' /workspace/.env; then
+        echo "ERROR: /workspace/.env contains raw JSON — GCP_SA_JSON_B64 looks like multi-line JSON instead of base64."
+        echo "Fix: base64 -i ~/.config/gcloud/application_default_credentials.json | tr -d '\\n' (single-line, paste as the secret value)."
+        exit 1
+      fi
+      set -a
+      . /workspace/.env
+      set +a
+      if [ -z "$GCP_SA_JSON_B64" ]; then
+        echo "ERROR: GCP_SA_JSON_B64 is empty — secret not configured in tsuite DB"
+        exit 1
+      fi
+      echo "$GCP_SA_JSON_B64" | base64 -d > /workspace/sa.json
+      chmod 600 /workspace/sa.json
+      grep -v '^GCP_SA_JSON_B64=' /workspace/.env > /workspace/.env.tmp && mv /workspace/.env.tmp /workspace/.env
+      echo "sa.json bytes: $(wc -c < /workspace/sa.json)"
+      python3 -c "import json; json.load(open('/workspace/sa.json')); print('sa.json: valid JSON')"
+    capture: sa_materialize
+  # Verify all files copied
+  - name: "Verify workspace files"
+    handler: shell
+    command: "ls -la /workspace/"
+    capture: ls_output
+  # Install npm dependencies (handler auto-detects local/published mode)
+  - name: "Install npm dependencies"
+    handler: npm-install
+    path: /workspace/vertex-ai-agent-ts
+  # Start the vertex-ai-agent-ts with env file + ADC pointing at sa.json
+  - name: "Start vertex-ai-agent-ts"
+    handler: shell
+    command: "meshctl start vertex-ai-agent-ts/src/index.ts --env-file .env --env GOOGLE_APPLICATION_CREDENTIALS=/workspace/sa.json --env MCP_MESH_HTTP_PORT=3041 -d"
+    workdir: /workspace
+    capture: start_output
+  # Wait for provider to register (TS startup can be slower than Python)
+  - name: "Wait for provider to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for vertex-ai-agent-ts to register..."
+      for i in $(seq 1 45); do
+        AGENTS=$(meshctl list 2>/dev/null || echo "")
+        if echo "$AGENTS" | grep -q "vertex-ai-agent-ts"; then
+          echo "Agent registered after $((i*2))s"
+          exit 0
+        fi
+        if [ $((i % 10)) -eq 0 ]; then
+          echo "Still waiting... ($((i*2))s)"
+        fi
+        sleep 2
+      done
+      echo "ERROR: Agent did not register within 90s"
+      meshctl logs vertex-ai-agent-ts 2>/dev/null | tail -80 || true
+      exit 1
+    capture: wait_registration
+    timeout: 120
+  # Verify agent is running
+  - name: "Verify agent is running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: list_output
+  # List available tools
+  - name: "List available tools"
+    handler: shell
+    command: "meshctl list -t"
+    workdir: /workspace
+    capture: tools_output
+  # Call capital_of via the structured-output tool
+  - name: "Call capital_of - France"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call capital_of '{"country": "France"}'
+    capture: llm_response
+    timeout: 90
+  # Capture agent log to confirm Vertex routing (vs AI Studio fallback)
+  - name: "Capture agent log for routing assertion"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl logs vertex-ai-agent-ts 2>/dev/null | tail -200 || true"
+    capture: agent_log
+  # Stop agent
+  - name: "Stop agent"
+    handler: shell
+    command: "meshctl stop"
+    workdir: /workspace
+assertions:
+  # Agent registered
+  - expr: "${captured.list_output} contains 'vertex-ai-agent-ts'"
+    message: "vertex-ai-agent-ts should appear in meshctl list"
+  # Tool registered (TS registers by name)
+  - expr: "${captured.tools_output} contains 'capital_of'"
+    message: "capital_of tool should be listed"
+  # Capability is correct
+  - expr: "${captured.tools_output} contains 'capital_lookup'"
+    message: "Tool should expose capital_lookup capability"
+  # Structured response shape: contains the field names + the answer
+  - expr: "${captured.llm_response} contains 'name'"
+    message: "Response should contain the 'name' field"
+  - expr: "${captured.llm_response} contains 'capital'"
+    message: "Response should contain the 'capital' field"
+  - expr: "${captured.llm_response} contains 'Paris'"
+    message: "Response should contain Paris as the capital"
+  # Routing — confirm we actually went through the Vertex path, not AI Studio.
+  # The TS Vercel AI SDK emits a startup line like:
+  #   AI SDK Warning (google.vertex.chat / gemini-2.0-flash): ...
+  # which is the smoking gun for @ai-sdk/google-vertex (vs @ai-sdk/google AI Studio)..
+  # The TS provider is registered as "vertex_chat" and the runtime selects
+  # GeminiHandler for vendor "vertex_ai".
+  - expr: "${captured.agent_log} contains 'google.vertex'"
+    message: "Agent log should contain 'google.vertex' (AI SDK marker confirming @ai-sdk/google-vertex was used, not @ai-sdk/google AI Studio)"
+post_run:
+  # Stop any remaining agents and clean up SA JSON
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true; rm -f /workspace/sa.json /workspace/.env 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc04_llm_integration/tc36_vertex_provider_java/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc36_vertex_provider_java/test.yaml
@@ -1,0 +1,199 @@
+# Test Case: Vertex AI Provider Integration - Java
+# Verifies Gemini-via-Vertex-AI LLM provider using Spring AI's
+# spring-ai-starter-model-vertex-ai-gemini and the @MeshLlm(provider = "vertex_ai")
+# annotation (IAM auth via GCP ADC, NOT AI Studio API key).
+#
+# REQUIRED secrets in tsuite DB (configured via the secrets handler):
+#   - GCP_SA_JSON_B64                        : base64-encoded service-account JSON (single-line —
+#                                              multi-line values mangle .env when sourced via
+#                                              `set -a && . .env`).
+#                                              Generate via: `base64 -i ~/.config/gcloud/application_default_credentials.json | tr -d '\n'`
+#   - SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID  : GCP project id (e.g., eng-cache-151909)
+#   - SPRING_AI_VERTEX_AI_GEMINI_LOCATION    : GCP region    (e.g., us-central1)
+# Without these, the materialize step fails with a clear "secret not configured" error.
+#
+# Note: Java's @MeshLlm direct mode logs "(mode=direct:vertex_ai)" on registration
+# — that's the marker we assert on to confirm Vertex routing (vs AI Studio fallback).
+#
+# Note: Java registers tools by capability name, so we call `capital_lookup`
+# (not `capital_of`). Also, the Gemini model sometimes returns name=null in the
+# CapitalInfo record (model interpretation, not a routing bug), so we DON'T
+# strictly assert "France" — `Paris` + the field names is sufficient proof
+# the structured response shape is correct.
+#
+# Related: https://github.com/dhyansraj/mcp-mesh/issues/816
+
+name: "Vertex AI Provider Integration - Java"
+description: "Test Gemini via Vertex AI (IAM auth) provider end-to-end (Java / Spring AI)"
+tags:
+  - llm
+  - gemini
+  - vertex
+  - provider
+  - java
+  - issue-816
+timeout: 360
+# Note: Skip this test with --skip-tag llm if no GCP credentials are available
+pre_run:
+  - routine: global.setup_for_java_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  # Copy artifact to workspace (symlink resolves to examples/java/vertex-ai-agent)
+  - name: "Copy artifact to workspace"
+    handler: shell
+    command: |
+      cp -rL /uc-artifacts/java-vertex-ai-agent /workspace/
+      ls -la /workspace/java-vertex-ai-agent/
+    capture: copy_output
+
+  # Materialize all secrets (incl. multi-line GCP_SA_JSON) into the agent .env
+  - name: "Create env file with secrets"
+    handler: secrets
+    target: /workspace/java-vertex-ai-agent/.env
+
+  # Materialize the SA JSON to a file, then strip GCP_SA_JSON from .env
+  - name: "Materialize service-account JSON to file"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # Defensive: detect raw-JSON secret value before sourcing it.
+      if grep -qE '^\{$|"account"|"client_id"' /workspace/java-vertex-ai-agent/.env; then
+        echo "ERROR: .env contains raw JSON — GCP_SA_JSON_B64 looks like multi-line JSON instead of base64."
+        echo "Fix: base64 -i ~/.config/gcloud/application_default_credentials.json | tr -d '\\n' (single-line, paste as the secret value)."
+        exit 1
+      fi
+      set -a
+      . /workspace/java-vertex-ai-agent/.env
+      set +a
+      if [ -z "$GCP_SA_JSON_B64" ]; then
+        echo "ERROR: GCP_SA_JSON_B64 is empty — secret not configured in tsuite DB"
+        exit 1
+      fi
+      echo "$GCP_SA_JSON_B64" | base64 -d > /workspace/sa.json
+      chmod 600 /workspace/sa.json
+      grep -v '^GCP_SA_JSON_B64=' /workspace/java-vertex-ai-agent/.env > /workspace/java-vertex-ai-agent/.env.tmp \
+        && mv /workspace/java-vertex-ai-agent/.env.tmp /workspace/java-vertex-ai-agent/.env
+      echo "sa.json bytes: $(wc -c < /workspace/sa.json)"
+      python3 -c "import json; json.load(open('/workspace/sa.json')); print('sa.json: valid JSON')"
+    capture: sa_materialize
+
+  # Install Maven dependencies
+  - name: "Install Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-vertex-ai-agent
+    timeout: 600
+
+  # Start the vertex-ai-agent-java with env file + ADC pointing at sa.json.
+  # MCP_MESH_HTTP_PORT=0 lets the runtime pick a free port (matches tc12 pattern).
+  - name: "Start vertex-ai-agent (Java)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl start /workspace/java-vertex-ai-agent \
+        --env MCP_MESH_HTTP_PORT=0 \
+        --env GOOGLE_APPLICATION_CREDENTIALS=/workspace/sa.json \
+        --env-file /workspace/java-vertex-ai-agent/.env \
+        -d
+      echo "vertex-ai-agent (Java) starting via meshctl"
+    capture: start_output
+
+  # Wait for provider to register (Java is slow to start — Spring Boot warmup)
+  - name: "Wait for provider registration"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for vertex-ai-agent-java..."
+      for i in $(seq 1 60); do
+        AGENTS=$(meshctl list 2>/dev/null || echo "")
+        if echo "$AGENTS" | grep -q "vertex-ai-agent-java"; then
+          echo "Provider registered after $((i*2))s"
+          exit 0
+        fi
+        if [ $((i % 10)) -eq 0 ]; then
+          echo "Still waiting... ($((i*2))s)"
+        fi
+        sleep 2
+      done
+      echo "ERROR: Provider did not register within 120s"
+      meshctl logs vertex-ai-agent-java 2>/dev/null | tail -80 || true
+      exit 1
+    capture: wait_registration
+    timeout: 180
+
+  # Verify agent is running
+  - name: "Verify agent is running"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: list_output
+
+  # List available tools
+  - name: "List available tools"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list -t"
+    capture: tools_output
+
+  # Call capital_lookup (Java registers tools by capability name)
+  - name: "Call capital_lookup - France"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call capital_lookup '{"country": "France"}'
+    capture: llm_response
+    timeout: 90
+
+  # Capture agent log to confirm Vertex routing (vs AI Studio fallback)
+  - name: "Capture agent log for routing assertion"
+    handler: shell
+    workdir: /workspace
+    # Agent registers itself as 'vertex-ai-agent-java' (per @MeshAgent name in
+     # VertexAiAgentApplication.java); the workspace dir 'java-vertex-ai-agent'
+     # is just the artifact path. Use the registered agent name for logs.
+    command: "meshctl logs vertex-ai-agent-java 2>/dev/null | tail -300 || true"
+    capture: agent_log
+
+  # Stop agent
+  - name: "Stop agent"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl stop"
+
+assertions:
+  # Agent registered (the @MeshAgent name is "vertex-ai-agent-java")
+  - expr: "${captured.list_output} contains 'vertex-ai-agent-java'"
+    message: "vertex-ai-agent-java should appear in meshctl list"
+
+  # Tool is registered by capability (Java behavior, confirmed in local test)
+  - expr: "${captured.tools_output} contains 'capital_lookup'"
+    message: "capital_lookup tool should be listed"
+
+  # Structured response shape: contains the field names + the answer.
+  # We DON'T strictly assert "France" — the Gemini model occasionally returns
+  # name=null in the structured CapitalInfo record (model interpretation issue,
+  # not a routing bug). Paris + the field names is enough proof the
+  # structured response shape is correct.
+  - expr: "${captured.llm_response} contains 'name'"
+    message: "Response should contain the 'name' field"
+  - expr: "${captured.llm_response} contains 'capital'"
+    message: "Response should contain the 'capital' field"
+  - expr: "${captured.llm_response} contains 'Paris'"
+    message: "Response should contain Paris as the capital"
+
+  # Routing — confirm @MeshLlm registered in direct:vertex_ai mode
+  # (this is the marker emitted by MeshLlmRegistry, NOT AI Studio's "gemini").
+  - expr: "${captured.agent_log} contains 'mode=direct:vertex_ai'"
+    message: "Agent log should show @MeshLlm registered with mode=direct:vertex_ai"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop 2>/dev/null || true
+      pkill -f "spring-boot:run" 2>/dev/null || true
+      pkill -f "java.*vertex-ai-agent" 2>/dev/null || true
+      rm -f /workspace/sa.json 2>/dev/null || true
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc04_llm_integration/tc36_vertex_provider_java/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc36_vertex_provider_java/test.yaml
@@ -32,7 +32,7 @@ tags:
   - provider
   - java
   - issue-816
-timeout: 360
+timeout: 900
 # Note: Skip this test with --skip-tag llm if no GCP credentials are available
 pre_run:
   - routine: global.setup_for_java_agent
@@ -194,6 +194,6 @@ post_run:
       meshctl stop 2>/dev/null || true
       pkill -f "spring-boot:run" 2>/dev/null || true
       pkill -f "java.*vertex-ai-agent" 2>/dev/null || true
-      rm -f /workspace/sa.json 2>/dev/null || true
+      rm -f /workspace/sa.json /workspace/java-vertex-ai-agent/.env 2>/dev/null || true
     ignore_errors: true
   - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

Adds first-class Google Cloud Vertex AI as an alternative to Google AI Studio for Gemini models, across all three mcp-mesh runtimes. Same agent code in all cases — switch between AI Studio and Vertex by changing the model prefix and auth env vars.

### Per-runtime changes

- **Python** (LiteLLM): registry alias `vertex_ai` → `GeminiHandler` so HINT-mode prompt-shaping applies (was silently falling through to GenericHandler). New `[vertex]` extra in `pyproject.toml` (both local + PyPI manifests) installs `google-auth` for ADC reading.
- **TypeScript** (Vercel AI SDK): added `@ai-sdk/google-vertex` dep; `llm-provider.ts` extended to recognize `vertex_ai/*` model prefix; gemini-handler aliased.
- **Java** (Spring AI 2.0.0-M4): `SpringAiLlmProvider.normalizeProvider/getModelForProvider/isProviderAvailable` now recognize `vertex_ai` (and `vertexai` alias) and route directly to `vertexAiGeminiChatModel`, bypassing the AI Studio preference shortcut. `LlmProviderHandlerRegistry` aliases. `spring-ai-vertex-ai-gemini` added as `<optional>true</optional>` dep.

### Bonus latent fixes (surfaced during this work)

- **TypeScript `providerOptions` key mismatch**: mesh was setting `providerOptions: { gemini: ... }` but Vercel AI SDK parses options under provider's own SDK key (`google` for `@ai-sdk/google`, `vertex` for `@ai-sdk/google-vertex`). New `PROVIDER_OPTIONS_KEY` map fixes for all vendors. Note: this activates a previously-dead code path for Gemini AI Studio's no-tools structured output (responseFormat now actually applied).
- **Java `GeminiHandler` ClassCastException**: `generateWithToolsNoExecute` hardcoded `GoogleGenAiChatOptions`, would throw `ClassCastException` when the underlying ChatModel is `VertexAiGeminiChatModel`. New `buildToolNoExecuteOptions` helper branches via reflection so AI-Studio-only consumers (who don't pull in Vertex) don't get NoClassDefFoundError when the helper is invoked. Reflection-based class lookup pattern is documented in javadoc.

### Examples + Tests

- 3 reference example agents (`examples/{python,typescript,java}/vertex-ai-agent/`), all live-tested end-to-end against a real Vertex AI project (gemini-2.0-flash, gcloud user ADC + project/location)
- 3 tsuite integration tests (`tc34_vertex_provider_py`, `tc35_vertex_provider_ts`, `tc36_vertex_provider_java`) — all green against tsuite secrets in DB
- New unit tests: 12 Python (provider_handler_registry alias coverage), 6 TS (providerOptionsKey mapping), 3 TS (media-resolver vertex_ai paths), 2 Java (GeminiHandler.buildToolNoExecuteOptions branching)

### Docs

- 5 mkdocs pages: env-vars + per-runtime LLM integration pages updated with per-runtime Vertex AI setup section, when-to-use, and switching-from-AI-Studio recipes
- 4 meshctl man pages: matching coverage in `llm.md`, `llm_typescript.md`, `llm_java.md`, `environment.md`
- Replaced inaccurate `GOOGLE_PROJECT_ID` line that was speculatively documented for Java Vertex but never read by Spring AI; replaced with correct `SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID` (Spring Boot relaxed-binding form)

## Review notes

Independent review surfaced 2 BLOCKERs + 6 WARNINGs. All addressed in commit `88ecf80b`:

- **BLOCKER (Java NoClassDefFoundError)**: `GeminiHandler` had direct `instanceof VertexAiGeminiChatModel` check that would crash AI-Studio-only consumers. Fixed via reflection-based class lookup + isolated builder method (JVM lazy class resolution makes this safe). Design rationale documented in javadoc.
- **BLOCKER (docs typo)**: Python LLM page's "switching backends" snippet showed the OLD model string as active. Fixed.
- **WARNING (media resolver vendor maps)**: `vertex_ai` was missing from `VENDOR_FORMATTERS`, the PDF branch, and `TOOL_IMAGE_UNSUPPORTED_VENDORS` in both Python and TS. Vertex agents handling PDFs would get the OpenAI fallback. Fixed; 3 new TS resolver tests cover the paths.
- **WARNING (lockfile drift)**: investigated; benign. `fastmcp ^3.34.0`, `mcp-proxy 6.4.4`, SDK version `1.3.4` were declared in earlier merged commits (PR #738/#740 and release commits); the lockfile was stale and the `npm install` for this PR caught up several previously-deferred resolutions in addition to adding `@ai-sdk/google-vertex`.
- Other WARNINGs (Gemini providerOptions latent fix activates a dead path; handler `vendor` field reports `"google"` for vertex_ai) — acknowledged as pre-existing patterns / intentional behavior changes worth release-noting; no code changes.

Closes #816

## Test plan

- [x] Python: live-tested against Vertex AI (eng-cache-151909 project), structured output via `vertex_ai/gemini-2.0-flash` returns correct JSON
- [x] TypeScript: same — `@ai-sdk/google-vertex` provider routing confirmed via `google.vertex` log marker
- [x] Java: same — `mode=direct:vertex_ai` registration log confirms vertex_ai routing (not AI Studio fallback)
- [x] tsuite tc34 + tc35 + tc36 all green against tsuite secrets in DB
- [x] 561 Python unit tests pass; 384 TS unit tests pass; 120 Java tests pass
- [x] Existing AI Studio (`gemini/*`) path unaffected — verified no regressions in registry caching, handler selection, or media resolver behavior
- [ ] Reviewer should sanity-check the Java reflection pattern compiles + works under both classpath conditions (with and without spring-ai-vertex-ai-gemini)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Google Cloud Vertex AI as an LLM provider with Gemini model access
  * Support available across Python, TypeScript, and Java runtimes
  * Authentication via Google Cloud IAM (Application Default Credentials)
  * Optional `google-auth` dependency for Python runtime

* **Documentation**
  * Comprehensive Vertex AI setup guides for all runtimes
  * Environment variables and configuration examples added
  * Migration guides from AI Studio to Vertex AI

* **Examples**
  * New Vertex AI agent examples for Python, TypeScript, and Java

* **Tests**
  * Added integration tests for Vertex AI provider across all runtimes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->