### PR TITLE
fix(java): auto-rebuild Rust FFI dylib in mcp-mesh-native local mvn install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,6 +405,7 @@ jobs:
         run: |
           cd src/runtime/java
           mvn clean verify -DskipTests \
+            -Dskip.rust.build=true \
             -Dgpg.skip=false \
             -Dgpg.passphrase="" \
             -Dgpg.keyname="F94266795DCA259D!"

--- a/src/runtime/java/mcp-mesh-native/pom.xml
+++ b/src/runtime/java/mcp-mesh-native/pom.xml
@@ -23,6 +23,11 @@
         <developerConnection>scm:git:git@github.com:dhyansraj/mcp-mesh.git</developerConnection>
     </scm>
 
+    <properties>
+        <skip.rust.build>false</skip.rust.build>
+        <cargo.executable>cargo</cargo.executable>
+    </properties>
+
     <!--
     This module bundles the native libraries for all supported platforms.
     The libraries are located in src/main/resources/META-INF/native/{classifier}/:
@@ -42,6 +47,103 @@
                 </includes>
             </resource>
         </resources>
+
+        <!--
+        Local-build only: rebuild the Rust FFI dylib for the host classifier and
+        copy it into src/main/resources/META-INF/native/${native.classifier}/ so the
+        packaged jar always contains a fresh native library matching current source.
+        Requires `cargo` toolchain on PATH for local builds; CI sets
+        -Dskip.rust.build=true since matrix jobs supply prebuilt cross-platform libs.
+        Cross-compile targets (e.g. linux on macOS) require `rustup target add <triple>` first.
+        -->
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-native-properties</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skip.rust.build}</skip>
+                            <rules>
+                                <requireProperty>
+                                    <property>native.classifier</property>
+                                    <message>Unsupported host platform for local Rust build (os.name=${os.name}, os.arch=${os.arch}). Set -Dskip.rust.build=true to skip the local rebuild and use the existing META-INF/native/ contents.</message>
+                                </requireProperty>
+                                <requireProperty>
+                                    <property>native.lib-name</property>
+                                    <message>Unsupported host platform for local Rust build (os.name=${os.name}, os.arch=${os.arch}). Set -Dskip.rust.build=true to skip the local rebuild and use the existing META-INF/native/ contents.</message>
+                                </requireProperty>
+                                <requireProperty>
+                                    <property>rust.target</property>
+                                    <message>Unsupported host platform for local Rust build (os.name=${os.name}, os.arch=${os.arch}). Set -Dskip.rust.build=true to skip the local rebuild and use the existing META-INF/native/ contents.</message>
+                                </requireProperty>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>build-rust-ffi</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skip.rust.build}</skip>
+                            <executable>${cargo.executable}</executable>
+                            <workingDirectory>${project.basedir}/../../core</workingDirectory>
+                            <arguments>
+                                <argument>build</argument>
+                                <argument>--release</argument>
+                                <argument>--target</argument>
+                                <argument>${rust.target}</argument>
+                                <argument>--features</argument>
+                                <argument>ffi</argument>
+                                <argument>--no-default-features</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-native-lib</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skip.rust.build}</skip>
+                            <outputDirectory>${project.basedir}/src/main/resources/META-INF/native/${native.classifier}</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/../../core/target/${rust.target}/release</directory>
+                                    <includes>
+                                        <include>${native.lib-name}</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>
@@ -56,6 +158,8 @@
             </activation>
             <properties>
                 <native.classifier>osx-aarch_64</native.classifier>
+                <native.lib-name>libmcp_mesh_core.dylib</native.lib-name>
+                <rust.target>aarch64-apple-darwin</rust.target>
             </properties>
         </profile>
         <profile>
@@ -68,30 +172,50 @@
             </activation>
             <properties>
                 <native.classifier>osx-x86_64</native.classifier>
+                <native.lib-name>libmcp_mesh_core.dylib</native.lib-name>
+                <rust.target>x86_64-apple-darwin</rust.target>
             </properties>
         </profile>
         <profile>
             <id>native-linux-x86_64</id>
             <activation>
                 <os>
-                    <family>unix</family>
+                    <name>Linux</name>
                     <arch>amd64</arch>
                 </os>
             </activation>
             <properties>
                 <native.classifier>linux-x86_64</native.classifier>
+                <native.lib-name>libmcp_mesh_core.so</native.lib-name>
+                <rust.target>x86_64-unknown-linux-gnu</rust.target>
             </properties>
         </profile>
         <profile>
             <id>native-linux-aarch_64</id>
             <activation>
                 <os>
-                    <family>unix</family>
+                    <name>Linux</name>
                     <arch>aarch64</arch>
                 </os>
             </activation>
             <properties>
                 <native.classifier>linux-aarch_64</native.classifier>
+                <native.lib-name>libmcp_mesh_core.so</native.lib-name>
+                <rust.target>aarch64-unknown-linux-gnu</rust.target>
+            </properties>
+        </profile>
+        <profile>
+            <id>native-windows-x86_64</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                    <arch>amd64</arch>
+                </os>
+            </activation>
+            <properties>
+                <native.classifier>windows-x86_64</native.classifier>
+                <native.lib-name>mcp_mesh_core.dll</native.lib-name>
+                <rust.target>x86_64-pc-windows-msvc</rust.target>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
## Summary

Local `cd src/runtime/java && mvn install` now rebuilds the Rust FFI dylib for the host platform and packages it into the `mcp-mesh-native` jar, so the artifact in your local Maven repo always matches current source. Previously, the module bundled whatever stale (or empty) dylib happened to be in `META-INF/native/` — leading to `UnsatisfiedLinkError` on fresh clones and silent ABI mismatches after Rust source edits (we hit this during the #816 vertex-ai work, where the bundled dylib was missing `mesh_get_tls_config`).

**Production unaffected.** CI release workflow passes `-Dskip.rust.build=true` so the matrix-built fat-jar layout (4 cross-compiled dylibs pre-staged before `mvn install`) is preserved unchanged.

### Changes
- `mcp-mesh-native/pom.xml`:
  - `exec-maven-plugin` runs `cargo build --release --target <triple> --features ffi --no-default-features` in `generate-resources` phase
  - `maven-resources-plugin` copies the built lib into `META-INF/native/<classifier>/` so `default-resources` sees a fresh file before packaging
  - `maven-enforcer-plugin` fails the build with a clear message if the host platform doesn't match a supported profile (instead of silently producing a directory literally named `${native.classifier}`)
  - Per-OS profiles now declare both `<native.lib-name>` and `<rust.target>` so cargo writes to a known `target/<triple>/release/` path even when the developer has `CARGO_BUILD_TARGET` set globally
  - Tightened Linux activation from `<family>unix</family>` to `<name>Linux</name>` (the previous setting also matched macOS, leaving `native.classifier` ambiguous on Apple Silicon — harmless before, but the new copy step consumes the property)
  - Added `windows-x86_64` profile for Windows local devs
- `.github/workflows/release.yml`: pass `-Dskip.rust.build=true` to `mvn clean verify`

## Review Notes

Caught and addressed during code review:
- **BLOCKER fix**: enforcer rules guarantee unsupported hosts fail-fast with a helpful message + a hint to use `-Dskip.rust.build=true`.
- **Cross-compile fix**: explicit `--target <triple>` makes the build immune to dev-set `CARGO_BUILD_TARGET` / `~/.cargo/config.toml` `[build] target = ...` overrides.

Closes #823

## Test plan

- [x] Local `mvn -pl mcp-mesh-native -am clean install -DskipTests -Dgpg.skip=true`: cargo runs with `--target aarch64-apple-darwin`, dylib refreshed in source tree, packaged jar contains it (5.8 MB, fresh)
- [x] Local with `-Dskip.rust.build=true`: enforcer + cargo + copy all skipped, build succeeds, jar packages whatever was already in `META-INF/native/`
- [x] Enforcer triggers correctly when no OS profile matches: clear message including `os.name` / `os.arch` + the skip-flag hint
- [ ] CI release pipeline (will validate on next release tag): matrix-built fat jar layout preserved, no host-rebuild interference
- [ ] Windows local dev with `cargo` installed (not yet verified — no Windows env handy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced native library build configuration and cross-platform packaging support for macOS, Linux, and Windows x86_64
  * Implemented configurable build optimization options for SDK publishing workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->