### PR TITLE
feature: MeshJob Python integration test suite + sweep interval env var

### DIFF
--- a/src/core/registry/ent_handlers_jobs_extended_test.go
+++ b/src/core/registry/ent_handlers_jobs_extended_test.go
@@ -442,15 +442,23 @@ func TestCancelJob_OwnedForwardsToOwner(t *testing.T) {
 	defer cleanup()
 
 	// Stand up a fake owner agent that records the cancel callback.
+	// ``hits`` stays atomic so the polling loop below can read it without
+	// holding the mutex; ``gotURL``/``gotBody`` are written in the handler
+	// goroutine and read by the main test goroutine after the poll, so
+	// they need explicit synchronization to keep ``go test -race`` happy.
 	var (
+		mu      sync.Mutex
 		gotURL  string
 		gotBody []byte
 		hits    int32
 	)
 	owner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&hits, 1)
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
 		gotURL = r.URL.Path
-		gotBody, _ = io.ReadAll(r.Body)
+		gotBody = body
+		mu.Unlock()
+		atomic.AddInt32(&hits, 1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer owner.Close()
@@ -493,8 +501,12 @@ func TestCancelJob_OwnedForwardsToOwner(t *testing.T) {
 
 	// Owner saw the forward.
 	assert.Equal(t, int32(1), atomic.LoadInt32(&hits), "owner should receive exactly one cancel forward")
-	assert.Equal(t, "/jobs/"+j.ID+"/cancel", gotURL)
-	assert.Contains(t, string(gotBody), "client cancel")
+	mu.Lock()
+	gotURLCopy := gotURL
+	gotBodyCopy := append([]byte(nil), gotBody...)
+	mu.Unlock()
+	assert.Equal(t, "/jobs/"+j.ID+"/cancel", gotURLCopy)
+	assert.Contains(t, string(gotBodyCopy), "client cancel")
 }
 
 func TestCancelJob_NotFound(t *testing.T) {

--- a/src/core/registry/sweep.go
+++ b/src/core/registry/sweep.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"sync"
@@ -24,11 +25,38 @@ import (
 // Internal sweep tunables. Operators get a single env-var knob
 // (MCP_MESH_RETENTION); these are deliberately not configurable so the
 // surface area stays small.
+//
+// Exception: sweepInterval is overridable via MCP_MESH_SWEEP_INTERVAL so
+// integration tests that exercise crash-recovery and total_deadline expiry
+// don't have to wait the full 5-minute default for a tick. Production
+// deployments should leave this unset.
 const (
-	sweepInterval    = 5 * time.Minute
-	defaultRetention = 1 * time.Hour
-	eventMaxRows     = 100_000
+	defaultSweepInterval = 5 * time.Minute
+	defaultRetention     = 1 * time.Hour
+	eventMaxRows         = 100_000
 )
+
+// sweepInterval is read once at package init from MCP_MESH_SWEEP_INTERVAL.
+// var (not const) because the env read happens at runtime.
+var sweepInterval = readSweepIntervalFromEnv()
+
+// readSweepIntervalFromEnv parses MCP_MESH_SWEEP_INTERVAL as a Go duration
+// string (e.g. "5m", "30s", "1m30s"). Falls back to defaultSweepInterval
+// when the env var is unset or malformed. Logs at INFO when a valid override
+// is applied; stays silent when unset (default behaviour, no noise).
+func readSweepIntervalFromEnv() time.Duration {
+	raw := os.Getenv("MCP_MESH_SWEEP_INTERVAL")
+	if raw == "" {
+		return defaultSweepInterval
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		log.Printf("[sweep] invalid MCP_MESH_SWEEP_INTERVAL=%q, using default %s", raw, defaultSweepInterval)
+		return defaultSweepInterval
+	}
+	log.Printf("[sweep] using MCP_MESH_SWEEP_INTERVAL=%s (overrides default %s)", d, defaultSweepInterval)
+	return d
+}
 
 // SweepConfig holds the configuration for the registry sweep job.
 //

--- a/src/core/registry/sweep.go
+++ b/src/core/registry/sweep.go
@@ -63,6 +63,14 @@ func readSweepIntervalFromEnv() time.Duration {
 		log.Printf("[sweep] invalid MCP_MESH_SWEEP_INTERVAL=%q, using default %s", raw, defaultSweepInterval)
 		return defaultSweepInterval
 	}
+	// time.ParseDuration accepts zero ("0s") and negative values ("-5m"),
+	// but time.NewTicker panics on a non-positive duration. Reject both
+	// here so a misconfigured env var falls back to the default rather
+	// than crashing the registry on Start.
+	if d <= 0 {
+		log.Printf("[sweep] non-positive MCP_MESH_SWEEP_INTERVAL=%q (parsed=%s), using default %s", raw, d, defaultSweepInterval)
+		return defaultSweepInterval
+	}
 	log.Printf("[sweep] using MCP_MESH_SWEEP_INTERVAL=%s (overrides default %s)", d, defaultSweepInterval)
 	return d
 }

--- a/src/core/registry/sweep.go
+++ b/src/core/registry/sweep.go
@@ -44,6 +44,15 @@ var sweepInterval = readSweepIntervalFromEnv()
 // string (e.g. "5m", "30s", "1m30s"). Falls back to defaultSweepInterval
 // when the env var is unset or malformed. Logs at INFO when a valid override
 // is applied; stays silent when unset (default behaviour, no noise).
+//
+// NOTE: this function deliberately uses the stdlib `log` package rather
+// than the project's `*logger.Logger` because it is invoked at package
+// init time (via the `var sweepInterval = readSweepIntervalFromEnv()`
+// initialiser above) — long before the structured logger is constructed
+// in cmd/registry. Switching to the project logger here would require
+// either lazily initialising it or moving the env read into Start(),
+// both of which lose the ability to surface a malformed override
+// before the registry binary even starts up.
 func readSweepIntervalFromEnv() time.Duration {
 	raw := os.Getenv("MCP_MESH_SWEEP_INTERVAL")
 	if raw == "" {

--- a/src/core/registry/sweep_env_test.go
+++ b/src/core/registry/sweep_env_test.go
@@ -1,0 +1,49 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// TestReadSweepIntervalFromEnv covers the three cases for the
+// MCP_MESH_SWEEP_INTERVAL override: unset (default), valid override,
+// and malformed value (fall back to default).
+//
+// We test readSweepIntervalFromEnv() directly rather than the package-
+// level sweepInterval var because the env read happens once at package
+// init, so the var is fixed by the time any test runs.
+func TestReadSweepIntervalFromEnv(t *testing.T) {
+	t.Run("unset_uses_default", func(t *testing.T) {
+		// t.Setenv with empty string still sets the var. We need to
+		// actually unset it for this case.
+		t.Setenv("MCP_MESH_SWEEP_INTERVAL", "")
+		got := readSweepIntervalFromEnv()
+		if got != 5*time.Minute {
+			t.Fatalf("expected default 5m, got %s", got)
+		}
+	})
+
+	t.Run("valid_override_applied", func(t *testing.T) {
+		t.Setenv("MCP_MESH_SWEEP_INTERVAL", "10s")
+		got := readSweepIntervalFromEnv()
+		if got != 10*time.Second {
+			t.Fatalf("expected 10s, got %s", got)
+		}
+	})
+
+	t.Run("valid_compound_duration", func(t *testing.T) {
+		t.Setenv("MCP_MESH_SWEEP_INTERVAL", "1m30s")
+		got := readSweepIntervalFromEnv()
+		if got != 90*time.Second {
+			t.Fatalf("expected 1m30s (=90s), got %s", got)
+		}
+	})
+
+	t.Run("invalid_falls_back_to_default", func(t *testing.T) {
+		t.Setenv("MCP_MESH_SWEEP_INTERVAL", "garbage")
+		got := readSweepIntervalFromEnv()
+		if got != 5*time.Minute {
+			t.Fatalf("expected default 5m on invalid input, got %s", got)
+		}
+	})
+}

--- a/src/core/registry/sweep_env_test.go
+++ b/src/core/registry/sweep_env_test.go
@@ -46,4 +46,24 @@ func TestReadSweepIntervalFromEnv(t *testing.T) {
 			t.Fatalf("expected default 5m on invalid input, got %s", got)
 		}
 	})
+
+	// time.ParseDuration accepts "0s" / "0" and negative durations, but
+	// time.NewTicker panics on a non-positive value. The env reader must
+	// fall back to the default instead of letting a misconfigured
+	// override crash the registry at sweep start.
+	t.Run("zero_falls_back_to_default", func(t *testing.T) {
+		t.Setenv("MCP_MESH_SWEEP_INTERVAL", "0s")
+		got := readSweepIntervalFromEnv()
+		if got != 5*time.Minute {
+			t.Fatalf("expected default 5m for zero override, got %s", got)
+		}
+	})
+
+	t.Run("negative_falls_back_to_default", func(t *testing.T) {
+		t.Setenv("MCP_MESH_SWEEP_INTERVAL", "-5m")
+		got := readSweepIntervalFromEnv()
+		if got != 5*time.Minute {
+			t.Fatalf("expected default 5m for negative override, got %s", got)
+		}
+	})
 }

--- a/tests/integration/suites/uc21_meshjob/artifacts/bystander-x
+++ b/tests/integration/suites/uc21_meshjob/artifacts/bystander-x
@@ -1,0 +1,1 @@
+../fixtures/bystander-x

--- a/tests/integration/suites/uc21_meshjob/artifacts/bystander-y
+++ b/tests/integration/suites/uc21_meshjob/artifacts/bystander-y
@@ -1,0 +1,1 @@
+../fixtures/bystander-y

--- a/tests/integration/suites/uc21_meshjob/artifacts/downstream-sleeper
+++ b/tests/integration/suites/uc21_meshjob/artifacts/downstream-sleeper
@@ -1,0 +1,1 @@
+../fixtures/downstream-sleeper

--- a/tests/integration/suites/uc21_meshjob/artifacts/long-task-consumer
+++ b/tests/integration/suites/uc21_meshjob/artifacts/long-task-consumer
@@ -1,0 +1,1 @@
+../fixtures/long-task-consumer

--- a/tests/integration/suites/uc21_meshjob/artifacts/long-task-provider
+++ b/tests/integration/suites/uc21_meshjob/artifacts/long-task-provider
@@ -1,0 +1,1 @@
+../fixtures/long-task-provider

--- a/tests/integration/suites/uc21_meshjob/artifacts/orchestrator-agent
+++ b/tests/integration/suites/uc21_meshjob/artifacts/orchestrator-agent
@@ -1,0 +1,1 @@
+../fixtures/orchestrator-agent

--- a/tests/integration/suites/uc21_meshjob/fixtures/bystander-x/main.py
+++ b/tests/integration/suites/uc21_meshjob/fixtures/bystander-x/main.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Bystander X (uc21) — used by tc16 to verify third-party status reads.
+
+Has no MeshJob deps and no task=True tools. The framework still
+auto-registers ``__mesh_job_status`` / ``__mesh_job_result`` /
+``__mesh_job_cancel`` on every mesh agent, so the test can read
+job state from this agent for a job_id it did not submit.
+
+Distinct fixture file (separate from bystander-y) so meshctl's
+"is this agent already running" check (which keys off the
+``@mesh.agent(name=...)`` decorator) doesn't conflate the two
+instances.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Bystander X (uc21)")
+
+
+@app.tool()
+@mesh.tool(
+    capability="bystander_x_ping",
+    description="Trivial tool — keeps bystander X alive in the registry.",
+)
+async def bystander_x_ping() -> dict:
+    return {"ok": True, "agent": "bystander-x"}
+
+
+@mesh.agent(
+    name="bystander-x",
+    version="1.0.0",
+    description="Bystander agent X — verifies third-party status reads (tc16).",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9104")),
+    enable_http=True,
+    auto_run=True,
+)
+class BystanderX:
+    pass

--- a/tests/integration/suites/uc21_meshjob/fixtures/bystander-y/main.py
+++ b/tests/integration/suites/uc21_meshjob/fixtures/bystander-y/main.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Bystander Y (uc21) — used by tc16 to verify third-party status reads.
+
+Mirror of bystander-x in every way except agent name; deployed
+alongside X so the test can prove BOTH agents (each with no
+involvement in the job) can read its state via the framework's
+helper tools.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Bystander Y (uc21)")
+
+
+@app.tool()
+@mesh.tool(
+    capability="bystander_y_ping",
+    description="Trivial tool — keeps bystander Y alive in the registry.",
+)
+async def bystander_y_ping() -> dict:
+    return {"ok": True, "agent": "bystander-y"}
+
+
+@mesh.agent(
+    name="bystander-y",
+    version="1.0.0",
+    description="Bystander agent Y — verifies third-party status reads (tc16).",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9105")),
+    enable_http=True,
+    auto_run=True,
+)
+class BystanderY:
+    pass

--- a/tests/integration/suites/uc21_meshjob/fixtures/downstream-sleeper/main.py
+++ b/tests/integration/suites/uc21_meshjob/fixtures/downstream-sleeper/main.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Downstream sleeper agent (uc21) — exercises cancel propagation.
+
+Provides ``slow_downstream``, a regular (non-task) tool that sleeps
+for the requested number of seconds. The producer agent's
+``report_with_downstream_call`` invokes this via the mesh proxy; when
+the producer's job is cancelled, the cancel token in the producer's
+async-local context aborts the in-flight outbound HTTP — so this
+sleeper never finishes its 30s timer for the cancel scenario.
+
+The sleeper writes a marker line to stderr when it observes the
+request being aborted (``asyncio.CancelledError``) so tests can
+distinguish a true cancel propagation from "the downstream just took
+too long and the test gave up".
+"""
+
+import asyncio
+import os
+import sys
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Downstream Sleeper (uc21)")
+
+
+@app.tool()
+@mesh.tool(
+    capability="slow_downstream",
+    description="Sleeps for the requested number of seconds (regular tool, not task=True).",
+)
+async def slow_downstream(user_id: str, seconds: int = 30) -> dict:
+    print(
+        f"[downstream-sleeper] starting {seconds}s sleep for user={user_id}",
+        file=sys.stderr,
+        flush=True,
+    )
+    try:
+        await asyncio.sleep(seconds)
+    except asyncio.CancelledError:
+        # Loud marker the test grep's for. Re-raise so the wrapper
+        # surfaces the abort to the caller as expected.
+        print(
+            f"[downstream-sleeper] sleep CANCELLED for user={user_id} "
+            "(client closed / cancel token fired)",
+            file=sys.stderr,
+            flush=True,
+        )
+        raise
+    print(
+        f"[downstream-sleeper] sleep completed for user={user_id} (NOT cancelled)",
+        file=sys.stderr,
+        flush=True,
+    )
+    return {"user_id": user_id, "slept": seconds}
+
+
+@mesh.agent(
+    name="downstream-sleeper",
+    version="1.0.0",
+    description="Slow downstream tool used to verify mesh-job cancel propagation.",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9102")),
+    enable_http=True,
+    auto_run=True,
+)
+class DownstreamSleeper:
+    pass

--- a/tests/integration/suites/uc21_meshjob/fixtures/long-task-consumer/main.py
+++ b/tests/integration/suites/uc21_meshjob/fixtures/long-task-consumer/main.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""MeshJob test-suite consumer (uc21).
+
+Hosts several variants of the submit-and-await pattern so individual
+test cases can exercise behavioural knobs without forking new agents:
+
+- ``commission_report`` — submit + wait; raises on terminal error.
+  Mirrors the upstream example.
+- ``commission_with_options`` — submit + wait with caller-supplied
+  ``max_retries`` and an optional ``total_deadline_secs`` (relative,
+  converted to a UTC datetime under the hood). Returns a structured
+  envelope on terminal failure instead of raising — lets tests assert
+  status / error fields directly.
+- ``commission_submit_only`` — submit and return ``{job_id}``
+  immediately. Tests poll status / result / cancel themselves via
+  the helper tools, which is the right shape for cancellation /
+  recovery scenarios where blocking on ``wait()`` would hide signal.
+- ``commission_explicit_fail`` — submits ``report_with_explicit_fail``
+  with caller-supplied ``max_retries``. Always returns the structured
+  envelope so tc05 can assert ``status=failed`` + attempt_count.
+- ``commission_crash`` — submits ``report_that_crashes`` with caller-
+  supplied ``max_retries`` and (optional) ``total_deadline_secs``.
+- ``commission_overlong`` — submits ``runs_overlong``. Used by
+  cancel-token tests.
+- ``commission_downstream`` — submits ``report_with_downstream_call``.
+  Used by tc09 to verify cancel aborts the downstream HTTP.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+import mesh
+from fastmcp import FastMCP
+from mesh import MeshJob
+
+app = FastMCP("Long Task Consumer (uc21)")
+
+
+def _utc_deadline_from_relative(secs: Optional[int]) -> Optional[datetime]:
+    if secs is None:
+        return None
+    return datetime.now(timezone.utc) + timedelta(seconds=secs)
+
+
+# ---------------------------------------------------------------------------
+# Submit + wait (raises on terminal error) — happy-path baseline
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="commission_report",
+    dependencies=["generate_report"],
+    description="Submit a generate_report job and wait up to 60s for the result.",
+)
+async def commission_report(
+    user_id: str,
+    sections: list[str],
+    generate_report: MeshJob = None,
+) -> dict:
+    if generate_report is None:
+        return {"error": "generate_report submitter not injected"}
+    proxy = await generate_report.submit(
+        user_id=user_id,
+        sections=sections,
+        max_duration=60,
+    )
+    return await proxy.wait(timeout_secs=60)
+
+
+# ---------------------------------------------------------------------------
+# Submit + wait with caller-controlled retry / deadline knobs
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="commission_with_options",
+    dependencies=["generate_report"],
+    description="Submit generate_report with caller-supplied max_retries / total_deadline_secs.",
+)
+async def commission_with_options(
+    user_id: str,
+    sections: list[str],
+    max_retries: int = 1,
+    total_deadline_secs: Optional[int] = None,
+    wait_timeout_secs: int = 60,
+    generate_report: MeshJob = None,
+) -> dict:
+    if generate_report is None:
+        return {"error": "generate_report submitter not injected"}
+    proxy = await generate_report.submit(
+        user_id=user_id,
+        sections=sections,
+        max_duration=60,
+        max_retries=max_retries,
+        total_deadline=_utc_deadline_from_relative(total_deadline_secs),
+    )
+    job_id = getattr(proxy, "job_id", None)
+    try:
+        result = await proxy.wait(timeout_secs=wait_timeout_secs)
+        return {"job_id": job_id, "status": "completed", "result": result}
+    except Exception as e:  # pragma: no cover - structured envelope for tests
+        return {"job_id": job_id, "status": "wait_raised", "error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Submit-only — return job_id immediately
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="commission_submit_only",
+    dependencies=["generate_report"],
+    description="Submit generate_report and return the job_id without waiting.",
+)
+async def commission_submit_only(
+    user_id: str,
+    sections: list[str],
+    max_retries: int = 1,
+    max_duration: int = 60,
+    generate_report: MeshJob = None,
+) -> dict:
+    if generate_report is None:
+        return {"error": "generate_report submitter not injected"}
+    proxy = await generate_report.submit(
+        user_id=user_id,
+        sections=sections,
+        max_duration=max_duration,
+        max_retries=max_retries,
+    )
+    return {"job_id": getattr(proxy, "job_id", None)}
+
+
+# ---------------------------------------------------------------------------
+# Explicit-fail submitter — submits report_with_explicit_fail
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="commission_explicit_fail",
+    dependencies=["report_with_explicit_fail"],
+    description="Submit report_with_explicit_fail with caller-supplied max_retries.",
+)
+async def commission_explicit_fail(
+    user_id: str,
+    max_retries: int = 3,
+    wait_timeout_secs: int = 30,
+    report_with_explicit_fail: MeshJob = None,
+) -> dict:
+    if report_with_explicit_fail is None:
+        return {"error": "report_with_explicit_fail submitter not injected"}
+    proxy = await report_with_explicit_fail.submit(
+        user_id=user_id,
+        max_duration=30,
+        max_retries=max_retries,
+    )
+    job_id = getattr(proxy, "job_id", None)
+    try:
+        result = await proxy.wait(timeout_secs=wait_timeout_secs)
+        return {"job_id": job_id, "status": "completed", "result": result}
+    except Exception as e:
+        return {"job_id": job_id, "status": "wait_raised", "error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Crash submitter — submits report_that_crashes
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="commission_crash",
+    dependencies=["report_that_crashes"],
+    description="Submit report_that_crashes (always raises) with caller-supplied retry / deadline.",
+)
+async def commission_crash(
+    user_id: str,
+    max_retries: int = 0,
+    total_deadline_secs: Optional[int] = None,
+    report_that_crashes: MeshJob = None,
+) -> dict:
+    if report_that_crashes is None:
+        return {"error": "report_that_crashes submitter not injected"}
+    proxy = await report_that_crashes.submit(
+        user_id=user_id,
+        max_duration=30,
+        max_retries=max_retries,
+        total_deadline=_utc_deadline_from_relative(total_deadline_secs),
+    )
+    return {"job_id": getattr(proxy, "job_id", None)}
+
+
+# ---------------------------------------------------------------------------
+# Overlong submitter — submits runs_overlong (cancel-token tests)
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="commission_overlong",
+    dependencies=["runs_overlong"],
+    description="Submit runs_overlong and return the job_id (no wait).",
+)
+async def commission_overlong(
+    user_id: str,
+    seconds: int = 30,
+    runs_overlong: MeshJob = None,
+) -> dict:
+    if runs_overlong is None:
+        return {"error": "runs_overlong submitter not injected"}
+    proxy = await runs_overlong.submit(
+        user_id=user_id,
+        seconds=seconds,
+        max_duration=120,
+    )
+    return {"job_id": getattr(proxy, "job_id", None)}
+
+
+# ---------------------------------------------------------------------------
+# Downstream-call submitter — submits report_with_downstream_call
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="commission_downstream",
+    dependencies=["report_with_downstream_call"],
+    description="Submit report_with_downstream_call (provider calls slow_downstream) and return job_id.",
+)
+async def commission_downstream(
+    user_id: str,
+    report_with_downstream_call: MeshJob = None,
+) -> dict:
+    if report_with_downstream_call is None:
+        return {"error": "report_with_downstream_call submitter not injected"}
+    proxy = await report_with_downstream_call.submit(
+        user_id=user_id,
+        max_duration=120,
+    )
+    return {"job_id": getattr(proxy, "job_id", None)}
+
+
+import os  # noqa: E402  (kept here for clarity that env-port is the only env hook)
+
+
+@mesh.agent(
+    name="long-task-consumer",
+    version="1.0.0",
+    description="MeshJob test consumer (uc21) — multi-capability fixture for the integration suite.",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9101")),
+    enable_http=True,
+    auto_run=True,
+)
+class LongTaskConsumer:
+    pass

--- a/tests/integration/suites/uc21_meshjob/fixtures/long-task-provider/main.py
+++ b/tests/integration/suites/uc21_meshjob/fixtures/long-task-provider/main.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""MeshJob test-suite producer (uc21).
+
+Hosts a small zoo of ``task=True`` capabilities, one per scenario the
+suite needs to exercise. Each capability is intentionally minimal — we
+avoid stuffing branching logic into a single tool because branching
+across scenarios via payload args makes failures harder to triage when
+the substrate misbehaves.
+
+Capabilities:
+
+- ``generate_report`` — happy path. Emits progress per section (~2s
+  each) then explicitly calls ``job.complete(...)``. Mirrors the
+  upstream example.
+- ``report_with_explicit_complete`` — same shape but with a fixed
+  marker payload so tc03 can assert the exact terminal value.
+- ``report_with_implicit_complete`` — returns a value WITHOUT calling
+  ``job.complete()``. Validates the runtime's auto-complete-on-return.
+- ``report_with_explicit_fail`` — calls ``job.fail("...")`` and is
+  expected to NOT trigger any retry attempts even when the submitter
+  asked for ``max_retries > 0``.
+- ``report_that_crashes`` — raises an unhandled exception. Used to
+  drive crash-recovery / retry-exhaustion tests when paired with
+  ``MCP_MESH_SWEEP_INTERVAL=10s``.
+- ``report_with_downstream_call`` — invokes a regular tool (downstream
+  ``slow_downstream``) so cancel propagation through ``X-Mesh-Timeout``
+  + cancel-token can be observed end-to-end.
+- ``runs_overlong`` — slow task whose only purpose is being long-lived
+  enough to allow a mid-flight cancel / kill.
+"""
+
+import asyncio
+import os
+from typing import Any
+
+import mesh
+from fastmcp import FastMCP
+from mesh import MeshJob, McpMeshAgent
+
+app = FastMCP("Long Task Provider (uc21)")
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="generate_report",
+    task=True,
+    description="Long-running multi-section report generator with progress.",
+)
+async def generate_report(
+    user_id: str,
+    sections: list[str],
+    job: MeshJob = None,
+) -> dict[str, Any]:
+    if job is not None:
+        await job.update_progress(0.0, "starting")
+
+    results = []
+    total = max(len(sections), 1)
+    for i, section in enumerate(sections):
+        await asyncio.sleep(2)
+        results.append({"section": section, "content": f"Generated content for {section}"})
+        if job is not None:
+            await job.update_progress((i + 1) / total, f"finished section {i + 1}/{total}")
+
+    payload = {"user_id": user_id, "report": results}
+    if job is not None:
+        await job.complete(payload)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Explicit complete with fixed marker payload
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="report_with_explicit_complete",
+    task=True,
+    description="Calls job.complete({...}) with a fixed marker payload.",
+)
+async def report_with_explicit_complete(
+    user_id: str,
+    job: MeshJob = None,
+) -> dict[str, Any]:
+    if job is not None:
+        await job.update_progress(0.5, "midpoint")
+        await asyncio.sleep(0.5)
+        # Explicit terminal payload — tc03 asserts these exact fields.
+        await job.complete({"explicit": True, "marker": "X", "user_id": user_id})
+    # Fast-path return so synchronous tools/call still works.
+    return {"explicit": True, "marker": "X", "user_id": user_id}
+
+
+# ---------------------------------------------------------------------------
+# Implicit complete (auto-complete on return)
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="report_with_implicit_complete",
+    task=True,
+    description="Returns a value WITHOUT calling job.complete() — relies on auto-complete.",
+)
+async def report_with_implicit_complete(
+    user_id: str,
+    job: MeshJob = None,
+) -> dict[str, Any]:
+    if job is not None:
+        # Update progress to confirm controller binding worked. We
+        # intentionally do NOT call job.complete() — the runtime's
+        # auto-complete path should fire on return.
+        await job.update_progress(0.5, "halfway")
+        await asyncio.sleep(0.5)
+        await job.update_progress(0.9, "almost done")
+    return {"implicit": True, "user_id": user_id}
+
+
+# ---------------------------------------------------------------------------
+# Explicit fail — no retry
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="report_with_explicit_fail",
+    task=True,
+    description="Calls job.fail('reason') — must NOT trigger retry even with max_retries > 0.",
+)
+async def report_with_explicit_fail(
+    user_id: str,
+    job: MeshJob = None,
+) -> dict[str, Any]:
+    if job is not None:
+        await job.update_progress(0.1, "about to fail")
+        await asyncio.sleep(0.3)
+        await job.fail("explicit: not retryable")
+    # If invoked synchronously (no job context), surface the same intent.
+    return {"failed": True, "reason": "explicit: not retryable"}
+
+
+# ---------------------------------------------------------------------------
+# Crash-on-attempt
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="report_that_crashes",
+    task=True,
+    description="Always raises mid-attempt — drives crash-recovery / retry-exhaustion tests.",
+)
+async def report_that_crashes(
+    user_id: str,
+    job: MeshJob = None,
+) -> dict[str, Any]:
+    if job is not None:
+        await job.update_progress(0.1, "about to crash")
+        await asyncio.sleep(0.3)
+    # Unhandled exception — propagates up through the wrapper, the
+    # producer-side runtime marks the attempt failed, and the registry
+    # sweep is the safety net for orphan re-claim or exhaustion.
+    raise RuntimeError("simulated crash for crash-recovery test")
+
+
+# ---------------------------------------------------------------------------
+# Long-running task — useful for mid-flight cancel / external kill
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="runs_overlong",
+    task=True,
+    description="Sleeps for many small intervals so cancel / kill can land mid-flight.",
+)
+async def runs_overlong(
+    user_id: str,
+    seconds: int = 30,
+    job: MeshJob = None,
+) -> dict[str, Any]:
+    # Loop in small chunks so the cancel token can interrupt promptly.
+    elapsed = 0.0
+    step = 0.5
+    total = max(float(seconds), step)
+    while elapsed < total:
+        await asyncio.sleep(step)
+        elapsed += step
+        if job is not None:
+            await job.update_progress(min(elapsed / total, 0.99), f"alive at {elapsed:.1f}s")
+    payload = {"user_id": user_id, "elapsed": elapsed}
+    if job is not None:
+        await job.complete(payload)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Job that calls a downstream regular tool — exercises cancel propagation
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="report_with_downstream_call",
+    task=True,
+    dependencies=["slow_downstream"],
+    description="Calls a downstream regular tool that sleeps; cancel must abort the in-flight HTTP.",
+)
+async def report_with_downstream_call(
+    user_id: str,
+    slow_downstream: McpMeshAgent = None,
+    job: MeshJob = None,
+) -> dict[str, Any]:
+    if job is not None:
+        await job.update_progress(0.1, "calling downstream")
+    if slow_downstream is None:
+        return {"error": "slow_downstream dependency not injected"}
+    # The downstream tool sleeps 30s. With cancel propagation working,
+    # the cancel token aborts the in-flight HTTP request well before
+    # the 30s timer elapses.
+    result = await slow_downstream(user_id=user_id, seconds=30)
+    if job is not None:
+        await job.complete(result)
+    return result
+
+
+@mesh.agent(
+    name="long-task-provider",
+    version="1.0.0",
+    description="MeshJob test producer (uc21) — multi-capability fixture for the integration suite.",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9100")),
+    enable_http=True,
+    auto_run=True,
+)
+class LongTaskProvider:
+    pass

--- a/tests/integration/suites/uc21_meshjob/fixtures/long-task-provider/main.py
+++ b/tests/integration/suites/uc21_meshjob/fixtures/long-task-provider/main.py
@@ -220,7 +220,15 @@ async def report_with_downstream_call(
     if job is not None:
         await job.update_progress(0.1, "calling downstream")
     if slow_downstream is None:
-        return {"error": "slow_downstream dependency not injected"}
+        # Returning a dict here would trip the runtime's auto-complete
+        # path (W8 fix from PR #878) and mark the job COMPLETED with the
+        # error dict as its result. The intent is the opposite — surface
+        # the missing-dep state as a terminal failure. job.fail() sets
+        # the terminal state explicitly; auto-complete is a no-op once a
+        # terminal state has been recorded.
+        if job is not None:
+            await job.fail({"error": "slow_downstream dependency not injected"})
+        return None
     # The downstream tool sleeps 30s. With cancel propagation working,
     # the cancel token aborts the in-flight HTTP request well before
     # the 30s timer elapses.

--- a/tests/integration/suites/uc21_meshjob/fixtures/orchestrator-agent/main.py
+++ b/tests/integration/suites/uc21_meshjob/fixtures/orchestrator-agent/main.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Orchestrator agent (uc21) — has NO task=True tools and NO mesh deps.
+
+Used by tc14_helpers_on_every_agent to prove the three framework
+helper tools (``__mesh_job_status`` / ``__mesh_job_result`` /
+``__mesh_job_cancel``) auto-register on every mesh agent regardless
+of whether that agent participates in the job lifecycle.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Orchestrator (uc21)")
+
+
+@app.tool()
+@mesh.tool(
+    capability="orchestrator_ping",
+    description="Trivial tool — only purpose is to keep the agent alive in the registry.",
+)
+async def orchestrator_ping() -> dict:
+    return {"ok": True, "agent": "orchestrator-agent"}
+
+
+@mesh.agent(
+    name="orchestrator-agent",
+    version="1.0.0",
+    description="Agent with no task tools and no mesh deps — verifies helper-tool auto-registration is universal.",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9103")),
+    enable_http=True,
+    auto_run=True,
+)
+class OrchestratorAgent:
+    pass

--- a/tests/integration/suites/uc21_meshjob/routines.yaml
+++ b/tests/integration/suites/uc21_meshjob/routines.yaml
@@ -58,9 +58,13 @@ routines:
           for i in $(seq 1 20); do
             if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
               echo "registry ready after ${i}s"
-              # Verify the sweep override stamped its log line.
-              grep -E '\[sweep\] using MCP_MESH_SWEEP_INTERVAL' \
-                ~/.mcp-mesh/logs/registry.log 2>/dev/null | tail -3 || true
+              # Verify the sweep override actually stamped its log line.
+              # If MCP_MESH_SWEEP_INTERVAL didn't take effect the suite
+              # must fail loudly here, not via slow per-test timeouts.
+              grep -qE '\[sweep\] using MCP_MESH_SWEEP_INTERVAL' \
+                ~/.mcp-mesh/logs/registry.log \
+                || { echo "FAIL: MCP_MESH_SWEEP_INTERVAL override did not take effect"; exit 1; }
+              echo "[setup] confirmed sweep override active"
               exit 0
             fi
             sleep 1

--- a/tests/integration/suites/uc21_meshjob/routines.yaml
+++ b/tests/integration/suites/uc21_meshjob/routines.yaml
@@ -1,0 +1,81 @@
+# UC-level routines for uc21_meshjob.
+#
+# The MeshJob substrate's recovery / deadline expiry paths are driven
+# by the registry's stale-agent + total_deadline sweep. Default sweep
+# tick is 5 minutes — far too slow for a tests suite that runs in
+# seconds. ``MCP_MESH_SWEEP_INTERVAL`` (Go duration format) overrides
+# the default; we set ``10s`` for every suite invocation so retry /
+# orphan / deadline tests can resolve in ~15s instead of ~5min.
+#
+# The env var must be exported in the shell BEFORE starting the
+# registry: the registry binary inherits ``os.Environ()`` from the
+# meshctl process, and meshctl in turn inherits from the shell.
+# Both auto-spawn (from ``meshctl start agent.py -d``) and explicit
+# ``meshctl start --registry-only -d`` paths follow this chain, so
+# either invocation works as long as the variable is exported in the
+# shell step that starts (or auto-spawns) the registry.
+
+routines:
+  # Start the registry explicitly with all the knobs cranked down so
+  # crash-recovery + deadline tests resolve in seconds instead of
+  # minutes.
+  #
+  # Three knobs matter — the chain is:
+  #   1. ``DEFAULT_TIMEOUT_THRESHOLD=15``    — heartbeat-missed window
+  #      after which AgentHealthMonitor flips status to unhealthy
+  #      (default: 60s).
+  #   2. ``MCP_MESH_HEALTH_CHECK_INTERVAL=5`` — how often the health
+  #      monitor loop runs (default: 30s).
+  #   3. ``MCP_MESH_SWEEP_INTERVAL=10s``     — how often the sweep loop
+  #      runs (default: 5min). The sweep purges agents whose status is
+  #      already ``unhealthy`` AND whose ``updated_at`` is older than
+  #      ``MCP_MESH_RETENTION``.
+  #   4. ``MCP_MESH_RETENTION=10s``          — how stale an unhealthy
+  #      agent must be before sweep purges it (default: 1h).
+  # After purgeStaleAgents removes the agent row, ResetOrphanedJobs
+  # spots the working+owner-but-no-agent state and either resets to
+  # claimable (within retry budget) or marks failed (exhausted).
+  #
+  # End-to-end after a SIGKILL: ~15s flip-to-unhealthy + ~10s
+  # retention + ~10s next sweep tick = ~35s worst case for the
+  # orphan reset to land. The crash-recovery tests wait 30-40s
+  # accordingly.
+  #
+  # The env-var prefix carries into meshctl, which exec's the registry
+  # binary inheriting os.Environ() — so all overrides reach the
+  # registry's config + sweep + health-monitor inits.
+  start_registry_with_fast_sweep:
+    description: "Start the mesh registry with all timing knobs cranked for fast recovery tests"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: |
+          MCP_MESH_SWEEP_INTERVAL=10s \
+          MCP_MESH_RETENTION=10s \
+          MCP_MESH_HEALTH_CHECK_INTERVAL=5 \
+          DEFAULT_TIMEOUT_THRESHOLD=15 \
+            meshctl start --registry-only -d
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "registry ready after ${i}s"
+              # Verify the sweep override stamped its log line.
+              grep -E '\[sweep\] using MCP_MESH_SWEEP_INTERVAL' \
+                ~/.mcp-mesh/logs/registry.log 2>/dev/null | tail -3 || true
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: registry did not become ready in 20s"
+          tail -50 ~/.mcp-mesh/logs/registry.log 2>/dev/null || true
+          exit 1
+        capture: registry_start
+        timeout: 30
+
+  # Stop everything started by this test (agents + registry).
+  stop_all:
+    description: "Stop all mesh processes started by this test"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: meshctl stop 2>/dev/null || true
+        ignore_errors: true

--- a/tests/integration/suites/uc21_meshjob/routines.yaml
+++ b/tests/integration/suites/uc21_meshjob/routines.yaml
@@ -61,8 +61,11 @@ routines:
               # Verify the sweep override actually stamped its log line.
               # If MCP_MESH_SWEEP_INTERVAL didn't take effect the suite
               # must fail loudly here, not via slow per-test timeouts.
-              grep -qE '\[sweep\] using MCP_MESH_SWEEP_INTERVAL' \
-                ~/.mcp-mesh/logs/registry.log \
+              # Tail the log so a stale match from an earlier run in the
+              # same shell session can't make a misconfigured current
+              # run look healthy.
+              tail -n 200 ~/.mcp-mesh/logs/registry.log \
+                | grep -qE '\[sweep\] using MCP_MESH_SWEEP_INTERVAL' \
                 || { echo "FAIL: MCP_MESH_SWEEP_INTERVAL override did not take effect"; exit 1; }
               echo "[setup] confirmed sweep override active"
               exit 0

--- a/tests/integration/suites/uc21_meshjob/tc01_submit_wait_happy/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc01_submit_wait_happy/test.yaml
@@ -22,7 +22,7 @@ tags:
   - smoke
   - python
   - issue-872
-timeout: 60
+timeout: 90
 
 pre_run:
   - routine: global.setup_for_python_agent

--- a/tests/integration/suites/uc21_meshjob/tc01_submit_wait_happy/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc01_submit_wait_happy/test.yaml
@@ -1,0 +1,104 @@
+# tc01_submit_wait_happy — headline regression test for MeshJob Phase 1.
+#
+# Scenario:
+#   - Registry up with MCP_MESH_SWEEP_INTERVAL=10s (uniform across suite)
+#   - long-task-provider hosts generate_report (task=True)
+#   - long-task-consumer hosts commission_report (deps=["generate_report"])
+#   - Client invokes commission_report with sections=[intro, analysis, summary]
+#   - Consumer's submit() + wait() pattern returns the structured payload
+#     after ~6s (3 sections * 2s each).
+#
+# Asserts:
+#   - meshctl call response is NOT an MCP error envelope (no "isError": true)
+#   - structuredContent.report has 3 entries with the expected section names
+#     and the canonical "Generated content for ..." marker text
+#
+# Tags: smoke (this is the most important regression for issue #872)
+
+name: "MeshJob: submit-and-wait happy path returns structured result"
+description: "Producer + consumer: commission_report -> generate_report (3 sections) -> wait -> structured result"
+tags:
+  - meshjob
+  - smoke
+  - python
+  - issue-872
+timeout: 60
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start consumer (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for consumer registration + DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Verify both agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Call commission_report — submit + wait the full job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_report '{"user_id": "alice", "sections": ["intro", "analysis", "summary"]}'
+    capture: commission_response
+    timeout: 60
+
+assertions:
+  - expr: "${captured.agent_list} contains 'long-task-provider'"
+    message: "provider should be registered"
+  - expr: "${captured.agent_list} contains 'long-task-consumer'"
+    message: "consumer should be registered"
+  # MCP envelope assertions: must not be an isError response.
+  - expr: "${captured.commission_response} not contains '\"isError\": true'"
+    message: "commission_report should NOT return an MCP error envelope"
+  # Consumer returns generate_report's complete() payload verbatim. With
+  # FastMCP this surfaces as both structuredContent and the textual
+  # content[0].text. Assert against the structured shape.
+  - expr: "${captured.commission_response} contains '\"user_id\": \"alice\"'"
+    message: "result should echo the submitted user_id"
+  - expr: "${captured.commission_response} contains '\"section\": \"intro\"'"
+    message: "result should include the intro section"
+  - expr: "${captured.commission_response} contains '\"section\": \"analysis\"'"
+    message: "result should include the analysis section"
+  - expr: "${captured.commission_response} contains '\"section\": \"summary\"'"
+    message: "result should include the summary section"
+  - expr: "${captured.commission_response} contains 'Generated content for intro'"
+    message: "result should include the canonical marker for intro"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc02_progress_visible_midflight/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc02_progress_visible_midflight/test.yaml
@@ -1,6 +1,6 @@
 # tc02_progress_visible_midflight — validates the batching tick.
 #
-# Submits a long-enough generate_report job (5 sections * 2s = 10s) and
+# Submits a long-enough generate_report job (7 sections * 2s = 14s) and
 # polls __mesh_job_status mid-flight. The producer's JobController
 # emits update_progress() after each section; those deltas flow to the
 # registry via /jobs/batch on the batching tick. By the time at least
@@ -11,7 +11,7 @@
 #   - first / mid polls show status="working" with progress strictly
 #     between 0 and 1.0 at least once
 #   - final poll shows status="completed" with progress=1.0
-#   - the report has 5 sections in the result
+#   - the report has 7 sections in the result
 
 name: "MeshJob: mid-flight progress visible via __mesh_job_status"
 description: "Submit long job, poll status mid-flight, observe progress advance through working->completed"

--- a/tests/integration/suites/uc21_meshjob/tc02_progress_visible_midflight/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc02_progress_visible_midflight/test.yaml
@@ -1,0 +1,149 @@
+# tc02_progress_visible_midflight — validates the batching tick.
+#
+# Submits a long-enough generate_report job (5 sections * 2s = 10s) and
+# polls __mesh_job_status mid-flight. The producer's JobController
+# emits update_progress() after each section; those deltas flow to the
+# registry via /jobs/batch on the batching tick. By the time at least
+# one mid-flight status read happens during a working interval, we
+# should observe progress > 0 AND status == "working".
+#
+# Asserts (structural, not exact-text):
+#   - first / mid polls show status="working" with progress strictly
+#     between 0 and 1.0 at least once
+#   - final poll shows status="completed" with progress=1.0
+#   - the report has 5 sections in the result
+
+name: "MeshJob: mid-flight progress visible via __mesh_job_status"
+description: "Submit long job, poll status mid-flight, observe progress advance through working->completed"
+tags:
+  - meshjob
+  - python
+  - issue-872
+  - progress
+timeout: 90
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start consumer (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for consumer + DI resolution"
+    handler: wait
+    seconds: 18
+
+  # Submit-only via the consumer so we can poll status independently.
+  - name: "Submit generate_report (7 sections, ~14s) — get job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g"],"max_retries":1,"max_duration":60}' --raw
+    capture: submit_response
+    timeout: 30
+
+  - name: "Extract job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # The MCP envelope wraps structuredContent; pull job_id out via jq.
+      # Both the textual content and structuredContent carry it.
+      RESP='${captured.submit_response}'
+      JOB_ID=$(echo "$RESP" | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      echo "JOB_ID=${JOB_ID}"
+    capture: job_id_extract
+    timeout: 10
+
+  # Poll mid-flight: kick off after a 4s settle (claim + first
+  # iteration), then poll every 2s for 6 ticks. Producer takes
+  # ~14s for 7 sections, so this window straddles working at
+  # ~0.14, 0.28, 0.42, 0.57, 0.71, 0.85.
+  - name: "Poll status 6x mid-flight"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "polling job_id=$JOB_ID"
+      sleep 4
+      for i in 1 2 3 4 5 6; do
+        echo "--- poll $i ---"
+        meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}" --raw 2>&1 || true
+        sleep 2
+      done
+    capture: midflight_polls
+    timeout: 45
+
+  # Wait for terminal then read final state.
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 12
+
+  - name: "Final status read"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}" --raw
+    capture: final_status
+    timeout: 15
+
+assertions:
+  # Submit succeeded
+  - expr: "${captured.submit_response} contains 'job_id'"
+    message: "submit response should carry a job_id"
+
+  # At least one mid-flight poll showed working status
+  - expr: "${captured.midflight_polls} contains '\"working\"'"
+    message: "at least one mid-flight poll should observe status=working"
+
+  # At least one mid-flight poll showed in-progress (> 0, < 1.0). The
+  # textual progress field is a float — we just need some non-zero
+  # decimal that's not exactly 1. Any one of these suffices.
+  - expr: "${captured.midflight_polls} matches '\"progress\":\\s*0\\.[1-9]'"
+    message: "at least one mid-flight poll should observe progress in (0, 1)"
+
+  # Final state must be completed with progress 1.0
+  - expr: "${captured.final_status} contains '\"completed\"'"
+    message: "final status should be completed"
+  - expr: "${captured.final_status} matches '\"progress\":\\s*1(\\.0)?'"
+    message: "final progress should be 1.0"
+
+  # Result includes all 7 sections. ``meshctl call --raw`` outputs the
+  # MCP envelope verbatim — compact JSON, no spaces around colons.
+  - expr: "${captured.final_status} contains 'Generated content for a'"
+    message: "final result should include section a content"
+  - expr: "${captured.final_status} contains 'Generated content for g'"
+    message: "final result should include section g content (7 total)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc03_explicit_complete/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc03_explicit_complete/test.yaml
@@ -1,0 +1,105 @@
+# tc03_explicit_complete — handler explicitly calls job.complete(value).
+#
+# Producer fixture ``report_with_explicit_complete`` always calls
+# ``await job.complete({"explicit": true, "marker": "X", ...})`` —
+# i.e. the runtime's auto-complete path is NOT exercised here, the
+# user's explicit terminal payload must surface verbatim.
+#
+# Asserts:
+#   - status=completed
+#   - structured result includes both ``explicit`` and ``marker`` fields
+
+name: "MeshJob: explicit job.complete() returns the user-supplied payload"
+description: "Producer calls job.complete({...}) with a fixed marker; consumer receives it verbatim"
+tags:
+  - meshjob
+  - python
+  - issue-872
+timeout: 60
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for consumer + DI resolution"
+    handler: wait
+    seconds: 18
+
+  # The consumer doesn't have a dedicated wrapper for
+  # report_with_explicit_complete; submit by direct registry POST so
+  # we exercise the explicit-complete path without needing yet
+  # another consumer capability.
+  - name: "POST /jobs for report_with_explicit_complete"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:8000/jobs \
+        -H 'Content-Type: application/json' \
+        -d '{"capability":"report_with_explicit_complete","submitted_payload":{"user_id":"alice"},"submitted_by":"tc03","max_duration":30,"max_retries":1}'
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Extract job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      echo "JOB_ID=${JOB_ID}"
+    capture: job_id_extract
+
+  # Wait long enough for the producer's claim worker to pull it,
+  # run the ~1s body, and post the explicit complete.
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 12
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
+    capture: final_status
+
+assertions:
+  - expr: "${captured.final_status} contains '\"completed\"'"
+    message: "status should be completed"
+  - expr: "${captured.final_status} contains '\"explicit\": true'"
+    message: "result should include explicit:true marker from job.complete()"
+  - expr: "${captured.final_status} contains '\"marker\": \"X\"'"
+    message: "result should include marker:X from job.complete()"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc03_explicit_complete/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc03_explicit_complete/test.yaml
@@ -15,7 +15,7 @@ tags:
   - meshjob
   - python
   - issue-872
-timeout: 60
+timeout: 120
 
 pre_run:
   - routine: global.setup_for_python_agent

--- a/tests/integration/suites/uc21_meshjob/tc04_implicit_complete_on_return/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc04_implicit_complete_on_return/test.yaml
@@ -1,0 +1,99 @@
+# tc04_implicit_complete_on_return — auto-complete on return path.
+#
+# Producer fixture ``report_with_implicit_complete`` updates progress
+# but NEVER calls ``job.complete()``. The job-dispatch wrapper's
+# auto-complete-on-return path should observe the non-terminal
+# is_terminal() probe and flush the user's return value as the
+# terminal payload.
+#
+# Asserts:
+#   - status=completed (auto-complete fired)
+#   - result.implicit == true (user's return value was used as payload)
+
+name: "MeshJob: handler returns without complete() — auto-complete fires"
+description: "Producer doesn't call job.complete; runtime auto-completes with the return value"
+tags:
+  - meshjob
+  - python
+  - issue-872
+  - auto-complete
+timeout: 60
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for consumer"
+    handler: wait
+    seconds: 18
+
+  - name: "POST /jobs for report_with_implicit_complete"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:8000/jobs \
+        -H 'Content-Type: application/json' \
+        -d '{"capability":"report_with_implicit_complete","submitted_payload":{"user_id":"alice"},"submitted_by":"tc04","max_duration":30,"max_retries":1}'
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Extract job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      echo "JOB_ID=${JOB_ID}"
+    capture: job_id_extract
+
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 12
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
+    capture: final_status
+
+assertions:
+  - expr: "${captured.final_status} contains '\"completed\"'"
+    message: "status should be completed via auto-complete path"
+  - expr: "${captured.final_status} contains '\"implicit\": true'"
+    message: "result should be the user's return value (implicit:true)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc05_explicit_fail_no_retry/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc05_explicit_fail_no_retry/test.yaml
@@ -1,0 +1,98 @@
+# tc05_explicit_fail_no_retry — job.fail() must NOT be retried.
+#
+# Producer fixture ``report_with_explicit_fail`` always calls
+# ``await job.fail("explicit: not retryable")``. We submit it with
+# ``max_retries=3`` — the substrate must distinguish "developer
+# explicitly failed the job" from "agent crashed mid-attempt" and
+# NOT increment attempt_count further past the initial attempt.
+#
+# Asserts:
+#   - status=failed
+#   - error contains the exact reason string the user supplied
+#   - attempt_count == 1 (no retry despite max_retries=3)
+
+name: "MeshJob: explicit job.fail() does not trigger retry"
+description: "Producer calls job.fail('reason'); registry must mark failed and NOT retry"
+tags:
+  - meshjob
+  - python
+  - issue-872
+  - retry
+timeout: 60
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for consumer + DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Submit explicit-fail job with max_retries=3"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_explicit_fail \
+        '{"user_id":"alice","max_retries":3,"wait_timeout_secs":20}'
+    capture: commission_response
+    timeout: 45
+
+  # Even with max_retries=3, an explicit fail() must NOT trigger
+  # additional attempts. Wait long enough that any (incorrect)
+  # retry would have completed (~30s if retries fired) before we
+  # do the final attempt_count read.
+  - name: "Wait for any retries to settle"
+    handler: wait
+    seconds: 15
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.commission_response}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      echo "JOB_ID=${JOB_ID}"
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
+    capture: final_status
+
+assertions:
+  - expr: "${captured.final_status} contains '\"failed\"'"
+    message: "status should be failed"
+  - expr: "${captured.final_status} contains 'explicit: not retryable'"
+    message: "error should preserve the exact reason from job.fail()"
+  - expr: "${captured.final_status} contains '\"attempt_count\": 1'"
+    message: "attempt_count must stay at 1 — explicit fail must NOT retry"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc06_cancel_alive_owner/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc06_cancel_alive_owner/test.yaml
@@ -104,8 +104,13 @@ assertions:
     message: "__mesh_job_cancel should return ok:true"
   - expr: "${captured.final_status} contains '\"cancelled\"'"
     message: "final status should be cancelled (not completed) — task aborted mid-flight"
-  - expr: "${captured.final_status} not contains '\"completed\"'"
-    message: "status must NOT be completed — cancel happened before natural finish"
+  # Belt-and-suspenders: ensure the *status field* didn't reach
+  # "completed". Bare `'"completed"'` would collide with the
+  # `completed_at` timestamp field in the response payload (still
+  # serialised even when the job is cancelled), so we anchor on the
+  # exact status-field shape "\"status\": \"completed\"" instead.
+  - expr: "${captured.final_status} not contains '\"status\": \"completed\"'"
+    message: "status field must NOT be completed — cancel happened before natural finish"
 
 post_run:
   - routine: stop_all

--- a/tests/integration/suites/uc21_meshjob/tc06_cancel_alive_owner/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc06_cancel_alive_owner/test.yaml
@@ -1,0 +1,112 @@
+# tc06_cancel_alive_owner — registry forwards cancel to owner replica.
+#
+# Submits an overlong job (~30s), waits 3s for the producer's claim
+# worker to take ownership, then calls __mesh_job_cancel. The
+# registry's CancelJob handler marks the row cancelled AND
+# best-effort POSTs /jobs/{id}/cancel to the owner — which fires the
+# in-process cancel token, aborting the in-flight task.
+#
+# Asserts:
+#   - cancel returns ok=true with the owner's instance id forwarded
+#   - final status=cancelled (NOT completed) — task aborted before its
+#     30s sleep finished
+#   - elapsed time from submit to cancelled is much less than 30s
+#     (~5s slack: 3s pre-cancel + cancel propagation + status read)
+
+name: "MeshJob: cancel forwards to alive owner and aborts the job"
+description: "Submit overlong job, cancel mid-flight, observe cancelled status without natural completion"
+tags:
+  - meshjob
+  - python
+  - issue-872
+  - cancel
+timeout: 90
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for consumer + DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Submit a 30-second job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_overlong '{"user_id":"alice","seconds":30}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Wait 5s for claim + start"
+    handler: wait
+    seconds: 5
+
+  - name: "Cancel the job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      echo "JOB_ID=${JOB_ID}"
+      meshctl call __mesh_job_cancel "{\"job_id\":\"${JOB_ID}\",\"reason\":\"tc06 client requested abort\"}"
+    capture: cancel_response
+    timeout: 15
+
+  # Allow the cancel-token to propagate, the task to unwind, and the
+  # producer's wrapper to flush the cancellation. A natural 30s
+  # completion would still take ~25s from this point — anything
+  # less than that proves the cancel actually worked.
+  - name: "Wait for cancel to settle"
+    handler: wait
+    seconds: 5
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
+    capture: final_status
+
+assertions:
+  - expr: "${captured.cancel_response} contains '\"ok\": true'"
+    message: "__mesh_job_cancel should return ok:true"
+  - expr: "${captured.final_status} contains '\"cancelled\"'"
+    message: "final status should be cancelled (not completed) — task aborted mid-flight"
+  - expr: "${captured.final_status} not contains '\"completed\"'"
+    message: "status must NOT be completed — cancel happened before natural finish"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc07_cancel_orphan_no_owner/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc07_cancel_orphan_no_owner/test.yaml
@@ -1,0 +1,85 @@
+# tc07_cancel_orphan_no_owner — direct registry cancel for unowned job.
+#
+# Strategy: POST /jobs directly to the registry for a capability that
+# NO running provider hosts (e.g. ``ghost_capability``). With no
+# producer in the mesh that advertises that capability, the
+# registry's claim path will never assign an owner_instance_id —
+# the row stays in ``status=working, owner=NULL`` (the unowned
+# orphan / pre-claim shape).
+#
+# Cancel that job and assert:
+#   - cancel returns 200 with ``forwarded_to_instance_id == null``
+#   - final status=cancelled
+#
+# We deliberately do NOT start any producer for this test — the
+# scenario is about the unowned-pre-claim cancel path, not about
+# racing the claim worker.
+
+name: "MeshJob: cancel for unowned/orphan job (no claim has happened)"
+description: "POST /jobs for a capability nobody hosts; cancel before claim; verify forwarded_to_instance_id is null"
+tags:
+  - meshjob
+  - python
+  - issue-872
+  - cancel
+timeout: 60
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Submit job for a capability nobody hosts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:8000/jobs \
+        -H 'Content-Type: application/json' \
+        -d '{"capability":"ghost_capability","submitted_payload":{"x":1},"submitted_by":"tc07","max_duration":30,"max_retries":0}'
+    capture: submit_resp
+    timeout: 10
+
+  - name: "Confirm the row is owner=NULL"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}"
+    capture: pre_cancel_status
+
+  - name: "Cancel via direct registry POST"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      curl -s -X POST "http://localhost:8000/jobs/${JOB_ID}/cancel" \
+        -H 'Content-Type: application/json' \
+        -d '{"reason":"tc07 unowned cancel"}' \
+        -w "\nHTTP_CODE=%{http_code}"
+    capture: cancel_response
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}"
+    capture: final_status
+
+assertions:
+  - expr: "${captured.pre_cancel_status} contains '\"owner_instance_id\":null'"
+    message: "row should have owner_instance_id=null (no provider for ghost_capability to claim it)"
+  - expr: "${captured.cancel_response} contains 'HTTP_CODE=200'"
+    message: "cancel HTTP should return 200"
+  - expr: "${captured.cancel_response} contains '\"forwarded_to_instance_id\":null'"
+    message: "no owner to forward to — forwarded_to_instance_id must be null"
+  - expr: "${captured.cancel_response} contains '\"status\":\"cancelled\"'"
+    message: "cancel response should report status:cancelled"
+  - expr: "${captured.final_status} contains '\"status\":\"cancelled\"'"
+    message: "final status row should be cancelled"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc08_cancel_already_terminal/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc08_cancel_already_terminal/test.yaml
@@ -1,0 +1,134 @@
+# tc08_cancel_already_terminal — 409 conflict on cancel of terminal job.
+#
+# Submit a fast generate_report job and wait for it to complete.
+# Then attempt to cancel the now-completed job. The registry's
+# CancelJob handler returns HTTP 409 with reason "job is already in
+# a terminal state". The helper-tool wrapper currently raises a
+# RuntimeError with that message; meshctl call surfaces it as an
+# MCP isError envelope.
+#
+# Asserts:
+#   - direct registry POST returns HTTP 409 with the canonical
+#     "already in a terminal state" message
+#   - the helper tool ``__mesh_job_cancel`` surfaces it through MCP
+#     as an isError response containing the same canonical phrase
+
+name: "MeshJob: cancel of already-terminal job returns 409 / structured error"
+description: "Complete a job, then cancel it; both registry HTTP and helper tool must reject as conflict"
+tags:
+  - meshjob
+  - python
+  - issue-872
+  - cancel
+timeout: 90
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for consumer + DI resolution"
+    handler: wait
+    seconds: 18
+
+  # Run a quick 1-section job to completion (~2s) via commission_report.
+  - name: "Run a fast job to completion"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_report '{"user_id":"alice","sections":["only"]}' --raw
+    capture: commission_resp
+    timeout: 30
+
+  # The commission_report consumer waits internally and returns the
+  # final result — by the time we get here, the job IS terminal.
+  # Look up the recently-completed job_id by scanning recent agents.
+  # We can't easily extract the job_id from the result envelope
+  # because commission_report's wait() returns just the structured
+  # complete() payload (no job_id). Submit a *separate* job via
+  # submit-only so we have an explicit handle.
+  - name: "Submit a second job (submit-only) to capture job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only '{"user_id":"alice","sections":["only"],"max_retries":1,"max_duration":30}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Wait for second job to complete (~3s)"
+    handler: wait
+    seconds: 6
+
+  - name: "Confirm it is terminal"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.status'
+    capture: terminal_check
+
+  - name: "Direct registry cancel — expect HTTP 409"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      curl -s -X POST "http://localhost:8000/jobs/${JOB_ID}/cancel" \
+        -H 'Content-Type: application/json' -d '{}' \
+        -w "\nHTTP_CODE=%{http_code}"
+    capture: registry_cancel
+
+  - name: "Helper-tool cancel — expect MCP isError"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      meshctl call __mesh_job_cancel "{\"job_id\":\"${JOB_ID}\"}" 2>&1 || true
+    capture: helper_cancel
+
+assertions:
+  - expr: "${captured.terminal_check} contains 'completed'"
+    message: "second job should have completed before cancel attempt"
+  - expr: "${captured.registry_cancel} contains 'HTTP_CODE=409'"
+    message: "direct registry cancel of completed job must return 409"
+  - expr: "${captured.registry_cancel} contains 'terminal'"
+    message: "registry 409 message should mention terminal state"
+  # The helper tool surfaces conflicts through MCP. Either it
+  # returns isError:true with the conflict reason, or meshctl call
+  # exits non-zero with the error in stderr — accept either.
+  - expr: "${captured.helper_cancel} icontains 'conflict'"
+    message: "helper-tool cancel should surface 409 conflict"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc09_cancel_aborts_outbound_http/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc09_cancel_aborts_outbound_http/test.yaml
@@ -1,0 +1,139 @@
+# tc09_cancel_aborts_outbound_http — cancel propagates through downstream calls.
+#
+# Three-agent chain:
+#   consumer (commission_downstream)
+#     -> producer.report_with_downstream_call (task=True)
+#         -> downstream-sleeper.slow_downstream (sleeps 30s)
+#
+# After submit, wait briefly then cancel. The producer's
+# JobController is bound to the cancel registry; firing the cancel
+# token aborts the in-flight HTTP request to slow_downstream — the
+# sleeper's stderr should show the canonical "sleep CANCELLED"
+# marker, and the job should reach status=cancelled in well under
+# 30s (much less than the natural sleep duration).
+
+name: "MeshJob: cancel aborts in-flight downstream HTTP call"
+description: "Producer calls slow_downstream(30s); cancel must abort the HTTP and finish in <15s"
+tags:
+  - meshjob
+  - python
+  - issue-872
+  - cancel
+  - propagation
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+      cp -rL /uc-artifacts/downstream-sleeper /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - name: "Install sleeper deps"
+    handler: pip-install
+    path: /workspace/downstream-sleeper
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start downstream-sleeper (port 9102) FIRST"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start downstream-sleeper/main.py --env MCP_MESH_HTTP_PORT=9102 -d
+
+  - name: "Wait for sleeper"
+    handler: wait
+    seconds: 12
+
+  - name: "Start provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider DI to resolve slow_downstream"
+    handler: wait
+    seconds: 18
+
+  - name: "Start consumer (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for consumer DI"
+    handler: wait
+    seconds: 18
+
+  - name: "Submit job that calls downstream"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_downstream '{"user_id":"alice"}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Wait 4s — let producer pick up + start downstream call"
+    handler: wait
+    seconds: 4
+
+  - name: "Cancel the job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      echo "JOB_ID=${JOB_ID}"
+      START=$(date +%s)
+      meshctl call __mesh_job_cancel "{\"job_id\":\"${JOB_ID}\"}"
+      echo "CANCEL_AT=${START}"
+    capture: cancel_response
+    timeout: 15
+
+  # Should propagate within a few seconds — definitely well below
+  # the 30s sleep that's still running on the sleeper.
+  - name: "Wait for cancel to propagate"
+    handler: wait
+    seconds: 8
+
+  - name: "Read final status + sleeper log"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      echo "=== final status ==="
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
+      echo
+      echo "=== downstream-sleeper log tail ==="
+      meshctl logs downstream-sleeper 2>&1 | tail -30
+    capture: final_check
+
+assertions:
+  - expr: "${captured.cancel_response} contains '\"ok\": true'"
+    message: "cancel should ack ok:true"
+  - expr: "${captured.final_check} contains '\"cancelled\"'"
+    message: "job status should be cancelled"
+  # The progress at cancel time should still reflect the producer
+  # being mid-downstream-call (progress=0.1, message="calling
+  # downstream"). If the cancel had not propagated through the
+  # downstream call, the producer would have continued past
+  # update_progress(0.1, "calling downstream") and either reached
+  # job.complete() or hung — neither of which leaves the row
+  # cancelled with that exact mid-call progress.
+  - expr: "${captured.final_check} contains 'calling downstream'"
+    message: "cancel should land while producer is still in the downstream call (progress message frozen at 'calling downstream')"
+  - expr: "${captured.final_check} not contains '\"completed\"'"
+    message: "the producer should NOT have reached job.complete() — the downstream HTTP must have been aborted, not awaited to natural finish"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc09_cancel_aborts_outbound_http/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc09_cancel_aborts_outbound_http/test.yaml
@@ -133,6 +133,16 @@ assertions:
     message: "cancel should land while producer is still in the downstream call (progress message frozen at 'calling downstream')"
   - expr: "${captured.final_check} not contains '\"completed\"'"
     message: "the producer should NOT have reached job.complete() — the downstream HTTP must have been aborted, not awaited to natural finish"
+  # NOTE on the downstream `sleep CANCELLED` marker: the fixture
+  # writes that line from its asyncio.CancelledError handler, but
+  # FastMCP does not currently propagate client disconnects as task
+  # cancellations to the tool handler — so the sleeper keeps running
+  # past the producer-side cancel and the marker never lands. The
+  # producer-side correctness is still proven by:
+  #   - status == cancelled (above)
+  #   - progress message frozen at "calling downstream" (above)
+  #   - status != completed (above)
+  # Tracking the downstream-side propagation gap as a separate issue.
 
 post_run:
   - routine: stop_all

--- a/tests/integration/suites/uc21_meshjob/tc10_crash_recovery_max_retries_1/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc10_crash_recovery_max_retries_1/test.yaml
@@ -1,0 +1,157 @@
+# tc10_crash_recovery_max_retries_1 — default crash-recovery (1 retry).
+#
+# Submits a 14s job (7 sections * 2s) to a single provider+consumer
+# pair, kills the provider mid-flight, then waits for the registry
+# sweep (MCP_MESH_SWEEP_INTERVAL=10s) to detect the orphan and
+# re-claim the row to a NEW provider replica we start afterward.
+#
+# With max_retries=1 (the registry default — 1 retry on top of the
+# initial attempt), the orphan path resets owner=NULL/lease=NULL on
+# the row and the next claim picks it up. attempt_count becomes 2
+# (initial + 1 retry).
+#
+# Asserts:
+#   - final status=completed
+#   - attempt_count == 2 (initial attempt + 1 retry after crash)
+
+name: "MeshJob: crash recovery with default max_retries=1 — orphan reclaim"
+description: "Submit, kill provider, wait for sweep, start new provider, observe completion via retry"
+tags:
+  - meshjob
+  - python
+  - issue-872
+  - retry
+  - crash-recovery
+  - slow
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for consumer + DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Submit job (7 sections, max_retries=1)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g"],"max_retries":1,"max_duration":60}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Wait 4s for the producer to claim + start"
+    handler: wait
+    seconds: 4
+
+  - name: "Kill the provider mid-flight (SIGKILL — no graceful cleanup)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      MY_PID=$$
+      MY_PPID=$PPID
+      PID=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        case "$cmd" in
+          *python*long-task-provider/main.py*) PID="$pid"; break ;;
+        esac
+      done
+      [ -n "$PID" ] && kill -9 "$PID" && echo "killed PID=$PID" || echo "WARN: provider PID not found"
+    capture: kill_output
+
+  # End-to-end timeline after SIGKILL:
+  #   ~15s — health-monitor flips agent status to unhealthy
+  #   +10s — retention window before purge
+  #   +10s — next sweep tick that purges the agent + resets orphan
+  - name: "Wait for sweep to orphan the job (~35s end-to-end)"
+    handler: wait
+    seconds: 45
+
+  - name: "Confirm orphan is back in claimable state"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,owner_instance_id,attempt_count,error}'
+    capture: orphaned_check
+
+  - name: "Stale PID cleanup — meshctl still tracks the killed PID"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # SIGKILL leaves no chance for meshctl's process tracking to
+      # observe the exit; clear the stale entry before respawning.
+      meshctl stop long-task-provider 2>&1 || true
+      # Defensive: remove the per-agent pid + group files if they
+      # remain. Path layout follows lifecycle/layout.go.
+      rm -f ~/.mcp-mesh/agents/long-task-provider/* 2>/dev/null || true
+      echo "stale entry cleared"
+
+  - name: "Start a fresh provider — same capability, new instance_id"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for fresh provider to register + claim + run"
+    handler: wait
+    seconds: 30
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,attempt_count,progress,error}'
+    capture: final_status
+
+assertions:
+  - expr: "${captured.orphaned_check} contains '\"owner_instance_id\": null'"
+    message: "after sweep, owner should be cleared (orphan re-claim path)"
+  - expr: "${captured.final_status} contains '\"status\": \"completed\"'"
+    message: "fresh provider should have completed the retried job"
+  - expr: "${captured.final_status} contains '\"attempt_count\": 2'"
+    message: "attempt_count should be 2 (initial + 1 retry)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc11_max_retries_0_disables_retry/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc11_max_retries_0_disables_retry/test.yaml
@@ -1,0 +1,145 @@
+# tc11_max_retries_0_disables_retry — single attempt, no retry on crash.
+#
+# With max_retries=0, the orphan path's check
+# ``if attempt_count > max_retries`` becomes ``1 > 0`` after the
+# crash → registry marks status=failed with the canonical
+# "orphaned: max retries exceeded" reason instead of resetting the
+# owner for re-claim.
+#
+# Asserts:
+#   - final status=failed
+#   - error contains "orphaned" (and "max retries exceeded")
+#   - attempt_count == 1 (just the failed initial attempt)
+
+name: "MeshJob: max_retries=0 disables retry — orphan goes straight to failed"
+description: "Kill provider mid-flight; with max_retries=0 the sweep marks failed instead of re-claiming"
+tags:
+  - meshjob
+  - python
+  - issue-872
+  - retry
+  - crash-recovery
+  - slow
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for consumer DI"
+    handler: wait
+    seconds: 18
+
+  - name: "Submit job with max_retries=0"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g"],"max_retries":0,"max_duration":60}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Wait 4s for the producer to claim + start"
+    handler: wait
+    seconds: 4
+
+  - name: "Kill the provider mid-flight (SIGKILL — no graceful cleanup)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # /proc walk: pkill is unavailable in the slim runtime image.
+      # SIGKILL means the producer never gets to post ctrl.fail(),
+      # so the row stays working+owned until the sweep observes the
+      # missed heartbeats and the agent is purged.
+      #
+      # IMPORTANT: skip our own PID (and PPID) — the bash command
+      # below contains the literal path "long-task-provider/main.py"
+      # in its argv, so a naive grep matches the shell that is
+      # running the search. Killing ourselves returns a -1 exit
+      # code instead of locating the actual python child.
+      MY_PID=$$
+      MY_PPID=$PPID
+      PID=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        # Match only the python process, not the bash that's running
+        # this loop. The python child's cmdline starts with
+        # /workspace/.venv/bin/python or python.
+        case "$cmd" in
+          *python*long-task-provider/main.py*)
+            PID="$pid"
+            break
+            ;;
+        esac
+      done
+      if [ -n "$PID" ]; then
+        echo "Killing provider PID: $PID"
+        kill -9 "$PID"
+        echo "provider killed"
+      else
+        echo "WARN: provider PID not found"
+      fi
+    capture: kill_output
+
+  - name: "Wait for health-monitor flip + sweep to mark failed (~35s end-to-end)"
+    handler: wait
+    seconds: 45
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,attempt_count,error,owner_instance_id}'
+    capture: final_status
+
+assertions:
+  - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
+    message: "max_retries=0 should mark failed after crash (no re-claim)"
+  - expr: "${captured.final_status} contains 'orphaned'"
+    message: "error should mention 'orphaned'"
+  - expr: "${captured.final_status} contains 'max retries exceeded'"
+    message: "error should mention 'max retries exceeded'"
+  - expr: "${captured.final_status} contains '\"attempt_count\": 1'"
+    message: "only one attempt counted — no retry"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc12_max_retries_exhausted_marks_failed/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc12_max_retries_exhausted_marks_failed/test.yaml
@@ -1,0 +1,184 @@
+# tc12_max_retries_exhausted_marks_failed — exhaust retry budget.
+#
+# Note on the spec wording vs substrate behaviour: the design says
+# "agent crashes" trigger retry (via stale-agent sweep + orphan
+# reroute). Handler-raised exceptions, however, are caught by the
+# claim dispatcher and reported as ``ctrl.fail(str(e))`` — the
+# explicit-fail path that does NOT retry (see tc05). So a "producer
+# that always crashes (raises)" wouldn't actually consume the retry
+# budget; the registry would mark the job failed on the first
+# attempt regardless of max_retries.
+#
+# To exhaust the budget, we must orphan the row by killing the
+# AGENT PROCESS (mimicking a crash that loses the
+# claim_dispatcher's chance to post ctrl.fail). Two SIGKILL cycles
+# with max_retries=1 leaves attempt_count=2, max_retries=1 → the
+# orphan-reset path's check ``attempt_count > max_retries`` (2 > 1)
+# trips and the row is marked failed with the "orphaned: max
+# retries exceeded" reason.
+
+name: "MeshJob: retry budget exhausted via repeated crashes — marked failed"
+description: "Two crash + sweep cycles with max_retries=1; final attempt_count=2 > max_retries → exhausted"
+tags:
+  - meshjob
+  - python
+  - issue-872
+  - retry
+  - crash-recovery
+  - slow
+timeout: 240
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (round 1)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for consumer DI"
+    handler: wait
+    seconds: 18
+
+  - name: "Submit job with max_retries=1"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g","h","i"],"max_retries":1,"max_duration":60}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Wait 4s for claim"
+    handler: wait
+    seconds: 4
+
+  - name: "Kill provider — round 1 (attempt 1 crashes)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      MY_PID=$$
+      MY_PPID=$PPID
+      PID=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        case "$cmd" in
+          *python*long-task-provider/main.py*) PID="$pid"; break ;;
+        esac
+      done
+      [ -n "$PID" ] && kill -9 "$PID" && echo "killed PID=$PID" || echo "no provider PID found"
+      echo "round 1 kill done"
+    capture: kill1
+
+  - name: "Wait for sweep to reset orphan (~35s end-to-end)"
+    handler: wait
+    seconds: 45
+
+  - name: "Status after round 1 (should be working, owner=null)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,owner_instance_id,attempt_count}'
+    capture: after_round_1
+
+  - name: "Stale PID cleanup before round 2 (SIGKILL leaves stale tracking)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop long-task-provider 2>&1 || true
+      rm -f ~/.mcp-mesh/agents/long-task-provider/* 2>/dev/null || true
+      echo "stale entry cleared"
+
+  - name: "Start provider (round 2)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for round 2 claim"
+    handler: wait
+    seconds: 14
+
+  - name: "Kill provider — round 2 (attempt 2 crashes)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      MY_PID=$$
+      MY_PPID=$PPID
+      PID=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        case "$cmd" in
+          *python*long-task-provider/main.py*) PID="$pid"; break ;;
+        esac
+      done
+      [ -n "$PID" ] && kill -9 "$PID" && echo "killed PID=$PID" || echo "no provider PID found"
+      echo "round 2 kill done"
+    capture: kill2
+
+  - name: "Wait for sweep to mark exhausted (~35s end-to-end)"
+    handler: wait
+    seconds: 45
+
+  - name: "Final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,owner_instance_id,attempt_count,error}'
+    capture: final_status
+
+assertions:
+  # After round 1: orphan reset to claimable
+  - expr: "${captured.after_round_1} contains '\"status\": \"working\"'"
+    message: "after round 1 sweep, status should still be working (orphan reset)"
+  - expr: "${captured.after_round_1} contains '\"owner_instance_id\": null'"
+    message: "after round 1 sweep, owner should be cleared"
+  # After round 2: budget exhausted
+  - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
+    message: "after round 2 sweep with attempt_count > max_retries, must be failed"
+  - expr: "${captured.final_status} contains 'max retries exceeded'"
+    message: "error should mention max retries exceeded"
+  - expr: "${captured.final_status} contains '\"attempt_count\": 2'"
+    message: "attempt_count should be 2 (1 initial + 1 retry attempt) — budget exceeded"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc13_total_deadline_expires/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc13_total_deadline_expires/test.yaml
@@ -1,0 +1,143 @@
+# tc13_total_deadline_expires — total_deadline overrides retry budget.
+#
+# Submits a job with ``total_deadline=now+5s`` and a generous
+# max_retries=10. The producer is killed mid-flight to make the
+# row eligible for the orphan path. By the time the sweep tick
+# (10s with our override) fires, total_deadline has already passed
+# — so ExpireDeadlinedJobs marks the row failed with reason
+# "deadline_exceeded" BEFORE the orphan-reset path can put it back
+# in the claim pool.
+#
+# Asserts:
+#   - status=failed
+#   - error == "deadline_exceeded" (the canonical reason)
+#   - attempt_count == 1 (NOT incremented further regardless of
+#     max_retries=10)
+
+name: "MeshJob: total_deadline expiry overrides retry budget"
+description: "deadline=now+5s with max_retries=10; deadline-sweep marks failed before any retry"
+tags:
+  - meshjob
+  - python
+  - issue-872
+  - retry
+  - deadline
+  - slow
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for consumer DI"
+    handler: wait
+    seconds: 18
+
+  # commission_with_options propagates total_deadline_secs (relative)
+  # → datetime in UTC for the submitter.
+  - name: "Submit with total_deadline=now+5s, max_retries=10"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_with_options \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g"],"max_retries":10,"total_deadline_secs":5,"wait_timeout_secs":2}'
+    capture: submit_resp
+    timeout: 30
+
+  # Get the job_id from the structured envelope. commission_with_options
+  # returns {job_id, status, ...} on either success OR wait_raised.
+  - name: "Capture job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1 | xargs -I{} echo "JOB_ID={}"
+    capture: job_id_extract
+
+  - name: "Kill provider — make the row a candidate for orphan/deadline sweep"
+    handler: shell
+    workdir: /workspace
+    command: |
+      MY_PID=$$
+      MY_PPID=$PPID
+      PID=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        case "$cmd" in
+          *python*long-task-provider/main.py*) PID="$pid"; break ;;
+        esac
+      done
+      [ -n "$PID" ] && kill -9 "$PID" && echo "killed PID=$PID" || echo "no provider PID found"
+      echo "kill done"
+
+  # Deadline path doesn't depend on health-monitor + retention — the
+  # ExpireDeadlinedJobs pass runs on every sweep tick (~10s). With
+  # total_deadline=now+5s and the first sweep tick after submit, the
+  # row is marked failed within ~10-15s. The longer wait here is
+  # belt-and-braces.
+  - name: "Wait for deadline sweep"
+    handler: wait
+    seconds: 25
+
+  - name: "Final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,attempt_count,error,total_deadline,owner_instance_id}'
+    capture: final_status
+
+assertions:
+  - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
+    message: "deadline-expired job must be marked failed"
+  - expr: "${captured.final_status} contains 'deadline_exceeded'"
+    message: "error must be the canonical 'deadline_exceeded' reason — NOT 'orphaned'"
+  - expr: "${captured.final_status} not contains 'orphaned'"
+    message: "deadline path must take precedence over orphan-reset; error must NOT mention 'orphaned'"
+  # The deadline can fire before the producer claims (attempt_count=0)
+  # or during the in-flight first attempt (attempt_count=1). What
+  # MUST NOT happen is the substrate iterating to attempt_count=10
+  # despite max_retries=10 — total_deadline has to short-circuit
+  # the retry path. We assert attempt_count <= 1 below.
+  - expr: "${captured.final_status} matches '\"attempt_count\":\\s*[01]\\b'"
+    message: "attempt_count must be 0 or 1 — deadline overrides max_retries=10"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc14_helpers_on_every_agent/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc14_helpers_on_every_agent/test.yaml
@@ -1,0 +1,151 @@
+# tc14_helpers_on_every_agent — auto-registration is universal.
+#
+# Three agents: producer (task=True only), consumer (deps + submit
+# wrapper), and orchestrator (no task tools, no MeshJob deps —
+# pure bystander). All three should advertise __mesh_job_status,
+# __mesh_job_result, and __mesh_job_cancel via the registry.
+#
+# Submit a job through the consumer, capture job_id, then call all
+# three helpers on EACH of the three agents and confirm the same
+# job state is returned regardless of which agent fields the call.
+
+name: "MeshJob: helper tools auto-registered on every mesh agent"
+description: "Producer, consumer, and bystander all expose __mesh_job_* and return correct data"
+tags:
+  - meshjob
+  - python
+  - issue-872
+  - helpers
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+      cp -rL /uc-artifacts/orchestrator-agent /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - name: "Install orchestrator deps"
+    handler: pip-install
+    path: /workspace/orchestrator-agent
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Start orchestrator (no task tools, no deps)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start orchestrator-agent/main.py --env MCP_MESH_HTTP_PORT=9103 -d
+
+  - name: "Wait for all 3 to register"
+    handler: wait
+    seconds: 22
+
+  - name: "Capture full agent IDs"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl list 2>&1
+      echo "---"
+      curl -s http://localhost:8000/agents | jq -r '.agents[].id'
+    capture: agent_ids
+
+  - name: "Submit a job via consumer (commission_report on a 1-section job)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["only"],"max_retries":1,"max_duration":30}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  # Wait long enough for the job to complete so __mesh_job_result
+  # can return the terminal payload.
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 8
+
+  - name: "Call __mesh_job_status on PROVIDER"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider") | .id')
+      echo "JOB_ID=${JOB_ID} AGENT=${AGENT}"
+      meshctl call "${AGENT}:__mesh_job_status" "{\"job_id\":\"${JOB_ID}\"}"
+    capture: status_on_provider
+
+  - name: "Call __mesh_job_result on CONSUMER"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-consumer") | .id')
+      meshctl call "${AGENT}:__mesh_job_result" "{\"job_id\":\"${JOB_ID}\"}"
+    capture: result_on_consumer
+
+  - name: "Call __mesh_job_status on ORCHESTRATOR (bystander)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="orchestrator-agent") | .id')
+      meshctl call "${AGENT}:__mesh_job_status" "{\"job_id\":\"${JOB_ID}\"}"
+    capture: status_on_orchestrator
+
+  - name: "Confirm cancel-tool exists on orchestrator (no-op against terminal)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="orchestrator-agent") | .id')
+      # Check the orchestrator's tools list contains the helpers via meshctl list --tools
+      meshctl list --tools 2>&1 | grep -E "orchestrator|__mesh_job_" | head -10
+    capture: orchestrator_tools
+
+assertions:
+  - expr: "${captured.agent_ids} contains 'long-task-provider'"
+    message: "provider should be registered"
+  - expr: "${captured.agent_ids} contains 'long-task-consumer'"
+    message: "consumer should be registered"
+  - expr: "${captured.agent_ids} contains 'orchestrator-agent'"
+    message: "orchestrator (bystander) should be registered"
+  - expr: "${captured.status_on_provider} contains '\"completed\"'"
+    message: "__mesh_job_status on provider should return the same completed state"
+  - expr: "${captured.result_on_consumer} contains 'completed'"
+    message: "__mesh_job_result on consumer should return terminal status=completed"
+  - expr: "${captured.status_on_orchestrator} contains '\"completed\"'"
+    message: "__mesh_job_status on bystander orchestrator should also return completed"
+  # Cross-agent helper symmetry — same job_id returns same data regardless
+  # of which agent serves it (proves "all reads → registry, no caching").
+  - expr: "${captured.status_on_orchestrator} contains 'long-task-provider'"
+    message: "bystander's status read should include the producer's owner_instance_id (registry-sourced)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc14_helpers_on_every_agent/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc14_helpers_on_every_agent/test.yaml
@@ -123,9 +123,16 @@ test:
     handler: shell
     workdir: /workspace
     command: |
-      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="orchestrator-agent") | .id')
-      # Check the orchestrator's tools list contains the helpers via meshctl list --tools
-      meshctl list --tools 2>&1 | grep -E "orchestrator|__mesh_job_" | head -10
+      # Scope strictly to the orchestrator agent's own capabilities via
+      # the registry API. ``meshctl list --tools`` (no positional) returns
+      # tools from ALL agents and the table layout has no agent-scoped
+      # filter flag, so an unfiltered grep + ``head -10`` could pick up a
+      # match from the producer or consumer (both also auto-register the
+      # __mesh_job_* helpers) and silently mask a missing registration on
+      # the orchestrator. Filtering on the agent record's capabilities
+      # array is deterministic.
+      curl -s http://localhost:8000/agents \
+        | jq -r '.agents[] | select(.name=="orchestrator-agent") | .capabilities[].function_name'
     capture: orchestrator_tools
 
 assertions:

--- a/tests/integration/suites/uc21_meshjob/tc14_helpers_on_every_agent/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc14_helpers_on_every_agent/test.yaml
@@ -146,6 +146,17 @@ assertions:
   - expr: "${captured.status_on_orchestrator} contains 'long-task-provider'"
     message: "bystander's status read should include the producer's owner_instance_id (registry-sourced)"
 
+  # Auto-registration check: even the bystander orchestrator (no task
+  # tools, no MeshJob deps) advertises all three __mesh_job_* helpers.
+  # This is the test's headline claim ("helpers on EVERY agent") — the
+  # capture above (`orchestrator_tools`) was previously dead.
+  - expr: "${captured.orchestrator_tools} contains '__mesh_job_status'"
+    message: "orchestrator (bystander) must auto-register __mesh_job_status"
+  - expr: "${captured.orchestrator_tools} contains '__mesh_job_result'"
+    message: "orchestrator (bystander) must auto-register __mesh_job_result"
+  - expr: "${captured.orchestrator_tools} contains '__mesh_job_cancel'"
+    message: "orchestrator (bystander) must auto-register __mesh_job_cancel"
+
 post_run:
   - routine: stop_all
   - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc15_status_for_unknown_id/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc15_status_for_unknown_id/test.yaml
@@ -81,8 +81,17 @@ assertions:
     message: "must NOT mention 'unauthorized' — auth model is job_id-as-capability"
   - expr: "${captured.helper_response} not contains 'permission denied'"
     message: "must NOT mention 'permission denied' — auth model is job_id-as-capability"
-  - expr: "${captured.helper_response} not contains 'HTTP 500'"
-    message: "must NOT surface as a 500 — registry returns 404 cleanly"
+  # The error must be the structured NotFound shape (404 round-trip
+  # surfaces as `RuntimeError("backend error: job not found: <id>")`).
+  # If the registry hit a real 500 instead, the message would carry the
+  # `BackendError::Server` rendering "server error (HTTP 500)" — that
+  # exact phrase is the canonical 500-shaped error and MUST be absent.
+  - expr: "${captured.helper_response} contains 'backend error'"
+    message: "must surface as the structured BackendError envelope (proves the 404 round-trip, not a transport-level failure)"
+  - expr: "${captured.helper_response} not contains 'server error (HTTP 5'"
+    message: "must NOT surface as a 5xx server error — registry returns a clean 404 NotFound"
+  - expr: "${captured.helper_response} not contains '500 Internal Server Error'"
+    message: "must NOT carry a literal HTTP 500 status line — the registry path is 404, not 500"
 
 post_run:
   - routine: stop_all

--- a/tests/integration/suites/uc21_meshjob/tc15_status_for_unknown_id/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc15_status_for_unknown_id/test.yaml
@@ -1,0 +1,89 @@
+# tc15_status_for_unknown_id — bogus ID returns structured "not found".
+#
+# Calls __mesh_job_status with a UUID that's not in the registry.
+# The registry's GetJob handler returns HTTP 404 with
+# "job not found: <id>". The Rust JobProxy.status() turns that
+# into a JobError::NotFound which the helper-tool wrapper raises as
+# RuntimeError → meshctl call surfaces as MCP isError envelope.
+#
+# Asserts (per task spec — structural, NOT auth-flavoured):
+#   - response is an MCP error (isError:true) OR meshctl call exit
+#     code != 0 with "not found" in stderr
+#   - the message contains "not found" (case-insensitive)
+#   - the message MUST NOT contain "unauthorized" / "permission denied"
+#     — the auth model is presigned-URL semantics, not gating
+
+name: "MeshJob: __mesh_job_status with unknown job_id returns structured not-found"
+description: "Bogus UUID returns NotFound-shaped error (not a 500, not an auth error)"
+tags:
+  - meshjob
+  - python
+  - issue-872
+  - helpers
+  - errors
+timeout: 60
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/orchestrator-agent /workspace/
+
+  - name: "Install agent deps"
+    handler: pip-install
+    path: /workspace/orchestrator-agent
+
+  - routine: start_registry_with_fast_sweep
+
+  # Just one bystander agent — enough to expose the helper tools.
+  - name: "Start orchestrator agent"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start orchestrator-agent/main.py --env MCP_MESH_HTTP_PORT=9103 -d
+
+  - name: "Wait for registration"
+    handler: wait
+    seconds: 14
+
+  - name: "Direct registry GET — confirm 404 shape"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -w "\nHTTP_CODE=%{http_code}" \
+        "http://localhost:8000/jobs/00000000-0000-0000-0000-000000000000"
+    capture: registry_404
+
+  - name: "Helper tool with bogus job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call __mesh_job_status \
+        '{"job_id":"00000000-0000-0000-0000-000000000000"}' 2>&1 || true
+    capture: helper_response
+
+assertions:
+  - expr: "${captured.registry_404} contains 'HTTP_CODE=404'"
+    message: "registry GET /jobs/<bogus-id> should return HTTP 404"
+  - expr: "${captured.registry_404} icontains 'job not found'"
+    message: "registry 404 body should say 'job not found'"
+  # Helper tool surfaces NotFound through MCP. meshctl call may
+  # exit non-zero with stderr (when the wrapper raises) or
+  # return an isError envelope. Either way, "not found" must
+  # appear in the visible output.
+  - expr: "${captured.helper_response} icontains 'not found'"
+    message: "helper-tool error should mention 'not found'"
+  # Auth-model assertions: presigned-URL semantics → NOT gated.
+  - expr: "${captured.helper_response} not contains 'unauthorized'"
+    message: "must NOT mention 'unauthorized' — auth model is job_id-as-capability"
+  - expr: "${captured.helper_response} not contains 'permission denied'"
+    message: "must NOT mention 'permission denied' — auth model is job_id-as-capability"
+  - expr: "${captured.helper_response} not contains 'HTTP 500'"
+    message: "must NOT surface as a 500 — registry returns 404 cleanly"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc16_third_party_can_read_status/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc16_third_party_can_read_status/test.yaml
@@ -2,8 +2,11 @@
 #
 # Four agents: producer, consumer (submits the job), and two
 # bystanders X and Y that have no involvement with the job. The
-# bystanders are deployed with overridden MCP_MESH_AGENT_NAME so the
-# same fixture serves both — distinct agent IDs in the registry.
+# bystanders are two distinct fixtures (``bystander-x/main.py`` and
+# ``bystander-y/main.py``) deployed on separate ports — each has its
+# own ``@mesh.agent`` declaration with a unique name so the registry
+# sees two genuinely independent agents (no shared MCP_MESH_AGENT_NAME
+# override trickery).
 #
 # Submit a job via the consumer; capture job_id. Then call
 # __mesh_job_status on each bystander targeting that job_id.

--- a/tests/integration/suites/uc21_meshjob/tc16_third_party_can_read_status/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc16_third_party_can_read_status/test.yaml
@@ -1,0 +1,155 @@
+# tc16_third_party_can_read_status — job_id-as-capability auth model.
+#
+# Four agents: producer, consumer (submits the job), and two
+# bystanders X and Y that have no involvement with the job. The
+# bystanders are deployed with overridden MCP_MESH_AGENT_NAME so the
+# same fixture serves both — distinct agent IDs in the registry.
+#
+# Submit a job via the consumer; capture job_id. Then call
+# __mesh_job_status on each bystander targeting that job_id.
+# The substrate's "presigned-URL semantics" mandates: possession of
+# the UUID = read access. Both bystanders MUST return the actual
+# job state, NOT an authorization error.
+
+name: "MeshJob: third-party agents can read status by job_id (presigned-URL auth)"
+description: "Two unrelated bystanders read job status — no auth gating, only ID-as-capability"
+tags:
+  - meshjob
+  - python
+  - issue-872
+  - helpers
+  - auth
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+      cp -rL /uc-artifacts/bystander-x /workspace/
+      cp -rL /uc-artifacts/bystander-y /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - name: "Install bystander-x deps"
+    handler: pip-install
+    path: /workspace/bystander-x
+
+  - name: "Install bystander-y deps"
+    handler: pip-install
+    path: /workspace/bystander-y
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Start bystander X"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start bystander-x/main.py --env MCP_MESH_HTTP_PORT=9104 -d
+
+  - name: "Start bystander Y"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start bystander-y/main.py --env MCP_MESH_HTTP_PORT=9105 -d
+
+  - name: "Wait for all 4 to register + DI to settle"
+    handler: wait
+    seconds: 25
+
+  - name: "Confirm all 4 agents in registry"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s http://localhost:8000/agents | jq -r '.agents[].name' | sort
+    capture: agent_names
+
+  - name: "Submit job via consumer"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["one","two"],"max_retries":1,"max_duration":30}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 8
+
+  - name: "Bystander X reads status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="bystander-x") | .id')
+      echo "AGENT=${AGENT} JOB=${JOB_ID}"
+      meshctl call "${AGENT}:__mesh_job_status" "{\"job_id\":\"${JOB_ID}\"}"
+    capture: bystander_x_status
+
+  - name: "Bystander Y reads status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="bystander-y") | .id')
+      meshctl call "${AGENT}:__mesh_job_status" "{\"job_id\":\"${JOB_ID}\"}"
+    capture: bystander_y_status
+
+assertions:
+  - expr: "${captured.agent_names} contains 'long-task-provider'"
+    message: "provider should be registered"
+  - expr: "${captured.agent_names} contains 'long-task-consumer'"
+    message: "consumer should be registered"
+  - expr: "${captured.agent_names} contains 'bystander-x'"
+    message: "bystander-x should be registered"
+  - expr: "${captured.agent_names} contains 'bystander-y'"
+    message: "bystander-y should be registered"
+
+  # Both bystanders return the real status — NOT an auth error.
+  - expr: "${captured.bystander_x_status} contains '\"completed\"'"
+    message: "bystander-x should read the actual completed status (no auth gating)"
+  - expr: "${captured.bystander_y_status} contains '\"completed\"'"
+    message: "bystander-y should read the actual completed status (no auth gating)"
+
+  # Both responses must reference the producer's owner_instance_id —
+  # confirms the data flow: bystander → its helper-tool wrapper →
+  # registry GET /jobs/{id} → identical row data regardless of
+  # which agent fields the read.
+  - expr: "${captured.bystander_x_status} contains 'long-task-provider'"
+    message: "bystander-x's read should include the producer owner_instance_id"
+  - expr: "${captured.bystander_y_status} contains 'long-task-provider'"
+    message: "bystander-y's read should include the producer owner_instance_id"
+
+  # Make sure neither bystander returned an auth-flavoured error.
+  - expr: "${captured.bystander_x_status} not contains 'unauthorized'"
+    message: "bystander-x must NOT see 'unauthorized'"
+  - expr: "${captured.bystander_y_status} not contains 'permission denied'"
+    message: "bystander-y must NOT see 'permission denied'"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc16_third_party_can_read_status/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc16_third_party_can_read_status/test.yaml
@@ -144,9 +144,16 @@ assertions:
   - expr: "${captured.bystander_y_status} contains 'long-task-provider'"
     message: "bystander-y's read should include the producer owner_instance_id"
 
-  # Make sure neither bystander returned an auth-flavoured error.
+  # Make sure neither bystander returned an auth-flavoured error —
+  # check both phrases for both bystanders (was previously asymmetric:
+  # bystander-x only checked 'unauthorized', bystander-y only checked
+  # 'permission denied', so each missed half the auth-error surface).
   - expr: "${captured.bystander_x_status} not contains 'unauthorized'"
     message: "bystander-x must NOT see 'unauthorized'"
+  - expr: "${captured.bystander_x_status} not contains 'permission denied'"
+    message: "bystander-x must NOT see 'permission denied'"
+  - expr: "${captured.bystander_y_status} not contains 'unauthorized'"
+    message: "bystander-y must NOT see 'unauthorized'"
   - expr: "${captured.bystander_y_status} not contains 'permission denied'"
     message: "bystander-y must NOT see 'permission denied'"
 


### PR DESCRIPTION
Closes #872. Phase 1 integration coverage for the MeshJob substrate landed in PR #878. Plus a small Go change adding ` MCP_MESH_SWEEP_INTERVAL` env var so sweep-driven tests resolve in seconds instead of minutes.

## Summary

**Test suite (16 tests, all passing at ` --parallel 1/4/8`)** — ` tests/integration/suites/uc21_meshjob/`:

- **A. Happy path (5)** — submit/wait, mid-flight progress visibility, explicit complete, implicit complete on return, explicit fail (no retry, attempt_count NOT incremented)
- **B. Cancellation (4)** — alive-owner forward, orphan direct, already-terminal 409, cancel-token aborts in-flight downstream HTTP
- **C. Retry & recovery (4)** — default ` max_retries=1` succeeds, ` max_retries=0` disables, exhaustion → failed, ` total_deadline` overrides budget
- **F. Helper tools & auth (3)** — helpers on every agent, unknown ID = "not found", third-party can read with valid ID (presigned-URL semantics)

**Sweep interval env var** — ` src/core/registry/sweep.go`:

- ` MCP_MESH_SWEEP_INTERVAL=10s` (Go duration format) overrides hardcoded 5min default
- Default unchanged when unset
- Logs override application; warns + falls back to default on malformed value
- Unit test covers all three branches

## Review Notes

Independent code review (=review-agent=) found 0 BLOCKERs, 3 WARNINGs, 7 INFOs. All 3 WARNINGs and 4 substantive INFOs addressed in commit ` e684e6a8`:

- =routines.yaml=: now hard-fails if ` MCP_MESH_SWEEP_INTERVAL` override doesn't take effect (was silently swallowing grep failure with ` || true`)
- ` tc06`: dropped ` not contains '"completed"'` negation (collided with ` completed_at` field)
- ` tc15`: replaced weak ` not contains 'HTTP 500'` with anchored assertions on the canonical Rust ` BackendError` envelope
- ` tc14`: added missing ` orchestrator_tools` assertions for the three ` __mesh_job_*` helpers
- ` tc16`: symmetric ` unauthorized` + ` permission denied` checks for both bystanders
- ` tc09`: assertions stay producer-side (status=cancelled + frozen progress message); see #882 for the FastMCP gap that prevents asserting downstream cancel marker

## Substrate observations filed during this work

These were discovered while writing the tests; not fixed in this PR:

- **#879** — Handler-raised exceptions don't trigger retry (differs from Sidekiq/Celery convention; tc12 reworked to use SIGKILL accordingly)
- **#880** — Last ` update_progress` clobbered by ` complete()` in terminal flush race (cosmetic; tc02 assertions don't depend on it)
- **#882** — FastMCP-Python doesn't propagate client disconnect to running tool handlers as ` CancelledError` (downstream cancel propagation gap; affects tc09's strongest possible signal)

Closes #872

## Test plan

- [x] ` tsuite run --suite-path tests/integration --uc uc21_meshjob --parallel 1` — 16/16 pass, ~185s
- [x] ` tsuite run --suite-path tests/integration --uc uc21_meshjob --parallel 4` — 16/16 pass, ~187s
- [x] ` tsuite run --suite-path tests/integration --uc uc21_meshjob --parallel 8` — 16/16 pass, ~181s
- [x] ` go test ./registry/...` — passes including new ` sweep_env_test.go`
- [ ] CI green
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sweep interval for registry cleanup now configurable via the `MCP_MESH_SWEEP_INTERVAL` environment variable; defaults to 5 minutes.

* **Tests**
  * Added comprehensive integration test suite for MeshJob functionality covering submit-and-wait, progress tracking, explicit completion, cancellation, retry logic, deadline expiry, and multi-agent scenarios.
  * Added test fixtures and configuration for accelerated test execution with fast-recovery settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->