### PR TITLE
fix: LLM stack cleanups — kwarg collision + per-loop httpx + vendor-aware emitter (#863, #866, #860)

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
@@ -813,6 +813,12 @@ class MeshLlmAgent:
             if self.output_mode
             else effective_kwargs
         )
+        # Avoid kwarg collision: prepare_request takes output_type as an
+        # explicit kwarg below; pop it from call_kwargs to prevent
+        # "got multiple values for keyword argument 'output_type'" TypeError
+        # if it leaked into _default_model_params (e.g., via decorator
+        # **kwargs capture in @mesh.llm). See #863.
+        call_kwargs.pop("output_type", None)
         effective_tools = (
             self._enrich_tools_with_endpoints()
             if self._is_mesh_delegated and self._tool_schemas

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
@@ -26,6 +26,7 @@ Design notes:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -47,65 +48,99 @@ _DATABRICKS_ANTHROPIC_PREFIX = "databricks/anthropic."
 
 
 # ---------------------------------------------------------------------------
-# Shared httpx connection pool (issue #834 perf fix)
+# Per-event-loop httpx connection pool (issue #834 perf fix + #866 cross-loop fix)
 # ---------------------------------------------------------------------------
-# A single ``httpx.AsyncClient`` is reused across all native Anthropic calls
-# in this process. ``anthropic.AsyncAnthropic`` accepts ``http_client=`` and
-# uses the supplied client (and its connection pool) instead of constructing
-# a fresh one per call. This eliminates ~150-300ms per-call TLS+H2 setup
-# overhead measured against LiteLLM (which does its own pool reuse).
+# An ``httpx.AsyncClient`` is reused across all native Anthropic calls in this
+# process — but the cache is keyed by the *running asyncio event loop* rather
+# than process-globally. ``anthropic.AsyncAnthropic`` accepts ``http_client=``
+# and uses the supplied client (and its connection pool) instead of
+# constructing a fresh one per call. This eliminates ~150-300ms per-call
+# TLS+H2 setup overhead measured against LiteLLM (which does its own pool
+# reuse).
 #
-# K8s secret rotation still works because the api_key is still read fresh
-# per call by callers and forwarded to the per-call ``AsyncAnthropic``
-# wrapper — the pool itself carries no credential state, only TCP/TLS
-# connections.
-_CACHED_HTTPX_CLIENT: httpx.AsyncClient | None = None
-# Guards lazy-init / rebuild of the shared httpx client. The pool itself is
-# safe for concurrent use; the lock only protects the check-then-create race
-# at construction. Cheap (uncontended after first call) and correct under
-# threaded harnesses (tests, sync wrapper paths) that touch the cache.
+# WHY PER-LOOP (preventive fix mirroring gemini_native — issue #866):
+# ``httpx.AsyncClient`` (via httpcore) lazily constructs anyio synchronization
+# primitives — ``Lock`` / ``Semaphore`` / ``Event`` for the connection pool
+# — on first I/O. Those primitives bind to the *event loop that issues the
+# first request* and CANNOT be reused from a different loop ("bound to a
+# different event loop" RuntimeError).
+#
+# In mesh, ``shared/tool_executor.py`` runs an N-worker thread pool, each
+# thread owning its own long-lived asyncio event loop. Tool calls are
+# round-robin dispatched across workers. A single process-wide ``httpx``
+# pool would bind to the first worker's loop and then break the moment a
+# call lands on a different worker. Anthropic's current integration tests
+# happen not to surface this on their current test mix, but the same
+# mechanism trips reliably in Gemini's uc10_toolcalls suite — applying the
+# fix uniformly so future test patterns can't trip the same regression.
+#
+# Per-loop caching keeps the connection-reuse win within a single loop
+# (tool calls scheduled to the same worker share its pool) while
+# guaranteeing each loop owns its own anyio primitives. ``id(loop)`` is the
+# cache key — sufficient because loops are long-lived (workers run for the
+# process lifetime); when a loop closes the cached client is dropped from
+# the map by the next access if found stale.
+#
+# K8s secret rotation still works because the api_key is read fresh per call
+# by callers and forwarded to the per-call ``AsyncAnthropic`` wrapper — the
+# pool itself carries no credential state, only TCP/TLS connections.
+_CACHED_HTTPX_CLIENT_BY_LOOP: dict[int, httpx.AsyncClient] = {}
+# Guards lazy-init / rebuild of the per-loop httpx client cache. The pool
+# instances themselves are safe for concurrent use within their owning loop;
+# the lock only protects the check-then-create race at construction. Cheap
+# (uncontended after first call per loop).
 _CACHED_HTTPX_CLIENT_LOCK = threading.Lock()
 
 
-def _get_shared_httpx_client() -> httpx.AsyncClient:
-    """Lazily construct (or rebuild if closed) the shared httpx client.
+def _build_httpx_client() -> httpx.AsyncClient:
+    """Construct a fresh httpx.AsyncClient with the standard mesh tuning."""
+    return httpx.AsyncClient(
+        timeout=httpx.Timeout(
+            connect=10.0,  # connection establishment
+            read=600.0,    # body read — LLM responses can be slow
+            write=30.0,    # request body write
+            pool=5.0,      # waiting for free connection from pool
+        ),
+        limits=httpx.Limits(
+            max_keepalive_connections=20,
+            max_connections=100,
+            keepalive_expiry=30.0,
+        ),
+    )
 
-    Single connection pool shared across all native Anthropic calls in this
-    process. Per-call ``AsyncAnthropic`` wrappers reuse this pool —
-    eliminating ~150-300ms per-call TLS+H2 setup overhead. K8s secret
-    rotation still works: ``api_key`` is read fresh per call; the pool
-    carries no credential state.
+
+def _get_shared_httpx_client() -> httpx.AsyncClient:
+    """Return an httpx.AsyncClient bound to the current event loop.
+
+    Cached per-loop (NOT process-globally) — see the module-level comment
+    for the rationale. Falls back to constructing a fresh client when no
+    loop is currently running (sync test paths); that client is NOT cached
+    so it gets garbage-collected promptly.
     """
-    global _CACHED_HTTPX_CLIENT
-    # Fast path — no lock when the cached client is healthy. The check is
-    # benign-racy (worst case: two threads both observe None and both enter
-    # the lock; the second one finds the cache populated under the lock and
-    # returns early).
-    if _CACHED_HTTPX_CLIENT is not None and not _CACHED_HTTPX_CLIENT.is_closed:
-        return _CACHED_HTTPX_CLIENT
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop — caller is in sync code (most likely test setup).
+        # Return an uncached client; the caller is responsible for cleanup.
+        return _build_httpx_client()
+
+    loop_id = id(loop)
+    # Fast path — no lock when the cached client for this loop is healthy.
+    cached = _CACHED_HTTPX_CLIENT_BY_LOOP.get(loop_id)
+    if cached is not None and not cached.is_closed:
+        return cached
     with _CACHED_HTTPX_CLIENT_LOCK:
-        if _CACHED_HTTPX_CLIENT is None or _CACHED_HTTPX_CLIENT.is_closed:
-            _CACHED_HTTPX_CLIENT = httpx.AsyncClient(
-                timeout=httpx.Timeout(
-                    connect=10.0,  # connection establishment
-                    read=600.0,    # body read — LLM responses can be slow
-                    write=30.0,    # request body write
-                    pool=5.0,      # waiting for free connection from pool
-                ),
-                limits=httpx.Limits(
-                    max_keepalive_connections=20,
-                    max_connections=100,
-                    keepalive_expiry=30.0,
-                ),
-            )
-        return _CACHED_HTTPX_CLIENT
+        cached = _CACHED_HTTPX_CLIENT_BY_LOOP.get(loop_id)
+        if cached is None or cached.is_closed:
+            cached = _build_httpx_client()
+            _CACHED_HTTPX_CLIENT_BY_LOOP[loop_id] = cached
+        return cached
 
 
 def _reset_shared_httpx_client() -> None:
-    """For tests — reset the cached client. NOT for production use."""
-    global _CACHED_HTTPX_CLIENT
+    """For tests — drop all cached per-loop clients. NOT for production use."""
     with _CACHED_HTTPX_CLIENT_LOCK:
-        _CACHED_HTTPX_CLIENT = None
+        _CACHED_HTTPX_CLIENT_BY_LOOP.clear()
 
 
 # ---------------------------------------------------------------------------

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
@@ -77,9 +77,15 @@ _DATABRICKS_ANTHROPIC_PREFIX = "databricks/anthropic."
 # Per-loop caching keeps the connection-reuse win within a single loop
 # (tool calls scheduled to the same worker share its pool) while
 # guaranteeing each loop owns its own anyio primitives. ``id(loop)`` is the
-# cache key — sufficient because loops are long-lived (workers run for the
-# process lifetime); when a loop closes the cached client is dropped from
-# the map by the next access if found stale.
+# cache key.
+#
+# ASSUMPTION: mesh's worker loops live for the process lifetime — loop ids
+# are stable per worker. If short-lived loops were ever introduced (e.g.,
+# ad-hoc ``asyncio.run()`` outside a worker), id() reuse could surface a
+# stale-but-not-closed cached client bound to the original (now-dead) loop.
+# The current code does NOT detect this — ``is_closed`` only flips on
+# explicit ``aclose()``, not on owning-loop closure. A weakref-keyed cache
+# would handle this; deferred per #860.
 #
 # K8s secret rotation still works because the api_key is read fresh per call
 # by callers and forwarded to the per-call ``AsyncAnthropic`` wrapper — the

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
@@ -97,9 +97,15 @@ _VERTEX_PREFIX = "vertex_ai/"
 # Per-loop caching keeps the connection-reuse win within a single loop
 # (tool calls scheduled to the same worker share its pool) while
 # guaranteeing each loop owns its own anyio primitives. ``id(loop)`` is the
-# cache key — sufficient because loops are long-lived (workers run for the
-# process lifetime); when a loop closes the cached client is dropped from
-# the map by the next access if found stale.
+# cache key.
+#
+# ASSUMPTION: mesh's worker loops live for the process lifetime — loop ids
+# are stable per worker. If short-lived loops were ever introduced (e.g.,
+# ad-hoc ``asyncio.run()`` outside a worker), id() reuse could surface a
+# stale-but-not-closed cached client bound to the original (now-dead) loop.
+# The current code does NOT detect this — ``is_closed`` only flips on
+# explicit ``aclose()``, not on owning-loop closure. A weakref-keyed cache
+# would handle this; deferred per #860.
 #
 # K8s secret rotation still works because the api_key is read fresh per call
 # by callers and forwarded to the per-call ``genai.Client`` wrapper — the

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -75,9 +75,15 @@ _OPENAI_PREFIX = "openai/"
 # Per-loop caching keeps the connection-reuse win within a single loop
 # (tool calls scheduled to the same worker share its pool) while
 # guaranteeing each loop owns its own anyio primitives. ``id(loop)`` is the
-# cache key — sufficient because loops are long-lived (workers run for the
-# process lifetime); when a loop closes the cached client is dropped from
-# the map by the next access if found stale.
+# cache key.
+#
+# ASSUMPTION: mesh's worker loops live for the process lifetime — loop ids
+# are stable per worker. If short-lived loops were ever introduced (e.g.,
+# ad-hoc ``asyncio.run()`` outside a worker), id() reuse could surface a
+# stale-but-not-closed cached client bound to the original (now-dead) loop.
+# The current code does NOT detect this — ``is_closed`` only flips on
+# explicit ``aclose()``, not on owning-loop closure. A weakref-keyed cache
+# would handle this; deferred per #860.
 #
 # K8s secret rotation still works because the api_key is read fresh per call
 # by callers and forwarded to the per-call ``AsyncOpenAI`` wrapper — the

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -30,6 +30,7 @@ Out of scope (PR 2 of issue #834):
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -46,64 +47,98 @@ _OPENAI_PREFIX = "openai/"
 
 
 # ---------------------------------------------------------------------------
-# Shared httpx connection pool (issue #834 perf fix)
+# Per-event-loop httpx connection pool (issue #834 perf fix + #866 cross-loop fix)
 # ---------------------------------------------------------------------------
-# A single ``httpx.AsyncClient`` is reused across all native OpenAI calls in
-# this process. ``openai.AsyncOpenAI`` accepts ``http_client=`` and uses the
-# supplied client (and its connection pool) instead of constructing a fresh
-# one per call. This eliminates ~150-300ms per-call TLS+H2 setup overhead
-# vs. LiteLLM (which does its own pool reuse).
+# An ``httpx.AsyncClient`` is reused across all native OpenAI calls in this
+# process — but the cache is keyed by the *running asyncio event loop* rather
+# than process-globally. ``openai.AsyncOpenAI`` accepts ``http_client=`` and
+# uses the supplied client (and its connection pool) instead of constructing
+# a fresh one per call. This eliminates ~150-300ms per-call TLS+H2 setup
+# overhead vs. LiteLLM (which does its own pool reuse).
 #
-# K8s secret rotation still works because the api_key is still read fresh
-# per call by callers and forwarded to the per-call ``AsyncOpenAI`` wrapper
-# — the pool itself carries no credential state, only TCP/TLS connections.
-_CACHED_HTTPX_CLIENT: httpx.AsyncClient | None = None
-# Guards lazy-init / rebuild of the shared httpx client. The pool itself is
-# safe for concurrent use; the lock only protects the check-then-create race
-# at construction. Cheap (uncontended after first call) and correct under
-# threaded harnesses (tests, sync wrapper paths) that touch the cache.
+# WHY PER-LOOP (preventive fix mirroring gemini_native — issue #866):
+# ``httpx.AsyncClient`` (via httpcore) lazily constructs anyio synchronization
+# primitives — ``Lock`` / ``Semaphore`` / ``Event`` for the connection pool
+# — on first I/O. Those primitives bind to the *event loop that issues the
+# first request* and CANNOT be reused from a different loop ("bound to a
+# different event loop" RuntimeError).
+#
+# In mesh, ``shared/tool_executor.py`` runs an N-worker thread pool, each
+# thread owning its own long-lived asyncio event loop. Tool calls are
+# round-robin dispatched across workers. A single process-wide ``httpx``
+# pool would bind to the first worker's loop and then break the moment a
+# call lands on a different worker. OpenAI's current integration tests
+# happen not to surface this on their current test mix, but the same
+# mechanism trips reliably in Gemini's uc10_toolcalls suite — applying the
+# fix uniformly so future test patterns can't trip the same regression.
+#
+# Per-loop caching keeps the connection-reuse win within a single loop
+# (tool calls scheduled to the same worker share its pool) while
+# guaranteeing each loop owns its own anyio primitives. ``id(loop)`` is the
+# cache key — sufficient because loops are long-lived (workers run for the
+# process lifetime); when a loop closes the cached client is dropped from
+# the map by the next access if found stale.
+#
+# K8s secret rotation still works because the api_key is read fresh per call
+# by callers and forwarded to the per-call ``AsyncOpenAI`` wrapper — the
+# pool itself carries no credential state, only TCP/TLS connections.
+_CACHED_HTTPX_CLIENT_BY_LOOP: dict[int, httpx.AsyncClient] = {}
+# Guards lazy-init / rebuild of the per-loop httpx client cache. The pool
+# instances themselves are safe for concurrent use within their owning loop;
+# the lock only protects the check-then-create race at construction. Cheap
+# (uncontended after first call per loop).
 _CACHED_HTTPX_CLIENT_LOCK = threading.Lock()
 
 
-def _get_shared_httpx_client() -> httpx.AsyncClient:
-    """Lazily construct (or rebuild if closed) the shared httpx client.
+def _build_httpx_client() -> httpx.AsyncClient:
+    """Construct a fresh httpx.AsyncClient with the standard mesh tuning."""
+    return httpx.AsyncClient(
+        timeout=httpx.Timeout(
+            connect=10.0,  # connection establishment
+            read=600.0,    # body read — LLM responses can be slow
+            write=30.0,    # request body write
+            pool=5.0,      # waiting for free connection from pool
+        ),
+        limits=httpx.Limits(
+            max_keepalive_connections=20,
+            max_connections=100,
+            keepalive_expiry=30.0,
+        ),
+    )
 
-    Single connection pool shared across all native OpenAI calls in this
-    process. Per-call ``AsyncOpenAI`` wrappers reuse this pool —
-    eliminating ~150-300ms per-call TLS+H2 setup overhead. K8s secret
-    rotation still works: ``api_key`` is read fresh per call; the pool
-    carries no credential state.
+
+def _get_shared_httpx_client() -> httpx.AsyncClient:
+    """Return an httpx.AsyncClient bound to the current event loop.
+
+    Cached per-loop (NOT process-globally) — see the module-level comment
+    for the rationale. Falls back to constructing a fresh client when no
+    loop is currently running (sync test paths); that client is NOT cached
+    so it gets garbage-collected promptly.
     """
-    global _CACHED_HTTPX_CLIENT
-    # Fast path — no lock when the cached client is healthy. The check is
-    # benign-racy (worst case: two threads both observe None and both enter
-    # the lock; the second one finds the cache populated under the lock and
-    # returns early).
-    if _CACHED_HTTPX_CLIENT is not None and not _CACHED_HTTPX_CLIENT.is_closed:
-        return _CACHED_HTTPX_CLIENT
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop — caller is in sync code (most likely test setup).
+        # Return an uncached client; the caller is responsible for cleanup.
+        return _build_httpx_client()
+
+    loop_id = id(loop)
+    # Fast path — no lock when the cached client for this loop is healthy.
+    cached = _CACHED_HTTPX_CLIENT_BY_LOOP.get(loop_id)
+    if cached is not None and not cached.is_closed:
+        return cached
     with _CACHED_HTTPX_CLIENT_LOCK:
-        if _CACHED_HTTPX_CLIENT is None or _CACHED_HTTPX_CLIENT.is_closed:
-            _CACHED_HTTPX_CLIENT = httpx.AsyncClient(
-                timeout=httpx.Timeout(
-                    connect=10.0,  # connection establishment
-                    read=600.0,    # body read — LLM responses can be slow
-                    write=30.0,    # request body write
-                    pool=5.0,      # waiting for free connection from pool
-                ),
-                limits=httpx.Limits(
-                    max_keepalive_connections=20,
-                    max_connections=100,
-                    keepalive_expiry=30.0,
-                ),
-            )
-        return _CACHED_HTTPX_CLIENT
+        cached = _CACHED_HTTPX_CLIENT_BY_LOOP.get(loop_id)
+        if cached is None or cached.is_closed:
+            cached = _build_httpx_client()
+            _CACHED_HTTPX_CLIENT_BY_LOOP[loop_id] = cached
+        return cached
 
 
 def _reset_shared_httpx_client() -> None:
-    """For tests — reset the cached client. NOT for production use."""
-    global _CACHED_HTTPX_CLIENT
+    """For tests — drop all cached per-loop clients. NOT for production use."""
     with _CACHED_HTTPX_CLIENT_LOCK:
-        _CACHED_HTTPX_CLIENT = None
+        _CACHED_HTTPX_CLIENT_BY_LOOP.clear()
 
 
 # ---------------------------------------------------------------------------

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native.py
@@ -25,6 +25,7 @@ Real network calls are mocked.
 
 from __future__ import annotations
 
+import asyncio
 import builtins
 import importlib
 import json
@@ -1021,9 +1022,13 @@ class TestSharedHttpxClient:
         yield
         anthropic_native._reset_shared_httpx_client()
 
-    def test_shared_httpx_client_reused_across_calls(self):
-        """Two ``_build_client`` calls must reuse the same ``http_client``
-        instance — proves we have a single connection pool process-wide."""
+    @pytest.mark.asyncio
+    async def test_shared_httpx_client_reused_within_same_loop(self):
+        """Two ``_build_client`` calls on the same event loop must reuse
+        the same ``http_client`` instance — proves we have a single
+        connection pool per loop. Run inside an async context so
+        _get_shared_httpx_client() picks up the running loop and caches
+        against it."""
         cls_mock = MagicMock(return_value=MagicMock())
         with patch("anthropic.AsyncAnthropic", cls_mock):
             anthropic_native._build_client(
@@ -1055,7 +1060,8 @@ class TestSharedHttpxClient:
         assert second is not first
         assert second.is_closed is False
 
-    def test_api_key_rotation_works_with_shared_pool(self):
+    @pytest.mark.asyncio
+    async def test_api_key_rotation_works_with_shared_pool(self):
         """K8s secret rotation: the api_key changes per call but the shared
         http_client stays the same. Each call still creates a NEW
         ``AsyncAnthropic`` wrapper so the rotated key is honored."""
@@ -1098,7 +1104,8 @@ class TestSharedHttpxClient:
         # No http_client passed on the Bedrock path.
         assert "http_client" not in bedrock_cls.call_args.kwargs
 
-    def test_httpx_timeout_configuration(self):
+    @pytest.mark.asyncio
+    async def test_httpx_timeout_configuration(self):
         """The shared client carries the documented per-stage timeouts.
         ``read=600`` is critical — LLM responses can take minutes on long
         generations, and a too-tight read timeout would spuriously cut off
@@ -1109,7 +1116,8 @@ class TestSharedHttpxClient:
         assert client.timeout.write == 30.0
         assert client.timeout.pool == 5.0
 
-    def test_httpx_limits_configuration(self):
+    @pytest.mark.asyncio
+    async def test_httpx_limits_configuration(self):
         """The shared pool's connection limits are applied as documented.
 
         Reads private ``_transport._pool`` attrs because httpx does not
@@ -1121,6 +1129,94 @@ class TestSharedHttpxClient:
         pool = client._transport._pool
         assert pool._max_keepalive_connections == 20
         assert pool._max_connections == 100
+
+    def test_per_loop_httpx_pool_isolates_event_loops(self):
+        """Different event loops MUST get different httpx pool instances.
+
+        This is the preventive fix mirrored from gemini_native (issue #866):
+        mesh's ``shared/tool_executor.py`` round-robins tool calls across
+        worker threads, each owning its own long-lived loop. A process-global
+        ``httpx.AsyncClient`` would bind its anyio sync primitives to the
+        first worker's loop and break the moment a call lands on a different
+        worker.
+        """
+        captured_clients: list = []
+
+        async def _capture_client():
+            captured_clients.append(anthropic_native._get_shared_httpx_client())
+
+        # Two distinct event loops. Each must produce its own httpx pool.
+        loop_a = asyncio.new_event_loop()
+        try:
+            loop_a.run_until_complete(_capture_client())
+        finally:
+            loop_a.close()
+
+        loop_b = asyncio.new_event_loop()
+        try:
+            loop_b.run_until_complete(_capture_client())
+        finally:
+            loop_b.close()
+
+        assert len(captured_clients) == 2
+        assert captured_clients[0] is not captured_clients[1], (
+            "Same httpx.AsyncClient was reused across event loops — would "
+            "trigger 'bound to a different event loop' RuntimeError on the "
+            "second loop's first request"
+        )
+
+    def test_cross_loop_dispatch_does_not_raise(self, monkeypatch):
+        """End-to-end: simulate the mesh worker-pool scenario — two
+        ``complete()`` calls on two distinct event loops. The fix
+        guarantees no cross-loop bug surfaces; without it the second
+        loop's first request would raise.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+        # Build a fake API response shaped like anthropic.types.Message.
+        api_resp = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="hi")],
+            usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+            model="claude-sonnet-4-5",
+        )
+
+        def _fresh_anthropic_mock():
+            instance = MagicMock()
+            instance.messages = MagicMock()
+            instance.messages.create = AsyncMock(return_value=api_resp)
+            return MagicMock(return_value=instance)
+
+        cls_mock = _fresh_anthropic_mock()
+        monkeypatch.setattr("anthropic.AsyncAnthropic", cls_mock)
+
+        async def _one_call():
+            await anthropic_native.complete(
+                {"messages": [{"role": "user", "content": "hi"}]},
+                model="anthropic/claude-sonnet-4-5",
+            )
+
+        loop_a = asyncio.new_event_loop()
+        try:
+            loop_a.run_until_complete(_one_call())
+        finally:
+            loop_a.close()
+
+        loop_b = asyncio.new_event_loop()
+        try:
+            # Pre-fix: this raised "bound to a different event loop" if the
+            # cached httpx pool was reused. Post-fix: each loop gets its
+            # own pool from _get_shared_httpx_client.
+            loop_b.run_until_complete(_one_call())
+        finally:
+            loop_b.close()
+
+    def test_get_shared_httpx_returns_uncached_when_no_loop(self):
+        """Sync test paths (no running loop) get an uncached client back —
+        otherwise we'd cache against a nonexistent loop id."""
+        c1 = anthropic_native._get_shared_httpx_client()
+        c2 = anthropic_native._get_shared_httpx_client()
+        # Each sync call returns a fresh client (not cached).
+        assert c1 is not c2
 
 
 # ---------------------------------------------------------------------------

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native.py
@@ -1215,8 +1215,15 @@ class TestSharedHttpxClient:
         otherwise we'd cache against a nonexistent loop id."""
         c1 = anthropic_native._get_shared_httpx_client()
         c2 = anthropic_native._get_shared_httpx_client()
-        # Each sync call returns a fresh client (not cached).
-        assert c1 is not c2
+        try:
+            # Each sync call returns a fresh client (not cached).
+            assert c1 is not c2
+        finally:
+            # Sync-path clients aren't cached — caller must close them.
+            # Use asyncio.run(...) since aclose() is async and we have no
+            # running loop here (that's the whole point of this test).
+            asyncio.run(c1.aclose())
+            asyncio.run(c2.aclose())
 
 
 # ---------------------------------------------------------------------------

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
@@ -1361,8 +1361,15 @@ class TestSharedHttpxClient:
         otherwise we'd cache against a nonexistent loop id."""
         c1 = openai_native._get_shared_httpx_client()
         c2 = openai_native._get_shared_httpx_client()
-        # Each sync call returns a fresh client (not cached).
-        assert c1 is not c2
+        try:
+            # Each sync call returns a fresh client (not cached).
+            assert c1 is not c2
+        finally:
+            # Sync-path clients aren't cached — caller must close them.
+            # Use asyncio.run(...) since aclose() is async and we have no
+            # running loop here (that's the whole point of this test).
+            asyncio.run(c1.aclose())
+            asyncio.run(c2.aclose())
 
 
 # ---------------------------------------------------------------------------

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
@@ -26,6 +26,7 @@ Real network calls are mocked.
 
 from __future__ import annotations
 
+import asyncio
 import builtins
 import json
 import sys
@@ -1179,9 +1180,13 @@ class TestSharedHttpxClient:
         yield
         openai_native._reset_shared_httpx_client()
 
-    def test_shared_httpx_client_reused_across_calls(self):
-        """Two ``_build_client`` calls must reuse the same ``http_client``
-        instance — proves we have a single connection pool process-wide."""
+    @pytest.mark.asyncio
+    async def test_shared_httpx_client_reused_within_same_loop(self):
+        """Two ``_build_client`` calls on the same event loop must reuse
+        the same ``http_client`` instance — proves we have a single
+        connection pool per loop. Run inside an async context so
+        _get_shared_httpx_client() picks up the running loop and caches
+        against it."""
         cls_mock = MagicMock(return_value=MagicMock())
         with patch("openai.AsyncOpenAI", cls_mock):
             openai_native._build_client(
@@ -1213,7 +1218,8 @@ class TestSharedHttpxClient:
         assert second is not first
         assert second.is_closed is False
 
-    def test_api_key_rotation_works_with_shared_pool(self):
+    @pytest.mark.asyncio
+    async def test_api_key_rotation_works_with_shared_pool(self):
         """K8s secret rotation: the api_key changes per call but the shared
         http_client stays the same. Each call still creates a NEW
         ``AsyncOpenAI`` wrapper so the rotated key is honored."""
@@ -1235,7 +1241,8 @@ class TestSharedHttpxClient:
         # But the same shared httpx client.
         assert first_kwargs["http_client"] is second_kwargs["http_client"]
 
-    def test_httpx_timeout_configuration(self):
+    @pytest.mark.asyncio
+    async def test_httpx_timeout_configuration(self):
         """The shared client carries the documented per-stage timeouts.
         ``read=600`` is critical — LLM responses can take minutes on long
         generations, and a too-tight read timeout would spuriously cut off
@@ -1246,7 +1253,8 @@ class TestSharedHttpxClient:
         assert client.timeout.write == 30.0
         assert client.timeout.pool == 5.0
 
-    def test_httpx_limits_configuration(self):
+    @pytest.mark.asyncio
+    async def test_httpx_limits_configuration(self):
         """The shared pool's connection limits are applied as documented.
 
         Reads private ``_transport._pool`` attrs because httpx does not
@@ -1258,6 +1266,103 @@ class TestSharedHttpxClient:
         pool = client._transport._pool
         assert pool._max_keepalive_connections == 20
         assert pool._max_connections == 100
+
+    def test_per_loop_httpx_pool_isolates_event_loops(self):
+        """Different event loops MUST get different httpx pool instances.
+
+        This is the preventive fix mirrored from gemini_native (issue #866):
+        mesh's ``shared/tool_executor.py`` round-robins tool calls across
+        worker threads, each owning its own long-lived loop. A process-global
+        ``httpx.AsyncClient`` would bind its anyio sync primitives to the
+        first worker's loop and break the moment a call lands on a different
+        worker.
+        """
+        captured_clients: list = []
+
+        async def _capture_client():
+            captured_clients.append(openai_native._get_shared_httpx_client())
+
+        # Two distinct event loops. Each must produce its own httpx pool.
+        loop_a = asyncio.new_event_loop()
+        try:
+            loop_a.run_until_complete(_capture_client())
+        finally:
+            loop_a.close()
+
+        loop_b = asyncio.new_event_loop()
+        try:
+            loop_b.run_until_complete(_capture_client())
+        finally:
+            loop_b.close()
+
+        assert len(captured_clients) == 2
+        assert captured_clients[0] is not captured_clients[1], (
+            "Same httpx.AsyncClient was reused across event loops — would "
+            "trigger 'bound to a different event loop' RuntimeError on the "
+            "second loop's first request"
+        )
+
+    def test_cross_loop_dispatch_does_not_raise(self, monkeypatch):
+        """End-to-end: simulate the mesh worker-pool scenario — two
+        ``complete()`` calls on two distinct event loops. The fix
+        guarantees no cross-loop bug surfaces; without it the second
+        loop's first request would raise.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+        # Build a fake API response shaped like openai.types.ChatCompletion.
+        api_resp = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="hi", role="assistant", tool_calls=None
+                    ),
+                    finish_reason="stop",
+                    index=0,
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+            model="gpt-4o-mini",
+        )
+
+        def _fresh_openai_mock():
+            instance = MagicMock()
+            instance.chat = MagicMock()
+            instance.chat.completions = MagicMock()
+            instance.chat.completions.create = AsyncMock(return_value=api_resp)
+            return MagicMock(return_value=instance)
+
+        cls_mock = _fresh_openai_mock()
+        monkeypatch.setattr("openai.AsyncOpenAI", cls_mock)
+
+        async def _one_call():
+            await openai_native.complete(
+                {"messages": [{"role": "user", "content": "hi"}]},
+                model="openai/gpt-4o-mini",
+            )
+
+        loop_a = asyncio.new_event_loop()
+        try:
+            loop_a.run_until_complete(_one_call())
+        finally:
+            loop_a.close()
+
+        loop_b = asyncio.new_event_loop()
+        try:
+            # Pre-fix: this raised "bound to a different event loop" if the
+            # cached httpx pool was reused. Post-fix: each loop gets its
+            # own pool from _get_shared_httpx_client.
+            loop_b.run_until_complete(_one_call())
+        finally:
+            loop_b.close()
+
+    def test_get_shared_httpx_returns_uncached_when_no_loop(self):
+        """Sync test paths (no running loop) get an uncached client back —
+        otherwise we'd cache against a nonexistent loop id."""
+        c1 = openai_native._get_shared_httpx_client()
+        c2 = openai_native._get_shared_httpx_client()
+        # Each sync call returns a fresh client (not cached).
+        assert c1 is not c2
 
 
 # ---------------------------------------------------------------------------

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -442,6 +442,7 @@ async def _execute_tool_calls_for_iteration(
     parallel: bool,
     vendor: str | None,
     loop_logger: logging.Logger | None,
+    has_native_dispatch: bool = False,
 ) -> tuple[list[dict], list[dict]]:
     """Execute one iteration's tool calls (parallel or sequential).
 
@@ -455,16 +456,18 @@ async def _execute_tool_calls_for_iteration(
       * Look up the MCP endpoint from ``tool_endpoints`` (returns an error
         tool message if missing).
       * Dispatch via :class:`UnifiedMCPProxy.call_tool`.
-      * Resolve resource_link items in the tool result to multimodal content
-        using the OpenAI-compatible image_url format (LiteLLM converts to the
-        provider-native format).
+      * Resolve resource_link items in the tool result to multimodal content.
+        The resolver formats per the destination vendor when known —
+        vendor-native shape (issue #860) for the native dispatch path,
+        OpenAI-shape (image_url + data URI, the historical default) for the
+        LiteLLM fallback path so LiteLLM's vendor adapters handle conversion.
       * For vendors that do not support images in role:tool messages
         (OpenAI / Gemini / Google), strip image parts out of the tool message
         and accumulate them so the caller can synthesize a follow-up user
         message after all tool results.
       * For vendors that do support images in role:tool messages
-        (Anthropic / Claude via LiteLLM), inline the resolved multimodal
-        content directly in the tool message.
+        (Anthropic / Claude), inline the resolved multimodal content directly
+        in the tool message.
 
     Args:
         message: The ``response.choices[0].message`` from LiteLLM whose
@@ -482,6 +485,16 @@ async def _execute_tool_calls_for_iteration(
             resolution is skipped and tool results pass through as JSON.
         loop_logger: Logger used for debug/info/warning output. May be
             ``None`` to suppress logging.
+        has_native_dispatch: When True, the surrounding agentic loop is
+            dispatching through the vendor's native SDK adapter (e.g.
+            ``anthropic_native``) and resource_link resolution should emit
+            vendor-native content blocks (issue #860). When False (LiteLLM
+            fallback path or unknown vendor), resolution stays on the
+            historical OpenAI-shape contract — LiteLLM handles vendor
+            translation internally and changing the upstream shape would
+            break the LiteLLM adapter chain. Defaults to False so callers
+            that don't yet plumb dispatch awareness fall back to the
+            pre-#860 behaviour.
 
     Returns:
         A tuple ``(tool_messages, accumulated_images)`` where:
@@ -489,13 +502,27 @@ async def _execute_tool_calls_for_iteration(
             ``{role: "tool", tool_call_id: ..., content: ...}`` dicts to be
             appended to the conversation immediately after the assistant
             message that requested the tools.
-          * ``accumulated_images`` is the list of image dicts (in
-            OpenAI-compatible format) to be sent in a follow-up user message
-            after all tool results, for vendors that do not support images
-            in role:tool messages. Empty for other vendors.
+          * ``accumulated_images`` is the list of image dicts (vendor-native
+            shape on native dispatch path, OpenAI-shape on LiteLLM path) to
+            be sent in a follow-up user message after all tool results, for
+            vendors that do not support images in role:tool messages. Empty
+            for other vendors.
     """
     from _mcp_mesh.engine.unified_mcp_proxy import UnifiedMCPProxy
     from _mcp_mesh.media.resolver import _has_resource_link, resolve_resource_links
+
+    # Issue #860: pick the resolver vendor argument so that:
+    #   * native dispatch (e.g. anthropic_native, gemini_native) receives the
+    #     vendor-native content shape directly — no per-adapter translation
+    #     needed downstream;
+    #   * LiteLLM fallback path keeps the historical OpenAI-shape contract,
+    #     because LiteLLM's vendor adapters expect image_url + data URI and
+    #     translate to the wire format themselves.
+    # Note: ``_format_for_gemini`` is currently aliased to ``_format_for_openai``
+    # in the resolver, so for vendor="gemini"/"google"/"vertex_ai" the shape
+    # is identical regardless of dispatch path. Only vendor="anthropic" sees
+    # an actual shape difference today (image_url → Claude image block).
+    resolver_vendor = vendor if has_native_dispatch and vendor else "openai"
 
     async def _execute_single_tool(tc) -> tuple[dict, list[dict]]:
         """Execute a single tool call and return (tool_message, image_parts)."""
@@ -530,14 +557,13 @@ async def _execute_tool_calls_for_iteration(
             result = await proxy.call_tool(tool_name, args)
 
             # Resolve resource_link items to multimodal content.
-            # Always use OpenAI-compatible format (image_url with
-            # data URIs) — LiteLLM converts to provider-native.
+            # ``resolver_vendor`` is "openai" on the LiteLLM fallback path
+            # (preserves historical contract) and the actual vendor on the
+            # native dispatch path (issue #860 — vendor-native shape upstream).
             if vendor and _has_resource_link(result):
                 try:
-                    # Always use OpenAI format — LiteLLM converts to
-                    # provider-native format internally.
                     resolved_parts = await resolve_resource_links(
-                        result, "openai"
+                        result, resolver_vendor
                     )
                 except Exception as resolve_err:
                     if loop_logger:
@@ -853,7 +879,12 @@ async def _provider_agentic_loop(
             current_messages.append(assistant_msg)
 
             tool_messages, accumulated_images = await _execute_tool_calls_for_iteration(
-                message, tool_endpoints, parallel, vendor, loop_logger
+                message,
+                tool_endpoints,
+                parallel,
+                vendor,
+                loop_logger,
+                has_native_dispatch=_native_handler.has_native(),
             )
             current_messages.extend(tool_messages)
 
@@ -1255,6 +1286,7 @@ async def _provider_agentic_loop_stream(
                         parallel,
                         vendor,
                         loop_logger,
+                        has_native_dispatch=_native_handler.has_native(),
                     )
                 )
                 current_messages.extend(tool_messages)

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -73,6 +73,35 @@ _MESH_HINT_KEYS = (
 _DEFAULT_HINT_FALLBACK_TIMEOUT = 90
 
 
+# Per-vendor dedupe set for the "native dispatch claims unknown vendor" WARN.
+# Keyed by vendor name so each unique vendor produces exactly one log line per
+# process, even though the dispatch path is hit once per agentic-loop iteration.
+_logged_unknown_native_vendors: set[str] = set()
+
+
+def _warn_native_dispatch_unknown_vendor_once(vendor: str) -> None:
+    """Emit a one-time WARN when native dispatch reports a vendor that has no
+    formatter in ``mesh.media.resolver._VENDOR_FORMATTERS``.
+
+    Symptom this catches: a new native handler is wired up (advertises
+    ``has_native=True`` for some vendor X) but the matching emitter formatter
+    in the resolver is never added. The resource_link resolver would then
+    silently fall back to OpenAI shape on a path that explicitly asked for
+    vendor-native shape — i.e., the very misconfiguration #860 introduced
+    upstream emission to surface.
+    """
+    if vendor in _logged_unknown_native_vendors:
+        return
+    _logged_unknown_native_vendors.add(vendor)
+    logger.warning(
+        "Native dispatch reports vendor=%r but %r has no entry in "
+        "_VENDOR_FORMATTERS; falling back to OpenAI-shape blocks. "
+        "Add a formatter to mesh.media.resolver._VENDOR_FORMATTERS to "
+        "emit vendor-native shape on the native path.",
+        vendor, vendor,
+    )
+
+
 def _pop_mesh_hint_flags(
     completion_args: dict[str, Any],
     defaults: tuple[bool, dict | None, int, str] = (
@@ -522,7 +551,19 @@ async def _execute_tool_calls_for_iteration(
     # in the resolver, so for vendor="gemini"/"google"/"vertex_ai" the shape
     # is identical regardless of dispatch path. Only vendor="anthropic" sees
     # an actual shape difference today (image_url → Claude image block).
-    resolver_vendor = vendor if has_native_dispatch and vendor else "openai"
+    if has_native_dispatch and vendor:
+        # Validate the vendor has a formatter; if not, fall back to OpenAI
+        # shape (safe default — won't crash) but log loudly so the operator
+        # learns the native handler was added without a matching emitter.
+        from _mcp_mesh.media.resolver import _VENDOR_FORMATTERS
+
+        if vendor in _VENDOR_FORMATTERS:
+            resolver_vendor = vendor
+        else:
+            _warn_native_dispatch_unknown_vendor_once(vendor)
+            resolver_vendor = "openai"
+    else:
+        resolver_vendor = "openai"
 
     async def _execute_single_tool(tc) -> tuple[dict, list[dict]]:
         """Execute a single tool call and return (tool_message, image_parts)."""

--- a/src/runtime/python/tests/unit/test_media_resolver_vendor_dispatch.py
+++ b/src/runtime/python/tests/unit/test_media_resolver_vendor_dispatch.py
@@ -1,0 +1,248 @@
+"""Unit tests for ``_mcp_mesh.media.resolver`` vendor dispatch.
+
+Background:
+    Issue #860 moved LLM content-block translation upstream — the mesh
+    emitter is now the source of vendor-native shape on the native dispatch
+    path (e.g. ``_provider_agentic_loop`` calling ``anthropic_native``),
+    while the LiteLLM fallback path keeps emitting OpenAI-shape blocks for
+    LiteLLM's adapters to translate.
+
+    The resolver is the single source of vendor-native shape — these tests
+    pin its formatter contract so that:
+
+    * a regression in ``_VENDOR_FORMATTERS`` is caught at unit-test time,
+      not at end-to-end test time on a real provider call;
+    * the relationship between "ask the resolver for vendor X" and "get a
+      block the vendor's API will accept" is explicit;
+    * future formatter changes (e.g. real Gemini-native ``inline_data``
+      from the resolver instead of the current OpenAI-alias) are visible
+      diffs to these tests.
+
+    No vendor SDK is required to run these tests — they exercise pure
+    formatting logic with stub byte data and ``patch``ed media stores.
+"""
+
+import base64
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from _mcp_mesh.media.resolver import (
+    _VENDOR_FORMATTERS,
+    _format_for_claude,
+    _format_for_gemini,
+    _format_for_openai,
+    resolve_resource_links,
+)
+
+
+# ---------------------------------------------------------------------------
+# Vendor formatter mapping
+# ---------------------------------------------------------------------------
+
+
+class TestVendorFormatterMap:
+    """Pin the vendor → formatter dispatch table directly. The mapping is the
+    contract upstream callers rely on; if a vendor key is removed or its
+    formatter is swapped, downstream code (helpers.py, native adapters)
+    breaks silently — make it explicit."""
+
+    def test_anthropic_routes_to_claude_formatter(self):
+        assert _VENDOR_FORMATTERS["anthropic"] is _format_for_claude
+
+    def test_openai_routes_to_openai_formatter(self):
+        assert _VENDOR_FORMATTERS["openai"] is _format_for_openai
+
+    def test_gemini_aliases_route_to_gemini_formatter(self):
+        # ``_format_for_gemini`` is currently aliased to ``_format_for_openai``
+        # because LiteLLM's gemini adapter expects OpenAI-shape input. When
+        # we eventually emit native ``inline_data`` from the resolver, the
+        # alias will be replaced — this test pins the dispatch keys, not the
+        # alias.
+        assert _VENDOR_FORMATTERS["gemini"] is _format_for_gemini
+        assert _VENDOR_FORMATTERS["google"] is _format_for_gemini
+        assert _VENDOR_FORMATTERS["vertex_ai"] is _format_for_gemini
+
+
+# ---------------------------------------------------------------------------
+# Per-formatter shape contracts
+# ---------------------------------------------------------------------------
+
+
+class TestFormatterShapes:
+    """Each formatter emits a well-defined block shape that the corresponding
+    vendor's API (Claude / OpenAI / Gemini-via-LiteLLM) accepts. Pin those
+    shapes so that a downstream API rejecting the block surfaces at unit
+    test time."""
+
+    def test_claude_formatter_emits_anthropic_image_block(self):
+        block = _format_for_claude("BASE64DATA", "image/png")
+        assert block == {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "BASE64DATA",
+            },
+        }
+
+    def test_openai_formatter_emits_image_url_data_uri(self):
+        block = _format_for_openai("BASE64DATA", "image/jpeg")
+        assert block == {
+            "type": "image_url",
+            "image_url": {
+                "url": "data:image/jpeg;base64,BASE64DATA",
+                "detail": "high",
+            },
+        }
+
+    def test_gemini_formatter_currently_emits_openai_shape(self):
+        """Pinning the alias: today the gemini formatter is OpenAI-shape so
+        LiteLLM's gemini adapter handles conversion. When this test starts
+        failing because the formatter was switched to native ``inline_data``,
+        update the assertion AND verify ``gemini_native``'s translator is a
+        no-op for the new shape."""
+        block = _format_for_gemini("BASE64DATA", "image/png")
+        assert block == {
+            "type": "image_url",
+            "image_url": {
+                "url": "data:image/png;base64,BASE64DATA",
+                "detail": "high",
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# resolve_resource_links: end-to-end vendor dispatch on a resource_link
+# ---------------------------------------------------------------------------
+
+
+class TestResolveResourceLinksVendorDispatch:
+    """Verify the public ``resolve_resource_links`` entry point picks the
+    correct formatter based on the ``vendor`` arg. This is the call site
+    that ``mesh/helpers.py:_execute_tool_calls_for_iteration`` and
+    ``mesh_llm_agent._resolve_media_in_tool_results`` invoke — its vendor
+    contract is what issue #860 is about."""
+
+    def _patched_store(self, payload: bytes, mime: str):
+        store_mock = AsyncMock()
+        store_mock.fetch = AsyncMock(return_value=(payload, mime))
+        return patch(
+            "_mcp_mesh.media.resolver.get_media_store",
+            return_value=store_mock,
+        )
+
+    @pytest.mark.asyncio
+    async def test_resource_link_image_with_anthropic_vendor_returns_claude_block(
+        self,
+    ):
+        resource_link = {
+            "type": "resource_link",
+            "resource": {
+                "uri": "file:///tmp/cat.png",
+                "mimeType": "image/png",
+                "name": "cat.png",
+            },
+        }
+        png_bytes = b"\x89PNG\r\n\x1a\n"
+        expected_b64 = base64.b64encode(png_bytes).decode("ascii")
+
+        with self._patched_store(png_bytes, "image/png"):
+            parts = await resolve_resource_links(resource_link, "anthropic")
+
+        assert parts == [
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": expected_b64,
+                },
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_resource_link_image_with_openai_vendor_returns_image_url(self):
+        resource_link = {
+            "type": "resource_link",
+            "resource": {
+                "uri": "file:///tmp/cat.png",
+                "mimeType": "image/png",
+                "name": "cat.png",
+            },
+        }
+        png_bytes = b"\x89PNG\r\n\x1a\n"
+        expected_b64 = base64.b64encode(png_bytes).decode("ascii")
+
+        with self._patched_store(png_bytes, "image/png"):
+            parts = await resolve_resource_links(resource_link, "openai")
+
+        assert parts == [
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:image/png;base64,{expected_b64}",
+                    "detail": "high",
+                },
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_resource_link_image_with_gemini_vendor_returns_image_url(self):
+        """Gemini formatter is aliased to OpenAI today (see
+        ``TestFormatterShapes.test_gemini_formatter_currently_emits_openai_shape``).
+        LiteLLM's gemini adapter handles conversion to native ``inline_data``."""
+        resource_link = {
+            "type": "resource_link",
+            "resource": {
+                "uri": "file:///tmp/cat.png",
+                "mimeType": "image/png",
+                "name": "cat.png",
+            },
+        }
+        png_bytes = b"\x89PNG\r\n\x1a\n"
+        expected_b64 = base64.b64encode(png_bytes).decode("ascii")
+
+        with self._patched_store(png_bytes, "image/png"):
+            parts = await resolve_resource_links(resource_link, "gemini")
+
+        assert parts == [
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:image/png;base64,{expected_b64}",
+                    "detail": "high",
+                },
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_resource_link_image_with_unknown_vendor_falls_back_to_openai(self):
+        """Unknown vendor → OpenAI formatter (the safe default that LiteLLM
+        accepts). Pin this so a typo in the vendor string doesn't silently
+        produce something Anthropic-shaped going to OpenAI."""
+        resource_link = {
+            "type": "resource_link",
+            "resource": {
+                "uri": "file:///tmp/cat.png",
+                "mimeType": "image/png",
+                "name": "cat.png",
+            },
+        }
+        png_bytes = b"\x89PNG\r\n\x1a\n"
+        expected_b64 = base64.b64encode(png_bytes).decode("ascii")
+
+        with self._patched_store(png_bytes, "image/png"):
+            parts = await resolve_resource_links(resource_link, "claude")  # not in map
+
+        # ``claude`` is not in ``_VENDOR_FORMATTERS`` (only "anthropic" is) —
+        # so the resolver falls back to ``_format_for_openai``.
+        assert parts == [
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:image/png;base64,{expected_b64}",
+                    "detail": "high",
+                },
+            }
+        ]

--- a/src/runtime/python/tests/unit/test_mesh_llm_agent_proxy.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_agent_proxy.py
@@ -2407,10 +2407,15 @@ class TestBuildRequestParamsKwargCollision:
         # Returned params include output_type from the explicit kwarg path.
         assert params["output_type"] is ChatResponse
 
-    def test_build_request_params_call_time_output_type_kwarg_also_dropped(self):
-        """Defense-in-depth: even if a caller passes output_type=... at
-        call time (e.g., stale **kwargs forwarding), the explicit
-        ``self.output_type`` wins and no TypeError occurs."""
+    def test_build_request_params_call_time_output_type_kwarg_pops_safely(self):
+        """Defense-in-depth: caller-supplied ``output_type`` kwarg at call
+        time is popped before the splat — preventing collision with the
+        explicit ``output_type=self.output_type`` passed to
+        ``prepare_request``. ``self.output_type`` is always authoritative
+        (set at agent construction); call-time ``output_type`` is never
+        honored, by design. The pop is what keeps a stale **kwargs forward
+        from raising ``TypeError: prepare_request() got multiple values for
+        keyword argument 'output_type'``."""
         from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
 
         agent = MeshLlmAgent(
@@ -2441,6 +2446,7 @@ class TestBuildRequestParamsKwargCollision:
                 output_type=ComplexResponse,  # caller-provided collision
             )
 
-        # Self.output_type wins (no collision raised, value is from agent).
+        # ``self.output_type`` is what reaches the handler — call-time
+        # ``output_type`` is unconditionally popped, never honored.
         assert captured["output_type"] is ChatResponse
         assert "output_type" not in captured["kwargs"]

--- a/src/runtime/python/tests/unit/test_mesh_llm_agent_proxy.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_agent_proxy.py
@@ -2344,3 +2344,103 @@ class TestMeshDelegationMeta:
 
         assert usage is None
         assert model is None
+
+
+class TestBuildRequestParamsKwargCollision:
+    """Regression tests for #863: output_type kwarg collision in
+    _build_request_params when output_type leaks into _default_model_params
+    (e.g., via @mesh.llm decorator **kwargs capture)."""
+
+    def test_build_request_params_no_kwarg_collision_when_output_type_in_default_params(
+        self,
+    ):
+        """#863: prepare_request was failing with 'got multiple values for
+        keyword argument output_type' when output_type leaked into
+        _default_model_params (decorator **kwargs capture path)."""
+        from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+
+        agent = MeshLlmAgent(
+            config=make_test_config(
+                provider="claude",
+                model="claude-3-5-sonnet-20241022",
+                api_key="test-key",
+                max_iterations=10,
+            ),
+            filtered_tools=[],
+            output_type=ChatResponse,
+        )
+
+        # Simulate output_type leaking into _default_model_params via the
+        # decorator path (resolved_config.update(kwargs) in @mesh.llm).
+        agent._default_model_params["output_type"] = ChatResponse
+
+        # Capture prepare_request invocation; assert no TypeError raised
+        # and output_type arrives exactly once with the agent's value.
+        captured: dict = {}
+
+        def fake_prepare_request(*, messages, tools, output_type, **kwargs):
+            captured["messages"] = messages
+            captured["tools"] = tools
+            captured["output_type"] = output_type
+            captured["kwargs"] = kwargs
+            return {
+                "messages": messages,
+                "tools": tools,
+                "output_type": output_type,
+                **kwargs,
+            }
+
+        with patch.object(
+            agent._provider_handler,
+            "prepare_request",
+            side_effect=fake_prepare_request,
+        ):
+            params = agent._build_request_params(
+                [{"role": "user", "content": "hi"}]
+            )
+
+        # Did not raise TypeError; reached the handler exactly once.
+        assert captured["output_type"] is ChatResponse
+        # output_type should NOT also appear in **kwargs (would imply
+        # collision risk if upstream signatures changed).
+        assert "output_type" not in captured["kwargs"]
+        # Returned params include output_type from the explicit kwarg path.
+        assert params["output_type"] is ChatResponse
+
+    def test_build_request_params_call_time_output_type_kwarg_also_dropped(self):
+        """Defense-in-depth: even if a caller passes output_type=... at
+        call time (e.g., stale **kwargs forwarding), the explicit
+        ``self.output_type`` wins and no TypeError occurs."""
+        from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+
+        agent = MeshLlmAgent(
+            config=make_test_config(
+                provider="claude",
+                model="claude-3-5-sonnet-20241022",
+                api_key="test-key",
+                max_iterations=10,
+            ),
+            filtered_tools=[],
+            output_type=ChatResponse,
+        )
+
+        captured: dict = {}
+
+        def fake_prepare_request(*, messages, tools, output_type, **kwargs):
+            captured["output_type"] = output_type
+            captured["kwargs"] = kwargs
+            return {"output_type": output_type, **kwargs}
+
+        with patch.object(
+            agent._provider_handler,
+            "prepare_request",
+            side_effect=fake_prepare_request,
+        ):
+            agent._build_request_params(
+                [{"role": "user", "content": "hi"}],
+                output_type=ComplexResponse,  # caller-provided collision
+            )
+
+        # Self.output_type wins (no collision raised, value is from agent).
+        assert captured["output_type"] is ChatResponse
+        assert "output_type" not in captured["kwargs"]

--- a/src/runtime/python/tests/unit/test_provider_tool_execution_helper.py
+++ b/src/runtime/python/tests/unit/test_provider_tool_execution_helper.py
@@ -21,7 +21,9 @@ import pytest
 from mesh.helpers import (
     _TOOL_IMAGE_UNSUPPORTED_VENDORS,
     _execute_tool_calls_for_iteration,
+    _warn_native_dispatch_unknown_vendor_once,
 )
+import mesh.helpers as _mesh_helpers
 
 
 # ---------------------------------------------------------------------------
@@ -538,3 +540,111 @@ class TestModuleConstants:
         """The vendor set drives image-handling policy; if it changes,
         provider-side image behavior changes silently. Pin it explicitly."""
         assert _TOOL_IMAGE_UNSUPPORTED_VENDORS == {"openai", "gemini", "google"}
+
+
+# ---------------------------------------------------------------------------
+# Issue #860 cleanup — WARN when native dispatch claims an unknown vendor
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownNativeVendorWarn:
+    """The native dispatch path validates ``vendor`` against
+    ``_VENDOR_FORMATTERS``; an unknown vendor falls back to OpenAI shape but
+    emits a one-time WARN so the operator notices the misconfiguration
+    instead of silently shipping wrong content blocks."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_dedupe(self):
+        """Per-vendor dedupe set persists for the process; reset between
+        tests so each one observes the WARN-once behavior cleanly."""
+        _mesh_helpers._logged_unknown_native_vendors.clear()
+        yield
+        _mesh_helpers._logged_unknown_native_vendors.clear()
+
+    def test_warn_emits_once_per_vendor(self, caplog):
+        with caplog.at_level("WARNING", logger=_mesh_helpers.logger.name):
+            _warn_native_dispatch_unknown_vendor_once("brand_new_vendor")
+            _warn_native_dispatch_unknown_vendor_once("brand_new_vendor")
+            _warn_native_dispatch_unknown_vendor_once("brand_new_vendor")
+
+        warn_msgs = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING" and "brand_new_vendor" in r.getMessage()
+        ]
+        assert len(warn_msgs) == 1, (
+            f"expected exactly one WARN per unique vendor; got "
+            f"{len(warn_msgs)}: {warn_msgs}"
+        )
+
+    def test_warn_emits_once_per_unique_vendor(self, caplog):
+        """Distinct unknown vendors each get their own one-shot WARN."""
+        with caplog.at_level("WARNING", logger=_mesh_helpers.logger.name):
+            _warn_native_dispatch_unknown_vendor_once("vendor_a")
+            _warn_native_dispatch_unknown_vendor_once("vendor_b")
+            _warn_native_dispatch_unknown_vendor_once("vendor_a")
+            _warn_native_dispatch_unknown_vendor_once("vendor_c")
+
+        warn_msgs = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING"
+            and "_VENDOR_FORMATTERS" in r.getMessage()
+        ]
+        # Three distinct vendors → three WARNs total.
+        assert len(warn_msgs) == 3
+        assert sum("vendor_a" in m for m in warn_msgs) == 1
+        assert sum("vendor_b" in m for m in warn_msgs) == 1
+        assert sum("vendor_c" in m for m in warn_msgs) == 1
+
+    @pytest.mark.asyncio
+    async def test_native_dispatch_with_unknown_vendor_warns_and_falls_back(
+        self, caplog
+    ):
+        """End-to-end: ``_execute_tool_calls_for_iteration`` with
+        has_native_dispatch=True and a vendor not in _VENDOR_FORMATTERS must
+        (a) call the resolver with vendor="openai" (safe fallback) and
+        (b) emit the WARN."""
+        message = _make_message_mock(
+            [_make_tool_call_mock("call_1", "screenshot", "{}")]
+        )
+        tool_endpoints = {"screenshot": "http://localhost:9000"}
+
+        proxy_instance = MagicMock()
+        proxy_instance.call_tool = AsyncMock(
+            return_value={"resource_link": True}
+        )
+
+        resolve_mock = AsyncMock(return_value=[{"type": "text", "text": "ok"}])
+
+        with patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.UnifiedMCPProxy",
+            return_value=proxy_instance,
+        ), patch(
+            "_mcp_mesh.media.resolver._has_resource_link", return_value=True
+        ), patch(
+            "_mcp_mesh.media.resolver.resolve_resource_links", new=resolve_mock
+        ), caplog.at_level("WARNING", logger=_mesh_helpers.logger.name):
+            await _execute_tool_calls_for_iteration(
+                message=message,
+                tool_endpoints=tool_endpoints,
+                parallel=False,
+                vendor="cohere",  # not in _VENDOR_FORMATTERS today
+                loop_logger=None,
+                has_native_dispatch=True,
+            )
+
+        # Resolver was called with the safe fallback vendor.
+        assert resolve_mock.await_count == 1
+        assert resolve_mock.await_args.args[1] == "openai"
+
+        # WARN fired once for the unknown vendor.
+        warn_msgs = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING" and "cohere" in r.getMessage()
+        ]
+        assert len(warn_msgs) == 1, (
+            f"expected one WARN about unknown native vendor 'cohere'; "
+            f"got: {warn_msgs}"
+        )

--- a/src/runtime/python/tests/unit/test_provider_tool_execution_helper.py
+++ b/src/runtime/python/tests/unit/test_provider_tool_execution_helper.py
@@ -309,6 +309,226 @@ class TestErrorPaths:
 
 
 # ---------------------------------------------------------------------------
+# Issue #860 — vendor-native upstream emission on the native dispatch path
+# (and OpenAI-shape fallback on the LiteLLM path)
+# ---------------------------------------------------------------------------
+
+
+class TestNativeDispatchResolverVendor:
+    """Verify the ``has_native_dispatch`` flag drives the vendor argument
+    passed to ``resolve_resource_links``. This is the upstream half of the
+    #860 architectural cleanup: native dispatch path receives vendor-native
+    content blocks straight from the resolver; LiteLLM fallback path keeps
+    the historical OpenAI-shape contract so LiteLLM's own vendor adapters
+    handle the conversion."""
+
+    def _patch_resolver(self, parts: list):
+        """Patch the resolver so we can capture the vendor argument."""
+        resolve_mock = AsyncMock(return_value=parts)
+        return (
+            patch(
+                "_mcp_mesh.media.resolver._has_resource_link",
+                return_value=True,
+            ),
+            patch(
+                "_mcp_mesh.media.resolver.resolve_resource_links",
+                new=resolve_mock,
+            ),
+            resolve_mock,
+        )
+
+    @pytest.mark.asyncio
+    async def test_litellm_path_uses_openai_shape_for_anthropic_vendor(self):
+        """LiteLLM fallback path (``has_native_dispatch=False``): even though
+        vendor is "anthropic", the resolver is asked for OpenAI shape so the
+        existing LiteLLM adapter chain keeps working unchanged."""
+        message = _make_message_mock(
+            [_make_tool_call_mock("call_1", "screenshot", "{}")]
+        )
+        tool_endpoints = {"screenshot": "http://localhost:9000"}
+
+        proxy_instance = MagicMock()
+        proxy_instance.call_tool = AsyncMock(
+            return_value={"resource_link": True}
+        )
+
+        link_patch, resolve_patch, resolve_mock = self._patch_resolver(
+            parts=[{"type": "text", "text": "ok"}]
+        )
+
+        with patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.UnifiedMCPProxy",
+            return_value=proxy_instance,
+        ), link_patch, resolve_patch:
+            await _execute_tool_calls_for_iteration(
+                message=message,
+                tool_endpoints=tool_endpoints,
+                parallel=False,
+                vendor="anthropic",
+                loop_logger=None,
+                has_native_dispatch=False,
+            )
+
+        assert resolve_mock.await_count == 1
+        # Second positional arg is the vendor passed to the resolver.
+        called_vendor = resolve_mock.await_args.args[1]
+        assert called_vendor == "openai", (
+            "LiteLLM fallback path must keep emitting OpenAI-shape blocks; "
+            f"got vendor={called_vendor!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_native_dispatch_uses_vendor_native_shape_for_anthropic(self):
+        """Native dispatch path (``has_native_dispatch=True``): vendor flows
+        through to the resolver so the resolver emits Claude-native image
+        blocks directly. The native Anthropic adapter's content-block
+        translator becomes a no-op for these blocks."""
+        message = _make_message_mock(
+            [_make_tool_call_mock("call_1", "screenshot", "{}")]
+        )
+        tool_endpoints = {"screenshot": "http://localhost:9000"}
+
+        proxy_instance = MagicMock()
+        proxy_instance.call_tool = AsyncMock(
+            return_value={"resource_link": True}
+        )
+
+        link_patch, resolve_patch, resolve_mock = self._patch_resolver(
+            parts=[{"type": "text", "text": "ok"}]
+        )
+
+        with patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.UnifiedMCPProxy",
+            return_value=proxy_instance,
+        ), link_patch, resolve_patch:
+            await _execute_tool_calls_for_iteration(
+                message=message,
+                tool_endpoints=tool_endpoints,
+                parallel=False,
+                vendor="anthropic",
+                loop_logger=None,
+                has_native_dispatch=True,
+            )
+
+        assert resolve_mock.await_count == 1
+        called_vendor = resolve_mock.await_args.args[1]
+        assert called_vendor == "anthropic", (
+            "Native dispatch path must emit vendor-native blocks; "
+            f"got vendor={called_vendor!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_native_dispatch_uses_vendor_native_shape_for_gemini(self):
+        """Native dispatch + vendor=gemini: resolver is called with "gemini".
+        The resolver's ``_format_for_gemini`` is currently aliased to
+        ``_format_for_openai``, so the wire shape is identical to the
+        LiteLLM path — but the call CONTRACT is "ask for gemini" so future
+        gemini-native shape changes flow through automatically."""
+        message = _make_message_mock(
+            [_make_tool_call_mock("call_1", "screenshot", "{}")]
+        )
+        tool_endpoints = {"screenshot": "http://localhost:9000"}
+
+        proxy_instance = MagicMock()
+        proxy_instance.call_tool = AsyncMock(
+            return_value={"resource_link": True}
+        )
+
+        link_patch, resolve_patch, resolve_mock = self._patch_resolver(
+            parts=[{"type": "text", "text": "ok"}]
+        )
+
+        with patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.UnifiedMCPProxy",
+            return_value=proxy_instance,
+        ), link_patch, resolve_patch:
+            await _execute_tool_calls_for_iteration(
+                message=message,
+                tool_endpoints=tool_endpoints,
+                parallel=False,
+                vendor="gemini",
+                loop_logger=None,
+                has_native_dispatch=True,
+            )
+
+        assert resolve_mock.await_count == 1
+        called_vendor = resolve_mock.await_args.args[1]
+        assert called_vendor == "gemini"
+
+    @pytest.mark.asyncio
+    async def test_default_has_native_dispatch_preserves_legacy_behavior(self):
+        """Callers that don't yet plumb ``has_native_dispatch`` (third-party
+        or mid-rebase) MUST get the pre-#860 behavior: resolver called with
+        OpenAI shape, LiteLLM downstream handles conversion."""
+        message = _make_message_mock(
+            [_make_tool_call_mock("call_1", "screenshot", "{}")]
+        )
+        tool_endpoints = {"screenshot": "http://localhost:9000"}
+
+        proxy_instance = MagicMock()
+        proxy_instance.call_tool = AsyncMock(
+            return_value={"resource_link": True}
+        )
+
+        link_patch, resolve_patch, resolve_mock = self._patch_resolver(
+            parts=[{"type": "text", "text": "ok"}]
+        )
+
+        with patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.UnifiedMCPProxy",
+            return_value=proxy_instance,
+        ), link_patch, resolve_patch:
+            # Note: no has_native_dispatch kwarg -> default False.
+            await _execute_tool_calls_for_iteration(
+                message=message,
+                tool_endpoints=tool_endpoints,
+                parallel=False,
+                vendor="anthropic",
+                loop_logger=None,
+            )
+
+        assert resolve_mock.await_args.args[1] == "openai"
+
+    @pytest.mark.asyncio
+    async def test_native_dispatch_with_unknown_vendor_falls_back_to_openai(self):
+        """vendor=None on native dispatch path is nonsensical (the loop only
+        sets has_native_dispatch=True after picking a vendor that has a
+        handler) — but we defend against it: the resolver still gets a valid
+        vendor string."""
+        message = _make_message_mock(
+            [_make_tool_call_mock("call_1", "screenshot", "{}")]
+        )
+        tool_endpoints = {"screenshot": "http://localhost:9000"}
+
+        proxy_instance = MagicMock()
+        proxy_instance.call_tool = AsyncMock(
+            return_value={"resource_link": True}
+        )
+
+        link_patch, resolve_patch, resolve_mock = self._patch_resolver(
+            parts=[{"type": "text", "text": "ok"}]
+        )
+
+        with patch(
+            "_mcp_mesh.engine.unified_mcp_proxy.UnifiedMCPProxy",
+            return_value=proxy_instance,
+        ), link_patch, resolve_patch:
+            await _execute_tool_calls_for_iteration(
+                message=message,
+                tool_endpoints=tool_endpoints,
+                parallel=False,
+                vendor=None,
+                loop_logger=None,
+                has_native_dispatch=True,
+            )
+
+        # When vendor is None, the resolver guard inside the helper means the
+        # resolver shouldn't even be invoked (it's gated on
+        # ``vendor and _has_resource_link(result)``). Pin that fact.
+        assert resolve_mock.await_count == 0
+
+
+# ---------------------------------------------------------------------------
 # Module-level invariants
 # ---------------------------------------------------------------------------
 

--- a/src/runtime/python/tests/unit/test_provider_tool_execution_helper.py
+++ b/src/runtime/python/tests/unit/test_provider_tool_execution_helper.py
@@ -492,11 +492,11 @@ class TestNativeDispatchResolverVendor:
         assert resolve_mock.await_args.args[1] == "openai"
 
     @pytest.mark.asyncio
-    async def test_native_dispatch_with_unknown_vendor_falls_back_to_openai(self):
-        """vendor=None on native dispatch path is nonsensical (the loop only
-        sets has_native_dispatch=True after picking a vendor that has a
-        handler) — but we defend against it: the resolver still gets a valid
-        vendor string."""
+    async def test_native_dispatch_with_none_vendor_skips_resolver(self):
+        """When vendor is None on the native dispatch path, the upstream
+        ``vendor and _has_resource_link(...)`` short-circuit prevents resolver
+        invocation entirely. (Unknown-but-non-None vendor fallback is covered
+        separately in TestUnknownNativeVendorWarn.)"""
         message = _make_message_mock(
             [_make_tool_call_mock("call_1", "screenshot", "{}")]
         )


### PR DESCRIPTION
## Summary

Three small LLM-stack cleanups bundled into one PR for batch review.

## Changes

### #863 — output_type kwarg collision in MeshLlmAgent._build_request_params

`prepare_request(..., output_type=self.output_type, **call_kwargs)` raised `TypeError: got multiple values for keyword argument 'output_type'` when `output_type` leaked into `_default_model_params` from decorator capture (root cause: `INTERNAL_CONFIG_KEYS` didn't list `output_type`, so it survived the filter).

**Fix**: defensive `call_kwargs.pop("output_type", None)` before the splat. `self.output_type` is unconditionally authoritative.

### #866 — Cross-loop httpx pool binding (preventive backport)

Backport Gemini's per-event-loop httpx pool pattern (PR #865) to `anthropic_native.py` and `openai_native.py`. Same architectural vulnerability — single process-global `httpx.AsyncClient` binds anyio sync primitives to the loop that issues the first request, breaks on cross-worker calls. Mesh's `tool_executor` runs N worker threads each with their own asyncio loop.

**Fix**: replace single global with `_CACHED_HTTPX_CLIENT_BY_LOOP: dict[int, httpx.AsyncClient]` keyed by `id(asyncio.get_running_loop())`. Sync paths return uncached client. `threading.Lock` semantics preserved.

Documentation honesty: comments now explicitly state the assumption (mesh worker loops live for process lifetime; `is_closed` does NOT detect owning-loop closure). `weakref`-keyed eviction deferred.

### #860 — Move LLM content-block translation upstream (provider native path)

Provider-side `_execute_tool_calls_for_iteration` now routes `resolve_resource_links` through `_VENDOR_FORMATTERS[vendor]` when `has_native_dispatch` is true — emitter produces vendor-native shape upstream of the adapter for the native path. LiteLLM fallback path keeps emitting OpenAI shape (LiteLLM's contract).

**Constrained scope per investigation**:
- Only provider-side `_execute_tool_calls_for_iteration` is vendor-aware now; consumer-side `_resolve_media_inputs` / `_resolve_media_in_tool_results` route through LiteLLM and stay on OpenAI shape (out of #860 scope)
- Adapter translators (anthropic_native, gemini_native) kept as **defensive idempotent passthroughs** — already handle vendor-native input as no-op; remain the safety net for the consumer→provider mesh-delegation path
- `_format_for_gemini` currently aliases to `_format_for_openai` (LiteLLM's gemini adapter expects OpenAI shape); native gemini does its own translation. Test pinned so future Gemini-native formatter migration produces a deliberate failure with documented next steps
- WARN-once when `has_native_dispatch=True` but vendor unknown to `_VENDOR_FORMATTERS` (surfaces #860 plumbing gaps for new vendors)

## Pre-PR review iterations

2 rounds of review-agent cleanup before opening:

| Round | Findings | Status |
|---|---|---|
| 1 | 1 BLOCKER + 4 WARN + 3 INFO | All actionable addressed (1 BLOCKER + 4 WARN) |
| 2 | 0 BLOCKER + 1 WARN + 2 INFO | WARN addressed (renamed test for accuracy); INFOs deferred |

BLOCKER: leaked httpx.AsyncClient in sync-path test — wrapped try/finally + explicit `asyncio.run(c.aclose())`.

WARNs round 1: silent vendor fallback (now WARN-once), misleading test name (renamed), id(loop) reuse documentation honesty (3 adapter comments rewritten).

WARN round 2: another misnamed test (renamed to match behavior).

## Test results

- **1117 unit tests pass** (1093 baseline + 24 new across the 3 fixes + review-fix iterations)
- Zero regressions

## Out of scope (deferred follow-ups)

- Extract shared `_httpx_pool.py` module across the 3 native adapters (architectural cleanup, code duplication concern)
- `weakref`-keyed httpx cache eviction for short-lived loops (theoretical risk; not surfaced in mesh's actual deployment pattern)
- Add `output_type` to `INTERNAL_CONFIG_KEYS` in injector (eliminates root cause of #863 leak; defensive pop covers it sufficiently)
- Native `_format_for_gemini` (currently aliases to OpenAI shape; native Gemini does its own translation — pinned test catches the migration when ready)
- Consumer-side vendor-aware media translation (out of #860 scope; would require larger refactor)

## Test plan

- [ ] CI integration suite passes (no regressions)
- [ ] Reviewer confirms LiteLLM contract preservation reasoning (OpenAI shape still emitted for non-native dispatch path)
- [ ] Reviewer confirms ID-reuse documentation reflects the actual deployment assumption

Closes #860
Closes #863  
Closes #866