### PR TITLE
feature: streaming bonus tutorial + mesh-delegate streaming (#849)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,3 +293,4 @@ src/ui/dist/
 src/ui/node_modules/
 mcp-mesh-ui
 uisample/
+dump.rdb

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -113,10 +113,10 @@ The two modes share the same author surface; the resolver picks the right varian
 
 | Consumer return type | Resolver matches | Provider tool used |
 |----------------------|------------------|--------------------|
-| `mesh.Stream[str]`   | `+ai.mcpmesh.stream` | `process_chat_stream` (streaming) |
-| `str` / Pydantic     | `-ai.mcpmesh.stream` | `process_chat` (buffered) |
+| `mesh.Stream[str]`   | `ai.mcpmesh.stream` (REQUIRED) | `process_chat_stream` (streaming) |
+| `str` / Pydantic     | `-ai.mcpmesh.stream` (EXCLUDED) | `process_chat` (buffered) |
 
-If the resolved provider is older and never advertised the streaming variant, mesh logs a warning and falls back to a single buffered chunk so the consumer doesn't break.
+The matcher operators are unprefixed = REQUIRED, `+` = PREFERRED (bonus score), `-` = EXCLUDED. The streaming consumer requires the tag — a consumer with `Stream[str]` will fail to resolve a pre-Phase-5 provider that never advertised the tag (rather than silently degrading to buffered). A defensive runtime fallback exists for the rare case where the provider matched on tag but the streaming MCP tool itself errors with "unknown tool" mid-call.
 
 ## What it does NOT do (v1 limitations)
 

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -105,9 +105,20 @@ Pre-flight checks in `chat_endpoint` fire BEFORE `StreamingResponse` is built, s
 
 Both patterns are valid — pick the one that matches the error model. If only mid-stream errors matter, the simpler `async def ... yield` form is fine; if pre-flight failures must be visible to non-SSE clients via HTTP status, use the coroutine-returns-generator pattern.
 
-## What it does NOT do (v1 limitations)
+## Direct vs mesh-delegate streaming
 
-- **Direct-mode LLM only.** `MeshLlmAgent.stream()` works when the injected provider does direct LiteLLM calls. Mesh-delegated providers (zero-code `@mesh.llm_provider` wrappers) raise `NotImplementedError` for `stream()`. Provider-mode streaming is planned for a follow-up.
+`MeshLlmAgent.stream()` works in both modes. **Direct mode** (consumer-supplied LiteLLM call) streams chunks straight from the vendor SDK. **Mesh-delegate mode** (zero-code `@mesh.llm_provider`) streams through the provider's auto-generated `process_chat_stream` tool — the provider runs the agentic loop, the consumer just iterates chunks.
+
+The two modes share the same author surface; the resolver picks the right variant based on the consumer's return type:
+
+| Consumer return type | Resolver matches | Provider tool used |
+|----------------------|------------------|--------------------|
+| `mesh.Stream[str]`   | `+ai.mcpmesh.stream` | `process_chat_stream` (streaming) |
+| `str` / Pydantic     | `-ai.mcpmesh.stream` | `process_chat` (buffered) |
+
+If the resolved provider is older and never advertised the streaming variant, mesh logs a warning and falls back to a single buffered chunk so the consumer doesn't break.
+
+## What it does NOT do (v1 limitations)
 
 - **`Stream[str]` only.** `Stream[T]` for any `T != str` is rejected at decorator-time with a clear error. Typed Pydantic streaming is intentionally unsupported — the consumer needs complete JSON for schema validation, which contradicts the streaming model.
 

--- a/docs/tutorial/day-10-bonus-streaming-ui.md
+++ b/docs/tutorial/day-10-bonus-streaming-ui.md
@@ -1,0 +1,571 @@
+# Day 10 Bonus -- Streaming UI
+
+Your Day 9 mesh produces complete trip plans, but the user stares at a spinner
+for 30+ seconds while Claude composes the response, the committee runs, and
+tools fetch real data. Today's bonus chapter swaps the buffered request/response
+pattern for **token-by-token streaming** — the itinerary appears as Claude
+writes it, and a mobile-first React UI renders the stream live.
+
+You'll change exactly two files (the planner and the gateway), add a single
+HTML file for the UI, and watch chunks flow through the **deepest pipeline
+mcp-mesh can compose**: browser → SSE → gateway → planner → committee
+(parallel fan-out) → LLM provider → tool calls → final streaming Claude call.
+Every hop you built across Days 1-9 still runs unchanged.
+
+!!! info "Prerequisites"
+    Day 9's mesh must be running (all 13 agents, locally or in Kubernetes).
+    The bonus chapter swaps the planner and gateway for streaming variants —
+    the other 11 agents stay exactly as they are. You'll also need
+    `ANTHROPIC_API_KEY` set so Claude actually streams (no API key →
+    `MESH_LLM_DRY_RUN=1` produces a deterministic test stream).
+
+## What we're building today
+
+```mermaid
+graph LR
+    UI[React UI] -->|"fetch /plan<br/>(SSE)"| GW[gateway]
+    GW -->|"trip_planning<br/>Stream[str]"| PL[planner]
+    PL -.->|tier-1| CH[chat-history]
+    PL -.->|tier-1| UPA[user-prefs]
+    PL ==>|fan-out| BA[budget-analyst]
+    PL ==>|fan-out| AA[adventure-advisor]
+    PL ==>|fan-out| LP[logistics-planner]
+    PL -->|"+claude<br/>llm.stream()"| CP[claude-provider]
+    CP -.->|tier-2| FA[flight-agent]
+    CP -.->|tier-2| HA[hotel-agent]
+    CP -.->|tier-2| WA[weather-agent]
+    CP -.->|tier-2| PA[poi-agent]
+
+    style UI fill:#e67e22,color:#fff
+    style GW fill:#e67e22,color:#fff
+    style PL fill:#9b59b6,color:#fff
+    style CP fill:#9b59b6,color:#fff
+    style BA fill:#f39c12,color:#fff
+    style AA fill:#f39c12,color:#fff
+    style LP fill:#f39c12,color:#fff
+    style FA fill:#4a9eff,color:#fff
+    style HA fill:#4a9eff,color:#fff
+    style WA fill:#4a9eff,color:#fff
+    style PA fill:#4a9eff,color:#fff
+    style UPA fill:#1a8a4a,color:#fff
+    style CH fill:#1abc9c,color:#fff
+```
+
+The mesh topology is identical to Day 9. The only thing that changes is **how
+chunks travel along the dotted edges**: instead of a single buffered
+`CallToolResult` arriving at the end, the planner's final Claude call streams
+text chunks back through the planner, through the gateway, and out as SSE
+events to the browser — live as Claude generates them.
+
+Today has five parts:
+
+1. **Stream[str] in 60 seconds** — the opt-in API
+2. **Update the planner** — fan out the committee, then stream the final LLM call
+3. **Update the gateway** — `@mesh.route` + `mesh.Stream[str]` = automatic SSE
+4. **Add the React UI** — a single HTML file, no build step
+5. **Run it and watch tokens flow**
+
+## Part 1: Stream[str] in 60 seconds
+
+Streaming in mcp-mesh is **opt-in per tool by return type annotation**. Two
+changes to a tool flip it from buffered to streaming:
+
+- Return type goes from `str` (or a Pydantic model) to `mesh.Stream[str]`
+- The function `yield`s chunks instead of `return`ing the final string
+
+```python
+@mesh.tool(capability="chat")
+async def chat(prompt: str, llm: mesh.MeshLlmAgent = None) -> mesh.Stream[str]:
+    async for chunk in llm.stream(prompt):
+        yield chunk
+```
+
+That's it. The framework detects the `Stream[str]` annotation, picks the
+streaming code path on the producer (sends each chunk as an MCP
+`notifications/progress` message) and on the consumer (`proxy.stream(...)`
+returns an async iterator). Nothing else changes.
+
+When a consumer's return type is `Stream[str]`, the resolver automatically
+picks the **streaming variant** of any LLM provider (the auto-generated
+`process_chat_stream` tool) — Claude's chunks flow through the provider's
+agentic loop and out to the consumer in real time.
+
+!!! tip "When does streaming actually buffer?"
+    LLM agentic loops can run multiple iterations: the LLM may call a tool,
+    get a result, call another tool, get a result, and only THEN produce the
+    final text. Mesh streams **only the final iteration** — intermediate
+    tool-calling iterations are buffered because the LLM needs the complete
+    tool result in its context for the next step. In TripPlanner this means a
+    brief silent pause (Claude calls `flight_search`, `hotel_search`,
+    `get_weather`, `search_pois` — each fully completes), then the itinerary
+    streams token-by-token as Claude composes the final answer.
+
+For the full streaming concept doc, see
+[Concepts: Streaming](../concepts/streaming.md). The rest of today is about
+applying it to the trip planner.
+
+## Part 2: Update the planner
+
+The Day 7 planner returned `str` and called the LLM with `await llm(...)`.
+The streaming variant returns `mesh.Stream[str]`, pre-fetches the committee
+in parallel, then streams the final LLM call chunk-by-chunk.
+
+The downloadable bonus already contains the full planner — the snippets below
+walk through what changed.
+
+### Imports and context model (unchanged)
+
+```python
+--8<-- "examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py:imports"
+```
+
+```python
+--8<-- "examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py:context_model"
+```
+
+The Pydantic context model carries `destination`, `dates`, `budget`,
+`user_preferences`, and `committee_insights` into the Jinja prompt — same as
+Day 7, plus the new `committee_insights` field that holds the pre-fetched
+specialist output.
+
+### Same dependencies, new return type
+
+```python
+--8<-- "examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py:committee_deps"
+```
+
+The dependency list is identical to Day 7. Five tier-1 dependencies:
+`user_preferences`, `chat_history`, plus the three committee specialists.
+Tools (flight/hotel/weather/POI) come in via the `@mesh.llm` decorator's
+`filter` block above this.
+
+The function signature changes the return annotation:
+
+```python
+async def plan_trip(
+    destination: str,
+    dates: str,
+    budget: str,
+    message: str = "",
+    session_id: str = "",
+    ...
+    ctx: TripRequest = None,
+    llm: mesh.MeshLlmAgent = None,
+) -> mesh.Stream[str]:
+    """Stream a trip itinerary one chunk at a time as the LLM generates it."""
+```
+
+`-> mesh.Stream[str]` is the only structural change required to flip from
+buffered to streaming.
+
+### Pre-fetch the committee in parallel
+
+The committee runs **before** the streaming LLM call so its insights can be
+injected into the LLM context. Each specialist agent is itself an `@mesh.llm`
+function with `max_iterations=1` — they make their own non-streaming Claude
+calls in parallel via `asyncio.gather`:
+
+```python
+--8<-- "examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py:committee_prefetch"
+```
+
+This is the same fan-out pattern from Day 7, just hoisted up so it runs
+before the streaming call instead of after a buffered one.
+
+!!! info "Why aren't the specialists streaming too?"
+    Each specialist returns a Pydantic model (`BudgetAnalysis`,
+    `AdventureAdvice`, `LogisticsPlan`) — structured outputs genuinely cannot
+    stream because the consumer needs complete valid JSON to validate against
+    the schema. The planner consumes them as buffered Pydantic objects,
+    weaves the insights into the Claude prompt, and **only the planner's
+    final user-visible Claude call streams**. This mirrors how production
+    streaming UIs work: the UI doesn't need to see specialist JSON arrive
+    char-by-char, just the human-readable answer.
+
+### Stream the final LLM call
+
+The final piece is the streaming Claude call. `llm.stream(...)` returns an
+async iterator — `yield` each chunk straight through to the consumer:
+
+```python
+--8<-- "examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py:streaming_llm"
+```
+
+Two notes on this block:
+
+1. The committee's pre-computed insights are injected via the `context=` kwarg.
+   The Jinja template (`prompts/plan_trip.j2`) renders them into the system
+   prompt under a `Committee Insights` section.
+2. `accumulated.append(chunk)` collects the full text alongside streaming so
+   chat history can persist the assistant's complete reply after the stream
+   ends.
+
+### Persist conversation history (unchanged from Day 6)
+
+After the stream completes, the planner saves both the user message and the
+assistant's full reply to chat history — same pattern as Day 6:
+
+```python
+--8<-- "examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py:chat_history_save"
+```
+
+### Optional: dry-run mode for tests
+
+The planner also supports a deterministic `MESH_LLM_DRY_RUN=1` mode that
+yields a fixed sequence of test chunks. The `uc20_streaming` integration test
+uses this to verify the streaming pipeline end-to-end without burning Claude
+tokens:
+
+```python
+--8<-- "examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py:dry_run"
+```
+
+## Part 3: Update the gateway
+
+The gateway change is even smaller. `@mesh.route` already understands
+`mesh.Stream[str]` — when the route's return type is a stream, FastAPI's
+response is automatically wrapped as Server-Sent Events.
+
+### Mount static files for the UI
+
+The gateway also serves the React UI from a `static/` directory. Two lines of
+imports and one mount call:
+
+```python
+--8<-- "examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/main.py:imports"
+```
+
+```python
+--8<-- "examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/main.py:ui_route"
+```
+
+`GET /` serves `static/index.html`. `GET /static/*` serves the rest (only
+`index.html` exists — no build step, no asset pipeline).
+
+### `/plan` returns a stream
+
+The streaming endpoint is structurally similar to Day 5's gateway, with two
+critical changes: the function signature returns `mesh.Stream[str]`, and the
+async iteration over `plan_trip.stream(...)` happens inside a separate inner
+function:
+
+```python
+--8<-- "examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/main.py:plan_endpoint"
+```
+
+The split between `plan_trip` (the route handler) and `_stream_plan` (the
+inner generator) is **intentional**, not stylistic.
+
+!!! warning "FastAPI streaming gotcha — pre-flight errors"
+    If you write the streaming logic directly in the route handler (as a
+    single `async def ... yield`), the function becomes an async generator.
+    FastAPI starts the SSE response immediately — and any `HTTPException`
+    you raise to validate the request body (`if "destination" not in body:
+    raise HTTPException(400)`) fires AFTER the response has already
+    committed to HTTP 200. The client sees a 200 OK with an `event: error`
+    SSE frame instead of a proper 400.
+
+    The two-function pattern fixes this: `plan_trip` is a regular coroutine
+    that runs the validation, then **returns** a generator (`_stream_plan`)
+    without awaiting it. `HTTPException` raised inside `plan_trip` propagates
+    as a real 400/503 status code; errors raised inside `_stream_plan` (after
+    the stream starts) still surface as `event: error` frames. Pick the
+    error model consciously.
+
+The SSE wire format is plain MCP — each chunk becomes a `data: <chunk>\n\n`
+line, and the stream terminates with `data: [DONE]\n\n`. Browsers consume it
+via `fetch` + `ReadableStream` (the standard `EventSource` API is GET-only,
+which is why we use `fetch` below).
+
+## Part 4: Add the React UI
+
+The UI is a **single HTML file** — React + Babel-standalone loaded from a
+CDN. No npm install, no bundler, no build step. Drop the file into
+`gateway/static/index.html` and the gateway serves it.
+
+The complete file is in
+`examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/static/index.html`.
+Here are the three pieces that make it stream:
+
+### Submit the form via fetch (not EventSource)
+
+`EventSource` only supports GET. Streaming POST requires
+`fetch` + `ReadableStream`:
+
+```javascript
+const resp = await fetch("/plan", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "X-Session-Id": sessionRef.current,
+  },
+  body: JSON.stringify({ destination, dates, budget, message }),
+});
+```
+
+The `X-Session-Id` header carries the session UUID so the planner can fetch
+prior chat history and persist this turn — same pattern as Day 6.
+
+### Read the SSE stream chunk-by-chunk
+
+```javascript
+const reader = resp.body.getReader();
+const decoder = new TextDecoder();
+let buffer = "";
+let acc = "";
+
+while (!done) {
+  const { value, done: rdDone } = await reader.read();
+  if (rdDone) break;
+  buffer += decoder.decode(value, { stream: true });
+
+  // SSE framing: events separated by \n\n, payload after "data: "
+  let sep;
+  while ((sep = buffer.indexOf("\n\n")) !== -1) {
+    const event = buffer.slice(0, sep);
+    buffer = buffer.slice(sep + 2);
+    const data = event
+      .split("\n")
+      .filter((l) => l.startsWith("data: "))
+      .map((l) => l.slice(6))
+      .join("\n");
+    if (data === "[DONE]") { done = true; break; }
+    acc += data;
+    setStreaming(acc);  // re-render with the accumulated text
+  }
+}
+```
+
+The accumulator `acc` builds up the full text. Each `setStreaming(acc)` call
+triggers a React re-render, so the user sees the itinerary grow chunk by
+chunk.
+
+### Render the streaming text
+
+```jsx
+{waiting && !streaming && <div className="spinner">contacting the committee...</div>}
+{error && <div className="response error">{error}</div>}
+{streaming && <div className="response">{streaming}</div>}
+```
+
+A spinner shows while we wait for the committee to finish (those buffered
+specialist calls take 5-10s each). The first streaming chunk swaps the
+spinner for the response container, and from that point on every new chunk
+appends to the visible text. The whole UI is mobile-first — `max-width:
+640px`, system fonts, dark-mode support via `prefers-color-scheme`, no
+JavaScript framework beyond React + Babel.
+
+## Part 5: Run it and watch tokens flow
+
+### Stop the Day 9 planner and gateway
+
+The other 11 agents stay exactly as they are. Only the planner and gateway
+get swapped:
+
+```shell
+$ meshctl stop planner-agent gateway
+```
+
+### Start the streaming variants
+
+From `examples/tutorial/trip-planner/day-10/bonus-ui/python/`:
+
+```shell
+$ meshctl start --debug -d -w \
+    planner-agent/main.py \
+    gateway/main.py
+```
+
+Verify the mesh:
+
+```shell
+$ meshctl list
+```
+
+```
+Registry: running (http://localhost:8000) - 13 healthy
+
+NAME                             RUNTIME   TYPE    STATUS    DEPS    ENDPOINT           ...
+adventure-advisor-...            Python    Agent   healthy   0/0     ...
+budget-analyst-...               Python    Agent   healthy   0/0     ...
+chat-history-agent-...           Python    Agent   healthy   0/0     ...
+claude-provider-...              Python    Agent   healthy   0/0     ...
+flight-agent-...                 Python    Agent   healthy   1/1     ...
+gateway-...                      Python    API     healthy   1/1     10.0.0.74:8080
+hotel-agent-...                  Python    Agent   healthy   0/0     ...
+logistics-planner-...            Python    Agent   healthy   0/0     ...
+openai-provider-...              Python    Agent   healthy   0/0     ...
+planner-agent-...                Python    Agent   healthy   5/5     ...
+poi-agent-...                    Python    Agent   healthy   1/1     ...
+user-prefs-agent-...             Python    Agent   healthy   0/0     ...
+weather-agent-...                Python    Agent   healthy   0/0     ...
+```
+
+13 healthy agents, planner shows 5/5 deps. Same topology as Day 9 — only the
+streaming code paths are new.
+
+### Open the UI
+
+Visit [http://localhost:8080/](http://localhost:8080/) in any browser. You
+get the mobile-first form. Enter a destination, dates, and budget, then click
+**Plan my trip**.
+
+What you'll see:
+
+1. The spinner (`contacting the committee...`) shows for ~5-10 seconds while
+   the committee runs in parallel and Claude makes its tool calls
+   (flight/hotel/weather/POI).
+2. The first text chunk arrives — the spinner disappears.
+3. The itinerary streams **token by token** as Claude composes the response.
+4. Total wall-clock time matches Day 9 (~30-40s for a 5-day plan), but the
+   user sees output starting much earlier.
+
+### Curl it for the raw SSE wire format
+
+```shell
+$ curl -N -X POST http://localhost:8080/plan \
+    -H "Content-Type: application/json" \
+    -H "X-Session-Id: my-curl-session" \
+    -d '{"destination":"Tokyo","dates":"June 1-5, 2026","budget":"$2000"}'
+```
+
+```
+data: ##
+
+data:  Tokyo
+
+data:  Trip
+
+data:  Itinerary
+
+data: :
+
+data:  June
+
+...
+data: [DONE]
+```
+
+Each `data:` line is one chunk Claude produced. The `[DONE]` sentinel marks
+end-of-stream — the React client uses it to stop reading.
+
+### Walk the trace
+
+Open the mesh UI:
+
+```shell
+$ meshctl start --ui -d
+```
+
+Navigate to `http://localhost:3080` and click the most recent trace. You'll
+see the same fan-out you saw on Day 7, but now with one streaming span:
+
+```
+└─ plan_trip (planner-agent) [38712ms] ✓
+   ├─ get_history (chat-history-agent) [2ms] ✓
+   ├─ get_user_prefs (user-prefs-agent) [1ms] ✓
+   ├─ budget_analysis (budget-analyst) [8204ms] ✓        ← parallel
+   ├─ adventure_advice (adventure-advisor) [7891ms] ✓    ← parallel
+   ├─ logistics_planning (logistics-planner) [8102ms] ✓  ← parallel
+   ├─ process_chat_stream (claude-provider) [21438ms] ✓  ← STREAMING
+   │  ├─ flight_search (flight-agent) [14ms] ✓
+   │  ├─ hotel_search (hotel-agent) [1ms] ✓
+   │  ├─ get_weather (weather-agent) [0ms] ✓
+   │  └─ search_pois (poi-agent) [21ms] ✓
+   ├─ save_turn (chat-history-agent) [1ms] ✓
+   └─ save_turn (chat-history-agent) [1ms] ✓
+```
+
+Two structural changes from Day 7:
+
+- The committee specialists run **first** and in parallel (the planner
+  pre-fetches their insights before the streaming call).
+- The Claude call resolves to `process_chat_stream` (the streaming variant
+  of `claude-provider`'s auto-generated tool) instead of `claude_provider`.
+  That's the resolver picking the right variant based on the planner's
+  `Stream[str]` return type — no manual config required.
+
+## Stop and clean up
+
+```shell
+$ meshctl stop
+```
+
+## Troubleshooting
+
+**Spinner never disappears, then everything appears at once.** This is the
+classic "buffered, not streaming" failure mode. Check three things in order:
+
+1. The planner function's return annotation is exactly `mesh.Stream[str]`
+   (not `str`, not `AsyncIterator[str]`).
+2. The function uses `yield` inside the body, not `return`.
+3. No intermediate hop in the chain accumulates with
+   `"".join([c async for c in ...])`. Each hop must be a pass-through
+   `async for chunk in upstream.stream(...): yield chunk`.
+
+**Browser receives `event: error` frame with HTTP 200 instead of 4xx.** The
+gateway's route handler became an async generator — request validation fires
+after the SSE response committed to 200. Fix: split the handler into a
+regular coroutine (validation + return) and an inner generator
+(streaming). See the warning callout in Part 3.
+
+**`[DONE]` never arrives, browser hangs after final chunk.** Make sure the
+gateway's `_stream_plan` generator function returns cleanly (no unhandled
+exception in the `async for` loop). The mesh's SSE wrapper appends
+`[DONE]` only when the generator exhausts normally.
+
+**Tools time out during the streaming Claude call.** Each tool the LLM calls
+is buffered (intermediate iterations don't stream). If a tool agent is slow
+or down, the streaming portion never starts — there's just a long silent
+pause. Check `meshctl list` for agent health and `meshctl logs <agent>`
+for errors.
+
+**`ctx` parameter not recognized as the prompt context model.** Mesh injects
+the FastMCP `Context` object by **type annotation**, not by parameter name.
+If you declare `ctx: SomeContextModel` (Pydantic) the framework treats it as
+your prompt context, NOT as FastMCP `Context`. This is the intended
+behavior — name your context-model parameter whatever makes the prompt
+template most readable.
+
+## Recap
+
+You took the buffered Day 9 mesh and made the user-visible Claude response
+stream live with two file changes:
+
+- **Planner** — return `mesh.Stream[str]`, hoist the committee fan-out before
+  the LLM call, replace `await llm(...)` with `async for chunk in
+  llm.stream(...)`.
+- **Gateway** — return `mesh.Stream[str]` from the `@mesh.route` handler,
+  split the route into a coroutine + inner generator so pre-flight errors
+  propagate as proper HTTP status codes.
+
+Plus a single HTML file for a mobile-first React UI.
+
+The 11 other agents — committee specialists, tool agents, providers, chat
+history — stay unchanged. The mesh resolver picks the streaming variant of
+`claude-provider` automatically because the planner's return type is
+`Stream[str]`. The same `@mesh.llm_provider` you scaffolded on Day 3 now
+streams without any code changes on the provider side.
+
+This is the deepest pipeline mcp-mesh ships: browser → SSE → gateway →
+streaming planner → parallel committee fan-out → mesh-delegated LLM provider
+→ buffered tool calls → final streaming Claude response → all the way back
+to the user's screen, token by token.
+
+## See also
+
+- [Concepts: Streaming](../concepts/streaming.md) — the full streaming
+  architecture (Stream[str] type, MCP progress notifications wire protocol,
+  multi-hop composition, direct vs mesh-delegate modes)
+- `meshctl man decorators` — `@mesh.tool`, `@mesh.llm`, `@mesh.route`
+  reference
+- [Day 7 — Committee of Specialists](day-07-committee.md) — the original
+  buffered version of the planner with the committee fan-out
+- [Day 5 — HTTP Gateway](day-05-http-gateway.md) — the original buffered
+  `@mesh.route` gateway
+
+## Next up
+
+This is the end of the TripPlanner tutorial. Head back to
+[Day 10 — What's Next](day-10-whats-next.md) for production-readiness
+pointers, scaling tips, and challenges to take TripPlanner further.

--- a/docs/tutorial/day-10-whats-next.md
+++ b/docs/tutorial/day-10-whats-next.md
@@ -265,13 +265,14 @@ headers so log lines correlate with distributed traces. Ship logs to Grafana
 Loki and cross-reference with Tempo traces for full request-level
 observability.
 
-### Build a mobile client
+### Build a streaming mobile UI
 
-Create a lightweight web UI that talks to the gateway's `/plan` endpoint.
-A starter project is waiting in
-`examples/tutorial/trip-planner/day-10/bonus-ui/` -- check the README for
-status. The gateway already exposes a REST API, so the client is a standard
-fetch/axios integration.
+Already built — see the
+[Day 10 Bonus — Streaming UI](day-10-bonus-streaming-ui.md) chapter. It
+takes the buffered Day 9 mesh and makes the user-visible Claude response
+stream live, token by token, into a mobile-first React UI. Two file changes
+(planner + gateway) plus a single HTML file. The deepest pipeline mcp-mesh
+ships, end to end.
 
 ---
 

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/README.md
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/README.md
@@ -1,4 +1,37 @@
-# TripPlanner Bonus UI
+# TripPlanner Streaming UI (Bonus Chapter)
 
-A mobile-first UI for TripPlanner is coming as a bonus for completing this
-tutorial. Check back soon.
+Mobile-first React UI that streams trip plans live as Claude generates them
+through the multi-agent committee pipeline. See
+`docs/tutorial/day-10-bonus-streaming-ui.md` for the full walkthrough.
+
+## Quick start
+
+Requires the full Day 9 mesh running (all 13 agents) plus `ANTHROPIC_API_KEY`.
+
+Replace the existing planner-agent and gateway with the streaming variants:
+
+```bash
+meshctl stop planner gateway
+meshctl start day-10/bonus-ui/python/planner-agent/main.py -d
+meshctl start day-10/bonus-ui/python/gateway/main.py -d
+```
+
+Open <http://localhost:8080/> in a browser and watch tokens stream as Claude
+plans your trip across the committee + tool dependencies.
+
+## What's in here
+
+- `python/planner-agent/` — streaming variant: returns `mesh.Stream[str]`,
+  pre-fetches committee insights, then streams the final LLM call.
+- `python/gateway/` — streaming variant: `/plan` returns `mesh.Stream[str]`
+  (auto SSE), `GET /` serves the React UI from `static/index.html`.
+
+## Testing without an API key
+
+Set `MESH_LLM_DRY_RUN=1` on the planner. It exercises every dependency
+(committee + chat history + user prefs) and yields a deterministic chunk
+sequence — used by the streaming integration test (uc20 tc06).
+
+```bash
+MESH_LLM_DRY_RUN=1 meshctl start day-10/bonus-ui/python/planner-agent/main.py -d
+```

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/README.md
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/README.md
@@ -30,7 +30,8 @@ plans your trip across the committee + tool dependencies.
 
 Set `MESH_LLM_DRY_RUN=1` on the planner. It exercises every dependency
 (committee + chat history + user prefs) and yields a deterministic chunk
-sequence — used by the streaming integration test (uc20 tc06).
+sequence — used by the streaming integration test
+(`uc20/tc11_day10_bonus_streaming`).
 
 ```bash
 MESH_LLM_DRY_RUN=1 meshctl start day-10/bonus-ui/python/planner-agent/main.py -d

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/Dockerfile
@@ -1,0 +1,25 @@
+# Dockerfile for gateway MCP Mesh streaming API gateway
+FROM mcpmesh/python-runtime:1.4.1
+
+WORKDIR /app
+
+# Switch to root to copy files (base image runs as non-root mcp-mesh user)
+USER root
+
+# Copy requirements and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy agent source code and set permissions
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
+
+# Switch back to non-root user for security
+USER mcp-mesh
+
+# Expose the agent port
+EXPOSE 8080
+
+# Run the agent
+# NOTE: Base image has ENTRYPOINT ["python"], so CMD only needs the script name
+CMD ["main.py"]

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/README.md
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/README.md
@@ -1,0 +1,28 @@
+# gateway (streaming, Day 10 bonus)
+
+Streaming variant of the Day 9 gateway. The `/plan` route returns
+`mesh.Stream[str]` so chunks from the planner flow straight through to the
+browser as SSE frames.
+
+## What's different from Day 9
+
+- `/plan` returns `mesh.Stream[str]` instead of buffered JSON.
+- The route uses the **coroutine-returns-generator pattern** so pre-stream
+  errors (missing dependency, malformed body) raise `HTTPException` and
+  surface as proper HTTP status codes.
+- A new `GET /` route serves the bundled mobile-first React UI from
+  `static/index.html`.
+
+## Running
+
+```bash
+meshctl start main.py
+```
+
+Open `http://localhost:8080/` in a browser to use the UI, or POST directly:
+
+```bash
+curl -N -X POST http://localhost:8080/plan \
+  -H "Content-Type: application/json" \
+  -d '{"destination": "Tokyo", "dates": "Jun 1-5, 2026", "budget": "$2000"}'
+```

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/__init__.py
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/__init__.py
@@ -1,0 +1,1 @@
+"""Gateway API Gateway - MCP Mesh streaming API gateway (Day 10 bonus)."""

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/__main__.py
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/__main__.py
@@ -1,8 +1,5 @@
 """Entry point for gateway module."""
 
-from main import app  # noqa: F401
 
 if __name__ == "__main__":
-    import uvicorn
-
-    uvicorn.run(app, host="0.0.0.0", port=8080, log_level="info")
+    pass  # MCP Mesh handles startup via @mesh.route auto-detection

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/__main__.py
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point for gateway module."""
+
+from main import app  # noqa: F401
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8080, log_level="info")

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/helm-values.yaml
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/helm-values.yaml
@@ -1,0 +1,44 @@
+# Helm values for deploying gateway with mcp-mesh-agent chart
+# Usage: helm install gateway oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent -f helm-values.yaml
+# Check latest version: helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent
+
+image:
+  repository: your-registry/gateway
+  tag: "v1.0.0"  # Your image version. Override with: --set image.tag=v1.2.3
+  pullPolicy: IfNotPresent
+
+agent:
+  name: gateway
+  runtime: python
+  # K8s uses port 8080 by default (each pod has its own IP, no conflicts)
+  # http:
+  #   port: 8080
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+mesh:
+  enabled: true
+  # Short name resolves in same namespace as core. For cross-namespace:
+  #   registry.host: mcp-core-mcp-mesh-registry.<core-namespace>.svc.cluster.local
+
+registry:
+  host: "mcp-core-mcp-mesh-registry"
+  port: "8000"
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"
+
+# Optional: Secrets (creates a K8s Secret, injected via envFrom)
+# Uncomment to add — leaving commented avoids overriding base values
+# secrets:
+#   DATABASE_URL: "postgres://user:pass@host:5432/db"
+#   API_KEY: "your-api-key"

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/main.py
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/main.py
@@ -1,0 +1,83 @@
+# --8<-- [start:full_file]
+# --8<-- [start:imports]
+import uuid
+from pathlib import Path
+
+import mesh
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from mesh.types import McpMeshTool
+
+app = FastAPI(title="Trip Planner Streaming Gateway", version="2.1.0")
+
+_STATIC_DIR = Path(__file__).parent / "static"
+if _STATIC_DIR.is_dir():
+    app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
+# --8<-- [end:imports]
+
+
+@app.get("/health")
+async def health():
+    """Health check endpoint."""
+    return {"status": "healthy"}
+
+
+# --8<-- [start:ui_route]
+@app.get("/")
+async def index():
+    """Serve the single-page React trip-planner UI."""
+    index_path = _STATIC_DIR / "index.html"
+    if not index_path.is_file():
+        raise HTTPException(status_code=500, detail="index.html missing")
+    return FileResponse(str(index_path))
+# --8<-- [end:ui_route]
+
+
+# --8<-- [start:plan_endpoint]
+@app.post("/plan")
+@mesh.route(dependencies=["trip_planning"])
+async def plan_trip(
+    request: Request,
+    plan_trip: McpMeshTool = None,
+) -> mesh.Stream[str]:
+    """Stream the trip plan via SSE: gateway -> planner -> committee + tools + Claude.
+
+    Pre-stream errors (missing dependency, bad request body) are raised here
+    BEFORE returning the generator so they propagate as proper HTTP status
+    codes. Errors raised inside the generator body fire after StreamingResponse
+    has committed to HTTP 200 and surface as ``event: error`` SSE frames.
+    """
+    if plan_trip is None:
+        raise HTTPException(
+            status_code=503, detail="trip_planning capability unavailable"
+        )
+
+    body = await request.json()
+    if "destination" not in body or "dates" not in body or "budget" not in body:
+        raise HTTPException(
+            status_code=400,
+            detail="missing required fields: destination, dates, budget",
+        )
+
+    session_id = request.headers.get("X-Session-Id") or str(uuid.uuid4())
+    return _stream_plan(plan_trip, body, session_id)
+
+
+async def _stream_plan(plan_trip: McpMeshTool, body: dict, session_id: str):
+    async for chunk in plan_trip.stream(
+        destination=body["destination"],
+        dates=body["dates"],
+        budget=body["budget"],
+        message=body.get("message", ""),
+        session_id=session_id,
+    ):
+        yield chunk
+# --8<-- [end:plan_endpoint]
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8080, log_level="info")
+# --8<-- [end:full_file]

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/main.py
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/main.py
@@ -53,7 +53,14 @@ async def plan_trip(
             status_code=503, detail="trip_planning capability unavailable"
         )
 
-    body = await request.json()
+    try:
+        body = await request.json()
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=400, detail="invalid JSON body")
+    if not isinstance(body, dict):
+        raise HTTPException(
+            status_code=400, detail="request body must be a JSON object"
+        )
     if "destination" not in body or "dates" not in body or "budget" not in body:
         raise HTTPException(
             status_code=400,

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/requirements.txt
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/requirements.txt
@@ -1,0 +1,3 @@
+# gateway dependencies
+# Add your third-party dependencies here
+# Note: mcp-mesh is provided by the runtime environment (local venv or Docker base image)

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/static/index.html
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/static/index.html
@@ -145,7 +145,9 @@
           while (!done) {
             const { value, done: rdDone } = await reader.read();
             if (rdDone) break;
-            buffer += decoder.decode(value, { stream: true });
+            // Normalize CRLF to LF so the same parser handles either line
+            // ending if a proxy or alternative SSE writer uses CRLF.
+            buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, "\n");
             let sep;
             while ((sep = buffer.indexOf("\n\n")) !== -1) {
               const event = buffer.slice(0, sep);

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/static/index.html
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/static/index.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#0f1115" />
+  <title>TripPlanner</title>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <style>
+    :root {
+      --bg: #f7f7f8;
+      --fg: #1f2328;
+      --muted: #6b7280;
+      --border: #e5e7eb;
+      --card: #ffffff;
+      --accent: #2563eb;
+      --error: #ef4444;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0f1115;
+        --fg: #e5e7eb;
+        --muted: #9ca3af;
+        --border: #2a2f3a;
+        --card: #1a1d23;
+        --accent: #60a5fa;
+        --error: #f87171;
+      }
+    }
+    * { box-sizing: border-box; }
+    html, body {
+      margin: 0; padding: 0; min-height: 100%;
+      background: var(--bg); color: var(--fg);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      font-size: 16px; line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+    }
+    #root { display: flex; justify-content: center; padding: 16px; }
+    .app {
+      width: 100%; max-width: 640px;
+      display: flex; flex-direction: column; gap: 16px;
+    }
+    header h1 { margin: 0 0 4px; font-size: 22px; font-weight: 600; }
+    header p { margin: 0; color: var(--muted); font-size: 14px; }
+    form {
+      display: flex; flex-direction: column; gap: 12px;
+      padding: 16px; background: var(--card);
+      border: 1px solid var(--border); border-radius: 14px;
+    }
+    label {
+      display: flex; flex-direction: column; gap: 6px;
+      font-size: 13px; color: var(--muted); font-weight: 500;
+    }
+    input, textarea {
+      width: 100%; padding: 12px 14px; min-height: 44px;
+      border-radius: 10px; border: 1px solid var(--border);
+      background: var(--bg); color: var(--fg);
+      font: inherit; outline: none;
+    }
+    textarea { resize: vertical; min-height: 72px; }
+    input:focus, textarea:focus { border-color: var(--accent); }
+    button {
+      padding: 14px 18px; min-height: 48px;
+      border-radius: 10px; border: 0;
+      background: var(--accent); color: white;
+      font: inherit; font-weight: 600; font-size: 16px;
+      cursor: pointer;
+    }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .response {
+      padding: 16px; background: var(--card);
+      border: 1px solid var(--border); border-radius: 14px;
+      white-space: pre-wrap; word-wrap: break-word;
+      font-size: 15px;
+    }
+    .response.empty { color: var(--muted); font-style: italic; }
+    .response.error { border-color: var(--error); color: var(--error); }
+    .spinner {
+      display: inline-flex; align-items: center; gap: 8px;
+      color: var(--muted); font-size: 13px;
+    }
+    .spinner::before {
+      content: ""; width: 14px; height: 14px; border-radius: 50%;
+      border: 2px solid var(--border); border-top-color: var(--accent);
+      animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    const { useState, useRef } = React;
+
+    function App() {
+      const [destination, setDestination] = useState("Tokyo");
+      const [dates, setDates] = useState("June 1-5, 2026");
+      const [budget, setBudget] = useState("$2000");
+      const [message, setMessage] = useState("");
+      const [streaming, setStreaming] = useState("");
+      const [waiting, setWaiting] = useState(false);
+      const [error, setError] = useState("");
+      const sessionRef = useRef(crypto.randomUUID());
+
+      async function plan(e) {
+        e.preventDefault();
+        if (waiting) return;
+        setWaiting(true);
+        setStreaming("");
+        setError("");
+
+        let resp;
+        try {
+          resp = await fetch("/plan", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-Session-Id": sessionRef.current,
+            },
+            body: JSON.stringify({ destination, dates, budget, message }),
+          });
+        } catch (err) {
+          setWaiting(false);
+          setError("network error: " + err.message);
+          return;
+        }
+
+        if (!resp.ok || !resp.body) {
+          setWaiting(false);
+          const detail = await resp.text().catch(() => "");
+          setError(`HTTP ${resp.status}: ${detail || resp.statusText}`);
+          return;
+        }
+
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let acc = "";
+        let firstChunk = true;
+        let done = false;
+
+        try {
+          while (!done) {
+            const { value, done: rdDone } = await reader.read();
+            if (rdDone) break;
+            buffer += decoder.decode(value, { stream: true });
+            let sep;
+            while ((sep = buffer.indexOf("\n\n")) !== -1) {
+              const event = buffer.slice(0, sep);
+              buffer = buffer.slice(sep + 2);
+              const data = event
+                .split("\n")
+                .filter((l) => l.startsWith("data: "))
+                .map((l) => l.slice(6))
+                .join("\n");
+              if (data === "[DONE]") { done = true; break; }
+              if (firstChunk) { firstChunk = false; setWaiting(false); }
+              acc += data;
+              setStreaming(acc);
+            }
+          }
+        } catch (err) {
+          setError("stream error: " + (err && err.message ? err.message : String(err)));
+        } finally {
+          setWaiting(false);
+        }
+      }
+
+      return (
+        <div className="app">
+          <header>
+            <h1>TripPlanner</h1>
+            <p>Streamed live by Claude through the multi-agent committee.</p>
+          </header>
+          <form onSubmit={plan}>
+            <label>
+              Destination
+              <input value={destination} onChange={(e) => setDestination(e.target.value)} required />
+            </label>
+            <label>
+              Dates
+              <input value={dates} onChange={(e) => setDates(e.target.value)} required />
+            </label>
+            <label>
+              Budget
+              <input value={budget} onChange={(e) => setBudget(e.target.value)} required />
+            </label>
+            <label>
+              Anything else? (optional)
+              <textarea
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                placeholder="e.g. prefer mornings free, vegetarian-friendly restaurants..."
+              />
+            </label>
+            <button type="submit" disabled={waiting}>
+              {waiting ? "Planning..." : "Plan my trip"}
+            </button>
+          </form>
+          {waiting && !streaming && <div className="spinner">contacting the committee...</div>}
+          {error && <div className="response error">{error}</div>}
+          {streaming && <div className="response">{streaming}</div>}
+          {!waiting && !streaming && !error && (
+            <div className="response empty">Your itinerary will stream here.</div>
+          )}
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+  </script>
+</body>
+</html>

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/Dockerfile
@@ -1,0 +1,25 @@
+# Dockerfile for planner-agent MCP Mesh streaming LLM agent
+FROM mcpmesh/python-runtime:1.4.1
+
+WORKDIR /app
+
+# Switch to root to copy files (base image runs as non-root mcp-mesh user)
+USER root
+
+# Copy requirements and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy agent source code and set permissions
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
+
+# Switch back to non-root user for security
+USER mcp-mesh
+
+# Expose the agent port
+EXPOSE 9107
+
+# Run the agent
+# NOTE: Base image has ENTRYPOINT ["python"], so CMD only needs the script name
+CMD ["main.py"]

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/README.md
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/README.md
@@ -1,0 +1,28 @@
+# planner-agent (streaming, Day 10 bonus)
+
+Streaming variant of the Day 9 planner. Returns `mesh.Stream[str]` so the
+final user-visible response is yielded chunk-by-chunk while the agentic loop
+runs (real flight/hotel/weather/poi tool calls included).
+
+## What's different from Day 9
+
+- Return type: `mesh.Stream[str]` instead of `str`
+- The committee specialists (budget, adventure, logistics) run BEFORE the
+  streaming LLM call so their insights can be injected into the LLM context.
+  Each specialist is still a buffered, non-streaming call.
+- A `MESH_LLM_DRY_RUN=1` mode emits a deterministic chunk sequence without
+  hitting Claude — used by the streaming integration test (uc20 tc06).
+
+## Running
+
+```bash
+meshctl start main.py
+```
+
+Or with the dry-run mode for tests without an Anthropic API key:
+
+```bash
+MESH_LLM_DRY_RUN=1 meshctl start main.py
+```
+
+The agent listens on port 9107 (same as the Day 9 planner).

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/__init__.py
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/__init__.py
@@ -1,0 +1,1 @@
+"""PlannerAgent Agent - MCP Mesh streaming LLM agent (Day 10 bonus)."""

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/__main__.py
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/__main__.py
@@ -1,0 +1,5 @@
+"""Entry point for planner-agent module."""
+
+
+if __name__ == "__main__":
+    pass  # MCP Mesh handles startup via @mesh.agent

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/helm-values.yaml
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/helm-values.yaml
@@ -1,0 +1,58 @@
+# Helm values for deploying planner-agent with mcp-mesh-agent chart
+# Usage: helm install planner-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent -f helm-values.yaml
+# Check latest version: helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent
+
+image:
+  repository: your-registry/planner-agent
+  tag: "v1.0.0"  # Your image version. Override with: --set image.tag=v1.2.3
+  pullPolicy: IfNotPresent
+
+agent:
+  name: planner-agent
+  runtime: python
+  # K8s uses port 8080 by default (each pod has its own IP, no conflicts)
+  # http:
+  #   port: 8080
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 200m
+    memory: 256Mi
+
+mesh:
+  enabled: true
+  # Short name resolves in same namespace as core. For cross-namespace:
+  #   registry.host: mcp-core-mcp-mesh-registry.<core-namespace>.svc.cluster.local
+
+registry:
+  host: "mcp-core-mcp-mesh-registry"
+  port: "8000"
+
+# LLM agent typically needs API keys.
+# The refs below point to a secret named `llm-secrets` — update the `name:` values
+# below to match your cluster's secret, or create the secret:
+#   kubectl create secret generic llm-secrets \
+#     --from-literal=anthropic-api-key=sk-ant-... \
+#     --from-literal=openai-api-key=sk-...
+env:
+  - name: ANTHROPIC_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: llm-secrets
+        key: anthropic-api-key
+        optional: true
+  - name: OPENAI_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: llm-secrets
+        key: openai-api-key
+        optional: true
+
+# Optional: Secrets (creates a K8s Secret, injected via envFrom)
+# Uncomment to add — leaving commented avoids overriding base values
+# secrets:
+#   DATABASE_URL: "postgres://user:pass@host:5432/db"
+#   API_KEY: "your-api-key"

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py
@@ -1,0 +1,246 @@
+# --8<-- [start:full_file]
+# --8<-- [start:imports]
+import asyncio
+import os
+
+import mesh
+from fastmcp import FastMCP
+from mesh import MeshContextModel
+from pydantic import Field
+
+app = FastMCP("Planner Agent")
+# --8<-- [end:imports]
+
+
+# --8<-- [start:context_model]
+class TripRequest(MeshContextModel):
+    """Context model for the trip planning prompt template."""
+
+    destination: str = Field(..., description="Travel destination city")
+    dates: str = Field(..., description="Travel dates (e.g. June 1-5, 2026)")
+    budget: str = Field(..., description="Total trip budget (e.g. $2000)")
+    user_preferences: str = Field(
+        default="", description="User travel preferences (injected at runtime)"
+    )
+    committee_insights: str = Field(
+        default="",
+        description="Pre-computed committee specialist insights injected at runtime",
+    )
+# --8<-- [end:context_model]
+
+
+_DRY_RUN_CHUNKS = [
+    "Planning ",
+    "your trip to ",
+    "{destination}",
+    "...\n\n",
+    "Day 1: ",
+    "Arrival and check-in. ",
+    "Day 2: ",
+    "Local exploration.\n\n",
+    "Total budget: {budget}.",
+]
+
+
+def _dry_run_enabled() -> bool:
+    return os.environ.get("MESH_LLM_DRY_RUN", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+# --8<-- [start:llm_function]
+@app.tool()
+@mesh.llm(
+    system_prompt="file://prompts/plan_trip.j2",
+    context_param="ctx",
+    provider={"capability": "llm", "tags": ["+claude"]},
+    filter=[
+        {"capability": "flight_search"},
+        {"capability": "hotel_search"},
+        {"capability": "weather_forecast"},
+        {"capability": "poi_search"},
+    ],
+    filter_mode="all",
+    max_iterations=10,
+)
+# --8<-- [start:committee_deps]
+@mesh.tool(
+    capability="trip_planning",
+    description="Stream a trip itinerary live from an LLM with real travel data",
+    tags=["planner", "travel", "llm", "streaming"],
+    dependencies=[
+        "user_preferences",
+        "chat_history",
+        "budget_analysis",
+        "adventure_advice",
+        "logistics_planning",
+    ],
+)
+# --8<-- [end:committee_deps]
+async def plan_trip(
+    destination: str,
+    dates: str,
+    budget: str,
+    message: str = "",
+    session_id: str = "",
+    conversation_history: list[dict] = [],
+    user_prefs: mesh.McpMeshTool = None,
+    chat_history: mesh.McpMeshTool = None,
+    budget_analyst: mesh.McpMeshTool = None,
+    adventure_advisor: mesh.McpMeshTool = None,
+    logistics_planner: mesh.McpMeshTool = None,
+    ctx: TripRequest = None,
+    llm: mesh.MeshLlmAgent = None,
+) -> mesh.Stream[str]:
+    """Stream a trip itinerary one chunk at a time as the LLM generates it."""
+    prefs = {}
+    if user_prefs:
+        prefs = await user_prefs(user_id="demo-user")
+
+    prefs_summary = (
+        f"Preferred airlines: {', '.join(prefs.get('preferred_airlines', []))}. "
+        f"Budget limit: ${prefs.get('budget_usd', 'flexible')}. "
+        f"Interests: {', '.join(prefs.get('interests', []))}. "
+        f"Minimum hotel stars: {prefs.get('hotel_min_stars', 'any')}."
+        if prefs
+        else "No user preferences available."
+    )
+
+    # --8<-- [start:chat_history_fetch]
+    history = []
+    if session_id and chat_history:
+        history = await chat_history.call_tool("get_history", {
+            "session_id": session_id,
+            "limit": 20,
+        })
+        if isinstance(history, dict):
+            history = history.get("result", [])
+    # --8<-- [end:chat_history_fetch]
+
+    user_text = message or (
+        f"Plan a trip to {destination} from {dates} with a budget of {budget}."
+    )
+
+    # --8<-- [start:committee_prefetch]
+    # Run the committee in parallel BEFORE the streaming LLM call so their
+    # insights can be injected into the LLM context. The committee remains
+    # buffered (each specialist runs its own non-streaming LLM internally);
+    # only the planner's final user-visible call streams.
+    request_summary = (
+        f"Trip request: destination={destination}, dates={dates}, budget={budget}. "
+        f"User message: {user_text}"
+    )
+
+    specialist_tasks = []
+    specialist_labels = []
+    if budget_analyst:
+        specialist_tasks.append(
+            budget_analyst(
+                destination=destination,
+                plan_summary=request_summary,
+                budget=budget,
+            )
+        )
+        specialist_labels.append("Budget Analysis")
+    if adventure_advisor:
+        specialist_tasks.append(
+            adventure_advisor(destination=destination, plan_summary=request_summary)
+        )
+        specialist_labels.append("Adventure Recommendations")
+    if logistics_planner:
+        specialist_tasks.append(
+            logistics_planner(
+                destination=destination,
+                plan_summary=request_summary,
+                dates=dates,
+            )
+        )
+        specialist_labels.append("Logistics Plan")
+
+    committee_insights = ""
+    if specialist_tasks:
+        specialist_results = await asyncio.gather(*specialist_tasks)
+        sections = []
+        for label, result in zip(specialist_labels, specialist_results):
+            sections.append(f"### {label}\n{result}")
+        committee_insights = "\n\n".join(sections)
+    # --8<-- [end:committee_prefetch]
+
+    # --8<-- [start:dry_run]
+    if _dry_run_enabled():
+        accumulated_chunks = []
+        for chunk in _DRY_RUN_CHUNKS:
+            rendered = chunk.replace("{destination}", destination).replace(
+                "{budget}", budget
+            )
+            accumulated_chunks.append(rendered)
+            yield rendered
+
+        if session_id and chat_history:
+            await chat_history.call_tool("save_turn", {
+                "session_id": session_id,
+                "role": "user",
+                "content": user_text,
+            })
+            await chat_history.call_tool("save_turn", {
+                "session_id": session_id,
+                "role": "assistant",
+                "content": "".join(accumulated_chunks),
+            })
+        return
+    # --8<-- [end:dry_run]
+
+    if llm is None:
+        raise RuntimeError(
+            "plan_trip: LLM dependency not injected and MESH_LLM_DRY_RUN is not set"
+        )
+
+    # --8<-- [start:streaming_llm]
+    if history:
+        messages = list(history)
+        messages.append({"role": "user", "content": user_text})
+        prompt = messages
+    else:
+        prompt = user_text
+
+    accumulated = []
+    async for chunk in llm.stream(
+        prompt,
+        context={
+            "user_preferences": prefs_summary,
+            "committee_insights": committee_insights,
+        },
+    ):
+        accumulated.append(chunk)
+        yield chunk
+    # --8<-- [end:streaming_llm]
+
+    # --8<-- [start:chat_history_save]
+    if session_id and chat_history:
+        await chat_history.call_tool("save_turn", {
+            "session_id": session_id,
+            "role": "user",
+            "content": user_text,
+        })
+        await chat_history.call_tool("save_turn", {
+            "session_id": session_id,
+            "role": "assistant",
+            "content": "".join(accumulated),
+        })
+    # --8<-- [end:chat_history_save]
+# --8<-- [end:llm_function]
+
+
+@mesh.agent(
+    name="planner-agent",
+    version="1.0.0",
+    description="TripPlanner streaming planner with committee of specialists -- Day 10 bonus",
+    http_port=9107,
+    enable_http=True,
+    auto_run=True,
+)
+class PlannerAgent:
+    pass
+# --8<-- [end:full_file]

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py
@@ -119,8 +119,13 @@ async def plan_trip(
             history = history.get("result", [])
     # --8<-- [end:chat_history_fetch]
 
-    user_text = message or (
+    base_request = (
         f"Plan a trip to {destination} from {dates} with a budget of {budget}."
+    )
+    user_text = (
+        f"{base_request} Additional preferences from user: {message}"
+        if message
+        else base_request
     )
 
     # --8<-- [start:committee_prefetch]

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py
@@ -85,7 +85,6 @@ async def plan_trip(
     budget: str,
     message: str = "",
     session_id: str = "",
-    conversation_history: list[dict] = [],
     user_prefs: mesh.McpMeshTool = None,
     chat_history: mesh.McpMeshTool = None,
     budget_analyst: mesh.McpMeshTool = None,

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/main.py
@@ -127,6 +127,33 @@ async def plan_trip(
         else base_request
     )
 
+    # --8<-- [start:dry_run]
+    # Dry-run gate fires BEFORE the committee fan-out so unit/integration
+    # tests don't burn LLM tokens on specialist calls. When MESH_LLM_DRY_RUN
+    # is set on the planner, neither the committee nor Claude is invoked.
+    if _dry_run_enabled():
+        accumulated_chunks = []
+        for chunk in _DRY_RUN_CHUNKS:
+            rendered = chunk.replace("{destination}", destination).replace(
+                "{budget}", budget
+            )
+            accumulated_chunks.append(rendered)
+            yield rendered
+
+        if session_id and chat_history:
+            await chat_history.call_tool("save_turn", {
+                "session_id": session_id,
+                "role": "user",
+                "content": user_text,
+            })
+            await chat_history.call_tool("save_turn", {
+                "session_id": session_id,
+                "role": "assistant",
+                "content": "".join(accumulated_chunks),
+            })
+        return
+    # --8<-- [end:dry_run]
+
     # --8<-- [start:committee_prefetch]
     # Run the committee in parallel BEFORE the streaming LLM call so their
     # insights can be injected into the LLM context. The committee remains
@@ -171,30 +198,6 @@ async def plan_trip(
             sections.append(f"### {label}\n{result}")
         committee_insights = "\n\n".join(sections)
     # --8<-- [end:committee_prefetch]
-
-    # --8<-- [start:dry_run]
-    if _dry_run_enabled():
-        accumulated_chunks = []
-        for chunk in _DRY_RUN_CHUNKS:
-            rendered = chunk.replace("{destination}", destination).replace(
-                "{budget}", budget
-            )
-            accumulated_chunks.append(rendered)
-            yield rendered
-
-        if session_id and chat_history:
-            await chat_history.call_tool("save_turn", {
-                "session_id": session_id,
-                "role": "user",
-                "content": user_text,
-            })
-            await chat_history.call_tool("save_turn", {
-                "session_id": session_id,
-                "role": "assistant",
-                "content": "".join(accumulated_chunks),
-            })
-        return
-    # --8<-- [end:dry_run]
 
     if llm is None:
         raise RuntimeError(

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/prompts/plan_trip.j2
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/prompts/plan_trip.j2
@@ -1,0 +1,34 @@
+{# --8<-- [start:full_file] #}
+You are a travel planner. Given a destination, travel dates, and budget,
+create a concise day-by-day itinerary.
+
+Destination: {{ destination }}
+Dates: {{ dates }}
+Budget: {{ budget }}
+
+{# --8<-- [start:user_prefs_section] #}
+{% if user_preferences %}
+User Preferences:
+{{ user_preferences }}
+{% endif %}
+{# --8<-- [end:user_prefs_section] #}
+
+{# --8<-- [start:committee_section] #}
+{% if committee_insights %}
+Committee Insights (pre-computed by specialist agents — incorporate these
+naturally into your itinerary rather than restating them verbatim):
+{{ committee_insights }}
+{% endif %}
+{# --8<-- [end:committee_section] #}
+
+Guidelines:
+- Use the available tools to look up real flight prices, hotel availability,
+  weather forecasts, and points of interest. Base your plan on actual data
+  rather than guessing.
+- Suggest specific activities for each day (morning, afternoon, evening).
+- Include one restaurant recommendation per day.
+- Stay within the stated budget for the entire trip.
+- Keep the plan practical — account for travel time between locations.
+- Respect the user's preferences when choosing airlines, hotels, and activities.
+- Weave the committee insights into your final plan when relevant.
+{# --8<-- [end:full_file] #}

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/requirements.txt
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/requirements.txt
@@ -1,0 +1,3 @@
+# planner-agent dependencies
+# Add your third-party dependencies here
+# Note: mcp-mesh is provided by the runtime environment (local venv or Docker base image)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -173,6 +173,7 @@ nav:
           - "Day 8 — Docker Compose": tutorial/day-08-docker-compose.md
           - "Day 9 — Kubernetes": tutorial/day-09-kubernetes.md
           - "Day 10 — What's Next": tutorial/day-10-whats-next.md
+          - "Day 10 Bonus — Streaming UI": tutorial/day-10-bonus-streaming-ui.md
       - Downloads: tutorial/downloads.md
 
   # Python SDK - Generated from meshctl man pages

--- a/src/core/registry/llm_provider_resolver_test.go
+++ b/src/core/registry/llm_provider_resolver_test.go
@@ -325,3 +325,102 @@ func TestResolveLLMProvidersFromMetadata(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveProvider_ReturnsKwargs_OnResolvedLLMProvider verifies that
+// provider tool kwargs (e.g. stream_type=text from @mesh.llm_provider's
+// auto-generated streaming variant) are surfaced on the ResolvedLLMProvider
+// returned to the consumer. This is the registry-side half of the streaming
+// kwargs plumbing for issue #849 Stage A.
+func TestResolveProvider_ReturnsKwargs_OnResolvedLLMProvider(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	ctx := context.Background()
+
+	streamingAgent, err := client.Agent.Create().
+		SetID("claude-streaming-provider").
+		SetName("Claude Streaming Provider").
+		SetNamespace("default").
+		SetHTTPHost("localhost").
+		SetHTTPPort(9030).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Provider capability with kwargs that mirror what @mesh.llm_provider
+	// stamps onto the auto-generated streaming variant.
+	_, err = client.Capability.Create().
+		SetFunctionName("process_chat_stream").
+		SetCapability("llm").
+		SetDescription("Streaming Claude provider").
+		SetTags([]string{"claude", "stream"}).
+		SetVersion("1.0.0").
+		SetInputSchema(map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"messages": map[string]interface{}{"type": "array"},
+			},
+		}).
+		SetKwargs(map[string]interface{}{
+			"stream_type": "text",
+			"vendor":      "anthropic",
+		}).
+		SetAgent(streamingAgent).
+		Save(ctx)
+	require.NoError(t, err)
+
+	provider, err := ResolveProvider(ctx, client, map[string]interface{}{
+		"capability": "llm",
+		"tags":       []interface{}{"claude", "stream"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	require.NotNil(t, provider.Kwargs, "ResolvedLLMProvider.Kwargs must be populated when capability has kwargs")
+	kwargs := *provider.Kwargs
+	assert.Equal(t, "text", kwargs["stream_type"], "stream_type must round-trip through ResolveProvider")
+	assert.Equal(t, "anthropic", kwargs["vendor"], "vendor must round-trip through ResolveProvider")
+}
+
+// TestResolveProvider_NoKwargs_OmitsKwargsField verifies the default case —
+// when a provider capability has no kwargs, ResolvedLLMProvider.Kwargs stays
+// nil. Important for forward-compat: older Rust core with `#[serde(default)]`
+// on the new field won't choke on a missing key.
+func TestResolveProvider_NoKwargs_OmitsKwargsField(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	ctx := context.Background()
+
+	bareAgent, err := client.Agent.Create().
+		SetID("bare-provider").
+		SetName("Bare Provider").
+		SetNamespace("default").
+		SetHTTPHost("localhost").
+		SetHTTPPort(9031).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = client.Capability.Create().
+		SetFunctionName("process_chat").
+		SetCapability("llm").
+		SetDescription("Bare provider with no kwargs").
+		SetTags([]string{"bare"}).
+		SetVersion("1.0.0").
+		SetInputSchema(map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"messages": map[string]interface{}{"type": "array"},
+			},
+		}).
+		SetAgent(bareAgent).
+		Save(ctx)
+	require.NoError(t, err)
+
+	provider, err := ResolveProvider(ctx, client, map[string]interface{}{
+		"capability": "llm",
+		"tags":       []interface{}{"bare"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+	assert.Nil(t, provider.Kwargs, "Kwargs must be nil when the provider capability ships no kwargs")
+}

--- a/src/runtime/core/src/events.rs
+++ b/src/runtime/core/src/events.rs
@@ -141,6 +141,12 @@ pub struct LlmProviderInfo {
 
     /// Vendor name for handler selection (e.g., "gemini", "anthropic")
     pub vendor: Option<String>,
+
+    /// Provider tool's @mesh.tool kwargs serialized as JSON; None if absent.
+    /// Mirrors `MeshEvent.kwargs` for regular tool deps so SDKs can configure
+    /// the provider proxy from the producer's advertised behavior (e.g.
+    /// `stream_type`).
+    pub kwargs: Option<String>,
 }
 
 /// Tool specification for LLM tools update event.
@@ -311,7 +317,8 @@ impl MeshEvent {
 
     /// Get provider_info as a Python object with attributes.
     /// Returns None if no provider info, otherwise returns an object with
-    /// function_id, agent_id, endpoint, function_name, and model attributes.
+    /// function_id, agent_id, endpoint, function_name, model, vendor, and
+    /// kwargs attributes (kwargs is a JSON-serialized string or None).
     #[getter]
     fn provider_info(&self, py: Python<'_>) -> PyResult<Option<pyo3::Py<pyo3::PyAny>>> {
         match &self.provider_info {
@@ -325,6 +332,7 @@ impl MeshEvent {
                 kwargs.set_item("function_name", &info.function_name)?;
                 kwargs.set_item("model", &info.model)?;
                 kwargs.set_item("vendor", &info.vendor)?;
+                kwargs.set_item("kwargs", &info.kwargs)?;
                 let obj = provider_class.call((), Some(&kwargs))?;
                 Ok(Some(obj.into()))
             }
@@ -524,6 +532,47 @@ mod tests {
             event.kwargs,
             Some(r#"{"stream_type":"text"}"#.to_string())
         );
+    }
+
+    #[test]
+    fn test_llm_provider_available_event_with_kwargs() {
+        let provider_info = LlmProviderInfo {
+            function_id: "chat_abc123".to_string(),
+            agent_id: "claude-provider".to_string(),
+            endpoint: "http://localhost:9020".to_string(),
+            function_name: "process_chat".to_string(),
+            model: Some("anthropic/claude-sonnet-4-5".to_string()),
+            vendor: Some("anthropic".to_string()),
+            kwargs: Some(r#"{"stream_type":"text"}"#.to_string()),
+        };
+
+        let event = MeshEvent::llm_provider_available(provider_info);
+
+        assert_eq!(event.event_type, EventType::LlmProviderAvailable);
+        assert_eq!(event.event_type.as_str(), "llm_provider_available");
+        let info = event.provider_info.expect("provider_info should be set");
+        assert_eq!(info.function_id, "chat_abc123");
+        assert_eq!(info.endpoint, "http://localhost:9020");
+        assert_eq!(info.function_name, "process_chat");
+        assert_eq!(info.vendor, Some("anthropic".to_string()));
+        assert_eq!(info.kwargs, Some(r#"{"stream_type":"text"}"#.to_string()));
+    }
+
+    #[test]
+    fn test_llm_provider_available_event_without_kwargs() {
+        let provider_info = LlmProviderInfo {
+            function_id: "chat_abc123".to_string(),
+            agent_id: "claude-provider".to_string(),
+            endpoint: "http://localhost:9020".to_string(),
+            function_name: "process_chat".to_string(),
+            model: None,
+            vendor: None,
+            kwargs: None,
+        };
+
+        let event = MeshEvent::llm_provider_available(provider_info);
+        let info = event.provider_info.expect("provider_info should be set");
+        assert!(info.kwargs.is_none());
     }
 
     #[test]

--- a/src/runtime/core/src/napi.rs
+++ b/src/runtime/core/src/napi.rs
@@ -128,6 +128,10 @@ pub struct JsLlmProviderInfo {
     pub model: Option<String>,
     /// Vendor name for handler selection (e.g., "gemini", "anthropic")
     pub vendor: Option<String>,
+    /// Provider tool's @mesh.tool kwargs as a JSON string. SDKs decode this
+    /// to configure the provider proxy from the producer's advertised
+    /// behavior (e.g. `stream_type`).
+    pub kwargs: Option<String>,
 }
 
 impl From<LlmProviderInfo> for JsLlmProviderInfo {
@@ -139,6 +143,7 @@ impl From<LlmProviderInfo> for JsLlmProviderInfo {
             function_name: info.function_name,
             model: info.model,
             vendor: info.vendor,
+            kwargs: info.kwargs,
         }
     }
 }

--- a/src/runtime/core/src/registry.rs
+++ b/src/runtime/core/src/registry.rs
@@ -123,6 +123,10 @@ pub struct LlmToolInfo {
 }
 
 /// Resolved LLM provider information.
+///
+/// `kwargs` carries the provider tool's @mesh.tool kwargs (e.g. `stream_type`)
+/// so the consumer's provider proxy can configure itself from the producer's
+/// advertised behavior. Mirrors `ResolvedDependency.kwargs`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ResolvedLlmProvider {
     pub agent_id: String,
@@ -140,6 +144,8 @@ pub struct ResolvedLlmProvider {
     pub vendor: Option<String>,
     #[serde(default)]
     pub version: Option<String>,
+    #[serde(default)]
+    pub kwargs: Option<serde_json::Value>,
 }
 
 /// Full heartbeat response from registry.

--- a/src/runtime/core/src/runtime.rs
+++ b/src/runtime/core/src/runtime.rs
@@ -30,7 +30,11 @@ pub enum RuntimeCommand {
     UpdatePort(u16),
 }
 
-/// Internal provider tracking (non-PyO3 to avoid GIL issues in tokio thread)
+/// Internal provider tracking (non-PyO3 to avoid GIL issues in tokio thread).
+///
+/// `kwargs` is the provider tool's @mesh.tool kwargs serialized as JSON so it
+/// can travel through the FFI boundary. SDKs decode it to configure the
+/// provider proxy.
 #[derive(Debug, Clone)]
 struct TrackedProvider {
     function_id: String,
@@ -38,6 +42,7 @@ struct TrackedProvider {
     endpoint: String,
     function_name: String,
     model: Option<String>,
+    kwargs: Option<String>,
 }
 
 /// Configuration for the agent runtime.
@@ -625,6 +630,13 @@ impl AgentRuntime {
         llm_providers: &HashMap<String, crate::registry::ResolvedLlmProvider>,
     ) {
         for (function_id, provider) in llm_providers {
+            // Serialize kwargs once so the same JSON string is used for both the
+            // tracking struct (for change detection) and the emitted event.
+            let kwargs_json = provider
+                .kwargs
+                .as_ref()
+                .and_then(|v| serde_json::to_string(v).ok());
+
             // Use internal tracking struct to avoid GIL issues
             let tracked = TrackedProvider {
                 function_id: function_id.clone(),
@@ -632,13 +644,16 @@ impl AgentRuntime {
                 endpoint: provider.endpoint.clone(),
                 function_name: provider.function_name.clone(),
                 model: provider.model.clone(),
+                kwargs: kwargs_json.clone(),
             };
 
-            // Check if changed
+            // Check if changed (kwargs included so kwargs-only changes still
+            // emit a fresh event — mirrors process_dependency_changes).
             let changed = match self.topology.llm_providers.get(function_id) {
                 Some(old_provider) => {
                     old_provider.endpoint != tracked.endpoint
                         || old_provider.function_name != tracked.function_name
+                        || old_provider.kwargs != tracked.kwargs
                 }
                 None => true,
             };
@@ -662,6 +677,7 @@ impl AgentRuntime {
                     function_name: provider.function_name.clone(),
                     model: provider.model.clone(),
                     vendor: provider.vendor.clone(),
+                    kwargs: kwargs_json,
                 };
                 let _ = self
                     .event_tx

--- a/src/runtime/core/src/runtime.rs
+++ b/src/runtime/core/src/runtime.rs
@@ -647,12 +647,18 @@ impl AgentRuntime {
                 kwargs: kwargs_json.clone(),
             };
 
-            // Check if changed (kwargs included so kwargs-only changes still
-            // emit a fresh event — mirrors process_dependency_changes).
+            // Check if changed (kwargs/agent_id/model included so any field
+            // change emits a fresh event — mirrors process_dependency_changes).
+            // Note: `vendor` lives on LlmProviderInfo (the emitted event) but
+            // not on TrackedProvider; vendor changes will be picked up via the
+            // model field, which always changes when the LiteLLM model string
+            // (vendor/model) changes.
             let changed = match self.topology.llm_providers.get(function_id) {
                 Some(old_provider) => {
-                    old_provider.endpoint != tracked.endpoint
+                    old_provider.agent_id != tracked.agent_id
+                        || old_provider.endpoint != tracked.endpoint
                         || old_provider.function_name != tracked.function_name
+                        || old_provider.model != tracked.model
                         || old_provider.kwargs != tracked.kwargs
                 }
                 None => true,

--- a/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
@@ -23,6 +23,20 @@ from .signature_analyzer import get_mesh_agent_positions, has_llm_agent_paramete
 
 logger = logging.getLogger(__name__)
 
+# Internal parameter name used to receive FastMCP's auto-injected ``Context``
+# in streaming wrappers. Must NOT collide with anything a user could plausibly
+# declare on their own ``@mesh.tool`` function.
+#
+# Why not just call it ``ctx``? Users routinely declare ``ctx`` themselves —
+# in particular ``@mesh.llm(context_param="ctx", ...)`` is the natural default
+# and pairs with ``ctx: SomeContextModel`` on the function. If we synthesize a
+# parameter with the same NAME but a different TYPE (``Context``), FastMCP's
+# ``transform_context_annotations`` reads the user's annotation, doesn't see
+# ``Context``, and silently never injects — streaming then degrades to a
+# buffered single-chunk response. The ``_mesh_`` prefix signals "framework
+# internal, don't touch" and avoids any realistic collision.
+_MESH_PROGRESS_CTX_PARAM = "_mesh_progress_ctx"
+
 # Cached convention for ctx.report_progress; resolved lazily per FastMCP
 # version. Newer FastMCP exposes a ``message`` kwarg; older builds only accept
 # ``(progress, total)`` positionally with a third positional ``message``.
@@ -96,9 +110,16 @@ def _build_stream_signature(func: Callable) -> inspect.Signature:
 
     Starts from the user function's clean signature (McpMeshTool /
     MeshLlmAgent params already removed) and appends a keyword-only
-    ``ctx: Context | None = None`` so FastMCP's
+    ``_mesh_progress_ctx: Context | None = None`` so FastMCP's
     ``transform_context_annotations`` auto-fills it at call time without
     exposing it on the tool's input schema.
+
+    The parameter is intentionally NOT named ``ctx``: users can (and often
+    do) have their own ``ctx`` parameter — typically a ``MeshContextModel``
+    paired with ``@mesh.llm(context_param="ctx", ...)``. Reusing the name
+    would silently disable streaming because FastMCP injects ``Context``
+    by type annotation, and the user's annotation wins. See
+    ``_MESH_PROGRESS_CTX_PARAM`` for the full rationale.
     """
     from fastmcp import Context
 
@@ -109,12 +130,15 @@ def _build_stream_signature(func: Callable) -> inspect.Signature:
         except (TypeError, ValueError):
             base = inspect.Signature(parameters=[])
 
-    if "ctx" in base.parameters:
+    # Idempotency: if we've already augmented this signature once, don't add
+    # the synthesized parameter twice. (User parameters cannot collide with
+    # the ``_mesh_`` prefix unless they're deliberately poking at internals.)
+    if _MESH_PROGRESS_CTX_PARAM in base.parameters:
         return base
 
     params = list(base.parameters.values())
     ctx_param = inspect.Parameter(
-        "ctx",
+        _MESH_PROGRESS_CTX_PARAM,
         kind=inspect.Parameter.KEYWORD_ONLY,
         default=None,
         annotation=Optional[Context],
@@ -131,20 +155,29 @@ def _make_stream_wrapper(
 ) -> Callable:
     """Build a wrapper that drives an async-iterator tool over MCP progress.
 
-    The returned coroutine accepts an optional ``ctx`` keyword (FastMCP
-    auto-fills it for tools whose signature declares a ``Context``-typed
-    param). Each chunk yielded by the user function is forwarded via
-    ``ctx.report_progress`` as a progress notification, then accumulated;
-    the final return value is the concatenated text so non-streaming
-    consumers still get the full response in the ``CallToolResult``.
+    FastMCP auto-fills ``Context`` for any tool parameter annotated with
+    it. We declare that parameter under the internal name
+    ``_mesh_progress_ctx`` (see ``_MESH_PROGRESS_CTX_PARAM``) so it cannot
+    collide with the user's own ``ctx`` parameter. The wrapper pops it out
+    of ``**kwargs`` and never forwards it to the user function. Each chunk
+    yielded by the user function is forwarded via ``ctx.report_progress``
+    as a progress notification, then accumulated; the final return value
+    is the concatenated text so non-streaming consumers still get the full
+    response in the ``CallToolResult``.
 
     Cancellation by the consumer propagates back to the user function via
     ``gen.aclose()`` so generators can run their ``finally`` blocks.
     """
-    from fastmcp import Context
+    # Imported for side-effect of validating fastmcp is installed; the
+    # actual Context type is referenced in the synthesized signature.
+    from fastmcp import Context  # noqa: F401
 
     @functools.wraps(func)
-    async def stream_wrapper(*args, ctx: Context | None = None, **kwargs):
+    async def stream_wrapper(*args, **kwargs):
+        # FastMCP injects its Context under our internal name; pop it so
+        # it never leaks into the user function's kwargs.
+        progress_ctx = kwargs.pop(_MESH_PROGRESS_CTX_PARAM, None)
+
         final_kwargs, injected_count = _prepare_injection_kwargs(
             func,
             kwargs,
@@ -181,7 +214,7 @@ def _make_stream_wrapper(
                         f"of type {type(chunk).__name__}; v1 supports str only."
                     )
                 chunks.append(chunk)
-                await _forward_chunk(ctx, index, chunk)
+                await _forward_chunk(progress_ctx, index, chunk)
                 index += 1
         except asyncio.CancelledError:
             aclose = getattr(gen, "aclose", None)

--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
@@ -1418,10 +1418,20 @@ class MeshLlmAgent:
                 f"'{provider_proxy.function_name}'."
             )
 
-        # Buffered fallback: call the provider's regular tool and yield the
-        # full content as one chunk. Cross-runtime providers (Java, TS) may
+        # Buffered fallback: call the provider's NON-streaming sibling tool
+        # (strip the trailing ``_stream`` suffix from the resolved name) and
+        # yield the full content as one chunk. Calling provider_proxy(...)
+        # directly would re-invoke ``self.function_name`` — i.e. the same
+        # streaming tool we just got "unknown tool" for — so we explicitly
+        # name the buffered variant. Cross-runtime providers (Java, TS) may
         # return a JSON string instead of a dict; normalize the shape.
-        result = await provider_proxy(request=request_dict)
+        if stream_tool_name.endswith("_stream"):
+            buffered_tool_name = stream_tool_name[: -len("_stream")]
+        else:
+            buffered_tool_name = stream_tool_name
+        result = await provider_proxy.call_tool_with_tracing(
+            buffered_tool_name, {"request": request_dict}
+        )
         if isinstance(result, str):
             try:
                 parsed = json.loads(result)
@@ -1498,7 +1508,12 @@ class MeshLlmAgent:
             )
 
         if self._is_mesh_delegated:
-            async for chunk in self._stream_mesh_delegated(message, media, context, context_mode):
+            # Forward call-time kwargs (temperature, max_tokens, etc.) so
+            # mesh-delegated streaming honors the same overrides as the
+            # buffered __call__ path.
+            async for chunk in self._stream_mesh_delegated(
+                message, media, context, context_mode, **kwargs
+            ):
                 yield chunk
             return
 

--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
@@ -1281,6 +1281,151 @@ class MeshLlmAgent:
                         slot["function"]["arguments"] += fn.arguments
         return [tc for tc in merged.values() if tc["id"] is not None]
 
+    async def _stream_mesh_delegated(
+        self,
+        message: Union[str, list[dict[str, Any]]],
+        media: Union[list, None],
+        context: Union[dict, None, object],
+        context_mode: Literal["replace", "append", "prepend"],
+        **kwargs,
+    ) -> AsyncIterator[str]:
+        """Stream from a mesh-delegated provider (provider={"capability": ...}).
+
+        Routes to the provider's auto-generated ``<name>_stream`` MCP tool
+        when present (Python providers built with @mesh.llm_provider after
+        Phase 3 expose this side-by-side with the buffered ``<name>``
+        tool). When the provider does NOT expose a streaming variant — for
+        example older Python providers, TS / Java SDK providers, or any
+        provider where the streaming tool was disabled — we soft-fall-back
+        to the buffered ``provider_proxy(request=...)`` and yield its
+        content as a single chunk so the consumer's ``async for`` always
+        observes at least one item on a successful call.
+
+        Request shape is identical to ``_call_mesh_provider``: same five
+        fields go into the ``MeshLlmRequest`` dict (messages, tools,
+        model_params, context, request_id, caller_agent). The provider
+        side reconstructs a ``MeshLlmRequest`` and delegates to its own
+        provider-managed loop (buffered or streaming).
+        """
+        from mesh.types import MeshLlmRequest
+
+        provider_proxy = await self._get_mesh_provider()
+
+        messages = await self._build_messages_for_run(
+            message, media, context, context_mode
+        )
+
+        try:
+            request_params = self._build_request_params(messages, **kwargs)
+        except Exception as e:
+            logger.error(f"❌ stream(mesh): failed to build request params: {e}")
+            raise LLMAPIError(
+                provider=str(self.provider),
+                model=self.model,
+                original_error=e,
+            ) from e
+
+        effective_tools = (
+            self._enrich_tools_with_endpoints()
+            if self._tool_schemas
+            else None
+        )
+
+        # Mesh delegation: extract model_params to send to provider.
+        # Mirrors __call__'s mesh-delegate branch (mesh_llm_agent.py:929-963)
+        # so the streaming and buffered paths land identical request shapes
+        # on the provider side.
+        model_params = {
+            k: v
+            for k, v in request_params.items()
+            if k
+            not in [
+                "messages",
+                "tools",
+                "api_key",
+                "output_mode",
+                "model",
+            ]
+        }
+        if self.model:
+            model_params["model"] = self.model
+        if self.output_type is not str and hasattr(
+            self.output_type, "model_json_schema"
+        ):
+            model_params["output_schema"] = self.output_type.model_json_schema()
+            model_params["output_type_name"] = self.output_type.__name__
+        if self._parallel_tool_calls:
+            model_params["parallel_tool_calls"] = True
+
+        request = MeshLlmRequest(
+            messages=messages,
+            tools=effective_tools if effective_tools else None,
+            model_params=model_params if model_params else None,
+        )
+        request_dict = {
+            "messages": request.messages,
+            "tools": request.tools,
+            "model_params": request.model_params,
+            "context": request.context,
+            "request_id": request.request_id,
+            "caller_agent": request.caller_agent,
+        }
+
+        stream_tool_name = f"{provider_proxy.function_name}_stream"
+        logger.debug(
+            f"📤 stream(mesh): routing to {provider_proxy.endpoint}/"
+            f"{stream_tool_name} (messages={len(messages)}, "
+            f"tools={len(effective_tools) if effective_tools else 0})"
+        )
+
+        try:
+            async for chunk in provider_proxy.stream(
+                name=stream_tool_name, request=request_dict
+            ):
+                yield chunk
+            return
+        except Exception as e:
+            # FastMCP surfaces an unknown tool as fastmcp.exceptions.ToolError
+            # with message "Unknown tool: ..." (server raises NotFoundError,
+            # client._parse_call_tool_result re-raises as ToolError). We only
+            # fall back on that specific shape so genuine provider errors
+            # (timeout, network, model API failure) still surface to the
+            # consumer with the original exception class intact.
+            err_msg = str(e).lower()
+            looks_like_missing_tool = (
+                "unknown tool" in err_msg or "tool not found" in err_msg
+            )
+            if not looks_like_missing_tool:
+                raise
+
+            logger.warning(
+                f"Provider {provider_proxy.endpoint} does not expose streaming "
+                f"variant '{stream_tool_name}'; falling back to buffered "
+                f"single-chunk yield via '{provider_proxy.function_name}'."
+            )
+
+        # Buffered fallback: call the provider's regular tool and yield the
+        # full content as one chunk. Cross-runtime providers (Java, TS) may
+        # return a JSON string instead of a dict; normalize the shape.
+        result = await provider_proxy(request=request_dict)
+        if isinstance(result, str):
+            try:
+                parsed = json.loads(result)
+                message_dict = parsed if isinstance(parsed, dict) else {
+                    "role": "assistant",
+                    "content": result,
+                }
+            except (json.JSONDecodeError, TypeError):
+                message_dict = {"role": "assistant", "content": result}
+        elif isinstance(result, dict):
+            message_dict = result
+        else:
+            message_dict = {"role": "assistant", "content": str(result)}
+
+        content = message_dict.get("content") or ""
+        if content:
+            yield content
+
     async def stream(
         self,
         message: Union[str, list[dict[str, Any]]],
@@ -1319,28 +1464,30 @@ class MeshLlmAgent:
         ExecutionTracer's post-call read still sees accurate counts.
 
         Constraints:
-            - Direct mode only. Mesh-delegated providers (``provider`` is a
-              dict / @mesh.llm_provider) raise ``NotImplementedError``;
-              provider-mode streaming is a separate phase.
             - String output only — typed Pydantic outputs cannot be
               meaningfully streamed and would defeat token-by-token UX.
+            - Mesh-delegated providers route through the provider's
+              auto-generated ``<name>_stream`` tool when present, falling
+              back to a single-chunk yield from the buffered ``<name>``
+              tool when the provider does not advertise a streaming
+              variant (e.g., older Python providers and TS / Java SDKs).
 
         Yields:
             ``str`` chunks from the final assistant message (and any
             preamble text that precedes intermediate tool calls).
         """
-        if self._is_mesh_delegated:
-            raise NotImplementedError(
-                "MeshLlmAgent.stream() is direct-mode only. Streaming with "
-                "provider={'capability': ...} (mesh-delegated providers) is "
-                "not supported in this phase."
-            )
         if self.output_type is not str:
             raise NotImplementedError(
                 "MeshLlmAgent.stream() supports only str output_type; got "
                 f"{getattr(self.output_type, '__name__', self.output_type)!r}. "
                 "Use MeshLlmAgent.__call__() for typed responses."
             )
+
+        if self._is_mesh_delegated:
+            async for chunk in self._stream_mesh_delegated(message, media, context, context_mode):
+                yield chunk
+            return
+
         if acompletion is None:
             raise ImportError(
                 "litellm is required for MeshLlmAgent.stream(). "

--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
@@ -1404,10 +1404,18 @@ class MeshLlmAgent:
             if not looks_like_missing_tool:
                 raise
 
+            # With Phase 5C tag-based discrimination the resolver will not
+            # normally hand us a provider that lacks the streaming tool —
+            # this branch fires only in the rare race where a provider
+            # advertised the ai.mcpmesh.stream tag but the streaming MCP
+            # tool itself is unreachable (e.g. transient registration
+            # mismatch). Defensive single-chunk degrade keeps the consumer
+            # alive instead of bubbling a hard failure.
             logger.warning(
-                f"Provider {provider_proxy.endpoint} does not expose streaming "
-                f"variant '{stream_tool_name}'; falling back to buffered "
-                f"single-chunk yield via '{provider_proxy.function_name}'."
+                f"Provider {provider_proxy.endpoint} advertised the streaming "
+                f"variant but tool '{stream_tool_name}' is not exposed; "
+                f"degrading to a single buffered chunk via "
+                f"'{provider_proxy.function_name}'."
             )
 
         # Buffered fallback: call the provider's regular tool and yield the

--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
@@ -1371,7 +1371,13 @@ class MeshLlmAgent:
             "caller_agent": request.caller_agent,
         }
 
-        stream_tool_name = f"{provider_proxy.function_name}_stream"
+        # Phase 5C: tag-based discrimination (ai.mcpmesh.stream) makes the
+        # registry resolver return the streaming variant directly when the
+        # consumer's @mesh.llm function returns Stream[str]. provider_proxy
+        # .function_name is already the streaming tool name — no suffix
+        # mangling needed. (Pre-Phase-5C this was f"{name}_stream" because
+        # the resolver was non-deterministic; that's no longer the case.)
+        stream_tool_name = provider_proxy.function_name
         logger.debug(
             f"📤 stream(mesh): routing to {provider_proxy.endpoint}/"
             f"{stream_tool_name} (messages={len(messages)}, "

--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent_injector.py
@@ -353,14 +353,20 @@ class MeshLlmAgentInjector(BaseInjector):
                 f"Provider {function_name} has invalid endpoint (expected string): {endpoint}"
             )
 
-        # Create proxy with endpoint URL
+        # Create proxy with endpoint URL.
+        # Spread provider_data["kwargs"] (the provider tool's @mesh.tool kwargs)
+        # into kwargs_config so producer-advertised behavior — e.g.
+        # stream_type=text — reaches the provider proxy. Mirrors the
+        # producer-kwargs propagation for regular tool deps (issue #849 Stage A).
+        kwargs_config = {
+            "capability": provider_data.get("capability", "llm"),
+            "agent_id": provider_data.get("agent_id"),
+            **(provider_data.get("kwargs") or {}),
+        }
         proxy = UnifiedMCPProxy(
             endpoint=endpoint,
             function_name=function_name,
-            kwargs_config={
-                "capability": provider_data.get("capability", "llm"),
-                "agent_id": provider_data.get("agent_id"),
-            },
+            kwargs_config=kwargs_config,
         )
 
         logger.debug(f"🔧 Created provider proxy for {function_name} at {endpoint}")

--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent_injector.py
@@ -358,10 +358,13 @@ class MeshLlmAgentInjector(BaseInjector):
         # into kwargs_config so producer-advertised behavior — e.g.
         # stream_type=text — reaches the provider proxy. Mirrors the
         # producer-kwargs propagation for regular tool deps (issue #849 Stage A).
+        # Producer kwargs first; consumer-config keys (capability, agent_id)
+        # are spread LAST so a producer can never silently shadow them by
+        # advertising those names in their @mesh.tool kwargs.
         kwargs_config = {
+            **(provider_data.get("kwargs") or {}),
             "capability": provider_data.get("capability", "llm"),
             "agent_id": provider_data.get("agent_id"),
-            **(provider_data.get("kwargs") or {}),
         }
         proxy = UnifiedMCPProxy(
             endpoint=endpoint,

--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent_injector.py
@@ -360,9 +360,20 @@ class MeshLlmAgentInjector(BaseInjector):
         # producer-kwargs propagation for regular tool deps (issue #849 Stage A).
         # Producer kwargs first; consumer-config keys (capability, agent_id)
         # are spread LAST so a producer can never silently shadow them by
-        # advertising those names in their @mesh.tool kwargs.
+        # advertising those names in their @mesh.tool kwargs. Defensive
+        # type check on producer kwargs: the JSON parse upstream already
+        # validates shape, but if a caller hand-builds provider_data with
+        # a non-mapping value here we coerce to {} rather than raising.
+        from collections.abc import Mapping
+        _raw_provider_kwargs = provider_data.get("kwargs")
+        if _raw_provider_kwargs and not isinstance(_raw_provider_kwargs, Mapping):
+            logger.warning(
+                f"Provider {function_name}: kwargs is not a mapping "
+                f"(got {type(_raw_provider_kwargs).__name__}); ignoring"
+            )
+            _raw_provider_kwargs = None
         kwargs_config = {
-            **(provider_data.get("kwargs") or {}),
+            **(_raw_provider_kwargs or {}),
             "capability": provider_data.get("capability", "llm"),
             "agent_id": provider_data.get("agent_id"),
         }

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
@@ -382,6 +382,14 @@ class ClaudeHandler(BaseProviderHandler):
                     _raw_timeout,
                 )
                 fallback_timeout = 90
+            else:
+                if fallback_timeout <= 0:
+                    logger.warning(
+                        "MCP_MESH_CLAUDE_HINT_FALLBACK_TIMEOUT=%r must be positive; "
+                        "using default 90s",
+                        _raw_timeout,
+                    )
+                    fallback_timeout = 90
         model_params["_mesh_hint_mode"] = True
         model_params["_mesh_hint_schema"] = sanitized_schema
         model_params["_mesh_hint_fallback_timeout"] = fallback_timeout

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
@@ -364,9 +364,15 @@ class ClaudeHandler(BaseProviderHandler):
         # Internal flags read by _provider_agentic_loop. Prefixed with
         # "_mesh_" so the loop strips them before calling LiteLLM (these
         # are NOT API params).
+        # Fallback timeout: 30s was too tight for complex nested schemas
+        # (e.g. list[NestedModel] where Claude generates multi-day itineraries).
+        # Configurable via MCP_MESH_CLAUDE_HINT_FALLBACK_TIMEOUT (seconds).
+        fallback_timeout = int(
+            os.environ.get("MCP_MESH_CLAUDE_HINT_FALLBACK_TIMEOUT", "90")
+        )
         model_params["_mesh_hint_mode"] = True
         model_params["_mesh_hint_schema"] = sanitized_schema
-        model_params["_mesh_hint_fallback_timeout"] = 30
+        model_params["_mesh_hint_fallback_timeout"] = fallback_timeout
         model_params["_mesh_hint_output_type_name"] = output_type_name or "Response"
 
         # Explicitly DO NOT set response_format — that's the bug we're avoiding.

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
@@ -367,9 +367,21 @@ class ClaudeHandler(BaseProviderHandler):
         # Fallback timeout: 30s was too tight for complex nested schemas
         # (e.g. list[NestedModel] where Claude generates multi-day itineraries).
         # Configurable via MCP_MESH_CLAUDE_HINT_FALLBACK_TIMEOUT (seconds).
-        fallback_timeout = int(
-            os.environ.get("MCP_MESH_CLAUDE_HINT_FALLBACK_TIMEOUT", "90")
-        )
+        # Fail-open on a malformed env value so a typo can't break the
+        # provider mid-request — log a warning and use the default.
+        _raw_timeout = os.environ.get("MCP_MESH_CLAUDE_HINT_FALLBACK_TIMEOUT")
+        if _raw_timeout is None:
+            fallback_timeout = 90
+        else:
+            try:
+                fallback_timeout = int(_raw_timeout)
+            except ValueError:
+                logger.warning(
+                    "MCP_MESH_CLAUDE_HINT_FALLBACK_TIMEOUT=%r is not an integer; "
+                    "using default 90s",
+                    _raw_timeout,
+                )
+                fallback_timeout = 90
         model_params["_mesh_hint_mode"] = True
         model_params["_mesh_hint_schema"] = sanitized_schema
         model_params["_mesh_hint_fallback_timeout"] = fallback_timeout

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
@@ -835,12 +835,24 @@ async def _handle_llm_provider_update(
     parsed_provider_kwargs: dict = {}
     if raw_provider_kwargs:
         try:
-            parsed_provider_kwargs = json.loads(raw_provider_kwargs) or {}
+            _decoded = json.loads(raw_provider_kwargs)
         except (TypeError, ValueError) as e:
             logger.warning(
                 f"Could not parse provider kwargs for {function_id}: {e}; "
                 f"falling back to empty config"
             )
+            _decoded = None
+        if _decoded is None:
+            parsed_provider_kwargs = {}
+        elif isinstance(_decoded, dict):
+            parsed_provider_kwargs = _decoded
+        else:
+            logger.warning(
+                f"Provider kwargs for {function_id} parsed to "
+                f"{type(_decoded).__name__}, expected object; "
+                f"falling back to empty config"
+            )
+            parsed_provider_kwargs = {}
 
     # Import injector
     from ...engine.dependency_injector import get_global_injector

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
@@ -816,6 +816,12 @@ async def _handle_llm_provider_update(
     Handle LLM provider resolution event.
 
     Updates the LLM provider for the given function via the DI system.
+
+    ``provider_info.kwargs`` is the provider tool's @mesh.tool kwargs as a
+    JSON string (issue #849 Stage A). The provider proxy is configured from
+    this so producer-advertised behavior (e.g. ``stream_type=text``) reaches
+    the consumer-side proxy. Mirrors the producer-kwargs propagation for
+    regular tool dependencies.
     """
     function_id = provider_info.function_id
     logger.info(
@@ -823,14 +829,31 @@ async def _handle_llm_provider_update(
         f"{provider_info.function_name} at {provider_info.endpoint}"
     )
 
+    # Parse provider kwargs (JSON string from Rust event). Defensive parse
+    # mirrors _handle_dependency_change for symmetry with regular tool deps.
+    raw_provider_kwargs = getattr(provider_info, "kwargs", None)
+    parsed_provider_kwargs: dict = {}
+    if raw_provider_kwargs:
+        try:
+            parsed_provider_kwargs = json.loads(raw_provider_kwargs) or {}
+        except (TypeError, ValueError) as e:
+            logger.warning(
+                f"Could not parse provider kwargs for {function_id}: {e}; "
+                f"falling back to empty config"
+            )
+
     # Import injector
     from ...engine.dependency_injector import get_global_injector
     from ...engine.unified_mcp_proxy import EnhancedUnifiedMCPProxy
 
-    # Create proxy for the LLM provider
+    # Create proxy for the LLM provider. Forward producer kwargs so streaming
+    # etc. is configured even on this generic-dependency registration path
+    # (MeshLlmAgent uses a different proxy via the injector, but we keep
+    # symmetry here too).
     proxy = EnhancedUnifiedMCPProxy(
         provider_info.endpoint,
         provider_info.function_name,
+        kwargs_config=dict(parsed_provider_kwargs),
     )
 
     # Register as the LLM provider for this function
@@ -838,7 +861,10 @@ async def _handle_llm_provider_update(
     provider_key = f"{function_id}:llm_provider"
     await injector.register_dependency(provider_key, proxy)
 
-    # Also store provider metadata for the mesh agent to use (using "name" for OpenAPI contract)
+    # Also store provider metadata for the mesh agent to use (using "name" for OpenAPI contract).
+    # ``kwargs`` carries the provider tool's @mesh.tool kwargs so the
+    # MeshLlmAgentInjector can lift them onto the provider proxy's
+    # kwargs_config (issue #849 Stage A).
     llm_providers = {
         function_id: {
             "agent_id": provider_info.agent_id,
@@ -846,6 +872,7 @@ async def _handle_llm_provider_update(
             "name": provider_info.function_name,  # OpenAPI contract uses "name"
             "model": provider_info.model,
             "vendor": provider_info.vendor,  # For handler selection
+            "kwargs": parsed_provider_kwargs,  # Producer @mesh.tool kwargs (e.g. stream_type)
         }
     }
     injector.process_llm_providers(llm_providers)

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -1527,8 +1527,23 @@ def route(
                 if detect_stream_type(target) == "text":
                     import inspect as _inspect
 
+                    from _mcp_mesh.engine.dependency_injector import (
+                        _MESH_PROGRESS_CTX_PARAM,
+                    )
+
                     wrapper_anns = dict(getattr(wrapped, "__annotations__", {}) or {})
                     wrapper_anns.pop("return", None)
+                    # The streaming wrapper's signature carries an internal
+                    # parameter (``_MESH_PROGRESS_CTX_PARAM``) typed as
+                    # ``Optional[Context]`` so FastMCP's tool path can
+                    # auto-fill the progress channel. FastAPI/Pydantic do not
+                    # tolerate field names with a leading underscore when
+                    # building the route's body model — and the SSE wrapper
+                    # handles streaming through its own pipe (not via
+                    # FastMCP's Context), so the synthesized param has no
+                    # business being visible here. Strip it from both the
+                    # annotations dict and the explicit signature.
+                    wrapper_anns.pop(_MESH_PROGRESS_CTX_PARAM, None)
                     wrapped.__annotations__ = wrapper_anns
                     if hasattr(wrapped, "__wrapped__"):
                         try:
@@ -1537,8 +1552,14 @@ def route(
                             pass
                     explicit_sig = wrapped.__dict__.get("__signature__")
                     if explicit_sig is not None:
+                        cleaned_params = [
+                            p
+                            for n, p in explicit_sig.parameters.items()
+                            if n != _MESH_PROGRESS_CTX_PARAM
+                        ]
                         wrapped.__signature__ = explicit_sig.replace(
-                            return_annotation=_inspect.Signature.empty
+                            parameters=cleaned_params,
+                            return_annotation=_inspect.Signature.empty,
                         )
             except Exception as e:
                 logger.debug(
@@ -1866,6 +1887,27 @@ def llm(
         if llm_stream_type == "text":
             output_type = str
 
+        # Auto-discriminate stream vs buffered LLM provider variants via the
+        # ``ai.mcpmesh.stream`` tag — consumer half of the contract with
+        # ``@mesh.llm_provider``, which stamps the tag on its streaming variant
+        # only. Stream consumers require the tag; buffered consumers exclude
+        # it, so the registry resolver picks the right variant deterministically
+        # via the existing +/- tag-operator semantics. If the user explicitly
+        # set a discrimination tag (any operator form), don't override.
+        if isinstance(resolved_provider, dict):
+            provider_tags = list(resolved_provider.get("tags") or [])
+            has_stream_tag = any(
+                t in ("ai.mcpmesh.stream", "+ai.mcpmesh.stream", "-ai.mcpmesh.stream")
+                for t in provider_tags
+            )
+            if not has_stream_tag:
+                if llm_stream_type == "text":
+                    provider_tags.append("ai.mcpmesh.stream")
+                else:
+                    provider_tags.append("-ai.mcpmesh.stream")
+                resolved_provider = {**resolved_provider, "tags": provider_tags}
+                resolved_config["provider"] = resolved_provider
+
         # Step 3: Find MeshLlmAgent parameter
         from mesh.types import MeshLlmAgent
 
@@ -1980,10 +2022,11 @@ def llm(
 
             # Override signature to hide LLM parameter from FastMCP schema.
             # Start from the existing wrapper's signature (not raw ``func``):
-            # for streaming tools, ``@mesh.tool`` already appended the ``ctx``
-            # keyword so FastMCP can auto-fill it. Reading from ``func`` here
-            # would drop that ``ctx`` and silently disable progress
-            # notifications (issue #645 bug 3).
+            # for streaming tools, ``@mesh.tool`` already appended the
+            # synthesized progress-context keyword so FastMCP can auto-fill
+            # ``Context`` for progress notifications. Reading from ``func``
+            # here would drop that param and silently disable streaming
+            # (issue #645 bug 3).
             try:
                 _sig = (
                     inspect.signature(existing_wrapper)

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -65,10 +65,21 @@ _MESH_HINT_KEYS = (
     "_mesh_hint_output_type_name",
 )
 
+# Single source of truth for the HINT → response_format fallback timeout when
+# a handler did not explicitly inject one. ClaudeHandler now defaults to 90s
+# (configurable via MCP_MESH_CLAUDE_HINT_FALLBACK_TIMEOUT) — keep this in
+# sync so loop paths that bypass the handler don't silently revert to 30.
+_DEFAULT_HINT_FALLBACK_TIMEOUT = 90
+
 
 def _pop_mesh_hint_flags(
     completion_args: dict[str, Any],
-    defaults: tuple[bool, dict | None, int, str] = (False, None, 30, "Response"),
+    defaults: tuple[bool, dict | None, int, str] = (
+        False,
+        None,
+        _DEFAULT_HINT_FALLBACK_TIMEOUT,
+        "Response",
+    ),
 ) -> tuple[bool, dict | None, int, str]:
     """Strip ``_mesh_*`` HINT-mode flags from ``completion_args`` in place.
 
@@ -490,7 +501,7 @@ async def _provider_agentic_loop(
     # Captured outside the loop so the fallback after the loop has access.
     hint_mode = False
     hint_schema: dict[str, Any] | None = None
-    hint_fallback_timeout = 30
+    hint_fallback_timeout = _DEFAULT_HINT_FALLBACK_TIMEOUT
     hint_output_type_name = "Response"
 
     while iteration < max_iterations:
@@ -751,7 +762,7 @@ async def _provider_agentic_loop_stream(
 
     hint_mode = False
     hint_schema: dict[str, Any] | None = None
-    hint_fallback_timeout = 30
+    hint_fallback_timeout = _DEFAULT_HINT_FALLBACK_TIMEOUT
     hint_output_type_name = "Response"
 
     total_input_tokens = 0

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -964,6 +964,23 @@ async def _provider_agentic_loop_stream(
                 if final_content:
                     yield final_content
 
+                # If the HINT fallback actually fired (_resp is not None),
+                # its tokens/model belong in observability metadata. The
+                # streamed attempt's totals already reflect the failed first
+                # try; add the fallback's usage so the trace shows the
+                # true work performed.
+                if _resp is not None and hasattr(_resp, "usage") and _resp.usage:
+                    _fb_usage = _resp.usage
+                    total_input_tokens += (
+                        getattr(_fb_usage, "prompt_tokens", 0) or 0
+                    )
+                    total_output_tokens += (
+                        getattr(_fb_usage, "completion_tokens", 0) or 0
+                    )
+                    _fb_model = getattr(_resp, "model", None)
+                    if _fb_model:
+                        effective_model = _fb_model
+
             set_llm_metadata(
                 model=effective_model,
                 provider=vendor or "",

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -189,56 +189,73 @@ def _extract_text_from_message_content(content: Any) -> str:
     return str(content)
 
 
-async def _provider_agentic_loop(
-    effective_model: str,
-    messages: list,
-    tools: list,
-    tool_endpoints: dict[str, str],
-    model_params: dict,
-    litellm_kwargs: dict,
-    max_iterations: int = 10,
-    loop_logger: logging.Logger | None = None,
-    vendor: str | None = None,
-) -> dict[str, Any]:
-    """Execute tools provider-side and return final response.
+# Vendors that do NOT support images in tool/function result messages.
+# OpenAI strictly rejects images in role:tool messages.
+# For these vendors, images are accumulated and sent as one user message
+# after ALL tool results for the iteration.
+_TOOL_IMAGE_UNSUPPORTED_VENDORS = {"openai", "gemini", "google"}
 
-    Runs a full agentic loop on the provider: calls the LLM, executes any
-    tool calls via MCP proxies, feeds results back, and repeats until the
-    LLM produces a final text response (no tool calls).
+
+async def _execute_tool_calls_for_iteration(
+    message: Any,
+    tool_endpoints: dict[str, str],
+    parallel: bool,
+    vendor: str | None,
+    loop_logger: logging.Logger | None,
+) -> tuple[list[dict], list[dict]]:
+    """Execute one iteration's tool calls (parallel or sequential).
+
+    Encapsulates the per-iteration tool dispatch logic shared by the buffered
+    provider agentic loop (``_provider_agentic_loop``) and the streaming
+    provider agentic loop (Phase 2 of issue #849). Behavior is intentionally
+    identical to the previous inline implementation so that callers can drop
+    in this helper without observable changes.
+
+    For each ``tool_call`` in ``message.tool_calls``:
+      * Look up the MCP endpoint from ``tool_endpoints`` (returns an error
+        tool message if missing).
+      * Dispatch via :class:`UnifiedMCPProxy.call_tool`.
+      * Resolve resource_link items in the tool result to multimodal content
+        using the OpenAI-compatible image_url format (LiteLLM converts to the
+        provider-native format).
+      * For vendors that do not support images in role:tool messages
+        (OpenAI / Gemini / Google), strip image parts out of the tool message
+        and accumulate them so the caller can synthesize a follow-up user
+        message after all tool results.
+      * For vendors that do support images in role:tool messages
+        (Anthropic / Claude via LiteLLM), inline the resolved multimodal
+        content directly in the tool message.
 
     Args:
-        effective_model: LiteLLM model identifier to use.
-        messages: Conversation messages (will be copied internally).
-        tools: OpenAI-format tool schemas (already cleaned of _mesh_endpoint).
+        message: The ``response.choices[0].message`` from LiteLLM whose
+            ``tool_calls`` should be executed. Must have a non-empty
+            ``tool_calls`` attribute — callers are expected to gate on
+            ``message.tool_calls`` themselves.
         tool_endpoints: Mapping of tool_name -> MCP endpoint URL.
-        model_params: Extra model parameters for litellm.completion().
-        litellm_kwargs: Base kwargs captured by the decorator.
-        max_iterations: Safety limit on loop iterations.
-        loop_logger: Logger instance for debug/info output.
-        vendor: Vendor name for media resolution (e.g., "anthropic", "openai").
+        parallel: When True (and there is more than one tool call), execute
+            the tool calls concurrently via :func:`asyncio.gather`. Otherwise
+            execute sequentially in declaration order.
+        vendor: Vendor name extracted from the model string (e.g.,
+            ``"anthropic"``, ``"openai"``, ``"gemini"``). Drives both
+            resource_link resolution and image-handling restrictions. May be
+            ``None`` for unknown vendors — in that case, resource_link
+            resolution is skipped and tool results pass through as JSON.
+        loop_logger: Logger used for debug/info/warning output. May be
+            ``None`` to suppress logging.
 
     Returns:
-        Message dict with role, content, and optionally _mesh_usage.
+        A tuple ``(tool_messages, accumulated_images)`` where:
+          * ``tool_messages`` is the ordered list of
+            ``{role: "tool", tool_call_id: ..., content: ...}`` dicts to be
+            appended to the conversation immediately after the assistant
+            message that requested the tools.
+          * ``accumulated_images`` is the list of image dicts (in
+            OpenAI-compatible format) to be sent in a follow-up user message
+            after all tool results, for vendors that do not support images
+            in role:tool messages. Empty for other vendors.
     """
-    import litellm
-
     from _mcp_mesh.engine.unified_mcp_proxy import UnifiedMCPProxy
     from _mcp_mesh.media.resolver import _has_resource_link, resolve_resource_links
-
-    # Vendors that do NOT support images in tool/function result messages.
-    # OpenAI strictly rejects images in role:tool messages.
-    # For these vendors, images are accumulated and sent as one user message
-    # after ALL tool results for the iteration.
-    _tool_image_unsupported = {"openai", "gemini", "google"}
-
-    iteration = 0
-    current_messages = list(messages)
-
-    # Pop parallel_tool_calls before it reaches completion_args
-    # (Claude handler strips it, but OpenAI would pass it to API)
-    parallel = model_params.pop("parallel_tool_calls", False)
-    if parallel and loop_logger:
-        loop_logger.info("🔀 Provider parallel tool calls enabled — tools will execute concurrently via asyncio.gather()")
 
     async def _execute_single_tool(tc) -> tuple[dict, list[dict]]:
         """Execute a single tool call and return (tool_message, image_parts)."""
@@ -294,7 +311,7 @@ async def _provider_agentic_loop(
                 )
 
                 if has_image:
-                    if vendor in _tool_image_unsupported:
+                    if vendor in _TOOL_IMAGE_UNSUPPORTED_VENDORS:
                         # OpenAI/Gemini: images NOT allowed in tool messages.
                         # Put text-only parts in the tool message, accumulate
                         # images for a single user message after all tool results.
@@ -387,6 +404,73 @@ async def _provider_agentic_loop(
             [],
         )
 
+    tool_messages: list[dict] = []
+    accumulated_images: list[dict] = []
+
+    if parallel and len(message.tool_calls) > 1:
+        # Parallel execution via asyncio.gather
+        if loop_logger:
+            loop_logger.info(
+                f"⚡ Provider executing {len(message.tool_calls)} tool calls in parallel"
+            )
+        results = await asyncio.gather(
+            *[_execute_single_tool(tc) for tc in message.tool_calls]
+        )
+        for tool_msg, images in results:
+            tool_messages.append(tool_msg)
+            accumulated_images.extend(images)
+    else:
+        # Sequential execution (original behavior)
+        for tc in message.tool_calls:
+            tool_msg, images = await _execute_single_tool(tc)
+            tool_messages.append(tool_msg)
+            accumulated_images.extend(images)
+
+    return tool_messages, accumulated_images
+
+
+async def _provider_agentic_loop(
+    effective_model: str,
+    messages: list,
+    tools: list,
+    tool_endpoints: dict[str, str],
+    model_params: dict,
+    litellm_kwargs: dict,
+    max_iterations: int = 10,
+    loop_logger: logging.Logger | None = None,
+    vendor: str | None = None,
+) -> dict[str, Any]:
+    """Execute tools provider-side and return final response.
+
+    Runs a full agentic loop on the provider: calls the LLM, executes any
+    tool calls via MCP proxies, feeds results back, and repeats until the
+    LLM produces a final text response (no tool calls).
+
+    Args:
+        effective_model: LiteLLM model identifier to use.
+        messages: Conversation messages (will be copied internally).
+        tools: OpenAI-format tool schemas (already cleaned of _mesh_endpoint).
+        tool_endpoints: Mapping of tool_name -> MCP endpoint URL.
+        model_params: Extra model parameters for litellm.completion().
+        litellm_kwargs: Base kwargs captured by the decorator.
+        max_iterations: Safety limit on loop iterations.
+        loop_logger: Logger instance for debug/info output.
+        vendor: Vendor name for media resolution (e.g., "anthropic", "openai").
+
+    Returns:
+        Message dict with role, content, and optionally _mesh_usage.
+    """
+    import litellm
+
+    iteration = 0
+    current_messages = list(messages)
+
+    # Pop parallel_tool_calls before it reaches completion_args
+    # (Claude handler strips it, but OpenAI would pass it to API)
+    parallel = model_params.pop("parallel_tool_calls", False)
+    if parallel and loop_logger:
+        loop_logger.info("🔀 Provider parallel tool calls enabled — tools will execute concurrently via asyncio.gather()")
+
     # HINT-mode state (set by ClaudeHandler.apply_structured_output).
     # Captured outside the loop so the fallback after the loop has access.
     hint_mode = False
@@ -455,26 +539,10 @@ async def _provider_agentic_loop(
             }
             current_messages.append(assistant_msg)
 
-            accumulated_images: list[dict] = []
-
-            if parallel and len(message.tool_calls) > 1:
-                # Parallel execution via asyncio.gather
-                if loop_logger:
-                    loop_logger.info(
-                        f"⚡ Provider executing {len(message.tool_calls)} tool calls in parallel"
-                    )
-                results = await asyncio.gather(
-                    *[_execute_single_tool(tc) for tc in message.tool_calls]
-                )
-                for tool_msg, images in results:
-                    current_messages.append(tool_msg)
-                    accumulated_images.extend(images)
-            else:
-                # Sequential execution (original behavior)
-                for tc in message.tool_calls:
-                    tool_msg, images = await _execute_single_tool(tc)
-                    current_messages.append(tool_msg)
-                    accumulated_images.extend(images)
+            tool_messages, accumulated_images = await _execute_tool_calls_for_iteration(
+                message, tool_endpoints, parallel, vendor, loop_logger
+            )
+            current_messages.extend(tool_messages)
 
             # After ALL tool results: inject accumulated images as one user message.
             # Sequence: assistant(tool_calls) -> tool -> tool -> ... -> user(images)

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import re
+from collections.abc import AsyncIterator
 from typing import Any
 
 from _mcp_mesh.shared.logging_config import format_log_value
@@ -633,6 +634,344 @@ async def _provider_agentic_loop(
     }
 
 
+async def _provider_agentic_loop_stream(
+    effective_model: str,
+    messages: list,
+    tools: list,
+    tool_endpoints: dict[str, str],
+    model_params: dict,
+    litellm_kwargs: dict,
+    max_iterations: int = 10,
+    loop_logger: logging.Logger | None = None,
+    vendor: str | None = None,
+) -> AsyncIterator[str]:
+    """Streaming counterpart to :func:`_provider_agentic_loop`.
+
+    Mirrors the buffered provider agentic loop one-for-one, but yields text
+    chunks as they arrive from ``litellm.acompletion(stream=True, ...)``.
+    Intermediate iterations whose assistant turn requests tool_calls are
+    handled internally (tools execute on the provider, results feed back
+    into the loop). The final iteration's text streams chunk-by-chunk to
+    the consumer — except in HINT mode (see below).
+
+    Mid-stream tool_call detection (Option B):
+        Within each iteration we open one ``acompletion(stream=True)`` call
+        and consume chunks live. Text deltas yield to the consumer as they
+        arrive UNTIL we see the first ``tool_calls`` delta — at that point
+        we stop yielding and continue draining the stream so we collect all
+        ``tool_call`` argument fragments and the trailing ``usage`` block.
+        Once the stream exhausts, we reassemble the tool_calls (via
+        :meth:`MeshLlmAgent._merge_streamed_tool_calls`), execute them via
+        :func:`_execute_tool_calls_for_iteration`, append assistant + tool
+        messages to the conversation, and continue the outer while-loop. An
+        iteration that produces no tool_calls IS the final answer — its
+        text was already yielded live, so we just publish usage metadata
+        and return.
+
+    HINT mode caveat (Claude HINT):
+        When :class:`ClaudeHandler` signaled HINT mode (i.e. the provider
+        is expected to return JSON conforming to a schema), we cannot
+        stream the final iteration's text live because the validation
+        + bounded-timeout fallback (issue #820) needs the complete content
+        to decide whether to re-issue the call with native
+        ``response_format``. In that case we BUFFER the final iteration's
+        text, run :func:`_maybe_run_hint_fallback`, and yield the
+        validated (or fallback) text as a single chunk. This is a known
+        UX limitation — HINT + streaming becomes effectively non-streaming
+        for the final response — and is logged at INFO when entered.
+
+    Cancellation:
+        If the consumer breaks out of the ``async for`` early, we close
+        the underlying ``litellm.acompletion`` async iterator via
+        ``aclose()`` to release server resources promptly.
+
+    Token-usage publication:
+        Cumulative ``input``/``output`` tokens across iterations are
+        published via :func:`set_llm_metadata` after each stream
+        completion (LiteLLM emits ``usage`` in the final chunk when
+        ``stream_options={"include_usage": True}`` is requested). This
+        mirrors the direct-mode streaming agent so ExecutionTracer's
+        post-call read sees accurate counts.
+
+    Args:
+        effective_model: LiteLLM model identifier to use (e.g.
+            ``"anthropic/claude-sonnet-4-5"``).
+        messages: Conversation messages (will be copied internally).
+        tools: OpenAI-format tool schemas (already cleaned of
+            ``_mesh_endpoint``).
+        tool_endpoints: Mapping of tool_name -> MCP endpoint URL.
+        model_params: Extra model parameters for ``litellm.acompletion``.
+            ``parallel_tool_calls`` is popped early because Claude's
+            handler strips it; OpenAI would otherwise pass it to the API.
+        litellm_kwargs: Base kwargs captured by the decorator (api_key,
+            base_url, etc.).
+        max_iterations: Safety limit on loop iterations.
+        loop_logger: Logger for debug/info/warning output. May be
+            ``None`` to suppress logging.
+        vendor: Vendor name extracted from the model (e.g.
+            ``"anthropic"``, ``"openai"``). Drives image handling in
+            tool-result messages — see
+            :func:`_execute_tool_calls_for_iteration`.
+
+    Yields:
+        ``str`` text chunks. The empty stream is valid (e.g. tool-call
+        iterations followed by a final iteration that returns empty
+        content).
+    """
+    import litellm
+
+    # Imported here to avoid a circular import: ``_mcp_mesh.engine`` imports
+    # this module via the @mesh.llm_provider decorator path.
+    from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+    from _mcp_mesh.tracing.context import set_llm_metadata
+
+    iteration = 0
+    current_messages = list(messages)
+
+    parallel = model_params.pop("parallel_tool_calls", False)
+    if parallel and loop_logger:
+        loop_logger.info(
+            "🔀 Provider parallel tool calls enabled — tools will execute "
+            "concurrently via asyncio.gather()"
+        )
+
+    hint_mode = False
+    hint_schema: dict[str, Any] | None = None
+    hint_fallback_timeout = 30
+    hint_output_type_name = "Response"
+
+    total_input_tokens = 0
+    total_output_tokens = 0
+
+    while iteration < max_iterations:
+        iteration += 1
+
+        completion_args: dict[str, Any] = {
+            "model": effective_model,
+            "messages": current_messages,
+            "tools": tools,
+            **litellm_kwargs,
+        }
+        if model_params:
+            completion_args.update(model_params)
+
+        # Strip internal mesh control flags before they reach LiteLLM
+        # (mirrors the buffered loop and the legacy single-call path).
+        (
+            hint_mode,
+            hint_schema,
+            hint_fallback_timeout,
+            hint_output_type_name,
+        ) = _pop_mesh_hint_flags(
+            completion_args,
+            defaults=(
+                hint_mode,
+                hint_schema,
+                hint_fallback_timeout,
+                hint_output_type_name,
+            ),
+        )
+
+        existing_stream_opts = completion_args.get("stream_options") or {}
+        completion_args["stream"] = True
+        completion_args["stream_options"] = {
+            **existing_stream_opts,
+            "include_usage": True,
+        }
+
+        stream_iter = await litellm.acompletion(**completion_args)
+
+        chunks: list[Any] = []
+        saw_tool_call = False
+        stream_completed = False
+
+        # When HINT mode is active we cannot yield the final iteration's
+        # text live: the bounded-timeout fallback (issue #820) needs the
+        # complete content for schema validation. Buffer instead.
+        buffer_for_hint = bool(hint_mode and hint_schema)
+        if buffer_for_hint and loop_logger:
+            loop_logger.info(
+                "HINT mode active — buffering final iteration for validation "
+                "(streaming UX degrades to single-chunk for this response)"
+            )
+
+        try:
+            async for chunk in stream_iter:
+                chunks.append(chunk)
+
+                if MeshLlmAgent._chunk_has_tool_call(chunk):
+                    saw_tool_call = True
+                    continue
+
+                if saw_tool_call:
+                    continue
+
+                if buffer_for_hint:
+                    # Drain without yielding; we need the full content to
+                    # validate against the schema before emitting anything.
+                    continue
+
+                text = MeshLlmAgent._extract_text_from_chunk(chunk)
+                if text:
+                    yield text
+            stream_completed = True
+
+            iter_usage = MeshLlmAgent._extract_usage_from_chunks(chunks)
+            if iter_usage:
+                total_input_tokens += iter_usage.get("prompt_tokens", 0) or 0
+                total_output_tokens += (
+                    iter_usage.get("completion_tokens", 0) or 0
+                )
+            iter_model = MeshLlmAgent._extract_model_from_chunks(chunks)
+            if iter_model:
+                effective_model = iter_model
+
+            if saw_tool_call:
+                merged_tool_calls = MeshLlmAgent._merge_streamed_tool_calls(chunks)
+                if not merged_tool_calls:
+                    raise RuntimeError(
+                        "provider stream produced tool_call deltas but no "
+                        "complete tool_call could be merged"
+                    )
+
+                preamble_text = MeshLlmAgent._join_text_from_chunks(chunks)
+                if loop_logger:
+                    loop_logger.debug(
+                        f"Provider executing {len(merged_tool_calls)} tool calls "
+                        f"(iteration {iteration}/{max_iterations})"
+                    )
+
+                assistant_msg: dict[str, Any] = {
+                    "role": "assistant",
+                    "content": preamble_text or "",
+                    "tool_calls": [
+                        {
+                            "id": tc["id"],
+                            "type": tc["type"],
+                            "function": {
+                                "name": tc["function"]["name"],
+                                "arguments": tc["function"]["arguments"],
+                            },
+                        }
+                        for tc in merged_tool_calls
+                    ],
+                }
+                current_messages.append(assistant_msg)
+
+                # Synthesize a litellm-shaped message so the Phase 1 helper
+                # (which reads ``message.tool_calls``) works unchanged.
+                from _mcp_mesh.engine.mesh_llm_agent import _MockMessage
+
+                mock_message = _MockMessage(
+                    {
+                        "role": "assistant",
+                        "content": preamble_text or "",
+                        "tool_calls": merged_tool_calls,
+                    }
+                )
+
+                tool_messages, accumulated_images = (
+                    await _execute_tool_calls_for_iteration(
+                        mock_message,
+                        tool_endpoints,
+                        parallel,
+                        vendor,
+                        loop_logger,
+                    )
+                )
+                current_messages.extend(tool_messages)
+
+                if accumulated_images:
+                    current_messages.append(
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "Here are the images from the tool results above:",
+                                },
+                                *accumulated_images,
+                            ],
+                        }
+                    )
+                    if loop_logger:
+                        loop_logger.info(
+                            f"Injected user message with {len(accumulated_images)} "
+                            f"accumulated images (vendor={vendor})"
+                        )
+
+                # Continue the outer loop for the next iteration.
+                continue
+
+            # No tool_calls observed this iteration → final answer.
+            final_content = MeshLlmAgent._join_text_from_chunks(chunks)
+
+            if buffer_for_hint:
+                # Run HINT validation + bounded-timeout fallback. The
+                # fallback uses ``litellm.completion`` (sync) so it
+                # returns a buffered response; we yield its content as
+                # one chunk regardless of whether it ran.
+                fallback_base_args = {
+                    k: v
+                    for k, v in completion_args.items()
+                    if k not in ("tools", "stream", "stream_options")
+                }
+                try:
+                    final_content, _msg, _resp = await _maybe_run_hint_fallback(
+                        final_content=final_content,
+                        message=None,
+                        response=None,
+                        base_completion_args=fallback_base_args,
+                        hint_mode=hint_mode,
+                        hint_schema=hint_schema,
+                        hint_fallback_timeout=hint_fallback_timeout,
+                        hint_output_type_name=hint_output_type_name,
+                        fallback_logger=loop_logger,
+                    )
+                except Exception as e:
+                    if loop_logger:
+                        loop_logger.error(
+                            "Claude HINT fallback to response_format failed: %s",
+                            e,
+                        )
+                    raise
+
+                if final_content:
+                    yield final_content
+
+            set_llm_metadata(
+                model=effective_model,
+                provider=vendor or "",
+                input_tokens=total_input_tokens,
+                output_tokens=total_output_tokens,
+            )
+
+            if loop_logger:
+                loop_logger.info(
+                    f"Provider-managed stream loop completed in {iteration} iterations"
+                )
+            return
+        finally:
+            if not stream_completed:
+                aclose = getattr(stream_iter, "aclose", None)
+                if aclose is not None:
+                    try:
+                        await aclose()
+                    except Exception as e:
+                        if loop_logger:
+                            loop_logger.debug(
+                                f"provider stream: aclose() failed during teardown: {e}"
+                            )
+
+    # Safety: max iterations reached. Emit a textual indicator so consumers
+    # iterating ``async for`` always see at least one chunk in this edge.
+    if loop_logger:
+        loop_logger.warning(
+            f"Provider-managed stream loop hit max iterations ({max_iterations})"
+        )
+    yield "Maximum tool call iterations reached"
+
+
 def _extract_vendor_from_model(model: str) -> str | None:
     """
     Extract vendor name from LiteLLM model string.
@@ -751,7 +1090,7 @@ def llm_provider(
         import sys
 
         from mesh import tool
-        from mesh.types import MeshLlmRequest
+        from mesh.types import MeshLlmRequest, Stream
 
         # Find FastMCP app in current module
         current_module = sys.modules.get(func.__module__)
@@ -791,19 +1130,34 @@ def llm_provider(
                     f"using 'unknown'"
                 )
 
-        # Generate the LLM handler function
-        async def process_chat(request: MeshLlmRequest) -> dict[str, Any]:
+        def _prepare_provider_request(
+            request: MeshLlmRequest,
+        ) -> tuple[
+            str,
+            list[dict[str, Any]],
+            list[dict[str, Any]] | None,
+            dict[str, str],
+            dict[str, Any],
+        ]:
+            """Shared setup for ``process_chat`` and ``process_chat_stream``.
+
+            Both the buffered and streaming auto-generated handlers need the
+            same preamble: resolve the effective model (with consumer
+            override), apply vendor-specific structured-output handling
+            (issue #459), extract mesh tool endpoints from
+            ``request.tools`` (mutating each tool dict to strip
+            ``_mesh_endpoint`` — same as the original inline code), and
+            format the system prompt via the vendor handler when tools are
+            present. Centralizing keeps both paths in lock-step so a future
+            change to one cannot drift from the other.
+
+            Returns a 5-tuple:
+                ``(effective_model, messages, clean_tools, tool_endpoints,
+                model_params_copy)``
+            where ``clean_tools`` is ``None`` when ``request.tools`` is
+            None / empty (preserving the legacy buffered path's existing
+            behavior of omitting ``tools`` from ``completion_args``).
             """
-            Auto-generated LLM handler.
-
-            Args:
-                request: MeshLlmRequest with messages, tools, model_params
-
-            Returns:
-                Full message dict with content, role, and tool_calls (if present)
-            """
-            import litellm
-
             # Determine effective model (check for consumer override - issue #308)
             effective_model = model  # Default to provider's model
             model_params_copy = (
@@ -891,6 +1245,36 @@ def llm_provider(
                     else:
                         formatted_messages.append(msg)
                 messages = formatted_messages
+
+            return (
+                effective_model,
+                messages,
+                clean_tools,
+                tool_endpoints,
+                model_params_copy,
+            )
+
+        # Generate the LLM handler function
+        async def process_chat(request: MeshLlmRequest) -> dict[str, Any]:
+            """
+            Auto-generated LLM handler.
+
+            Args:
+                request: MeshLlmRequest with messages, tools, model_params
+
+            Returns:
+                Full message dict with content, role, and tool_calls (if present)
+            """
+            import litellm
+
+            (
+                effective_model,
+                messages,
+                clean_tools,
+                tool_endpoints,
+                model_params_copy,
+            ) = _prepare_provider_request(request)
+            effective_tools = clean_tools if clean_tools is not None else request.tools
 
             if tool_endpoints:
                 # Provider-managed agentic loop: execute tools internally
@@ -1039,6 +1423,132 @@ def llm_provider(
                 logger.error(f"LLM provider {func.__name__} failed: {e}")
                 raise
 
+        # Auto-generated streaming counterpart: yields text chunks from the
+        # provider's agentic loop. Co-exists with ``process_chat`` and shares
+        # the same capability + tags so consumers can soft-fall-back to the
+        # buffered tool when no streaming variant is registered. The
+        # ``Stream[str]`` return annotation triggers
+        # :func:`detect_stream_type` in the ``@mesh.tool`` layer, which
+        # stamps ``metadata["stream_type"] = "text"`` and switches FastMCP
+        # to the streaming runtime wrapper (chunks → progress notifications).
+        async def process_chat_stream(request: MeshLlmRequest) -> Stream[str]:
+            """Auto-generated streaming LLM handler.
+
+            Yields text chunks from the provider's agentic loop. Intermediate
+            iterations whose assistant turn requests tool_calls execute the
+            tools internally on the provider; the final iteration's text
+            streams chunk-by-chunk to the consumer via FastMCP progress
+            notifications. HINT-mode requests buffer the final iteration to
+            run the schema-validation fallback (see
+            ``_provider_agentic_loop_stream``).
+            """
+            (
+                effective_model,
+                messages,
+                clean_tools,
+                tool_endpoints,
+                model_params_copy,
+            ) = _prepare_provider_request(request)
+            effective_tools = (
+                clean_tools if clean_tools is not None else request.tools
+            )
+
+            if tool_endpoints:
+                logger.info(
+                    f"Provider-managed stream loop: {len(tool_endpoints)} tools with endpoints"
+                )
+                async for chunk in _provider_agentic_loop_stream(
+                    effective_model=effective_model,
+                    messages=messages,
+                    tools=clean_tools or [],
+                    tool_endpoints=tool_endpoints,
+                    model_params=model_params_copy,
+                    litellm_kwargs=litellm_kwargs,
+                    max_iterations=10,
+                    loop_logger=logger,
+                    vendor=vendor,
+                ):
+                    yield chunk
+                logger.info(
+                    f"LLM provider {func.__name__}_stream completed "
+                    f"(model={effective_model}, messages={len(request.messages)})"
+                )
+                return
+
+            # Legacy no-tools path: single ``litellm.acompletion(stream=True)``
+            # passthrough. Mirrors the no-tools branch of ``process_chat`` but
+            # streams chunks instead of buffering. We do NOT run the HINT
+            # fallback here because the no-tools path does not pre-inject the
+            # HINT-mode flags (those come from ``handler.apply_structured_output``
+            # which only runs when ``output_schema`` is set in
+            # ``model_params``); the buffered legacy path's HINT branch is
+            # preserved exactly as-is in ``process_chat``.
+            import litellm
+
+            completion_args: dict[str, Any] = {
+                "model": effective_model,
+                "messages": messages,
+                **litellm_kwargs,
+            }
+            if effective_tools:
+                completion_args["tools"] = effective_tools
+            if model_params_copy:
+                completion_args.update(model_params_copy)
+
+            # Strip internal mesh control flags before they reach LiteLLM
+            # (mirrors the buffered legacy path). Captured values are not
+            # used here — HINT validation cannot be applied to a live
+            # stream without buffering, and this no-tools branch never
+            # runs ``apply_structured_output``. Future work could buffer
+            # if HINT mode is later signaled by another route.
+            _pop_mesh_hint_flags(completion_args)
+
+            existing_stream_opts = completion_args.get("stream_options") or {}
+            completion_args["stream"] = True
+            completion_args["stream_options"] = {
+                **existing_stream_opts,
+                "include_usage": True,
+            }
+
+            from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+            from _mcp_mesh.tracing.context import set_llm_metadata
+
+            stream_iter = await litellm.acompletion(**completion_args)
+            chunks: list[Any] = []
+            stream_completed = False
+            try:
+                async for chunk in stream_iter:
+                    chunks.append(chunk)
+                    text = MeshLlmAgent._extract_text_from_chunk(chunk)
+                    if text:
+                        yield text
+                stream_completed = True
+            finally:
+                if not stream_completed:
+                    aclose = getattr(stream_iter, "aclose", None)
+                    if aclose is not None:
+                        try:
+                            await aclose()
+                        except Exception as e:
+                            logger.debug(
+                                f"provider stream (no-tools): aclose() failed: {e}"
+                            )
+
+            usage = MeshLlmAgent._extract_usage_from_chunks(chunks)
+            iter_model = MeshLlmAgent._extract_model_from_chunks(chunks)
+            set_llm_metadata(
+                model=iter_model or effective_model,
+                provider=vendor or "",
+                input_tokens=(usage or {}).get("prompt_tokens", 0) or 0,
+                output_tokens=(usage or {}).get("completion_tokens", 0) or 0,
+            )
+
+            logger.info(
+                f"LLM provider {func.__name__}_stream completed "
+                f"(model={effective_model}, messages={len(request.messages)}, "
+                f"no-tools-path)"
+            )
+
         # Preserve original function's docstring metadata
         if func.__doc__:
             process_chat.__doc__ = func.__doc__ + "\n\n" + (process_chat.__doc__ or "")
@@ -1049,6 +1559,12 @@ def llm_provider(
         # would be registered as "process_chat" and overwrite each other.
         process_chat.__name__ = func.__name__
         process_chat.__qualname__ = func.__qualname__
+
+        # Streaming variant follows the same pattern but with a ``_stream``
+        # suffix so the consumer can call ``proxy.stream(name=f"{fn}_stream")``
+        # and fall back to ``proxy(...)`` when the suffix tool is absent.
+        process_chat_stream.__name__ = f"{func.__name__}_stream"
+        process_chat_stream.__qualname__ = f"{func.__qualname__}_stream"
 
         # CRITICAL: Apply @mesh.tool() FIRST (before FastMCP caches the function)
         # This ensures mesh DI wrapper is in place when FastMCP caches the function
@@ -1063,12 +1579,26 @@ def llm_provider(
         # Then apply @app.tool() for MCP registration (caches the wrapped version)
         process_chat = app.tool()(process_chat)
 
+        # Same decorator order for the streaming variant. Same capability /
+        # tags / vendor — soft-fallback to the buffered tool is keyed off the
+        # ``_stream`` suffix on the tool NAME, not on a separate capability.
+        process_chat_stream = tool(
+            capability=capability,
+            tags=tags,
+            version=version,
+            vendor=vendor,
+        )(process_chat_stream)
+        process_chat_stream = app.tool()(process_chat_stream)
+
         logger.info(
             f"✅ Created LLM provider '{func.__name__}' "
-            f"(model={model}, capability={capability}, tags={tags}, vendor={vendor})"
+            f"(+ streaming variant '{func.__name__}_stream'; "
+            f"model={model}, capability={capability}, tags={tags}, vendor={vendor})"
         )
 
-        # Return the generated function (replaces the placeholder)
+        # Return the generated function (replaces the placeholder).
+        # The streaming variant is registered via @app.tool() and @tool()
+        # side effects above; it does not need to be returned to the caller.
         return process_chat
 
     return decorator

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -131,13 +131,27 @@ async def _maybe_run_hint_fallback(
             hint_fallback_timeout,
         )
 
+    # Anthropic's structured output requires additionalProperties: false on every
+    # object type in the schema. Pydantic-generated schemas don't include that by
+    # default. The base apply_structured_output path already strict-ifies via
+    # make_schema_strict; the HINT fallback was missing the same step, causing
+    # Anthropic's "output_format.schema: ... must be explicitly set to false"
+    # rejection on complex schemas (nested BaseModels). add_all_required=False
+    # because Claude — unlike OpenAI/Gemini — does not require every property
+    # to be in 'required'.
+    from _mcp_mesh.engine.provider_handlers.base_provider_handler import (
+        make_schema_strict,
+    )
+
+    strict_hint_schema = make_schema_strict(hint_schema, add_all_required=False)
+
     fallback_args = {
         **base_completion_args,
         "response_format": {
             "type": "json_schema",
             "json_schema": {
                 "name": hint_output_type_name,
-                "schema": hint_schema,
+                "schema": strict_hint_schema,
                 "strict": True,
             },
         },
@@ -1582,9 +1596,17 @@ def llm_provider(
         # Same decorator order for the streaming variant. Same capability /
         # tags / vendor — soft-fallback to the buffered tool is keyed off the
         # ``_stream`` suffix on the tool NAME, not on a separate capability.
+        #
+        # The ``ai.mcpmesh.stream`` tag is the producer half of a contract with
+        # ``@mesh.llm``: the consumer-side decorator augments its provider tags
+        # filter with ``ai.mcpmesh.stream`` (required) when the consumer returns
+        # ``Stream[str]`` and ``-ai.mcpmesh.stream`` (excluded) otherwise. This
+        # lets the registry resolver pick the right variant deterministically
+        # via existing tag-operator semantics — no resolver special-casing.
+        stream_tags = list(tags or []) + ["ai.mcpmesh.stream"]
         process_chat_stream = tool(
             capability=capability,
-            tags=tags,
+            tags=stream_tags,
             version=version,
             vendor=vendor,
         )(process_chat_stream)

--- a/src/runtime/python/tests/unit/test_claude_handler_hint_mode.py
+++ b/src/runtime/python/tests/unit/test_claude_handler_hint_mode.py
@@ -43,11 +43,13 @@ class TestClaudeApplyStructuredOutputHintMode:
         }
 
     def setup_method(self):
-        # Ensure env var doesn't leak between tests in this class
+        # Ensure env vars don't leak between tests in this class
         os.environ.pop("MCP_MESH_CLAUDE_FORCE_RESPONSE_FORMAT", None)
+        os.environ.pop("MCP_MESH_CLAUDE_HINT_FALLBACK_TIMEOUT", None)
 
     def teardown_method(self):
         os.environ.pop("MCP_MESH_CLAUDE_FORCE_RESPONSE_FORMAT", None)
+        os.environ.pop("MCP_MESH_CLAUDE_HINT_FALLBACK_TIMEOUT", None)
 
     def test_does_not_set_response_format(self):
         """HINT-mode override must NOT set ``response_format``."""
@@ -105,7 +107,7 @@ class TestClaudeApplyStructuredOutputHintMode:
             self._schema(), "MyType", model_params
         )
 
-        assert result.get("_mesh_hint_fallback_timeout") == 30
+        assert result.get("_mesh_hint_fallback_timeout") == 90
         assert result.get("_mesh_hint_output_type_name") == "MyType"
 
     def test_injects_hint_into_system_prompt(self):

--- a/src/runtime/python/tests/unit/test_claude_handler_hint_mode.py
+++ b/src/runtime/python/tests/unit/test_claude_handler_hint_mode.py
@@ -330,7 +330,7 @@ class TestPopMeshHintFlags:
         hint_mode, hint_schema, hint_timeout, hint_name = _pop_mesh_hint_flags(args)
         assert hint_mode is False
         assert hint_schema is None
-        assert hint_timeout == 30
+        assert hint_timeout == 90  # _DEFAULT_HINT_FALLBACK_TIMEOUT
         assert hint_name == "Response"
         # Original args untouched
         assert args == {"model": "x", "messages": []}

--- a/src/runtime/python/tests/unit/test_llm_decorator_stream_tag_filter.py
+++ b/src/runtime/python/tests/unit/test_llm_decorator_stream_tag_filter.py
@@ -1,0 +1,166 @@
+"""Unit tests for the consumer-side ``ai.mcpmesh.stream`` tag augmentation.
+
+Phase 5C of the mesh-delegate streaming work for issue #849.
+
+The ``@mesh.llm`` decorator inspects the consumer function's return type and
+augments the ``provider["tags"]`` filter that gets sent to the registry
+resolver:
+  * ``Stream[str]`` → append ``ai.mcpmesh.stream`` (required match — only the
+    streaming variant of the provider matches).
+  * Anything else (``str``, Pydantic model, etc.) → append ``-ai.mcpmesh.stream``
+    (excluded — only the buffered variant matches).
+
+The producer half of the contract is in ``@mesh.llm_provider``: the auto-
+generated ``process_chat_stream`` carries ``ai.mcpmesh.stream``; the buffered
+``process_chat`` does not. The registry's existing +/- tag-operator semantics
+do the rest — no resolver special-casing.
+"""
+
+import pytest
+from pydantic import BaseModel
+
+import mesh
+from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+
+def _provider_config(agent_data) -> dict:
+    """Helper to extract the resolved provider dict from registered metadata."""
+    provider = agent_data.config["provider"]
+    assert isinstance(provider, dict), (
+        f"Expected provider dict, got {type(provider).__name__}: {provider!r}"
+    )
+    return provider
+
+
+class _ChatResponse(BaseModel):
+    answer: str
+    confidence: float
+
+
+class TestStreamTagAugmentation:
+    """Consumer-side tag augmentation based on return type."""
+
+    def setup_method(self):
+        DecoratorRegistry._mesh_llm_agents = {}
+
+    def test_stream_return_adds_required_tag(self):
+        """``Stream[str]`` return type → ``ai.mcpmesh.stream`` (required) appended."""
+
+        @mesh.llm(provider={"capability": "llm", "tags": ["existing"]})
+        async def chat(message: str, llm: mesh.MeshLlmAgent = None) -> mesh.Stream[str]:
+            async for chunk in llm.stream(message):
+                yield chunk
+
+        agents = DecoratorRegistry.get_mesh_llm_agents()
+        agent_data = next(iter(agents.values()))
+        provider = _provider_config(agent_data)
+
+        assert provider["capability"] == "llm"
+        assert provider["tags"] == ["existing", "ai.mcpmesh.stream"]
+
+    def test_buffered_return_adds_excluded_tag(self):
+        """``str`` return type → ``-ai.mcpmesh.stream`` (excluded) appended."""
+
+        @mesh.llm(provider={"capability": "llm", "tags": ["existing"]})
+        async def chat(message: str, llm: mesh.MeshLlmAgent = None) -> str:
+            return await llm(message)
+
+        agents = DecoratorRegistry.get_mesh_llm_agents()
+        agent_data = next(iter(agents.values()))
+        provider = _provider_config(agent_data)
+
+        assert provider["tags"] == ["existing", "-ai.mcpmesh.stream"]
+
+    def test_pydantic_return_adds_excluded_tag(self):
+        """Pydantic-model return → buffered → ``-ai.mcpmesh.stream``."""
+
+        @mesh.llm(provider={"capability": "llm", "tags": ["existing"]})
+        async def chat(message: str, llm: mesh.MeshLlmAgent = None) -> _ChatResponse:
+            return await llm(message)
+
+        agents = DecoratorRegistry.get_mesh_llm_agents()
+        agent_data = next(iter(agents.values()))
+        provider = _provider_config(agent_data)
+
+        assert provider["tags"] == ["existing", "-ai.mcpmesh.stream"]
+
+    def test_explicit_user_required_tag_respected(self):
+        """User-supplied ``ai.mcpmesh.stream`` (required) is preserved verbatim."""
+
+        @mesh.llm(provider={"capability": "llm", "tags": ["ai.mcpmesh.stream"]})
+        async def chat(message: str, llm: mesh.MeshLlmAgent = None) -> str:
+            # Buffered return type, but user explicitly asked for streaming
+            # provider — don't fight them.
+            return await llm(message)
+
+        agents = DecoratorRegistry.get_mesh_llm_agents()
+        agent_data = next(iter(agents.values()))
+        provider = _provider_config(agent_data)
+
+        assert provider["tags"] == ["ai.mcpmesh.stream"]
+
+    def test_explicit_user_preferred_tag_respected(self):
+        """User-supplied ``+ai.mcpmesh.stream`` (preferred) is preserved verbatim."""
+
+        @mesh.llm(provider={"capability": "llm", "tags": ["+ai.mcpmesh.stream"]})
+        async def chat(message: str, llm: mesh.MeshLlmAgent = None) -> mesh.Stream[str]:
+            async for chunk in llm.stream(message):
+                yield chunk
+
+        agents = DecoratorRegistry.get_mesh_llm_agents()
+        agent_data = next(iter(agents.values()))
+        provider = _provider_config(agent_data)
+
+        assert provider["tags"] == ["+ai.mcpmesh.stream"]
+
+    def test_explicit_user_excluded_tag_respected(self):
+        """User-supplied ``-ai.mcpmesh.stream`` (excluded) is preserved verbatim."""
+
+        @mesh.llm(provider={"capability": "llm", "tags": ["-ai.mcpmesh.stream"]})
+        async def chat(message: str, llm: mesh.MeshLlmAgent = None) -> mesh.Stream[str]:
+            async for chunk in llm.stream(message):
+                yield chunk
+
+        agents = DecoratorRegistry.get_mesh_llm_agents()
+        agent_data = next(iter(agents.values()))
+        provider = _provider_config(agent_data)
+
+        assert provider["tags"] == ["-ai.mcpmesh.stream"]
+
+    def test_no_provider_dict_no_tag_change(self):
+        """Direct mode (string provider) — no augmentation, provider stays a string."""
+
+        @mesh.llm(provider="claude")
+        async def chat(message: str, llm: mesh.MeshLlmAgent = None) -> str:
+            return await llm(message)
+
+        agents = DecoratorRegistry.get_mesh_llm_agents()
+        agent_data = next(iter(agents.values()))
+        assert agent_data.config["provider"] == "claude"
+
+    def test_provider_dict_without_user_tags(self):
+        """Provider dict with no ``tags`` key gets a fresh single-tag list."""
+
+        @mesh.llm(provider={"capability": "llm"})
+        async def chat(message: str, llm: mesh.MeshLlmAgent = None) -> str:
+            return await llm(message)
+
+        agents = DecoratorRegistry.get_mesh_llm_agents()
+        agent_data = next(iter(agents.values()))
+        provider = _provider_config(agent_data)
+
+        assert provider["tags"] == ["-ai.mcpmesh.stream"]
+
+    def test_user_provider_dict_not_mutated(self):
+        """The user's provider dict must not be mutated in place."""
+
+        user_provider = {"capability": "llm", "tags": ["existing"]}
+        original_tags = user_provider["tags"]
+
+        @mesh.llm(provider=user_provider)
+        async def chat(message: str, llm: mesh.MeshLlmAgent = None) -> str:
+            return await llm(message)
+
+        # The user's dict is untouched: same list object, same contents.
+        assert user_provider["tags"] is original_tags
+        assert user_provider["tags"] == ["existing"]

--- a/src/runtime/python/tests/unit/test_llm_provider_decorator_streaming.py
+++ b/src/runtime/python/tests/unit/test_llm_provider_decorator_streaming.py
@@ -1,0 +1,324 @@
+"""Unit tests for the auto-generated streaming variant in @mesh.llm_provider.
+
+Phase 3 of the mesh-delegate streaming work for issue #849.
+
+The decorator now generates TWO tools per ``@mesh.llm_provider``-decorated
+function: the existing buffered ``<name>`` (returns a message dict) and a new
+streaming ``<name>_stream`` (yields ``mesh.Stream[str]`` text chunks). Both
+share the same capability + tags so consumers can soft-fall-back to the
+buffered variant when no streaming tool is registered (handled in Phase 4
+by ``MeshLlmAgent._stream_mesh_delegated``).
+
+These tests pin down:
+  * Both tools are registered on the FastMCP app.
+  * The streaming tool has ``metadata["stream_type"] == "text"`` so the
+    runtime forwards chunks via FastMCP progress notifications.
+  * Two ``@mesh.llm_provider`` in one module register 4 distinct tools
+    (regression for issue #227 — name conflicts between providers).
+  * Calling the streaming tool yields chunks from the underlying provider
+    loop.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_module_with_app(module_name: str = "test_module"):
+    """Create a fake module with a FastMCP ``app`` attribute.
+
+    @mesh.llm_provider looks up the ``app`` via ``sys.modules[func.__module__]``,
+    so we have to register a real module entry. We also clear the
+    DecoratorRegistry's mesh_tools dict to keep tests isolated — the registry
+    is class-level state shared across the whole test run.
+    """
+    from fastmcp import FastMCP
+
+    from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+    mod = types.ModuleType(module_name)
+    mod.app = FastMCP(module_name)
+    sys.modules[module_name] = mod
+    # Snapshot existing tools so we can restore after the test.
+    DecoratorRegistry._test_snapshot = dict(DecoratorRegistry._mesh_tools)
+    DecoratorRegistry._mesh_tools.clear()
+    return mod
+
+
+def _drop_module(module_name: str):
+    from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+    sys.modules.pop(module_name, None)
+    snapshot = getattr(DecoratorRegistry, "_test_snapshot", None)
+    if snapshot is not None:
+        DecoratorRegistry._mesh_tools.clear()
+        DecoratorRegistry._mesh_tools.update(snapshot)
+        del DecoratorRegistry._test_snapshot
+
+
+def _make_provider_in_module(mod, module_name: str, func_name: str, **kwargs):
+    """Build a function whose ``__module__`` matches ``module_name`` BEFORE
+    @mesh.llm_provider is applied.
+
+    The decorator looks up the FastMCP ``app`` via
+    ``sys.modules[func.__module__]``, so the function's ``__module__`` must
+    be set before decoration.
+    """
+    import mesh
+
+    def placeholder():
+        pass
+
+    placeholder.__name__ = func_name
+    placeholder.__qualname__ = func_name
+    placeholder.__module__ = module_name
+    decorated = mesh.llm_provider(**kwargs)(placeholder)
+    setattr(mod, func_name, decorated)
+    return decorated
+
+
+# ---------------------------------------------------------------------------
+# Both tools are registered
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingVariantRegistered:
+    @pytest.mark.asyncio
+    async def test_both_tools_present_after_decoration(self):
+        module_name = "_test_llm_provider_streaming_both_tools"
+        mod = _make_module_with_app(module_name)
+        try:
+            _make_provider_in_module(
+                mod,
+                module_name,
+                "claude_provider",
+                model="anthropic/claude-3-5-haiku-20241022",
+                capability="llm",
+                tags=["claude", "test"],
+                version="1.0.0",
+            )
+
+            registered = await mod.app.list_tools()
+            tool_names = {t.name for t in registered}
+
+            assert "claude_provider" in tool_names
+            assert "claude_provider_stream" in tool_names
+        finally:
+            _drop_module(module_name)
+
+    @pytest.mark.asyncio
+    async def test_streaming_tool_advertises_stream_type_text(self):
+        module_name = "_test_llm_provider_streaming_meta"
+        mod = _make_module_with_app(module_name)
+        try:
+            _make_provider_in_module(
+                mod,
+                module_name,
+                "claude_provider",
+                model="anthropic/claude-3-5-haiku-20241022",
+                capability="llm",
+                tags=["claude"],
+            )
+
+            from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+            mesh_tools = DecoratorRegistry.get_mesh_tools()
+            stream_meta = mesh_tools.get("claude_provider_stream")
+            assert stream_meta is not None, (
+                "@mesh.tool metadata for streaming variant not registered"
+            )
+            assert stream_meta.metadata.get("stream_type") == "text"
+
+            # The buffered tool must NOT have stream_type stamped.
+            buffered_meta = mesh_tools.get("claude_provider")
+            assert buffered_meta is not None
+            assert "stream_type" not in buffered_meta.metadata
+        finally:
+            _drop_module(module_name)
+
+    @pytest.mark.asyncio
+    async def test_streaming_tool_shares_capability_and_tags(self):
+        """Soft-fallback works because both tools advertise the same capability+tags."""
+        module_name = "_test_llm_provider_streaming_caps"
+        mod = _make_module_with_app(module_name)
+        try:
+            _make_provider_in_module(
+                mod,
+                module_name,
+                "claude_provider",
+                model="anthropic/claude-3-5-haiku-20241022",
+                capability="llm",
+                tags=["claude", "fast"],
+                version="2.1.0",
+            )
+
+            from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+            mesh_tools = DecoratorRegistry.get_mesh_tools()
+            buffered = mesh_tools["claude_provider"].metadata
+            stream = mesh_tools["claude_provider_stream"].metadata
+
+            assert buffered["capability"] == stream["capability"] == "llm"
+            assert buffered["tags"] == stream["tags"]
+            assert buffered["version"] == stream["version"] == "2.1.0"
+        finally:
+            _drop_module(module_name)
+
+
+# ---------------------------------------------------------------------------
+# Issue #227: multiple providers in one module register all variants
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleProvidersInModule:
+    @pytest.mark.asyncio
+    async def test_two_providers_register_four_distinct_tools(self):
+        """Issue #227 regression check, extended for the streaming variant."""
+        module_name = "_test_llm_provider_streaming_multi"
+        mod = _make_module_with_app(module_name)
+        try:
+            _make_provider_in_module(
+                mod,
+                module_name,
+                "claude_provider",
+                model="anthropic/claude-3-5-haiku-20241022",
+                capability="llm",
+                tags=["claude"],
+            )
+            _make_provider_in_module(
+                mod,
+                module_name,
+                "openai_provider",
+                model="openai/gpt-4o-mini",
+                capability="llm",
+                tags=["openai"],
+            )
+
+            registered = await mod.app.list_tools()
+            tool_names = {t.name for t in registered}
+
+            assert {
+                "claude_provider",
+                "claude_provider_stream",
+                "openai_provider",
+                "openai_provider_stream",
+            }.issubset(tool_names)
+        finally:
+            _drop_module(module_name)
+
+
+# ---------------------------------------------------------------------------
+# Streaming tool yields chunks via the provider stream loop
+# ---------------------------------------------------------------------------
+
+
+class _FakeStream:
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+    async def aclose(self):
+        pass
+
+
+def _delta(content=None, tool_calls=None):
+    d = MagicMock()
+    d.content = content
+    d.tool_calls = tool_calls
+    return d
+
+
+def _choice(delta):
+    c = MagicMock()
+    c.delta = delta
+    return c
+
+
+def _chunk(content=None, usage=None, model=None):
+    ch = MagicMock()
+    ch.choices = [_choice(_delta(content=content))]
+    ch.usage = (
+        MagicMock(
+            prompt_tokens=usage.get("prompt_tokens", 0),
+            completion_tokens=usage.get("completion_tokens", 0),
+        )
+        if usage
+        else None
+    )
+    ch.model = model
+    return ch
+
+
+class TestStreamingToolYieldsChunks:
+    @pytest.mark.asyncio
+    async def test_no_tools_path_streams_chunks_through_acompletion(self):
+        """Direct text-streaming when ``request.tools`` is empty.
+
+        We exercise the underlying async generator function (resolved via
+        ``_mesh_original_func`` on the DI wrapper) rather than the FastMCP
+        stream wrapper — the wrapper accumulates chunks and returns a string,
+        so testing it requires a FastMCP Context. The streaming behavior we
+        care about is in the generator itself; the wrapper's chunk-forwarding
+        is covered by ``test_stream_wrapper.py``.
+        """
+        import inspect
+
+        from mesh.types import MeshLlmRequest
+
+        module_name = "_test_llm_provider_streaming_yield"
+        mod = _make_module_with_app(module_name)
+        try:
+            _make_provider_in_module(
+                mod,
+                module_name,
+                "claude_provider",
+                model="anthropic/claude-3-5-haiku-20241022",
+                capability="llm",
+                tags=["claude"],
+            )
+
+            from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+            mesh_tools = DecoratorRegistry.get_mesh_tools()
+            stream_meta = mesh_tools["claude_provider_stream"]
+            wrapper = stream_meta.function
+            # Walk back to the original async-generator function.
+            original = getattr(wrapper, "_mesh_original_func", wrapper)
+            assert inspect.isasyncgenfunction(original), (
+                f"expected async-generator function, got {type(original).__name__}"
+            )
+
+            request = MeshLlmRequest(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=None,
+                model_params=None,
+            )
+
+            chunks = [
+                _chunk(content="Hi", model="claude-3-5-haiku"),
+                _chunk(content=" there"),
+                _chunk(usage={"prompt_tokens": 5, "completion_tokens": 2}),
+            ]
+
+            with patch("litellm.acompletion", new=AsyncMock()) as mock_ac:
+                mock_ac.return_value = _FakeStream(chunks)
+
+                collected: list[str] = []
+                async for piece in original(request):
+                    collected.append(piece)
+
+            assert collected == ["Hi", " there"]
+        finally:
+            _drop_module(module_name)

--- a/src/runtime/python/tests/unit/test_llm_provider_decorator_streaming.py
+++ b/src/runtime/python/tests/unit/test_llm_provider_decorator_streaming.py
@@ -142,8 +142,13 @@ class TestStreamingVariantRegistered:
             _drop_module(module_name)
 
     @pytest.mark.asyncio
-    async def test_streaming_tool_shares_capability_and_tags(self):
-        """Soft-fallback works because both tools advertise the same capability+tags."""
+    async def test_streaming_tool_shares_capability_and_version(self):
+        """Soft-fallback works because both tools advertise the same capability+version.
+
+        Tags differ by exactly one entry: the streaming variant carries the
+        ``ai.mcpmesh.stream`` discrimination tag (Phase 5C, issue #849), the
+        buffered variant does not. All user-supplied tags appear on both.
+        """
         module_name = "_test_llm_provider_streaming_caps"
         mod = _make_module_with_app(module_name)
         try:
@@ -164,8 +169,65 @@ class TestStreamingVariantRegistered:
             stream = mesh_tools["claude_provider_stream"].metadata
 
             assert buffered["capability"] == stream["capability"] == "llm"
-            assert buffered["tags"] == stream["tags"]
             assert buffered["version"] == stream["version"] == "2.1.0"
+            # User-supplied tags are present on both variants.
+            for t in ("claude", "fast"):
+                assert t in buffered["tags"]
+                assert t in stream["tags"]
+        finally:
+            _drop_module(module_name)
+
+    @pytest.mark.asyncio
+    async def test_streaming_variant_has_ai_mcpmesh_stream_tag(self):
+        """Producer-side contract for Phase 5C (issue #849): the streaming
+        variant carries ``ai.mcpmesh.stream``; the buffered variant does not.
+
+        The consumer half (@mesh.llm) augments its provider tags filter to
+        require or exclude this tag so the registry resolver picks the right
+        variant deterministically.
+        """
+        module_name = "_test_llm_provider_streaming_tag"
+        mod = _make_module_with_app(module_name)
+        try:
+            _make_provider_in_module(
+                mod,
+                module_name,
+                "claude_provider",
+                model="anthropic/claude-3-5-haiku-20241022",
+                capability="llm",
+                tags=["claude"],
+            )
+
+            from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+            mesh_tools = DecoratorRegistry.get_mesh_tools()
+            buffered = mesh_tools["claude_provider"].metadata
+            stream = mesh_tools["claude_provider_stream"].metadata
+
+            assert "ai.mcpmesh.stream" in stream["tags"]
+            assert "ai.mcpmesh.stream" not in buffered["tags"]
+        finally:
+            _drop_module(module_name)
+
+    @pytest.mark.asyncio
+    async def test_streaming_variant_tag_added_when_no_user_tags(self):
+        """``ai.mcpmesh.stream`` is appended even when the user passes no tags."""
+        module_name = "_test_llm_provider_streaming_tag_no_user_tags"
+        mod = _make_module_with_app(module_name)
+        try:
+            _make_provider_in_module(
+                mod,
+                module_name,
+                "claude_provider",
+                model="anthropic/claude-3-5-haiku-20241022",
+                capability="llm",
+            )
+
+            from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+            mesh_tools = DecoratorRegistry.get_mesh_tools()
+            stream = mesh_tools["claude_provider_stream"].metadata
+            assert "ai.mcpmesh.stream" in stream["tags"]
         finally:
             _drop_module(module_name)
 

--- a/src/runtime/python/tests/unit/test_llm_provider_kwargs_propagation.py
+++ b/src/runtime/python/tests/unit/test_llm_provider_kwargs_propagation.py
@@ -1,0 +1,291 @@
+"""Unit tests for issue #849 Stage A: provider tool's @mesh.llm_provider /
+@mesh.tool kwargs must reach the consumer-side provider proxy via the
+registry's resolved LLM provider event.
+
+Mirrors the producer-kwargs propagation tests for regular tool dependencies
+(``test_dep_event_kwargs_propagation.py``). The fix flows:
+
+  Producer @mesh.llm_provider → registry stores capability.kwargs
+  Registry resolves provider → ResolvedLLMProvider.kwargs (Go)
+  Wire → Rust ResolvedLlmProvider.kwargs → LlmProviderInfo.kwargs (JSON string)
+  Python event handler parses kwargs → injector dict["kwargs"]
+  MeshLlmAgentInjector._create_provider_proxy spreads dict["kwargs"]
+  into proxy.kwargs_config so streaming etc. is configured.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# rust_heartbeat._handle_llm_provider_update — parses provider_info.kwargs
+# and forwards it through ``injector.process_llm_providers``.
+# ---------------------------------------------------------------------------
+
+
+class TestLlmProviderUpdateForwardsKwargs:
+    @pytest.mark.asyncio
+    async def test_provider_kwargs_reach_provider_proxy(self):
+        """provider_info.kwargs JSON must be parsed and reach
+        ``injector.process_llm_providers`` keyed under ``kwargs``."""
+        from _mcp_mesh.pipeline.mcp_heartbeat import rust_heartbeat
+
+        provider_info = SimpleNamespace(
+            function_id="chat_abc123",
+            function_name="process_chat_stream",
+            endpoint="http://provider:9170",
+            agent_id="claude-provider",
+            model="anthropic/claude-sonnet-4-5",
+            vendor="anthropic",
+            kwargs=json.dumps({"stream_type": "text", "vendor": "anthropic"}),
+        )
+
+        injector = MagicMock()
+        injector.register_dependency = AsyncMock()
+        injector.process_llm_providers = MagicMock()
+
+        with patch(
+            "_mcp_mesh.engine.dependency_injector.get_global_injector",
+            return_value=injector,
+        ), patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.EnhancedUnifiedMCPProxy",
+            MagicMock(),
+        ):
+            await rust_heartbeat._handle_llm_provider_update(
+                provider_info=provider_info,
+                context={},
+            )
+
+        injector.process_llm_providers.assert_called_once()
+        call_arg = injector.process_llm_providers.call_args.args[0]
+        assert "chat_abc123" in call_arg
+        provider_data = call_arg["chat_abc123"]
+        assert provider_data["kwargs"] == {
+            "stream_type": "text",
+            "vendor": "anthropic",
+        }
+
+    @pytest.mark.asyncio
+    async def test_provider_kwargs_absent_yields_empty_dict(self):
+        """When the provider tool ships no kwargs, the dict's ``kwargs``
+        slot must be present and empty — not missing."""
+        from _mcp_mesh.pipeline.mcp_heartbeat import rust_heartbeat
+
+        provider_info = SimpleNamespace(
+            function_id="chat_abc123",
+            function_name="process_chat",
+            endpoint="http://provider:9170",
+            agent_id="claude-provider",
+            model="anthropic/claude-sonnet-4-5",
+            vendor="anthropic",
+            kwargs=None,
+        )
+
+        injector = MagicMock()
+        injector.register_dependency = AsyncMock()
+        injector.process_llm_providers = MagicMock()
+
+        with patch(
+            "_mcp_mesh.engine.dependency_injector.get_global_injector",
+            return_value=injector,
+        ), patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.EnhancedUnifiedMCPProxy",
+            MagicMock(),
+        ):
+            await rust_heartbeat._handle_llm_provider_update(
+                provider_info=provider_info,
+                context={},
+            )
+
+        call_arg = injector.process_llm_providers.call_args.args[0]
+        assert call_arg["chat_abc123"]["kwargs"] == {}
+
+    @pytest.mark.asyncio
+    async def test_provider_kwargs_invalid_json_falls_back(self, caplog):
+        """Malformed JSON must be logged and fall back to empty dict —
+        the proxy is still constructed."""
+        from _mcp_mesh.pipeline.mcp_heartbeat import rust_heartbeat
+
+        provider_info = SimpleNamespace(
+            function_id="chat_abc123",
+            function_name="process_chat",
+            endpoint="http://provider:9170",
+            agent_id="claude-provider",
+            model="anthropic/claude-sonnet-4-5",
+            vendor="anthropic",
+            kwargs="not-json{",
+        )
+
+        injector = MagicMock()
+        injector.register_dependency = AsyncMock()
+        injector.process_llm_providers = MagicMock()
+
+        with caplog.at_level("WARNING"), patch(
+            "_mcp_mesh.engine.dependency_injector.get_global_injector",
+            return_value=injector,
+        ), patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.EnhancedUnifiedMCPProxy",
+            MagicMock(),
+        ):
+            await rust_heartbeat._handle_llm_provider_update(
+                provider_info=provider_info,
+                context={},
+            )
+
+        call_arg = injector.process_llm_providers.call_args.args[0]
+        assert call_arg["chat_abc123"]["kwargs"] == {}
+        assert any(
+            "Could not parse provider kwargs" in r.message for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_provider_info_without_kwargs_attr_is_safe(self):
+        """Forward-compat with older Rust core that doesn't ship the kwargs
+        attribute on provider_info — getattr fallback to None must work."""
+        from _mcp_mesh.pipeline.mcp_heartbeat import rust_heartbeat
+
+        # Build provider_info WITHOUT the kwargs attribute at all.
+        provider_info = SimpleNamespace(
+            function_id="chat_abc123",
+            function_name="process_chat",
+            endpoint="http://provider:9170",
+            agent_id="claude-provider",
+            model="anthropic/claude-sonnet-4-5",
+            vendor="anthropic",
+        )
+
+        injector = MagicMock()
+        injector.register_dependency = AsyncMock()
+        injector.process_llm_providers = MagicMock()
+
+        with patch(
+            "_mcp_mesh.engine.dependency_injector.get_global_injector",
+            return_value=injector,
+        ), patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.EnhancedUnifiedMCPProxy",
+            MagicMock(),
+        ):
+            await rust_heartbeat._handle_llm_provider_update(
+                provider_info=provider_info,
+                context={},
+            )
+
+        call_arg = injector.process_llm_providers.call_args.args[0]
+        assert call_arg["chat_abc123"]["kwargs"] == {}
+
+
+# ---------------------------------------------------------------------------
+# MeshLlmAgentInjector._create_provider_proxy — spreads provider_data["kwargs"]
+# onto the proxy's kwargs_config.
+# ---------------------------------------------------------------------------
+
+
+class TestCreateProviderProxySpreadsKwargs:
+    def test_provider_kwargs_lifted_onto_proxy_kwargs_config(self):
+        """``provider_data["kwargs"]`` must be spread onto the proxy's
+        ``kwargs_config`` alongside the existing ``capability`` / ``agent_id``
+        keys. This is what Stage A unblocks for streaming."""
+        from _mcp_mesh.engine.mesh_llm_agent_injector import MeshLlmAgentInjector
+
+        injector = MeshLlmAgentInjector()
+
+        captured: dict = {}
+
+        class FakeProxy:
+            def __init__(self, endpoint, function_name, kwargs_config=None):
+                captured["endpoint"] = endpoint
+                captured["function_name"] = function_name
+                captured["kwargs_config"] = kwargs_config
+
+        with patch(
+            "_mcp_mesh.engine.mesh_llm_agent_injector.UnifiedMCPProxy", FakeProxy
+        ):
+            injector._create_provider_proxy(
+                {
+                    "name": "process_chat_stream",
+                    "endpoint": "http://provider:9170",
+                    "capability": "llm",
+                    "agent_id": "claude-provider",
+                    "kwargs": {"stream_type": "text", "vendor": "anthropic"},
+                }
+            )
+
+        assert captured["endpoint"] == "http://provider:9170"
+        assert captured["function_name"] == "process_chat_stream"
+        assert captured["kwargs_config"] == {
+            "capability": "llm",
+            "agent_id": "claude-provider",
+            "stream_type": "text",
+            "vendor": "anthropic",
+        }
+
+    def test_provider_kwargs_absent_yields_today_behavior(self):
+        """No ``kwargs`` key in provider_data → kwargs_config matches the
+        pre-fix two-key dict. Verifies we didn't regress the buffered path."""
+        from _mcp_mesh.engine.mesh_llm_agent_injector import MeshLlmAgentInjector
+
+        injector = MeshLlmAgentInjector()
+
+        captured: dict = {}
+
+        class FakeProxy:
+            def __init__(self, endpoint, function_name, kwargs_config=None):
+                captured["function_name"] = function_name
+                captured["kwargs_config"] = kwargs_config
+
+        with patch(
+            "_mcp_mesh.engine.mesh_llm_agent_injector.UnifiedMCPProxy", FakeProxy
+        ):
+            injector._create_provider_proxy(
+                {
+                    "name": "process_chat",
+                    "endpoint": "http://provider:9170",
+                    "capability": "llm",
+                    "agent_id": "claude-provider",
+                    # No "kwargs" key — older registry / non-streaming provider.
+                }
+            )
+
+        # CRITICAL: function_name unchanged → buffered tool routing preserved.
+        assert captured["function_name"] == "process_chat"
+        assert captured["kwargs_config"] == {
+            "capability": "llm",
+            "agent_id": "claude-provider",
+        }
+        assert "stream_type" not in captured["kwargs_config"]
+
+    def test_provider_kwargs_none_handled_gracefully(self):
+        """``provider_data["kwargs"]`` explicitly None must not crash —
+        the spread must coerce to an empty dict."""
+        from _mcp_mesh.engine.mesh_llm_agent_injector import MeshLlmAgentInjector
+
+        injector = MeshLlmAgentInjector()
+
+        captured: dict = {}
+
+        class FakeProxy:
+            def __init__(self, endpoint, function_name, kwargs_config=None):
+                captured["kwargs_config"] = kwargs_config
+
+        with patch(
+            "_mcp_mesh.engine.mesh_llm_agent_injector.UnifiedMCPProxy", FakeProxy
+        ):
+            injector._create_provider_proxy(
+                {
+                    "name": "process_chat",
+                    "endpoint": "http://provider:9170",
+                    "capability": "llm",
+                    "agent_id": "claude-provider",
+                    "kwargs": None,
+                }
+            )
+
+        assert captured["kwargs_config"] == {
+            "capability": "llm",
+            "agent_id": "claude-provider",
+        }

--- a/src/runtime/python/tests/unit/test_mesh_llm_preserves_stream_ctx.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_preserves_stream_ctx.py
@@ -1,5 +1,6 @@
-"""Unit tests for issue #645 bug 3: ``@mesh.llm`` must preserve the ``ctx``
-parameter that ``@mesh.tool`` appended for streaming wrappers.
+"""Unit tests for issue #645 bug 3: ``@mesh.llm`` must preserve the
+synthesized progress-context parameter that ``@mesh.tool`` appended for
+streaming wrappers.
 
 The decoration chain on a streaming LLM tool is:
 
@@ -8,14 +9,19 @@ The decoration chain on a streaming LLM tool is:
     @mesh.tool(...)      # inner (runs first; the result is what @mesh.llm sees)
     async def chat(prompt: str, llm: MeshLlmAgent) -> mesh.Stream[str]: ...
 
-``@mesh.tool`` builds a stream wrapper whose ``__signature__`` exposes
-``ctx: Context | None = None`` so FastMCP auto-fills the progress context.
-``@mesh.llm`` then strips its own ``llm`` parameter from the public signature
-and used to start fresh from the original ``func`` — losing the appended
-``ctx`` and silently disabling progress notifications.
+``@mesh.tool`` builds a stream wrapper whose ``__signature__`` exposes the
+internal ``_mesh_progress_ctx: Context | None = None`` parameter so
+FastMCP auto-fills the progress context. ``@mesh.llm`` then strips its own
+``llm`` parameter from the public signature and used to start fresh from
+the original ``func`` — losing the appended progress-context parameter
+and silently disabling progress notifications.
 
 After the fix, ``@mesh.llm`` reads from the wrapper's already-rebuilt
-signature, so ``ctx`` survives the strip.
+signature, so the synthesized parameter survives the strip.
+
+The parameter is named ``_mesh_progress_ctx`` (not ``ctx``) on purpose —
+see ``_MESH_PROGRESS_CTX_PARAM`` in dependency_injector.py for the
+ctx-collision rationale.
 """
 
 # NOTE: do NOT add ``from __future__ import annotations`` — the @mesh.llm
@@ -28,6 +34,7 @@ import pytest
 
 import mesh
 from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+from _mcp_mesh.engine.dependency_injector import _MESH_PROGRESS_CTX_PARAM
 
 
 @pytest.fixture(autouse=True)
@@ -38,8 +45,9 @@ def _reset_decorator_registry():
 
 
 class TestMeshLlmPreservesStreamCtx:
-    def test_streaming_tool_with_mesh_llm_keeps_ctx_param(self):
-        """Combined @mesh.llm + @mesh.tool + Stream[str] must keep ``ctx``."""
+    def test_streaming_tool_with_mesh_llm_keeps_progress_ctx_param(self):
+        """Combined @mesh.llm + @mesh.tool + Stream[str] must keep the
+        synthesized progress-context param."""
 
         @mesh.llm(
             provider={"capability": "llm"},
@@ -62,18 +70,22 @@ class TestMeshLlmPreservesStreamCtx:
         assert "llm" not in sig.parameters
         # The ``prompt`` user-facing param must remain.
         assert "prompt" in sig.parameters
-        # The ``ctx`` keyword that @mesh.tool's stream wrapper appended for
-        # FastMCP's progress-handler auto-fill MUST survive @mesh.llm's strip.
-        assert "ctx" in sig.parameters, (
-            "ctx parameter dropped by @mesh.llm — progress notifications will "
-            "no-op. See issue #645 bug 3."
+        # The synthesized progress-context keyword that @mesh.tool's stream
+        # wrapper appended for FastMCP's auto-fill MUST survive @mesh.llm's
+        # strip. (Pre-fix, the param was named ``ctx`` and could collide
+        # with a user-declared ``ctx`` — see issue #645 bug 3 + ctx
+        # collision fix.)
+        assert _MESH_PROGRESS_CTX_PARAM in sig.parameters, (
+            f"{_MESH_PROGRESS_CTX_PARAM} parameter dropped by @mesh.llm — "
+            "progress notifications will no-op. See issue #645 bug 3."
         )
-        ctx_param = sig.parameters["ctx"]
+        ctx_param = sig.parameters[_MESH_PROGRESS_CTX_PARAM]
         assert ctx_param.kind == inspect.Parameter.KEYWORD_ONLY
         assert ctx_param.default is None
 
-    def test_non_streaming_tool_with_mesh_llm_does_not_invent_ctx(self):
-        """No Stream[str] return → no ``ctx`` should appear in the signature."""
+    def test_non_streaming_tool_with_mesh_llm_does_not_invent_progress_ctx(self):
+        """No Stream[str] return → no synthesized progress-ctx param should
+        appear in the signature."""
 
         @mesh.llm(
             provider={"capability": "llm"},
@@ -93,8 +105,8 @@ class TestMeshLlmPreservesStreamCtx:
         sig = inspect.signature(chat)
         assert "llm" not in sig.parameters
         assert "prompt" in sig.parameters
-        # No streaming → @mesh.tool didn't append ctx → it stays absent.
-        assert "ctx" not in sig.parameters
+        # No streaming → @mesh.tool didn't append the progress-ctx param.
+        assert _MESH_PROGRESS_CTX_PARAM not in sig.parameters
 
     def test_mesh_llm_stream_str_normalizes_output_type_to_str(self):
         """``Stream[str]`` return must register output_type=str.

--- a/src/runtime/python/tests/unit/test_mesh_llm_stream.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_stream.py
@@ -417,24 +417,6 @@ class TestStreamYieldsChunksWithRealisticDelays:
 
 class TestStreamConstraints:
     @pytest.mark.asyncio
-    async def test_mesh_delegated_raises(self):
-        agent = MeshLlmAgent(
-            config=LLMConfig(
-                provider={"capability": "llm"},
-                model="claude-3-5-haiku",
-                api_key=None,
-                max_iterations=5,
-                system_prompt=None,
-            ),
-            filtered_tools=[],
-            output_type=str,
-        )
-
-        with pytest.raises(NotImplementedError, match="direct-mode only"):
-            async for _ in agent.stream("hi"):
-                pass
-
-    @pytest.mark.asyncio
     async def test_typed_output_raises(self):
         class Resp(BaseModel):
             answer: str
@@ -447,6 +429,206 @@ class TestStreamConstraints:
         with pytest.raises(NotImplementedError, match="str output_type"):
             async for _ in agent.stream("hi"):
                 pass
+
+
+# ---------------------------------------------------------------------------
+# Mesh-delegated streaming (Phase 4 — issue #849)
+# ---------------------------------------------------------------------------
+
+
+def _make_mesh_agent(
+    parallel_tool_calls: bool = False,
+    output_type: type = str,
+) -> MeshLlmAgent:
+    """Build a mesh-delegated MeshLlmAgent with no tools and a given proxy."""
+    return MeshLlmAgent(
+        config=LLMConfig(
+            provider={"capability": "llm"},
+            model="claude-3-5-haiku",
+            api_key=None,
+            max_iterations=5,
+            system_prompt=None,
+        ),
+        filtered_tools=[],
+        output_type=output_type,
+        parallel_tool_calls=parallel_tool_calls,
+    )
+
+
+class _FakeAsyncIter:
+    """Minimal async iterator over a list of values."""
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+class TestMeshDelegatedStreaming:
+    """Phase 4: ``MeshLlmAgent.stream()`` for mesh-delegated providers."""
+
+    @pytest.mark.asyncio
+    async def test_routes_to_stream_variant(self):
+        """When the provider exposes ``<name>_stream``, chunks pass through."""
+        agent = _make_mesh_agent()
+
+        proxy = MagicMock()
+        proxy.endpoint = "http://provider"
+        proxy.function_name = "claude_provider"
+
+        captured: dict = {}
+
+        def fake_stream(*, name, request):
+            captured["name"] = name
+            captured["request"] = request
+            return _FakeAsyncIter(["Hello, ", "world", "!"])
+
+        proxy.stream = MagicMock(side_effect=fake_stream)
+        agent._mesh_provider_proxy = proxy
+
+        collected: list[str] = []
+        async for piece in agent.stream("hi"):
+            collected.append(piece)
+
+        assert collected == ["Hello, ", "world", "!"]
+        assert captured["name"] == "claude_provider_stream"
+        # Request shape mirrors _call_mesh_provider: same five keys.
+        assert set(captured["request"].keys()) >= {
+            "messages",
+            "tools",
+            "model_params",
+            "context",
+            "request_id",
+            "caller_agent",
+        }
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_stream_variant_missing(self, caplog):
+        """ToolError("Unknown tool: ...") triggers buffered single-chunk fallback.
+
+        We hand-build the proxy as a small class instead of MagicMock so the
+        ``__call__`` protocol is unambiguously async and there's only one
+        place to patch behavior.
+        """
+        from fastmcp.exceptions import ToolError
+
+        captured_call_kwargs: dict = {}
+
+        class _FakeProxy:
+            endpoint = "http://provider"
+            function_name = "claude_provider"
+
+            async def __call__(self, **kwargs):
+                captured_call_kwargs.update(kwargs)
+                return {
+                    "role": "assistant",
+                    "content": "Buffered final response.",
+                }
+
+            def stream(self, *, name, request):
+                async def _raise():
+                    raise ToolError(f"Unknown tool: {name}")
+                    yield  # pragma: no cover
+
+                return _raise()
+
+        agent = _make_mesh_agent()
+        agent._mesh_provider_proxy = _FakeProxy()
+
+        with caplog.at_level("WARNING"):
+            collected: list[str] = []
+            async for piece in agent.stream("hi"):
+                collected.append(piece)
+
+        assert collected == ["Buffered final response."]
+        assert "request" in captured_call_kwargs
+        assert any(
+            "does not expose streaming variant" in rec.message
+            for rec in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_unknown_tool_error_propagates(self):
+        """A non-"unknown tool" ToolError must NOT trigger the fallback."""
+        from fastmcp.exceptions import ToolError
+
+        agent = _make_mesh_agent()
+
+        proxy = MagicMock()
+        proxy.endpoint = "http://provider"
+        proxy.function_name = "claude_provider"
+
+        async def raise_other(*args, **kwargs):
+            raise ToolError("Anthropic API rate limited")
+            yield  # pragma: no cover
+
+        proxy.stream = MagicMock(return_value=raise_other())
+        agent._mesh_provider_proxy = proxy
+
+        with pytest.raises(ToolError, match="rate limited"):
+            async for _ in agent.stream("hi"):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_passes_parallel_tool_calls_in_model_params(self):
+        """parallel_tool_calls=True must end up in ``request.model_params``."""
+        agent = _make_mesh_agent(parallel_tool_calls=True)
+
+        proxy = MagicMock()
+        proxy.endpoint = "http://provider"
+        proxy.function_name = "claude_provider"
+
+        captured: dict = {}
+
+        def fake_stream(*, name, request):
+            captured["request"] = request
+            return _FakeAsyncIter(["x"])
+
+        proxy.stream = MagicMock(side_effect=fake_stream)
+        agent._mesh_provider_proxy = proxy
+
+        async for _ in agent.stream("hi"):
+            pass
+
+        assert captured["request"]["model_params"]["parallel_tool_calls"] is True
+
+    @pytest.mark.asyncio
+    async def test_request_shape_unchanged_from_call_mesh_provider(self):
+        """Streaming and buffered paths build the same request keys."""
+        agent = _make_mesh_agent()
+
+        proxy = MagicMock()
+        proxy.endpoint = "http://provider"
+        proxy.function_name = "claude_provider"
+
+        captured: dict = {}
+
+        def fake_stream(*, name, request):
+            captured["request"] = request
+            return _FakeAsyncIter([])
+
+        proxy.stream = MagicMock(side_effect=fake_stream)
+        agent._mesh_provider_proxy = proxy
+
+        async for _ in agent.stream("hi"):
+            pass
+
+        # Same five keys + request_id + caller_agent that _call_mesh_provider
+        # writes (see mesh_llm_agent.py:580-587).
+        assert set(captured["request"].keys()) == {
+            "messages",
+            "tools",
+            "model_params",
+            "context",
+            "request_id",
+            "caller_agent",
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/src/runtime/python/tests/unit/test_mesh_llm_stream.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_stream.py
@@ -475,12 +475,15 @@ class TestMeshDelegatedStreaming:
 
     @pytest.mark.asyncio
     async def test_routes_to_stream_variant(self):
-        """When the provider exposes ``<name>_stream``, chunks pass through."""
+        """Per Phase 5C tag-based discrimination, the resolver returns the
+        streaming-variant tool directly (via ai.mcpmesh.stream tag match), so
+        ``provider_proxy.function_name`` IS the streaming tool name. No suffix
+        mangling — call the proxy with that name as-is."""
         agent = _make_mesh_agent()
 
         proxy = MagicMock()
         proxy.endpoint = "http://provider"
-        proxy.function_name = "claude_provider"
+        proxy.function_name = "claude_provider_stream"
 
         captured: dict = {}
 

--- a/src/runtime/python/tests/unit/test_mesh_llm_stream.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_stream.py
@@ -521,14 +521,28 @@ class TestMeshDelegatedStreaming:
         """
         from fastmcp.exceptions import ToolError
 
-        captured_call_kwargs: dict = {}
+        # Resolver gives us the streaming variant (function_name ends in
+        # "_stream"); the fallback must explicitly invoke the buffered
+        # sibling (without the suffix), not re-call the streaming tool.
+        captured_buffered_name: list[str] = []
+        captured_buffered_args: dict = {}
 
         class _FakeProxy:
             endpoint = "http://provider"
-            function_name = "claude_provider"
+            function_name = "claude_provider_stream"
 
             async def __call__(self, **kwargs):
-                captured_call_kwargs.update(kwargs)
+                # Should NOT be reached — fallback must use call_tool_with_tracing
+                # with the explicit buffered name, not __call__ which would
+                # re-invoke the streaming tool name.
+                raise AssertionError(
+                    "fallback must call call_tool_with_tracing with the "
+                    "buffered name, not provider_proxy(request=...)"
+                )
+
+            async def call_tool_with_tracing(self, name, arguments):
+                captured_buffered_name.append(name)
+                captured_buffered_args.update(arguments)
                 return {
                     "role": "assistant",
                     "content": "Buffered final response.",
@@ -550,7 +564,9 @@ class TestMeshDelegatedStreaming:
                 collected.append(piece)
 
         assert collected == ["Buffered final response."]
-        assert "request" in captured_call_kwargs
+        # Fallback invoked the buffered sibling, NOT the streaming tool name.
+        assert captured_buffered_name == ["claude_provider"]
+        assert "request" in captured_buffered_args
         assert any(
             "advertised the streaming variant but tool" in rec.message
             and "is not exposed" in rec.message

--- a/src/runtime/python/tests/unit/test_mesh_llm_stream.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_stream.py
@@ -552,7 +552,8 @@ class TestMeshDelegatedStreaming:
         assert collected == ["Buffered final response."]
         assert "request" in captured_call_kwargs
         assert any(
-            "does not expose streaming variant" in rec.message
+            "advertised the streaming variant but tool" in rec.message
+            and "is not exposed" in rec.message
             for rec in caplog.records
         )
 

--- a/src/runtime/python/tests/unit/test_provider_agentic_loop_stream.py
+++ b/src/runtime/python/tests/unit/test_provider_agentic_loop_stream.py
@@ -1,0 +1,495 @@
+"""Unit tests for ``_provider_agentic_loop_stream`` (mesh.helpers).
+
+Phase 2 of the mesh-delegate streaming work for issue #849.
+
+The streaming counterpart to ``_provider_agentic_loop`` mirrors the buffered
+loop one-for-one but yields text chunks live as they arrive from
+``litellm.acompletion(stream=True, ...)``. These tests pin down the contract:
+
+  * Text-only iterations yield chunks in order.
+  * Tool-call iterations execute tools internally (via the Phase 1 helper)
+    and feed results back into the loop.
+  * Text preamble before a tool_call IS yielded live; subsequent text
+    deltas after the tool_call are dropped (Anthropic doesn't interleave).
+  * Parallel tool calls dispatch via the Phase 1 helper's parallel branch.
+  * HINT mode buffers the final iteration for schema validation, then
+    yields the validated/fallback content as a single chunk.
+  * Vendor restrictions on images in tool messages flow through unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Streaming chunk fakes mirroring litellm.acompletion(stream=True) shape.
+# Kept independent from test_mesh_llm_stream.py so each test file is
+# self-contained.
+# ---------------------------------------------------------------------------
+
+
+def _delta(content: str | None = None, tool_calls: list | None = None) -> MagicMock:
+    d = MagicMock()
+    d.content = content
+    d.tool_calls = tool_calls
+    return d
+
+
+def _choice(delta: MagicMock) -> MagicMock:
+    c = MagicMock()
+    c.delta = delta
+    return c
+
+
+def _chunk(
+    content: str | None = None,
+    tool_calls: list | None = None,
+    usage: dict | None = None,
+    model: str | None = None,
+) -> MagicMock:
+    ch = MagicMock()
+    ch.choices = [_choice(_delta(content=content, tool_calls=tool_calls))]
+    ch.usage = (
+        MagicMock(
+            prompt_tokens=usage.get("prompt_tokens", 0),
+            completion_tokens=usage.get("completion_tokens", 0),
+        )
+        if usage
+        else None
+    )
+    ch.model = model
+    return ch
+
+
+def _tool_call_delta(
+    index: int,
+    id: str | None = None,
+    name: str | None = None,
+    arguments: str | None = None,
+    type: str | None = None,
+) -> MagicMock:
+    tc = MagicMock()
+    tc.index = index
+    tc.id = id
+    tc.type = type
+    fn = MagicMock()
+    fn.name = name
+    fn.arguments = arguments
+    tc.function = fn
+    return tc
+
+
+class _FakeStream:
+    """Minimal async-iterable that yields chunks then stops, with aclose()."""
+
+    def __init__(self, chunks: list[MagicMock]):
+        self._chunks = list(chunks)
+        self.aclosed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+    async def aclose(self):
+        self.aclosed = True
+
+
+# ---------------------------------------------------------------------------
+# No tools: text-only single iteration
+# ---------------------------------------------------------------------------
+
+
+class TestTextOnlySingleIteration:
+    @pytest.mark.asyncio
+    async def test_yields_chunks_in_order(self):
+        from mesh.helpers import _provider_agentic_loop_stream
+
+        chunks = [
+            _chunk(content="Hello", model="claude-3-5-haiku"),
+            _chunk(content=", "),
+            _chunk(content="world!"),
+            _chunk(usage={"prompt_tokens": 5, "completion_tokens": 3}),
+        ]
+        with patch("litellm.acompletion", new=AsyncMock()) as mock_ac:
+            mock_ac.return_value = _FakeStream(chunks)
+
+            collected: list[str] = []
+            async for c in _provider_agentic_loop_stream(
+                effective_model="anthropic/claude-3-5-haiku",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                tool_endpoints={},
+                model_params={},
+                litellm_kwargs={"api_key": "sk-test"},
+                max_iterations=5,
+                loop_logger=None,
+                vendor="anthropic",
+            ):
+                collected.append(c)
+
+        assert collected == ["Hello", ", ", "world!"]
+        # stream + stream_options were injected
+        call_kwargs = mock_ac.call_args.kwargs
+        assert call_kwargs["stream"] is True
+        assert call_kwargs["stream_options"] == {"include_usage": True}
+
+    @pytest.mark.asyncio
+    async def test_pops_parallel_tool_calls_from_model_params(self):
+        """``parallel_tool_calls`` must NOT reach litellm (Claude rejects it)."""
+        from mesh.helpers import _provider_agentic_loop_stream
+
+        chunks = [_chunk(content="ok"), _chunk(usage={"prompt_tokens": 1, "completion_tokens": 1})]
+        with patch("litellm.acompletion", new=AsyncMock()) as mock_ac:
+            mock_ac.return_value = _FakeStream(chunks)
+
+            async for _ in _provider_agentic_loop_stream(
+                effective_model="anthropic/claude-3-5-haiku",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                tool_endpoints={},
+                model_params={"parallel_tool_calls": True, "temperature": 0.5},
+                litellm_kwargs={},
+                vendor="anthropic",
+            ):
+                pass
+
+        call_kwargs = mock_ac.call_args.kwargs
+        assert "parallel_tool_calls" not in call_kwargs
+        assert call_kwargs.get("temperature") == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Tool-call iteration followed by text-only iteration
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallIteration:
+    @pytest.mark.asyncio
+    async def test_preamble_text_yielded_then_tool_runs_then_final_text(self):
+        from mesh.helpers import _provider_agentic_loop_stream
+
+        # Iteration 1: text preamble + tool_call.
+        tc_first = _tool_call_delta(
+            index=0,
+            id="call_1",
+            type="function",
+            name="get_weather",
+            arguments='{"city":',
+        )
+        tc_second = _tool_call_delta(index=0, arguments='"SF"}')
+        first_iter = [
+            _chunk(content="Let me "),
+            _chunk(content="check..."),
+            _chunk(tool_calls=[tc_first]),
+            _chunk(tool_calls=[tc_second]),
+            _chunk(usage={"prompt_tokens": 10, "completion_tokens": 5}),
+        ]
+        # Iteration 2: pure text final answer.
+        second_iter = [
+            _chunk(content="It is "),
+            _chunk(content="72F."),
+            _chunk(usage={"prompt_tokens": 15, "completion_tokens": 4}),
+        ]
+
+        with patch("litellm.acompletion", new=AsyncMock()) as mock_ac, patch(
+            "mesh.helpers._execute_tool_calls_for_iteration",
+            new=AsyncMock(return_value=([{"role": "tool", "tool_call_id": "call_1", "content": "sunny"}], [])),
+        ) as mock_exec:
+            mock_ac.side_effect = [
+                _FakeStream(first_iter),
+                _FakeStream(second_iter),
+            ]
+
+            collected: list[str] = []
+            async for c in _provider_agentic_loop_stream(
+                effective_model="anthropic/claude-3-5-haiku",
+                messages=[{"role": "user", "content": "weather?"}],
+                tools=[{"type": "function", "function": {"name": "get_weather"}}],
+                tool_endpoints={"get_weather": "http://weather"},
+                model_params={},
+                litellm_kwargs={},
+                max_iterations=5,
+                vendor="anthropic",
+            ):
+                collected.append(c)
+
+        # Preamble live, then tool ran, then final answer streams.
+        assert collected == ["Let me ", "check...", "It is ", "72F."]
+        assert mock_exec.await_count == 1
+        message_arg = mock_exec.await_args.args[0]
+        assert message_arg.tool_calls[0].function.name == "get_weather"
+        assert message_arg.tool_calls[0].function.arguments == '{"city":"SF"}'
+        assert mock_ac.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_parallel_tool_calls_pass_through_to_helper(self):
+        from mesh.helpers import _provider_agentic_loop_stream
+
+        tc_a = _tool_call_delta(
+            index=0,
+            id="call_a",
+            type="function",
+            name="tool_a",
+            arguments="{}",
+        )
+        tc_b = _tool_call_delta(
+            index=1,
+            id="call_b",
+            type="function",
+            name="tool_b",
+            arguments="{}",
+        )
+        first_iter = [
+            _chunk(tool_calls=[tc_a]),
+            _chunk(tool_calls=[tc_b]),
+            _chunk(usage={"prompt_tokens": 1, "completion_tokens": 1}),
+        ]
+        second_iter = [
+            _chunk(content="done"),
+            _chunk(usage={"prompt_tokens": 1, "completion_tokens": 1}),
+        ]
+
+        with patch("litellm.acompletion", new=AsyncMock()) as mock_ac, patch(
+            "mesh.helpers._execute_tool_calls_for_iteration",
+            new=AsyncMock(
+                return_value=(
+                    [
+                        {"role": "tool", "tool_call_id": "call_a", "content": "A"},
+                        {"role": "tool", "tool_call_id": "call_b", "content": "B"},
+                    ],
+                    [],
+                )
+            ),
+        ) as mock_exec:
+            mock_ac.side_effect = [
+                _FakeStream(first_iter),
+                _FakeStream(second_iter),
+            ]
+
+            async for _ in _provider_agentic_loop_stream(
+                effective_model="anthropic/claude-3-5-haiku",
+                messages=[{"role": "user", "content": "do both"}],
+                tools=[],
+                tool_endpoints={"tool_a": "http://a", "tool_b": "http://b"},
+                model_params={"parallel_tool_calls": True},
+                litellm_kwargs={},
+                vendor="anthropic",
+            ):
+                pass
+
+        # Parallel flag forwarded to the Phase 1 helper.
+        assert mock_exec.await_args.args[2] is True
+
+    @pytest.mark.asyncio
+    async def test_accumulated_images_become_user_message_after_tool_results(self):
+        """Vendor=openai: image parts are accumulated and injected as a user message."""
+        from mesh.helpers import _provider_agentic_loop_stream
+
+        tc = _tool_call_delta(
+            index=0,
+            id="call_1",
+            type="function",
+            name="snap",
+            arguments="{}",
+        )
+        first_iter = [
+            _chunk(tool_calls=[tc]),
+            _chunk(usage={"prompt_tokens": 1, "completion_tokens": 1}),
+        ]
+        second_iter = [
+            _chunk(content="ok"),
+            _chunk(usage={"prompt_tokens": 1, "completion_tokens": 1}),
+        ]
+
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,abc"},
+        }
+        with patch("litellm.acompletion", new=AsyncMock()) as mock_ac, patch(
+            "mesh.helpers._execute_tool_calls_for_iteration",
+            new=AsyncMock(
+                return_value=(
+                    [{"role": "tool", "tool_call_id": "call_1", "content": "[Image]"}],
+                    [image_part],
+                )
+            ),
+        ):
+            mock_ac.side_effect = [
+                _FakeStream(first_iter),
+                _FakeStream(second_iter),
+            ]
+
+            async for _ in _provider_agentic_loop_stream(
+                effective_model="openai/gpt-4o",
+                messages=[{"role": "user", "content": "snap please"}],
+                tools=[],
+                tool_endpoints={"snap": "http://cam"},
+                model_params={},
+                litellm_kwargs={},
+                vendor="openai",
+            ):
+                pass
+
+        # The second acompletion call's messages should include the
+        # synthesized user message with the image_part.
+        second_call_messages = mock_ac.call_args_list[1].kwargs["messages"]
+        # Find the synthesized user message after the tool message.
+        user_messages_after_tool = [
+            m
+            for m in second_call_messages
+            if m.get("role") == "user"
+            and isinstance(m.get("content"), list)
+            and any(p.get("type") == "image_url" for p in m["content"])
+        ]
+        assert len(user_messages_after_tool) == 1
+
+
+# ---------------------------------------------------------------------------
+# Max iterations safety net
+# ---------------------------------------------------------------------------
+
+
+class TestMaxIterations:
+    @pytest.mark.asyncio
+    async def test_emits_max_iterations_indicator_when_loop_never_terminates(self):
+        from mesh.helpers import _provider_agentic_loop_stream
+
+        # Each iteration always produces a tool_call so the loop never terminates.
+        def make_tool_call_iter():
+            tc = _tool_call_delta(
+                index=0,
+                id="call_x",
+                type="function",
+                name="loop_tool",
+                arguments="{}",
+            )
+            return [
+                _chunk(tool_calls=[tc]),
+                _chunk(usage={"prompt_tokens": 1, "completion_tokens": 1}),
+            ]
+
+        with patch("litellm.acompletion", new=AsyncMock()) as mock_ac, patch(
+            "mesh.helpers._execute_tool_calls_for_iteration",
+            new=AsyncMock(
+                return_value=(
+                    [{"role": "tool", "tool_call_id": "call_x", "content": "{}"}],
+                    [],
+                )
+            ),
+        ):
+            mock_ac.side_effect = [_FakeStream(make_tool_call_iter()) for _ in range(2)]
+
+            collected: list[str] = []
+            async for c in _provider_agentic_loop_stream(
+                effective_model="anthropic/claude-3-5-haiku",
+                messages=[{"role": "user", "content": "loop"}],
+                tools=[],
+                tool_endpoints={"loop_tool": "http://x"},
+                model_params={},
+                litellm_kwargs={},
+                max_iterations=2,
+                vendor="anthropic",
+            ):
+                collected.append(c)
+
+        assert collected == ["Maximum tool call iterations reached"]
+
+
+# ---------------------------------------------------------------------------
+# HINT mode: final iteration is buffered, validated, then yielded once
+# ---------------------------------------------------------------------------
+
+
+class TestHintMode:
+    @pytest.mark.asyncio
+    async def test_hint_mode_buffers_final_iteration_and_yields_once(self):
+        """HINT-mode final iteration must NOT yield live mid-stream chunks."""
+        from mesh.helpers import _provider_agentic_loop_stream
+
+        # Schema-passing JSON content split across chunks. Without HINT-mode
+        # buffering, three live yields would be observed.
+        content_chunks = [
+            _chunk(content='{"answer":'),
+            _chunk(content='"42"'),
+            _chunk(content='}'),
+            _chunk(usage={"prompt_tokens": 1, "completion_tokens": 1}),
+        ]
+
+        # Provider handler signals HINT mode by injecting these flags into
+        # model_params (ClaudeHandler.apply_structured_output does this).
+        model_params = {
+            "_mesh_hint_mode": True,
+            "_mesh_hint_schema": {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+                "required": ["answer"],
+            },
+            "_mesh_hint_fallback_timeout": 30,
+            "_mesh_hint_output_type_name": "Answer",
+        }
+
+        with patch("litellm.acompletion", new=AsyncMock()) as mock_ac:
+            mock_ac.return_value = _FakeStream(content_chunks)
+
+            collected: list[str] = []
+            async for c in _provider_agentic_loop_stream(
+                effective_model="anthropic/claude-3-5-haiku",
+                messages=[{"role": "user", "content": "answer in JSON"}],
+                tools=[],
+                tool_endpoints={},
+                model_params=model_params,
+                litellm_kwargs={},
+                vendor="anthropic",
+            ):
+                collected.append(c)
+
+        # Single combined chunk, NOT three live deltas.
+        assert collected == ['{"answer":"42"}']
+
+    @pytest.mark.asyncio
+    async def test_hint_mode_strips_internal_flags_from_litellm_call(self):
+        """``_mesh_*`` flags must be stripped before they reach litellm."""
+        from mesh.helpers import _provider_agentic_loop_stream
+
+        content_chunks = [
+            _chunk(content='{"a":1}'),
+            _chunk(usage={"prompt_tokens": 1, "completion_tokens": 1}),
+        ]
+        model_params = {
+            "_mesh_hint_mode": True,
+            "_mesh_hint_schema": {"type": "object", "properties": {"a": {"type": "integer"}}},
+        }
+
+        with patch("litellm.acompletion", new=AsyncMock()) as mock_ac:
+            mock_ac.return_value = _FakeStream(content_chunks)
+
+            async for _ in _provider_agentic_loop_stream(
+                effective_model="anthropic/claude-3-5-haiku",
+                messages=[{"role": "user", "content": "answer"}],
+                tools=[],
+                tool_endpoints={},
+                model_params=model_params,
+                litellm_kwargs={},
+                vendor="anthropic",
+            ):
+                pass
+
+        call_kwargs = mock_ac.call_args.kwargs
+        for forbidden in (
+            "_mesh_hint_mode",
+            "_mesh_hint_schema",
+            "_mesh_hint_fallback_timeout",
+            "_mesh_hint_output_type_name",
+        ):
+            assert forbidden not in call_kwargs, (
+                f"{forbidden} must be stripped from completion_args"
+            )

--- a/src/runtime/python/tests/unit/test_provider_tool_execution_helper.py
+++ b/src/runtime/python/tests/unit/test_provider_tool_execution_helper.py
@@ -1,0 +1,320 @@
+"""
+Unit tests for ``_execute_tool_calls_for_iteration`` (mesh.helpers).
+
+Background:
+    Phase 1 of the mesh-delegate streaming work for issue #849 extracted the
+    per-iteration tool dispatch logic out of ``_provider_agentic_loop`` into a
+    standalone async helper. The helper is also intended for reuse by the
+    Phase 2 streaming provider loop. These tests pin down the helper's
+    contract directly (independent of the surrounding agentic loop) so that
+    future refactors do not silently change behavior.
+
+    The helper imports ``UnifiedMCPProxy`` and the resolver functions inside
+    its body, so patches must target the original module paths.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mesh.helpers import (
+    _TOOL_IMAGE_UNSUPPORTED_VENDORS,
+    _execute_tool_calls_for_iteration,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_function_mock(name: str, arguments: str):
+    func = MagicMock()
+    func.name = name
+    func.arguments = arguments
+    return func
+
+
+def _make_tool_call_mock(id: str, name: str, arguments: str = "{}"):
+    """Build a tool_call mock matching the litellm message shape."""
+    tool_call = MagicMock()
+    tool_call.id = id
+    tool_call.type = "function"
+    tool_call.function = _make_function_mock(name, arguments)
+    return tool_call
+
+
+def _make_message_mock(tool_calls: list):
+    """Build a litellm-style message mock with .tool_calls."""
+    message = MagicMock()
+    message.tool_calls = tool_calls
+    return message
+
+
+# ---------------------------------------------------------------------------
+# Sequential / parallel dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestSequentialAndParallelDispatch:
+    """Verify the parallel vs sequential branch and the returned tuple shape."""
+
+    @pytest.mark.asyncio
+    async def test_single_sequential_tool_call(self):
+        """One tool call, parallel=False -> 1 tool message, 0 images."""
+        message = _make_message_mock(
+            [_make_tool_call_mock("call_1", "echo", '{"x": 1}')]
+        )
+        tool_endpoints = {"echo": "http://localhost:9000"}
+
+        proxy_instance = MagicMock()
+        proxy_instance.call_tool = AsyncMock(return_value="hello")
+
+        with patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.UnifiedMCPProxy",
+            return_value=proxy_instance,
+        ):
+            tool_messages, images = await _execute_tool_calls_for_iteration(
+                message=message,
+                tool_endpoints=tool_endpoints,
+                parallel=False,
+                vendor="anthropic",
+                loop_logger=None,
+            )
+
+        assert len(tool_messages) == 1
+        assert images == []
+        assert tool_messages[0]["role"] == "tool"
+        assert tool_messages[0]["tool_call_id"] == "call_1"
+        assert tool_messages[0]["content"] == "hello"
+        proxy_instance.call_tool.assert_awaited_once_with("echo", {"x": 1})
+
+    @pytest.mark.asyncio
+    async def test_two_parallel_tool_calls(self):
+        """Two tool calls, parallel=True -> 2 tool messages (in order), 0 images."""
+        message = _make_message_mock(
+            [
+                _make_tool_call_mock("call_1", "tool_a", "{}"),
+                _make_tool_call_mock("call_2", "tool_b", "{}"),
+            ]
+        )
+        tool_endpoints = {
+            "tool_a": "http://localhost:9001",
+            "tool_b": "http://localhost:9002",
+        }
+
+        # Each UnifiedMCPProxy() invocation returns a different mock instance.
+        # Map by function_name so call_tool returns distinct results.
+        def proxy_factory(endpoint: str, function_name: str):
+            inst = MagicMock()
+            inst.call_tool = AsyncMock(return_value=f"result-{function_name}")
+            return inst
+
+        with patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.UnifiedMCPProxy",
+            side_effect=proxy_factory,
+        ):
+            tool_messages, images = await _execute_tool_calls_for_iteration(
+                message=message,
+                tool_endpoints=tool_endpoints,
+                parallel=True,
+                vendor="anthropic",
+                loop_logger=None,
+            )
+
+        assert len(tool_messages) == 2
+        assert images == []
+        # Order must match message.tool_calls order — even with asyncio.gather,
+        # the helper preserves declaration order in the returned list.
+        assert tool_messages[0]["tool_call_id"] == "call_1"
+        assert tool_messages[0]["content"] == "result-tool_a"
+        assert tool_messages[1]["tool_call_id"] == "call_2"
+        assert tool_messages[1]["content"] == "result-tool_b"
+
+    @pytest.mark.asyncio
+    async def test_parallel_with_single_call_uses_sequential_path(self):
+        """parallel=True with len(tool_calls)==1 falls through to the sequential
+        branch — there is no benefit to ``asyncio.gather`` for a single call,
+        and the original loop made the same micro-optimization."""
+        message = _make_message_mock(
+            [_make_tool_call_mock("call_1", "echo", "{}")]
+        )
+        tool_endpoints = {"echo": "http://localhost:9000"}
+
+        proxy_instance = MagicMock()
+        proxy_instance.call_tool = AsyncMock(return_value="ok")
+
+        with patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.UnifiedMCPProxy",
+            return_value=proxy_instance,
+        ):
+            tool_messages, images = await _execute_tool_calls_for_iteration(
+                message=message,
+                tool_endpoints=tool_endpoints,
+                parallel=True,
+                vendor="anthropic",
+                loop_logger=None,
+            )
+
+        assert len(tool_messages) == 1
+        assert tool_messages[0]["content"] == "ok"
+        assert images == []
+
+
+# ---------------------------------------------------------------------------
+# Vendor-specific image handling
+# ---------------------------------------------------------------------------
+
+
+class TestVendorImageHandling:
+    """Verify the image accumulation contract for vendors that do/don't allow
+    images in role:tool messages."""
+
+    def _patch_resolver(self, has_image: bool, parts: list):
+        """Patch ``_has_resource_link`` to return True and
+        ``resolve_resource_links`` to return the supplied parts."""
+        return (
+            patch(
+                "_mcp_mesh.media.resolver._has_resource_link",
+                return_value=True,
+            ),
+            patch(
+                "_mcp_mesh.media.resolver.resolve_resource_links",
+                new=AsyncMock(return_value=parts),
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_image_with_openai_vendor_accumulates_image(self):
+        """vendor=openai: image part is stripped from the tool message and
+        accumulated for a follow-up user message; tool message gets a stub
+        ``[Image from tool result]`` text."""
+        message = _make_message_mock(
+            [_make_tool_call_mock("call_1", "screenshot", "{}")]
+        )
+        tool_endpoints = {"screenshot": "http://localhost:9000"}
+
+        proxy_instance = MagicMock()
+        proxy_instance.call_tool = AsyncMock(return_value={"resource_link": True})
+
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,AAA", "detail": "high"},
+        }
+
+        link_patch, resolve_patch = self._patch_resolver(
+            has_image=True, parts=[image_part]
+        )
+        with patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.UnifiedMCPProxy",
+            return_value=proxy_instance,
+        ), link_patch, resolve_patch:
+            tool_messages, images = await _execute_tool_calls_for_iteration(
+                message=message,
+                tool_endpoints=tool_endpoints,
+                parallel=False,
+                vendor="openai",
+                loop_logger=None,
+            )
+
+        assert len(tool_messages) == 1
+        assert tool_messages[0]["role"] == "tool"
+        assert tool_messages[0]["tool_call_id"] == "call_1"
+        # No text parts in resolved output -> stub text in tool message.
+        assert tool_messages[0]["content"] == "[Image from tool result]"
+        assert images == [image_part]
+
+    @pytest.mark.asyncio
+    async def test_image_with_anthropic_vendor_inlines_image(self):
+        """vendor=anthropic: resolved multimodal parts are inlined as the tool
+        message content; nothing accumulated for a follow-up user message."""
+        message = _make_message_mock(
+            [_make_tool_call_mock("call_1", "screenshot", "{}")]
+        )
+        tool_endpoints = {"screenshot": "http://localhost:9000"}
+
+        proxy_instance = MagicMock()
+        proxy_instance.call_tool = AsyncMock(return_value={"resource_link": True})
+
+        resolved_parts = [
+            {"type": "text", "text": "Screenshot of homepage"},
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": "data:image/png;base64,AAA",
+                    "detail": "high",
+                },
+            },
+        ]
+
+        link_patch, resolve_patch = self._patch_resolver(
+            has_image=True, parts=resolved_parts
+        )
+        with patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.UnifiedMCPProxy",
+            return_value=proxy_instance,
+        ), link_patch, resolve_patch:
+            tool_messages, images = await _execute_tool_calls_for_iteration(
+                message=message,
+                tool_endpoints=tool_endpoints,
+                parallel=False,
+                vendor="anthropic",
+                loop_logger=None,
+            )
+
+        assert len(tool_messages) == 1
+        assert tool_messages[0]["role"] == "tool"
+        assert tool_messages[0]["tool_call_id"] == "call_1"
+        # Multimodal parts inlined verbatim (LiteLLM converts to native format).
+        assert tool_messages[0]["content"] == resolved_parts
+        assert images == []
+
+
+# ---------------------------------------------------------------------------
+# Endpoint-missing / error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPaths:
+    @pytest.mark.asyncio
+    async def test_missing_endpoint_returns_error_tool_message(self):
+        """Tool with no endpoint -> error tool message with JSON error
+        content; UnifiedMCPProxy is NOT constructed, no images."""
+        message = _make_message_mock(
+            [_make_tool_call_mock("call_1", "ghost_tool", "{}")]
+        )
+        tool_endpoints: dict[str, str] = {}  # no endpoint registered
+
+        with patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.UnifiedMCPProxy"
+        ) as proxy_cls:
+            tool_messages, images = await _execute_tool_calls_for_iteration(
+                message=message,
+                tool_endpoints=tool_endpoints,
+                parallel=False,
+                vendor="anthropic",
+                loop_logger=None,
+            )
+
+        assert images == []
+        assert len(tool_messages) == 1
+        assert tool_messages[0]["role"] == "tool"
+        assert tool_messages[0]["tool_call_id"] == "call_1"
+        # Content is a JSON-encoded error envelope.
+        decoded = json.loads(tool_messages[0]["content"])
+        assert decoded == {"error": "Tool ghost_tool not available"}
+        # The proxy class is never instantiated for missing endpoints.
+        proxy_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Module-level invariants
+# ---------------------------------------------------------------------------
+
+
+class TestModuleConstants:
+    def test_tool_image_unsupported_vendors_set(self):
+        """The vendor set drives image-handling policy; if it changes,
+        provider-side image behavior changes silently. Pin it explicitly."""
+        assert _TOOL_IMAGE_UNSUPPORTED_VENDORS == {"openai", "gemini", "google"}

--- a/src/runtime/python/tests/unit/test_stream_wrapper.py
+++ b/src/runtime/python/tests/unit/test_stream_wrapper.py
@@ -2,12 +2,20 @@
 
 Covers P4 of issue #645:
 - Stream-aware wrapper detection (``_is_stream_tool``).
-- ``_build_stream_signature`` exposes ``ctx`` so FastMCP auto-fills it.
+- ``_build_stream_signature`` exposes the synthesized progress-context
+  parameter so FastMCP auto-fills its ``Context`` at call time.
 - Wrapper forwards each chunk via ``ctx.report_progress`` and accumulates
   the joined string as the return value.
-- Graceful no-op when ``ctx`` is None (caller didn't pass progressToken).
+- Graceful no-op when no ``Context`` is injected (caller didn't pass
+  ``progressToken``).
 - ``CancelledError`` propagates ``gen.aclose()`` to user finally blocks.
 - Defensive ``report_progress`` signature probe falls back to positional.
+
+Also covers the ctx-collision fix: users who declare their own ``ctx``
+parameter (typically a ``MeshContextModel`` paired with
+``@mesh.llm(context_param="ctx", ...)``) must not have streaming silently
+disabled. The wrapper synthesizes its progress channel under an internal
+name (``_mesh_progress_ctx``) to avoid clobbering the user's annotation.
 """
 
 from __future__ import annotations
@@ -15,7 +23,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import AsyncIterator as AbcAsyncIterator
-from typing import AsyncIterator
+from typing import AsyncIterator, Optional
 from unittest.mock import patch
 
 import pytest
@@ -23,6 +31,7 @@ import pytest
 import mesh
 from _mcp_mesh.engine import dependency_injector as di
 from _mcp_mesh.engine.dependency_injector import (
+    _MESH_PROGRESS_CTX_PARAM,
     DependencyInjector,
     _build_stream_signature,
     _forward_chunk,
@@ -104,24 +113,76 @@ class TestIsStreamTool:
 
 
 class TestBuildStreamSignature:
-    def test_appends_ctx_keyword_only_with_default_none(self):
+    def test_appends_progress_ctx_keyword_only_with_default_none(self):
         async def chat(prompt: str) -> AsyncIterator[str]:
             yield prompt
 
         sig = _build_stream_signature(chat)
         assert "prompt" in sig.parameters
-        assert "ctx" in sig.parameters
-        ctx_param = sig.parameters["ctx"]
+        assert _MESH_PROGRESS_CTX_PARAM in sig.parameters
+        ctx_param = sig.parameters[_MESH_PROGRESS_CTX_PARAM]
         assert ctx_param.kind == inspect.Parameter.KEYWORD_ONLY
         assert ctx_param.default is None
 
-    def test_does_not_duplicate_ctx_when_present(self):
-        async def chat(prompt: str, ctx: object = None) -> AsyncIterator[str]:
+    def test_progress_ctx_is_context_typed_so_fastmcp_can_inject(self):
+        """FastMCP injects ``Context`` by TYPE annotation, not by name. The
+        synthesized parameter must carry ``Optional[Context]`` (or ``Context``
+        nested under a ``Union``/``Optional``) for
+        ``transform_context_annotations`` to recognize it.
+        """
+        from fastmcp import Context
+
+        async def chat(prompt: str) -> AsyncIterator[str]:
             yield prompt
 
         sig = _build_stream_signature(chat)
-        ctx_params = [p for p in sig.parameters if p == "ctx"]
-        assert len(ctx_params) == 1
+        ctx_param = sig.parameters[_MESH_PROGRESS_CTX_PARAM]
+        # Annotation is ``Optional[Context]``.
+        assert ctx_param.annotation == Optional[Context]
+
+    def test_user_ctx_param_passes_through_unchanged(self):
+        """A user function that declares its own ``ctx`` parameter (a common
+        pattern with ``@mesh.llm(context_param="ctx", ...)``) must keep that
+        parameter untouched in the wrapper signature — same name, same
+        annotation, same default — and the synthesized progress-context
+        parameter must be added alongside it.
+        """
+
+        class UserContext:
+            pass
+
+        async def chat(prompt: str, ctx: UserContext = None) -> AsyncIterator[str]:
+            yield prompt
+
+        sig = _build_stream_signature(chat)
+        # User's ctx is preserved.
+        assert "ctx" in sig.parameters
+        user_ctx = sig.parameters["ctx"]
+        # Note: ``from __future__ import annotations`` (PEP 563) at the top
+        # of this module converts annotations to strings, so we compare the
+        # string form rather than the class object.
+        assert user_ctx.annotation in (UserContext, "UserContext")
+        assert user_ctx.default is None
+        # Synthesized parameter is added (this is the regression that the
+        # name-collision fix addresses).
+        assert _MESH_PROGRESS_CTX_PARAM in sig.parameters
+
+    def test_idempotent_when_progress_ctx_already_present(self):
+        """Running the builder twice on the same signature must not duplicate
+        the synthesized parameter."""
+
+        async def chat(prompt: str) -> AsyncIterator[str]:
+            yield prompt
+
+        sig_once = _build_stream_signature(chat)
+        # Simulate re-entry by attaching the augmented signature back to
+        # the function and calling again.
+        chat.__signature__ = sig_once
+        sig_twice = _build_stream_signature(chat)
+        progress_params = [
+            p for p in sig_twice.parameters if p == _MESH_PROGRESS_CTX_PARAM
+        ]
+        assert len(progress_params) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -141,7 +202,8 @@ class TestStreamWrapperForwardsChunks:
         wrapper = injector.create_injection_wrapper(chat, [])
 
         ctx = _RecordingCtx()
-        result = await wrapper("hello world", ctx=ctx)
+        # FastMCP injects under the synthesized internal name.
+        result = await wrapper("hello world", **{_MESH_PROGRESS_CTX_PARAM: ctx})
 
         assert result == "hello world "
         assert ctx.events == [(0, None, "hello "), (1, None, "world ")]
@@ -159,15 +221,84 @@ class TestStreamWrapperForwardsChunks:
         assert result == "ab"
 
     @pytest.mark.asyncio
-    async def test_ctx_explicitly_none_no_op(self):
+    async def test_progress_ctx_explicitly_none_no_op(self):
         async def chat(prompt: str) -> AsyncIterator[str]:
             yield "a"
 
         injector = DependencyInjector()
         wrapper = injector.create_injection_wrapper(chat, [])
 
-        result = await wrapper("p", ctx=None)
+        result = await wrapper("p", **{_MESH_PROGRESS_CTX_PARAM: None})
         assert result == "a"
+
+    @pytest.mark.asyncio
+    async def test_stream_wrapper_works_when_user_has_ctx_parameter(self):
+        """Regression test for the ctx-name-collision bug.
+
+        When the user declares their own ``ctx: SomeOtherType`` parameter on
+        the streaming function (which is the natural shape produced by
+        ``@mesh.llm(context_param="ctx", ...)``), the wrapper must still
+        forward chunks via FastMCP's injected ``Context``. Before the fix
+        the synthesized parameter was also named ``ctx`` and was suppressed
+        when the user already had one — leaving ``ctx`` ``None`` at runtime
+        and silently degrading streaming to a buffered single chunk.
+
+        Verifies:
+          * ``report_progress`` is called per chunk on the FastMCP-injected
+            mock context.
+          * The user's ``ctx`` keyword (their own context object) is passed
+            through to the user function untouched.
+          * The joined text is returned at the end.
+        """
+
+        class UserContext:
+            def __init__(self, label: str):
+                self.label = label
+
+        seen_user_ctx: list[UserContext | None] = []
+
+        async def chat(prompt: str, ctx: UserContext = None) -> AsyncIterator[str]:
+            seen_user_ctx.append(ctx)
+            yield "alpha "
+            yield "beta"
+
+        chat._mesh_tool_metadata = {"stream_type": "text"}
+        injector = DependencyInjector()
+        wrapper = injector.create_injection_wrapper(chat, [])
+
+        progress_ctx = _RecordingCtx()
+        user_ctx = UserContext(label="user-supplied")
+
+        result = await wrapper(
+            "p",
+            ctx=user_ctx,  # user's own context — must reach the user function
+            **{_MESH_PROGRESS_CTX_PARAM: progress_ctx},
+        )
+
+        # Joined string returned.
+        assert result == "alpha beta"
+        # Each chunk forwarded via FastMCP's Context.
+        assert progress_ctx.events == [(0, None, "alpha "), (1, None, "beta")]
+        # User's ctx survived the wrapper untouched.
+        assert seen_user_ctx == [user_ctx]
+
+    @pytest.mark.asyncio
+    async def test_user_ctx_kwarg_does_not_leak_progress_ctx(self):
+        """The synthesized progress-context kwarg must be popped before the
+        user function is invoked — otherwise the user function would receive
+        an unexpected ``_mesh_progress_ctx`` kwarg and raise ``TypeError``.
+        """
+
+        async def chat(prompt: str) -> AsyncIterator[str]:
+            yield "x"
+
+        chat._mesh_tool_metadata = {"stream_type": "text"}
+        injector = DependencyInjector()
+        wrapper = injector.create_injection_wrapper(chat, [])
+
+        # Should not raise — the wrapper must strip the internal kwarg.
+        result = await wrapper("p", **{_MESH_PROGRESS_CTX_PARAM: _RecordingCtx()})
+        assert result == "x"
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +332,9 @@ class TestStreamWrapperCancellation:
 
         ctx = _SlowCtx()
 
-        task = asyncio.create_task(wrapper("p", ctx=ctx))
+        task = asyncio.create_task(
+            wrapper("p", **{_MESH_PROGRESS_CTX_PARAM: ctx})
+        )
         await asyncio.sleep(0.05)
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
@@ -290,7 +423,7 @@ class TestStreamWrapperTypeErrors:
         wrapper = injector.create_injection_wrapper(bad_stream, [])
 
         with pytest.raises(TypeError, match="non-str chunk"):
-            await wrapper("p", ctx=_RecordingCtx())
+            await wrapper("p", **{_MESH_PROGRESS_CTX_PARAM: _RecordingCtx()})
 
     @pytest.mark.asyncio
     async def test_function_returning_non_async_iterator_raises(self):
@@ -302,4 +435,4 @@ class TestStreamWrapperTypeErrors:
         wrapper = injector.create_injection_wrapper(bad, [])
 
         with pytest.raises(TypeError, match="did not return an async iterator"):
-            await wrapper("p", ctx=_RecordingCtx())
+            await wrapper("p", **{_MESH_PROGRESS_CTX_PARAM: _RecordingCtx()})

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/adventure-advisor
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/adventure-advisor
@@ -1,0 +1,1 @@
+../../../../../../examples/tutorial/trip-planner/day-09/python/adventure-advisor

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/budget-analyst
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/budget-analyst
@@ -1,0 +1,1 @@
+../../../../../../examples/tutorial/trip-planner/day-09/python/budget-analyst

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/chat-history-agent
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/chat-history-agent
@@ -1,0 +1,1 @@
+../../../../../../examples/tutorial/trip-planner/day-09/python/chat-history-agent

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/claude-provider
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/claude-provider
@@ -1,0 +1,1 @@
+../../../../../../examples/tutorial/trip-planner/day-09/python/claude-provider

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/flight-agent
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/flight-agent
@@ -1,0 +1,1 @@
+../../../../../../examples/tutorial/trip-planner/day-09/python/flight-agent

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/gateway
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/gateway
@@ -1,0 +1,1 @@
+../../../../../../examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/hotel-agent
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/hotel-agent
@@ -1,0 +1,1 @@
+../../../../../../examples/tutorial/trip-planner/day-09/python/hotel-agent

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/logistics-planner
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/logistics-planner
@@ -1,0 +1,1 @@
+../../../../../../examples/tutorial/trip-planner/day-09/python/logistics-planner

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/openai-provider
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/openai-provider
@@ -1,0 +1,1 @@
+../../../../../../examples/tutorial/trip-planner/day-09/python/openai-provider

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/planner-agent
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/planner-agent
@@ -1,0 +1,1 @@
+../../../../../../examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/poi-agent
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/poi-agent
@@ -1,0 +1,1 @@
+../../../../../../examples/tutorial/trip-planner/day-09/python/poi-agent

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/user-prefs-agent
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/user-prefs-agent
@@ -1,0 +1,1 @@
+../../../../../../examples/tutorial/trip-planner/day-09/python/user-prefs-agent

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/weather-agent
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/artifacts/weather-agent
@@ -1,0 +1,1 @@
+../../../../../../examples/tutorial/trip-planner/day-09/python/weather-agent

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/test.yaml
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/test.yaml
@@ -1,0 +1,292 @@
+# Test Case: Day 10 Bonus — Real-time Streaming Trip Planner
+# Validates the Day 10 bonus streaming chapter (#849, stage 2): the bonus-ui
+# planner returns mesh.Stream[str] from llm.stream(), and the bonus-ui gateway
+# wraps it with @mesh.route SSE auto-emission. Verifies tokens stream end-to-end
+# through the deepest pipeline mcp-mesh has been tested with:
+#
+#   curl -> gateway (mesh.route SSE) -> planner (Stream[str], llm.stream())
+#         -> user_prefs + chat_history (Tier-1 deps, buffered)
+#         -> 3 committee agents in parallel (each with own LLM call, buffered)
+#         -> final streaming LLM call with 4 tool deps (flight/hotel/weather/poi
+#            via filter)
+#         -> tokens stream back through entire pipeline to browser
+#
+# 13 agents total = 11 unchanged from day-09 (claude-provider, openai-provider,
+# user-prefs-agent, chat-history-agent, flight/hotel/weather/poi-agents,
+# budget-analyst, adventure-advisor, logistics-planner) + bonus planner-agent
+# + bonus gateway (drop-in replacements that add streaming).
+#
+# Requires ANTHROPIC_API_KEY and OPENAI_API_KEY — tagged with 'llm' so CI can
+# skip without keys. Committee specialists each make their own real LLM call,
+# so a dry-run path would not exercise the full pipeline (matches the opt-in
+# real-LLM pattern from tc04/tc05/tc07).
+
+name: "Tutorial Day 10 Bonus: Real-time Streaming Trip Planner"
+description: "Verify deepest streaming pipeline (gateway SSE -> planner Stream -> committee + tools + LLM) delivers multi-chunk tokens end-to-end"
+tags:
+  - tutorial
+  - day10
+  - bonus
+  - streaming
+  - python
+  - llm
+  - gateway
+timeout: 600
+
+pre_run:
+  - routine: global.start_observability
+
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+  - handler: shell
+    command: "/workspace/.venv/bin/pip install fastapi uvicorn redis"
+
+test:
+  # Copy all 13 agents to workspace. The bonus planner + gateway come from
+  # day-10/bonus-ui; the other 11 come from day-09 unchanged.
+  - name: "Copy agents to workspace"
+    handler: shell
+    command: |
+      cp -rL /artifacts/flight-agent /workspace/
+      cp -rL /artifacts/hotel-agent /workspace/
+      cp -rL /artifacts/weather-agent /workspace/
+      cp -rL /artifacts/poi-agent /workspace/
+      cp -rL /artifacts/user-prefs-agent /workspace/
+      cp -rL /artifacts/claude-provider /workspace/
+      cp -rL /artifacts/openai-provider /workspace/
+      cp -rL /artifacts/planner-agent /workspace/
+      cp -rL /artifacts/chat-history-agent /workspace/
+      cp -rL /artifacts/gateway /workspace/
+      cp -rL /artifacts/budget-analyst /workspace/
+      cp -rL /artifacts/adventure-advisor /workspace/
+      cp -rL /artifacts/logistics-planner /workspace/
+    capture: copy_output
+
+  # Create env file with secrets (tsuite injects ANTHROPIC_API_KEY +
+  # OPENAI_API_KEY automatically).
+  - name: "Create env file with secrets"
+    handler: secrets
+    target: /workspace/.env
+
+  # Start the 12 named agents (tools, providers, planner, committee). Single
+  # invocation matches tc07 pattern.
+  - name: "Start tool, provider, planner, and specialist agents"
+    handler: shell
+    command: "meshctl start flight-agent/main.py hotel-agent/main.py weather-agent/main.py poi-agent/main.py user-prefs-agent/main.py claude-provider/main.py openai-provider/main.py planner-agent/main.py chat-history-agent/main.py budget-analyst/main.py adventure-advisor/main.py logistics-planner/main.py --env-file .env -d"
+    workdir: /workspace
+    capture: start_agents_output
+
+  # Wait for registration and DI resolution.
+  - name: "Wait for all agents to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      EXPECTED="flight-agent hotel-agent weather-agent poi-agent user-prefs-agent claude-provider openai-provider planner-agent chat-history-agent budget-analyst adventure-advisor logistics-planner"
+      EXPECTED_COUNT=12
+      echo "Waiting for $EXPECTED_COUNT agents to register..."
+      for i in $(seq 1 30); do
+        AGENTS=$(meshctl list 2>/dev/null || true)
+        COUNT=0
+        for agent in $EXPECTED; do
+          if echo "$AGENTS" | grep -q "$agent"; then
+            COUNT=$((COUNT + 1))
+          fi
+        done
+        if [ "$COUNT" -ge "$EXPECTED_COUNT" ]; then
+          echo "All $EXPECTED_COUNT agents registered after $((i * 2))s"
+          meshctl list
+          exit 0
+        fi
+        echo "  $COUNT/$EXPECTED_COUNT agents registered (attempt $i/30)..."
+        sleep 2
+      done
+      echo "ERROR: Only $COUNT/$EXPECTED_COUNT agents registered within 60s"
+      meshctl list 2>/dev/null || true
+      exit 1
+    capture: wait_agents_output
+    timeout: 90
+
+  # Start the bonus streaming gateway (port 8080).
+  - name: "Start bonus streaming gateway"
+    handler: shell
+    command: "meshctl start gateway/main.py --env-file .env -d"
+    workdir: /workspace
+    capture: start_gateway_output
+
+  # Wait for the API gateway to register and resolve trip_planning dep.
+  - name: "Wait for gateway to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for API gateway to register..."
+      for i in $(seq 1 30); do
+        if meshctl list 2>/dev/null | grep -qi "API"; then
+          echo "API gateway registered after $((i * 2))s"
+          meshctl list
+          exit 0
+        fi
+        echo "  API gateway not yet registered (attempt $i/30)..."
+        sleep 2
+      done
+      echo "ERROR: API gateway not registered within 60s"
+      meshctl list 2>/dev/null || true
+      exit 1
+    capture: wait_gateway_output
+    timeout: 90
+
+  # Brief settle so the gateway's `trip_planning` dep resolves before the SSE
+  # POST fires (mirrors the uc18/tc01 pattern).
+  - name: "Brief settle for gateway trip_planning dep resolution"
+    handler: wait
+    seconds: 5
+
+  # Verify all 13 agents are registered.
+  - name: "Verify all agents are registered"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: list_output
+
+  # Verify gateway health endpoint (non-streaming regression — proves the
+  # FastAPI app is up before we hit the streaming endpoint).
+  - name: "Verify gateway health endpoint"
+    handler: shell
+    command: |
+      RESPONSE=$(curl -s http://localhost:8080/health 2>&1)
+      echo "$RESPONSE"
+      if echo "$RESPONSE" | grep -q '"healthy"'; then
+        echo "PASS: gateway health check passed"
+      else
+        echo "FAIL: gateway health check failed"
+        exit 1
+      fi
+    workdir: /workspace
+    capture: health_check
+
+  # Capture SSE response body. -N disables curl buffering so we observe
+  # incremental flushes as separate `data: ` lines. Real-LLM streaming +
+  # 3 committee LLM calls + 4 tool calls can take 30-60s, so timeout 240.
+  - name: "POST /plan and capture full SSE stream body"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -N --max-time 220 -X POST http://localhost:8080/plan \
+        -H "Content-Type: application/json" \
+        -H "X-Session-Id: test-session-day10-bonus" \
+        -d '{"destination":"Tokyo","dates":"June 1-5, 2026","budget":"$3000","message":"family trip"}' \
+        2>&1
+    capture: sse_output
+    timeout: 240
+
+  # Capture response headers separately (-D - dumps headers, -o /dev/null
+  # discards body) to verify Content-Type is text/event-stream.
+  - name: "POST /plan with header dump (verify SSE Content-Type)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -D - --max-time 220 -X POST http://localhost:8080/plan \
+        -H "Content-Type: application/json" \
+        -H "X-Session-Id: test-session-day10-bonus-headers" \
+        -d '{"destination":"Tokyo","dates":"June 1-5, 2026","budget":"$3000","message":"family trip"}' \
+        -o /dev/null 2>&1
+    capture: sse_headers
+    timeout: 240
+
+  # Count the number of `data: ` SSE chunks. > 5 proves the response is
+  # actually streaming (multi-chunk delivery), not a single buffered payload
+  # wrapped in one SSE frame at the end.
+  - name: "Count SSE data chunks (multi-chunk streaming proof)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # Re-grep the captured stream from the previous step is not possible
+      # cross-step in shell, so re-run a smaller probe and count `data: ` lines.
+      # We probe the same endpoint independently to avoid any cross-step
+      # state issues. This also doubles as a smoke test that the second call
+      # works (no session-state regressions).
+      RESPONSE=$(curl -s -N --max-time 220 -X POST http://localhost:8080/plan \
+        -H "Content-Type: application/json" \
+        -H "X-Session-Id: test-session-day10-bonus-count" \
+        -d '{"destination":"Tokyo","dates":"June 1-5, 2026","budget":"$3000","message":"family trip"}' \
+        2>&1)
+      DATA_COUNT=$(echo "$RESPONSE" | grep -c '^data: ' || true)
+      echo "DATA_CHUNK_COUNT=$DATA_COUNT"
+      echo "--- last 20 lines of response ---"
+      echo "$RESPONSE" | tail -20
+    capture: chunk_count
+    timeout: 240
+
+assertions:
+  # --- All 13 agents registered ---
+  - expr: "${captured.list_output} contains 'flight-agent'"
+    message: "flight-agent should appear in meshctl list"
+
+  - expr: "${captured.list_output} contains 'hotel-agent'"
+    message: "hotel-agent should appear in meshctl list"
+
+  - expr: "${captured.list_output} contains 'weather-agent'"
+    message: "weather-agent should appear in meshctl list"
+
+  - expr: "${captured.list_output} contains 'poi-agent'"
+    message: "poi-agent should appear in meshctl list"
+
+  - expr: "${captured.list_output} contains 'user-prefs-agent'"
+    message: "user-prefs-agent should appear in meshctl list"
+
+  - expr: "${captured.list_output} contains 'claude-provider'"
+    message: "claude-provider should appear in meshctl list"
+
+  - expr: "${captured.list_output} contains 'openai-provider'"
+    message: "openai-provider should appear in meshctl list"
+
+  - expr: "${captured.list_output} contains 'planner-agent'"
+    message: "planner-agent should appear in meshctl list"
+
+  - expr: "${captured.list_output} contains 'chat-history-agent'"
+    message: "chat-history-agent should appear in meshctl list"
+
+  - expr: "${captured.list_output} contains 'API'"
+    message: "API gateway should appear in meshctl list"
+
+  - expr: "${captured.list_output} contains 'budget-analyst'"
+    message: "budget-analyst should appear in meshctl list"
+
+  - expr: "${captured.list_output} contains 'adventure-advisor'"
+    message: "adventure-advisor should appear in meshctl list"
+
+  - expr: "${captured.list_output} contains 'logistics-planner'"
+    message: "logistics-planner should appear in meshctl list"
+
+  # --- Gateway health (non-streaming regression) ---
+  - expr: "${captured.health_check} contains 'PASS'"
+    message: "gateway /health endpoint should return healthy (non-streaming regression)"
+
+  # --- SSE body structural assertions (no exact-text matching on LLM
+  #     output — per project memory feedback_llm_test_assertions.md) ---
+  - expr: "${captured.sse_output} contains 'data: '"
+    message: "SSE stream must contain at least one 'data: ' chunk"
+
+  - expr: "${captured.sse_output} contains '[DONE]'"
+    message: "SSE stream must end with the '[DONE]' terminator (proves @mesh.route SSE auto-emission ran to completion)"
+
+  - expr: "${captured.sse_output} icontains 'tokyo'"
+    message: "SSE stream body must mention the input destination (case-insensitive 'Tokyo'), proving the input traversed gateway -> planner -> committee -> LLM end-to-end"
+
+  # --- SSE header assertion ---
+  - expr: "${captured.sse_headers} contains 'text/event-stream'"
+    message: "Response Content-Type must be text/event-stream (proves @mesh.route SSE adapter wrapped the Stream[str] return)"
+
+  # --- Multi-chunk streaming proof (NOT a single buffered payload) ---
+  # If the response were buffered into one frame, DATA_CHUNK_COUNT would be 1
+  # or 2 (one for the body, one for [DONE]). > 5 proves real streaming.
+  - expr: "${jq:captured.chunk_count:[. | split(\"\\n\")[] | select(startswith(\"DATA_CHUNK_COUNT=\")) | sub(\"DATA_CHUNK_COUNT=\"; \"\") | tonumber] | first} > 5"
+    message: "Expected > 5 SSE data chunks (proves true streaming, not a single buffered payload). Got fewer — the response may be buffered, not streaming."
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

- Adds **Day 10 Bonus — Streaming UI** chapter to the trip-planner tutorial (`docs/tutorial/day-10-bonus-streaming-ui.md`) walking through the deepest pipeline mcp-mesh ships: browser → SSE gateway → streaming planner → committee fan-out → mesh-delegated LLM provider → buffered tool calls → final streaming Claude call.
- Lands the **mesh-delegate streaming** SDK work needed to make the chapter actually run end-to-end: producer-side `process_chat_stream` auto-tool, tag-based variant discrimination via the new `ai.mcpmesh.stream` tag, kwargs propagation through the Rust event pipeline, and a `ctx` parameter collision fix that was silently no-op'ing every progress notification.
- Includes the full streaming bonus example (`examples/tutorial/trip-planner/day-10/bonus-ui/`): streaming planner-agent, gateway with SSE, single-file React UI with no build step.
- Integration test `uc20/tc11_day10_bonus_streaming` exercises the whole pipeline end to end with a live Claude call (gated on `MESH_LLM_DRY_RUN`-able).
- Mitigation for the HINT-first slowness traced during local testing: bumps the Claude HINT→response_format fallback timeout default from 30s → 90s and exposes `MCP_MESH_CLAUDE_HINT_FALLBACK_TIMEOUT` to override. Root cause stays in #834.

## Notable internals

- **Phase 5C tag discrimination** — producer's auto-generated streaming tool gets the bare `ai.mcpmesh.stream` (REQUIRED) tag, consumer's `@mesh.llm` decorator augments the provider tag filter with `ai.mcpmesh.stream` for `Stream[str]` returns and `-ai.mcpmesh.stream` (EXCLUDED) for buffered returns. Symmetric exclusive matching, no resolver special cases.
- **Phase 5A kwargs plumbing** — added `Option<String>` `kwargs` field to `LlmProviderInfo`, `JsLlmProviderInfo`, `ResolvedLlmProvider`, `TrackedProvider`. All append-only, `serde(default)`, `getattr(... , default=None)` on the Python side — older registry / older SDK behave as before.
- **`ctx` parameter collision fix** — `dependency_injector._make_stream_wrapper` now synthesizes the FastMCP Context parameter under the internal name `_mesh_progress_ctx`. User-typed `ctx: SomeContextModel` no longer shadows the framework-injected `ctx: Context`, which had been silently no-op'ing chunk forwarding.

## Review Notes

Pre-PR review (1 BLOCKER + 5 WARNINGs) addressed in commit `3cbfba95`:
- Doc tag-operator semantics (`+` PREFERRED vs unprefixed REQUIRED)
- Producer kwargs no longer shadow consumer-config keys
- Env-var int parse is now fail-open
- Removed mutable-default-argument + dead `conversation_history` param from tutorial code
- Soft-fallback log/comment updated to reflect actual scenario
- `_DEFAULT_HINT_FALLBACK_TIMEOUT = 90` now a single constant

Closes #849

## Test plan

- [x] 739 Python unit tests pass (`pytest src/runtime/python/tests/unit -q`)
- [x] Go registry tests pass (kwargs serialization for `ResolvedLLMProvider`)
- [x] mkdocs build clean — bonus chapter renders, snippets resolve
- [x] Local end-to-end real-Claude streaming verified through trip-planner bonus UI (233 chunks across 48s of real wall-clock streaming)
- [x] Integration test `uc20/tc11_day10_bonus_streaming` passes (live Claude path)
- [ ] CI — full src-tests + integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time streaming responses for trip planning using Server-Sent Events
  * New mobile-first React UI for incrementally displaying streamed trip plans

* **Documentation**
  * New "Day 10 Bonus — Streaming UI" tutorial with complete walkthrough and examples
  * Updated concepts documentation to explain streaming behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->