### PR TITLE
fix: integration test de-flake (#856) + src-tests perf (#857)

### DIFF
--- a/tests/integration/suites/uc12_registration_trust/tc13_vault_typescript/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc13_vault_typescript/test.yaml
@@ -93,8 +93,11 @@ test:
     capture: agent_start
 
   - name: "Wait for agent registration"
+    # 15s was too tight on loaded test boxes — TS agent startup +
+    # Vault credential fetch + register call exceeded the budget on
+    # run 7c9009ac (test 51431, "no healthy agent found").
     handler: wait
-    seconds: 15
+    seconds: 30
 
   - name: "Check agent registered"
     handler: shell

--- a/tests/integration/suites/uc12_registration_trust/tc16_spire_python/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc16_spire_python/test.yaml
@@ -120,8 +120,11 @@ test:
     capture: agent_start
 
   - name: "Wait for agent registration"
+    # 15s was too tight on loaded test boxes — Python agent startup +
+    # SPIRE SVID fetch + register call exceeded the budget on
+    # run 7c9009ac (test 51434, "no healthy agent found").
     handler: wait
-    seconds: 15
+    seconds: 30
 
   - name: "Check agent registered"
     handler: shell

--- a/tests/integration/suites/uc12_registration_trust/tc18_spire_java/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc18_spire_java/test.yaml
@@ -123,20 +123,23 @@ test:
     workdir: /workspace
     capture: java_start
 
-  - name: "Wait for Java agent to register (up to 90s)"
+  - name: "Wait for Java agent to register (up to 180s)"
+    # Java cold-start (Spring Boot init + SPIRE SVID fetch) regularly
+    # exceeded 90s on loaded test boxes — bumped to 180s after run
+    # 7c9009ac (test 51436 hit "agent did not register within 90s").
     handler: shell
     command: |
-      for i in $(seq 1 45); do
+      for i in $(seq 1 90); do
         if curl -sk https://localhost:8000/agents 2>/dev/null | grep -q "greeter-java"; then
           echo "REGISTERED after $((i*2)) seconds"
           exit 0
         fi
         sleep 2
       done
-      echo "TIMEOUT: agent did not register within 90s"
+      echo "TIMEOUT: agent did not register within 180s"
       exit 1
     capture: wait_output
-    timeout: 120
+    timeout: 210
 
   - name: "Check agent registered"
     handler: shell

--- a/tests/integration/suites/uc15_parallel_tool_calls/tc16_direct_claude_java/test.yaml
+++ b/tests/integration/suites/uc15_parallel_tool_calls/tc16_direct_claude_java/test.yaml
@@ -95,12 +95,18 @@ test:
     handler: shell
     workdir: /workspace
     command: |
-      RESPONSE=$(meshctl call parallelAnalyze --timeout 120 '{"ctx": {"query": "You MUST call all three tools in parallel for ticker NVDA: get_stock_price, get_company_info, AND get_market_sentiment. Return the raw values from each tool — do not summarize or omit any field. Include the literal sentiment value (Bullish/Bearish/Neutral) and recommendation (Buy/Hold/Sell) from get_market_sentiment.", "ticker": "NVDA"}}' 2>&1)
+      RESPONSE=$(meshctl call parallelAnalyze --timeout 120 '{"ctx": {"query": "You MUST call all three tools in parallel for ticker NVDA: get_stock_price, get_company_info, AND get_market_sentiment. Return the raw values from each tool — do not summarize or omit any field. Include the sentiment value and recommendation (Buy/Hold/Sell) from get_market_sentiment.", "ticker": "NVDA"}}' 2>&1)
       echo "$RESPONSE"
       # Verdict token: did Claude actually call get_market_sentiment? The
       # tool returns one of {Bullish, Bearish, Neutral, Very Bullish, Very
       # Bearish}. tsuite assertion expressions don't support OR, so we
       # collapse the disjunction here in shell.
+      #
+      # IMPORTANT: the verdict words must NOT appear in the prompt itself —
+      # if meshctl ever echoes the request payload back into stdout (debug,
+      # error paths) the verdict would PASS without Claude calling the tool.
+      # The prompt above intentionally avoids the literal "Bullish/Bearish/
+      # Neutral" string for this reason.
       if echo "$RESPONSE" | grep -qE 'Bullish|Bearish|Neutral'; then
         echo "SENTIMENT_TOOL_VERDICT=PASS"
       else

--- a/tests/integration/suites/uc15_parallel_tool_calls/tc16_direct_claude_java/test.yaml
+++ b/tests/integration/suites/uc15_parallel_tool_calls/tc16_direct_claude_java/test.yaml
@@ -86,11 +86,26 @@ test:
     capture: agent_list
 
   # 7. Call parallelAnalyze with stock query (should trigger all 3 tools)
+  # The prompt is imperative ("MUST call all three") and the verdict step
+  # below checks for tool-returned literal values (Bullish/Bearish/Neutral),
+  # not the word "sentiment" — Claude tends to write "sentiment" in prose
+  # even when get_market_sentiment wasn't called, so the literal-value
+  # check is a more reliable proof that all 3 parallel tools ran.
   - name: "Parallel tool query"
     handler: shell
     workdir: /workspace
     command: |
-      meshctl call parallelAnalyze --timeout 120 '{"ctx": {"query": "Give me a comprehensive analysis of NVDA stock. Get the stock price, company info, and market sentiment.", "ticker": "NVDA"}}'
+      RESPONSE=$(meshctl call parallelAnalyze --timeout 120 '{"ctx": {"query": "You MUST call all three tools in parallel for ticker NVDA: get_stock_price, get_company_info, AND get_market_sentiment. Return the raw values from each tool — do not summarize or omit any field. Include the literal sentiment value (Bullish/Bearish/Neutral) and recommendation (Buy/Hold/Sell) from get_market_sentiment.", "ticker": "NVDA"}}' 2>&1)
+      echo "$RESPONSE"
+      # Verdict token: did Claude actually call get_market_sentiment? The
+      # tool returns one of {Bullish, Bearish, Neutral, Very Bullish, Very
+      # Bearish}. tsuite assertion expressions don't support OR, so we
+      # collapse the disjunction here in shell.
+      if echo "$RESPONSE" | grep -qE 'Bullish|Bearish|Neutral'; then
+        echo "SENTIMENT_TOOL_VERDICT=PASS"
+      else
+        echo "SENTIMENT_TOOL_VERDICT=FAIL"
+      fi
     capture: parallel_response
     timeout: 180
 
@@ -111,8 +126,15 @@ assertions:
   # Verify response contains data from all 3 tools
   - expr: "${captured.parallel_response} contains 'NVDA'"
     message: "Response should reference the NVDA ticker"
-  - expr: "${captured.parallel_response} contains 'sentiment'"
-    message: "Response should contain sentiment data (from get_market_sentiment)"
+  # Verdict-token pattern: shell collapses the OR-disjunction into a single
+  # PASS/FAIL token because tsuite assertion expressions don't support OR.
+  # PASS = Claude's response contains a sentiment value (Bullish/Bearish/
+  # Neutral) returned by the get_market_sentiment tool, proving all 3
+  # parallel tools were called.
+  - expr: "${captured.parallel_response} contains 'SENTIMENT_TOOL_VERDICT=PASS'"
+    message: "Response should contain a sentiment value (Bullish/Bearish/Neutral) returned by get_market_sentiment, proving all 3 parallel tools ran"
+  - expr: "${captured.parallel_response} not contains 'SENTIMENT_TOOL_VERDICT=FAIL'"
+    message: "Sentiment-tool verdict must be PASS (negative guard)"
 post_run:
   - handler: shell
     workdir: /workspace

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/test.yaml
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/test.yaml
@@ -213,6 +213,16 @@ test:
         2>&1)
       DATA_COUNT=$(echo "$RESPONSE" | grep -c '^data: ' || true)
       echo "DATA_CHUNK_COUNT=$DATA_COUNT"
+      # Emit a verdict token the assertion matches by string-contains. The
+      # earlier ${jq:...} expression returned <nil> in tsuite even though
+      # DATA_CHUNK_COUNT=333 was clearly captured (run 7c9009ac/test 51528).
+      # Verdict pattern avoids the jq round-trip and matches the same
+      # robustness fix applied to uc18 tc04+tc05.
+      if [ "$DATA_COUNT" -gt 5 ]; then
+        echo "MULTI_CHUNK_VERDICT=PASS"
+      else
+        echo "MULTI_CHUNK_VERDICT=FAIL"
+      fi
       echo "--- last 20 lines of response ---"
       echo "$RESPONSE" | tail -20
     capture: chunk_count
@@ -281,8 +291,10 @@ assertions:
   # --- Multi-chunk streaming proof (NOT a single buffered payload) ---
   # If the response were buffered into one frame, DATA_CHUNK_COUNT would be 1
   # or 2 (one for the body, one for [DONE]). > 5 proves real streaming.
-  - expr: "${jq:captured.chunk_count:[. | split(\"\\n\")[] | select(startswith(\"DATA_CHUNK_COUNT=\")) | sub(\"DATA_CHUNK_COUNT=\"; \"\") | tonumber] | first} > 5"
+  - expr: "${captured.chunk_count} contains 'MULTI_CHUNK_VERDICT=PASS'"
     message: "Expected > 5 SSE data chunks (proves true streaming, not a single buffered payload). Got fewer — the response may be buffered, not streaming."
+  - expr: "${captured.chunk_count} not contains 'MULTI_CHUNK_VERDICT=FAIL'"
+    message: "Multi-chunk verdict must be PASS (negative guard against the verdict token regressing)"
 
 post_run:
   - handler: shell

--- a/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/test.yaml
+++ b/tests/integration/suites/uc20_tutorial/tc11_day10_bonus_streaming/test.yaml
@@ -212,6 +212,9 @@ test:
         -d '{"destination":"Tokyo","dates":"June 1-5, 2026","budget":"$3000","message":"family trip"}' \
         2>&1)
       DATA_COUNT=$(echo "$RESPONSE" | grep -c '^data: ' || true)
+      # Guard against an empty count crashing the numeric comparison below
+      # (would emit neither PASS nor FAIL → silent half-failure).
+      DATA_COUNT=${DATA_COUNT:-0}
       echo "DATA_CHUNK_COUNT=$DATA_COUNT"
       # Emit a verdict token the assertion matches by string-contains. The
       # earlier ${jq:...} expression returned <nil> in tsuite even though

--- a/tests/src-tests/suites/build/tc02a_build_rust_core_nodejs/test.yaml
+++ b/tests/src-tests/suites/build/tc02a_build_rust_core_nodejs/test.yaml
@@ -5,7 +5,13 @@
 # Build commands execute inside src-build:latest via docker run
 
 name: "Build Rust Core (Node.js)"
-depends_on: [tc02_build_rust_core]
+# Only depends on the build environment — does NOT consume tc02's output.
+# Each test runs in an isolated `docker run --rm` container with its own
+# Rust source copy and cargo target/, so tc02a + tc02 + tc04a can all
+# build the Rust core in parallel without contention. Lets the napi build
+# move forward to Wave 2 alongside tc02 (Python wheel) and tc04a (Java
+# FFI), which in turn lets tc04 (TS SDK) start in Wave 3 instead of Wave 4.
+depends_on: [tc00_build_environment]
 description: "Build @mcpmesh/core npm tarball with native bindings using napi-rs"
 tags:
   - build

--- a/tests/src-tests/suites/build/tc04_build_typescript_sdk/test.yaml
+++ b/tests/src-tests/suites/build/tc04_build_typescript_sdk/test.yaml
@@ -5,8 +5,12 @@
 # Build commands execute inside src-build:latest via docker run
 
 name: "Build TypeScript SDK"
-depends_on: [tc00_build_environment]
-description: "Build @mcpmesh/sdk npm tarball from source using docker run"
+# Depends on tc02a (which transitively depends on tc02 and tc00) so we can
+# consume the pre-built @mcpmesh/core npm tarball instead of rebuilding the
+# Rust+napi bindings inline. Saves one full Rust compilation per src-tests
+# run; tc04 becomes a pure TypeScript compile.
+depends_on: [tc02a_build_rust_core_nodejs]
+description: "Build @mcpmesh/sdk npm tarball, consuming pre-built @mcpmesh/core from tc02a"
 tags:
   - build
   - typescript
@@ -49,39 +53,32 @@ test:
       echo "Output: $OUTPUT_ABS"
 
       echo "Building TypeScript SDK inside container (clean build)..."
-      # TypeScript SDK depends on @mcpmesh/core (file:../core/typescript), whose
-      # napi-generated index.js / index.d.ts / *.node are NOT in git. We must
-      # build them inline first, then build the SDK. Mirrors tc04a's pattern.
+      # The SDK's package.json declares `@mcpmesh/core: file:../core/typescript`
+      # which (in source) refers to a Rust+napi project that needs building.
+      # tc02a already built it and produced an npm tarball. We extract that
+      # tarball into the expected location so npm install resolves the file:
+      # ref to a ready-to-use package — pure TypeScript build, no Rust here.
       docker run --rm \
         -v "$SOURCE_ABS:/src-host:ro" \
         -v "$OUTPUT_ABS:/out" \
         ${config.build.image} \
         bash -c "
           set -euo pipefail
-          mkdir -p /src/mcp-mesh/src/runtime/typescript /src/mcp-mesh/src/runtime/core && \
-          mkdir -p /out/packages && \
-          # Copy napi core build inputs (full Rust source needed for napi build)
-          cp /src-host/src/runtime/core/Cargo.toml /src/mcp-mesh/src/runtime/core/ && \
-          # Cargo.lock may not exist on a fresh tree; tolerate missing-file
-          # only — any other cp failure (permission, IO) must propagate via
-          # set -euo pipefail.
-          if [ -f /src-host/src/runtime/core/Cargo.lock ]; then \
-            cp /src-host/src/runtime/core/Cargo.lock /src/mcp-mesh/src/runtime/core/; \
+          mkdir -p /src/mcp-mesh/src/runtime/typescript /src/mcp-mesh/src/runtime/core/typescript /out/packages && \
+          # Locate tc02a's @mcpmesh/core tarball
+          CORE_TGZ=\$(ls /out/packages/mcpmesh-core-*.tgz 2>/dev/null | head -1) && \
+          if [ -z \"\$CORE_TGZ\" ]; then \
+            echo 'ERROR: @mcpmesh/core tarball not found in /out/packages/ — tc02a should produce it'; \
+            ls -la /out/packages/ || true; \
+            exit 1; \
           fi && \
-          cp /src-host/src/runtime/core/build.rs /src/mcp-mesh/src/runtime/core/ && \
-          cp -r /src-host/src/runtime/core/src /src/mcp-mesh/src/runtime/core/ && \
-          cp -r /src-host/src/runtime/core/typescript /src/mcp-mesh/src/runtime/core/ && \
+          echo \"Extracting pre-built @mcpmesh/core from \$CORE_TGZ\" && \
+          tar -xzf \"\$CORE_TGZ\" -C /src/mcp-mesh/src/runtime/core/typescript --strip-components=1 && \
           # Copy SDK source
           cp /src-host/src/runtime/typescript/package.json /src/mcp-mesh/src/runtime/typescript/ && \
           cp /src-host/src/runtime/typescript/tsconfig.json /src/mcp-mesh/src/runtime/typescript/ && \
           cp -r /src-host/src/runtime/typescript/src /src/mcp-mesh/src/runtime/typescript/ && \
-          # Build napi core wrappers FIRST (generates index.js, index.d.ts, *.node)
-          echo '=== Building @mcpmesh/core napi wrappers ===' && \
-          cd /src/mcp-mesh/src/runtime/core/typescript && \
-          npm install && \
-          npm run build && \
-          # Then build the SDK
-          echo '=== Building @mcpmesh/sdk ===' && \
+          echo '=== Building @mcpmesh/sdk (consuming pre-built @mcpmesh/core) ===' && \
           cd /src/mcp-mesh/src/runtime/typescript && \
           npm install && \
           npm run build && \

--- a/tests/src-tests/suites/build/tc04_build_typescript_sdk/test.yaml
+++ b/tests/src-tests/suites/build/tc04_build_typescript_sdk/test.yaml
@@ -65,22 +65,43 @@ test:
         bash -c "
           set -euo pipefail
           mkdir -p /src/mcp-mesh/src/runtime/typescript /src/mcp-mesh/src/runtime/core/typescript /out/packages && \
-          # Locate tc02a's @mcpmesh/core tarball
-          CORE_TGZ=\$(ls /out/packages/mcpmesh-core-*.tgz 2>/dev/null | head -1) && \
-          if [ -z \"\$CORE_TGZ\" ]; then \
+          # Locate tc02a's @mcpmesh/core tarball. Use `ls -t` (newest first
+          # by mtime) so a stale older tarball left from a prior failed run
+          # doesn't shadow the fresh one. Fail loudly if multiple unique
+          # versions exist — that's a cleanup signal, not something to
+          # silently pick from.
+          CORE_TGZ_COUNT=\$(ls /out/packages/mcpmesh-core-*.tgz 2>/dev/null | wc -l) && \
+          if [ \"\$CORE_TGZ_COUNT\" -eq 0 ]; then \
             echo 'ERROR: @mcpmesh/core tarball not found in /out/packages/ — tc02a should produce it'; \
             ls -la /out/packages/ || true; \
             exit 1; \
           fi && \
+          if [ \"\$CORE_TGZ_COUNT\" -gt 1 ]; then \
+            echo \"WARNING: multiple @mcpmesh/core tarballs in /out/packages/ — using newest by mtime\"; \
+            ls -la /out/packages/mcpmesh-core-*.tgz; \
+          fi && \
+          CORE_TGZ=\$(ls -t /out/packages/mcpmesh-core-*.tgz | head -1) && \
           echo \"Extracting pre-built @mcpmesh/core from \$CORE_TGZ\" && \
           tar -xzf \"\$CORE_TGZ\" -C /src/mcp-mesh/src/runtime/core/typescript --strip-components=1 && \
+          # The packed @mcpmesh/core package.json still declares
+          # `scripts.build = napi build ...` (the source build pipeline).
+          # Strip the build/install/prepare scripts from the EXTRACTED
+          # package.json so npm doesn't re-invoke napi build (which would
+          # fail — no Rust source / Cargo.toml at the install location).
+          # The packed JS + .node files are already what the SDK needs.
+          if [ -f /src/mcp-mesh/src/runtime/core/typescript/package.json ]; then \
+            node -e \"const fs=require('fs'); const p='/src/mcp-mesh/src/runtime/core/typescript/package.json'; const j=JSON.parse(fs.readFileSync(p)); for (const k of ['build','prepare','prepublish','install','postinstall']) { if (j.scripts) delete j.scripts[k]; } fs.writeFileSync(p, JSON.stringify(j, null, 2));\"; \
+          fi && \
           # Copy SDK source
           cp /src-host/src/runtime/typescript/package.json /src/mcp-mesh/src/runtime/typescript/ && \
           cp /src-host/src/runtime/typescript/tsconfig.json /src/mcp-mesh/src/runtime/typescript/ && \
           cp -r /src-host/src/runtime/typescript/src /src/mcp-mesh/src/runtime/typescript/ && \
           echo '=== Building @mcpmesh/sdk (consuming pre-built @mcpmesh/core) ===' && \
           cd /src/mcp-mesh/src/runtime/typescript && \
-          npm install && \
+          # --ignore-scripts: belt-and-suspenders defense in case the
+          # core/typescript scripts strip above missed anything (or if any
+          # transitive dep tries to run native build steps).
+          npm install --ignore-scripts && \
           npm run build && \
           npm pack --pack-destination /out/packages
         "


### PR DESCRIPTION
## Summary

Two independent test-infrastructure improvements landing in one PR.

### Closes #856 — integration test de-flake (5 tests)

Run 7c9009ac surfaced 8 failing integration tests. After triage, 3 were transient flakes that passed on rerun without changes (uc05 tc23/tc30 cold-start, uc20 tc04 LLM non-determinism). 5 needed real fixes:

| Test | Root cause | Fix |
|---|---|---|
| uc20/tc11_day10_bonus_streaming | `${jq:...}` returned `<nil>` despite captured `DATA_CHUNK_COUNT=333` | Verdict-token pattern (`MULTI_CHUNK_VERDICT=PASS`) — same approach as the recent CodeRabbit-driven fix on uc18 tc04+tc05 |
| uc12/tc13_vault_typescript | Wait 15s too tight for TS startup + Vault cred fetch | Bumped to 30s |
| uc12/tc16_spire_python | Wait 15s too tight for Python startup + SPIRE SVID fetch | Bumped to 30s |
| uc12/tc18_spire_java | Polling 90s too tight for Java cold-start + SPIRE | Bumped to 180s |
| uc15/tc16_direct_claude_java | Persistent across 2 runs — Claude consistently skipped `get_market_sentiment`. Assertion checked for the literal word "sentiment" which Claude wrote in prose anyway | Imperative prompt (`You MUST call all three tools...`) + verdict-token assertion checking for tool-returned literal values (Bullish/Bearish/Neutral) |

All 5 verified passing on rerun (run `517e0368` for the original 8, run `bbgmoqxwk` for the tc16 verification).

### Closes #857 — src-tests DAG optimization (2 changes)

Two small DAG edge changes that eliminate one redundant Rust+napi compile per src-tests run:

- **tc04_build_typescript_sdk**: depends on tc02a (was: tc00 only) + consumes pre-built `@mcpmesh/core` tarball instead of inlining a Rust+napi build. tc04 becomes a pure TypeScript compile (~2-3 min vs ~5 min before).
- **tc02a_build_rust_core_nodejs**: depends on tc00 (was: tc02). The dep on tc02 was artificial sequencing — each test runs in isolated `docker run --rm` with its own cargo target/. Removing it lets tc02a run in Wave 2 alongside tc02. Knock-on: tc04 starts in Wave 3 instead of Wave 4.

DAG before/after, and effect:

```
Wave 2 before: tc01, tc01a, tc01b, tc02, tc04 (inline Rust+napi+tsc), tc04a  (5 parallel)
Wave 2 after:  tc01, tc01a, tc01b, tc02, tc02a, tc04a                        (6 parallel)
Wave 3 before: tc02a (after tc02), tc03 (after tc02)
Wave 3 after:  tc03 (after tc02), tc04 (after tc02a)
```

- Eliminates one full Rust+napi compilation per src-tests run
- TS critical path: ~10 min → ~7 min (saves ~3 min of CPU work)
- Wall-clock unchanged — tc04a Java path (~10 min) still dominates
- Verified DAG behavior on beelink5: tc02a turns ⟳ alongside tc02 in Wave 2; tc04 stays ○ until tc02a finishes

## Review notes

Pre-PR review found 1 BLOCKER + 4 WARNINGs; addressed in commit `f630e4f3`:

- **tc04 npm lifecycle scripts** — extracted `@mcpmesh/core/package.json` still has `"build": "napi build ..."`; if npm runs lifecycle scripts on file: directory installs the SDK build would try to re-execute napi against a Cargo.toml that doesn't exist. Now strips `build`/`prepare`/`prepublish`/`install`/`postinstall` from the extracted package.json + adds `--ignore-scripts` to `npm install`.
- **tc16 verdict regex matched the prompt itself** — original prompt literally contained "Bullish/Bearish/Neutral"; if meshctl ever echoed the request payload back the verdict would PASS without Claude calling the tool. Removed the literal hint from the prompt.
- **tc04 head -1 stale tarball** — switched to `ls -t | head -1` (newest by mtime) + warn loudly when count > 1.
- **tc11 DATA_COUNT default** — `DATA_COUNT=${DATA_COUNT:-0}` guards against an empty grep result crashing the numeric comparison.

Skipped (not actionable in this PR): tc18 diagnostic logging on slow path (cosmetic), tc16 imperative-prompt-may-cause-refusal (theoretical — rerun PASSED), tc02a cargo-target sharing (verified isolated), tc13/tc16 wait→poll (stylistic).

## Out of scope

Not addressed in this PR — separate follow-ups if needed:

- uc05/tc23_watch_java_greet and uc05/tc30_watch_mixed_single_start: passed on rerun; if persistent, the SDK fork-barrier in `src/core/cli/start_execution.go:853` (currently hardcoded 180s) would need a bump to ~300s to support cold-cache Java starts in 3-agent single-command flows.
- Splitting tc04a into separate Rust-FFI + Java-SDK tests for further wall-clock savings.

Closes #856
Closes #857

## Test plan

- [x] All 5 fixed integration tests verified passing on local rerun
- [x] tc04 perf change verified locally — DAG correctly orders tc02a → tc04
- [x] tc02a Wave 2 promotion verified locally — tc02a turns ⟳ alongside tc02
- [ ] CI src-tests + integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased timeouts for agent registration test scenarios to accommodate startup times and credential initialization.
  * Enhanced parallel tool execution validation with deterministic verification logic.
  * Improved multi-chunk streaming test verification.
  * Reorganized build test dependencies to enable parallel execution and leverage pre-built artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->