### PR TITLE
fix(release): drop TS SDK package-lock before npm install (unblock v1.4.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -761,6 +761,12 @@ jobs:
           # Update @mcpmesh/core dependency from file: to npm version
           sed -i 's|"@mcpmesh/core": "file:../core/typescript"|"@mcpmesh/core": "'"${VERSION}"'"|' package.json
 
+          # Drop the committed lockfile so npm install resolves @mcpmesh/core from
+          # the updated package.json (registry) instead of honoring the lockfile's
+          # `file:../core/typescript` link, which in CI points at an empty dir
+          # (build artifacts are gitignored). See #830 for the failure trace.
+          rm -f package-lock.json
+
           echo "Updated package.json:"
           cat package.json
 


### PR DESCRIPTION
## Summary

One-line workflow fix to unblock the v1.4.0 release. The \`publish-typescript-sdk\` job has been failing because \`npm install\` honored \`src/runtime/typescript/package-lock.json\`'s \`@mcpmesh/core\` file-link entry (pointing at \`../core/typescript/\`) instead of fetching from the registry per the sed-modified \`package.json\`. In CI the link target only contains \`package.json\` and \`package-lock.json\` (the JS/TS/native binaries are gitignored), so tsc then fails with \"Cannot find module '@mcpmesh/core'\".

Adding \`rm -f package-lock.json\` between the sed step and \`npm install\` forces npm to resolve purely from the modified \`package.json\`. Verified locally:
- Before fix: \`node_modules/@mcpmesh/core/\` has only \`package.json\` + \`package-lock.json\`, tsc fails
- After fix: \`node_modules/@mcpmesh/core/\` has \`index.js\`, \`index.d.ts\`, all \`*.node\` binaries, tsc passes

## Why v1.3.4 worked but v1.4.0 doesn't

v1.3.4's lockfile had the linked entry pinned at version \`0.9.0\`. The sed bumped to \`1.3.4\` and npm noticed the big version delta, reconciled by fetching from the registry. PR #824 (Vertex AI) regenerated the lockfile during local development, leaving the linked entry at \`1.3.4\`. The \`1.3.4 → 1.4.0\` delta is too small to trigger npm's reconcile heuristic, so it sticks with the file-link resolution. Hence the regression.

## Recovery plan after merge

\`\`\`
gh workflow run release.yml -f version=v1.4.0 -f environment=production
\`\`\`

The \`workflow_dispatch\` run uses main's updated workflow definition. Already-published artifacts (npm \`@mcpmesh/core@1.4.0\`, PyPI \`mcp-mesh@1.4.0\`, PyPI \`mcp-mesh-core@1.4.0\`, Maven Central Java SDK at \`1.4.0\`) will either no-op (\`skip-existing: true\`) or fail-on-duplicate (Maven). The missing artifacts (\`@mcpmesh/sdk@1.4.0\`, all Docker images) will publish.

Closes #830

## Test plan

- [x] Reproduced the failure locally with current main's workflow steps
- [x] Confirmed fix locally: \`rm -f package-lock.json\` + \`npm install\` → \`@mcpmesh/core\` resolves from registry, all binaries present
- [ ] Merge + workflow_dispatch v1.4.0 + verify publish-typescript-sdk + build-docker complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to ensure proper dependency resolution during the TypeScript SDK publish process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->