### PR TITLE
feature: native Gemini SDK (AI Studio + Vertex) for @mesh.llm_provider (#834)

### DIFF
--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -49,6 +49,13 @@ requires-python = ">=3.11"
 # silently fall back to LiteLLM. (openai is also a transitive dep of
 # litellm today; promoting to a direct base dep prevents breakage if
 # litellm ever drops it as transitive.)
+#
+# google-genai SDK is included by default for native Gemini dispatch
+# (issue #834 PR 3). Supports both AI Studio (gemini/*) and Vertex AI
+# (vertex_ai/*) backends via constructor flag. When MCP_MESH_NATIVE_LLM
+# is unset (default ON), Gemini provider agents dispatch through the
+# native google-genai SDK; without it they would silently fall back to
+# LiteLLM.
 dependencies = [
     # Rust core runtime (required - no Python fallback)
     "mcp-mesh-core>=1.4.1",
@@ -67,6 +74,7 @@ dependencies = [
     "litellm>=1.80.5,!=1.82.7,!=1.82.8",
     "anthropic>=0.42",
     "openai>=1.60",
+    "google-genai>=0.8.0",
     "prometheus-client>=0.19.0,<1.0.0",
     "pyyaml>=6.0,<7.0",
     "jinja2>=3.1.0",
@@ -121,6 +129,13 @@ openai = [
     # #834 PR 2). This entry is kept so existing ``pip install mcp-mesh[openai]``
     # commands continue to work without error.
     "openai>=1.60"
+]
+gemini = [
+    # Backward-compat alias: ``google-genai`` is now a base dependency
+    # (issue #834 PR 3). This entry is kept so existing
+    # ``pip install mcp-mesh[gemini]`` commands continue to work without
+    # error.
+    "google-genai>=0.8.0"
 ]
 
 [project.urls]

--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
@@ -1247,7 +1247,16 @@ class MeshLlmAgent:
         subsequent chunks at the same index. We coalesce by index and drop
         any partial entries (defensive — providers very rarely truncate
         mid-stream, but the math still works).
+
+        Gemini-only: deltas may carry a ``_thought_signature`` (bytes) — the
+        opaque blob from Gemini 2.0+ thought-mode functionCall Parts that the
+        API requires to be echoed back on the next-turn functionCall. Forward
+        it onto the merged dict as ``_gemini_thought_signature`` (base64-
+        encoded so JSON-shaped consumers can round-trip it). Other vendors
+        don't set this attribute so the branch is a no-op for them.
         """
+        import base64 as _base64
+
         merged: dict[int, dict[str, Any]] = {}
         for chunk in buffered:
             choices = getattr(chunk, "choices", None) or []
@@ -1279,6 +1288,18 @@ class MeshLlmAgent:
                         slot["function"]["name"] = fn.name
                     if getattr(fn, "arguments", None):
                         slot["function"]["arguments"] += fn.arguments
+                # Gemini-only thought_signature passthrough (last fragment
+                # wins; Gemini emits the whole functionCall Part in a single
+                # chunk so coalescing isn't a real concern in practice).
+                # Strict ``bytes`` check — MagicMock test doubles otherwise
+                # auto-generate truthy attributes that aren't bytes-like
+                # and break b64encode (and other vendors will never set
+                # this attr to anything but bytes / None).
+                sig = getattr(tc, "_thought_signature", None)
+                if isinstance(sig, (bytes, bytearray)) and sig:
+                    slot["_gemini_thought_signature"] = _base64.b64encode(
+                        sig
+                    ).decode("ascii")
         return [tc for tc in merged.values() if tc["id"] is not None]
 
     async def _stream_mesh_delegated(

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
@@ -940,6 +940,12 @@ def _sanitize_gemini_parameters_schema(schema: Any) -> Any:
                 # ``enum`` is a list of literal values, not nested schemas.
                 out[key] = list(value)
                 continue
+            if key in ("default", "example"):
+                # Literal payload (any JSON value), NOT a nested schema. Pass
+                # through verbatim — recursing would strip JSON-Schema-named
+                # keys from user-provided literals (silent data corruption).
+                out[key] = value
+                continue
             out[key] = _sanitize_gemini_parameters_schema(value)
         return out
     if isinstance(schema, list):
@@ -1068,7 +1074,13 @@ _GEMINI_PASSTHROUGH_KWARGS = frozenset({
     "response_mime_type",
     "presence_penalty",
     "frequency_penalty",
-    "candidate_count",
+    # NOTABLY ABSENT: ``candidate_count``. Mesh's contract is single-completion
+    # (anthropic_native + openai_native both implicitly assume n=1) and the
+    # Gemini response/stream adapters here only consume ``candidates[0]``.
+    # Forwarding ``candidate_count > 1`` would silently drop additional
+    # candidates. Letting the kwarg fall through to the WARN path gives
+    # callers a loud signal that mesh doesn't support multi-candidate output
+    # instead of silently returning 1 of N.
 })
 
 # Keys explicitly handled (consumed or routed) inside this adapter — the
@@ -1182,7 +1194,9 @@ def _build_create_kwargs(
         ("seed", "seed"),
         ("presence_penalty", "presence_penalty"),
         ("frequency_penalty", "frequency_penalty"),
-        ("candidate_count", "candidate_count"),
+        # ``candidate_count`` deliberately NOT forwarded — see the comment on
+        # ``_GEMINI_PASSTHROUGH_KWARGS``. Lets the WARN path surface the
+        # unsupported-knob signal instead of silently dropping N-1 candidates.
     ):
         value = request_params.get(src)
         if value is None:

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
@@ -1,0 +1,1429 @@
+"""Native Gemini SDK adapter for the @mesh.llm_provider invocation layer.
+
+Adapts ``google.genai.Client`` (the unified google-genai SDK) to the
+_Response/_StreamChunk shape contract that mesh's agentic loop in
+``mesh/helpers.py`` expects (mirrors litellm.completion()'s shape via
+mesh_llm_agent._MockResponse, and matches the anthropic_native /
+openai_native adapters introduced in PR 1 / PR 2 of issue #834).
+
+Backend selection by model prefix:
+  * ``gemini/<model>``    → ``genai.Client(api_key=...)`` (AI Studio backend)
+  * ``vertex_ai/<model>`` → ``genai.Client(vertexai=True, project=..., location=...)``
+                            (Vertex AI backend; reads GOOGLE_CLOUD_PROJECT
+                            and GOOGLE_CLOUD_LOCATION env vars)
+
+Wire-shape divergence from OpenAI/Anthropic is significant — see
+``_extract_system_instruction``, ``_convert_messages_to_gemini``,
+``_convert_tools``, and ``_translate_content_block_to_gemini`` for the
+translation surface. Key transformations:
+  * System message → top-level ``systemInstruction`` (NOT in contents).
+  * Roles renamed: ``assistant`` → ``model``; tool result → ``user`` with a
+    ``functionResponse`` part (and a back-reference to the function NAME,
+    not its id — Gemini has no tool-call ids).
+  * OpenAI tools list → single ``functionDeclarations`` wrapper.
+  * tool_choice → ``toolConfig.functionCallingConfig`` enum (AUTO / ANY / NONE).
+  * Multimodal blocks: data-URI → ``inlineData``; https URL → ``fileData``.
+
+Tool calls have NO id field on Gemini — we synthesize ``gemini_call_<index>``
+identifiers when adapting responses, and maintain a ``tool_call_id → name``
+map (built from the preceding assistant turn's tool_calls) when converting
+tool result messages back into Gemini's NAME-keyed ``functionResponse`` parts.
+
+K8s secret rotation: ``genai.Client`` is constructed per-call (no caching of
+the wrapper itself); the underlying ``httpx.AsyncClient`` connection pool IS
+cached process-wide via ``_get_shared_httpx_client`` and forwarded through
+``HttpOptions(httpx_async_client=...)`` so TLS handshakes are reused across
+calls. The pool carries no credential state.
+
+HINT-mode preservation: the existing ``GeminiHandler.prepare_request`` decides
+whether to attach ``response_format`` (no tools present) vs. fall back to HINT
+mode (tools + Pydantic output — Gemini API has a non-deterministic infinite-
+tool-loop bug for that combo). The native adapter just executes whatever the
+handler hands it; HINT-mode flow is identical between native and LiteLLM
+paths.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Matches: data:<mime>;base64,<data>
+_DATA_URI_RE = re.compile(r"^data:(?P<mime>[^;,]+);base64,(?P<data>.+)$", re.DOTALL)
+
+# Model prefixes that route through this adapter.
+_GEMINI_PREFIX = "gemini/"
+_VERTEX_PREFIX = "vertex_ai/"
+
+
+# ---------------------------------------------------------------------------
+# Shared httpx connection pool (issue #834 perf fix)
+# ---------------------------------------------------------------------------
+# A single ``httpx.AsyncClient`` is reused across all native Gemini calls in
+# this process. ``google.genai.Client`` accepts a custom async httpx client
+# via ``HttpOptions(httpx_async_client=...)`` and uses the supplied pool
+# instead of constructing a fresh one per call. This eliminates ~150-300ms
+# per-call TLS+H2 setup overhead vs. LiteLLM (which does its own pool reuse).
+#
+# K8s secret rotation still works because the api_key is read fresh per call
+# by callers and forwarded to the per-call ``genai.Client`` wrapper — the
+# pool itself carries no credential state, only TCP/TLS connections.
+_CACHED_HTTPX_CLIENT: httpx.AsyncClient | None = None
+# Guards lazy-init / rebuild of the shared httpx client. The pool itself is
+# safe for concurrent use; the lock only protects the check-then-create race
+# at construction. Cheap (uncontended after first call) and correct under
+# threaded harnesses (tests, sync wrapper paths) that touch the cache.
+_CACHED_HTTPX_CLIENT_LOCK = threading.Lock()
+
+
+def _get_shared_httpx_client() -> httpx.AsyncClient:
+    """Lazily construct (or rebuild if closed) the shared httpx client.
+
+    Single connection pool shared across all native Gemini calls in this
+    process. Per-call ``genai.Client`` wrappers reuse this pool —
+    eliminating ~150-300ms per-call TLS+H2 setup overhead. K8s secret
+    rotation still works: ``api_key`` is read fresh per call; the pool
+    carries no credential state.
+    """
+    global _CACHED_HTTPX_CLIENT
+    # Fast path — no lock when the cached client is healthy. The check is
+    # benign-racy (worst case: two threads both observe None and both enter
+    # the lock; the second one finds the cache populated under the lock and
+    # returns early).
+    if _CACHED_HTTPX_CLIENT is not None and not _CACHED_HTTPX_CLIENT.is_closed:
+        return _CACHED_HTTPX_CLIENT
+    with _CACHED_HTTPX_CLIENT_LOCK:
+        if _CACHED_HTTPX_CLIENT is None or _CACHED_HTTPX_CLIENT.is_closed:
+            _CACHED_HTTPX_CLIENT = httpx.AsyncClient(
+                timeout=httpx.Timeout(
+                    connect=10.0,  # connection establishment
+                    read=600.0,    # body read — LLM responses can be slow
+                    write=30.0,    # request body write
+                    pool=5.0,      # waiting for free connection from pool
+                ),
+                limits=httpx.Limits(
+                    max_keepalive_connections=20,
+                    max_connections=100,
+                    keepalive_expiry=30.0,
+                ),
+            )
+        return _CACHED_HTTPX_CLIENT
+
+
+def _reset_shared_httpx_client() -> None:
+    """For tests — reset the cached client. NOT for production use."""
+    global _CACHED_HTTPX_CLIENT
+    with _CACHED_HTTPX_CLIENT_LOCK:
+        _CACHED_HTTPX_CLIENT = None
+
+
+# ---------------------------------------------------------------------------
+# litellm-shaped response objects
+# ---------------------------------------------------------------------------
+# These mirror _MockResponse / _MockMessage / _MockChoice / _MockUsage in
+# ``_mcp_mesh.engine.mesh_llm_agent`` (and the corresponding shapes in
+# ``anthropic_native`` / ``openai_native``). Kept independent here so this
+# module does not import from mesh_llm_agent (avoids circular imports through
+# the provider_handlers package).
+
+
+class _Function:
+    __slots__ = ("name", "arguments")
+
+    def __init__(self, name: str, arguments: str):
+        self.name = name
+        self.arguments = arguments
+
+
+class _ToolCall:
+    __slots__ = ("id", "type", "function")
+
+    def __init__(self, id: str, name: str, arguments: str):
+        self.id = id
+        self.type = "function"
+        self.function = _Function(name=name, arguments=arguments)
+
+
+class _Message:
+    __slots__ = ("content", "role", "tool_calls")
+
+    def __init__(
+        self,
+        content: str | None,
+        role: str = "assistant",
+        tool_calls: list[_ToolCall] | None = None,
+    ):
+        self.content = content
+        self.role = role
+        self.tool_calls = tool_calls or None
+
+
+class _Choice:
+    __slots__ = ("message", "finish_reason", "index")
+
+    def __init__(self, message: _Message, finish_reason: str = "stop"):
+        self.message = message
+        self.finish_reason = finish_reason
+        self.index = 0
+
+
+class _Usage:
+    __slots__ = ("prompt_tokens", "completion_tokens", "total_tokens")
+
+    def __init__(self, prompt_tokens: int, completion_tokens: int):
+        self.prompt_tokens = prompt_tokens or 0
+        self.completion_tokens = completion_tokens or 0
+        self.total_tokens = (prompt_tokens or 0) + (completion_tokens or 0)
+
+
+class _Response:
+    __slots__ = ("choices", "usage", "model")
+
+    def __init__(
+        self,
+        message: _Message,
+        usage: _Usage | None,
+        model: str | None,
+        finish_reason: str = "stop",
+    ):
+        self.choices = [_Choice(message, finish_reason=finish_reason)]
+        self.usage = usage
+        self.model = model
+
+
+# ---------------------------------------------------------------------------
+# litellm-shaped streaming chunk objects
+# ---------------------------------------------------------------------------
+
+
+class _Delta:
+    __slots__ = ("content", "tool_calls", "role")
+
+    def __init__(
+        self,
+        content: str | None = None,
+        tool_calls: list[Any] | None = None,
+        role: str | None = None,
+    ):
+        self.content = content
+        self.tool_calls = tool_calls
+        self.role = role
+
+
+class _StreamChoice:
+    __slots__ = ("delta", "index", "finish_reason")
+
+    def __init__(
+        self,
+        delta: _Delta,
+        index: int = 0,
+        finish_reason: str | None = None,
+    ):
+        self.delta = delta
+        self.index = index
+        self.finish_reason = finish_reason
+
+
+class _StreamChunk:
+    __slots__ = ("choices", "usage", "model")
+
+    def __init__(
+        self,
+        delta: _Delta,
+        usage: _Usage | None = None,
+        model: str | None = None,
+        finish_reason: str | None = None,
+    ):
+        self.choices = [_StreamChoice(delta, finish_reason=finish_reason)]
+        self.usage = usage
+        self.model = model
+
+
+class _StreamFunctionDelta:
+    __slots__ = ("name", "arguments")
+
+    def __init__(self, name: str | None = None, arguments: str | None = None):
+        self.name = name
+        self.arguments = arguments
+
+
+class _StreamToolCallDelta:
+    """Tool-call fragment matching litellm's streamed tool_call shape.
+
+    ``MeshLlmAgent._merge_streamed_tool_calls`` reads ``index``, ``id``,
+    ``type``, and ``function.name`` / ``function.arguments`` off these
+    deltas. Gemini emits ``function_call`` parts as COMPLETE objects within
+    a single chunk (no incremental argument streaming like OpenAI/Anthropic),
+    so we always populate id+name+arguments together — the merger handles
+    "everything in one fragment" cleanly because subsequent fragment lookups
+    return None and the existing fields stay intact.
+    """
+
+    __slots__ = ("index", "id", "type", "function")
+
+    def __init__(
+        self,
+        index: int,
+        id: str | None = None,
+        name: str | None = None,
+        arguments: str | None = None,
+    ):
+        self.index = index
+        self.id = id
+        self.type = "function" if id is not None else None
+        self.function = _StreamFunctionDelta(name=name, arguments=arguments)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+_IS_AVAILABLE_CACHE: bool | None = None
+
+
+def is_available() -> bool:
+    """True if the ``google.genai`` SDK is importable in this process.
+
+    Result is cached after the first probe — the SDK presence does not
+    change at runtime, and the import-then-immediately-discard pattern
+    showed up as needless overhead on the dispatch-decision hot path in
+    PR 1 (anthropic_native) so the same caching is applied here.
+    """
+    global _IS_AVAILABLE_CACHE
+    if _IS_AVAILABLE_CACHE is not None:
+        return _IS_AVAILABLE_CACHE
+    try:
+        import google.genai  # noqa: F401
+    except ImportError:
+        _IS_AVAILABLE_CACHE = False
+        return False
+    _IS_AVAILABLE_CACHE = True
+    return True
+
+
+def _reset_is_available_cache() -> None:
+    """For tests — reset the cached availability probe. NOT for production."""
+    global _IS_AVAILABLE_CACHE
+    _IS_AVAILABLE_CACHE = None
+
+
+def supports_model(model: str) -> bool:
+    """True if ``model`` routes to the Gemini SDK.
+
+    Matches:
+      * ``gemini/<name>``    (Google AI Studio backend, GOOGLE_API_KEY auth).
+      * ``vertex_ai/<name>`` (Vertex AI backend, ADC / Workload Identity auth).
+    """
+    if not model:
+        return False
+    if model.startswith(_GEMINI_PREFIX):
+        return True
+    if model.startswith(_VERTEX_PREFIX):
+        return True
+    return False
+
+
+def _strip_prefix(model: str) -> str:
+    """Return the bare Gemini model id for the SDK call.
+
+    ``gemini/gemini-2.0-flash`` → ``gemini-2.0-flash``
+    ``vertex_ai/gemini-2.0-flash`` → ``gemini-2.0-flash``
+    """
+    if model.startswith(_GEMINI_PREFIX):
+        return model[len(_GEMINI_PREFIX):]
+    if model.startswith(_VERTEX_PREFIX):
+        return model[len(_VERTEX_PREFIX):]
+    return model
+
+
+def _build_client(
+    model: str,
+    api_key: str | None,
+    base_url: str | None,
+):
+    """Construct the appropriate google-genai Client per backend.
+
+    AI Studio backend (``gemini/*``):
+      * Requires ``GOOGLE_API_KEY`` env var or explicit ``api_key`` kwarg.
+
+    Vertex AI backend (``vertex_ai/*``):
+      * Requires ``GOOGLE_CLOUD_PROJECT`` env var (no decorator-kwarg path
+        in this PR — env-var-only, follow-up issue tracks credential kwargs).
+      * ``GOOGLE_CLOUD_LOCATION`` optional; defaults to ``us-central1``.
+      * Auth is via ADC (gcloud auth application-default login or Workload
+        Identity in K8s). ``api_key`` is ignored on this backend; we WARN
+        once if the caller passes one.
+
+    The wrapper is built fresh per call (no caching) so K8s secret rotation
+    works. The shared ``httpx.AsyncClient`` is forwarded through
+    ``HttpOptions(httpx_async_client=...)`` for connection-pool reuse.
+    """
+    import google.genai as genai
+    from google.genai.types import HttpOptions
+
+    http_options = HttpOptions(httpx_async_client=_get_shared_httpx_client())
+
+    if model.startswith(_VERTEX_PREFIX):
+        project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+        location = os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1")
+        if not project:
+            raise ValueError(
+                "Native Vertex AI dispatch requires GOOGLE_CLOUD_PROJECT env "
+                "var. Set GOOGLE_CLOUD_PROJECT (and optionally "
+                "GOOGLE_CLOUD_LOCATION; default 'us-central1'), ensure ADC is "
+                "configured (gcloud auth application-default login OR "
+                "Workload Identity in K8s), or set MCP_MESH_NATIVE_LLM=0 to "
+                "fall back to LiteLLM."
+            )
+        if api_key:
+            # Vertex backend uses Google Cloud IAM, NOT api_key. Surface a
+            # one-time WARN so users who mistakenly pass it know it's ignored.
+            _warn_unsupported_kwarg_once("api_key (vertex_ai backend)")
+        return genai.Client(
+            vertexai=True,
+            project=project,
+            location=location,
+            http_options=http_options,
+        )
+
+    # AI Studio backend.
+    resolved_key = api_key or os.environ.get("GOOGLE_API_KEY")
+    if not resolved_key:
+        raise ValueError(
+            "Native Gemini (AI Studio) dispatch requires GOOGLE_API_KEY env "
+            "var or explicit api_key argument. Set GOOGLE_API_KEY or pass "
+            "api_key= to @mesh.llm_provider, or set MCP_MESH_NATIVE_LLM=0 to "
+            "fall back to LiteLLM."
+        )
+    kwargs: dict[str, Any] = {"api_key": resolved_key, "http_options": http_options}
+    return genai.Client(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Translators (the meat of this PR)
+# ---------------------------------------------------------------------------
+
+
+def _extract_system_instruction(
+    messages: list[dict[str, Any]],
+) -> tuple[str | None, list[dict[str, Any]]]:
+    """Split out system message(s) into a top-level systemInstruction string.
+
+    Gemini's ``systemInstruction`` is a separate top-level request field,
+    NOT an entry in the contents array. Walks ``messages``, pulls out any
+    role=system entries, and returns ``(instruction, non_system_messages)``.
+
+    Behavior:
+      * No system messages → ``(None, messages)``.
+      * Exactly one with string content → instruction is that string.
+      * Multiple system messages → concatenated with double newlines.
+      * List-content system messages → text parts joined with newlines (image
+        parts in system messages are dropped — Gemini systemInstruction is
+        text-only).
+    """
+    system_chunks: list[str] = []
+    rest: list[dict[str, Any]] = []
+    for msg in messages:
+        if msg.get("role") == "system":
+            content = msg.get("content")
+            if isinstance(content, str):
+                if content:
+                    system_chunks.append(content)
+            elif isinstance(content, list):
+                # Pull text from each text block; skip non-text (Gemini
+                # systemInstruction is text-only).
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text = block.get("text", "")
+                        if text:
+                            system_chunks.append(text)
+            elif content is not None:
+                system_chunks.append(str(content))
+        else:
+            rest.append(msg)
+
+    if not system_chunks:
+        return None, rest
+    return "\n\n".join(system_chunks), rest
+
+
+def _build_tool_id_to_name_map(
+    messages: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Build a tool_call_id → tool_name map by walking assistant turns.
+
+    Tool result messages (``role: tool``) carry ONLY ``tool_call_id``, not
+    the function name — but Gemini's ``functionResponse`` part requires the
+    NAME (it has no concept of tool-call ids). The id-to-name link comes
+    from the immediately preceding assistant turn's ``tool_calls`` list.
+
+    We walk all assistant messages once up front so the converter can do an
+    O(1) lookup per tool result. Multiple turns are supported; the last
+    binding for a given id wins (matches OpenAI/litellm conventions where
+    ids are unique per request).
+    """
+    mapping: dict[str, str] = {}
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        for tc in msg.get("tool_calls") or []:
+            tc_id = tc.get("id")
+            fn = tc.get("function") or {}
+            tc_name = fn.get("name")
+            if tc_id and tc_name:
+                mapping[tc_id] = tc_name
+    return mapping
+
+
+def _translate_content_block_to_gemini(block: Any) -> dict | None:
+    """Translate one OpenAI-shape content block to Gemini-native part shape.
+
+    Returns a single part dict, or ``None`` to skip the block.
+
+    Supported translations:
+      * ``{"type": "text", "text": "..."}``
+        → ``{"text": "..."}``
+      * ``{"type": "image_url", "image_url": {"url": "data:<mime>;base64,<data>"}}``
+        → ``{"inline_data": {"mime_type": <mime>, "data": <data>}}``
+      * ``{"type": "image_url", "image_url": {"url": "https://..."}}``
+        → ``{"file_data": {"mime_type": "application/octet-stream",
+                            "file_uri": <url>}}``
+
+    Already-native parts (text/inline_data/file_data/function_call/
+    function_response) pass through unchanged.
+
+    Unknown block shapes pass through with a one-time WARN — surfaces the
+    next OpenAI-shape block we forget to translate without flooding the log.
+    """
+    if not isinstance(block, dict):
+        # Strings can appear inside a content list — treat as bare text.
+        if isinstance(block, str):
+            return {"text": block}
+        return block
+
+    btype = block.get("type")
+
+    # Already-native part shapes — passthrough (idempotent).
+    if "text" in block and btype is None:
+        return block
+    if "inline_data" in block or "inlineData" in block:
+        return block
+    if "file_data" in block or "fileData" in block:
+        return block
+    if "function_call" in block or "functionCall" in block:
+        return block
+    if "function_response" in block or "functionResponse" in block:
+        return block
+
+    if btype == "text":
+        return {"text": block.get("text", "")}
+
+    if btype == "image_url":
+        image_url_field = block.get("image_url", {})
+        # OpenAI typically uses ``image_url: {"url": "..."}``; some clients
+        # pass a bare string. Accept both.
+        if isinstance(image_url_field, str):
+            url = image_url_field
+        elif isinstance(image_url_field, dict):
+            url = image_url_field.get("url", "")
+        else:
+            url = ""
+
+        if not url:
+            logger.warning(
+                "image_url block missing url; passing through (will likely error)"
+            )
+            return block
+
+        m = _DATA_URI_RE.match(url)
+        if m:
+            return {
+                "inline_data": {
+                    "mime_type": m.group("mime"),
+                    "data": m.group("data"),
+                }
+            }
+
+        if url.startswith(("http://", "https://")):
+            # Gemini's fileData accepts arbitrary http(s) URIs but requires a
+            # mime_type. We default to application/octet-stream when the
+            # caller didn't supply one — Gemini will sniff in many cases.
+            return {
+                "file_data": {
+                    "mime_type": "application/octet-stream",
+                    "file_uri": url,
+                }
+            }
+
+        logger.warning(
+            "image_url block has unrecognized url scheme: %s; passing through",
+            url[:50],
+        )
+        return block
+
+    # Unknown block — passthrough + WARN once.
+    _warn_unsupported_kwarg_once(f"content_block_type:{btype!r}")
+    return block
+
+
+def _translate_content_list_to_gemini(content: Any) -> list[dict]:
+    """Apply ``_translate_content_block_to_gemini`` to a content list.
+
+    If ``content`` is a string, wraps it in a single text part. If it's a
+    list, returns a NEW list with each block translated (None entries are
+    skipped). Anything else falls back to ``str()`` wrapped as text.
+    """
+    if isinstance(content, str):
+        return [{"text": content}]
+    if isinstance(content, list):
+        out: list[dict] = []
+        for block in content:
+            translated = _translate_content_block_to_gemini(block)
+            if translated is not None:
+                out.append(translated)
+        return out
+    if content is None:
+        return []
+    return [{"text": str(content)}]
+
+
+def _convert_messages_to_gemini(
+    messages: list[dict[str, Any]],
+    tool_id_to_name: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Translate litellm-shape messages → Gemini contents array.
+
+    Key transforms:
+      * Roles: ``user`` stays ``user``; ``assistant`` becomes ``model``;
+        ``tool`` becomes ``user`` with a single ``functionResponse`` part.
+      * ``assistant`` with ``tool_calls`` → ``model`` role with one
+        ``functionCall`` part per call (id is dropped — Gemini tool calls
+        have no id; the preceding-turn id-to-name map is built upstream so
+        tool results can find the right name).
+      * ``tool`` result message → ``user`` role with a single
+        ``functionResponse`` part. Name is looked up in ``tool_id_to_name``;
+        if missing (mid-conversation reorder, tool result without preceding
+        call, etc.) we WARN and emit a placeholder ``unknown_tool`` name —
+        the request will likely fail at the API layer but the dispatch
+        contract is preserved.
+
+    Assumes ``messages`` does NOT contain system entries (caller already
+    extracted them via ``_extract_system_instruction``).
+    """
+    out: list[dict[str, Any]] = []
+    for msg in messages:
+        role = msg.get("role")
+
+        if role == "tool":
+            tool_call_id = msg.get("tool_call_id", "")
+            tool_name = tool_id_to_name.get(tool_call_id)
+            if not tool_name:
+                logger.warning(
+                    "Gemini tool result message missing name in id-map "
+                    "(tool_call_id=%r); using placeholder 'unknown_tool'",
+                    tool_call_id,
+                )
+                tool_name = "unknown_tool"
+
+            content = msg.get("content", "")
+            # Gemini's functionResponse.response is an arbitrary JSON object;
+            # we conventionally wrap textual results under {"result": "..."}.
+            # Already-dict results pass through to preserve structure.
+            if isinstance(content, dict):
+                response_value: Any = content
+            elif isinstance(content, str):
+                response_value = {"result": content}
+            else:
+                # Lists or other — try JSON serialization, fall back to repr.
+                try:
+                    response_value = {"result": json.dumps(content)}
+                except (TypeError, ValueError):
+                    response_value = {"result": repr(content)}
+
+            out.append(
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "function_response": {
+                                "name": tool_name,
+                                "response": response_value,
+                            }
+                        }
+                    ],
+                }
+            )
+            continue
+
+        if role == "assistant":
+            parts: list[dict[str, Any]] = []
+            text = msg.get("content")
+            if isinstance(text, str) and text:
+                parts.append({"text": text})
+            elif isinstance(text, list):
+                parts.extend(_translate_content_list_to_gemini(text))
+
+            for tc in msg.get("tool_calls") or []:
+                fn = tc.get("function") or {}
+                args_raw = fn.get("arguments", "{}")
+                try:
+                    parsed_args = (
+                        json.loads(args_raw)
+                        if isinstance(args_raw, str)
+                        else args_raw
+                    )
+                except (json.JSONDecodeError, ValueError):
+                    parsed_args = {}
+                if not isinstance(parsed_args, dict):
+                    parsed_args = {}
+                parts.append(
+                    {
+                        "function_call": {
+                            "name": fn.get("name", ""),
+                            "args": parsed_args,
+                        }
+                    }
+                )
+
+            if not parts:
+                # Skip empty assistant messages — Gemini rejects empty parts.
+                continue
+            out.append({"role": "model", "parts": parts})
+            continue
+
+        # user (default) or any other role — fall through as user.
+        # Gemini only knows "user" and "model" roles in contents; map
+        # anything unrecognized to "user" so the request stays valid.
+        gemini_role = "user" if role != "model" else "model"
+        parts = _translate_content_list_to_gemini(msg.get("content", ""))
+        if not parts:
+            # Still emit an empty-text placeholder so multi-turn ordering is
+            # preserved (Gemini rejects truly empty parts arrays, but a
+            # single empty-string text part is accepted).
+            parts = [{"text": ""}]
+        out.append({"role": gemini_role, "parts": parts})
+
+    return out
+
+
+# Whitelist of OpenAPI 3.0 Schema fields that Gemini's function_declarations
+# parameters accept. Everything else is stripped by
+# ``_sanitize_gemini_parameters_schema`` before it reaches the API — Gemini
+# returns HTTP 400 INVALID_ARGUMENT for unknown fields like
+# ``additionalProperties`` (which Pydantic-generated mesh tool schemas always
+# emit) or ``$schema`` / ``title`` / ``$ref``.
+#
+# Reference: Gemini API "FunctionDeclaration" / "Schema" docs —
+# https://ai.google.dev/api/caching#Schema
+# (Gemini supports a documented subset of OpenAPI 3.0 Schema; the closed list
+# of accepted fields is below. LiteLLM's Gemini adapter performs the
+# equivalent translation internally; native dispatch must do the same.)
+_GEMINI_SCHEMA_KEYS = frozenset({
+    "type",
+    "format",
+    "description",
+    "nullable",
+    "enum",
+    "properties",
+    "required",
+    "items",
+    "minimum",
+    "maximum",
+    "minItems",
+    "maxItems",
+    "minLength",
+    "maxLength",
+    "pattern",
+    "default",
+    "example",
+    "anyOf",
+    "allOf",
+    "oneOf",
+    # NOTABLY ABSENT (rejected by Gemini): additionalProperties, $schema,
+    # title, $ref, definitions, $defs, propertyNames, patternProperties,
+    # exclusiveMinimum, exclusiveMaximum, multipleOf, const, not, contains.
+})
+
+
+def _sanitize_gemini_parameters_schema(schema: Any) -> Any:
+    """Strip JSON-Schema fields Gemini's function_declarations doesn't accept.
+
+    Gemini accepts an OpenAPI 3.0 Schema subset for function parameters.
+    Fields like ``additionalProperties``, ``$schema``, ``title``, ``$ref``
+    are rejected with HTTP 400 INVALID_ARGUMENT. Walk the schema recursively
+    and keep only the whitelisted keys (see ``_GEMINI_SCHEMA_KEYS``).
+
+    Mesh's tool schema generator (Pydantic-based) emits standard JSON Schema
+    which always includes ``additionalProperties: False`` on object schemas;
+    this helper bridges the gap so native dispatch matches LiteLLM's adapter
+    behavior (LiteLLM has been silently doing this translation for us).
+
+    Whitelist (not blacklist) approach is deliberate: the list of valid
+    Gemini schema fields is fixed and documented; new JSON-Schema fields
+    introduced by Pydantic upgrades would otherwise leak through and
+    silently break tool calls again.
+
+    ``properties`` needs special handling because it's a name → schema map
+    (the keys are user-defined property names, NOT JSON-Schema field names),
+    so we keep the keys as-is and only sanitize the value sub-schemas.
+    """
+    if isinstance(schema, dict):
+        out: dict[str, Any] = {}
+        for key, value in schema.items():
+            if key not in _GEMINI_SCHEMA_KEYS:
+                continue
+            if key == "properties" and isinstance(value, dict):
+                # Property names are arbitrary identifiers — keep them
+                # verbatim, sanitize each property's sub-schema.
+                out[key] = {
+                    prop_name: _sanitize_gemini_parameters_schema(prop_schema)
+                    for prop_name, prop_schema in value.items()
+                }
+                continue
+            if key == "required" and isinstance(value, list):
+                # ``required`` is a list of property-name strings, not nested
+                # schemas — pass through verbatim.
+                out[key] = list(value)
+                continue
+            if key == "enum" and isinstance(value, list):
+                # ``enum`` is a list of literal values, not nested schemas.
+                out[key] = list(value)
+                continue
+            out[key] = _sanitize_gemini_parameters_schema(value)
+        return out
+    if isinstance(schema, list):
+        return [_sanitize_gemini_parameters_schema(item) for item in schema]
+    return schema
+
+
+def _convert_tools(
+    tools: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]] | None:
+    """Translate OpenAI/litellm tool schema → Gemini functionDeclarations.
+
+    OpenAI shape (what mesh / litellm uses):
+        [{"type": "function", "function": {"name": ..., "description": ...,
+                                           "parameters": {...}}}, ...]
+
+    Gemini shape:
+        [{"function_declarations": [{"name": ..., "description": ...,
+                                     "parameters": {...}}, ...]}]
+
+    Note all declarations are bundled under ONE wrapper (Gemini expects a
+    list of Tool objects each carrying a list of function_declarations; we
+    use the canonical single-wrapper form because it's what the SDK
+    documents and what litellm emits).
+
+    The ``parameters`` field is sanitized via
+    ``_sanitize_gemini_parameters_schema`` to strip JSON-Schema fields
+    Gemini rejects (notably ``additionalProperties`` which mesh's
+    Pydantic-based schema generator always emits).
+
+    Tools already in Gemini shape (``function_declarations`` present)
+    pass through unchanged.
+    """
+    if not tools:
+        return None
+
+    declarations: list[dict[str, Any]] = []
+    passthrough_tools: list[dict[str, Any]] = []
+    for tool in tools:
+        if "function_declarations" in tool or "functionDeclarations" in tool:
+            # Already-native — keep as a separate Tool entry.
+            passthrough_tools.append(tool)
+            continue
+        fn = tool.get("function") or {}
+        decl: dict[str, Any] = {
+            "name": fn.get("name", ""),
+            "description": fn.get("description", ""),
+            "parameters": _sanitize_gemini_parameters_schema(
+                fn.get("parameters", {"type": "object", "properties": {}})
+            ),
+        }
+        declarations.append(decl)
+
+    out: list[dict[str, Any]] = []
+    if declarations:
+        out.append({"function_declarations": declarations})
+    out.extend(passthrough_tools)
+    return out or None
+
+
+def _convert_tool_choice(tool_choice: Any) -> dict[str, Any] | None:
+    """Translate OpenAI tool_choice → Gemini toolConfig.functionCallingConfig.
+
+    | OpenAI                                          | Gemini                                                   |
+    |-------------------------------------------------|----------------------------------------------------------|
+    | ``"auto"``                                      | ``{function_calling_config: {mode: "AUTO"}}``            |
+    | ``"none"``                                      | ``{function_calling_config: {mode: "NONE"}}``            |
+    | ``"required"`` / ``"any"``                      | ``{function_calling_config: {mode: "ANY"}}``             |
+    | ``{"type": "function", "function": {"name": "X"}}`` | ``{function_calling_config: {mode: "ANY", allowed_function_names: ["X"]}}`` |
+
+    Returns ``None`` when ``tool_choice`` is None / unrecognized — the
+    caller should omit ``tool_config`` entirely in that case (Gemini
+    defaults to AUTO when tools are present).
+    """
+    if tool_choice is None:
+        return None
+
+    if tool_choice == "auto":
+        return {"function_calling_config": {"mode": "AUTO"}}
+    if tool_choice == "none":
+        return {"function_calling_config": {"mode": "NONE"}}
+    if tool_choice in ("required", "any"):
+        return {"function_calling_config": {"mode": "ANY"}}
+
+    if isinstance(tool_choice, dict):
+        if tool_choice.get("type") == "function":
+            fn = tool_choice.get("function") or {}
+            name = fn.get("name")
+            if name:
+                return {
+                    "function_calling_config": {
+                        "mode": "ANY",
+                        "allowed_function_names": [name],
+                    }
+                }
+        # Best-effort passthrough if it already looks Gemini-shaped.
+        if (
+            "function_calling_config" in tool_choice
+            or "functionCallingConfig" in tool_choice
+        ):
+            return tool_choice
+
+    # Unknown — omit toolConfig (Gemini defaults to AUTO).
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Request building
+# ---------------------------------------------------------------------------
+
+# Kwargs we know how to translate / forward; anything outside this set
+# (and not in _GEMINI_HANDLED_KWARGS) triggers a once-per-key WARN so the
+# next litellm-only knob we forget shows up early.
+_GEMINI_PASSTHROUGH_KWARGS = frozenset({
+    "messages",
+    "tools",
+    "tool_choice",
+    "max_tokens",
+    "max_completion_tokens",
+    "temperature",
+    "top_p",
+    "top_k",
+    "stop",
+    "seed",
+    "response_format",
+    "response_mime_type",
+    "presence_penalty",
+    "frequency_penalty",
+    "candidate_count",
+})
+
+# Keys explicitly handled (consumed or routed) inside this adapter — the
+# WARN filter must not flag these as "dropped".
+_GEMINI_HANDLED_KWARGS = frozenset({
+    "model",
+    "api_key",
+    "base_url",
+    "stream",
+})
+
+
+def _build_create_kwargs(
+    request_params: dict[str, Any],
+    *,
+    model: str,
+) -> dict[str, Any]:
+    """Translate mesh/litellm-shape request_params → genai.Client kwargs.
+
+    Returns a dict with keys ``model``, ``contents``, and ``config`` —
+    matching ``aio.models.generate_content`` / ``generate_content_stream``.
+
+    Translation steps:
+      1. Extract the system message into a top-level ``system_instruction``.
+      2. Build a ``tool_call_id → name`` map from the assistant turns so
+         tool result messages can populate Gemini's ``functionResponse.name``.
+      3. Convert messages → ``contents`` (role rename, multimodal block
+         translation, tool_calls → functionCall parts, tool result →
+         functionResponse part).
+      4. Convert tools → ``functionDeclarations`` wrapper.
+      5. Convert tool_choice → ``toolConfig.functionCallingConfig`` enum.
+      6. Forward generation params (temperature, top_p, top_k, stop, seed)
+         under their Gemini names (camel/snake — google-genai accepts both
+         via dict input; we use snake_case for clarity).
+
+    HINT-mode passthrough: ``response_format`` is forwarded as
+    ``response_mime_type=application/json`` + ``response_schema``. The
+    upstream ``GeminiHandler.prepare_request`` already strips
+    ``response_format`` when tools are present (the HINT-mode workaround
+    for the Gemini API infinite-loop bug); the adapter forwards whatever
+    the handler hands it.
+    """
+    # 1. Extract system instruction.
+    raw_messages = request_params.get("messages") or []
+    system_instruction, non_system = _extract_system_instruction(raw_messages)
+
+    # 2. Build tool_call_id → name map (for tool result conversion).
+    tool_id_to_name = _build_tool_id_to_name_map(non_system)
+
+    # 3. Convert messages → contents.
+    contents = _convert_messages_to_gemini(non_system, tool_id_to_name)
+
+    # 4. Convert tools.
+    converted_tools = _convert_tools(request_params.get("tools"))
+
+    # 5. Convert tool_choice → toolConfig.
+    tool_config = _convert_tool_choice(request_params.get("tool_choice"))
+
+    # 6. Assemble GenerateContentConfig dict.
+    config: dict[str, Any] = {}
+    if system_instruction:
+        config["system_instruction"] = system_instruction
+    if converted_tools:
+        config["tools"] = converted_tools
+    if tool_config:
+        config["tool_config"] = tool_config
+
+    # response_format → response_mime_type + response_schema (handler may
+    # also be using HINT mode — in that case response_format is absent and
+    # the JSON instructions live in the system prompt; this branch is a no-op).
+    rf = request_params.get("response_format")
+    if isinstance(rf, dict):
+        if rf.get("type") == "json_schema":
+            schema = (rf.get("json_schema") or {}).get("schema") or {}
+            config["response_mime_type"] = "application/json"
+            if schema:
+                config["response_schema"] = schema
+        elif rf.get("type") == "json_object":
+            config["response_mime_type"] = "application/json"
+    # Allow callers to set response_mime_type directly too.
+    rmt = request_params.get("response_mime_type")
+    if rmt is not None and "response_mime_type" not in config:
+        config["response_mime_type"] = rmt
+
+    # max_tokens / max_completion_tokens → max_output_tokens.
+    # Explicit max_tokens=None must be DROPPED (don't forward as None which
+    # Gemini would reject) — same lesson as openai_native.
+    max_tokens = request_params.get("max_tokens")
+    if max_tokens is None:
+        max_tokens = request_params.get("max_completion_tokens")
+    if max_tokens is not None:
+        config["max_output_tokens"] = max_tokens
+
+    # Generation params: forward under Gemini names. Drop None values so
+    # callers passing ``temperature=None`` get the SDK default (Gemini
+    # rejects None for these fields).
+    for src, dst in (
+        ("temperature", "temperature"),
+        ("top_p", "top_p"),
+        ("top_k", "top_k"),
+        ("stop", "stop_sequences"),
+        ("seed", "seed"),
+        ("presence_penalty", "presence_penalty"),
+        ("frequency_penalty", "frequency_penalty"),
+        ("candidate_count", "candidate_count"),
+    ):
+        value = request_params.get(src)
+        if value is None:
+            continue
+        config[dst] = value
+
+    # WARN-log any kwargs the adapter is silently dropping. Internal mesh
+    # markers (``_mesh_*``) are not forwarded but should also not warn —
+    # they're handled upstream in helpers._pop_mesh_*_flags. Dedupe per-key.
+    for k in request_params:
+        if k.startswith("_mesh_"):
+            continue
+        if k in _GEMINI_PASSTHROUGH_KWARGS:
+            continue
+        if k in _GEMINI_HANDLED_KWARGS:
+            continue
+        _warn_unsupported_kwarg_once(k)
+
+    return {
+        "model": _strip_prefix(model),
+        "contents": contents,
+        "config": config,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Response / chunk adaptation
+# ---------------------------------------------------------------------------
+
+
+# Gemini finish reasons → litellm-shape strings consumed by helpers.py.
+_FINISH_REASON_MAP = {
+    "STOP": "stop",
+    "MAX_TOKENS": "length",
+    "SAFETY": "content_filter",
+    "RECITATION": "content_filter",
+    "BLOCKLIST": "content_filter",
+    "PROHIBITED_CONTENT": "content_filter",
+    "SPII": "content_filter",
+    "LANGUAGE": "stop",
+    "OTHER": "stop",
+    "FINISH_REASON_UNSPECIFIED": "stop",
+}
+
+
+def _normalize_finish_reason(raw: Any, has_tool_calls: bool) -> str:
+    """Translate Gemini's FinishReason enum → litellm-style string.
+
+    When the response contains tool/function calls and Gemini reports STOP,
+    helpers.py's agentic loop expects ``tool_calls`` so it knows to invoke
+    the tools. We surface that mapping here so the dispatch contract holds.
+    """
+    if raw is None:
+        return "tool_calls" if has_tool_calls else "stop"
+    # Enum members serialize to their str value by default.
+    name = getattr(raw, "name", None) or str(raw)
+    # Strip enum-like prefixes.
+    if "." in name:
+        name = name.rsplit(".", 1)[-1]
+    mapped = _FINISH_REASON_MAP.get(name, "stop")
+    if has_tool_calls and mapped == "stop":
+        return "tool_calls"
+    return mapped
+
+
+def _adapt_response(raw: Any, *, model: str) -> _Response:
+    """Translate genai.GenerateContentResponse → litellm-shape ``_Response``.
+
+    Walks ``candidates[0].content.parts`` collecting text parts (concatenated
+    into ``message.content``) and function_call parts (each becomes a
+    ``_ToolCall`` with synthesized id ``gemini_call_<index>``). usage_metadata
+    maps to ``_Usage`` with prompt_token_count / candidates_token_count
+    field-name translation.
+    """
+    candidates = getattr(raw, "candidates", None) or []
+    first_candidate = candidates[0] if candidates else None
+
+    text_parts: list[str] = []
+    tool_calls: list[_ToolCall] = []
+    raw_finish_reason: Any = None
+
+    if first_candidate is not None:
+        raw_finish_reason = getattr(first_candidate, "finish_reason", None)
+        content = getattr(first_candidate, "content", None)
+        parts = getattr(content, "parts", None) if content is not None else None
+        for part in parts or []:
+            text = getattr(part, "text", None)
+            if text:
+                text_parts.append(text)
+            fc = getattr(part, "function_call", None)
+            if fc is not None:
+                fc_name = getattr(fc, "name", "") or ""
+                fc_args = getattr(fc, "args", {}) or {}
+                # Gemini args come back as a dict; the litellm contract
+                # carries arguments as a JSON string for downstream parsers.
+                try:
+                    args_str = json.dumps(fc_args)
+                except (TypeError, ValueError):
+                    args_str = "{}"
+                # Synthesize a stable id since Gemini has no tool-call ids.
+                synth_id = f"gemini_call_{len(tool_calls)}"
+                tool_calls.append(
+                    _ToolCall(id=synth_id, name=fc_name, arguments=args_str)
+                )
+
+    finish_reason = _normalize_finish_reason(
+        raw_finish_reason, has_tool_calls=bool(tool_calls)
+    )
+
+    message = _Message(
+        content="".join(text_parts) if text_parts else None,
+        role="assistant",
+        tool_calls=tool_calls or None,
+    )
+
+    usage_obj = getattr(raw, "usage_metadata", None)
+    if usage_obj is not None:
+        usage = _Usage(
+            prompt_tokens=getattr(usage_obj, "prompt_token_count", 0) or 0,
+            completion_tokens=getattr(usage_obj, "candidates_token_count", 0) or 0,
+        )
+    else:
+        usage = None
+
+    # Gemini surfaces the resolved model id as ``model_version`` on the
+    # response (``response.model`` does not exist). Fall back to the request
+    # model if absent.
+    response_model = getattr(raw, "model_version", None) or model
+
+    return _Response(
+        message=message,
+        usage=usage,
+        model=response_model,
+        finish_reason=finish_reason,
+    )
+
+
+def _adapt_stream_chunk(
+    raw_chunk: Any,
+    *,
+    model: str,
+    tool_call_index_state: list[int],
+) -> _StreamChunk:
+    """Translate one streamed GenerateContentResponse chunk → ``_StreamChunk``.
+
+    Each Gemini chunk carries:
+      * Optional ``candidates[0].content.parts`` with text deltas and/or
+        complete ``function_call`` parts (Gemini does NOT stream function
+        call argument fragments — function_call appears as a single complete
+        part within one chunk).
+      * Optional ``usage_metadata`` (cumulative; emitted on most chunks
+        including the final one).
+
+    ``tool_call_index_state`` is a single-element list used as a mutable
+    integer counter so the synthesized id stays monotonic across chunks
+    yielded by the same stream — Python closures can't rebind ints.
+    """
+    candidates = getattr(raw_chunk, "candidates", None) or []
+    first_candidate = candidates[0] if candidates else None
+
+    content_str: str | None = None
+    tool_call_deltas: list[_StreamToolCallDelta] | None = None
+    raw_finish_reason: Any = None
+
+    if first_candidate is not None:
+        raw_finish_reason = getattr(first_candidate, "finish_reason", None)
+        content = getattr(first_candidate, "content", None)
+        parts = getattr(content, "parts", None) if content is not None else None
+        text_buf: list[str] = []
+        for part in parts or []:
+            text = getattr(part, "text", None)
+            if text:
+                text_buf.append(text)
+            fc = getattr(part, "function_call", None)
+            if fc is not None:
+                if tool_call_deltas is None:
+                    tool_call_deltas = []
+                fc_name = getattr(fc, "name", "") or ""
+                fc_args = getattr(fc, "args", {}) or {}
+                try:
+                    args_str = json.dumps(fc_args)
+                except (TypeError, ValueError):
+                    args_str = "{}"
+                idx = tool_call_index_state[0]
+                tool_call_index_state[0] = idx + 1
+                tool_call_deltas.append(
+                    _StreamToolCallDelta(
+                        index=idx,
+                        id=f"gemini_call_{idx}",
+                        name=fc_name,
+                        arguments=args_str,
+                    )
+                )
+        if text_buf:
+            content_str = "".join(text_buf)
+
+    finish_reason: str | None = None
+    if raw_finish_reason is not None:
+        finish_reason = _normalize_finish_reason(
+            raw_finish_reason,
+            has_tool_calls=bool(tool_call_deltas),
+        )
+
+    usage_obj = getattr(raw_chunk, "usage_metadata", None)
+    usage: _Usage | None = None
+    if usage_obj is not None:
+        usage = _Usage(
+            prompt_tokens=getattr(usage_obj, "prompt_token_count", 0) or 0,
+            completion_tokens=getattr(usage_obj, "candidates_token_count", 0) or 0,
+        )
+
+    chunk_model = getattr(raw_chunk, "model_version", None) or model
+
+    return _StreamChunk(
+        delta=_Delta(content=content_str, tool_calls=tool_call_deltas),
+        usage=usage,
+        model=chunk_model,
+        finish_reason=finish_reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level dispatch
+# ---------------------------------------------------------------------------
+
+
+async def complete(
+    request_params: dict[str, Any],
+    *,
+    model: str,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> _Response:
+    """Run a buffered Gemini completion and adapt to litellm-shape response.
+
+    The upstream ``GeminiHandler.prepare_request`` makes the
+    response_format-vs-HINT decision (Gemini API has an infinite-tool-loop
+    bug for ``response_format + tools`` — handler omits response_format in
+    that case and routes the schema through HINT mode in the system prompt
+    instead). The adapter just forwards whatever request_params carries.
+    """
+    client = _build_client(model, api_key, base_url)
+    create_kwargs = _build_create_kwargs(request_params, model=model)
+
+    raw = await client.aio.models.generate_content(**create_kwargs)
+    return _adapt_response(raw, model=create_kwargs["model"])
+
+
+async def complete_stream(
+    request_params: dict[str, Any],
+    *,
+    model: str,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> AsyncIterator[Any]:
+    """Stream a Gemini completion as litellm-shape chunks.
+
+    google-genai exposes streaming via ``await
+    client.aio.models.generate_content_stream(...)`` which returns an
+    async iterator of ``GenerateContentResponse`` chunks (each carrying
+    incremental text + cumulative usage_metadata; function_calls appear as
+    complete parts within a single chunk, not streamed-as-fragments).
+
+    Best-effort usage emission: if the stream is interrupted before a
+    final usage chunk arrives (server cutoff, consumer aclose, network
+    drop), the ``finally`` block emits a fallback usage chunk built from
+    the last counters we observed so telemetry doesn't silently record
+    0 tokens for partial generations.
+    """
+    client = _build_client(model, api_key, base_url)
+    create_kwargs = _build_create_kwargs(request_params, model=model)
+
+    # Single-element list as a mutable int counter so the synthesized
+    # tool-call id stays monotonic across chunks (Python closures can't
+    # rebind ints; a list cell can).
+    tool_call_index_state: list[int] = [0]
+
+    # Track usage for finally-block fallback (telemetry integrity if stream
+    # is interrupted — same pattern as anthropic_native / openai_native).
+    last_input_tokens = 0
+    last_output_tokens = 0
+    last_model: str = create_kwargs["model"]
+    # Tracks whether an authoritative usage chunk was successfully delivered
+    # to the consumer. Set True ONLY after the yield returns — so any
+    # failure mode (stream raises, consumer cancels mid-yield) leaves it
+    # False and the ``finally`` block emits the best-effort fallback.
+    final_usage_emitted = False
+
+    try:
+        stream = await client.aio.models.generate_content_stream(**create_kwargs)
+        async for raw_chunk in stream:
+            chunk = _adapt_stream_chunk(
+                raw_chunk,
+                model=create_kwargs["model"],
+                tool_call_index_state=tool_call_index_state,
+            )
+            if chunk.model:
+                last_model = chunk.model
+            if chunk.usage is not None:
+                last_input_tokens = chunk.usage.prompt_tokens
+                last_output_tokens = chunk.usage.completion_tokens
+                yield chunk
+                # Set the flag AFTER the yield so a consumer abort
+                # mid-yield falls into the finally fallback path.
+                final_usage_emitted = True
+                continue
+            yield chunk
+    finally:
+        # If no authoritative usage chunk reached the consumer (server
+        # cutoff, consumer cancelled mid-yield, network drop, etc.), emit
+        # a best-effort usage chunk built from the last counters we
+        # observed. Otherwise telemetry would silently record zero tokens
+        # for any interrupted stream — masking real cost on partial
+        # generations.
+        if not final_usage_emitted and (last_input_tokens or last_output_tokens):
+            try:
+                yield _StreamChunk(
+                    delta=_Delta(),
+                    usage=_Usage(
+                        prompt_tokens=last_input_tokens,
+                        completion_tokens=last_output_tokens,
+                    ),
+                    model=last_model,
+                )
+            except (GeneratorExit, StopAsyncIteration):
+                # The consumer has already called ``aclose()`` on this async
+                # generator, so executing ``yield`` inside ``finally`` raises
+                # GeneratorExit (or in rare cases StopAsyncIteration). Python
+                # forbids re-raising during finally cleanup — and there's
+                # nowhere to deliver the fallback usage chunk anyway. Swallow
+                # silently and let normal generator teardown proceed.
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Fallback-logging helpers
+# ---------------------------------------------------------------------------
+
+_logged_fallback_once = False
+
+
+def log_fallback_once() -> None:
+    """Emit the LiteLLM-fallback notice exactly once per process.
+
+    Called from ``GeminiHandler.has_native()`` when native dispatch was
+    attempted (the default) but the ``google.genai`` SDK is not importable.
+    In normal installs the SDK is a base dep so this branch should never
+    fire — kept for symmetry with the Anthropic / OpenAI paths and to guard
+    against custom installs that strip the SDK.
+    """
+    global _logged_fallback_once
+    if _logged_fallback_once:
+        return
+    _logged_fallback_once = True
+    logger.info(
+        "Install `mcp-mesh[gemini]` for native SDK with full feature "
+        "support — falling back to LiteLLM"
+    )
+
+
+def is_fallback_logged() -> bool:
+    """True once :func:`log_fallback_once` has emitted its notice.
+
+    Lets callers (notably ``GeminiHandler.has_native``) skip the call
+    entirely on the hot path after the first miss — avoids one
+    function-frame per request once we've already published the install
+    nudge.
+    """
+    return _logged_fallback_once
+
+
+# Module-level dedupe set for the unsupported-kwarg WARN. WARN once per
+# unique kwarg name across the lifetime of the process — high-volume
+# providers receiving the same litellm-only kwarg every request would
+# otherwise flood the log with identical messages (unbounded growth
+# pre-fix).
+_logged_unsupported_kwargs: set[str] = set()
+
+
+def _warn_unsupported_kwarg_once(key: str) -> None:
+    """WARN once per unique unsupported kwarg name.
+
+    Used by ``_build_create_kwargs`` to surface litellm-only knobs the
+    adapter is silently dropping (or new fields the google-genai SDK
+    doesn't accept yet) without logging on every single request.
+    """
+    if key in _logged_unsupported_kwargs:
+        return
+    _logged_unsupported_kwargs.add(key)
+    logger.warning(
+        "Native Gemini adapter dropping unsupported kwarg: '%s' "
+        "(LiteLLM-only — not forwarded to google.genai.Client.aio.models.generate_content)",
+        key,
+    )

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
@@ -46,6 +46,7 @@ paths.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import logging
 import os
@@ -181,12 +182,33 @@ class _Function:
 
 
 class _ToolCall:
-    __slots__ = ("id", "type", "function")
+    """A tool-call descriptor in litellm-shape, with one Gemini-only extra.
 
-    def __init__(self, id: str, name: str, arguments: str):
+    ``_thought_signature`` is the opaque blob Gemini's thought-mode (Gemini
+    2.0+ thinking models) emits on each ``functionCall`` Part. The Gemini API
+    REQUIRES this signature to be echoed back on the next-turn ``functionCall``
+    Part of the same multi-turn tool-calling conversation; without it the API
+    rejects the request with HTTP 400 "Function call is missing a
+    thought_signature in functionCall parts." The field is silently ignored by
+    every other vendor — kept on this object so the agentic loop can serialize
+    it into the conversation dict (under ``_gemini_thought_signature``,
+    base64-encoded) and ``_convert_messages_to_gemini`` can recover it on the
+    next iteration to build a valid Gemini ``functionCall`` Part.
+    """
+
+    __slots__ = ("id", "type", "function", "_thought_signature")
+
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        arguments: str,
+        thought_signature: bytes | None = None,
+    ):
         self.id = id
         self.type = "function"
         self.function = _Function(name=name, arguments=arguments)
+        self._thought_signature = thought_signature
 
 
 class _Message:
@@ -302,9 +324,15 @@ class _StreamToolCallDelta:
     so we always populate id+name+arguments together — the merger handles
     "everything in one fragment" cleanly because subsequent fragment lookups
     return None and the existing fields stay intact.
+
+    ``_thought_signature`` carries Gemini's thought-mode opaque blob from the
+    response Part through the agentic loop — see ``_ToolCall`` docstring for
+    the full rationale. The merger forwards it under the
+    ``_gemini_thought_signature`` key (base64-encoded) on the merged dict so
+    the next iteration's ``_convert_messages_to_gemini`` can echo it back.
     """
 
-    __slots__ = ("index", "id", "type", "function")
+    __slots__ = ("index", "id", "type", "function", "_thought_signature")
 
     def __init__(
         self,
@@ -312,11 +340,13 @@ class _StreamToolCallDelta:
         id: str | None = None,
         name: str | None = None,
         arguments: str | None = None,
+        thought_signature: bytes | None = None,
     ):
         self.index = index
         self.id = id
         self.type = "function" if id is not None else None
         self.function = _StreamFunctionDelta(name=name, arguments=arguments)
+        self._thought_signature = thought_signature
 
 
 # ---------------------------------------------------------------------------
@@ -761,14 +791,38 @@ def _convert_messages_to_gemini(
                     parsed_args = {}
                 if not isinstance(parsed_args, dict):
                     parsed_args = {}
-                parts.append(
-                    {
-                        "function_call": {
-                            "name": fn.get("name", ""),
-                            "args": parsed_args,
-                        }
+                fc_part: dict[str, Any] = {
+                    "function_call": {
+                        "name": fn.get("name", ""),
+                        "args": parsed_args,
                     }
-                )
+                }
+                # Echo Gemini's thought-mode signature back on the next-turn
+                # functionCall Part. Required for Gemini 2.0+ thinking models
+                # — without it the API rejects the request with HTTP 400
+                # "Function call is missing a thought_signature in
+                # functionCall parts." The signature was lifted off the
+                # response Part by ``_adapt_response`` and serialized into
+                # the assistant tool_call dict (base64-encoded) by the
+                # mesh agentic-loop machinery; decode and place at the Part
+                # level (NOT nested in function_call — see
+                # google.genai.types.Part.thought_signature). Other vendors
+                # don't emit this key, so the branch is a no-op for them.
+                sig_b64 = tc.get("_gemini_thought_signature")
+                if sig_b64:
+                    try:
+                        fc_part["thought_signature"] = base64.b64decode(sig_b64)
+                    except (ValueError, TypeError) as exc:
+                        # Corrupted signature — log and proceed without it.
+                        # The request will likely fail at the API layer but
+                        # the dispatch contract is preserved.
+                        logger.warning(
+                            "Discarding malformed _gemini_thought_signature "
+                            "on tool_call id=%r: %s",
+                            tc.get("id"),
+                            exc,
+                        )
+                parts.append(fc_part)
 
             if not parts:
                 # Skip empty assistant messages — Gemini rejects empty parts.
@@ -1199,6 +1253,13 @@ def _adapt_response(raw: Any, *, model: str) -> _Response:
     ``_ToolCall`` with synthesized id ``gemini_call_<index>``). usage_metadata
     maps to ``_Usage`` with prompt_token_count / candidates_token_count
     field-name translation.
+
+    Gemini 2.0+ thinking models attach a Part-level ``thought_signature``
+    (``bytes``) on functionCall parts that the API requires to be echoed back
+    on the next-turn functionCall in multi-turn tool calling — we lift it onto
+    the synthesized ``_ToolCall`` so the agentic loop can carry it through to
+    ``_convert_messages_to_gemini`` on the next iteration. See the ``_ToolCall``
+    docstring for the full lifecycle.
     """
     candidates = getattr(raw, "candidates", None) or []
     first_candidate = candidates[0] if candidates else None
@@ -1227,8 +1288,17 @@ def _adapt_response(raw: Any, *, model: str) -> _Response:
                     args_str = "{}"
                 # Synthesize a stable id since Gemini has no tool-call ids.
                 synth_id = f"gemini_call_{len(tool_calls)}"
+                # thought_signature lives on the Part (not on FunctionCall) —
+                # see google.genai.types.Part.thought_signature. Empty-bytes
+                # signatures are treated as absent.
+                sig = getattr(part, "thought_signature", None) or None
                 tool_calls.append(
-                    _ToolCall(id=synth_id, name=fc_name, arguments=args_str)
+                    _ToolCall(
+                        id=synth_id,
+                        name=fc_name,
+                        arguments=args_str,
+                        thought_signature=sig,
+                    )
                 )
 
     finish_reason = _normalize_finish_reason(
@@ -1311,12 +1381,17 @@ def _adapt_stream_chunk(
                     args_str = "{}"
                 idx = tool_call_index_state[0]
                 tool_call_index_state[0] = idx + 1
+                # thought_signature lives on the Part, not on FunctionCall
+                # (google.genai.types.Part.thought_signature). Empty bytes
+                # are treated as absent.
+                sig = getattr(part, "thought_signature", None) or None
                 tool_call_deltas.append(
                     _StreamToolCallDelta(
                         index=idx,
                         id=f"gemini_call_{idx}",
                         name=fc_name,
                         arguments=args_str,
+                        thought_signature=sig,
                     )
                 )
         if text_buf:

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
@@ -749,6 +749,11 @@ _GEMINI_SCHEMA_KEYS = frozenset({
     "anyOf",
     "allOf",
     "oneOf",
+    # Gemini-specific OpenAPI extension to control output property ordering;
+    # not currently emitted by mesh's Pydantic generator but accepted by the
+    # API and may appear in user-supplied schemas — whitelist for forward
+    # compatibility.
+    "propertyOrdering",
     # NOTABLY ABSENT (rejected by Gemini): additionalProperties, $schema,
     # title, $ref, definitions, $defs, propertyNames, patternProperties,
     # exclusiveMinimum, exclusiveMaximum, multipleOf, const, not, contains.
@@ -1075,6 +1080,10 @@ _FINISH_REASON_MAP = {
     "LANGUAGE": "stop",
     "OTHER": "stop",
     "FINISH_REASON_UNSPECIFIED": "stop",
+    # Model attempted a tool call but emitted a malformed function_call part.
+    # Map to "tool_calls" so helpers.py's agentic loop surfaces the failure
+    # path naturally (rather than treating it as a normal STOP).
+    "MALFORMED_FUNCTION_CALL": "tool_calls",
 }
 
 

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
@@ -45,6 +45,7 @@ paths.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -66,64 +67,99 @@ _VERTEX_PREFIX = "vertex_ai/"
 
 
 # ---------------------------------------------------------------------------
-# Shared httpx connection pool (issue #834 perf fix)
+# Per-event-loop httpx connection pool (issue #834 perf fix + asyncio binding fix)
 # ---------------------------------------------------------------------------
-# A single ``httpx.AsyncClient`` is reused across all native Gemini calls in
-# this process. ``google.genai.Client`` accepts a custom async httpx client
-# via ``HttpOptions(httpx_async_client=...)`` and uses the supplied pool
-# instead of constructing a fresh one per call. This eliminates ~150-300ms
-# per-call TLS+H2 setup overhead vs. LiteLLM (which does its own pool reuse).
+# An ``httpx.AsyncClient`` is reused across all native Gemini calls in this
+# process — but the cache is keyed by the *running asyncio event loop* rather
+# than process-globally. ``google.genai.Client`` accepts a custom async httpx
+# client via ``HttpOptions(httpx_async_client=...)`` and uses the supplied
+# pool instead of constructing a fresh one per call. This eliminates
+# ~150-300ms per-call TLS+H2 setup overhead vs. LiteLLM (which does its own
+# pool reuse).
+#
+# WHY PER-LOOP (and why this DIFFERS from anthropic_native / openai_native):
+# ``httpx.AsyncClient`` (via httpcore) lazily constructs anyio synchronization
+# primitives — ``Lock`` / ``Semaphore`` / ``Event`` for the connection pool
+# — on first I/O. Those primitives bind to the *event loop that issues the
+# first request* and CANNOT be reused from a different loop ("bound to a
+# different event loop" RuntimeError).
+#
+# In mesh, ``shared/tool_executor.py`` runs an N-worker thread pool, each
+# thread owning its own long-lived asyncio event loop. Tool calls are
+# round-robin dispatched across workers. A single process-wide ``httpx``
+# pool would bind to the first worker's loop and then break the moment a
+# call lands on a different worker. Anthropic/OpenAI integration tests
+# happen not to surface this on their current test mix; Gemini's
+# uc10_toolcalls suite exercises enough cross-worker churn to trip it
+# every run.
+#
+# Per-loop caching keeps the connection-reuse win within a single loop
+# (tool calls scheduled to the same worker share its pool) while
+# guaranteeing each loop owns its own anyio primitives. ``id(loop)`` is the
+# cache key — sufficient because loops are long-lived (workers run for the
+# process lifetime); when a loop closes the cached client is dropped from
+# the map by the next access if found stale.
 #
 # K8s secret rotation still works because the api_key is read fresh per call
 # by callers and forwarded to the per-call ``genai.Client`` wrapper — the
 # pool itself carries no credential state, only TCP/TLS connections.
-_CACHED_HTTPX_CLIENT: httpx.AsyncClient | None = None
-# Guards lazy-init / rebuild of the shared httpx client. The pool itself is
-# safe for concurrent use; the lock only protects the check-then-create race
-# at construction. Cheap (uncontended after first call) and correct under
-# threaded harnesses (tests, sync wrapper paths) that touch the cache.
+_CACHED_HTTPX_CLIENT_BY_LOOP: dict[int, httpx.AsyncClient] = {}
+# Guards lazy-init / rebuild of the per-loop httpx client cache. The pool
+# instances themselves are safe for concurrent use within their owning loop;
+# the lock only protects the check-then-create race at construction. Cheap
+# (uncontended after first call per loop).
 _CACHED_HTTPX_CLIENT_LOCK = threading.Lock()
 
 
-def _get_shared_httpx_client() -> httpx.AsyncClient:
-    """Lazily construct (or rebuild if closed) the shared httpx client.
+def _build_httpx_client() -> httpx.AsyncClient:
+    """Construct a fresh httpx.AsyncClient with the standard mesh tuning."""
+    return httpx.AsyncClient(
+        timeout=httpx.Timeout(
+            connect=10.0,  # connection establishment
+            read=600.0,    # body read — LLM responses can be slow
+            write=30.0,    # request body write
+            pool=5.0,      # waiting for free connection from pool
+        ),
+        limits=httpx.Limits(
+            max_keepalive_connections=20,
+            max_connections=100,
+            keepalive_expiry=30.0,
+        ),
+    )
 
-    Single connection pool shared across all native Gemini calls in this
-    process. Per-call ``genai.Client`` wrappers reuse this pool —
-    eliminating ~150-300ms per-call TLS+H2 setup overhead. K8s secret
-    rotation still works: ``api_key`` is read fresh per call; the pool
-    carries no credential state.
+
+def _get_shared_httpx_client() -> httpx.AsyncClient:
+    """Return an httpx.AsyncClient bound to the current event loop.
+
+    Cached per-loop (NOT process-globally) — see the module-level comment
+    for the rationale. Falls back to constructing a fresh client when no
+    loop is currently running (sync test paths); that client is NOT cached
+    so it gets garbage-collected promptly.
     """
-    global _CACHED_HTTPX_CLIENT
-    # Fast path — no lock when the cached client is healthy. The check is
-    # benign-racy (worst case: two threads both observe None and both enter
-    # the lock; the second one finds the cache populated under the lock and
-    # returns early).
-    if _CACHED_HTTPX_CLIENT is not None and not _CACHED_HTTPX_CLIENT.is_closed:
-        return _CACHED_HTTPX_CLIENT
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop — caller is in sync code (most likely test setup).
+        # Return an uncached client; the caller is responsible for cleanup.
+        return _build_httpx_client()
+
+    loop_id = id(loop)
+    # Fast path — no lock when the cached client for this loop is healthy.
+    cached = _CACHED_HTTPX_CLIENT_BY_LOOP.get(loop_id)
+    if cached is not None and not cached.is_closed:
+        return cached
     with _CACHED_HTTPX_CLIENT_LOCK:
-        if _CACHED_HTTPX_CLIENT is None or _CACHED_HTTPX_CLIENT.is_closed:
-            _CACHED_HTTPX_CLIENT = httpx.AsyncClient(
-                timeout=httpx.Timeout(
-                    connect=10.0,  # connection establishment
-                    read=600.0,    # body read — LLM responses can be slow
-                    write=30.0,    # request body write
-                    pool=5.0,      # waiting for free connection from pool
-                ),
-                limits=httpx.Limits(
-                    max_keepalive_connections=20,
-                    max_connections=100,
-                    keepalive_expiry=30.0,
-                ),
-            )
-        return _CACHED_HTTPX_CLIENT
+        cached = _CACHED_HTTPX_CLIENT_BY_LOOP.get(loop_id)
+        if cached is None or cached.is_closed:
+            cached = _build_httpx_client()
+            _CACHED_HTTPX_CLIENT_BY_LOOP[loop_id] = cached
+        return cached
 
 
 def _reset_shared_httpx_client() -> None:
-    """For tests — reset the cached client. NOT for production use."""
-    global _CACHED_HTTPX_CLIENT
+    """For tests — drop all cached per-loop clients. NOT for production use."""
     with _CACHED_HTTPX_CLIENT_LOCK:
-        _CACHED_HTTPX_CLIENT = None
+        _CACHED_HTTPX_CLIENT_BY_LOOP.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -346,6 +382,37 @@ def _strip_prefix(model: str) -> str:
     return model
 
 
+def _derive_vertex_project_from_adc() -> str | None:
+    """Best-effort: load Google ADC and return the resolved project id.
+
+    Mirrors LiteLLM's Vertex behavior — when ``GOOGLE_CLOUD_PROJECT`` is
+    unset, ADC's loaded credentials carry a quota project (from the
+    ``GOOGLE_APPLICATION_CREDENTIALS`` JSON's ``quota_project_id`` field
+    OR the gcloud-default-login flow OR Workload Identity metadata).
+
+    Returns ``None`` (not raising) when ``google-auth`` isn't installed or
+    ADC fails to load — callers fall back to the explicit-env-var error
+    message in that case. Intentionally permissive: a deployment with
+    valid ADC but no env var should "just work."
+    """
+    try:
+        import google.auth  # type: ignore[import-untyped]
+    except ImportError:
+        # google-auth ships transitively with google-genai but defend
+        # against custom installs that strip it.
+        return None
+    try:
+        _credentials, default_project = google.auth.default()
+    except Exception as exc:  # noqa: BLE001 — ADC has many failure modes
+        logger.debug(
+            "Vertex project ADC auto-derive failed: %s; "
+            "fall back to explicit-env-var error path",
+            exc,
+        )
+        return None
+    return default_project or None
+
+
 def _build_client(
     model: str,
     api_key: str | None,
@@ -377,13 +444,21 @@ def _build_client(
         project = os.environ.get("GOOGLE_CLOUD_PROJECT")
         location = os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1")
         if not project:
+            # Auto-derive from Application Default Credentials. Matches
+            # LiteLLM's behavior — the credentials JSON's quota_project_id
+            # (or the loaded ADC's quota project) is used when the env var
+            # isn't explicitly set. Works seamlessly with Workload Identity
+            # / gcloud-default-login deployments where users typically don't
+            # set GOOGLE_CLOUD_PROJECT explicitly.
+            project = _derive_vertex_project_from_adc()
+        if not project:
             raise ValueError(
-                "Native Vertex AI dispatch requires GOOGLE_CLOUD_PROJECT env "
-                "var. Set GOOGLE_CLOUD_PROJECT (and optionally "
-                "GOOGLE_CLOUD_LOCATION; default 'us-central1'), ensure ADC is "
-                "configured (gcloud auth application-default login OR "
-                "Workload Identity in K8s), or set MCP_MESH_NATIVE_LLM=0 to "
-                "fall back to LiteLLM."
+                "Native Vertex AI dispatch requires a project. Set "
+                "GOOGLE_CLOUD_PROJECT env var, ensure ADC is configured "
+                "with a quota project (gcloud auth application-default "
+                "login OR Workload Identity in K8s), or set "
+                "MCP_MESH_NATIVE_LLM=0 to fall back to LiteLLM. Optional: "
+                "GOOGLE_CLOUD_LOCATION (default 'us-central1')."
             )
         if api_key:
             # Vertex backend uses Google Cloud IAM, NOT api_key. Surface a
@@ -1003,13 +1078,22 @@ def _build_create_kwargs(
     # response_format → response_mime_type + response_schema (handler may
     # also be using HINT mode — in that case response_format is absent and
     # the JSON instructions live in the system prompt; this branch is a no-op).
+    #
+    # responseSchema MUST go through the same sanitizer as tool parameters.
+    # Pydantic-generated schemas always emit ``additionalProperties: False``
+    # (camelCase) AND some upstream paths normalize to ``additional_properties``
+    # (snake_case) — Gemini rejects both with HTTP 400 INVALID_ARGUMENT
+    # ("Unknown name 'additional_properties'..."). The whitelist sanitizer
+    # strips both casings (snake_case keys aren't in the whitelist either).
     rf = request_params.get("response_format")
     if isinstance(rf, dict):
         if rf.get("type") == "json_schema":
             schema = (rf.get("json_schema") or {}).get("schema") or {}
             config["response_mime_type"] = "application/json"
             if schema:
-                config["response_schema"] = schema
+                config["response_schema"] = _sanitize_gemini_parameters_schema(
+                    schema
+                )
         elif rf.get("type") == "json_object":
             config["response_mime_type"] = "application/json"
     # Allow callers to set response_mime_type directly too.

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
@@ -468,7 +468,14 @@ def _build_client(
     import google.genai as genai
     from google.genai.types import HttpOptions
 
-    http_options = HttpOptions(httpx_async_client=_get_shared_httpx_client())
+    http_options_kwargs: dict[str, Any] = {
+        "httpx_async_client": _get_shared_httpx_client()
+    }
+    if base_url:
+        # Forward custom Gemini-compatible endpoints (proxies, test endpoints)
+        # — HttpOptions.base_url is a documented field on the google-genai SDK.
+        http_options_kwargs["base_url"] = base_url
+    http_options = HttpOptions(**http_options_kwargs)
 
     if model.startswith(_VERTEX_PREFIX):
         project = os.environ.get("GOOGLE_CLOUD_PROJECT")
@@ -1399,9 +1406,17 @@ def _adapt_stream_chunk(
 
     finish_reason: str | None = None
     if raw_finish_reason is not None:
+        # Gemini may emit function_call parts in one chunk and finish_reason=STOP
+        # in a LATER chunk that has no parts. Without consulting the cumulative
+        # tool-call counter we'd map that final STOP to "stop" and helpers.py's
+        # agentic loop would terminate without executing the prior chunk's
+        # tool calls. Treat the stream as having tool calls if either THIS
+        # chunk emitted one OR any prior chunk did (counter > 0).
         finish_reason = _normalize_finish_reason(
             raw_finish_reason,
-            has_tool_calls=bool(tool_call_deltas),
+            has_tool_calls=(
+                bool(tool_call_deltas) or tool_call_index_state[0] > 0
+            ),
         )
 
     usage_obj = getattr(raw_chunk, "usage_metadata", None)

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
@@ -1698,3 +1698,329 @@ class TestIsFallbackLogged:
         assert gemini_native.is_fallback_logged() is False
         gemini_native.log_fallback_once()
         assert gemini_native.is_fallback_logged() is True
+
+
+# ---------------------------------------------------------------------------
+# thought_signature preservation (Gemini 2.0+ thinking-model multi-turn fix)
+# ---------------------------------------------------------------------------
+# Recent google-genai versions emit a Part-level ``thought_signature`` (bytes)
+# on functionCall response Parts when the model is a Gemini 2.0+ thinking
+# model. The Gemini API REQUIRES this signature to be echoed back on the
+# next-turn functionCall Part of the same multi-turn conversation, otherwise
+# rejecting with HTTP 400 "Function call is missing a thought_signature in
+# functionCall parts." LiteLLM preserves the signature internally; the native
+# adapter must too. The transport carrier is a base64-encoded ``_gemini_*``
+# sidecar field on the conversation tool_call dict — survives the helpers.py
+# round-trip naturally and is silently ignored by other vendors.
+
+
+def _make_gemini_response_with_signature(
+    *,
+    function_calls_with_sigs: list[tuple[dict, bytes | None]],
+    finish_reason: str = "STOP",
+    model_version: str | None = "gemini-2.0-flash-thinking",
+):
+    """Build a fake genai.GenerateContentResponse where each function_call
+    Part carries an explicit thought_signature (or None to model an absent
+    sig — useful for backward-compat checks)."""
+    parts = []
+    for fc, sig in function_calls_with_sigs:
+        # thought_signature lives on the Part (NOT nested inside FunctionCall)
+        # — see google.genai.types.Part.thought_signature (types.py line 1970).
+        parts.append(
+            SimpleNamespace(
+                text=None,
+                function_call=SimpleNamespace(
+                    name=fc["name"], args=fc.get("args", {})
+                ),
+                thought_signature=sig,
+            )
+        )
+    content = SimpleNamespace(parts=parts, role="model")
+    fr_obj = SimpleNamespace(name=finish_reason)
+    candidate = SimpleNamespace(content=content, finish_reason=fr_obj, index=0)
+    usage = SimpleNamespace(
+        prompt_token_count=10,
+        candidates_token_count=5,
+        total_token_count=15,
+    )
+    return SimpleNamespace(
+        candidates=[candidate],
+        usage_metadata=usage,
+        model_version=model_version,
+    )
+
+
+class TestThoughtSignatureExtraction:
+    """``_adapt_response`` must lift the Part-level ``thought_signature`` onto
+    the synthesized ``_ToolCall._thought_signature`` so the agentic loop can
+    serialize it into the conversation dict for the next iteration."""
+
+    def test_response_extracts_thought_signature_from_function_call(self):
+        sig_bytes = b"opaque-signature-blob-123"
+        raw = _make_gemini_response_with_signature(
+            function_calls_with_sigs=[
+                ({"name": "get_weather", "args": {"city": "NYC"}}, sig_bytes),
+            ],
+        )
+        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        tcs = out.choices[0].message.tool_calls
+        assert len(tcs) == 1
+        # Signature stashed on the _ToolCall as raw bytes (not yet encoded).
+        assert tcs[0]._thought_signature == sig_bytes
+
+    def test_absent_signature_is_none(self):
+        """Backward-compat: parts without a thought_signature attribute (older
+        non-thinking models, mocked test parts) result in None — must not
+        raise AttributeError."""
+        raw = _make_gemini_response(
+            function_calls=[{"name": "get_weather", "args": {"city": "NYC"}}],
+        )
+        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        tcs = out.choices[0].message.tool_calls
+        assert len(tcs) == 1
+        assert tcs[0]._thought_signature is None
+
+    def test_explicit_none_signature_is_none(self):
+        """When the SDK returns ``thought_signature=None`` (explicitly), the
+        _ToolCall carries None — sanity check that the ``getattr ... or None``
+        idiom in _adapt_response coerces falsy values to None."""
+        raw = _make_gemini_response_with_signature(
+            function_calls_with_sigs=[
+                ({"name": "get_weather", "args": {}}, None),
+            ],
+        )
+        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        assert out.choices[0].message.tool_calls[0]._thought_signature is None
+
+    def test_empty_bytes_signature_treated_as_absent(self):
+        """An empty-bytes signature (b"") is semantically absent — Gemini
+        wouldn't echo it on the next turn anyway. Coerced to None so the
+        downstream serializer doesn't emit a useless ``_gemini_*`` field."""
+        raw = _make_gemini_response_with_signature(
+            function_calls_with_sigs=[
+                ({"name": "get_weather", "args": {}}, b""),
+            ],
+        )
+        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        assert out.choices[0].message.tool_calls[0]._thought_signature is None
+
+    def test_multiple_function_calls_each_carry_own_signature(self):
+        """When a single response Part-list contains multiple function_calls
+        (each with its own Part), each ``_ToolCall`` carries its own
+        signature — sanity check that the per-Part loop doesn't bleed values
+        across calls."""
+        sig_a = b"sig-for-call-A"
+        sig_b = b"sig-for-call-B"
+        raw = _make_gemini_response_with_signature(
+            function_calls_with_sigs=[
+                ({"name": "call_A", "args": {}}, sig_a),
+                ({"name": "call_B", "args": {}}, sig_b),
+            ],
+        )
+        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        tcs = out.choices[0].message.tool_calls
+        assert len(tcs) == 2
+        assert tcs[0]._thought_signature == sig_a
+        assert tcs[1]._thought_signature == sig_b
+        # Synthesized ids are still monotonic (independent of signatures).
+        assert tcs[0].id == "gemini_call_0"
+        assert tcs[1].id == "gemini_call_1"
+
+
+class TestThoughtSignatureStreamingExtraction:
+    """``_adapt_stream_chunk`` must also lift the Part-level signature onto
+    the ``_StreamToolCallDelta`` so the streaming merger can forward it onto
+    the merged dict (under the ``_gemini_thought_signature`` key, b64-encoded)
+    for the next iteration."""
+
+    def test_streaming_extracts_thought_signature(self):
+        sig_bytes = b"streaming-sig-456"
+        # Build a single chunk with one function_call Part carrying a sig.
+        part = SimpleNamespace(
+            text=None,
+            function_call=SimpleNamespace(name="get_weather", args={"city": "NYC"}),
+            thought_signature=sig_bytes,
+        )
+        candidate = SimpleNamespace(
+            content=SimpleNamespace(parts=[part], role="model"),
+            finish_reason=None,
+            index=0,
+        )
+        chunk = SimpleNamespace(
+            candidates=[candidate],
+            usage_metadata=None,
+            model_version="gemini-2.0-flash-thinking",
+        )
+        adapted = gemini_native._adapt_stream_chunk(
+            chunk, model="gemini-2.0-flash", tool_call_index_state=[0]
+        )
+        deltas = adapted.choices[0].delta.tool_calls
+        assert deltas is not None and len(deltas) == 1
+        assert deltas[0]._thought_signature == sig_bytes
+        assert deltas[0].id == "gemini_call_0"
+
+    def test_streaming_absent_signature_is_none(self):
+        """Backward-compat for streaming chunks: parts without
+        thought_signature attr produce None — older non-thinking models."""
+        # Use the existing _make_stream_chunk helper which doesn't set
+        # thought_signature on its parts.
+        chunk = _make_stream_chunk(
+            function_call={"name": "get_weather", "args": {}},
+        )
+        adapted = gemini_native._adapt_stream_chunk(
+            chunk, model="gemini-2.0-flash", tool_call_index_state=[0]
+        )
+        deltas = adapted.choices[0].delta.tool_calls
+        assert deltas is not None and len(deltas) == 1
+        assert deltas[0]._thought_signature is None
+
+
+class TestThoughtSignatureRoundTrip:
+    """``_convert_messages_to_gemini`` must decode the ``_gemini_*`` sidecar
+    on the assistant tool_call dict and place the bytes at the Part level of
+    the outbound functionCall (NOT nested inside ``function_call``) — see
+    google.genai.types.Part.thought_signature."""
+
+    def test_convert_messages_round_trips_thought_signature(self):
+        import base64
+
+        sig_bytes = b"round-trip-signature-789"
+        sig_b64 = base64.b64encode(sig_bytes).decode("ascii")
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "gemini_call_0",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "NYC"}',
+                        },
+                        "_gemini_thought_signature": sig_b64,
+                    }
+                ],
+            }
+        ]
+        out = gemini_native._convert_messages_to_gemini(msgs, {})
+        assert len(out) == 1
+        assert out[0]["role"] == "model"
+        # Find the functionCall part — signature must be at the Part level.
+        fc_parts = [p for p in out[0]["parts"] if "function_call" in p]
+        assert len(fc_parts) == 1
+        # Part-level field (NOT nested inside function_call).
+        assert fc_parts[0].get("thought_signature") == sig_bytes
+        # function_call sub-dict still carries name/args, NOT the signature.
+        assert fc_parts[0]["function_call"]["name"] == "get_weather"
+        assert "thought_signature" not in fc_parts[0]["function_call"]
+
+    def test_convert_messages_no_signature_works(self):
+        """Backward-compat: tool_call dict WITHOUT ``_gemini_thought_signature``
+        produces a clean Gemini Part — no signature field, no error. This is
+        the steady-state path for non-thinking Gemini models AND for any
+        cross-vendor tool_call dict that lands in a Gemini conversation."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "gemini_call_0",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "NYC"}',
+                        },
+                    }
+                ],
+            }
+        ]
+        out = gemini_native._convert_messages_to_gemini(msgs, {})
+        fc_parts = [p for p in out[0]["parts"] if "function_call" in p]
+        assert len(fc_parts) == 1
+        # No thought_signature field anywhere on the Part.
+        assert "thought_signature" not in fc_parts[0]
+        assert "thought_signature" not in fc_parts[0]["function_call"]
+
+    def test_convert_messages_malformed_signature_warns_and_skips(self, caplog):
+        """A corrupted base64 signature must NOT crash the request — log a
+        WARN and proceed without the signature (the API will likely reject
+        the resulting request, but the dispatch contract is preserved)."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "gemini_call_0",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                        "_gemini_thought_signature": "!!!not-valid-base64!!!",
+                    }
+                ],
+            }
+        ]
+        with caplog.at_level("WARNING", logger=gemini_native.logger.name):
+            out = gemini_native._convert_messages_to_gemini(msgs, {})
+        fc_parts = [p for p in out[0]["parts"] if "function_call" in p]
+        assert len(fc_parts) == 1
+        # No signature on the resulting Part (skipped due to decode error).
+        assert "thought_signature" not in fc_parts[0]
+        # WARN must mention the malformed signature + the call id.
+        assert any(
+            "_gemini_thought_signature" in r.getMessage()
+            and "gemini_call_0" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_full_round_trip_response_to_next_turn_request(self):
+        """End-to-end: response Part → ``_ToolCall._thought_signature`` →
+        simulate the helpers.py serializer (b64-encode onto dict) →
+        ``_convert_messages_to_gemini`` → outbound Gemini Part with the
+        original bytes restored at the Part level. Mirrors the actual
+        agentic-loop data flow.
+        """
+        import base64
+
+        # 1. Response side: Gemini returns a functionCall Part with a sig.
+        original_sig = b"\x00\x01\x02\xff\xfe\xfd-binary-signature-blob"
+        raw = _make_gemini_response_with_signature(
+            function_calls_with_sigs=[
+                ({"name": "get_weather", "args": {"city": "NYC"}}, original_sig),
+            ],
+        )
+        adapted = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        tc = adapted.choices[0].message.tool_calls[0]
+
+        # 2. Simulate helpers.py serializer (mesh.helpers
+        # ._build_assistant_tool_call_dict) — same logic, kept inline so this
+        # test doesn't depend on the helper's import path.
+        assistant_msg = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": tc.id,
+                    "type": tc.type,
+                    "function": {
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    },
+                    "_gemini_thought_signature": base64.b64encode(
+                        tc._thought_signature
+                    ).decode("ascii"),
+                }
+            ],
+        }
+
+        # 3. Next-turn request: run the message dict back through Gemini's
+        # message converter and verify the original bytes land at the Part
+        # level of the outbound functionCall.
+        out = gemini_native._convert_messages_to_gemini([assistant_msg], {})
+        fc_part = next(p for p in out[0]["parts"] if "function_call" in p)
+        assert fc_part["thought_signature"] == original_sig
+        # And confirm the args round-trip too (sanity).
+        assert fc_part["function_call"]["name"] == "get_weather"
+        assert fc_part["function_call"]["args"] == {"city": "NYC"}

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
@@ -126,8 +126,11 @@ class TestSupportsModel:
         assert gemini_native.supports_model(model) is False
 
     def test_none_returns_false(self):
-        # Defensive: None should not crash; treat as unsupported.
-        assert gemini_native.supports_model(None or "") is False
+        # Defensive: None must not crash; treat as unsupported. The previous
+        # form ``supports_model(None or "")`` evaluated to ``""`` and never
+        # exercised the None branch — the existing ``if not model`` guard
+        # in ``supports_model`` covers it cleanly.
+        assert gemini_native.supports_model(None) is False
 
 
 class TestStripPrefix:
@@ -762,6 +765,51 @@ class TestSanitizeGeminiParametersSchema:
     def test_empty_dict_returns_empty_dict(self):
         assert gemini_native._sanitize_gemini_parameters_schema({}) == {}
 
+    def test_default_literal_payload_passes_through(self):
+        """``default`` holds an arbitrary literal JSON value, NOT a nested
+        schema. Recursing into it would strip JSON-Schema-named keys from a
+        user-supplied default whose own keys happen to match schema fields
+        (e.g. a default object ``{"additionalProperties": False, ...}``) —
+        silent corruption of user data. The literal must round-trip verbatim.
+        """
+        schema = {
+            "type": "object",
+            "default": {
+                "additionalProperties": False,
+                "value": 42,
+                "title": "preserved",
+            },
+            "properties": {"v": {"type": "integer"}},
+        }
+        out = gemini_native._sanitize_gemini_parameters_schema(schema)
+        # The full default dict must be preserved — no key stripping.
+        assert out["default"] == {
+            "additionalProperties": False,
+            "value": 42,
+            "title": "preserved",
+        }
+
+    def test_example_literal_payload_passes_through(self):
+        """Same contract as ``default``: ``example`` is a literal payload, not
+        a nested schema. Recursion would silently mangle user examples whose
+        keys happen to collide with JSON-Schema field names.
+        """
+        schema = {
+            "type": "object",
+            "example": {
+                "additionalProperties": False,
+                "title": "Sample",
+                "value": [1, 2, 3],
+            },
+            "properties": {"v": {"type": "integer"}},
+        }
+        out = gemini_native._sanitize_gemini_parameters_schema(schema)
+        assert out["example"] == {
+            "additionalProperties": False,
+            "title": "Sample",
+            "value": [1, 2, 3],
+        }
+
 
 class TestConvertToolChoice:
     def test_auto(self):
@@ -1137,6 +1185,32 @@ class TestUnsupportedKwargWarn:
             if r.levelname == "WARNING" and "dropping unsupported kwarg" in r.getMessage()
         ]
         assert len(warns) == 3
+
+    def test_candidate_count_warns_and_dropped(self, caplog):
+        """``candidate_count`` is intentionally NOT forwarded — mesh's
+        contract is single-completion (n=1) and the response/stream adapters
+        only consume ``candidates[0]``. Silently dropping N-1 candidates would
+        be surprising; instead the kwarg falls through to the WARN path so
+        callers get a loud signal that mesh doesn't support it.
+        """
+        with caplog.at_level("WARNING", logger=gemini_native.logger.name):
+            out = gemini_native._build_create_kwargs(
+                {
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "candidate_count": 3,
+                },
+                model="gemini/gemini-2.0-flash",
+            )
+        # Not forwarded into the SDK config.
+        assert "candidate_count" not in out["config"]
+        # WARN must mention candidate_count (single-completion contract surface).
+        warn_msgs = [
+            r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+        ]
+        assert any(
+            "candidate_count" in m and "dropping unsupported kwarg" in m
+            for m in warn_msgs
+        ), f"Expected WARN about candidate_count; got: {warn_msgs}"
 
 
 # ---------------------------------------------------------------------------

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
@@ -1056,6 +1056,18 @@ class TestAdaptResponse:
         assert out.usage is None
         assert out.choices[0].message.content == "hi"
 
+    def test_finish_reason_malformed_function_call_maps_to_tool_calls(self):
+        """Recent google-genai versions emit MALFORMED_FUNCTION_CALL when the
+        model attempted a tool call but produced invalid JSON. Map to
+        ``tool_calls`` so helpers.py's agentic loop can surface the failure
+        path naturally instead of treating it as a normal STOP."""
+        raw = _make_gemini_response(
+            text="garbled tool call",
+            finish_reason="MALFORMED_FUNCTION_CALL",
+        )
+        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        assert out.choices[0].finish_reason == "tool_calls"
+
 
 # ---------------------------------------------------------------------------
 # complete() — request dispatch + adaptation

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
@@ -317,6 +317,23 @@ class TestBuildClient:
             "vertex_ai backend" in r.getMessage() for r in caplog.records
         )
 
+    def test_base_url_forwarded_to_http_options(self, monkeypatch):
+        """A non-None base_url must be forwarded into HttpOptions so callers
+        can route Gemini requests through a custom proxy or test endpoint.
+        Regression: previously _build_client accepted base_url and silently
+        dropped it, leaving HttpOptions on the SDK default."""
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("google.genai.Client", cls_mock)
+
+        gemini_native._build_client(
+            "gemini/gemini-2.0-flash",
+            "GAK-test",
+            "https://custom-proxy.example.com",
+        )
+
+        http_options = cls_mock.call_args.kwargs["http_options"]
+        assert http_options.base_url == "https://custom-proxy.example.com"
+
 
 # ---------------------------------------------------------------------------
 # Translators: system message extraction
@@ -1540,6 +1557,48 @@ class TestCompleteStream:
         # returned.
         usage_chunks = [c for c in chunks if c.usage is not None]
         assert len(usage_chunks) == 1
+
+    @pytest.mark.asyncio
+    async def test_stream_final_chunk_with_only_finish_reason_maps_to_tool_calls_when_prior_chunk_had_tool_call(
+        self, monkeypatch
+    ):
+        """Gemini may emit a function_call part in one chunk and then deliver
+        finish_reason=STOP in a LATER chunk that has no parts. The adapter
+        must consult the cumulative tool-call counter so the final chunk's
+        finish_reason maps to "tool_calls" — otherwise helpers.py's agentic
+        loop sees "stop" and terminates without executing the tool that
+        arrived in an earlier chunk."""
+        chunks_in = [
+            _make_stream_chunk(
+                function_call={
+                    "name": "get_weather",
+                    "args": {"city": "NYC"},
+                },
+                model_version="gemini-2.0-flash",
+            ),
+            _make_stream_chunk(
+                finish_reason="STOP",
+                usage={"prompt_tokens": 5, "completion_tokens": 2},
+            ),
+        ]
+        _patched_streaming_genai(chunks_in, monkeypatch=monkeypatch)
+
+        stream = gemini_native.complete_stream(
+            {"messages": [{"role": "user", "content": "weather?"}]},
+            model="gemini/gemini-2.0-flash",
+        )
+        chunks = []
+        async for c in stream:
+            chunks.append(c)
+
+        # The final-finish chunk has no parts but must still be tagged
+        # tool_calls because a prior chunk emitted a function_call.
+        finish_chunks = [
+            c for c in chunks
+            if c.choices and c.choices[0].finish_reason is not None
+        ]
+        assert len(finish_chunks) == 1
+        assert finish_chunks[0].choices[0].finish_reason == "tool_calls"
 
 
 # ---------------------------------------------------------------------------

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
@@ -1,0 +1,1416 @@
+"""Unit tests for the native Gemini SDK adapter (issue #834 PR 3).
+
+Covers:
+  * is_available() reflects ImportError of the SDK and caches the probe
+  * supports_model() matches the gemini/* and vertex_ai/* prefixes
+  * _strip_prefix() correctness for both prefixes
+  * _build_client() backend dispatch + credential validation
+  * Translator surface (the bulk of this PR's complexity):
+    - System message extraction → top-level systemInstruction
+    - Role rename: assistant → model
+    - Tool result conversion via tool_call_id → name map
+    - OpenAI tools → functionDeclarations wrapper
+    - tool_choice → toolConfig.functionCallingConfig enum
+    - Multimodal block translation (data-URI → inlineData; URL → fileData)
+  * _build_create_kwargs() request shaping + per-key WARN dedupe
+  * _adapt_response() text + function_calls + usage_metadata mapping
+  * complete_stream() chunk shape + best-effort usage emission
+  * Shared httpx pool reused across calls; lazy-per-call client construction
+
+Real network calls are mocked.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip(
+    "google.genai", reason="native Gemini adapter requires the google-genai SDK"
+)
+
+from _mcp_mesh.engine.native_clients import gemini_native
+
+
+# ---------------------------------------------------------------------------
+# is_available()
+# ---------------------------------------------------------------------------
+
+
+class TestIsAvailable:
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self):
+        """is_available() caches its result module-wide; reset between tests
+        in this class so each one re-probes the import."""
+        gemini_native._reset_is_available_cache()
+        yield
+        gemini_native._reset_is_available_cache()
+
+    def test_returns_true_when_sdk_importable(self):
+        # The SDK is installed in the test environment; this should be True.
+        assert gemini_native.is_available() is True
+
+    def test_returns_false_when_import_fails(self, monkeypatch):
+        """Simulate the SDK being absent by stubbing __import__ to raise."""
+        original_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "google.genai" or name.startswith("google.genai."):
+                raise ImportError("No module named 'google.genai'")
+            return original_import(name, *args, **kwargs)
+
+        # Drop the cached module so the function re-evaluates the import.
+        monkeypatch.delitem(sys.modules, "google.genai", raising=False)
+        with patch("builtins.__import__", side_effect=_fake_import):
+            assert gemini_native.is_available() is False
+
+    def test_caches_result_across_calls(self):
+        """Once probed, is_available() must not re-import on every call —
+        the SDK presence does not change at runtime and the per-call import
+        was showing up as needless overhead on the dispatch-decision path.
+        """
+        original_import = builtins.__import__
+        call_count = {"n": 0}
+
+        def _counting_import(name, *args, **kwargs):
+            if name == "google.genai":
+                call_count["n"] += 1
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=_counting_import):
+            gemini_native.is_available()
+            gemini_native.is_available()
+            gemini_native.is_available()
+
+        # Exactly one import attempt across three calls.
+        assert call_count["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# supports_model() and _strip_prefix()
+# ---------------------------------------------------------------------------
+
+
+class TestSupportsModel:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gemini/gemini-2.0-flash",
+            "gemini/gemini-1.5-pro",
+            "gemini/gemini-3-pro-preview",
+            "vertex_ai/gemini-2.0-flash",
+            "vertex_ai/gemini-1.5-pro",
+        ],
+    )
+    def test_supported_prefixes(self, model):
+        assert gemini_native.supports_model(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "anthropic/claude-sonnet-4-5",
+            "openai/gpt-4o",
+            "bedrock/anthropic.claude-3-5-sonnet",
+            "azure/gpt-4o",
+            "gemini-2.0-flash",  # bare, no prefix
+            "",
+        ],
+    )
+    def test_unsupported(self, model):
+        assert gemini_native.supports_model(model) is False
+
+    def test_none_returns_false(self):
+        # Defensive: None should not crash; treat as unsupported.
+        assert gemini_native.supports_model(None or "") is False
+
+
+class TestStripPrefix:
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("gemini/gemini-2.0-flash", "gemini-2.0-flash"),
+            ("gemini/gemini-1.5-pro", "gemini-1.5-pro"),
+            ("vertex_ai/gemini-2.0-flash", "gemini-2.0-flash"),
+            ("vertex_ai/gemini-3-pro-preview", "gemini-3-pro-preview"),
+            ("gemini-2.0-flash", "gemini-2.0-flash"),  # bare passthrough
+        ],
+    )
+    def test_strip_prefix(self, model, expected):
+        assert gemini_native._strip_prefix(model) == expected
+
+
+# ---------------------------------------------------------------------------
+# Backend selection / _build_client
+# ---------------------------------------------------------------------------
+
+
+class TestBuildClient:
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
+        """Make sure GOOGLE_* env vars don't leak between tests."""
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_LOCATION", raising=False)
+        yield
+
+    def test_ai_studio_with_explicit_api_key(self, monkeypatch):
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("google.genai.Client", cls_mock)
+        gemini_native._build_client("gemini/gemini-2.0-flash", "GAK-test", None)
+        kwargs = cls_mock.call_args.kwargs
+        assert kwargs["api_key"] == "GAK-test"
+        # AI Studio backend must NOT pass vertexai/project/location.
+        assert "vertexai" not in kwargs
+        assert "project" not in kwargs
+
+    def test_ai_studio_with_env_var(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "GAK-from-env")
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("google.genai.Client", cls_mock)
+        gemini_native._build_client("gemini/gemini-2.0-flash", None, None)
+        # api_key flows from env into the resolved kwarg.
+        kwargs = cls_mock.call_args.kwargs
+        assert kwargs["api_key"] == "GAK-from-env"
+
+    def test_ai_studio_raises_when_no_api_key(self, monkeypatch):
+        with pytest.raises(ValueError) as exc_info:
+            gemini_native._build_client("gemini/gemini-2.0-flash", None, None)
+        msg = str(exc_info.value)
+        assert "GOOGLE_API_KEY" in msg
+        assert "MCP_MESH_NATIVE_LLM=0" in msg
+
+    def test_vertex_with_project_env(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("google.genai.Client", cls_mock)
+        gemini_native._build_client("vertex_ai/gemini-2.0-flash", None, None)
+        kwargs = cls_mock.call_args.kwargs
+        assert kwargs["vertexai"] is True
+        assert kwargs["project"] == "my-gcp-project"
+        # Default location applied when GOOGLE_CLOUD_LOCATION is unset.
+        assert kwargs["location"] == "us-central1"
+
+    def test_vertex_with_explicit_location(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
+        monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "europe-west4")
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("google.genai.Client", cls_mock)
+        gemini_native._build_client("vertex_ai/gemini-2.0-flash", None, None)
+        kwargs = cls_mock.call_args.kwargs
+        assert kwargs["location"] == "europe-west4"
+
+    def test_vertex_raises_when_no_project(self, monkeypatch):
+        with pytest.raises(ValueError) as exc_info:
+            gemini_native._build_client("vertex_ai/gemini-2.0-flash", None, None)
+        msg = str(exc_info.value)
+        assert "GOOGLE_CLOUD_PROJECT" in msg
+        assert "MCP_MESH_NATIVE_LLM=0" in msg
+
+    def test_vertex_ignores_api_key_with_warn(self, monkeypatch, caplog):
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("google.genai.Client", cls_mock)
+        # Reset WARN dedupe so this test is order-independent.
+        gemini_native._logged_unsupported_kwargs.clear()
+        with caplog.at_level("WARNING", logger=gemini_native.logger.name):
+            gemini_native._build_client(
+                "vertex_ai/gemini-2.0-flash", "GAK-ignored", None
+            )
+        # api_key MUST NOT be forwarded on the Vertex backend.
+        kwargs = cls_mock.call_args.kwargs
+        assert "api_key" not in kwargs
+        # And a one-time WARN should fire so users see the misuse.
+        assert any(
+            "vertex_ai backend" in r.getMessage() for r in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# Translators: system message extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSystemInstruction:
+    def test_no_system_message(self):
+        msgs = [{"role": "user", "content": "Hi"}]
+        instruction, rest = gemini_native._extract_system_instruction(msgs)
+        assert instruction is None
+        assert rest == msgs
+
+    def test_single_system_message_string_content(self):
+        msgs = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hi"},
+        ]
+        instruction, rest = gemini_native._extract_system_instruction(msgs)
+        assert instruction == "You are helpful."
+        assert rest == [{"role": "user", "content": "Hi"}]
+
+    def test_multiple_system_messages_concatenated(self):
+        msgs = [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user", "content": "Hi"},
+            {"role": "system", "content": "Be concise."},
+        ]
+        instruction, rest = gemini_native._extract_system_instruction(msgs)
+        assert instruction == "Be helpful.\n\nBe concise."
+        assert rest == [{"role": "user", "content": "Hi"}]
+
+    def test_system_message_with_list_content(self):
+        msgs = [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "Be helpful."},
+                    {"type": "text", "text": "Always cite sources."},
+                ],
+            },
+            {"role": "user", "content": "Hi"},
+        ]
+        instruction, _ = gemini_native._extract_system_instruction(msgs)
+        # Both text blocks joined.
+        assert "Be helpful." in instruction
+        assert "Always cite sources." in instruction
+
+
+# ---------------------------------------------------------------------------
+# Translators: messages → contents
+# ---------------------------------------------------------------------------
+
+
+class TestConvertMessages:
+    def test_user_role_stays_user(self):
+        out = gemini_native._convert_messages_to_gemini(
+            [{"role": "user", "content": "Hello"}], {}
+        )
+        assert out == [{"role": "user", "parts": [{"text": "Hello"}]}]
+
+    def test_assistant_role_renamed_to_model(self):
+        out = gemini_native._convert_messages_to_gemini(
+            [{"role": "assistant", "content": "Hi there"}], {}
+        )
+        assert out == [{"role": "model", "parts": [{"text": "Hi there"}]}]
+
+    def test_assistant_with_tool_calls_emits_function_call_parts(self):
+        out = gemini_native._convert_messages_to_gemini(
+            [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city": "NYC"}',
+                            },
+                        }
+                    ],
+                }
+            ],
+            {},
+        )
+        assert len(out) == 1
+        assert out[0]["role"] == "model"
+        # function_call part: NAME present, NO id (Gemini has no tool-call ids).
+        fc_parts = [p for p in out[0]["parts"] if "function_call" in p]
+        assert len(fc_parts) == 1
+        fc = fc_parts[0]["function_call"]
+        assert fc["name"] == "get_weather"
+        assert fc["args"] == {"city": "NYC"}
+        # No id field anywhere on the part.
+        assert "id" not in fc
+
+    def test_tool_result_converted_to_user_with_function_response(self):
+        # tool_call_id → name map provided.
+        id_map = {"call_1": "get_weather"}
+        out = gemini_native._convert_messages_to_gemini(
+            [
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "content": "Sunny, 72°F",
+                }
+            ],
+            id_map,
+        )
+        assert len(out) == 1
+        assert out[0]["role"] == "user"
+        fr_parts = [p for p in out[0]["parts"] if "function_response" in p]
+        assert len(fr_parts) == 1
+        fr = fr_parts[0]["function_response"]
+        assert fr["name"] == "get_weather"
+        # String content wrapped under {"result": ...}.
+        assert fr["response"] == {"result": "Sunny, 72°F"}
+
+    def test_tool_result_id_to_name_lookup_via_helper(self):
+        """The id-map builder walks assistant turns; verify end-to-end that
+        a tool result message in a multi-turn conversation finds its name."""
+        msgs = [
+            {"role": "user", "content": "weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_xyz",
+                        "function": {"name": "get_weather", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_xyz", "content": "rain"},
+        ]
+        id_map = gemini_native._build_tool_id_to_name_map(msgs)
+        assert id_map == {"call_xyz": "get_weather"}
+
+        out = gemini_native._convert_messages_to_gemini(msgs, id_map)
+        # Tool result is the last message → user role + functionResponse.
+        last = out[-1]
+        assert last["role"] == "user"
+        fr = last["parts"][0]["function_response"]
+        assert fr["name"] == "get_weather"
+
+    def test_missing_name_in_id_map_warns_and_uses_placeholder(self, caplog):
+        with caplog.at_level("WARNING", logger=gemini_native.logger.name):
+            out = gemini_native._convert_messages_to_gemini(
+                [
+                    {
+                        "role": "tool",
+                        "tool_call_id": "missing_id",
+                        "content": "result",
+                    }
+                ],
+                {},  # empty id-map
+            )
+        fr = out[0]["parts"][0]["function_response"]
+        assert fr["name"] == "unknown_tool"
+        # WARN must mention the missing id.
+        assert any("missing_id" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Translators: tools / tool_choice
+# ---------------------------------------------------------------------------
+
+
+class TestConvertTools:
+    def test_openai_tools_to_function_declarations(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Look up the weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "send_email",
+                    "description": "Send mail",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ]
+        out = gemini_native._convert_tools(tools)
+        # ALL declarations bundled under ONE wrapper.
+        assert len(out) == 1
+        assert "function_declarations" in out[0]
+        decls = out[0]["function_declarations"]
+        assert len(decls) == 2
+        names = sorted(d["name"] for d in decls)
+        assert names == ["get_weather", "send_email"]
+
+    def test_empty_tools_returns_none(self):
+        assert gemini_native._convert_tools(None) is None
+        assert gemini_native._convert_tools([]) is None
+
+    def test_already_native_passthrough(self):
+        tools = [
+            {
+                "function_declarations": [
+                    {"name": "foo", "description": "", "parameters": {}}
+                ]
+            }
+        ]
+        out = gemini_native._convert_tools(tools)
+        assert out == tools
+
+    def test_convert_tools_applies_sanitization(self):
+        """Mesh's Pydantic-generated schemas always emit
+        ``additionalProperties: False`` — Gemini rejects that field with
+        HTTP 400. Verify _convert_tools strips it (and other unsupported
+        JSON-Schema fields) so native dispatch matches LiteLLM behavior.
+        """
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Look up the weather",
+                    "parameters": {
+                        "type": "object",
+                        "title": "WeatherParams",  # rejected by Gemini
+                        "additionalProperties": False,  # rejected by Gemini
+                        "$schema": "http://json-schema.org/draft-07/schema#",  # rejected
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                                "title": "City",  # nested — also stripped
+                            },
+                        },
+                        "required": ["city"],
+                    },
+                },
+            },
+        ]
+        out = gemini_native._convert_tools(tools)
+        decl = out[0]["function_declarations"][0]
+        params = decl["parameters"]
+        # Stripped:
+        assert "additionalProperties" not in params
+        assert "title" not in params
+        assert "$schema" not in params
+        assert "title" not in params["properties"]["city"]
+        # Preserved:
+        assert params["type"] == "object"
+        assert params["properties"]["city"]["type"] == "string"
+        assert params["required"] == ["city"]
+
+    def test_convert_tools_preserves_function_metadata(self):
+        """Sanitization must only touch ``parameters`` — ``name`` and
+        ``description`` round-trip untouched through the translation."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "send_email",
+                    "description": "Send an email to a recipient",
+                    "parameters": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {"to": {"type": "string"}},
+                    },
+                },
+            },
+        ]
+        out = gemini_native._convert_tools(tools)
+        decl = out[0]["function_declarations"][0]
+        assert decl["name"] == "send_email"
+        assert decl["description"] == "Send an email to a recipient"
+
+
+class TestSanitizeGeminiParametersSchema:
+    """Direct unit tests for the schema-sanitization helper.
+
+    Gemini's function_declarations.parameters accept an OpenAPI 3.0 Schema
+    subset. Anything outside ``_GEMINI_SCHEMA_KEYS`` is rejected with
+    HTTP 400 INVALID_ARGUMENT (per
+    https://ai.google.dev/api/caching#Schema). This helper bridges the
+    gap so mesh's Pydantic-generated schemas (which always include
+    ``additionalProperties: False``) work with native dispatch.
+    """
+
+    def test_strips_additional_properties(self):
+        schema = {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {"city": {"type": "string"}},
+        }
+        out = gemini_native._sanitize_gemini_parameters_schema(schema)
+        assert "additionalProperties" not in out
+        assert out == {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+        }
+
+    def test_strips_dollar_schema(self):
+        schema = {
+            "type": "object",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "properties": {},
+        }
+        out = gemini_native._sanitize_gemini_parameters_schema(schema)
+        assert "$schema" not in out
+
+    def test_strips_title(self):
+        schema = {"type": "object", "title": "MyParams", "properties": {}}
+        out = gemini_native._sanitize_gemini_parameters_schema(schema)
+        assert "title" not in out
+
+    def test_strips_dollar_ref_and_definitions(self):
+        """Pydantic emits ``$ref`` + ``definitions`` for nested models;
+        both are rejected by Gemini and must be stripped."""
+        schema = {
+            "type": "object",
+            "$ref": "#/definitions/Foo",
+            "definitions": {"Foo": {"type": "string"}},
+            "properties": {},
+        }
+        out = gemini_native._sanitize_gemini_parameters_schema(schema)
+        assert "$ref" not in out
+        assert "definitions" not in out
+
+    def test_keeps_required_fields(self):
+        schema = {
+            "type": "object",
+            "description": "A test schema",
+            "properties": {
+                "city": {
+                    "type": "string",
+                    "description": "City name",
+                    "enum": ["NYC", "LA"],
+                },
+            },
+            "required": ["city"],
+        }
+        out = gemini_native._sanitize_gemini_parameters_schema(schema)
+        assert out == schema
+
+    def test_recursive_strips_nested_objects(self):
+        """Nested object schemas (properties.foo.additionalProperties) are
+        also sanitized — the helper walks recursively."""
+        schema = {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "address": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "title": "Address",
+                    "properties": {
+                        "street": {"type": "string", "title": "Street"},
+                    },
+                },
+            },
+        }
+        out = gemini_native._sanitize_gemini_parameters_schema(schema)
+        assert "additionalProperties" not in out
+        assert "additionalProperties" not in out["properties"]["address"]
+        assert "title" not in out["properties"]["address"]
+        assert "title" not in out["properties"]["address"]["properties"]["street"]
+        # Structural fields preserved:
+        assert out["properties"]["address"]["type"] == "object"
+        assert (
+            out["properties"]["address"]["properties"]["street"]["type"]
+            == "string"
+        )
+
+    def test_recursive_strips_array_items(self):
+        """Array ``items`` schemas are recursively sanitized too."""
+        schema = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "title": "Item",
+                "properties": {"id": {"type": "integer"}},
+            },
+        }
+        out = gemini_native._sanitize_gemini_parameters_schema(schema)
+        assert "additionalProperties" not in out["items"]
+        assert "title" not in out["items"]
+        assert out["items"]["type"] == "object"
+        assert out["items"]["properties"]["id"]["type"] == "integer"
+
+    def test_handles_anyof_oneof_allof(self):
+        """Union types are preserved; each subschema is sanitized."""
+        schema = {
+            "anyOf": [
+                {"type": "string", "title": "AsString"},
+                {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {"x": {"type": "integer"}},
+                },
+            ],
+            "oneOf": [{"type": "null", "title": "Nothing"}],
+            "allOf": [{"type": "object", "$schema": "x", "properties": {}}],
+        }
+        out = gemini_native._sanitize_gemini_parameters_schema(schema)
+        # anyOf preserved as a list, sanitization applied to each entry.
+        assert "anyOf" in out and isinstance(out["anyOf"], list)
+        assert len(out["anyOf"]) == 2
+        assert "title" not in out["anyOf"][0]
+        assert "additionalProperties" not in out["anyOf"][1]
+        # oneOf / allOf likewise.
+        assert "title" not in out["oneOf"][0]
+        assert "$schema" not in out["allOf"][0]
+
+    def test_passes_through_non_dict_non_list(self):
+        """Primitive leaves (str, int, bool, None) round-trip unchanged."""
+        assert gemini_native._sanitize_gemini_parameters_schema("foo") == "foo"
+        assert gemini_native._sanitize_gemini_parameters_schema(42) == 42
+        assert gemini_native._sanitize_gemini_parameters_schema(True) is True
+        assert gemini_native._sanitize_gemini_parameters_schema(None) is None
+
+    def test_empty_dict_returns_empty_dict(self):
+        assert gemini_native._sanitize_gemini_parameters_schema({}) == {}
+
+
+class TestConvertToolChoice:
+    def test_auto(self):
+        assert gemini_native._convert_tool_choice("auto") == {
+            "function_calling_config": {"mode": "AUTO"}
+        }
+
+    def test_none(self):
+        assert gemini_native._convert_tool_choice("none") == {
+            "function_calling_config": {"mode": "NONE"}
+        }
+
+    @pytest.mark.parametrize("value", ["required", "any"])
+    def test_required_and_any(self, value):
+        assert gemini_native._convert_tool_choice(value) == {
+            "function_calling_config": {"mode": "ANY"}
+        }
+
+    def test_function_dict_with_name(self):
+        choice = {"type": "function", "function": {"name": "foo"}}
+        assert gemini_native._convert_tool_choice(choice) == {
+            "function_calling_config": {
+                "mode": "ANY",
+                "allowed_function_names": ["foo"],
+            }
+        }
+
+    def test_none_input_returns_none(self):
+        assert gemini_native._convert_tool_choice(None) is None
+
+    def test_unrecognized_returns_none(self):
+        assert gemini_native._convert_tool_choice("not_a_real_value") is None
+
+
+# ---------------------------------------------------------------------------
+# Translators: multimodal content blocks
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateContentBlock:
+    def test_text_block(self):
+        out = gemini_native._translate_content_block_to_gemini(
+            {"type": "text", "text": "hello"}
+        )
+        assert out == {"text": "hello"}
+
+    def test_data_uri_image_block(self):
+        out = gemini_native._translate_content_block_to_gemini(
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": "data:image/jpeg;base64,abc123",
+                },
+            }
+        )
+        assert out == {
+            "inline_data": {
+                "mime_type": "image/jpeg",
+                "data": "abc123",
+            }
+        }
+
+    def test_https_url_image_block(self):
+        out = gemini_native._translate_content_block_to_gemini(
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/cat.png"},
+            }
+        )
+        assert out == {
+            "file_data": {
+                "mime_type": "application/octet-stream",
+                "file_uri": "https://example.com/cat.png",
+            }
+        }
+
+    def test_already_native_text_passthrough(self):
+        block = {"text": "already native"}
+        out = gemini_native._translate_content_block_to_gemini(block)
+        assert out == block
+
+    def test_already_native_inline_data_passthrough(self):
+        block = {"inline_data": {"mime_type": "image/png", "data": "xyz"}}
+        out = gemini_native._translate_content_block_to_gemini(block)
+        assert out == block
+
+    def test_string_block_treated_as_text(self):
+        # A bare string inside a content list — common for some clients.
+        out = gemini_native._translate_content_block_to_gemini("hello")
+        assert out == {"text": "hello"}
+
+
+# ---------------------------------------------------------------------------
+# _build_create_kwargs() — request shaping
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCreateKwargs:
+    def test_full_happy_path(self):
+        out = gemini_native._build_create_kwargs(
+            {
+                "messages": [
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "Hi"},
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "noop",
+                            "description": "",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+                "tool_choice": "auto",
+                "temperature": 0.3,
+                "max_tokens": 512,
+            },
+            model="gemini/gemini-2.0-flash",
+        )
+        assert out["model"] == "gemini-2.0-flash"
+        # System message NOT in contents.
+        assert all(
+            m.get("role") != "system" for m in out["contents"]
+        ), out["contents"]
+        # System surfaced in config.systemInstruction.
+        assert out["config"]["system_instruction"] == "You are helpful."
+        # Tools wrapped under functionDeclarations.
+        assert "tools" in out["config"]
+        assert "function_declarations" in out["config"]["tools"][0]
+        # tool_choice translated.
+        assert out["config"]["tool_config"] == {
+            "function_calling_config": {"mode": "AUTO"}
+        }
+        # Generation params translated.
+        assert out["config"]["temperature"] == 0.3
+        assert out["config"]["max_output_tokens"] == 512
+
+    def test_system_extracted_to_config_not_contents(self):
+        out = gemini_native._build_create_kwargs(
+            {
+                "messages": [
+                    {"role": "system", "content": "Be brief."},
+                    {"role": "user", "content": "Hi"},
+                ]
+            },
+            model="gemini/gemini-2.0-flash",
+        )
+        assert out["config"]["system_instruction"] == "Be brief."
+        # Contents has only the user message.
+        assert out["contents"] == [
+            {"role": "user", "parts": [{"text": "Hi"}]}
+        ]
+
+    def test_max_tokens_explicit_none_is_dropped(self):
+        out = gemini_native._build_create_kwargs(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": None,
+            },
+            model="gemini/gemini-2.0-flash",
+        )
+        # Don't forward None to the SDK (Gemini rejects it).
+        assert "max_output_tokens" not in out["config"]
+
+    def test_max_completion_tokens_used_as_fallback(self):
+        out = gemini_native._build_create_kwargs(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_completion_tokens": 200,
+            },
+            model="gemini/gemini-2.0-flash",
+        )
+        assert out["config"]["max_output_tokens"] == 200
+
+    def test_generation_params_translate_correctly(self):
+        out = gemini_native._build_create_kwargs(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "temperature": 0.5,
+                "top_p": 0.9,
+                "top_k": 40,
+                "stop": ["END"],
+                "seed": 42,
+            },
+            model="gemini/gemini-2.0-flash",
+        )
+        cfg = out["config"]
+        assert cfg["temperature"] == 0.5
+        assert cfg["top_p"] == 0.9
+        assert cfg["top_k"] == 40
+        assert cfg["stop_sequences"] == ["END"]
+        assert cfg["seed"] == 42
+
+    def test_response_format_json_schema_translates(self):
+        out = gemini_native._build_create_kwargs(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "Plan",
+                        "schema": {"type": "object"},
+                        "strict": True,
+                    },
+                },
+            },
+            model="gemini/gemini-2.0-flash",
+        )
+        assert out["config"]["response_mime_type"] == "application/json"
+        assert out["config"]["response_schema"] == {"type": "object"}
+
+    def test_drops_internal_mesh_sentinels(self):
+        """``_mesh_*`` sentinels must NOT trigger a WARN — they're handled
+        upstream in helpers._pop_mesh_*_flags."""
+        gemini_native._logged_unsupported_kwargs.clear()
+        out = gemini_native._build_create_kwargs(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "_mesh_hint_mode": True,
+                "_mesh_hint_schema": {"type": "object"},
+            },
+            model="gemini/gemini-2.0-flash",
+        )
+        # No WARN logged for the _mesh_ keys.
+        assert all(
+            not k.startswith("_mesh_")
+            for k in gemini_native._logged_unsupported_kwargs
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unsupported-kwarg WARN dedupe
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupportedKwargWarn:
+    @pytest.fixture(autouse=True)
+    def _reset_dedupe(self):
+        gemini_native._logged_unsupported_kwargs.clear()
+        yield
+        gemini_native._logged_unsupported_kwargs.clear()
+
+    def test_warn_logs_for_unknown_kwarg(self, caplog):
+        with caplog.at_level("WARNING", logger=gemini_native.logger.name):
+            gemini_native._build_create_kwargs(
+                {
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "request_timeout": 30,
+                },
+                model="gemini/gemini-2.0-flash",
+            )
+        warn_msgs = [
+            r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+        ]
+        assert any(
+            "request_timeout" in m and "dropping unsupported kwarg" in m
+            for m in warn_msgs
+        ), f"Expected WARN about request_timeout; got: {warn_msgs}"
+
+    def test_warn_emits_only_once_per_key(self, caplog):
+        with caplog.at_level("WARNING", logger=gemini_native.logger.name):
+            gemini_native._warn_unsupported_kwarg_once("request_timeout")
+            gemini_native._warn_unsupported_kwarg_once("request_timeout")
+            gemini_native._warn_unsupported_kwarg_once("request_timeout")
+        warns = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING" and "request_timeout" in r.getMessage()
+        ]
+        assert len(warns) == 1
+
+    def test_warn_emits_once_per_unique_key(self, caplog):
+        with caplog.at_level("WARNING", logger=gemini_native.logger.name):
+            gemini_native._warn_unsupported_kwarg_once("a")
+            gemini_native._warn_unsupported_kwarg_once("b")
+            gemini_native._warn_unsupported_kwarg_once("a")
+            gemini_native._warn_unsupported_kwarg_once("c")
+        warns = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING" and "dropping unsupported kwarg" in r.getMessage()
+        ]
+        assert len(warns) == 3
+
+
+# ---------------------------------------------------------------------------
+# _adapt_response()
+# ---------------------------------------------------------------------------
+
+
+def _make_gemini_response(
+    *,
+    text: str | None = None,
+    function_calls: list[dict] | None = None,
+    prompt_tokens: int = 12,
+    completion_tokens: int = 7,
+    finish_reason: str = "STOP",
+    model_version: str | None = "gemini-2.0-flash",
+):
+    """Build a fake genai.GenerateContentResponse-like object."""
+    parts = []
+    if text is not None:
+        parts.append(SimpleNamespace(text=text, function_call=None))
+    for fc in function_calls or []:
+        parts.append(
+            SimpleNamespace(
+                text=None,
+                function_call=SimpleNamespace(
+                    name=fc["name"], args=fc.get("args", {})
+                ),
+            )
+        )
+    content = SimpleNamespace(parts=parts, role="model")
+    fr_obj = SimpleNamespace(name=finish_reason)
+    candidate = SimpleNamespace(content=content, finish_reason=fr_obj, index=0)
+    usage = SimpleNamespace(
+        prompt_token_count=prompt_tokens,
+        candidates_token_count=completion_tokens,
+        total_token_count=prompt_tokens + completion_tokens,
+    )
+    return SimpleNamespace(
+        candidates=[candidate],
+        usage_metadata=usage,
+        model_version=model_version,
+    )
+
+
+class TestAdaptResponse:
+    def test_text_only_response(self):
+        raw = _make_gemini_response(text="Hello world", finish_reason="STOP")
+        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        assert out.choices[0].message.content == "Hello world"
+        assert out.choices[0].message.role == "assistant"
+        assert out.choices[0].message.tool_calls is None
+        assert out.choices[0].finish_reason == "stop"
+        assert out.usage.prompt_tokens == 12
+        assert out.usage.completion_tokens == 7
+        assert out.model == "gemini-2.0-flash"
+
+    def test_function_call_response_synthesizes_ids(self):
+        raw = _make_gemini_response(
+            function_calls=[
+                {"name": "get_weather", "args": {"city": "NYC"}},
+                {"name": "send_email", "args": {"to": "a@b"}},
+            ],
+            finish_reason="STOP",
+        )
+        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        tcs = out.choices[0].message.tool_calls
+        assert len(tcs) == 2
+        # Synthesized ids are sequential gemini_call_<index>.
+        assert tcs[0].id == "gemini_call_0"
+        assert tcs[1].id == "gemini_call_1"
+        assert tcs[0].function.name == "get_weather"
+        assert json.loads(tcs[0].function.arguments) == {"city": "NYC"}
+        # Finish reason promoted to "tool_calls" when function calls present
+        # (helpers.py expects this for the agentic loop to invoke tools).
+        assert out.choices[0].finish_reason == "tool_calls"
+
+    def test_mixed_text_and_function_calls(self):
+        raw = _make_gemini_response(
+            text="Calling weather...",
+            function_calls=[{"name": "get_weather", "args": {"city": "NYC"}}],
+        )
+        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        assert out.choices[0].message.content == "Calling weather..."
+        assert len(out.choices[0].message.tool_calls) == 1
+
+    def test_usage_metadata_field_name_mapping(self):
+        raw = _make_gemini_response(
+            text="hi",
+            prompt_tokens=100,
+            completion_tokens=50,
+        )
+        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        # promptTokenCount → prompt_tokens; candidatesTokenCount → completion_tokens.
+        assert out.usage.prompt_tokens == 100
+        assert out.usage.completion_tokens == 50
+        assert out.usage.total_tokens == 150
+
+    def test_no_usage_does_not_crash(self):
+        raw = SimpleNamespace(
+            candidates=[
+                SimpleNamespace(
+                    content=SimpleNamespace(
+                        parts=[SimpleNamespace(text="hi", function_call=None)]
+                    ),
+                    finish_reason=SimpleNamespace(name="STOP"),
+                )
+            ],
+            usage_metadata=None,
+            model_version="gemini-2.0-flash",
+        )
+        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        assert out.usage is None
+        assert out.choices[0].message.content == "hi"
+
+
+# ---------------------------------------------------------------------------
+# complete() — request dispatch + adaptation
+# ---------------------------------------------------------------------------
+
+
+def _patched_genai_client(api_response, *, monkeypatch):
+    """Return (cls_mock, generate_mock, instance_mock).
+
+    Patches google.genai.Client so its instance has an
+    ``.aio.models.generate_content`` AsyncMock returning ``api_response``.
+    """
+    instance = MagicMock()
+    generate_mock = AsyncMock(return_value=api_response)
+    instance.aio = MagicMock()
+    instance.aio.models = MagicMock()
+    instance.aio.models.generate_content = generate_mock
+    cls_mock = MagicMock(return_value=instance)
+    monkeypatch.setattr("google.genai.Client", cls_mock)
+    return cls_mock, generate_mock, instance
+
+
+class TestComplete:
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "GAK-test")
+        yield
+
+    @pytest.mark.asyncio
+    async def test_strips_model_prefix(self, monkeypatch):
+        api_resp = _make_gemini_response(text="hi")
+        cls_mock, generate_mock, _ = _patched_genai_client(
+            api_resp, monkeypatch=monkeypatch
+        )
+        await gemini_native.complete(
+            {"messages": [{"role": "user", "content": "Hi"}]},
+            model="gemini/gemini-2.0-flash",
+        )
+        kwargs = generate_mock.call_args.kwargs
+        assert kwargs["model"] == "gemini-2.0-flash"
+
+    @pytest.mark.asyncio
+    async def test_complete_returns_adapted_response(self, monkeypatch):
+        api_resp = _make_gemini_response(
+            text="Hello!", prompt_tokens=10, completion_tokens=3
+        )
+        _patched_genai_client(api_resp, monkeypatch=monkeypatch)
+        out = await gemini_native.complete(
+            {"messages": [{"role": "user", "content": "Hi"}]},
+            model="gemini/gemini-2.0-flash",
+        )
+        assert out.choices[0].message.content == "Hello!"
+        assert out.usage.prompt_tokens == 10
+        assert out.usage.completion_tokens == 3
+
+
+# ---------------------------------------------------------------------------
+# complete_stream() — streaming chunks + best-effort usage
+# ---------------------------------------------------------------------------
+
+
+class _FakeAsyncStream:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def __aiter__(self):
+        async def _gen():
+            for c in self._chunks:
+                yield c
+
+        return _gen()
+
+
+def _make_stream_chunk(
+    *,
+    text: str | None = None,
+    function_call: dict | None = None,
+    finish_reason: str | None = None,
+    usage: dict | None = None,
+    model_version: str | None = None,
+):
+    """Build a fake genai streaming chunk."""
+    parts = []
+    if text is not None:
+        parts.append(SimpleNamespace(text=text, function_call=None))
+    if function_call is not None:
+        parts.append(
+            SimpleNamespace(
+                text=None,
+                function_call=SimpleNamespace(
+                    name=function_call["name"],
+                    args=function_call.get("args", {}),
+                ),
+            )
+        )
+    fr_obj = SimpleNamespace(name=finish_reason) if finish_reason else None
+    candidates = []
+    if parts or finish_reason:
+        candidates.append(
+            SimpleNamespace(
+                content=SimpleNamespace(parts=parts, role="model")
+                if parts
+                else None,
+                finish_reason=fr_obj,
+                index=0,
+            )
+        )
+    usage_obj = None
+    if usage is not None:
+        usage_obj = SimpleNamespace(
+            prompt_token_count=usage.get("prompt_tokens", 0),
+            candidates_token_count=usage.get("completion_tokens", 0),
+            total_token_count=(
+                usage.get("prompt_tokens", 0) + usage.get("completion_tokens", 0)
+            ),
+        )
+    return SimpleNamespace(
+        candidates=candidates,
+        usage_metadata=usage_obj,
+        model_version=model_version,
+    )
+
+
+def _patched_streaming_genai(chunks, *, monkeypatch):
+    instance = MagicMock()
+    fake_stream = _FakeAsyncStream(chunks)
+    instance.aio = MagicMock()
+    instance.aio.models = MagicMock()
+    instance.aio.models.generate_content_stream = AsyncMock(
+        return_value=fake_stream
+    )
+    cls_mock = MagicMock(return_value=instance)
+    monkeypatch.setattr("google.genai.Client", cls_mock)
+    return cls_mock, instance
+
+
+class TestCompleteStream:
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "GAK-test")
+        yield
+
+    @pytest.mark.asyncio
+    async def test_text_stream_yields_litellm_chunks(self, monkeypatch):
+        chunks_in = [
+            _make_stream_chunk(text="Hello ", model_version="gemini-2.0-flash"),
+            _make_stream_chunk(text="world"),
+            _make_stream_chunk(
+                finish_reason="STOP",
+                usage={"prompt_tokens": 10, "completion_tokens": 4},
+            ),
+        ]
+        _patched_streaming_genai(chunks_in, monkeypatch=monkeypatch)
+
+        stream = gemini_native.complete_stream(
+            {"messages": [{"role": "user", "content": "Hi"}]},
+            model="gemini/gemini-2.0-flash",
+        )
+        chunks = []
+        async for c in stream:
+            chunks.append(c)
+
+        text_pieces = []
+        for c in chunks:
+            if c.choices:
+                d = c.choices[0].delta
+                if getattr(d, "content", None):
+                    text_pieces.append(d.content)
+        assert "".join(text_pieces) == "Hello world"
+
+        # Final chunk carries usage.
+        usage_chunks = [c for c in chunks if c.usage is not None]
+        assert len(usage_chunks) == 1
+        assert usage_chunks[0].usage.prompt_tokens == 10
+        assert usage_chunks[0].usage.completion_tokens == 4
+
+    @pytest.mark.asyncio
+    async def test_function_call_stream_emits_synthesized_id(
+        self, monkeypatch
+    ):
+        chunks_in = [
+            _make_stream_chunk(
+                function_call={
+                    "name": "get_weather",
+                    "args": {"city": "NYC"},
+                },
+                model_version="gemini-2.0-flash",
+            ),
+            _make_stream_chunk(
+                finish_reason="STOP",
+                usage={"prompt_tokens": 5, "completion_tokens": 2},
+            ),
+        ]
+        _patched_streaming_genai(chunks_in, monkeypatch=monkeypatch)
+
+        stream = gemini_native.complete_stream(
+            {"messages": [{"role": "user", "content": "weather?"}]},
+            model="gemini/gemini-2.0-flash",
+        )
+        chunks = []
+        async for c in stream:
+            chunks.append(c)
+
+        # Find the chunk containing the tool_call delta.
+        tc_chunks = [
+            c for c in chunks
+            if c.choices and c.choices[0].delta.tool_calls
+        ]
+        assert len(tc_chunks) == 1
+        tc_delta = tc_chunks[0].choices[0].delta.tool_calls[0]
+        assert tc_delta.id == "gemini_call_0"
+        assert tc_delta.function.name == "get_weather"
+        assert json.loads(tc_delta.function.arguments) == {"city": "NYC"}
+
+    @pytest.mark.asyncio
+    async def test_no_usage_chunk_when_stream_yields_no_usage(
+        self, monkeypatch
+    ):
+        """If the stream ends without ever yielding usage_metadata, the
+        finally block has nothing to fall back on (counters are 0) and
+        must NOT emit a misleading 0-token usage chunk."""
+        chunks_in = [
+            _make_stream_chunk(text="Hello", model_version="gemini-2.0-flash"),
+            _make_stream_chunk(finish_reason="STOP"),
+        ]
+        _patched_streaming_genai(chunks_in, monkeypatch=monkeypatch)
+
+        stream = gemini_native.complete_stream(
+            {"messages": [{"role": "user", "content": "Hi"}]},
+            model="gemini/gemini-2.0-flash",
+        )
+        chunks = []
+        async for c in stream:
+            chunks.append(c)
+
+        usage_chunks = [c for c in chunks if c.usage is not None]
+        assert usage_chunks == []
+
+    @pytest.mark.asyncio
+    async def test_emits_best_effort_usage_when_stream_raises(
+        self, monkeypatch
+    ):
+        """If the stream raises AFTER usage was observed and successfully
+        yielded to the consumer, the finally block must NOT re-emit
+        (final_usage_emitted is True)."""
+
+        class _RaisingStream:
+            def __init__(self, chunks):
+                self._chunks = chunks
+
+            def __aiter__(self):
+                async def _gen():
+                    for c in self._chunks:
+                        if c == "RAISE":
+                            raise RuntimeError("server cutoff")
+                        yield c
+
+                return _gen()
+
+        chunks_in = [
+            _make_stream_chunk(
+                text="partial",
+                usage={"prompt_tokens": 5, "completion_tokens": 1},
+                model_version="gemini-2.0-flash",
+            ),
+            "RAISE",
+        ]
+        instance = MagicMock()
+        instance.aio = MagicMock()
+        instance.aio.models = MagicMock()
+        instance.aio.models.generate_content_stream = AsyncMock(
+            return_value=_RaisingStream(chunks_in)
+        )
+        cls_mock = MagicMock(return_value=instance)
+        monkeypatch.setattr("google.genai.Client", cls_mock)
+
+        stream = gemini_native.complete_stream(
+            {"messages": [{"role": "user", "content": "Hi"}]},
+            model="gemini/gemini-2.0-flash",
+        )
+        chunks = []
+        raised = None
+        try:
+            async for c in stream:
+                chunks.append(c)
+        except RuntimeError as exc:
+            raised = exc
+
+        assert raised is not None and "server cutoff" in str(raised)
+        # Single usage chunk delivered before the raise; finally must NOT
+        # re-emit because final_usage_emitted was set True after the yield
+        # returned.
+        usage_chunks = [c for c in chunks if c.usage is not None]
+        assert len(usage_chunks) == 1
+
+
+# ---------------------------------------------------------------------------
+# Shared httpx connection pool
+# ---------------------------------------------------------------------------
+
+
+class TestSharedHttpxClient:
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self):
+        gemini_native._reset_shared_httpx_client()
+        yield
+        gemini_native._reset_shared_httpx_client()
+
+    def test_shared_httpx_client_reused_across_calls(self, monkeypatch):
+        """Two ``_build_client`` calls must reuse the same httpx pool —
+        proves we have a single connection pool process-wide."""
+        monkeypatch.setenv("GOOGLE_API_KEY", "GAK-test")
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("google.genai.Client", cls_mock)
+        gemini_native._build_client("gemini/gemini-2.0-flash", "GAK-A", None)
+        gemini_native._build_client("gemini/gemini-2.0-flash", "GAK-B", None)
+        # Each call gets HttpOptions whose httpx_async_client is the SAME
+        # cached pool instance — two distinct HttpOptions wrappers but the
+        # same underlying httpx client.
+        first_http = cls_mock.call_args_list[0].kwargs["http_options"].httpx_async_client
+        second_http = cls_mock.call_args_list[1].kwargs["http_options"].httpx_async_client
+        assert first_http is second_http
+
+    @pytest.mark.asyncio
+    async def test_shared_httpx_client_recreated_after_close(self):
+        first = gemini_native._get_shared_httpx_client()
+        assert first.is_closed is False
+        await first.aclose()
+        assert first.is_closed is True
+        second = gemini_native._get_shared_httpx_client()
+        assert second is not first
+        assert second.is_closed is False
+
+    def test_lazy_per_call_client_construction(self, monkeypatch):
+        """Two consecutive calls must build TWO genai.Client wrappers — the
+        wrapper itself is NOT cached, so K8s secret rotation works."""
+        monkeypatch.setenv("GOOGLE_API_KEY", "GAK-test")
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("google.genai.Client", cls_mock)
+        gemini_native._build_client("gemini/gemini-2.0-flash", "GAK-A", None)
+        gemini_native._build_client("gemini/gemini-2.0-flash", "GAK-B", None)
+        assert cls_mock.call_count == 2
+        # Second call has the rotated key.
+        second_kwargs = cls_mock.call_args_list[1].kwargs
+        assert second_kwargs["api_key"] == "GAK-B"
+
+
+# ---------------------------------------------------------------------------
+# Fallback-log helper getter
+# ---------------------------------------------------------------------------
+
+
+class TestIsFallbackLogged:
+    def test_returns_false_initially_then_true_after_log(self, monkeypatch):
+        monkeypatch.setattr(gemini_native, "_logged_fallback_once", False)
+        assert gemini_native.is_fallback_logged() is False
+        gemini_native.log_fallback_once()
+        assert gemini_native.is_fallback_logged() is True

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
@@ -22,6 +22,7 @@ Real network calls are mocked.
 
 from __future__ import annotations
 
+import asyncio
 import builtins
 import json
 import sys
@@ -205,11 +206,98 @@ class TestBuildClient:
         assert kwargs["location"] == "europe-west4"
 
     def test_vertex_raises_when_no_project(self, monkeypatch):
+        # Stub ADC auto-derive to return None — simulates a deployment
+        # where neither GOOGLE_CLOUD_PROJECT env var nor ADC carries a
+        # project. Without this stub the test would pick up the test
+        # author's gcloud-default-login project.
+        monkeypatch.setattr(
+            gemini_native, "_derive_vertex_project_from_adc", lambda: None
+        )
         with pytest.raises(ValueError) as exc_info:
             gemini_native._build_client("vertex_ai/gemini-2.0-flash", None, None)
         msg = str(exc_info.value)
         assert "GOOGLE_CLOUD_PROJECT" in msg
         assert "MCP_MESH_NATIVE_LLM=0" in msg
+
+    def test_vertex_auto_derives_project_from_adc(self, monkeypatch):
+        """When GOOGLE_CLOUD_PROJECT is unset, fall back to ADC-derived
+        project — matches LiteLLM's behavior and works seamlessly with
+        Workload Identity / gcloud-default-login (no env var required)."""
+        monkeypatch.setattr(
+            gemini_native,
+            "_derive_vertex_project_from_adc",
+            lambda: "adc-derived-project",
+        )
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("google.genai.Client", cls_mock)
+        gemini_native._build_client("vertex_ai/gemini-2.0-flash", None, None)
+        kwargs = cls_mock.call_args.kwargs
+        assert kwargs["project"] == "adc-derived-project"
+        assert kwargs["vertexai"] is True
+
+    def test_vertex_env_var_wins_over_adc_derive(self, monkeypatch):
+        """Explicit GOOGLE_CLOUD_PROJECT env var takes precedence over the
+        ADC-derived project — auto-derive is a fallback, not an override."""
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "explicit-env-project")
+        # Make the ADC stub fail loudly if it's called — env var should
+        # short-circuit the derive path.
+        monkeypatch.setattr(
+            gemini_native,
+            "_derive_vertex_project_from_adc",
+            lambda: pytest.fail(
+                "ADC derive must not be called when env var is set"
+            ),
+        )
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("google.genai.Client", cls_mock)
+        gemini_native._build_client("vertex_ai/gemini-2.0-flash", None, None)
+        assert cls_mock.call_args.kwargs["project"] == "explicit-env-project"
+
+    def test_derive_vertex_project_calls_google_auth_default(
+        self, monkeypatch
+    ):
+        """The derive helper calls google.auth.default() and returns the
+        second tuple element (the resolved default project)."""
+        import google.auth as _ga
+
+        monkeypatch.setattr(
+            _ga, "default", lambda: (MagicMock(), "auth-default-project")
+        )
+        assert (
+            gemini_native._derive_vertex_project_from_adc()
+            == "auth-default-project"
+        )
+
+    def test_derive_vertex_project_returns_none_when_auth_unavailable(
+        self, monkeypatch
+    ):
+        """If google.auth isn't importable (custom install stripping the
+        transitive dep), the helper returns None — caller surfaces the
+        explicit-env-var error message."""
+        original_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "google.auth" or name.startswith("google.auth."):
+                raise ImportError("No module named 'google.auth'")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.delitem(sys.modules, "google.auth", raising=False)
+        with patch("builtins.__import__", side_effect=_fake_import):
+            assert gemini_native._derive_vertex_project_from_adc() is None
+
+    def test_derive_vertex_project_returns_none_when_default_raises(
+        self, monkeypatch
+    ):
+        """ADC has many failure modes (no creds, no metadata server, etc.).
+        The helper swallows them and returns None so the caller surfaces
+        the explicit-env-var error message."""
+        import google.auth as _ga
+
+        def _raise(*_args, **_kwargs):
+            raise RuntimeError("Could not automatically determine credentials")
+
+        monkeypatch.setattr(_ga, "default", _raise)
+        assert gemini_native._derive_vertex_project_from_adc() is None
 
     def test_vertex_ignores_api_key_with_warn(self, monkeypatch, caplog):
         monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
@@ -870,6 +958,96 @@ class TestBuildCreateKwargs:
         assert out["config"]["response_mime_type"] == "application/json"
         assert out["config"]["response_schema"] == {"type": "object"}
 
+    def test_response_schema_strips_camelcase_additional_properties(self):
+        """Pydantic-generated schemas always emit
+        ``additionalProperties: False`` (camelCase). Gemini rejects it
+        with HTTP 400 INVALID_ARGUMENT — must be stripped from
+        responseSchema (not just tool parameters)."""
+        out = gemini_native._build_create_kwargs(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "Plan",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "properties": {"answer": {"type": "string"}},
+                            "required": ["answer"],
+                        },
+                    },
+                },
+            },
+            model="gemini/gemini-2.0-flash",
+        )
+        rs = out["config"]["response_schema"]
+        assert "additionalProperties" not in rs
+        assert rs["type"] == "object"
+        assert rs["properties"] == {"answer": {"type": "string"}}
+        assert rs["required"] == ["answer"]
+
+    def test_response_schema_strips_snake_case_additional_properties(self):
+        """Some upstream paths (Pydantic dump, LiteLLM normalization) emit
+        ``additional_properties`` (snake_case). The whitelist sanitizer
+        strips it because it's not in ``_GEMINI_SCHEMA_KEYS`` — verifies
+        the snake_case variant doesn't slip past via responseSchema."""
+        out = gemini_native._build_create_kwargs(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "Plan",
+                        "schema": {
+                            "type": "object",
+                            "additional_properties": False,  # snake_case
+                            "exclusive_minimum": 0,
+                            "properties": {"answer": {"type": "string"}},
+                        },
+                    },
+                },
+            },
+            model="gemini/gemini-2.0-flash",
+        )
+        rs = out["config"]["response_schema"]
+        # Both casings dropped (only camelCase whitelist members survive).
+        assert "additional_properties" not in rs
+        assert "additionalProperties" not in rs
+        assert "exclusive_minimum" not in rs
+        assert rs["type"] == "object"
+
+    def test_response_schema_strips_dollar_schema_and_title(self):
+        """The whole rejected-key family (``$schema``, ``title``, ``$ref``,
+        ``definitions``) must be stripped from response_schema too —
+        same as for tool parameters."""
+        out = gemini_native._build_create_kwargs(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "Plan",
+                        "schema": {
+                            "type": "object",
+                            "title": "PlanSchema",
+                            "$schema": "http://json-schema.org/draft-07/schema#",
+                            "$ref": "#/definitions/Plan",
+                            "definitions": {"Plan": {"type": "string"}},
+                            "properties": {"answer": {"type": "string"}},
+                        },
+                    },
+                },
+            },
+            model="gemini/gemini-2.0-flash",
+        )
+        rs = out["config"]["response_schema"]
+        assert "title" not in rs
+        assert "$schema" not in rs
+        assert "$ref" not in rs
+        assert "definitions" not in rs
+        assert rs["type"] == "object"
+
     def test_drops_internal_mesh_sentinels(self):
         """``_mesh_*`` sentinels must NOT trigger a WARN — they're handled
         upstream in helpers._pop_mesh_*_flags."""
@@ -1376,20 +1554,114 @@ class TestSharedHttpxClient:
         yield
         gemini_native._reset_shared_httpx_client()
 
-    def test_shared_httpx_client_reused_across_calls(self, monkeypatch):
-        """Two ``_build_client`` calls must reuse the same httpx pool —
-        proves we have a single connection pool process-wide."""
+    @pytest.mark.asyncio
+    async def test_shared_httpx_client_reused_within_same_loop(
+        self, monkeypatch
+    ):
+        """Two ``_build_client`` calls on the same event loop must reuse
+        the same httpx pool — connection-pool reuse within a loop is the
+        whole reason we cache."""
         monkeypatch.setenv("GOOGLE_API_KEY", "GAK-test")
         cls_mock = MagicMock(return_value=MagicMock())
         monkeypatch.setattr("google.genai.Client", cls_mock)
-        gemini_native._build_client("gemini/gemini-2.0-flash", "GAK-A", None)
-        gemini_native._build_client("gemini/gemini-2.0-flash", "GAK-B", None)
-        # Each call gets HttpOptions whose httpx_async_client is the SAME
-        # cached pool instance — two distinct HttpOptions wrappers but the
-        # same underlying httpx client.
+
+        # Run inside an async context so _get_shared_httpx_client() picks
+        # up the running loop and caches against it.
+        async def _do_two_builds():
+            gemini_native._build_client("gemini/gemini-2.0-flash", "GAK-A", None)
+            gemini_native._build_client("gemini/gemini-2.0-flash", "GAK-B", None)
+
+        await _do_two_builds()
+
         first_http = cls_mock.call_args_list[0].kwargs["http_options"].httpx_async_client
         second_http = cls_mock.call_args_list[1].kwargs["http_options"].httpx_async_client
         assert first_http is second_http
+
+    def test_per_loop_httpx_pool_isolates_event_loops(self, monkeypatch):
+        """Different event loops MUST get different httpx pool instances.
+
+        This is the regression fix for the "asyncio.locks.Event ... is bound
+        to a different event loop" bug — mesh's ``shared/tool_executor.py``
+        round-robins tool calls across worker threads, each owning its own
+        long-lived loop. A process-global ``httpx.AsyncClient`` would bind
+        its anyio sync primitives to the first worker's loop and break the
+        moment a call lands on a different worker.
+        """
+        monkeypatch.setenv("GOOGLE_API_KEY", "GAK-test")
+
+        captured_clients: list = []
+
+        async def _capture_client():
+            captured_clients.append(gemini_native._get_shared_httpx_client())
+
+        # Two distinct event loops. Each must produce its own httpx pool.
+        loop_a = asyncio.new_event_loop()
+        try:
+            loop_a.run_until_complete(_capture_client())
+        finally:
+            loop_a.close()
+
+        loop_b = asyncio.new_event_loop()
+        try:
+            loop_b.run_until_complete(_capture_client())
+        finally:
+            loop_b.close()
+
+        assert len(captured_clients) == 2
+        assert captured_clients[0] is not captured_clients[1], (
+            "Same httpx.AsyncClient was reused across event loops — would "
+            "trigger 'bound to a different event loop' RuntimeError on the "
+            "second loop's first request"
+        )
+
+    def test_cross_loop_dispatch_does_not_raise(self, monkeypatch):
+        """End-to-end: simulate the mesh worker-pool scenario — two
+        ``complete()`` calls on two distinct event loops. The fix
+        guarantees no cross-loop bug surfaces; without it the second
+        loop's first request would raise.
+        """
+        monkeypatch.setenv("GOOGLE_API_KEY", "GAK-test")
+
+        api_resp = _make_gemini_response(text="hi")
+
+        def _fresh_genai_mock():
+            instance = MagicMock()
+            instance.aio = MagicMock()
+            instance.aio.models = MagicMock()
+            instance.aio.models.generate_content = AsyncMock(return_value=api_resp)
+            return MagicMock(return_value=instance)
+
+        cls_mock = _fresh_genai_mock()
+        monkeypatch.setattr("google.genai.Client", cls_mock)
+
+        async def _one_call():
+            await gemini_native.complete(
+                {"messages": [{"role": "user", "content": "hi"}]},
+                model="gemini/gemini-2.0-flash",
+            )
+
+        loop_a = asyncio.new_event_loop()
+        try:
+            loop_a.run_until_complete(_one_call())
+        finally:
+            loop_a.close()
+
+        loop_b = asyncio.new_event_loop()
+        try:
+            # Pre-fix: this raised "bound to a different event loop" if the
+            # cached httpx pool was reused. Post-fix: each loop gets its
+            # own pool from _get_shared_httpx_client.
+            loop_b.run_until_complete(_one_call())
+        finally:
+            loop_b.close()
+
+    def test_get_shared_httpx_returns_uncached_when_no_loop(self):
+        """Sync test paths (no running loop) get an uncached client back —
+        otherwise we'd cache against a nonexistent loop id."""
+        c1 = gemini_native._get_shared_httpx_client()
+        c2 = gemini_native._get_shared_httpx_client()
+        # Each sync call returns a fresh client (not cached).
+        assert c1 is not c2
 
     @pytest.mark.asyncio
     async def test_shared_httpx_client_recreated_after_close(self):

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
@@ -81,6 +81,18 @@ SYNTHETIC_FORMAT_SYSTEM_INSTRUCTION = (
 _DISPATCH_STATUS_LOGGED = False
 
 
+def is_dispatch_status_logged() -> bool:
+    """Return True once the one-time dispatch-status log has fired.
+
+    Exposed so ``has_native()`` can skip the call frame for
+    ``_log_dispatch_status_once`` on every dispatch decision after the
+    first — the function dedupes internally, but on the hot path
+    avoiding the call entirely is cheaper. Mirrors ``is_fallback_logged``
+    on the native-client modules.
+    """
+    return _DISPATCH_STATUS_LOGGED
+
+
 def _log_dispatch_status_once() -> None:
     """Log the resolved native-dispatch status once per process at DEBUG level.
 
@@ -99,7 +111,7 @@ def _log_dispatch_status_once() -> None:
         logger.debug(
             "Claude native dispatch: disabled "
             "(MCP_MESH_NATIVE_LLM=%s explicitly set; using LiteLLM)",
-            env_value or "<unset>",
+            env_value,
         )
         return
 
@@ -669,7 +681,11 @@ class ClaudeHandler(BaseProviderHandler):
         # Emit the one-time dispatch-status DEBUG log. Lazy here (vs. at
         # module/handler init) so it fires when the first dispatch decision
         # is actually made — the most useful signal for ``--debug`` runs.
-        _log_dispatch_status_once()
+        # Skip the call entirely once the log has fired — the function
+        # dedupes internally, but avoiding the call frame on the hot path
+        # is cheaper still.
+        if not is_dispatch_status_logged():
+            _log_dispatch_status_once()
 
         flag = os.environ.get("MCP_MESH_NATIVE_LLM", "").strip().lower()
         # Explicit opt-out wins over SDK availability.

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
@@ -55,6 +55,18 @@ logger = logging.getLogger(__name__)
 _DISPATCH_STATUS_LOGGED = False
 
 
+def is_dispatch_status_logged() -> bool:
+    """Return True once the one-time dispatch-status log has fired.
+
+    Exposed so ``has_native()`` can skip the call frame for
+    ``_log_dispatch_status_once`` on every dispatch decision after the
+    first — the function dedupes internally, but on the hot path
+    avoiding the call entirely is cheaper. Mirrors ``is_fallback_logged``
+    on the native-client modules.
+    """
+    return _DISPATCH_STATUS_LOGGED
+
+
 def _log_dispatch_status_once() -> None:
     """Log the resolved native-dispatch status once per process at DEBUG level.
 
@@ -74,7 +86,7 @@ def _log_dispatch_status_once() -> None:
         logger.debug(
             "Gemini native dispatch: disabled "
             "(MCP_MESH_NATIVE_LLM=%s explicitly set; using LiteLLM)",
-            env_value or "<unset>",
+            env_value,
         )
         return
 
@@ -371,7 +383,11 @@ class GeminiHandler(BaseProviderHandler):
         # Emit the one-time dispatch-status DEBUG log. Lazy here (vs. at
         # module/handler init) so it fires when the first dispatch decision
         # is actually made — the most useful signal for ``--debug`` runs.
-        _log_dispatch_status_once()
+        # Skip the call entirely once the log has fired — the function
+        # dedupes internally, but avoiding the call frame on the hot path
+        # is cheaper still.
+        if not is_dispatch_status_logged():
+            _log_dispatch_status_once()
 
         flag = os.environ.get("MCP_MESH_NATIVE_LLM", "").strip().lower()
         # Explicit opt-out wins over SDK availability.

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
@@ -24,6 +24,7 @@ Reference:
 
 import json
 import logging
+import os
 from typing import Any, Optional
 
 from pydantic import BaseModel
@@ -45,6 +46,55 @@ OUTPUT_MODE_STRICT = "strict"
 OUTPUT_MODE_HINT = "hint"
 
 logger = logging.getLogger(__name__)
+
+
+# One-time guard so the dispatch-status DEBUG log fires exactly once per
+# process. Mirrors ``_logged_fallback_once`` in gemini_native — we
+# deliberately keep the state at module level (not on the handler instance)
+# because mesh constructs a fresh handler per request in some paths.
+_DISPATCH_STATUS_LOGGED = False
+
+
+def _log_dispatch_status_once() -> None:
+    """Log the resolved native-dispatch status once per process at DEBUG level.
+
+    Designed so users running with ``meshctl ... --debug`` can confirm whether
+    a Gemini provider agent is using the native google-genai SDK or falling
+    back to LiteLLM. Fires on first call only; subsequent invocations are
+    no-ops.
+    """
+    global _DISPATCH_STATUS_LOGGED
+    if _DISPATCH_STATUS_LOGGED:
+        return
+    _DISPATCH_STATUS_LOGGED = True
+
+    env_value = os.getenv("MCP_MESH_NATIVE_LLM", "").strip().lower()
+
+    if env_value in ("0", "false", "no", "off"):
+        logger.debug(
+            "Gemini native dispatch: disabled "
+            "(MCP_MESH_NATIVE_LLM=%s explicitly set; using LiteLLM)",
+            env_value or "<unset>",
+        )
+        return
+
+    from _mcp_mesh.engine.native_clients import gemini_native
+
+    if gemini_native.is_available():
+        try:
+            import google.genai as genai
+            version = getattr(genai, "__version__", "<unknown>")
+        except Exception:
+            version = "<import-failed>"
+        logger.debug(
+            "Gemini native dispatch: enabled (google-genai SDK %s)",
+            version,
+        )
+    else:
+        logger.debug(
+            "Gemini native dispatch: disabled "
+            "(google-genai SDK not installed; install mcp-mesh[gemini] to enable)"
+        )
 
 
 class GeminiHandler(BaseProviderHandler):
@@ -295,3 +345,92 @@ class GeminiHandler(BaseProviderHandler):
             output_type_name or "Response",
         )
         return model_params
+
+    # ------------------------------------------------------------------
+    # Native Gemini SDK dispatch (issue #834, PR 3)
+    # ------------------------------------------------------------------
+    # Default ON when the google-genai SDK is importable. Set
+    # ``MCP_MESH_NATIVE_LLM=0`` (or false/no/off) to force the LiteLLM
+    # fallback path. In normal installs the google-genai SDK is a base dep,
+    # so the missing-SDK branch should never trigger — kept for symmetry
+    # with the Anthropic / OpenAI handlers and to guard against custom
+    # installs that strip the SDK.
+    #
+    # HINT-mode preservation: ``prepare_request`` already decides
+    # response_format vs HINT (the existing Gemini API infinite-tool-loop
+    # workaround for ``response_format + tools``). The native adapter
+    # forwards whatever the handler hands it — no behavioral change.
+
+    def has_native(self) -> bool:
+        """Native dispatch is enabled by default when the google-genai SDK is
+        importable. Set ``MCP_MESH_NATIVE_LLM=0`` (or ``false``/``no``/``off``)
+        to disable and force the LiteLLM fallback path. Setting the flag to
+        ``1``/``true``/``yes``/``on`` is accepted as an explicit-enable
+        (same behavior as the default).
+        """
+        # Emit the one-time dispatch-status DEBUG log. Lazy here (vs. at
+        # module/handler init) so it fires when the first dispatch decision
+        # is actually made — the most useful signal for ``--debug`` runs.
+        _log_dispatch_status_once()
+
+        flag = os.environ.get("MCP_MESH_NATIVE_LLM", "").strip().lower()
+        # Explicit opt-out wins over SDK availability.
+        if flag in ("0", "false", "no", "off"):
+            return False
+
+        # Lazy import inside the function so module import does not fail
+        # when the SDK is absent; this mirrors what the call sites do.
+        from _mcp_mesh.engine.native_clients import gemini_native
+
+        if not gemini_native.is_available():
+            # Skip the log call entirely once it has already fired — the
+            # function dedupes internally, but on the no-native hot path
+            # avoiding the call frame altogether is cheaper still.
+            if not gemini_native.is_fallback_logged():
+                gemini_native.log_fallback_once()
+            return False
+
+        return True
+
+    async def complete(
+        self,
+        request_params: dict[str, Any],
+        *,
+        model: str,
+        **kwargs: Any,
+    ) -> Any:
+        """Dispatch a buffered completion to the native Gemini SDK adapter."""
+        from _mcp_mesh.engine.native_clients import gemini_native
+
+        return await gemini_native.complete(
+            request_params,
+            model=model,
+            api_key=kwargs.get("api_key"),
+            base_url=kwargs.get("base_url"),
+        )
+
+    async def complete_stream(
+        self,
+        request_params: dict[str, Any],
+        *,
+        model: str,
+        **kwargs: Any,
+    ):
+        """Streaming completion via the native Gemini SDK.
+
+        Note: this method is ``async def`` but ``return``s (without
+        awaiting) the async generator from
+        ``gemini_native.complete_stream``. Callers ``await`` the handler
+        call (which resolves the coroutine to the AG), then
+        ``async for chunk in stream_iter:`` to consume. Mirrors the
+        dispatch contract used in mesh/helpers.py and matches the
+        ClaudeHandler / OpenAIHandler patterns.
+        """
+        from _mcp_mesh.engine.native_clients import gemini_native
+
+        return gemini_native.complete_stream(
+            request_params,
+            model=model,
+            api_key=kwargs.get("api_key"),
+            base_url=kwargs.get("base_url"),
+        )

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/openai_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/openai_handler.py
@@ -28,6 +28,18 @@ logger = logging.getLogger(__name__)
 _DISPATCH_STATUS_LOGGED = False
 
 
+def is_dispatch_status_logged() -> bool:
+    """Return True once the one-time dispatch-status log has fired.
+
+    Exposed so ``has_native()`` can skip the call frame for
+    ``_log_dispatch_status_once`` on every dispatch decision after the
+    first — the function dedupes internally, but on the hot path
+    avoiding the call entirely is cheaper. Mirrors ``is_fallback_logged``
+    on the native-client modules.
+    """
+    return _DISPATCH_STATUS_LOGGED
+
+
 def _log_dispatch_status_once() -> None:
     """Log the resolved native-dispatch status once per process at DEBUG level.
 
@@ -46,7 +58,7 @@ def _log_dispatch_status_once() -> None:
         logger.debug(
             "OpenAI native dispatch: disabled "
             "(MCP_MESH_NATIVE_LLM=%s explicitly set; using LiteLLM)",
-            env_value or "<unset>",
+            env_value,
         )
         return
 
@@ -240,7 +252,11 @@ class OpenAIHandler(BaseProviderHandler):
         # Emit the one-time dispatch-status DEBUG log. Lazy here (vs. at
         # module/handler init) so it fires when the first dispatch decision
         # is actually made — the most useful signal for ``--debug`` runs.
-        _log_dispatch_status_once()
+        # Skip the call entirely once the log has fired — the function
+        # dedupes internally, but avoiding the call frame on the hot path
+        # is cheaper still.
+        if not is_dispatch_status_logged():
+            _log_dispatch_status_once()
 
         flag = os.environ.get("MCP_MESH_NATIVE_LLM", "").strip().lower()
         # Explicit opt-out wins over SDK availability.

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_gemini_handler_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_gemini_handler_native.py
@@ -351,6 +351,24 @@ class TestDispatchStatusLog:
         assert first_count == 1
         assert second_count == 1
 
+    def test_is_dispatch_status_logged_short_circuits_after_first_call(
+        self, _reset_dispatch_status_log
+    ):
+        """``has_native()`` consults ``is_dispatch_status_logged()`` so it can
+        skip the log-once call frame on the hot path. Verify the getter
+        flips False → True after the first ``has_native()`` invocation."""
+        handler = GeminiHandler()
+        assert "MCP_MESH_NATIVE_LLM" not in os.environ
+        assert gemini_handler_module.is_dispatch_status_logged() is False
+
+        with patch(
+            "_mcp_mesh.engine.native_clients.gemini_native.is_available",
+            return_value=True,
+        ):
+            handler.has_native()
+
+        assert gemini_handler_module.is_dispatch_status_logged() is True
+
 
 # ---------------------------------------------------------------------------
 # HINT-mode preservation

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_gemini_handler_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_gemini_handler_native.py
@@ -1,0 +1,425 @@
+"""Unit tests for GeminiHandler native SDK dispatch (issue #834 PR 3).
+
+Covers:
+  * has_native() returns True by default when the SDK is importable
+    (opt-out semantics — MCP_MESH_NATIVE_LLM=0 disables)
+  * has_native() returns False when MCP_MESH_NATIVE_LLM is explicitly set
+    to a falsy value (0/false/no/off)
+  * has_native() returns False when the SDK is missing (regardless of
+    flag value)
+  * has_native() returns True when MCP_MESH_NATIVE_LLM=1 (or other truthy
+    value) and the SDK is available — same as the default
+  * has_native() emits a one-time DEBUG dispatch-status log on first call
+    so ``meshctl ... --debug`` runs can confirm whether native or LiteLLM
+    is in play
+  * complete()/complete_stream() dispatch into the native module when
+    has_native() is True
+  * HINT-mode preservation: the existing prepare_request behavior (omit
+    response_format when tools present + Pydantic output) is unchanged on
+    the native dispatch path — the dispatch decision is independent of the
+    prepare_request output.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+pytest.importorskip(
+    "google.genai",
+    reason="GeminiHandler native dispatch tests require the google-genai SDK",
+)
+
+from _mcp_mesh.engine.provider_handlers import gemini_handler as gemini_handler_module
+from _mcp_mesh.engine.provider_handlers.gemini_handler import GeminiHandler
+
+
+# ---------------------------------------------------------------------------
+# has_native() gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    """Make sure the feature flag does not leak between tests."""
+    original = os.environ.pop("MCP_MESH_NATIVE_LLM", None)
+    yield
+    os.environ.pop("MCP_MESH_NATIVE_LLM", None)
+    if original is not None:
+        os.environ["MCP_MESH_NATIVE_LLM"] = original
+
+
+class TestHasNative:
+    def test_returns_true_when_flag_unset_and_sdk_available(self):
+        """Default ON: with the env var unset and the SDK importable, native
+        dispatch is enabled. This is the opt-out semantics flip — previously
+        the flag had to be set explicitly to enable native dispatch.
+        """
+        handler = GeminiHandler()
+        assert "MCP_MESH_NATIVE_LLM" not in os.environ
+
+        with patch(
+            "_mcp_mesh.engine.native_clients.gemini_native.is_available",
+            return_value=True,
+        ):
+            assert handler.has_native() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "False", "no", "OFF"])
+    def test_returns_false_when_flag_explicitly_off(self, value):
+        """Explicit opt-out via MCP_MESH_NATIVE_LLM=0/false/no/off forces the
+        LiteLLM fallback path even when the SDK is importable."""
+        handler = GeminiHandler()
+        os.environ["MCP_MESH_NATIVE_LLM"] = value
+
+        with patch(
+            "_mcp_mesh.engine.native_clients.gemini_native.is_available",
+            return_value=True,
+        ):
+            assert handler.has_native() is False
+
+    def test_returns_false_when_flag_unset_but_sdk_missing(self):
+        """SDK gate: with the SDK missing, native dispatch is unavailable
+        even on the default-ON path. Falls back to LiteLLM with a one-time
+        INFO log. (In normal installs this branch never fires — google-genai
+        is a base dep.)"""
+        handler = GeminiHandler()
+        assert "MCP_MESH_NATIVE_LLM" not in os.environ
+
+        with patch(
+            "_mcp_mesh.engine.native_clients.gemini_native.is_available",
+            return_value=False,
+        ):
+            assert handler.has_native() is False
+
+    def test_returns_false_when_flag_explicit_on_but_sdk_missing(self):
+        """Even with explicit MCP_MESH_NATIVE_LLM=1, a missing SDK falls back."""
+        handler = GeminiHandler()
+        os.environ["MCP_MESH_NATIVE_LLM"] = "1"
+
+        with patch(
+            "_mcp_mesh.engine.native_clients.gemini_native.is_available",
+            return_value=False,
+        ):
+            assert handler.has_native() is False
+
+    def test_returns_true_when_flag_explicit_on_and_sdk_available(self):
+        """Explicit-enable matches the default; preserved for backward compat
+        with existing deployments that set MCP_MESH_NATIVE_LLM=1."""
+        handler = GeminiHandler()
+        os.environ["MCP_MESH_NATIVE_LLM"] = "1"
+
+        with patch(
+            "_mcp_mesh.engine.native_clients.gemini_native.is_available",
+            return_value=True,
+        ):
+            assert handler.has_native() is True
+
+    @pytest.mark.parametrize("value", ["", "1", "true", "True", "yes", "ON"])
+    def test_default_on_accepts_unset_or_truthy_flag_values(self, value):
+        """Empty string (unset → default), and any truthy value all enable
+        native dispatch when the SDK is importable."""
+        handler = GeminiHandler()
+        if value:
+            os.environ["MCP_MESH_NATIVE_LLM"] = value
+        with patch(
+            "_mcp_mesh.engine.native_clients.gemini_native.is_available",
+            return_value=True,
+        ):
+            assert handler.has_native() is True
+
+    def test_logs_fallback_once_when_sdk_missing(self):
+        """When native is attempted (default ON) but the SDK is missing,
+        log_fallback_once() must be invoked so the user sees a single
+        nudge per process. The handler also short-circuits the call on
+        subsequent misses via ``is_fallback_logged()`` — verify both:
+        the first call invokes the log function, the second one does not.
+        """
+        handler = GeminiHandler()
+        assert "MCP_MESH_NATIVE_LLM" not in os.environ
+
+        with (
+            patch(
+                "_mcp_mesh.engine.native_clients.gemini_native.is_available",
+                return_value=False,
+            ),
+            patch(
+                "_mcp_mesh.engine.native_clients.gemini_native.log_fallback_once"
+            ) as mock_log,
+            patch(
+                "_mcp_mesh.engine.native_clients.gemini_native.is_fallback_logged",
+                side_effect=[False, True],
+            ),
+        ):
+            handler.has_native()
+            handler.has_native()
+            assert mock_log.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# complete() / complete_stream() dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestComplete:
+    @pytest.mark.asyncio
+    async def test_complete_dispatches_to_native_module(self):
+        handler = GeminiHandler()
+        sentinel = MagicMock(name="response")
+        with patch(
+            "_mcp_mesh.engine.native_clients.gemini_native.complete",
+            new=AsyncMock(return_value=sentinel),
+        ) as mock_complete:
+            result = await handler.complete(
+                {"messages": [{"role": "user", "content": "Hi"}]},
+                model="gemini/gemini-2.0-flash",
+                api_key="GAK-test",
+                base_url=None,
+            )
+
+        assert result is sentinel
+        mock_complete.assert_awaited_once()
+        kwargs = mock_complete.await_args.kwargs
+        assert kwargs["model"] == "gemini/gemini-2.0-flash"
+        assert kwargs["api_key"] == "GAK-test"
+
+    @pytest.mark.asyncio
+    async def test_complete_stream_dispatches_to_native_module(self):
+        handler = GeminiHandler()
+
+        async def _fake_iter():
+            yield "chunk1"
+            yield "chunk2"
+
+        with patch(
+            "_mcp_mesh.engine.native_clients.gemini_native.complete_stream",
+            return_value=_fake_iter(),
+        ) as mock_stream:
+            stream = await handler.complete_stream(
+                {"messages": [{"role": "user", "content": "Hi"}]},
+                model="gemini/gemini-2.0-flash",
+                api_key="GAK-test",
+            )
+            chunks = [c async for c in stream]
+
+        assert chunks == ["chunk1", "chunk2"]
+        mock_stream.assert_called_once()
+        kwargs = mock_stream.call_args.kwargs
+        assert kwargs["model"] == "gemini/gemini-2.0-flash"
+        assert kwargs["api_key"] == "GAK-test"
+
+    @pytest.mark.asyncio
+    async def test_vertex_model_dispatches_through_native(self):
+        """vertex_ai/* models route through the same native adapter as
+        gemini/* — the handler doesn't care about the prefix; backend
+        selection happens inside ``gemini_native._build_client``."""
+        handler = GeminiHandler()
+        sentinel = MagicMock(name="vertex_response")
+        with patch(
+            "_mcp_mesh.engine.native_clients.gemini_native.complete",
+            new=AsyncMock(return_value=sentinel),
+        ) as mock_complete:
+            result = await handler.complete(
+                {"messages": [{"role": "user", "content": "Hi"}]},
+                model="vertex_ai/gemini-2.0-flash",
+            )
+        assert result is sentinel
+        assert mock_complete.await_args.kwargs["model"] == (
+            "vertex_ai/gemini-2.0-flash"
+        )
+
+
+# ---------------------------------------------------------------------------
+# One-time DEBUG dispatch-status log
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _reset_dispatch_status_log():
+    """Reset the module-level one-time guard so each test starts clean."""
+    original = gemini_handler_module._DISPATCH_STATUS_LOGGED
+    gemini_handler_module._DISPATCH_STATUS_LOGGED = False
+    yield
+    gemini_handler_module._DISPATCH_STATUS_LOGGED = original
+
+
+class TestDispatchStatusLog:
+    """``has_native()`` should fire a DEBUG log exactly once per process so
+    operators running ``meshctl ... --debug`` can confirm whether the native
+    Gemini SDK is in play (or whether mesh has fallen back to LiteLLM)."""
+
+    def test_logs_enabled_when_sdk_available_and_flag_unset(
+        self, caplog, _reset_dispatch_status_log
+    ):
+        handler = GeminiHandler()
+        assert "MCP_MESH_NATIVE_LLM" not in os.environ
+
+        with (
+            caplog.at_level(
+                logging.DEBUG,
+                logger="_mcp_mesh.engine.provider_handlers.gemini_handler",
+            ),
+            patch(
+                "_mcp_mesh.engine.native_clients.gemini_native.is_available",
+                return_value=True,
+            ),
+        ):
+            handler.has_native()
+
+        status_records = [
+            r for r in caplog.records if "Gemini native dispatch:" in r.message
+        ]
+        assert len(status_records) == 1
+        assert status_records[0].levelno == logging.DEBUG
+        assert "enabled" in status_records[0].message
+
+    def test_logs_disabled_when_flag_explicitly_off(
+        self, caplog, _reset_dispatch_status_log
+    ):
+        handler = GeminiHandler()
+        os.environ["MCP_MESH_NATIVE_LLM"] = "0"
+
+        with caplog.at_level(
+            logging.DEBUG,
+            logger="_mcp_mesh.engine.provider_handlers.gemini_handler",
+        ):
+            handler.has_native()
+
+        status_records = [
+            r for r in caplog.records if "Gemini native dispatch:" in r.message
+        ]
+        assert len(status_records) == 1
+        assert status_records[0].levelno == logging.DEBUG
+        assert "disabled" in status_records[0].message
+        assert "MCP_MESH_NATIVE_LLM=0" in status_records[0].message
+
+    def test_logs_disabled_when_sdk_missing(
+        self, caplog, _reset_dispatch_status_log
+    ):
+        handler = GeminiHandler()
+        assert "MCP_MESH_NATIVE_LLM" not in os.environ
+
+        with (
+            caplog.at_level(
+                logging.DEBUG,
+                logger="_mcp_mesh.engine.provider_handlers.gemini_handler",
+            ),
+            patch(
+                "_mcp_mesh.engine.native_clients.gemini_native.is_available",
+                return_value=False,
+            ),
+        ):
+            handler.has_native()
+
+        status_records = [
+            r for r in caplog.records if "Gemini native dispatch:" in r.message
+        ]
+        assert len(status_records) == 1
+        assert status_records[0].levelno == logging.DEBUG
+        assert "disabled" in status_records[0].message
+        assert "google-genai SDK not installed" in status_records[0].message
+        assert "mcp-mesh[gemini]" in status_records[0].message
+
+    def test_log_fires_only_once_across_calls(
+        self, caplog, _reset_dispatch_status_log
+    ):
+        handler = GeminiHandler()
+        assert "MCP_MESH_NATIVE_LLM" not in os.environ
+
+        with (
+            caplog.at_level(
+                logging.DEBUG,
+                logger="_mcp_mesh.engine.provider_handlers.gemini_handler",
+            ),
+            patch(
+                "_mcp_mesh.engine.native_clients.gemini_native.is_available",
+                return_value=True,
+            ),
+        ):
+            handler.has_native()
+            first_count = sum(
+                1 for r in caplog.records if "Gemini native dispatch:" in r.message
+            )
+            handler.has_native()
+            second_count = sum(
+                1 for r in caplog.records if "Gemini native dispatch:" in r.message
+            )
+
+        assert first_count == 1
+        assert second_count == 1
+
+
+# ---------------------------------------------------------------------------
+# HINT-mode preservation
+# ---------------------------------------------------------------------------
+
+
+class _SamplePydantic(BaseModel):
+    answer: str
+    confidence: int
+
+
+class TestHintModePreservation:
+    """The existing GeminiHandler.prepare_request behavior must be unchanged
+    on the native dispatch path:
+
+    * No tools + Pydantic output → response_format IS attached (STRICT mode).
+    * Tools + Pydantic output → response_format is OMITTED (HINT mode; the
+      schema lives in the system prompt instead — workaround for the Gemini
+      API infinite-tool-loop bug for that combination).
+
+    The native adapter just executes whatever request_params it receives;
+    the dispatch decision (has_native()) is independent of prepare_request's
+    output. This test pins the behavior end-to-end so a future refactor of
+    either piece doesn't accidentally regress the workaround.
+    """
+
+    def test_no_tools_pydantic_output_attaches_response_format(self):
+        handler = GeminiHandler()
+        params = handler.prepare_request(
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            output_type=_SamplePydantic,
+        )
+        # STRICT mode: response_format IS attached when no tools present.
+        assert "response_format" in params
+        assert params["response_format"]["type"] == "json_schema"
+
+    def test_tools_with_pydantic_output_omits_response_format(self):
+        """The HINT-mode workaround: when tools + Pydantic output, the
+        handler MUST NOT attach response_format (Gemini API has a non-
+        deterministic infinite-tool-loop bug for that combo). The schema
+        gets surfaced through the system prompt by ``format_system_prompt``
+        instead."""
+        handler = GeminiHandler()
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "noop",
+                    "description": "",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        params = handler.prepare_request(
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            output_type=_SamplePydantic,
+        )
+        # response_format MUST be absent when tools + Pydantic output.
+        assert "response_format" not in params
+        # Tools still flow through.
+        assert params["tools"] == tools
+
+    def test_str_output_skips_response_format(self):
+        handler = GeminiHandler()
+        params = handler.prepare_request(
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            output_type=str,
+        )
+        assert "response_format" not in params

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -198,6 +198,71 @@ def _inject_synthetic_format_tool(
     return augmented
 
 
+def _build_assistant_tool_call_dict(tc: Any) -> dict[str, Any]:
+    """Serialize one ``_ToolCall``-shape object into the conversation dict.
+
+    Whitelists the four canonical fields (``id``, ``type``,
+    ``function.name``, ``function.arguments``) plus one Gemini-only sidecar:
+    ``_gemini_thought_signature`` (base64-encoded bytes) when present on the
+    source object. The signature originates from Gemini 2.0+ thinking models
+    that emit a Part-level ``thought_signature`` on each functionCall response
+    Part — the Gemini API REQUIRES this signature to be echoed back on the
+    next-turn functionCall of the same multi-turn conversation, otherwise
+    rejecting with HTTP 400 ("Function call is missing a thought_signature").
+
+    The Gemini native adapter (``gemini_native._adapt_response``) lifts the
+    signature off the response Part and stores it on the synthesized
+    ``_ToolCall._thought_signature`` attribute. We forward it onto the
+    serialized dict here so that the next-iteration's
+    ``gemini_native._convert_messages_to_gemini`` can recover it and place it
+    back on the outbound functionCall Part. Other vendor adapters
+    (anthropic_native, openai_native, litellm) never set the attribute; the
+    sidecar is simply absent for them — fully backward-compatible.
+    """
+    out: dict[str, Any] = {
+        "id": tc.id,
+        "type": tc.type,
+        "function": {
+            "name": tc.function.name,
+            "arguments": tc.function.arguments,
+        },
+    }
+    # Strict ``bytes`` check — only the Gemini native adapter sets this attr
+    # and only ever to bytes / None. MagicMock test doubles otherwise
+    # auto-generate truthy attributes that aren't bytes-like and would break
+    # the b64encode call below.
+    sig = getattr(tc, "_thought_signature", None)
+    if isinstance(sig, (bytes, bytearray)) and sig:
+        import base64
+
+        out["_gemini_thought_signature"] = base64.b64encode(sig).decode("ascii")
+    return out
+
+
+def _build_assistant_tool_call_dict_from_merged(tc: dict[str, Any]) -> dict[str, Any]:
+    """Same as :func:`_build_assistant_tool_call_dict` but for the streaming
+    merger's pre-coalesced dict shape.
+
+    ``MeshLlmAgent._merge_streamed_tool_calls`` returns a list of dicts (not
+    ``_ToolCall`` objects); the Gemini-only thought_signature is forwarded
+    onto those dicts as ``_gemini_thought_signature`` (already base64-encoded)
+    so this serializer just whitelist-passes-through. Other vendors don't set
+    the key so the field is silently absent for them.
+    """
+    out: dict[str, Any] = {
+        "id": tc["id"],
+        "type": tc["type"],
+        "function": {
+            "name": tc["function"]["name"],
+            "arguments": tc["function"]["arguments"],
+        },
+    }
+    sig_b64 = tc.get("_gemini_thought_signature")
+    if sig_b64:
+        out["_gemini_thought_signature"] = sig_b64
+    return out
+
+
 def _extract_synthetic_format_arguments(
     message: Any,
     synthetic_tool_name: str,
@@ -762,19 +827,26 @@ async def _provider_agentic_loop(
                     f"(iteration {iteration}/{max_iterations})"
                 )
 
-            # Add assistant message with tool_calls to conversation
+            # Add assistant message with tool_calls to conversation.
+            #
+            # ``_gemini_thought_signature`` (when present, base64-encoded
+            # bytes) is a Gemini-only sidecar: Gemini 2.0+ thinking models
+            # emit a Part-level ``thought_signature`` on each ``functionCall``
+            # response Part that the API REQUIRES to be echoed back on the
+            # next-turn ``functionCall`` of a multi-turn tool-calling
+            # conversation. Without it Gemini rejects the request with
+            # HTTP 400. The native Gemini adapter (gemini_native._adapt_response)
+            # lifts the signature off the response Part onto its ``_ToolCall``;
+            # we serialize it onto the conversation dict here so that the
+            # next iteration's ``_convert_messages_to_gemini`` can recover it
+            # and place it back on the outbound functionCall Part. Other
+            # vendors never set the attribute, so the field is silently
+            # absent for them.
             assistant_msg: dict[str, Any] = {
                 "role": "assistant",
                 "content": message.content or "",
                 "tool_calls": [
-                    {
-                        "id": tc.id,
-                        "type": tc.type,
-                        "function": {
-                            "name": tc.function.name,
-                            "arguments": tc.function.arguments,
-                        },
-                    }
+                    _build_assistant_tool_call_dict(tc)
                     for tc in message.tool_calls
                 ],
             }
@@ -1148,18 +1220,17 @@ async def _provider_agentic_loop_stream(
                         f"(iteration {iteration}/{max_iterations})"
                     )
 
+                # See ``_build_assistant_tool_call_dict`` for the
+                # ``_gemini_thought_signature`` rationale — the merged dict
+                # may carry that Gemini-only sidecar (the streaming merger
+                # forwards it from ``_StreamToolCallDelta._thought_signature``)
+                # and we propagate it onto the conversation dict so the
+                # next iteration's Gemini Part-conversion can echo it back.
                 assistant_msg: dict[str, Any] = {
                     "role": "assistant",
                     "content": preamble_text or "",
                     "tool_calls": [
-                        {
-                            "id": tc["id"],
-                            "type": tc["type"],
-                            "function": {
-                                "name": tc["function"]["name"],
-                                "arguments": tc["function"]["arguments"],
-                            },
-                        }
+                        _build_assistant_tool_call_dict_from_merged(tc)
                         for tc in merged_tool_calls
                     ],
                 }

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -1863,16 +1863,19 @@ def llm_provider(
                 }
 
                 # Include tool_calls if present (critical for agentic loop support!)
+                #
+                # Use the shared ``_build_assistant_tool_call_dict`` helper so
+                # the Gemini-only ``_gemini_thought_signature`` sidecar is
+                # forwarded onto the conversation dict. Inline construction
+                # would silently drop the signature, breaking the next-iteration
+                # request to thinking Gemini models with HTTP 400 ("Function
+                # call is missing a thought_signature"). This single-call
+                # branch fires for callers who hit ``process_chat`` directly
+                # (no agentic-loop path) — the loop branch (~line 849) already
+                # uses the helper.
                 if hasattr(message, "tool_calls") and message.tool_calls:
                     message_dict["tool_calls"] = [
-                        {
-                            "id": tc.id,
-                            "type": tc.type,
-                            "function": {
-                                "name": tc.function.name,
-                                "arguments": tc.function.arguments,
-                            },
-                        }
+                        _build_assistant_tool_call_dict(tc)
                         for tc in message.tool_calls
                     ]
 

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -49,6 +49,13 @@ requires-python = ">=3.11"
 # silently fall back to LiteLLM. (openai is also a transitive dep of
 # litellm today; promoting to a direct base dep prevents breakage if
 # litellm ever drops it as transitive.)
+#
+# google-genai SDK is included by default for native Gemini dispatch
+# (issue #834 PR 3). Supports both AI Studio (gemini/*) and Vertex AI
+# (vertex_ai/*) backends via constructor flag. When MCP_MESH_NATIVE_LLM
+# is unset (default ON), Gemini provider agents dispatch through the
+# native google-genai SDK; without it they would silently fall back to
+# LiteLLM.
 dependencies = [
     "fastapi>=0.104.0",
     "uvicorn>=0.24.0",
@@ -65,6 +72,7 @@ dependencies = [
     "litellm>=1.80.5,!=1.82.7,!=1.82.8",
     "anthropic>=0.42",
     "openai>=1.60",
+    "google-genai>=0.8.0",
     "prometheus-client>=0.19.0",
     "pyyaml>=6.0",
     "jinja2>=3.1.0",
@@ -123,6 +131,13 @@ openai = [
     # as a no-op so ``pip install mcp-mesh[openai]`` still resolves cleanly
     # for users who pinned it from earlier docs.
     "openai>=1.60"
+]
+gemini = [
+    # Backward-compat alias: ``google-genai`` is now a base dependency
+    # (issue #834 PR 3 — native dispatch is default ON). This extra is
+    # preserved as a no-op so ``pip install mcp-mesh[gemini]`` still
+    # resolves cleanly for users who pinned it from earlier docs.
+    "google-genai>=0.8.0"
 ]
 
 [project.urls]

--- a/src/runtime/python/tests/unit/test_assistant_tool_call_dict_helper.py
+++ b/src/runtime/python/tests/unit/test_assistant_tool_call_dict_helper.py
@@ -1,0 +1,211 @@
+"""Unit tests for ``_build_assistant_tool_call_dict`` (mesh.helpers).
+
+Background:
+    The Gemini native adapter lifts a Part-level ``thought_signature`` (bytes)
+    off each ``functionCall`` response Part onto the synthesized ``_ToolCall``
+    as ``_thought_signature``. The Gemini API REQUIRES that signature to be
+    echoed back on the next-turn ``functionCall`` of a multi-turn tool-calling
+    conversation; otherwise it rejects with HTTP 400 ("Function call is
+    missing a thought_signature").
+
+    Mesh's two paths that serialize an assistant tool_call message into the
+    conversation dict are:
+
+      1. ``_provider_agentic_loop`` (line ~849) — the agentic-loop branch.
+      2. ``process_chat`` legacy single-call branch (line ~1867) — fires when
+         a caller hits ``process_chat`` directly with no agentic-loop context
+         but still gets tool_calls back.
+
+    Both must serialize the ``_gemini_thought_signature`` sidecar; both must
+    route through ``_build_assistant_tool_call_dict`` (the canonical helper)
+    so the contract stays consistent and silent regressions are caught here.
+
+    These tests pin the helper's contract directly so future refactors of
+    either branch don't drop the signature again.
+"""
+
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+
+from mesh.helpers import _build_assistant_tool_call_dict
+
+
+def _make_tool_call(
+    *,
+    tc_id: str = "call_0",
+    name: str = "get_weather",
+    arguments: str = '{"city": "NYC"}',
+    thought_signature: bytes | None = None,
+) -> SimpleNamespace:
+    """Build a minimal ``_ToolCall``-shape object using SimpleNamespace.
+
+    Avoids MagicMock — its auto-generated attributes would falsely satisfy
+    the ``isinstance(sig, (bytes, bytearray))`` check inside the helper and
+    mask real bugs.
+    """
+    fn = SimpleNamespace(name=name, arguments=arguments)
+    tc = SimpleNamespace(
+        id=tc_id,
+        type="function",
+        function=fn,
+        _thought_signature=thought_signature,
+    )
+    return tc
+
+
+class TestCanonicalFields:
+    """The four canonical fields (``id``, ``type``, ``function.name``,
+    ``function.arguments``) round-trip exactly."""
+
+    def test_basic_serialization(self):
+        tc = _make_tool_call(
+            tc_id="call_42", name="add", arguments='{"a": 1, "b": 2}'
+        )
+        out = _build_assistant_tool_call_dict(tc)
+        assert out == {
+            "id": "call_42",
+            "type": "function",
+            "function": {"name": "add", "arguments": '{"a": 1, "b": 2}'},
+        }
+
+    def test_no_signature_no_sidecar_field(self):
+        """Steady-state path for non-Gemini vendors: ``_thought_signature``
+        is None / absent and the sidecar key must NOT appear in the output.
+        """
+        tc = _make_tool_call(thought_signature=None)
+        out = _build_assistant_tool_call_dict(tc)
+        assert "_gemini_thought_signature" not in out
+
+
+class TestThoughtSignatureSidecar:
+    """Gemini-only: the ``_gemini_thought_signature`` sidecar carries a
+    base64-encoded snapshot of the source bytes through the conversation
+    dict so the next-turn request can decode and replay it."""
+
+    def test_signature_serialized_as_base64(self):
+        sig_bytes = b"sig-abcd-1234"
+        tc = _make_tool_call(thought_signature=sig_bytes)
+        out = _build_assistant_tool_call_dict(tc)
+        assert "_gemini_thought_signature" in out
+        # Round-trip: b64 string must decode back to the original bytes.
+        decoded = base64.b64decode(out["_gemini_thought_signature"])
+        assert decoded == sig_bytes
+
+    def test_binary_signature_round_trips(self):
+        """Real Gemini signatures are opaque binary blobs (not printable
+        ASCII). The base64 encoding must handle arbitrary bytes including
+        nulls and high-byte values without truncation."""
+        sig_bytes = b"\x00\x01\x02\xff\xfe\xfd-binary-blob"
+        tc = _make_tool_call(thought_signature=sig_bytes)
+        out = _build_assistant_tool_call_dict(tc)
+        decoded = base64.b64decode(out["_gemini_thought_signature"])
+        assert decoded == sig_bytes
+
+    def test_empty_bytes_treated_as_absent(self):
+        """``b""`` is falsy; the helper's ``... and sig`` guard skips it.
+        Mirrors the Gemini adapter's behavior where empty-bytes signatures
+        are treated as absent (google.genai may emit them on non-thinking
+        models)."""
+        tc = _make_tool_call(thought_signature=b"")
+        out = _build_assistant_tool_call_dict(tc)
+        assert "_gemini_thought_signature" not in out
+
+    def test_non_bytes_signature_ignored(self):
+        """The strict ``isinstance(sig, (bytes, bytearray))`` check guards
+        against accidentally serializing a stray non-bytes attribute (e.g.
+        from a MagicMock test double or a misbehaving adapter). Anything
+        non-bytes-like must be silently dropped, NOT crash the b64 call."""
+        # Set the attribute to a non-bytes value via SimpleNamespace.
+        tc = _make_tool_call()
+        tc._thought_signature = "not-actually-bytes"
+        out = _build_assistant_tool_call_dict(tc)
+        assert "_gemini_thought_signature" not in out
+
+    def test_bytearray_signature_round_trips(self):
+        """``bytearray`` is in the isinstance whitelist alongside ``bytes``;
+        both must be handled symmetrically (some upstream paths produce one
+        vs the other)."""
+        sig = bytearray(b"bytearray-sig-content")
+        tc = _make_tool_call(thought_signature=sig)
+        out = _build_assistant_tool_call_dict(tc)
+        decoded = base64.b64decode(out["_gemini_thought_signature"])
+        assert decoded == bytes(sig)
+
+
+class TestLegacyBranchSerialization:
+    """Pins down the contract for the ``process_chat`` legacy single-call
+    branch (helpers.py ~line 1867). That branch was previously building the
+    tool_calls dict inline and silently dropped ``_gemini_thought_signature``;
+    now it routes through this helper. This test simulates that branch's
+    serialization shape and verifies the signature survives.
+    """
+
+    def test_legacy_branch_preserves_thought_signature(self):
+        """Simulates the legacy branch's list comprehension pattern:
+
+            message_dict["tool_calls"] = [
+                _build_assistant_tool_call_dict(tc) for tc in message.tool_calls
+            ]
+
+        With a Gemini ``_ToolCall`` carrying ``_thought_signature``, the
+        resulting dict's first tool_call entry must include the
+        base64-encoded sidecar — otherwise the next-turn Gemini request
+        would fail with HTTP 400.
+        """
+        sig_bytes = b"legacy-branch-signature"
+        message = SimpleNamespace(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                _make_tool_call(
+                    tc_id="gemini_call_0",
+                    name="get_weather",
+                    arguments='{"city": "SF"}',
+                    thought_signature=sig_bytes,
+                )
+            ],
+        )
+        # Mirror the legacy branch's serialization (helpers.py ~1867).
+        tool_calls_dicts = [
+            _build_assistant_tool_call_dict(tc) for tc in message.tool_calls
+        ]
+        assert len(tool_calls_dicts) == 1
+        tc_dict = tool_calls_dicts[0]
+        # Canonical fields preserved.
+        assert tc_dict["id"] == "gemini_call_0"
+        assert tc_dict["function"]["name"] == "get_weather"
+        # Gemini sidecar present + decodes back to original bytes.
+        assert "_gemini_thought_signature" in tc_dict
+        assert (
+            base64.b64decode(tc_dict["_gemini_thought_signature"])
+            == sig_bytes
+        )
+
+    def test_legacy_branch_non_gemini_no_sidecar(self):
+        """Backward-compat: a non-Gemini tool_call (no ``_thought_signature``
+        attribute set, or set to None) must produce a clean dict with no
+        sidecar key — same shape other vendors expect."""
+        message = SimpleNamespace(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                _make_tool_call(
+                    tc_id="call_xyz",
+                    name="tool",
+                    arguments="{}",
+                    thought_signature=None,
+                )
+            ],
+        )
+        tool_calls_dicts = [
+            _build_assistant_tool_call_dict(tc) for tc in message.tool_calls
+        ]
+        assert tool_calls_dicts == [
+            {
+                "id": "call_xyz",
+                "type": "function",
+                "function": {"name": "tool", "arguments": "{}"},
+            }
+        ]

--- a/tests/integration/suites/uc04_llm_integration/tc34_vertex_provider_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc34_vertex_provider_py/test.yaml
@@ -3,12 +3,16 @@
 # the "vertex_ai/<model>" prefix (IAM auth, NOT AI Studio API key).
 #
 # REQUIRED secrets in tsuite DB (configured via the secrets handler):
-#   - GCP_SA_JSON_B64     : base64-encoded service-account JSON (single-line — multi-line
-#                           values mangle the .env file when sourced via `set -a && . .env`).
-#                           Generate via: `base64 -i ~/.config/gcloud/application_default_credentials.json | tr -d '\n'`
-#   - VERTEXAI_PROJECT    : GCP project id (e.g., eng-cache-151909)
-#   - VERTEXAI_LOCATION   : GCP region    (e.g., us-central1)
+#   - GCP_SA_JSON_B64       : base64-encoded service-account JSON (single-line — multi-line
+#                             values mangle the .env file when sourced via `set -a && . .env`).
+#                             Generate via: `base64 -i ~/.config/gcloud/application_default_credentials.json | tr -d '\n'`
+#   - GOOGLE_CLOUD_PROJECT  : GCP project id (e.g., eng-cache-151909)
+#   - GOOGLE_CLOUD_LOCATION : GCP region    (e.g., us-central1)
 # Without these, the materialize step fails with a clear "secret not configured" error.
+#
+# Note: secret names are the env var names that mcp-mesh reads. PR3 native Gemini
+# dispatch (#834) uses Google-standard env vars GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_LOCATION
+# (NOT the LiteLLM convention VERTEXAI_PROJECT/VERTEXAI_LOCATION).
 #
 # Related: https://github.com/dhyansraj/mcp-mesh/issues/816
 

--- a/tests/integration/suites/uc05_meshctl/tc10_watch_flag/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc10_watch_flag/test.yaml
@@ -66,7 +66,7 @@ test:
 
   - name: "Wait for watch to detect change and reload"
     handler: wait
-    seconds: 8
+    seconds: 20
 
   - name: "Call greet after modification"
     handler: shell
@@ -106,7 +106,7 @@ test:
 
   - name: "Wait for watch to detect change and reload"
     handler: wait
-    seconds: 10
+    seconds: 20
 
   - name: "Call add after modification"
     handler: shell


### PR DESCRIPTION
## Summary

PR 3 of #834 — native `google-genai` Python SDK dispatch in `@mesh.llm_provider`, default ON. Both backends in one PR per design discussion:
- `gemini/*` → `google.genai.Client(api_key=...)` (AI Studio)
- `vertex_ai/*` → `google.genai.Client(vertexai=True, project=..., location=...)` (Vertex AI)

**Closes #834 entirely** — completes the Anthropic (#862) + OpenAI (#864) + Gemini trilogy.

## Why this is the trickiest of the big 3

Gemini's API diverges significantly from OpenAI/Anthropic — the adapter does heavy translation:

| Concept | mesh internal (OpenAI shape) | Gemini API |
|---|---|---|
| System message | `{role: "system"}` in messages | `systemInstruction` (top-level field, NOT in messages) |
| Assistant role | `"assistant"` | `"model"` |
| Tool calls | `{id: "call_x", function: {...}}` | `{functionCall: {...}}` — **NO id field** |
| Tools shape | `[{type: "function", function: {...}}]` | `[{functionDeclarations: [{...}]}]` |
| tool_choice | string or dict | `toolConfig: {functionCallingConfig: {mode}}` |
| Images | `{type: "image_url", image_url: {url: "data:..."}}` | `{inlineData: {mimeType, data}}` (raw b64) |
| response_format | `{type: "json_schema", json_schema: {...}}` | `responseSchema` + `responseMimeType` (top-level) |
| Streaming usage | Final chunk only | **Every** chunk |

Plus a **schema sanitizer** is required: Gemini's `function_declarations.parameters` rejects JSON-Schema fields like `additionalProperties`, `$schema`, `title`, `$ref` with HTTP 400. Mesh's Pydantic schema generator emits these. Native adapter now whitelists Gemini-supported OpenAPI 3.0 fields and strips the rest. LiteLLM had been silently doing this; native dispatch inherits responsibility.

## Architecture

Mirrors PR 1 (Anthropic) and PR 2 (OpenAI) patterns:
- `gemini_native.py` adapter wrapping `google.genai.Client`
- `GeminiHandler.has_native()/.complete()/.complete_stream()` methods
- Diagnostic DEBUG log: `Gemini native dispatch: enabled (google-genai SDK X.Y.Z)`
- Shared httpx pool via google-genai's `HttpOptions(httpx_async_client=...)` — discovered during impl, cleaner than expected
- Per-call lazy client (K8s secret rotation)
- Per-key WARN dedupe for unsupported kwargs
- Upfront credential validation (separate AI Studio vs Vertex error messages)
- Tool-call ID synthesis (`gemini_call_<index>`) with strict ordering preservation
- `final_usage_emitted` flag set AFTER yield (no telemetry hole on stream interruption)

**Critical preservation**: HINT-mode workaround for `response_format + tools` combination. Gemini API has documented infinite-loop bug; existing `GeminiHandler.prepare_request()` omits `response_format` when tools present and uses prompt-injection HINT mode. Native path inherits this unchanged — `prepare_request` decides, native adapter just executes whatever it gets.

**ContextVar isolation preserved**: existing `GeminiHandler` uses ContextVars for per-request schema state isolation (singleton handler + concurrent async). Critical; not touched.

## Backend dispatch

```python
def _build_client(model, api_key, base_url):
    if model.startswith("vertex_ai/"):
        project = os.environ.get("GOOGLE_CLOUD_PROJECT")  # required
        location = os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1")
        if not project: raise ValueError("...")
        return genai.Client(vertexai=True, project=project, location=location)
    # AI Studio
    if not api_key and not os.environ.get("GOOGLE_API_KEY"): raise ValueError("...")
    return genai.Client(api_key=api_key or os.environ.get("GOOGLE_API_KEY"))
```

Vertex credentials = env-var only for now (per design discussion); decorator kwargs follow-up.

## E2E verification

Local meshctl-managed agents + httpx wire logs:

```
DEBUG Gemini native dispatch: enabled (google-genai SDK 1.75.0)
===WIRE_REQUEST=== POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
DEBUG 📥 LLM provider response: <_mcp_mesh.engine.native_clients.gemini_native._Response object>
```

Trap-based dispatch verification (3-row matrix + 1 critical):
- Default ON + litellm trap: succeeds (proves native bypass)
- `MCP_MESH_NATIVE_LLM=0` + trap: fails with LITELLM CALLED (proves opt-out)
- `MCP_MESH_NATIVE_LLM=0` + no trap: succeeds via `litellm.ModelResponse`
- **Native + tools + Pydantic (HINT-mode + schema sanitizer)**: succeeds — 2-iteration agentic loop completes cleanly, `WeatherReport` parses with `temp_f: 41`. Caught a real bug pre-merge (additionalProperties rejected by Gemini API), fixed via schema sanitizer.

Vertex backend: skipped locally (GOOGLE_CLOUD_PROJECT unset).

## Tests

- `gemini_native.py` (1334 LOC, 90 tests): backend dispatch, credential validation, all translators (system instruction extraction, message conversion, tool conversion, tool_choice translation, content-block translation), request shaping, response adaptation, streaming with per-chunk usage, shared httpx pool, schema sanitizer (12 tests covering recursive nested objects, arrays, anyOf/oneOf/allOf, etc.)
- `gemini_handler_native.py` (425 LOC, 26 tests): has_native gating, dispatch DEBUG log, complete/complete_stream dispatch, HINT-mode preservation pinned (no response_format when tools present)
- **1055 unit tests pass total** (937 baseline post-PR2 + 116 new + 2 from cleanup)

## Pre-PR review

3 review iterations:
1. Initial: 0 BLOCKER + 0 WARN + 5 INFO (already cleanest first-pass of any PR in the trilogy)
2. Cleanup commit: 4 INFOs addressed (dead env-value fallback in disabled-state log, has_native short-circuit consistency with PR 1/2, MALFORMED_FUNCTION_CALL → tool_calls in finish reason map, propertyOrdering added to schema whitelist)
3. INFOs #1 + #4 mirrored across all 3 handlers (Gemini/OpenAI/Claude) for cross-vendor consistency

Skipped INFO #2 (already-native passthrough sanitization) — design-level; input shape determined by mesh emitters, not external input.

## Out of scope (deferred)

- **Grounding** (`tools=[{google_search:{}}]`) and **code execution** as built-in tool declarations — net-new Gemini features, surface via decorator kwarg
- **`thinking_config`** for Gemini 2.5+ reasoning budget — net-new feature
- **Re-enabling `response_format + tools`** when Gemini API fixes the infinite-loop bug — needs API-version detection
- **Vertex decorator-kwarg credentials** — env-var-only for PR 3 per design
- **Latency benchmarks** vs LiteLLM
- **Re-enabling 16 disabled Gemini tests** — analyzed; none of the disable reasons (Vercel SDK bugs, Gemini API quota #840) are addressed by PR 3. All remain disabled until upstream/infra fixes.

## Pyproject

`google-genai>=0.8.0` promoted to base dep in both `src/runtime/python/pyproject.toml` and `packaging/pypi/pyproject.toml`. Backward-compat `[gemini]` extras alias added.

## Test plan

- [ ] CI integration suite passes (default ON exercises native path on all Python Gemini tests)
- [ ] Reviewer confirms HINT-mode preservation reasoning (response_format + tools combo)
- [ ] Optional: validate Vertex backend with GOOGLE_CLOUD_PROJECT set (not exercised locally)

Closes #834 (final partial — Anthropic done, OpenAI done, Gemini done)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native Google Gemini and Vertex AI SDK support with streaming, tool-calling, multimodal (text/images/inline) handling, and thought-signature preservation across streams.
* **Behavior & Reliability**
  * Improved one-time dispatch/fallback logging and safer per-event-loop connection pooling and fallback usage reporting.
* **Tests**
  * Extensive coverage for native dispatch, streaming, tool-calls, multimodal conversion, auth scenarios, and edge cases.
* **Dependencies**
  * Added google-genai>=0.8.0 and a gemini optional extra.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->