### PR TITLE
feature: MeshJob TypeScript implementation — runtime + napi bindings + examples

### DIFF
--- a/examples/jobs-ts/README.md
+++ b/examples/jobs-ts/README.md
@@ -1,0 +1,68 @@
+# MeshJob Phase 1 — TypeScript Examples
+
+TypeScript port of `examples/jobs/`. Two minimal agents demonstrating
+the producer + consumer pattern for long-running tasks with `MeshJob`.
+
+## Layout
+
+- `long-task-provider-ts/index.ts` — registers `generate_report` as a
+  `task: true` tool. Hosts the producer-side `JobController` flow:
+  progress updates and structured terminal results.
+- `long-task-consumer-ts/index.ts` — registers `commission_report`
+  which depends on `generate_report` (with `meshJobDepIndex: 0` so the
+  dep slot holds a `MeshJobSubmitter` instead of a regular proxy).
+  Demonstrates the consumer-side `submit(...)` + `proxy.wait(...)`
+  pattern.
+
+## Quick start
+
+```bash
+# Install (once per example)
+cd examples/jobs-ts/long-task-provider-ts && npm install
+cd ../long-task-consumer-ts && npm install
+```
+
+In three terminals:
+
+```bash
+# Terminal 1 — registry
+go run ./cmd/mcp-mesh-registry
+
+# Terminal 2 — provider (port 9110)
+MCP_MESH_REGISTRY_URL=http://localhost:8000 \
+  npx tsx examples/jobs-ts/long-task-provider-ts/index.ts
+
+# Terminal 3 — consumer (port 9111)
+MCP_MESH_REGISTRY_URL=http://localhost:8000 \
+  npx tsx examples/jobs-ts/long-task-consumer-ts/index.ts
+```
+
+Then commission a report by calling the consumer's `commission_report`
+tool:
+
+```bash
+meshctl call long-task-consumer-ts:commission_report \
+  '{"user_id": "demo", "sections": ["intro", "analysis", "summary"]}'
+```
+
+Expected flow:
+
+1. Consumer's `submit(...)` posts to `POST /jobs` on the registry.
+2. Provider's claim worker picks up the job and dispatches it to
+   `generate_report` with a `JobController` injected at `meshJobParamIndex`.
+3. Provider emits progress updates (~6s total for the three sections).
+4. Consumer's `wait(...)` returns the structured `report` payload.
+
+## Inspecting in flight
+
+While a job is running, hit any agent for status — the helper tools
+auto-register on every TS mesh agent:
+
+```bash
+meshctl call long-task-provider-ts:__mesh_job_status \
+  '{"jobId": "<uuid-from-submit>"}'
+```
+
+The three framework helpers (`__mesh_job_status` / `__mesh_job_result`
+/ `__mesh_job_cancel`) read directly from the registry, so any replica
+can serve the request.

--- a/examples/jobs-ts/long-task-consumer-ts/index.ts
+++ b/examples/jobs-ts/long-task-consumer-ts/index.ts
@@ -1,0 +1,85 @@
+/**
+ * MeshJob Phase 1 — TypeScript Consumer Example: commission a remote long-running job.
+ *
+ * Demonstrates the consumer-side dispatch surface:
+ *
+ *     agent.addTool({
+ *       name: "commission_report",
+ *       capability: "commission_report",
+ *       dependencies: [{ capability: "generate_report" }],
+ *       meshJobDepIndex: 0,        // dep[0] is task=true
+ *       parameters: z.object({ ... }),
+ *       execute: async (
+ *         { user_id, sections },
+ *         generateReport: MeshJob | null = null,
+ *       ) => {
+ *         const proxy = await generateReport!.submit({ ... });
+ *         return await proxy.wait(60);
+ *       },
+ *     });
+ *
+ * The DI layer sees `meshJobDepIndex: 0` and injects a
+ * `MeshJobSubmitter` (instead of a regular `McpMeshTool` proxy) at
+ * dep slot 0. `submit(...)` posts to `POST /jobs` on the registry and
+ * returns a `JobProxy` bound to the new job id; `wait(...)` polls
+ * `GET /jobs/{id}` until the status is terminal.
+ *
+ * Run after the provider is up:
+ *     MCP_MESH_REGISTRY_URL=http://localhost:8000 npx tsx index.ts
+ */
+import { FastMCP } from "fastmcp";
+import { mesh, type MeshJob } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const server = new FastMCP({
+  name: "Long Task Consumer (TS)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "long-task-consumer-ts",
+  httpPort: 9111,
+  description:
+    "MeshJob Phase 1 consumer (TS) — commissions and awaits remote reports",
+});
+
+agent.addTool({
+  name: "commission_report",
+  capability: "commission_report",
+  dependencies: [{ capability: "generate_report" }],
+  // Replace dep[0]'s slot with a MeshJobSubmitter.
+  meshJobDepIndex: 0,
+  description:
+    "Commission a report from the long-task provider and await its " +
+    "result. Demonstrates the submit-and-wait pattern.",
+  parameters: z.object({
+    user_id: z.string(),
+    sections: z.array(z.string()),
+  }),
+  execute: async (
+    { user_id, sections },
+    generateReport: MeshJob | null = null,
+  ) => {
+    if (!generateReport || !generateReport.submit) {
+      return {
+        error:
+          "generate_report submitter not injected — check that the " +
+          "long-task-provider-ts is registered with task=true",
+      };
+    }
+    // submit() posts to /jobs and returns a JobProxy bound to the new
+    // job id. maxDuration is the per-attempt soft timeout the provider
+    // runtime enforces.
+    const proxy = await generateReport.submit(
+      { user_id, sections },
+      { maxDuration: 60 },
+    );
+    if (!proxy.wait) {
+      return { error: "submitter returned a proxy without .wait()" };
+    }
+    // Poll the registry until terminal. Returns the producer's
+    // complete() payload on success; rejects on failure / cancel /
+    // timeout.
+    return await proxy.wait(60);
+  },
+});

--- a/examples/jobs-ts/long-task-consumer-ts/package-lock.json
+++ b/examples/jobs-ts/long-task-consumer-ts/package-lock.json
@@ -1,0 +1,2829 @@
+{
+  "name": "long-task-consumer-ts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "long-task-consumer-ts",
+      "version": "1.0.0",
+      "dependencies": {
+        "@mcpmesh/core": "file:../../../src/runtime/core/typescript",
+        "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+        "fastmcp": "^3.34.0",
+        "zod": "^3.24.2"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.29",
+        "tsx": "^4.19.4",
+        "typescript": "^5.8.3"
+      }
+    },
+    "../../../src/runtime/core/typescript": {
+      "name": "@mcpmesh/core",
+      "version": "1.4.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@napi-rs/cli": "^3.5.1"
+      }
+    },
+    "../../../src/runtime/typescript": {
+      "name": "@mcpmesh/sdk",
+      "version": "1.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/google-vertex": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@mcpmesh/core": "file:../core/typescript",
+        "ai": "^6.0.0",
+        "fastmcp": "^3.34.0",
+        "handlebars": "^4.7.8",
+        "mcp-proxy": "6.4.4",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.0",
+        "@types/express-v5": "npm:@types/express@^5.0.0",
+        "@types/node": "^22.0.0",
+        "express": "^4.18.0",
+        "express-v5": "npm:express@^5.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@mcpmesh/core": {
+      "resolved": "../../../src/runtime/core/typescript",
+      "link": true
+    },
+    "node_modules/@mcpmesh/sdk": {
+      "resolved": "../../../src/runtime/typescript",
+      "link": true
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastmcp": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.35.0.tgz",
+      "integrity": "sha512-bcyAaVa3Zw5f4xighGg6fNNgEzZoP6tX/O+ZfS2lIhbEULWe/zUWG533JyFEUOjZT7EB+tiZW1ot4eWKmYJ6DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.24.3",
+        "@standard-schema/spec": "^1.0.0",
+        "execa": "^9.6.1",
+        "file-type": "^21.1.1",
+        "fuse.js": "^7.1.0",
+        "hono": "^4.11.5",
+        "mcp-proxy": "^6.4.0",
+        "strict-event-emitter-types": "^2.0.0",
+        "undici": "^7.16.0",
+        "uri-templates": "^0.2.0",
+        "xsschema": "^0.4.3",
+        "yargs": "^18.0.0",
+        "zod": "^4.1.13",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "bin": {
+        "fastmcp": "dist/bin/fastmcp.js"
+      },
+      "peerDependencies": {
+        "jose": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jose": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fastmcp/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/human-readable-ids": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/human-readable-ids/-/human-readable-ids-1.0.4.tgz",
+      "integrity": "sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA==",
+      "license": "Apache2",
+      "dependencies": {
+        "knuth-shuffle": "^1.0.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/knuth-shuffle": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/knuth-shuffle/-/knuth-shuffle-1.0.8.tgz",
+      "integrity": "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ==",
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/koa": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.0.tgz",
+      "integrity": "sha512-TrM4/tnNY7uJ1aW55sIIa+dqBvc4V14WRIAlGcWat9wV5pRS9Wr5Zk2ZTjQP1jtfIHDoHiSbPuV08P0fUZo2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~1.0.1",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/koa-router": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-14.0.0.tgz",
+      "integrity": "sha512-Ue8f/PRsLLNm6b7y+eS6xkqvsG2xH11d2VB1HPcfdfW6p5736kCHf2pXaq8q9XPQ01x0Dk7V/P5Il9pe+tGTxA==",
+      "deprecated": "Please use @koa/router instead, starting from v9! ",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "path-to-regexp": "^8.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/koa/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/koa/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-proxy": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.4.6.tgz",
+      "integrity": "sha512-tUGAvjzORMUO28shoWNO7yH3kH3r6sYLdAD9w6zoYpjy5zKMFq76nniaMkajpeX/zbemzgICl9sfXhrwQt+hlw==",
+      "license": "MIT",
+      "dependencies": {
+        "pipenet": "^1.3.0"
+      },
+      "bin": {
+        "mcp-proxy": "dist/bin/mcp-proxy.mjs"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pipenet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.0.tgz",
+      "integrity": "sha512-Uc3EH2i8hnJUD0Eupj9z2jaZPjjAbooaiHGh0iFdExbE8/BDt6Lf0919Dtwx5VM83elHNWFzCOsvzsViTD5YZg==",
+      "dependencies": {
+        "axios": "^1.7.3",
+        "debug": "^4.3.6",
+        "human-readable-ids": "^1.0.4",
+        "koa": "^3.1.1",
+        "koa-router": "^14.0.0",
+        "pump": "^3.0.3",
+        "tldjs": "^2.3.2",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "pipenet": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tldjs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.2.tgz",
+      "integrity": "sha512-EORDwFMSZKrHPUVDhejCMDeAovRS5d8jZKiqALFiPp3cjKjEldPkxBY39ZSx3c45awz3RpKwJD1cCgGxEfy8/A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-templates": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.2.0.tgz",
+      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==",
+      "license": "http://geraintluff.github.io/tv4/LICENSE.txt"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xsschema": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/xsschema/-/xsschema-0.4.4.tgz",
+      "integrity": "sha512-TMhbk8AhxO+YuDOn3rXBjGXQ+Vja3T13UPQkHx/FemhusaOzRfCSj2seykt0mdnFPsOtO9l3ANf4adcp+4NRGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@valibot/to-json-schema": "^1.0.0",
+        "arktype": "^2.1.20",
+        "effect": "^3.16.0",
+        "sury": "^10.0.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "@valibot/to-json-schema": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "sury": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/jobs-ts/long-task-consumer-ts/package.json
+++ b/examples/jobs-ts/long-task-consumer-ts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "long-task-consumer-ts",
+  "version": "1.0.0",
+  "description": "MCP Mesh — TypeScript MeshJob consumer example",
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/core": "file:../../../src/runtime/core/typescript",
+    "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.4",
+    "@types/node": "^22.15.29",
+    "typescript": "^5.8.3"
+  }
+}

--- a/examples/jobs-ts/long-task-provider-ts/index.ts
+++ b/examples/jobs-ts/long-task-provider-ts/index.ts
@@ -1,0 +1,91 @@
+/**
+ * MeshJob Phase 1 — TypeScript Provider Example: long-running report generator.
+ *
+ * Demonstrates the producer-side dispatch surface in TS:
+ *
+ *     agent.addTool({
+ *       name: "generate_report",
+ *       capability: "generate_report",
+ *       task: true,
+ *       meshJobParamIndex: 1,            // job lands at sig pos 1 (after `args`)
+ *       parameters: z.object({ ... }),
+ *       execute: async ({ user_id, sections }, job: MeshJob | null = null) => {
+ *         await job?.updateProgress(...);
+ *         await job?.complete({ ... });
+ *       },
+ *     });
+ *
+ * When invoked via the consumer's `MeshJobSubmitter.submit(...)` (see
+ * `../long-task-consumer-ts/index.ts`), the dispatcher claims the job
+ * from the registry, builds a `JobController` bound to the claimed
+ * id, and injects it at `meshJobParamIndex`. Progress updates and the
+ * terminal `complete()` flush directly to the registry — the
+ * consumer's `await proxy.wait(...)` polls until terminal.
+ *
+ * If you call `generate_report` synchronously (regular `tools/call`,
+ * no `X-Mesh-Job-Id` header), the runtime injects `null` for `job`
+ * per `MESHJOB_DDDI_CONTRACT.md` — the function then runs the fast
+ * path and returns its result.
+ *
+ * Run:
+ *     MCP_MESH_REGISTRY_URL=http://localhost:8000 npx tsx index.ts
+ */
+import { FastMCP } from "fastmcp";
+import { mesh, type MeshJob } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const server = new FastMCP({
+  name: "Long Task Provider (TS)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "long-task-provider-ts",
+  httpPort: 9110,
+  description:
+    "MeshJob Phase 1 producer (TS) — generates reports as long-running jobs",
+});
+
+agent.addTool({
+  name: "generate_report",
+  capability: "generate_report",
+  task: true,
+  // Signature position 1: position 0 is `args`, the MeshJob lands at 1.
+  meshJobParamIndex: 1,
+  description:
+    "Long-running report generator. Demonstrates progress updates and " +
+    "structured terminal results.",
+  parameters: z.object({
+    user_id: z.string(),
+    sections: z.array(z.string()),
+  }),
+  execute: async ({ user_id, sections }, job: MeshJob | null = null) => {
+    if (job?.updateProgress) {
+      await job.updateProgress(0.0, "starting");
+    }
+    const results: { section: string; content: string }[] = [];
+    const total = Math.max(sections.length, 1);
+    for (let i = 0; i < sections.length; i++) {
+      // Simulate substantive work — in a real producer this might be
+      // an LLM call, a long DB query, or video transcoding.
+      await new Promise((r) => setTimeout(r, 2000));
+      results.push({
+        section: sections[i],
+        content: `Generated content for ${sections[i]}`,
+      });
+      if (job?.updateProgress) {
+        await job.updateProgress(
+          (i + 1) / total,
+          `finished section ${i + 1}/${total}`,
+        );
+      }
+    }
+    const payload = { user_id, report: results };
+    if (job?.complete) {
+      // Explicit terminal — flushes immediately so the consumer sees
+      // status=completed without waiting on the next batch tick.
+      await job.complete(payload);
+    }
+    return payload;
+  },
+});

--- a/examples/jobs-ts/long-task-provider-ts/package-lock.json
+++ b/examples/jobs-ts/long-task-provider-ts/package-lock.json
@@ -1,0 +1,2829 @@
+{
+  "name": "long-task-provider-ts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "long-task-provider-ts",
+      "version": "1.0.0",
+      "dependencies": {
+        "@mcpmesh/core": "file:../../../src/runtime/core/typescript",
+        "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+        "fastmcp": "^3.34.0",
+        "zod": "^3.24.2"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.29",
+        "tsx": "^4.19.4",
+        "typescript": "^5.8.3"
+      }
+    },
+    "../../../src/runtime/core/typescript": {
+      "name": "@mcpmesh/core",
+      "version": "1.4.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@napi-rs/cli": "^3.5.1"
+      }
+    },
+    "../../../src/runtime/typescript": {
+      "name": "@mcpmesh/sdk",
+      "version": "1.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/google-vertex": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@mcpmesh/core": "file:../core/typescript",
+        "ai": "^6.0.0",
+        "fastmcp": "^3.34.0",
+        "handlebars": "^4.7.8",
+        "mcp-proxy": "6.4.4",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.0",
+        "@types/express-v5": "npm:@types/express@^5.0.0",
+        "@types/node": "^22.0.0",
+        "express": "^4.18.0",
+        "express-v5": "npm:express@^5.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@mcpmesh/core": {
+      "resolved": "../../../src/runtime/core/typescript",
+      "link": true
+    },
+    "node_modules/@mcpmesh/sdk": {
+      "resolved": "../../../src/runtime/typescript",
+      "link": true
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastmcp": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.35.0.tgz",
+      "integrity": "sha512-bcyAaVa3Zw5f4xighGg6fNNgEzZoP6tX/O+ZfS2lIhbEULWe/zUWG533JyFEUOjZT7EB+tiZW1ot4eWKmYJ6DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.24.3",
+        "@standard-schema/spec": "^1.0.0",
+        "execa": "^9.6.1",
+        "file-type": "^21.1.1",
+        "fuse.js": "^7.1.0",
+        "hono": "^4.11.5",
+        "mcp-proxy": "^6.4.0",
+        "strict-event-emitter-types": "^2.0.0",
+        "undici": "^7.16.0",
+        "uri-templates": "^0.2.0",
+        "xsschema": "^0.4.3",
+        "yargs": "^18.0.0",
+        "zod": "^4.1.13",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "bin": {
+        "fastmcp": "dist/bin/fastmcp.js"
+      },
+      "peerDependencies": {
+        "jose": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jose": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fastmcp/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/human-readable-ids": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/human-readable-ids/-/human-readable-ids-1.0.4.tgz",
+      "integrity": "sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA==",
+      "license": "Apache2",
+      "dependencies": {
+        "knuth-shuffle": "^1.0.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/knuth-shuffle": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/knuth-shuffle/-/knuth-shuffle-1.0.8.tgz",
+      "integrity": "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ==",
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/koa": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.0.tgz",
+      "integrity": "sha512-TrM4/tnNY7uJ1aW55sIIa+dqBvc4V14WRIAlGcWat9wV5pRS9Wr5Zk2ZTjQP1jtfIHDoHiSbPuV08P0fUZo2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~1.0.1",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/koa-router": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-14.0.0.tgz",
+      "integrity": "sha512-Ue8f/PRsLLNm6b7y+eS6xkqvsG2xH11d2VB1HPcfdfW6p5736kCHf2pXaq8q9XPQ01x0Dk7V/P5Il9pe+tGTxA==",
+      "deprecated": "Please use @koa/router instead, starting from v9! ",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "path-to-regexp": "^8.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/koa/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/koa/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-proxy": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.4.6.tgz",
+      "integrity": "sha512-tUGAvjzORMUO28shoWNO7yH3kH3r6sYLdAD9w6zoYpjy5zKMFq76nniaMkajpeX/zbemzgICl9sfXhrwQt+hlw==",
+      "license": "MIT",
+      "dependencies": {
+        "pipenet": "^1.3.0"
+      },
+      "bin": {
+        "mcp-proxy": "dist/bin/mcp-proxy.mjs"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pipenet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.0.tgz",
+      "integrity": "sha512-Uc3EH2i8hnJUD0Eupj9z2jaZPjjAbooaiHGh0iFdExbE8/BDt6Lf0919Dtwx5VM83elHNWFzCOsvzsViTD5YZg==",
+      "dependencies": {
+        "axios": "^1.7.3",
+        "debug": "^4.3.6",
+        "human-readable-ids": "^1.0.4",
+        "koa": "^3.1.1",
+        "koa-router": "^14.0.0",
+        "pump": "^3.0.3",
+        "tldjs": "^2.3.2",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "pipenet": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tldjs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.2.tgz",
+      "integrity": "sha512-EORDwFMSZKrHPUVDhejCMDeAovRS5d8jZKiqALFiPp3cjKjEldPkxBY39ZSx3c45awz3RpKwJD1cCgGxEfy8/A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-templates": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.2.0.tgz",
+      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==",
+      "license": "http://geraintluff.github.io/tv4/LICENSE.txt"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xsschema": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/xsschema/-/xsschema-0.4.4.tgz",
+      "integrity": "sha512-TMhbk8AhxO+YuDOn3rXBjGXQ+Vja3T13UPQkHx/FemhusaOzRfCSj2seykt0mdnFPsOtO9l3ANf4adcp+4NRGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@valibot/to-json-schema": "^1.0.0",
+        "arktype": "^2.1.20",
+        "effect": "^3.16.0",
+        "sury": "^10.0.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "@valibot/to-json-schema": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "sury": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/jobs-ts/long-task-provider-ts/package.json
+++ b/examples/jobs-ts/long-task-provider-ts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "long-task-provider-ts",
+  "version": "1.0.0",
+  "description": "MCP Mesh — TypeScript MeshJob producer example",
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/core": "file:../../../src/runtime/core/typescript",
+    "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.4",
+    "@types/node": "^22.15.29",
+    "typescript": "^5.8.3"
+  }
+}

--- a/src/runtime/core/src/jobs_napi.rs
+++ b/src/runtime/core/src/jobs_napi.rs
@@ -1,0 +1,460 @@
+//! napi-rs bindings for the MeshJob substrate (Phase 1 — TypeScript SDK).
+//!
+//! Mirror of [`crate::jobs_py`] for Node.js. Exposes the producer-side
+//! [`crate::jobs::JobController`] and consumer-side [`crate::jobs::JobProxy`]
+//! to TypeScript, plus the [`crate::jobs::submit_job`] entry point and a
+//! snapshot accessor for the active [`crate::job_context`].
+//!
+//! The TypeScript SDK wraps these in an idiomatic surface (`MeshJob` Protocol
+//! type + `mesh.tool({ task: true })` option); raw bindings here intentionally
+//! stay thin so the Rust core remains the source of truth for state-machine
+//! semantics.
+//!
+//! # Async pattern
+//! Methods that block from JavaScript return `Promise`s constructed via
+//! napi-rs's `async` feature (`async fn` on `#[napi]` methods). This matches
+//! the existing pattern in [`crate::napi`] (e.g. `JsAgentHandle::next_event`).
+//!
+//! # Caveat — Rust task-local visibility from JavaScript
+//! Like the Python equivalent: the Rust `tokio::task_local!` bound by
+//! [`crate::job_context::with_job`] is only visible to Rust futures polled
+//! within the scope. JS code running on the Node event loop does NOT inherit
+//! the task-local across the FFI boundary. The TypeScript SDK compensates by
+//! mirroring the context in `AsyncLocalStorage` (see `job-context.ts`),
+//! which IS visible to user code and JS-originated outbound calls. The Rust
+//! side handles the cancel-registry binding plus header injection on
+//! Rust-originated outbound work (e.g. LLM provider `call_tool`).
+
+#![cfg(feature = "typescript")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+use crate::cancel_registry;
+use crate::job_context::{self, JobContext};
+use crate::jobs::{
+    new_coalescing_queue, run_as_job, spawn_batching_tick, submit_job, BatchingConfig,
+    BatchingHandle, JobController, JobError, JobProxy, SubmitJobArgs,
+};
+use crate::task_backend::{
+    Job, JobStatus, RegistryHttpBackend, TaskBackend,
+};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Build an `Arc<dyn TaskBackend>` from a registry URL. Returns a napi
+/// error on transport-construction failure (mirrors `backend_from_url`
+/// in `jobs_py.rs`).
+fn backend_from_url(registry_url: &str) -> napi::Result<Arc<dyn TaskBackend>> {
+    let backend = RegistryHttpBackend::new(registry_url)
+        .map_err(|e| Error::from_reason(format!("backend init failed: {}", e)))?;
+    Ok(backend.into_arc())
+}
+
+/// Map [`JobError`] onto a napi error with reasonable messages so callers
+/// can `try/catch` cleanly. We don't have language-level distinct exception
+/// types like Python's `TimeoutError`, so we encode the variant name as
+/// the leading token; SDK code can string-match if it needs to discriminate.
+fn job_error_to_napi(err: JobError) -> Error {
+    match err {
+        JobError::Timeout(d) => {
+            Error::from_reason(format!("timeout: wait timed out after {:?}", d))
+        }
+        JobError::Cancelled => {
+            Error::from_reason("cancelled: job cancelled by enclosing context")
+        }
+        other => Error::from_reason(other.to_string()),
+    }
+}
+
+/// Convert a [`Job`] into a JSON value the TS layer can `JSON.parse`-style
+/// consume directly. napi-rs's `serde-json` integration converts to a JS
+/// object on the boundary so the SDK doesn't need a separate parse step.
+fn job_to_json(job: Job) -> serde_json::Value {
+    serde_json::json!({
+        "id": job.id,
+        "capability": job.capability,
+        "owner_instance_id": job.owner_instance_id,
+        "status": job_status_to_str(job.status),
+        "progress": job.progress,
+        "progress_message": job.progress_message,
+        "result": job.result.unwrap_or(serde_json::Value::Null),
+        "error": job.error,
+        "submitted_payload": job.submitted_payload,
+        "attempt_count": job.attempt_count,
+        "max_retries": job.max_retries,
+        "max_duration": job.max_duration,
+        "total_deadline": job.total_deadline,
+        "lease_expires_at": job.lease_expires_at,
+        "last_heartbeat_at": job.last_heartbeat_at,
+        "submitted_at": job.submitted_at,
+        "submitted_by": job.submitted_by,
+    })
+}
+
+fn job_status_to_str(s: JobStatus) -> &'static str {
+    match s {
+        JobStatus::Working => "working",
+        JobStatus::InputRequired => "input_required",
+        JobStatus::Completed => "completed",
+        JobStatus::Failed => "failed",
+        JobStatus::Cancelled => "cancelled",
+    }
+}
+
+// =============================================================================
+// JsJobController (producer-side)
+// =============================================================================
+
+/// Producer-side handle bound to a single job. Application code receives one
+/// via DDDI injection (the inbound tool wrapper, next dispatch); the
+/// constructor is also exposed for tests and the claim worker dispatch path.
+///
+/// Each controller owns a per-instance coalescing queue plus a background
+/// batching tick that flushes mid-flight progress deltas to the registry on a
+/// fixed cadence. The tick is shut down (with a final flush) when the
+/// controller is dropped by JS GC.
+#[napi(js_name = "JobController")]
+pub struct JsJobController {
+    inner: JobController,
+    /// Background batching tick handle; held so it lives as long as this
+    /// controller. Optional: if no Tokio runtime is available at construction
+    /// time the batching tick is skipped (terminal flushes still work).
+    _batching: Option<BatchingHandle>,
+}
+
+#[napi]
+impl JsJobController {
+    /// Construct a controller bound to `(jobId, instanceId)` against the
+    /// given `registryUrl`. Spawns a per-controller background batching tick
+    /// so mid-flight `updateProgress` calls reach the registry on the
+    /// configured cadence (default 2s); the tick is torn down with a final
+    /// flush when the controller is dropped.
+    #[napi(constructor)]
+    pub fn new(job_id: String, instance_id: String, registry_url: String) -> Result<Self> {
+        let backend = backend_from_url(&registry_url)?;
+        let queue = new_coalescing_queue();
+        let inner = JobController::new(
+            job_id,
+            instance_id.clone(),
+            backend.clone(),
+            queue.clone(),
+        );
+        // Try to enter the napi-rs Tokio runtime so `tokio::spawn` inside
+        // `spawn_batching_tick` finds a runtime. If the construction site
+        // has no runtime context (rare, but possible from some sync paths),
+        // fall through without the tick — terminal flushes still work.
+        let batching = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                let _guard = handle.enter();
+                Some(spawn_batching_tick(
+                    queue,
+                    backend,
+                    instance_id,
+                    BatchingConfig::default(),
+                ))
+            }
+            Err(_) => None,
+        };
+        Ok(Self {
+            inner,
+            _batching: batching,
+        })
+    }
+
+    /// The job ID this controller is bound to.
+    #[napi(getter)]
+    pub fn job_id(&self) -> String {
+        self.inner.job_id().to_string()
+    }
+
+    /// Enqueue a progress update. Coalesces with any prior pending progress
+    /// for this job — only the latest survives the next batch flush.
+    #[napi]
+    pub async fn update_progress(&self, progress: f64, message: Option<String>) -> Result<()> {
+        // f32 on Rust side, f64 on JS side: clamp via cast (JS Number is
+        // f64; values outside f32 range round to ±inf which still works
+        // as a sentinel — registry will validate range upstream).
+        self.inner.update_progress(progress as f32, message).await;
+        Ok(())
+    }
+
+    /// Mark the job complete with the given result. Flushes immediately.
+    /// `result` is any JSON-shaped JS value (object/array/primitive) —
+    /// mirrors MCP's "results are JSON" contract.
+    #[napi]
+    pub async fn complete(&self, result: serde_json::Value) -> Result<()> {
+        self.inner
+            .complete(result)
+            .await
+            .map_err(job_error_to_napi)?;
+        Ok(())
+    }
+
+    /// Mark the job failed with the given error reason. Flushes immediately.
+    #[napi]
+    pub async fn fail(&self, error: String) -> Result<()> {
+        self.inner.fail(error).await.map_err(job_error_to_napi)?;
+        Ok(())
+    }
+
+    /// Whether `complete` / `fail` has already been called on this
+    /// controller. The TS dispatch wrapper uses this to decide whether a
+    /// returning user function needs an auto-`complete` — users who already
+    /// `await job.complete(...)` closed out the row, so the wrapper must
+    /// NOT double-flush.
+    ///
+    /// Sync from JS's perspective: returns a Promise<boolean> because the
+    /// underlying queue read is async, but the call is short.
+    #[napi]
+    pub async fn is_terminal(&self) -> bool {
+        self.inner.is_terminal().await
+    }
+}
+
+// =============================================================================
+// JsJobProxy (consumer-side)
+// =============================================================================
+
+/// Consumer-side handle: returned by [`submit_job_napi`] and exposes
+/// `wait` / `status` / `cancel` for code that wants to await a remote job.
+#[napi(js_name = "JobProxy")]
+pub struct JsJobProxy {
+    inner: JobProxy,
+}
+
+#[napi]
+impl JsJobProxy {
+    /// Construct a proxy bound to a known `jobId` + `registryUrl`. Normally
+    /// callers obtain a proxy via [`submit_job_napi`] / DDDI injection
+    /// rather than constructing one directly.
+    #[napi(constructor)]
+    pub fn new(job_id: String, registry_url: String) -> Result<Self> {
+        let backend = backend_from_url(&registry_url)?;
+        Ok(Self {
+            inner: JobProxy::new(job_id, backend),
+        })
+    }
+
+    /// The job ID this proxy is bound to.
+    #[napi(getter)]
+    pub fn job_id(&self) -> String {
+        self.inner.job_id().to_string()
+    }
+
+    /// Read the latest job state from the registry (single GET).
+    /// Returns the full job row as a JSON object.
+    #[napi]
+    pub async fn status(&self) -> Result<serde_json::Value> {
+        let job = self.inner.status().await.map_err(job_error_to_napi)?;
+        Ok(job_to_json(job))
+    }
+
+    /// Poll until the job reaches a terminal state. Returns the result
+    /// payload as a JS value (object/array/primitive) on success;
+    /// rejects with a "timeout: ..." error on `timeoutSecs`, or
+    /// "cancelled" / other reason on non-success terminal.
+    #[napi]
+    pub async fn wait(&self, timeout_secs: Option<f64>) -> Result<serde_json::Value> {
+        let timeout = timeout_secs.map(Duration::from_secs_f64);
+        self.inner
+            .wait(timeout)
+            .await
+            .map_err(job_error_to_napi)
+    }
+
+    /// Request cancellation. The registry forwards the signal to the
+    /// owner replica when alive. Resolves once the registry has
+    /// acknowledged.
+    #[napi]
+    pub async fn cancel(&self, reason: Option<String>) -> Result<()> {
+        self.inner.cancel(reason).await.map_err(job_error_to_napi)?;
+        Ok(())
+    }
+}
+
+// =============================================================================
+// Submit-job arguments (TS-shaped object)
+// =============================================================================
+
+/// Arguments for [`submit_job_napi`]. Mirrors [`SubmitJobArgs`]
+/// field-for-field; `payload` is any JSON-shaped JS value.
+///
+/// Optional `i64` fields are typed as `Option<i64>` — JavaScript Number
+/// safely represents integers up to 2^53; callers passing unix-epoch
+/// timestamps stay well inside that range.
+#[napi(object, js_name = "SubmitJobArgs")]
+pub struct JsSubmitJobArgs {
+    pub registry_url: String,
+    pub capability: String,
+    pub payload: serde_json::Value,
+    pub submitted_by: String,
+    pub owner_instance_id: Option<String>,
+    pub max_duration: Option<u32>,
+    pub max_retries: Option<u32>,
+    pub total_deadline: Option<i64>,
+}
+
+/// Submit a new job via the registry and return a [`JsJobProxy`].
+///
+/// Mirrors [`SubmitJobArgs`] field-for-field. Single-arg shape matches
+/// Python's PyO3 binding.
+#[napi(js_name = "submitJob")]
+pub async fn submit_job_napi(args: JsSubmitJobArgs) -> Result<JsJobProxy> {
+    let backend = backend_from_url(&args.registry_url)?;
+    let rust_args = SubmitJobArgs {
+        capability: args.capability,
+        payload: args.payload,
+        submitted_by: args.submitted_by,
+        owner_instance_id: args.owner_instance_id,
+        max_duration: args.max_duration,
+        max_retries: args.max_retries,
+        total_deadline: args.total_deadline,
+    };
+    let (proxy, _resp) = submit_job(backend, rust_args)
+        .await
+        .map_err(job_error_to_napi)?;
+    Ok(JsJobProxy { inner: proxy })
+}
+
+// =============================================================================
+// Job-context accessors
+// =============================================================================
+
+/// Snapshot of the active job context returned by [`current_job_napi`].
+/// Mirrors the TS-side `JobContextSnapshot` interface in `job-context.ts`.
+#[napi(object, js_name = "JobContextSnapshot")]
+pub struct JsJobContextSnapshot {
+    pub job_id: String,
+    /// `None` if no deadline is set on the active context.
+    pub deadline_secs_remaining: Option<u32>,
+}
+
+/// Snapshot of the active job context on the current Tokio task, or `null`
+/// if no job is in scope.
+///
+/// Source of truth is the Rust [`crate::job_context`] (set via
+/// `with_job` / `run_as_job` by the inbound HTTP wrapper or claim worker).
+/// JS code typically reads the AsyncLocalStorage mirror — this binding is
+/// for cross-FFI parity / debugging / Rust-originated paths.
+#[napi(js_name = "currentJob")]
+pub fn current_job_napi() -> Option<JsJobContextSnapshot> {
+    job_context::current().map(|ctx| {
+        let remaining = ctx.remaining_seconds().map(|s| s as u32);
+        JsJobContextSnapshot {
+            job_id: ctx.job_id,
+            deadline_secs_remaining: remaining,
+        }
+    })
+}
+
+/// Headers injected by [`inject_job_headers_napi`].
+///
+/// Both fields are optional individually: when an active context has no
+/// deadline, `xMeshTimeout` is `None`. When no job context is active at all,
+/// the function returns `None` instead of an empty object.
+#[napi(object, js_name = "JobHeaders")]
+pub struct JsJobHeaders {
+    /// `X-Mesh-Job-Id` header value.
+    pub x_mesh_job_id: String,
+    /// `X-Mesh-Timeout` header value (seconds remaining as decimal string),
+    /// or `None` if the active context has no deadline.
+    pub x_mesh_timeout: Option<String>,
+}
+
+/// Compute the `X-Mesh-Job-Id` / `X-Mesh-Timeout` header values for the
+/// active job context, if any.
+///
+/// Returns `null` when no job context is active on the current task.
+/// The TS outbound HTTP layer (e.g. the proxy `createProxy` factory)
+/// merges these into the request headers alongside any existing
+/// `X-Trace-Id` propagation.
+///
+/// Header *name shape*: this function returns a plain object the SDK can
+/// destructure or spread into a request-headers map. We deliberately do NOT
+/// reach across into a JS `Headers` instance here — that's TS-runtime
+/// territory (Express/Fetch/undici) and varies between transport stacks.
+#[napi(js_name = "injectJobHeaders")]
+pub fn inject_job_headers_napi() -> Option<JsJobHeaders> {
+    job_context::current().map(|ctx| {
+        let timeout = ctx.remaining_seconds().map(|s| s.to_string());
+        JsJobHeaders {
+            x_mesh_job_id: ctx.job_id,
+            x_mesh_timeout: timeout,
+        }
+    })
+}
+
+// =============================================================================
+// cancel_active_job
+// =============================================================================
+
+/// Fire the cancel token registered for `jobId` in the process-wide
+/// cancel registry, if any. Returns `true` iff a token was found and
+/// fired (matches [`crate::cancel_registry::cancel_active_job`] semantics).
+///
+/// Used by the SDK-owned `POST /jobs/{job_id}/cancel` HTTP route — when the
+/// registry forwards a cancel to this replica, the route handler calls this
+/// to abort the in-flight job. (Route wiring lands in the next dispatch.)
+#[napi(js_name = "cancelActiveJob")]
+pub fn cancel_active_job_napi(job_id: String) -> bool {
+    cancel_registry::cancel_active_job(&job_id)
+}
+
+// =============================================================================
+// with_job_async
+// =============================================================================
+
+/// Run an in-flight JS Promise inside a fresh [`crate::jobs::run_as_job`]
+/// scope so the cancel-registry entry under `jobId` is bound for the
+/// duration of the await (so the `POST /jobs/{id}/cancel` HTTP route can
+/// fire the in-flight cancel token).
+///
+/// **Important caveat — Rust task-local visibility from JS:** the Rust
+/// `tokio::task_local!` bound by `with_job` is NOT visible to JS user
+/// code on the Node event loop (different runtimes). The TS SDK MUST
+/// set its own `AsyncLocalStorage` (`CURRENT_JOB`) in parallel — that
+/// mirror is the source of truth for in-process JS reads and for
+/// JS-originated outbound calls. The Rust side handles two things:
+///
+///   1. cancel-registry binding so `POST /jobs/{id}/cancel` can fire
+///      the in-flight cancel token (visible to any Rust futures
+///      polled within the scope, including the napi-rs HTTP path of
+///      `call_tool`/`submit_job`/etc.);
+///   2. header injection for Rust-originated outbound work via
+///      [`inject_job_headers_napi`].
+///
+/// This is the FFI helper the inbound tool wrapper (next dispatch) uses
+/// when an `X-Mesh-Job-Id` header arrives on a `tools/call`. It awaits
+/// a JS Promise and resolves with whatever the Promise resolves to.
+///
+/// Arguments:
+///   * `jobId` — server-assigned job UUID this call is bound to.
+///   * `deadlineSecs` — optional per-attempt deadline in seconds.
+///     `null` / `undefined` means no deadline (unlimited per design-doc
+///     default).
+///   * `body` — in-flight JS Promise resolving to a JSON value. The
+///     SDK's TS wrapper typically constructs this with the user
+///     function's return value already JSON-serialised.
+///
+/// NB on lifecycle: napi-rs's `Promise<T>` only completes when the
+/// underlying JS Promise settles. The `run_as_job` scope keeps the
+/// cancel registry entry alive for that whole window, then drops it
+/// (panic-safe via the internal drop guard).
+#[napi(js_name = "withJobAsync")]
+pub async fn with_job_async_napi(
+    job_id: String,
+    deadline_secs: Option<f64>,
+    body: Promise<serde_json::Value>,
+) -> Result<serde_json::Value> {
+    let ctx = match deadline_secs {
+        Some(secs) if secs > 0.0 => JobContext::with_timeout(job_id, Duration::from_secs_f64(secs)),
+        _ => JobContext::new(job_id),
+    };
+    run_as_job(ctx, async move { body.await }).await
+}

--- a/src/runtime/core/src/jobs_napi.rs
+++ b/src/runtime/core/src/jobs_napi.rs
@@ -450,15 +450,68 @@ pub fn cancel_active_job_napi(job_id: String) -> bool {
 /// underlying JS Promise settles. The `run_as_job` scope keeps the
 /// cancel registry entry alive for that whole window, then drops it
 /// (panic-safe via the internal drop guard).
+/// Validate `deadline_secs` for [`with_job_async_napi`]. Returns the
+/// [`napi::Error`] message that would be propagated to JS, or `None`
+/// when the input is acceptable. Extracted from `with_job_async_napi`
+/// so it can be unit-tested without the napi `Promise<T>` boundary.
+fn validate_deadline_secs(deadline_secs: Option<f64>, job_id: &str) -> Option<String> {
+    match deadline_secs {
+        Some(secs) if !secs.is_finite() || secs < 0.0 => Some(format!(
+            "withJobAsync: invalid deadline_secs ({}) for job {} — must be a non-negative finite number or null",
+            secs, job_id,
+        )),
+        _ => None,
+    }
+}
+
 #[napi(js_name = "withJobAsync")]
 pub async fn with_job_async_napi(
     job_id: String,
     deadline_secs: Option<f64>,
     body: Promise<serde_json::Value>,
 ) -> Result<serde_json::Value> {
+    // Reject negative / NaN / Inf deadlines explicitly: silently aliasing
+    // them to "no deadline" (the previous behaviour) papers over upstream
+    // bugs where a caller arithmetic'd a negative remaining-time or
+    // produced NaN through a buggy clock computation.
+    if let Some(msg) = validate_deadline_secs(deadline_secs, &job_id) {
+        return Err(Error::from_reason(msg));
+    }
     let ctx = match deadline_secs {
         Some(secs) if secs > 0.0 => JobContext::with_timeout(job_id, Duration::from_secs_f64(secs)),
         _ => JobContext::new(job_id),
     };
     run_as_job(ctx, async move { body.await }).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_deadline_secs;
+
+    #[test]
+    fn validate_deadline_secs_accepts_none_and_zero_and_positive() {
+        assert!(validate_deadline_secs(None, "j-1").is_none());
+        assert!(validate_deadline_secs(Some(0.0), "j-1").is_none());
+        assert!(validate_deadline_secs(Some(1.5), "j-1").is_none());
+        assert!(validate_deadline_secs(Some(60.0), "j-1").is_none());
+    }
+
+    #[test]
+    fn validate_deadline_secs_rejects_negative() {
+        let msg = validate_deadline_secs(Some(-0.001), "j-neg").expect("should reject");
+        assert!(msg.contains("invalid deadline_secs"));
+        assert!(msg.contains("j-neg"));
+        assert!(msg.contains("-0.001"));
+
+        let msg = validate_deadline_secs(Some(-30.0), "abc").expect("should reject");
+        assert!(msg.contains("-30"));
+        assert!(msg.contains("abc"));
+    }
+
+    #[test]
+    fn validate_deadline_secs_rejects_nan_and_inf() {
+        assert!(validate_deadline_secs(Some(f64::NAN), "j-nan").is_some());
+        assert!(validate_deadline_secs(Some(f64::INFINITY), "j-inf").is_some());
+        assert!(validate_deadline_secs(Some(f64::NEG_INFINITY), "j-ninf").is_some());
+    }
 }

--- a/src/runtime/core/src/jobs_napi.rs
+++ b/src/runtime/core/src/jobs_napi.rs
@@ -123,8 +123,11 @@ fn job_status_to_str(s: JobStatus) -> &'static str {
 pub struct JsJobController {
     inner: JobController,
     /// Background batching tick handle; held so it lives as long as this
-    /// controller. Optional: if no Tokio runtime is available at construction
-    /// time the batching tick is skipped (terminal flushes still work).
+    /// controller. Spawned inside napi-rs's Tokio runtime in the
+    /// constructor (see `within_runtime_if_available` below) and dropped
+    /// (= cancelled with final flush) when JS GC collects the controller.
+    /// `Option<...>` is preserved for forward-compat with a possible
+    /// noop-feature build where `within_runtime_if_available` may degrade.
     _batching: Option<BatchingHandle>,
 }
 
@@ -145,25 +148,26 @@ impl JsJobController {
             backend.clone(),
             queue.clone(),
         );
-        // Try to enter the napi-rs Tokio runtime so `tokio::spawn` inside
-        // `spawn_batching_tick` finds a runtime. If the construction site
-        // has no runtime context (rare, but possible from some sync paths),
-        // fall through without the tick — terminal flushes still work.
-        let batching = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => {
-                let _guard = handle.enter();
-                Some(spawn_batching_tick(
-                    queue,
-                    backend,
-                    instance_id,
-                    BatchingConfig::default(),
-                ))
-            }
-            Err(_) => None,
-        };
+        // Spawn the batching tick inside napi-rs's shared Tokio runtime so
+        // mid-flight progress deltas actually reach the registry. The
+        // `#[napi(constructor)]` is invoked synchronously from JS context
+        // with NO ambient Tokio runtime — `Handle::try_current()` would
+        // return `Err` and the tick would be silently skipped (mirrors
+        // Python's `pyo3_async_runtimes::tokio::get_runtime().enter()`).
+        // `within_runtime_if_available` enters napi-rs's `RT` for the
+        // duration of the closure so `tokio::spawn` inside
+        // `spawn_batching_tick` resolves a valid runtime handle.
+        let batching = napi::bindgen_prelude::within_runtime_if_available(|| {
+            spawn_batching_tick(
+                queue,
+                backend,
+                instance_id,
+                BatchingConfig::default(),
+            )
+        });
         Ok(Self {
             inner,
-            _batching: batching,
+            _batching: Some(batching),
         })
     }
 

--- a/src/runtime/core/src/lib.rs
+++ b/src/runtime/core/src/lib.rs
@@ -42,6 +42,8 @@ pub mod job_context;
 pub mod jobs;
 #[cfg(feature = "python")]
 pub mod jobs_py;
+#[cfg(feature = "typescript")]
+pub mod jobs_napi;
 pub mod registry;
 pub mod response_parser;
 pub mod runtime;

--- a/src/runtime/typescript/package-lock.json
+++ b/src/runtime/typescript/package-lock.json
@@ -18,6 +18,7 @@
         "fastmcp": "^3.34.0",
         "handlebars": "^4.7.8",
         "mcp-proxy": "6.4.4",
+        "undici": "^6.21.0",
         "zod": "^3.24.1",
         "zod-to-json-schema": "^3.24.1"
       },
@@ -2870,6 +2871,15 @@
         }
       }
     },
+    "node_modules/fastmcp/node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/fastmcp/node_modules/zod": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
@@ -4741,12 +4751,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/src/runtime/typescript/package.json
+++ b/src/runtime/typescript/package.json
@@ -40,7 +40,7 @@
     "fastmcp": "^3.34.0",
     "mcp-proxy": "6.4.4",
     "handlebars": "^4.7.8",
-    "undici": "^7.18.0",
+    "undici": "^6.21.0",
     "zod": "^3.24.1",
     "zod-to-json-schema": "^3.24.1"
   },

--- a/src/runtime/typescript/package.json
+++ b/src/runtime/typescript/package.json
@@ -40,6 +40,7 @@
     "fastmcp": "^3.34.0",
     "mcp-proxy": "6.4.4",
     "handlebars": "^4.7.8",
+    "undici": "^7.18.0",
     "zod": "^3.24.1",
     "zod-to-json-schema": "^3.24.1"
   },

--- a/src/runtime/typescript/src/__tests__/agent-add-tool.spec.ts
+++ b/src/runtime/typescript/src/__tests__/agent-add-tool.spec.ts
@@ -1,0 +1,318 @@
+/**
+ * `addTool` registration-time validation tests (Phase 1 — MeshJob substrate).
+ *
+ * Targets the misuse-detection layer in `agent.ts`'s `addTool` —
+ * specifically the `meshJobParamIndex` invariants from the BLOCKER
+ * review finding on PR #883:
+ *
+ *   - position 0 is reserved for the `args` payload, so the controller
+ *     can only land at sig pos 1+;
+ *   - non-integer values (NaN, 1.5, etc.) silently skipped controller
+ *     injection before the fix → user saw `null` where they expected
+ *     a `JobController` and got a cryptic `TypeError` at first await;
+ *   - the upper bound (10) is a sanity check for typos.
+ *
+ * The test stubs FastMCP minimally and overrides `_autoStart` on the
+ * prototype to keep the auto-scheduled startup from spinning up an HTTP
+ * server during the test run.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { z } from "zod";
+import type { JobController } from "@mcpmesh/core";
+import { MeshAgent } from "../agent.js";
+import { spliceJobController } from "../inbound-job-dispatch.js";
+
+// Minimal FastMCP stub: `addTool` is the only surface `addTool`
+// validation reaches BEFORE throwing. `start`, `getApp`, etc. would
+// only run inside `_autoStart` — which we stub out below.
+function makeFastMCPStub() {
+  return {
+    addTool: vi.fn(),
+    start: vi.fn(),
+    getApp: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+// Spy on `_autoStart` so the auto-scheduled `process.nextTick(...)`
+// call inside the constructor doesn't actually start an HTTP server /
+// reach out to a registry. The validation we're testing happens
+// synchronously inside `addTool`, before any auto-start.
+let autoStartSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+beforeEach(() => {
+  autoStartSpy = vi
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .spyOn(MeshAgent.prototype as any, "_autoStart")
+    .mockImplementation(async () => {
+      /* no-op */
+    });
+});
+
+afterEach(() => {
+  if (autoStartSpy) {
+    autoStartSpy.mockRestore();
+    autoStartSpy = null;
+  }
+});
+
+describe("addTool — meshJobParamIndex validation", () => {
+  function newAgent(): MeshAgent {
+    return new MeshAgent(makeFastMCPStub(), {
+      name: "test-agent",
+      httpPort: 0,
+    });
+  }
+
+  it("rejects 0 (position 0 is reserved for args)", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad-zero",
+        task: true,
+        parameters: z.object({}),
+        meshJobParamIndex: 0,
+        execute: async () => "x",
+      }),
+    ).toThrow(/meshJobParamIndex must be an integer >= 1.*got: 0/);
+  });
+
+  it("rejects negative values", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad-neg",
+        task: true,
+        parameters: z.object({}),
+        meshJobParamIndex: -1,
+        execute: async () => "x",
+      }),
+    ).toThrow(/meshJobParamIndex must be an integer >= 1.*got: -1/);
+  });
+
+  it("rejects NaN", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad-nan",
+        task: true,
+        parameters: z.object({}),
+        meshJobParamIndex: Number.NaN,
+        execute: async () => "x",
+      }),
+    ).toThrow(/meshJobParamIndex must be an integer >= 1.*got: NaN/);
+  });
+
+  it("rejects non-integer (1.5)", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad-frac",
+        task: true,
+        parameters: z.object({}),
+        meshJobParamIndex: 1.5,
+        execute: async () => "x",
+      }),
+    ).toThrow(/meshJobParamIndex must be an integer >= 1.*got: 1\.5/);
+  });
+
+  it("rejects values beyond a sane upper bound (typo guard)", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad-big",
+        task: true,
+        parameters: z.object({}),
+        meshJobParamIndex: 99,
+        execute: async () => "x",
+      }),
+    ).toThrow(/meshJobParamIndex must be an integer >= 1.*got: 99/);
+  });
+
+  it("accepts 1 (most common case — no deps, just a controller)", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "ok-one",
+        task: true,
+        parameters: z.object({}),
+        meshJobParamIndex: 1,
+        execute: async () => "x",
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts 3 (controller after a couple of deps)", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "ok-three",
+        task: true,
+        parameters: z.object({}),
+        dependencies: ["a", "b"],
+        meshJobParamIndex: 3,
+        execute: async () => "x",
+      }),
+    ).not.toThrow();
+  });
+});
+
+// =============================================================================
+// W1 — splice helper (de-duplicated splice loop)
+// =============================================================================
+
+describe("spliceJobController helper", () => {
+  // The helper is purely positional — pass primitive sentinels so
+  // the assertions don't depend on McpMeshTool / JobController types.
+  const C = "<<controller>>" as unknown as JobController;
+
+  it("returns just [payload] when no deps and no MeshJob slot", () => {
+    expect(spliceJobController({ p: 1 }, [], null, undefined)).toEqual([
+      { p: 1 },
+    ]);
+  });
+
+  it("appends deps after payload when no meshJobParamIndex", () => {
+    expect(
+      spliceJobController({ p: 1 }, ["d0", "d1"], C, undefined),
+    ).toEqual([{ p: 1 }, "d0", "d1"]);
+  });
+
+  it("places controller at sig pos 1 when no deps and meshJobParamIndex=1", () => {
+    expect(spliceJobController({ p: 1 }, [], C, 1)).toEqual([{ p: 1 }, C]);
+  });
+
+  it("interleaves: meshJobParamIndex=2 with two deps shifts the second dep past the controller", () => {
+    // signature: (args, dep0, controller, dep1)
+    expect(
+      spliceJobController({ p: 1 }, ["d0", "d1"], C, 2),
+    ).toEqual([{ p: 1 }, "d0", C, "d1"]);
+  });
+
+  it("trailing slot: meshJobParamIndex=3 with one dep pads with null and places controller at the trailing position", () => {
+    // signature: (args, dep0, ?, controller) — pos 2 has no dep, pads null.
+    expect(spliceJobController({ p: 1 }, ["d0"], C, 3)).toEqual([
+      { p: 1 },
+      "d0",
+      null,
+      C,
+    ]);
+  });
+
+  it("uses null for the controller slot when caller passes null", () => {
+    // The wrapper passes `null` when the call is NOT running under a job
+    // context — the helper must still reserve the slot at meshJobParamIndex.
+    expect(spliceJobController({ p: 1 }, ["d0"], null, 1)).toEqual([
+      { p: 1 },
+      null,
+      "d0",
+    ]);
+  });
+});
+
+// =============================================================================
+// W4 — worker-isolation force-disable warning visibility
+// =============================================================================
+
+describe("addTool — W4 worker-isolation force-disable warning", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  const originalEnv = process.env.MCP_MESH_TOOL_ISOLATION;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+    if (originalEnv === undefined) {
+      delete process.env.MCP_MESH_TOOL_ISOLATION;
+    } else {
+      process.env.MCP_MESH_TOOL_ISOLATION = originalEnv;
+    }
+  });
+
+  function newAgent(): MeshAgent {
+    return new MeshAgent(makeFastMCPStub(), {
+      name: "test-agent-w4",
+      httpPort: 0,
+    });
+  }
+
+  it("does NOT warn when isolation env is unset (default)", () => {
+    delete process.env.MCP_MESH_TOOL_ISOLATION;
+    const agent = newAgent();
+    agent.addTool({
+      name: "task-tool",
+      task: true,
+      parameters: z.object({}),
+      execute: async () => "x",
+    });
+    const isolationCall = warnSpy.mock.calls.find((c) =>
+      String(c[0]).includes("worker isolation"),
+    );
+    expect(isolationCall).toBeUndefined();
+  });
+
+  it("warns when MCP_MESH_TOOL_ISOLATION=true is set explicitly for a task: true tool", () => {
+    process.env.MCP_MESH_TOOL_ISOLATION = "true";
+    const agent = newAgent();
+    agent.addTool({
+      name: "task-tool",
+      task: true,
+      parameters: z.object({}),
+      execute: async () => "x",
+    });
+    const isolationCall = warnSpy.mock.calls.find((c) =>
+      String(c[0]).includes("worker isolation is disabled"),
+    );
+    expect(isolationCall).toBeDefined();
+    expect(String(isolationCall![0])).toContain("'task-tool'");
+    expect(String(isolationCall![0])).toContain("task: true");
+  });
+
+  it("warns for meshJobDepIndex consumer tools too", () => {
+    process.env.MCP_MESH_TOOL_ISOLATION = "true";
+    const agent = newAgent();
+    agent.addTool({
+      name: "consumer-tool",
+      parameters: z.object({}),
+      dependencies: ["producer"],
+      meshJobDepIndex: 0,
+      execute: async () => "x",
+    });
+    const isolationCall = warnSpy.mock.calls.find((c) =>
+      String(c[0]).includes("worker isolation is disabled"),
+    );
+    expect(isolationCall).toBeDefined();
+    expect(String(isolationCall![0])).toContain("'consumer-tool'");
+    expect(String(isolationCall![0])).toContain("meshJobDepIndex: 0");
+  });
+
+  it("does NOT warn when isolation env is explicitly set to 'false'", () => {
+    process.env.MCP_MESH_TOOL_ISOLATION = "false";
+    const agent = newAgent();
+    agent.addTool({
+      name: "task-tool",
+      task: true,
+      parameters: z.object({}),
+      execute: async () => "x",
+    });
+    const isolationCall = warnSpy.mock.calls.find((c) =>
+      String(c[0]).includes("worker isolation"),
+    );
+    expect(isolationCall).toBeUndefined();
+  });
+
+  it("does NOT warn for non-job-bound tools regardless of env", () => {
+    process.env.MCP_MESH_TOOL_ISOLATION = "true";
+    const agent = newAgent();
+    agent.addTool({
+      name: "regular-tool",
+      parameters: z.object({}),
+      execute: async () => "x",
+    });
+    const isolationCall = warnSpy.mock.calls.find((c) =>
+      String(c[0]).includes("worker isolation"),
+    );
+    expect(isolationCall).toBeUndefined();
+  });
+});

--- a/src/runtime/typescript/src/__tests__/agent-add-tool.spec.ts
+++ b/src/runtime/typescript/src/__tests__/agent-add-tool.spec.ts
@@ -157,6 +157,80 @@ describe("addTool — meshJobParamIndex validation", () => {
   });
 });
 
+describe("addTool — meshJobDepIndex validation", () => {
+  function newAgent(): MeshAgent {
+    return new MeshAgent(makeFastMCPStub(), {
+      name: "test-agent-depidx",
+      httpPort: 0,
+    });
+  }
+
+  it("rejects negative values", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad-neg",
+        parameters: z.object({}),
+        dependencies: ["a"],
+        meshJobDepIndex: -1,
+        execute: async () => "x",
+      }),
+    ).toThrow(/meshJobDepIndex must be a non-negative integer.*got: -1/);
+  });
+
+  it("rejects NaN", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad-nan",
+        parameters: z.object({}),
+        dependencies: ["a"],
+        meshJobDepIndex: Number.NaN,
+        execute: async () => "x",
+      }),
+    ).toThrow(/meshJobDepIndex must be a non-negative integer.*got: NaN/);
+  });
+
+  it("rejects fractional values", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad-frac",
+        parameters: z.object({}),
+        dependencies: ["a", "b"],
+        meshJobDepIndex: 0.5,
+        execute: async () => "x",
+      }),
+    ).toThrow(/meshJobDepIndex must be a non-negative integer.*got: 0\.5/);
+  });
+
+  it("rejects out-of-range values (>= depCount) with the original range error", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad-oor",
+        parameters: z.object({}),
+        dependencies: ["a"], // length 1
+        meshJobDepIndex: 5,
+        execute: async () => "x",
+      }),
+    ).toThrow(/out of range — the tool declares 1 dependencies/);
+  });
+
+  it("accepts 0 (first dep is the MeshJob slot)", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "ok-zero",
+        parameters: z.object({}),
+        dependencies: ["a", "b"],
+        meshJobDepIndex: 0,
+        execute: async () => "x",
+      }),
+    ).not.toThrow();
+  });
+});
+
 // =============================================================================
 // W1 — splice helper (de-duplicated splice loop)
 // =============================================================================

--- a/src/runtime/typescript/src/__tests__/claim-dispatcher.spec.ts
+++ b/src/runtime/typescript/src/__tests__/claim-dispatcher.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for ClaimDispatcher (Phase 1 — MeshJob substrate).
+ *
+ * The dispatcher polls `POST /jobs/claim` periodically and dispatches
+ * claimed work via the local handler. Heavy on side effects, so tests
+ * use a stubbed `fetch` and a minimal handler — we exercise:
+ *
+ *   - Empty-claim behaviour (HTTP 204 → backoff, no handler call).
+ *   - Successful claim → handler invoked with payload, controller
+ *     constructed via napi.
+ *   - The claim-then-acquire ordering: even with an immediate claim,
+ *     the dispatcher must hold a permit before issuing the POST so
+ *     it never owns more jobs than it can run.
+ *   - Stop semantics: a long-running handler doesn't block stop().
+ *
+ * The napi `JobController` constructor is real — it doesn't reach out
+ * to the registry until `complete()`/`updateProgress()` is called, so
+ * the test stays in-process.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ClaimDispatcher } from "../claim-dispatcher.js";
+
+// Mock @mcpmesh/core so the real JobController/withJobAsync don't
+// actually try to reach the registry. The dispatcher uses `fetch`
+// directly for /jobs/claim (mocked separately below).
+vi.mock("@mcpmesh/core", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@mcpmesh/core");
+  return {
+    ...actual,
+    // The dispatcher constructs JobController via makeJobController
+    // (which calls `new JobController(...)`). Replace with a stub so
+    // the constructor doesn't spawn the per-controller batching tick
+    // (which would keep the test process alive past the test).
+    JobController: class {
+      jobId: string;
+      constructor(jobId: string, _instanceId: string, _registryUrl: string) {
+        this.jobId = jobId;
+      }
+      isTerminal = vi.fn().mockResolvedValue(true);
+      complete = vi.fn().mockResolvedValue(undefined);
+      fail = vi.fn().mockResolvedValue(undefined);
+      updateProgress = vi.fn().mockResolvedValue(undefined);
+    },
+    // withJobAsync just runs the body without binding the Rust
+    // task-local — fine for a test.
+    withJobAsync: vi.fn(async (
+      _jobId: string,
+      _deadline: number | null,
+      body: Promise<unknown>,
+    ) => body),
+  };
+});
+
+const originalFetch = globalThis.fetch;
+
+describe("ClaimDispatcher", () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = vi.fn();
+  });
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = originalFetch;
+  });
+
+  it("polls /jobs/claim and skips when registry returns 204 (no work)", async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      status: 204,
+      json: async () => ({}),
+    } as unknown as Response);
+
+    const handler = vi.fn().mockResolvedValue("ok");
+    const d = new ClaimDispatcher(
+      "cap",
+      "agent-instance",
+      "http://reg",
+      handler,
+    );
+    d.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await d.stop();
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+
+    // Check the URL + body the dispatcher used to claim.
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://reg/jobs/claim");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body);
+    expect(body.capability).toBe("cap");
+    expect(body.instance_id).toBe("agent-instance");
+  });
+
+  it("dispatches a claimed job to the handler with the submitted payload", async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    let calls = 0;
+    fetchMock.mockImplementation(async () => {
+      calls += 1;
+      // First poll returns one claim; subsequent polls return empty
+      // so the dispatcher backs off and the test can stop cleanly.
+      if (calls === 1) {
+        return {
+          status: 200,
+          json: async () => ({
+            claimed: [
+              {
+                id: "job-uuid-1",
+                submitted_payload: { user_id: "u", n: 5 },
+                max_duration: 30,
+              },
+            ],
+          }),
+        } as unknown as Response;
+      }
+      return { status: 204, json: async () => ({}) } as unknown as Response;
+    });
+
+    const handler = vi.fn().mockResolvedValue({ done: true });
+    const d = new ClaimDispatcher("cap", "agent-instance", "http://reg", handler);
+    d.start();
+    await new Promise((r) => setTimeout(r, 100));
+    await d.stop();
+
+    expect(handler).toHaveBeenCalledOnce();
+    const [payload, ctrl] = handler.mock.calls[0];
+    expect(payload).toEqual({ user_id: "u", n: 5 });
+    expect(ctrl).toBeDefined();
+    // Stub controller exposes jobId.
+    expect((ctrl as { jobId: string }).jobId).toBe("job-uuid-1");
+  });
+
+  it("treats malformed claim responses as no work (no crash, no handler call)", async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      status: 200,
+      json: async () => ({ claimed: "not-a-list" }),
+    } as unknown as Response);
+
+    const handler = vi.fn();
+    const d = new ClaimDispatcher("cap", "i", "http://r", handler);
+    d.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await d.stop();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("filters out claimed entries without an id", async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    let calls = 0;
+    fetchMock.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          status: 200,
+          json: async () => ({
+            claimed: [
+              { not_an_id: true },
+              { id: "" },
+              { id: "real-job", submitted_payload: {} },
+            ],
+          }),
+        } as unknown as Response;
+      }
+      return { status: 204, json: async () => ({}) } as unknown as Response;
+    });
+
+    const handler = vi.fn().mockResolvedValue("done");
+    const d = new ClaimDispatcher("cap", "i", "http://r", handler);
+    d.start();
+    await new Promise((r) => setTimeout(r, 100));
+    await d.stop();
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0][1].jobId).toBe("real-job");
+  });
+
+  it("stop() exits even when the handler is long-running", async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    let calls = 0;
+    fetchMock.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          status: 200,
+          json: async () => ({
+            claimed: [{ id: "long", submitted_payload: {} }],
+          }),
+        } as unknown as Response;
+      }
+      return { status: 204, json: async () => ({}) } as unknown as Response;
+    });
+
+    let resolveHandler!: () => void;
+    const handler = vi.fn(
+      () =>
+        new Promise<unknown>((resolve) => {
+          resolveHandler = () => resolve("done");
+        }),
+    );
+    const d = new ClaimDispatcher("cap", "i", "http://r", handler);
+    d.start();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Stop should resolve promptly even though the handler hasn't.
+    const stopPromise = d.stop();
+    // Resolve handler after stop call to avoid leaking the promise.
+    setTimeout(() => resolveHandler(), 20);
+    await stopPromise;
+    expect(handler).toHaveBeenCalledOnce();
+  });
+});

--- a/src/runtime/typescript/src/__tests__/claim-dispatcher.spec.ts
+++ b/src/runtime/typescript/src/__tests__/claim-dispatcher.spec.ts
@@ -20,6 +20,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ClaimDispatcher } from "../claim-dispatcher.js";
 import { getCurrentPropagatedHeaders } from "../proxy.js";
+import * as inboundDispatch from "../inbound-job-dispatch.js";
 
 // Mock @mcpmesh/core so the real JobController/withJobAsync don't
 // actually try to reach the registry. The dispatcher uses `fetch`
@@ -321,5 +322,73 @@ describe("ClaimDispatcher", () => {
     setTimeout(() => resolveHandler(), 20);
     await stopPromise;
     expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("posts a `failed` /jobs/batch delta when JobController construction throws (W2)", async () => {
+    // Review finding W2: previously a `console.warn` + early return left
+    // the registry believing this replica owned the job until lease
+    // expiry, leaving the row stuck in `working`. The fix is to fire a
+    // POST /jobs/batch failed delta directly (bypassing the controller
+    // we couldn't construct) so the row flips terminal immediately and
+    // unblocks retry.
+    const ctorSpy = vi
+      .spyOn(inboundDispatch, "makeJobController")
+      .mockImplementation(() => {
+        throw new Error("boom: napi binding refused");
+      });
+
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    let calls = 0;
+    const claimUrl = "http://reg/jobs/claim";
+    const batchUrl = "http://reg/jobs/batch";
+    fetchMock.mockImplementation(async (url: string) => {
+      calls += 1;
+      if (url === claimUrl && calls === 1) {
+        return {
+          status: 200,
+          json: async () => ({
+            claimed: [
+              {
+                id: "job-broken-ctor",
+                submitted_payload: { x: 1 },
+              },
+            ],
+          }),
+        } as unknown as Response;
+      }
+      if (url === batchUrl) {
+        return { status: 200, json: async () => ({}) } as unknown as Response;
+      }
+      return { status: 204, json: async () => ({}) } as unknown as Response;
+    });
+
+    const handler = vi.fn();
+    const d = new ClaimDispatcher("cap-broken", "agent-x", "http://reg", handler);
+    d.start();
+    await new Promise((r) => setTimeout(r, 100));
+    await d.stop();
+
+    // Handler must NOT have been invoked — the dispatcher bailed before
+    // calling it because we couldn't build a controller.
+    expect(handler).not.toHaveBeenCalled();
+
+    // The fail-fast path must have POSTed a `failed` delta to /jobs/batch.
+    const batchCall = fetchMock.mock.calls.find(
+      (call) => call[0] === batchUrl,
+    );
+    expect(batchCall, "expected a POST /jobs/batch fail-fast call").toBeDefined();
+    const init = batchCall![1] as RequestInit;
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body.instance_id).toBe("agent-x");
+    expect(body.deltas).toHaveLength(1);
+    const delta = body.deltas[0];
+    expect(delta.id).toBe("job-broken-ctor");
+    expect(delta.status).toBe("failed");
+    expect(typeof delta.error).toBe("string");
+    expect(delta.error).toContain("controller construction failed");
+    expect(delta.error).toContain("boom: napi binding refused");
+
+    ctorSpy.mockRestore();
   });
 });

--- a/src/runtime/typescript/src/__tests__/claim-dispatcher.spec.ts
+++ b/src/runtime/typescript/src/__tests__/claim-dispatcher.spec.ts
@@ -289,7 +289,13 @@ describe("ClaimDispatcher", () => {
     expect(agent.closed || agent.destroyed).toBe(true);
   });
 
-  it("stop() exits even when the handler is long-running", async () => {
+  it("stop() drains in-flight handlers before closing the keep-alive pool", async () => {
+    // Verifies the F7 follow-up: stop() must await any handler
+    // dispatches that are still mid-fetch before it tears down the
+    // shared `_httpAgent`. Without the drain, controller.complete /
+    // controller.fail HTTP calls would race with Agent.close() and
+    // surface as cryptic socket-closed errors — worse, the terminal
+    // delta might never reach the registry, leaving the row stuck.
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     let calls = 0;
     fetchMock.mockImplementation(async () => {
@@ -299,6 +305,73 @@ describe("ClaimDispatcher", () => {
           status: 200,
           json: async () => ({
             claimed: [{ id: "long", submitted_payload: {} }],
+          }),
+        } as unknown as Response;
+      }
+      return { status: 204, json: async () => ({}) } as unknown as Response;
+    });
+
+    let resolveHandler!: () => void;
+    let handlerObservedFinish = false;
+    const handler = vi.fn(
+      () =>
+        new Promise<unknown>((resolve) => {
+          resolveHandler = () => {
+            handlerObservedFinish = true;
+            resolve("done");
+          };
+        }),
+    );
+    const d = new ClaimDispatcher("cap", "i", "http://r", handler);
+    // The Agent is private; verify close ordering relative to handler
+    // resolution. eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const httpAgent = (d as any)._httpAgent as { close: () => Promise<void> };
+    let closedAt = 0;
+    const closeSpy = vi.spyOn(httpAgent, "close").mockImplementation(async () => {
+      closedAt = Date.now();
+    });
+
+    d.start();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Kick off stop(); resolve the handler ~20ms later.
+    const stopStart = Date.now();
+    const stopPromise = d.stop();
+    let resolvedAt = 0;
+    setTimeout(() => {
+      resolvedAt = Date.now();
+      resolveHandler();
+    }, 20);
+    await stopPromise;
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handlerObservedFinish).toBe(true);
+    // The keep-alive pool must close STRICTLY AFTER the handler
+    // resolved — that's the whole point of the drain.
+    expect(closeSpy).toHaveBeenCalled();
+    expect(resolvedAt).toBeGreaterThan(0);
+    expect(closedAt).toBeGreaterThanOrEqual(resolvedAt);
+    // Sanity: stop() should still be quick — the bounded timeout is
+    // 30s default, but we resolved at 20ms, so total wall < 1s.
+    expect(Date.now() - stopStart).toBeLessThan(1000);
+
+    closeSpy.mockRestore();
+  });
+
+  it("stop(timeoutMs=0) skips the drain when the caller asks for an immediate close", async () => {
+    // Defensive: the bounded-drain default is 30s, but the caller can
+    // pass `0` to force-close (e.g. tests that stub a long-running
+    // handler and don't want to wait for it). Verify the path doesn't
+    // hang on the in-flight handler.
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    let calls = 0;
+    fetchMock.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          status: 200,
+          json: async () => ({
+            claimed: [{ id: "never-finishes", submitted_payload: {} }],
           }),
         } as unknown as Response;
       }
@@ -316,12 +389,13 @@ describe("ClaimDispatcher", () => {
     d.start();
     await new Promise((r) => setTimeout(r, 50));
 
-    // Stop should resolve promptly even though the handler hasn't.
-    const stopPromise = d.stop();
-    // Resolve handler after stop call to avoid leaking the promise.
-    setTimeout(() => resolveHandler(), 20);
-    await stopPromise;
-    expect(handler).toHaveBeenCalledOnce();
+    const t0 = Date.now();
+    await d.stop(0);
+    expect(Date.now() - t0).toBeLessThan(500);
+
+    // Cleanup: resolve the dangling handler so it doesn't keep the
+    // event loop alive past the test.
+    resolveHandler();
   });
 
   it("posts a `failed` /jobs/batch delta when JobController construction throws (W2)", async () => {

--- a/src/runtime/typescript/src/__tests__/claim-dispatcher.spec.ts
+++ b/src/runtime/typescript/src/__tests__/claim-dispatcher.spec.ts
@@ -19,6 +19,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ClaimDispatcher } from "../claim-dispatcher.js";
+import { getCurrentPropagatedHeaders } from "../proxy.js";
 
 // Mock @mcpmesh/core so the real JobController/withJobAsync don't
 // actually try to reach the registry. The dispatcher uses `fetch`
@@ -173,6 +174,118 @@ describe("ClaimDispatcher", () => {
     await d.stop();
     expect(handler).toHaveBeenCalledOnce();
     expect(handler.mock.calls[0][1].jobId).toBe("real-job");
+  });
+
+  it("seeds the propagated-headers ALS with x-mesh-job-id (and x-mesh-timeout when present)", async () => {
+    // Verifies follow-up #2: claim-path dispatches must seed the
+    // propagated-headers AsyncLocalStorage so outbound calls made by
+    // the handler continue the submitter's trace tree (Python parity
+    // — see `_mcp_mesh.engine.claim_dispatcher.PythonClaimDispatcher
+    // ._dispatch`'s `TraceContext.set_propagated_headers` block).
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    let calls = 0;
+    fetchMock.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          status: 200,
+          json: async () => ({
+            claimed: [
+              {
+                id: "job-trace-1",
+                submitted_payload: { foo: "bar" },
+                max_duration: 45,
+              },
+            ],
+          }),
+        } as unknown as Response;
+      }
+      return { status: 204, json: async () => ({}) } as unknown as Response;
+    });
+
+    let observed: Record<string, string> | null = null;
+    const handler = vi.fn(async () => {
+      // Snapshot the ALS view from inside the user handler — exactly
+      // where outbound proxy calls would read it.
+      observed = { ...getCurrentPropagatedHeaders() };
+      return { ok: true };
+    });
+    const d = new ClaimDispatcher("cap-trace", "agent-1", "http://reg", handler);
+    d.start();
+    await new Promise((r) => setTimeout(r, 100));
+    await d.stop();
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(observed).not.toBeNull();
+    expect(observed!["x-mesh-job-id"]).toBe("job-trace-1");
+    expect(observed!["x-mesh-timeout"]).toBe("45");
+  });
+
+  it("omits x-mesh-timeout when claim has no max_duration", async () => {
+    // Defensive: a claim without max_duration must not seed an empty
+    // / zero-valued timeout header (downstream parsers would reject it).
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    let calls = 0;
+    fetchMock.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          status: 200,
+          json: async () => ({
+            claimed: [{ id: "job-no-timeout", submitted_payload: {} }],
+          }),
+        } as unknown as Response;
+      }
+      return { status: 204, json: async () => ({}) } as unknown as Response;
+    });
+
+    let observed: Record<string, string> | null = null;
+    const handler = vi.fn(async () => {
+      observed = { ...getCurrentPropagatedHeaders() };
+      return null;
+    });
+    const d = new ClaimDispatcher("cap-no-timeout", "i", "http://r", handler);
+    d.start();
+    await new Promise((r) => setTimeout(r, 100));
+    await d.stop();
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(observed).not.toBeNull();
+    expect(observed!["x-mesh-job-id"]).toBe("job-no-timeout");
+    expect(observed!["x-mesh-timeout"]).toBeUndefined();
+  });
+
+  it("stop() closes the keep-alive http agent (no leaked sockets)", async () => {
+    // Verifies follow-up #3: each ClaimDispatcher owns an undici Agent
+    // for connection reuse on /jobs/claim polls; stop() must close
+    // it so long-lived test harnesses don't leak sockets across
+    // agent restarts.
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      status: 204,
+      json: async () => ({}),
+    } as unknown as Response);
+
+    const d = new ClaimDispatcher("cap-stop", "i", "http://r", vi.fn());
+    // The Agent is private; reach in to verify close-state transitions.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const agent = (d as any)._httpAgent as {
+      close: () => Promise<void>;
+      destroyed: boolean;
+      closed: boolean;
+    };
+    const closeSpy = vi.spyOn(agent, "close");
+
+    d.start();
+    await new Promise((r) => setTimeout(r, 30));
+    await d.stop();
+
+    // We invoke close() once from stop(); undici's DispatcherBase
+    // re-enters close(callback) internally, which the spy records as
+    // a second call. We only care that it was invoked (and that the
+    // agent is now in the closed state).
+    expect(closeSpy).toHaveBeenCalled();
+    expect(agent.closed || agent.destroyed).toBe(true);
   });
 
   it("stop() exits even when the handler is long-running", async () => {

--- a/src/runtime/typescript/src/__tests__/inbound-job-dispatch.spec.ts
+++ b/src/runtime/typescript/src/__tests__/inbound-job-dispatch.spec.ts
@@ -118,11 +118,61 @@ describe("runWithJobContext", () => {
       stub as any,
       async () => userValue,
     );
-    // withJobAsync round-trips through napi-rs serde so the resolved
-    // value is a structurally-equal copy, not the same reference.
-    expect(result).toStrictEqual(userValue);
+    // The user's value is captured in a closure and returned directly
+    // (no napi serde round-trip), so the same reference is preserved.
+    expect(result).toBe(userValue);
     expect(stub.complete).toHaveBeenCalledOnce();
     expect(stub.complete).toHaveBeenCalledWith(userValue);
+  });
+
+  it("returns non-JSON-safe values to the caller and wraps for auto-complete", async () => {
+    // Map / Set / class instance / Symbol — any of these would have
+    // tripped the napi serde-json round-trip with a cryptic Rust error
+    // before the fix. Now they pass through to the caller untouched
+    // (Rust never sees them) and the auto-complete wraps them as
+    // `{ value: String(...) }` for the registry.
+    const cases: Array<{ name: string; build: () => unknown }> = [
+      { name: "Map", build: () => new Map([["k", 1]]) },
+      { name: "Set", build: () => new Set([1, 2, 3]) },
+      {
+        name: "class instance",
+        build: () => {
+          class Foo {
+            x = 1;
+            describe() {
+              return "foo";
+            }
+          }
+          return new Foo();
+        },
+      },
+      { name: "BigInt", build: () => BigInt(123) },
+      { name: "undefined", build: () => undefined },
+    ];
+    for (const c of cases) {
+      const stub = {
+        isTerminal: vi.fn().mockResolvedValue(false),
+        complete: vi.fn().mockResolvedValue(undefined),
+        fail: vi.fn().mockResolvedValue(undefined),
+      };
+      const value = c.build();
+      const result = await runWithJobContext(
+        `job-${c.name}`,
+        null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        stub as any,
+        async () => value as unknown,
+      );
+      // The user value is preserved verbatim — it never crosses napi.
+      expect(result, `case=${c.name} return value`).toBe(value);
+      // And the registry sees a JSON-safe wrap.
+      expect(stub.complete, `case=${c.name} complete called`).toHaveBeenCalledOnce();
+      const completedWith = stub.complete.mock.calls[0][0];
+      expect(
+        completedWith,
+        `case=${c.name} complete payload is wrapped`,
+      ).toMatchObject({ value: expect.any(String) });
+    }
   });
 
   it("auto-completes nested JSON-safe arrays/objects verbatim", async () => {

--- a/src/runtime/typescript/src/__tests__/inbound-job-dispatch.spec.ts
+++ b/src/runtime/typescript/src/__tests__/inbound-job-dispatch.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the inbound MeshJob dispatch wrapper (Phase 1).
+ *
+ * Mirrors the behavioural envelope of Python's
+ * `tests/test_job_dispatch.py`. We don't bind to the napi-rs
+ * `JobController` here — those are exercised by the cross-FFI test
+ * suite. Instead we verify:
+ *
+ *   - `readJobHeaders` returns the right shape on the standard
+ *     headers + on absent / malformed inputs;
+ *   - `runWithJobContext` runs the thunk inside `CURRENT_JOB.run`
+ *     when a controller is present, and bypasses the wrap when
+ *     either jobId or controller is null;
+ *   - the auto-complete path fires only when the controller hadn't
+ *     already gone terminal, and propagates user exceptions verbatim.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  readJobHeaders,
+  runWithJobContext,
+} from "../inbound-job-dispatch.js";
+import { currentJob } from "../job-context.js";
+
+describe("readJobHeaders", () => {
+  it("returns [null, null] when headers is null/undefined", () => {
+    expect(readJobHeaders(null)).toEqual([null, null]);
+    expect(readJobHeaders(undefined)).toEqual([null, null]);
+    expect(readJobHeaders({})).toEqual([null, null]);
+  });
+
+  it("extracts job id only when X-Mesh-Timeout is absent", () => {
+    expect(readJobHeaders({ "x-mesh-job-id": "job-123" })).toEqual([
+      "job-123",
+      null,
+    ]);
+  });
+
+  it("extracts both headers and parses timeout as float", () => {
+    expect(
+      readJobHeaders({
+        "x-mesh-job-id": "job-456",
+        "x-mesh-timeout": "12.5",
+      }),
+    ).toEqual(["job-456", 12.5]);
+  });
+
+  it("ignores malformed timeout (non-numeric / non-positive)", () => {
+    expect(
+      readJobHeaders({
+        "x-mesh-job-id": "j1",
+        "x-mesh-timeout": "abc",
+      }),
+    ).toEqual(["j1", null]);
+    expect(
+      readJobHeaders({
+        "x-mesh-job-id": "j2",
+        "x-mesh-timeout": "0",
+      }),
+    ).toEqual(["j2", null]);
+    expect(
+      readJobHeaders({
+        "x-mesh-job-id": "j3",
+        "x-mesh-timeout": "-1.5",
+      }),
+    ).toEqual(["j3", null]);
+  });
+});
+
+describe("runWithJobContext", () => {
+  it("runs the thunk directly when jobId or controller is null", async () => {
+    const result = await runWithJobContext(null, null, null, async () => {
+      // No active job inside the thunk.
+      expect(currentJob()).toBeNull();
+      return "ran";
+    });
+    expect(result).toBe("ran");
+  });
+
+  it("sets CURRENT_JOB inside the scope when controller is provided", async () => {
+    // Build a stub that mimics the JobController surface readWithJobContext
+    // touches: isTerminal() and complete(). The napi binding's actual
+    // behaviour is exercised in the Rust test suite.
+    const stub = {
+      isTerminal: vi.fn().mockResolvedValue(true), // already terminal → no auto-complete
+      complete: vi.fn().mockResolvedValue(undefined),
+      fail: vi.fn().mockResolvedValue(undefined),
+    };
+    const result = await runWithJobContext(
+      "job-abc",
+      30,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      stub as any,
+      async () => {
+        const cur = currentJob();
+        expect(cur?.jobId).toBe("job-abc");
+        expect(cur?.deadlineSecsRemaining).toBe(30);
+        return 42;
+      },
+    );
+    expect(result).toBe(42);
+    // Already-terminal probe → no auto-complete.
+    expect(stub.complete).not.toHaveBeenCalled();
+    // Outside the scope CURRENT_JOB is gone again.
+    expect(currentJob()).toBeNull();
+  });
+
+  it("auto-completes when the controller is not yet terminal", async () => {
+    const stub = {
+      isTerminal: vi.fn().mockResolvedValue(false),
+      complete: vi.fn().mockResolvedValue(undefined),
+      fail: vi.fn().mockResolvedValue(undefined),
+    };
+    const userValue = { ok: true, n: 42 };
+    const result = await runWithJobContext(
+      "job-auto",
+      null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      stub as any,
+      async () => userValue,
+    );
+    // withJobAsync round-trips through napi-rs serde so the resolved
+    // value is a structurally-equal copy, not the same reference.
+    expect(result).toStrictEqual(userValue);
+    expect(stub.complete).toHaveBeenCalledOnce();
+    expect(stub.complete).toHaveBeenCalledWith(userValue);
+  });
+
+  it("auto-completes nested JSON-safe arrays/objects verbatim", async () => {
+    const stub = {
+      isTerminal: vi.fn().mockResolvedValue(false),
+      complete: vi.fn().mockResolvedValue(undefined),
+      fail: vi.fn().mockResolvedValue(undefined),
+    };
+    const userValue = { items: [1, 2, { nested: "ok" }], count: 3 };
+    await runWithJobContext(
+      "job-deep",
+      null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      stub as any,
+      async () => userValue,
+    );
+    // Nested-but-JSON-safe → forwarded verbatim, no { value: ... } wrap.
+    expect(stub.complete).toHaveBeenCalledWith(userValue);
+  });
+
+  it("calls fail() on user exception when not yet terminal", async () => {
+    const stub = {
+      isTerminal: vi.fn().mockResolvedValue(false),
+      complete: vi.fn().mockResolvedValue(undefined),
+      fail: vi.fn().mockResolvedValue(undefined),
+    };
+    await expect(
+      runWithJobContext(
+        "job-fail",
+        null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        stub as any,
+        async () => {
+          throw new Error("boom");
+        },
+      ),
+    ).rejects.toThrow("boom");
+    expect(stub.fail).toHaveBeenCalledOnce();
+    expect(stub.fail).toHaveBeenCalledWith("boom");
+    expect(stub.complete).not.toHaveBeenCalled();
+  });
+
+  it("does not call fail() when the controller is already terminal", async () => {
+    const stub = {
+      isTerminal: vi.fn().mockResolvedValue(true),
+      complete: vi.fn().mockResolvedValue(undefined),
+      fail: vi.fn().mockResolvedValue(undefined),
+    };
+    await expect(
+      runWithJobContext(
+        "job-already",
+        null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        stub as any,
+        async () => {
+          throw new Error("ignored-fail");
+        },
+      ),
+    ).rejects.toThrow("ignored-fail");
+    expect(stub.fail).not.toHaveBeenCalled();
+  });
+});

--- a/src/runtime/typescript/src/__tests__/job-controller-progress.spec.ts
+++ b/src/runtime/typescript/src/__tests__/job-controller-progress.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression test for the napi `JobController` constructor's batching tick.
+ *
+ * The `#[napi(constructor)]` is invoked synchronously from JS context with
+ * NO ambient Tokio runtime — `Handle::try_current()` returns Err there,
+ * so an earlier implementation silently skipped `spawn_batching_tick` and
+ * mid-flight `updateProgress` calls accumulated in the coalescing queue
+ * forever (only `complete()`/`fail()` flushed because those are async napi
+ * methods that run inside napi-rs's Tokio runtime).
+ *
+ * The fix uses `napi::bindgen_prelude::within_runtime_if_available` so
+ * the tick spawns inside napi-rs's shared runtime regardless of whether
+ * the caller is sync or async — mirroring Python's pattern of entering
+ * `pyo3_async_runtimes::tokio::get_runtime()`.
+ *
+ * This test spins up a tiny HTTP server playing the role of the registry,
+ * constructs a real `JobController` against it, calls `updateProgress`,
+ * and asserts that the batching tick eventually POSTs to `/jobs/batch`
+ * with the queued delta — proving the tick actually runs.
+ */
+import { describe, it, expect } from "vitest";
+import { JobController } from "@mcpmesh/core";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+interface RecordedBatch {
+  instance_id: string;
+  deltas: Array<{
+    id: string;
+    progress?: number | null;
+    progress_message?: string | null;
+    status?: string | null;
+  }>;
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+describe("JobController batching tick", () => {
+  it("flushes updateProgress via the batching tick on a fake registry", async () => {
+    const recorded: RecordedBatch[] = [];
+
+    // Tiny registry mock: accept POST /jobs/batch, record body, return 200.
+    const server = http.createServer((req, res) => {
+      if (req.method === "POST" && req.url === "/jobs/batch") {
+        readBody(req)
+          .then((body) => {
+            recorded.push(JSON.parse(body) as RecordedBatch);
+            res.statusCode = 200;
+            res.setHeader("content-type", "application/json");
+            res.end(JSON.stringify({ accepted: 1, rejected: [] }));
+          })
+          .catch(() => {
+            res.statusCode = 500;
+            res.end();
+          });
+        return;
+      }
+      res.statusCode = 404;
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as AddressInfo).port;
+    const registryUrl = `http://127.0.0.1:${port}`;
+
+    try {
+      // Construct a real napi JobController — this is the exact code path
+      // that was broken: the constructor must spawn the batching tick on
+      // napi-rs's runtime, not on `Handle::try_current()` (which returns
+      // Err from a synchronous JS context).
+      const ctrl = new JobController("job-batch-test", "inst-1", registryUrl);
+
+      await ctrl.updateProgress(0.5, "halfway");
+
+      // Default batching interval is 2s. Wait long enough for at least one
+      // tick to fire. If the tick wasn't spawned, recorded stays empty.
+      await new Promise((r) => setTimeout(r, 2500));
+
+      expect(
+        recorded.length,
+        "batching tick must POST at least one batch with the queued progress delta",
+      ).toBeGreaterThanOrEqual(1);
+
+      const seen = recorded[0];
+      expect(seen.instance_id).toBe("inst-1");
+      expect(seen.deltas.length).toBe(1);
+      expect(seen.deltas[0].id).toBe("job-batch-test");
+      expect(seen.deltas[0].progress).toBeCloseTo(0.5, 5);
+      expect(seen.deltas[0].progress_message).toBe("halfway");
+      // Mid-flight delta — no terminal status.
+      expect(seen.deltas[0].status ?? null).toBeNull();
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }, 10_000);
+});

--- a/src/runtime/typescript/src/__tests__/job-controller-progress.spec.ts
+++ b/src/runtime/typescript/src/__tests__/job-controller-progress.spec.ts
@@ -81,7 +81,10 @@ describe("JobController batching tick", () => {
 
       // Default batching interval is 2s. Wait long enough for at least one
       // tick to fire. If the tick wasn't spawned, recorded stays empty.
-      await new Promise((r) => setTimeout(r, 2500));
+      // Use 5s of slack so this isn't flaky on slow CI runners — 500ms
+      // of headroom over a 2s tick was too tight, the cost of ~2.5s
+      // extra wall time is acceptable for a single test.
+      await new Promise((r) => setTimeout(r, 5000));
 
       expect(
         recorded.length,
@@ -99,5 +102,5 @@ describe("JobController batching tick", () => {
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
-  }, 10_000);
+  }, 15_000);
 });

--- a/src/runtime/typescript/src/__tests__/jobs-cancel-route.spec.ts
+++ b/src/runtime/typescript/src/__tests__/jobs-cancel-route.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Cancel-route registration visibility tests (W5 — PR review finding).
+ *
+ * Cancel-mid-flight is a primary control-plane signal for long-running
+ * jobs. Before the fix, registration failures landed at `console.warn`
+ * — operators who only watched `error`-level logs would never see the
+ * regression and the agent would silently degrade to lease-expiry
+ * cancellation.
+ *
+ * This file verifies the escalation:
+ *   - failures land at `console.error`;
+ *   - the message includes the underlying reason so the failure mode
+ *     is debuggable from logs alone.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { FastMCP } from "fastmcp";
+import { registerCancelRoute } from "../jobs-cancel-route.js";
+
+describe("registerCancelRoute — visibility", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("logs at console.error (not warn) when getApp() throws, including the reason", () => {
+    const stubServer = {
+      getApp: () => {
+        throw new Error("FastMCP server not started");
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as unknown as FastMCP;
+
+    const ok = registerCancelRoute(stubServer);
+    expect(ok).toBe(false);
+
+    // Escalated to error, NOT warn.
+    expect(errorSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    // Reason is included so operators can debug from logs alone.
+    const msg = errorSpy.mock.calls[0][0] as string;
+    expect(msg).toContain("cancel route NOT registered");
+    expect(msg).toContain("FastMCP server not started");
+  });
+
+  it("logs at console.error when getApp() returns null", () => {
+    const stubServer = {
+      getApp: () => null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as unknown as FastMCP;
+
+    const ok = registerCancelRoute(stubServer);
+    expect(ok).toBe(false);
+
+    expect(errorSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).not.toHaveBeenCalled();
+    const msg = errorSpy.mock.calls[0][0] as string;
+    expect(msg).toContain("cancel route NOT registered");
+    expect(msg).toContain("returned null");
+  });
+
+  it("logs at console.error when app.post() raises, including the reason", () => {
+    const stubServer = {
+      getApp: () => ({
+        post: () => {
+          throw new Error("hono internal: route conflict");
+        },
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as unknown as FastMCP;
+
+    const ok = registerCancelRoute(stubServer);
+    expect(ok).toBe(false);
+
+    expect(errorSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).not.toHaveBeenCalled();
+    const msg = errorSpy.mock.calls[0][0] as string;
+    expect(msg).toContain("cancel route NOT registered");
+    expect(msg).toContain("hono internal: route conflict");
+  });
+
+  it("returns true and does not log anything when registration succeeds", () => {
+    const postSpy = vi.fn();
+    const stubServer = {
+      getApp: () => ({ post: postSpy }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as unknown as FastMCP;
+
+    const ok = registerCancelRoute(stubServer);
+    expect(ok).toBe(true);
+    expect(postSpy).toHaveBeenCalledWith(
+      "/jobs/:job_id/cancel",
+      expect.any(Function),
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/runtime/typescript/src/__tests__/mesh-job-submitter.spec.ts
+++ b/src/runtime/typescript/src/__tests__/mesh-job-submitter.spec.ts
@@ -4,8 +4,8 @@
  * We don't bind to a real registry here — the napi `submitJob` is
  * mocked via vitest. The tests exercise:
  *
- *   - The retry policy (3 attempts on transient errors with 200ms /
- *     1s / 5s backoff — same as Python).
+ *   - The retry policy (3 attempts on transient errors with 200ms then
+ *     1s of backoff between attempts — 2 gaps for 3 attempts).
  *   - Fail-fast on non-transient errors (404 / 4xx / serialization).
  *   - Date → unix-epoch-seconds conversion for `totalDeadline`.
  *   - Number → unix-epoch-seconds normalisation (heuristic for

--- a/src/runtime/typescript/src/__tests__/mesh-job-submitter.spec.ts
+++ b/src/runtime/typescript/src/__tests__/mesh-job-submitter.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for MeshJobSubmitter (Phase 1 — MeshJob substrate).
+ *
+ * We don't bind to a real registry here — the napi `submitJob` is
+ * mocked via vitest. The tests exercise:
+ *
+ *   - The retry policy (3 attempts on transient errors with 200ms /
+ *     1s / 5s backoff — same as Python).
+ *   - Fail-fast on non-transient errors (404 / 4xx / serialization).
+ *   - Date → unix-epoch-seconds conversion for `totalDeadline`.
+ *   - Number → unix-epoch-seconds normalisation (heuristic for
+ *     callers that pass milliseconds).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MeshJobSubmitter } from "../mesh-job-submitter.js";
+
+// Mock napi-rs core's submit_job. Vitest hoists the factory above
+// imports so the SDK reads the mock regardless of import order.
+vi.mock("@mcpmesh/core", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@mcpmesh/core");
+  return {
+    ...actual,
+    submitJob: vi.fn(),
+  };
+});
+
+import { submitJob } from "@mcpmesh/core";
+
+const submitJobMock = submitJob as unknown as ReturnType<typeof vi.fn>;
+
+describe("MeshJobSubmitter", () => {
+  beforeEach(() => {
+    submitJobMock.mockReset();
+  });
+
+  it("calls napi submitJob with the bound capability + payload", async () => {
+    submitJobMock.mockResolvedValueOnce({ jobId: "job-123" });
+    const sub = new MeshJobSubmitter(
+      "generate_report",
+      "consumer-abc",
+      "http://localhost:8000",
+    );
+    const proxy = await sub.submit({ user_id: "u1", sections: ["a"] });
+    expect(proxy).toEqual({ jobId: "job-123" });
+    expect(submitJobMock).toHaveBeenCalledOnce();
+    expect(submitJobMock).toHaveBeenCalledWith({
+      registryUrl: "http://localhost:8000",
+      capability: "generate_report",
+      payload: { user_id: "u1", sections: ["a"] },
+      submittedBy: "consumer-abc",
+      ownerInstanceId: undefined,
+      maxDuration: undefined,
+      maxRetries: undefined,
+      totalDeadline: undefined,
+    });
+  });
+
+  it("forwards optional knobs to napi submit", async () => {
+    submitJobMock.mockResolvedValueOnce({ jobId: "j" });
+    const sub = new MeshJobSubmitter("c", "by", "http://r");
+    const deadlineMs = 1735689600 * 1000; // 2025-01-01T00:00:00Z
+    await sub.submit(
+      { foo: 1 },
+      {
+        maxDuration: 60,
+        maxRetries: 3,
+        totalDeadline: new Date(deadlineMs),
+      },
+    );
+    const call = submitJobMock.mock.calls[0][0];
+    expect(call.maxDuration).toBe(60);
+    expect(call.maxRetries).toBe(3);
+    expect(call.totalDeadline).toBe(1735689600);
+  });
+
+  it("normalises a millisecond-shaped number to seconds for totalDeadline", async () => {
+    submitJobMock.mockResolvedValueOnce({});
+    const sub = new MeshJobSubmitter("c", "by", "http://r");
+    await sub.submit({}, { totalDeadline: 1735689600_000 });
+    expect(submitJobMock.mock.calls[0][0].totalDeadline).toBe(1735689600);
+  });
+
+  it("passes seconds-shaped number through unchanged", async () => {
+    submitJobMock.mockResolvedValueOnce({});
+    const sub = new MeshJobSubmitter("c", "by", "http://r");
+    await sub.submit({}, { totalDeadline: 1735689600 });
+    expect(submitJobMock.mock.calls[0][0].totalDeadline).toBe(1735689600);
+  });
+
+  it("retries up to 3 times on a network error then succeeds", async () => {
+    submitJobMock
+      .mockRejectedValueOnce(new Error("backend error: network error: ECONNREFUSED"))
+      .mockRejectedValueOnce(new Error("backend error: network error: ECONNREFUSED"))
+      .mockResolvedValueOnce({ jobId: "ok" });
+    const sub = new MeshJobSubmitter("c", "by", "http://r");
+    const proxy = await sub.submit({});
+    expect(proxy).toEqual({ jobId: "ok" });
+    expect(submitJobMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails-fast on a 4xx error (not transient)", async () => {
+    submitJobMock.mockRejectedValueOnce(
+      new Error("backend error: backend error: HTTP 400: bad payload"),
+    );
+    const sub = new MeshJobSubmitter("c", "by", "http://r");
+    await expect(sub.submit({})).rejects.toThrow(/HTTP 400/);
+    expect(submitJobMock).toHaveBeenCalledOnce();
+  });
+
+  it("fails-fast on job-not-found (404)", async () => {
+    submitJobMock.mockRejectedValueOnce(
+      new Error("backend error: job not found: abc"),
+    );
+    const sub = new MeshJobSubmitter("c", "by", "http://r");
+    await expect(sub.submit({})).rejects.toThrow(/not found/);
+    expect(submitJobMock).toHaveBeenCalledOnce();
+  });
+
+  it("propagates the last transient error after exhausting retries", async () => {
+    submitJobMock.mockRejectedValue(
+      new Error("backend error: backend unavailable: 503"),
+    );
+    const sub = new MeshJobSubmitter("c", "by", "http://r");
+    await expect(sub.submit({})).rejects.toThrow(/backend unavailable/);
+    // 3 attempts total per the policy.
+    expect(submitJobMock).toHaveBeenCalledTimes(3);
+  }, 10_000);
+
+  it("rejects an invalid totalDeadline shape with a TypeError", async () => {
+    const sub = new MeshJobSubmitter("c", "by", "http://r");
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sub.submit({}, { totalDeadline: "not-a-date" as any }),
+    ).rejects.toThrow(TypeError);
+  });
+});

--- a/src/runtime/typescript/src/__tests__/resolver-meshjob.spec.ts
+++ b/src/runtime/typescript/src/__tests__/resolver-meshjob.spec.ts
@@ -1,0 +1,244 @@
+/**
+ * DDDI resolver tests for the `MeshJob` injectable (Phase 1).
+ *
+ * These tests are the TypeScript instance of the cross-runtime test
+ * seam specified in `MESHJOB_DDDI_CONTRACT.md` → "Equivalence across
+ * SDKs". The same scenarios MUST be covered by the Python and Java
+ * SDKs in their corresponding files
+ * (`tests/test_resolver_meshjob.py` and `MeshJobResolverTest.java`).
+ *
+ * If any behaviour here changes, update the contract first, then
+ * mirror across both other SDK test files. Each numbered scenario maps
+ * to the checklist in the contract document.
+ *
+ * # TS-shape note
+ *
+ * Python's resolver classifies parameters by reflection on
+ * `inspect.signature` + `typing.get_type_hints`. TypeScript erases
+ * types at runtime, so the TS resolver's input is the explicit
+ * `addTool({ dependencies, meshJobParamIndex })` declaration. The
+ * scenarios below translate the contract's signature-shape examples
+ * into the equivalent declarative form, then assert the same
+ * `meshToolDeps[*].signaturePosition` and `meshJobParamIndex` outputs
+ * the contract requires.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveMeshJobSignature,
+  ResolverError,
+  type ResolvedSignature,
+} from "../resolver-meshjob.js";
+
+// ===========================================================================
+// Contract scenarios 1-5 (must mirror across all three SDK test seams)
+// ===========================================================================
+
+describe("Resolver contract scenarios", () => {
+  it("scenario 1: MeshTool only — unchanged behaviour", () => {
+    // Python equivalent: fn(name, dep_a: McpMeshTool, dep_b: McpMeshTool)
+    // → mesh_tool_positions == [1, 2], no MeshJob.
+    //
+    // TS declarative form: dependencies ["dep_a", "dep_b"], no
+    // meshJobParamIndex. `args` lives at signature position 0; deps
+    // start at position 1.
+    const result = resolveMeshJobSignature({
+      dependencies: ["dep_a", "dep_b"],
+    });
+
+    expect(result.meshToolDeps).toEqual<ResolvedSignature["meshToolDeps"]>([
+      { depIndex: 0, signaturePosition: 1 },
+      { depIndex: 1, signaturePosition: 2 },
+    ]);
+    expect(result.meshJobParamIndex).toBeUndefined();
+  });
+
+  it("scenario 2: MeshJob only — no tools, MeshJob index recorded", () => {
+    // Python: fn(user_id, job: MeshJob) → mesh_tool_positions == [],
+    // mesh_job_param_index == 1.
+    const result = resolveMeshJobSignature({
+      dependencies: [],
+      meshJobParamIndex: 1,
+    });
+
+    expect(result.meshToolDeps).toEqual([]);
+    expect(result.meshJobParamIndex).toBe(1);
+  });
+
+  it("scenario 3: both, MeshJob in middle — MeshTool positions skip MeshJob", () => {
+    // Python: plan_trip(
+    //   user_id: str,                      # pos 0
+    //   weather_lookup: McpMeshTool,       # pos 1 — MeshTool[0]
+    //   job: MeshJob,                      # pos 2 — orthogonal
+    //   flight_search: McpMeshTool,        # pos 3 — MeshTool[1]
+    // )
+    // → mesh_tool_positions == [1, 3] (NOT [1, 2]); the resolver MUST
+    // NOT renumber tool slots when MeshJob is interleaved.
+    const result = resolveMeshJobSignature({
+      dependencies: ["weather_lookup", "flight_search"],
+      meshJobParamIndex: 2,
+    });
+
+    expect(result.meshToolDeps).toEqual([
+      { depIndex: 0, signaturePosition: 1 },
+      { depIndex: 1, signaturePosition: 3 }, // 3, not 2 — MeshJob skipped
+    ]);
+    expect(result.meshJobParamIndex).toBe(2);
+  });
+
+  it("scenario 4: neither — no DDDI metadata", () => {
+    // Python: fn(a, b) → empty resolution.
+    const result = resolveMeshJobSignature({ dependencies: [] });
+
+    expect(result.meshToolDeps).toEqual([]);
+    expect(result.meshJobParamIndex).toBeUndefined();
+  });
+
+  it("scenario 5: MeshJob trailing — index = last signature position", () => {
+    // Python: fn(a, b, tool: McpMeshTool, job: MeshJob)
+    // → mesh_tool_positions == [2], mesh_job_param_index == 3.
+    //
+    // TS form: one dep, MeshJob at the end. Note: in TS the user-arg
+    // shape is a single `args` object, so positions a/b are inside
+    // args (signature pos 0). The MeshTool dep takes pos 1 and the
+    // MeshJob takes pos 2 (the last slot).
+    const result = resolveMeshJobSignature({
+      dependencies: ["tool"],
+      meshJobParamIndex: 2,
+    });
+
+    expect(result.meshToolDeps).toEqual([
+      { depIndex: 0, signaturePosition: 1 },
+    ]);
+    expect(result.meshJobParamIndex).toBe(2);
+  });
+});
+
+// ===========================================================================
+// Contract edge cases — "Edge cases (REQUIRED)" in MESHJOB_DDDI_CONTRACT.md
+// ===========================================================================
+
+describe("Resolver edge cases", () => {
+  it("multiple MeshJob params raises ResolverError with the contract wording", () => {
+    // Phase 1: a tool function may declare at most one MeshJob param.
+    // The resolver MUST reject with the exact wording the contract
+    // specifies so the developer sees the misuse at registration time.
+    expect(() =>
+      resolveMeshJobSignature({
+        dependencies: [],
+        meshJobParamIndex: 1,
+        meshJobParamNames: ["firstJob", "secondJob"],
+      })
+    ).toThrow(ResolverError);
+
+    try {
+      resolveMeshJobSignature({
+        dependencies: [],
+        meshJobParamIndex: 1,
+        meshJobParamNames: ["firstJob", "secondJob"],
+      });
+    } catch (err) {
+      const msg = (err as Error).message.toLowerCase();
+      // Contract wording: "a tool function may declare at most one MeshJob parameter"
+      expect(msg).toContain("at most one");
+      expect(msg).toContain("meshjob");
+      // Both offending names should appear so the developer can fix it.
+      expect(msg).toContain("firstjob");
+      expect(msg).toContain("secondjob");
+    }
+  });
+
+  it("MeshJob first position — orthogonal at any signature index", () => {
+    // Per contract: "MeshJob mixed with MeshTool at any position —
+    // permitted". The resolver MUST NOT enforce a trailing-position
+    // rule.
+    const result = resolveMeshJobSignature({
+      dependencies: ["dep_a"],
+      meshJobParamIndex: 1, // MeshJob at sig pos 1, dep slides to pos 2
+    });
+
+    expect(result.meshToolDeps).toEqual([
+      { depIndex: 0, signaturePosition: 2 },
+    ]);
+    expect(result.meshJobParamIndex).toBe(1);
+  });
+
+  it("explicit meshToolPositions — collision with MeshJob throws", () => {
+    // Defensive: if the caller supplies both meshToolPositions and
+    // meshJobParamIndex and they overlap, that's a contract violation
+    // — fail loudly rather than silently overwrite.
+    expect(() =>
+      resolveMeshJobSignature({
+        dependencies: ["x"],
+        meshToolPositions: [2],
+        meshJobParamIndex: 2,
+      })
+    ).toThrow(ResolverError);
+  });
+
+  it("explicit meshToolPositions — length mismatch throws", () => {
+    expect(() =>
+      resolveMeshJobSignature({
+        dependencies: ["a", "b"],
+        meshToolPositions: [1], // length 1 vs deps length 2
+      })
+    ).toThrow(ResolverError);
+  });
+});
+
+// ===========================================================================
+// Surface tests — the public exports + JS-side contextvar (job-context.ts)
+// ===========================================================================
+
+describe("MeshJob public surface", () => {
+  it("MeshJob type marker is importable from the package types module", async () => {
+    // Smoke test the export so a typo doesn't silently break the
+    // public API. We dynamic-import to assert it parses; the
+    // type-only import at the top of this file would be erased by
+    // tsc and not fail at runtime if the export disappeared.
+    const types = await import("../types.js");
+    // MeshJob is an interface (erased at runtime) — verify it's at
+    // least a key on the module type so consumers can `import type`
+    // it. The runtime presence we care about is the resolver +
+    // job-context, exercised by the other suites.
+    expect(types).toBeDefined();
+  });
+
+  it("currentJob() returns null outside any active job scope", async () => {
+    const { currentJob, remainingSeconds } = await import("../job-context.js");
+    expect(currentJob()).toBeNull();
+    expect(remainingSeconds()).toBeNull();
+  });
+
+  it("withJobAsync sets CURRENT_JOB visible to currentJob() inside the scope", async () => {
+    const { currentJob, remainingSeconds, withJobAsync } = await import(
+      "../job-context.js"
+    );
+
+    const inside = await withJobAsync(
+      { jobId: "job-set", deadlineSecsRemaining: 12.5 },
+      async () => {
+        const cur = currentJob();
+        expect(cur).not.toBeNull();
+        expect(cur?.jobId).toBe("job-set");
+        expect(remainingSeconds()).toBe(12.5);
+        return "done";
+      }
+    );
+    expect(inside).toBe("done");
+
+    // Outside the scope: gone again.
+    expect(currentJob()).toBeNull();
+  });
+
+  it("snapshot with no deadline returns null remainingSeconds", async () => {
+    const { remainingSeconds, withJobAsync } = await import("../job-context.js");
+
+    await withJobAsync(
+      { jobId: "job-no-deadline", deadlineSecsRemaining: null },
+      async () => {
+        expect(remainingSeconds()).toBeNull();
+      }
+    );
+  });
+});

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -35,6 +35,15 @@ import { resolveConfig, generateAgentIdSuffix, findAvailablePort } from "./confi
 import { enrichSchemaWithMediaTypes } from "./media-param.js";
 import { createProxy, normalizeDependency, runWithTraceContext, runWithPropagatedHeaders, PROXY_DISPATCH_META } from "./proxy.js";
 import {
+  readJobHeaders,
+  runWithJobContext,
+  makeJobController,
+} from "./inbound-job-dispatch.js";
+import { MeshJobSubmitter } from "./mesh-job-submitter.js";
+import { ClaimDispatcher, type ClaimHandler } from "./claim-dispatcher.js";
+import { registerJobHelperTools, type HelperToolMeta } from "./jobs-helper-tools.js";
+import { registerCancelRoute } from "./jobs-cancel-route.js";
+import {
   clusterStrictEnabled,
   normalizeSchemaWithPolicy,
 } from "./schema-normalize.js";
@@ -165,6 +174,21 @@ export class MeshAgent {
   // registry / Rust core wiring (no Express port conflict, no double-register).
   private _workerMode = false;
 
+  /**
+   * Phase 1 MeshJob substrate: per-tool ClaimHandler for `task: true`
+   * tools. Indexed by capability so the ClaimDispatcher can look up
+   * the local handler without re-traversing the tools map. Populated
+   * by addTool() at registration time; consumed by _autoStart() to
+   * spawn one dispatcher per task tool.
+   */
+  private _taskHandlers: Map<string, ClaimHandler> = new Map();
+  /**
+   * Active claim dispatchers (one per task=true capability). Started
+   * during _autoStart(); stopped during shutdown(). Empty for agents
+   * that own no task=true tools.
+   */
+  private _claimDispatchers: ClaimDispatcher[] = [];
+
   constructor(server: FastMCP, config: AgentConfig) {
     if (_isWorkerMode) {
       // Worker thread: skip ALL init. Only addTool() runs (in worker-mode
@@ -242,8 +266,25 @@ export class MeshAgent {
         }
         // Other constructor names (GeneratorFunction, etc.) are
         // unusual; let them through with a console warning rather
-        // than blocking — Phase B's dispatch wrapper will surface
-        // any actual misuse at first invocation.
+        // than blocking — the dispatch wrapper will surface any actual
+        // misuse at first invocation.
+      }
+    }
+
+    // Phase 1 MeshJob substrate (consumer-side validation): if the
+    // tool declares meshJobDepIndex, that index MUST point to a
+    // valid dependency. Catch the misuse at registration so the
+    // developer doesn't see a confusing TypeError at runtime when
+    // the wrapper tries to swap the dep proxy for a submitter.
+    if (def.meshJobDepIndex !== undefined) {
+      const depCount = (def.dependencies ?? []).length;
+      if (def.meshJobDepIndex < 0 || def.meshJobDepIndex >= depCount) {
+        throw new Error(
+          `addTool({ meshJobDepIndex: ${def.meshJobDepIndex} }) for tool ` +
+            `'${toolName}' is out of range — the tool declares ${depCount} ` +
+            `dependencies. meshJobDepIndex must be a valid index into ` +
+            `dependencies[].`,
+        );
       }
     }
 
@@ -265,11 +306,34 @@ export class MeshAgent {
     );
     const depEndpoints = normalizedDeps.map((d) => d.capability);
 
+    // Capture for closures — these reads must be live at invocation
+    // time (e.g. registryUrl/agentId aren't set yet at addTool time).
+    const isTaskTool = def.task === true;
+    const meshJobDepIndex = def.meshJobDepIndex;
+    const meshJobParamIndex = def.meshJobParamIndex;
+
     // Create wrapper that injects dependencies positionally and handles tracing
     const wrappedExecute = async (args: z.infer<T>): Promise<string> => {
       // Build positional deps array using composite keys (toolName:dep_index)
-      const depsArray: (McpMeshTool | null)[] = normalizedDeps.map(
-        (_, depIndex) => this.resolvedDeps.get(`${toolName}:dep_${depIndex}`) ?? null
+      // Phase 1 MeshJob substrate (consumer-side): if meshJobDepIndex is
+      // set, swap the McpMeshTool proxy at that slot for a
+      // MeshJobSubmitter targeting that dep's capability. We bind the
+      // submitter to the live registryUrl/agentId so it can submit
+      // jobs without needing access to the agent instance.
+      const depsArray: (McpMeshTool | MeshJobSubmitter | null)[] = normalizedDeps.map(
+        (dep, depIndex) => {
+          if (depIndex === meshJobDepIndex) {
+            // Build the submitter lazily per call so we always pick
+            // up the current registryUrl (test harnesses sometimes
+            // mutate it between calls).
+            return new MeshJobSubmitter(
+              dep.capability,
+              this.agentId,
+              this.config.registryUrl,
+            );
+          }
+          return this.resolvedDeps.get(`${toolName}:dep_${depIndex}`) ?? null;
+        },
       );
       const injectedCount = depsArray.filter((d) => d !== null).length;
 
@@ -323,7 +387,19 @@ export class MeshAgent {
       // Python implementation in _mcp_mesh/shared/tool_executor.py.
       // Default ON; set MCP_MESH_TOOL_ISOLATION=false to revert to inline
       // execution on the main loop (legacy behavior).
+      //
+      // Phase 1 MeshJob substrate: force-disable isolation for tools
+      // that bind to a JobController or MeshJobSubmitter. The
+      // controller/submitter wrap napi-rs handles plus
+      // AsyncLocalStorage state that cannot be cleanly serialised
+      // across the worker_threads boundary. Running inline on the
+      // main loop is the right trade — task=true tools are
+      // long-running by definition and benefit less from isolation
+      // (their wall-clock time is dominated by the user's `await`s,
+      // not CPU bursts that block the event loop).
+      const isJobBound = isTaskTool || meshJobDepIndex !== undefined;
       const isolationEnabled =
+        !isJobBound &&
         (process.env.MCP_MESH_TOOL_ISOLATION ?? "true").toLowerCase() !== "false";
 
       try {
@@ -365,10 +441,70 @@ export class MeshAgent {
           });
         } else {
           // Legacy inline execution on the main thread. Preserved as a clean
-          // fallback for users who explicitly opt out of isolation.
+          // fallback for users who explicitly opt out of isolation, AND used
+          // unconditionally for job-bound tools (see isJobBound above).
+          //
+          // Phase 1 MeshJob substrate: when this tool is task=true and the
+          // inbound headers carry X-Mesh-Job-Id, build a JobController,
+          // splice it into the call args at meshJobParamIndex, and run the
+          // user function inside both the JS-side ALS (CURRENT_JOB) and the
+          // Rust-side task-local (withJobAsync) so cancel-registry binding
+          // + outbound header injection work transparently.
           result = await runWithTraceContext(traceContext, async () => {
             return await runWithPropagatedHeaders(propagatedHeaders, async () => {
-              return await execute(cleanArgs, ...depsArray);
+              if (isTaskTool) {
+                const [jobId, deadlineSecs] = readJobHeaders(propagatedHeaders);
+                let controller = null;
+                if (jobId && this.config.registryUrl && this.agentId) {
+                  try {
+                    controller = makeJobController(
+                      jobId,
+                      this.agentId,
+                      this.config.registryUrl,
+                    );
+                  } catch (err) {
+                    console.warn(
+                      `[mesh-jobs] could not construct JobController for tool ` +
+                        `'${toolName}' job=${jobId}; running as a regular call:`,
+                      err,
+                    );
+                  }
+                }
+                // Build the call args, splicing the controller (or null) at
+                // meshJobParamIndex if specified. Position 0 is `args`; deps
+                // begin at position 1. The MeshJob slot is orthogonal —
+                // when meshJobParamIndex skips a position, deps shift past
+                // it (caller's signature must reflect that).
+                const callArgs: unknown[] = [cleanArgs];
+                let depCursor = 0;
+                let pos = 1;
+                while (depCursor < depsArray.length || pos === meshJobParamIndex) {
+                  if (pos === meshJobParamIndex) {
+                    callArgs.push(controller);
+                    pos += 1;
+                    continue;
+                  }
+                  callArgs.push(depsArray[depCursor]);
+                  depCursor += 1;
+                  pos += 1;
+                }
+                // Trailing meshJobParamIndex case (after all deps).
+                if (
+                  meshJobParamIndex !== undefined &&
+                  callArgs.length <= meshJobParamIndex
+                ) {
+                  while (callArgs.length < meshJobParamIndex) {
+                    callArgs.push(null);
+                  }
+                  callArgs[meshJobParamIndex] = controller;
+                }
+                return await runWithJobContext(jobId, deadlineSecs, controller, () =>
+                  Promise.resolve(
+                    (execute as (...a: unknown[]) => unknown)(...callArgs),
+                  ),
+                );
+              }
+              return await execute(cleanArgs, ...(depsArray as (McpMeshTool | null)[]));
             });
           });
         }
@@ -431,6 +567,54 @@ export class MeshAgent {
       execute: wrappedExecute,
     });
 
+    // Phase 1 MeshJob substrate: register a ClaimHandler for this
+    // tool so the per-capability ClaimDispatcher (spawned in
+    // _autoStart) can dispatch claimed jobs to the same execute fn
+    // — without going through FastMCP's HTTP transport. The handler
+    // builds the same callArgs shape the inbound wrapper does, but
+    // gets the controller passed in directly (no header parsing
+    // needed) and bypasses FastMCP's tool-call serialisation.
+    if (isTaskTool) {
+      const capability = def.capability ?? toolName;
+      this._taskHandlers.set(capability, async (payload, controller) => {
+        const callArgs: unknown[] = [payload];
+        let depCursor = 0;
+        let pos = 1;
+        const liveDeps: (McpMeshTool | MeshJobSubmitter | null)[] = normalizedDeps.map(
+          (dep, depIndex) => {
+            if (depIndex === meshJobDepIndex) {
+              return new MeshJobSubmitter(
+                dep.capability,
+                this.agentId,
+                this.config.registryUrl,
+              );
+            }
+            return this.resolvedDeps.get(`${toolName}:dep_${depIndex}`) ?? null;
+          },
+        );
+        while (depCursor < liveDeps.length || pos === meshJobParamIndex) {
+          if (pos === meshJobParamIndex) {
+            callArgs.push(controller);
+            pos += 1;
+            continue;
+          }
+          callArgs.push(liveDeps[depCursor]);
+          depCursor += 1;
+          pos += 1;
+        }
+        if (
+          meshJobParamIndex !== undefined &&
+          callArgs.length <= meshJobParamIndex
+        ) {
+          while (callArgs.length < meshJobParamIndex) {
+            callArgs.push(null);
+          }
+          callArgs[meshJobParamIndex] = controller;
+        }
+        return await (execute as (...a: unknown[]) => unknown)(...callArgs);
+      });
+    }
+
     // Store mesh metadata with JSON Schema for LLM tool resolution
     const inputSchema = this.convertZodToJsonSchema(def.parameters);
     enrichSchemaWithMediaTypes(inputSchema as Record<string, unknown>);
@@ -456,6 +640,8 @@ export class MeshAgent {
       // read this to decide between job semantics and a regular
       // tools/call.
       task: def.task === true,
+      meshJobParamIndex: def.meshJobParamIndex,
+      meshJobDepIndex: def.meshJobDepIndex,
     });
 
     return this;
@@ -647,11 +833,87 @@ export class MeshAgent {
     // 2. Register LLM tools from LlmToolRegistry
     this.registerLlmTools();
 
+    // 2.5 Phase 1 MeshJob substrate: register the three framework
+    // helper tools (`__mesh_job_status`/`_result`/`_cancel`) on
+    // every TS agent regardless of whether it owns task=true tools.
+    // Mirrors Python's JobsHelperToolsStep. Skipped when there's no
+    // registry URL — the helpers can't function without it.
+    this.registerJobsHelperTools();
+
+    // 2.6 Phase 1 MeshJob substrate: mount POST /jobs/:job_id/cancel
+    // on FastMCP's underlying Hono app so the registry's cancel
+    // forwarder can fire the in-process cancel token. Best-effort —
+    // failures here are logged, not fatal.
+    if (this.config.registryUrl) {
+      registerCancelRoute(this.server);
+    }
+
     // 3. Start heartbeat to registry via Rust core
     await this.startHeartbeat();
 
+    // 3.5 Phase 1 MeshJob substrate: spawn one ClaimDispatcher per
+    // task=true tool so the agent can poll the registry's
+    // /jobs/claim and dispatch claimed work locally. Started after
+    // heartbeat so the registry already knows this replica when the
+    // first claim arrives (eliminates the "claim before
+    // registration" race).
+    this.startClaimDispatchers();
+
     // 4. Install signal handlers for graceful shutdown
     this.installSignalHandlers();
+  }
+
+  /**
+   * Phase 1 MeshJob substrate: register the three framework helper
+   * tools on the FastMCP server AND in the agent's tool catalog so
+   * the heartbeat ships them to the registry as visible capabilities.
+   */
+  private registerJobsHelperTools(): void {
+    if (!this.config.registryUrl) {
+      return;
+    }
+    let helpers: Map<string, HelperToolMeta>;
+    try {
+      helpers = registerJobHelperTools(this.server, this.config.registryUrl);
+    } catch (err) {
+      console.warn("[mesh-jobs] failed to register job helper tools:", err);
+      return;
+    }
+    for (const [name, meta] of helpers.entries()) {
+      // Don't overwrite a user-defined tool with the same name.
+      if (this.tools.has(name)) continue;
+      this.tools.set(name, {
+        capability: meta.capability,
+        version: meta.version,
+        tags: meta.tags,
+        description: meta.description,
+        inputSchema: meta.inputSchema,
+        outputSchemaStrict: true,
+        dependencies: [],
+        dependencyKwargs: undefined,
+        task: meta.task,
+      });
+    }
+  }
+
+  /**
+   * Phase 1 MeshJob substrate: spawn ClaimDispatchers for every
+   * task=true tool registered. Skipped if no registry URL or no task
+   * handlers are present.
+   */
+  private startClaimDispatchers(): void {
+    if (!this.config.registryUrl) return;
+    if (this._taskHandlers.size === 0) return;
+    for (const [capability, handler] of this._taskHandlers.entries()) {
+      const dispatcher = new ClaimDispatcher(
+        capability,
+        this.agentId,
+        this.config.registryUrl,
+        handler,
+      );
+      dispatcher.start();
+      this._claimDispatchers.push(dispatcher);
+    }
   }
 
   /**
@@ -1153,6 +1415,16 @@ export class MeshAgent {
    * Shutdown the agent gracefully.
    */
   async shutdown(): Promise<void> {
+    // Phase 1 MeshJob substrate: stop claim dispatchers first so
+    // they don't pull a fresh job mid-shutdown.
+    for (const d of this._claimDispatchers) {
+      try {
+        await d.stop();
+      } catch (err) {
+        console.warn(`[mesh-jobs] error stopping claim dispatcher:`, err);
+      }
+    }
+    this._claimDispatchers = [];
     try {
       await closeHttpPool();
     } catch (err) {

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -273,15 +273,26 @@ export class MeshAgent {
     }
 
     // Phase 1 MeshJob substrate (consumer-side validation): if the
-    // tool declares meshJobDepIndex, that index MUST point to a
-    // valid dependency. Catch the misuse at registration so the
-    // developer doesn't see a confusing TypeError at runtime when
-    // the wrapper tries to swap the dep proxy for a submitter.
+    // tool declares meshJobDepIndex, that index MUST be a non-negative
+    // integer pointing to a valid dependency. Catch misuse at
+    // registration so the developer doesn't see a confusing TypeError
+    // at runtime when the wrapper tries to swap the dep proxy for a
+    // submitter. Mirrors the meshJobParamIndex validation below —
+    // NaN / fractional / negative values must fail-fast here too.
     if (def.meshJobDepIndex !== undefined) {
       const depCount = (def.dependencies ?? []).length;
-      if (def.meshJobDepIndex < 0 || def.meshJobDepIndex >= depCount) {
+      const v = def.meshJobDepIndex;
+      const isInt = Number.isInteger(v) && v >= 0;
+      if (!isInt) {
         throw new Error(
-          `addTool({ meshJobDepIndex: ${def.meshJobDepIndex} }) for tool ` +
+          `addTool({ meshJobDepIndex: ${v} }) for tool '${toolName}': ` +
+            `meshJobDepIndex must be a non-negative integer (index into ` +
+            `dependencies[]), got: ${v}`,
+        );
+      }
+      if (v >= depCount) {
+        throw new Error(
+          `addTool({ meshJobDepIndex: ${v} }) for tool ` +
             `'${toolName}' is out of range — the tool declares ${depCount} ` +
             `dependencies. meshJobDepIndex must be a valid index into ` +
             `dependencies[].`,
@@ -509,11 +520,20 @@ export class MeshAgent {
                       this.config.registryUrl,
                     );
                   } catch (err) {
-                    console.warn(
-                      `[mesh-jobs] could not construct JobController for tool ` +
-                        `'${toolName}' job=${jobId}; running as a regular call:`,
+                    // Don't silently fall back to a regular tool call —
+                    // a `task: true` tool that needs a controller will
+                    // misbehave (return a dict instead of completing the
+                    // row, leaving the registry's job stuck in `working`
+                    // until lease expiry). Surface the failure so the
+                    // outer FastMCP handler reports it AND the inbound
+                    // wrapper's catch (or its caller) can fail-fast.
+                    console.error(
+                      `[mesh-jobs] makeJobController failed for tool ` +
+                        `'${toolName}' job=${jobId} agent=${this.agentId} ` +
+                        `registry=${this.config.registryUrl}:`,
                       err,
                     );
+                    throw err;
                   }
                 }
                 // Build the call args, splicing the controller (or null) at

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -213,6 +213,40 @@ export class MeshAgent {
     const toolName = def.name;
     const execute = def.execute;
 
+    // Phase 1 MeshJob substrate: validate `task: true` requires an
+    // async function. Long-running tools need a Promise-based control
+    // flow so the dispatch wrapper (Phase B) can await
+    // `MeshJob.updateProgress()` / cancellation / outbound polling.
+    // Fail loudly at `addTool` so the developer sees the misuse before
+    // the agent even tries to register with the registry.
+    //
+    // Heuristic: AsyncFunction.constructor.name === "AsyncFunction".
+    // We only flag the obvious sync case (an arrow/function literal)
+    // — any function returning a Promise will pass this check, which
+    // is the right relaxation for users who wrap their handler in a
+    // Promise factory.
+    if (def.task === true) {
+      const ctorName = (execute as { constructor?: { name?: string } })
+        ?.constructor?.name;
+      if (ctorName !== "AsyncFunction") {
+        // We can't reliably detect Promise-returning sync functions
+        // without invoking them, but we CAN reject the unambiguous
+        // "function() { ... }" case where the developer probably
+        // forgot the `async` keyword.
+        if (ctorName === "Function") {
+          throw new Error(
+            `addTool({ task: true }) requires an async execute function; ` +
+              `tool '${toolName}' has a sync execute. Mark it 'async' or ` +
+              `remove task: true.`
+          );
+        }
+        // Other constructor names (GeneratorFunction, etc.) are
+        // unusual; let them through with a console warning rather
+        // than blocking — Phase B's dispatch wrapper will surface
+        // any actual misuse at first invocation.
+      }
+    }
+
     // Worker mode: register the raw execute fn in the worker tool map and
     // skip FastMCP registration, dependency wiring, and metadata storage.
     // The worker entry will look up tools by name when handling dispatched
@@ -417,6 +451,11 @@ export class MeshAgent {
       outputSchemaStrict: def.outputSchemaStrict !== false,
       dependencies: normalizedDeps,
       dependencyKwargs: def.dependencyKwargs,
+      // Phase 1 MeshJob substrate: stamp producer's long-running flag
+      // so the heartbeat pipeline ships it to the registry. Consumers
+      // read this to decide between job semantics and a regular
+      // tools/call.
+      task: def.task === true,
     });
 
     return this;

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -38,6 +38,7 @@ import {
   readJobHeaders,
   runWithJobContext,
   makeJobController,
+  spliceJobController,
 } from "./inbound-job-dispatch.js";
 import { MeshJobSubmitter } from "./mesh-job-submitter.js";
 import { ClaimDispatcher, type ClaimHandler } from "./claim-dispatcher.js";
@@ -288,6 +289,29 @@ export class MeshAgent {
       }
     }
 
+    // Phase 1 MeshJob substrate (producer-side validation): if the
+    // tool declares meshJobParamIndex, that position MUST be a sane
+    // integer >= 1. Position 0 is reserved for the args payload, so
+    // the controller can only land at sig pos 1+. Without this
+    // guard, values 0 / negative / NaN / non-integer silently skip
+    // controller injection — the user's handler then sees `null`
+    // where it expected a JobController and throws a confusing
+    // `TypeError: Cannot read properties of null` at first await.
+    //
+    // Upper bound is a sanity check: > 10 almost certainly means a
+    // typo (no real producer signature has that many params).
+    if (def.meshJobParamIndex !== undefined) {
+      const v = def.meshJobParamIndex;
+      const ok = Number.isInteger(v) && v >= 1 && v <= 10;
+      if (!ok) {
+        throw new Error(
+          `addTool({ meshJobParamIndex: ${v} }) for tool '${toolName}': ` +
+            `meshJobParamIndex must be an integer >= 1 (position of MeshJob ` +
+            `param after the args payload), got: ${v}`,
+        );
+      }
+    }
+
     // Worker mode: register the raw execute fn in the worker tool map and
     // skip FastMCP registration, dependency wiring, and metadata storage.
     // The worker entry will look up tools by name when handling dispatched
@@ -311,6 +335,28 @@ export class MeshAgent {
     const isTaskTool = def.task === true;
     const meshJobDepIndex = def.meshJobDepIndex;
     const meshJobParamIndex = def.meshJobParamIndex;
+
+    // Phase 1 MeshJob substrate: when a job-bound tool exists AND the
+    // user explicitly opted into worker isolation via env, log a single
+    // warning at registration time. The wrapper force-disables
+    // isolation for job-bound tools because controllers + the
+    // AsyncLocalStorage / Rust task-local job context don't cross the
+    // worker_threads boundary cleanly. Without this log the
+    // force-disable was silent — users who set MCP_MESH_TOOL_ISOLATION
+    // expected it to apply to every tool.
+    const isJobBoundForLog = isTaskTool || meshJobDepIndex !== undefined;
+    const isolationEnvSet =
+      typeof process.env.MCP_MESH_TOOL_ISOLATION === "string" &&
+      process.env.MCP_MESH_TOOL_ISOLATION.toLowerCase() !== "false";
+    if (isJobBoundForLog && isolationEnvSet) {
+      console.warn(
+        `[mesh-tool] '${toolName}' has ` +
+          (isTaskTool ? "task: true" : `meshJobDepIndex: ${meshJobDepIndex}`) +
+          `; worker isolation is disabled for job-bound tools ` +
+          `(controllers/AsyncLocalStorage don't cross worker boundaries). ` +
+          `Set 'task: true' explicitly if you intend a producer.`,
+      );
+    }
 
     // Create wrapper that injects dependencies positionally and handles tracing
     const wrappedExecute = async (args: z.infer<T>): Promise<string> => {
@@ -475,29 +521,12 @@ export class MeshAgent {
                 // begin at position 1. The MeshJob slot is orthogonal —
                 // when meshJobParamIndex skips a position, deps shift past
                 // it (caller's signature must reflect that).
-                const callArgs: unknown[] = [cleanArgs];
-                let depCursor = 0;
-                let pos = 1;
-                while (depCursor < depsArray.length || pos === meshJobParamIndex) {
-                  if (pos === meshJobParamIndex) {
-                    callArgs.push(controller);
-                    pos += 1;
-                    continue;
-                  }
-                  callArgs.push(depsArray[depCursor]);
-                  depCursor += 1;
-                  pos += 1;
-                }
-                // Trailing meshJobParamIndex case (after all deps).
-                if (
-                  meshJobParamIndex !== undefined &&
-                  callArgs.length <= meshJobParamIndex
-                ) {
-                  while (callArgs.length < meshJobParamIndex) {
-                    callArgs.push(null);
-                  }
-                  callArgs[meshJobParamIndex] = controller;
-                }
+                const callArgs = spliceJobController(
+                  cleanArgs,
+                  depsArray,
+                  controller,
+                  meshJobParamIndex,
+                );
                 return await runWithJobContext(jobId, deadlineSecs, controller, () =>
                   Promise.resolve(
                     (execute as (...a: unknown[]) => unknown)(...callArgs),
@@ -577,9 +606,6 @@ export class MeshAgent {
     if (isTaskTool) {
       const capability = def.capability ?? toolName;
       this._taskHandlers.set(capability, async (payload, controller) => {
-        const callArgs: unknown[] = [payload];
-        let depCursor = 0;
-        let pos = 1;
         const liveDeps: (McpMeshTool | MeshJobSubmitter | null)[] = normalizedDeps.map(
           (dep, depIndex) => {
             if (depIndex === meshJobDepIndex) {
@@ -592,25 +618,12 @@ export class MeshAgent {
             return this.resolvedDeps.get(`${toolName}:dep_${depIndex}`) ?? null;
           },
         );
-        while (depCursor < liveDeps.length || pos === meshJobParamIndex) {
-          if (pos === meshJobParamIndex) {
-            callArgs.push(controller);
-            pos += 1;
-            continue;
-          }
-          callArgs.push(liveDeps[depCursor]);
-          depCursor += 1;
-          pos += 1;
-        }
-        if (
-          meshJobParamIndex !== undefined &&
-          callArgs.length <= meshJobParamIndex
-        ) {
-          while (callArgs.length < meshJobParamIndex) {
-            callArgs.push(null);
-          }
-          callArgs[meshJobParamIndex] = controller;
-        }
+        const callArgs = spliceJobController(
+          payload,
+          liveDeps,
+          controller,
+          meshJobParamIndex,
+        );
         return await (execute as (...a: unknown[]) => unknown)(...callArgs);
       });
     }
@@ -843,9 +856,20 @@ export class MeshAgent {
     // 2.6 Phase 1 MeshJob substrate: mount POST /jobs/:job_id/cancel
     // on FastMCP's underlying Hono app so the registry's cancel
     // forwarder can fire the in-process cancel token. Best-effort —
-    // failures here are logged, not fatal.
+    // failures here are logged, not fatal. When this agent owns
+    // task: true tools and the route fails to register, escalate to
+    // a second console.error so the operator can't miss the
+    // cancel-mid-flight regression in logs.
     if (this.config.registryUrl) {
-      registerCancelRoute(this.server);
+      const cancelRouteOk = registerCancelRoute(this.server);
+      if (!cancelRouteOk && this._taskHandlers.size > 0) {
+        console.error(
+          `[mesh-jobs] agent ${this.agentId} owns ${this._taskHandlers.size} ` +
+            `task: true tool(s) but the cancel route failed to register. ` +
+            `Cancel requests for in-flight jobs will fall through to ` +
+            `lease expiry — see the prior [mesh-jobs] error for the cause.`,
+        );
+      }
     }
 
     // 3. Start heartbeat to registry via Rust core

--- a/src/runtime/typescript/src/claim-dispatcher.ts
+++ b/src/runtime/typescript/src/claim-dispatcher.ts
@@ -86,6 +86,15 @@ export class ClaimDispatcher {
   /** Wake-up callbacks for the backoff sleep (so stop() exits promptly). */
   private _sleepWaiters: Array<() => void> = [];
   /**
+   * In-flight handler dispatch promises. Tracked so `stop()` can drain
+   * them before closing `_httpAgent` — without this, the keep-alive
+   * pool gets torn down while handler `controller.complete(...)` /
+   * `controller.fail(...)` calls are still mid-fetch, which surfaces
+   * as cryptic socket-close errors and (worse) leaves rows in `working`
+   * because the terminal delta never reached the registry.
+   */
+  private _inflightHandlers: Set<Promise<void>> = new Set();
+  /**
    * Per-dispatcher keep-alive HTTP agent for `/jobs/claim` polls.
    *
    * Mirrors Python's `httpx.AsyncClient(timeout=10)` lifetime — one
@@ -124,8 +133,25 @@ export class ClaimDispatcher {
     });
   }
 
-  /** Signal stop and await the loop. Best-effort; never throws. */
-  async stop(): Promise<void> {
+  /**
+   * Signal stop and await the loop. Best-effort; never throws.
+   *
+   * Drain order:
+   *   1. flip `_stopped` so the loop exits at its next yield;
+   *   2. wake any blocked waiters so the loop observes the signal;
+   *   3. await the loop promise (no more new dispatches after this);
+   *   4. await any in-flight handler dispatches (bounded by `timeoutMs`)
+   *      so handlers finish their final `controller.complete/fail` HTTP
+   *      calls before `_httpAgent` is torn down;
+   *   5. close the keep-alive pool.
+   *
+   * @param timeoutMs - Bounded wait for in-flight handlers. Defaults to
+   *   30s — long enough that a typical job's terminal flush completes,
+   *   short enough that a runaway handler doesn't block shutdown
+   *   forever. Caller is free to override (e.g. tests pass `0` for an
+   *   immediate close).
+   */
+  async stop(timeoutMs: number = 30_000): Promise<void> {
     this._stopped = true;
     // Wake any waiters so the loop can observe the stop signal.
     while (this._permitWaiters.length) this._permitWaiters.shift()!();
@@ -135,6 +161,32 @@ export class ClaimDispatcher {
         await this._loopPromise;
       } catch {
         /* swallow */
+      }
+    }
+    // Drain in-flight handler dispatches before closing the keep-alive
+    // pool. `_inflightHandlers` is a Set<Promise<void>> populated in
+    // _dispatchWithPermit; entries self-remove via .finally().
+    if (this._inflightHandlers.size > 0) {
+      const drain = Promise.allSettled([...this._inflightHandlers]);
+      if (timeoutMs <= 0) {
+        // Caller asked for an immediate close — skip the drain entirely.
+      } else {
+        let drainTimer: ReturnType<typeof setTimeout> | null = null;
+        const drainTimeout = new Promise<void>((resolve) => {
+          drainTimer = setTimeout(() => {
+            console.warn(
+              `[mesh-claim] capability=${this.capability} instance=${this.instanceId}: ` +
+                `stop() drain timed out after ${timeoutMs}ms with ${this._inflightHandlers.size} ` +
+                `handler(s) still in-flight; closing keep-alive pool anyway`,
+            );
+            resolve();
+          }, timeoutMs);
+        });
+        try {
+          await Promise.race([drain, drainTimeout]);
+        } finally {
+          if (drainTimer) clearTimeout(drainTimer);
+        }
       }
     }
     // Close the keep-alive pool so sockets don't leak across agent
@@ -456,7 +508,13 @@ export class ClaimDispatcher {
   private _dispatchWithPermit(claimed: Record<string, unknown>): void {
     // Spawn but do NOT await — _runLoop continues to the next claim
     // attempt. The permit is released when this dispatch finishes.
-    void this._dispatch(claimed).finally(() => this._release());
+    // Track the promise in `_inflightHandlers` so `stop()` can drain
+    // any in-flight handlers before closing the keep-alive Agent.
+    const p: Promise<void> = this._dispatch(claimed).finally(() => {
+      this._inflightHandlers.delete(p);
+      this._release();
+    });
+    this._inflightHandlers.add(p);
   }
 
   private _sleep(ms: number): Promise<void> {

--- a/src/runtime/typescript/src/claim-dispatcher.ts
+++ b/src/runtime/typescript/src/claim-dispatcher.ts
@@ -240,6 +240,62 @@ export class ClaimDispatcher {
     ) as Array<Record<string, unknown>>;
   }
 
+  /**
+   * Fail a job by posting a single `failed` delta to `/jobs/batch`,
+   * bypassing the (failed) controller construction path. Used as a
+   * fallback when `makeJobController` throws — without this the row
+   * stays in `working` until the lease sweep, which can be minutes.
+   *
+   * Best-effort: any error here is logged at warn level (we already
+   * lost the controller for the original error, can't lose visibility
+   * of the fallback too) but does not throw — the registry sweep is
+   * still the ultimate backstop.
+   */
+  private async _failJobByIdDirectly(
+    jobId: string,
+    reason: string,
+  ): Promise<void> {
+    const url = `${this.registryUrl.replace(/\/$/, "")}/jobs/batch`;
+    const body = {
+      instance_id: this.instanceId,
+      deltas: [
+        {
+          id: jobId,
+          status: "failed",
+          error: reason,
+        },
+      ],
+    };
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10_000);
+      try {
+        const resp = await fetch(url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          dispatcher: this._httpAgent as any,
+        } as RequestInit);
+        if (resp.status !== 200) {
+          console.warn(
+            `[mesh-claim] /jobs/batch returned ${resp.status} when failing ` +
+              `job=${jobId} after controller construction failure; relying ` +
+              `on registry sweep`,
+          );
+        }
+      } finally {
+        clearTimeout(timeout);
+      }
+    } catch (err) {
+      console.warn(
+        `[mesh-claim] /jobs/batch fail-fast for job=${jobId} raised:`,
+        err,
+      );
+    }
+  }
+
   private _logClaimFailure(detail: string): void {
     const msg =
       `[mesh-claim] capability=${this.capability} instance=${this.instanceId}: ` +
@@ -276,6 +332,19 @@ export class ClaimDispatcher {
       console.warn(
         `[mesh-claim] failed to construct JobController for job=${jobId}:`,
         err,
+      );
+      // Fail the job immediately so the registry doesn't wait on lease
+      // expiry to mark the row terminal — without this the row sits in
+      // `working` indefinitely (visible to users as a stuck job) until
+      // the lease sweeper notices. We can't use controller.fail()
+      // because controller construction is what failed; instead we
+      // POST a single `failed` delta to /jobs/batch directly using the
+      // dispatcher's keep-alive agent.
+      await this._failJobByIdDirectly(
+        jobId,
+        `controller construction failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
       );
       return;
     }
@@ -333,6 +402,24 @@ export class ClaimDispatcher {
       let permitTransferred = false;
       try {
         const claimed = await this._claimOnce();
+        if (claimed.length > 1) {
+          // Defensive warn (W3): the Phase 1 wire is single-claim by
+          // design — `POST /jobs/claim` returns at most one job per
+          // round-trip (see `crate::claim_worker::ClaimWorkerConfig`
+          // and the registry's ClaimJobs handler). Receiving > 1 here
+          // means a future wire change (multi-claim) shipped without
+          // re-validating the dispatcher's permit accounting. We
+          // already handle the multi-claim case via the
+          // re-acquire-per-extra loop below — the warn just surfaces
+          // the unexpected shape so a future wire change is caught
+          // explicitly rather than silently relying on the loop.
+          console.warn(
+            `[mesh-claim] capability=${this.capability} instance=${this.instanceId}: ` +
+              `unexpected multi-claim response (got ${claimed.length} jobs) — ` +
+              `Phase 1 wire is single-claim by design; defensive multi-claim ` +
+              `path engaged`,
+          );
+        }
         if (claimed.length > 0) {
           // First claim: hand the permit ownership to the dispatch
           // task. Future-safe extras: re-acquire permits one-by-one.

--- a/src/runtime/typescript/src/claim-dispatcher.ts
+++ b/src/runtime/typescript/src/claim-dispatcher.ts
@@ -32,11 +32,13 @@
  * job after the lease expired. PR #883 fixed this same divergence in
  * the Python dispatcher; we mirror the fix here from the start.
  */
+import { Agent } from "undici";
 import { JobController } from "@mcpmesh/core";
 import {
   runWithJobContext,
   makeJobController,
 } from "./inbound-job-dispatch.js";
+import { runWithPropagatedHeaders } from "./proxy.js";
 
 const _POLL_BASE_MS = 500;
 const _POLL_MAX_MS = 5000;
@@ -83,6 +85,21 @@ export class ClaimDispatcher {
   private _permitWaiters: Array<() => void> = [];
   /** Wake-up callbacks for the backoff sleep (so stop() exits promptly). */
   private _sleepWaiters: Array<() => void> = [];
+  /**
+   * Per-dispatcher keep-alive HTTP agent for `/jobs/claim` polls.
+   *
+   * Mirrors Python's `httpx.AsyncClient(timeout=10)` lifetime — one
+   * client per dispatcher (not per poll) so the TLS handshake + TCP
+   * connection are reused across the polling loop. Pool size matches
+   * the dispatch semaphore (`_MAX_CONCURRENT_DISPATCHES`) since claim
+   * polls are serialised by the loop and never need more than that.
+   * Closed in `stop()` so socket pools don't leak across agent restarts.
+   */
+  private readonly _httpAgent: Agent = new Agent({
+    keepAliveTimeout: 30_000,
+    keepAliveMaxTimeout: 60_000,
+    connections: _MAX_CONCURRENT_DISPATCHES,
+  });
 
   constructor(
     capability: string,
@@ -119,6 +136,14 @@ export class ClaimDispatcher {
       } catch {
         /* swallow */
       }
+    }
+    // Close the keep-alive pool so sockets don't leak across agent
+    // restarts in long-lived test harnesses (mirrors the Python
+    // dispatcher's `httpx.AsyncClient.aclose()` in `stop()`).
+    try {
+      await this._httpAgent.close();
+    } catch {
+      /* best-effort cleanup */
     }
   }
 
@@ -165,7 +190,13 @@ export class ClaimDispatcher {
           headers: { "content-type": "application/json" },
           body: JSON.stringify(body),
           signal: controller.signal,
-        });
+          // Keep-alive pool — reuses TCP/TLS across polls. See
+          // `_httpAgent` field for sizing rationale. Cast required
+          // because Node's `fetch` types don't expose the undici
+          // dispatcher slot; runtime accepts it.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          dispatcher: this._httpAgent as any,
+        } as RequestInit);
       } finally {
         clearTimeout(timeout);
       }
@@ -249,9 +280,29 @@ export class ClaimDispatcher {
       return;
     }
 
+    // Seed the propagated-headers ALS so outbound calls made by the
+    // handler continue the submitter's trace tree and carry the job
+    // context onward. Mirrors Python's
+    // `TraceContext.set_propagated_headers` block in
+    // `_mcp_mesh.engine.claim_dispatcher.PythonClaimDispatcher._dispatch`.
+    //
+    // Trace headers (`x-trace-id`, `x-parent-span`) are not echoed by
+    // the registry's claim response in the current wire (see
+    // `src/core/registry/ent_handlers_jobs.go::ClaimJobs`), so we only
+    // seed `x-mesh-job-id` + `x-mesh-timeout` here. If a future schema
+    // adds `trace_id` to ClaimedJob, fold it in alongside.
+    const headers: Record<string, string> = {
+      "x-mesh-job-id": jobId,
+    };
+    if (deadlineSecs !== null && deadlineSecs > 0) {
+      headers["x-mesh-timeout"] = String(deadlineSecs);
+    }
+
     try {
-      await runWithJobContext(jobId, deadlineSecs, controller, () =>
-        this.handler(payload, controller),
+      await runWithPropagatedHeaders(headers, () =>
+        runWithJobContext(jobId, deadlineSecs, controller, () =>
+          this.handler(payload, controller),
+        ),
       );
     } catch (err) {
       console.warn(

--- a/src/runtime/typescript/src/claim-dispatcher.ts
+++ b/src/runtime/typescript/src/claim-dispatcher.ts
@@ -1,0 +1,339 @@
+/**
+ * TypeScript-side claim dispatcher (Phase 1 — MeshJob substrate).
+ *
+ * Mirrors Python's `_mcp_mesh.engine.claim_dispatcher.PythonClaimDispatcher`.
+ *
+ * Per `MESHJOB_DESIGN.org` / "Producer-side flow / Resched": the
+ * registry's HEAD heartbeat may include `X-Mesh-Pending-Jobs: <n>` when
+ * this agent has unclaimed jobs in capabilities it serves. The runtime
+ * calls `POST /jobs/claim` to atomically acquire one job per round-trip,
+ * then dispatches it locally.
+ *
+ * Architecture choice for Phase 1
+ * --------------------------------
+ *
+ * The Rust core exposes the substrate to do this in-process via
+ * `crate::claim_worker::spawn_claim_worker` + a per-language
+ * `ClaimDispatcher` trait. Bridging that trait to a JS object across
+ * napi-rs (with proper `Send + Sync + 'static` bounds and an async
+ * return) is non-trivial — the cleanest cross-language design ships in
+ * Phase 2. For Phase 1 the dispatcher is implemented purely in TS:
+ * a polling loop bound to the agent lifecycle.
+ *
+ * Concurrency cap defaults to 4 in-flight handlers, matching:
+ *   - `crate::claim_worker::ClaimWorkerConfig::new` (Rust core)
+ *   - `_MAX_CONCURRENT_DISPATCHES` (Python claim dispatcher)
+ *
+ * The permit is acquired BEFORE polling `/jobs/claim` (not after) so
+ * the dispatcher cannot claim more jobs than it can immediately
+ * execute. Without this, the dispatcher could pull a 5th job from the
+ * registry and stamp itself as owner while it sat in a queue with the
+ * lease ticking down — the registry would then orphan and re-claim the
+ * job after the lease expired. PR #883 fixed this same divergence in
+ * the Python dispatcher; we mirror the fix here from the start.
+ */
+import { JobController } from "@mcpmesh/core";
+import {
+  runWithJobContext,
+  makeJobController,
+} from "./inbound-job-dispatch.js";
+
+const _POLL_BASE_MS = 500;
+const _POLL_MAX_MS = 5000;
+const _MAX_CONCURRENT_DISPATCHES = 4;
+const _CONSECUTIVE_FAILURES_ERROR_THRESHOLD = 5;
+
+/**
+ * Handler signature: the user's `task=true` execute function as
+ * registered via `agent.addTool({ task: true, execute: ... })`. The
+ * dispatcher invokes it with the claimed payload as args + the
+ * controller injected at `meshJobParamIndex` (or appended if no index
+ * is set on the spec).
+ *
+ * Returning a value is fine — the wrapper auto-completes the job with
+ * the return value (matching Python's W8 fix). Throwing is also fine —
+ * the wrapper reports the failure to the registry.
+ */
+export type ClaimHandler = (
+  payload: Record<string, unknown>,
+  controller: JobController,
+) => Promise<unknown>;
+
+/**
+ * One dispatcher per (capability, handler) pair. Spawned on agent
+ * startup for every tool registered with `task: true`.
+ */
+export class ClaimDispatcher {
+  readonly capability: string;
+  readonly instanceId: string;
+  readonly registryUrl: string;
+  private readonly handler: ClaimHandler;
+
+  private _stopped = false;
+  private _loopPromise: Promise<void> | null = null;
+  private _consecutiveFailures = 0;
+  /**
+   * Permits in-flight; counts down toward 0. The loop blocks on
+   * `acquire()` before issuing a claim, so the dispatcher never owns
+   * more jobs than it can immediately execute. Released in the
+   * dispatch task's `finally` block.
+   */
+  private _permits = _MAX_CONCURRENT_DISPATCHES;
+  /** Wake-up callbacks for the permit semaphore. */
+  private _permitWaiters: Array<() => void> = [];
+  /** Wake-up callbacks for the backoff sleep (so stop() exits promptly). */
+  private _sleepWaiters: Array<() => void> = [];
+
+  constructor(
+    capability: string,
+    instanceId: string,
+    registryUrl: string,
+    handler: ClaimHandler,
+  ) {
+    this.capability = capability;
+    this.instanceId = instanceId;
+    this.registryUrl = registryUrl;
+    this.handler = handler;
+  }
+
+  /** Spawn the polling loop. Idempotent. */
+  start(): void {
+    if (this._loopPromise) return;
+    this._loopPromise = this._runLoop().catch((err) => {
+      console.error(
+        `[mesh-claim] dispatcher capability=${this.capability} loop crashed:`,
+        err,
+      );
+    });
+  }
+
+  /** Signal stop and await the loop. Best-effort; never throws. */
+  async stop(): Promise<void> {
+    this._stopped = true;
+    // Wake any waiters so the loop can observe the stop signal.
+    while (this._permitWaiters.length) this._permitWaiters.shift()!();
+    while (this._sleepWaiters.length) this._sleepWaiters.shift()!();
+    if (this._loopPromise) {
+      try {
+        await this._loopPromise;
+      } catch {
+        /* swallow */
+      }
+    }
+  }
+
+  private async _acquire(): Promise<void> {
+    if (this._permits > 0) {
+      this._permits -= 1;
+      return;
+    }
+    return new Promise<void>((resolve) => {
+      this._permitWaiters.push(() => {
+        this._permits -= 1;
+        resolve();
+      });
+    });
+  }
+
+  private _release(): void {
+    this._permits += 1;
+    const next = this._permitWaiters.shift();
+    if (next) next();
+  }
+
+  /**
+   * Single `POST /jobs/claim` round-trip. Returns the list of claimed
+   * jobs (empty when no work is available, or 1-element when a job
+   * was claimed — the Phase 1 wire is single-claim).
+   *
+   * Errors are logged and treated as "no work" so the loop backs off
+   * rather than crashing.
+   */
+  private async _claimOnce(): Promise<Array<Record<string, unknown>>> {
+    const url = `${this.registryUrl.replace(/\/$/, "")}/jobs/claim`;
+    const body = {
+      capability: this.capability,
+      instance_id: this.instanceId,
+    };
+    let resp: Response;
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10_000);
+      try {
+        resp = await fetch(url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timeout);
+      }
+    } catch (err) {
+      this._consecutiveFailures += 1;
+      this._logClaimFailure(
+        `claim_once error: ${(err as Error)?.name ?? "Error"}: ${
+          (err as Error)?.message ?? String(err)
+        }`,
+      );
+      return [];
+    }
+    if (resp.status === 204) {
+      this._consecutiveFailures = 0;
+      return [];
+    }
+    if (resp.status !== 200) {
+      this._consecutiveFailures += 1;
+      this._logClaimFailure(`unexpected status ${resp.status} from ${url}`);
+      return [];
+    }
+    let parsed: unknown;
+    try {
+      parsed = await resp.json();
+    } catch (err) {
+      this._consecutiveFailures += 1;
+      this._logClaimFailure(`malformed JSON: ${(err as Error)?.message}`);
+      return [];
+    }
+    const claimed = (parsed as { claimed?: unknown })?.claimed;
+    if (!Array.isArray(claimed)) {
+      this._consecutiveFailures += 1;
+      this._logClaimFailure(
+        `malformed response — 'claimed' is not a list: ${JSON.stringify(claimed)}`,
+      );
+      return [];
+    }
+    this._consecutiveFailures = 0;
+    return claimed.filter(
+      (c) => c && typeof c === "object" && (c as { id?: unknown }).id,
+    ) as Array<Record<string, unknown>>;
+  }
+
+  private _logClaimFailure(detail: string): void {
+    const msg =
+      `[mesh-claim] capability=${this.capability} instance=${this.instanceId}: ` +
+      `${detail} (consecutive_failures=${this._consecutiveFailures})`;
+    if (this._consecutiveFailures >= _CONSECUTIVE_FAILURES_ERROR_THRESHOLD) {
+      console.error(msg);
+    } else {
+      console.warn(msg);
+    }
+  }
+
+  /**
+   * Run the local handler for a claimed job. The handler signature is
+   * `(payload, controller) => Promise<unknown>`; the wrapper sets both
+   * job contexts (JS ALS + Rust task-local) and auto-completes if the
+   * handler returns without explicitly closing the row.
+   */
+  private async _dispatch(claimed: Record<string, unknown>): Promise<void> {
+    const jobId = String(claimed.id ?? "");
+    if (!jobId) return;
+
+    const payload =
+      claimed.submitted_payload && typeof claimed.submitted_payload === "object"
+        ? (claimed.submitted_payload as Record<string, unknown>)
+        : {};
+    const maxDur = claimed.max_duration as number | undefined;
+    const deadlineSecs =
+      typeof maxDur === "number" && maxDur > 0 ? maxDur : null;
+
+    let controller: JobController;
+    try {
+      controller = makeJobController(jobId, this.instanceId, this.registryUrl);
+    } catch (err) {
+      console.warn(
+        `[mesh-claim] failed to construct JobController for job=${jobId}:`,
+        err,
+      );
+      return;
+    }
+
+    try {
+      await runWithJobContext(jobId, deadlineSecs, controller, () =>
+        this.handler(payload, controller),
+      );
+    } catch (err) {
+      console.warn(
+        `[mesh-claim] handler raised for job=${jobId} capability=${this.capability}:`,
+        err,
+      );
+      // runWithJobContext already attempted a best-effort
+      // controller.fail() before re-throwing; nothing more to do here.
+    }
+  }
+
+  /**
+   * Main loop. Acquire-then-claim ordering — see class docstring.
+   */
+  private async _runLoop(): Promise<void> {
+    let backoffMs = _POLL_BASE_MS;
+    console.log(
+      `[mesh-claim] dispatcher started: capability=${this.capability} instance=${this.instanceId}`,
+    );
+
+    while (!this._stopped) {
+      // Acquire BEFORE claim so we never pull a job we can't run.
+      await this._acquire();
+      if (this._stopped) {
+        this._release();
+        break;
+      }
+      let permitTransferred = false;
+      try {
+        const claimed = await this._claimOnce();
+        if (claimed.length > 0) {
+          // First claim: hand the permit ownership to the dispatch
+          // task. Future-safe extras: re-acquire permits one-by-one.
+          let first = true;
+          for (const job of claimed) {
+            if (first) {
+              first = false;
+              permitTransferred = true;
+              this._dispatchWithPermit(job);
+            } else {
+              await this._acquire();
+              this._dispatchWithPermit(job);
+            }
+          }
+          backoffMs = _POLL_BASE_MS;
+          continue;
+        }
+        // No work — wait with backoff. Release permit; we won't use it.
+        this._release();
+        permitTransferred = true; // already released; finally must skip
+        await this._sleep(backoffMs);
+        backoffMs = Math.min(backoffMs * 2, _POLL_MAX_MS);
+      } finally {
+        if (!permitTransferred) {
+          this._release();
+        }
+      }
+    }
+    console.log(
+      `[mesh-claim] dispatcher stopped: capability=${this.capability} instance=${this.instanceId}`,
+    );
+  }
+
+  private _dispatchWithPermit(claimed: Record<string, unknown>): void {
+    // Spawn but do NOT await — _runLoop continues to the next claim
+    // attempt. The permit is released when this dispatch finishes.
+    void this._dispatch(claimed).finally(() => this._release());
+  }
+
+  private _sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      let resolved = false;
+      const wake = () => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(handle);
+        const idx = this._sleepWaiters.indexOf(wake);
+        if (idx >= 0) this._sleepWaiters.splice(idx, 1);
+        resolve();
+      };
+      const handle = setTimeout(wake, ms);
+      this._sleepWaiters.push(wake);
+    });
+  }
+}

--- a/src/runtime/typescript/src/inbound-job-dispatch.ts
+++ b/src/runtime/typescript/src/inbound-job-dispatch.ts
@@ -67,15 +67,32 @@ export function readJobHeaders(
  *
  * Mirrors the Python helper: primitives, plain arrays of safe values,
  * and plain objects keyed by strings with safe values pass through.
- * Anything else gets wrapped as `{ value: String(result) }` so the
- * Rust JSON layer doesn't error inside auto-complete.
+ * Anything else (Map, Set, class instances, Symbol, BigInt, undefined,
+ * functions) gets wrapped as `{ value: String(result) }` so the Rust
+ * JSON layer doesn't error inside auto-complete.
+ *
+ * The plain-object check uses `Object.getPrototypeOf` rather than
+ * `Object.entries`, because Maps/Sets/class instances have empty
+ * `Object.entries(...)` results — which would otherwise (mis-)pass the
+ * "every entry is safe" guard.
  */
 function isJsonSafe(value: unknown): boolean {
   if (value === null) return true;
   const t = typeof value;
-  if (t === "boolean" || t === "number" || t === "string") return true;
+  if (t === "boolean" || t === "number" || t === "string") {
+    // Reject NaN / +Infinity — they JSON-stringify to `null` and would
+    // round-trip lossy through the registry's payload column.
+    if (t === "number" && !Number.isFinite(value as number)) return false;
+    return true;
+  }
   if (Array.isArray(value)) return value.every(isJsonSafe);
   if (t === "object") {
+    // Plain-object check: prototype must be Object.prototype or null.
+    // This rejects Maps, Sets, Dates, class instances, etc. — all of
+    // which serialise to `{}` (lossy) under default JSON.stringify and
+    // would not survive the FFI serde-json round-trip cleanly.
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== Object.prototype && proto !== null) return false;
     return Object.entries(value as Record<string, unknown>).every(
       ([k, v]) => typeof k === "string" && isJsonSafe(v),
     );
@@ -124,10 +141,21 @@ export async function runWithJobContext<T>(
   // close the row themselves. Matches Python's `_run_and_autocomplete`.
   // On exception we let the throw propagate; we attempt a best-effort
   // `controller.fail(...)` only if the controller is not yet terminal.
-  const runAndAutoComplete = async (): Promise<T> => {
-    let result: T;
+  //
+  // We capture the user's actual return value in a closure (`captured`)
+  // and feed only a JSON-safe sentinel (`null`) through the napi
+  // boundary in `withJobAsync`. The user value goes back to the JS
+  // caller via the returned closure variable — keeping non-JSON-safe
+  // returns (Map, Symbol, class instance, BigInt, undefined) from
+  // hitting the Rust serde-json round-trip and producing a cryptic
+  // FFI error. The auto-complete path still applies `isJsonSafe` and
+  // wraps non-safe values for `controller.complete(...)`.
+  let captured: T;
+  let didCapture = false;
+  const runAndAutoComplete = async (): Promise<null> => {
     try {
-      result = await invoke();
+      captured = await invoke();
+      didCapture = true;
     } catch (err) {
       // Best-effort terminal report so the registry doesn't have to
       // wait on the lease expiry to mark the row failed.
@@ -147,28 +175,45 @@ export async function runWithJobContext<T>(
     // Only auto-complete if the user didn't already call complete/fail.
     try {
       const alreadyTerminal = await controller.isTerminal();
-      if (alreadyTerminal) return result;
+      if (alreadyTerminal) return null;
     } catch {
       // If we can't probe, skip auto-complete to avoid double-flush.
-      return result;
+      return null;
     }
     try {
-      const safe = isJsonSafe(result) ? result : { value: String(result) };
+      const safe = isJsonSafe(captured)
+        ? captured
+        : { value: String(captured) };
       await controller.complete(safe);
     } catch {
       // Auto-complete failed — registry sweep will eventually mark
       // the row terminal. Don't shadow the user's return value.
     }
-    return result;
+    return null;
   };
 
   // Bind the JS-side ALS first; then bind the Rust-side task-local
   // around the same Promise so cancel registry + outbound headers see
   // the active job. Both must be set in parallel because the Rust
   // task-local does NOT cross the FFI boundary into the Node loop.
+  //
+  // The Promise handed to `withJobAsync` resolves to `null` (the
+  // sentinel) — Rust serde never sees the user's value, so non-JSON
+  // returns can't trip the FFI boundary. The user's actual return is
+  // pulled from `captured` after the await resolves.
   return CURRENT_JOB.run(snap, async () => {
     const body = runAndAutoComplete();
-    return (await withJobAsync(jobId, deadlineSecs, body)) as T;
+    await withJobAsync(jobId, deadlineSecs, body);
+    if (!didCapture) {
+      // Defensive: the body resolved without setting `captured` —
+      // should be unreachable since runAndAutoComplete only returns
+      // after invoke() succeeds (which sets captured), but guard
+      // against future refactors.
+      throw new Error(
+        "runWithJobContext: invoke completed but no value was captured",
+      );
+    }
+    return captured;
   });
 }
 

--- a/src/runtime/typescript/src/inbound-job-dispatch.ts
+++ b/src/runtime/typescript/src/inbound-job-dispatch.ts
@@ -230,3 +230,60 @@ export function makeJobController(
 ): JobController {
   return new JobController(jobId, instanceId, registryUrl);
 }
+
+/**
+ * Build the positional call args array for a `task: true` tool, splicing
+ * the `controller` into the user signature at `meshJobParamIndex`.
+ *
+ * Position 0 is always the parsed `args` payload; deps begin at 1. The
+ * MeshJob slot is orthogonal to MeshTool positional indexing — when
+ * `meshJobParamIndex` lands inside the dep range the deps shift past
+ * it; when it lands after all deps the helper pads any gap with `null`
+ * and places the controller at the trailing position.
+ *
+ * Centralised here so both the inbound HTTP wrapper (agent.ts) and the
+ * claim-path dispatcher (claim handler in agent.ts) share one
+ * implementation — historically these splice loops had drifted apart.
+ *
+ * @param payload - The parsed `args` payload (signature position 0).
+ * @param deps - Resolved dep proxies (or `MeshJobSubmitter` for the
+ *   meshJobDepIndex slot, or `null` for unresolved deps) in declaration
+ *   order. Positionally injected starting at sig pos 1.
+ * @param controller - The `JobController` to inject at
+ *   `meshJobParamIndex`, or `null` when the call is not running under
+ *   a job context.
+ * @param meshJobParamIndex - Signature position where the controller
+ *   should land, or `undefined` when the user didn't declare a MeshJob
+ *   slot (controller is then dropped — the user just doesn't get one).
+ */
+export function spliceJobController<D>(
+  payload: unknown,
+  deps: ReadonlyArray<D>,
+  controller: JobController | null,
+  meshJobParamIndex: number | undefined,
+): unknown[] {
+  const callArgs: unknown[] = [payload];
+  let depCursor = 0;
+  let pos = 1;
+  while (depCursor < deps.length || pos === meshJobParamIndex) {
+    if (pos === meshJobParamIndex) {
+      callArgs.push(controller);
+      pos += 1;
+      continue;
+    }
+    callArgs.push(deps[depCursor]);
+    depCursor += 1;
+    pos += 1;
+  }
+  // Trailing meshJobParamIndex case (after all deps).
+  if (
+    meshJobParamIndex !== undefined &&
+    callArgs.length <= meshJobParamIndex
+  ) {
+    while (callArgs.length < meshJobParamIndex) {
+      callArgs.push(null);
+    }
+    callArgs[meshJobParamIndex] = controller;
+  }
+  return callArgs;
+}

--- a/src/runtime/typescript/src/inbound-job-dispatch.ts
+++ b/src/runtime/typescript/src/inbound-job-dispatch.ts
@@ -1,0 +1,187 @@
+/**
+ * Inbound `MeshJob` dispatch wrapper (Phase 1 — MeshJob substrate).
+ *
+ * Mirrors Python's `_mcp_mesh.engine.job_dispatch.maybe_dispatch_as_job`.
+ *
+ * When a tool registered with `task: true` receives an inbound
+ * `tools/call` carrying `X-Mesh-Job-Id`, this wrapper:
+ *
+ *   1. Reads `X-Mesh-Job-Id` and (optionally) `X-Mesh-Timeout` from the
+ *      propagated headers (TS upstream proxies inject these into the
+ *      tool's args under `_mesh_headers`; the inbound `tools/call`
+ *      handler in agent.ts extracts them into a header dict before
+ *      invoking this wrapper).
+ *   2. Builds a `JobController` from `@mcpmesh/core` bound to that job
+ *      id and the running agent's instance id.
+ *   3. Sets BOTH the JS-side `CURRENT_JOB` AsyncLocalStorage AND the
+ *      Rust-side `with_job` task-local via `withJobAsync` from
+ *      `@mcpmesh/core`. Both are needed:
+ *        * JS-side for in-process `currentJob()` reads;
+ *        * Rust-side for the cancel-registry binding (so
+ *          `POST /jobs/{id}/cancel` can fire the in-flight token) and
+ *          for outbound HTTP header injection on Rust-originated work.
+ *   4. Injects the `JobController` into the user function's args at
+ *      `meshJobParamIndex`.
+ *   5. Awaits the user function inside both contexts.
+ *   6. Auto-completes the controller with the user's return value if the
+ *      user did not explicitly call `complete()`/`fail()`.
+ *
+ * Tools without `task: true` are bypassed entirely (zero overhead).
+ * `task: true` tools invoked WITHOUT `X-Mesh-Job-Id` (a regular
+ * synchronous `tools/call`) fall through to the user function with
+ * `null` in the MeshJob slot per `MESHJOB_DDDI_CONTRACT.md`.
+ *
+ * The dispatch logic is centralised here so the per-tool wrapper in
+ * `agent.ts` and the claim dispatcher both call into the same path.
+ */
+import { JobController, withJobAsync } from "@mcpmesh/core";
+import { CURRENT_JOB, type JobContextSnapshot } from "./job-context.js";
+
+const _HDR_JOB_ID = "x-mesh-job-id";
+const _HDR_TIMEOUT = "x-mesh-timeout";
+
+/**
+ * Read `X-Mesh-Job-Id` / `X-Mesh-Timeout` from a header dict (case
+ * normalised to lowercase). Returns `[null, null]` when absent or
+ * malformed.
+ */
+export function readJobHeaders(
+  headers: Record<string, string> | null | undefined,
+): [string | null, number | null] {
+  if (!headers) return [null, null];
+  const jobId = headers[_HDR_JOB_ID] ?? null;
+  if (!jobId) return [null, null];
+  const timeoutRaw = headers[_HDR_TIMEOUT];
+  let deadlineSecs: number | null = null;
+  if (timeoutRaw) {
+    const parsed = parseFloat(timeoutRaw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      deadlineSecs = parsed;
+    }
+  }
+  return [jobId, deadlineSecs];
+}
+
+/**
+ * Best-effort JSON-safety check for the auto-complete payload.
+ *
+ * Mirrors the Python helper: primitives, plain arrays of safe values,
+ * and plain objects keyed by strings with safe values pass through.
+ * Anything else gets wrapped as `{ value: String(result) }` so the
+ * Rust JSON layer doesn't error inside auto-complete.
+ */
+function isJsonSafe(value: unknown): boolean {
+  if (value === null) return true;
+  const t = typeof value;
+  if (t === "boolean" || t === "number" || t === "string") return true;
+  if (Array.isArray(value)) return value.every(isJsonSafe);
+  if (t === "object") {
+    return Object.entries(value as Record<string, unknown>).every(
+      ([k, v]) => typeof k === "string" && isJsonSafe(v),
+    );
+  }
+  return false;
+}
+
+/**
+ * Run `invoke()` inside a job context (when `jobId` is set) or
+ * directly (otherwise).
+ *
+ * `invoke` must be a thunk — when the caller wants to inject the
+ * controller into the user function's args, it is the caller's
+ * responsibility to overlay the controller before passing the thunk.
+ *
+ * `controller` may be `null` when the call is NOT a job (no
+ * `X-Mesh-Job-Id`). In that case the wrapper just runs the thunk.
+ *
+ * @param jobId - Server-assigned job UUID (from `X-Mesh-Job-Id`), or
+ *   `null` when the call is a regular `tools/call`.
+ * @param deadlineSecs - Per-attempt deadline in seconds (from
+ *   `X-Mesh-Timeout`), or `null`.
+ * @param controller - Pre-constructed `JobController` bound to `jobId`,
+ *   or `null` when not running as a job.
+ * @param invoke - Thunk that runs the user function and returns its
+ *   result. The caller has already overlaid the controller into the
+ *   user function's args at `meshJobParamIndex`.
+ */
+export async function runWithJobContext<T>(
+  jobId: string | null,
+  deadlineSecs: number | null,
+  controller: JobController | null,
+  invoke: () => Promise<T>,
+): Promise<T> {
+  if (!jobId || !controller) {
+    // Not a job — run directly.
+    return invoke();
+  }
+
+  const snap: JobContextSnapshot = {
+    jobId,
+    deadlineSecsRemaining: deadlineSecs,
+  };
+
+  // Auto-complete on successful return iff the user didn't already
+  // close the row themselves. Matches Python's `_run_and_autocomplete`.
+  // On exception we let the throw propagate; we attempt a best-effort
+  // `controller.fail(...)` only if the controller is not yet terminal.
+  const runAndAutoComplete = async (): Promise<T> => {
+    let result: T;
+    try {
+      result = await invoke();
+    } catch (err) {
+      // Best-effort terminal report so the registry doesn't have to
+      // wait on the lease expiry to mark the row failed.
+      try {
+        const alreadyTerminal = await controller.isTerminal();
+        if (!alreadyTerminal) {
+          await controller.fail(
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      } catch {
+        // Swallow — the registry sweep is the ultimate backstop.
+      }
+      throw err;
+    }
+
+    // Only auto-complete if the user didn't already call complete/fail.
+    try {
+      const alreadyTerminal = await controller.isTerminal();
+      if (alreadyTerminal) return result;
+    } catch {
+      // If we can't probe, skip auto-complete to avoid double-flush.
+      return result;
+    }
+    try {
+      const safe = isJsonSafe(result) ? result : { value: String(result) };
+      await controller.complete(safe);
+    } catch {
+      // Auto-complete failed — registry sweep will eventually mark
+      // the row terminal. Don't shadow the user's return value.
+    }
+    return result;
+  };
+
+  // Bind the JS-side ALS first; then bind the Rust-side task-local
+  // around the same Promise so cancel registry + outbound headers see
+  // the active job. Both must be set in parallel because the Rust
+  // task-local does NOT cross the FFI boundary into the Node loop.
+  return CURRENT_JOB.run(snap, async () => {
+    const body = runAndAutoComplete();
+    return (await withJobAsync(jobId, deadlineSecs, body)) as T;
+  });
+}
+
+/**
+ * Construct a `JobController` for `(jobId, instanceId, registryUrl)`.
+ *
+ * Wraps the napi binding so callers don't import `@mcpmesh/core`
+ * directly — keeps the injection point in agent.ts compact.
+ */
+export function makeJobController(
+  jobId: string,
+  instanceId: string,
+  registryUrl: string,
+): JobController {
+  return new JobController(jobId, instanceId, registryUrl);
+}

--- a/src/runtime/typescript/src/index.ts
+++ b/src/runtime/typescript/src/index.ts
@@ -266,6 +266,26 @@ export {
   formatZodError,
 } from "./response-parser.js";
 
+// MeshJob substrate (Phase 1) — see MESHJOB_DDDI_CONTRACT.md.
+// Re-export the MeshJob type marker, AsyncLocalStorage mirror, and the
+// DDDI resolver so consumers can use either the SDK entry points or
+// drop down to the underlying primitives in tests / advanced wiring.
+export type { MeshJob } from "./types.js";
+export {
+  CURRENT_JOB,
+  currentJob,
+  remainingSeconds,
+  withJobAsync,
+  type JobContextSnapshot,
+} from "./job-context.js";
+export {
+  resolveMeshJobSignature,
+  ResolverError,
+  type ResolvedSignature,
+  type ResolvedMeshToolDep,
+  type ResolverInput,
+} from "./resolver-meshjob.js";
+
 // Types
 export type {
   AgentConfig,

--- a/src/runtime/typescript/src/index.ts
+++ b/src/runtime/typescript/src/index.ts
@@ -285,6 +285,25 @@ export {
   type ResolvedMeshToolDep,
   type ResolverInput,
 } from "./resolver-meshjob.js";
+export {
+  MeshJobSubmitter,
+  type SubmitOptions,
+} from "./mesh-job-submitter.js";
+export {
+  readJobHeaders,
+  runWithJobContext,
+  makeJobController,
+} from "./inbound-job-dispatch.js";
+export {
+  ClaimDispatcher,
+  type ClaimHandler,
+} from "./claim-dispatcher.js";
+export { registerJobHelperTools } from "./jobs-helper-tools.js";
+export { registerCancelRoute } from "./jobs-cancel-route.js";
+// Re-export napi-rs job primitives for users who want to drop down
+// to the underlying handles directly (e.g. constructing a JobProxy
+// from a known job_id).
+export { JobController, JobProxy } from "@mcpmesh/core";
 
 // Types
 export type {

--- a/src/runtime/typescript/src/job-context.ts
+++ b/src/runtime/typescript/src/job-context.ts
@@ -1,0 +1,123 @@
+/**
+ * AsyncLocalStorage mirror of the Rust core's `JobContext` (Phase 1 —
+ * MeshJob substrate).
+ *
+ * The Rust core (`mcp_mesh_core::job_context`) holds the source of truth
+ * for the active job context — set via `with_job` / `run_as_job` from
+ * the inbound HTTP tool wrapper or the claim worker. The Rust outbound
+ * paths read it via `injectJobHeaders` to attach
+ * `X-Mesh-Job-Id` / `X-Mesh-Timeout` headers to downstream calls.
+ *
+ * JS user code can also need to read the active job context (e.g. to
+ * log the current job id or branch on whether a tool is running under a
+ * job). Crossing the FFI boundary on every read is wasteful, AND the
+ * Rust task-local does not propagate into the Node event loop across
+ * the FFI boundary — so this module exposes an `AsyncLocalStorage`
+ * mirror that the inbound wrapper (next dispatch) sets alongside the
+ * Rust call.
+ *
+ * For the current dispatch only the JS surface is defined; the inbound
+ * wrapper that populates it lands in the next dispatch. Until then
+ * `currentJob()` returns `null` (no active job) — which is the correct
+ * answer for any tool invoked via a regular `tools/call` rather than a
+ * job-dispatch path.
+ *
+ * See `MESHJOB_DESIGN.org` → "Timeout & Cancellation" → "Async-local
+ * primitives" for the cross-runtime parity (Python `contextvars` ≡
+ * TypeScript `AsyncLocalStorage` ≡ Java `ThreadLocal`).
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * Read-only snapshot of the active job context for the current async
+ * scope. Mirrors the fields of the Rust core's `JobContext` that JS
+ * user code can usefully observe. The cancel token itself stays in the
+ * Rust core — JS observes its effects via FFI (e.g. an awaited Rust
+ * future rejecting with "cancelled") rather than polling it directly.
+ */
+export interface JobContextSnapshot {
+  /** Server-assigned job UUID this scope is executing for. */
+  jobId: string;
+  /**
+   * Seconds left until the per-attempt deadline expires, or `null` if
+   * no deadline is set (unlimited per design-doc default).
+   *
+   * NB: this snapshot value is captured at the time `withJobAsync`
+   * binds the context. It does NOT auto-decrement as wall-clock time
+   * passes. For an always-fresh remaining-seconds value, query the
+   * Rust core via `currentJob()` from `@mcpmesh/core` instead.
+   */
+  deadlineSecsRemaining: number | null;
+}
+
+/**
+ * Active `JobContextSnapshot` on the current async scope, or `null`.
+ *
+ * The inbound HTTP tool wrapper (next dispatch) sets this alongside
+ * the Rust core's `withJobAsync` so JS user code can read either side
+ * without crossing FFI. When neither side is active, the value is
+ * `null`.
+ *
+ * Exported so the dispatch wrapper (and tests) can call `.run()` /
+ * `.exit()` / `.getStore()` directly when finer control than
+ * `withJobAsync` is required.
+ */
+export const CURRENT_JOB = new AsyncLocalStorage<JobContextSnapshot | null>();
+
+/**
+ * Return the active job snapshot for the current async scope, or
+ * `null`.
+ *
+ * Safe to call from any context — never throws. Returns `null` outside
+ * any active job (e.g. for tools invoked via a regular `tools/call` or
+ * in unit tests with no job-dispatch path).
+ *
+ * Note: The source of truth is the Rust core. This function reads the
+ * JS-side mirror for fast in-process access; for cross-FFI parity (and
+ * always-fresh `deadlineSecsRemaining`) use `currentJob()` from
+ * `@mcpmesh/core`.
+ */
+export function currentJob(): JobContextSnapshot | null {
+  return CURRENT_JOB.getStore() ?? null;
+}
+
+/**
+ * Seconds remaining on the active job's deadline, or `null`.
+ *
+ * Returns `null` if no job is active, or if the active job has no
+ * deadline set (unlimited). Returns `0` once the deadline has passed —
+ * caller should treat that as "no time left" and abort outbound work.
+ *
+ * Snapshot semantics (see {@link JobContextSnapshot.deadlineSecsRemaining}):
+ * this returns the value captured when the scope was bound, not a
+ * live wall-clock countdown.
+ */
+export function remainingSeconds(): number | null {
+  const snap = CURRENT_JOB.getStore();
+  if (!snap) return null;
+  return snap.deadlineSecsRemaining;
+}
+
+/**
+ * Run `fn` inside an `AsyncLocalStorage` scope with `snap` as the
+ * active job context.
+ *
+ * This is the JS-side analogue of the Rust `with_job` task-local
+ * binding. The inbound dispatch wrapper (next dispatch) calls BOTH
+ * this AND the Rust `withJobAsync` so:
+ *
+ *   - JS user code reading via `currentJob()` sees the snapshot;
+ *   - Rust-originated work (e.g. `call_tool`, `submit_job`) within
+ *     the scope sees the Rust task-local for header injection and
+ *     cancel-registry binding.
+ *
+ * The two contexts are deliberately set in parallel because the Rust
+ * task-local does not cross the FFI boundary into the Node event loop.
+ */
+export async function withJobAsync<T>(
+  snap: JobContextSnapshot,
+  fn: () => Promise<T>
+): Promise<T> {
+  return CURRENT_JOB.run(snap, fn);
+}

--- a/src/runtime/typescript/src/jobs-cancel-route.ts
+++ b/src/runtime/typescript/src/jobs-cancel-route.ts
@@ -35,19 +35,29 @@ import { cancelActiveJob } from "@mcpmesh/core";
  * falls back to lease-expiry.
  */
 export function registerCancelRoute(server: FastMCP): boolean {
+  // Visibility: cancel-mid-flight is a primary control-plane signal for
+  // long-running jobs. When registration fails the agent silently
+  // degrades to lease-expiry — operators who only watch ERROR-level
+  // logs would never see the regression. Emit at console.error and
+  // include the underlying reason so the failure mode is debuggable
+  // from logs alone.
   let app: ReturnType<FastMCP["getApp"]> | null = null;
   try {
     app = server.getApp();
   } catch (err) {
-    console.warn(
-      "[mesh-jobs] FastMCP.getApp() unavailable — cancel route not registered:",
-      err,
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[mesh-jobs] cancel route NOT registered — FastMCP.getApp() ` +
+        `unavailable: ${reason}. Cancel-mid-flight will silently degrade ` +
+        `to lease expiry for any task: true tools on this agent.`,
     );
     return false;
   }
   if (!app) {
-    console.warn(
-      "[mesh-jobs] FastMCP.getApp() returned null — cancel route not registered",
+    console.error(
+      `[mesh-jobs] cancel route NOT registered — FastMCP.getApp() ` +
+        `returned null. Cancel-mid-flight will silently degrade to lease ` +
+        `expiry for any task: true tools on this agent.`,
     );
     return false;
   }
@@ -74,7 +84,12 @@ export function registerCancelRoute(server: FastMCP): boolean {
     });
     return true;
   } catch (err) {
-    console.warn("[mesh-jobs] failed to register cancel route:", err);
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[mesh-jobs] cancel route NOT registered — app.post() raised: ` +
+        `${reason}. Cancel-mid-flight will silently degrade to lease ` +
+        `expiry for any task: true tools on this agent.`,
+    );
     return false;
   }
 }

--- a/src/runtime/typescript/src/jobs-cancel-route.ts
+++ b/src/runtime/typescript/src/jobs-cancel-route.ts
@@ -1,0 +1,80 @@
+/**
+ * Mount the cancel HTTP route on the agent's HTTP server (Phase 1 —
+ * MeshJob substrate).
+ *
+ * Mirrors Python's
+ * `_mcp_mesh.pipeline.mcp_startup.jobs_cancel_route.JobsCancelRouteStep`.
+ *
+ * Per `MESHJOB_DESIGN.org` "Wire Protocol / New endpoints" /
+ * "Cancellation": when the registry receives a cancel request for a
+ * job whose owner is alive, it forwards the call to the owner
+ * replica's `POST /jobs/{job_id}/cancel` HTTP route. That route fires
+ * the in-process cancel token registered by the inbound tool wrapper
+ * (or the claim worker) so any outbound HTTP calls under the active
+ * `with_job_async` scope abort.
+ *
+ * The route is registered on FastMCP's underlying Hono app. FastMCP
+ * exposes the Hono instance via `server.getApp()` after the server has
+ * started; calling that BEFORE start would throw. We register at the
+ * front of the routes table so the explicit `/jobs/:job_id/cancel`
+ * matches before any catch-all FastMCP routes (Hono matches routes in
+ * registration order by default, so calling `app.post(...)` after the
+ * server starts is sufficient — Hono inserts at the end, but the
+ * FastMCP catch-alls only match the configured `endpoint` path which
+ * defaults to `/mcp` — there's no overlap).
+ */
+import type { FastMCP } from "fastmcp";
+import { cancelActiveJob } from "@mcpmesh/core";
+
+/**
+ * Register `POST /jobs/:job_id/cancel` on the FastMCP server's Hono
+ * app. Returns `true` iff the route was registered (i.e. the FastMCP
+ * server exposes a Hono instance). Logs a warning and returns `false`
+ * on any failure — cancel is a best-effort signal; missing the route
+ * just means the registry's forward attempt 404s and the cancel
+ * falls back to lease-expiry.
+ */
+export function registerCancelRoute(server: FastMCP): boolean {
+  let app: ReturnType<FastMCP["getApp"]> | null = null;
+  try {
+    app = server.getApp();
+  } catch (err) {
+    console.warn(
+      "[mesh-jobs] FastMCP.getApp() unavailable — cancel route not registered:",
+      err,
+    );
+    return false;
+  }
+  if (!app) {
+    console.warn(
+      "[mesh-jobs] FastMCP.getApp() returned null — cancel route not registered",
+    );
+    return false;
+  }
+
+  try {
+    app.post("/jobs/:job_id/cancel", async (c) => {
+      const jobId = c.req.param("job_id");
+      let cancelled = false;
+      try {
+        cancelled = Boolean(cancelActiveJob(jobId));
+      } catch (err) {
+        // The napi binding shouldn't throw under normal conditions;
+        // log + report cancelled=false so the registry's forwarder
+        // gets a deterministic answer.
+        console.warn(
+          `[mesh-jobs] cancelActiveJob napi raised for job=${jobId}:`,
+          err,
+        );
+      }
+      console.log(
+        `[mesh-jobs] cancel route: job_id=${jobId} cancelled=${cancelled}`,
+      );
+      return c.json({ cancelled, job_id: jobId });
+    });
+    return true;
+  } catch (err) {
+    console.warn("[mesh-jobs] failed to register cancel route:", err);
+    return false;
+  }
+}

--- a/src/runtime/typescript/src/jobs-helper-tools.ts
+++ b/src/runtime/typescript/src/jobs-helper-tools.ts
@@ -1,0 +1,179 @@
+/**
+ * Auto-register the three MeshJob helper tools on every TS mesh agent
+ * (Phase 1 — MeshJob substrate).
+ *
+ * Mirrors Python's
+ * `_mcp_mesh.pipeline.mcp_startup.jobs_helper_tools.JobsHelperToolsStep`.
+ *
+ * Per `MESHJOB_DESIGN.org` "Helper tool placement: auto-registered on
+ * every mesh agent": `__mesh_job_status` / `__mesh_job_result` /
+ * `__mesh_job_cancel` are framework primitives, exposed on every agent
+ * that initialises the mesh runtime — independent of whether that
+ * agent owns any `task: true` tools. External MCP clients can call any
+ * agent to poll job status; the call lands at the registry, not at any
+ * specific owner replica.
+ *
+ * The helpers are thin wrappers around `JobProxy` from `@mcpmesh/core`
+ * (which terminates at the registry's `GET /jobs/{id}` /
+ * `POST /jobs/{id}/cancel`). No replica-side caching, no owner-bound
+ * routing for reads (per "Status read path" decision in design doc).
+ */
+import type { FastMCP } from "fastmcp";
+import { z } from "zod";
+import { JobProxy } from "@mcpmesh/core";
+
+const TOOL_NAME_STATUS = "__mesh_job_status";
+const TOOL_NAME_RESULT = "__mesh_job_result";
+const TOOL_NAME_CANCEL = "__mesh_job_cancel";
+
+const DESCRIPTIONS: Record<string, string> = {
+  [TOOL_NAME_STATUS]:
+    "[Framework] Return the latest mesh-registry state for a job_id. " +
+    "Reads terminate at the registry; safe to call from any agent.",
+  [TOOL_NAME_RESULT]:
+    "[Framework] Return the terminal result/status/error for a job_id " +
+    "via a single registry read.",
+  [TOOL_NAME_CANCEL]:
+    "[Framework] Request cancellation for a job_id. The registry " +
+    "forwards the signal to the owner replica when alive.",
+};
+
+/**
+ * Metadata stamp for the three helper tools — same shape `MeshAgent`
+ * builds for user tools, so the Rust core ships them to the registry
+ * as regular capabilities under the framework_internal=true tag.
+ */
+export interface HelperToolMeta {
+  capability: string;
+  version: string;
+  tags: string[];
+  description: string;
+  inputSchema: string;
+  task: boolean;
+}
+
+/**
+ * Register `__mesh_job_status` / `__mesh_job_result` /
+ * `__mesh_job_cancel` on the FastMCP server and return their mesh
+ * metadata so the agent can ship them in the heartbeat tool catalog.
+ *
+ * Skipped if `registryUrl` is empty — without a registry there's
+ * nothing for the helpers to read from. Returns an empty metadata map
+ * in that case so the caller can still proceed with startup.
+ *
+ * Idempotent w.r.t. an already-registered tool name (FastMCP throws on
+ * duplicate names; we catch + log so a hot-reload doesn't crash).
+ */
+export function registerJobHelperTools(
+  server: FastMCP,
+  registryUrl: string,
+): Map<string, HelperToolMeta> {
+  const meta = new Map<string, HelperToolMeta>();
+  if (!registryUrl) {
+    return meta;
+  }
+
+  const inputParams = z.object({
+    jobId: z.string().describe("Job UUID returned by submit_job"),
+  });
+  const cancelParams = z.object({
+    jobId: z.string().describe("Job UUID returned by submit_job"),
+    reason: z.string().optional().describe("Optional reason string"),
+  });
+
+  // We pass JSON-stringified inputSchema downstream just like the user
+  // tools do (see agent.ts addTool path).
+  const inputSchemaJson = JSON.stringify({
+    type: "object",
+    properties: {
+      jobId: { type: "string", description: "Job UUID returned by submit_job" },
+    },
+    required: ["jobId"],
+  });
+  const cancelSchemaJson = JSON.stringify({
+    type: "object",
+    properties: {
+      jobId: { type: "string", description: "Job UUID returned by submit_job" },
+      reason: { type: "string", description: "Optional reason string" },
+    },
+    required: ["jobId"],
+  });
+
+  // Status: GET /jobs/{id} via JobProxy.status()
+  try {
+    server.addTool({
+      name: TOOL_NAME_STATUS,
+      description: DESCRIPTIONS[TOOL_NAME_STATUS],
+      parameters: inputParams,
+      execute: async (args: { jobId: string }) => {
+        const proxy = new JobProxy(args.jobId, registryUrl);
+        const snapshot = await proxy.status();
+        return JSON.stringify(snapshot);
+      },
+    });
+    meta.set(TOOL_NAME_STATUS, {
+      capability: TOOL_NAME_STATUS,
+      version: "1.0.0",
+      tags: ["mesh-jobs", "framework"],
+      description: DESCRIPTIONS[TOOL_NAME_STATUS],
+      inputSchema: inputSchemaJson,
+      task: false,
+    });
+  } catch (err) {
+    console.warn(`[mesh-jobs] could not register ${TOOL_NAME_STATUS}:`, err);
+  }
+
+  // Result: same wire as status; helper unwraps just the terminal bits.
+  try {
+    server.addTool({
+      name: TOOL_NAME_RESULT,
+      description: DESCRIPTIONS[TOOL_NAME_RESULT],
+      parameters: inputParams,
+      execute: async (args: { jobId: string }) => {
+        const proxy = new JobProxy(args.jobId, registryUrl);
+        const snapshot = (await proxy.status()) as Record<string, unknown>;
+        return JSON.stringify({
+          status: snapshot.status,
+          result: snapshot.result,
+          error: snapshot.error,
+        });
+      },
+    });
+    meta.set(TOOL_NAME_RESULT, {
+      capability: TOOL_NAME_RESULT,
+      version: "1.0.0",
+      tags: ["mesh-jobs", "framework"],
+      description: DESCRIPTIONS[TOOL_NAME_RESULT],
+      inputSchema: inputSchemaJson,
+      task: false,
+    });
+  } catch (err) {
+    console.warn(`[mesh-jobs] could not register ${TOOL_NAME_RESULT}:`, err);
+  }
+
+  // Cancel: POST /jobs/{id}/cancel via JobProxy.cancel()
+  try {
+    server.addTool({
+      name: TOOL_NAME_CANCEL,
+      description: DESCRIPTIONS[TOOL_NAME_CANCEL],
+      parameters: cancelParams,
+      execute: async (args: { jobId: string; reason?: string }) => {
+        const proxy = new JobProxy(args.jobId, registryUrl);
+        await proxy.cancel(args.reason ?? null);
+        return JSON.stringify({ ok: true, jobId: args.jobId });
+      },
+    });
+    meta.set(TOOL_NAME_CANCEL, {
+      capability: TOOL_NAME_CANCEL,
+      version: "1.0.0",
+      tags: ["mesh-jobs", "framework"],
+      description: DESCRIPTIONS[TOOL_NAME_CANCEL],
+      inputSchema: cancelSchemaJson,
+      task: false,
+    });
+  } catch (err) {
+    console.warn(`[mesh-jobs] could not register ${TOOL_NAME_CANCEL}:`, err);
+  }
+
+  return meta;
+}

--- a/src/runtime/typescript/src/mesh-job-submitter.ts
+++ b/src/runtime/typescript/src/mesh-job-submitter.ts
@@ -1,0 +1,170 @@
+/**
+ * Consumer-side `MeshJob` submitter (Phase 1 — MeshJob substrate).
+ *
+ * Mirrors Python's `_mcp_mesh.engine.mesh_job_submitter.MeshJobSubmitter`.
+ *
+ * When a consumer tool declares a parameter typed as `MeshJob` (i.e.
+ * `meshJobParamIndex` is set on the resolved tool definition), the
+ * runtime injects an instance of this class into that slot. The user
+ * calls `await submitter.submit({ payload: ..., maxDuration: ... })` to
+ * enqueue work on the remote producer and gets back a `JobProxy`
+ * exposing `wait`/`status`/`cancel`.
+ *
+ * Per the design's "decouple resolver from capability metadata"
+ * decision: this class does NOT verify the target capability is
+ * registered with `task=true`. The registry rejects `submit_job`
+ * against a non-task capability with a clear error which surfaces
+ * verbatim to the caller.
+ *
+ * Resilience: `submit` retries on transient registry errors (network
+ * drops / 5xx / 503) up to 3 attempts with 200ms→1s→5s backoff.
+ * 4xx / NotFound / Conflict / serialization errors propagate
+ * immediately — those won't self-heal.
+ */
+import { submitJob, type JobProxy } from "@mcpmesh/core";
+
+const _SUBMIT_MAX_ATTEMPTS = 3;
+// Backoff per attempt (seconds): 200ms, 1s, 5s — matches Python.
+const _SUBMIT_BACKOFF_MS = [200, 1000, 5000];
+
+/**
+ * Heuristic: does this error string represent a transient registry
+ * failure that's worth retrying? Errs on the side of NOT retrying when
+ * the signal is ambiguous — submit failures are user-facing and a fast
+ * clear failure beats a slow flaky one.
+ *
+ * The Rust napi binding propagates `JobError` as `Error(message)`. The
+ * Rust side emits messages like:
+ *   "backend error: network error: <reqwest::Error>"
+ *   "backend error: backend unavailable: <body>"
+ *   "backend error: server error (HTTP 502): <body>"
+ *   "backend error: backend error: HTTP 400: <body>"   (4xx, NOT transient)
+ *   "backend error: job not found: <id>"               (404, NOT transient)
+ *   "backend error: conflict: <reason>"                (409, NOT transient)
+ */
+function isTransientSubmitError(err: unknown): boolean {
+  const msg = String((err as Error)?.message ?? err).toLowerCase();
+  if (msg.includes("network error")) return true;
+  if (msg.includes("backend unavailable")) return true;
+  if (msg.includes("server error (http 5")) return true;
+  return false;
+}
+
+/**
+ * Per-submission options for `MeshJobSubmitter.submit(...)`. Matches
+ * the napi `SubmitJobArgs` shape (minus `registryUrl`/`capability`/
+ * `submittedBy` which the submitter binds at construction).
+ */
+export interface SubmitOptions {
+  /** Per-attempt soft timeout (seconds). `undefined` ≡ registry default. */
+  maxDuration?: number;
+  /**
+   * Maximum retries on failure (registry default is 1 — one attempt,
+   * no retry). `undefined` ≡ registry default.
+   */
+  maxRetries?: number;
+  /**
+   * Absolute wall-clock deadline across all retries. Accepts a `Date`
+   * or a unix-epoch number (seconds). `undefined` ≡ unlimited per the
+   * "Resolved Decisions" section of MESHJOB_DESIGN.org.
+   */
+  totalDeadline?: Date | number;
+}
+
+/**
+ * Per-binding submit handle for a `MeshJob`-typed dependency.
+ *
+ * Constructed by the dependency injector at agent startup, one per
+ * (consumer-tool, dependency-capability) pair.
+ */
+export class MeshJobSubmitter {
+  /** Remote capability this submitter targets. */
+  readonly capability: string;
+  /** Identifier written to the registry's `submitted_by` column. */
+  readonly submittedBy: string;
+  /** Base URL of the mesh registry. */
+  readonly registryUrl: string;
+
+  constructor(
+    capability: string,
+    submittedBy: string,
+    registryUrl: string,
+  ) {
+    this.capability = capability;
+    this.submittedBy = submittedBy;
+    this.registryUrl = registryUrl;
+  }
+
+  /**
+   * Submit a new job on the bound capability and return a `JobProxy`.
+   *
+   * The first positional argument carries the user-supplied payload
+   * fields the producer will receive as its tool args. Optional
+   * second-arg knobs map to registry columns (`max_duration`,
+   * `max_retries`, `total_deadline`).
+   *
+   * @example
+   * ```ts
+   * const proxy = await jobSubmitter.submit(
+   *   { user_id: "demo", sections: ["intro", "summary"] },
+   *   { maxDuration: 60 },
+   * );
+   * const result = await proxy.wait(60);
+   * ```
+   *
+   * Error semantics:
+   *   - Transient registry errors (network/5xx/503) → retried 3 times
+   *     with 200ms/1s/5s backoff before propagating.
+   *   - 4xx / NotFound / Conflict / serialization → fail-fast.
+   */
+  async submit(
+    payload: Record<string, unknown>,
+    options: SubmitOptions = {},
+  ): Promise<JobProxy> {
+    let totalDeadlineEpoch: number | undefined;
+    if (options.totalDeadline !== undefined) {
+      if (options.totalDeadline instanceof Date) {
+        totalDeadlineEpoch = Math.floor(options.totalDeadline.getTime() / 1000);
+      } else if (typeof options.totalDeadline === "number") {
+        // If looks like ms, downgrade to seconds. Anything > 1e12 is ms.
+        totalDeadlineEpoch =
+          options.totalDeadline > 1e12
+            ? Math.floor(options.totalDeadline / 1000)
+            : Math.floor(options.totalDeadline);
+      } else {
+        throw new TypeError(
+          `MeshJobSubmitter.submit: totalDeadline must be a Date or a number ` +
+            `(unix epoch seconds); got ${typeof options.totalDeadline}`,
+        );
+      }
+    }
+
+    let lastErr: unknown = null;
+    for (let attempt = 1; attempt <= _SUBMIT_MAX_ATTEMPTS; attempt++) {
+      try {
+        const proxy = await submitJob({
+          registryUrl: this.registryUrl,
+          capability: this.capability,
+          payload,
+          submittedBy: this.submittedBy,
+          // Let the registry assign owner via pull-claim.
+          ownerInstanceId: undefined,
+          maxDuration: options.maxDuration,
+          maxRetries: options.maxRetries,
+          totalDeadline: totalDeadlineEpoch,
+        });
+        return proxy;
+      } catch (err) {
+        lastErr = err;
+        if (!isTransientSubmitError(err) || attempt >= _SUBMIT_MAX_ATTEMPTS) {
+          throw err;
+        }
+        const backoffMs =
+          _SUBMIT_BACKOFF_MS[Math.min(attempt - 1, _SUBMIT_BACKOFF_MS.length - 1)];
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+      }
+    }
+    // Defensive — unreachable: we either return or throw above.
+    throw lastErr ?? new Error("MeshJobSubmitter.submit: unreachable");
+  }
+}

--- a/src/runtime/typescript/src/mesh-job-submitter.ts
+++ b/src/runtime/typescript/src/mesh-job-submitter.ts
@@ -17,15 +17,18 @@
  * verbatim to the caller.
  *
  * Resilience: `submit` retries on transient registry errors (network
- * drops / 5xx / 503) up to 3 attempts with 200ms→1s→5s backoff.
- * 4xx / NotFound / Conflict / serialization errors propagate
- * immediately — those won't self-heal.
+ * drops / 5xx / 503) up to 3 attempts with 200ms then 1s backoff
+ * between them. 4xx / NotFound / Conflict / serialization errors
+ * propagate immediately — those won't self-heal.
  */
 import { submitJob, type JobProxy } from "@mcpmesh/core";
 
 const _SUBMIT_MAX_ATTEMPTS = 3;
-// Backoff per attempt (seconds): 200ms, 1s, 5s — matches Python.
-const _SUBMIT_BACKOFF_MS = [200, 1000, 5000];
+// Backoff applied BETWEEN attempts. With 3 attempts there are 2 gaps,
+// so this array has exactly 2 entries — a third entry would never be
+// reached (the previous `[200, 1000, 5000]` had the 5s tier silently
+// dead). Tests assert 3 total attempts; mirror that here precisely.
+const _SUBMIT_BACKOFF_MS = [200, 1000];
 
 /**
  * Heuristic: does this error string represent a transient registry
@@ -113,8 +116,8 @@ export class MeshJobSubmitter {
    * ```
    *
    * Error semantics:
-   *   - Transient registry errors (network/5xx/503) → retried 3 times
-   *     with 200ms/1s/5s backoff before propagating.
+   *   - Transient registry errors (network/5xx/503) → up to 3 attempts
+   *     with 200ms then 1s backoff between them before propagating.
    *   - 4xx / NotFound / Conflict / serialization → fail-fast.
    */
   async submit(

--- a/src/runtime/typescript/src/resolver-meshjob.ts
+++ b/src/runtime/typescript/src/resolver-meshjob.ts
@@ -1,0 +1,259 @@
+/**
+ * DDDI resolver for `MeshJob` parameters (Phase 1 — MeshJob substrate).
+ *
+ * Implements `MESHJOB_DDDI_CONTRACT.md` for the TypeScript SDK. Mirrors
+ * Python's `analyze_mesh_job_signature` from
+ * `_mcp_mesh.engine.signature_analyzer`.
+ *
+ * # TS-specific shape
+ *
+ * Python uses `inspect.signature` + `typing.get_type_hints` to classify
+ * parameters by annotation type. TypeScript erases types at runtime,
+ * and the existing SDK does not depend on `reflect-metadata` decorators
+ * — `agent.addTool({ ... })` is fully declarative. So the TS resolver
+ * input is the explicit declaration:
+ *
+ *   - `dependencies`: array of MeshTool deps in declaration order
+ *     (matches Python's `dep_index` ordering today).
+ *   - `meshToolPositions`: signature positions for each MeshTool dep
+ *     (where in the user `execute(args, ...)` parameter list each
+ *     dep proxy lands).
+ *   - `meshJobParamIndex`: signature position of the single MeshJob
+ *     parameter, or `undefined` if the tool has none.
+ *
+ * The resolver verifies the contract invariants:
+ *
+ *   - At most one MeshJob parameter per tool (reject otherwise).
+ *   - MeshTool positions don't overlap with the MeshJob position.
+ *
+ * Then produces the canonical `ResolvedSignature` the dispatch wrapper
+ * uses to inject deps + the MeshJob into `execute(args, ...)`.
+ *
+ * # Test seam
+ *
+ * `__tests__/resolver-meshjob.spec.ts` covers the same scenarios as
+ * Python's `tests/test_resolver_meshjob.py` and Java's
+ * (forthcoming) `MeshJobResolverTest.java`. Whenever any SDK's
+ * resolver behaviour changes, update `MESHJOB_DDDI_CONTRACT.md` first
+ * then mirror across all three test seams.
+ */
+
+/**
+ * One mesh-tool dependency slot recognised by the resolver. Mirrors
+ * Python's `mesh_tool_positions[i]` entry: each entry knows where in
+ * the user function's parameter list it should be injected.
+ */
+export interface ResolvedMeshToolDep {
+  /** Index into the original `dependencies` array. */
+  depIndex: number;
+  /**
+   * Signature position (0-indexed) where the resolved proxy should be
+   * injected as a positional arg to the user `execute` function. For
+   * the TS SDK these positions follow `args` (the first positional
+   * parameter is always the parsed args object, then deps).
+   */
+  signaturePosition: number;
+}
+
+/**
+ * Resolver output. Mirrors Python's `MeshJobResolution` plus the
+ * `meshToolDeps` projection for TS callers (Python returns just
+ * positions; the TS dispatch path threads `depIndex` through).
+ */
+export interface ResolvedSignature {
+  /**
+   * Mesh-tool dependency slots in declaration order. The dispatch
+   * wrapper iterates this list to inject the resolved proxies.
+   *
+   * Empty when the tool declares no `dependencies`.
+   */
+  meshToolDeps: ResolvedMeshToolDep[];
+
+  /**
+   * Signature position of the single MeshJob parameter, or
+   * `undefined` if the tool does not declare one.
+   *
+   * Phase 1 invariant: at most one MeshJob param per tool. The
+   * resolver throws (see {@link resolveMeshJobSignature}) if this
+   * invariant is violated.
+   */
+  meshJobParamIndex?: number;
+}
+
+/**
+ * Input shape for the resolver. The SDK builds this from the user's
+ * `addTool({ dependencies, meshToolPositions, meshJobParamIndex })`
+ * config; explicit fields keep the resolver pure and easy to test
+ * without spinning up a FastMCP server.
+ */
+export interface ResolverInput {
+  /**
+   * Capability names of declared dependencies in declaration order.
+   * The length defines the number of MeshTool slots.
+   */
+  dependencies: string[];
+
+  /**
+   * Optional explicit signature positions for each MeshTool dep. When
+   * omitted, the resolver assigns positions starting at 1 (after
+   * `args`) and skipping `meshJobParamIndex` if set, matching the
+   * contract's "positional indexing rule".
+   *
+   * Length MUST match `dependencies.length` when provided.
+   */
+  meshToolPositions?: number[];
+
+  /**
+   * Signature position of the MeshJob parameter (if any). The contract
+   * classifies it as orthogonal to MeshTool positional indexing — it
+   * is recorded separately so adding/removing a MeshJob param does
+   * NOT shift MeshTool positions.
+   */
+  meshJobParamIndex?: number;
+
+  /**
+   * Optional name(s) of MeshJob parameters detected at the call site.
+   * Used by the resolver to surface a clearer error message when the
+   * user accidentally declares more than one. Pass an array like
+   * `["job", "secondJob"]` to enable the "at most one" check —
+   * undefined skips the check (single position only).
+   */
+  meshJobParamNames?: string[];
+}
+
+/**
+ * Sentinel error class for resolver violations. Subclasses `Error` so
+ * standard `try/catch` works; the SDK calls `addTool` re-throws this
+ * verbatim so the user sees the misuse at registration time.
+ *
+ * The contract specifies the exact wording for the multi-MeshJob case
+ * — keeping it stable here lets tests assert against it.
+ */
+export class ResolverError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ResolverError";
+  }
+}
+
+/**
+ * Classify a tool's signature per `MESHJOB_DDDI_CONTRACT.md`.
+ *
+ * For each dependency in declaration order, assigns a signature
+ * position. If `meshJobParamIndex` is set, that position is RESERVED
+ * for the MeshJob and skipped when assigning MeshTool positions.
+ *
+ * Phase 1 invariant: at most one MeshJob parameter — multiple raises
+ * `ResolverError` with the contract-specified wording so users see
+ * the misuse at registration time.
+ *
+ * The TS SDK's existing tool-positional layout is `(args, ...deps)` —
+ * args is signature position 0, deps start at 1. When
+ * `meshJobParamIndex` is set inside that range, it consumes one slot
+ * and the resolver shifts subsequent MeshTool positions accordingly.
+ *
+ * @example MeshTool only
+ * ```ts
+ * resolveMeshJobSignature({ dependencies: ["a", "b"] })
+ * // → { meshToolDeps: [{depIndex:0, signaturePosition:1}, {depIndex:1, signaturePosition:2}] }
+ * ```
+ *
+ * @example MeshJob in middle (sig pos 2)
+ * ```ts
+ * resolveMeshJobSignature({
+ *   dependencies: ["weather", "flights"],
+ *   meshJobParamIndex: 2,
+ * })
+ * // → { meshToolDeps: [{depIndex:0, signaturePosition:1}, {depIndex:1, signaturePosition:3}],
+ * //     meshJobParamIndex: 2 }
+ * ```
+ *
+ * @example Multiple MeshJob params → throws
+ * ```ts
+ * resolveMeshJobSignature({
+ *   dependencies: [],
+ *   meshJobParamIndex: 1,
+ *   meshJobParamNames: ["firstJob", "secondJob"],
+ * })
+ * // → throws ResolverError("a tool function may declare at most one MeshJob parameter; ...")
+ * ```
+ */
+export function resolveMeshJobSignature(
+  input: ResolverInput
+): ResolvedSignature {
+  // Phase 1 invariant: at most one MeshJob param. This is checked when
+  // the caller supplies the optional `meshJobParamNames` (set by the
+  // hypothetical type-reflective shim that Phase B will introduce in
+  // the dispatch wrapper). When the input plumbing only carries a
+  // single index, by construction we already have at most one — so
+  // skip the check rather than reject ambiguous input shapes.
+  if (input.meshJobParamNames && input.meshJobParamNames.length > 1) {
+    throw new ResolverError(
+      `a tool function may declare at most one MeshJob parameter; ` +
+        `function declares ${input.meshJobParamNames.length}: ` +
+        `${input.meshJobParamNames.map((n) => `'${n}'`).join(", ")}`
+    );
+  }
+
+  const meshJobParamIndex = input.meshJobParamIndex;
+
+  // Sanity-check explicit positions if provided.
+  if (input.meshToolPositions !== undefined) {
+    if (input.meshToolPositions.length !== input.dependencies.length) {
+      throw new ResolverError(
+        `meshToolPositions length (${input.meshToolPositions.length}) ` +
+          `does not match dependencies length (${input.dependencies.length})`
+      );
+    }
+    if (
+      meshJobParamIndex !== undefined &&
+      input.meshToolPositions.includes(meshJobParamIndex)
+    ) {
+      throw new ResolverError(
+        `meshJobParamIndex ${meshJobParamIndex} collides with a ` +
+          `MeshTool position; MeshJob is orthogonal — it must occupy ` +
+          `its own signature slot per MESHJOB_DDDI_CONTRACT.md`
+      );
+    }
+  }
+
+  // Compute mesh-tool positions. Two paths:
+  //
+  //   1. Caller supplied them explicitly — use as-is (after the
+  //      collision check above).
+  //   2. Default: counter starts at 1 (after `args`), skip the
+  //      MeshJob position if any.
+  //
+  // The contract's "positional indexing rule" says: maintain a
+  // mesh_tool_position_counter, increment for each MeshTool, and do
+  // not touch it for MeshJob. We translate that into "skip the
+  // MeshJob signature position" because the TS SDK uses the same
+  // signature for `execute(args, ...deps)` whether or not a MeshJob
+  // is present.
+  let positions: number[];
+  if (input.meshToolPositions !== undefined) {
+    positions = input.meshToolPositions;
+  } else {
+    positions = [];
+    let counter = 1; // signature pos 0 is always `args`
+    for (let i = 0; i < input.dependencies.length; i++) {
+      if (counter === meshJobParamIndex) {
+        counter += 1; // skip MeshJob slot
+      }
+      positions.push(counter);
+      counter += 1;
+    }
+  }
+
+  const meshToolDeps: ResolvedMeshToolDep[] = positions.map(
+    (signaturePosition, depIndex) => ({
+      depIndex,
+      signaturePosition,
+    })
+  );
+
+  return {
+    meshToolDeps,
+    meshJobParamIndex,
+  };
+}

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -448,7 +448,7 @@ export interface MeshToolDef<T extends z.ZodType = z.ZodType> {
    */
   execute: (
     args: z.infer<T>,
-    ...deps: (McpMeshTool | null)[]
+    ...deps: (McpMeshTool | MeshJob | null)[]
   ) => Promise<unknown> | unknown;
 }
 

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -57,6 +57,80 @@ export type {
 } from "@mcpmesh/core";
 
 /**
+ * Type marker for DDDI injection of a long-running-task handle (Phase 1
+ * — MeshJob substrate).
+ *
+ * Used as a parameter-position type annotation on a tool registered with
+ * `agent.addTool({ task: true, ... })` (producer) or `mesh.route(...)`
+ * with a `task=true` dependency (consumer). The mesh runtime injects:
+ *
+ * - On the **producer side** (a tool decorated `{ task: true }` invoked
+ *   via the inbound job-dispatch path or claim worker): a
+ *   `JobController` exposing
+ *   `await job.updateProgress(...)` /
+ *   `await job.complete(result)` / `await job.fail(error)`.
+ *
+ * - On the **consumer side** (a function depending on a remote
+ *   `task=true` capability): a submitter that returns a `JobProxy`
+ *   exposing `await proxy.wait(timeoutSecs?)` / `await proxy.status()`
+ *   / `await proxy.cancel(reason?)`.
+ *
+ * A MeshJob parameter is **orthogonal** to positional MeshTool slots
+ * per `MESHJOB_DDDI_CONTRACT.md` — it does not consume a positional
+ * dependency-injection index.
+ *
+ * If a function declaring a MeshJob param is invoked as a regular
+ * synchronous tool call (no `X-Mesh-Job-Id` header, no claim path),
+ * the runtime injects `null` for the slot. Producer code SHOULD treat
+ * `null` as a fast path with no progress reporting.
+ *
+ * The type itself is structurally minimal because TypeScript erases
+ * structural types at runtime; the DDDI resolver records signature
+ * positions explicitly when the SDK builds the tool definition (see
+ * `__tests__/resolver-meshjob.spec.ts`).
+ *
+ * @example Producer
+ * ```typescript
+ * agent.addTool({
+ *   name: "plan_trip",
+ *   capability: "plan_trip",
+ *   task: true,
+ *   parameters: z.object({ userId: z.string() }),
+ *   dependencies: [{ capability: "weather" }],
+ *   meshJobParamIndex: 2,  // signature position of `job` below
+ *   execute: async (
+ *     { userId },
+ *     weather: McpMeshTool | null = null,
+ *     job: MeshJob | null = null,
+ *   ) => {
+ *     await job?.updateProgress(0.1, "checking weather");
+ *     const w = await weather?.({ city: "PDX" });
+ *     await job?.updateProgress(0.9, "done");
+ *     return { itinerary: w };
+ *   },
+ * });
+ * ```
+ */
+export interface MeshJob {
+  // Producer-side surface (when injected as JobController):
+  jobId?: string;
+  updateProgress?(progress: number, message?: string): Promise<void>;
+  complete?(result: unknown): Promise<void>;
+  fail?(error: string): Promise<void>;
+
+  // Consumer-side surface (when injected as JobProxy / submitter):
+  submit?(payload?: Record<string, unknown>, options?: {
+    maxDuration?: number;
+    maxRetries?: number;
+    totalDeadline?: number;
+    ownerInstanceId?: string;
+  }): Promise<MeshJob>;
+  wait?(timeoutSecs?: number): Promise<unknown>;
+  status?(): Promise<Record<string, unknown>>;
+  cancel?(reason?: string): Promise<void>;
+}
+
+/**
  * Dependency specification for mesh tool DI.
  *
  * Can be specified as a simple string (capability name) or
@@ -239,6 +313,26 @@ export interface MeshToolDef<T extends z.ZodType = z.ZodType> {
    */
   outputSchemaStrict?: boolean;
   /**
+   * Phase 1 MeshJob substrate: mark this tool as long-running.
+   *
+   * When `true`, producers advertise `task=true` in their tool
+   * metadata so consumers know to invoke this capability via job
+   * semantics (`mesh.MeshJob.submit(...) → wait/poll`) rather than as
+   * a regular synchronous `tools/call`. The actual job-context binding
+   * happens at inbound call time via the dispatch wrapper (Phase B).
+   *
+   * Constraints (validated at `addTool` time):
+   *
+   *   - `execute` MUST be an `async` function (long-running tools need
+   *     a Promise-based control flow to drive `MeshJob.updateProgress()`,
+   *     cancellation, and outbound polling). Sync `execute` raises a
+   *     clear error at registration.
+   *
+   * Default: `false` (regular synchronous tool). See
+   * `MESHJOB_DESIGN.org` "Producer-side flow".
+   */
+  task?: boolean;
+  /**
    * Dependencies required by this tool.
    * Injected positionally as McpMeshTool params after args.
    *
@@ -395,6 +489,10 @@ export interface ToolMeta {
   dependencies: NormalizedDependency[];
   /** Per-dependency configuration indexed by position (matches dependencies array) */
   dependencyKwargs?: DependencyKwargs[];
+  /** Phase 1 MeshJob substrate: producer flag advertising this tool as
+   * long-running so consumers invoke via job semantics. See
+   * MeshToolDef.task for full semantics. */
+  task?: boolean;
 }
 
 // ============================================================================

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -319,7 +319,7 @@ export interface MeshToolDef<T extends z.ZodType = z.ZodType> {
    * metadata so consumers know to invoke this capability via job
    * semantics (`mesh.MeshJob.submit(...) → wait/poll`) rather than as
    * a regular synchronous `tools/call`. The actual job-context binding
-   * happens at inbound call time via the dispatch wrapper (Phase B).
+   * happens at inbound call time via the dispatch wrapper.
    *
    * Constraints (validated at `addTool` time):
    *
@@ -332,6 +332,66 @@ export interface MeshToolDef<T extends z.ZodType = z.ZodType> {
    * `MESHJOB_DESIGN.org` "Producer-side flow".
    */
   task?: boolean;
+  /**
+   * Phase 1 MeshJob substrate (producer-side): signature position of
+   * the `MeshJob` parameter on the user's `execute` function.
+   *
+   * When set on a `task: true` tool, the runtime injects a
+   * `JobController` at this position when the tool is invoked under
+   * a job context (claim path or inbound call carrying
+   * `X-Mesh-Job-Id`). When the tool is invoked synchronously without
+   * a job context, the runtime injects `null` per
+   * `MESHJOB_DDDI_CONTRACT.md`.
+   *
+   * Position 0 is reserved for `args`; deps start at 1. The
+   * `MeshJob` slot is orthogonal to MeshTool positional indexing —
+   * MeshTool deps skip the `meshJobParamIndex` position and shift
+   * accordingly. See `resolver-meshjob.ts` for the contract test
+   * seam.
+   *
+   * Producer example with one MeshTool dep and a MeshJob slot:
+   * ```ts
+   * agent.addTool({
+   *   task: true,
+   *   dependencies: ["weather"],
+   *   meshJobParamIndex: 2,  // job at sig pos 2
+   *   execute: async (
+   *     { city },
+   *     weather: McpMeshTool | null = null,  // dep at sig pos 1
+   *     job: MeshJob | null = null,           // controller at sig pos 2
+   *   ) => { ... },
+   * });
+   * ```
+   */
+  meshJobParamIndex?: number;
+  /**
+   * Phase 1 MeshJob substrate (consumer-side): index into
+   * `dependencies` whose proxy should be injected as a
+   * `MeshJobSubmitter` (returns a `JobProxy`) instead of a regular
+   * `McpMeshTool` proxy.
+   *
+   * Use this when the consumer wants to call a remote `task: true`
+   * capability via job semantics (submit + poll/wait) rather than as
+   * a regular synchronous `tools/call`. The user function receives a
+   * `MeshJob`-typed handle at the dep's positional slot.
+   *
+   * Consumer example:
+   * ```ts
+   * agent.addTool({
+   *   name: "commission_report",
+   *   dependencies: ["generate_report"],
+   *   meshJobDepIndex: 0,  // generate_report is task=true
+   *   execute: async ({ userId }, generateReport: MeshJob | null = null) => {
+   *     const proxy = await generateReport!.submit(
+   *       { user_id: userId, sections: ["intro"] },
+   *       { maxDuration: 60 },
+   *     );
+   *     return await proxy.wait(60);
+   *   },
+   * });
+   * ```
+   */
+  meshJobDepIndex?: number;
   /**
    * Dependencies required by this tool.
    * Injected positionally as McpMeshTool params after args.
@@ -493,6 +553,14 @@ export interface ToolMeta {
    * long-running so consumers invoke via job semantics. See
    * MeshToolDef.task for full semantics. */
   task?: boolean;
+  /** Phase 1 MeshJob substrate: producer-side signature position of
+   * the MeshJob param. Used by the inbound dispatch wrapper to inject
+   * a JobController when running as a job. */
+  meshJobParamIndex?: number;
+  /** Phase 1 MeshJob substrate: consumer-side index into dependencies
+   * whose slot should hold a MeshJobSubmitter (instead of a regular
+   * McpMeshTool proxy). */
+  meshJobDepIndex?: number;
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #873. Mirrors Python's PR #878 for the TypeScript runtime. Integration tests + Python ↔ TS polyglot smoke land separately in #884.

## Summary

**napi-rs bindings** (` src/runtime/core/src/jobs_napi.rs`):
- ` JobController`, ` JobProxy`, ` submitJob`, ` currentJob`, ` cancelActiveJob`, ` withJobAsync`, ` injectJobHeaders` exposed to TS via napi-rs

**TS runtime** (` src/runtime/typescript/src/`):
- ` MeshJob` type marker (` types.ts`); ` task: boolean` on ` MeshToolDef` with async-only validation
- ` AsyncLocalStorage` mirror (` job-context.ts`) of Rust task-local
- DDDI resolver (` resolver-meshjob.ts`) per ` MESHJOB_DDDI_CONTRACT.md` — declarative shape since TS types erase at runtime
- Inbound MCP tool wrapper (` inbound-job-dispatch.ts`) reads ` X-Mesh-Job-Id`, sets both Rust + JS contexts, injects ` JobController` at ` meshJobParamIndex`, auto-completes on successful return
- ` MeshJobSubmitter` (` mesh-job-submitter.ts`) with retry on transient errors (3 attempts, 200ms→1s→5s)
- Pure-TS ` ClaimDispatcher` (` claim-dispatcher.ts`) with semaphore=4 + undici keep-alive Agent + trace-header propagation through claim path
- Cancel HTTP route ` POST /jobs/:job_id/cancel` (` jobs-cancel-route.ts`) via FastMCP's Hono ` getApp()`
- ` __mesh_job_status` / ` _result` / ` _cancel` helpers auto-registered on every TS agent (` jobs-helper-tools.ts`)

**Examples** (` examples/jobs-ts/`):
- ` long-task-provider-ts/` and ` long-task-consumer-ts/` — TS analogs of the Python examples

## Architectural decisions

- TS uses **declarative** ` addTool({task, meshJobParamIndex, meshJobDepIndex})` rather than reflective param classification. Same canonical contract output, different input shape than Python's ` inspect.signature` approach.
- **Two index fields** because TS types erase at runtime: ` meshJobParamIndex` (producer-side controller injection) and ` meshJobDepIndex` (consumer-side submitter slot).
- Worker isolation auto-disabled for job-bound tools (napi handles + AsyncLocalStorage don't cross thread boundaries cleanly) — logged at registration when affected.
- Batching tick spawns via ` napi::bindgen_prelude::within_runtime_if_available` in the constructor — direct mirror of Python's ` pyo3_async_runtimes::tokio::get_runtime().enter()` pattern. Fixes a bug where ` Handle::try_current()` returned ` Err` in the napi sync constructor context.

## Review Notes

Independent code review (=review-agent=) found 1 BLOCKER + 5 WARNINGs + 4 INFOs. **All BLOCKER + 5 WARNINGs addressed in commit ` 411a390d`** (4 substantively + 1 documented as defensive). 4 INFOs noted (docs / hardcoded constants / by-design behavior) — not blockers.

Highlights:
- ` meshJobParamIndex` validation at ` addTool` time (was silently failing on 0/negative/NaN)
- ` spliceJobController()` helper extracted to prevent inbound ↔ claim drift
- ClaimDispatcher fires ` job.fail()` directly when ` makeJobController` throws (was silently leaving job stuck until lease expiry)
- Cancel-route registration failure escalated to ` console.error`; secondary error if task tools registered without functional cancel route

## Substrate observations during this work

- **Mid-flight progress invisible** (caught in local validation): napi constructor sync context had no tokio runtime, batching tick never spawned. Fixed in ` fddf526d` using napi-rs's runtime accessor.

## E2E validation

4 scenarios verified locally (` 411a390d` post-fix):
- ✅ Smoke (TS consumer ↔ TS provider commission_report)
- ✅ Mid-flight progress visibility
- ✅ Cancel mid-flight (` __mesh_job_cancel` → status=cancelled)
- ✅ Helper tools on every agent (auto-registered)

Closes #873

## Test plan

- [x] ` cargo test --features typescript --lib` — passes
- [x] ` npm test` — **501 tests pass** (was 478 baseline + 23 new across resolver / submitter / dispatcher / inbound / agent / cancel-route)
- [x] napi binary rebuilds cleanly via ` npm run build` in ` src/runtime/core/`
- [x] e2e smoke (TS↔TS commission_report)
- [x] e2e mid-flight progress reads
- [x] e2e cancel mid-flight
- [x] e2e helper tools on both agents
- [ ] CI green
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MeshJob substrate for producer/consumer long-running task patterns with progress tracking and structured result handling.
  * Added helper tools for inspecting in-flight job status and canceling active jobs.
  * Added job context APIs to read current job ID and remaining deadline within tool execution scope.

* **Documentation**
  * Added TypeScript examples demonstrating producer and consumer job workflows with step-by-step setup instructions.

* **Tests**
  * Added comprehensive test coverage for job submission, dispatching, context management, and cancellation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->