### PR TITLE
fix: output_type kwarg collision in MeshLlmAgent (#863)

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
@@ -813,6 +813,12 @@ class MeshLlmAgent:
             if self.output_mode
             else effective_kwargs
         )
+        # Avoid kwarg collision: prepare_request takes output_type as an
+        # explicit kwarg below; pop it from call_kwargs to prevent
+        # "got multiple values for keyword argument 'output_type'" TypeError
+        # if it leaked into _default_model_params (e.g., via decorator
+        # **kwargs capture in @mesh.llm). See #863.
+        call_kwargs.pop("output_type", None)
         effective_tools = (
             self._enrich_tools_with_endpoints()
             if self._is_mesh_delegated and self._tool_schemas

--- a/src/runtime/python/tests/unit/test_mesh_llm_agent_proxy.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_agent_proxy.py
@@ -2344,3 +2344,103 @@ class TestMeshDelegationMeta:
 
         assert usage is None
         assert model is None
+
+
+class TestBuildRequestParamsKwargCollision:
+    """Regression tests for #863: output_type kwarg collision in
+    _build_request_params when output_type leaks into _default_model_params
+    (e.g., via @mesh.llm decorator **kwargs capture)."""
+
+    def test_build_request_params_no_kwarg_collision_when_output_type_in_default_params(
+        self,
+    ):
+        """#863: prepare_request was failing with 'got multiple values for
+        keyword argument output_type' when output_type leaked into
+        _default_model_params (decorator **kwargs capture path)."""
+        from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+
+        agent = MeshLlmAgent(
+            config=make_test_config(
+                provider="claude",
+                model="claude-3-5-sonnet-20241022",
+                api_key="test-key",
+                max_iterations=10,
+            ),
+            filtered_tools=[],
+            output_type=ChatResponse,
+        )
+
+        # Simulate output_type leaking into _default_model_params via the
+        # decorator path (resolved_config.update(kwargs) in @mesh.llm).
+        agent._default_model_params["output_type"] = ChatResponse
+
+        # Capture prepare_request invocation; assert no TypeError raised
+        # and output_type arrives exactly once with the agent's value.
+        captured: dict = {}
+
+        def fake_prepare_request(*, messages, tools, output_type, **kwargs):
+            captured["messages"] = messages
+            captured["tools"] = tools
+            captured["output_type"] = output_type
+            captured["kwargs"] = kwargs
+            return {
+                "messages": messages,
+                "tools": tools,
+                "output_type": output_type,
+                **kwargs,
+            }
+
+        with patch.object(
+            agent._provider_handler,
+            "prepare_request",
+            side_effect=fake_prepare_request,
+        ):
+            params = agent._build_request_params(
+                [{"role": "user", "content": "hi"}]
+            )
+
+        # Did not raise TypeError; reached the handler exactly once.
+        assert captured["output_type"] is ChatResponse
+        # output_type should NOT also appear in **kwargs (would imply
+        # collision risk if upstream signatures changed).
+        assert "output_type" not in captured["kwargs"]
+        # Returned params include output_type from the explicit kwarg path.
+        assert params["output_type"] is ChatResponse
+
+    def test_build_request_params_call_time_output_type_kwarg_also_dropped(self):
+        """Defense-in-depth: even if a caller passes output_type=... at
+        call time (e.g., stale **kwargs forwarding), the explicit
+        ``self.output_type`` wins and no TypeError occurs."""
+        from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+
+        agent = MeshLlmAgent(
+            config=make_test_config(
+                provider="claude",
+                model="claude-3-5-sonnet-20241022",
+                api_key="test-key",
+                max_iterations=10,
+            ),
+            filtered_tools=[],
+            output_type=ChatResponse,
+        )
+
+        captured: dict = {}
+
+        def fake_prepare_request(*, messages, tools, output_type, **kwargs):
+            captured["output_type"] = output_type
+            captured["kwargs"] = kwargs
+            return {"output_type": output_type, **kwargs}
+
+        with patch.object(
+            agent._provider_handler,
+            "prepare_request",
+            side_effect=fake_prepare_request,
+        ):
+            agent._build_request_params(
+                [{"role": "user", "content": "hi"}],
+                output_type=ComplexResponse,  # caller-provided collision
+            )
+
+        # Self.output_type wins (no collision raised, value is from agent).
+        assert captured["output_type"] is ChatResponse
+        assert "output_type" not in captured["kwargs"]


### PR DESCRIPTION
## Summary

Pop `output_type` from `call_kwargs` before splatting into `prepare_request`, preventing `TypeError: got multiple values for keyword argument 'output_type'` when `output_type` leaks into `_default_model_params` from decorator capture.

Discovered during PR 2 of #834 (#864) E2E testing.

## Root cause

1. `mesh/decorators.py:1840` — `resolved_config.update(kwargs)` merges all caller kwargs (including `output_type=...`) into `resolved_config`
2. `_mcp_mesh/engine/mesh_llm_agent_injector.py:752-769` — builds `default_model_params` filtering by `INTERNAL_CONFIG_KEYS`, which doesn't include `"output_type"` — so it passes through to the agent
3. `mesh_llm_agent.py:_build_request_params` (line ~821) — does `prepare_request(..., output_type=self.output_type, **call_kwargs)`. If `call_kwargs` ALSO contains `output_type` from `_default_model_params`, Python raises `TypeError`.

## Fix

Single-line defensive pop at the consumer site:

```python
# Avoid kwarg collision: prepare_request takes output_type as explicit
# kwarg below; pop from call_kwargs to prevent "got multiple values"
# TypeError if it leaked into _default_model_params (e.g., from decorator
# capture). See #863.
call_kwargs.pop("output_type", None)
```

`self.output_type` (set at agent construction) is authoritative — wins over any leaked-through kwarg.

## Other call sites checked + safe

- `mesh_llm_agent.py:732` `format_system_prompt` — explicit kwarg, no spread
- Helper-routed call sites at `:918`, `:1340`, `:1565` — all go through `_build_request_params`, protected by the single fix
- Mesh-delegate streaming branch `:1373` — builds `model_params` via filter, no spread collision

## Tests

2 regression tests in `test_mesh_llm_agent_proxy.py`:
1. `test_build_request_params_no_kwarg_collision_when_output_type_in_default_params` — direct repro by planting `output_type` in `_default_model_params`; asserts no TypeError + `output_type` arrives exactly once with agent's value
2. `test_build_request_params_call_time_output_type_kwarg_also_dropped` — defense-in-depth: caller-supplied `output_type=...` at call time is also dropped; `self.output_type` wins

Both would fail without the one-line fix (verified independently — the bug reproduces).

## Test results

- 1093 unit tests pass (1091 baseline + 2 new)
- Zero regressions

## Deeper fix (deferred)

The cleanest long-term fix is to add `"output_type"` to `INTERNAL_CONFIG_KEYS` in `mesh_llm_agent_injector.py:752` so `_default_model_params` doesn't carry the redundant value at all. Not done here per minimal-fix scope; defensive pop covers all flows uniformly. Could be a small follow-up if drift cleanliness matters.

Closes #863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a TypeError that occurred when output type parameters were inadvertently duplicated during request preparation.

* **Tests**
  * Added regression tests to ensure output type parameter handling remains stable and prevents future collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->