### PR TITLE
Registry sweep job: purge stale agents and old events

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -188,6 +188,29 @@ export HEALTH_CHECK_INTERVAL=10
 export DEFAULT_EVICTION_THRESHOLD=60
 ```
 
+### Registry Sweep / Retention
+
+```bash
+# How long unhealthy/unknown agents are kept in the registry before the
+# sweep job purges them. Go duration string (e.g. "30m", "2h", "48h").
+# Default: 1h. Set to "0" to disable the sweep entirely (forensic mode —
+# keeps all rows). Affects both `meshctl list` (purged agents disappear
+# from output) and the underlying RegistryEvent table (event rows are
+# governed by a separate hardcoded 100,000 rolling cap, not by this
+# variable).
+export MCP_MESH_RETENTION=1h
+```
+
+**Notes:**
+
+- The sweep runs on a hardcoded 5-minute interval, so actual purge can
+  lag retention by up to ~5 minutes.
+- Setting `MCP_MESH_RETENTION` shorter than 5m (e.g. `1m`) will not
+  speed up the purge cadence — it only affects when an agent becomes
+  eligible for purge.
+- Hardcoded internal constants: sweep interval = 5m, event hard cap =
+  100,000 rows.
+
 ### Cache and Performance
 
 ```bash

--- a/src/core/cli/list.go
+++ b/src/core/cli/list.go
@@ -42,7 +42,7 @@ Shows agent status, dependency resolution, uptime, and endpoint information
 in a docker-compose-style format for easy monitoring.
 
 By default, only healthy agents are shown. Use --all to see all agents
-including unhealthy/expired ones.
+including unhealthy ones (purged after MCP_MESH_RETENTION, default 1h).
 
 Examples:
   meshctl list                                    # Show healthy agents only (default)
@@ -72,7 +72,7 @@ Tools listing:
 
 	// New enhanced filtering and display options
 	cmd.Flags().String("since", "", "Show agents active since duration (e.g., 1h, 30m, 24h)")
-	cmd.Flags().Bool("all", false, "Show all agents including unhealthy/expired (default: healthy only)")
+	cmd.Flags().Bool("all", false, "Show all agents including unhealthy (default: healthy only)")
 
 	// Tools listing - use --tools to list all, --tools=<name> for specific tool details
 	cmd.Flags().StringP("tools", "t", "", "List tools: use --tools or -t to list all, --tools=<tool> for details")
@@ -111,28 +111,28 @@ type RegistryStatus struct {
 
 // EnhancedAgent contains comprehensive agent information for display
 type EnhancedAgent struct {
-	ID                       string                   `json:"id"`
-	Name                     string                   `json:"name"`
-	AgentType                string                   `json:"agent_type"`
-	Status                   string                   `json:"status"`
-	Runtime                  string                   `json:"runtime,omitempty"`
-	Endpoint                 string                   `json:"endpoint"`
-	Tools                    []ToolInfo               `json:"tools"`
-	Dependencies             []Dependency             `json:"dependencies"`
-	DependencyResolutions    []DependencyResolution   `json:"dependency_resolutions,omitempty"`
-	LLMToolResolutions       []LLMToolResolution      `json:"llm_tool_resolutions,omitempty"`
-	LLMProviderResolutions   []LLMProviderResolution  `json:"llm_provider_resolutions,omitempty"`
-	DependenciesResolved     int                      `json:"dependencies_resolved"`
-	DependenciesTotal        int                      `json:"dependencies_total"`
-	LastHeartbeat            *time.Time               `json:"last_heartbeat,omitempty"`
-	CreatedAt                time.Time                `json:"created_at"`
-	UpdatedAt                time.Time                `json:"updated_at"`
-	Version                  string                   `json:"version,omitempty"`
-	PID                      int                      `json:"pid,omitempty"`
-	FilePath                 string                   `json:"file_path,omitempty"`
-	StartTime                time.Time                `json:"start_time,omitempty"`
-	Config                   map[string]interface{}   `json:"config,omitempty"`
-	Labels                   map[string]interface{}   `json:"labels,omitempty"`
+	ID                     string                  `json:"id"`
+	Name                   string                  `json:"name"`
+	AgentType              string                  `json:"agent_type"`
+	Status                 string                  `json:"status"`
+	Runtime                string                  `json:"runtime,omitempty"`
+	Endpoint               string                  `json:"endpoint"`
+	Tools                  []ToolInfo              `json:"tools"`
+	Dependencies           []Dependency            `json:"dependencies"`
+	DependencyResolutions  []DependencyResolution  `json:"dependency_resolutions,omitempty"`
+	LLMToolResolutions     []LLMToolResolution     `json:"llm_tool_resolutions,omitempty"`
+	LLMProviderResolutions []LLMProviderResolution `json:"llm_provider_resolutions,omitempty"`
+	DependenciesResolved   int                     `json:"dependencies_resolved"`
+	DependenciesTotal      int                     `json:"dependencies_total"`
+	LastHeartbeat          *time.Time              `json:"last_heartbeat,omitempty"`
+	CreatedAt              time.Time               `json:"created_at"`
+	UpdatedAt              time.Time               `json:"updated_at"`
+	Version                string                  `json:"version,omitempty"`
+	PID                    int                     `json:"pid,omitempty"`
+	FilePath               string                  `json:"file_path,omitempty"`
+	StartTime              time.Time               `json:"start_time,omitempty"`
+	Config                 map[string]interface{}  `json:"config,omitempty"`
+	Labels                 map[string]interface{}  `json:"labels,omitempty"`
 }
 
 // ToolFilter represents a single filter specification for matching tools
@@ -354,17 +354,17 @@ func getRegistryStatus(registryURL string) RegistryStatus {
 
 // AgentInfoAPI represents the agent structure returned by the registry API
 type AgentInfoAPI struct {
-	ID                   string      `json:"id"`
-	Name                 string      `json:"name"`
-	AgentType            string      `json:"agent_type"`
-	Status               string      `json:"status"`
-	Runtime              *string     `json:"runtime,omitempty"`
-	Endpoint             string      `json:"endpoint"`
-	Version              *string     `json:"version,omitempty"`
-	CreatedAt            *time.Time  `json:"created_at,omitempty"`
-	LastSeen             *time.Time  `json:"last_seen,omitempty"`
-	TotalDependencies    int         `json:"total_dependencies"`
-	DependenciesResolved int         `json:"dependencies_resolved"`
+	ID                   string     `json:"id"`
+	Name                 string     `json:"name"`
+	AgentType            string     `json:"agent_type"`
+	Status               string     `json:"status"`
+	Runtime              *string    `json:"runtime,omitempty"`
+	Endpoint             string     `json:"endpoint"`
+	Version              *string    `json:"version,omitempty"`
+	CreatedAt            *time.Time `json:"created_at,omitempty"`
+	LastSeen             *time.Time `json:"last_seen,omitempty"`
+	TotalDependencies    int        `json:"total_dependencies"`
+	DependenciesResolved int        `json:"dependencies_resolved"`
 	Capabilities         []struct {
 		Name         string         `json:"name"`
 		Version      string         `json:"version"`
@@ -544,12 +544,12 @@ func getDetailedAgents(registryURL string) ([]map[string]interface{}, error) {
 			llmProviderRes := make([]interface{}, len(agent.LLMProviderResolutions))
 			for j, res := range agent.LLMProviderResolutions {
 				resMap := map[string]interface{}{
-					"function_name":     res.ConsumerFunctionName,
+					"function_name":       res.ConsumerFunctionName,
 					"required_capability": res.RequiredCapability,
-					"provider_agent_id": res.ProviderAgentID,
-					"mcp_tool":          res.ProviderFunctionName,
-					"endpoint":          res.Endpoint,
-					"status":            res.Status,
+					"provider_agent_id":   res.ProviderAgentID,
+					"mcp_tool":            res.ProviderFunctionName,
+					"endpoint":            res.Endpoint,
+					"status":              res.Status,
 				}
 				if len(res.RequiredTags) > 0 {
 					resMap["required_tags"] = res.RequiredTags
@@ -629,8 +629,8 @@ func processAgentData(data map[string]interface{}) EnhancedAgent {
 		for _, cap := range capabilities {
 			if capMap, ok := cap.(map[string]interface{}); ok {
 				tool := ToolInfo{
-					Name:         getString(capMap, "name"),        // capability name from API
-					Capability:   getString(capMap, "name"),        // same as name
+					Name:         getString(capMap, "name"), // capability name from API
+					Capability:   getString(capMap, "name"), // same as name
 					FunctionName: getString(capMap, "function_name"),
 					Version:      getString(capMap, "version"),
 				}
@@ -1016,7 +1016,7 @@ func showRegistryStatus(registry RegistryStatus) {
 		// Show healthy/unhealthy breakdown
 		fmt.Printf(" - %s%d healthy%s", colorGreen, registry.HealthyCount, colorReset)
 		if registry.UnhealthyCount > 0 {
-			fmt.Printf(", %s%d unhealthy/expired%s", colorGray, registry.UnhealthyCount, colorReset)
+			fmt.Printf(", %s%d unhealthy%s", colorGray, registry.UnhealthyCount, colorReset)
 		}
 	}
 
@@ -1046,7 +1046,7 @@ func formatAgentTypeDisplay(agentType string) string {
 
 // calculateColumnWidths determines optimal column widths for table alignment
 func calculateColumnWidths(agents []EnhancedAgent, wide bool) (nameWidth, runtimeWidth, statusWidth, typeWidth, endpointWidth int) {
-	nameWidth = 15 // minimum width
+	nameWidth = 15    // minimum width
 	runtimeWidth = 12 // minimum width for "RUNTIME" header + padding (TypeScript = 10 chars)
 	statusWidth = 10
 	typeWidth = 5 // minimum width for "Type"
@@ -1240,7 +1240,7 @@ func formatDependencies(resolved, total int) string {
 	color := colorGreen
 	if resolved < total {
 		if resolved == 0 {
-			color = colorRed    // No dependencies resolved
+			color = colorRed // No dependencies resolved
 		} else {
 			color = colorYellow // Partially resolved
 		}

--- a/src/core/registry/ent_service.go
+++ b/src/core/registry/ent_service.go
@@ -1954,6 +1954,13 @@ func (s *EntService) markAgentStaleAttempt(ctx context.Context, staleAgent *ent.
 
 	// Optimistic conditional update - only update if agent hasn't changed since we queried it.
 	// This prevents overwriting a concurrent heartbeat that may have updated the agent.
+	//
+	// We deliberately do NOT bump UpdatedAt here: that field is the agent's
+	// last-heartbeat timestamp from the sweep job's perspective
+	// (purgeStaleAgents filters on UpdatedAtLT(now-retention)). Bumping it
+	// would make every just-marked-stale agent survive the immediate sweep
+	// tick even if it had been silent for hours/days. The status change is
+	// still recorded via the RegistryEvent below, which uses `now`.
 	affected, err := tx.Agent.
 		Update().
 		Where(
@@ -1962,7 +1969,6 @@ func (s *EntService) markAgentStaleAttempt(ctx context.Context, staleAgent *ent.
 			agent.StatusEQ(staleAgent.Status),
 		).
 		SetStatus(agent.StatusUnhealthy).
-		SetUpdatedAt(now).
 		Save(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to update agent: %w", err)

--- a/src/core/registry/ent_service.go
+++ b/src/core/registry/ent_service.go
@@ -36,8 +36,8 @@ var ErrEntityIDMismatch = errors.New("entity_id mismatch")
 // Replaces the old database.Dependency from GORM models
 type Dependency struct {
 	Capability      string     `json:"capability"`
-	Version         string     `json:"version,omitempty"`         // e.g., ">=1.0.0"
-	Tags            []string   `json:"tags,omitempty"`            // e.g., ["production", "US_EAST"]
+	Version         string     `json:"version,omitempty"`          // e.g., ">=1.0.0"
+	Tags            []string   `json:"tags,omitempty"`             // e.g., ["production", "US_EAST"]
 	TagAlternatives [][]string `json:"tag_alternatives,omitempty"` // OR alternatives, e.g., [["python", "typescript"]]
 }
 
@@ -47,9 +47,9 @@ type RegistryConfig struct {
 	DefaultTimeoutThreshold  int
 	DefaultEvictionThreshold int
 	HealthCheckInterval      int
-	StartupCleanupThreshold  int  // Threshold in seconds for marking stale agents on startup (default: 30)
+	StartupCleanupThreshold  int // Threshold in seconds for marking stale agents on startup (default: 30)
 	EnableResponseCache      bool
-	TracingEnabled           bool // Enable distributed tracing
+	TracingEnabled           bool   // Enable distributed tracing
 	TlsMode                  string // "off", "auto", "strict" — from MCP_MESH_TLS_MODE
 	TrustBackend             string // comma-separated backend names — from MCP_MESH_TRUST_BACKEND
 	TlsCertFile              string // registry server cert — from MCP_MESH_TLS_CERT
@@ -103,7 +103,7 @@ type DependencyResolution struct {
 // e.g., tags: ["addition", ["python", "typescript"]] means addition AND (python OR typescript)
 type DependencySpec struct {
 	Capability      string     `json:"capability"`
-	Tags            []string   `json:"tags,omitempty"`            // Simple required tags
+	Tags            []string   `json:"tags,omitempty"`             // Simple required tags
 	TagAlternatives [][]string `json:"tag_alternatives,omitempty"` // OR alternatives (each inner array is an OR group)
 	Version         string     `json:"version,omitempty"`
 	Namespace       string     `json:"namespace,omitempty"`
@@ -694,16 +694,39 @@ func (s *EntService) StoreDependencyResolutions(
 	return nil
 }
 
-// UpdateDependencyStatusOnAgentOffline marks all dependencies provided by an agent as unavailable
+// UpdateDependencyStatusOnAgentOffline marks all resolutions provided by an
+// agent as unavailable. This covers all three resolution tables that hold a
+// nullable provider_agent_id with OnDelete: SetNull:
+//   - dependency_resolution    (@mesh.tool deps)
+//   - llm_tool_resolution      (@mesh.llm tool filter)
+//   - llm_provider_resolution  (@mesh.llm provider config)
+//
+// All three need to be flipped together when an agent goes offline so that
+// consumer-side state stays consistent before the FK-driven SetNull leaves
+// the rows dangling with status=available.
 func (s *EntService) UpdateDependencyStatusOnAgentOffline(ctx context.Context, agentID string) error {
-	_, err := s.entDB.DependencyResolution.Update().
+	if _, err := s.entDB.DependencyResolution.Update().
 		Where(dependencyresolution.ProviderAgentIDEQ(agentID)).
 		SetStatus(dependencyresolution.StatusUnavailable).
 		ClearResolvedAt().
-		Save(ctx)
-
-	if err != nil {
+		Save(ctx); err != nil {
 		return fmt.Errorf("failed to update dependency status: %w", err)
+	}
+
+	if _, err := s.entDB.LLMToolResolution.Update().
+		Where(llmtoolresolution.ProviderAgentIDEQ(agentID)).
+		SetStatus(llmtoolresolution.StatusUnavailable).
+		ClearResolvedAt().
+		Save(ctx); err != nil {
+		return fmt.Errorf("failed to update llm tool resolution status: %w", err)
+	}
+
+	if _, err := s.entDB.LLMProviderResolution.Update().
+		Where(llmproviderresolution.ProviderAgentIDEQ(agentID)).
+		SetStatus(llmproviderresolution.StatusUnavailable).
+		ClearResolvedAt().
+		Save(ctx); err != nil {
+		return fmt.Errorf("failed to update llm provider resolution status: %w", err)
 	}
 
 	s.logger.Info("Updated dependency status for offline agent %s", agentID)
@@ -1015,7 +1038,7 @@ func (s *EntService) UpdateHeartbeat(req *HeartbeatRequest) (*HeartbeatResponse,
 					}
 					return &HeartbeatResponse{
 						Status:    "error",
-						Timestamp:    now.Format(time.RFC3339),
+						Timestamp: now.Format(time.RFC3339),
 						Message:   err.Error(),
 					}, nil
 				}
@@ -1556,8 +1579,8 @@ func (s *EntService) Health() map[string]interface{} {
 	}
 
 	return map[string]interface{}{
-		"status":        "healthy",
-		"service":       "mcp-mesh-registry",
+		"status":  "healthy",
+		"service": "mcp-mesh-registry",
 		"database_type": func() string {
 			if s.entDB.IsPostgreSQL() {
 				return "postgresql"

--- a/src/core/registry/integration_test.go
+++ b/src/core/registry/integration_test.go
@@ -212,3 +212,67 @@ func TestEntServiceStatusChangeIntegration(t *testing.T) {
 
 	t.Logf("Integration test completed successfully with %d status change events", hookEvents)
 }
+
+// TestSweepJobIntegration exercises the sweep job end-to-end against a real
+// EntService: register an agent via the public API, force its updated_at and
+// status to look stale, run one sweep tick, and verify ListAgents no longer
+// returns it.
+func TestSweepJobIntegration(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:sweep_integration?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	testConfig := &config.Config{LogLevel: "INFO"}
+	testLogger := logger.New(testConfig)
+	entDB := &database.EntDatabase{Client: client}
+	service := NewEntService(entDB, nil, testLogger)
+
+	ctx := context.Background()
+
+	registerReq := &AgentRegistrationRequest{
+		AgentID:   "sweep-target",
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Metadata: map[string]interface{}{
+			"agent_type": "mcp_agent",
+			"name":       "sweep-target",
+			"version":    "1.0.0",
+		},
+	}
+	if _, err := service.RegisterAgent(registerReq); err != nil {
+		t.Fatalf("Failed to register agent: %v", err)
+	}
+
+	// Force the agent into a stale unhealthy state: timestamp > AgentRetention
+	// in the past, status=unhealthy. This mimics a real-world agent whose
+	// heartbeat stopped over an hour ago and was already flagged by the
+	// health monitor.
+	twoHoursAgo := time.Now().UTC().Add(-2 * time.Hour)
+	if _, err := entDB.Client.Agent.UpdateOneID("sweep-target").
+		SetStatus(agent.StatusUnhealthy).
+		SetUpdatedAt(twoHoursAgo).
+		Save(ctx); err != nil {
+		t.Fatalf("Failed to force stale state: %v", err)
+	}
+
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	job := NewSweepJob(cfg, entDB, service, testLogger)
+
+	purgedAgents, _, err := job.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if purgedAgents != 1 {
+		t.Errorf("expected 1 agent purged, got %d", purgedAgents)
+	}
+
+	// Sanity-check via the public ListAgents API: the agent must be gone
+	// from both the default (healthy-only) and unfiltered views.
+	resp, err := service.ListAgents(&AgentQueryParams{})
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	for _, a := range resp.Agents {
+		if a.Id == "sweep-target" {
+			t.Errorf("sweep-target still present in ListAgents after purge")
+		}
+	}
+}

--- a/src/core/registry/server.go
+++ b/src/core/registry/server.go
@@ -28,6 +28,7 @@ type Server struct {
 	startTime      time.Time
 	handlers       *EntBusinessLogicHandlers
 	healthMonitor  *AgentHealthMonitor
+	sweepJob       *SweepJob
 	tracingManager *tracing.TracingManager
 	trustChain     *trust.TrustChain
 	logger         *logger.Logger
@@ -45,6 +46,10 @@ func NewServer(entDB *database.EntDatabase, config *RegistryConfig, logger *logg
 	heartbeatTimeout := time.Duration(config.DefaultTimeoutThreshold) * time.Second
 	checkInterval := time.Duration(config.HealthCheckInterval) * time.Second
 	healthMonitor := NewAgentHealthMonitor(entService, logger, heartbeatTimeout, checkInterval)
+
+	// Create sweep job (issue #835): purge stale agents and old registry events.
+	sweepCfg := LoadSweepConfigFromEnv(logger)
+	sweepJob := NewSweepJob(sweepCfg, entDB, entService, logger)
 
 	// Initialize distributed tracing if enabled
 	var tracingManager *tracing.TracingManager
@@ -92,6 +97,7 @@ func NewServer(entDB *database.EntDatabase, config *RegistryConfig, logger *logg
 		startTime:      time.Now().UTC(),
 		handlers:       handlers,
 		healthMonitor:  healthMonitor,
+		sweepJob:       sweepJob,
 		tracingManager: tracingManager,
 		trustChain:     trustChain,
 		logger:         logger,
@@ -119,6 +125,11 @@ func (s *Server) Run(addr string) error {
 
 	// Start health monitor
 	s.healthMonitor.Start()
+
+	// Start sweep job (issue #835)
+	if s.sweepJob != nil {
+		s.sweepJob.Start(context.Background())
+	}
 
 	// Start distributed tracing if enabled
 	if s.tracingManager != nil {
@@ -152,6 +163,11 @@ func (s *Server) Start() error {
 func (s *Server) Stop() error {
 	// Stop health monitor
 	s.healthMonitor.Stop()
+
+	// Stop sweep job
+	if s.sweepJob != nil {
+		s.sweepJob.Stop()
+	}
 
 	// Stop distributed tracing if enabled
 	if s.tracingManager != nil {
@@ -249,9 +265,9 @@ func (s *Server) handleTracingStats(c *gin.Context) {
 	stats := s.tracingManager.GetStats()
 	if stats == nil {
 		c.JSON(200, map[string]interface{}{
-			"enabled": true,
+			"enabled":         true,
 			"stats_available": false,
-			"reason": "statistics collection not enabled",
+			"reason":          "statistics collection not enabled",
 		})
 		return
 	}

--- a/src/core/registry/startup_cleanup_test.go
+++ b/src/core/registry/startup_cleanup_test.go
@@ -1,0 +1,97 @@
+package registry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"mcp-mesh/src/core/config"
+	"mcp-mesh/src/core/database"
+	"mcp-mesh/src/core/ent/agent"
+	"mcp-mesh/src/core/ent/enttest"
+	"mcp-mesh/src/core/ent/registryevent"
+	"mcp-mesh/src/core/logger"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// TestCleanupStaleAgentsOnStartupPreservesUpdatedAt verifies that the startup
+// stale-agent sweep flips status to unhealthy WITHOUT bumping updated_at.
+//
+// updated_at is the agent's last-heartbeat timestamp from the periodic sweep
+// job's perspective (it filters on UpdatedAtLT(now-retention)). If startup
+// cleanup bumped updated_at, just-marked-stale agents would survive the
+// immediate sweep tick even when they had been silent for hours/days.
+func TestCleanupStaleAgentsOnStartupPreservesUpdatedAt(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:startup_cleanup_preserve?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	testLogger := logger.New(&config.Config{LogLevel: "ERROR"})
+	entDB := &database.EntDatabase{Client: client}
+	cfg := &RegistryConfig{
+		StartupCleanupThreshold: 30, // 30s
+	}
+	service := NewEntService(entDB, cfg, testLogger)
+	// Status change hooks would create extra events; we assert the
+	// markAgentStaleAttempt-emitted event explicitly below.
+	service.DisableStatusChangeHooks()
+
+	ctx := context.Background()
+
+	// Seed a healthy agent whose updated_at is 2h in the past — well beyond
+	// the 30s threshold, so it qualifies as stale on startup.
+	oldUpdatedAt := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Microsecond)
+	agentID := "stale-on-startup"
+	if _, err := client.Agent.Create().
+		SetID(agentID).
+		SetName(agentID).
+		SetAgentType(agent.AgentTypeMcpAgent).
+		SetStatus(agent.StatusHealthy).
+		SetUpdatedAt(oldUpdatedAt).
+		Save(ctx); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	// Defensive re-write of updated_at in case any default fired.
+	if _, err := client.Agent.UpdateOneID(agentID).SetUpdatedAt(oldUpdatedAt).Save(ctx); err != nil {
+		t.Fatalf("force updated_at: %v", err)
+	}
+
+	// Run the startup cleanup.
+	cleaned, err := service.CleanupStaleAgentsOnStartup(ctx)
+	if err != nil {
+		t.Fatalf("CleanupStaleAgentsOnStartup: %v", err)
+	}
+	if cleaned != 1 {
+		t.Fatalf("cleaned = %d, want 1", cleaned)
+	}
+
+	// Verify status flipped to unhealthy AND updated_at was preserved.
+	got, err := client.Agent.Get(ctx, agentID)
+	if err != nil {
+		t.Fatalf("re-fetch agent: %v", err)
+	}
+	if got.Status != agent.StatusUnhealthy {
+		t.Errorf("Status = %s, want %s", got.Status, agent.StatusUnhealthy)
+	}
+	if !got.UpdatedAt.Equal(oldUpdatedAt) {
+		t.Errorf("UpdatedAt = %s, want preserved %s (last-heartbeat semantic must survive startup cleanup)",
+			got.UpdatedAt.UTC().Format(time.RFC3339Nano),
+			oldUpdatedAt.Format(time.RFC3339Nano))
+	}
+
+	// Verify the unhealthy event was created with timestamp = now (not the
+	// preserved updated_at). It records when the cleanup happened.
+	events, err := client.RegistryEvent.Query().
+		Where(registryevent.EventTypeEQ(registryevent.EventTypeUnhealthy)).
+		All(ctx)
+	if err != nil {
+		t.Fatalf("query events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("unhealthy events = %d, want 1", len(events))
+	}
+	if !events[0].Timestamp.After(oldUpdatedAt) {
+		t.Errorf("event timestamp %s should be after preserved updated_at %s",
+			events[0].Timestamp, oldUpdatedAt)
+	}
+}

--- a/src/core/registry/sweep.go
+++ b/src/core/registry/sweep.go
@@ -38,15 +38,23 @@ type SweepConfig struct {
 //
 // Only MCP_MESH_RETENTION is honored:
 //   - unset / empty: defaults to 1h
-//   - any time.ParseDuration value (e.g. "2h", "30m"): use that value
+//   - any positive time.ParseDuration value (e.g. "2h", "30m"): use that value
 //   - "0" / "0s": disables the sweep job entirely
+//   - negative (e.g. "-1h"): warn and fall back to default (likely a typo;
+//     0 is the documented disable mechanism)
 //   - invalid: warn and fall back to default
 func LoadSweepConfigFromEnv(log *logger.Logger) SweepConfig {
 	cfg := SweepConfig{Retention: defaultRetention}
 
 	if v := os.Getenv("MCP_MESH_RETENTION"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
-			cfg.Retention = d
+			if d < 0 {
+				if log != nil {
+					log.Warning("Invalid MCP_MESH_RETENTION %q: negative durations are not allowed (use 0 to disable); using default %s", v, cfg.Retention)
+				}
+			} else {
+				cfg.Retention = d
+			}
 		} else if log != nil {
 			log.Warning("Invalid MCP_MESH_RETENTION %q, using default %s: %v", v, cfg.Retention, err)
 		}

--- a/src/core/registry/sweep.go
+++ b/src/core/registry/sweep.go
@@ -1,0 +1,381 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"mcp-mesh/src/core/database"
+	"mcp-mesh/src/core/ent"
+	"mcp-mesh/src/core/ent/agent"
+	"mcp-mesh/src/core/ent/dependencyresolution"
+	"mcp-mesh/src/core/ent/llmproviderresolution"
+	"mcp-mesh/src/core/ent/llmtoolresolution"
+	"mcp-mesh/src/core/ent/registryevent"
+	"mcp-mesh/src/core/logger"
+)
+
+// Internal sweep tunables. Operators get a single env-var knob
+// (MCP_MESH_RETENTION); these are deliberately not configurable so the
+// surface area stays small.
+const (
+	sweepInterval    = 5 * time.Minute
+	defaultRetention = 1 * time.Hour
+	eventMaxRows     = 100_000
+)
+
+// SweepConfig holds the configuration for the registry sweep job.
+//
+// Set Retention to 0 to disable the sweep entirely (forensic escape hatch:
+// no goroutine is launched, no agents or events are purged).
+type SweepConfig struct {
+	Retention time.Duration
+}
+
+// LoadSweepConfigFromEnv reads sweep configuration from the environment.
+//
+// Only MCP_MESH_RETENTION is honored:
+//   - unset / empty: defaults to 1h
+//   - any time.ParseDuration value (e.g. "2h", "30m"): use that value
+//   - "0" / "0s": disables the sweep job entirely
+//   - invalid: warn and fall back to default
+func LoadSweepConfigFromEnv(log *logger.Logger) SweepConfig {
+	cfg := SweepConfig{Retention: defaultRetention}
+
+	if v := os.Getenv("MCP_MESH_RETENTION"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.Retention = d
+		} else if log != nil {
+			log.Warning("Invalid MCP_MESH_RETENTION %q, using default %s: %v", v, cfg.Retention, err)
+		}
+	}
+
+	return cfg
+}
+
+// SweepJob purges stale agents and old registry events on a periodic timer.
+//
+// On each tick the job runs (in order):
+//  1. Purge agents in unhealthy/unknown status whose updated_at is older
+//     than Retention. Before deleting, dependency_resolution rows where
+//     the purged agent is a provider are flipped to status=unavailable so
+//     consumer-side state stays consistent.
+//  2. If the event row count exceeds the internal hard cap (100,000),
+//     delete oldest rows until back under the cap. Events are governed
+//     solely by row count, not age.
+type SweepJob struct {
+	cfg     SweepConfig
+	entDB   *database.EntDatabase
+	service *EntService
+	logger  *logger.Logger
+
+	clock        func() time.Time
+	eventMaxRows int
+
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	running bool
+}
+
+// NewSweepJob constructs a SweepJob with the given configuration.
+//
+// The clock and eventMaxRows are injectable for tests; production callers
+// should leave them unset so they default to time.Now (UTC) and the
+// internal eventMaxRows constant respectively.
+func NewSweepJob(cfg SweepConfig, entDB *database.EntDatabase, service *EntService, log *logger.Logger) *SweepJob {
+	return &SweepJob{
+		cfg:          cfg,
+		entDB:        entDB,
+		service:      service,
+		logger:       log,
+		clock:        func() time.Time { return time.Now().UTC() },
+		eventMaxRows: eventMaxRows,
+	}
+}
+
+// Start launches the sweep goroutine. It performs an initial sweep
+// immediately (catches missed sweeps after registry downtime) and then
+// runs every sweepInterval until the goroutine's context is cancelled or
+// Stop is called.
+//
+// If cfg.Retention is zero or negative the job is treated as disabled
+// and Start is a no-op.
+func (s *SweepJob) Start(ctx context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.cfg.Retention <= 0 {
+		if s.logger != nil {
+			s.logger.Info("🧹 Registry sweep job disabled (MCP_MESH_RETENTION=0)")
+		}
+		return
+	}
+	if s.running {
+		if s.logger != nil {
+			s.logger.Warning("Sweep job already running")
+		}
+		return
+	}
+
+	jobCtx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.running = true
+	s.wg.Add(1)
+
+	go func() {
+		defer s.wg.Done()
+		if s.logger != nil {
+			s.logger.Info("🧹 Starting registry sweep job (retention=%s)", s.cfg.Retention)
+		}
+
+		// Run once at startup to catch missed sweeps after downtime.
+		s.tick(jobCtx)
+
+		ticker := time.NewTicker(sweepInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				s.tick(jobCtx)
+			case <-jobCtx.Done():
+				if s.logger != nil {
+					s.logger.Info("🛑 Registry sweep job stopped")
+				}
+				return
+			}
+		}
+	}()
+}
+
+// Stop cancels the sweep goroutine and waits for the current tick to finish.
+// Safe to call even if Start was never invoked or the job is already stopped.
+func (s *SweepJob) Stop() {
+	s.mu.Lock()
+	if !s.running {
+		s.mu.Unlock()
+		return
+	}
+	s.running = false
+	cancel := s.cancel
+	s.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	s.wg.Wait()
+}
+
+// tick runs a single sweep iteration with logging. Errors are logged but
+// not surfaced; the next tick will retry.
+func (s *SweepJob) tick(ctx context.Context) {
+	start := s.clock()
+	agentsPurged, eventsPurged, err := s.runOnce(ctx)
+	took := time.Since(start)
+
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error("sweep: failed (took %s): %v", took, err)
+		}
+		return
+	}
+
+	if s.logger != nil {
+		if agentsPurged > 0 || eventsPurged > 0 {
+			s.logger.Info("sweep: purged %d agents, %d events (took %s)", agentsPurged, eventsPurged, took)
+		} else {
+			s.logger.Debug("sweep: nothing to purge (took %s)", took)
+		}
+	}
+}
+
+// runOnce performs a single sweep iteration and returns the number of
+// agents and events purged. Exported (lower-cased but callable from
+// tests in the same package) for unit tests; production callers should
+// use Start.
+func (s *SweepJob) runOnce(ctx context.Context) (agentsPurged, eventsPurged int, err error) {
+	now := s.clock()
+
+	if s.cfg.Retention > 0 {
+		n, err := s.purgeStaleAgents(ctx, now)
+		if err != nil {
+			return 0, 0, fmt.Errorf("purge stale agents: %w", err)
+		}
+		agentsPurged = n
+	}
+
+	n, err := s.enforceEventCap(ctx)
+	if err != nil {
+		return agentsPurged, 0, fmt.Errorf("enforce event cap: %w", err)
+	}
+	eventsPurged = n
+
+	return agentsPurged, eventsPurged, nil
+}
+
+// purgeStaleAgents deletes agents in unhealthy/unknown status that have
+// not heartbeated within Retention.
+//
+// For each candidate agent we first flip provider-side resolution rows
+// (dependency_resolution, llm_tool_resolution, llm_provider_resolution)
+// to status=unavailable so consumers don't see stale "available"
+// pointers, then delete the agent. The schema-level OnDelete: Cascade
+// removes capabilities, events, and consumer-side rows automatically;
+// the provider-side rows have SetNull, which is why we explicitly mark
+// them unavailable beforehand.
+//
+// The orphan-fix and delete are wrapped in a single transaction. Inside
+// the transaction we re-query the agent against the same staleness
+// predicate to detect a concurrent heartbeat that would have revived
+// it; if the predicate no longer matches we skip the row entirely (the
+// transaction commits as a no-op).
+func (s *SweepJob) purgeStaleAgents(ctx context.Context, now time.Time) (int, error) {
+	threshold := now.Add(-s.cfg.Retention)
+
+	candidates, err := s.entDB.Client.Agent.
+		Query().
+		Where(
+			agent.StatusIn(agent.StatusUnhealthy, agent.StatusUnknown),
+			agent.UpdatedAtLT(threshold),
+		).
+		All(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("query stale agents: %w", err)
+	}
+
+	if len(candidates) == 0 {
+		return 0, nil
+	}
+
+	var purged int
+	for _, a := range candidates {
+		didPurge, err := s.purgeOneAgent(ctx, a, threshold)
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Error("sweep: failed to purge agent %s: %v", a.ID, err)
+			}
+			continue
+		}
+		if didPurge {
+			purged++
+		}
+	}
+	return purged, nil
+}
+
+// purgeOneAgent runs the orphan-fix + delete pair for a single agent
+// inside a transaction. Returns (true, nil) when the agent was actually
+// deleted, (false, nil) when a concurrent heartbeat revived it (race
+// lost; no-op), or (_, err) on failure.
+//
+// The race-safety strategy: re-query the agent inside the tx using the
+// same staleness predicate as the candidate scan. If the agent no longer
+// matches (heartbeat arrived between scan and tx open), we abort early
+// and skip orphan-fix entirely. The re-query inside the tx, plus the
+// transaction's isolation, prevents the unconditional DeleteOneID below
+// from killing a freshly-healthy agent.
+func (s *SweepJob) purgeOneAgent(ctx context.Context, a *ent.Agent, threshold time.Time) (bool, error) {
+	var deleted bool
+
+	err := s.entDB.Transaction(ctx, func(tx *ent.Tx) error {
+		// Re-check staleness inside the tx. If the agent heartbeated
+		// between the candidate scan and this tx, it will no longer
+		// match the predicate and we bail out without touching deps.
+		match, err := tx.Agent.Query().
+			Where(
+				agent.IDEQ(a.ID),
+				agent.StatusIn(agent.StatusUnhealthy, agent.StatusUnknown),
+				agent.UpdatedAtLT(threshold),
+			).
+			Count(ctx)
+		if err != nil {
+			return fmt.Errorf("re-check agent %s: %w", a.ID, err)
+		}
+		if match == 0 {
+			// Race lost: agent revived. No-op, commit empty tx.
+			if s.logger != nil {
+				s.logger.Debug("sweep: skipped purge of agent %s (no longer stale)", a.ID)
+			}
+			return nil
+		}
+
+		// Orphan-fix: flip all three resolution tables before deleting.
+		// The FK is SetNull (not Cascade), so without this the rows
+		// would be left dangling with status=available and a NULL
+		// provider_agent_id after the delete.
+		if _, err := tx.DependencyResolution.Update().
+			Where(dependencyresolution.ProviderAgentIDEQ(a.ID)).
+			SetStatus(dependencyresolution.StatusUnavailable).
+			ClearResolvedAt().
+			Save(ctx); err != nil {
+			return fmt.Errorf("flip dep resolutions for %s: %w", a.ID, err)
+		}
+		if _, err := tx.LLMToolResolution.Update().
+			Where(llmtoolresolution.ProviderAgentIDEQ(a.ID)).
+			SetStatus(llmtoolresolution.StatusUnavailable).
+			ClearResolvedAt().
+			Save(ctx); err != nil {
+			return fmt.Errorf("flip llm tool resolutions for %s: %w", a.ID, err)
+		}
+		if _, err := tx.LLMProviderResolution.Update().
+			Where(llmproviderresolution.ProviderAgentIDEQ(a.ID)).
+			SetStatus(llmproviderresolution.StatusUnavailable).
+			ClearResolvedAt().
+			Save(ctx); err != nil {
+			return fmt.Errorf("flip llm provider resolutions for %s: %w", a.ID, err)
+		}
+
+		if err := tx.Agent.DeleteOneID(a.ID).Exec(ctx); err != nil {
+			return fmt.Errorf("delete agent %s: %w", a.ID, err)
+		}
+
+		deleted = true
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+
+	if deleted && s.logger != nil {
+		s.logger.Debug("sweep: purged agent %s (status=%s, last updated %s)", a.ID, a.Status, a.UpdatedAt.UTC().Format(time.RFC3339))
+	}
+	return deleted, nil
+}
+
+// enforceEventCap deletes the oldest events when the table exceeds the
+// internal hard cap (s.eventMaxRows, defaulting to the package constant).
+// Events are governed solely by row count, not age.
+func (s *SweepJob) enforceEventCap(ctx context.Context) (int, error) {
+	count, err := s.entDB.Client.RegistryEvent.Query().Count(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("count events: %w", err)
+	}
+	if count <= s.eventMaxRows {
+		return 0, nil
+	}
+
+	excess := count - s.eventMaxRows
+	oldest, err := s.entDB.Client.RegistryEvent.
+		Query().
+		Order(ent.Asc(registryevent.FieldTimestamp)).
+		Limit(excess).
+		IDs(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("select oldest events: %w", err)
+	}
+	if len(oldest) == 0 {
+		return 0, nil
+	}
+
+	n, err := s.entDB.Client.RegistryEvent.
+		Delete().
+		Where(registryevent.IDIn(oldest...)).
+		Exec(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("delete excess events: %w", err)
+	}
+	return n, nil
+}

--- a/src/core/registry/sweep_test.go
+++ b/src/core/registry/sweep_test.go
@@ -534,4 +534,16 @@ func TestLoadSweepConfigFromEnv(t *testing.T) {
 			t.Errorf("Retention with invalid value = %s, want %s (default)", cfg.Retention, defaultRetention)
 		}
 	})
+
+	t.Run("negative falls back to default", func(t *testing.T) {
+		// Negative durations parse successfully via time.ParseDuration but
+		// would silently disable sweep via the Retention<=0 check in Start().
+		// Treat them as a typo (likely meant a positive value) and keep the
+		// default; 0 remains the documented disable mechanism.
+		t.Setenv("MCP_MESH_RETENTION", "-1h")
+		cfg := LoadSweepConfigFromEnv(nil)
+		if cfg.Retention != defaultRetention {
+			t.Errorf("Retention with negative value = %s, want %s (default)", cfg.Retention, defaultRetention)
+		}
+	})
 }

--- a/src/core/registry/sweep_test.go
+++ b/src/core/registry/sweep_test.go
@@ -1,0 +1,537 @@
+package registry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"mcp-mesh/src/core/config"
+	"mcp-mesh/src/core/database"
+	"mcp-mesh/src/core/ent"
+	"mcp-mesh/src/core/ent/agent"
+	"mcp-mesh/src/core/ent/dependencyresolution"
+	"mcp-mesh/src/core/ent/enttest"
+	"mcp-mesh/src/core/ent/llmproviderresolution"
+	"mcp-mesh/src/core/ent/llmtoolresolution"
+	"mcp-mesh/src/core/ent/registryevent"
+	"mcp-mesh/src/core/logger"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// newSweepTestEnv constructs an in-memory Ent client + EntService + sweep job
+// with a mock clock fixed at `now`. The returned cleanup func closes the client.
+func newSweepTestEnv(t *testing.T, cfg SweepConfig, now time.Time) (*ent.Client, *EntService, *SweepJob, func()) {
+	t.Helper()
+
+	client := enttest.Open(t, "sqlite3", "file:sweep_"+t.Name()+"?mode=memory&cache=shared&_fk=1")
+	testLogger := logger.New(&config.Config{LogLevel: "ERROR"})
+	entDB := &database.EntDatabase{Client: client}
+	service := NewEntService(entDB, nil, testLogger)
+	// Status change hooks would create extra events on every status update we
+	// do via direct Ent calls; that pollutes the event-counts under test.
+	service.DisableStatusChangeHooks()
+
+	job := NewSweepJob(cfg, entDB, service, testLogger)
+	job.clock = func() time.Time { return now }
+
+	cleanup := func() {
+		client.Close()
+	}
+	return client, service, job, cleanup
+}
+
+// seedAgent inserts an agent directly via Ent with the requested status and
+// updated_at, bypassing RegisterAgent (which always sets updated_at = now).
+func seedAgent(t *testing.T, client *ent.Client, id string, status agent.Status, updatedAt time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := client.Agent.Create().
+		SetID(id).
+		SetName(id).
+		SetAgentType(agent.AgentTypeMcpAgent).
+		SetStatus(status).
+		SetUpdatedAt(updatedAt).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("seed agent %s: %v", id, err)
+	}
+	// SetUpdatedAt on Create is honored, but defensive: force it again via
+	// Update so the field reflects exactly what we asked for even if hooks
+	// fire. The test env disables hooks, so this is belt-and-suspenders.
+	_, err = client.Agent.UpdateOneID(id).SetUpdatedAt(updatedAt).Save(ctx)
+	if err != nil {
+		t.Fatalf("force updated_at on %s: %v", id, err)
+	}
+}
+
+func seedEvent(t *testing.T, client *ent.Client, agentID string, ts time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := client.RegistryEvent.Create().
+		SetAgentID(agentID).
+		SetEventType(registryevent.EventTypeHeartbeat).
+		SetTimestamp(ts).
+		SetData(map[string]interface{}{}).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("seed event for %s: %v", agentID, err)
+	}
+}
+
+// TestSweepStaleAgentsOnly verifies that only agents in unhealthy/unknown
+// status with updated_at older than the retention window are purged, and
+// that healthy agents (regardless of age) are left alone.
+func TestSweepStaleAgentsOnly(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	// Stale unhealthy: should be purged (2h old > 1h retention).
+	seedAgent(t, client, "stale-unhealthy", agent.StatusUnhealthy, now.Add(-2*time.Hour))
+	// Stale unknown: should also be purged.
+	seedAgent(t, client, "stale-unknown", agent.StatusUnknown, now.Add(-2*time.Hour))
+	// Healthy and old: should NOT be purged (status filter).
+	seedAgent(t, client, "old-healthy", agent.StatusHealthy, now.Add(-2*time.Hour))
+	// Recently unhealthy: should NOT be purged (updated_at within retention).
+	seedAgent(t, client, "fresh-unhealthy", agent.StatusUnhealthy, now.Add(-30*time.Minute))
+
+	purgedAgents, purgedEvents, err := job.runOnce(context.Background())
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if purgedAgents != 2 {
+		t.Errorf("expected 2 agents purged, got %d", purgedAgents)
+	}
+	if purgedEvents != 0 {
+		t.Errorf("expected 0 events purged, got %d", purgedEvents)
+	}
+
+	// Verify exactly the expected agents remain.
+	remaining, err := client.Agent.Query().IDs(context.Background())
+	if err != nil {
+		t.Fatalf("query remaining: %v", err)
+	}
+	want := map[string]bool{"old-healthy": true, "fresh-unhealthy": true}
+	if len(remaining) != len(want) {
+		t.Errorf("expected %d remaining agents, got %d (%v)", len(want), len(remaining), remaining)
+	}
+	for _, id := range remaining {
+		if !want[id] {
+			t.Errorf("unexpected agent remained: %s", id)
+		}
+	}
+}
+
+// TestSweepBoth verifies a tick that purges a stale agent and trims excess
+// events via the rolling cap in one pass.
+func TestSweepBoth(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	// One stale agent + one healthy host for events.
+	seedAgent(t, client, "host", agent.StatusHealthy, now)
+	seedAgent(t, client, "stale", agent.StatusUnhealthy, now.Add(-3*time.Hour))
+
+	// Seed events; with the production cap (100k) none of these would be
+	// trimmed, so we drop the cap for this test by manipulating the count
+	// via the rolling-cap test below. Here we just verify the agent purge
+	// happens and event purge stays at 0 because we're well under the cap.
+	seedEvent(t, client, "host", now.Add(-2*24*time.Hour))
+	seedEvent(t, client, "host", now.Add(-1*time.Minute))
+
+	purgedAgents, purgedEvents, err := job.runOnce(context.Background())
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if purgedAgents != 1 {
+		t.Errorf("expected 1 agent purged, got %d", purgedAgents)
+	}
+	if purgedEvents != 0 {
+		t.Errorf("expected 0 events purged (under cap), got %d", purgedEvents)
+	}
+}
+
+// TestSweepEventMaxRowsUnderCap verifies that nothing is purged when the
+// event row count is at or below the cap.
+func TestSweepEventMaxRowsUnderCap(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	seedAgent(t, client, "host", agent.StatusHealthy, now)
+
+	// Seed 5 events; well under the 100k cap, so nothing should be purged.
+	for i := 0; i < 5; i++ {
+		seedEvent(t, client, "host", now.Add(-time.Duration(5-i)*time.Minute))
+	}
+
+	purgedAgents, purgedEvents, err := job.runOnce(context.Background())
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if purgedAgents != 0 {
+		t.Errorf("expected 0 agents purged, got %d", purgedAgents)
+	}
+	if purgedEvents != 0 {
+		t.Errorf("expected 0 events purged (under cap), got %d", purgedEvents)
+	}
+
+	count, err := client.RegistryEvent.Query().Count(context.Background())
+	if err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if count != 5 {
+		t.Errorf("expected 5 events remaining (under cap), got %d", count)
+	}
+}
+
+// TestSweepEventMaxRowsOverCap verifies that when the event row count
+// exceeds the cap, exactly the oldest excess rows are deleted (in
+// timestamp ASC order) and the newest cap-many rows remain.
+func TestSweepEventMaxRowsOverCap(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	// Override the cap to a small number so the test can drive the
+	// over-cap branch without seeding 100k rows.
+	job.eventMaxRows = 3
+
+	seedAgent(t, client, "host", agent.StatusHealthy, now)
+
+	// Seed 5 events with strictly increasing timestamps. The 2 oldest
+	// (i=0, i=1) should be deleted; the 3 newest (i=2, i=3, i=4) remain.
+	timestamps := make([]time.Time, 5)
+	for i := 0; i < 5; i++ {
+		timestamps[i] = now.Add(-time.Duration(5-i) * time.Minute)
+		seedEvent(t, client, "host", timestamps[i])
+	}
+
+	purgedAgents, purgedEvents, err := job.runOnce(context.Background())
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if purgedAgents != 0 {
+		t.Errorf("expected 0 agents purged, got %d", purgedAgents)
+	}
+	if purgedEvents != 2 {
+		t.Errorf("expected 2 events purged (5 - cap of 3), got %d", purgedEvents)
+	}
+
+	// Verify exactly 3 events remain, and they are the 3 newest.
+	remaining, err := client.RegistryEvent.Query().
+		Order(ent.Asc(registryevent.FieldTimestamp)).
+		All(context.Background())
+	if err != nil {
+		t.Fatalf("query remaining events: %v", err)
+	}
+	if len(remaining) != 3 {
+		t.Fatalf("expected 3 events remaining, got %d", len(remaining))
+	}
+	for i, ev := range remaining {
+		want := timestamps[i+2] // we deleted indices 0 and 1
+		if !ev.Timestamp.Equal(want) {
+			t.Errorf("event[%d] timestamp = %s, want %s (oldest 2 should have been deleted)", i, ev.Timestamp, want)
+		}
+	}
+}
+
+// TestSweepDisabledRetention verifies that retention=0 makes runOnce a
+// no-op for the agent-purge path (gated by the Retention > 0 check) while
+// the seeded event is preserved — the latter happens because the single
+// event is well under the 100k cap, not because enforceEventCap is gated
+// (it always runs regardless of Retention).
+//
+// Note: Start() bails out before launching the goroutine when retention=0;
+// runOnce here is invoked directly to confirm the agent path is gated.
+func TestSweepDisabledRetention(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 0}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	seedAgent(t, client, "stale", agent.StatusUnhealthy, now.Add(-100*24*time.Hour))
+	seedEvent(t, client, "stale", now.Add(-100*24*time.Hour))
+
+	purgedAgents, _, err := job.runOnce(context.Background())
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if purgedAgents != 0 {
+		t.Errorf("expected 0 agents purged with retention=0, got %d", purgedAgents)
+	}
+
+	// The stale agent row should still exist.
+	if n, _ := client.Agent.Query().Count(context.Background()); n != 1 {
+		t.Errorf("expected 1 agent kept, got %d", n)
+	}
+	if n, _ := client.RegistryEvent.Query().Count(context.Background()); n != 1 {
+		t.Errorf("expected 1 event kept, got %d", n)
+	}
+}
+
+// TestSweepDisabledStartIsNoop verifies that Start() with retention=0 does
+// not launch the goroutine (the operator's forensic escape hatch).
+func TestSweepDisabledStartIsNoop(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 0}
+	_, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	job.Start(context.Background())
+
+	job.mu.Lock()
+	running := job.running
+	job.mu.Unlock()
+
+	if running {
+		t.Errorf("expected sweep job to NOT be running when Retention=0, but running=true")
+	}
+}
+
+// TestSweepFixesOrphanProviderResolutions verifies that purging an agent
+// flips consumer-side rows in ALL THREE resolution tables pointing to it
+// from status=available to status=unavailable BEFORE the cascade-set-null
+// FK would otherwise leave them dangling. The three tables are:
+//   - dependency_resolution    (@mesh.tool deps)
+//   - llm_tool_resolution      (@mesh.llm tool filter)
+//   - llm_provider_resolution  (@mesh.llm provider config)
+func TestSweepFixesOrphanProviderResolutions(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Healthy consumer agent (will survive sweep).
+	seedAgent(t, client, "consumer", agent.StatusHealthy, now)
+	// Stale provider agent (will be purged by sweep).
+	seedAgent(t, client, "provider", agent.StatusUnhealthy, now.Add(-3*time.Hour))
+
+	// Insert a dependency_resolution row pointing consumer -> provider, status=available.
+	_, err := client.DependencyResolution.Create().
+		SetConsumerAgentID("consumer").
+		SetConsumerFunctionName("do_thing").
+		SetCapabilityRequired("widget").
+		SetProviderAgentID("provider").
+		SetProviderFunctionName("widget_impl").
+		SetEndpoint("http://provider:8080").
+		SetStatus(dependencyresolution.StatusAvailable).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("seed dep resolution: %v", err)
+	}
+
+	// Insert an llm_tool_resolution row pointing consumer -> provider, status=available.
+	_, err = client.LLMToolResolution.Create().
+		SetConsumerAgentID("consumer").
+		SetConsumerFunctionName("ask_llm").
+		SetProviderAgentID("provider").
+		SetProviderFunctionName("time_tool").
+		SetProviderCapability("time_service").
+		SetEndpoint("http://provider:8080").
+		SetStatus(llmtoolresolution.StatusAvailable).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("seed llm tool resolution: %v", err)
+	}
+
+	// Insert an llm_provider_resolution row pointing consumer -> provider, status=available.
+	_, err = client.LLMProviderResolution.Create().
+		SetConsumerAgentID("consumer").
+		SetConsumerFunctionName("ask_llm").
+		SetRequiredCapability("llm").
+		SetProviderAgentID("provider").
+		SetProviderFunctionName("llm").
+		SetEndpoint("http://provider:8080").
+		SetStatus(llmproviderresolution.StatusAvailable).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("seed llm provider resolution: %v", err)
+	}
+
+	if _, _, err := job.runOnce(ctx); err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+
+	// Provider should be gone.
+	if n, _ := client.Agent.Query().Where(agent.IDEQ("provider")).Count(ctx); n != 0 {
+		t.Errorf("expected provider purged, got count=%d", n)
+	}
+
+	// dependency_resolution: consumer-side row remains, status flipped.
+	depResolutions, err := client.DependencyResolution.Query().
+		Where(dependencyresolution.ConsumerAgentIDEQ("consumer")).
+		All(ctx)
+	if err != nil {
+		t.Fatalf("query dep resolutions: %v", err)
+	}
+	if len(depResolutions) != 1 {
+		t.Fatalf("expected 1 dep resolution row for consumer, got %d", len(depResolutions))
+	}
+	if depResolutions[0].Status != dependencyresolution.StatusUnavailable {
+		t.Errorf("expected dep resolution status=unavailable after provider purge, got %s", depResolutions[0].Status)
+	}
+
+	// llm_tool_resolution: consumer-side row remains, status flipped.
+	toolResolutions, err := client.LLMToolResolution.Query().
+		Where(llmtoolresolution.ConsumerAgentIDEQ("consumer")).
+		All(ctx)
+	if err != nil {
+		t.Fatalf("query llm tool resolutions: %v", err)
+	}
+	if len(toolResolutions) != 1 {
+		t.Fatalf("expected 1 llm tool resolution row for consumer, got %d", len(toolResolutions))
+	}
+	if toolResolutions[0].Status != llmtoolresolution.StatusUnavailable {
+		t.Errorf("expected llm tool resolution status=unavailable after provider purge, got %s", toolResolutions[0].Status)
+	}
+
+	// llm_provider_resolution: consumer-side row remains, status flipped.
+	provResolutions, err := client.LLMProviderResolution.Query().
+		Where(llmproviderresolution.ConsumerAgentIDEQ("consumer")).
+		All(ctx)
+	if err != nil {
+		t.Fatalf("query llm provider resolutions: %v", err)
+	}
+	if len(provResolutions) != 1 {
+		t.Fatalf("expected 1 llm provider resolution row for consumer, got %d", len(provResolutions))
+	}
+	if provResolutions[0].Status != llmproviderresolution.StatusUnavailable {
+		t.Errorf("expected llm provider resolution status=unavailable after provider purge, got %s", provResolutions[0].Status)
+	}
+}
+
+// TestSweepSkipsAgentRevivedDuringTick verifies the race-safety re-query
+// inside the purge transaction: if an agent appears in the candidate set
+// but heartbeats (becoming healthy with a fresh updated_at) before the
+// purge transaction runs, the unconditional delete is skipped and
+// orphan-fix does NOT touch the consumer-side resolution rows.
+func TestSweepSkipsAgentRevivedDuringTick(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Consumer + stale provider, both seeded.
+	seedAgent(t, client, "consumer", agent.StatusHealthy, now)
+	seedAgent(t, client, "provider", agent.StatusUnhealthy, now.Add(-3*time.Hour))
+
+	_, err := client.DependencyResolution.Create().
+		SetConsumerAgentID("consumer").
+		SetConsumerFunctionName("do_thing").
+		SetCapabilityRequired("widget").
+		SetProviderAgentID("provider").
+		SetProviderFunctionName("widget_impl").
+		SetEndpoint("http://provider:8080").
+		SetStatus(dependencyresolution.StatusAvailable).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("seed dep resolution: %v", err)
+	}
+
+	// Simulate the race by manually walking the sweep flow:
+	//   1. Snapshot the candidate set (would-be-purged).
+	//   2. Heartbeat the provider (status -> healthy, updated_at -> now).
+	//   3. Call purgeOneAgent on the stale snapshot — the re-query
+	//      inside the tx must see the now-healthy agent and bail out.
+	threshold := now.Add(-cfg.Retention)
+	candidates, err := client.Agent.Query().
+		Where(
+			agent.StatusIn(agent.StatusUnhealthy, agent.StatusUnknown),
+			agent.UpdatedAtLT(threshold),
+		).
+		All(ctx)
+	if err != nil {
+		t.Fatalf("query candidates: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].ID != "provider" {
+		t.Fatalf("expected exactly one candidate (provider), got %v", candidates)
+	}
+
+	// Heartbeat: provider revives between snapshot and purge.
+	_, err = client.Agent.UpdateOneID("provider").
+		SetStatus(agent.StatusHealthy).
+		SetUpdatedAt(now).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("heartbeat provider: %v", err)
+	}
+
+	didPurge, err := job.purgeOneAgent(ctx, candidates[0], threshold)
+	if err != nil {
+		t.Fatalf("purgeOneAgent: %v", err)
+	}
+	if didPurge {
+		t.Errorf("expected purge to be skipped (race lost), got didPurge=true")
+	}
+
+	// Provider must still exist and be healthy.
+	a, err := client.Agent.Get(ctx, "provider")
+	if err != nil {
+		t.Fatalf("get provider: %v", err)
+	}
+	if a.Status != agent.StatusHealthy {
+		t.Errorf("expected provider status=healthy after revival, got %s", a.Status)
+	}
+
+	// Dependency resolution must NOT have been flipped (orphan-fix
+	// rolled back / never ran because the re-query bailed out).
+	resolutions, err := client.DependencyResolution.Query().
+		Where(dependencyresolution.ConsumerAgentIDEQ("consumer")).
+		All(ctx)
+	if err != nil {
+		t.Fatalf("query resolutions: %v", err)
+	}
+	if len(resolutions) != 1 {
+		t.Fatalf("expected 1 resolution row, got %d", len(resolutions))
+	}
+	if resolutions[0].Status != dependencyresolution.StatusAvailable {
+		t.Errorf("expected resolution status to remain available (race lost), got %s", resolutions[0].Status)
+	}
+}
+
+// TestLoadSweepConfigFromEnv verifies env-var parsing and defaults for the
+// single MCP_MESH_RETENTION knob.
+func TestLoadSweepConfigFromEnv(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv("MCP_MESH_RETENTION", "")
+		cfg := LoadSweepConfigFromEnv(nil)
+		if cfg.Retention != defaultRetention {
+			t.Errorf("Retention default = %s, want %s", cfg.Retention, defaultRetention)
+		}
+	})
+
+	t.Run("custom value parsed", func(t *testing.T) {
+		t.Setenv("MCP_MESH_RETENTION", "2h")
+		cfg := LoadSweepConfigFromEnv(nil)
+		if cfg.Retention != 2*time.Hour {
+			t.Errorf("Retention = %s, want 2h", cfg.Retention)
+		}
+	})
+
+	t.Run("zero disables", func(t *testing.T) {
+		t.Setenv("MCP_MESH_RETENTION", "0s")
+		cfg := LoadSweepConfigFromEnv(nil)
+		if cfg.Retention != 0 {
+			t.Errorf("Retention = %s, want 0", cfg.Retention)
+		}
+	})
+
+	t.Run("invalid falls back to default", func(t *testing.T) {
+		t.Setenv("MCP_MESH_RETENTION", "not-a-duration")
+		cfg := LoadSweepConfigFromEnv(nil)
+		if cfg.Retention != defaultRetention {
+			t.Errorf("Retention with invalid value = %s, want %s (default)", cfg.Retention, defaultRetention)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds a periodic sweep goroutine in the Go registry that purges agents in `unhealthy`/`unknown` status whose `updated_at` is older than `MCP_MESH_RETENTION` (default `1h`)
- Single env var knob: `MCP_MESH_RETENTION` (set to `0` to disable the sweep entirely as a forensic escape hatch). Sweep interval (5m) and event hard cap (100k rows) are internal constants — operators get one knob, not four
- Folds in a latent orphan-fix bug: when sweep purges a provider agent, all three resolution tables (`dependency_resolution`, `llm_tool_resolution`, `llm_provider_resolution`) get flipped from `status=available` to `status=unavailable` BEFORE the cascade-set-null FK fires. Without this, consumers would see stale "available" rows pointing at NULL provider FK
- Sweep runs at startup (catches missed sweeps after registry downtime), then every 5 minutes
- Documentation: `MCP_MESH_RETENTION` added to `docs/environment-variables.md`
- meshctl `list` summary text updated: `unhealthy/expired` → `unhealthy` (sweep removes the long tail of expired rows that prompted user feedback about noise)

## Review Notes

Two-round code review caught a BLOCKER and four WARNINGs in the first iteration; all addressed in this PR:

- **BLOCKER (fixed)**: Original orphan-fix only flipped `dependency_resolution` — missed the two sibling tables (`llm_tool_resolution`, `llm_provider_resolution`) with identical schema. `UpdateDependencyStatusOnAgentOffline()` extended to all three.
- **Race-safety (fixed)**: Inside the transaction, the agent is re-queried with the same staleness predicate (`status IN (unhealthy, unknown) AND updated_at < threshold`). If a heartbeat revives the agent between candidate scan and tx open, the re-query returns 0 rows and the tx commits as a no-op. New `TestSweepSkipsAgentRevivedDuringTick` exercises this path.
- **Atomicity (fixed)**: Orphan-fix + delete now run inside a single Ent transaction (`s.entDB.Transaction(ctx, ...)`).
- **Test coverage (fixed)**: `eventMaxRows` is now injectable on `SweepJob` (parallel to the `clock` field). New `TestSweepEventMaxRowsOverCap` sets cap=3, seeds 5 strictly-increasing-timestamp events, and asserts the 2 oldest are deleted in the right order.
- **Boot wiring (simplified)**: Removed redundant `sweepCtx`/`sweepCancel` fields on `Server` — `SweepJob.Stop()` already self-cancels and waits.

### Cascade limitation (accepted)

The existing `Agent.events` edge has `OnDelete: Cascade`, which means purging an agent also deletes its `RegistryEvent` history. For v1 we accept this — the dependency-resolution audit feature (#836) will need to detangle this if forensic event history matters. Captured here so reviewers know it's intentional.

### Verified locally

End-to-end smoke-tested against real agents from `examples/simple/`:
- Healthy agents stay registered; ungraceful kill → marked unhealthy by health monitor → purged on next sweep tick after retention
- Provider purge correctly flips consumer-side `dependency_resolution.status` to `unavailable` before the agent row is deleted
- Sweep handles backlog from previous sessions (33 stale agents purged on first tick after a long downtime)
- `MCP_MESH_RETENTION=0` correctly skips launching the goroutine

Closes #835

## Test plan

- [x] All Go unit tests pass (`go test ./src/core/registry/...`)
- [x] `go build ./...` clean
- [x] Smoke tested with `MCP_MESH_RETENTION=2m` against `examples/simple/` agents
- [x] Verified DB rows actually deleted (sqlite3 query), not just hidden by CLI
- [x] Verified orphan-fix flips consumer-side `dependency_resolutions` row before delete
- [x] Verified `MCP_MESH_RETENTION=0` produces the disabled startup log line and no sweep goroutine
- [x] Verified existing caller of broadened `UpdateDependencyStatusOnAgentOffline` (`TestTopologyChange_AgentOffline`) still passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic registry sweep job with configurable retention period via `MCP_MESH_RETENTION` environment variable (default: 1 hour; disable with "0")
  * Sweep removes stale/unhealthy agents and maintains event log size limits
  * Enhanced `meshctl list --all` to include unhealthy agents with automatic purging

* **Bug Fixes**
  * Registry now properly marks related resolution records as unavailable when agents go offline

* **Documentation**
  * Added `MCP_MESH_RETENTION` environment variable documentation with timing and scope details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->