### PR TITLE
feature: TS MeshJob integration test suite + Python ↔ TS polyglot smoke

### DIFF
--- a/tests/integration/suites/uc22_meshjob_ts/artifacts/bystander-x-ts
+++ b/tests/integration/suites/uc22_meshjob_ts/artifacts/bystander-x-ts
@@ -1,0 +1,1 @@
+../fixtures/bystander-x-ts

--- a/tests/integration/suites/uc22_meshjob_ts/artifacts/bystander-y-ts
+++ b/tests/integration/suites/uc22_meshjob_ts/artifacts/bystander-y-ts
@@ -1,0 +1,1 @@
+../fixtures/bystander-y-ts

--- a/tests/integration/suites/uc22_meshjob_ts/artifacts/downstream-sleeper-ts
+++ b/tests/integration/suites/uc22_meshjob_ts/artifacts/downstream-sleeper-ts
@@ -1,0 +1,1 @@
+../fixtures/downstream-sleeper-ts

--- a/tests/integration/suites/uc22_meshjob_ts/artifacts/long-task-consumer
+++ b/tests/integration/suites/uc22_meshjob_ts/artifacts/long-task-consumer
@@ -1,0 +1,1 @@
+../../uc21_meshjob/fixtures/long-task-consumer

--- a/tests/integration/suites/uc22_meshjob_ts/artifacts/long-task-consumer-ts
+++ b/tests/integration/suites/uc22_meshjob_ts/artifacts/long-task-consumer-ts
@@ -1,0 +1,1 @@
+../fixtures/long-task-consumer-ts

--- a/tests/integration/suites/uc22_meshjob_ts/artifacts/long-task-provider
+++ b/tests/integration/suites/uc22_meshjob_ts/artifacts/long-task-provider
@@ -1,0 +1,1 @@
+../../uc21_meshjob/fixtures/long-task-provider

--- a/tests/integration/suites/uc22_meshjob_ts/artifacts/long-task-provider-ts
+++ b/tests/integration/suites/uc22_meshjob_ts/artifacts/long-task-provider-ts
@@ -1,0 +1,1 @@
+../fixtures/long-task-provider-ts

--- a/tests/integration/suites/uc22_meshjob_ts/artifacts/orchestrator-agent
+++ b/tests/integration/suites/uc22_meshjob_ts/artifacts/orchestrator-agent
@@ -1,0 +1,1 @@
+../../uc21_meshjob/fixtures/orchestrator-agent

--- a/tests/integration/suites/uc22_meshjob_ts/artifacts/orchestrator-agent-ts
+++ b/tests/integration/suites/uc22_meshjob_ts/artifacts/orchestrator-agent-ts
@@ -1,0 +1,1 @@
+../fixtures/orchestrator-agent-ts

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "bystander-x-ts",
+  "version": "1.0.0",
+  "description": "MCP Mesh — bystander X agent (uc22 TS)",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^1.4.1",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/src/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Bystander X (uc22 TS) — used by tc16 to verify third-party status reads.
+ *
+ * Has no MeshJob deps and no task=true tools. The framework still
+ * auto-registers `__mesh_job_status` / `__mesh_job_result` /
+ * `__mesh_job_cancel` on every mesh agent, so the test can read job
+ * state from this agent for a job_id it did not submit.
+ *
+ * Distinct fixture file (separate from bystander-y-ts) so meshctl's
+ * "is this agent already running" check (which keys off the
+ * `mesh(server, { name })` decorator) doesn't conflate the two
+ * instances.
+ */
+import { FastMCP, mesh } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9114", 10);
+
+const server = new FastMCP({
+  name: "Bystander X (uc22 TS)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "bystander-x-ts",
+  httpPort: HTTP_PORT,
+  description: "Bystander agent X (TS) — verifies third-party status reads (tc16).",
+});
+
+agent.addTool({
+  name: "bystander_x_ping",
+  capability: "bystander_x_ping",
+  description: "Trivial tool — keeps bystander X alive in the registry.",
+  parameters: z.object({}),
+  execute: async () => ({ ok: true, agent: "bystander-x-ts" }),
+});
+
+console.log(
+  `bystander-x-ts uc22 fixture defined on port ${HTTP_PORT}. Waiting for auto-start...`,
+);

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/src/index.ts
@@ -14,7 +14,12 @@
 import { FastMCP, mesh } from "@mcpmesh/sdk";
 import { z } from "zod";
 
-const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9114", 10);
+const HTTP_PORT = (() => {
+  const parsed = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "", 10);
+  return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535
+    ? parsed
+    : 9114;
+})();
 
 const server = new FastMCP({
   name: "Bystander X (uc22 TS)",

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/tsconfig.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "bystander-y-ts",
+  "version": "1.0.0",
+  "description": "MCP Mesh — bystander Y agent (uc22 TS)",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^1.4.1",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/src/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Bystander Y (uc22 TS) — used by tc16 to verify third-party status reads.
+ *
+ * Mirror of bystander-x-ts in every way except agent name; deployed
+ * alongside X so the test can prove BOTH agents (each with no involvement
+ * in the job) can read its state via the framework's helper tools.
+ */
+import { FastMCP, mesh } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9115", 10);
+
+const server = new FastMCP({
+  name: "Bystander Y (uc22 TS)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "bystander-y-ts",
+  httpPort: HTTP_PORT,
+  description: "Bystander agent Y (TS) — verifies third-party status reads (tc16).",
+});
+
+agent.addTool({
+  name: "bystander_y_ping",
+  capability: "bystander_y_ping",
+  description: "Trivial tool — keeps bystander Y alive in the registry.",
+  parameters: z.object({}),
+  execute: async () => ({ ok: true, agent: "bystander-y-ts" }),
+});
+
+console.log(
+  `bystander-y-ts uc22 fixture defined on port ${HTTP_PORT}. Waiting for auto-start...`,
+);

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/src/index.ts
@@ -8,7 +8,12 @@
 import { FastMCP, mesh } from "@mcpmesh/sdk";
 import { z } from "zod";
 
-const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9115", 10);
+const HTTP_PORT = (() => {
+  const parsed = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "", 10);
+  return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535
+    ? parsed
+    : 9115;
+})();
 
 const server = new FastMCP({
   name: "Bystander Y (uc22 TS)",

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/tsconfig.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "downstream-sleeper-ts",
+  "version": "1.0.0",
+  "description": "MCP Mesh — slow downstream sleeper for cancel propagation tests (uc22 TS)",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^1.4.1",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/src/index.ts
@@ -64,6 +64,14 @@ agent.addTool({
         void t;
       });
     } catch (err) {
+      // UNREACHABLE — the Promise above never rejects (the only signal
+      // is setTimeout's resolve). This catch + marker line is a
+      // ready-for-#886 placeholder: once the TS proxy wires AbortSignal
+      // to the per-job cancel registry AND FastMCP-TS surfaces inbound
+      // client-disconnect to the tool handler, the inner Promise will
+      // gain a `reject` path and this marker will start firing for
+      // cancelled jobs. Do NOT debug "why doesn't the marker fire" —
+      // it cannot until #886 lands. See header comment for context.
       process.stderr.write(
         `[downstream-sleeper-ts] sleep CANCELLED for user=${user_id} ` +
           `(client closed / cancel token fired) — err=${err}\n`,

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/src/index.ts
@@ -1,0 +1,82 @@
+/**
+ * Downstream sleeper agent (uc22 TS) — exercises cancel propagation.
+ *
+ * TS port of uc21_meshjob/fixtures/downstream-sleeper/main.py.
+ *
+ * Provides `slow_downstream`, a regular (non-task) tool that sleeps for
+ * the requested number of seconds. The producer agent's
+ * `report_with_downstream_call` invokes this via the mesh proxy; when
+ * the producer's job is cancelled, the cancel token in the producer's
+ * async-local context aborts the in-flight outbound HTTP — so this
+ * sleeper never finishes its 30s timer for the cancel scenario.
+ *
+ * The sleeper logs a marker line to stderr if the request is aborted at
+ * the inbound side (FastMCP-TS would have to surface client-disconnect
+ * cancellation as a rejected promise for this to fire). At the time of
+ * writing, the FastMCP-TS substrate does NOT propagate inbound HTTP
+ * disconnects to the tool handler — the sleep runs to its natural end
+ * regardless of whether the producer side cancelled. Same gap as the
+ * Python equivalent (uc21/tc09 documents this in detail).
+ *
+ * Producer-side correctness (cancel landed, downstream HTTP aborted) is
+ * still observable from outside via:
+ *   - status == cancelled
+ *   - progress message frozen at "calling downstream"
+ *   - status != completed
+ */
+import { FastMCP, mesh } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9112", 10);
+
+const server = new FastMCP({
+  name: "Downstream Sleeper (uc22 TS)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "downstream-sleeper-ts",
+  httpPort: HTTP_PORT,
+  description:
+    "Slow downstream tool used to verify mesh-job cancel propagation (TS).",
+});
+
+agent.addTool({
+  name: "slow_downstream",
+  capability: "slow_downstream",
+  description:
+    "Sleeps for the requested number of seconds (regular tool, not task=true).",
+  parameters: z.object({
+    user_id: z.string(),
+    seconds: z.number().int().default(30),
+  }),
+  execute: async ({ user_id, seconds }) => {
+    process.stderr.write(
+      `[downstream-sleeper-ts] starting ${seconds}s sleep for user=${user_id}\n`,
+    );
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const t = setTimeout(resolve, seconds * 1000);
+        // If the inbound transport surfaced a cancel as an event we'd
+        // wire it here. FastMCP-TS does not yet expose such a hook —
+        // documented gap, parallel to FastMCP-Python's #882.
+        // No-op for now; the timer just runs to completion.
+        void t;
+      });
+    } catch (err) {
+      process.stderr.write(
+        `[downstream-sleeper-ts] sleep CANCELLED for user=${user_id} ` +
+          `(client closed / cancel token fired) — err=${err}\n`,
+      );
+      throw err;
+    }
+    process.stderr.write(
+      `[downstream-sleeper-ts] sleep completed for user=${user_id} (NOT cancelled)\n`,
+    );
+    return { user_id, slept: seconds };
+  },
+});
+
+console.log(
+  `downstream-sleeper-ts uc22 fixture defined on port ${HTTP_PORT}. Waiting for auto-start...`,
+);

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/src/index.ts
@@ -48,7 +48,9 @@ agent.addTool({
     "Sleeps for the requested number of seconds (regular tool, not task=true).",
   parameters: z.object({
     user_id: z.string(),
-    seconds: z.number().int().default(30),
+    // 0 allowed for fast-finish edge cases; negative would yield an
+    // immediate setTimeout completion and defeat the cancel scenario.
+    seconds: z.number().int().min(0).default(30),
   }),
   execute: async ({ user_id, seconds }) => {
     process.stderr.write(

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/tsconfig.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "long-task-consumer-ts",
+  "version": "1.0.0",
+  "description": "MCP Mesh — TypeScript MeshJob test consumer (uc22)",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^1.4.1",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/src/index.ts
@@ -1,0 +1,280 @@
+/**
+ * MeshJob test-suite consumer (uc22_meshjob_ts) — TypeScript port of
+ * uc21_meshjob/fixtures/long-task-consumer/main.py.
+ *
+ * Hosts several variants of the submit-and-await pattern so individual
+ * test cases can exercise behavioural knobs without forking new agents.
+ * Capability names match the Python fixture exactly so test assertions
+ * (and the polyglot tc17–tc20 fixtures) can call them interchangeably.
+ *
+ *   - commission_report           — submit + wait; returns terminal payload
+ *   - commission_with_options     — submit + wait with caller-supplied
+ *                                   max_retries + total_deadline_secs;
+ *                                   structured envelope on terminal failure
+ *   - commission_submit_only      — submit and return {job_id} immediately
+ *   - commission_explicit_fail    — submits report_with_explicit_fail
+ *   - commission_crash            — submits report_that_crashes
+ *   - commission_overlong         — submits runs_overlong
+ *   - commission_downstream       — submits report_with_downstream_call
+ */
+import { FastMCP, mesh, type MeshJob } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9111", 10);
+
+const server = new FastMCP({
+  name: "Long Task Consumer (uc22 TS)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "long-task-consumer-ts",
+  httpPort: HTTP_PORT,
+  description:
+    "MeshJob test consumer (uc22 TS) — multi-capability fixture for the integration suite.",
+});
+
+function utcDeadlineFromRelative(secs?: number | null): number | undefined {
+  if (secs === undefined || secs === null) return undefined;
+  // Mesh-job submit accepts a unix-epoch (seconds) or Date — pass seconds.
+  return Math.floor(Date.now() / 1000) + secs;
+}
+
+// ---------------------------------------------------------------------------
+// Submit + wait — happy path baseline (tc01)
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "commission_report",
+  capability: "commission_report",
+  dependencies: [{ capability: "generate_report" }],
+  meshJobDepIndex: 0,
+  description: "Submit a generate_report job and wait up to 60s for the result.",
+  parameters: z.object({
+    user_id: z.string(),
+    sections: z.array(z.string()),
+  }),
+  execute: async (
+    { user_id, sections },
+    generateReport: MeshJob | null = null,
+  ) => {
+    if (!generateReport?.submit) {
+      return { error: "generate_report submitter not injected" };
+    }
+    const proxy = await generateReport.submit(
+      { user_id, sections },
+      { maxDuration: 60 },
+    );
+    if (!proxy.wait) {
+      return { error: "submitter returned a proxy without .wait()" };
+    }
+    return await proxy.wait(60);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Submit + wait with caller-controlled retry / deadline knobs (tc13)
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "commission_with_options",
+  capability: "commission_with_options",
+  dependencies: [{ capability: "generate_report" }],
+  meshJobDepIndex: 0,
+  description:
+    "Submit generate_report with caller-supplied max_retries / total_deadline_secs.",
+  parameters: z.object({
+    user_id: z.string(),
+    sections: z.array(z.string()),
+    max_retries: z.number().int().default(1),
+    total_deadline_secs: z.number().int().nullable().optional(),
+    wait_timeout_secs: z.number().int().default(60),
+  }),
+  execute: async (
+    { user_id, sections, max_retries, total_deadline_secs, wait_timeout_secs },
+    generateReport: MeshJob | null = null,
+  ) => {
+    if (!generateReport?.submit) {
+      return { error: "generate_report submitter not injected" };
+    }
+    const proxy = await generateReport.submit(
+      { user_id, sections },
+      {
+        maxDuration: 60,
+        maxRetries: max_retries,
+        totalDeadline: utcDeadlineFromRelative(total_deadline_secs),
+      },
+    );
+    const job_id = (proxy as { jobId?: string }).jobId ?? null;
+    try {
+      const result = await proxy.wait!(wait_timeout_secs);
+      return { job_id, status: "completed", result };
+    } catch (e) {
+      return {
+        job_id,
+        status: "wait_raised",
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Submit-only — return job_id immediately (tc02, tc06, tc10–tc12, tc14, tc16)
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "commission_submit_only",
+  capability: "commission_submit_only",
+  dependencies: [{ capability: "generate_report" }],
+  meshJobDepIndex: 0,
+  description: "Submit generate_report and return the job_id without waiting.",
+  parameters: z.object({
+    user_id: z.string(),
+    sections: z.array(z.string()),
+    max_retries: z.number().int().default(1),
+    max_duration: z.number().int().default(60),
+  }),
+  execute: async (
+    { user_id, sections, max_retries, max_duration },
+    generateReport: MeshJob | null = null,
+  ) => {
+    if (!generateReport?.submit) {
+      return { error: "generate_report submitter not injected" };
+    }
+    const proxy = await generateReport.submit(
+      { user_id, sections },
+      { maxDuration: max_duration, maxRetries: max_retries },
+    );
+    return { job_id: (proxy as { jobId?: string }).jobId ?? null };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Explicit-fail submitter (tc05)
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "commission_explicit_fail",
+  capability: "commission_explicit_fail",
+  dependencies: [{ capability: "report_with_explicit_fail" }],
+  meshJobDepIndex: 0,
+  description:
+    "Submit report_with_explicit_fail with caller-supplied max_retries.",
+  parameters: z.object({
+    user_id: z.string(),
+    max_retries: z.number().int().default(3),
+    wait_timeout_secs: z.number().int().default(30),
+  }),
+  execute: async (
+    { user_id, max_retries, wait_timeout_secs },
+    reportWithExplicitFail: MeshJob | null = null,
+  ) => {
+    if (!reportWithExplicitFail?.submit) {
+      return { error: "report_with_explicit_fail submitter not injected" };
+    }
+    const proxy = await reportWithExplicitFail.submit(
+      { user_id },
+      { maxDuration: 30, maxRetries: max_retries },
+    );
+    const job_id = (proxy as { jobId?: string }).jobId ?? null;
+    try {
+      const result = await proxy.wait!(wait_timeout_secs);
+      return { job_id, status: "completed", result };
+    } catch (e) {
+      return {
+        job_id,
+        status: "wait_raised",
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Crash submitter (tc12)
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "commission_crash",
+  capability: "commission_crash",
+  dependencies: [{ capability: "report_that_crashes" }],
+  meshJobDepIndex: 0,
+  description:
+    "Submit report_that_crashes (always raises) with caller-supplied retry/deadline.",
+  parameters: z.object({
+    user_id: z.string(),
+    max_retries: z.number().int().default(0),
+    total_deadline_secs: z.number().int().nullable().optional(),
+  }),
+  execute: async (
+    { user_id, max_retries, total_deadline_secs },
+    reportThatCrashes: MeshJob | null = null,
+  ) => {
+    if (!reportThatCrashes?.submit) {
+      return { error: "report_that_crashes submitter not injected" };
+    }
+    const proxy = await reportThatCrashes.submit(
+      { user_id },
+      {
+        maxDuration: 30,
+        maxRetries: max_retries,
+        totalDeadline: utcDeadlineFromRelative(total_deadline_secs),
+      },
+    );
+    return { job_id: (proxy as { jobId?: string }).jobId ?? null };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Overlong submitter (tc06, tc20)
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "commission_overlong",
+  capability: "commission_overlong",
+  dependencies: [{ capability: "runs_overlong" }],
+  meshJobDepIndex: 0,
+  description: "Submit runs_overlong and return the job_id (no wait).",
+  parameters: z.object({
+    user_id: z.string(),
+    seconds: z.number().int().default(30),
+  }),
+  execute: async (
+    { user_id, seconds },
+    runsOverlong: MeshJob | null = null,
+  ) => {
+    if (!runsOverlong?.submit) {
+      return { error: "runs_overlong submitter not injected" };
+    }
+    const proxy = await runsOverlong.submit(
+      { user_id, seconds },
+      { maxDuration: 120 },
+    );
+    return { job_id: (proxy as { jobId?: string }).jobId ?? null };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Downstream-call submitter (tc09)
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "commission_downstream",
+  capability: "commission_downstream",
+  dependencies: [{ capability: "report_with_downstream_call" }],
+  meshJobDepIndex: 0,
+  description:
+    "Submit report_with_downstream_call (provider calls slow_downstream) and return job_id.",
+  parameters: z.object({ user_id: z.string() }),
+  execute: async (
+    { user_id },
+    reportWithDownstreamCall: MeshJob | null = null,
+  ) => {
+    if (!reportWithDownstreamCall?.submit) {
+      return { error: "report_with_downstream_call submitter not injected" };
+    }
+    const proxy = await reportWithDownstreamCall.submit(
+      { user_id },
+      { maxDuration: 120 },
+    );
+    return { job_id: (proxy as { jobId?: string }).jobId ?? null };
+  },
+});
+
+console.log(
+  `long-task-consumer-ts uc22 fixture defined on port ${HTTP_PORT}. Waiting for auto-start...`,
+);

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/src/index.ts
@@ -104,8 +104,11 @@ agent.addTool({
       },
     );
     const job_id = (proxy as { jobId?: string }).jobId ?? null;
+    if (!proxy.wait) {
+      return { job_id, status: "submitted", result: null };
+    }
     try {
-      const result = await proxy.wait!(wait_timeout_secs);
+      const result = await proxy.wait(wait_timeout_secs);
       return { job_id, status: "completed", result };
     } catch (e) {
       return {
@@ -174,8 +177,11 @@ agent.addTool({
       { maxDuration: 30, maxRetries: max_retries },
     );
     const job_id = (proxy as { jobId?: string }).jobId ?? null;
+    if (!proxy.wait) {
+      return { job_id, status: "submitted", result: null };
+    }
     try {
-      const result = await proxy.wait!(wait_timeout_secs);
+      const result = await proxy.wait(wait_timeout_secs);
       return { job_id, status: "completed", result };
     } catch (e) {
       return {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/tsconfig.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "long-task-provider-ts",
+  "version": "1.0.0",
+  "description": "MCP Mesh — TypeScript MeshJob test producer (uc22)",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^1.4.1",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/src/index.ts
@@ -1,0 +1,246 @@
+/**
+ * MeshJob test-suite producer (uc22_meshjob_ts) — TypeScript port of
+ * uc21_meshjob/fixtures/long-task-provider/main.py.
+ *
+ * Hosts a small zoo of `task: true` capabilities, one per scenario the
+ * suite needs to exercise. Each capability is intentionally minimal —
+ * we avoid stuffing branching logic into a single tool because branching
+ * across scenarios via payload args makes failures harder to triage when
+ * the substrate misbehaves.
+ *
+ * Capabilities (mirror the Python fixture name-for-name):
+ *
+ *   - generate_report                   — happy path, progress + complete
+ *   - report_with_explicit_complete     — explicit complete({...}) marker
+ *   - report_with_implicit_complete     — return value WITHOUT complete()
+ *   - report_with_explicit_fail         — calls fail("reason")
+ *   - report_that_crashes               — raises mid-attempt
+ *   - runs_overlong                     — long sleep loop for cancel tests
+ *   - report_with_downstream_call       — calls slow_downstream regular tool
+ */
+import { FastMCP, mesh, type MeshJob, type McpMeshTool } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9110", 10);
+
+const server = new FastMCP({
+  name: "Long Task Provider (uc22 TS)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "long-task-provider-ts",
+  httpPort: HTTP_PORT,
+  description:
+    "MeshJob test producer (uc22 TS) — multi-capability fixture for the integration suite.",
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "generate_report",
+  capability: "generate_report",
+  task: true,
+  meshJobParamIndex: 1,
+  description: "Long-running multi-section report generator with progress.",
+  parameters: z.object({
+    user_id: z.string(),
+    sections: z.array(z.string()),
+  }),
+  execute: async ({ user_id, sections }, job: MeshJob | null = null) => {
+    if (job?.updateProgress) {
+      await job.updateProgress(0.0, "starting");
+    }
+    const results: { section: string; content: string }[] = [];
+    const total = Math.max(sections.length, 1);
+    for (let i = 0; i < sections.length; i++) {
+      await new Promise((r) => setTimeout(r, 2000));
+      results.push({
+        section: sections[i],
+        content: `Generated content for ${sections[i]}`,
+      });
+      if (job?.updateProgress) {
+        await job.updateProgress(
+          (i + 1) / total,
+          `finished section ${i + 1}/${total}`,
+        );
+      }
+    }
+    const payload = { user_id, report: results };
+    if (job?.complete) {
+      await job.complete(payload);
+    }
+    return payload;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Explicit complete with fixed marker payload (tc03)
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "report_with_explicit_complete",
+  capability: "report_with_explicit_complete",
+  task: true,
+  meshJobParamIndex: 1,
+  description: "Calls job.complete({...}) with a fixed marker payload.",
+  parameters: z.object({ user_id: z.string() }),
+  execute: async ({ user_id }, job: MeshJob | null = null) => {
+    if (job?.updateProgress) {
+      await job.updateProgress(0.5, "midpoint");
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    const payload = { explicit: true, marker: "X", user_id };
+    if (job?.complete) {
+      await job.complete(payload);
+    }
+    return payload;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Implicit complete (auto-complete on return) (tc04)
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "report_with_implicit_complete",
+  capability: "report_with_implicit_complete",
+  task: true,
+  meshJobParamIndex: 1,
+  description:
+    "Returns a value WITHOUT calling job.complete() — relies on auto-complete.",
+  parameters: z.object({ user_id: z.string() }),
+  execute: async ({ user_id }, job: MeshJob | null = null) => {
+    // Update progress to confirm controller binding worked. We
+    // intentionally do NOT call job.complete() — the runtime's
+    // auto-complete-on-return path should fire.
+    if (job?.updateProgress) {
+      await job.updateProgress(0.5, "halfway");
+      await new Promise((r) => setTimeout(r, 500));
+      await job.updateProgress(0.9, "almost done");
+    }
+    return { implicit: true, user_id };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Explicit fail — no retry (tc05)
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "report_with_explicit_fail",
+  capability: "report_with_explicit_fail",
+  task: true,
+  meshJobParamIndex: 1,
+  description:
+    "Calls job.fail('reason') — must NOT trigger retry even with max_retries > 0.",
+  parameters: z.object({ user_id: z.string() }),
+  execute: async ({ user_id: _user_id }, job: MeshJob | null = null) => {
+    if (job?.updateProgress) {
+      await job.updateProgress(0.1, "about to fail");
+      await new Promise((r) => setTimeout(r, 300));
+    }
+    if (job?.fail) {
+      await job.fail("explicit: not retryable");
+    }
+    return { failed: true, reason: "explicit: not retryable" };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Crash on attempt (tc12)
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "report_that_crashes",
+  capability: "report_that_crashes",
+  task: true,
+  meshJobParamIndex: 1,
+  description:
+    "Always raises mid-attempt — drives crash-recovery / retry-exhaustion tests.",
+  parameters: z.object({ user_id: z.string() }),
+  execute: async ({ user_id: _user_id }, job: MeshJob | null = null) => {
+    if (job?.updateProgress) {
+      await job.updateProgress(0.1, "about to crash");
+      await new Promise((r) => setTimeout(r, 300));
+    }
+    throw new Error("simulated crash for crash-recovery test");
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Long-running task (tc06, tc09, tc10–tc13 use this via SIGKILL) (runs_overlong)
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "runs_overlong",
+  capability: "runs_overlong",
+  task: true,
+  meshJobParamIndex: 1,
+  description:
+    "Sleeps for many small intervals so cancel / kill can land mid-flight.",
+  parameters: z.object({
+    user_id: z.string(),
+    seconds: z.number().int().default(30),
+  }),
+  execute: async ({ user_id, seconds }, job: MeshJob | null = null) => {
+    let elapsed = 0;
+    const step = 0.5;
+    const total = Math.max(seconds, step);
+    while (elapsed < total) {
+      await new Promise((r) => setTimeout(r, step * 1000));
+      elapsed += step;
+      if (job?.updateProgress) {
+        await job.updateProgress(
+          Math.min(elapsed / total, 0.99),
+          `alive at ${elapsed.toFixed(1)}s`,
+        );
+      }
+    }
+    const payload = { user_id, elapsed };
+    if (job?.complete) {
+      await job.complete(payload);
+    }
+    return payload;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Job that calls a downstream regular tool (tc09)
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "report_with_downstream_call",
+  capability: "report_with_downstream_call",
+  task: true,
+  // dep[0] is slow_downstream (regular McpMeshTool); job lands at sig pos 2.
+  meshJobParamIndex: 2,
+  dependencies: [{ capability: "slow_downstream" }],
+  description:
+    "Calls a downstream regular tool that sleeps; cancel must abort the in-flight HTTP.",
+  parameters: z.object({ user_id: z.string() }),
+  execute: async (
+    { user_id },
+    slow_downstream: McpMeshTool | null = null,
+    job: MeshJob | null = null,
+  ) => {
+    if (job?.updateProgress) {
+      await job.updateProgress(0.1, "calling downstream");
+    }
+    if (!slow_downstream) {
+      // Mirror the Python fixture's deliberate fail() instead of returning
+      // the error dict — auto-complete would otherwise mark the row
+      // COMPLETED with the error dict as result.
+      if (job?.fail) {
+        await job.fail("slow_downstream dependency not injected");
+      }
+      return null;
+    }
+    // Downstream sleeps 30s. With cancel propagation working, the cancel
+    // token aborts the in-flight HTTP well before the 30s timer elapses.
+    const result = await slow_downstream({ user_id, seconds: 30 });
+    if (job?.complete) {
+      await job.complete(result);
+    }
+    return result;
+  },
+});
+
+console.log(
+  `long-task-provider-ts uc22 fixture defined on port ${HTTP_PORT}. Waiting for auto-start...`,
+);

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/tsconfig.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "orchestrator-agent-ts",
+  "version": "1.0.0",
+  "description": "MCP Mesh — bystander orchestrator agent (uc22 TS)",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^1.4.1",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/src/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Orchestrator agent (uc22 TS) — TS port of orchestrator-agent.
+ *
+ * Has NO task=true tools and NO mesh deps. Used by tc14 to prove the
+ * three framework helper tools (`__mesh_job_status` /
+ * `__mesh_job_result` / `__mesh_job_cancel`) auto-register on every TS
+ * mesh agent regardless of whether that agent participates in the job
+ * lifecycle. Also reused by tc15 + tc19 (cross-runtime status read).
+ */
+import { FastMCP, mesh } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9113", 10);
+
+const server = new FastMCP({
+  name: "Orchestrator (uc22 TS)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "orchestrator-agent-ts",
+  httpPort: HTTP_PORT,
+  description:
+    "Agent with no task tools and no mesh deps — verifies helper-tool auto-registration is universal (TS).",
+});
+
+agent.addTool({
+  name: "orchestrator_ping",
+  capability: "orchestrator_ping",
+  description:
+    "Trivial tool — only purpose is to keep the agent alive in the registry.",
+  parameters: z.object({}),
+  execute: async () => {
+    return { ok: true, agent: "orchestrator-agent-ts" };
+  },
+});
+
+console.log(
+  `orchestrator-agent-ts uc22 fixture defined on port ${HTTP_PORT}. Waiting for auto-start...`,
+);

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/tsconfig.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc22_meshjob_ts/routines.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/routines.yaml
@@ -1,0 +1,60 @@
+# UC-level routines for uc22_meshjob_ts.
+#
+# Mirror of uc21_meshjob/routines.yaml — TS port of the MeshJob suite.
+# Same registry knobs (MCP_MESH_SWEEP_INTERVAL=10s + retention/health) so
+# crash-recovery / orphan-reroute / deadline tests resolve in seconds
+# instead of the registry's 5-minute defaults.
+#
+# Identical to the Python suite: the substrate's recovery + deadline
+# expiry paths are runtime-agnostic — they live entirely in the registry
+# (Go) — so the same env-var overrides apply regardless of whether the
+# producer/consumer is Python or TypeScript.
+
+routines:
+  # See uc21_meshjob/routines.yaml for the full chain-of-effects writeup
+  # of MCP_MESH_SWEEP_INTERVAL / RETENTION / HEALTH_CHECK_INTERVAL /
+  # DEFAULT_TIMEOUT_THRESHOLD. The numbers below are intentionally
+  # identical to keep the suite-suite math (~35s end-to-end after a
+  # SIGKILL for orphan reset) the same across both runtimes.
+  start_registry_with_fast_sweep:
+    description: "Start the mesh registry with all timing knobs cranked for fast recovery tests"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: |
+          MCP_MESH_SWEEP_INTERVAL=10s \
+          MCP_MESH_RETENTION=10s \
+          MCP_MESH_HEALTH_CHECK_INTERVAL=5 \
+          DEFAULT_TIMEOUT_THRESHOLD=15 \
+            meshctl start --registry-only -d
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "registry ready after ${i}s"
+              # Verify the sweep override actually stamped its log line.
+              # If MCP_MESH_SWEEP_INTERVAL didn't take effect the suite
+              # must fail loudly here, not via slow per-test timeouts.
+              # Tail the log so a stale match from an earlier run in the
+              # same shell session can't make a misconfigured current
+              # run look healthy.
+              tail -n 200 ~/.mcp-mesh/logs/registry.log \
+                | grep -qE '\[sweep\] using MCP_MESH_SWEEP_INTERVAL' \
+                || { echo "FAIL: MCP_MESH_SWEEP_INTERVAL override did not take effect"; exit 1; }
+              echo "[setup] confirmed sweep override active"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: registry did not become ready in 20s"
+          tail -50 ~/.mcp-mesh/logs/registry.log 2>/dev/null || true
+          exit 1
+        capture: registry_start
+        timeout: 30
+
+  # Stop everything started by this test (agents + registry).
+  stop_all:
+    description: "Stop all mesh processes started by this test"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: meshctl stop 2>/dev/null || true
+        ignore_errors: true

--- a/tests/integration/suites/uc22_meshjob_ts/tc01_submit_wait_happy_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc01_submit_wait_happy_ts/test.yaml
@@ -1,0 +1,98 @@
+# tc01_submit_wait_happy_ts — TS port of uc21/tc01_submit_wait_happy.
+#
+# Headline regression test for MeshJob Phase 1, TypeScript runtime.
+#
+# Scenario:
+#   - Registry up with MCP_MESH_SWEEP_INTERVAL=10s
+#   - long-task-provider-ts hosts generate_report (task=true)
+#   - long-task-consumer-ts hosts commission_report (deps=["generate_report"])
+#   - Client invokes commission_report with sections=[intro, analysis, summary]
+#   - Consumer's submit() + wait() returns the structured payload after ~6s
+
+name: "MeshJob TS: submit-and-wait happy path returns structured result"
+description: "TS producer + TS consumer: commission_report -> generate_report (3 sections) -> wait -> structured result"
+tags:
+  - meshjob
+  - smoke
+  - typescript
+  - issue-884
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9110)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for provider registration"
+    handler: wait
+    seconds: 15
+
+  - name: "Start consumer (port 9111)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Wait for consumer registration + DI resolution"
+    handler: wait
+    seconds: 22
+
+  - name: "Verify both agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Call commission_report — submit + wait the full job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_report '{"user_id": "alice", "sections": ["intro", "analysis", "summary"]}'
+    capture: commission_response
+    timeout: 60
+
+assertions:
+  - expr: "${captured.agent_list} contains 'long-task-provider-ts'"
+    message: "TS provider should be registered"
+  - expr: "${captured.agent_list} contains 'long-task-consumer-ts'"
+    message: "TS consumer should be registered"
+  # NB: TS runtime serializes results compactly (no spaces around `:`)
+  # AND meshctl's MCP envelope JSON-escapes the inner text — so the
+  # captured string carries `\"user_id\":\"alice\"` (backslash-quoted).
+  # Match that escaped, compact form.
+  - expr: "${captured.commission_response} not contains '\"isError\":true'"
+    message: "commission_report should NOT return an MCP error envelope"
+  - expr: "${captured.commission_response} contains '\\\"user_id\\\":\\\"alice\\\"'"
+    message: "result should echo the submitted user_id"
+  - expr: "${captured.commission_response} contains '\\\"section\\\":\\\"intro\\\"'"
+    message: "result should include the intro section"
+  - expr: "${captured.commission_response} contains '\\\"section\\\":\\\"analysis\\\"'"
+    message: "result should include the analysis section"
+  - expr: "${captured.commission_response} contains '\\\"section\\\":\\\"summary\\\"'"
+    message: "result should include the summary section"
+  - expr: "${captured.commission_response} contains 'Generated content for intro'"
+    message: "result should include the canonical marker for intro"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc02_progress_visible_midflight_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc02_progress_visible_midflight_ts/test.yaml
@@ -1,0 +1,144 @@
+# tc02_progress_visible_midflight_ts — TS port of uc21/tc02.
+#
+# Submit a long-enough generate_report job (7 sections * 2s = 14s) and
+# poll __mesh_job_status mid-flight. The TS producer's JobController
+# emits update_progress() after each section; deltas flow to the
+# registry via /jobs/batch on the batching tick. By the time at least
+# one mid-flight status read happens during a working interval, we
+# should observe progress > 0 AND status == "working".
+
+name: "MeshJob TS: mid-flight progress visible via __mesh_job_status"
+description: "TS submit long job, poll status mid-flight, observe progress advance through working->completed"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+  - progress
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9110)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start consumer (port 9111)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Wait for consumer + DI resolution"
+    handler: wait
+    seconds: 22
+
+  - name: "Submit generate_report (7 sections, ~14s) — get job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g"],"max_retries":1,"max_duration":60}' --raw
+    capture: submit_response
+    timeout: 30
+
+  - name: "Extract job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # TS responses lack structuredContent — only content[].text holds
+      # the JSON-stringified inner payload. Pull the text field, parse
+      # the inner JSON, then read .job_id.
+      RESP='${captured.submit_response}'
+      JOB_ID=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+    capture: job_id_extract
+    timeout: 10
+
+  # Poll mid-flight: kick off after a 4s settle (claim + first
+  # iteration), then poll every 2s for 6 ticks. Producer takes
+  # ~14s for 7 sections, so this window straddles working at
+  # ~0.14, 0.28, 0.42, 0.57, 0.71, 0.85.
+  - name: "Poll status 6x mid-flight"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "polling job_id=$JOB_ID"
+      sleep 4
+      for i in 1 2 3 4 5 6; do
+        echo "--- poll $i ---"
+        # TS helper uses jobId (camelCase); Python uses job_id.
+        # This is a TS agent so jobId.
+        meshctl call __mesh_job_status "{\"jobId\":\"${JOB_ID}\"}" --raw 2>&1 || true
+        sleep 2
+      done
+    capture: midflight_polls
+    timeout: 45
+
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 12
+
+  - name: "Final status read"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      meshctl call __mesh_job_status "{\"jobId\":\"${JOB_ID}\"}" --raw
+    capture: final_status
+    timeout: 15
+
+assertions:
+  - expr: "${captured.submit_response} contains 'job_id'"
+    message: "submit response should carry a job_id"
+
+  # At least one mid-flight poll showed working status. The registry's
+  # GET /jobs/{id} returns snake_case status, regardless of which
+  # runtime's helper tool fielded the read.
+  - expr: "${captured.midflight_polls} contains 'working'"
+    message: "at least one mid-flight poll should observe status=working"
+
+  # At least one mid-flight poll showed in-progress (> 0, < 1.0). The
+  # captured JSON-escaped text from meshctl carries
+  # `\"progress\":0.2857...` for working-state reads. Match the
+  # `\"progress\":0.` prefix — leading 0.<nonzero> proves (0, 1).
+  - expr: "${captured.midflight_polls} contains '\\\"progress\\\":0.'"
+    message: "at least one mid-flight poll should observe progress in (0, 1)"
+
+  - expr: "${captured.final_status} contains 'completed'"
+    message: "final status should be completed"
+  # Final progress is 1 (compact JSON serializes 1.0 as 1, no decimal).
+  - expr: "${captured.final_status} contains '\\\"progress\\\":1'"
+    message: "final progress should be 1"
+
+  - expr: "${captured.final_status} contains 'Generated content for a'"
+    message: "final result should include section a content"
+  - expr: "${captured.final_status} contains 'Generated content for g'"
+    message: "final result should include section g content (7 total)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc03_explicit_complete_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc03_explicit_complete_ts/test.yaml
@@ -87,8 +87,8 @@ test:
 assertions:
   - expr: "${captured.final_status} contains 'completed'"
     message: "status should be completed"
-  - expr: "${captured.final_status} contains 'explicit'"
-    message: "result should include the explicit:true marker from job.complete()"
+  - expr: "${captured.final_status} contains '\\\"explicit\\\":true'"
+    message: "result must include the explicit:true marker from job.complete() (not just the capability name)"
   - expr: "${captured.final_status} contains 'marker'"
     message: "result should include the marker key from job.complete()"
   # Marker value is `\"X\"` in the JSON-escaped meshctl envelope text.

--- a/tests/integration/suites/uc22_meshjob_ts/tc03_explicit_complete_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc03_explicit_complete_ts/test.yaml
@@ -1,0 +1,100 @@
+# tc03_explicit_complete_ts — TS port of uc21/tc03.
+#
+# Producer fixture report_with_explicit_complete always calls
+# await job.complete({explicit:true, marker:"X", user_id}). Tests that
+# the runtime's auto-complete path is NOT exercised — the user's
+# explicit terminal payload must surface verbatim.
+
+name: "MeshJob TS: explicit job.complete() returns the user-supplied payload"
+description: "TS producer calls job.complete({...}) with a fixed marker; consumer receives it verbatim"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Wait for consumer + DI"
+    handler: wait
+    seconds: 22
+
+  # Submit by direct registry POST so we hit report_with_explicit_complete
+  # (no consumer wrapper for it — same pattern as Python tc03).
+  - name: "POST /jobs for report_with_explicit_complete"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:8000/jobs \
+        -H 'Content-Type: application/json' \
+        -d '{"capability":"report_with_explicit_complete","submitted_payload":{"user_id":"alice"},"submitted_by":"tc03","max_duration":30,"max_retries":1}'
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Extract job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      echo "JOB_ID=${JOB_ID}"
+    capture: job_id_extract
+
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 12
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      meshctl call __mesh_job_status "{\"jobId\":\"${JOB_ID}\"}"
+    capture: final_status
+
+assertions:
+  - expr: "${captured.final_status} contains 'completed'"
+    message: "status should be completed"
+  - expr: "${captured.final_status} contains 'explicit'"
+    message: "result should include the explicit:true marker from job.complete()"
+  - expr: "${captured.final_status} contains 'marker'"
+    message: "result should include the marker key from job.complete()"
+  # Marker value is `\"X\"` in the JSON-escaped meshctl envelope text.
+  - expr: "${captured.final_status} contains '\\\"X\\\"'"
+    message: "result should include the marker value 'X'"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc04_implicit_complete_on_return_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc04_implicit_complete_on_return_ts/test.yaml
@@ -84,10 +84,14 @@ test:
     capture: final_status
 
 assertions:
-  - expr: "${captured.final_status} contains 'completed'"
-    message: "status should be completed via auto-complete path"
-  - expr: "${captured.final_status} contains 'implicit'"
-    message: "result should be the user's return value (implicit:true)"
+  # Anchor on the status field itself — bare `completed` would also match
+  # the `completed_at` timestamp field that's present on any terminal row.
+  - expr: "${captured.final_status} contains '\\\"status\\\":\\\"completed\\\"'"
+    message: "status field should be completed via auto-complete path"
+  # Anchor on the result-payload key — bare `implicit` would also match
+  # the capability name `report_with_implicit_complete` in the envelope.
+  - expr: "${captured.final_status} contains '\\\"implicit\\\":true'"
+    message: "result must be the user's return value carrying implicit:true (not just the capability name)"
 
 post_run:
   - routine: stop_all

--- a/tests/integration/suites/uc22_meshjob_ts/tc04_implicit_complete_on_return_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc04_implicit_complete_on_return_ts/test.yaml
@@ -1,0 +1,94 @@
+# tc04_implicit_complete_on_return_ts — TS port of uc21/tc04.
+#
+# Producer fixture report_with_implicit_complete updates progress but
+# NEVER calls job.complete(). The TS dispatch wrapper's auto-complete
+# path should observe the non-terminal isTerminal() probe and flush the
+# user's return value as the terminal payload.
+
+name: "MeshJob TS: handler returns without complete() — auto-complete fires"
+description: "TS producer doesn't call job.complete; runtime auto-completes with the return value"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+  - auto-complete
+timeout: 90
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Wait for consumer"
+    handler: wait
+    seconds: 22
+
+  - name: "POST /jobs for report_with_implicit_complete"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:8000/jobs \
+        -H 'Content-Type: application/json' \
+        -d '{"capability":"report_with_implicit_complete","submitted_payload":{"user_id":"alice"},"submitted_by":"tc04","max_duration":30,"max_retries":1}'
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Extract job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      echo "JOB_ID=${JOB_ID}"
+    capture: job_id_extract
+
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 12
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      meshctl call __mesh_job_status "{\"jobId\":\"${JOB_ID}\"}"
+    capture: final_status
+
+assertions:
+  - expr: "${captured.final_status} contains 'completed'"
+    message: "status should be completed via auto-complete path"
+  - expr: "${captured.final_status} contains 'implicit'"
+    message: "result should be the user's return value (implicit:true)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc05_explicit_fail_no_retry_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc05_explicit_fail_no_retry_ts/test.yaml
@@ -1,0 +1,93 @@
+# tc05_explicit_fail_no_retry_ts — TS port of uc21/tc05.
+#
+# Producer fixture report_with_explicit_fail always calls
+# await job.fail("explicit: not retryable"). Submitting with
+# max_retries=3 must NOT retry — the substrate must distinguish
+# "developer explicitly failed the job" from "agent crashed mid-attempt".
+
+name: "MeshJob TS: explicit job.fail() does not trigger retry"
+description: "TS producer calls job.fail('reason'); registry must mark failed and NOT retry"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+  - retry
+timeout: 90
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Wait for consumer + DI"
+    handler: wait
+    seconds: 22
+
+  - name: "Submit explicit-fail job with max_retries=3"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_explicit_fail \
+        '{"user_id":"alice","max_retries":3,"wait_timeout_secs":20}' --raw
+    capture: commission_response
+    timeout: 45
+
+  # Even with max_retries=3, an explicit fail() must NOT trigger
+  # additional attempts. Wait long enough that any (incorrect) retry
+  # would have completed (~30s if retries fired).
+  - name: "Wait for any retries to settle"
+    handler: wait
+    seconds: 15
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.commission_response}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+      meshctl call __mesh_job_status "{\"jobId\":\"${JOB_ID}\"}"
+    capture: final_status
+
+assertions:
+  - expr: "${captured.final_status} contains 'failed'"
+    message: "status should be failed"
+  - expr: "${captured.final_status} contains 'explicit: not retryable'"
+    message: "error should preserve the exact reason from job.fail()"
+  - expr: "${captured.final_status} contains 'attempt_count'"
+    message: "response should include attempt_count"
+  - expr: "${captured.final_status} contains '\\\"attempt_count\\\":1'"
+    message: "attempt_count must stay at 1 — explicit fail must NOT retry"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc06_cancel_alive_owner_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc06_cancel_alive_owner_ts/test.yaml
@@ -90,8 +90,9 @@ test:
 
 assertions:
   # TS helper returns {ok:true, jobId:...} (camelCase); compact JSON.
-  - expr: "${captured.cancel_response} contains 'ok'"
-    message: "__mesh_job_cancel response should include ok"
+  # Anchor on the field key+value — bare `ok` matches "lookup", URLs, etc.
+  - expr: "${captured.cancel_response} contains '\\\"ok\\\":true'"
+    message: "__mesh_job_cancel response should include ok:true"
   - expr: "${captured.final_status} contains 'cancelled'"
     message: "final status should be cancelled (not completed)"
   # Belt-and-suspenders: the *status field* must not be completed.

--- a/tests/integration/suites/uc22_meshjob_ts/tc06_cancel_alive_owner_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc06_cancel_alive_owner_ts/test.yaml
@@ -93,12 +93,10 @@ assertions:
   # Anchor on the field key+value — bare `ok` matches "lookup", URLs, etc.
   - expr: "${captured.cancel_response} contains '\\\"ok\\\":true'"
     message: "__mesh_job_cancel response should include ok:true"
-  - expr: "${captured.final_status} contains 'cancelled'"
-    message: "final status should be cancelled (not completed)"
-  # Belt-and-suspenders: the *status field* must not be completed.
-  # The compact JSON shape carries the field as `\"status\":\"cancelled\"`.
-  - expr: "${captured.final_status} not contains '\\\"status\\\":\\\"completed\\\"'"
-    message: "status field must NOT be completed — cancel happened mid-flight"
+  # Anchor on the status field key+value — bare `cancelled` could match
+  # an error string elsewhere in the JSON envelope.
+  - expr: "${captured.final_status} contains '\\\"status\\\":\\\"cancelled\\\"'"
+    message: "final status field should be cancelled (not completed)"
 
 post_run:
   - routine: stop_all

--- a/tests/integration/suites/uc22_meshjob_ts/tc06_cancel_alive_owner_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc06_cancel_alive_owner_ts/test.yaml
@@ -1,0 +1,104 @@
+# tc06_cancel_alive_owner_ts — TS port of uc21/tc06.
+#
+# Submits an overlong job (~30s), waits 5s for the producer's claim
+# worker to take ownership, then calls __mesh_job_cancel. The
+# registry's CancelJob handler marks the row cancelled AND best-effort
+# POSTs /jobs/{id}/cancel to the owner — which fires the in-process
+# cancel token registered by the inbound dispatch wrapper.
+
+name: "MeshJob TS: cancel forwards to alive owner and aborts the job"
+description: "TS submit overlong job, cancel mid-flight, observe cancelled status without natural completion"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+  - cancel
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Wait for consumer + DI"
+    handler: wait
+    seconds: 22
+
+  - name: "Submit a 30-second job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_overlong '{"user_id":"alice","seconds":30}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Wait 5s for claim + start"
+    handler: wait
+    seconds: 5
+
+  - name: "Cancel the job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+      meshctl call __mesh_job_cancel "{\"jobId\":\"${JOB_ID}\",\"reason\":\"tc06 client requested abort\"}"
+    capture: cancel_response
+    timeout: 15
+
+  - name: "Wait for cancel to settle"
+    handler: wait
+    seconds: 8
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      meshctl call __mesh_job_status "{\"jobId\":\"${JOB_ID}\"}"
+    capture: final_status
+
+assertions:
+  # TS helper returns {ok:true, jobId:...} (camelCase); compact JSON.
+  - expr: "${captured.cancel_response} contains 'ok'"
+    message: "__mesh_job_cancel response should include ok"
+  - expr: "${captured.final_status} contains 'cancelled'"
+    message: "final status should be cancelled (not completed)"
+  # Belt-and-suspenders: the *status field* must not be completed.
+  # The compact JSON shape carries the field as `\"status\":\"cancelled\"`.
+  - expr: "${captured.final_status} not contains '\\\"status\\\":\\\"completed\\\"'"
+    message: "status field must NOT be completed — cancel happened mid-flight"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc07_cancel_orphan_no_owner_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc07_cancel_orphan_no_owner_ts/test.yaml
@@ -1,0 +1,79 @@
+# tc07_cancel_orphan_no_owner_ts — TS port of uc21/tc07.
+#
+# Direct registry POST /jobs for a capability that NO running provider
+# hosts (ghost_capability). With no producer, the registry's claim path
+# never assigns owner_instance_id — row stays in working+owner=NULL.
+# Cancel that job, assert HTTP 200 with forwarded_to_instance_id == null.
+#
+# This test is runtime-agnostic — it talks to the registry directly.
+# We tag it as TS because it lives in the TS suite, but the mechanism
+# is identical to uc21/tc07.
+
+name: "MeshJob TS: cancel for unowned/orphan job (no claim has happened)"
+description: "POST /jobs for a capability nobody hosts; cancel before claim; verify forwarded_to_instance_id is null"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+  - cancel
+timeout: 60
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Submit job for a capability nobody hosts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:8000/jobs \
+        -H 'Content-Type: application/json' \
+        -d '{"capability":"ghost_capability","submitted_payload":{"x":1},"submitted_by":"tc07","max_duration":30,"max_retries":0}'
+    capture: submit_resp
+    timeout: 10
+
+  - name: "Confirm the row is owner=NULL"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}"
+    capture: pre_cancel_status
+
+  - name: "Cancel via direct registry POST"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      curl -s -X POST "http://localhost:8000/jobs/${JOB_ID}/cancel" \
+        -H 'Content-Type: application/json' \
+        -d '{"reason":"tc07 unowned cancel"}' \
+        -w "\nHTTP_CODE=%{http_code}"
+    capture: cancel_response
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}"
+    capture: final_status
+
+assertions:
+  - expr: "${captured.pre_cancel_status} contains '\"owner_instance_id\":null'"
+    message: "row should have owner_instance_id=null (no provider for ghost_capability to claim it)"
+  - expr: "${captured.cancel_response} contains 'HTTP_CODE=200'"
+    message: "cancel HTTP should return 200"
+  - expr: "${captured.cancel_response} contains '\"forwarded_to_instance_id\":null'"
+    message: "no owner to forward to — forwarded_to_instance_id must be null"
+  - expr: "${captured.cancel_response} contains '\"status\":\"cancelled\"'"
+    message: "cancel response should report status:cancelled"
+  - expr: "${captured.final_status} contains '\"status\":\"cancelled\"'"
+    message: "final status row should be cancelled"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc08_cancel_already_terminal_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc08_cancel_already_terminal_ts/test.yaml
@@ -1,0 +1,109 @@
+# tc08_cancel_already_terminal_ts — TS port of uc21/tc08.
+#
+# Submit a fast generate_report job and wait for it to complete. Then
+# attempt to cancel the now-completed job. Registry returns HTTP 409
+# with "job is already in a terminal state". The TS helper-tool wrapper
+# surfaces it through MCP as an isError envelope (or a thrown error).
+
+name: "MeshJob TS: cancel of already-terminal job returns 409 / structured error"
+description: "TS — complete a job, then cancel it; both registry HTTP and helper tool must reject as conflict"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+  - cancel
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Wait for consumer + DI"
+    handler: wait
+    seconds: 22
+
+  - name: "Submit a quick job (submit-only) to capture job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["only"],"max_retries":1,"max_duration":30}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Wait for job to complete (~3s)"
+    handler: wait
+    seconds: 8
+
+  - name: "Confirm it is terminal"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.status'
+    capture: terminal_check
+
+  - name: "Direct registry cancel — expect HTTP 409"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      curl -s -X POST "http://localhost:8000/jobs/${JOB_ID}/cancel" \
+        -H 'Content-Type: application/json' -d '{}' \
+        -w "\nHTTP_CODE=%{http_code}"
+    capture: registry_cancel
+
+  - name: "Helper-tool cancel — expect MCP isError"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      meshctl call __mesh_job_cancel "{\"jobId\":\"${JOB_ID}\"}" 2>&1 || true
+    capture: helper_cancel
+
+assertions:
+  - expr: "${captured.terminal_check} contains 'completed'"
+    message: "job should have completed before cancel attempt"
+  - expr: "${captured.registry_cancel} contains 'HTTP_CODE=409'"
+    message: "direct registry cancel of completed job must return 409"
+  - expr: "${captured.registry_cancel} contains 'terminal'"
+    message: "registry 409 message should mention terminal state"
+  # TS helper tool surfaces conflict as an MCP error / thrown error.
+  - expr: "${captured.helper_cancel} icontains 'conflict'"
+    message: "helper-tool cancel should surface 409 conflict"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc09_cancel_aborts_outbound_http_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc09_cancel_aborts_outbound_http_ts/test.yaml
@@ -132,13 +132,10 @@ assertions:
   # Anchor on the field key+value — bare `ok` matches "lookup", URLs, etc.
   - expr: "${captured.cancel_response} contains '\\\"ok\\\":true'"
     message: "cancel should ack with ok:true"
-  - expr: "${captured.final_check} contains 'cancelled'"
-    message: "job status should be cancelled"
-  # The producer must NOT have reached job.complete() — natural finish
-  # would take 30s; cancel must have aborted before then. Status field
-  # in the compact-JSON-escaped envelope is `\"status\":\"...\"`.
-  - expr: "${captured.final_check} not contains '\\\"status\\\":\\\"completed\\\"'"
-    message: "the producer should NOT have reached job.complete() — cancel must have aborted before natural finish"
+  # Anchor on the status field key+value — bare `cancelled` could match
+  # an error string elsewhere in the JSON envelope.
+  - expr: "${captured.final_check} contains '\\\"status\\\":\\\"cancelled\\\"'"
+    message: "status field should be cancelled — cancel must have aborted before natural finish"
   # NB on `calling downstream`: this WOULD be the most informative
   # assertion (progress message frozen mid-downstream proves cancel
   # landed inside the outbound HTTP), BUT it's flaky on TS because

--- a/tests/integration/suites/uc22_meshjob_ts/tc09_cancel_aborts_outbound_http_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc09_cancel_aborts_outbound_http_ts/test.yaml
@@ -1,0 +1,155 @@
+# tc09_cancel_aborts_outbound_http_ts — TS port of uc21/tc09.
+#
+# Three-agent chain (all TS):
+#   consumer (commission_downstream)
+#     -> provider.report_with_downstream_call (task=true)
+#         -> downstream-sleeper-ts.slow_downstream (sleeps 30s)
+#
+# After submit, wait briefly then cancel. The TS provider's
+# cancel route fires the cancel registry token. Whether that aborts
+# the in-flight outbound HTTP depends on the substrate — at the time
+# of writing the TS proxy's AbortController is timeout-only and is
+# NOT registered with the per-job cancel registry. Same gap as the
+# Python equivalent (#882 lineage).
+#
+# Producer-side correctness (cancel landed) is still observable:
+#   - status == cancelled
+#   - status != completed
+# The downstream-sleeper-ts log marker would only fire if FastMCP-TS
+# propagated client disconnects (it does not at the time of writing).
+# Documented inline; assertions test what IS observable.
+
+name: "MeshJob TS: cancel aborts in-flight downstream HTTP call (or terminates job promptly)"
+description: "TS — provider calls slow_downstream(30s); cancel must result in cancelled status well below the 30s natural finish"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+  - cancel
+  - propagation
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+      cp -rL /uc-artifacts/downstream-sleeper-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - name: "Install sleeper deps"
+    handler: npm-install
+    path: /workspace/downstream-sleeper-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start downstream-sleeper-ts (port 9112) FIRST"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start downstream-sleeper-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9112 -d
+
+  - name: "Wait for sleeper"
+    handler: wait
+    seconds: 15
+
+  - name: "Start provider (port 9110)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for provider DI to resolve slow_downstream"
+    handler: wait
+    seconds: 22
+
+  - name: "Start consumer (port 9111)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Wait for consumer DI"
+    handler: wait
+    seconds: 22
+
+  - name: "Submit job that calls downstream"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_downstream '{"user_id":"alice"}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  # Give the producer enough time to enter the downstream call AND
+  # for the JobController batching tick (2s default) to flush the
+  # initial update_progress(0.1, "calling downstream"). Otherwise
+  # the cancel can land before any progress reaches the registry.
+  - name: "Wait 6s — let producer pick up + flush first progress + enter downstream"
+    handler: wait
+    seconds: 6
+
+  - name: "Cancel the job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+      meshctl call __mesh_job_cancel "{\"jobId\":\"${JOB_ID}\"}"
+    capture: cancel_response
+    timeout: 15
+
+  # Should propagate within a few seconds — definitely well below the
+  # 30s sleep that's still running on the sleeper. We allow a generous
+  # window because outbound HTTP abort propagation depends on substrate
+  # support (see header note).
+  - name: "Wait for cancel to propagate"
+    handler: wait
+    seconds: 10
+
+  - name: "Read final status + sleeper log"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "=== final status ==="
+      meshctl call __mesh_job_status "{\"jobId\":\"${JOB_ID}\"}"
+      echo
+      echo "=== downstream-sleeper-ts log tail ==="
+      meshctl logs downstream-sleeper-ts 2>&1 | tail -30
+    capture: final_check
+
+assertions:
+  - expr: "${captured.cancel_response} contains 'ok'"
+    message: "cancel should ack ok"
+  - expr: "${captured.final_check} contains 'cancelled'"
+    message: "job status should be cancelled"
+  # The producer must NOT have reached job.complete() — natural finish
+  # would take 30s; cancel must have aborted before then. Status field
+  # in the compact-JSON-escaped envelope is `\"status\":\"...\"`.
+  - expr: "${captured.final_check} not contains '\\\"status\\\":\\\"completed\\\"'"
+    message: "the producer should NOT have reached job.complete() — cancel must have aborted before natural finish"
+  # NB on `calling downstream`: this WOULD be the most informative
+  # assertion (progress message frozen mid-downstream proves cancel
+  # landed inside the outbound HTTP), BUT it's flaky on TS because
+  # the JobController batching tick may not have flushed the initial
+  # update_progress(0.1, ...) before the cancel landed. The "status
+  # not completed" check above is the substantive correctness signal.
+  # NOTE: the downstream `sleep CANCELLED` marker would only fire if
+  # FastMCP-TS surfaced inbound client-disconnect as a cancellation to
+  # the tool handler. At the time of writing it does NOT — the sleeper
+  # runs to natural completion regardless of producer-side cancel.
+  # Tracking the downstream-side propagation gap as part of #884 follow-ups.
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc09_cancel_aborts_outbound_http_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc09_cancel_aborts_outbound_http_ts/test.yaml
@@ -129,8 +129,9 @@ test:
     capture: final_check
 
 assertions:
-  - expr: "${captured.cancel_response} contains 'ok'"
-    message: "cancel should ack ok"
+  # Anchor on the field key+value — bare `ok` matches "lookup", URLs, etc.
+  - expr: "${captured.cancel_response} contains '\\\"ok\\\":true'"
+    message: "cancel should ack with ok:true"
   - expr: "${captured.final_check} contains 'cancelled'"
     message: "job status should be cancelled"
   # The producer must NOT have reached job.complete() — natural finish

--- a/tests/integration/suites/uc22_meshjob_ts/tc10_crash_recovery_max_retries_1_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc10_crash_recovery_max_retries_1_ts/test.yaml
@@ -93,6 +93,10 @@ test:
         esac
       done
       echo "killed PIDs:$KILLED"
+      if [ -z "$KILLED" ]; then
+        echo "ERROR: No provider processes were killed — recovery scenario invalid"
+        exit 1
+      fi
       rm -f ~/.mcp-mesh/agents/long-task-provider-ts/* 2>/dev/null || true
     capture: kill_output
 

--- a/tests/integration/suites/uc22_meshjob_ts/tc10_crash_recovery_max_retries_1_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc10_crash_recovery_max_retries_1_ts/test.yaml
@@ -1,0 +1,147 @@
+# tc10_crash_recovery_max_retries_1_ts — TS port of uc21/tc10.
+#
+# Submits a 14s job to a single TS provider+consumer pair, kills the
+# provider mid-flight (SIGKILL), then waits for the registry sweep to
+# detect the orphan and re-claim the row to a NEW provider replica.
+# With max_retries=1, attempt_count becomes 2 (initial + 1 retry).
+
+name: "MeshJob TS: crash recovery with default max_retries=1 — orphan reclaim"
+description: "TS — submit, kill provider, wait for sweep, start new provider, observe completion via retry"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+  - retry
+  - crash-recovery
+  - slow
+timeout: 240
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Wait for consumer + DI"
+    handler: wait
+    seconds: 22
+
+  - name: "Submit job (7 sections, max_retries=1)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g"],"max_retries":1,"max_duration":60}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Wait 4s for the producer to claim + start"
+    handler: wait
+    seconds: 4
+
+  - name: "Kill the provider mid-flight (SIGKILL — node tsx process)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # Kill EVERY node/tsx process whose cmdline mentions the agent
+      # script — meshctl start spawns tsx (parent) which forks a node
+      # child; killing only one leaves the other alive and the agent
+      # keeps heartbeating.
+      MY_PID=$$
+      MY_PPID=$PPID
+      KILLED=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        case "$cmd" in
+          *long-task-provider-ts/src/index.ts*)
+            kill -9 "$pid" 2>/dev/null && KILLED="$KILLED $pid"
+            ;;
+        esac
+      done
+      echo "killed PIDs:$KILLED"
+      rm -f ~/.mcp-mesh/agents/long-task-provider-ts/* 2>/dev/null || true
+    capture: kill_output
+
+  - name: "Wait for sweep to orphan the job (~35s end-to-end)"
+    handler: wait
+    seconds: 45
+
+  - name: "Confirm orphan is back in claimable state"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,owner_instance_id,attempt_count,error}'
+    capture: orphaned_check
+
+  - name: "Stale PID cleanup — meshctl still tracks the killed PID"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop long-task-provider-ts 2>&1 || true
+      rm -f ~/.mcp-mesh/agents/long-task-provider-ts/* 2>/dev/null || true
+      echo "stale entry cleared"
+
+  - name: "Start a fresh provider — same capability, new instance_id"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for fresh provider to register + claim + run"
+    handler: wait
+    seconds: 35
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,attempt_count,progress,error}'
+    capture: final_status
+
+assertions:
+  - expr: "${captured.orphaned_check} contains '\"owner_instance_id\": null'"
+    message: "after sweep, owner should be cleared (orphan re-claim path)"
+  - expr: "${captured.final_status} contains '\"status\": \"completed\"'"
+    message: "fresh provider should have completed the retried job"
+  - expr: "${captured.final_status} contains '\"attempt_count\": 2'"
+    message: "attempt_count should be 2 (initial + 1 retry)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc11_max_retries_0_disables_retry_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc11_max_retries_0_disables_retry_ts/test.yaml
@@ -94,6 +94,10 @@ test:
         esac
       done
       echo "killed PIDs:$KILLED"
+      if [ -z "$KILLED" ]; then
+        echo "ERROR: No provider processes were killed — recovery scenario invalid"
+        exit 1
+      fi
       # Clear meshctl tracking so it stops watching this agent.
       rm -f ~/.mcp-mesh/agents/long-task-provider-ts/* 2>/dev/null || true
     capture: kill_output

--- a/tests/integration/suites/uc22_meshjob_ts/tc11_max_retries_0_disables_retry_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc11_max_retries_0_disables_retry_ts/test.yaml
@@ -1,0 +1,126 @@
+# tc11_max_retries_0_disables_retry_ts — TS port of uc21/tc11.
+#
+# With max_retries=0, the orphan path's check
+#   if attempt_count > max_retries => 1 > 0
+# trips after the crash → registry marks status=failed with the
+# canonical "orphaned: max retries exceeded" reason.
+
+name: "MeshJob TS: max_retries=0 disables retry — orphan goes straight to failed"
+description: "TS — kill provider mid-flight; with max_retries=0 the sweep marks failed instead of re-claiming"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+  - retry
+  - crash-recovery
+  - slow
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Wait for consumer + DI"
+    handler: wait
+    seconds: 22
+
+  - name: "Submit job with max_retries=0"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g"],"max_retries":0,"max_duration":60}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Wait 4s for the producer to claim + start"
+    handler: wait
+    seconds: 4
+
+  - name: "Kill the provider mid-flight (SIGKILL)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # Kill EVERY node/tsx process whose cmdline mentions the agent
+      # script — meshctl start spawns tsx (parent) which forks a node
+      # child; killing only one leaves the other alive and the agent
+      # keeps heartbeating. Also clear meshctl's tracking so it doesn't
+      # attempt to auto-restart the agent (which would defeat the test).
+      MY_PID=$$
+      MY_PPID=$PPID
+      KILLED=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        case "$cmd" in
+          *long-task-provider-ts/src/index.ts*)
+            kill -9 "$pid" 2>/dev/null && KILLED="$KILLED $pid"
+            ;;
+        esac
+      done
+      echo "killed PIDs:$KILLED"
+      # Clear meshctl tracking so it stops watching this agent.
+      rm -f ~/.mcp-mesh/agents/long-task-provider-ts/* 2>/dev/null || true
+    capture: kill_output
+
+  - name: "Wait for health-monitor flip + sweep to mark failed (~35s end-to-end)"
+    handler: wait
+    seconds: 45
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,attempt_count,error,owner_instance_id}'
+    capture: final_status
+
+assertions:
+  - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
+    message: "max_retries=0 should mark failed after crash (no re-claim)"
+  - expr: "${captured.final_status} contains 'orphaned'"
+    message: "error should mention 'orphaned'"
+  - expr: "${captured.final_status} contains 'max retries exceeded'"
+    message: "error should mention 'max retries exceeded'"
+  - expr: "${captured.final_status} contains '\"attempt_count\": 1'"
+    message: "only one attempt counted — no retry"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc12_max_retries_exhausted_marks_failed_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc12_max_retries_exhausted_marks_failed_ts/test.yaml
@@ -90,6 +90,10 @@ test:
         esac
       done
       echo "killed PIDs:$KILLED"
+      if [ -z "$KILLED" ]; then
+        echo "ERROR: No provider processes were killed in round 1 — recovery scenario invalid"
+        exit 1
+      fi
       rm -f ~/.mcp-mesh/agents/long-task-provider-ts/* 2>/dev/null || true
       echo "round 1 kill done"
     capture: kill1
@@ -146,6 +150,10 @@ test:
         esac
       done
       echo "killed PIDs:$KILLED"
+      if [ -z "$KILLED" ]; then
+        echo "ERROR: No provider processes were killed in round 2 — recovery scenario invalid"
+        exit 1
+      fi
       rm -f ~/.mcp-mesh/agents/long-task-provider-ts/* 2>/dev/null || true
       echo "round 2 kill done"
     capture: kill2

--- a/tests/integration/suites/uc22_meshjob_ts/tc12_max_retries_exhausted_marks_failed_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc12_max_retries_exhausted_marks_failed_ts/test.yaml
@@ -1,0 +1,179 @@
+# tc12_max_retries_exhausted_marks_failed_ts — TS port of uc21/tc12.
+#
+# Two SIGKILL cycles with max_retries=1 leaves attempt_count=2,
+# max_retries=1 → orphan-reset path's check `attempt_count > max_retries`
+# (2 > 1) trips and marks failed with "orphaned: max retries exceeded".
+
+name: "MeshJob TS: retry budget exhausted via repeated crashes — marked failed"
+description: "TS — two crash + sweep cycles with max_retries=1; final attempt_count=2 > max_retries → exhausted"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+  - retry
+  - crash-recovery
+  - slow
+timeout: 300
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (round 1)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Wait for consumer + DI"
+    handler: wait
+    seconds: 22
+
+  - name: "Submit job with max_retries=1"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g","h","i"],"max_retries":1,"max_duration":60}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Wait 4s for claim"
+    handler: wait
+    seconds: 4
+
+  - name: "Kill provider — round 1 (attempt 1 crashes)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # Kill ALL node/tsx processes whose cmdline mentions the agent
+      # script — see tc11 for rationale (parent/child both need killing).
+      MY_PID=$$
+      MY_PPID=$PPID
+      KILLED=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        case "$cmd" in
+          *long-task-provider-ts/src/index.ts*)
+            kill -9 "$pid" 2>/dev/null && KILLED="$KILLED $pid"
+            ;;
+        esac
+      done
+      echo "killed PIDs:$KILLED"
+      rm -f ~/.mcp-mesh/agents/long-task-provider-ts/* 2>/dev/null || true
+      echo "round 1 kill done"
+    capture: kill1
+
+  - name: "Wait for sweep to reset orphan (~35s end-to-end)"
+    handler: wait
+    seconds: 45
+
+  - name: "Status after round 1 (should be working, owner=null)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,owner_instance_id,attempt_count}'
+    capture: after_round_1
+
+  - name: "Stale PID cleanup before round 2 (SIGKILL leaves stale tracking)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop long-task-provider-ts 2>&1 || true
+      rm -f ~/.mcp-mesh/agents/long-task-provider-ts/* 2>/dev/null || true
+      echo "stale entry cleared"
+
+  - name: "Start provider (round 2)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for round 2 claim"
+    handler: wait
+    seconds: 18
+
+  - name: "Kill provider — round 2 (attempt 2 crashes)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # Kill ALL node/tsx processes whose cmdline mentions the agent
+      # script — see tc11 for rationale (parent/child both need killing).
+      MY_PID=$$
+      MY_PPID=$PPID
+      KILLED=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        case "$cmd" in
+          *long-task-provider-ts/src/index.ts*)
+            kill -9 "$pid" 2>/dev/null && KILLED="$KILLED $pid"
+            ;;
+        esac
+      done
+      echo "killed PIDs:$KILLED"
+      rm -f ~/.mcp-mesh/agents/long-task-provider-ts/* 2>/dev/null || true
+      echo "round 2 kill done"
+    capture: kill2
+
+  - name: "Wait for sweep to mark exhausted (~35s end-to-end)"
+    handler: wait
+    seconds: 45
+
+  - name: "Final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,owner_instance_id,attempt_count,error}'
+    capture: final_status
+
+assertions:
+  - expr: "${captured.after_round_1} contains '\"status\": \"working\"'"
+    message: "after round 1 sweep, status should still be working (orphan reset)"
+  - expr: "${captured.after_round_1} contains '\"owner_instance_id\": null'"
+    message: "after round 1 sweep, owner should be cleared"
+  - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
+    message: "after round 2 sweep with attempt_count > max_retries, must be failed"
+  - expr: "${captured.final_status} contains 'max retries exceeded'"
+    message: "error should mention max retries exceeded"
+  - expr: "${captured.final_status} contains '\"attempt_count\": 2'"
+    message: "attempt_count should be 2 (1 initial + 1 retry attempt) — budget exceeded"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc13_total_deadline_expires_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc13_total_deadline_expires_ts/test.yaml
@@ -1,0 +1,137 @@
+# tc13_total_deadline_expires_ts — TS port of uc21/tc13.
+#
+# Submits a job with total_deadline=now+5s and a generous max_retries=10.
+# Producer is killed mid-flight to make the row eligible for the orphan
+# path. ExpireDeadlinedJobs marks the row failed with reason
+# "deadline_exceeded" BEFORE orphan-reset can put it back in the pool.
+
+name: "MeshJob TS: total_deadline expiry overrides retry budget"
+description: "TS — deadline=now+5s with max_retries=10; deadline-sweep marks failed before any retry"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+  - retry
+  - deadline
+  - slow
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Wait for consumer + DI"
+    handler: wait
+    seconds: 22
+
+  # commission_with_options propagates total_deadline_secs (relative)
+  # → unix-epoch seconds for the TS submitter.
+  - name: "Submit with total_deadline=now+5s, max_retries=10"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_with_options \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g"],"max_retries":10,"total_deadline_secs":5,"wait_timeout_secs":2}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Capture job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+    capture: job_id_extract
+
+  - name: "Kill provider — make the row a candidate for orphan/deadline sweep"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # Kill ALL node/tsx processes whose cmdline mentions the agent
+      # script — see tc11 for rationale.
+      MY_PID=$$
+      MY_PPID=$PPID
+      KILLED=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        case "$cmd" in
+          *long-task-provider-ts/src/index.ts*)
+            kill -9 "$pid" 2>/dev/null && KILLED="$KILLED $pid"
+            ;;
+        esac
+      done
+      echo "killed PIDs:$KILLED"
+      rm -f ~/.mcp-mesh/agents/long-task-provider-ts/* 2>/dev/null || true
+      echo "kill done"
+
+  # Deadline path runs on every sweep tick (~10s). With total_deadline=now+5s
+  # the row is marked failed within ~10–15s. The longer wait is belt-and-braces.
+  - name: "Wait for deadline sweep"
+    handler: wait
+    seconds: 25
+
+  - name: "Final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,attempt_count,error,total_deadline,owner_instance_id}'
+    capture: final_status
+
+assertions:
+  - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
+    message: "deadline-expired job must be marked failed"
+  - expr: "${captured.final_status} contains 'deadline_exceeded'"
+    message: "error must be the canonical 'deadline_exceeded' reason — NOT 'orphaned'"
+  - expr: "${captured.final_status} not contains 'orphaned'"
+    message: "deadline path must take precedence over orphan-reset"
+  # The deadline can fire before the producer claims (attempt_count=0)
+  # or during the in-flight first attempt (attempt_count=1). What MUST
+  # NOT happen is iterating up to max_retries=10. Belt-and-braces:
+  # check that the count is exactly 1 (typical) AND assert the count
+  # is not 2/3+ (which would mean retries had run despite the deadline).
+  - expr: "${captured.final_status} not contains '\"attempt_count\": 2'"
+    message: "attempt_count must NOT have iterated past 1 — deadline overrides max_retries=10"
+  - expr: "${captured.final_status} not contains '\"attempt_count\": 3'"
+    message: "attempt_count must NOT have iterated past 1 — deadline overrides max_retries=10"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc13_total_deadline_expires_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc13_total_deadline_expires_ts/test.yaml
@@ -97,6 +97,10 @@ test:
         esac
       done
       echo "killed PIDs:$KILLED"
+      if [ -z "$KILLED" ]; then
+        echo "ERROR: No provider processes were killed — deadline scenario invalid"
+        exit 1
+      fi
       rm -f ~/.mcp-mesh/agents/long-task-provider-ts/* 2>/dev/null || true
       echo "kill done"
 
@@ -115,6 +119,25 @@ test:
       curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,attempt_count,error,total_deadline,owner_instance_id}'
     capture: final_status
 
+  # Upper-bound check: the deadline can fire before the producer claims
+  # (attempt_count=0) or during the in-flight first attempt
+  # (attempt_count=1). What MUST NOT happen is iterating up to
+  # max_retries=10 — any value > 1 means retries ran despite the deadline.
+  - name: "Assert attempt_count <= 1 (deadline must prevent retries)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # Re-fetch the row directly — the captured.final_status capture
+      # is "JOB_ID=...\n{...}" (echo line + jq output) so it can't be
+      # piped back through jq. Source-of-truth read keeps the check robust.
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      COUNT=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.attempt_count')
+      if ! [ "$COUNT" -le 1 ] 2>/dev/null; then
+        echo "ERROR: attempt_count=$COUNT exceeds 1 — total_deadline should have prevented retry"
+        exit 1
+      fi
+      echo "attempt_count=$COUNT (<= 1, OK)"
+
 assertions:
   - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
     message: "deadline-expired job must be marked failed"
@@ -122,15 +145,6 @@ assertions:
     message: "error must be the canonical 'deadline_exceeded' reason — NOT 'orphaned'"
   - expr: "${captured.final_status} not contains 'orphaned'"
     message: "deadline path must take precedence over orphan-reset"
-  # The deadline can fire before the producer claims (attempt_count=0)
-  # or during the in-flight first attempt (attempt_count=1). What MUST
-  # NOT happen is iterating up to max_retries=10. Belt-and-braces:
-  # check that the count is exactly 1 (typical) AND assert the count
-  # is not 2/3+ (which would mean retries had run despite the deadline).
-  - expr: "${captured.final_status} not contains '\"attempt_count\": 2'"
-    message: "attempt_count must NOT have iterated past 1 — deadline overrides max_retries=10"
-  - expr: "${captured.final_status} not contains '\"attempt_count\": 3'"
-    message: "attempt_count must NOT have iterated past 1 — deadline overrides max_retries=10"
 
 post_run:
   - routine: stop_all

--- a/tests/integration/suites/uc22_meshjob_ts/tc14_helpers_on_every_agent_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc14_helpers_on_every_agent_ts/test.yaml
@@ -1,0 +1,151 @@
+# tc14_helpers_on_every_agent_ts — TS port of uc21/tc14.
+#
+# Three TS agents: producer (task=true only), consumer (deps + submit
+# wrapper), and orchestrator (no task tools, no deps — pure bystander).
+# All three should advertise __mesh_job_status, __mesh_job_result, and
+# __mesh_job_cancel via the registry.
+
+name: "MeshJob TS: helper tools auto-registered on every mesh agent"
+description: "TS — producer, consumer, and bystander all expose __mesh_job_* and return correct data"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+  - helpers
+timeout: 150
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+      cp -rL /uc-artifacts/orchestrator-agent-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - name: "Install orchestrator deps"
+    handler: npm-install
+    path: /workspace/orchestrator-agent-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Start orchestrator (no task tools, no deps)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start orchestrator-agent-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9113 -d
+
+  - name: "Wait for all 3 to register"
+    handler: wait
+    seconds: 28
+
+  - name: "Capture full agent IDs"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl list 2>&1
+      echo "---"
+      curl -s http://localhost:8000/agents | jq -r '.agents[].id'
+    capture: agent_ids
+
+  - name: "Submit a job via consumer (1 section)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["only"],"max_retries":1,"max_duration":30}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 8
+
+  - name: "Call __mesh_job_status on PROVIDER"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-ts") | .id')
+      echo "JOB_ID=${JOB_ID} AGENT=${AGENT}"
+      meshctl call "${AGENT}:__mesh_job_status" "{\"jobId\":\"${JOB_ID}\"}"
+    capture: status_on_provider
+
+  - name: "Call __mesh_job_result on CONSUMER"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-consumer-ts") | .id')
+      meshctl call "${AGENT}:__mesh_job_result" "{\"jobId\":\"${JOB_ID}\"}"
+    capture: result_on_consumer
+
+  - name: "Call __mesh_job_status on ORCHESTRATOR (bystander)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="orchestrator-agent-ts") | .id')
+      meshctl call "${AGENT}:__mesh_job_status" "{\"jobId\":\"${JOB_ID}\"}"
+    capture: status_on_orchestrator
+
+  - name: "Confirm helper tools auto-register on the orchestrator (bystander)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s http://localhost:8000/agents \
+        | jq -r '.agents[] | select(.name=="orchestrator-agent-ts") | .capabilities[].function_name'
+    capture: orchestrator_tools
+
+assertions:
+  - expr: "${captured.agent_ids} contains 'long-task-provider-ts'"
+    message: "TS provider should be registered"
+  - expr: "${captured.agent_ids} contains 'long-task-consumer-ts'"
+    message: "TS consumer should be registered"
+  - expr: "${captured.agent_ids} contains 'orchestrator-agent-ts'"
+    message: "TS orchestrator (bystander) should be registered"
+  - expr: "${captured.status_on_provider} contains 'completed'"
+    message: "__mesh_job_status on provider should return the same completed state"
+  - expr: "${captured.result_on_consumer} contains 'completed'"
+    message: "__mesh_job_result on consumer should return terminal status=completed"
+  - expr: "${captured.status_on_orchestrator} contains 'completed'"
+    message: "__mesh_job_status on bystander orchestrator should also return completed"
+  - expr: "${captured.status_on_orchestrator} contains 'long-task-provider-ts'"
+    message: "bystander's status read should include the producer's owner_instance_id"
+
+  # Auto-registration check: even the bystander orchestrator (no task
+  # tools, no MeshJob deps) advertises all three __mesh_job_* helpers.
+  - expr: "${captured.orchestrator_tools} contains '__mesh_job_status'"
+    message: "orchestrator (bystander) must auto-register __mesh_job_status"
+  - expr: "${captured.orchestrator_tools} contains '__mesh_job_result'"
+    message: "orchestrator (bystander) must auto-register __mesh_job_result"
+  - expr: "${captured.orchestrator_tools} contains '__mesh_job_cancel'"
+    message: "orchestrator (bystander) must auto-register __mesh_job_cancel"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc14_helpers_on_every_agent_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc14_helpers_on_every_agent_ts/test.yaml
@@ -121,6 +121,30 @@ test:
         | jq -r '.agents[] | select(.name=="orchestrator-agent-ts") | .capabilities[].function_name'
     capture: orchestrator_tools
 
+  # Strong owner_instance_id check — parse the JSON field rather than
+  # relying on substring match that could fire on agent name in errors.
+  # The bystander reads job state via the framework's helper tool; the
+  # MCP envelope wraps the registry status JSON in
+  #   {"content":[{"text":"{...}"}]}
+  # so we double-decode (.content[0].text | fromjson) before reading
+  # the owner_instance_id field.
+  - name: "Assert owner_instance_id starts with producer agent name"
+    handler: shell
+    workdir: /workspace
+    command: |
+      OWNER=$(echo '${captured.status_on_orchestrator}' \
+        | jq -r '.content[0].text | fromjson | .owner_instance_id')
+      echo "owner_instance_id=${OWNER}"
+      case "$OWNER" in
+        long-task-provider-ts-*)
+          echo "OK"
+          ;;
+        *)
+          echo "ERROR: owner_instance_id should start with 'long-task-provider-ts-' but got '$OWNER'"
+          exit 1
+          ;;
+      esac
+
 assertions:
   - expr: "${captured.agent_ids} contains 'long-task-provider-ts'"
     message: "TS provider should be registered"
@@ -134,8 +158,7 @@ assertions:
     message: "__mesh_job_result on consumer should return terminal status=completed"
   - expr: "${captured.status_on_orchestrator} contains 'completed'"
     message: "__mesh_job_status on bystander orchestrator should also return completed"
-  - expr: "${captured.status_on_orchestrator} contains 'long-task-provider-ts'"
-    message: "bystander's status read should include the producer's owner_instance_id"
+  # owner_instance_id field validated by the shell step above (jq-decoded).
 
   # Auto-registration check: even the bystander orchestrator (no task
   # tools, no MeshJob deps) advertises all three __mesh_job_* helpers.

--- a/tests/integration/suites/uc22_meshjob_ts/tc15_status_for_unknown_id_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc15_status_for_unknown_id_ts/test.yaml
@@ -1,0 +1,86 @@
+# tc15_status_for_unknown_id_ts — TS port of uc21/tc15.
+#
+# Calls __mesh_job_status with a UUID that's not in the registry.
+# Registry returns HTTP 404 with "job not found: <id>". TS JobProxy
+# turns that into an error; the helper-tool wrapper surfaces it through
+# MCP as an isError envelope or a thrown error.
+
+name: "MeshJob TS: __mesh_job_status with unknown job_id returns structured not-found"
+description: "TS — bogus UUID returns NotFound-shaped error (not a 500, not an auth error)"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+  - helpers
+  - errors
+timeout: 90
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/orchestrator-agent-ts /workspace/
+
+  - name: "Install agent deps"
+    handler: npm-install
+    path: /workspace/orchestrator-agent-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start orchestrator agent (TS)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start orchestrator-agent-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9113 -d
+
+  - name: "Wait for registration"
+    handler: wait
+    seconds: 18
+
+  - name: "Direct registry GET — confirm 404 shape"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -w "\nHTTP_CODE=%{http_code}" \
+        "http://localhost:8000/jobs/00000000-0000-0000-0000-000000000000"
+    capture: registry_404
+
+  - name: "Helper tool with bogus job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call __mesh_job_status \
+        '{"jobId":"00000000-0000-0000-0000-000000000000"}' 2>&1 || true
+    capture: helper_response
+
+assertions:
+  - expr: "${captured.registry_404} contains 'HTTP_CODE=404'"
+    message: "registry GET /jobs/<bogus-id> should return HTTP 404"
+  - expr: "${captured.registry_404} icontains 'job not found'"
+    message: "registry 404 body should say 'job not found'"
+  # The TS helper tool surfaces NotFound through MCP either as a
+  # thrown error (meshctl call exits non-zero with stderr) or as an
+  # isError envelope — both surface "not found" verbatim from the
+  # backend error message.
+  - expr: "${captured.helper_response} icontains 'not found'"
+    message: "helper-tool error should mention 'not found'"
+  # Auth-model assertions: presigned-URL semantics → NOT gated.
+  - expr: "${captured.helper_response} not contains 'unauthorized'"
+    message: "must NOT mention 'unauthorized' — auth model is job_id-as-capability"
+  - expr: "${captured.helper_response} not contains 'permission denied'"
+    message: "must NOT mention 'permission denied' — auth model is job_id-as-capability"
+  # Must surface as the structured BackendError envelope (proves the 404
+  # round-trip), not a 5xx server error.
+  - expr: "${captured.helper_response} contains 'backend error'"
+    message: "must surface as the structured BackendError envelope"
+  - expr: "${captured.helper_response} not contains 'server error (HTTP 5'"
+    message: "must NOT surface as a 5xx server error"
+  - expr: "${captured.helper_response} not contains '500 Internal Server Error'"
+    message: "must NOT carry a literal HTTP 500 status line"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc15_status_for_unknown_id_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc15_status_for_unknown_id_ts/test.yaml
@@ -56,6 +56,21 @@ test:
         '{"jobId":"00000000-0000-0000-0000-000000000000"}' 2>&1 || true
     capture: helper_response
 
+  # Auth-rejection check via case-insensitive grep — the DSL has
+  # `not contains` (case-sensitive) only, but real responses might
+  # surface "Unauthorized", "UNAUTHORIZED", or "Permission Denied".
+  - name: "Assert no auth-rejection phrasing (case-insensitive)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      LOWER=$(echo '${captured.helper_response}' | tr '[:upper:]' '[:lower:]')
+      if echo "$LOWER" | grep -q -E 'unauthorized|permission denied'; then
+        echo "ERROR: helper_response contains an auth-rejection phrase (job_id-as-capability auth must be open)"
+        echo "$LOWER"
+        exit 1
+      fi
+      echo "no auth-rejection phrasing detected"
+
 assertions:
   - expr: "${captured.registry_404} contains 'HTTP_CODE=404'"
     message: "registry GET /jobs/<bogus-id> should return HTTP 404"
@@ -67,11 +82,8 @@ assertions:
   # backend error message.
   - expr: "${captured.helper_response} icontains 'not found'"
     message: "helper-tool error should mention 'not found'"
-  # Auth-model assertions: presigned-URL semantics → NOT gated.
-  - expr: "${captured.helper_response} not contains 'unauthorized'"
-    message: "must NOT mention 'unauthorized' — auth model is job_id-as-capability"
-  - expr: "${captured.helper_response} not contains 'permission denied'"
-    message: "must NOT mention 'permission denied' — auth model is job_id-as-capability"
+  # Auth-model: presigned-URL semantics → NOT gated. Validated via the
+  # case-insensitive shell step above (DSL has no `not icontains`).
   # Must surface as the structured BackendError envelope (proves the 404
   # round-trip), not a 5xx server error.
   - expr: "${captured.helper_response} contains 'backend error'"

--- a/tests/integration/suites/uc22_meshjob_ts/tc16_third_party_can_read_status_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc16_third_party_can_read_status_ts/test.yaml
@@ -1,0 +1,150 @@
+# tc16_third_party_can_read_status_ts — TS port of uc21/tc16.
+#
+# Four TS agents: producer, consumer (submits), and two bystanders X / Y
+# (no involvement). Bystanders are distinct fixtures with unique
+# @mesh.agent names so the registry sees two genuinely independent agents.
+# Submit a job via consumer; capture job_id. Call __mesh_job_status on
+# each bystander. Presigned-URL semantics: possession of the UUID = read.
+
+name: "MeshJob TS: third-party agents can read status by job_id (presigned-URL auth)"
+description: "TS — two unrelated bystanders read job status — no auth gating, only ID-as-capability"
+tags:
+  - meshjob
+  - typescript
+  - issue-884
+  - helpers
+  - auth
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+      cp -rL /uc-artifacts/bystander-x-ts /workspace/
+      cp -rL /uc-artifacts/bystander-y-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - name: "Install bystander-x-ts deps"
+    handler: npm-install
+    path: /workspace/bystander-x-ts
+
+  - name: "Install bystander-y-ts deps"
+    handler: npm-install
+    path: /workspace/bystander-y-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Start bystander X"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start bystander-x-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9114 -d
+
+  - name: "Start bystander Y"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start bystander-y-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9115 -d
+
+  - name: "Wait for all 4 to register + DI to settle"
+    handler: wait
+    seconds: 30
+
+  - name: "Confirm all 4 agents in registry"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s http://localhost:8000/agents | jq -r '.agents[].name' | sort
+    capture: agent_names
+
+  - name: "Submit job via consumer"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["one","two"],"max_retries":1,"max_duration":30}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 8
+
+  - name: "Bystander X reads status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="bystander-x-ts") | .id')
+      echo "AGENT=${AGENT} JOB=${JOB_ID}"
+      meshctl call "${AGENT}:__mesh_job_status" "{\"jobId\":\"${JOB_ID}\"}"
+    capture: bystander_x_status
+
+  - name: "Bystander Y reads status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="bystander-y-ts") | .id')
+      meshctl call "${AGENT}:__mesh_job_status" "{\"jobId\":\"${JOB_ID}\"}"
+    capture: bystander_y_status
+
+assertions:
+  - expr: "${captured.agent_names} contains 'long-task-provider-ts'"
+    message: "TS provider should be registered"
+  - expr: "${captured.agent_names} contains 'long-task-consumer-ts'"
+    message: "TS consumer should be registered"
+  - expr: "${captured.agent_names} contains 'bystander-x-ts'"
+    message: "bystander-x-ts should be registered"
+  - expr: "${captured.agent_names} contains 'bystander-y-ts'"
+    message: "bystander-y-ts should be registered"
+
+  # Both bystanders return the real status — NOT an auth error.
+  - expr: "${captured.bystander_x_status} contains 'completed'"
+    message: "bystander-x-ts should read the actual completed status (no auth gating)"
+  - expr: "${captured.bystander_y_status} contains 'completed'"
+    message: "bystander-y-ts should read the actual completed status (no auth gating)"
+
+  # Both responses must reference the producer's owner_instance_id.
+  - expr: "${captured.bystander_x_status} contains 'long-task-provider-ts'"
+    message: "bystander-x-ts's read should include the producer owner_instance_id"
+  - expr: "${captured.bystander_y_status} contains 'long-task-provider-ts'"
+    message: "bystander-y-ts's read should include the producer owner_instance_id"
+
+  - expr: "${captured.bystander_x_status} not contains 'unauthorized'"
+    message: "bystander-x-ts must NOT see 'unauthorized'"
+  - expr: "${captured.bystander_x_status} not contains 'permission denied'"
+    message: "bystander-x-ts must NOT see 'permission denied'"
+  - expr: "${captured.bystander_y_status} not contains 'unauthorized'"
+    message: "bystander-y-ts must NOT see 'unauthorized'"
+  - expr: "${captured.bystander_y_status} not contains 'permission denied'"
+    message: "bystander-y-ts must NOT see 'permission denied'"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc17_polyglot_ts_consumer_python_provider/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc17_polyglot_ts_consumer_python_provider/test.yaml
@@ -1,0 +1,93 @@
+# tc17_polyglot_ts_consumer_python_provider — TS consumer ↔ Python provider.
+#
+# Validates that a TS MeshJobSubmitter can submit work to a Python
+# task=true tool. The Python provider's `generate_report` is the
+# upstream of choice (well-exercised in uc21). The TS consumer
+# (commission_report) issues submit + wait via the TS submitter.
+#
+# Setup:
+#   - Python long-task-provider on port 9100  (capability: generate_report)
+#   - TS long-task-consumer-ts on port 9111   (depends on generate_report)
+#
+# Both Python (uc21 fixture, reused via symlink) and TS fixtures.
+
+name: "MeshJob polyglot: TS consumer commissions Python provider"
+description: "TS MeshJobSubmitter -> Python task=true tool, end-to-end submit + wait"
+tags:
+  - meshjob
+  - polyglot
+  - typescript
+  - python
+  - issue-884
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts (Python provider + TS consumer)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+
+  - name: "Install Python provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install TS consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start Python provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for Python provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start TS consumer (port 9111)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Wait for TS consumer + DI resolution"
+    handler: wait
+    seconds: 22
+
+  - name: "Verify both runtimes registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Call commission_report — TS consumer -> Python provider"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_report '{"user_id":"alice","sections":["intro","analysis"]}'
+    capture: commission_response
+    timeout: 60
+
+assertions:
+  - expr: "${captured.agent_list} contains 'long-task-provider'"
+    message: "Python provider should be registered"
+  - expr: "${captured.agent_list} contains 'long-task-consumer-ts'"
+    message: "TS consumer should be registered"
+  # Result echoed verbatim from the Python complete() payload.
+  - expr: "${captured.commission_response} contains 'alice'"
+    message: "result should echo the submitted user_id"
+  - expr: "${captured.commission_response} contains 'Generated content for intro'"
+    message: "result should include the intro section content from Python provider"
+  - expr: "${captured.commission_response} contains 'Generated content for analysis'"
+    message: "result should include the analysis section content from Python provider"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc18_polyglot_python_consumer_ts_provider/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc18_polyglot_python_consumer_ts_provider/test.yaml
@@ -1,0 +1,94 @@
+# tc18_polyglot_python_consumer_ts_provider — Python consumer ↔ TS provider.
+#
+# Reverse of tc17. Validates that a Python MeshJobSubmitter can submit
+# work to a TS task=true tool. Uses the Python uc21 long-task-consumer
+# fixture (commission_report) and the TS long-task-provider-ts fixture
+# (generate_report).
+#
+# Setup:
+#   - TS long-task-provider-ts on port 9110  (capability: generate_report)
+#   - Python long-task-consumer on port 9101 (depends on generate_report)
+
+name: "MeshJob polyglot: Python consumer commissions TS provider"
+description: "Python MeshJobSubmitter -> TS addTool({task:true}), end-to-end submit + wait"
+tags:
+  - meshjob
+  - polyglot
+  - typescript
+  - python
+  - issue-884
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts (TS provider + Python consumer)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install TS provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install Python consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start TS provider (port 9110)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for TS provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start Python consumer (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for Python consumer + DI resolution"
+    handler: wait
+    seconds: 22
+
+  - name: "Verify both runtimes registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Call commission_report — Python consumer -> TS provider"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_report '{"user_id":"alice","sections":["intro","analysis"]}'
+    capture: commission_response
+    timeout: 60
+
+assertions:
+  - expr: "${captured.agent_list} contains 'long-task-provider-ts'"
+    message: "TS provider should be registered"
+  - expr: "${captured.agent_list} contains 'long-task-consumer'"
+    message: "Python consumer should be registered"
+  # Python wait() returns the structured result verbatim from the TS
+  # provider's complete() payload. Python serializes with spaces, the
+  # TS provider's payload is just JSON-shaped data — both produce the
+  # canonical fields.
+  - expr: "${captured.commission_response} contains 'alice'"
+    message: "result should echo the submitted user_id"
+  - expr: "${captured.commission_response} contains 'Generated content for intro'"
+    message: "result should include the intro section content from TS provider"
+  - expr: "${captured.commission_response} contains 'Generated content for analysis'"
+    message: "result should include the analysis section content from TS provider"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc19_polyglot_cross_runtime_status_read/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc19_polyglot_cross_runtime_status_read/test.yaml
@@ -1,0 +1,140 @@
+# tc19_polyglot_cross_runtime_status_read — Python orchestrator reads job
+# state for a job submitted/run entirely on TS.
+#
+# Three agents:
+#   - long-task-provider-ts (port 9110)         — TS, task=true tools
+#   - long-task-consumer-ts (port 9111)         — TS, submits the job
+#   - orchestrator-agent (port 9103)            — Python, no task tools
+#
+# Submit a job via the TS consumer; capture job_id; then call
+# __mesh_job_status from the PYTHON orchestrator. Verifies:
+#   1. Helper tools register on every TS agent (already covered)
+#   2. Python's __mesh_job_status (using job_id arg) can read state
+#      for a job whose row was written by TS code
+#   3. job_id-as-capability semantics work cross-runtime
+#
+# This is the "registry is the single source of truth, runtime-agnostic"
+# guarantee — possession of the UUID + an agent in the mesh = read access,
+# regardless of which runtime owns either side.
+
+name: "MeshJob polyglot: Python orchestrator reads status for TS-submitted job"
+description: "Cross-runtime status read — Python helper tool fetches state for a TS-owned job"
+tags:
+  - meshjob
+  - polyglot
+  - typescript
+  - python
+  - issue-884
+  - helpers
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts (TS provider + TS consumer + Python orchestrator)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+      cp -rL /uc-artifacts/orchestrator-agent /workspace/
+
+  - name: "Install TS provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install TS consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - name: "Install Python orchestrator deps"
+    handler: pip-install
+    path: /workspace/orchestrator-agent
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start TS provider (port 9110)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for TS provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start TS consumer (port 9111)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Start Python orchestrator (port 9103)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start orchestrator-agent/main.py --env MCP_MESH_HTTP_PORT=9103 -d
+
+  - name: "Wait for all 3 to register + DI"
+    handler: wait
+    seconds: 28
+
+  - name: "Verify all 3 agents registered"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s http://localhost:8000/agents | jq -r '.agents[].name' | sort
+    capture: agent_names
+
+  - name: "Submit a quick job via TS consumer"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["only"],"max_retries":1,"max_duration":30}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 10
+
+  # Now call the Python orchestrator's __mesh_job_status. Python helpers
+  # use the snake_case `job_id` arg name (vs TS `jobId`). Address the
+  # specific Python agent so the routing terminates on the Python side.
+  - name: "Call Python orchestrator's __mesh_job_status (snake_case job_id arg)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="orchestrator-agent") | .id')
+      echo "JOB_ID=${JOB_ID} AGENT=${AGENT}"
+      meshctl call "${AGENT}:__mesh_job_status" "{\"job_id\":\"${JOB_ID}\"}"
+    capture: status_from_python
+
+assertions:
+  - expr: "${captured.agent_names} contains 'long-task-provider-ts'"
+    message: "TS provider should be registered"
+  - expr: "${captured.agent_names} contains 'long-task-consumer-ts'"
+    message: "TS consumer should be registered"
+  - expr: "${captured.agent_names} contains 'orchestrator-agent'"
+    message: "Python orchestrator should be registered"
+  # The cross-runtime read returns the job's terminal state. Python's
+  # response includes structuredContent (pretty-printed) so the spaced
+  # form `"status": "completed"` lands in the captured text.
+  - expr: "${captured.status_from_python} contains 'completed'"
+    message: "Python orchestrator should be able to read terminal status for the TS-submitted job"
+  # The owner_instance_id field carries the TS provider's id —
+  # confirms data flow: Python helper -> JobProxy -> registry GET ->
+  # row data identical to a TS-side read of the same job_id.
+  - expr: "${captured.status_from_python} contains 'long-task-provider-ts'"
+    message: "Python's read should expose the TS provider's owner_instance_id"
+  # No auth-flavoured errors — job_id-as-capability semantics work
+  # cross-runtime (the helper doesn't gate on owner runtime).
+  - expr: "${captured.status_from_python} not contains 'unauthorized'"
+    message: "must NOT see 'unauthorized' — cross-runtime reads are open per ID-as-capability"
+  - expr: "${captured.status_from_python} not contains 'permission denied'"
+    message: "must NOT see 'permission denied' — cross-runtime reads are open per ID-as-capability"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/tc20_polyglot_cross_runtime_cancel/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc20_polyglot_cross_runtime_cancel/test.yaml
@@ -99,6 +99,10 @@ test:
       JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
       AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="orchestrator-agent") | .id')
       echo "JOB_ID=${JOB_ID} AGENT=${AGENT}"
+      if [ -z "$JOB_ID" ] || [ "$JOB_ID" = "null" ] || [ -z "$AGENT" ] || [ "$AGENT" = "null" ]; then
+        echo "ERROR: required vars empty — JOB_ID='$JOB_ID' AGENT='$AGENT'"
+        exit 1
+      fi
       meshctl call "${AGENT}:__mesh_job_cancel" "{\"job_id\":\"${JOB_ID}\",\"reason\":\"tc20 python-initiated cancel of TS job\"}"
     capture: cancel_response
     timeout: 15

--- a/tests/integration/suites/uc22_meshjob_ts/tc20_polyglot_cross_runtime_cancel/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc20_polyglot_cross_runtime_cancel/test.yaml
@@ -116,8 +116,10 @@ test:
     capture: final_status
 
 assertions:
-  - expr: "${captured.cancel_response} contains 'ok'"
-    message: "Python helper cancel should ack ok"
+  # Anchor on the field key+value — bare `ok` matches "lookup", URLs, etc.
+  # Python helper returns {"ok": True, "job_id": ...} -> escaped envelope.
+  - expr: "${captured.cancel_response} contains '\\\"ok\\\":true'"
+    message: "Python helper cancel should ack with ok:true"
   - expr: "${captured.final_status} contains '\"status\": \"cancelled\"'"
     message: "final status should be cancelled (not completed) — Python -> registry -> TS cancel route worked"
   # Owner is the TS provider — proves the registry forwarded the cancel

--- a/tests/integration/suites/uc22_meshjob_ts/tc20_polyglot_cross_runtime_cancel/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc20_polyglot_cross_runtime_cancel/test.yaml
@@ -1,0 +1,134 @@
+# tc20_polyglot_cross_runtime_cancel — Python agent issues cancel for a
+# TS-owned in-flight job.
+#
+# Three agents:
+#   - long-task-provider-ts (port 9110)         — TS, runs_overlong
+#   - long-task-consumer-ts (port 9111)         — TS, submits the job
+#   - orchestrator-agent (port 9103)            — Python, no task tools
+#
+# Submit a 30s job via TS consumer; mid-flight, call __mesh_job_cancel
+# from the PYTHON orchestrator agent. The registry must:
+#   1. Receive the cancel via Python helper -> JobProxy -> POST /jobs/{id}/cancel
+#   2. Mark the row cancelled
+#   3. Forward the cancel signal to the TS provider's
+#      POST /jobs/:job_id/cancel route (registered by registerCancelRoute)
+#   4. The TS provider's cancel route fires the in-process cancel token
+#
+# Validates that registry → TS cancel-route forwarding works for
+# Python-initiated cancels (mirror of the TS-initiated cancel path
+# tested in tc06).
+
+name: "MeshJob polyglot: Python cancels TS-owned in-flight job"
+description: "Cross-runtime cancel — Python helper tool fires registry cancel; TS provider's cancel route processes the forward"
+tags:
+  - meshjob
+  - polyglot
+  - typescript
+  - python
+  - issue-884
+  - cancel
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts (TS provider + TS consumer + Python orchestrator)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+      cp -rL /uc-artifacts/orchestrator-agent /workspace/
+
+  - name: "Install TS provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install TS consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - name: "Install Python orchestrator deps"
+    handler: pip-install
+    path: /workspace/orchestrator-agent
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start TS provider (port 9110)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for TS provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start TS consumer (port 9111)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Start Python orchestrator (port 9103)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start orchestrator-agent/main.py --env MCP_MESH_HTTP_PORT=9103 -d
+
+  - name: "Wait for all 3 + DI"
+    handler: wait
+    seconds: 28
+
+  - name: "Submit 30-second overlong job via TS consumer"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_overlong '{"user_id":"alice","seconds":30}' --raw
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Wait 5s for TS provider to claim + start"
+    handler: wait
+    seconds: 5
+
+  # Python helper: __mesh_job_cancel takes snake_case job_id.
+  - name: "Cancel via the Python orchestrator agent's helper tool"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="orchestrator-agent") | .id')
+      echo "JOB_ID=${JOB_ID} AGENT=${AGENT}"
+      meshctl call "${AGENT}:__mesh_job_cancel" "{\"job_id\":\"${JOB_ID}\",\"reason\":\"tc20 python-initiated cancel of TS job\"}"
+    capture: cancel_response
+    timeout: 15
+
+  - name: "Wait for cancel propagation"
+    handler: wait
+    seconds: 8
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,owner_instance_id,error,progress}'
+    capture: final_status
+
+assertions:
+  - expr: "${captured.cancel_response} contains 'ok'"
+    message: "Python helper cancel should ack ok"
+  - expr: "${captured.final_status} contains '\"status\": \"cancelled\"'"
+    message: "final status should be cancelled (not completed) — Python -> registry -> TS cancel route worked"
+  # Owner is the TS provider — proves the registry forwarded the cancel
+  # to the TS replica that holds the lease.
+  - expr: "${captured.final_status} contains 'long-task-provider-ts'"
+    message: "owner_instance_id should be the TS provider — confirms Python -> TS forwarding path"
+  # The progress at cancel time should be < 1.0 — the TS provider should
+  # NOT have run runs_overlong's natural 30s completion.
+  - expr: "${captured.final_status} not contains '\"status\": \"completed\"'"
+    message: "TS provider must not have completed naturally — cancel must have aborted the runs_overlong loop"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
Closes #884. TypeScript integration test coverage for the MeshJob substrate (#873/#885) plus Python ↔ TS polyglot smoke. Mirror of `uc21_meshjob` (Python — #883) for the TS runtime, with 4 added cross-runtime scenarios.

## Summary

20 tests in `tests/integration/suites/uc22_meshjob_ts/`:

**A. Happy path — TS↔TS (5)**: submit/wait, mid-flight progress, explicit complete, implicit complete, explicit fail
**B. Cancellation — TS↔TS (4)**: alive-owner forward, orphan direct, already-terminal 409, cancel-token aborts (producer-side; outbound gap → #886)
**C. Retry & recovery — TS↔TS (4)**: ` max_retries=1` succeeds, ` =0` disables, exhaustion → failed, ` total_deadline` overrides
**F. Helper tools & auth — TS↔TS (3)**: helpers on every agent, unknown ID, third-party reads
**G. Polyglot — Python ↔ TS (4 NEW)**:
- ` tc17` TS consumer → Python provider
- ` tc18` Python consumer → TS provider
- ` tc19` cross-runtime status read (Python orchestrator reads TS-owned job)
- ` tc20` cross-runtime cancel (Python ` __mesh_job_cancel` aborts TS-owned job)

5 TS fixtures (multi-cap provider/consumer + sleeper + orchestrator + 2 bystanders); polyglot tests reuse uc21's Python fixtures via relative symlinks under ` artifacts/` — no fixture duplication.

## Suite setup

` routines.yaml::start_registry_with_fast_sweep` reuses uc21's pattern: 4 registry env overrides (` MCP_MESH_SWEEP_INTERVAL=10s` + ` RETENTION=10s` + ` HEALTH_CHECK_INTERVAL=5` + ` DEFAULT_TIMEOUT_THRESHOLD=15`) so sweep-driven recovery tests resolve in ~35s instead of 5+min. Verifies the override applies via tail+grep.

## Review Notes

Independent code review found 0 BLOCKERs, 4 WARNINGs, 3 INFOs. **All 4 WARNINGs + 1 substantive INFO addressed in commit ` f082c37e`**:

- ` tc03` ` contains 'explicit'` matched capability name ` report_with_explicit_complete` → tightened to escape-aware ` '\\\"explicit\\\":true'` anchor
- ` tc04` ` contains 'implicit'`/` 'completed'` matched capability name + ` completed_at` field → tightened to specific JSON keys
- ` tc06`/` tc09`/` tc20` ` contains 'ok'` matched URLs/stray substrings → tightened to ` '\\\"ok\\\":true'`
- ` downstream-sleeper-ts` unreachable cancel-marker catch → flagged as ` // UNREACHABLE — see #886` placeholder

## Substrate observations filed (not blockers)

- **#886** — TS ` proxy.ts` outbound-HTTP cancel propagation gap (TS sibling of #882; tc09 documents inline)
- **#887** — TS MCP envelope omits ` structuredContent` (cosmetic vs Python; affects test-assertion form)

## Test results

Stable across two consecutive runs:
- ` --parallel 1` → 20/20 pass, 200s
- ` --parallel 4` → 20/20 pass, 197-198s

No flakes, no disabled tests.

Closes #884

## Test plan

- [x] ` tsuite run --suite-path tests/integration --uc uc22_meshjob_ts --parallel 1` — 20/20 pass, ~200s
- [x] ` tsuite run --suite-path tests/integration --uc uc22_meshjob_ts --parallel 4` — 20/20 pass, ~198s
- [x] Tightened assertions verified against actual payloads (no false-positives)
- [ ] CI green
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive TypeScript integration test suite for MeshJob functionality, including job submission, progress tracking, completion, cancellation, retry behavior, deadline handling, and cross-runtime polyglot scenarios with Python interoperability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->