### PR TITLE
Sweep job: GC orphan schema_entries with SERIALIZABLE isolation (#842)

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -194,10 +194,12 @@ export DEFAULT_EVICTION_THRESHOLD=60
 # How long unhealthy/unknown agents are kept in the registry before the
 # sweep job purges them. Go duration string (e.g. "30m", "2h", "48h").
 # Default: 1h. Set to "0" to disable the sweep entirely (forensic mode —
-# keeps all rows). Affects both `meshctl list` (purged agents disappear
-# from output) and the underlying RegistryEvent table (event rows are
-# governed by a separate hardcoded 100,000 rolling cap, not by this
-# variable).
+# keeps all rows). Affects `meshctl list` (purged agents disappear from
+# output), the underlying RegistryEvent table (event rows are governed
+# by a separate hardcoded 100,000 rolling cap, not by this variable),
+# and orphan schema_entries (rows in the content-addressed schema store
+# that are no longer referenced by any capability — purged when both
+# orphan and older than this retention window; #842).
 export MCP_MESH_RETENTION=1h
 ```
 

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -402,6 +402,14 @@ export DEFAULT_TIMEOUT_THRESHOLD=20   # Mark unhealthy (seconds)
 export HEALTH_CHECK_INTERVAL=10       # Scan frequency (seconds)
 export DEFAULT_EVICTION_THRESHOLD=60  # Evict stale agents (seconds)
 
+# Sweep retention — controls how long unhealthy/unknown agents and
+# orphan schema_entries (content-addressed schemas no longer referenced
+# by any capability; #842) are retained before the periodic sweep job
+# purges them. Go duration string (e.g. "30m", "2h"). Default: 1h.
+# Set to "0" to disable the sweep entirely (forensic mode — keeps all
+# rows). Event rows are governed by a separate hardcoded 100k row cap.
+export MCP_MESH_RETENTION=1h
+
 # Caching
 export CACHE_TTL=30
 export ENABLE_RESPONSE_CACHE=true

--- a/src/core/database/ent_database.go
+++ b/src/core/database/ent_database.go
@@ -268,3 +268,37 @@ func (db *EntDatabase) Transaction(ctx context.Context, fn func(*ent.Tx) error) 
 
 	return nil
 }
+
+// TransactionWithOptions executes a function within a database transaction
+// using the supplied sql.TxOptions (e.g. to request SERIALIZABLE isolation).
+//
+// On Postgres this enables Serializable Snapshot Isolation (SSI), which
+// can return a 40001 "could not serialize access" error at commit time;
+// callers must be prepared to handle that as a retryable condition.
+// SQLite uses SERIALIZABLE by default (single-writer model), so the
+// option is a no-op there.
+func (db *EntDatabase) TransactionWithOptions(ctx context.Context, opts *sql.TxOptions, fn func(*ent.Tx) error) error {
+	tx, err := db.Client.BeginTx(ctx, opts)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if v := recover(); v != nil {
+			tx.Rollback()
+			panic(v)
+		}
+	}()
+
+	if err := fn(tx); err != nil {
+		if rerr := tx.Rollback(); rerr != nil {
+			return fmt.Errorf("rolling back transaction: %w", rerr)
+		}
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing transaction: %w", err)
+	}
+
+	return nil
+}

--- a/src/core/registry/integration_test.go
+++ b/src/core/registry/integration_test.go
@@ -256,7 +256,7 @@ func TestSweepJobIntegration(t *testing.T) {
 	cfg := SweepConfig{Retention: 1 * time.Hour}
 	job := NewSweepJob(cfg, entDB, service, testLogger)
 
-	purgedAgents, _, err := job.runOnce(ctx)
+	purgedAgents, _, _, err := job.runOnce(ctx)
 	if err != nil {
 		t.Fatalf("runOnce: %v", err)
 	}

--- a/src/core/registry/sweep.go
+++ b/src/core/registry/sweep.go
@@ -2,8 +2,10 @@ package registry
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -406,24 +408,39 @@ func (s *SweepJob) enforceEventCap(ctx context.Context) (int, error) {
 // purgeOrphanSchemaEntries deletes schema_entries rows older than Retention
 // that are no longer referenced by any capability's input_schema_hash or
 // output_schema_hash. Runs after agent purge so newly-orphaned schemas
-// (whose last referencing capability got cascade-deleted) are caught in
-// the same sweep cycle.
+// (whose last referencing capability got cascade-deleted in this tick)
+// are eligible to be reconsidered.
+//
+// Note: a schema that becomes orphaned during this sweep cycle is only
+// purged if its own created_at is also older than Retention. Newly
+// orphaned schemas whose created_at is within the retention window are
+// picked up on a later sweep cycle once they age past the threshold.
 //
 // Schemas are intentionally not FK-bound to capabilities (loose coupling
 // for content-addressed dedup across agents), so they can outlive every
 // referrer. This sweep step closes that gap.
 //
 // Race-safety: candidates are queried outside any transaction; each
-// candidate is then re-checked inside its own per-row transaction
-// (staleness predicate + reference count) before deletion. A concurrent
-// agent registration that creates a capability referencing the hash
-// will be visible to the re-check and the delete is skipped.
+// candidate is then re-checked and deleted inside its own per-row
+// SERIALIZABLE transaction (see purgeOneSchemaEntry). On Postgres SSI
+// will abort one side of any predicate-conflicting transaction, so a
+// concurrent registration creating a capability referencing the hash
+// cannot race past the delete. SQLite's single-writer model achieves
+// the same property automatically.
 func (s *SweepJob) purgeOrphanSchemaEntries(ctx context.Context, now time.Time) (int, error) {
 	threshold := now.Add(-s.cfg.Retention)
 
-	candidates, err := s.entDB.Client.SchemaEntry.Query().
+	// Bounded to avoid loading all stale schema_entries into memory in
+	// pathological cases; remaining candidates picked up next tick.
+	// Select only the hash column to skip hydrating the canonical JSON
+	// blob (which can be large for big tool schemas) — the per-row tx
+	// re-reads the row anyway with the staleness predicate.
+	var candidates []string
+	err := s.entDB.Client.SchemaEntry.Query().
 		Where(schemaentry.CreatedAtLT(threshold)).
-		All(ctx)
+		Limit(1000).
+		Select(schemaentry.FieldHash).
+		Scan(ctx, &candidates)
 	if err != nil {
 		return 0, fmt.Errorf("query schema entries: %w", err)
 	}
@@ -433,11 +450,11 @@ func (s *SweepJob) purgeOrphanSchemaEntries(ctx context.Context, now time.Time) 
 	}
 
 	var purged int
-	for _, e := range candidates {
-		deleted, err := s.purgeOneSchemaEntry(ctx, e.Hash, threshold)
+	for _, hash := range candidates {
+		deleted, err := s.purgeOneSchemaEntry(ctx, hash, threshold)
 		if err != nil {
 			if s.logger != nil {
-				s.logger.Error("sweep: failed to purge schema_entry %s: %v", e.Hash, err)
+				s.logger.Error("sweep: failed to purge schema_entry %s: %v", hash, err)
 			}
 			continue
 		}
@@ -449,15 +466,33 @@ func (s *SweepJob) purgeOrphanSchemaEntries(ctx context.Context, now time.Time) 
 }
 
 // purgeOneSchemaEntry deletes a single schema_entry row inside a
-// transaction after re-verifying both its staleness and that no
-// capability still references it. Returns (true, nil) when deleted,
-// (false, nil) when a concurrent registration created a reference or
-// the entry was already gone / no longer stale, (false, err) on other
-// failures.
+// SERIALIZABLE transaction after re-verifying both its staleness and
+// that no capability still references it. Returns (true, nil) when
+// deleted, (false, nil) when the entry was already gone / no longer
+// stale / now referenced / lost a serialization race, (false, err) on
+// other failures.
+//
+// Race-safety: under READ COMMITTED (the previous default) a concurrent
+// registration could INSERT a capability referencing this hash between
+// the in-tx ref-count and COMMIT, leaving a capability row pointing at
+// a deleted schema_entry. The dependency resolver treats a missing
+// schema_entry as "skip schema check and keep the candidate", so a
+// consumer could end up wired to a producer whose schema check was
+// silently bypassed. The window is brief but the failure mode is
+// hostile (wrong producer selected, no obvious error trail).
+//
+// Using SERIALIZABLE causes Postgres SSI to detect the predicate
+// conflict between this tx (read: count of capabilities referencing
+// hash) and a concurrent INSERT into capability with that hash, and
+// abort one side at COMMIT with SQLSTATE 40001. We treat 40001 as
+// "skip this candidate; the next sweep tick will retry naturally" so
+// we never delete a schema_entry that a concurrent registration is in
+// the process of referencing. SQLite's single-writer model already
+// serializes these writes, so this is a no-op there.
 func (s *SweepJob) purgeOneSchemaEntry(ctx context.Context, hash string, threshold time.Time) (bool, error) {
 	var deleted bool
 
-	err := s.entDB.Transaction(ctx, func(tx *ent.Tx) error {
+	err := s.entDB.TransactionWithOptions(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable}, func(tx *ent.Tx) error {
 		// Re-verify staleness inside the tx (the entry could have been
 		// deleted by another sweep, or — in theory — re-inserted with a
 		// fresh created_at if upstream code ever does that).
@@ -477,7 +512,9 @@ func (s *SweepJob) purgeOneSchemaEntry(ctx context.Context, hash string, thresho
 
 		// Re-verify orphan-ness inside the tx. If a concurrent
 		// registration created a capability referencing this hash
-		// between the candidate scan and now, skip the delete.
+		// between the candidate scan and now, skip the delete. Under
+		// SERIALIZABLE this also establishes the predicate that SSI
+		// will use to detect a racing INSERT and abort us at COMMIT.
 		refCount, err := tx.Capability.Query().
 			Where(capability.Or(
 				capability.InputSchemaHashEQ(hash),
@@ -502,6 +539,12 @@ func (s *SweepJob) purgeOneSchemaEntry(ctx context.Context, hash string, thresho
 		return nil
 	})
 	if err != nil {
+		if isSerializationConflict(err) {
+			if s.logger != nil {
+				s.logger.Debug("sweep: schema_entry %s skipped due to serialization conflict; will retry next sweep cycle", hash)
+			}
+			return false, nil
+		}
 		return false, err
 	}
 
@@ -509,4 +552,17 @@ func (s *SweepJob) purgeOneSchemaEntry(ctx context.Context, hash string, thresho
 		s.logger.Debug("sweep: purged orphan schema_entry %s", hash)
 	}
 	return deleted, nil
+}
+
+// isSerializationConflict returns true when err is a Postgres SSI
+// serialization-failure error (SQLSTATE 40001). We string-match rather
+// than depend on a Postgres driver type so this stays portable across
+// the SQLite test path (which never raises 40001) and the Postgres
+// production path. The driver-emitted message contains the SQLSTATE
+// name "could not serialize access" verbatim.
+func isSerializationConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "could not serialize access")
 }

--- a/src/core/registry/sweep.go
+++ b/src/core/registry/sweep.go
@@ -10,10 +10,12 @@ import (
 	"mcp-mesh/src/core/database"
 	"mcp-mesh/src/core/ent"
 	"mcp-mesh/src/core/ent/agent"
+	"mcp-mesh/src/core/ent/capability"
 	"mcp-mesh/src/core/ent/dependencyresolution"
 	"mcp-mesh/src/core/ent/llmproviderresolution"
 	"mcp-mesh/src/core/ent/llmtoolresolution"
 	"mcp-mesh/src/core/ent/registryevent"
+	"mcp-mesh/src/core/ent/schemaentry"
 	"mcp-mesh/src/core/logger"
 )
 
@@ -63,7 +65,8 @@ func LoadSweepConfigFromEnv(log *logger.Logger) SweepConfig {
 	return cfg
 }
 
-// SweepJob purges stale agents and old registry events on a periodic timer.
+// SweepJob purges stale agents, old registry events, and orphan schema
+// entries on a periodic timer.
 //
 // On each tick the job runs (in order):
 //  1. Purge agents in unhealthy/unknown status whose updated_at is older
@@ -73,6 +76,10 @@ func LoadSweepConfigFromEnv(log *logger.Logger) SweepConfig {
 //  2. If the event row count exceeds the internal hard cap (100,000),
 //     delete oldest rows until back under the cap. Events are governed
 //     solely by row count, not age.
+//  3. Purge orphan schema_entries (no capability still references the
+//     hash) older than Retention. Runs after step 1 so newly-orphaned
+//     schemas (whose last referencing capability got cascade-deleted)
+//     are caught in the same sweep cycle.
 type SweepJob struct {
 	cfg     SweepConfig
 	entDB   *database.EntDatabase
@@ -181,7 +188,7 @@ func (s *SweepJob) Stop() {
 // not surfaced; the next tick will retry.
 func (s *SweepJob) tick(ctx context.Context) {
 	start := s.clock()
-	agentsPurged, eventsPurged, err := s.runOnce(ctx)
+	agentsPurged, eventsPurged, schemasPurged, err := s.runOnce(ctx)
 	took := time.Since(start)
 
 	if err != nil {
@@ -192,8 +199,8 @@ func (s *SweepJob) tick(ctx context.Context) {
 	}
 
 	if s.logger != nil {
-		if agentsPurged > 0 || eventsPurged > 0 {
-			s.logger.Info("sweep: purged %d agents, %d events (took %s)", agentsPurged, eventsPurged, took)
+		if agentsPurged > 0 || eventsPurged > 0 || schemasPurged > 0 {
+			s.logger.Info("sweep: purged %d agents, %d events, %d orphan schemas (took %s)", agentsPurged, eventsPurged, schemasPurged, took)
 		} else {
 			s.logger.Debug("sweep: nothing to purge (took %s)", took)
 		}
@@ -201,27 +208,35 @@ func (s *SweepJob) tick(ctx context.Context) {
 }
 
 // runOnce performs a single sweep iteration and returns the number of
-// agents and events purged. Exported (lower-cased but callable from
-// tests in the same package) for unit tests; production callers should
-// use Start.
-func (s *SweepJob) runOnce(ctx context.Context) (agentsPurged, eventsPurged int, err error) {
+// agents, events, and orphan schema_entries purged. Exported (lower-cased
+// but callable from tests in the same package) for unit tests; production
+// callers should use Start.
+func (s *SweepJob) runOnce(ctx context.Context) (agentsPurged, eventsPurged, schemasPurged int, err error) {
 	now := s.clock()
 
 	if s.cfg.Retention > 0 {
 		n, err := s.purgeStaleAgents(ctx, now)
 		if err != nil {
-			return 0, 0, fmt.Errorf("purge stale agents: %w", err)
+			return 0, 0, 0, fmt.Errorf("purge stale agents: %w", err)
 		}
 		agentsPurged = n
 	}
 
 	n, err := s.enforceEventCap(ctx)
 	if err != nil {
-		return agentsPurged, 0, fmt.Errorf("enforce event cap: %w", err)
+		return agentsPurged, 0, 0, fmt.Errorf("enforce event cap: %w", err)
 	}
 	eventsPurged = n
 
-	return agentsPurged, eventsPurged, nil
+	if s.cfg.Retention > 0 {
+		n, err := s.purgeOrphanSchemaEntries(ctx, now)
+		if err != nil {
+			return agentsPurged, eventsPurged, 0, fmt.Errorf("purge orphan schemas: %w", err)
+		}
+		schemasPurged = n
+	}
+
+	return agentsPurged, eventsPurged, schemasPurged, nil
 }
 
 // purgeStaleAgents deletes agents in unhealthy/unknown status that have
@@ -386,4 +401,112 @@ func (s *SweepJob) enforceEventCap(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("delete excess events: %w", err)
 	}
 	return n, nil
+}
+
+// purgeOrphanSchemaEntries deletes schema_entries rows older than Retention
+// that are no longer referenced by any capability's input_schema_hash or
+// output_schema_hash. Runs after agent purge so newly-orphaned schemas
+// (whose last referencing capability got cascade-deleted) are caught in
+// the same sweep cycle.
+//
+// Schemas are intentionally not FK-bound to capabilities (loose coupling
+// for content-addressed dedup across agents), so they can outlive every
+// referrer. This sweep step closes that gap.
+//
+// Race-safety: candidates are queried outside any transaction; each
+// candidate is then re-checked inside its own per-row transaction
+// (staleness predicate + reference count) before deletion. A concurrent
+// agent registration that creates a capability referencing the hash
+// will be visible to the re-check and the delete is skipped.
+func (s *SweepJob) purgeOrphanSchemaEntries(ctx context.Context, now time.Time) (int, error) {
+	threshold := now.Add(-s.cfg.Retention)
+
+	candidates, err := s.entDB.Client.SchemaEntry.Query().
+		Where(schemaentry.CreatedAtLT(threshold)).
+		All(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("query schema entries: %w", err)
+	}
+
+	if len(candidates) == 0 {
+		return 0, nil
+	}
+
+	var purged int
+	for _, e := range candidates {
+		deleted, err := s.purgeOneSchemaEntry(ctx, e.Hash, threshold)
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Error("sweep: failed to purge schema_entry %s: %v", e.Hash, err)
+			}
+			continue
+		}
+		if deleted {
+			purged++
+		}
+	}
+	return purged, nil
+}
+
+// purgeOneSchemaEntry deletes a single schema_entry row inside a
+// transaction after re-verifying both its staleness and that no
+// capability still references it. Returns (true, nil) when deleted,
+// (false, nil) when a concurrent registration created a reference or
+// the entry was already gone / no longer stale, (false, err) on other
+// failures.
+func (s *SweepJob) purgeOneSchemaEntry(ctx context.Context, hash string, threshold time.Time) (bool, error) {
+	var deleted bool
+
+	err := s.entDB.Transaction(ctx, func(tx *ent.Tx) error {
+		// Re-verify staleness inside the tx (the entry could have been
+		// deleted by another sweep, or — in theory — re-inserted with a
+		// fresh created_at if upstream code ever does that).
+		entry, err := tx.SchemaEntry.Query().
+			Where(
+				schemaentry.HashEQ(hash),
+				schemaentry.CreatedAtLT(threshold),
+			).
+			First(ctx)
+		if err != nil {
+			if ent.IsNotFound(err) {
+				// Already deleted or no longer stale — both OK.
+				return nil
+			}
+			return fmt.Errorf("re-query schema entry %s: %w", hash, err)
+		}
+
+		// Re-verify orphan-ness inside the tx. If a concurrent
+		// registration created a capability referencing this hash
+		// between the candidate scan and now, skip the delete.
+		refCount, err := tx.Capability.Query().
+			Where(capability.Or(
+				capability.InputSchemaHashEQ(hash),
+				capability.OutputSchemaHashEQ(hash),
+			)).
+			Count(ctx)
+		if err != nil {
+			return fmt.Errorf("count capability refs for %s: %w", hash, err)
+		}
+		if refCount > 0 {
+			if s.logger != nil {
+				s.logger.Debug("sweep: skipped purge of schema_entry %s (now referenced by %d capability rows)", hash, refCount)
+			}
+			return nil
+		}
+
+		if err := tx.SchemaEntry.DeleteOne(entry).Exec(ctx); err != nil {
+			return fmt.Errorf("delete schema entry %s: %w", hash, err)
+		}
+
+		deleted = true
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+
+	if deleted && s.logger != nil {
+		s.logger.Debug("sweep: purged orphan schema_entry %s", hash)
+	}
+	return deleted, nil
 }

--- a/src/core/registry/sweep.go
+++ b/src/core/registry/sweep.go
@@ -420,29 +420,86 @@ func (s *SweepJob) enforceEventCap(ctx context.Context) (int, error) {
 // for content-addressed dedup across agents), so they can outlive every
 // referrer. This sweep step closes that gap.
 //
+// Two-phase candidate selection: we first collect the set of currently-
+// referenced schema hashes from the capabilities table (bounded by
+// num_capabilities × 2 hash columns — typically dozens to a few hundred
+// in a real mesh) and then filter the stale-schema_entries query against
+// that set with HashNotIn. This guarantees the Limit(1000) per-tick cap
+// is spent on TRUE orphans only — without the DB-side filter, a registry
+// with >1000 stale-but-still-referenced schemas would hit the same
+// referenced rows on every tick and never make progress on the orphans
+// past position 1000 in the default order.
+//
 // Race-safety: candidates are queried outside any transaction; each
 // candidate is then re-checked and deleted inside its own per-row
-// SERIALIZABLE transaction (see purgeOneSchemaEntry). On Postgres SSI
-// will abort one side of any predicate-conflicting transaction, so a
-// concurrent registration creating a capability referencing the hash
-// cannot race past the delete. SQLite's single-writer model achieves
-// the same property automatically.
+// SERIALIZABLE transaction (see purgeOneSchemaEntry). The per-row tx
+// re-check still provides race protection against capabilities created
+// between the candidate scan and the per-row tx commit; the DB-side
+// filter just makes the candidate list correct under the steady state.
+// On Postgres SSI will abort one side of any predicate-conflicting
+// transaction, so a concurrent registration creating a capability
+// referencing the hash cannot race past the delete. SQLite's
+// single-writer model achieves the same property automatically.
 func (s *SweepJob) purgeOrphanSchemaEntries(ctx context.Context, now time.Time) (int, error) {
 	threshold := now.Add(-s.cfg.Retention)
 
-	// Bounded to avoid loading all stale schema_entries into memory in
-	// pathological cases; remaining candidates picked up next tick.
+	// Phase 1: collect all currently-referenced schema hashes from the
+	// capabilities table. Bounded by num_capabilities × 2 hash columns
+	// (typically small — dozens to a few hundred in a real mesh).
+	referencedSet := make(map[string]struct{})
+
+	var inputHashes []string
+	if err := s.entDB.Client.Capability.Query().
+		Where(capability.InputSchemaHashNotNil()).
+		Select(capability.FieldInputSchemaHash).
+		Scan(ctx, &inputHashes); err != nil {
+		return 0, fmt.Errorf("collect referenced input schema hashes: %w", err)
+	}
+	for _, h := range inputHashes {
+		if h != "" {
+			referencedSet[h] = struct{}{}
+		}
+	}
+
+	var outputHashes []string
+	if err := s.entDB.Client.Capability.Query().
+		Where(capability.OutputSchemaHashNotNil()).
+		Select(capability.FieldOutputSchemaHash).
+		Scan(ctx, &outputHashes); err != nil {
+		return 0, fmt.Errorf("collect referenced output schema hashes: %w", err)
+	}
+	for _, h := range outputHashes {
+		if h != "" {
+			referencedSet[h] = struct{}{}
+		}
+	}
+
+	referencedHashes := make([]string, 0, len(referencedSet))
+	for h := range referencedSet {
+		referencedHashes = append(referencedHashes, h)
+	}
+
+	// Phase 2: candidates are stale schema_entries NOT in the referenced
+	// set. Bounded by Limit(1000) per tick as defense-in-depth; the
+	// HashNotIn filter ensures the limit is spent on true orphans only,
+	// so any remainder picked up next tick is genuine new work and not
+	// the same referenced rows again.
+	//
 	// Select only the hash column to skip hydrating the canonical JSON
 	// blob (which can be large for big tool schemas) — the per-row tx
 	// re-reads the row anyway with the staleness predicate.
+	candidatesQuery := s.entDB.Client.SchemaEntry.Query().
+		Where(schemaentry.CreatedAtLT(threshold))
+	if len(referencedHashes) > 0 {
+		candidatesQuery = candidatesQuery.Where(schemaentry.HashNotIn(referencedHashes...))
+	}
+
 	var candidates []string
-	err := s.entDB.Client.SchemaEntry.Query().
-		Where(schemaentry.CreatedAtLT(threshold)).
+	if err := candidatesQuery.
 		Limit(1000).
 		Select(schemaentry.FieldHash).
-		Scan(ctx, &candidates)
-	if err != nil {
-		return 0, fmt.Errorf("query schema entries: %w", err)
+		Scan(ctx, &candidates); err != nil {
+		return 0, fmt.Errorf("query orphan schema candidates: %w", err)
 	}
 
 	if len(candidates) == 0 {
@@ -489,6 +546,12 @@ func (s *SweepJob) purgeOrphanSchemaEntries(ctx context.Context, now time.Time) 
 // we never delete a schema_entry that a concurrent registration is in
 // the process of referencing. SQLite's single-writer model already
 // serializes these writes, so this is a no-op there.
+//
+// NOTE: A Postgres-backed integration test that exercises the mid-tx SSI
+// race window is intentionally deferred. The unit tests in this package
+// run against SQLite (single-writer model, no SSI). Adding a Postgres
+// integration test would require new test infrastructure (testcontainers,
+// build tags); track in a follow-up issue if that infra is needed.
 func (s *SweepJob) purgeOneSchemaEntry(ctx context.Context, hash string, threshold time.Time) (bool, error) {
 	var deleted bool
 

--- a/src/core/registry/sweep_test.go
+++ b/src/core/registry/sweep_test.go
@@ -745,3 +745,89 @@ func TestSweep_PurgeOrphanSchemaEntries_RefCheckPreventsDelete(t *testing.T) {
 		t.Errorf("expected racing schema_entry preserved, got count=%d", count)
 	}
 }
+
+// TestSweep_PurgeOrphanSchemaEntries_SkipsReferencedAcrossLargeBatch
+// verifies the DB-side HashNotIn filter on the candidate scan: when
+// stale schema_entries include a mix of referenced and orphan rows,
+// runOnce must purge ONLY the true orphans and never spend the per-tick
+// limit on referenced rows.
+//
+// Without the DB-side filter, a registry with stale-but-still-referenced
+// schemas would have those rows fill the Limit(1000) candidate slot on
+// every tick and the true orphans past that position would never get
+// purged. We use small N here (well below 1000) but the assertion is
+// the same — every referenced row must be excluded from the candidate
+// list, so the deletion count equals exactly N_orphans regardless of
+// how many referenced rows would otherwise have come first in the
+// default order.
+func TestSweep_PurgeOrphanSchemaEntries_SkipsReferencedAcrossLargeBatch(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Seed a healthy provider to host capabilities that reference schemas.
+	seedAgent(t, client, "provider", agent.StatusHealthy, now)
+
+	// 20 stale schema entries (well past 1h retention). The first 10
+	// (by insertion order) will be referenced by capabilities; the last
+	// 10 are true orphans. Without the DB-side filter, the referenced
+	// rows would have come first in the default order and consumed the
+	// candidate slots on each tick.
+	const total = 20
+	const referenced = 10
+	staleAt := now.Add(-2 * time.Hour)
+	for i := 0; i < total; i++ {
+		hash := "sha256:entry-" + string(rune('a'+i))
+		seedSchemaEntryAt(t, client, hash, staleAt)
+	}
+
+	// Reference the first `referenced` schemas via a capability per row
+	// (alternating input vs output to exercise both code paths).
+	for i := 0; i < referenced; i++ {
+		hash := "sha256:entry-" + string(rune('a'+i))
+		create := client.Capability.Create().
+			SetAgentID("provider").
+			SetFunctionName("fn-" + string(rune('a'+i))).
+			SetCapability("cap-" + string(rune('a'+i)))
+		if i%2 == 0 {
+			create = create.SetInputSchemaHash(hash)
+		} else {
+			create = create.SetOutputSchemaHash(hash)
+		}
+		if _, err := create.Save(ctx); err != nil {
+			t.Fatalf("seed capability for %s: %v", hash, err)
+		}
+	}
+
+	_, _, schemasPurged, err := job.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+
+	wantPurged := total - referenced
+	if schemasPurged != wantPurged {
+		t.Errorf("expected %d schemas purged (total=%d, referenced=%d), got %d", wantPurged, total, referenced, schemasPurged)
+	}
+
+	// Verify the surviving rows are exactly the referenced ones.
+	remaining, err := client.SchemaEntry.Query().
+		Order(ent.Asc(schemaentry.FieldHash)).
+		All(ctx)
+	if err != nil {
+		t.Fatalf("query remaining schema entries: %v", err)
+	}
+	if len(remaining) != referenced {
+		t.Fatalf("expected %d schema entries remaining, got %d", referenced, len(remaining))
+	}
+	for _, e := range remaining {
+		// Each surviving entry must be one of the first `referenced` we seeded.
+		// e.Hash format: "sha256:entry-<letter>" where letter is in [a, a+referenced).
+		idx := int(e.Hash[len(e.Hash)-1] - 'a')
+		if idx < 0 || idx >= referenced {
+			t.Errorf("unexpected surviving entry %s (idx=%d, want < %d)", e.Hash, idx, referenced)
+		}
+	}
+}

--- a/src/core/registry/sweep_test.go
+++ b/src/core/registry/sweep_test.go
@@ -674,15 +674,18 @@ func TestSweep_PurgeOrphanSchemaEntries_KeepsRecent(t *testing.T) {
 	}
 }
 
-// TestSweep_PurgeOrphanSchemaEntries_RaceSafety simulates the race where
-// a schema_entry is in the candidate set (orphan + stale) but a
-// concurrent registration creates a capability referencing the hash
-// before the per-row delete tx runs. The in-tx re-check must catch this
-// and skip the delete. We exercise the race by calling
-// purgeOneSchemaEntry directly after seeding the racing capability —
-// this mirrors how TestSweepSkipsAgentRevivedDuringTick exercises the
-// agent purge race.
-func TestSweep_PurgeOrphanSchemaEntries_RaceSafety(t *testing.T) {
+// TestSweep_PurgeOrphanSchemaEntries_RefCheckPreventsDelete verifies
+// that when a capability already references a stale schema_entry by
+// the time the per-row delete tx runs, the in-tx ref-count returns >0
+// and the delete is skipped. This covers the "ref appeared before tx
+// open" arm of the race; the tighter "ref appears mid-tx" arm is
+// handled by SERIALIZABLE isolation in purgeOneSchemaEntry but cannot
+// be exercised in the SQLite unit-test environment (single-writer
+// model serializes the writes inherently). An integration test against
+// Postgres would be needed to verify SSI-level race prevention end-to-
+// end; this is tracked as follow-up work for the dedicated Postgres
+// integration suite.
+func TestSweep_PurgeOrphanSchemaEntries_RefCheckPreventsDelete(t *testing.T) {
 	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
 	cfg := SweepConfig{Retention: 1 * time.Hour}
 	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)

--- a/src/core/registry/sweep_test.go
+++ b/src/core/registry/sweep_test.go
@@ -14,6 +14,7 @@ import (
 	"mcp-mesh/src/core/ent/llmproviderresolution"
 	"mcp-mesh/src/core/ent/llmtoolresolution"
 	"mcp-mesh/src/core/ent/registryevent"
+	"mcp-mesh/src/core/ent/schemaentry"
 	"mcp-mesh/src/core/logger"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -97,7 +98,7 @@ func TestSweepStaleAgentsOnly(t *testing.T) {
 	// Recently unhealthy: should NOT be purged (updated_at within retention).
 	seedAgent(t, client, "fresh-unhealthy", agent.StatusUnhealthy, now.Add(-30*time.Minute))
 
-	purgedAgents, purgedEvents, err := job.runOnce(context.Background())
+	purgedAgents, purgedEvents, _, err := job.runOnce(context.Background())
 	if err != nil {
 		t.Fatalf("runOnce: %v", err)
 	}
@@ -143,7 +144,7 @@ func TestSweepBoth(t *testing.T) {
 	seedEvent(t, client, "host", now.Add(-2*24*time.Hour))
 	seedEvent(t, client, "host", now.Add(-1*time.Minute))
 
-	purgedAgents, purgedEvents, err := job.runOnce(context.Background())
+	purgedAgents, purgedEvents, _, err := job.runOnce(context.Background())
 	if err != nil {
 		t.Fatalf("runOnce: %v", err)
 	}
@@ -170,7 +171,7 @@ func TestSweepEventMaxRowsUnderCap(t *testing.T) {
 		seedEvent(t, client, "host", now.Add(-time.Duration(5-i)*time.Minute))
 	}
 
-	purgedAgents, purgedEvents, err := job.runOnce(context.Background())
+	purgedAgents, purgedEvents, _, err := job.runOnce(context.Background())
 	if err != nil {
 		t.Fatalf("runOnce: %v", err)
 	}
@@ -213,7 +214,7 @@ func TestSweepEventMaxRowsOverCap(t *testing.T) {
 		seedEvent(t, client, "host", timestamps[i])
 	}
 
-	purgedAgents, purgedEvents, err := job.runOnce(context.Background())
+	purgedAgents, purgedEvents, _, err := job.runOnce(context.Background())
 	if err != nil {
 		t.Fatalf("runOnce: %v", err)
 	}
@@ -259,7 +260,7 @@ func TestSweepDisabledRetention(t *testing.T) {
 	seedAgent(t, client, "stale", agent.StatusUnhealthy, now.Add(-100*24*time.Hour))
 	seedEvent(t, client, "stale", now.Add(-100*24*time.Hour))
 
-	purgedAgents, _, err := job.runOnce(context.Background())
+	purgedAgents, _, _, err := job.runOnce(context.Background())
 	if err != nil {
 		t.Fatalf("runOnce: %v", err)
 	}
@@ -357,7 +358,7 @@ func TestSweepFixesOrphanProviderResolutions(t *testing.T) {
 		t.Fatalf("seed llm provider resolution: %v", err)
 	}
 
-	if _, _, err := job.runOnce(ctx); err != nil {
+	if _, _, _, err := job.runOnce(ctx); err != nil {
 		t.Fatalf("runOnce: %v", err)
 	}
 
@@ -546,4 +547,198 @@ func TestLoadSweepConfigFromEnv(t *testing.T) {
 			t.Errorf("Retention with negative value = %s, want %s (default)", cfg.Retention, defaultRetention)
 		}
 	})
+}
+
+// seedSchemaEntryAt inserts a schema_entry directly via Ent with the given
+// hash and created_at, bypassing the upsert path used by RegisterAgent.
+func seedSchemaEntryAt(t *testing.T, client *ent.Client, hash string, createdAt time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := client.SchemaEntry.Create().
+		SetHash(hash).
+		SetCanonical(map[string]interface{}{"type": "object"}).
+		SetCreatedAt(createdAt).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("seed schema_entry %s: %v", hash, err)
+	}
+}
+
+// TestSweep_PurgeOrphanSchemaEntries_DeletesOrphan verifies that a
+// schema_entry with no referencing capability and a created_at older
+// than retention is purged.
+func TestSweep_PurgeOrphanSchemaEntries_DeletesOrphan(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Orphan schema entry, well past retention.
+	seedSchemaEntryAt(t, client, "sha256:orphan", now.Add(-2*time.Hour))
+
+	_, _, schemasPurged, err := job.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if schemasPurged != 1 {
+		t.Errorf("expected 1 schema purged, got %d", schemasPurged)
+	}
+
+	count, err := client.SchemaEntry.Query().Count(ctx)
+	if err != nil {
+		t.Fatalf("count schema entries: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 schema entries remaining, got %d", count)
+	}
+}
+
+// TestSweep_PurgeOrphanSchemaEntries_KeepsReferenced verifies that a
+// schema_entry referenced by a capability's input_schema_hash or
+// output_schema_hash is NOT purged, even when older than retention.
+func TestSweep_PurgeOrphanSchemaEntries_KeepsReferenced(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Healthy provider agent.
+	seedAgent(t, client, "provider", agent.StatusHealthy, now)
+
+	// Two stale schema entries: one referenced by input_schema_hash,
+	// one by output_schema_hash. Neither should be purged.
+	seedSchemaEntryAt(t, client, "sha256:input", now.Add(-2*time.Hour))
+	seedSchemaEntryAt(t, client, "sha256:output", now.Add(-2*time.Hour))
+
+	inHash := "sha256:input"
+	outHash := "sha256:output"
+	_, err := client.Capability.Create().
+		SetAgentID("provider").
+		SetFunctionName("do_thing").
+		SetCapability("widget").
+		SetInputSchemaHash(inHash).
+		SetOutputSchemaHash(outHash).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("seed capability: %v", err)
+	}
+
+	_, _, schemasPurged, err := job.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if schemasPurged != 0 {
+		t.Errorf("expected 0 schemas purged (both referenced), got %d", schemasPurged)
+	}
+
+	count, err := client.SchemaEntry.Query().Count(ctx)
+	if err != nil {
+		t.Fatalf("count schema entries: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 schema entries remaining, got %d", count)
+	}
+}
+
+// TestSweep_PurgeOrphanSchemaEntries_KeepsRecent verifies that an orphan
+// schema_entry younger than the retention window is NOT purged.
+func TestSweep_PurgeOrphanSchemaEntries_KeepsRecent(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Orphan, but only 30 minutes old (within 1h retention).
+	seedSchemaEntryAt(t, client, "sha256:fresh-orphan", now.Add(-30*time.Minute))
+
+	_, _, schemasPurged, err := job.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if schemasPurged != 0 {
+		t.Errorf("expected 0 schemas purged (within retention), got %d", schemasPurged)
+	}
+
+	count, err := client.SchemaEntry.Query().Count(ctx)
+	if err != nil {
+		t.Fatalf("count schema entries: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 schema entry remaining, got %d", count)
+	}
+}
+
+// TestSweep_PurgeOrphanSchemaEntries_RaceSafety simulates the race where
+// a schema_entry is in the candidate set (orphan + stale) but a
+// concurrent registration creates a capability referencing the hash
+// before the per-row delete tx runs. The in-tx re-check must catch this
+// and skip the delete. We exercise the race by calling
+// purgeOneSchemaEntry directly after seeding the racing capability —
+// this mirrors how TestSweepSkipsAgentRevivedDuringTick exercises the
+// agent purge race.
+func TestSweep_PurgeOrphanSchemaEntries_RaceSafety(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// 1. Orphan schema entry, past retention. Would be purged on a
+	//    naive sweep.
+	seedSchemaEntryAt(t, client, "sha256:racing", now.Add(-2*time.Hour))
+
+	// 2. Snapshot the candidate scan and confirm it would pick this
+	//    entry up.
+	threshold := now.Add(-cfg.Retention)
+	candidates, err := client.SchemaEntry.Query().
+		Where(schemaentry.CreatedAtLT(threshold)).
+		All(ctx)
+	if err != nil {
+		t.Fatalf("query candidates: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Hash != "sha256:racing" {
+		t.Fatalf("expected exactly one candidate (sha256:racing), got %v", candidates)
+	}
+
+	// 3. Simulate a concurrent registration: a capability now references
+	//    the hash. This is what the in-tx re-query must catch.
+	seedAgent(t, client, "racing-provider", agent.StatusHealthy, now)
+	racingHash := "sha256:racing"
+	_, err = client.Capability.Create().
+		SetAgentID("racing-provider").
+		SetFunctionName("late_arrival").
+		SetCapability("widget").
+		SetInputSchemaHash(racingHash).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("seed racing capability: %v", err)
+	}
+
+	// 4. Run the per-row delete. The in-tx Capability ref-count must
+	//    return >0 and the delete must be skipped.
+	deleted, err := job.purgeOneSchemaEntry(ctx, "sha256:racing", threshold)
+	if err != nil {
+		t.Fatalf("purgeOneSchemaEntry: %v", err)
+	}
+	if deleted {
+		t.Errorf("expected purge to be skipped (race lost), got deleted=true")
+	}
+
+	// 5. Schema entry must still exist.
+	count, err := client.SchemaEntry.Query().
+		Where(schemaentry.HashEQ("sha256:racing")).
+		Count(ctx)
+	if err != nil {
+		t.Fatalf("query schema entry: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected racing schema_entry preserved, got count=%d", count)
+	}
 }


### PR DESCRIPTION
## Summary

Extends the periodic sweep job (#835) to also GC orphan `schema_entries` rows from #547. Reuses the existing `MCP_MESH_RETENTION` env (no new env var). Race-safe across multi-replica Postgres deployments via SERIALIZABLE isolation on the per-row purge tx.

- Sweep step finds schemas older than retention with no `capability.input_schema_hash` / `output_schema_hash` reference
- Each candidate purge runs in a SERIALIZABLE tx so a concurrent registration that creates a referencing capability triggers Postgres SSI predicate-conflict detection (40001), aborts one tx, gets retried on the next sweep cycle
- SQLite uses SERIALIZABLE by default; no special handling needed for dev mode
- Forensic mode (`MCP_MESH_RETENTION=0`) skips the new step alongside the existing agent purge
- Candidate scan is bounded (`Limit(1000)` + hash-only `Select`) to defend against memory blowup if `schema_entries` ever grows pathologically

## Why this matters (race-safety detail)

The naive READ COMMITTED implementation has a real race window:
1. tx_sweep: Count(refs for hash H) = 0
2. tx_register (concurrent): INSERT capability with hash=H, commits
3. tx_sweep: DELETE schema_entry H, commits

Result: capability points to deleted hash → resolver's `loadCanonicalByHash` returns nil → silent fallback to "keep candidate" without schema check. In strict-mode multi-producer scenarios, this could send consumer traffic to the wrong producer for one resolution cycle. Self-healing on next heartbeat (~5s), but the dep_resolution decision is already persisted. Reproducing in production would be timing-dependent and hostile to debug.

SERIALIZABLE isolation makes the race statically impossible: PostgreSQL's SSI tracks the predicate dependency between sweep's `Count` and registration's `INSERT capability`, and aborts one tx when it detects the conflict.

## Review Notes

PR review found 1 BLOCKER + 4 WARNINGs; all 5 addressed:

- **BLOCKER**: race-safety claim under READ COMMITTED → fixed via SERIALIZABLE on `purgeOneSchemaEntry`
- **WARNING (memory)**: unbounded candidate load → bounded with `Limit(1000)` + hash-only Select
- **WARNING (test)**: race-safety test didn't actually exercise the in-tx window → renamed to `_RefCheckPreventsDelete` to honestly describe what it tests; comment notes that SSI verification needs a Postgres integration test (out of scope)
- **WARNING (doc)**: "same sweep cycle" claim was conditional → tightened
- **WARNING (doc)**: race-safety overstated → rewrote `purgeOneSchemaEntry` doc to honestly describe the SSI contract

INFOs (deferred): `Retention > 0` gate duplication, `created_at` immutability making in-tx re-check belt-and-suspenders, `DeleteOneID` micro-optimization, removing `(#842)` from end-user docs.

Closes #842

## Test plan

- [x] All 156 registry tests pass (existing 6 sweep tests + 4 new schema-purge tests)
- [x] `TestSweep_PurgeOrphanSchemaEntries_DeletesOrphan` — orphan + stale → deleted
- [x] `TestSweep_PurgeOrphanSchemaEntries_KeepsReferenced` — referenced via either hash field → kept
- [x] `TestSweep_PurgeOrphanSchemaEntries_KeepsRecent` — orphan but within retention → kept
- [x] `TestSweep_PurgeOrphanSchemaEntries_RefCheckPreventsDelete` — pre-existing capability reference prevents delete
- [x] `runOnce` return signature updated (3→4 values); 6 test call sites + 1 integration test fixed
- [ ] Reviewer to verify CI passes
- [ ] Future: Postgres integration test to verify SSI-level race prevention end-to-end (separate work — needs Postgres test fixture)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `MCP_MESH_RETENTION` environment variable to configure data retention and purging intervals (defaults to 1 hour; set to 0 to disable sweeping for forensic analysis).
  * Sweep job now purges orphan schema entries that are unreferenced and older than the retention window.

* **Documentation**
  * Expanded environment variable documentation with retention configuration details and clarified purge behavior for agents, events, and schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->