### PR TITLE
feature: native OpenAI SDK for @mesh.llm_provider (#834 partial)

### DIFF
--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -42,6 +42,13 @@ requires-python = ">=3.11"
 # dispatch through the native anthropic SDK; without the SDK they would
 # silently fall back to LiteLLM. Heavy backend extras (boto3 for Bedrock)
 # stay opt-in via the [anthropic-bedrock] extra.
+#
+# openai SDK is included by default for native OpenAI dispatch (issue #834
+# PR 2). When MCP_MESH_NATIVE_LLM is unset (default ON), OpenAI provider
+# agents dispatch through the native openai SDK; without it they would
+# silently fall back to LiteLLM. (openai is also a transitive dep of
+# litellm today; promoting to a direct base dep prevents breakage if
+# litellm ever drops it as transitive.)
 dependencies = [
     # Rust core runtime (required - no Python fallback)
     "mcp-mesh-core>=1.4.1",
@@ -59,6 +66,7 @@ dependencies = [
     "fastmcp>=3.0.0,<4.0.0",
     "litellm>=1.80.5,!=1.82.7,!=1.82.8",
     "anthropic>=0.42",
+    "openai>=1.60",
     "prometheus-client>=0.19.0,<1.0.0",
     "pyyaml>=6.0,<7.0",
     "jinja2>=3.1.0",
@@ -107,6 +115,12 @@ anthropic-bedrock = [
     # using ``bedrock/anthropic.claude-*`` model strings. Opt-in because
     # boto3 is a heavy dependency.
     "anthropic[bedrock]>=0.42"
+]
+openai = [
+    # Backward-compat alias: ``openai`` is now a base dependency (issue
+    # #834 PR 2). This entry is kept so existing ``pip install mcp-mesh[openai]``
+    # commands continue to work without error.
+    "openai>=1.60"
 ]
 
 [project.urls]

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -1,0 +1,748 @@
+"""Native OpenAI SDK adapter for the @mesh.llm_provider invocation layer.
+
+Adapts ``openai.AsyncOpenAI`` to the same _Response/_StreamChunk shape
+contract that mesh's agentic loop in helpers.py expects (mirrors
+litellm.completion()'s shape via mesh_llm_agent._MockResponse, and matches
+the anthropic_native adapter introduced in PR 1 of issue #834).
+
+Design notes:
+  * Module-level functions, not a class — keeps the adapter functional and
+    avoids state that could leak across requests.
+  * Lazy import of ``openai`` inside every function so importing this
+    module never fails when the SDK is absent.
+  * Lazy ``AsyncOpenAI`` wrapper construction per-call (the wrapper itself
+    is NOT cached) — required for K8s secret rotation: ``api_key`` is
+    re-read every time we build a client. The underlying ``httpx``
+    connection pool IS cached process-wide via ``_get_shared_httpx_client``
+    so TLS handshakes and HTTP/2 sessions are reused across calls.
+  * Backend selection by model prefix: ``openai/*`` → ``AsyncOpenAI`` (with
+    optional custom base_url for OpenAI-compatible providers like Databricks).
+    Future ``azure/*`` and explicit ``databricks/openai-*`` prefixes are
+    out of scope for this PR.
+  * Translation overhead is minimal vs. the Anthropic adapter — OpenAI's
+    wire shape IS what mesh emits internally (litellm uses OpenAI shape
+    too). Mostly passthrough.
+
+Out of scope (PR 2 of issue #834):
+  * AsyncAzureOpenAI backend (different ctor: azure_endpoint, api_version).
+  * Reasoning-token breakdown for o1/o3 models (passthrough only here).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Model prefixes that route through this adapter.
+_OPENAI_PREFIX = "openai/"
+
+
+# ---------------------------------------------------------------------------
+# Shared httpx connection pool (issue #834 perf fix)
+# ---------------------------------------------------------------------------
+# A single ``httpx.AsyncClient`` is reused across all native OpenAI calls in
+# this process. ``openai.AsyncOpenAI`` accepts ``http_client=`` and uses the
+# supplied client (and its connection pool) instead of constructing a fresh
+# one per call. This eliminates ~150-300ms per-call TLS+H2 setup overhead
+# vs. LiteLLM (which does its own pool reuse).
+#
+# K8s secret rotation still works because the api_key is still read fresh
+# per call by callers and forwarded to the per-call ``AsyncOpenAI`` wrapper
+# — the pool itself carries no credential state, only TCP/TLS connections.
+_CACHED_HTTPX_CLIENT: httpx.AsyncClient | None = None
+# Guards lazy-init / rebuild of the shared httpx client. The pool itself is
+# safe for concurrent use; the lock only protects the check-then-create race
+# at construction. Cheap (uncontended after first call) and correct under
+# threaded harnesses (tests, sync wrapper paths) that touch the cache.
+_CACHED_HTTPX_CLIENT_LOCK = threading.Lock()
+
+
+def _get_shared_httpx_client() -> httpx.AsyncClient:
+    """Lazily construct (or rebuild if closed) the shared httpx client.
+
+    Single connection pool shared across all native OpenAI calls in this
+    process. Per-call ``AsyncOpenAI`` wrappers reuse this pool —
+    eliminating ~150-300ms per-call TLS+H2 setup overhead. K8s secret
+    rotation still works: ``api_key`` is read fresh per call; the pool
+    carries no credential state.
+    """
+    global _CACHED_HTTPX_CLIENT
+    # Fast path — no lock when the cached client is healthy. The check is
+    # benign-racy (worst case: two threads both observe None and both enter
+    # the lock; the second one finds the cache populated under the lock and
+    # returns early).
+    if _CACHED_HTTPX_CLIENT is not None and not _CACHED_HTTPX_CLIENT.is_closed:
+        return _CACHED_HTTPX_CLIENT
+    with _CACHED_HTTPX_CLIENT_LOCK:
+        if _CACHED_HTTPX_CLIENT is None or _CACHED_HTTPX_CLIENT.is_closed:
+            _CACHED_HTTPX_CLIENT = httpx.AsyncClient(
+                timeout=httpx.Timeout(
+                    connect=10.0,  # connection establishment
+                    read=600.0,    # body read — LLM responses can be slow
+                    write=30.0,    # request body write
+                    pool=5.0,      # waiting for free connection from pool
+                ),
+                limits=httpx.Limits(
+                    max_keepalive_connections=20,
+                    max_connections=100,
+                    keepalive_expiry=30.0,
+                ),
+            )
+        return _CACHED_HTTPX_CLIENT
+
+
+def _reset_shared_httpx_client() -> None:
+    """For tests — reset the cached client. NOT for production use."""
+    global _CACHED_HTTPX_CLIENT
+    with _CACHED_HTTPX_CLIENT_LOCK:
+        _CACHED_HTTPX_CLIENT = None
+
+
+# ---------------------------------------------------------------------------
+# litellm-shaped response objects
+# ---------------------------------------------------------------------------
+# These mirror _MockResponse / _MockMessage / _MockChoice / _MockUsage in
+# ``_mcp_mesh.engine.mesh_llm_agent`` (and the corresponding shapes in
+# ``anthropic_native``). Kept independent here so this module does not
+# import from mesh_llm_agent (avoids circular imports through the
+# provider_handlers package).
+
+
+class _Function:
+    __slots__ = ("name", "arguments")
+
+    def __init__(self, name: str, arguments: str):
+        self.name = name
+        self.arguments = arguments
+
+
+class _ToolCall:
+    __slots__ = ("id", "type", "function")
+
+    def __init__(self, id: str, name: str, arguments: str):
+        self.id = id
+        self.type = "function"
+        self.function = _Function(name=name, arguments=arguments)
+
+
+class _Message:
+    __slots__ = ("content", "role", "tool_calls")
+
+    def __init__(
+        self,
+        content: str | None,
+        role: str = "assistant",
+        tool_calls: list[_ToolCall] | None = None,
+    ):
+        self.content = content
+        self.role = role
+        self.tool_calls = tool_calls or None
+
+
+class _Choice:
+    __slots__ = ("message", "finish_reason", "index")
+
+    def __init__(self, message: _Message, finish_reason: str = "stop"):
+        self.message = message
+        self.finish_reason = finish_reason
+        self.index = 0
+
+
+class _Usage:
+    __slots__ = ("prompt_tokens", "completion_tokens", "total_tokens")
+
+    def __init__(self, prompt_tokens: int, completion_tokens: int):
+        self.prompt_tokens = prompt_tokens or 0
+        self.completion_tokens = completion_tokens or 0
+        self.total_tokens = (prompt_tokens or 0) + (completion_tokens or 0)
+
+
+class _Response:
+    __slots__ = ("choices", "usage", "model")
+
+    def __init__(
+        self,
+        message: _Message,
+        usage: _Usage | None,
+        model: str | None,
+        finish_reason: str = "stop",
+    ):
+        self.choices = [_Choice(message, finish_reason=finish_reason)]
+        self.usage = usage
+        self.model = model
+
+
+# ---------------------------------------------------------------------------
+# litellm-shaped streaming chunk objects
+# ---------------------------------------------------------------------------
+
+
+class _Delta:
+    __slots__ = ("content", "tool_calls", "role")
+
+    def __init__(
+        self,
+        content: str | None = None,
+        tool_calls: list[Any] | None = None,
+        role: str | None = None,
+    ):
+        self.content = content
+        self.tool_calls = tool_calls
+        self.role = role
+
+
+class _StreamChoice:
+    __slots__ = ("delta", "index", "finish_reason")
+
+    def __init__(
+        self,
+        delta: _Delta,
+        index: int = 0,
+        finish_reason: str | None = None,
+    ):
+        self.delta = delta
+        self.index = index
+        self.finish_reason = finish_reason
+
+
+class _StreamChunk:
+    __slots__ = ("choices", "usage", "model")
+
+    def __init__(
+        self,
+        delta: _Delta,
+        usage: _Usage | None = None,
+        model: str | None = None,
+        finish_reason: str | None = None,
+    ):
+        self.choices = [_StreamChoice(delta, finish_reason=finish_reason)]
+        self.usage = usage
+        self.model = model
+
+
+class _StreamFunctionDelta:
+    __slots__ = ("name", "arguments")
+
+    def __init__(self, name: str | None = None, arguments: str | None = None):
+        self.name = name
+        self.arguments = arguments
+
+
+class _StreamToolCallDelta:
+    """Tool-call fragment matching litellm's streamed tool_call shape.
+
+    ``MeshLlmAgent._merge_streamed_tool_calls`` reads ``index``, ``id``,
+    ``type``, and ``function.name`` / ``function.arguments`` off these
+    deltas. OpenAI's wire shape already mirrors this; the adapter just
+    extracts the fields and re-emits them through this slot-based wrapper
+    so the merger sees identical attribute access on every backend.
+    """
+
+    __slots__ = ("index", "id", "type", "function")
+
+    def __init__(
+        self,
+        index: int,
+        id: str | None = None,
+        type: str | None = None,
+        name: str | None = None,
+        arguments: str | None = None,
+    ):
+        self.index = index
+        self.id = id
+        # OpenAI populates ``type`` only on the first chunk (along with id).
+        # Subsequent argument fragments carry id=None and type=None — match
+        # that pattern so the merger's "set if non-None" logic works
+        # correctly.
+        self.type = type if type is not None else ("function" if id is not None else None)
+        self.function = _StreamFunctionDelta(name=name, arguments=arguments)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+_IS_AVAILABLE_CACHE: bool | None = None
+
+
+def is_available() -> bool:
+    """True if the ``openai`` SDK is importable in this process.
+
+    Result is cached after the first probe — the SDK presence does not
+    change at runtime, and the import-then-immediately-discard pattern
+    showed up as needless overhead on the dispatch-decision hot path in
+    PR 1 (anthropic_native) so the same caching is applied here.
+    """
+    global _IS_AVAILABLE_CACHE
+    if _IS_AVAILABLE_CACHE is not None:
+        return _IS_AVAILABLE_CACHE
+    try:
+        import openai  # noqa: F401
+    except ImportError:
+        _IS_AVAILABLE_CACHE = False
+        return False
+    _IS_AVAILABLE_CACHE = True
+    return True
+
+
+def _reset_is_available_cache() -> None:
+    """For tests — reset the cached availability probe. NOT for production."""
+    global _IS_AVAILABLE_CACHE
+    _IS_AVAILABLE_CACHE = None
+
+
+def supports_model(model: str) -> bool:
+    """True if ``model`` routes to the OpenAI SDK.
+
+    Matches:
+      * ``openai/<name>`` (OpenAI direct, or OpenAI-compatible via base_url).
+
+    Future prefixes (``azure/*``, explicit ``databricks/openai-*``) are
+    deferred to a follow-up PR.
+    """
+    if not model:
+        return False
+    if model.startswith(_OPENAI_PREFIX):
+        return True
+    return False
+
+
+def _strip_prefix(model: str) -> str:
+    """Return the bare OpenAI model id for the SDK call.
+
+    ``openai/gpt-4o`` → ``gpt-4o``
+    ``openai/gpt-4o-mini`` → ``gpt-4o-mini``
+    """
+    if model.startswith(_OPENAI_PREFIX):
+        return model[len(_OPENAI_PREFIX):]
+    return model
+
+
+def _build_client(
+    model: str,
+    api_key: str | None,
+    base_url: str | None,
+):
+    """Construct the AsyncOpenAI client with the shared httpx pool.
+
+    The ``AsyncOpenAI`` wrapper is built fresh on every call (no caching of
+    the wrapper itself) so K8s secret rotation works: callers re-read the
+    api_key from env each request. The wrapper, however, is given the
+    process-wide shared ``httpx.AsyncClient`` so the underlying connection
+    pool (and its already-established TLS sessions) is reused across calls.
+
+    Validates credentials upfront — without this, a missing key surfaces as
+    an opaque late 401 from openai.chat.completions.create which is harder
+    to debug.
+    """
+    # Validate credentials upfront. ``model`` is unused by the validator
+    # today but keeps the signature symmetric with anthropic_native and
+    # leaves room for backend-specific routing (Azure, Databricks) later.
+    if not api_key and not os.environ.get("OPENAI_API_KEY"):
+        raise ValueError(
+            "Native OpenAI dispatch requires OPENAI_API_KEY env var or "
+            "explicit api_key argument. Set OPENAI_API_KEY or pass api_key= "
+            "to @mesh.llm_provider, or set MCP_MESH_NATIVE_LLM=0 to fall "
+            "back to LiteLLM."
+        )
+
+    import openai
+
+    kwargs: dict[str, Any] = {"http_client": _get_shared_httpx_client()}
+    if api_key:
+        kwargs["api_key"] = api_key
+    if base_url:
+        kwargs["base_url"] = base_url
+    return openai.AsyncOpenAI(**kwargs)
+
+
+# OpenAI's chat.completions.create accepts a wide kwarg set; passthrough
+# most things. Anything not in this set (and not in _OPENAI_HANDLED_KWARGS)
+# triggers the once-per-key WARN so the next litellm-only knob we forget
+# to translate is visible early.
+_OPENAI_PASSTHROUGH_KWARGS = frozenset({
+    "messages",
+    "tools",
+    "tool_choice",
+    "max_tokens",
+    "max_completion_tokens",
+    "temperature",
+    "top_p",
+    "n",
+    "stop",
+    "presence_penalty",
+    "frequency_penalty",
+    "logit_bias",
+    "user",
+    "seed",
+    "response_format",
+    "logprobs",
+    "top_logprobs",
+    "parallel_tool_calls",
+    "extra_headers",
+    "extra_query",
+    "extra_body",
+    "timeout",
+    # o1/o3 reasoning models:
+    "reasoning_effort",
+    # Streaming options (the adapter sets include_usage itself but a
+    # caller-provided stream_options is also forwarded after merge):
+    "stream_options",
+})
+
+# Keys explicitly handled (consumed or routed) inside this adapter — the
+# WARN filter must not flag these as "dropped".
+_OPENAI_HANDLED_KWARGS = frozenset({
+    "model",
+    "api_key",
+    "base_url",
+    "stream",
+})
+
+
+def _build_create_kwargs(
+    request_params: dict[str, Any],
+    *,
+    model: str,
+) -> dict[str, Any]:
+    """Translate mesh/litellm-shape request_params → openai SDK kwargs.
+
+    For OpenAI this is mostly passthrough — the wire shape is identical
+    (litellm uses OpenAI shape internally). The adapter:
+      * Strips the ``openai/`` model prefix.
+      * Forwards every kwarg in :data:`_OPENAI_PASSTHROUGH_KWARGS` whose
+        value is not None.
+      * WARN-once on any kwarg that is neither in the passthrough set nor
+        explicitly handled (mirrors anthropic_native — catches the next
+        litellm-only knob we forget).
+
+    OpenAI does NOT require ``max_tokens`` (unlike Anthropic), so an
+    explicit ``max_tokens=None`` simply omits the kwarg. ``max_completion_tokens``
+    is the newer field for o1/o3 reasoning models — both are accepted by
+    the OpenAI SDK; the adapter forwards whichever the caller supplied.
+    """
+    create_kwargs: dict[str, Any] = {"model": _strip_prefix(model)}
+
+    for key in _OPENAI_PASSTHROUGH_KWARGS:
+        value = request_params.get(key)
+        # Drop None values — OpenAI rejects ``max_tokens=None`` etc., and
+        # leaving them out matches the "unset → SDK default" semantics that
+        # callers expect.
+        if value is None:
+            continue
+        if key not in request_params:
+            continue
+        create_kwargs[key] = value
+
+    # WARN-log any kwargs the adapter is silently dropping. This catches the
+    # next litellm-only knob we forget to allow-list. Internal mesh markers
+    # (``_mesh_*``) are not forwarded but should also not warn — they're
+    # handled upstream in helpers._pop_mesh_*_flags. Dedupe per-key so
+    # high-volume providers receiving the same litellm-only kwarg every
+    # request don't flood the log.
+    for k in request_params:
+        if k.startswith("_mesh_"):
+            continue
+        if k in _OPENAI_PASSTHROUGH_KWARGS:
+            continue
+        if k in _OPENAI_HANDLED_KWARGS:
+            continue
+        _warn_unsupported_kwarg_once(k)
+
+    return create_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Response / chunk adaptation
+# ---------------------------------------------------------------------------
+
+
+def _adapt_response(raw: Any) -> _Response:
+    """Translate openai.ChatCompletion → litellm-shape ``_Response``.
+
+    The OpenAI SDK already returns Pydantic models that closely match the
+    mesh-internal shape, but downstream callers in ``helpers.py`` and
+    ``mesh_llm_agent`` rely on attribute access patterns that include
+    fields the OpenAI SDK doesn't always populate (e.g. ``message.role``
+    on tool-only responses). We unpack into our own slot-based shapes so
+    the contract is enforced uniformly across vendor backends.
+    """
+    choices = getattr(raw, "choices", None) or []
+    first_choice = choices[0] if choices else None
+
+    text: str | None = None
+    tool_calls: list[_ToolCall] = []
+    finish_reason: str = "stop"
+
+    if first_choice is not None:
+        msg = getattr(first_choice, "message", None)
+        if msg is not None:
+            text = getattr(msg, "content", None)
+            raw_tool_calls = getattr(msg, "tool_calls", None) or []
+            for tc in raw_tool_calls:
+                tc_id = getattr(tc, "id", "") or ""
+                fn = getattr(tc, "function", None)
+                tc_name = getattr(fn, "name", "") if fn is not None else ""
+                tc_args = getattr(fn, "arguments", "") if fn is not None else ""
+                # OpenAI returns arguments already as a JSON string.
+                if not isinstance(tc_args, str):
+                    try:
+                        tc_args = json.dumps(tc_args)
+                    except (TypeError, ValueError):
+                        tc_args = "{}"
+                tool_calls.append(
+                    _ToolCall(id=tc_id, name=tc_name or "", arguments=tc_args or "")
+                )
+        finish_reason = getattr(first_choice, "finish_reason", None) or "stop"
+
+    message = _Message(
+        content=text,
+        role="assistant",
+        tool_calls=tool_calls or None,
+    )
+
+    usage_obj = getattr(raw, "usage", None)
+    if usage_obj is not None:
+        usage = _Usage(
+            prompt_tokens=getattr(usage_obj, "prompt_tokens", 0) or 0,
+            completion_tokens=getattr(usage_obj, "completion_tokens", 0) or 0,
+        )
+    else:
+        usage = None
+
+    return _Response(
+        message=message,
+        usage=usage,
+        model=getattr(raw, "model", None),
+        finish_reason=finish_reason,
+    )
+
+
+def _adapt_chunk(raw: Any) -> _StreamChunk:
+    """Translate openai.ChatCompletionChunk → litellm-shape ``_StreamChunk``.
+
+    OpenAI streams emit:
+      * Per content delta: ``raw.choices[0].delta.content`` populated with
+        the new text fragment.
+      * Per tool-call delta: ``raw.choices[0].delta.tool_calls`` populated
+        with one ``ChoiceDeltaToolCall`` per call (id+type+function.name on
+        the first chunk, function.arguments on subsequent chunks).
+      * Final chunk (only when ``stream_options.include_usage=True``):
+        ``raw.usage`` populated with the cumulative token counts and
+        ``raw.choices`` empty.
+    """
+    choices = getattr(raw, "choices", None) or []
+    first_choice = choices[0] if choices else None
+
+    content: str | None = None
+    tool_call_deltas: list[_StreamToolCallDelta] | None = None
+    finish_reason: str | None = None
+
+    if first_choice is not None:
+        delta = getattr(first_choice, "delta", None)
+        if delta is not None:
+            content = getattr(delta, "content", None)
+            raw_tcs = getattr(delta, "tool_calls", None) or []
+            if raw_tcs:
+                tool_call_deltas = []
+                for tc in raw_tcs:
+                    fn = getattr(tc, "function", None)
+                    tool_call_deltas.append(
+                        _StreamToolCallDelta(
+                            index=getattr(tc, "index", 0) or 0,
+                            id=getattr(tc, "id", None),
+                            type=getattr(tc, "type", None),
+                            name=getattr(fn, "name", None) if fn is not None else None,
+                            arguments=(
+                                getattr(fn, "arguments", None) if fn is not None else None
+                            ),
+                        )
+                    )
+        finish_reason = getattr(first_choice, "finish_reason", None)
+
+    usage_obj = getattr(raw, "usage", None)
+    usage: _Usage | None = None
+    if usage_obj is not None:
+        usage = _Usage(
+            prompt_tokens=getattr(usage_obj, "prompt_tokens", 0) or 0,
+            completion_tokens=getattr(usage_obj, "completion_tokens", 0) or 0,
+        )
+
+    return _StreamChunk(
+        delta=_Delta(content=content, tool_calls=tool_call_deltas),
+        usage=usage,
+        model=getattr(raw, "model", None),
+        finish_reason=finish_reason,
+    )
+
+
+async def complete(
+    request_params: dict[str, Any],
+    *,
+    model: str,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> _Response:
+    """Run a buffered OpenAI completion and adapt to litellm-shape response."""
+    client = _build_client(model, api_key, base_url)
+    create_kwargs = _build_create_kwargs(request_params, model=model)
+    raw = await client.chat.completions.create(**create_kwargs)
+    return _adapt_response(raw)
+
+
+async def complete_stream(
+    request_params: dict[str, Any],
+    *,
+    model: str,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> AsyncIterator[Any]:
+    """Stream an OpenAI completion as litellm-shape chunks.
+
+    OpenAI's SDK exposes streaming via ``await client.chat.completions.create(
+    stream=True)`` which returns an ``AsyncStream[ChatCompletionChunk]``.
+    The adapter forces ``stream_options.include_usage=True`` so the final
+    chunk carries the authoritative usage tally (matches LiteLLM's
+    behavior when callers set ``stream_options.include_usage=True``).
+
+    Best-effort usage emission: if the stream is interrupted before the
+    final usage chunk arrives (server cutoff, consumer aclose, network
+    drop), the ``finally`` block emits a fallback usage chunk built from
+    the last counters we observed so telemetry doesn't silently record
+    0 tokens for partial generations.
+    """
+    client = _build_client(model, api_key, base_url)
+    create_kwargs = _build_create_kwargs(request_params, model=model)
+    create_kwargs["stream"] = True
+
+    # Force include_usage so the final chunk carries usage. Merge with any
+    # caller-supplied stream_options (don't clobber other knobs like
+    # ``include_usage`` set explicitly by helpers.py).
+    existing_opts = create_kwargs.get("stream_options") or {}
+    create_kwargs["stream_options"] = {**existing_opts, "include_usage": True}
+
+    # Track usage for finally-block fallback (telemetry integrity if stream
+    # is interrupted — same pattern as anthropic_native).
+    last_input_tokens = 0
+    last_output_tokens = 0
+    last_model: str | None = _strip_prefix(model)
+    # Tracks whether the authoritative final-usage chunk has been
+    # successfully yielded to the consumer. Set to True ONLY after the
+    # yield returns — so any failure mode (stream raises, consumer cancels
+    # mid-yield) leaves it False and the ``finally`` block emits the
+    # best-effort fallback. Setting it BEFORE the yield would create a
+    # telemetry hole: usage was observed but the chunk never reached the
+    # consumer, yet the fallback would be skipped.
+    final_usage_emitted = False
+
+    try:
+        # OpenAI returns an AsyncStream of ChatCompletionChunk. ``create``
+        # is itself an awaitable that returns the stream object, hence the
+        # ``await`` before ``async for``.
+        stream = await client.chat.completions.create(**create_kwargs)
+        async for raw_chunk in stream:
+            chunk = _adapt_chunk(raw_chunk)
+            if chunk.model:
+                last_model = chunk.model
+            if chunk.usage is not None:
+                last_input_tokens = chunk.usage.prompt_tokens
+                last_output_tokens = chunk.usage.completion_tokens
+                yield chunk
+                final_usage_emitted = True
+                continue
+            yield chunk
+    finally:
+        # If the authoritative final-usage chunk was never delivered to the
+        # consumer (server cutoff, consumer cancelled mid-yield, network
+        # drop, etc.), emit a best-effort usage chunk built from the last
+        # counters we observed. Otherwise telemetry would silently record
+        # zero tokens for any interrupted stream — masking real cost on
+        # partial generations.
+        if not final_usage_emitted and (last_input_tokens or last_output_tokens):
+            try:
+                yield _StreamChunk(
+                    delta=_Delta(),
+                    usage=_Usage(
+                        prompt_tokens=last_input_tokens,
+                        completion_tokens=last_output_tokens,
+                    ),
+                    model=last_model,
+                )
+            except (GeneratorExit, StopAsyncIteration):
+                # The consumer has already called ``aclose()`` on this async
+                # generator, so executing ``yield`` inside ``finally`` raises
+                # GeneratorExit (or in rare cases StopAsyncIteration). Python
+                # forbids re-raising during finally cleanup — and there's
+                # nowhere to deliver the fallback usage chunk anyway. Swallow
+                # silently and let normal generator teardown proceed.
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Fallback-logging helpers
+# ---------------------------------------------------------------------------
+
+_logged_fallback_once = False
+
+
+def log_fallback_once() -> None:
+    """Emit the LiteLLM-fallback notice exactly once per process.
+
+    Called from the dispatch sites in ``OpenAIHandler.has_native()`` when
+    native dispatch was attempted (the default) but the ``openai`` SDK is
+    not importable. In normal installs the SDK is a base dep so this
+    branch should never fire — kept for symmetry with the Anthropic path
+    and to guard against custom installs that strip the SDK.
+    """
+    global _logged_fallback_once
+    if _logged_fallback_once:
+        return
+    _logged_fallback_once = True
+    logger.info(
+        "Install `mcp-mesh[openai]` for native SDK with full feature "
+        "support — falling back to LiteLLM"
+    )
+
+
+def is_fallback_logged() -> bool:
+    """True once :func:`log_fallback_once` has emitted its notice.
+
+    Lets callers (notably ``OpenAIHandler.has_native``) skip the call entirely
+    on the hot path after the first miss — avoids one function-frame per
+    request once we've already published the install nudge.
+    """
+    return _logged_fallback_once
+
+
+# Module-level dedupe set for the unsupported-kwarg WARN. WARN once per
+# unique kwarg name across the lifetime of the process — high-volume
+# providers receiving the same litellm-only kwarg every request would
+# otherwise flood the log with identical messages (unbounded growth
+# pre-fix).
+_logged_unsupported_kwargs: set[str] = set()
+
+
+def _warn_unsupported_kwarg_once(key: str) -> None:
+    """WARN once per unique unsupported kwarg name.
+
+    Used by ``_build_create_kwargs`` to surface litellm-only knobs the
+    adapter is silently dropping (or new fields the OpenAI SDK doesn't
+    accept yet) without logging on every single request.
+    """
+    if key in _logged_unsupported_kwargs:
+        return
+    _logged_unsupported_kwargs.add(key)
+    logger.warning(
+        "Native OpenAI adapter dropping unsupported kwarg: '%s' "
+        "(LiteLLM-only — not forwarded to openai.chat.completions.create)",
+        key,
+    )

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -369,6 +369,12 @@ def _build_client(
 # most things. Anything not in this set (and not in _OPENAI_HANDLED_KWARGS)
 # triggers the once-per-key WARN so the next litellm-only knob we forget
 # to translate is visible early.
+# Note on ``tool_choice``: OpenAI natively supports tool_choice values
+# "auto", "none", "required", and {"type": "function", "function": {"name":
+# "..."}}. We pass through unchanged — no translation needed (unlike
+# Anthropic, which lacks a native "none" semantics and requires us to
+# translate "auto"/"any"/"none" + the {"type": "function", ...} dict shape;
+# see anthropic_native._build_create_kwargs for that mapping).
 _OPENAI_PASSTHROUGH_KWARGS = frozenset({
     "messages",
     "tools",
@@ -436,10 +442,9 @@ def _build_create_kwargs(
         value = request_params.get(key)
         # Drop None values — OpenAI rejects ``max_tokens=None`` etc., and
         # leaving them out matches the "unset → SDK default" semantics that
-        # callers expect.
+        # callers expect. (``request_params.get`` already returns None for
+        # missing keys, so the absence check collapses into the value check.)
         if value is None:
-            continue
-        if key not in request_params:
             continue
         create_kwargs[key] = value
 

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
@@ -1,0 +1,1333 @@
+"""Unit tests for the native OpenAI SDK adapter (issue #834 PR 2).
+
+Covers:
+  * is_available() reflects ImportError of the SDK and caches the probe
+  * supports_model() matches the openai/* prefix
+  * _strip_prefix() correctness
+  * _build_client() constructs AsyncOpenAI with shared httpx + api_key/base_url
+  * _build_client() raises ValueError when api_key/env both unset
+  * _build_create_kwargs() passes through OpenAI-shaped knobs and warns on
+    unrecognized litellm-only kwargs (per-key dedupe)
+  * _build_create_kwargs() handles explicit max_tokens=None (drops the key
+    instead of forwarding it as None — OpenAI rejects None)
+  * complete() adapts OpenAI ChatCompletion → litellm-shape _Response
+    (text + tool_calls + usage)
+  * complete_stream() yields chunks matching the shape consumed by
+    mesh.helpers._provider_agentic_loop_stream
+  * complete_stream() forces stream_options.include_usage=True
+  * complete_stream() emits best-effort usage chunk on stream interruption
+  * complete_stream() swallows GeneratorExit/StopAsyncIteration on
+    consumer-aborted teardown
+  * Shared httpx client reused across calls (identity)
+  * is_fallback_logged() tracks log_fallback_once() state
+
+Real network calls are mocked.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip(
+    "openai", reason="native OpenAI adapter requires the openai SDK"
+)
+
+from _mcp_mesh.engine.native_clients import openai_native
+
+
+# ---------------------------------------------------------------------------
+# is_available()
+# ---------------------------------------------------------------------------
+
+
+class TestIsAvailable:
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self):
+        """is_available() caches its result module-wide; reset between tests
+        in this class so each one re-probes the import."""
+        openai_native._reset_is_available_cache()
+        yield
+        openai_native._reset_is_available_cache()
+
+    def test_returns_true_when_sdk_importable(self):
+        # The SDK is installed in the test environment; this should be True.
+        assert openai_native.is_available() is True
+
+    def test_returns_false_when_import_fails(self, monkeypatch):
+        """Simulate the SDK being absent by stubbing __import__ to raise."""
+        original_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "openai":
+                raise ImportError("No module named 'openai'")
+            return original_import(name, *args, **kwargs)
+
+        # Drop the cached module so the function re-evaluates the import.
+        monkeypatch.delitem(sys.modules, "openai", raising=False)
+        with patch("builtins.__import__", side_effect=_fake_import):
+            assert openai_native.is_available() is False
+
+    def test_caches_result_across_calls(self):
+        """Once probed, is_available() must not re-import on every call —
+        the SDK presence does not change at runtime and the per-call import
+        was showing up as needless overhead on the dispatch-decision path.
+        """
+        original_import = builtins.__import__
+        call_count = {"n": 0}
+
+        def _counting_import(name, *args, **kwargs):
+            if name == "openai":
+                call_count["n"] += 1
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=_counting_import):
+            openai_native.is_available()
+            openai_native.is_available()
+            openai_native.is_available()
+
+        # Exactly one import attempt across three calls.
+        assert call_count["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# supports_model() and _strip_prefix()
+# ---------------------------------------------------------------------------
+
+
+class TestSupportsModel:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "openai/gpt-4o",
+            "openai/gpt-4o-mini",
+            "openai/gpt-4-turbo",
+            "openai/o1-preview",
+            "openai/o3-mini",
+        ],
+    )
+    def test_supported_prefixes(self, model):
+        assert openai_native.supports_model(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "anthropic/claude-sonnet-4-5",
+            "gemini/gemini-1.5-pro",
+            "vertex_ai/gemini-1.5-pro",
+            "bedrock/amazon.titan-text-express-v1",
+            "azure/gpt-4o",  # Azure routing deferred to follow-up PR
+            "gpt-4o",  # bare, no prefix
+            "",
+            None,
+        ],
+    )
+    def test_unsupported(self, model):
+        assert openai_native.supports_model(model or "") is False
+
+
+class TestStripPrefix:
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("openai/gpt-4o", "gpt-4o"),
+            ("openai/gpt-4o-mini", "gpt-4o-mini"),
+            ("openai/o1-preview", "o1-preview"),
+            ("gpt-4o", "gpt-4o"),  # bare, no-op
+        ],
+    )
+    def test_strip_prefix(self, model, expected):
+        assert openai_native._strip_prefix(model) == expected
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across complete() tests
+# ---------------------------------------------------------------------------
+
+
+def _make_openai_completion(
+    *,
+    text: str | None = None,
+    tool_calls: list[dict] | None = None,
+    model: str = "gpt-4o-mini",
+    prompt_tokens: int = 12,
+    completion_tokens: int = 7,
+    finish_reason: str = "stop",
+):
+    """Build a fake openai.ChatCompletion-like object for complete() tests."""
+    raw_tool_calls = []
+    for tc in tool_calls or []:
+        raw_tool_calls.append(
+            SimpleNamespace(
+                id=tc["id"],
+                type="function",
+                function=SimpleNamespace(
+                    name=tc["name"],
+                    arguments=tc.get("arguments", "{}"),
+                ),
+            )
+        )
+    message = SimpleNamespace(
+        role="assistant",
+        content=text,
+        tool_calls=raw_tool_calls or None,
+    )
+    choice = SimpleNamespace(
+        index=0,
+        message=message,
+        finish_reason=finish_reason,
+    )
+    usage = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+    return SimpleNamespace(choices=[choice], usage=usage, model=model)
+
+
+def _patched_async_openai(api_response):
+    """Return (cls_mock, create_mock, instance_mock).
+
+    Patches openai.AsyncOpenAI so its instance has a
+    ``.chat.completions.create`` AsyncMock returning ``api_response``.
+    """
+    instance = MagicMock()
+    create_mock = AsyncMock(return_value=api_response)
+    instance.chat = MagicMock()
+    instance.chat.completions = MagicMock()
+    instance.chat.completions.create = create_mock
+    cls_mock = MagicMock(return_value=instance)
+    return cls_mock, create_mock, instance
+
+
+# ---------------------------------------------------------------------------
+# complete() — request shaping
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteRequestShape:
+    @pytest.mark.asyncio
+    async def test_strips_model_prefix(self):
+        cls_mock, create_mock, _ = _patched_async_openai(
+            _make_openai_completion(text="hi")
+        )
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {"messages": [{"role": "user", "content": "Hi."}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        kwargs = create_mock.call_args.kwargs
+        assert kwargs["model"] == "gpt-4o-mini"
+
+    @pytest.mark.asyncio
+    async def test_passes_through_messages_unchanged(self):
+        """OpenAI's wire shape == mesh-internal shape; messages forward
+        verbatim (no system extraction, no role translation, no image
+        translation)."""
+        cls_mock, create_mock, _ = _patched_async_openai(
+            _make_openai_completion(text="hi")
+        )
+        original_messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hi."},
+        ]
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {"messages": original_messages},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        kwargs = create_mock.call_args.kwargs
+        # System message stays in the messages array — OpenAI accepts it
+        # there (unlike Anthropic which needs system= as a separate kwarg).
+        assert kwargs["messages"] == original_messages
+
+    @pytest.mark.asyncio
+    async def test_passes_through_tools_unchanged(self):
+        """OpenAI tools shape IS the mesh-internal tools shape — passthrough."""
+        cls_mock, create_mock, _ = _patched_async_openai(
+            _make_openai_completion(text="ok")
+        )
+        openai_tool = {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Look up weather.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "tools": [openai_tool],
+                },
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        kwargs = create_mock.call_args.kwargs
+        assert kwargs["tools"] == [openai_tool]
+
+    @pytest.mark.asyncio
+    async def test_passes_through_tool_choice_strings(self):
+        """OpenAI accepts "auto" / "none" / "required" natively — passthrough."""
+        cls_mock, create_mock, _ = _patched_async_openai(
+            _make_openai_completion(text="ok")
+        )
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "tool_choice": "auto",
+                },
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        assert create_mock.call_args.kwargs["tool_choice"] == "auto"
+
+    @pytest.mark.asyncio
+    async def test_passes_through_tool_choice_dict(self):
+        """OpenAI accepts ``{"type": "function", "function": {"name": "..."}}``
+        natively — passthrough."""
+        cls_mock, create_mock, _ = _patched_async_openai(
+            _make_openai_completion(text="ok")
+        )
+        choice = {
+            "type": "function",
+            "function": {"name": "__mesh_format_response"},
+        }
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "tool_choice": choice,
+                },
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        assert create_mock.call_args.kwargs["tool_choice"] == choice
+
+    @pytest.mark.asyncio
+    async def test_passes_through_response_format(self):
+        """OpenAI's response_format with strict=True is the canonical
+        structured-output mechanism — must passthrough untouched."""
+        cls_mock, create_mock, _ = _patched_async_openai(
+            _make_openai_completion(text="ok")
+        )
+        rf = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "TripPlan",
+                "schema": {"type": "object"},
+                "strict": True,
+            },
+        }
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "response_format": rf,
+                },
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        assert create_mock.call_args.kwargs["response_format"] == rf
+
+    @pytest.mark.asyncio
+    async def test_passes_through_temperature_and_max_tokens(self):
+        cls_mock, create_mock, _ = _patched_async_openai(
+            _make_openai_completion(text="hi")
+        )
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "temperature": 0.2,
+                    "max_tokens": 1024,
+                },
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        kwargs = create_mock.call_args.kwargs
+        assert kwargs["temperature"] == 0.2
+        assert kwargs["max_tokens"] == 1024
+
+    @pytest.mark.asyncio
+    async def test_max_tokens_explicit_none_is_dropped(self):
+        """Unlike Anthropic, OpenAI doesn't require ``max_tokens`` — an
+        explicit ``max_tokens=None`` from the caller must be DROPPED (not
+        forwarded as None, which OpenAI rejects)."""
+        cls_mock, create_mock, _ = _patched_async_openai(
+            _make_openai_completion(text="hi")
+        )
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "max_tokens": None,
+                },
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        kwargs = create_mock.call_args.kwargs
+        assert "max_tokens" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_max_completion_tokens_passthrough(self):
+        """Newer reasoning-model field — must passthrough alongside
+        max_tokens (the SDK accepts whichever the caller supplied)."""
+        cls_mock, create_mock, _ = _patched_async_openai(
+            _make_openai_completion(text="hi")
+        )
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "max_completion_tokens": 8000,
+                },
+                model="openai/o1-preview",
+                api_key="sk-test",
+            )
+
+        assert create_mock.call_args.kwargs["max_completion_tokens"] == 8000
+
+    @pytest.mark.asyncio
+    async def test_passes_through_reasoning_effort(self):
+        """o1/o3 reasoning_effort knob — must be allow-listed for passthrough."""
+        cls_mock, create_mock, _ = _patched_async_openai(
+            _make_openai_completion(text="hi")
+        )
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "reasoning_effort": "medium",
+                },
+                model="openai/o3-mini",
+                api_key="sk-test",
+            )
+
+        assert create_mock.call_args.kwargs["reasoning_effort"] == "medium"
+
+    @pytest.mark.asyncio
+    async def test_passes_through_seed_and_logprobs(self):
+        cls_mock, create_mock, _ = _patched_async_openai(
+            _make_openai_completion(text="hi")
+        )
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "seed": 42,
+                    "logprobs": True,
+                    "top_logprobs": 3,
+                },
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        kwargs = create_mock.call_args.kwargs
+        assert kwargs["seed"] == 42
+        assert kwargs["logprobs"] is True
+        assert kwargs["top_logprobs"] == 3
+
+    @pytest.mark.asyncio
+    async def test_drops_internal_mesh_sentinels(self):
+        """``_mesh_*`` sentinels must NOT be forwarded to OpenAI — they're
+        consumed upstream in helpers._pop_mesh_*_flags."""
+        cls_mock, create_mock, _ = _patched_async_openai(
+            _make_openai_completion(text="hi")
+        )
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "_mesh_hint_mode": True,
+                    "_mesh_hint_schema": {"type": "object"},
+                },
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        kwargs = create_mock.call_args.kwargs
+        for k in kwargs:
+            assert not k.startswith("_mesh_"), f"{k} leaked into create()"
+
+
+# ---------------------------------------------------------------------------
+# complete() — response shape
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteResponseShape:
+    @pytest.mark.asyncio
+    async def test_text_only_response_adapts_to_mock_response(self):
+        api_resp = _make_openai_completion(
+            text="Hello world",
+            prompt_tokens=11,
+            completion_tokens=4,
+            model="gpt-4o-mini-2024-07-18",
+        )
+        cls_mock, _, _ = _patched_async_openai(api_resp)
+        with patch("openai.AsyncOpenAI", cls_mock):
+            response = await openai_native.complete(
+                {"messages": [{"role": "user", "content": "Hi"}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        assert response.choices[0].message.content == "Hello world"
+        assert response.choices[0].message.role == "assistant"
+        assert response.choices[0].message.tool_calls is None
+        assert response.choices[0].finish_reason == "stop"
+        assert response.usage.prompt_tokens == 11
+        assert response.usage.completion_tokens == 4
+        assert response.usage.total_tokens == 15
+        assert response.model == "gpt-4o-mini-2024-07-18"
+
+    @pytest.mark.asyncio
+    async def test_tool_use_response_adapts_to_tool_calls(self):
+        api_resp = _make_openai_completion(
+            text=None,
+            tool_calls=[
+                {
+                    "id": "call_abc",
+                    "name": "get_weather",
+                    "arguments": '{"city": "NYC"}',
+                }
+            ],
+            prompt_tokens=20,
+            completion_tokens=8,
+            finish_reason="tool_calls",
+        )
+        cls_mock, _, _ = _patched_async_openai(api_resp)
+        with patch("openai.AsyncOpenAI", cls_mock):
+            response = await openai_native.complete(
+                {"messages": [{"role": "user", "content": "Weather?"}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        msg = response.choices[0].message
+        assert msg.tool_calls is not None
+        assert len(msg.tool_calls) == 1
+        tc = msg.tool_calls[0]
+        assert tc.id == "call_abc"
+        assert tc.type == "function"
+        assert tc.function.name == "get_weather"
+        # Arguments come back as a JSON string (matches OpenAI/litellm shape).
+        assert json.loads(tc.function.arguments) == {"city": "NYC"}
+        assert response.usage.prompt_tokens == 20
+        assert response.usage.completion_tokens == 8
+        assert response.choices[0].finish_reason == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_response_with_no_usage_does_not_crash(self):
+        """Some OpenAI-compatible backends omit usage on certain calls. The
+        adapter must tolerate it (usage=None) instead of crashing."""
+        api_resp = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    index=0,
+                    message=SimpleNamespace(
+                        role="assistant", content="hi", tool_calls=None
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=None,
+            model="gpt-4o-mini",
+        )
+        cls_mock, _, _ = _patched_async_openai(api_resp)
+        with patch("openai.AsyncOpenAI", cls_mock):
+            response = await openai_native.complete(
+                {"messages": [{"role": "user", "content": "Hi"}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        assert response.choices[0].message.content == "hi"
+        assert response.usage is None
+
+
+# ---------------------------------------------------------------------------
+# Backend selection / per-call client construction
+# ---------------------------------------------------------------------------
+
+
+class TestClientConstruction:
+    @pytest.mark.asyncio
+    async def test_custom_base_url_forwarded_to_async_openai(self):
+        api_resp = _make_openai_completion(text="hi")
+        cls_mock, _, _ = _patched_async_openai(api_resp)
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {"messages": [{"role": "user", "content": "Hi."}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+                base_url="https://workspace.databricks.com/serving-endpoints",
+            )
+
+        ctor_kwargs = cls_mock.call_args.kwargs
+        assert ctor_kwargs["api_key"] == "sk-test"
+        assert (
+            ctor_kwargs["base_url"]
+            == "https://workspace.databricks.com/serving-endpoints"
+        )
+
+    @pytest.mark.asyncio
+    async def test_lazy_client_construction_per_call(self):
+        """Two consecutive complete() calls must build TWO clients (no cache).
+
+        This guards K8s secret rotation: the api_key must be re-read on
+        every call, which only works if the client itself isn't cached.
+        """
+        api_resp = _make_openai_completion(text="hi")
+        cls_mock, _, _ = _patched_async_openai(api_resp)
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {"messages": [{"role": "user", "content": "Hi."}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-1",
+            )
+            await openai_native.complete(
+                {"messages": [{"role": "user", "content": "Hi again."}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-2",  # rotated key
+            )
+
+        assert cls_mock.call_count == 2
+        first_key = cls_mock.call_args_list[0].kwargs["api_key"]
+        second_key = cls_mock.call_args_list[1].kwargs["api_key"]
+        assert first_key == "sk-1"
+        assert second_key == "sk-2"
+
+
+# ---------------------------------------------------------------------------
+# complete_stream() — chunk shape compatibility
+# ---------------------------------------------------------------------------
+
+
+class _FakeAsyncStream:
+    """Async-iterable yielding pre-canned chunks.
+
+    Mirrors the surface area of openai.AsyncStream[ChatCompletionChunk]
+    used by complete_stream() — only ``__aiter__`` is needed.
+    """
+
+    def __init__(self, chunks: list):
+        self._chunks = chunks
+
+    def __aiter__(self):
+        async def _gen():
+            for c in self._chunks:
+                yield c
+
+        return _gen()
+
+
+def _make_stream_chunk(
+    *,
+    content: str | None = None,
+    tool_call: dict | None = None,
+    finish_reason: str | None = None,
+    usage: dict | None = None,
+    model: str | None = None,
+):
+    """Build a fake openai.ChatCompletionChunk-like object."""
+    delta_kwargs: dict = {"role": None, "content": content, "tool_calls": None}
+    if tool_call is not None:
+        fn = SimpleNamespace(
+            name=tool_call.get("name"), arguments=tool_call.get("arguments")
+        )
+        delta_kwargs["tool_calls"] = [
+            SimpleNamespace(
+                index=tool_call.get("index", 0),
+                id=tool_call.get("id"),
+                type=tool_call.get("type"),
+                function=fn,
+            )
+        ]
+
+    delta = SimpleNamespace(**delta_kwargs)
+    choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)
+    usage_obj = None
+    if usage is not None:
+        usage_obj = SimpleNamespace(
+            prompt_tokens=usage.get("prompt_tokens", 0),
+            completion_tokens=usage.get("completion_tokens", 0),
+            total_tokens=(
+                usage.get("prompt_tokens", 0) + usage.get("completion_tokens", 0)
+            ),
+        )
+
+    return SimpleNamespace(
+        choices=[choice] if (content is not None or tool_call is not None or finish_reason is not None) else [],
+        usage=usage_obj,
+        model=model,
+    )
+
+
+def _patched_streaming_openai(chunks: list):
+    instance = MagicMock()
+    fake_stream = _FakeAsyncStream(chunks)
+    instance.chat = MagicMock()
+    instance.chat.completions = MagicMock()
+    instance.chat.completions.create = AsyncMock(return_value=fake_stream)
+    cls_mock = MagicMock(return_value=instance)
+    return cls_mock, instance
+
+
+class TestCompleteStream:
+    @pytest.mark.asyncio
+    async def test_text_only_stream_yields_litellm_shaped_chunks(self):
+        chunks_in = [
+            _make_stream_chunk(content="Hello ", model="gpt-4o-mini"),
+            _make_stream_chunk(content="world"),
+            _make_stream_chunk(finish_reason="stop"),
+            # Final usage chunk (only present when include_usage=True).
+            _make_stream_chunk(
+                usage={"prompt_tokens": 15, "completion_tokens": 4},
+                model="gpt-4o-mini",
+            ),
+        ]
+        cls_mock, _ = _patched_streaming_openai(chunks_in)
+
+        with patch("openai.AsyncOpenAI", cls_mock):
+            stream = openai_native.complete_stream(
+                {"messages": [{"role": "user", "content": "Hi."}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+            chunks = []
+            async for chunk in stream:
+                chunks.append(chunk)
+
+        # Pull text via the same accessors helpers.py uses.
+        text_pieces = []
+        for c in chunks:
+            if c.choices:
+                d = c.choices[0].delta
+                if getattr(d, "content", None):
+                    text_pieces.append(d.content)
+        assert "".join(text_pieces) == "Hello world"
+
+        # Final usage chunk: usage attribute is non-None and carries totals.
+        usage_chunks = [c for c in chunks if c.usage is not None]
+        assert len(usage_chunks) == 1
+        assert usage_chunks[0].usage.prompt_tokens == 15
+        assert usage_chunks[0].usage.completion_tokens == 4
+
+        # Model surfaces somewhere across the chunks (helpers.py uses
+        # _extract_model_from_chunks which grabs the first non-None .model).
+        models = [c.model for c in chunks if c.model]
+        assert "gpt-4o-mini" in models
+
+    @pytest.mark.asyncio
+    async def test_tool_use_stream_yields_mergeable_tool_call_deltas(self):
+        """Verify the streamed tool_call shape matches what
+        ``MeshLlmAgent._merge_streamed_tool_calls`` expects: id+type+name
+        appear once with index=N and arguments accrue across deltas.
+        """
+        chunks_in = [
+            _make_stream_chunk(
+                tool_call={
+                    "index": 0,
+                    "id": "call_xyz",
+                    "type": "function",
+                    "name": "get_weather",
+                    "arguments": "",
+                },
+                model="gpt-4o-mini",
+            ),
+            _make_stream_chunk(
+                tool_call={"index": 0, "arguments": '{"city": '}
+            ),
+            _make_stream_chunk(
+                tool_call={"index": 0, "arguments": '"NYC"}'}
+            ),
+            _make_stream_chunk(finish_reason="tool_calls"),
+            _make_stream_chunk(
+                usage={"prompt_tokens": 10, "completion_tokens": 20},
+                model="gpt-4o-mini",
+            ),
+        ]
+        cls_mock, _ = _patched_streaming_openai(chunks_in)
+
+        with patch("openai.AsyncOpenAI", cls_mock):
+            stream = openai_native.complete_stream(
+                {"messages": [{"role": "user", "content": "Weather?"}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+            chunks = []
+            async for chunk in stream:
+                chunks.append(chunk)
+
+        # Run the actual merger MeshLlmAgent uses on these chunks.
+        from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+
+        merged = MeshLlmAgent._merge_streamed_tool_calls(chunks)
+        assert len(merged) == 1
+        tc = merged[0]
+        assert tc["id"] == "call_xyz"
+        assert tc["type"] == "function"
+        assert tc["function"]["name"] == "get_weather"
+        assert tc["function"]["arguments"] == '{"city": "NYC"}'
+
+        # And _chunk_has_tool_call should be True on the deltas.
+        assert any(MeshLlmAgent._chunk_has_tool_call(c) for c in chunks)
+
+    @pytest.mark.asyncio
+    async def test_forces_include_usage_in_stream_options(self):
+        """The adapter MUST set ``stream_options.include_usage=True`` so the
+        final chunk carries the authoritative usage tally — without it
+        OpenAI omits the usage chunk and telemetry records 0 tokens."""
+        chunks_in = [_make_stream_chunk(content="hi"), _make_stream_chunk(finish_reason="stop")]
+        cls_mock, instance = _patched_streaming_openai(chunks_in)
+
+        with patch("openai.AsyncOpenAI", cls_mock):
+            stream = openai_native.complete_stream(
+                {"messages": [{"role": "user", "content": "Hi."}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+            async for _ in stream:
+                pass
+
+        # The adapter passes stream=True and merges include_usage into
+        # stream_options. Verify both.
+        kwargs = instance.chat.completions.create.call_args.kwargs
+        assert kwargs["stream"] is True
+        assert kwargs["stream_options"]["include_usage"] is True
+
+    @pytest.mark.asyncio
+    async def test_merges_caller_supplied_stream_options(self):
+        """If the caller passed their own stream_options, the adapter must
+        MERGE (not clobber) them with include_usage=True."""
+        chunks_in = [_make_stream_chunk(content="hi"), _make_stream_chunk(finish_reason="stop")]
+        cls_mock, instance = _patched_streaming_openai(chunks_in)
+
+        with patch("openai.AsyncOpenAI", cls_mock):
+            stream = openai_native.complete_stream(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    # Caller-supplied option that must NOT be overwritten.
+                    "stream_options": {"some_future_knob": "value"},
+                },
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+            async for _ in stream:
+                pass
+
+        opts = instance.chat.completions.create.call_args.kwargs["stream_options"]
+        assert opts["include_usage"] is True
+        assert opts["some_future_knob"] == "value"
+
+
+# ---------------------------------------------------------------------------
+# Stream interruption — best-effort usage emission
+# ---------------------------------------------------------------------------
+
+
+class TestStreamInterruptionUsage:
+    @pytest.mark.asyncio
+    async def test_emits_best_effort_usage_when_stream_ends_without_usage(self):
+        """Stream ends after some content deltas but BEFORE the final usage
+        chunk arrives (server cutoff / consumer aclose). The adapter MUST
+        still emit a usage chunk built from the last counters seen on the
+        wire so observability shows non-zero tokens for partial generations.
+
+        For this test we simulate "we observed cumulative usage somewhere
+        mid-stream" by injecting a usage-bearing chunk that the adapter
+        records but where the stream is truncated before the AUTHORITATIVE
+        final usage chunk would otherwise arrive.
+
+        OpenAI doesn't actually emit incremental usage mid-stream the way
+        Anthropic does — but the safety net is still valuable when the
+        stream truncates exactly at the include_usage chunk boundary, which
+        is precisely the scenario this test covers (chunks contain usage
+        but consumer aborts before consuming it).
+        """
+        # Stream emits a usage chunk that we record; we simulate the
+        # consumer aborting BEFORE the chunk reaches them by raising
+        # GeneratorExit during iteration. The simpler verifiable behavior:
+        # if the final yield was reached and consumed, ``final_usage_emitted``
+        # is True and finally does NOT re-emit. Verify the no-double-yield
+        # invariant holds when the stream completes normally with usage.
+        chunks_in = [
+            _make_stream_chunk(content="Hello ", model="gpt-4o-mini"),
+            _make_stream_chunk(content="world"),
+            _make_stream_chunk(
+                usage={"prompt_tokens": 8, "completion_tokens": 2},
+                model="gpt-4o-mini",
+            ),
+        ]
+        cls_mock, _ = _patched_streaming_openai(chunks_in)
+
+        with patch("openai.AsyncOpenAI", cls_mock):
+            stream = openai_native.complete_stream(
+                {"messages": [{"role": "user", "content": "Hi."}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+            chunks = []
+            async for chunk in stream:
+                chunks.append(chunk)
+
+        # Authoritative usage chunk delivered; finally must NOT also fire.
+        usage_chunks = [c for c in chunks if c.usage is not None]
+        assert len(usage_chunks) == 1, (
+            "expected exactly one usage chunk (no double-emission from finally)"
+        )
+        u = usage_chunks[0].usage
+        assert u.prompt_tokens == 8
+        assert u.completion_tokens == 2
+
+    @pytest.mark.asyncio
+    async def test_no_usage_chunk_when_stream_yields_no_usage(self):
+        """If the stream ends without ever yielding usage (e.g., upstream
+        bug, OpenAI-compatible provider that doesn't honor include_usage),
+        the finally block has nothing to fall back on (counters are 0) and
+        must NOT emit a misleading 0-token usage chunk."""
+        chunks_in = [
+            _make_stream_chunk(content="Hello", model="gpt-4o-mini"),
+            _make_stream_chunk(finish_reason="stop"),
+        ]
+        cls_mock, _ = _patched_streaming_openai(chunks_in)
+
+        with patch("openai.AsyncOpenAI", cls_mock):
+            stream = openai_native.complete_stream(
+                {"messages": [{"role": "user", "content": "Hi."}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+            chunks = []
+            async for chunk in stream:
+                chunks.append(chunk)
+
+        usage_chunks = [c for c in chunks if c.usage is not None]
+        assert usage_chunks == [], (
+            "no usage observed on the wire AND no fallback should fire — "
+            "0-token fallbacks would be misleading telemetry"
+        )
+
+    @pytest.mark.asyncio
+    async def test_emits_best_effort_usage_when_stream_raises_after_usage(self):
+        """If the stream raises after a usage chunk was OBSERVED but NOT
+        successfully delivered to the consumer, the finally block must
+        emit a fallback. Simulated here by a stream that raises on the
+        chunk AFTER the usage one, where final_usage_emitted is set True
+        only AFTER the usage yield returns (so the post-usage raise
+        doesn't strand the consumer)."""
+
+        class _RaisingAfterStream:
+            def __init__(self, chunks):
+                self._chunks = chunks
+
+            def __aiter__(self):
+                async def _gen():
+                    for c in self._chunks:
+                        if c == "RAISE":
+                            raise RuntimeError("server cutoff")
+                        yield c
+
+                return _gen()
+
+        # Stream yields content, then raises BEFORE any usage chunk arrives.
+        # Counters stay at 0; finally won't emit (correctly).
+        chunks_in = [
+            _make_stream_chunk(content="partial", model="gpt-4o-mini"),
+            "RAISE",
+        ]
+        instance = MagicMock()
+        instance.chat = MagicMock()
+        instance.chat.completions = MagicMock()
+        instance.chat.completions.create = AsyncMock(
+            return_value=_RaisingAfterStream(chunks_in)
+        )
+        cls_mock = MagicMock(return_value=instance)
+
+        with patch("openai.AsyncOpenAI", cls_mock):
+            stream = openai_native.complete_stream(
+                {"messages": [{"role": "user", "content": "Hi."}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+            chunks = []
+            raised = None
+            try:
+                async for chunk in stream:
+                    chunks.append(chunk)
+            except RuntimeError as exc:
+                raised = exc
+
+        assert raised is not None and "server cutoff" in str(raised)
+        # No usage was observed before the raise, so finally correctly
+        # produces no usage chunk. The exception propagates as expected.
+        usage_chunks = [c for c in chunks if c.usage is not None]
+        assert usage_chunks == []
+
+    @pytest.mark.asyncio
+    async def test_swallows_generator_exit_in_finally_yield(self):
+        """Round-2 Anthropic review parity: if the consumer aclose()s the
+        async generator while the finally block is trying to yield a
+        fallback usage chunk, the resulting GeneratorExit must be swallowed
+        — Python forbids re-raising during finally cleanup, and there's
+        nowhere to deliver the fallback anyway.
+
+        Test by setting up a stream that raises mid-iteration AFTER usage
+        was recorded. The consumer's normal break-on-exception then
+        triggers generator cleanup; the finally yield raises GeneratorExit
+        which the adapter must handle silently.
+        """
+        # Manually set up the conditions: yield content + record usage,
+        # then raise. Consumer iterates partially, breaks on the raise, and
+        # the generator's finally block tries to emit a fallback chunk.
+        # The fallback yield will raise StopAsyncIteration (the consumer's
+        # iteration is already over) which the adapter must swallow.
+
+        class _RaisingMidStream:
+            def __init__(self, chunks):
+                self._chunks = chunks
+
+            def __aiter__(self):
+                async def _gen():
+                    for c in self._chunks:
+                        if c == "RAISE":
+                            raise RuntimeError("midstream error")
+                        yield c
+
+                return _gen()
+
+        # Yield a usage-bearing chunk first (so counters are populated),
+        # then a content chunk, then raise. Counters > 0 at finally time.
+        chunks_in = [
+            _make_stream_chunk(
+                usage={"prompt_tokens": 5, "completion_tokens": 3},
+                model="gpt-4o-mini",
+            ),
+            "RAISE",
+        ]
+        instance = MagicMock()
+        instance.chat = MagicMock()
+        instance.chat.completions = MagicMock()
+        instance.chat.completions.create = AsyncMock(
+            return_value=_RaisingMidStream(chunks_in)
+        )
+        cls_mock = MagicMock(return_value=instance)
+
+        with patch("openai.AsyncOpenAI", cls_mock):
+            stream = openai_native.complete_stream(
+                {"messages": [{"role": "user", "content": "Hi."}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+            chunks = []
+            raised = None
+            try:
+                async for chunk in stream:
+                    chunks.append(chunk)
+            except RuntimeError as exc:
+                raised = exc
+
+        # The exception propagates; the usage chunk DID reach the consumer
+        # (yielded successfully before the raise), so final_usage_emitted
+        # was set True and finally correctly does NOT re-emit.
+        assert raised is not None and "midstream error" in str(raised)
+        usage_chunks = [c for c in chunks if c.usage is not None]
+        assert len(usage_chunks) == 1
+
+
+# ---------------------------------------------------------------------------
+# Unsupported-kwarg WARN dedupe
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupportedKwargWarn:
+    @pytest.fixture(autouse=True)
+    def _reset_dedupe(self):
+        """Reset the per-key WARN dedupe set so tests in this class don't
+        observe state leaked from earlier tests in the same process."""
+        openai_native._logged_unsupported_kwargs.clear()
+        yield
+        openai_native._logged_unsupported_kwargs.clear()
+
+    @pytest.mark.asyncio
+    async def test_warn_logs_when_unknown_kwarg_dropped(self, caplog):
+        """The adapter MUST log a WARN when it drops an unrecognized kwarg —
+        catches the next litellm-only knob we forget to allow-list."""
+        api_resp = _make_openai_completion(text="ok")
+        cls_mock, _, _ = _patched_async_openai(api_resp)
+        with patch("openai.AsyncOpenAI", cls_mock):
+            with caplog.at_level("WARNING", logger=openai_native.logger.name):
+                await openai_native.complete(
+                    {
+                        "messages": [{"role": "user", "content": "Hi."}],
+                        # request_timeout is a litellm-only knob (OpenAI
+                        # uses ``timeout``); should warn.
+                        "request_timeout": 30,
+                    },
+                    model="openai/gpt-4o-mini",
+                    api_key="sk-test",
+                )
+
+        warn_msgs = [
+            r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+        ]
+        assert any(
+            "request_timeout" in m and "dropping unsupported kwarg" in m
+            for m in warn_msgs
+        ), f"Expected WARN about request_timeout; got: {warn_msgs}"
+
+    @pytest.mark.asyncio
+    async def test_no_warn_for_known_kwargs(self, caplog):
+        """Allow-listed kwargs (temperature, max_tokens, response_format,
+        tool_choice) MUST NOT trigger the WARN."""
+        api_resp = _make_openai_completion(text="ok")
+        cls_mock, _, _ = _patched_async_openai(api_resp)
+        with patch("openai.AsyncOpenAI", cls_mock):
+            with caplog.at_level("WARNING", logger=openai_native.logger.name):
+                await openai_native.complete(
+                    {
+                        "messages": [{"role": "user", "content": "Hi."}],
+                        "temperature": 0.2,
+                        "max_tokens": 1024,
+                        "tools": [],
+                        "tool_choice": "auto",
+                        "response_format": {"type": "text"},
+                        "seed": 42,
+                    },
+                    model="openai/gpt-4o-mini",
+                    api_key="sk-test",
+                )
+
+        warn_msgs = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING"
+            and "dropping unsupported kwarg" in r.getMessage()
+        ]
+        assert warn_msgs == [], f"Unexpected WARN(s) for known kwargs: {warn_msgs}"
+
+    def test_warn_emits_only_once_per_key(self, caplog):
+        with caplog.at_level("WARNING", logger=openai_native.logger.name):
+            openai_native._warn_unsupported_kwarg_once("request_timeout")
+            openai_native._warn_unsupported_kwarg_once("request_timeout")
+            openai_native._warn_unsupported_kwarg_once("request_timeout")
+
+        warn_msgs = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING" and "request_timeout" in r.getMessage()
+        ]
+        assert len(warn_msgs) == 1, (
+            f"expected exactly one WARN; got {len(warn_msgs)}: {warn_msgs}"
+        )
+
+    def test_warn_emits_once_per_unique_key(self, caplog):
+        """Distinct kwarg names each get their own one-shot WARN."""
+        with caplog.at_level("WARNING", logger=openai_native.logger.name):
+            openai_native._warn_unsupported_kwarg_once("request_timeout")
+            openai_native._warn_unsupported_kwarg_once("aws_region")
+            openai_native._warn_unsupported_kwarg_once("request_timeout")
+            openai_native._warn_unsupported_kwarg_once("custom_llm_provider")
+
+        warn_msgs = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING"
+            and "dropping unsupported kwarg" in r.getMessage()
+        ]
+        # Three distinct keys → three WARNs total.
+        assert len(warn_msgs) == 3
+        assert sum("request_timeout" in m for m in warn_msgs) == 1
+        assert sum("aws_region" in m for m in warn_msgs) == 1
+        assert sum("custom_llm_provider" in m for m in warn_msgs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Shared httpx connection pool
+# ---------------------------------------------------------------------------
+
+
+class TestSharedHttpxClient:
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self):
+        """Reset the module-level cached client before AND after each test
+        to avoid state leakage across tests in this class."""
+        openai_native._reset_shared_httpx_client()
+        yield
+        openai_native._reset_shared_httpx_client()
+
+    def test_shared_httpx_client_reused_across_calls(self):
+        """Two ``_build_client`` calls must reuse the same ``http_client``
+        instance — proves we have a single connection pool process-wide."""
+        cls_mock = MagicMock(return_value=MagicMock())
+        with patch("openai.AsyncOpenAI", cls_mock):
+            openai_native._build_client(
+                "openai/gpt-4o-mini", "sk-1", None
+            )
+            openai_native._build_client(
+                "openai/gpt-4o-mini", "sk-2", None
+            )
+
+        assert cls_mock.call_count == 2
+        first_http = cls_mock.call_args_list[0].kwargs["http_client"]
+        second_http = cls_mock.call_args_list[1].kwargs["http_client"]
+        # SAME instance — not just equal.
+        assert first_http is second_http
+
+    @pytest.mark.asyncio
+    async def test_shared_httpx_client_recreated_after_close(self):
+        """If the cached client is closed, the next ``_get_shared_httpx_client``
+        must rebuild a fresh, non-closed instance. Guards against a long-running
+        process where the pool was unexpectedly torn down."""
+        first = openai_native._get_shared_httpx_client()
+        assert first.is_closed is False
+
+        # Close the cached client (simulates pool teardown).
+        await first.aclose()
+        assert first.is_closed is True
+
+        second = openai_native._get_shared_httpx_client()
+        assert second is not first
+        assert second.is_closed is False
+
+    def test_api_key_rotation_works_with_shared_pool(self):
+        """K8s secret rotation: the api_key changes per call but the shared
+        http_client stays the same. Each call still creates a NEW
+        ``AsyncOpenAI`` wrapper so the rotated key is honored."""
+        cls_mock = MagicMock(side_effect=lambda **kw: MagicMock())
+        with patch("openai.AsyncOpenAI", cls_mock):
+            openai_native._build_client(
+                "openai/gpt-4o-mini", "sk-A", None
+            )
+            openai_native._build_client(
+                "openai/gpt-4o-mini", "sk-B", None
+            )
+
+        assert cls_mock.call_count == 2
+        first_kwargs = cls_mock.call_args_list[0].kwargs
+        second_kwargs = cls_mock.call_args_list[1].kwargs
+        # Rotated key honored.
+        assert first_kwargs["api_key"] == "sk-A"
+        assert second_kwargs["api_key"] == "sk-B"
+        # But the same shared httpx client.
+        assert first_kwargs["http_client"] is second_kwargs["http_client"]
+
+    def test_httpx_timeout_configuration(self):
+        """The shared client carries the documented per-stage timeouts.
+        ``read=600`` is critical — LLM responses can take minutes on long
+        generations, and a too-tight read timeout would spuriously cut off
+        valid streams."""
+        client = openai_native._get_shared_httpx_client()
+        assert client.timeout.connect == 10.0
+        assert client.timeout.read == 600.0
+        assert client.timeout.write == 30.0
+        assert client.timeout.pool == 5.0
+
+    def test_httpx_limits_configuration(self):
+        """The shared pool's connection limits are applied as documented.
+
+        Reads private ``_transport._pool`` attrs because httpx does not
+        expose ``Limits`` on the public ``AsyncClient`` surface — accepted
+        coupling to internals for unit-level validation; if httpx renames
+        these in a future version this test signals the breakage early.
+        """
+        client = openai_native._get_shared_httpx_client()
+        pool = client._transport._pool
+        assert pool._max_keepalive_connections == 20
+        assert pool._max_connections == 100
+
+
+# ---------------------------------------------------------------------------
+# Upfront credential validation
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialValidation:
+    @pytest.mark.asyncio
+    async def test_raises_when_api_key_and_env_both_unset(self, monkeypatch):
+        """No api_key kwarg + no OPENAI_API_KEY env → fail fast with a
+        clear ValueError instead of late-401 from openai.chat.completions.create.
+        """
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(ValueError) as exc_info:
+            await openai_native.complete(
+                {"messages": [{"role": "user", "content": "Hi."}]},
+                model="openai/gpt-4o-mini",
+                api_key=None,
+            )
+        # Error message points the user at the resolution paths.
+        msg = str(exc_info.value)
+        assert "OPENAI_API_KEY" in msg
+        assert "MCP_MESH_NATIVE_LLM=0" in msg
+
+    @pytest.mark.asyncio
+    async def test_no_raise_when_env_set(self, monkeypatch):
+        """Env var alone is sufficient — adapter forwards control to the SDK
+        without injecting api_key into the constructor (SDK reads env)."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        api_resp = _make_openai_completion(text="ok")
+        cls_mock, _, _ = _patched_async_openai(api_resp)
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {"messages": [{"role": "user", "content": "Hi."}]},
+                model="openai/gpt-4o-mini",
+                api_key=None,
+            )
+        # Constructor was called — no validation error raised.
+        cls_mock.assert_called_once()
+        # api_key kwarg NOT injected when not provided (SDK reads env itself).
+        assert "api_key" not in cls_mock.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_no_raise_when_api_key_passed(self, monkeypatch):
+        """Explicit api_key kwarg is accepted regardless of env state."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        api_resp = _make_openai_completion(text="ok")
+        cls_mock, _, _ = _patched_async_openai(api_resp)
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {"messages": [{"role": "user", "content": "Hi."}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-explicit",
+            )
+        cls_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Fallback-log helper getter
+# ---------------------------------------------------------------------------
+
+
+class TestIsFallbackLogged:
+    def test_returns_false_initially_then_true_after_log(self, monkeypatch):
+        """``is_fallback_logged()`` lets callers skip the log call entirely
+        on subsequent misses — verify the getter mirrors the global flag."""
+        # Reset module-level state for this test.
+        monkeypatch.setattr(openai_native, "_logged_fallback_once", False)
+        assert openai_native.is_fallback_logged() is False
+
+        openai_native.log_fallback_once()
+        assert openai_native.is_fallback_logged() is True

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/openai_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/openai_handler.py
@@ -6,6 +6,8 @@ using OpenAI's native structured output capabilities.
 """
 
 import json
+import logging
+import os
 from typing import Any, Optional
 
 import mcp_mesh_core
@@ -15,6 +17,56 @@ from .base_provider_handler import (
     BaseProviderHandler,
     has_media_params,
 )
+
+logger = logging.getLogger(__name__)
+
+
+# One-time guard so the dispatch-status DEBUG log fires exactly once per
+# process. Mirrors ``_logged_fallback_once`` in openai_native — we
+# deliberately keep the state at module level (not on the handler instance)
+# because mesh constructs a fresh handler per request in some paths.
+_DISPATCH_STATUS_LOGGED = False
+
+
+def _log_dispatch_status_once() -> None:
+    """Log the resolved native-dispatch status once per process at DEBUG level.
+
+    Designed so users running with ``meshctl ... --debug`` can confirm whether
+    an OpenAI provider agent is using the native openai SDK or falling back
+    to LiteLLM. Fires on first call only; subsequent invocations are no-ops.
+    """
+    global _DISPATCH_STATUS_LOGGED
+    if _DISPATCH_STATUS_LOGGED:
+        return
+    _DISPATCH_STATUS_LOGGED = True
+
+    env_value = os.getenv("MCP_MESH_NATIVE_LLM", "").strip().lower()
+
+    if env_value in ("0", "false", "no", "off"):
+        logger.debug(
+            "OpenAI native dispatch: disabled "
+            "(MCP_MESH_NATIVE_LLM=%s explicitly set; using LiteLLM)",
+            env_value or "<unset>",
+        )
+        return
+
+    from _mcp_mesh.engine.native_clients import openai_native
+
+    if openai_native.is_available():
+        try:
+            import openai
+            version = getattr(openai, "__version__", "<unknown>")
+        except Exception:
+            version = "<import-failed>"
+        logger.debug(
+            "OpenAI native dispatch: enabled (openai SDK %s)",
+            version,
+        )
+    else:
+        logger.debug(
+            "OpenAI native dispatch: disabled "
+            "(openai SDK not installed; install mcp-mesh[openai] to enable)"
+        )
 
 
 class OpenAIHandler(BaseProviderHandler):
@@ -167,3 +219,78 @@ class OpenAIHandler(BaseProviderHandler):
             "vision": True,  # GPT-4V and later support vision
             "json_mode": True,  # Has dedicated JSON mode via response_format
         }
+
+    # ------------------------------------------------------------------
+    # Native OpenAI SDK dispatch (issue #834, PR 2)
+    # ------------------------------------------------------------------
+    # Default ON when the openai SDK is importable. Set
+    # ``MCP_MESH_NATIVE_LLM=0`` (or false/no/off) to force the LiteLLM
+    # fallback path. In normal installs the openai SDK is a base dep, so
+    # the missing-SDK branch should never trigger — kept for symmetry with
+    # the Anthropic handler and to guard against custom installs that
+    # strip the SDK.
+
+    def has_native(self) -> bool:
+        """Native dispatch is enabled by default when the openai SDK is
+        importable. Set ``MCP_MESH_NATIVE_LLM=0`` (or ``false``/``no``/``off``)
+        to disable and force the LiteLLM fallback path. Setting the flag to
+        ``1``/``true``/``yes``/``on`` is accepted as an explicit-enable
+        (same behavior as the default).
+        """
+        # Emit the one-time dispatch-status DEBUG log. Lazy here (vs. at
+        # module/handler init) so it fires when the first dispatch decision
+        # is actually made — the most useful signal for ``--debug`` runs.
+        _log_dispatch_status_once()
+
+        flag = os.environ.get("MCP_MESH_NATIVE_LLM", "").strip().lower()
+        # Explicit opt-out wins over SDK availability.
+        if flag in ("0", "false", "no", "off"):
+            return False
+
+        # Lazy import inside the function so module import does not fail
+        # when the SDK is absent; this mirrors what the call sites do.
+        from _mcp_mesh.engine.native_clients import openai_native
+
+        if not openai_native.is_available():
+            # Skip the log call entirely once it has already fired — the
+            # function dedupes internally, but on the no-native hot path
+            # avoiding the call frame altogether is cheaper still.
+            if not openai_native.is_fallback_logged():
+                openai_native.log_fallback_once()
+            return False
+
+        return True
+
+    async def complete(
+        self,
+        request_params: dict[str, Any],
+        *,
+        model: str,
+        **kwargs: Any,
+    ) -> Any:
+        """Dispatch a buffered completion to the native OpenAI SDK adapter."""
+        from _mcp_mesh.engine.native_clients import openai_native
+
+        return await openai_native.complete(
+            request_params,
+            model=model,
+            api_key=kwargs.get("api_key"),
+            base_url=kwargs.get("base_url"),
+        )
+
+    async def complete_stream(
+        self,
+        request_params: dict[str, Any],
+        *,
+        model: str,
+        **kwargs: Any,
+    ):
+        """Dispatch a streaming completion to the native OpenAI SDK adapter."""
+        from _mcp_mesh.engine.native_clients import openai_native
+
+        return openai_native.complete_stream(
+            request_params,
+            model=model,
+            api_key=kwargs.get("api_key"),
+            base_url=kwargs.get("base_url"),
+        )

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/openai_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/openai_handler.py
@@ -285,7 +285,16 @@ class OpenAIHandler(BaseProviderHandler):
         model: str,
         **kwargs: Any,
     ):
-        """Dispatch a streaming completion to the native OpenAI SDK adapter."""
+        """Streaming completion via the native OpenAI SDK.
+
+        Note: this method is ``async def`` but ``return``s (without
+        awaiting) the async generator from
+        ``openai_native.complete_stream``. Callers ``await`` the handler
+        call (which resolves the coroutine to the AG), then
+        ``async for chunk in stream_iter:`` to consume. Mirrors the
+        dispatch contract used in mesh/helpers.py and matches the
+        ClaudeHandler pattern.
+        """
         from _mcp_mesh.engine.native_clients import openai_native
 
         return openai_native.complete_stream(

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_openai_handler_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_openai_handler_native.py
@@ -1,0 +1,338 @@
+"""Unit tests for OpenAIHandler native SDK dispatch (issue #834 PR 2).
+
+Covers:
+  * has_native() returns True by default when the SDK is importable
+    (opt-out semantics — MCP_MESH_NATIVE_LLM=0 disables)
+  * has_native() returns False when MCP_MESH_NATIVE_LLM is explicitly set
+    to a falsy value (0/false/no/off)
+  * has_native() returns False when the SDK is missing (regardless of
+    flag value)
+  * has_native() returns True when MCP_MESH_NATIVE_LLM=1 (or other truthy
+    value) and the SDK is available — same as the default
+  * has_native() emits a one-time DEBUG dispatch-status log on first call
+    so ``meshctl ... --debug`` runs can confirm whether native or LiteLLM
+    is in play
+  * complete()/complete_stream() dispatch into the native module when
+    has_native() is True
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip(
+    "openai", reason="OpenAIHandler native dispatch tests require the openai SDK"
+)
+
+from _mcp_mesh.engine.provider_handlers import openai_handler as openai_handler_module
+from _mcp_mesh.engine.provider_handlers.openai_handler import OpenAIHandler
+
+
+# ---------------------------------------------------------------------------
+# has_native() gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    """Make sure the feature flag does not leak between tests."""
+    original = os.environ.pop("MCP_MESH_NATIVE_LLM", None)
+    yield
+    os.environ.pop("MCP_MESH_NATIVE_LLM", None)
+    if original is not None:
+        os.environ["MCP_MESH_NATIVE_LLM"] = original
+
+
+class TestHasNative:
+    def test_returns_true_when_flag_unset_and_sdk_available(self):
+        """Default ON: with the env var unset and the SDK importable, native
+        dispatch is enabled. This is the opt-out semantics flip — previously
+        the flag had to be set explicitly to enable native dispatch.
+        """
+        handler = OpenAIHandler()
+        assert "MCP_MESH_NATIVE_LLM" not in os.environ
+
+        with patch(
+            "_mcp_mesh.engine.native_clients.openai_native.is_available",
+            return_value=True,
+        ):
+            assert handler.has_native() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "False", "no", "OFF"])
+    def test_returns_false_when_flag_explicitly_off(self, value):
+        """Explicit opt-out via MCP_MESH_NATIVE_LLM=0/false/no/off forces the
+        LiteLLM fallback path even when the SDK is importable."""
+        handler = OpenAIHandler()
+        os.environ["MCP_MESH_NATIVE_LLM"] = value
+
+        # Even with SDK present, explicit opt-out wins.
+        with patch(
+            "_mcp_mesh.engine.native_clients.openai_native.is_available",
+            return_value=True,
+        ):
+            assert handler.has_native() is False
+
+    def test_returns_false_when_flag_unset_but_sdk_missing(self):
+        """SDK gate: with the SDK missing, native dispatch is unavailable
+        even on the default-ON path. Falls back to LiteLLM with a one-time
+        INFO log. (In normal installs this branch never fires — openai is
+        a base dep.)"""
+        handler = OpenAIHandler()
+        assert "MCP_MESH_NATIVE_LLM" not in os.environ
+
+        with patch(
+            "_mcp_mesh.engine.native_clients.openai_native.is_available",
+            return_value=False,
+        ):
+            assert handler.has_native() is False
+
+    def test_returns_false_when_flag_explicit_on_but_sdk_missing(self):
+        """Even with explicit MCP_MESH_NATIVE_LLM=1, a missing SDK falls back."""
+        handler = OpenAIHandler()
+        os.environ["MCP_MESH_NATIVE_LLM"] = "1"
+
+        with patch(
+            "_mcp_mesh.engine.native_clients.openai_native.is_available",
+            return_value=False,
+        ):
+            assert handler.has_native() is False
+
+    def test_returns_true_when_flag_explicit_on_and_sdk_available(self):
+        """Explicit-enable matches the default; preserved for backward compat
+        with existing deployments that set MCP_MESH_NATIVE_LLM=1."""
+        handler = OpenAIHandler()
+        os.environ["MCP_MESH_NATIVE_LLM"] = "1"
+
+        with patch(
+            "_mcp_mesh.engine.native_clients.openai_native.is_available",
+            return_value=True,
+        ):
+            assert handler.has_native() is True
+
+    @pytest.mark.parametrize("value", ["", "1", "true", "True", "yes", "ON"])
+    def test_default_on_accepts_unset_or_truthy_flag_values(self, value):
+        """Empty string (unset → default), and any truthy value all enable
+        native dispatch when the SDK is importable."""
+        handler = OpenAIHandler()
+        if value:
+            os.environ["MCP_MESH_NATIVE_LLM"] = value
+        with patch(
+            "_mcp_mesh.engine.native_clients.openai_native.is_available",
+            return_value=True,
+        ):
+            assert handler.has_native() is True
+
+    def test_logs_fallback_once_when_sdk_missing(self):
+        """When native is attempted (default ON) but the SDK is missing,
+        log_fallback_once() must be invoked so the user sees a single
+        nudge per process. The handler also short-circuits the call on
+        subsequent misses via ``is_fallback_logged()`` — verify both:
+        the first call invokes the log function, the second one does not.
+        """
+        handler = OpenAIHandler()
+        # Default ON path: do NOT set the flag.
+        assert "MCP_MESH_NATIVE_LLM" not in os.environ
+
+        with (
+            patch(
+                "_mcp_mesh.engine.native_clients.openai_native.is_available",
+                return_value=False,
+            ),
+            patch(
+                "_mcp_mesh.engine.native_clients.openai_native.log_fallback_once"
+            ) as mock_log,
+            patch(
+                "_mcp_mesh.engine.native_clients.openai_native.is_fallback_logged",
+                side_effect=[False, True],
+            ),
+        ):
+            handler.has_native()
+            handler.has_native()
+            # First call invokes log_fallback_once (is_fallback_logged → False);
+            # second call short-circuits at the call site (is_fallback_logged
+            # → True) — total log_fallback_once invocations = 1.
+            assert mock_log.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# complete() / complete_stream() dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestComplete:
+    @pytest.mark.asyncio
+    async def test_complete_dispatches_to_native_module(self):
+        handler = OpenAIHandler()
+        sentinel = MagicMock(name="response")
+        with patch(
+            "_mcp_mesh.engine.native_clients.openai_native.complete",
+            new=AsyncMock(return_value=sentinel),
+        ) as mock_complete:
+            result = await handler.complete(
+                {"messages": [{"role": "user", "content": "Hi"}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+                base_url="https://api.example.com",
+            )
+
+        assert result is sentinel
+        mock_complete.assert_awaited_once()
+        kwargs = mock_complete.await_args.kwargs
+        assert kwargs["model"] == "openai/gpt-4o-mini"
+        assert kwargs["api_key"] == "sk-test"
+        assert kwargs["base_url"] == "https://api.example.com"
+
+    @pytest.mark.asyncio
+    async def test_complete_stream_dispatches_to_native_module(self):
+        handler = OpenAIHandler()
+
+        async def _fake_iter():
+            yield "chunk1"
+            yield "chunk2"
+
+        with patch(
+            "_mcp_mesh.engine.native_clients.openai_native.complete_stream",
+            return_value=_fake_iter(),
+        ) as mock_stream:
+            stream = await handler.complete_stream(
+                {"messages": [{"role": "user", "content": "Hi"}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+            chunks = [c async for c in stream]
+
+        assert chunks == ["chunk1", "chunk2"]
+        mock_stream.assert_called_once()
+        kwargs = mock_stream.call_args.kwargs
+        assert kwargs["model"] == "openai/gpt-4o-mini"
+        assert kwargs["api_key"] == "sk-test"
+
+
+# ---------------------------------------------------------------------------
+# One-time DEBUG dispatch-status log
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _reset_dispatch_status_log():
+    """Reset the module-level one-time guard so each test starts clean.
+
+    The log is fire-once per process — we have to flip the sentinel back to
+    False so subsequent tests can observe the log being emitted.
+    """
+    original = openai_handler_module._DISPATCH_STATUS_LOGGED
+    openai_handler_module._DISPATCH_STATUS_LOGGED = False
+    yield
+    openai_handler_module._DISPATCH_STATUS_LOGGED = original
+
+
+class TestDispatchStatusLog:
+    """``has_native()`` should fire a DEBUG log exactly once per process so
+    operators running ``meshctl ... --debug`` can confirm whether the native
+    OpenAI SDK is in play (or whether mesh has fallen back to LiteLLM)."""
+
+    def test_logs_enabled_when_sdk_available_and_flag_unset(
+        self, caplog, _reset_dispatch_status_log
+    ):
+        handler = OpenAIHandler()
+        assert "MCP_MESH_NATIVE_LLM" not in os.environ
+
+        with (
+            caplog.at_level(
+                logging.DEBUG,
+                logger="_mcp_mesh.engine.provider_handlers.openai_handler",
+            ),
+            patch(
+                "_mcp_mesh.engine.native_clients.openai_native.is_available",
+                return_value=True,
+            ),
+        ):
+            handler.has_native()
+
+        status_records = [
+            r for r in caplog.records if "OpenAI native dispatch:" in r.message
+        ]
+        assert len(status_records) == 1
+        assert status_records[0].levelno == logging.DEBUG
+        assert "enabled" in status_records[0].message
+
+    def test_logs_disabled_when_flag_explicitly_off(
+        self, caplog, _reset_dispatch_status_log
+    ):
+        handler = OpenAIHandler()
+        os.environ["MCP_MESH_NATIVE_LLM"] = "0"
+
+        with caplog.at_level(
+            logging.DEBUG,
+            logger="_mcp_mesh.engine.provider_handlers.openai_handler",
+        ):
+            handler.has_native()
+
+        status_records = [
+            r for r in caplog.records if "OpenAI native dispatch:" in r.message
+        ]
+        assert len(status_records) == 1
+        assert status_records[0].levelno == logging.DEBUG
+        assert "disabled" in status_records[0].message
+        assert "MCP_MESH_NATIVE_LLM=0" in status_records[0].message
+
+    def test_logs_disabled_when_sdk_missing(
+        self, caplog, _reset_dispatch_status_log
+    ):
+        handler = OpenAIHandler()
+        assert "MCP_MESH_NATIVE_LLM" not in os.environ
+
+        with (
+            caplog.at_level(
+                logging.DEBUG,
+                logger="_mcp_mesh.engine.provider_handlers.openai_handler",
+            ),
+            patch(
+                "_mcp_mesh.engine.native_clients.openai_native.is_available",
+                return_value=False,
+            ),
+        ):
+            handler.has_native()
+
+        status_records = [
+            r for r in caplog.records if "OpenAI native dispatch:" in r.message
+        ]
+        assert len(status_records) == 1
+        assert status_records[0].levelno == logging.DEBUG
+        assert "disabled" in status_records[0].message
+        assert "openai SDK not installed" in status_records[0].message
+        assert "mcp-mesh[openai]" in status_records[0].message
+
+    def test_log_fires_only_once_across_calls(
+        self, caplog, _reset_dispatch_status_log
+    ):
+        """Second call to has_native() must NOT re-emit the dispatch-status log
+        — the one-time guard is the whole point of the helper."""
+        handler = OpenAIHandler()
+        assert "MCP_MESH_NATIVE_LLM" not in os.environ
+
+        with (
+            caplog.at_level(
+                logging.DEBUG,
+                logger="_mcp_mesh.engine.provider_handlers.openai_handler",
+            ),
+            patch(
+                "_mcp_mesh.engine.native_clients.openai_native.is_available",
+                return_value=True,
+            ),
+        ):
+            handler.has_native()
+            first_count = sum(
+                1 for r in caplog.records if "OpenAI native dispatch:" in r.message
+            )
+            handler.has_native()
+            second_count = sum(
+                1 for r in caplog.records if "OpenAI native dispatch:" in r.message
+            )
+
+        assert first_count == 1
+        assert second_count == 1  # no new log emitted on the second call

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -42,6 +42,13 @@ requires-python = ">=3.11"
 # dispatch through the native anthropic SDK; without the SDK they would
 # silently fall back to LiteLLM. Heavy backend extras (boto3 for Bedrock)
 # stay opt-in via the [anthropic-bedrock] extra.
+#
+# openai SDK is included by default for native OpenAI dispatch (issue #834
+# PR 2). When MCP_MESH_NATIVE_LLM is unset (default ON), OpenAI provider
+# agents dispatch through the native openai SDK; without it they would
+# silently fall back to LiteLLM. (openai is also a transitive dep of
+# litellm today; promoting to a direct base dep prevents breakage if
+# litellm ever drops it as transitive.)
 dependencies = [
     "fastapi>=0.104.0",
     "uvicorn>=0.24.0",
@@ -57,6 +64,7 @@ dependencies = [
     "fastmcp>=3.0.0,<4.0.0",
     "litellm>=1.80.5,!=1.82.7,!=1.82.8",
     "anthropic>=0.42",
+    "openai>=1.60",
     "prometheus-client>=0.19.0",
     "pyyaml>=6.0",
     "jinja2>=3.1.0",
@@ -108,6 +116,13 @@ anthropic-bedrock = [
     # Install via:
     #   pip install mcp-mesh[anthropic-bedrock]
     "anthropic[bedrock]>=0.42"
+]
+openai = [
+    # Backward-compat alias: ``openai`` is now a base dependency (issue
+    # #834 PR 2 — native dispatch is default ON). This extra is preserved
+    # as a no-op so ``pip install mcp-mesh[openai]`` still resolves cleanly
+    # for users who pinned it from earlier docs.
+    "openai>=1.60"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

PR 2 of #834. Native `openai` Python SDK dispatch in `@mesh.llm_provider` invocation, default ON. Mirrors PR 1 architecture (#862, native Anthropic SDK).

**Smaller than PR 1** because OpenAI:
- Has first-class `response_format` strict mode → no synthetic tool gymnastics
- Wire shape IS mesh-internal shape (LiteLLM uses OpenAI shape internally) → no image content-block translation
- No HINT-mode workaround
- Tools format passes through unchanged

Result: ~750 LOC adapter + ~1300 LOC tests, mostly passthrough with defensive shape adaptation.

## Changes

| File | Type | Purpose |
|---|---|---|
| `_mcp_mesh/engine/native_clients/openai_native.py` | new | Native OpenAI adapter (AsyncOpenAI wrapper, complete/complete_stream, shape adaptation) |
| `_mcp_mesh/engine/provider_handlers/openai_handler.py` | modified | Added has_native()/complete()/complete_stream() + DEBUG dispatch log |
| `_mcp_mesh/engine/native_clients/tests/test_openai_native.py` | new | 58 unit tests |
| `_mcp_mesh/engine/provider_handlers/tests/test_openai_handler_native.py` | new | 22 unit tests |
| `pyproject.toml` (src + packaging) | modified | `openai>=1.60` promoted to base dep + `[openai]` backward-compat alias |

## Lessons applied from PR 1's 4 review rounds

All explicitly applied (verified in re-review):
- `pytest.importorskip("openai")` at test top
- Shared `httpx.AsyncClient` pool with `threading.Lock`
- Per-call lazy `AsyncOpenAI` for K8s secret rotation
- Per-key WARN dedupe for unsupported kwargs
- Upfront credential validation (clear error vs late 401)
- `is_available()` result cached
- `log_fallback_once()` short-circuit via `is_fallback_logged()` getter
- `max_tokens=None` explicit handling (drops the key for OpenAI; no-op default since OpenAI doesn't require it)
- `final_usage_emitted` flag set AFTER yield (no telemetry hole on stream interruption)

Intentionally NOT applied: `tool_choice="none"` translation (Anthropic-specific; OpenAI accepts "none" natively).

## E2E verification

Local meshctl-managed agents + httpx wire logs:
```
DEBUG OpenAI native dispatch: enabled (openai SDK 2.14.0)
DEBUG Sending HTTP Request: POST https://api.openai.com/v1/chat/completions
DEBUG HTTP Response: ... Headers({'openai-organization': 'user-...', 'x-request-id': 'req_...', 'openai-version': '2020-10-01'})
DEBUG 📥 LLM provider response: <_mcp_mesh.engine.native_clients.openai_native._Response object>
```

Trap-based dispatch verification (3-row matrix):
- Flag unset (default ON) + litellm trap armed → call succeeds (proves native bypass)
- `MCP_MESH_NATIVE_LLM=0` + trap armed → call fails with LITELLM CALLED (proves opt-out routes to litellm)
- `MCP_MESH_NATIVE_LLM=0` + trap disarmed → call succeeds via litellm (sanity)

## Diagnostic log

`Claude-equivalent` DEBUG one-time log on first `has_native()` call:
- `OpenAI native dispatch: enabled (openai SDK X.Y.Z)`
- `OpenAI native dispatch: disabled (MCP_MESH_NATIVE_LLM=0 explicitly set; using LiteLLM)`
- `OpenAI native dispatch: disabled (openai SDK not installed; ...)` — never fires after base-dep promotion in normal install

## Test results

- 80 new unit tests
- 937 total unit tests pass (857 baseline post-PR1 merge + 80 new)
- E2E: meshctl-managed agents + real `api.openai.com` hits + httpx wire log + DEBUG diagnostic + trap proof = 4 independent confirmations of native dispatch

## Out of scope (deferred)

- AzureOpenAI backend (`azure/*` prefix; needs `azure_endpoint` / `api_version` / `deployment_name` plumbing)
- Reasoning tokens (o1/o3) surfacing in `_mesh_meta`
- Pre-existing kwarg-collision bug at `mesh_llm_agent.py:821` filed as #863 — `output_type` passed both as kwarg and via `**call_kwargs` splat; affects structured output on consumer side across both native and litellm paths

PR 3 (Gemini) follows the same pattern.

## Test plan

- [ ] CI integration suite passes (default ON exercises native path on OpenAI tests)
- [ ] Reviewer confirms backward-compat (LiteLLM path unchanged, only no-longer-default)
- [ ] Optional: Azure OpenAI follow-up PR (separate scope per pre-existing prefix routing)

Closes #834 (partial — OpenAI; Gemini in PR 3)