### PR TITLE
feature: Java MeshJob implementation — runtime + C-ABI bindings + examples

### DIFF
--- a/examples/jobs-java/README.md
+++ b/examples/jobs-java/README.md
@@ -1,0 +1,85 @@
+# MeshJob Phase B Examples (Java)
+
+Two minimal Spring Boot agents demonstrating the producer + consumer
+pattern for long-running tasks with `MeshJob` on the Java SDK. Mirrors:
+
+- `examples/jobs/` — Python equivalents
+- `examples/jobs-ts/` — TypeScript equivalents
+
+## Layout
+
+- `long-task-provider-java/` — registers `generate_report` as a
+  `task=true` tool. Hosts the producer-side `JobController` flow:
+  progress updates, structured terminal results.
+- `long-task-consumer-java/` — registers `commission_report` which
+  depends on `generate_report`. Demonstrates the consumer-side
+  `MeshJobSubmitter.submit(...)` + `JobProxy.await(...)` pattern.
+
+## Quick start
+
+In three terminals:
+
+```bash
+# Terminal 1 — registry
+cd cmd/mcp-mesh-registry && go run .
+
+# Terminal 2 — Java provider (port 9120)
+cd examples/jobs-java/long-task-provider-java
+MCP_MESH_REGISTRY_URL=http://localhost:8000 mvn spring-boot:run
+
+# Terminal 3 — Java consumer (port 9121)
+cd examples/jobs-java/long-task-consumer-java
+MCP_MESH_REGISTRY_URL=http://localhost:8000 mvn spring-boot:run
+```
+
+Then commission a report by calling the consumer's `commission_report`
+tool — for example via `meshctl`:
+
+```bash
+meshctl call --timeout 60 long-task-consumer-java:commission_report \
+  '{"user_id":"demo","sections":["intro","analysis","summary"]}'
+```
+
+You should see:
+
+1. Consumer logs the `MeshJob consumer wired` startup line.
+2. Consumer's `submit(...)` posts to `POST /jobs` on the registry.
+3. Provider's claim worker (or the registry's owner-pinning if push-mode)
+   picks up the job and dispatches to `generate_report`.
+4. Provider emits progress updates (~6s total for the three sections).
+5. Consumer's `await(...)` returns the structured `report` payload.
+
+## Inspecting in flight
+
+While a job is running, hit any agent for status:
+
+```bash
+meshctl call long-task-provider-java:__mesh_job_status \
+  '{"job_id":"<uuid-from-submit>"}'
+```
+
+The three framework helper tools (`__mesh_job_status`,
+`__mesh_job_result`, `__mesh_job_cancel`) are auto-registered on every
+mesh agent — they read the registry directly, so any replica can serve
+reads even if the job is "owned" by a different one.
+
+## Cancelling
+
+```bash
+meshctl call long-task-provider-java:__mesh_job_cancel \
+  '{"job_id":"<uuid>","reason":"user requested abort"}'
+```
+
+The registry forwards the cancel to the owner replica via
+`POST /jobs/{id}/cancel` (registered on every Java mesh agent's MVC
+controller stack), which fires the in-process cancel token and aborts
+the in-flight job.
+
+## What's NOT in Phase B
+
+- Idempotency keys for retries (Phase 3).
+- Resumable checkpoints (Phase 3).
+- Webhook/SSE notifications (Phase 3).
+- SEP-1686 wire surfacing (Phase 2 — strictly additive on top).
+
+See `MESHJOB_DESIGN.org` at the repo root for the full roadmap.

--- a/examples/jobs-java/long-task-consumer-java/pom.xml
+++ b/examples/jobs-java/long-task-consumer-java/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>long-task-consumer-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>MeshJob Long-Task Consumer (Java)</name>
+    <description>Phase B MeshJob example — submits a remote task and awaits the result</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>local-maven-repo</id>
+            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.longtaskconsumer.LongTaskConsumerApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/jobs-java/long-task-consumer-java/pom.xml
+++ b/examples/jobs-java/long-task-consumer-java/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.6</version>
         <relativePath/>
     </parent>
 

--- a/examples/jobs-java/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
+++ b/examples/jobs-java/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
@@ -1,0 +1,114 @@
+package com.example.longtaskconsumer;
+
+import io.mcpmesh.JobProxy;
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshJobSubmitter;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * MeshJob Phase B — Java Consumer: commission a remote long-running job.
+ *
+ * <p>Demonstrates the consumer-side dispatch surface in Java:
+ * <pre>{@code
+ * @MeshTool(
+ *     capability = "commission_report",
+ *     dependencies = @Selector(capability = "generate_report"))
+ * public Map<String, Object> commissionReport(
+ *     @Param("user_id") String userId,
+ *     @Param("sections") List<String> sections,
+ *     MeshJob generateReport) {  // injected as MeshJobSubmitter
+ *   var proxy = ((MeshJobSubmitter) generateReport).submit(...).get();
+ *   return (Map<String, Object>) proxy.await(60.0);
+ * }
+ * }</pre>
+ *
+ * <p>The DI layer sees the {@code MeshJob}-typed parameter and that
+ * this method depends on a capability ({@code generate_report}); it
+ * injects a {@link MeshJobSubmitter} bound to that capability.
+ * {@code submit(...)} posts to {@code /jobs} on the registry and
+ * returns a {@link JobProxy} bound to the new job id; {@code await(...)}
+ * polls the registry's {@code GET /jobs/{id}} until the status is
+ * terminal.
+ *
+ * <p>Run after the provider is up:
+ * <pre>
+ * MCP_MESH_REGISTRY_URL=http://localhost:8000 mvn spring-boot:run
+ * </pre>
+ */
+@MeshAgent(
+    name = "long-task-consumer-java",
+    version = "1.0.0",
+    description = "MeshJob Phase B (Java) consumer — commissions and awaits remote reports",
+    port = 9121
+)
+@SpringBootApplication
+public class LongTaskConsumerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(LongTaskConsumerApplication.class, args);
+    }
+
+    @MeshTool(
+        capability = "commission_report",
+        description = "Commission a report from the long-task provider and await its result. "
+            + "Demonstrates the submit-and-wait pattern.",
+        dependencies = @Selector(capability = "generate_report")
+    )
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> commissionReport(
+            @Param("user_id") String userId,
+            @Param(value = "sections", required = false) List<String> sections,
+            MeshJob generateReport) throws Exception {
+
+        if (!(generateReport instanceof MeshJobSubmitter submitter)) {
+            // Defensive: in unit tests or if injection fails, fall back so
+            // callers see a clear error message rather than ClassCastException.
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error",
+                "generate_report submitter not injected — check that the "
+                + "long-task-provider-java is registered with task=true");
+            return err;
+        }
+
+        if (sections == null) {
+            sections = List.of("intro", "analysis", "summary");
+        }
+
+        // submit() posts to /jobs and returns a CompletableFuture<JobProxy>
+        // bound to the new job id. maxDuration is the per-attempt soft
+        // timeout the provider runtime enforces (and the registry's
+        // deadline-exceeded cron sweeps if the producer crashes).
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        payload.put("sections", sections);
+
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            payload,
+            null,    // ownerInstanceId — let the registry route via claim
+            60,      // maxDuration seconds
+            null,    // maxRetries — accept default
+            null     // totalDeadline — unlimited
+        );
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            // Poll the registry until terminal. Returns the producer's
+            // complete() payload on success; throws on failure / cancel
+            // / timeout.
+            Object result = proxy.await(60.0);
+            if (result instanceof Map<?, ?> m) {
+                return (Map<String, Object>) m;
+            }
+            Map<String, Object> wrapped = new LinkedHashMap<>();
+            wrapped.put("result", result);
+            return wrapped;
+        }
+    }
+}

--- a/examples/jobs-java/long-task-consumer-java/src/main/resources/application.properties
+++ b/examples/jobs-java/long-task-consumer-java/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+# Tomcat port for the Spring Boot HTTP server. Mesh's @MeshAgent(port=)
+# is the value advertised to the registry — it must match the actual
+# Tomcat port so other agents can route MCP calls to us.
+server.port=9121
+mesh.agent.port=9121

--- a/examples/jobs-java/long-task-provider-java/pom.xml
+++ b/examples/jobs-java/long-task-provider-java/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>long-task-provider-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>MeshJob Long-Task Provider (Java)</name>
+    <description>Phase B MeshJob example — task=true producer with progress updates</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>local-maven-repo</id>
+            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.longtaskprovider.LongTaskProviderApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/jobs-java/long-task-provider-java/pom.xml
+++ b/examples/jobs-java/long-task-provider-java/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.6</version>
         <relativePath/>
     </parent>
 

--- a/examples/jobs-java/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
+++ b/examples/jobs-java/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
@@ -1,0 +1,113 @@
+package com.example.longtaskprovider;
+
+import io.mcpmesh.JobController;
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * MeshJob Phase B — Java Provider: long-running report generator.
+ *
+ * <p>Demonstrates the producer-side dispatch surface in Java:
+ * <pre>{@code
+ * @MeshTool(capability = "generate_report", task = true)
+ * public Map<String, Object> generateReport(
+ *     @Param("user_id") String userId,
+ *     @Param("sections") List<String> sections,
+ *     MeshJob job) {
+ *   // ... progress updates via (JobController) job ...
+ * }
+ * }</pre>
+ *
+ * <p>When invoked via the consumer's {@code MeshJobSubmitter.submit(...)} (see
+ * {@code ../long-task-consumer-java}), the inbound tool wrapper sees the
+ * {@code X-Mesh-Job-Id} header attached by the registry's claim flow,
+ * builds a {@link JobController} bound to that job id, and injects it
+ * into the {@code job} parameter. Progress updates and the terminal
+ * {@code complete()} flush directly to the registry — the consumer's
+ * {@code proxy.await(...)} polls the registry until terminal.
+ *
+ * <p>If you call {@code generateReport} synchronously (regular
+ * {@code tools/call}, no {@code X-Mesh-Job-Id} header), the runtime
+ * passes {@code null} for {@code job} per
+ * {@code MESHJOB_DDDI_CONTRACT.md} — the function then runs the fast
+ * path and just returns its result.
+ *
+ * <p>Run:
+ * <pre>
+ * MCP_MESH_REGISTRY_URL=http://localhost:8000 mvn spring-boot:run
+ * </pre>
+ */
+@MeshAgent(
+    name = "long-task-provider-java",
+    version = "1.0.0",
+    description = "MeshJob Phase B (Java) producer — generates reports as long-running jobs",
+    port = 9120
+)
+@SpringBootApplication
+public class LongTaskProviderApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(LongTaskProviderApplication.class, args);
+    }
+
+    @MeshTool(
+        capability = "generate_report",
+        task = true,
+        description =
+            "Long-running report generator. Demonstrates progress updates "
+            + "and structured terminal results."
+    )
+    public Map<String, Object> generateReport(
+            @Param("user_id") String userId,
+            @Param(value = "sections", required = false) List<String> sections,
+            MeshJob job) throws InterruptedException {
+
+        if (sections == null) {
+            sections = List.of("default");
+        }
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller != null) {
+            controller.updateProgress(0.0, "starting");
+        }
+
+        List<Map<String, String>> results = new ArrayList<>();
+        int total = Math.max(sections.size(), 1);
+        for (int i = 0; i < sections.size(); i++) {
+            // Simulate substantive work — in a real producer this might be
+            // an LLM call, a long DB query, or video transcoding.
+            Thread.sleep(2000);
+            String section = sections.get(i);
+            Map<String, String> entry = new LinkedHashMap<>();
+            entry.put("section", section);
+            entry.put("content", "Generated content for " + section);
+            results.add(entry);
+            if (controller != null) {
+                controller.updateProgress(
+                    (i + 1.0) / total,
+                    "finished section " + (i + 1) + "/" + total);
+            }
+        }
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        payload.put("report", results);
+
+        if (controller != null) {
+            // Explicit terminal call — flushes immediately past the
+            // batching tick so the consumer sees status=completed
+            // without waiting on the next batch interval.
+            controller.complete(payload);
+        }
+
+        return payload;
+    }
+}

--- a/examples/jobs-java/long-task-provider-java/src/main/resources/application.properties
+++ b/examples/jobs-java/long-task-provider-java/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+# Tomcat port for the Spring Boot HTTP server. Mesh's @MeshAgent(port=)
+# is the value advertised to the registry — it must match the actual
+# Tomcat port so consumer agents can route MCP calls to us.
+server.port=9120
+mesh.agent.port=9120

--- a/src/runtime/core/include/mcp_mesh_core.h
+++ b/src/runtime/core/include/mcp_mesh_core.h
@@ -45,6 +45,17 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+// Opaque handle wrapping a [`JobController`] plus its background batching
+// tick. The tick is held alongside the controller so it lives until the
+// caller invokes [`mesh_job_controller_free`] (mirrors PyJobController /
+// JsJobController which both keep a `BatchingHandle` field).
+//
+// Not `#[repr(C)]` — internals stay opaque to C consumers.
+typedef struct JobControllerHandle JobControllerHandle;
+
+// Opaque handle wrapping a [`JobProxy`].
+typedef struct JobProxyHandle JobProxyHandle;
+
 // Opaque handle to a running MCP Mesh agent.
 //
 // This struct holds all resources needed to interact with the agent runtime.
@@ -670,6 +681,187 @@ char *mesh_add_tool_results(const char *state_json, const char *tool_results_jso
 // # Safety
 // * `state_json` must be a valid null-terminated C string
 char *mesh_get_loop_state(const char *state_json);
+
+// Construct a [`JobController`] bound to `(job_id, instance_id)` against the
+// given `registry_url`. Spawns a per-controller background batching tick so
+// mid-flight `update_progress` calls reach the registry on the configured
+// cadence (default 2s — see [`BatchingConfig::default`]); the tick is torn
+// down with a final flush when the handle is freed.
+//
+// # Returns
+// 0 on success (handle written to `*out_handle`), non-zero on error
+// (check `mesh_last_error`).
+//
+// # Safety
+// All input strings must be valid null-terminated UTF-8. `out_handle`
+// must point to writable memory for one `*mut JobControllerHandle`.
+int32_t mesh_job_controller_new(const char *job_id,
+                                const char *instance_id,
+                                const char *registry_url,
+                                struct JobControllerHandle **out_handle);
+
+// Enqueue a progress update. Coalesces with any prior pending progress
+// for this job — only the latest survives the next batch flush.
+//
+// `message` may be NULL (no message).
+//
+// # Safety
+// `handle` must come from [`mesh_job_controller_new`] and must not yet
+// have been freed.
+int32_t mesh_job_controller_update_progress(struct JobControllerHandle *handle,
+                                            double progress,
+                                            const char *message);
+
+// Mark the job complete with the given result (JSON-encoded). Flushes
+// immediately.
+//
+// # Safety
+// `result_json` must be a valid JSON string (UTF-8). Invalid JSON
+// returns -1 with last-error set.
+int32_t mesh_job_controller_complete(struct JobControllerHandle *handle, const char *result_json);
+
+// Mark the job failed with the given error reason. Flushes immediately.
+int32_t mesh_job_controller_fail(struct JobControllerHandle *handle, const char *error);
+
+// Whether `complete` / `fail` has already been called on this controller.
+//
+// # Returns
+// `1` if terminal, `0` if not, `-1` on error.
+int32_t mesh_job_controller_is_terminal(const struct JobControllerHandle *handle);
+
+// Read the job ID this controller is bound to. Caller frees the returned
+// string via `mesh_free_string`.
+int32_t mesh_job_controller_job_id(const struct JobControllerHandle *handle, char **out_job_id);
+
+// Free a [`JobControllerHandle`] returned by [`mesh_job_controller_new`].
+//
+// Drops the inner controller AND the background batching tick (which
+// triggers a final flush of any pending deltas before the tick stops).
+//
+// # Safety
+// `handle` must come from [`mesh_job_controller_new`] or be NULL. After
+// this call, `handle` is invalid and must not be used.
+void mesh_job_controller_free(struct JobControllerHandle *handle);
+
+// Submit a new job via the registry and return a [`JobProxyHandle`].
+//
+// `args_json` must encode a JSON object with these fields (mirroring
+// [`SubmitJobArgs`] field-for-field):
+//
+// ```json
+// {
+//   "registry_url": "http://...",
+//   "capability": "...",
+//   "payload": { ... },
+//   "submitted_by": "...",
+//   "owner_instance_id": "..." | null,
+//   "max_duration": 120 | null,
+//   "max_retries": 1 | null,
+//   "total_deadline": 1700000000 | null
+// }
+// ```
+//
+// JSON-shaped (rather than positional) args mirror the napi-rs
+// `JsSubmitJobArgs` object — keeps the C ABI signature stable as fields
+// are added.
+int32_t mesh_submit_job(const char *args_json, struct JobProxyHandle **out_handle);
+
+// Construct a [`JobProxyHandle`] bound to a known job id + registry URL.
+// Normally callers obtain a proxy via [`mesh_submit_job`] / DDDI injection
+// rather than constructing one directly.
+int32_t mesh_job_proxy_new(const char *job_id,
+                           const char *registry_url,
+                           struct JobProxyHandle **out_handle);
+
+// Read the job id this proxy is bound to. Caller frees via `mesh_free_string`.
+int32_t mesh_job_proxy_job_id(const struct JobProxyHandle *handle, char **out_job_id);
+
+// Read the latest job state from the registry (single GET). The full Job
+// row is serialized as JSON and written to `*out_job_json`; caller frees
+// via `mesh_free_string`.
+int32_t mesh_job_proxy_status(struct JobProxyHandle *handle, char **out_job_json);
+
+// Poll until the job reaches a terminal state. On success writes the job
+// `result` (JSON-encoded) to `*out_result_json`; caller frees via
+// `mesh_free_string`.
+//
+// `timeout_secs`: wall-clock timeout. Use a negative value (e.g. `-1`)
+// for "no timeout" (matches the Python / napi-rs `Optional<f64>` shape).
+int32_t mesh_job_proxy_wait(struct JobProxyHandle *handle,
+                            double timeout_secs,
+                            char **out_result_json);
+
+// Request cancellation. The registry forwards the signal to the owner
+// replica when alive. `reason` may be NULL.
+int32_t mesh_job_proxy_cancel(struct JobProxyHandle *handle, const char *reason);
+
+// Free a [`JobProxyHandle`] returned by [`mesh_submit_job`] /
+// [`mesh_job_proxy_new`].
+void mesh_job_proxy_free(struct JobProxyHandle *handle);
+
+// Snapshot of the active job context on the current Rust task, or NULL
+// if no job is in scope.
+//
+// Writes a JSON object of shape `{"job_id": str, "deadline_secs_remaining":
+// int|null}` to `*out_snapshot_json`. If no context is active, writes NULL
+// (same convention as Python's `current_job` returning `None`).
+//
+// Caller frees the JSON string via `mesh_free_string` if it is non-NULL.
+int32_t mesh_current_job(char **out_snapshot_json);
+
+// Compute the `X-Mesh-Job-Id` / `X-Mesh-Timeout` header values for the
+// active job context, if any.
+//
+// Writes a JSON object `{"X-Mesh-Job-Id": "...", "X-Mesh-Timeout":
+// "<secs>"}` (with `X-Mesh-Timeout` omitted when no deadline is set) to
+// `*out_headers_json`. If no context is active, writes NULL.
+//
+// Caller frees the JSON string via `mesh_free_string` if it is non-NULL.
+int32_t mesh_inject_job_headers(char **out_headers_json);
+
+// Fire the cancel token registered for `job_id` in the process-wide
+// cancel registry, if any.
+//
+// # Returns
+// `1` if a token was found and fired, `0` if no active job for that id,
+// `-1` on error (null/invalid `job_id`).
+int32_t mesh_cancel_active_job(const char *job_id);
+
+// Run a Java-provided callback inside a fresh [`crate::jobs::run_as_job`]
+// scope so the cancel-registry entry under the snapshot's `job_id` is
+// bound for the duration of the callback (allowing
+// `POST /jobs/{id}/cancel` to fire the in-flight cancel token).
+//
+// `snapshot_json` must encode a JSON object of shape
+// `{"job_id": "...", "deadline_secs": <number>|null}` mirroring the
+// payload Java SDK constructs from inbound `X-Mesh-Job-Id` / `X-Mesh-Timeout`
+// headers. `deadline_secs` is the per-attempt deadline (relative); null /
+// missing / non-positive ≡ no deadline.
+//
+// `callback` is invoked synchronously from the runtime's `block_on`. It
+// receives the opaque `user_data` pointer the caller passed in. The
+// callback's `i32` return value is propagated as this function's return
+// value (0 = success, non-zero = caller-defined error).
+//
+// # Safety
+// `callback` must be a valid C function pointer for the entire duration
+// of this call. `user_data` is passed through opaquely — Rust does not
+// dereference it. If the callback panics across the FFI boundary the
+// behaviour is undefined; Java callers must catch all checked / unchecked
+// exceptions in their bridge function.
+//
+// # Caveat
+// The Rust `tokio::task_local!` bound by `with_job` is only visible to
+// Rust futures polled within the scope. Java code in the callback will
+// NOT see the task-local — it must read its own `ThreadLocal` mirror.
+// The Rust side handles two things here:
+//   1. cancel-registry binding so a `POST /jobs/{id}/cancel` arriving
+//      mid-flight fires the in-flight token (the Java SDK reads this via
+//      `mesh_cancel_active_job` from its cancel HTTP route);
+//   2. header injection on Rust-originated outbound work (the cancel
+//      token + `X-Mesh-*` headers are visible to `mesh_call_tool` and
+//      friends polled inside the scope).
+int32_t mesh_run_as_job(const char *snapshot_json, int32_t (*callback)(void*), void *user_data);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/runtime/core/src/ffi.rs
+++ b/src/runtime/core/src/ffi.rs
@@ -32,12 +32,12 @@ thread_local! {
 }
 
 /// Set the last error message for the current thread.
-fn set_last_error(err: impl Into<String>) {
+pub(crate) fn set_last_error(err: impl Into<String>) {
     LAST_ERROR.with(|e| *e.borrow_mut() = Some(err.into()));
 }
 
 /// Take and clear the last error message for the current thread.
-fn take_last_error() -> Option<String> {
+pub(crate) fn take_last_error() -> Option<String> {
     LAST_ERROR.with(|e| e.borrow_mut().take())
 }
 

--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -580,8 +580,11 @@ pub unsafe extern "C" fn mesh_job_proxy_status(
 /// `result` (JSON-encoded) to `*out_result_json`; caller frees via
 /// `mesh_free_string`.
 ///
-/// `timeout_secs`: wall-clock timeout. Use a negative value (e.g. `-1`)
-/// for "no timeout" (matches the Python / napi-rs `Optional<f64>` shape).
+/// `timeout_secs`: wall-clock timeout. Any value `<= 0.0` (including
+/// `-0.0` and negatives such as `-1`) means "no timeout"; non-finite
+/// values (NaN, ±Inf) also fall back to "no timeout". Matches the
+/// Python / napi-rs `Optional<f64>` shape and keeps the same policy
+/// as [`mesh_run_as_job`] for consistency.
 #[no_mangle]
 pub unsafe extern "C" fn mesh_job_proxy_wait(
     handle: *mut JobProxyHandle,
@@ -594,7 +597,9 @@ pub unsafe extern "C" fn mesh_job_proxy_wait(
         return -1;
     }
     let handle = &*handle;
-    let timeout = if timeout_secs.is_sign_negative() || !timeout_secs.is_finite() {
+    // Uniform "no timeout" policy with mesh_run_as_job: `secs <= 0.0`
+    // (covers -0.0 which `< 0.0` would miss in IEEE-754) or non-finite.
+    let timeout = if !timeout_secs.is_finite() || timeout_secs <= 0.0 {
         None
     } else {
         Some(Duration::from_secs_f64(timeout_secs))
@@ -799,13 +804,17 @@ pub unsafe extern "C" fn mesh_run_as_job(
         }
     };
 
-    // Reject negative / NaN / Inf deadlines explicitly (matches the napi-rs
-    // validate_deadline_secs guard — silently aliasing them to "no deadline"
-    // would paper over upstream bugs).
+    // Reject non-finite deadlines explicitly (NaN / ±Inf indicate an
+    // upstream bug — silently aliasing them to "no deadline" would
+    // paper over it). Any finite value `<= 0.0` (including -0.0 and
+    // negatives) is treated as "no deadline" for uniformity with
+    // [`mesh_job_proxy_wait`]. The two functions previously diverged
+    // on -0.0 handling (`is_sign_negative` vs `< 0.0`); a single
+    // policy avoids future drift.
     if let Some(secs) = wire.deadline_secs {
-        if !secs.is_finite() || secs < 0.0 {
+        if !secs.is_finite() {
             set_last_error(format!(
-                "mesh_run_as_job: invalid deadline_secs ({}) for job {} — must be a non-negative finite number or null",
+                "mesh_run_as_job: invalid deadline_secs ({}) for job {} — must be a finite number or null",
                 secs, wire.job_id
             ));
             return -1;
@@ -905,15 +914,62 @@ mod tests {
         assert_eq!(rc, -1);
     }
 
-    /// Negative / NaN / Inf deadline rejection mirrors the napi-rs
-    /// `validate_deadline_secs` policy — surfaces a clean error instead of
-    /// silently aliasing to "no deadline".
+    /// Non-finite deadline (NaN / +Inf) rejection — these indicate a real
+    /// upstream bug, so we surface a clean error rather than silently
+    /// aliasing to "no deadline". Negative + zero values are NOT
+    /// rejected; they are treated as "no deadline" for uniformity with
+    /// `mesh_job_proxy_wait` (see `wait_treats_zero_and_negative_as_no_timeout`).
     #[test]
-    fn run_as_job_rejects_negative_deadline() {
+    fn run_as_job_rejects_non_finite_deadline() {
         extern "C" fn cb(_: *mut c_void) -> i32 { 0 }
-        let bad = CString::new(r#"{"job_id":"j-neg","deadline_secs":-5.0}"#).unwrap();
+        // NaN and +Inf both rejected — JSON does not encode these as
+        // numbers, but if a buggy caller stringifies them as "NaN" /
+        // "Infinity" the snapshot parse will already fail; the
+        // is_finite branch is the defence-in-depth check for futures
+        // where the wire encoding gains support.
+        let bad = CString::new(r#"{"job_id":"j-nan","deadline_secs":1e400}"#).unwrap();
         let rc = unsafe { mesh_run_as_job(bad.as_ptr(), cb, ptr::null_mut()) };
-        assert_eq!(rc, -1);
+        assert_eq!(rc, -1, "+Inf deadline must be rejected");
+    }
+
+    /// Boundary policy for `mesh_run_as_job`: zero, -0.0, and finite
+    /// negative deadlines all collapse to "no deadline" and the callback
+    /// runs successfully. Mirrors the same policy in
+    /// `mesh_job_proxy_wait` so future maintainers don't have to choose
+    /// between two operators.
+    #[test]
+    fn run_as_job_treats_zero_and_negative_deadline_as_no_deadline() {
+        extern "C" fn cb(_: *mut c_void) -> i32 { 0 }
+        for snap_json in [
+            r#"{"job_id":"j-zero","deadline_secs":0.0}"#,
+            r#"{"job_id":"j-negzero","deadline_secs":-0.0}"#,
+            r#"{"job_id":"j-neg","deadline_secs":-5.0}"#,
+        ] {
+            let snap = CString::new(snap_json).unwrap();
+            let rc = unsafe { mesh_run_as_job(snap.as_ptr(), cb, ptr::null_mut()) };
+            assert_eq!(rc, 0, "expected no-deadline policy for {}", snap_json);
+        }
+    }
+
+    /// Boundary policy for `mesh_job_proxy_wait`'s timeout argument:
+    /// zero, -0.0, and negative values all map to "no timeout"
+    /// (Option::None passed to the inner wait), and non-finite values
+    /// (NaN, ±Inf) map to "no timeout" too. We can't easily call the
+    /// wait FFI without a real handle here, so we exercise the same
+    /// predicate the FFI uses.
+    #[test]
+    fn wait_treats_zero_and_negative_as_no_timeout() {
+        fn would_be_no_timeout(secs: f64) -> bool {
+            !secs.is_finite() || secs <= 0.0
+        }
+        assert!(would_be_no_timeout(0.0));
+        assert!(would_be_no_timeout(-0.0));
+        assert!(would_be_no_timeout(-1.0));
+        assert!(would_be_no_timeout(f64::NAN));
+        assert!(would_be_no_timeout(f64::INFINITY));
+        assert!(would_be_no_timeout(f64::NEG_INFINITY));
+        assert!(!would_be_no_timeout(0.001));
+        assert!(!would_be_no_timeout(60.0));
     }
 
     /// Happy-path: snapshot with no deadline, callback returns 0.

--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -1,0 +1,934 @@
+//! C-ABI bindings for the MeshJob substrate (Phase 1 — Java SDK).
+//!
+//! Mirror of [`crate::jobs_py`] (PyO3) and [`crate::jobs_napi`] (napi-rs)
+//! exposed via the C ABI so JNR-FFI consumers (Java, Kotlin, etc.) can drive
+//! the producer-side [`crate::jobs::JobController`] and consumer-side
+//! [`crate::jobs::JobProxy`] from `libmcp_mesh_core.{dylib,so,dll}`.
+//!
+//! # Async pattern
+//! The C ABI cannot return Promises / Futures, so blocking-from-Java methods
+//! bridge through a process-wide [`tokio::runtime::Runtime`] (initialized
+//! lazily in [`jobs_runtime`]) and `block_on` the underlying async API.
+//! Java callers wrap these in `CompletableFuture` on their side if they
+//! want async ergonomics.
+//!
+//! # Error handling
+//! Functions return `i32` status codes (`0` = success, non-zero = error)
+//! and stash a thread-local error message in [`crate::ffi::set_last_error`]
+//! that callers fetch via `mesh_last_error`. String outputs are passed via
+//! `*mut *mut c_char` out-parameters; the caller frees with `mesh_free_string`.
+//!
+//! # Caveat — task-local visibility from Java
+//! Like the Python / TS bindings: the Rust `tokio::task_local!` bound by
+//! [`crate::job_context::with_job`] is only visible to Rust futures polled
+//! within the scope. Java threads do NOT inherit the task-local across the
+//! JNR-FFI boundary. The Java SDK MUST mirror the context in its own
+//! `ThreadLocal` (see `JobContext.java`) for visibility to user code and
+//! to Java-originated outbound calls. The Rust side handles two things:
+//!
+//!   1. cancel-registry binding so `POST /jobs/{id}/cancel` can fire the
+//!      in-flight cancel token (visible to any Rust futures polled within
+//!      the scope, including the `mesh_call_tool` outbound HTTP path);
+//!   2. header injection on Rust-originated outbound work via
+//!      [`mesh_inject_job_headers`].
+
+#![cfg(feature = "ffi")]
+
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_void};
+use std::ptr;
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use tokio::runtime::Runtime;
+
+use crate::cancel_registry;
+use crate::ffi::{set_last_error, take_last_error};
+use crate::job_context::{self, JobContext};
+use crate::jobs::{
+    new_coalescing_queue, run_as_job, spawn_batching_tick, submit_job, BatchingConfig,
+    BatchingHandle, JobController, JobError, JobProxy, SubmitJobArgs,
+};
+use crate::task_backend::{Job, JobStatus, RegistryHttpBackend, TaskBackend};
+
+// =============================================================================
+// Process-wide blocking runtime
+// =============================================================================
+
+/// Lazily-initialized multi-thread tokio runtime used by the FFI layer to
+/// `block_on` async core APIs (the C ABI cannot expose async). One runtime
+/// per process keeps the resource cost down — JNR-FFI consumers don't pay
+/// per-call overhead for runtime construction.
+fn jobs_runtime() -> &'static Runtime {
+    static RT: OnceLock<Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        Runtime::new().expect("failed to construct jobs FFI tokio runtime")
+    })
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Read a possibly-null `*const c_char` as `Option<&str>`. Returns `None`
+/// for null pointers; returns `Err` for invalid UTF-8 (with the error
+/// stashed in the thread-local last-error slot).
+unsafe fn opt_cstr<'a>(ptr: *const c_char, name: &str) -> Result<Option<&'a str>, ()> {
+    if ptr.is_null() {
+        return Ok(None);
+    }
+    match CStr::from_ptr(ptr).to_str() {
+        Ok(s) => Ok(Some(s)),
+        Err(e) => {
+            set_last_error(format!("Invalid UTF-8 in {}: {}", name, e));
+            Err(())
+        }
+    }
+}
+
+/// Read a non-null `*const c_char` as `&str`. Sets last-error and returns
+/// `Err` for null or invalid UTF-8.
+unsafe fn req_cstr<'a>(ptr: *const c_char, name: &str) -> Result<&'a str, ()> {
+    if ptr.is_null() {
+        set_last_error(format!("{} is null", name));
+        return Err(());
+    }
+    match CStr::from_ptr(ptr).to_str() {
+        Ok(s) => Ok(s),
+        Err(e) => {
+            set_last_error(format!("Invalid UTF-8 in {}: {}", name, e));
+            Err(())
+        }
+    }
+}
+
+/// Allocate a C string from a Rust string and write it to `out`. Returns
+/// 0 on success, -1 on allocation failure (with last-error set).
+unsafe fn write_out_string(out: *mut *mut c_char, value: String) -> i32 {
+    if out.is_null() {
+        set_last_error("output pointer is null");
+        return -1;
+    }
+    match CString::new(value) {
+        Ok(c) => {
+            *out = c.into_raw();
+            0
+        }
+        Err(e) => {
+            set_last_error(format!("Failed to create C string (interior NUL): {}", e));
+            -1
+        }
+    }
+}
+
+/// Build an `Arc<dyn TaskBackend>` from a registry URL. Sets last-error and
+/// returns `None` on transport-construction failure.
+fn backend_from_url(registry_url: &str) -> Option<Arc<dyn TaskBackend>> {
+    match RegistryHttpBackend::new(registry_url) {
+        Ok(b) => Some(b.into_arc()),
+        Err(e) => {
+            set_last_error(format!("backend init failed: {}", e));
+            None
+        }
+    }
+}
+
+/// Stash a [`JobError`] into the thread-local last-error slot. Returns the
+/// error code -1 so callers can `return jobs_set_err(e);` directly.
+fn jobs_set_err(err: JobError) -> i32 {
+    set_last_error(err.to_string());
+    -1
+}
+
+fn job_status_to_str(s: JobStatus) -> &'static str {
+    match s {
+        JobStatus::Working => "working",
+        JobStatus::InputRequired => "input_required",
+        JobStatus::Completed => "completed",
+        JobStatus::Failed => "failed",
+        JobStatus::Cancelled => "cancelled",
+    }
+}
+
+/// Serialize a [`Job`] row to JSON matching the wire shape Python/TS bindings
+/// expose (and the registry's `Job` schema). Java callers parse this with
+/// Jackson on their side.
+fn job_to_json_string(job: Job) -> String {
+    let value = serde_json::json!({
+        "id": job.id,
+        "capability": job.capability,
+        "owner_instance_id": job.owner_instance_id,
+        "status": job_status_to_str(job.status),
+        "progress": job.progress,
+        "progress_message": job.progress_message,
+        "result": job.result.unwrap_or(serde_json::Value::Null),
+        "error": job.error,
+        "submitted_payload": job.submitted_payload,
+        "attempt_count": job.attempt_count,
+        "max_retries": job.max_retries,
+        "max_duration": job.max_duration,
+        "total_deadline": job.total_deadline,
+        "lease_expires_at": job.lease_expires_at,
+        "last_heartbeat_at": job.last_heartbeat_at,
+        "submitted_at": job.submitted_at,
+        "submitted_by": job.submitted_by,
+    });
+    value.to_string()
+}
+
+// =============================================================================
+// Opaque handles (C-visible structs)
+// =============================================================================
+
+/// Opaque handle wrapping a [`JobController`] plus its background batching
+/// tick. The tick is held alongside the controller so it lives until the
+/// caller invokes [`mesh_job_controller_free`] (mirrors PyJobController /
+/// JsJobController which both keep a `BatchingHandle` field).
+///
+/// Not `#[repr(C)]` — internals stay opaque to C consumers.
+pub struct JobControllerHandle {
+    inner: JobController,
+    /// Per-controller batching tick — same per-instance pattern as the
+    /// Python/TS bindings. Dropped (= cancelled with final flush) when the
+    /// caller frees the handle. Optional so future feature flags can degrade
+    /// gracefully (terminal flushes work without it).
+    _batching: Option<BatchingHandle>,
+}
+
+/// Opaque handle wrapping a [`JobProxy`].
+pub struct JobProxyHandle {
+    inner: JobProxy,
+}
+
+// =============================================================================
+// JobController: producer-side C ABI
+// =============================================================================
+
+/// Construct a [`JobController`] bound to `(job_id, instance_id)` against the
+/// given `registry_url`. Spawns a per-controller background batching tick so
+/// mid-flight `update_progress` calls reach the registry on the configured
+/// cadence (default 2s — see [`BatchingConfig::default`]); the tick is torn
+/// down with a final flush when the handle is freed.
+///
+/// # Returns
+/// 0 on success (handle written to `*out_handle`), non-zero on error
+/// (check `mesh_last_error`).
+///
+/// # Safety
+/// All input strings must be valid null-terminated UTF-8. `out_handle`
+/// must point to writable memory for one `*mut JobControllerHandle`.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_controller_new(
+    job_id: *const c_char,
+    instance_id: *const c_char,
+    registry_url: *const c_char,
+    out_handle: *mut *mut JobControllerHandle,
+) -> i32 {
+    take_last_error();
+    if out_handle.is_null() {
+        set_last_error("out_handle is null");
+        return -1;
+    }
+    let job_id = match req_cstr(job_id, "job_id") {
+        Ok(s) => s.to_string(),
+        Err(()) => return -1,
+    };
+    let instance_id = match req_cstr(instance_id, "instance_id") {
+        Ok(s) => s.to_string(),
+        Err(()) => return -1,
+    };
+    let registry_url = match req_cstr(registry_url, "registry_url") {
+        Ok(s) => s,
+        Err(()) => return -1,
+    };
+    let backend = match backend_from_url(registry_url) {
+        Some(b) => b,
+        None => return -1,
+    };
+
+    let queue = new_coalescing_queue();
+    let inner = JobController::new(
+        job_id,
+        instance_id.clone(),
+        backend.clone(),
+        queue.clone(),
+    );
+
+    // Spawn the batching tick inside the FFI tokio runtime so mid-flight
+    // progress deltas actually reach the registry. Mirrors the Python /
+    // napi pattern of entering the runtime context for `tokio::spawn` to
+    // resolve a valid handle.
+    let batching = {
+        let _guard = jobs_runtime().enter();
+        spawn_batching_tick(queue, backend, instance_id, BatchingConfig::default())
+    };
+
+    let handle = Box::new(JobControllerHandle {
+        inner,
+        _batching: Some(batching),
+    });
+    *out_handle = Box::into_raw(handle);
+    0
+}
+
+/// Enqueue a progress update. Coalesces with any prior pending progress
+/// for this job — only the latest survives the next batch flush.
+///
+/// `message` may be NULL (no message).
+///
+/// # Safety
+/// `handle` must come from [`mesh_job_controller_new`] and must not yet
+/// have been freed.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_controller_update_progress(
+    handle: *mut JobControllerHandle,
+    progress: f64,
+    message: *const c_char,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    let handle = &*handle;
+    let message = match opt_cstr(message, "message") {
+        Ok(s) => s.map(str::to_string),
+        Err(()) => return -1,
+    };
+    let inner = handle.inner.clone();
+    let progress = progress as f32;
+    jobs_runtime().block_on(async move {
+        inner.update_progress(progress, message).await;
+    });
+    0
+}
+
+/// Mark the job complete with the given result (JSON-encoded). Flushes
+/// immediately.
+///
+/// # Safety
+/// `result_json` must be a valid JSON string (UTF-8). Invalid JSON
+/// returns -1 with last-error set.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_controller_complete(
+    handle: *mut JobControllerHandle,
+    result_json: *const c_char,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    let handle = &*handle;
+    let result_str = match req_cstr(result_json, "result_json") {
+        Ok(s) => s,
+        Err(()) => return -1,
+    };
+    let value: serde_json::Value = match serde_json::from_str(result_str) {
+        Ok(v) => v,
+        Err(e) => {
+            set_last_error(format!("invalid result_json: {}", e));
+            return -1;
+        }
+    };
+    let inner = handle.inner.clone();
+    jobs_runtime().block_on(async move { inner.complete(value).await })
+        .map(|_| 0)
+        .unwrap_or_else(jobs_set_err)
+}
+
+/// Mark the job failed with the given error reason. Flushes immediately.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_controller_fail(
+    handle: *mut JobControllerHandle,
+    error: *const c_char,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    let handle = &*handle;
+    let error_str = match req_cstr(error, "error") {
+        Ok(s) => s.to_string(),
+        Err(()) => return -1,
+    };
+    let inner = handle.inner.clone();
+    jobs_runtime().block_on(async move { inner.fail(error_str).await })
+        .map(|_| 0)
+        .unwrap_or_else(jobs_set_err)
+}
+
+/// Whether `complete` / `fail` has already been called on this controller.
+///
+/// # Returns
+/// `1` if terminal, `0` if not, `-1` on error.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_controller_is_terminal(
+    handle: *const JobControllerHandle,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    let handle = &*handle;
+    let inner = handle.inner.clone();
+    let terminal = jobs_runtime().block_on(async move { inner.is_terminal().await });
+    if terminal {
+        1
+    } else {
+        0
+    }
+}
+
+/// Read the job ID this controller is bound to. Caller frees the returned
+/// string via `mesh_free_string`.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_controller_job_id(
+    handle: *const JobControllerHandle,
+    out_job_id: *mut *mut c_char,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    let handle = &*handle;
+    write_out_string(out_job_id, handle.inner.job_id().to_string())
+}
+
+/// Free a [`JobControllerHandle`] returned by [`mesh_job_controller_new`].
+///
+/// Drops the inner controller AND the background batching tick (which
+/// triggers a final flush of any pending deltas before the tick stops).
+///
+/// # Safety
+/// `handle` must come from [`mesh_job_controller_new`] or be NULL. After
+/// this call, `handle` is invalid and must not be used.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_controller_free(handle: *mut JobControllerHandle) {
+    if handle.is_null() {
+        return;
+    }
+    drop(Box::from_raw(handle));
+}
+
+// =============================================================================
+// JobProxy: consumer-side C ABI
+// =============================================================================
+
+/// Submit a new job via the registry and return a [`JobProxyHandle`].
+///
+/// `args_json` must encode a JSON object with these fields (mirroring
+/// [`SubmitJobArgs`] field-for-field):
+///
+/// ```json
+/// {
+///   "registry_url": "http://...",
+///   "capability": "...",
+///   "payload": { ... },
+///   "submitted_by": "...",
+///   "owner_instance_id": "..." | null,
+///   "max_duration": 120 | null,
+///   "max_retries": 1 | null,
+///   "total_deadline": 1700000000 | null
+/// }
+/// ```
+///
+/// JSON-shaped (rather than positional) args mirror the napi-rs
+/// `JsSubmitJobArgs` object — keeps the C ABI signature stable as fields
+/// are added.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_submit_job(
+    args_json: *const c_char,
+    out_handle: *mut *mut JobProxyHandle,
+) -> i32 {
+    take_last_error();
+    if out_handle.is_null() {
+        set_last_error("out_handle is null");
+        return -1;
+    }
+    let args_str = match req_cstr(args_json, "args_json") {
+        Ok(s) => s,
+        Err(()) => return -1,
+    };
+
+    // Parse with a permissive shape so missing optional fields default to
+    // None. Required fields (registry_url, capability, payload, submitted_by)
+    // surface a clean error if absent.
+    #[derive(serde::Deserialize)]
+    struct SubmitArgsWire {
+        registry_url: String,
+        capability: String,
+        payload: serde_json::Value,
+        submitted_by: String,
+        #[serde(default)]
+        owner_instance_id: Option<String>,
+        #[serde(default)]
+        max_duration: Option<u32>,
+        #[serde(default)]
+        max_retries: Option<u32>,
+        #[serde(default)]
+        total_deadline: Option<i64>,
+    }
+    let wire: SubmitArgsWire = match serde_json::from_str(args_str) {
+        Ok(w) => w,
+        Err(e) => {
+            set_last_error(format!("invalid args_json: {}", e));
+            return -1;
+        }
+    };
+
+    let backend = match backend_from_url(&wire.registry_url) {
+        Some(b) => b,
+        None => return -1,
+    };
+    let args = SubmitJobArgs {
+        capability: wire.capability,
+        payload: wire.payload,
+        submitted_by: wire.submitted_by,
+        owner_instance_id: wire.owner_instance_id,
+        max_duration: wire.max_duration,
+        max_retries: wire.max_retries,
+        total_deadline: wire.total_deadline,
+    };
+
+    let result = jobs_runtime().block_on(async move { submit_job(backend, args).await });
+    match result {
+        Ok((proxy, _resp)) => {
+            let handle = Box::new(JobProxyHandle { inner: proxy });
+            *out_handle = Box::into_raw(handle);
+            0
+        }
+        Err(e) => jobs_set_err(e),
+    }
+}
+
+/// Construct a [`JobProxyHandle`] bound to a known job id + registry URL.
+/// Normally callers obtain a proxy via [`mesh_submit_job`] / DDDI injection
+/// rather than constructing one directly.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_proxy_new(
+    job_id: *const c_char,
+    registry_url: *const c_char,
+    out_handle: *mut *mut JobProxyHandle,
+) -> i32 {
+    take_last_error();
+    if out_handle.is_null() {
+        set_last_error("out_handle is null");
+        return -1;
+    }
+    let job_id = match req_cstr(job_id, "job_id") {
+        Ok(s) => s.to_string(),
+        Err(()) => return -1,
+    };
+    let registry_url = match req_cstr(registry_url, "registry_url") {
+        Ok(s) => s,
+        Err(()) => return -1,
+    };
+    let backend = match backend_from_url(registry_url) {
+        Some(b) => b,
+        None => return -1,
+    };
+    let handle = Box::new(JobProxyHandle {
+        inner: JobProxy::new(job_id, backend),
+    });
+    *out_handle = Box::into_raw(handle);
+    0
+}
+
+/// Read the job id this proxy is bound to. Caller frees via `mesh_free_string`.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_proxy_job_id(
+    handle: *const JobProxyHandle,
+    out_job_id: *mut *mut c_char,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    let handle = &*handle;
+    write_out_string(out_job_id, handle.inner.job_id().to_string())
+}
+
+/// Read the latest job state from the registry (single GET). The full Job
+/// row is serialized as JSON and written to `*out_job_json`; caller frees
+/// via `mesh_free_string`.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_proxy_status(
+    handle: *mut JobProxyHandle,
+    out_job_json: *mut *mut c_char,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    let handle = &*handle;
+    let inner = handle.inner.clone();
+    let result = jobs_runtime().block_on(async move { inner.status().await });
+    match result {
+        Ok(job) => write_out_string(out_job_json, job_to_json_string(job)),
+        Err(e) => jobs_set_err(e),
+    }
+}
+
+/// Poll until the job reaches a terminal state. On success writes the job
+/// `result` (JSON-encoded) to `*out_result_json`; caller frees via
+/// `mesh_free_string`.
+///
+/// `timeout_secs`: wall-clock timeout. Use a negative value (e.g. `-1`)
+/// for "no timeout" (matches the Python / napi-rs `Optional<f64>` shape).
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_proxy_wait(
+    handle: *mut JobProxyHandle,
+    timeout_secs: f64,
+    out_result_json: *mut *mut c_char,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    let handle = &*handle;
+    let timeout = if timeout_secs.is_sign_negative() || !timeout_secs.is_finite() {
+        None
+    } else {
+        Some(Duration::from_secs_f64(timeout_secs))
+    };
+    let inner = handle.inner.clone();
+    let result = jobs_runtime().block_on(async move { inner.wait(timeout).await });
+    match result {
+        Ok(value) => write_out_string(out_result_json, value.to_string()),
+        Err(e) => jobs_set_err(e),
+    }
+}
+
+/// Request cancellation. The registry forwards the signal to the owner
+/// replica when alive. `reason` may be NULL.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_proxy_cancel(
+    handle: *mut JobProxyHandle,
+    reason: *const c_char,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    let handle = &*handle;
+    let reason = match opt_cstr(reason, "reason") {
+        Ok(s) => s.map(str::to_string),
+        Err(()) => return -1,
+    };
+    let inner = handle.inner.clone();
+    jobs_runtime().block_on(async move { inner.cancel(reason).await })
+        .map(|_| 0)
+        .unwrap_or_else(jobs_set_err)
+}
+
+/// Free a [`JobProxyHandle`] returned by [`mesh_submit_job`] /
+/// [`mesh_job_proxy_new`].
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_proxy_free(handle: *mut JobProxyHandle) {
+    if handle.is_null() {
+        return;
+    }
+    drop(Box::from_raw(handle));
+}
+
+// =============================================================================
+// Context + cancel registry C ABI
+// =============================================================================
+
+/// Snapshot of the active job context on the current Rust task, or NULL
+/// if no job is in scope.
+///
+/// Writes a JSON object of shape `{"job_id": str, "deadline_secs_remaining":
+/// int|null}` to `*out_snapshot_json`. If no context is active, writes NULL
+/// (same convention as Python's `current_job` returning `None`).
+///
+/// Caller frees the JSON string via `mesh_free_string` if it is non-NULL.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_current_job(out_snapshot_json: *mut *mut c_char) -> i32 {
+    take_last_error();
+    if out_snapshot_json.is_null() {
+        set_last_error("out_snapshot_json is null");
+        return -1;
+    }
+    match job_context::current() {
+        None => {
+            *out_snapshot_json = ptr::null_mut();
+            0
+        }
+        Some(ctx) => {
+            let value = serde_json::json!({
+                "job_id": ctx.job_id,
+                "deadline_secs_remaining": ctx.remaining_seconds(),
+            });
+            write_out_string(out_snapshot_json, value.to_string())
+        }
+    }
+}
+
+/// Compute the `X-Mesh-Job-Id` / `X-Mesh-Timeout` header values for the
+/// active job context, if any.
+///
+/// Writes a JSON object `{"X-Mesh-Job-Id": "...", "X-Mesh-Timeout":
+/// "<secs>"}` (with `X-Mesh-Timeout` omitted when no deadline is set) to
+/// `*out_headers_json`. If no context is active, writes NULL.
+///
+/// Caller frees the JSON string via `mesh_free_string` if it is non-NULL.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_inject_job_headers(out_headers_json: *mut *mut c_char) -> i32 {
+    take_last_error();
+    if out_headers_json.is_null() {
+        set_last_error("out_headers_json is null");
+        return -1;
+    }
+    match job_context::current() {
+        None => {
+            *out_headers_json = ptr::null_mut();
+            0
+        }
+        Some(ctx) => {
+            let remaining = ctx.remaining_seconds();
+            let mut map = serde_json::Map::new();
+            map.insert(
+                "X-Mesh-Job-Id".to_string(),
+                serde_json::Value::String(ctx.job_id),
+            );
+            if let Some(secs) = remaining {
+                map.insert(
+                    "X-Mesh-Timeout".to_string(),
+                    serde_json::Value::String(secs.to_string()),
+                );
+            }
+            write_out_string(
+                out_headers_json,
+                serde_json::Value::Object(map).to_string(),
+            )
+        }
+    }
+}
+
+/// Fire the cancel token registered for `job_id` in the process-wide
+/// cancel registry, if any.
+///
+/// # Returns
+/// `1` if a token was found and fired, `0` if no active job for that id,
+/// `-1` on error (null/invalid `job_id`).
+#[no_mangle]
+pub unsafe extern "C" fn mesh_cancel_active_job(job_id: *const c_char) -> i32 {
+    take_last_error();
+    let job_id = match req_cstr(job_id, "job_id") {
+        Ok(s) => s,
+        Err(()) => return -1,
+    };
+    if cancel_registry::cancel_active_job(job_id) {
+        1
+    } else {
+        0
+    }
+}
+
+// =============================================================================
+// run_as_job — callback-based scope binding
+// =============================================================================
+
+/// Run a Java-provided callback inside a fresh [`crate::jobs::run_as_job`]
+/// scope so the cancel-registry entry under the snapshot's `job_id` is
+/// bound for the duration of the callback (allowing
+/// `POST /jobs/{id}/cancel` to fire the in-flight cancel token).
+///
+/// `snapshot_json` must encode a JSON object of shape
+/// `{"job_id": "...", "deadline_secs": <number>|null}` mirroring the
+/// payload Java SDK constructs from inbound `X-Mesh-Job-Id` / `X-Mesh-Timeout`
+/// headers. `deadline_secs` is the per-attempt deadline (relative); null /
+/// missing / non-positive ≡ no deadline.
+///
+/// `callback` is invoked synchronously from the runtime's `block_on`. It
+/// receives the opaque `user_data` pointer the caller passed in. The
+/// callback's `i32` return value is propagated as this function's return
+/// value (0 = success, non-zero = caller-defined error).
+///
+/// # Safety
+/// `callback` must be a valid C function pointer for the entire duration
+/// of this call. `user_data` is passed through opaquely — Rust does not
+/// dereference it. If the callback panics across the FFI boundary the
+/// behaviour is undefined; Java callers must catch all checked / unchecked
+/// exceptions in their bridge function.
+///
+/// # Caveat
+/// The Rust `tokio::task_local!` bound by `with_job` is only visible to
+/// Rust futures polled within the scope. Java code in the callback will
+/// NOT see the task-local — it must read its own `ThreadLocal` mirror.
+/// The Rust side handles two things here:
+///   1. cancel-registry binding so a `POST /jobs/{id}/cancel` arriving
+///      mid-flight fires the in-flight token (the Java SDK reads this via
+///      `mesh_cancel_active_job` from its cancel HTTP route);
+///   2. header injection on Rust-originated outbound work (the cancel
+///      token + `X-Mesh-*` headers are visible to `mesh_call_tool` and
+///      friends polled inside the scope).
+#[no_mangle]
+pub unsafe extern "C" fn mesh_run_as_job(
+    snapshot_json: *const c_char,
+    callback: extern "C" fn(*mut c_void) -> i32,
+    user_data: *mut c_void,
+) -> i32 {
+    take_last_error();
+    let snap_str = match req_cstr(snapshot_json, "snapshot_json") {
+        Ok(s) => s,
+        Err(()) => return -1,
+    };
+
+    #[derive(serde::Deserialize)]
+    struct SnapshotWire {
+        job_id: String,
+        #[serde(default)]
+        deadline_secs: Option<f64>,
+    }
+    let wire: SnapshotWire = match serde_json::from_str(snap_str) {
+        Ok(w) => w,
+        Err(e) => {
+            set_last_error(format!("invalid snapshot_json: {}", e));
+            return -1;
+        }
+    };
+
+    // Reject negative / NaN / Inf deadlines explicitly (matches the napi-rs
+    // validate_deadline_secs guard — silently aliasing them to "no deadline"
+    // would paper over upstream bugs).
+    if let Some(secs) = wire.deadline_secs {
+        if !secs.is_finite() || secs < 0.0 {
+            set_last_error(format!(
+                "mesh_run_as_job: invalid deadline_secs ({}) for job {} — must be a non-negative finite number or null",
+                secs, wire.job_id
+            ));
+            return -1;
+        }
+    }
+
+    let ctx = match wire.deadline_secs {
+        Some(secs) if secs > 0.0 => {
+            JobContext::with_timeout(wire.job_id, Duration::from_secs_f64(secs))
+        }
+        _ => JobContext::new(wire.job_id),
+    };
+
+    // Wrap the user pointer so we can move it into the async block without
+    // raw-pointer Send/Sync issues. The C contract is: `user_data` is
+    // opaque; Rust never derefs it, just hands it back to the callback.
+    struct UserDataPtr(*mut c_void);
+    unsafe impl Send for UserDataPtr {}
+    let ud = UserDataPtr(user_data);
+
+    jobs_runtime().block_on(async move {
+        run_as_job(ctx, async move {
+            let UserDataPtr(ptr) = ud;
+            callback(ptr)
+        })
+        .await
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+    use std::sync::atomic::{AtomicI32, Ordering};
+
+    /// Smoke test for the [`opt_cstr`] / [`req_cstr`] helpers — they are
+    /// unsafe internally but the safe inputs below cover the happy path
+    /// and the null-pointer guard without requiring native callers.
+    #[test]
+    fn req_cstr_rejects_null() {
+        let res = unsafe { req_cstr(ptr::null(), "x") };
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn opt_cstr_returns_none_for_null() {
+        let res = unsafe { opt_cstr(ptr::null(), "x") };
+        assert_eq!(res.unwrap(), None);
+    }
+
+    #[test]
+    fn opt_cstr_returns_some_for_value() {
+        let s = CString::new("hello").unwrap();
+        let res = unsafe { opt_cstr(s.as_ptr(), "x") };
+        assert_eq!(res.unwrap(), Some("hello"));
+    }
+
+    /// `mesh_current_job` must write NULL when no context is active —
+    /// matches Python's `current_job_py` returning `None` and TS's
+    /// `currentJob` returning `null`. Java callers branch on the null
+    /// pointer rather than parsing an empty object.
+    #[test]
+    fn current_job_writes_null_outside_scope() {
+        let mut out: *mut c_char = ptr::null_mut();
+        let rc = unsafe { mesh_current_job(&mut out as *mut _) };
+        assert_eq!(rc, 0);
+        assert!(out.is_null(), "expected NULL when no active context");
+    }
+
+    /// `mesh_inject_job_headers` outside-of-scope must also be NULL — same
+    /// "no headers" semantics as the napi `injectJobHeaders() -> null`.
+    #[test]
+    fn inject_job_headers_writes_null_outside_scope() {
+        let mut out: *mut c_char = ptr::null_mut();
+        let rc = unsafe { mesh_inject_job_headers(&mut out as *mut _) };
+        assert_eq!(rc, 0);
+        assert!(out.is_null());
+    }
+
+    /// `mesh_cancel_active_job` returns 0 when no active job — same
+    /// false-on-miss semantics as `cancel_registry::cancel_active_job`.
+    #[test]
+    fn cancel_active_job_returns_zero_when_unknown() {
+        let id = CString::new("does-not-exist-ffi-test").unwrap();
+        let rc = unsafe { mesh_cancel_active_job(id.as_ptr()) };
+        assert_eq!(rc, 0);
+    }
+
+    /// `mesh_run_as_job` must reject malformed JSON cleanly via the
+    /// last-error slot rather than panicking. Matches the pattern used by
+    /// `mesh_submit_job` for the wire-args parse failure.
+    #[test]
+    fn run_as_job_rejects_invalid_snapshot_json() {
+        extern "C" fn cb(_: *mut c_void) -> i32 { 0 }
+        let bad = CString::new("not-json").unwrap();
+        let rc = unsafe { mesh_run_as_job(bad.as_ptr(), cb, ptr::null_mut()) };
+        assert_eq!(rc, -1);
+    }
+
+    /// Negative / NaN / Inf deadline rejection mirrors the napi-rs
+    /// `validate_deadline_secs` policy — surfaces a clean error instead of
+    /// silently aliasing to "no deadline".
+    #[test]
+    fn run_as_job_rejects_negative_deadline() {
+        extern "C" fn cb(_: *mut c_void) -> i32 { 0 }
+        let bad = CString::new(r#"{"job_id":"j-neg","deadline_secs":-5.0}"#).unwrap();
+        let rc = unsafe { mesh_run_as_job(bad.as_ptr(), cb, ptr::null_mut()) };
+        assert_eq!(rc, -1);
+    }
+
+    /// Happy-path: snapshot with no deadline, callback returns 0.
+    /// Verifies the callback is actually invoked AND its return value
+    /// propagates as the FFI return value.
+    #[test]
+    fn run_as_job_invokes_callback_and_propagates_return() {
+        static SEEN: AtomicI32 = AtomicI32::new(0);
+        extern "C" fn cb(_: *mut c_void) -> i32 {
+            SEEN.fetch_add(1, Ordering::SeqCst);
+            42
+        }
+        let snap = CString::new(r#"{"job_id":"j-cb"}"#).unwrap();
+        let rc = unsafe { mesh_run_as_job(snap.as_ptr(), cb, ptr::null_mut()) };
+        assert_eq!(rc, 42, "callback return value must propagate");
+        assert_eq!(SEEN.load(Ordering::SeqCst), 1, "callback should run exactly once");
+    }
+}

--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -599,10 +599,22 @@ pub unsafe extern "C" fn mesh_job_proxy_wait(
     let handle = &*handle;
     // Uniform "no timeout" policy with mesh_run_as_job: `secs <= 0.0`
     // (covers -0.0 which `< 0.0` would miss in IEEE-754) or non-finite.
+    // Use try_from_secs_f64 — `from_secs_f64` panics on overflow (e.g.
+    // `f64::MAX`); we surface the failure cleanly via the last-error
+    // slot so a buggy caller can't crash the host process. (PR #891 review.)
     let timeout = if !timeout_secs.is_finite() || timeout_secs <= 0.0 {
         None
     } else {
-        Some(Duration::from_secs_f64(timeout_secs))
+        match Duration::try_from_secs_f64(timeout_secs) {
+            Ok(d) => Some(d),
+            Err(e) => {
+                set_last_error(format!(
+                    "mesh_job_proxy_wait: invalid timeout_secs ({}): {}",
+                    timeout_secs, e
+                ));
+                return -1;
+            }
+        }
     };
     let inner = handle.inner.clone();
     let result = jobs_runtime().block_on(async move { inner.wait(timeout).await });
@@ -821,10 +833,20 @@ pub unsafe extern "C" fn mesh_run_as_job(
         }
     }
 
+    // `try_from_secs_f64` rather than `from_secs_f64` — the latter panics
+    // for very-large finite values (e.g. `f64::MAX`); a buggy caller
+    // shouldn't be able to abort the host process. (PR #891 review.)
     let ctx = match wire.deadline_secs {
-        Some(secs) if secs > 0.0 => {
-            JobContext::with_timeout(wire.job_id, Duration::from_secs_f64(secs))
-        }
+        Some(secs) if secs > 0.0 => match Duration::try_from_secs_f64(secs) {
+            Ok(d) => JobContext::with_timeout(wire.job_id, d),
+            Err(e) => {
+                set_last_error(format!(
+                    "mesh_run_as_job: invalid deadline_secs ({}) for job {}: {}",
+                    secs, wire.job_id, e
+                ));
+                return -1;
+            }
+        },
         _ => JobContext::new(wire.job_id),
     };
 
@@ -970,6 +992,43 @@ mod tests {
         assert!(would_be_no_timeout(f64::NEG_INFINITY));
         assert!(!would_be_no_timeout(0.001));
         assert!(!would_be_no_timeout(60.0));
+    }
+
+    /// `f64::MAX` deadline must NOT panic — `Duration::from_secs_f64`
+    /// panics on values that overflow `u64` seconds; we now use the
+    /// fallible `try_from_secs_f64` and surface the failure via the
+    /// last-error slot. (PR #891 review.)
+    #[test]
+    fn run_as_job_rejects_overflowing_deadline() {
+        extern "C" fn cb(_: *mut c_void) -> i32 { 0 }
+        // `f64::MAX` is finite, positive, and overflows u64-seconds —
+        // exactly the case that previously panicked. Wrap the FFI call
+        // in `catch_unwind` to prove the absence of a panic regression
+        // even if the fix is reverted.
+        let payload = format!(
+            r#"{{"job_id":"j-overflow","deadline_secs":{}}}"#,
+            f64::MAX
+        );
+        let snap = CString::new(payload).unwrap();
+        let res = std::panic::catch_unwind(|| unsafe {
+            mesh_run_as_job(snap.as_ptr(), cb, ptr::null_mut())
+        });
+        assert!(res.is_ok(), "f64::MAX deadline must not panic");
+        assert_eq!(res.unwrap(), -1, "f64::MAX deadline must surface as error");
+        // last-error slot should carry the diagnostic.
+        let err = take_last_error();
+        assert!(err.is_some(), "expected last_error to be populated");
+    }
+
+    /// `mesh_job_proxy_wait` with an overflowing finite timeout must
+    /// also surface as -1 rather than panic. We can't easily exercise
+    /// the FFI without a live handle, so we cover the `try_from_secs_f64`
+    /// behaviour directly to lock the contract in.
+    #[test]
+    fn proxy_wait_overflowing_timeout_does_not_panic() {
+        // `from_secs_f64` would have panicked here.
+        let res = Duration::try_from_secs_f64(f64::MAX);
+        assert!(res.is_err(), "f64::MAX must fail try_from_secs_f64");
     }
 
     /// Happy-path: snapshot with no deadline, callback returns 0.

--- a/src/runtime/core/src/lib.rs
+++ b/src/runtime/core/src/lib.rs
@@ -87,6 +87,8 @@ pub use registry::{FastHeartbeatResponse, FastHeartbeatStatus, PENDING_JOBS_HEAD
 
 // C FFI bindings module
 pub mod ffi;
+#[cfg(feature = "ffi")]
+pub mod jobs_ffi;
 
 // Node.js/TypeScript bindings module (napi-rs)
 #[cfg(feature = "typescript")]

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
@@ -2,7 +2,9 @@ package io.mcpmesh.core;
 
 import jnr.ffi.LibraryLoader;
 import jnr.ffi.Pointer;
+import jnr.ffi.annotations.Delegate;
 import jnr.ffi.annotations.Encoding;
+import jnr.ffi.byref.PointerByReference;
 
 /**
  * JNR-FFI interface to the MCP Mesh Rust core library.
@@ -446,4 +448,228 @@ public interface MeshCore {
      * @return Capabilities JSON (caller must free with mesh_free_string), or NULL on error
      */
     Pointer mesh_get_vendor_capabilities(String provider);
+
+    // ==========================================================================
+    // MeshJob Functions (Phase 1 — see MESHJOB_DESIGN.org)
+    // ==========================================================================
+    //
+    // All MeshJob C-ABI functions return int32:
+    //   * 0  = success
+    //   * negative (typically -1) = error; call mesh_last_error() for details
+    // String outputs are written via PointerByReference out-parameters; caller
+    // frees with mesh_free_string. Opaque handles are owned by Java and must
+    // be freed with the matching mesh_*_free function (or leaked).
+    //
+    // Mirrors:
+    //   * jobs_py.rs (PyO3 bindings — Python SDK)
+    //   * jobs_napi.rs (napi-rs bindings — TypeScript SDK)
+    // The C ABI is the JNR-FFI consumption point.
+
+    // ---- JobController (producer-side) ---------------------------------------
+
+    /**
+     * Construct a JobController bound to (jobId, instanceId) against the
+     * given registryUrl. Spawns a per-controller background batching tick so
+     * mid-flight updateProgress calls reach the registry on the configured
+     * cadence (default 2s); the tick is torn down with a final flush when
+     * the handle is freed via mesh_job_controller_free.
+     *
+     * @param jobId       Job UUID this controller is bound to
+     * @param instanceId  Instance ID submitting deltas to the registry
+     * @param registryUrl Registry base URL
+     * @param outHandle   Out-param: receives the opaque handle on success
+     * @return 0 on success, -1 on error (see mesh_last_error)
+     */
+    int mesh_job_controller_new(String jobId, String instanceId, String registryUrl, PointerByReference outHandle);
+
+    /**
+     * Enqueue a progress update. Coalesces with any prior pending progress
+     * for this job — only the latest survives the next batch flush.
+     *
+     * @param handle  Controller handle from mesh_job_controller_new
+     * @param progress Progress value (typically 0.0..1.0)
+     * @param message Optional progress message (may be null)
+     * @return 0 on success, -1 on error
+     */
+    int mesh_job_controller_update_progress(Pointer handle, double progress, String message);
+
+    /**
+     * Mark the job complete with the given result (JSON-encoded). Flushes
+     * immediately.
+     *
+     * @param handle     Controller handle
+     * @param resultJson JSON string encoding the job result
+     * @return 0 on success, -1 on error
+     */
+    int mesh_job_controller_complete(Pointer handle, String resultJson);
+
+    /**
+     * Mark the job failed with the given error reason. Flushes immediately.
+     *
+     * @param handle Controller handle
+     * @param error  Error reason (free-form string)
+     * @return 0 on success, -1 on error
+     */
+    int mesh_job_controller_fail(Pointer handle, String error);
+
+    /**
+     * Whether complete / fail has already been called on this controller.
+     *
+     * @param handle Controller handle
+     * @return 1 if terminal, 0 if not, -1 on error
+     */
+    int mesh_job_controller_is_terminal(Pointer handle);
+
+    /**
+     * Read the job ID this controller is bound to.
+     *
+     * @param handle    Controller handle
+     * @param outJobId  Out-param: receives the job-id string (caller frees via mesh_free_string)
+     * @return 0 on success, -1 on error
+     */
+    int mesh_job_controller_job_id(Pointer handle, PointerByReference outJobId);
+
+    /**
+     * Free a JobController handle returned by mesh_job_controller_new.
+     * Drops the inner controller AND the background batching tick (which
+     * triggers a final flush of any pending deltas).
+     *
+     * @param handle Controller handle (may be null)
+     */
+    void mesh_job_controller_free(Pointer handle);
+
+    // ---- JobProxy (consumer-side) --------------------------------------------
+
+    /**
+     * Submit a new job via the registry and return a JobProxy handle.
+     *
+     * @param argsJson  JSON object encoding SubmitJobArgs (see jobs_ffi.rs)
+     * @param outHandle Out-param: receives the opaque proxy handle on success
+     * @return 0 on success, -1 on error
+     */
+    int mesh_submit_job(String argsJson, PointerByReference outHandle);
+
+    /**
+     * Construct a JobProxy bound to a known jobId + registryUrl. Normally
+     * callers obtain a proxy via mesh_submit_job rather than constructing
+     * one directly.
+     *
+     * @param jobId       Job UUID
+     * @param registryUrl Registry base URL
+     * @param outHandle   Out-param: receives the opaque proxy handle on success
+     * @return 0 on success, -1 on error
+     */
+    int mesh_job_proxy_new(String jobId, String registryUrl, PointerByReference outHandle);
+
+    /**
+     * Read the job id this proxy is bound to.
+     *
+     * @param handle   Proxy handle
+     * @param outJobId Out-param: receives the job-id string (caller frees via mesh_free_string)
+     * @return 0 on success, -1 on error
+     */
+    int mesh_job_proxy_job_id(Pointer handle, PointerByReference outJobId);
+
+    /**
+     * Read the latest job state from the registry (single GET). The full Job
+     * row is serialized as JSON.
+     *
+     * @param handle      Proxy handle
+     * @param outJobJson  Out-param: receives the JSON string (caller frees via mesh_free_string)
+     * @return 0 on success, -1 on error
+     */
+    int mesh_job_proxy_status(Pointer handle, PointerByReference outJobJson);
+
+    /**
+     * Poll until the job reaches a terminal state. On success writes the
+     * job result (JSON-encoded) to outResultJson.
+     *
+     * @param handle         Proxy handle
+     * @param timeoutSecs    Wall-clock timeout (negative = no timeout)
+     * @param outResultJson  Out-param: receives the JSON string (caller frees via mesh_free_string)
+     * @return 0 on success, -1 on error
+     */
+    int mesh_job_proxy_wait(Pointer handle, double timeoutSecs, PointerByReference outResultJson);
+
+    /**
+     * Request cancellation. The registry forwards the signal to the owner
+     * replica when alive.
+     *
+     * @param handle Proxy handle
+     * @param reason Optional cancel reason (may be null)
+     * @return 0 on success, -1 on error
+     */
+    int mesh_job_proxy_cancel(Pointer handle, String reason);
+
+    /**
+     * Free a JobProxy handle returned by mesh_submit_job / mesh_job_proxy_new.
+     *
+     * @param handle Proxy handle (may be null)
+     */
+    void mesh_job_proxy_free(Pointer handle);
+
+    // ---- Context + cancel registry ------------------------------------------
+
+    /**
+     * Snapshot of the active job context on the current Rust task, or null
+     * if no job is in scope. Writes a JSON object of shape
+     * {@code {"job_id": str, "deadline_secs_remaining": int|null}} or
+     * a null pointer.
+     *
+     * <p>Note: this reflects the Rust task-local context only. Java code
+     * should read its own ThreadLocal mirror (see {@link io.mcpmesh.JobContext}
+     * once added).
+     *
+     * @param outSnapshotJson Out-param: receives the JSON string or null pointer
+     * @return 0 on success, -1 on error
+     */
+    int mesh_current_job(PointerByReference outSnapshotJson);
+
+    /**
+     * Compute the X-Mesh-Job-Id / X-Mesh-Timeout header values for the
+     * active Rust-side job context, if any. Writes a JSON object or null.
+     *
+     * @param outHeadersJson Out-param: receives the JSON string or null pointer
+     * @return 0 on success, -1 on error
+     */
+    int mesh_inject_job_headers(PointerByReference outHeadersJson);
+
+    /**
+     * Fire the cancel token registered for jobId in the process-wide cancel
+     * registry, if any.
+     *
+     * @param jobId Job UUID
+     * @return 1 if a token was found and fired, 0 if no active job, -1 on error
+     */
+    int mesh_cancel_active_job(String jobId);
+
+    /**
+     * Callback type for {@link MeshCore#mesh_run_as_job}. The callback is
+     * invoked synchronously from the FFI runtime's block_on; its int return
+     * value propagates as mesh_run_as_job's return value.
+     */
+    interface RunAsJobCallback {
+        @Delegate
+        int invoke(Pointer userData);
+    }
+
+    /**
+     * Run a Java-provided callback inside a fresh run_as_job scope so the
+     * cancel-registry entry under the snapshot's job_id is bound for the
+     * duration of the callback. snapshotJson encodes
+     * {@code {"job_id": str, "deadline_secs": number|null}}.
+     *
+     * <p>The Rust task-local context is NOT visible to Java code in the
+     * callback — Java must mirror it in its own ThreadLocal. The Rust side
+     * handles cancel-registry binding (so {@code POST /jobs/{id}/cancel}
+     * fires the in-flight cancel token) and header injection on Rust-
+     * originated outbound work.
+     *
+     * @param snapshotJson Job context snapshot JSON
+     * @param callback     Java callback invoked inside the scope
+     * @param userData     Opaque pointer passed back to the callback (may be null)
+     * @return The callback's return value (0 = success, non-zero = caller-defined),
+     *         or -1 if the snapshot JSON is invalid (see mesh_last_error)
+     */
+    int mesh_run_as_job(String snapshotJson, RunAsJobCallback callback, Pointer userData);
 }

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobContext.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobContext.java
@@ -1,0 +1,170 @@
+package io.mcpmesh;
+
+import io.mcpmesh.core.MeshCore;
+import io.mcpmesh.core.MeshObjectMappers;
+import jnr.ffi.Pointer;
+import jnr.ffi.byref.PointerByReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Java-side mirror of the Rust {@code job_context::JobContext} task-local.
+ *
+ * <p>Two layers of context live in parallel and intentionally — see
+ * {@link io.mcpmesh.core.MeshCore#mesh_current_job} and the caveat block in
+ * {@code jobs_ffi.rs}:
+ *
+ * <ul>
+ *   <li><b>Rust side</b> — bound by {@code mesh_run_as_job}, visible to Rust
+ *       futures polled within the scope (cancel-registry binding,
+ *       Rust-originated outbound HTTP header injection).</li>
+ *   <li><b>Java side</b> — this class' {@link ThreadLocal}, visible to user
+ *       code and to Java-originated outbound calls. The two are mirrored
+ *       by the inbound dispatch wrapper (Phase B) so user code can read
+ *       {@link #current()} regardless of which side originated the work.</li>
+ * </ul>
+ *
+ * <p>{@code ThreadLocal} (rather than {@code ScopedValue} from Project Loom)
+ * is the safe-default: the rest of the project targets Java 17+ stable
+ * APIs. A future revision can opt into {@code ScopedValue} for virtual-
+ * thread fan-out scenarios.
+ *
+ * <p>Mirror of:
+ * <ul>
+ *   <li>Python {@code _mcp_mesh.engine.job_context.CURRENT_JOB} (contextvar)</li>
+ *   <li>TypeScript {@code @mcp-mesh/runtime ... CURRENT_JOB} (AsyncLocalStorage)</li>
+ * </ul>
+ */
+public final class JobContext {
+
+    private static final Logger log = LoggerFactory.getLogger(JobContext.class);
+    private static final ObjectMapper MAPPER = MeshObjectMappers.create();
+
+    /**
+     * Snapshot of the active job context. Mirrors the Python
+     * {@code JobContextSnapshot} dataclass and TS {@code JobContextSnapshot}
+     * interface field-for-field.
+     */
+    public static final class Snapshot {
+        public final String jobId;
+        /** Seconds remaining on the deadline, or null if no deadline is set. */
+        public final Long deadlineSecsRemaining;
+
+        public Snapshot(String jobId, Long deadlineSecsRemaining) {
+            this.jobId = jobId;
+            this.deadlineSecsRemaining = deadlineSecsRemaining;
+        }
+
+        @Override
+        public String toString() {
+            return "JobContext.Snapshot{jobId=" + jobId
+                + ", deadlineSecsRemaining=" + deadlineSecsRemaining + "}";
+        }
+    }
+
+    private static final ThreadLocal<Snapshot> CURRENT = new ThreadLocal<>();
+
+    private JobContext() {}
+
+    /**
+     * Snapshot of the active job context on the current thread, or null if
+     * no job is in scope. Reads the Java-side {@link ThreadLocal} mirror,
+     * NOT the Rust-side task-local (call
+     * {@link io.mcpmesh.core.MeshCore#mesh_current_job} directly to read
+     * the latter).
+     */
+    public static Snapshot current() {
+        return CURRENT.get();
+    }
+
+    /**
+     * Bind {@code snap} as the active job context on the current thread for
+     * the duration of {@code body}, then restore the previous value (or
+     * clear if there was none). Safe to nest.
+     *
+     * <p>This is the Java-side counterpart to Rust {@code with_job} — call it
+     * from the inbound dispatch wrapper (Phase B) so user code reading
+     * {@link #current()} during the tool invocation sees the right context.
+     *
+     * <p>For the full producer-side scope (cancel-registry binding +
+     * deadline propagation to Rust outbound calls), pair this with
+     * {@link MeshCore#mesh_run_as_job} so both sides are bound.
+     *
+     * @param snap Snapshot to bind (must not be null)
+     * @param body Callable executed inside the scope
+     * @return The body's return value
+     * @throws Exception whatever {@code body} throws (verbatim)
+     */
+    public static <T> T withJob(Snapshot snap, Callable<T> body) throws Exception {
+        if (snap == null) {
+            throw new IllegalArgumentException("snap is required");
+        }
+        if (body == null) {
+            throw new IllegalArgumentException("body is required");
+        }
+        Snapshot prev = CURRENT.get();
+        CURRENT.set(snap);
+        try {
+            return body.call();
+        } finally {
+            if (prev != null) {
+                CURRENT.set(prev);
+            } else {
+                CURRENT.remove();
+            }
+        }
+    }
+
+    /**
+     * Convenience: bind a snapshot synthesized from the inbound
+     * {@code X-Mesh-Job-Id} / {@code X-Mesh-Timeout} header pair. {@code
+     * deadlineSecsRemaining} may be null when no deadline header was
+     * present (matches the Rust "deadline opt-in / unlimited by default"
+     * semantics).
+     */
+    public static <T> T withJob(String jobId, Long deadlineSecsRemaining, Callable<T> body)
+            throws Exception {
+        return withJob(new Snapshot(jobId, deadlineSecsRemaining), body);
+    }
+
+    /**
+     * Read the Rust-side current job snapshot (NOT the Java ThreadLocal).
+     * Available for FFI-bridge code that needs to know what the Rust core
+     * sees — typically only used by the dispatch wrapper for parity checks.
+     *
+     * @return The snapshot, or null if no Rust task-local context is active
+     */
+    public static Snapshot currentFromNative() {
+        MeshCore core = MeshCore.load();
+        PointerByReference out = new PointerByReference();
+        int rc = core.mesh_current_job(out);
+        if (rc != 0) {
+            log.warn("mesh_current_job returned {}, treating as no active context", rc);
+            return null;
+        }
+        Pointer p = out.getValue();
+        if (p == null) {
+            return null;
+        }
+        try {
+            String json = p.getString(0);
+            tools.jackson.databind.JsonNode node = MAPPER.readTree(json);
+            String jobId = node.has("job_id") ? node.get("job_id").asText() : null;
+            Long remaining;
+            if (node.has("deadline_secs_remaining") && !node.get("deadline_secs_remaining").isNull()) {
+                remaining = node.get("deadline_secs_remaining").asLong();
+            } else {
+                remaining = null;
+            }
+            return new Snapshot(jobId, remaining);
+        } catch (Exception e) {
+            log.warn("Failed to parse current job snapshot: {}", e.getMessage());
+            return null;
+        } finally {
+            core.mesh_free_string(p);
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
@@ -87,16 +87,6 @@ public final class JobController implements MeshJob, AutoCloseable {
         return new JobController(core, handle, jobId);
     }
 
-    /**
-     * Internal constructor for the inbound dispatch path (Phase B). Allows
-     * the wrapper to construct a controller from an already-allocated native
-     * handle — used when the dispatcher creates the handle inside the Rust
-     * runtime scope.
-     */
-    static JobController fromHandle(MeshCore core, Pointer handle, String jobId) {
-        return new JobController(core, handle, jobId);
-    }
-
     /** The job ID this controller is bound to. */
     public String jobId() {
         return jobId;

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
@@ -1,0 +1,221 @@
+package io.mcpmesh;
+
+import io.mcpmesh.core.MeshCore;
+import io.mcpmesh.core.MeshException;
+import io.mcpmesh.core.MeshObjectMappers;
+import jnr.ffi.Pointer;
+import jnr.ffi.byref.PointerByReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Producer-side handle bound to a single job. Application code typically
+ * receives one via {@link MeshJob} DDDI injection — the inbound tool wrapper
+ * (Phase B) constructs it from the {@code X-Mesh-Job-Id} header on a
+ * dispatch-eligible {@code tools/call}.
+ *
+ * <p>Each controller owns a per-instance coalescing queue plus a background
+ * batching tick (spawned by the Rust core) that flushes mid-flight progress
+ * deltas to the registry on a fixed cadence (default 2s). Terminal calls
+ * ({@link #complete} / {@link #fail}) flush immediately. The tick is shut
+ * down with a final flush when {@link #close} runs.
+ *
+ * <p>Implements {@link AutoCloseable} so callers MAY use try-with-resources;
+ * the wrapper's finalizer is intentionally NOT relied upon for cleanup
+ * (those are unreliable). The runtime's tool dispatch wrapper closes the
+ * controller in a {@code finally} after invocation.
+ *
+ * <p>Mirror of:
+ * <ul>
+ *   <li>Python {@code _mcp_mesh.engine.job_controller.PyJobController}</li>
+ *   <li>TypeScript {@code @mcp-mesh/runtime ... JobController}</li>
+ * </ul>
+ *
+ * <p>Memory safety: the underlying native handle is freed exactly once via
+ * {@link #close}, guarded by an {@link AtomicBoolean} so concurrent
+ * close-from-multiple-threads is a no-op on the second call.
+ */
+public final class JobController implements MeshJob, AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(JobController.class);
+    private static final ObjectMapper MAPPER = MeshObjectMappers.create();
+
+    private final MeshCore core;
+    private final Pointer handle;
+    private final String jobId;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private JobController(MeshCore core, Pointer handle, String jobId) {
+        this.core = core;
+        this.handle = handle;
+        this.jobId = jobId;
+    }
+
+    /**
+     * Open a controller bound to the given job + instance against the registry.
+     *
+     * @param jobId       Server-assigned job UUID
+     * @param instanceId  This agent's instance ID (used by the registry to
+     *                    attribute deltas to a specific replica)
+     * @param registryUrl Registry base URL
+     * @return A new controller; caller MUST {@link #close} when done
+     * @throws MeshException if the native handle cannot be allocated
+     */
+    public static JobController open(String jobId, String instanceId, String registryUrl) {
+        if (jobId == null || jobId.isEmpty()) {
+            throw new IllegalArgumentException("jobId is required");
+        }
+        if (instanceId == null || instanceId.isEmpty()) {
+            throw new IllegalArgumentException("instanceId is required");
+        }
+        if (registryUrl == null || registryUrl.isEmpty()) {
+            throw new IllegalArgumentException("registryUrl is required");
+        }
+        MeshCore core = MeshCore.load();
+        PointerByReference out = new PointerByReference();
+        int rc = core.mesh_job_controller_new(jobId, instanceId, registryUrl, out);
+        if (rc != 0) {
+            throw new MeshException("mesh_job_controller_new failed: " + lastError(core));
+        }
+        Pointer handle = out.getValue();
+        if (handle == null) {
+            throw new MeshException("mesh_job_controller_new returned null handle");
+        }
+        return new JobController(core, handle, jobId);
+    }
+
+    /**
+     * Internal constructor for the inbound dispatch path (Phase B). Allows
+     * the wrapper to construct a controller from an already-allocated native
+     * handle — used when the dispatcher creates the handle inside the Rust
+     * runtime scope.
+     */
+    static JobController fromHandle(MeshCore core, Pointer handle, String jobId) {
+        return new JobController(core, handle, jobId);
+    }
+
+    /** The job ID this controller is bound to. */
+    public String jobId() {
+        return jobId;
+    }
+
+    /**
+     * Enqueue a progress update. Coalesces with any prior pending progress
+     * for this job — only the latest survives the next batch flush.
+     *
+     * @param progress Progress value (typically 0.0..1.0)
+     * @param message  Optional progress message (may be null)
+     * @throws MeshException if the controller is closed or the native call fails
+     */
+    public void updateProgress(double progress, String message) {
+        ensureOpen();
+        int rc = core.mesh_job_controller_update_progress(handle, progress, message);
+        if (rc != 0) {
+            throw new MeshException("mesh_job_controller_update_progress failed: " + lastError(core));
+        }
+    }
+
+    /**
+     * Mark the job complete with the given result. Flushes immediately.
+     * The result is JSON-serialized via Jackson (uses the project's shared
+     * {@link MeshObjectMappers} for consistency with other tool returns).
+     *
+     * @param result Any JSON-serializable value (record, POJO, Map, primitive...)
+     * @throws MeshException if serialization or the native call fails
+     */
+    public void complete(Object result) {
+        ensureOpen();
+        String json;
+        try {
+            // null → JSON null. Jackson handles this directly.
+            json = MAPPER.writeValueAsString(result);
+        } catch (Exception e) {
+            throw new MeshException("Failed to serialize job result", e);
+        }
+        int rc = core.mesh_job_controller_complete(handle, json);
+        if (rc != 0) {
+            throw new MeshException("mesh_job_controller_complete failed: " + lastError(core));
+        }
+    }
+
+    /**
+     * Mark the job failed with the given error reason. Flushes immediately.
+     * Retry semantics (or lack thereof) are decided by the registry based
+     * on the job's {@code max_retries} — see {@code MESHJOB_DESIGN.org}
+     * "Failure & Retry".
+     *
+     * @param error Error reason (free-form string surfaced to consumers)
+     * @throws MeshException if the native call fails
+     */
+    public void fail(String error) {
+        ensureOpen();
+        if (error == null) {
+            error = "";
+        }
+        int rc = core.mesh_job_controller_fail(handle, error);
+        if (rc != 0) {
+            throw new MeshException("mesh_job_controller_fail failed: " + lastError(core));
+        }
+    }
+
+    /**
+     * Whether {@link #complete} / {@link #fail} has already been called on
+     * this controller. The dispatch wrapper uses this to decide whether a
+     * returning user method needs an auto-{@code complete} (the
+     * "if the user forgot, finish the job for them" path).
+     *
+     * @return true if terminal, false otherwise
+     * @throws MeshException if the native call fails
+     */
+    public boolean isTerminal() {
+        ensureOpen();
+        int rc = core.mesh_job_controller_is_terminal(handle);
+        if (rc < 0) {
+            throw new MeshException("mesh_job_controller_is_terminal failed: " + lastError(core));
+        }
+        return rc == 1;
+    }
+
+    /**
+     * Free the underlying native handle and stop the background batching
+     * tick (with a final flush). Idempotent — repeated calls are no-ops.
+     */
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            try {
+                core.mesh_job_controller_free(handle);
+            } catch (RuntimeException e) {
+                // Don't swallow — but log so callers see the unusual case.
+                log.warn("mesh_job_controller_free threw for job {}: {}", jobId, e.getMessage());
+                throw e;
+            }
+        }
+    }
+
+    private void ensureOpen() {
+        if (closed.get()) {
+            throw new MeshException("JobController for job " + jobId + " is closed");
+        }
+    }
+
+    private static String lastError(MeshCore core) {
+        Pointer err = core.mesh_last_error();
+        if (err == null) {
+            return "<no error message>";
+        }
+        try {
+            return err.getString(0);
+        } finally {
+            core.mesh_free_string(err);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "JobController{jobId=" + jobId + ", closed=" + closed.get() + "}";
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
@@ -44,8 +44,18 @@ public final class JobController implements MeshJob, AutoCloseable {
     private static final ObjectMapper MAPPER = MeshObjectMappers.create();
 
     private final MeshCore core;
-    private final Pointer handle;
+    /**
+     * Native handle. {@code null} after {@link #close} runs. Read/written
+     * only while holding {@link #lock} so a concurrent {@code close()}
+     * cannot free the pointer while another thread is mid-FFI-call.
+     * Without this lock the SDK had a use-after-free under contention
+     * (PR #891 review): thread A passes {@link #ensureOpen} then enters
+     * the native call; thread B closes and frees; thread A's pointer
+     * dereference hits freed memory.
+     */
+    private Pointer handle;
     private final String jobId;
+    private final Object lock = new Object();
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
     private JobController(MeshCore core, Pointer handle, String jobId) {
@@ -101,10 +111,12 @@ public final class JobController implements MeshJob, AutoCloseable {
      * @throws MeshException if the controller is closed or the native call fails
      */
     public void updateProgress(double progress, String message) {
-        ensureOpen();
-        int rc = core.mesh_job_controller_update_progress(handle, progress, message);
-        if (rc != 0) {
-            throw new MeshException("mesh_job_controller_update_progress failed: " + lastError(core));
+        synchronized (lock) {
+            ensureOpen();
+            int rc = core.mesh_job_controller_update_progress(handle, progress, message);
+            if (rc != 0) {
+                throw new MeshException("mesh_job_controller_update_progress failed: " + lastError(core));
+            }
         }
     }
 
@@ -117,7 +129,9 @@ public final class JobController implements MeshJob, AutoCloseable {
      * @throws MeshException if serialization or the native call fails
      */
     public void complete(Object result) {
-        ensureOpen();
+        // Serialize OUTSIDE the lock — Jackson is thread-safe and the
+        // `writeValueAsString` call can be expensive for large payloads;
+        // we don't want to hold the FFI lock across user-data work.
         String json;
         try {
             // null → JSON null. Jackson handles this directly.
@@ -125,9 +139,12 @@ public final class JobController implements MeshJob, AutoCloseable {
         } catch (Exception e) {
             throw new MeshException("Failed to serialize job result", e);
         }
-        int rc = core.mesh_job_controller_complete(handle, json);
-        if (rc != 0) {
-            throw new MeshException("mesh_job_controller_complete failed: " + lastError(core));
+        synchronized (lock) {
+            ensureOpen();
+            int rc = core.mesh_job_controller_complete(handle, json);
+            if (rc != 0) {
+                throw new MeshException("mesh_job_controller_complete failed: " + lastError(core));
+            }
         }
     }
 
@@ -141,13 +158,15 @@ public final class JobController implements MeshJob, AutoCloseable {
      * @throws MeshException if the native call fails
      */
     public void fail(String error) {
-        ensureOpen();
         if (error == null) {
             error = "";
         }
-        int rc = core.mesh_job_controller_fail(handle, error);
-        if (rc != 0) {
-            throw new MeshException("mesh_job_controller_fail failed: " + lastError(core));
+        synchronized (lock) {
+            ensureOpen();
+            int rc = core.mesh_job_controller_fail(handle, error);
+            if (rc != 0) {
+                throw new MeshException("mesh_job_controller_fail failed: " + lastError(core));
+            }
         }
     }
 
@@ -161,12 +180,14 @@ public final class JobController implements MeshJob, AutoCloseable {
      * @throws MeshException if the native call fails
      */
     public boolean isTerminal() {
-        ensureOpen();
-        int rc = core.mesh_job_controller_is_terminal(handle);
-        if (rc < 0) {
-            throw new MeshException("mesh_job_controller_is_terminal failed: " + lastError(core));
+        synchronized (lock) {
+            ensureOpen();
+            int rc = core.mesh_job_controller_is_terminal(handle);
+            if (rc < 0) {
+                throw new MeshException("mesh_job_controller_is_terminal failed: " + lastError(core));
+            }
+            return rc == 1;
         }
-        return rc == 1;
     }
 
     /**
@@ -175,19 +196,36 @@ public final class JobController implements MeshJob, AutoCloseable {
      */
     @Override
     public void close() {
-        if (closed.compareAndSet(false, true)) {
-            try {
-                core.mesh_job_controller_free(handle);
-            } catch (RuntimeException e) {
-                // Don't swallow — but log so callers see the unusual case.
-                log.warn("mesh_job_controller_free threw for job {}: {}", jobId, e.getMessage());
-                throw e;
+        // Hold `lock` across the free so any in-flight FFI call
+        // (updateProgress / complete / fail / isTerminal) finishes
+        // before we drop the handle. The `closed` flag preserves
+        // idempotent semantics for repeated close() calls; it's still
+        // checked inside the lock by `ensureOpen` so a thread that
+        // wins the race observes the closed state.
+        synchronized (lock) {
+            if (closed.compareAndSet(false, true)) {
+                Pointer h = handle;
+                handle = null;
+                try {
+                    if (h != null) {
+                        core.mesh_job_controller_free(h);
+                    }
+                } catch (RuntimeException e) {
+                    // Don't swallow — but log so callers see the unusual case.
+                    log.warn("mesh_job_controller_free threw for job {}: {}", jobId, e.getMessage());
+                    throw e;
+                }
             }
         }
     }
 
+    /**
+     * Caller MUST hold {@link #lock} — this checks both the
+     * idempotent-close flag and the live handle before letting an FFI
+     * call dereference it.
+     */
     private void ensureOpen() {
-        if (closed.get()) {
+        if (closed.get() || handle == null) {
             throw new MeshException("JobController for job " + jobId + " is closed");
         }
     }

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobProxy.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobProxy.java
@@ -1,0 +1,203 @@
+package io.mcpmesh;
+
+import io.mcpmesh.core.MeshCore;
+import io.mcpmesh.core.MeshException;
+import io.mcpmesh.core.MeshObjectMappers;
+import jnr.ffi.Pointer;
+import jnr.ffi.byref.PointerByReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Consumer-side handle: returned by {@link MeshJobSubmitter#submit(Map)} (or
+ * obtained directly from a known job id) and exposes
+ * {@link #wait(double)} / {@link #status()} / {@link #cancel(String)} for
+ * code that wants to await a remote job.
+ *
+ * <p>Mirror of:
+ * <ul>
+ *   <li>Python {@code _mcp_mesh.engine.job_proxy.PyJobProxy}</li>
+ *   <li>TypeScript {@code @mcp-mesh/runtime ... JobProxy}</li>
+ * </ul>
+ *
+ * <p>Implements {@link AutoCloseable}; the underlying native handle is
+ * lightweight (just a backend reference + job id) but still needs an
+ * explicit {@link #close} to drop the FFI box. Idempotent.
+ */
+public final class JobProxy implements MeshJob, AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(JobProxy.class);
+    private static final ObjectMapper MAPPER = MeshObjectMappers.create();
+
+    private final MeshCore core;
+    private final Pointer handle;
+    private final String jobId;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    JobProxy(MeshCore core, Pointer handle, String jobId) {
+        this.core = core;
+        this.handle = handle;
+        this.jobId = jobId;
+    }
+
+    /**
+     * Open a proxy bound to a known {@code jobId} + {@code registryUrl}.
+     * Normally callers obtain a proxy via {@link MeshJobSubmitter#submit(Map)};
+     * this constructor is for tests and the fallback "I already know the
+     * job id, just give me a handle" path.
+     */
+    public static JobProxy open(String jobId, String registryUrl) {
+        if (jobId == null || jobId.isEmpty()) {
+            throw new IllegalArgumentException("jobId is required");
+        }
+        if (registryUrl == null || registryUrl.isEmpty()) {
+            throw new IllegalArgumentException("registryUrl is required");
+        }
+        MeshCore core = MeshCore.load();
+        PointerByReference out = new PointerByReference();
+        int rc = core.mesh_job_proxy_new(jobId, registryUrl, out);
+        if (rc != 0) {
+            throw new MeshException("mesh_job_proxy_new failed: " + lastError(core));
+        }
+        Pointer handle = out.getValue();
+        if (handle == null) {
+            throw new MeshException("mesh_job_proxy_new returned null handle");
+        }
+        return new JobProxy(core, handle, jobId);
+    }
+
+    /** The job id this proxy is bound to. */
+    public String jobId() {
+        return jobId;
+    }
+
+    /**
+     * Read the latest job state from the registry (single GET). Returns the
+     * full job row deserialized as a {@code Map<String, Object>} (matches
+     * the Python / TS bindings that return a dict / object).
+     *
+     * @throws MeshException if the registry call fails
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> status() {
+        ensureOpen();
+        PointerByReference out = new PointerByReference();
+        int rc = core.mesh_job_proxy_status(handle, out);
+        if (rc != 0) {
+            throw new MeshException("mesh_job_proxy_status failed: " + lastError(core));
+        }
+        Pointer p = out.getValue();
+        if (p == null) {
+            throw new MeshException("mesh_job_proxy_status returned null payload");
+        }
+        try {
+            String json = p.getString(0);
+            return (Map<String, Object>) MAPPER.readValue(json, Map.class);
+        } catch (Exception e) {
+            throw new MeshException("Failed to parse job status JSON", e);
+        } finally {
+            core.mesh_free_string(p);
+        }
+    }
+
+    /**
+     * Poll until the job reaches a terminal state. Returns the result
+     * payload as a generic Java value (Map / List / Number / String /
+     * Boolean / null) — Jackson default binding.
+     *
+     * <p>Named {@code await} (not {@code wait}) because {@link Object#wait()}
+     * is {@code final} on every Java object — overloading the name on a
+     * subclass is a compile error. Mirrors the Python {@code .wait()} and
+     * TypeScript {@code .wait()} APIs semantically; the rename is purely a
+     * Java language constraint.
+     *
+     * @param timeoutSecs Wall-clock timeout in seconds. Use a negative
+     *                    value (e.g. {@code -1.0}) for no timeout.
+     * @return The job result payload
+     * @throws MeshException on timeout, cancellation, or non-success terminal
+     *                       (the message starts with the variant name —
+     *                       {@code "timeout: ..."} / {@code "cancelled: ..."}
+     *                       / etc., matching the napi-rs surface).
+     */
+    public Object await(double timeoutSecs) {
+        ensureOpen();
+        PointerByReference out = new PointerByReference();
+        int rc = core.mesh_job_proxy_wait(handle, timeoutSecs, out);
+        if (rc != 0) {
+            throw new MeshException("mesh_job_proxy_wait failed: " + lastError(core));
+        }
+        Pointer p = out.getValue();
+        if (p == null) {
+            // await() succeeded but produced no payload — treat as JSON null.
+            return null;
+        }
+        try {
+            String json = p.getString(0);
+            return MAPPER.readValue(json, Object.class);
+        } catch (Exception e) {
+            throw new MeshException("Failed to parse job wait result JSON", e);
+        } finally {
+            core.mesh_free_string(p);
+        }
+    }
+
+    /** Convenience: {@link #await(double)} without a timeout. */
+    public Object await() {
+        return await(-1.0);
+    }
+
+    /**
+     * Request cancellation. The registry forwards the signal to the owner
+     * replica when alive. Returns once the registry has acknowledged.
+     *
+     * @param reason Optional cancel reason (may be null)
+     * @throws MeshException if the registry call fails
+     */
+    public void cancel(String reason) {
+        ensureOpen();
+        int rc = core.mesh_job_proxy_cancel(handle, reason);
+        if (rc != 0) {
+            throw new MeshException("mesh_job_proxy_cancel failed: " + lastError(core));
+        }
+    }
+
+    /** Free the underlying native handle. Idempotent. */
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            try {
+                core.mesh_job_proxy_free(handle);
+            } catch (RuntimeException e) {
+                log.warn("mesh_job_proxy_free threw for job {}: {}", jobId, e.getMessage());
+                throw e;
+            }
+        }
+    }
+
+    private void ensureOpen() {
+        if (closed.get()) {
+            throw new MeshException("JobProxy for job " + jobId + " is closed");
+        }
+    }
+
+    private static String lastError(MeshCore core) {
+        Pointer err = core.mesh_last_error();
+        if (err == null) {
+            return "<no error message>";
+        }
+        try {
+            return err.getString(0);
+        } finally {
+            core.mesh_free_string(err);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "JobProxy{jobId=" + jobId + ", closed=" + closed.get() + "}";
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobProxy.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobProxy.java
@@ -34,8 +34,15 @@ public final class JobProxy implements MeshJob, AutoCloseable {
     private static final ObjectMapper MAPPER = MeshObjectMappers.create();
 
     private final MeshCore core;
-    private final Pointer handle;
+    /**
+     * Native handle. {@code null} after {@link #close} runs. Read/written
+     * only while holding {@link #lock} — see {@link JobController} for
+     * the same fix; without it a concurrent close could free the
+     * pointer mid-FFI-call (PR #891 review).
+     */
+    private Pointer handle;
     private final String jobId;
+    private final Object lock = new Object();
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
     JobProxy(MeshCore core, Pointer handle, String jobId) {
@@ -84,13 +91,22 @@ public final class JobProxy implements MeshJob, AutoCloseable {
      */
     @SuppressWarnings("unchecked")
     public Map<String, Object> status() {
-        ensureOpen();
-        PointerByReference out = new PointerByReference();
-        int rc = core.mesh_job_proxy_status(handle, out);
-        if (rc != 0) {
-            throw new MeshException("mesh_job_proxy_status failed: " + lastError(core));
+        // FFI call inside the lock; JSON parse afterwards. We MUST own
+        // the returned `p` before releasing the lock — once `close()`
+        // runs it would otherwise be free to free a different handle
+        // — but the result string itself was allocated by Rust and is
+        // independent of the proxy handle, so we can parse it
+        // unguarded.
+        Pointer p;
+        synchronized (lock) {
+            ensureOpen();
+            PointerByReference out = new PointerByReference();
+            int rc = core.mesh_job_proxy_status(handle, out);
+            if (rc != 0) {
+                throw new MeshException("mesh_job_proxy_status failed: " + lastError(core));
+            }
+            p = out.getValue();
         }
-        Pointer p = out.getValue();
         if (p == null) {
             throw new MeshException("mesh_job_proxy_status returned null payload");
         }
@@ -132,13 +148,22 @@ public final class JobProxy implements MeshJob, AutoCloseable {
      *                       / etc., matching the napi-rs surface).
      */
     public Object await(double timeoutSecs) {
-        ensureOpen();
-        PointerByReference out = new PointerByReference();
-        int rc = core.mesh_job_proxy_wait(handle, timeoutSecs, out);
-        if (rc != 0) {
-            throw new MeshException("mesh_job_proxy_wait failed: " + lastError(core));
+        // The wait FFI may block for the full timeout — we hold the
+        // lock for that whole duration so a concurrent close() doesn't
+        // free the handle while the Rust runtime is still polling on
+        // it. Closing the proxy from another thread is a programming
+        // error if you also have an outstanding await(), but the lock
+        // prevents the worst (use-after-free) outcome.
+        Pointer p;
+        synchronized (lock) {
+            ensureOpen();
+            PointerByReference out = new PointerByReference();
+            int rc = core.mesh_job_proxy_wait(handle, timeoutSecs, out);
+            if (rc != 0) {
+                throw new MeshException("mesh_job_proxy_wait failed: " + lastError(core));
+            }
+            p = out.getValue();
         }
-        Pointer p = out.getValue();
         if (p == null) {
             // await() succeeded but produced no payload — treat as JSON null.
             return null;
@@ -166,28 +191,39 @@ public final class JobProxy implements MeshJob, AutoCloseable {
      * @throws MeshException if the registry call fails
      */
     public void cancel(String reason) {
-        ensureOpen();
-        int rc = core.mesh_job_proxy_cancel(handle, reason);
-        if (rc != 0) {
-            throw new MeshException("mesh_job_proxy_cancel failed: " + lastError(core));
+        synchronized (lock) {
+            ensureOpen();
+            int rc = core.mesh_job_proxy_cancel(handle, reason);
+            if (rc != 0) {
+                throw new MeshException("mesh_job_proxy_cancel failed: " + lastError(core));
+            }
         }
     }
 
     /** Free the underlying native handle. Idempotent. */
     @Override
     public void close() {
-        if (closed.compareAndSet(false, true)) {
-            try {
-                core.mesh_job_proxy_free(handle);
-            } catch (RuntimeException e) {
-                log.warn("mesh_job_proxy_free threw for job {}: {}", jobId, e.getMessage());
-                throw e;
+        // See JobController.close() for the rationale: hold the lock
+        // across the free so any in-flight FFI call finishes first.
+        synchronized (lock) {
+            if (closed.compareAndSet(false, true)) {
+                Pointer h = handle;
+                handle = null;
+                try {
+                    if (h != null) {
+                        core.mesh_job_proxy_free(h);
+                    }
+                } catch (RuntimeException e) {
+                    log.warn("mesh_job_proxy_free threw for job {}: {}", jobId, e.getMessage());
+                    throw e;
+                }
             }
         }
     }
 
+    /** Caller MUST hold {@link #lock}. */
     private void ensureOpen() {
-        if (closed.get()) {
+        if (closed.get() || handle == null) {
             throw new MeshException("JobProxy for job " + jobId + " is closed");
         }
     }

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobProxy.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobProxy.java
@@ -115,8 +115,16 @@ public final class JobProxy implements MeshJob, AutoCloseable {
      * TypeScript {@code .wait()} APIs semantically; the rename is purely a
      * Java language constraint.
      *
-     * @param timeoutSecs Wall-clock timeout in seconds. Use a negative
-     *                    value (e.g. {@code -1.0}) for no timeout.
+     * @param timeoutSecs Wall-clock timeout in seconds.
+     *                    <ul>
+     *                      <li>Negative or zero (including {@code -0.0})
+     *                          → no timeout (block until terminal).</li>
+     *                      <li>Positive finite → wait that many
+     *                          seconds, then surface a timeout error.</li>
+     *                      <li>Non-finite (NaN, ±Inf) → no timeout.</li>
+     *                    </ul>
+     *                    The {@link #await()} no-arg overload uses
+     *                    {@code -1.0} to opt into the no-timeout branch.
      * @return The job result payload
      * @throws MeshException on timeout, cancellation, or non-success terminal
      *                       (the message starts with the variant name —

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJob.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJob.java
@@ -1,0 +1,74 @@
+package io.mcpmesh;
+
+/**
+ * Type marker for DDDI injection of a long-running job handle.
+ *
+ * <p>Mirrors the Python {@code MeshJob} Protocol and the TypeScript
+ * {@code MeshJob} type marker. Application code declares a parameter of this
+ * type to opt into job semantics; the runtime injects the appropriate
+ * concrete implementation based on the call site:
+ *
+ * <ul>
+ *   <li><b>Producer side</b> — a method annotated with
+ *       {@code @MeshTool(task = true)} receives a {@code JobController} via
+ *       this slot when invoked through the job-dispatch path
+ *       ({@code X-Mesh-Job-Id} header present, or claimed from the pull
+ *       queue). The user calls {@code updateProgress() / complete() / fail()}
+ *       on it.</li>
+ *   <li><b>Consumer side</b> — a method depending on a {@code task = true}
+ *       capability receives a {@code MeshJobSubmitter} via this slot. The
+ *       user calls {@code .submit(...)} on it to start a job and
+ *       {@code .wait(...)} on the returned {@code JobProxy}.</li>
+ *   <li><b>Fast-path call</b> — when a {@code task = true} tool is invoked
+ *       as a regular synchronous {@code tools/call} (no job dispatch), the
+ *       runtime injects {@code null} into this slot. User code MUST tolerate
+ *       a {@code null} {@code MeshJob} parameter (typically by treating the
+ *       call as a non-job execution that doesn't update progress).</li>
+ * </ul>
+ *
+ * <p>See {@code MESHJOB_DDDI_CONTRACT.md} for the full DDDI resolver
+ * contract that all three SDKs (Python, TypeScript, Java) share.
+ *
+ * <h2>Example — producer side</h2>
+ * <pre>{@code
+ * @MeshTool(capability = "plan_trip", task = true)
+ * public CompletableFuture<TripPlan> planTrip(
+ *     @Param("user_id") String userId,
+ *     MeshJob job  // injected as JobController; null on non-job calls
+ * ) {
+ *     if (job instanceof JobController controller) {
+ *         controller.updateProgress(0.25, "fetching weather");
+ *         // ... long-running work ...
+ *         controller.updateProgress(0.75, "scoring options");
+ *     }
+ *     return CompletableFuture.completedFuture(new TripPlan(...));
+ * }
+ * }</pre>
+ *
+ * <h2>Example — consumer side</h2>
+ * <pre>{@code
+ * @MeshTool(
+ *     capability = "trip_planner_ui",
+ *     dependencies = @Selector(capability = "plan_trip")
+ * )
+ * public TripPlan kickOffTrip(
+ *     @Param("user_id") String userId,
+ *     MeshJob planTripJob  // injected as MeshJobSubmitter
+ * ) {
+ *     if (planTripJob instanceof MeshJobSubmitter submitter) {
+ *         JobProxy proxy = submitter.submit(Map.of("user_id", userId)).join();
+ *         return (TripPlan) proxy.wait(60).join();
+ *     }
+ *     throw new IllegalStateException("plan_trip dependency unavailable");
+ * }
+ * }</pre>
+ *
+ * <p><b>One MeshJob per method</b> — the resolver rejects methods declaring
+ * more than one {@code MeshJob} parameter. See
+ * {@code MESHJOB_DDDI_CONTRACT.md} → "Multiple MeshJob parameters".
+ */
+public interface MeshJob {
+    // Marker interface — runtime injects either JobController, JobProxy, or
+    // MeshJobSubmitter depending on call-site context. May also be null for
+    // a fast-path tools/call invocation on a task=true tool.
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJobSubmitter.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJobSubmitter.java
@@ -12,7 +12,9 @@ import tools.jackson.databind.node.ObjectNode;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Consumer-side submitter: injected via {@link MeshJob} DDDI for tools that
@@ -29,9 +31,12 @@ import java.util.concurrent.ForkJoinPool;
  * <p><b>Async ergonomics:</b> the underlying C ABI is sync (the FFI runtime
  * blocks on the registry call). The {@link #submit(Map)} entry point wraps
  * that in a {@link CompletableFuture} so application code can compose it
- * with other async work without holding a thread. The CF is completed by
- * the common {@link ForkJoinPool} — callers that want a different executor
- * can chain {@code thenApplyAsync(.., yourExecutor)}.
+ * with other async work without holding a thread. The CF is completed on
+ * a dedicated {@link #IO_EXECUTOR} cached thread pool — NOT the common
+ * {@link java.util.concurrent.ForkJoinPool}, because {@code mesh_submit_job}
+ * blocks on a network FFI call and a sustained burst of submissions
+ * would otherwise saturate the FJP and stall every other CompletableFuture
+ * in the JVM (PR #891 review).
  *
  * <p>The submitter itself is stateless after construction (capability +
  * registry URL only); a single instance can be used for many submissions.
@@ -40,6 +45,29 @@ public final class MeshJobSubmitter implements MeshJob {
 
     private static final Logger log = LoggerFactory.getLogger(MeshJobSubmitter.class);
     private static final ObjectMapper MAPPER = MeshObjectMappers.create();
+
+    /**
+     * Dedicated executor for the blocking {@code mesh_submit_job} FFI
+     * call. Cached pool — grows on demand under burst, threads die
+     * after 60s idle. Daemon threads so the JVM can shut down without
+     * waiting on idle workers.
+     *
+     * <p>Java 17 baseline (no virtual threads); when the project moves
+     * to Java 21+ this can become {@code Thread.ofVirtual().factory()}
+     * and the cached pool can shrink to a small fixed pool driving the
+     * VTs.
+     */
+    private static final Executor IO_EXECUTOR = Executors.newCachedThreadPool(
+        new java.util.concurrent.ThreadFactory() {
+            private final AtomicInteger seq = new AtomicInteger();
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r, "mesh-job-submit-io-" + seq.incrementAndGet());
+                t.setDaemon(true);
+                return t;
+            }
+        }
+    );
 
     private final MeshCore core;
     private final String capability;
@@ -114,7 +142,7 @@ public final class MeshJobSubmitter implements MeshJob {
             return CompletableFuture.failedFuture(
                 new MeshException("Failed to encode submit args", e));
         }
-        return CompletableFuture.supplyAsync(() -> doSubmit(argsJson));
+        return CompletableFuture.supplyAsync(() -> doSubmit(argsJson), IO_EXECUTOR);
     }
 
     private JobProxy doSubmit(String argsJson) {

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJobSubmitter.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJobSubmitter.java
@@ -1,0 +1,217 @@
+package io.mcpmesh;
+
+import io.mcpmesh.core.MeshCore;
+import io.mcpmesh.core.MeshException;
+import io.mcpmesh.core.MeshObjectMappers;
+import jnr.ffi.Pointer;
+import jnr.ffi.byref.PointerByReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
+
+/**
+ * Consumer-side submitter: injected via {@link MeshJob} DDDI for tools that
+ * depend on a {@code task = true} capability. Calling {@link #submit(Map)}
+ * returns a {@link JobProxy} the user can {@code wait()} / {@code status()} /
+ * {@code cancel()} on.
+ *
+ * <p>Mirror of:
+ * <ul>
+ *   <li>Python {@code _mcp_mesh.engine.job_submitter.MeshJobSubmitter}</li>
+ *   <li>TypeScript {@code @mcp-mesh/runtime ... MeshJobSubmitter}</li>
+ * </ul>
+ *
+ * <p><b>Async ergonomics:</b> the underlying C ABI is sync (the FFI runtime
+ * blocks on the registry call). The {@link #submit(Map)} entry point wraps
+ * that in a {@link CompletableFuture} so application code can compose it
+ * with other async work without holding a thread. The CF is completed by
+ * the common {@link ForkJoinPool} — callers that want a different executor
+ * can chain {@code thenApplyAsync(.., yourExecutor)}.
+ *
+ * <p>The submitter itself is stateless after construction (capability +
+ * registry URL only); a single instance can be used for many submissions.
+ */
+public final class MeshJobSubmitter implements MeshJob {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshJobSubmitter.class);
+    private static final ObjectMapper MAPPER = MeshObjectMappers.create();
+
+    private final MeshCore core;
+    private final String capability;
+    private final String submittedBy;
+    private final String registryUrl;
+
+    /**
+     * Construct a submitter bound to a capability + the local instance ID.
+     * Phase B's DDDI wiring constructs these per-call-site; the constructor
+     * is also exposed for tests.
+     *
+     * @param capability   Target capability name (the {@code task = true} tool)
+     * @param submittedBy  Submitter identity (typically this agent's instance id)
+     * @param registryUrl  Registry base URL
+     */
+    public MeshJobSubmitter(String capability, String submittedBy, String registryUrl) {
+        if (capability == null || capability.isEmpty()) {
+            throw new IllegalArgumentException("capability is required");
+        }
+        if (submittedBy == null || submittedBy.isEmpty()) {
+            throw new IllegalArgumentException("submittedBy is required");
+        }
+        if (registryUrl == null || registryUrl.isEmpty()) {
+            throw new IllegalArgumentException("registryUrl is required");
+        }
+        this.core = MeshCore.load();
+        this.capability = capability;
+        this.submittedBy = submittedBy;
+        this.registryUrl = registryUrl;
+    }
+
+    /** Capability this submitter targets. */
+    public String capability() {
+        return capability;
+    }
+
+    /** Identity recorded as {@code submitted_by} on each new job row. */
+    public String submittedBy() {
+        return submittedBy;
+    }
+
+    /**
+     * Submit a job with the given payload, no extra options.
+     *
+     * <p>Equivalent to {@link #submit(SubmitOptions)} with a default
+     * {@link SubmitOptions} carrying just the payload.
+     */
+    public CompletableFuture<JobProxy> submit(Map<String, Object> payload) {
+        return submit(new SubmitOptions(payload, null, null, null, null));
+    }
+
+    /**
+     * Submit a job with full control over registry-side options.
+     *
+     * @param options Submission options (payload + optional duration / retries / deadline)
+     * @return A future resolving to a {@link JobProxy} for the new job, or
+     *         completing exceptionally with a {@link MeshException} on
+     *         submission failure.
+     */
+    public CompletableFuture<JobProxy> submit(SubmitOptions options) {
+        if (options == null) {
+            return CompletableFuture.failedFuture(
+                new IllegalArgumentException("options is required"));
+        }
+        // Build the args envelope on the calling thread (cheap, deterministic
+        // failure surface) — the heavy lifting (network call) happens on
+        // the FJP worker.
+        final String argsJson;
+        try {
+            argsJson = buildArgsJson(options);
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(
+                new MeshException("Failed to encode submit args", e));
+        }
+        return CompletableFuture.supplyAsync(() -> doSubmit(argsJson));
+    }
+
+    private JobProxy doSubmit(String argsJson) {
+        PointerByReference out = new PointerByReference();
+        int rc = core.mesh_submit_job(argsJson, out);
+        if (rc != 0) {
+            throw new MeshException("mesh_submit_job failed: " + lastError(core));
+        }
+        Pointer handle = out.getValue();
+        if (handle == null) {
+            throw new MeshException("mesh_submit_job returned null handle");
+        }
+        // Read the job id off the proxy so the wrapper can carry it without
+        // a second FFI hop later.
+        PointerByReference idOut = new PointerByReference();
+        int rc2 = core.mesh_job_proxy_job_id(handle, idOut);
+        if (rc2 != 0) {
+            // Free the handle we just leaked into ownership-land.
+            core.mesh_job_proxy_free(handle);
+            throw new MeshException("mesh_job_proxy_job_id failed: " + lastError(core));
+        }
+        Pointer idPtr = idOut.getValue();
+        String jobId;
+        try {
+            jobId = idPtr != null ? idPtr.getString(0) : "";
+        } finally {
+            if (idPtr != null) {
+                core.mesh_free_string(idPtr);
+            }
+        }
+        log.debug("Submitted job {} for capability {}", jobId, capability);
+        return new JobProxy(core, handle, jobId);
+    }
+
+    private String buildArgsJson(SubmitOptions options) {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("registry_url", registryUrl);
+        root.put("capability", capability);
+        root.put("submitted_by", submittedBy);
+        // Payload may be null → emit JSON null so the wire schema validates.
+        root.set("payload", MAPPER.valueToTree(options.payload));
+        if (options.ownerInstanceId != null) {
+            root.put("owner_instance_id", options.ownerInstanceId);
+        }
+        if (options.maxDuration != null) {
+            root.put("max_duration", options.maxDuration);
+        }
+        if (options.maxRetries != null) {
+            root.put("max_retries", options.maxRetries);
+        }
+        if (options.totalDeadline != null) {
+            root.put("total_deadline", options.totalDeadline);
+        }
+        return MAPPER.writeValueAsString(root);
+    }
+
+    private static String lastError(MeshCore core) {
+        Pointer err = core.mesh_last_error();
+        if (err == null) {
+            return "<no error message>";
+        }
+        try {
+            return err.getString(0);
+        } finally {
+            core.mesh_free_string(err);
+        }
+    }
+
+    /**
+     * Submission options. All fields except {@code payload} are optional;
+     * pass {@code null} to accept the registry / runtime defaults.
+     *
+     * <p>Field semantics match {@code SubmitJobArgs} in the Rust core
+     * ({@code jobs.rs}): {@code maxDuration} is per-attempt seconds,
+     * {@code maxRetries} caps the retry budget, {@code totalDeadline} is
+     * an absolute Unix-epoch second cap across all retries (null ≡
+     * unlimited), and {@code ownerInstanceId} pins the job to a specific
+     * replica (push mode) vs. leaving it unclaimed for pull-mode workers.
+     */
+    public static final class SubmitOptions {
+        public final Map<String, Object> payload;
+        public final String ownerInstanceId;
+        public final Integer maxDuration;
+        public final Integer maxRetries;
+        public final Long totalDeadline;
+
+        public SubmitOptions(
+                Map<String, Object> payload,
+                String ownerInstanceId,
+                Integer maxDuration,
+                Integer maxRetries,
+                Long totalDeadline) {
+            this.payload = payload;
+            this.ownerInstanceId = ownerInstanceId;
+            this.maxDuration = maxDuration;
+            this.maxRetries = maxRetries;
+            this.totalDeadline = totalDeadline;
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshTool.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshTool.java
@@ -137,4 +137,45 @@ public @interface MeshTool {
      * }</pre>
      */
     boolean outputSchemaStrict() default true;
+
+    /**
+     * Marks this tool as a long-running <b>task</b> (MeshJob).
+     *
+     * <p>When {@code true}, the runtime treats this method as a producer for
+     * the MeshJob substrate (Phase 1 — see {@code MESHJOB_DESIGN.org}):
+     * <ul>
+     *   <li>Inbound HTTP calls bearing an {@code X-Mesh-Job-Id} header dispatch
+     *       through the job pipeline, with a {@link MeshJob}-typed parameter
+     *       receiving an injected {@code JobController} for progress / result /
+     *       failure reporting.</li>
+     *   <li>Pull-mode workers can claim queued jobs for this capability via
+     *       {@code POST /jobs/claim} when the registry's
+     *       {@code X-Mesh-Pending-Jobs} header signals work.</li>
+     *   <li>The capability is advertised to the registry with the
+     *       {@code task} attribute so consumers depending on it receive a
+     *       {@code MeshJobSubmitter} (rather than the synchronous
+     *       {@code McpMeshTool} proxy) via DDDI.</li>
+     * </ul>
+     *
+     * <p>The method MUST also declare exactly one {@link MeshJob} parameter (per
+     * {@code MESHJOB_DDDI_CONTRACT.md}); the resolver rejects multiple. The
+     * parameter may legitimately receive {@code null} when the tool is called
+     * synchronously via the regular {@code tools/call} fast path — user code
+     * must tolerate that.
+     *
+     * <p>Default {@code false} preserves existing tool semantics.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * @MeshTool(capability = "plan_trip", task = true)
+     * public CompletableFuture<TripPlan> planTrip(
+     *     @Param("user_id") String userId,
+     *     MeshJob job
+     * ) {
+     *     if (job instanceof JobController c) c.updateProgress(0.25, "...");
+     *     return CompletableFuture.completedFuture(...);
+     * }
+     * }</pre>
+     */
+    boolean task() default false;
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ClaimDispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ClaimDispatcher.java
@@ -1,0 +1,503 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.JobContext;
+import io.mcpmesh.JobController;
+import io.mcpmesh.core.MeshObjectMappers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Pure-Java claim dispatcher for {@code task=true} producers (Phase B —
+ * MeshJob substrate). One dispatcher is spawned per registered task
+ * capability; each runs a polling loop that:
+ *
+ * <ol>
+ *   <li>Acquires a permit from a {@link Semaphore} sized to the
+ *       concurrency cap (default 4 — matches Rust core +
+ *       Python {@code _MAX_CONCURRENT_DISPATCHES} + TS dispatcher).</li>
+ *   <li>POSTs to {@code /jobs/claim} on the registry. On 204 / empty,
+ *       releases the permit and backs off (200ms → 1s → 5s).</li>
+ *   <li>On a successful claim, hands the permit to the dispatch
+ *       executor; the dispatch task constructs a {@link JobController},
+ *       sets both Java + native contexts, invokes the user method via
+ *       reflection, and auto-completes / fails as the inbound wrapper
+ *       does. Releases the permit in {@code finally}.</li>
+ * </ol>
+ *
+ * <p><b>Acquire-before-claim ordering</b> is critical — see PR #883 (Python)
+ * and PR #885 (TypeScript) for the same fix. Without it, a 5th
+ * concurrent claim could be granted while four handlers were still
+ * running; the registry would record this agent as the owner and tick
+ * down the lease, then orphan + reclaim once the lease expired.
+ *
+ * <p>Mirror of:
+ * <ul>
+ *   <li>Python {@code _mcp_mesh.engine.claim_dispatcher.PythonClaimDispatcher}</li>
+ *   <li>TypeScript {@code @mcp-mesh/runtime ClaimDispatcher} (claim-dispatcher.ts)</li>
+ * </ul>
+ */
+public final class ClaimDispatcher implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(ClaimDispatcher.class);
+    private static final ObjectMapper MAPPER = MeshObjectMappers.create();
+
+    /** Concurrency cap matches Rust core + Python + TS. */
+    private static final int MAX_CONCURRENT_DISPATCHES = 4;
+
+    private static final long POLL_BASE_MS = 200L;
+    private static final long POLL_STEP_MS = 1_000L;
+    private static final long POLL_MAX_MS = 5_000L;
+
+    private static final long CLAIM_HTTP_TIMEOUT_SECS = 10L;
+    private static final int CONSECUTIVE_FAILURE_ERROR_THRESHOLD = 5;
+
+    private static final long DEFAULT_DRAIN_TIMEOUT_MS = 30_000L;
+
+    /** Handler invoked with the claimed payload + a producer controller. */
+    public interface ClaimHandler {
+        /**
+         * Run the user method for one claimed job. The dispatcher has
+         * already constructed the controller and bound both job
+         * contexts — the handler just calls the user method with the
+         * payload and returns its result. Auto-complete is handled by
+         * the dispatcher's caller (matches the inbound wrapper path).
+         *
+         * @param payload    The {@code submitted_payload} from the claim
+         * @param controller A controller bound to the claimed job_id
+         * @return The user method's return value
+         * @throws Exception whatever the user method throws
+         */
+        Object handle(Map<String, Object> payload, JobController controller) throws Exception;
+    }
+
+    private final String capability;
+    private final String instanceId;
+    private final String registryUrl;
+    private final ClaimHandler handler;
+
+    private final Semaphore permits = new Semaphore(MAX_CONCURRENT_DISPATCHES);
+    private final AtomicBoolean stopped = new AtomicBoolean(false);
+    private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
+
+    /**
+     * Tracks in-flight handler dispatches so {@link #stop(long)} can
+     * drain them with a bounded timeout before closing the HttpClient
+     * pool. Mirrors the TS dispatcher's {@code _inflightHandlers}
+     * fix from PR #885.
+     */
+    private final Set<Future<?>> inflight = ConcurrentHashMap.newKeySet();
+
+    /** The polling loop's executor (single-threaded, daemon). */
+    private final ExecutorService loopExecutor;
+    /** The dispatch executor — handlers run here so the loop stays free. */
+    private final ExecutorService dispatchExecutor;
+    /** HTTP client for /jobs/claim polls. Closed on stop(). */
+    private final HttpClient httpClient;
+
+    private Future<?> loopFuture;
+
+    public ClaimDispatcher(String capability, String instanceId, String registryUrl, ClaimHandler handler) {
+        if (capability == null || capability.isEmpty()) {
+            throw new IllegalArgumentException("capability is required");
+        }
+        if (instanceId == null || instanceId.isEmpty()) {
+            throw new IllegalArgumentException("instanceId is required");
+        }
+        if (registryUrl == null || registryUrl.isEmpty()) {
+            throw new IllegalArgumentException("registryUrl is required");
+        }
+        if (handler == null) {
+            throw new IllegalArgumentException("handler is required");
+        }
+        this.capability = capability;
+        this.instanceId = instanceId;
+        this.registryUrl = stripTrailingSlash(registryUrl);
+        this.handler = handler;
+        this.loopExecutor = Executors.newSingleThreadExecutor(named("mesh-claim-loop-" + capability));
+        this.dispatchExecutor = Executors.newFixedThreadPool(MAX_CONCURRENT_DISPATCHES,
+            named("mesh-claim-dispatch-" + capability));
+        this.httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(CLAIM_HTTP_TIMEOUT_SECS))
+            .build();
+    }
+
+    /** Spawn the polling loop. Idempotent. */
+    public synchronized void start() {
+        if (loopFuture != null) {
+            return;
+        }
+        log.info("ClaimDispatcher started: capability={} instance={}", capability, instanceId);
+        loopFuture = loopExecutor.submit(this::runLoop);
+    }
+
+    /**
+     * Signal stop and drain in-flight handlers with the default 30s
+     * timeout, then close the HttpClient pool. Idempotent.
+     */
+    @Override
+    public void close() {
+        stop(DEFAULT_DRAIN_TIMEOUT_MS);
+    }
+
+    /**
+     * Signal stop and drain in-flight handlers with the given timeout.
+     * Best-effort — never throws. Pass {@code 0} for an immediate close
+     * (skips the drain entirely; tests use this).
+     */
+    public void stop(long drainTimeoutMs) {
+        if (!stopped.compareAndSet(false, true)) {
+            return;
+        }
+        log.info("ClaimDispatcher stopping: capability={} instance={} (drainTimeoutMs={})",
+            capability, instanceId, drainTimeoutMs);
+        // Wake the loop if it's blocked on permit acquire.
+        permits.release(MAX_CONCURRENT_DISPATCHES * 2);
+
+        // Stop the loop executor — it will exit at the next iteration check.
+        loopExecutor.shutdownNow();
+        try {
+            loopExecutor.awaitTermination(2, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // Drain in-flight handler dispatches before closing the HttpClient.
+        if (drainTimeoutMs > 0 && !inflight.isEmpty()) {
+            long deadline = System.currentTimeMillis() + drainTimeoutMs;
+            for (Future<?> f : new HashSet<>(inflight)) {
+                long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    log.warn("ClaimDispatcher capability={} instance={}: drain timed out " +
+                        "with {} handler(s) still in-flight; closing pool anyway",
+                        capability, instanceId, inflight.size());
+                    break;
+                }
+                try {
+                    f.get(remaining, TimeUnit.MILLISECONDS);
+                } catch (TimeoutException te) {
+                    log.warn("ClaimDispatcher drain: handler still in-flight after timeout");
+                    break;
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                } catch (ExecutionException ee) {
+                    // Handler error already logged inside dispatch — ignore here.
+                }
+            }
+        }
+
+        dispatchExecutor.shutdownNow();
+        try {
+            dispatchExecutor.awaitTermination(2, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // HttpClient (java.net.http) doesn't expose a close() in Java 17;
+        // shutdown() / close() were added in 21. Use reflection so the
+        // dispatcher compiles on 17 and still cleanly closes on 21+.
+        try {
+            httpClient.getClass().getMethod("close").invoke(httpClient);
+        } catch (NoSuchMethodException nme) {
+            // Java 17 — no explicit close. Pool will be GC'd; fine for
+            // test harnesses since the ClassLoader survives.
+        } catch (Exception e) {
+            log.debug("HttpClient close failed: {}", e.getMessage());
+        }
+    }
+
+    // ===== Internals ==========================================================
+
+    private void runLoop() {
+        long backoffMs = POLL_BASE_MS;
+        try {
+            while (!stopped.get() && !Thread.currentThread().isInterrupted()) {
+                // Acquire BEFORE polling /jobs/claim so we never claim
+                // more jobs than we can immediately execute. See class
+                // javadoc for the cross-SDK rationale.
+                try {
+                    permits.acquire();
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                if (stopped.get()) {
+                    permits.release();
+                    return;
+                }
+
+                Map<String, Object> claimed;
+                boolean permitTransferred = false;
+                try {
+                    claimed = claimOnce();
+                } catch (Exception e) {
+                    int n = consecutiveFailures.incrementAndGet();
+                    String msg = "claim_once raised: " + e + " (consecutive_failures=" + n + ")";
+                    if (n >= CONSECUTIVE_FAILURE_ERROR_THRESHOLD) {
+                        log.error("[mesh-claim] capability={} instance={}: {}", capability, instanceId, msg);
+                    } else {
+                        log.warn("[mesh-claim] capability={} instance={}: {}", capability, instanceId, msg);
+                    }
+                    permits.release();
+                    sleep(backoffMs);
+                    backoffMs = Math.min(backoffMs == POLL_BASE_MS ? POLL_STEP_MS : backoffMs * 5, POLL_MAX_MS);
+                    continue;
+                }
+
+                if (claimed != null) {
+                    consecutiveFailures.set(0);
+                    backoffMs = POLL_BASE_MS;
+                    // Hand the permit ownership to the dispatch task.
+                    permitTransferred = true;
+                    Future<?> f = dispatchExecutor.submit(() -> {
+                        try {
+                            dispatch(claimed);
+                        } finally {
+                            permits.release();
+                        }
+                    });
+                    inflight.add(f);
+                    f = wrapInflight(f);
+                } else {
+                    // No work — release permit and back off.
+                    permits.release();
+                    sleep(backoffMs);
+                    backoffMs = Math.min(backoffMs == POLL_BASE_MS ? POLL_STEP_MS : backoffMs * 5, POLL_MAX_MS);
+                }
+                if (!permitTransferred && stopped.get()) {
+                    return;
+                }
+            }
+        } finally {
+            log.info("ClaimDispatcher stopped: capability={} instance={}", capability, instanceId);
+        }
+    }
+
+    /**
+     * Wrap the dispatch future so it self-removes from {@link #inflight}
+     * on completion. Returns the original future.
+     */
+    private Future<?> wrapInflight(Future<?> f) {
+        // We can't add a completion callback to a Future directly without
+        // a CompletableFuture, so the dispatch executor's submit returns
+        // a Future we registered. Self-removal is handled by the
+        // dispatch task's finally below. Here we just return the future
+        // for the caller's reference.
+        return f;
+    }
+
+    /**
+     * One {@code POST /jobs/claim} round-trip. Returns the single
+     * claimed-job map (Phase 1 wire is single-claim) or null when no
+     * work is available / on error. Errors increment
+     * {@link #consecutiveFailures}; the loop logs at warn or error
+     * depending on the count.
+     */
+    private Map<String, Object> claimOnce() throws Exception {
+        String url = registryUrl + "/jobs/claim";
+        String body = "{\"capability\":\"" + capability.replace("\"", "\\\"")
+            + "\",\"instance_id\":\"" + instanceId.replace("\"", "\\\"") + "\"}";
+        HttpRequest req = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .timeout(Duration.ofSeconds(CLAIM_HTTP_TIMEOUT_SECS))
+            .header("content-type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+        HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() == 204) {
+            return null;
+        }
+        if (resp.statusCode() != 200) {
+            throw new RuntimeException("unexpected status " + resp.statusCode() + " from " + url);
+        }
+        JsonNode root = MAPPER.readTree(resp.body());
+        JsonNode claimedArr = root.get("claimed");
+        if (claimedArr == null || !claimedArr.isArray() || claimedArr.size() == 0) {
+            return null;
+        }
+        // Phase 1 wire is single-claim by design. Defensive: take the first.
+        if (claimedArr.size() > 1) {
+            log.warn("[mesh-claim] capability={} instance={}: multi-claim response (got {} jobs) — " +
+                "Phase 1 wire is single-claim by design; taking first only",
+                capability, instanceId, claimedArr.size());
+        }
+        JsonNode first = claimedArr.get(0);
+        if (first == null || !first.isObject()) {
+            return null;
+        }
+        @SuppressWarnings("unchecked")
+        Map<String, Object> claimedMap = MAPPER.convertValue(first, Map.class);
+        if (claimedMap.get("id") == null) {
+            return null;
+        }
+        return claimedMap;
+    }
+
+    /**
+     * Run the local handler for one claimed job. Constructs a controller,
+     * sets both Java + native job contexts, invokes the handler, auto-
+     * completes / fails. Mirrors the inbound dispatch wrapper exactly so
+     * push-mode (header-based) and pull-mode (claim-based) producers use
+     * the same auto-complete semantics.
+     */
+    private void dispatch(Map<String, Object> claimed) {
+        String jobId = String.valueOf(claimed.getOrDefault("id", ""));
+        if (jobId.isEmpty()) return;
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> payload = claimed.get("submitted_payload") instanceof Map
+            ? (Map<String, Object>) claimed.get("submitted_payload")
+            : Map.of();
+        Long deadlineSecs = null;
+        Object maxDur = claimed.get("max_duration");
+        if (maxDur instanceof Number n && n.longValue() > 0) {
+            deadlineSecs = n.longValue();
+        }
+
+        JobController controller;
+        try {
+            controller = JobController.open(jobId, instanceId, registryUrl);
+        } catch (Exception e) {
+            log.warn("[mesh-claim] failed to construct controller for job={}: {}", jobId, e.getMessage());
+            // Best-effort: tell the registry we failed so the row doesn't
+            // sit in `working` until the lease sweep notices.
+            failJobByIdDirectly(jobId, "controller construction failed: " + e.getMessage());
+            return;
+        }
+
+        try {
+            // Bind the Java-side ThreadLocal job context for the user
+            // method's duration. We intentionally do NOT call
+            // mesh_run_as_job here for the same reason as the inbound
+            // wrapper — see MeshToolWrapper.dispatchAsJob class javadoc.
+            // (Rust task-local + cancel-registry binding is Phase B-
+            // deferred; the registry sweep is the backstop on cancel.)
+            JobContext.Snapshot snap = new JobContext.Snapshot(jobId, deadlineSecs);
+            try {
+                JobContext.withJob(snap, () -> {
+                    runHandler(payload, controller);
+                    return null;
+                });
+            } catch (Throwable t) {
+                log.warn("[mesh-claim] handler raised for job={} capability={}: {}",
+                    jobId, capability, t.getMessage());
+            }
+        } finally {
+            controller.close();
+        }
+    }
+
+    private void runHandler(Map<String, Object> payload, JobController controller) {
+        Object result;
+        try {
+            result = handler.handle(payload, controller);
+        } catch (Exception e) {
+            tryFail(controller, e.toString());
+            return;
+        }
+        // Auto-complete iff the user didn't already close the row.
+        try {
+            if (!controller.isTerminal()) {
+                controller.complete(result);
+            }
+        } catch (Exception e) {
+            log.warn("Auto-complete failed for job {}: {}", controller.jobId(), e.getMessage());
+        }
+    }
+
+    private static void tryFail(JobController controller, String reason) {
+        try {
+            if (!controller.isTerminal()) {
+                controller.fail(reason);
+            }
+        } catch (Exception ignored) {
+            // Best-effort.
+        }
+    }
+
+    /**
+     * Fail a job by posting a single {@code failed} delta to
+     * {@code /jobs/batch}, bypassing the (failed) controller construction
+     * path. Without this the row stays in {@code working} until the
+     * registry's lease sweeper notices, which can be minutes.
+     */
+    private void failJobByIdDirectly(String jobId, String reason) {
+        try {
+            String body = MAPPER.writeValueAsString(Map.of(
+                "instance_id", instanceId,
+                "deltas", new Object[]{ Map.of(
+                    "id", jobId,
+                    "status", "failed",
+                    "error", reason
+                )}
+            ));
+            HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create(registryUrl + "/jobs/batch"))
+                .timeout(Duration.ofSeconds(CLAIM_HTTP_TIMEOUT_SECS))
+                .header("content-type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+            HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() != 200) {
+                log.warn("[mesh-claim] /jobs/batch returned {} when failing job={}; relying on registry sweep",
+                    resp.statusCode(), jobId);
+            }
+        } catch (Exception e) {
+            log.warn("[mesh-claim] /jobs/batch fail-fast for job={} raised: {}", jobId, e.getMessage());
+        }
+    }
+
+    private static String buildSnapshotJson(String jobId, Long deadlineSecs) {
+        StringBuilder sb = new StringBuilder("{\"job_id\":\"")
+            .append(jobId.replace("\"", "\\\""))
+            .append('"');
+        if (deadlineSecs != null) {
+            sb.append(",\"deadline_secs\":").append(deadlineSecs);
+        }
+        sb.append('}');
+        return sb.toString();
+    }
+
+    private static String stripTrailingSlash(String url) {
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static ThreadFactory named(String prefix) {
+        AtomicInteger seq = new AtomicInteger();
+        return r -> {
+            Thread t = new Thread(r, prefix + "-" + seq.incrementAndGet());
+            t.setDaemon(true);
+            return t;
+        };
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ClaimDispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ClaimDispatcher.java
@@ -274,17 +274,46 @@ public final class ClaimDispatcher implements AutoCloseable {
                     // finally — without this, every claimed job would
                     // accumulate a Future entry holding the full payload
                     // map for the lifetime of the JVM (PR review #874).
+                    //
+                    // Construct the FutureTask FIRST and add it to
+                    // `inflight` BEFORE handing it to the executor. With
+                    // the previous `executor.submit() then add`
+                    // pattern, a fast worker could run the whole
+                    // handler + finally.remove() before the caller's
+                    // add() landed — leaving a completed-but-never-
+                    // removed Future leaked in the set (PR #891 review).
+                    final java.util.concurrent.FutureTask<?> task =
+                        new java.util.concurrent.FutureTask<Void>(() -> {
+                            try {
+                                dispatch(claimed);
+                            } finally {
+                                permits.release();
+                                // `task` is in scope via the lambda
+                                // capture; this is safe because the
+                                // FutureTask reference is established
+                                // before .execute() runs the body.
+                            }
+                            return null;
+                        });
+                    inflight.add(task);
                     permitTransferred = true;
-                    final Future<?>[] holder = new Future<?>[1];
-                    holder[0] = dispatchExecutor.submit(() -> {
-                        try {
-                            dispatch(claimed);
-                        } finally {
-                            permits.release();
-                            inflight.remove(holder[0]);
-                        }
-                    });
-                    inflight.add(holder[0]);
+                    try {
+                        dispatchExecutor.execute(() -> {
+                            try {
+                                task.run();
+                            } finally {
+                                inflight.remove(task);
+                            }
+                        });
+                    } catch (RuntimeException rejected) {
+                        // Executor refused (shutdown race). Undo the
+                        // bookkeeping so we don't leak a Future that
+                        // never completes.
+                        inflight.remove(task);
+                        permits.release();
+                        permitTransferred = false;
+                        throw rejected;
+                    }
                 } else {
                     // No work — release permit and back off.
                     permits.release();
@@ -398,8 +427,36 @@ public final class ClaimDispatcher implements AutoCloseable {
                     return null;
                 });
             } catch (Throwable t) {
-                log.warn("[mesh-claim] handler raised for job={} capability={}: {}",
-                    jobId, capability, t.getMessage());
+                // `runHandler` itself catches user-method exceptions and
+                // calls `controller.fail(...)` — anything that lands here
+                // is a dispatcher-internal error (JobContext binding,
+                // reflection on the handler lambda, etc.). Without an
+                // eager fail() the job stays in `working` until the
+                // registry's lease sweep notices, which can be minutes.
+                // (PR #891 review.)
+                log.error("[mesh-claim] dispatcher-internal error for job={} capability={}: {}",
+                    jobId, capability, t, t);
+                String reason = "dispatcher-internal: " + (t.getMessage() != null
+                    ? t.getMessage()
+                    : t.getClass().getSimpleName());
+                // Try the open controller first (cheap, already authenticated);
+                // fall back to a direct /jobs/batch POST if the controller is
+                // already terminal or its FFI call also fails.
+                boolean reported = false;
+                try {
+                    if (!controller.isTerminal()) {
+                        controller.fail(reason);
+                        reported = true;
+                    } else {
+                        reported = true;  // already terminal — nothing more to do
+                    }
+                } catch (Throwable failErr) {
+                    log.warn("[mesh-claim] controller.fail() failed for job={}: {}; " +
+                        "falling back to /jobs/batch", jobId, failErr.getMessage());
+                }
+                if (!reported) {
+                    failJobByIdDirectly(jobId, reason);
+                }
             }
         } finally {
             controller.close();

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ClaimDispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ClaimDispatcher.java
@@ -269,17 +269,22 @@ public final class ClaimDispatcher implements AutoCloseable {
                 if (claimed != null) {
                     consecutiveFailures.set(0);
                     backoffMs = POLL_BASE_MS;
-                    // Hand the permit ownership to the dispatch task.
+                    // Hand the permit ownership to the dispatch task. The
+                    // task self-removes its own Future from `inflight` in
+                    // finally — without this, every claimed job would
+                    // accumulate a Future entry holding the full payload
+                    // map for the lifetime of the JVM (PR review #874).
                     permitTransferred = true;
-                    Future<?> f = dispatchExecutor.submit(() -> {
+                    final Future<?>[] holder = new Future<?>[1];
+                    holder[0] = dispatchExecutor.submit(() -> {
                         try {
                             dispatch(claimed);
                         } finally {
                             permits.release();
+                            inflight.remove(holder[0]);
                         }
                     });
-                    inflight.add(f);
-                    f = wrapInflight(f);
+                    inflight.add(holder[0]);
                 } else {
                     // No work — release permit and back off.
                     permits.release();
@@ -296,19 +301,6 @@ public final class ClaimDispatcher implements AutoCloseable {
     }
 
     /**
-     * Wrap the dispatch future so it self-removes from {@link #inflight}
-     * on completion. Returns the original future.
-     */
-    private Future<?> wrapInflight(Future<?> f) {
-        // We can't add a completion callback to a Future directly without
-        // a CompletableFuture, so the dispatch executor's submit returns
-        // a Future we registered. Self-removal is handled by the
-        // dispatch task's finally below. Here we just return the future
-        // for the caller's reference.
-        return f;
-    }
-
-    /**
      * One {@code POST /jobs/claim} round-trip. Returns the single
      * claimed-job map (Phase 1 wire is single-claim) or null when no
      * work is available / on error. Errors increment
@@ -317,8 +309,13 @@ public final class ClaimDispatcher implements AutoCloseable {
      */
     private Map<String, Object> claimOnce() throws Exception {
         String url = registryUrl + "/jobs/claim";
-        String body = "{\"capability\":\"" + capability.replace("\"", "\\\"")
-            + "\",\"instance_id\":\"" + instanceId.replace("\"", "\\\"") + "\"}";
+        // Use Jackson rather than manual escape — capability / instance_id
+        // are well-formed in practice but a stray '\' or control char in
+        // either would otherwise produce invalid JSON (PR review #874).
+        String body = MAPPER.writeValueAsString(Map.of(
+            "capability", capability,
+            "instance_id", instanceId
+        ));
         HttpRequest req = HttpRequest.newBuilder()
             .uri(URI.create(url))
             .timeout(Duration.ofSeconds(CLAIM_HTTP_TIMEOUT_SECS))
@@ -467,17 +464,6 @@ public final class ClaimDispatcher implements AutoCloseable {
         } catch (Exception e) {
             log.warn("[mesh-claim] /jobs/batch fail-fast for job={} raised: {}", jobId, e.getMessage());
         }
-    }
-
-    private static String buildSnapshotJson(String jobId, Long deadlineSecs) {
-        StringBuilder sb = new StringBuilder("{\"job_id\":\"")
-            .append(jobId.replace("\"", "\\\""))
-            .append('"');
-        if (deadlineSecs != null) {
-            sb.append(",\"deadline_secs\":").append(deadlineSecs);
-        }
-        sb.append('}');
-        return sb.toString();
     }
 
     private static String stripTrailingSlash(String url) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobCancelController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobCancelController.java
@@ -1,0 +1,56 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.core.MeshCore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Spring MVC controller exposing {@code POST /jobs/{jobId}/cancel} on every
+ * mesh agent (Phase B — MeshJob substrate). The registry forwards cancel
+ * requests for an active job to its owner replica via this route; the
+ * handler fires the in-process cancel token via
+ * {@link MeshCore#mesh_cancel_active_job}, which signals any
+ * {@code mesh_run_as_job}-bound futures to abort.
+ *
+ * <p>Mirror of:
+ * <ul>
+ *   <li>Python {@code _mcp_mesh.engine.cancel_route} (FastAPI handler)</li>
+ *   <li>TypeScript {@code @mcp-mesh/runtime registerCancelRoute} in agent.ts</li>
+ * </ul>
+ *
+ * <p>Returns {@code {"cancelled": <bool>, "jobId": <id>}} per
+ * {@code MESHJOB_DESIGN.org} → "Cancel route response". The boolean is
+ * true iff a token was found and fired (i.e. this replica owned an
+ * active job for the id), false otherwise — the registry treats the
+ * 200/false response as "owner replica is alive but the job has already
+ * gone terminal" and proceeds to mark the row cancelled.
+ */
+@RestController
+public class JobCancelController {
+
+    private static final Logger log = LoggerFactory.getLogger(JobCancelController.class);
+
+    @PostMapping("/jobs/{jobId}/cancel")
+    public Map<String, Object> cancelJob(@PathVariable String jobId) {
+        MeshCore core = MeshCore.load();
+        int rc = core.mesh_cancel_active_job(jobId);
+        boolean cancelled = rc == 1;
+        if (rc < 0) {
+            log.warn("mesh_cancel_active_job returned {} for jobId={}", rc, jobId);
+        } else if (cancelled) {
+            log.info("Cancelled active job {}", jobId);
+        } else {
+            log.debug("No active job for {} (registry will still mark cancelled)", jobId);
+        }
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("cancelled", cancelled);
+        body.put("jobId", jobId);
+        return body;
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsHelperToolHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsHelperToolHandler.java
@@ -1,0 +1,173 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.JobProxy;
+import io.mcpmesh.core.MeshException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Handlers for the three framework-internal MeshJob helper tools (Phase B
+ * — MeshJob substrate). Auto-registered on every Java mesh agent
+ * regardless of whether the agent owns any {@code task=true} tools, so
+ * any MCP client can poll job status / result / cancel by calling any
+ * agent.
+ *
+ * <p>The handlers are thin shims around {@link JobProxy} — all reads /
+ * cancels terminate at the registry's {@code GET /jobs/{id}} /
+ * {@code POST /jobs/{id}/cancel}. No replica-side caching, no owner-
+ * bound routing for reads (matches the "Status read path" decision in
+ * {@code MESHJOB_DESIGN.org}).
+ *
+ * <p>Mirror of:
+ * <ul>
+ *   <li>Python {@code _mcp_mesh.pipeline.mcp_startup.jobs_helper_tools}</li>
+ *   <li>TypeScript {@code @mcp-mesh/runtime jobs-helper-tools.ts}</li>
+ * </ul>
+ *
+ * <p>Tool names use a {@code __mesh_job_} prefix so MCP clients can
+ * filter them out of user-facing tool lists if desired. Reading is
+ * unauthenticated by design — knowledge of the job_id is the capability
+ * (presigned-URL semantics, ~122-bit UUID).
+ */
+public final class JobsHelperToolHandler implements McpToolHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(JobsHelperToolHandler.class);
+
+    public static final String TOOL_NAME_STATUS = "__mesh_job_status";
+    public static final String TOOL_NAME_RESULT = "__mesh_job_result";
+    public static final String TOOL_NAME_CANCEL = "__mesh_job_cancel";
+
+    enum Op {
+        STATUS, RESULT, CANCEL;
+
+        String toolName() {
+            return switch (this) {
+                case STATUS -> TOOL_NAME_STATUS;
+                case RESULT -> TOOL_NAME_RESULT;
+                case CANCEL -> TOOL_NAME_CANCEL;
+            };
+        }
+
+        String description() {
+            return switch (this) {
+                case STATUS -> "[Framework] Return the latest mesh-registry state for a "
+                    + "job_id. Reads terminate at the registry; safe to call from any agent.";
+                case RESULT -> "[Framework] Return the terminal result/status/error for a "
+                    + "job_id via a single registry read.";
+                case CANCEL -> "[Framework] Request cancellation for a job_id. The registry "
+                    + "forwards the signal to the owner replica when alive.";
+            };
+        }
+    }
+
+    private final Op op;
+    private final String registryUrl;
+
+    JobsHelperToolHandler(Op op, String registryUrl) {
+        this.op = op;
+        this.registryUrl = registryUrl;
+    }
+
+    /** Build all three helper handlers bound to {@code registryUrl}. */
+    public static List<JobsHelperToolHandler> all(String registryUrl) {
+        return List.of(
+            new JobsHelperToolHandler(Op.STATUS, registryUrl),
+            new JobsHelperToolHandler(Op.RESULT, registryUrl),
+            new JobsHelperToolHandler(Op.CANCEL, registryUrl)
+        );
+    }
+
+    @Override
+    public String getFuncId() {
+        // Use a synthetic prefix so this never collides with a user-declared funcId
+        return "__mesh_jobs_helper." + op.toolName();
+    }
+
+    @Override
+    public String getCapability() {
+        return op.toolName();
+    }
+
+    @Override
+    public String getMethodName() {
+        return op.toolName();
+    }
+
+    @Override
+    public String getDescription() {
+        return op.description();
+    }
+
+    @Override
+    public Map<String, Object> getInputSchema() {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", "object");
+        Map<String, Object> props = new LinkedHashMap<>();
+        Map<String, Object> jobIdProp = new LinkedHashMap<>();
+        jobIdProp.put("type", "string");
+        jobIdProp.put("description", "Job UUID");
+        props.put("job_id", jobIdProp);
+        if (op == Op.CANCEL) {
+            Map<String, Object> reasonProp = new LinkedHashMap<>();
+            reasonProp.put("type", "string");
+            reasonProp.put("description", "Optional cancel reason");
+            props.put("reason", reasonProp);
+        }
+        schema.put("properties", props);
+        schema.put("required", List.of("job_id"));
+        return schema;
+    }
+
+    @Override
+    public Object invoke(Map<String, Object> mcpArgs) throws Exception {
+        if (mcpArgs == null) {
+            throw new IllegalArgumentException("Missing required parameter: job_id");
+        }
+        Object jobIdObj = mcpArgs.get("job_id");
+        if (!(jobIdObj instanceof String jobId) || jobId.isEmpty()) {
+            throw new IllegalArgumentException("job_id must be a non-empty string");
+        }
+        if (registryUrl == null || registryUrl.isEmpty()) {
+            throw new MeshException(op.toolName() + ": no registry URL configured");
+        }
+
+        try (JobProxy proxy = JobProxy.open(jobId, registryUrl)) {
+            return switch (op) {
+                case STATUS -> proxy.status();
+                case RESULT -> {
+                    Map<String, Object> snapshot = proxy.status();
+                    Map<String, Object> out = new LinkedHashMap<>();
+                    out.put("status", snapshot.get("status"));
+                    out.put("result", snapshot.get("result"));
+                    out.put("error", snapshot.get("error"));
+                    yield out;
+                }
+                case CANCEL -> {
+                    String reason = mcpArgs.get("reason") instanceof String s ? s : null;
+                    proxy.cancel(reason);
+                    Map<String, Object> ok = new LinkedHashMap<>();
+                    ok.put("ok", true);
+                    ok.put("job_id", jobId);
+                    yield ok;
+                }
+            };
+        } catch (Exception e) {
+            log.warn("{} failed for job_id={}: {}", op.toolName(), jobId, e.getMessage());
+            throw e;
+        }
+    }
+
+    @Override
+    public int getDependencyCount() {
+        return 0;
+    }
+
+    @Override
+    public int getLlmAgentCount() {
+        return 0;
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsHelperToolHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsHelperToolHandler.java
@@ -147,7 +147,21 @@ public final class JobsHelperToolHandler implements McpToolHandler {
                     yield out;
                 }
                 case CANCEL -> {
-                    String reason = mcpArgs.get("reason") instanceof String s ? s : null;
+                    // Reject non-string `reason` explicitly rather than
+                    // silently coercing to null — a misformed call
+                    // should surface as a clear contract error, not as
+                    // a cancel-with-no-reason. (PR #891 review.)
+                    Object rawReason = mcpArgs.get("reason");
+                    String reason;
+                    if (rawReason == null) {
+                        reason = null;
+                    } else if (rawReason instanceof String s) {
+                        reason = s;
+                    } else {
+                        throw new IllegalArgumentException(
+                            "__mesh_job_cancel: 'reason' must be a string, got "
+                                + rawReason.getClass().getName());
+                    }
                     proxy.cancel(reason);
                     Map<String, Object> ok = new LinkedHashMap<>();
                     ok.put("ok", true);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsHelperToolsRegistrar.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsHelperToolsRegistrar.java
@@ -1,0 +1,98 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.core.AgentSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Auto-registers the three MeshJob helper tools (Phase B) on every Java
+ * mesh agent — independent of whether the agent owns any
+ * {@code task=true} tools. Mirror of:
+ * <ul>
+ *   <li>Python {@code _mcp_mesh.pipeline.mcp_startup.JobsHelperToolsStep}</li>
+ *   <li>TypeScript {@code @mcp-mesh/runtime registerJobsHelperTools}</li>
+ * </ul>
+ *
+ * <p>Two registrations are performed:
+ * <ul>
+ *   <li><b>Wrapper registry</b> — so MCP {@code tools/call} requests for
+ *       the helper names land at {@link JobsHelperToolHandler}.</li>
+ *   <li><b>Tool registry</b> (synthetic) — so the heartbeat advertises
+ *       the helpers as capabilities in the registry's catalog. Without
+ *       this, {@code meshctl call <agent> __mesh_job_status ...} would
+ *       fail with "tool not found" because the registry doesn't know
+ *       they exist (matches Python bug #5 fix).</li>
+ * </ul>
+ *
+ * <p>Skipped when no {@code MCP_MESH_REGISTRY_URL} is configured —
+ * without a registry to talk to, the helpers can't function.
+ */
+public final class JobsHelperToolsRegistrar {
+
+    private static final Logger log = LoggerFactory.getLogger(JobsHelperToolsRegistrar.class);
+
+    private JobsHelperToolsRegistrar() {}
+
+    /**
+     * Register the three helper tools with both registries.
+     *
+     * @param toolRegistry      Heartbeat catalog (synthetic tool spec)
+     * @param wrapperRegistry   MCP dispatch registry (real handler)
+     * @param registryUrl       Mesh registry base URL — handlers POST/GET against it
+     */
+    public static void register(
+            MeshToolRegistry toolRegistry,
+            MeshToolWrapperRegistry wrapperRegistry,
+            String registryUrl) {
+
+        if (registryUrl == null || registryUrl.isEmpty()) {
+            log.info("MeshJob helper tools skipped: no registry URL configured");
+            return;
+        }
+
+        List<JobsHelperToolHandler> handlers = JobsHelperToolHandler.all(registryUrl);
+        for (JobsHelperToolHandler handler : handlers) {
+            wrapperRegistry.registerHandler(handler);
+            toolRegistry.addSyntheticTool(buildSyntheticSpec(handler));
+        }
+        log.info("Registered {} MeshJob helper tools (status, result, cancel) on this agent",
+            handlers.size());
+    }
+
+    private static AgentSpec.ToolSpec buildSyntheticSpec(JobsHelperToolHandler handler) {
+        AgentSpec.ToolSpec spec = new AgentSpec.ToolSpec();
+        spec.setFunctionName(handler.getMethodName());
+        spec.setCapability(handler.getCapability());
+        spec.setDescription(handler.getDescription());
+        spec.setVersion("1.0.0");
+        spec.setTags(List.of("mesh-jobs", "framework"));
+        // Build a minimal input schema string for the registry catalog.
+        Map<String, Object> schema = handler.getInputSchema();
+        try {
+            String json = tools.jackson.databind.json.JsonMapper.builder().build()
+                .writeValueAsString(schema);
+            spec.setInputSchema(json);
+        } catch (Exception e) {
+            // Fall through with empty schema — heartbeat will still register
+            // the capability; only schema-aware matching loses precision.
+            log.debug("Failed to serialize helper tool schema: {}", e.getMessage());
+        }
+        // Mark as framework-internal via kwargs so future filters can
+        // distinguish helper tools from user-declared tools (matches the
+        // Python "framework_internal: true" metadata flag).
+        try {
+            Map<String, Object> kwargs = new LinkedHashMap<>();
+            kwargs.put("framework_internal", true);
+            String kwargsJson = tools.jackson.databind.json.JsonMapper.builder().build()
+                .writeValueAsString(kwargs);
+            spec.setKwargs(kwargsJson);
+        } catch (Exception ignored) {
+            // Best-effort; absence of the marker doesn't break dispatch.
+        }
+        return spec;
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsHelperToolsRegistrar.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsHelperToolsRegistrar.java
@@ -1,8 +1,10 @@
 package io.mcpmesh.spring;
 
 import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.core.MeshObjectMappers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -34,6 +36,15 @@ import java.util.Map;
 public final class JobsHelperToolsRegistrar {
 
     private static final Logger log = LoggerFactory.getLogger(JobsHelperToolsRegistrar.class);
+
+    /**
+     * Shared mapper — hoisted out of {@link #buildSyntheticSpec} which
+     * would otherwise allocate two new {@code JsonMapper} instances per
+     * helper tool (six per agent startup) just to serialize a tiny
+     * schema. Matches the {@code static final} pattern used elsewhere
+     * (e.g. {@link ClaimDispatcher}).
+     */
+    private static final ObjectMapper MAPPER = MeshObjectMappers.create();
 
     private JobsHelperToolsRegistrar() {}
 
@@ -73,8 +84,7 @@ public final class JobsHelperToolsRegistrar {
         // Build a minimal input schema string for the registry catalog.
         Map<String, Object> schema = handler.getInputSchema();
         try {
-            String json = tools.jackson.databind.json.JsonMapper.builder().build()
-                .writeValueAsString(schema);
+            String json = MAPPER.writeValueAsString(schema);
             spec.setInputSchema(json);
         } catch (Exception e) {
             // Fall through with empty schema — heartbeat will still register
@@ -87,8 +97,7 @@ public final class JobsHelperToolsRegistrar {
         try {
             Map<String, Object> kwargs = new LinkedHashMap<>();
             kwargs.put("framework_internal", true);
-            String kwargsJson = tools.jackson.databind.json.JsonMapper.builder().build()
-                .writeValueAsString(kwargs);
+            String kwargsJson = MAPPER.writeValueAsString(kwargs);
             spec.setKwargs(kwargsJson);
         } catch (Exception ignored) {
             // Best-effort; absence of the marker doesn't break dispatch.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
@@ -2,12 +2,15 @@ package io.mcpmesh.spring;
 
 import io.mcpmesh.JobController;
 import io.mcpmesh.MeshJobSubmitter;
+import io.mcpmesh.types.McpMeshTool;
+import io.mcpmesh.types.MeshLlmAgent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -102,6 +105,17 @@ public final class JobsRuntimeManager implements SmartLifecycle {
     private void wireProducers(String instanceId, String registryUrl) {
         for (MeshToolRegistry.ToolMetadata meta : toolRegistry.getAllTools()) {
             if (!meta.task()) continue;
+            // Phase 1 limit: the claim path doesn't resolve dependency
+            // proxies (the dispatcher is a thin reflection invoker —
+            // wireConsumers / per-call dep injection is the wrapper's
+            // job, not the dispatcher's). A `task=true` producer that
+            // declares `McpMeshTool` / `MeshLlmAgent` parameters would
+            // therefore see them as null on the claim path and the
+            // user code would NPE. Reject this combination eagerly at
+            // startup so the failure mode is obvious; mirrors the
+            // "Phase 1 limit" comment in `invokeViaReflection`. (PR
+            // #891 review.)
+            validateProducerParams(meta);
             MeshToolWrapper wrapper = lookupWrapperForMethod(meta);
             if (wrapper == null) {
                 log.warn("No wrapper found for task=true tool {}; producer dispatch will be inert",
@@ -136,7 +150,22 @@ public final class JobsRuntimeManager implements SmartLifecycle {
             // tolerates null per the DDDI contract).
             List<MeshToolRegistry.DependencyInfo> deps = meta.dependencies();
             if (deps == null || deps.isEmpty()) continue;
-            String depCapability = deps.get(0).capability();
+            // Pick the dep that backs the MeshJob slot: walk the
+            // declared dependencies and pick the first one whose
+            // capability is itself registered as `task=true` on this
+            // agent. The previous `deps.get(0)` heuristic was wrong
+            // when the user declared a `task=true` dep AFTER an
+            // ordinary dep — the submitter would be bound to the
+            // wrong capability and silently target a non-task tool.
+            // (PR #891 review.) If no task-backed dep is found, leave
+            // the slot null — the consumer probably meant to compose
+            // a JobProxy by hand.
+            String depCapability = pickTaskBackedDependency(deps);
+            if (depCapability == null) {
+                log.debug("Consumer {} declares MeshJob slot but no task=true dep found in registry; " +
+                    "skipping submitter wiring", meta.capability());
+                continue;
+            }
             try {
                 MeshJobSubmitter submitter = new MeshJobSubmitter(depCapability, instanceId, registryUrl);
                 wrapper.setJobSubmitter(submitter);
@@ -145,6 +174,60 @@ public final class JobsRuntimeManager implements SmartLifecycle {
             } catch (Exception e) {
                 log.warn("Failed to wire MeshJobSubmitter for {}: {}",
                     wrapper.getFuncId(), e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Pick the capability of the first declared dependency that
+     * resolves to a {@code task=true} tool in the local registry.
+     * Returns {@code null} if no such dep is declared. Used by
+     * {@link #wireConsumers} to bind the {@link MeshJobSubmitter} to
+     * the correct slot when the consumer mixes ordinary + task deps.
+     *
+     * <p>The local registry only knows about THIS agent's tools; for
+     * remote task=true deps the consumer should rely on the registry's
+     * dependency-resolution metadata (Phase 2). Today the consumer +
+     * task producer in the same agent is the only well-tested path.
+     */
+    private String pickTaskBackedDependency(List<MeshToolRegistry.DependencyInfo> deps) {
+        for (MeshToolRegistry.DependencyInfo dep : deps) {
+            MeshToolRegistry.ToolMetadata localTool = toolRegistry.getTool(dep.capability());
+            if (localTool != null && localTool.task()) {
+                return dep.capability();
+            }
+        }
+        // Fallback: cross-agent task deps aren't introspectable from
+        // this side without a registry round-trip. If exactly one dep
+        // is declared, accept it — preserves the Phase 1 happy path
+        // for the canonical "consumer + remote task producer" example
+        // without reintroducing the wrong-pick bug above.
+        if (deps.size() == 1) {
+            return deps.get(0).capability();
+        }
+        return null;
+    }
+
+    /**
+     * Reject {@code @MeshTool(task=true)} producers that declare
+     * {@link McpMeshTool} or {@link MeshLlmAgent} parameters. The
+     * claim path runs in a thin reflection dispatcher and does not
+     * resolve dependency proxies — the params would be null and the
+     * user code would NPE. Force the user to split the helper deps
+     * into a separate non-task tool. (PR #891 review.)
+     */
+    private static void validateProducerParams(MeshToolRegistry.ToolMetadata meta) {
+        Method m = meta.method();
+        Parameter[] params = m.getParameters();
+        for (int i = 0; i < params.length; i++) {
+            Class<?> t = params[i].getType();
+            if (McpMeshTool.class.isAssignableFrom(t) || MeshLlmAgent.class.isAssignableFrom(t)) {
+                throw new IllegalStateException(String.format(
+                    "@MeshTool(task=true) method %s.%s declares a %s parameter at index %d. " +
+                    "task=true producers cannot have McpMeshTool/MeshLlmAgent dependencies " +
+                    "because the claim path doesn't resolve them. Move the dep to a " +
+                    "non-task helper method and call it from the producer.",
+                    m.getDeclaringClass().getName(), m.getName(), t.getSimpleName(), i));
             }
         }
     }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
@@ -1,0 +1,265 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.JobController;
+import io.mcpmesh.MeshJobSubmitter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Lifecycle manager for the Phase B MeshJob substrate on the Java side.
+ *
+ * <p>Wires producer + consumer + helper-tool plumbing together once the
+ * mesh runtime is up:
+ *
+ * <ul>
+ *   <li><b>Producer side</b> — for every {@code @MeshTool(task=true)}
+ *       wrapper, calls {@link MeshToolWrapper#setJobBindingContext} so
+ *       inbound calls bearing {@code X-Mesh-Job-Id} can construct a
+ *       {@link JobController}, AND spawns a {@link ClaimDispatcher} that
+ *       polls {@code POST /jobs/claim} for that capability (pull-mode).</li>
+ *   <li><b>Consumer side</b> — for every wrapper that declares a
+ *       {@link io.mcpmesh.MeshJob}-typed parameter and at least one
+ *       declared dependency, constructs a {@link MeshJobSubmitter}
+ *       bound to the first declared dependency capability and calls
+ *       {@link MeshToolWrapper#setJobSubmitter} so the slot is filled
+ *       on each invocation (Phase 1 simplification — see contract).</li>
+ *   <li><b>Helper tools</b> — invokes
+ *       {@link JobsHelperToolsRegistrar#register} so every Java mesh
+ *       agent advertises the three framework-internal helpers.</li>
+ * </ul>
+ *
+ * <p>Lifecycle: starts AFTER {@link MeshRuntime} (so we know the
+ * agent's per-replica id + registry URL), stops BEFORE it (so
+ * dispatchers drain in-flight handlers before the runtime tears
+ * down). Phase {@code MAX_VALUE - 30} sits between MeshRuntime
+ * (MAX_VALUE - 100) and MeshEventProcessor (MAX_VALUE - 50) — it
+ * stops earlier than both so handlers' terminal {@code complete()}
+ * calls land on the registry before we lose the FFI runtime.
+ */
+public final class JobsRuntimeManager implements SmartLifecycle {
+
+    private static final Logger log = LoggerFactory.getLogger(JobsRuntimeManager.class);
+    private static final int LIFECYCLE_PHASE = Integer.MAX_VALUE - 30;
+
+    private final MeshRuntime runtime;
+    private final MeshToolRegistry toolRegistry;
+    private final MeshToolWrapperRegistry wrapperRegistry;
+
+    private final Map<String, ClaimDispatcher> dispatchers = new ConcurrentHashMap<>();
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final AtomicBoolean stopped = new AtomicBoolean(false);
+
+    public JobsRuntimeManager(
+            MeshRuntime runtime,
+            MeshToolRegistry toolRegistry,
+            MeshToolWrapperRegistry wrapperRegistry) {
+        this.runtime = runtime;
+        this.toolRegistry = toolRegistry;
+        this.wrapperRegistry = wrapperRegistry;
+    }
+
+    @Override
+    public void start() {
+        if (!started.compareAndSet(false, true)) {
+            return;
+        }
+
+        String registryUrl = runtime.getAgentSpec().getRegistryUrl();
+        String instanceId = runtime.getAgentSpec().getAgentId();
+        if (registryUrl == null || registryUrl.isEmpty()) {
+            log.info("MeshJob runtime: no registry URL — skipping job substrate wiring");
+            return;
+        }
+        if (instanceId == null || instanceId.isEmpty()) {
+            log.warn("MeshJob runtime: agent id not set — skipping job substrate wiring");
+            return;
+        }
+
+        // 1. Producer-side: bind context on every task=true wrapper, spawn
+        //    one ClaimDispatcher per task capability.
+        wireProducers(instanceId, registryUrl);
+
+        // 2. Consumer-side: any wrapper with a MeshJob slot AND at least
+        //    one declared dependency gets a MeshJobSubmitter bound to
+        //    dep[0] (Phase 1 simplification — Phase 2 will surface task=
+        //    true status from the registry's dependency events).
+        wireConsumers(instanceId, registryUrl);
+
+        // Helper tools are registered earlier (in MeshAutoConfiguration's
+        // buildAgentSpec) so the synthetic ToolSpecs make it into the
+        // heartbeat catalog. Don't double-register here.
+    }
+
+    private void wireProducers(String instanceId, String registryUrl) {
+        for (MeshToolRegistry.ToolMetadata meta : toolRegistry.getAllTools()) {
+            if (!meta.task()) continue;
+            MeshToolWrapper wrapper = lookupWrapperForMethod(meta);
+            if (wrapper == null) {
+                log.warn("No wrapper found for task=true tool {}; producer dispatch will be inert",
+                    meta.capability());
+                continue;
+            }
+            wrapper.setJobBindingContext(instanceId, registryUrl);
+
+            // Spawn a ClaimDispatcher that invokes the same method via reflection.
+            ClaimDispatcher dispatcher = new ClaimDispatcher(
+                meta.capability(),
+                instanceId,
+                registryUrl,
+                (payload, controller) -> invokeViaReflection(meta, payload, controller)
+            );
+            dispatcher.start();
+            dispatchers.put(meta.capability(), dispatcher);
+            log.info("MeshJob producer wired: capability={} (wrapper={}, dispatcher started)",
+                meta.capability(), wrapper.getFuncId());
+        }
+    }
+
+    private void wireConsumers(String instanceId, String registryUrl) {
+        for (MeshToolRegistry.ToolMetadata meta : toolRegistry.getAllTools()) {
+            MeshToolWrapper wrapper = lookupWrapperForMethod(meta);
+            if (wrapper == null || wrapper.getMeshJobParamIndex() == null) continue;
+            // Producer slot — the inbound dispatch path fills it with a
+            // controller; nothing to wire here.
+            if (meta.task()) continue;
+            // Consumer needs at least one declared dependency to bind the
+            // submitter. Without one, leave the slot empty (user code
+            // tolerates null per the DDDI contract).
+            List<MeshToolRegistry.DependencyInfo> deps = meta.dependencies();
+            if (deps == null || deps.isEmpty()) continue;
+            String depCapability = deps.get(0).capability();
+            try {
+                MeshJobSubmitter submitter = new MeshJobSubmitter(depCapability, instanceId, registryUrl);
+                wrapper.setJobSubmitter(submitter);
+                log.info("MeshJob consumer wired: tool={} → MeshJobSubmitter for capability={}",
+                    wrapper.getFuncId(), depCapability);
+            } catch (Exception e) {
+                log.warn("Failed to wire MeshJobSubmitter for {}: {}",
+                    wrapper.getFuncId(), e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Reflectively invoke the producer method for one claimed job.
+     *
+     * <p>Mirrors the inbound dispatch wrapper's argument-shaping logic
+     * (mcp params + dep slots + MeshJob slot) — but for the claim path,
+     * deps are NOT injected (the claim path is intentionally limited to
+     * "user method + payload + controller"; deps would require resolving
+     * them from the registry inside the dispatcher, which Phase 2 may
+     * add). User methods that depend on deps AND are claim-dispatched
+     * will see null deps; design.org calls this out as a Phase 1 limit.
+     */
+    private Object invokeViaReflection(
+            MeshToolRegistry.ToolMetadata meta,
+            Map<String, Object> payload,
+            JobController controller) throws Exception {
+        Method method = meta.method();
+        Object bean = meta.bean();
+        method.setAccessible(true);
+
+        Object[] fullArgs = new Object[method.getParameterCount()];
+        java.lang.reflect.Parameter[] params = method.getParameters();
+        for (int i = 0; i < params.length; i++) {
+            Class<?> type = params[i].getType();
+            if (io.mcpmesh.MeshJob.class.isAssignableFrom(type)) {
+                fullArgs[i] = controller;
+                continue;
+            }
+            io.mcpmesh.Param paramAnn = params[i].getAnnotation(io.mcpmesh.Param.class);
+            if (paramAnn != null) {
+                Object val = payload != null ? payload.get(paramAnn.value()) : null;
+                fullArgs[i] = coerce(val, type);
+                continue;
+            }
+            // McpMeshTool / MeshLlmAgent on the claim path are filled with null
+            // (Phase 1 limit — see method javadoc).
+            fullArgs[i] = null;
+        }
+
+        try {
+            Object result = method.invoke(bean, fullArgs);
+            if (result instanceof java.util.concurrent.CompletableFuture<?> cf) {
+                result = cf.get();
+            }
+            return result;
+        } catch (InvocationTargetException ite) {
+            Throwable cause = ite.getCause();
+            if (cause instanceof Exception ex) throw ex;
+            throw new RuntimeException(cause);
+        }
+    }
+
+    /** Best-effort scalar coercion — identical to MeshToolWrapper's fast path. */
+    private static Object coerce(Object val, Class<?> target) {
+        if (val == null) {
+            if (target.isPrimitive()) {
+                if (target == boolean.class) return false;
+                if (target == int.class) return 0;
+                if (target == long.class) return 0L;
+                if (target == double.class) return 0.0d;
+                if (target == float.class) return 0.0f;
+                if (target == short.class) return (short) 0;
+                if (target == byte.class) return (byte) 0;
+                if (target == char.class) return '\0';
+            }
+            return null;
+        }
+        if (target.isInstance(val)) return val;
+        if (val instanceof Number n) {
+            if (target == Integer.class || target == int.class) return n.intValue();
+            if (target == Long.class || target == long.class) return n.longValue();
+            if (target == Double.class || target == double.class) return n.doubleValue();
+        }
+        return val;
+    }
+
+    private MeshToolWrapper lookupWrapperForMethod(MeshToolRegistry.ToolMetadata meta) {
+        // Wrappers are keyed by funcId == className.methodName
+        String funcId = meta.bean().getClass().getName() + "." + meta.method().getName();
+        MeshToolWrapper wrapper = wrapperRegistry.getWrapper(funcId);
+        if (wrapper == null) {
+            // Fall back via method name (covers CGLIB-proxied beans where
+            // the class name diverges from the user's source class).
+            wrapper = wrapperRegistry.getWrapperByMethodName(meta.method().getName());
+        }
+        return wrapper;
+    }
+
+    @Override
+    public void stop() {
+        if (!stopped.compareAndSet(false, true)) {
+            return;
+        }
+        log.info("Stopping MeshJob runtime: {} active dispatcher(s)", dispatchers.size());
+        List<ClaimDispatcher> snapshot = new ArrayList<>(dispatchers.values());
+        for (ClaimDispatcher d : snapshot) {
+            try {
+                d.close();
+            } catch (Exception e) {
+                log.debug("Dispatcher close raised: {}", e.getMessage());
+            }
+        }
+        dispatchers.clear();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return started.get() && !stopped.get();
+    }
+
+    @Override
+    public int getPhase() {
+        return LIFECYCLE_PHASE;
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -204,6 +204,33 @@ public class MeshAutoConfiguration {
         return new MeshHealthController(runtime);
     }
 
+    /**
+     * Phase B MeshJob substrate: cancel route handler. Mounted on every
+     * mesh agent so the registry can forward cancel signals to owner
+     * replicas. Safe to register unconditionally — Spring MVC only
+     * invokes the handler on POST /jobs/{jobId}/cancel matches.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public JobCancelController jobCancelController() {
+        return new JobCancelController();
+    }
+
+    /**
+     * Phase B MeshJob substrate: orchestrator that wires producers,
+     * consumers, and helper tools together once the mesh runtime is up.
+     * SmartLifecycle phase ensures it starts AFTER MeshRuntime and stops
+     * BEFORE it (so dispatchers drain in-flight handlers cleanly).
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public JobsRuntimeManager jobsRuntimeManager(
+            MeshRuntime runtime,
+            MeshToolRegistry toolRegistry,
+            MeshToolWrapperRegistry wrapperRegistry) {
+        return new JobsRuntimeManager(runtime, toolRegistry, wrapperRegistry);
+    }
+
     private AgentSpec buildAgentSpec(
             MeshProperties properties,
             MeshToolRegistry toolRegistry,
@@ -282,6 +309,21 @@ public class MeshAutoConfiguration {
         // Registry URL
         String propertiesRegistryUrl = properties.getRegistry().getUrl();
         spec.setRegistryUrl(configResolver.resolve("registry_url", propertiesRegistryUrl));
+
+        // Phase B MeshJob substrate: register the three helper tools as
+        // synthetic specs BEFORE getToolSpecs() is read into the
+        // heartbeat catalog. Without this the registry never learns the
+        // helpers exist (they were registered too late in JobsRuntimeManager).
+        // Also registers the wrapper-side handlers so MCP tools/call
+        // requests for the helper names dispatch correctly. Skips
+        // gracefully when no registry URL is configured.
+        String resolvedRegistryUrl = configResolver.resolve("registry_url",
+            properties.getRegistry().getUrl());
+        try {
+            JobsHelperToolsRegistrar.register(toolRegistry, wrapperRegistry, resolvedRegistryUrl);
+        } catch (Exception e) {
+            log.warn("Failed to register MeshJob helper tools at startup: {}", e.getMessage());
+        }
 
         // Add tools from registry (dependencies are embedded in tool specs)
         List<AgentSpec.ToolSpec> allTools = new ArrayList<>(toolRegistry.getToolSpecs());

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -322,7 +322,7 @@ public class MeshAutoConfiguration {
         try {
             JobsHelperToolsRegistrar.register(toolRegistry, wrapperRegistry, resolvedRegistryUrl);
         } catch (Exception e) {
-            log.warn("Failed to register MeshJob helper tools at startup: {}", e.getMessage());
+            log.warn("Failed to register MeshJob helper tools at startup", e);
         }
 
         // Add tools from registry (dependencies are embedded in tool specs)

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshJobResolver.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshJobResolver.java
@@ -1,0 +1,135 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.types.McpMeshTool;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Reflective DDDI resolver implementing the contract in
+ * {@code MESHJOB_DDDI_CONTRACT.md}. Sister implementation of:
+ * <ul>
+ *   <li>Python {@code _mcp_mesh.engine.signature_analyzer.analyze_mesh_job_signature}</li>
+ *   <li>TypeScript {@code @mcp-mesh/runtime ... analyzeMeshJobSignature}</li>
+ * </ul>
+ *
+ * <p>For each parameter in declaration order:
+ * <ul>
+ *   <li>Type assignable to {@link McpMeshTool} → mesh dependency, assigned
+ *       the next positional slot ({@code mesh_tool_position_counter}++).</li>
+ *   <li>Type assignable to {@link MeshJob} → mesh job param, recorded by
+ *       <i>signature</i> position in {@link Resolved#meshJobParamIndex}.
+ *       Does NOT touch the positional counter.</li>
+ *   <li>Anything else → user argument (caller-supplied at signature index).</li>
+ * </ul>
+ *
+ * <p><b>Validation</b> (per the contract):
+ * <ul>
+ *   <li>At most one {@link MeshJob} parameter — multiple is rejected at
+ *       resolve time with {@link IllegalStateException}.</li>
+ *   <li>{@link MeshJob} may appear at any position (including in the middle
+ *       of {@link McpMeshTool} params) — no trailing-only rule.</li>
+ * </ul>
+ *
+ * <p>This class is intentionally a free-standing static helper rather than
+ * folded into {@link MeshToolWrapper#analyzeParameters} so the contract has
+ * a clean test seam ({@code MeshJobResolverTest}) without spinning up the
+ * full Spring + native bridge.
+ */
+public final class MeshJobResolver {
+
+    private MeshJobResolver() {}
+
+    /**
+     * Resolved view of a method signature.
+     *
+     * @param meshToolPositions   Signature positions of {@code McpMeshTool}
+     *                            parameters in declaration order. Index in
+     *                            this list is the dependency's positional
+     *                            slot (the {@code mesh_tool_position_counter}
+     *                            value at assignment).
+     * @param meshJobParamIndex   Signature position of the (single) MeshJob
+     *                            parameter, or empty if none.
+     * @param totalParameterCount Convenience: total parameter count of the
+     *                            analyzed method.
+     */
+    public record Resolved(
+        List<Integer> meshToolPositions,
+        Optional<Integer> meshJobParamIndex,
+        int totalParameterCount
+    ) {
+        public Resolved {
+            // Defensive copy so the returned list can't be mutated.
+            meshToolPositions = List.copyOf(meshToolPositions);
+        }
+
+        /** Number of {@link McpMeshTool} dependencies declared on this method. */
+        public int meshToolCount() {
+            return meshToolPositions.size();
+        }
+
+        /** True iff the method declares a {@link MeshJob} parameter. */
+        public boolean hasMeshJob() {
+            return meshJobParamIndex.isPresent();
+        }
+    }
+
+    /**
+     * Resolve the signature of {@code method}.
+     *
+     * @param method The method to analyze
+     * @return The resolved signature view
+     * @throws IllegalArgumentException if {@code method} is null
+     * @throws IllegalStateException if more than one {@link MeshJob} parameter
+     *         is declared (per {@code MESHJOB_DDDI_CONTRACT.md})
+     */
+    public static Resolved resolve(Method method) {
+        if (method == null) {
+            throw new IllegalArgumentException("method is required");
+        }
+        Parameter[] params = method.getParameters();
+        List<Integer> meshToolPositions = new ArrayList<>();
+        Integer meshJobIndex = null;
+
+        for (int i = 0; i < params.length; i++) {
+            Class<?> type = params[i].getType();
+            // Order matters: MeshJob check first so a class implementing
+            // BOTH (theoretically possible if a user creates a custom
+            // MeshJob marker that also implements McpMeshTool — odd but
+            // valid Java) classifies as MeshJob, matching the Python
+            // resolver which checks the MeshJob Protocol before the
+            // MeshTool Protocol. In practice the SDK's first-party types
+            // (JobController, JobProxy, MeshJobSubmitter) implement only
+            // MeshJob.
+            if (MeshJob.class.isAssignableFrom(type)) {
+                if (meshJobIndex != null) {
+                    throw new IllegalStateException(
+                        "Method " + method.getDeclaringClass().getName() + "."
+                            + method.getName()
+                            + " declares multiple MeshJob parameters (positions "
+                            + meshJobIndex + " and " + i
+                            + "); a tool function may declare at most one MeshJob "
+                            + "parameter — see MESHJOB_DDDI_CONTRACT.md."
+                    );
+                }
+                meshJobIndex = i;
+            } else if (McpMeshTool.class.isAssignableFrom(type)) {
+                meshToolPositions.add(i);
+            }
+            // Everything else: user arg. Not tracked here — handled by
+            // the caller (MeshToolWrapper) which already classifies them
+            // via @Param.
+        }
+
+        return new Resolved(
+            Collections.unmodifiableList(meshToolPositions),
+            Optional.ofNullable(meshJobIndex),
+            params.length
+        );
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
@@ -93,7 +93,9 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor {
         // Extract dependency names from @MeshTool(dependencies=...)
         List<String> dependencyNames = extractDependencyNames(annotation);
 
-        // Create wrapper
+        // Create wrapper. Phase B MeshJob substrate: the `task` flag controls
+        // whether inbound calls bearing X-Mesh-Job-Id dispatch through the
+        // job pipeline (JobController injection + auto-complete).
         MeshToolWrapper wrapper = new MeshToolWrapper(
             funcId,
             annotation.capability(),
@@ -101,7 +103,8 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor {
             bean,
             method,
             dependencyNames,
-            objectMapper
+            objectMapper,
+            annotation.task()
         );
 
         // Register with wrapper registry

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
@@ -84,12 +84,19 @@ public class MeshToolRegistry {
         if (spec == null || spec.getCapability() == null) {
             return;
         }
-        for (AgentSpec.ToolSpec existing : syntheticTools) {
-            if (spec.getCapability().equals(existing.getCapability())) {
-                return;
+        // Synchronize the check-then-add: CopyOnWriteArrayList serializes
+        // mutations individually, but the iterate-then-add window is open
+        // to concurrent registrations from two threads observing
+        // "no existing capability" simultaneously and both appending.
+        // (PR #891 review.)
+        synchronized (syntheticTools) {
+            for (AgentSpec.ToolSpec existing : syntheticTools) {
+                if (spec.getCapability().equals(existing.getCapability())) {
+                    return;
+                }
             }
+            syntheticTools.add(spec);
         }
-        syntheticTools.add(spec);
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
@@ -73,8 +73,22 @@ public class MeshToolRegistry {
      * Add a synthetic tool spec to be merged into the heartbeat catalog.
      * Used by {@link JobsHelperToolsRegistrar} to advertise the three
      * MeshJob helper tools as registry-visible capabilities.
+     *
+     * <p>Idempotent by capability: if a synthetic tool with the same
+     * capability is already registered the call is a no-op. Without
+     * this guard a repeated {@code buildAgentSpec()} (e.g. test refresh
+     * or context restart in the same JVM) would accumulate duplicate
+     * helper specs in the heartbeat (PR review #874).
      */
     public void addSyntheticTool(AgentSpec.ToolSpec spec) {
+        if (spec == null || spec.getCapability() == null) {
+            return;
+        }
+        for (AgentSpec.ToolSpec existing : syntheticTools) {
+            if (spec.getCapability().equals(existing.getCapability())) {
+                return;
+            }
+        }
         syntheticTools.add(spec);
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
@@ -53,12 +53,29 @@ public class MeshToolRegistry {
             outputType,
             // Issue #547 Phase 4: per-tool override (default true = current behavior).
             annotation.outputSchemaStrict(),
+            // Phase B MeshJob substrate: surfaced via kwargs JSON so the
+            // registry / consumer SDK knows this is a task=true producer.
+            annotation.task(),
             bean,
             method
         );
 
         tools.put(capability, metadata);
-        log.info("Registered mesh tool: {} ({})", capability, method);
+        log.info("Registered mesh tool: {} ({}, task={})", capability, method, annotation.task());
+    }
+
+    // Phase B MeshJob substrate: synthetic tool specs registered outside
+    // the @MeshTool scan path (e.g. helper tools). Appended to the
+    // heartbeat catalog after user tools so they advertise in the registry.
+    private final List<AgentSpec.ToolSpec> syntheticTools = new java.util.concurrent.CopyOnWriteArrayList<>();
+
+    /**
+     * Add a synthetic tool spec to be merged into the heartbeat catalog.
+     * Used by {@link JobsHelperToolsRegistrar} to advertise the three
+     * MeshJob helper tools as registry-visible capabilities.
+     */
+    public void addSyntheticTool(AgentSpec.ToolSpec spec) {
+        syntheticTools.add(spec);
     }
 
     /**
@@ -125,6 +142,21 @@ public class MeshToolRegistry {
                 spec.setSchemaWarnings(warnings);
             }
 
+            // Phase B MeshJob substrate: surface task=true through kwargs
+            // so the registry / consumer SDK can detect this is a task tool
+            // (matches Python's "kwargs spread of @mesh.tool decorator
+            // metadata" wire — see rust_heartbeat.py kwargs_data block).
+            if (meta.task()) {
+                try {
+                    Map<String, Object> kwargs = new LinkedHashMap<>();
+                    kwargs.put("task", true);
+                    spec.setKwargs(jsonMapper.writeValueAsString(kwargs));
+                } catch (Exception e) {
+                    log.warn("Failed to serialize kwargs for task tool '{}': {}",
+                        meta.capability(), e.getMessage());
+                }
+            }
+
             // Add dependencies to the tool spec
             for (DependencyInfo dep : meta.dependencies()) {
                 AgentSpec.DependencySpec depSpec = new AgentSpec.DependencySpec();
@@ -141,6 +173,9 @@ public class MeshToolRegistry {
 
             specs.add(spec);
         }
+
+        // Phase B MeshJob substrate: append synthetic tools (helper tools).
+        specs.addAll(syntheticTools);
 
         return specs;
     }
@@ -340,9 +375,27 @@ public class MeshToolRegistry {
         Map<String, Object> inputSchema,
         Class<?> outputType,
         boolean outputSchemaStrict,
+        boolean task,
         Object bean,
         Method method
-    ) {}
+    ) {
+        // Backward-compatible 10-arg constructor for callers that haven't
+        // adopted the Phase B `task` flag yet (defaults to false).
+        public ToolMetadata(
+                String capability,
+                String description,
+                String version,
+                List<String> tags,
+                List<DependencyInfo> dependencies,
+                Map<String, Object> inputSchema,
+                Class<?> outputType,
+                boolean outputSchemaStrict,
+                Object bean,
+                Method method) {
+            this(capability, description, version, tags, dependencies, inputSchema,
+                outputType, outputSchemaStrict, false, bean, method);
+        }
+    }
 
     /**
      * Information about a tool dependency.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -3,6 +3,10 @@ package io.mcpmesh.spring;
 import tools.jackson.databind.JsonNode;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
 import tools.jackson.databind.ObjectMapper;
+import io.mcpmesh.JobContext;
+import io.mcpmesh.JobController;
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshJobSubmitter;
 import io.mcpmesh.Param;
 import io.mcpmesh.spring.tracing.ExecutionTracer;
 import io.mcpmesh.spring.tracing.SpanScope;
@@ -55,12 +59,14 @@ public class MeshToolWrapper implements McpToolHandler {
     private final String description;
     private final Object bean;
     private final Method method;
+    private final boolean task;
 
     // Parameter metadata
     private final List<ParamInfo> mcpParams;           // MCP-exposed parameters (with @Param)
     private final List<Integer> meshToolPositions;     // Positions of McpMeshTool params
     private final List<Type> meshToolReturnTypes;      // Generic return types for McpMeshTool params
     private final List<Integer> llmAgentPositions;     // Positions of MeshLlmAgent params
+    private final Integer meshJobParamIndex;           // Position of MeshJob param, or null
     private final Map<String, Object> inputSchema;     // JSON Schema for MCP
 
     // Mutable dependency arrays (updated by heartbeat)
@@ -70,6 +76,20 @@ public class MeshToolWrapper implements McpToolHandler {
 
     // Dependency names for error messages
     private final List<String> dependencyNames;
+
+    // Consumer-side: MeshJobSubmitter to inject when MeshJob slot is present
+    // and this method depends on a task=true capability. Set by the runtime
+    // wiring (MeshAutoConfiguration / MeshEventProcessor) once the registry
+    // tells us the dep is task=true. Null when this slot is producer-side
+    // only (i.e. method is task=true) or when no submitter applies.
+    private final AtomicReference<MeshJobSubmitter> jobSubmitter = new AtomicReference<>();
+
+    // Producer-side: agent's own per-replica instance ID + registry URL.
+    // Used to construct JobController on inbound dispatch when the request
+    // bears X-Mesh-Job-Id. Set lazily via setJobBindingContext (so the
+    // wrapper doesn't need a hard dep on MeshRuntime at construction time).
+    private final AtomicReference<String> instanceId = new AtomicReference<>();
+    private final AtomicReference<String> registryUrl = new AtomicReference<>();
 
     private final ObjectMapper objectMapper;
 
@@ -95,19 +115,40 @@ public class MeshToolWrapper implements McpToolHandler {
             Method method,
             List<String> dependencyNames,
             ObjectMapper objectMapper) {
+        this(funcId, capability, description, bean, method, dependencyNames, objectMapper, false);
+    }
+
+    /**
+     * Create a wrapper for a @MeshTool annotated method, with explicit
+     * task flag for MeshJob substrate (Phase B).
+     */
+    public MeshToolWrapper(
+            String funcId,
+            String capability,
+            String description,
+            Object bean,
+            Method method,
+            List<String> dependencyNames,
+            ObjectMapper objectMapper,
+            boolean task) {
 
         this.funcId = funcId;
         this.capability = capability;
         this.description = description;
         this.bean = bean;
         this.method = method;
+        this.task = task;
         this.dependencyNames = dependencyNames != null ? dependencyNames : List.of();
         this.objectMapper = objectMapper;
 
         // Make method accessible (for private methods)
         method.setAccessible(true);
 
-        // Analyze parameters
+        // Analyze parameters via the resolver so MeshJob index is captured.
+        MeshJobResolver.Resolved resolved = MeshJobResolver.resolve(method);
+        this.meshJobParamIndex = resolved.meshJobParamIndex().orElse(null);
+
+        // Analyze remaining parameters (mcp params + mesh deps + llm agents)
         this.mcpParams = new ArrayList<>();
         this.meshToolPositions = new ArrayList<>();
         this.meshToolReturnTypes = new ArrayList<>();
@@ -122,8 +163,9 @@ public class MeshToolWrapper implements McpToolHandler {
         // Generate input schema (excluding injected params)
         this.inputSchema = generateInputSchema();
 
-        log.debug("Created wrapper for {} with {} MCP params, {} mesh deps, {} LLM agents",
-            funcId, mcpParams.size(), meshToolPositions.size(), llmAgentPositions.size());
+        log.debug("Created wrapper for {} with {} MCP params, {} mesh deps, {} LLM agents, task={}, meshJobParamIndex={}",
+            funcId, mcpParams.size(), meshToolPositions.size(), llmAgentPositions.size(),
+            task, meshJobParamIndex);
     }
 
     /**
@@ -140,7 +182,13 @@ public class MeshToolWrapper implements McpToolHandler {
             Parameter param = params[i];
             Class<?> type = param.getType();
 
-            if (McpMeshTool.class.isAssignableFrom(type)) {
+            if (MeshJob.class.isAssignableFrom(type)) {
+                // Phase B MeshJob substrate: this slot is filled separately
+                // by the dispatch wrapper (JobController on inbound job
+                // dispatch, MeshJobSubmitter on consumer side). No @Param
+                // required; the param is exempt from the MCP input schema.
+                continue;
+            } else if (McpMeshTool.class.isAssignableFrom(type)) {
                 // Mesh tool dependency - will be injected
                 meshToolPositions.add(i);
                 // Extract generic type argument (e.g., Integer from McpMeshTool<Integer>)
@@ -164,7 +212,7 @@ public class MeshToolWrapper implements McpToolHandler {
                     // No @Param annotation on non-injectable parameter
                     throw new IllegalStateException(
                         "Parameter at position " + i + " in method " + method.getName() +
-                        " must have @Param annotation. Injectable types (McpMeshTool, MeshLlmAgent) are exempt."
+                        " must have @Param annotation. Injectable types (McpMeshTool, MeshLlmAgent, MeshJob) are exempt."
                     );
                 }
             }
@@ -267,6 +315,46 @@ public class MeshToolWrapper implements McpToolHandler {
      */
     public void setTracer(ExecutionTracer tracer) {
         tracerRef.set(tracer);
+    }
+
+    /**
+     * Bind the producer-side context needed to construct a {@link JobController}
+     * on inbound job dispatch. Called once at startup by the runtime wiring
+     * (MeshAutoConfiguration / MeshEventProcessor) once the agent's
+     * per-replica instance id and registry URL are known.
+     *
+     * <p>No-op when this tool is not {@code task=true} — the wrapper would
+     * never construct a controller in that case anyway.
+     *
+     * @param instanceId  Per-replica agent ID (matches what the registry
+     *                    sees as {@code owner_instance_id} on claim)
+     * @param registryUrl Mesh registry base URL
+     */
+    public void setJobBindingContext(String instanceId, String registryUrl) {
+        if (instanceId != null) this.instanceId.set(instanceId);
+        if (registryUrl != null) this.registryUrl.set(registryUrl);
+    }
+
+    /**
+     * Set or clear the consumer-side {@link MeshJobSubmitter} to inject at
+     * the {@code MeshJob} slot for a regular (non-job) tool call. Set by
+     * the runtime once the registry tells us a declared dependency is a
+     * {@code task=true} capability.
+     *
+     * @param submitter The submitter to inject, or null to clear
+     */
+    public void setJobSubmitter(MeshJobSubmitter submitter) {
+        this.jobSubmitter.set(submitter);
+    }
+
+    /** Whether this tool is registered with {@code task=true}. */
+    public boolean isTask() {
+        return task;
+    }
+
+    /** The position of the MeshJob param in the method signature, or null. */
+    public Integer getMeshJobParamIndex() {
+        return meshJobParamIndex;
     }
 
     // =========================================================================
@@ -387,6 +475,37 @@ public class MeshToolWrapper implements McpToolHandler {
      * Internal invoke method that handles the actual method invocation.
      */
     private Object invokeInternal(Map<String, Object> cleanArgs) throws Exception {
+        // Phase B MeshJob substrate: detect inbound job dispatch.
+        // X-Mesh-Job-Id is captured by TracingFilter (we register it as a
+        // propagation header in MeshAutoConfiguration), so it lands in
+        // TraceContext.getPropagatedHeaders() with a lowercased key.
+        Map<String, String> propagated = TraceContext.getPropagatedHeaders();
+        String jobIdHeader = propagated != null ? propagated.get("x-mesh-job-id") : null;
+        Long deadlineSecs = null;
+        if (jobIdHeader != null && !jobIdHeader.isEmpty()) {
+            String timeoutHeader = propagated.get("x-mesh-timeout");
+            if (timeoutHeader != null && !timeoutHeader.isEmpty()) {
+                try {
+                    double secs = Double.parseDouble(timeoutHeader.trim());
+                    if (Double.isFinite(secs) && secs > 0) {
+                        deadlineSecs = (long) secs;
+                    }
+                } catch (NumberFormatException nfe) {
+                    log.debug("Invalid X-Mesh-Timeout header value '{}': {}", timeoutHeader, nfe.getMessage());
+                }
+            }
+        }
+
+        // If task=true tool is being called as a job, dispatch through the
+        // job pipeline: build a JobController bound to this job_id, set
+        // both Java + native contexts, inject the controller at
+        // meshJobParamIndex, auto-complete on successful return.
+        if (task && jobIdHeader != null && !jobIdHeader.isEmpty()
+                && meshJobParamIndex != null
+                && instanceId.get() != null && registryUrl.get() != null) {
+            return dispatchAsJob(cleanArgs, jobIdHeader, deadlineSecs);
+        }
+
         // Build full argument array
         Object[] fullArgs = new Object[method.getParameterCount()];
 
@@ -400,6 +519,14 @@ public class MeshToolWrapper implements McpToolHandler {
 
             // Convert value to target type
             fullArgs[param.position()] = convertValue(value, param.type());
+        }
+
+        // Phase B MeshJob substrate: fill MeshJob slot for non-job paths.
+        // - Consumer side (method has dependencies + jobSubmitter set): inject submitter.
+        // - Otherwise (incl. task=true called sync): inject null.
+        if (meshJobParamIndex != null) {
+            MeshJobSubmitter submitter = jobSubmitter.get();
+            fullArgs[meshJobParamIndex] = submitter; // null when no submitter wired
         }
 
         // Fill McpMeshTool dependencies (null if unavailable for graceful degradation)
@@ -479,6 +606,149 @@ public class MeshToolWrapper implements McpToolHandler {
         }
 
         return result;
+    }
+
+    /**
+     * Phase B MeshJob substrate: invoke the user method as a job.
+     *
+     * <p>Constructs a {@link JobController} bound to {@code jobId}, sets
+     * the Java-side {@link JobContext} (for in-process reads via
+     * {@code JobContext.current()}), injects the controller at
+     * {@link #meshJobParamIndex}, invokes the user method, and auto-
+     * completes the controller with the return value if the user did
+     * not explicitly call {@code complete()} / {@code fail()}.
+     *
+     * <p>On exception, attempts a best-effort {@code controller.fail(...)}
+     * if not already terminal, then propagates the exception so the MCP
+     * SDK surfaces it as a tool-call error.
+     *
+     * <p><b>Why no {@code mesh_run_as_job} on the Java sync path?</b>
+     * The Rust {@code mesh_run_as_job} wraps its callback in
+     * {@code jobs_runtime().block_on}; calling any
+     * {@code mesh_job_controller_*} (which also block_on internally)
+     * from inside that callback panics with a "Cannot start a runtime
+     * from within a runtime" Tokio error. The Python and TypeScript
+     * SDKs use {@code with_job} (async) so the callback's awaits don't
+     * nest block_ons — Java's only synchronous JNR-FFI bindings can't
+     * compose the same way. Cancel-registry binding for the Java path
+     * is therefore Phase B-deferred (the registry sweep is the
+     * backstop); user code sees an interrupted thread on cancel via
+     * {@link Thread#interrupt} once Phase 2 wires that up.
+     *
+     * <p>Mirrors (Java-adapted):
+     * <ul>
+     *   <li>Python {@code _mcp_mesh.engine.job_dispatch._run_and_autocomplete}</li>
+     *   <li>TypeScript {@code runWithJobContext} in inbound-job-dispatch.ts</li>
+     * </ul>
+     */
+    private Object dispatchAsJob(Map<String, Object> cleanArgs, String jobId, Long deadlineSecs) throws Exception {
+        // Build full args with the controller injected at the MeshJob slot
+        Object[] fullArgs = new Object[method.getParameterCount()];
+        for (ParamInfo param : mcpParams) {
+            Object value = cleanArgs.get(param.name());
+            if (value == null && param.required()) {
+                throw new IllegalArgumentException("Missing required parameter: " + param.name());
+            }
+            fullArgs[param.position()] = convertValue(value, param.type());
+        }
+        // Fill McpMeshTool dependencies and LLM agents (mirrors the
+        // non-job path; needed so a task=true method that ALSO has deps
+        // / LLM agents sees them populated)
+        for (int i = 0; i < meshToolPositions.size(); i++) {
+            int paramPos = meshToolPositions.get(i);
+            McpMeshTool proxy = injectedDeps.get(i);
+            fullArgs[paramPos] = proxy;
+        }
+        for (int i = 0; i < llmAgentPositions.size(); i++) {
+            int paramPos = llmAgentPositions.get(i);
+            MeshLlmAgent agent = injectedLlmAgents.get(i);
+            if (agent instanceof MeshLlmAgentProxy proxy) {
+                Map<String, Object> context = extractContextForTemplate(proxy.getContextParamName(), cleanArgs);
+                if (context != null) {
+                    proxy.setInvocationContext(context);
+                }
+            }
+            fullArgs[paramPos] = agent;
+        }
+
+        // Construct the producer controller. Free in finally.
+        JobController controller = JobController.open(jobId, instanceId.get(), registryUrl.get());
+        try {
+            // Inject the controller at the MeshJob slot
+            fullArgs[meshJobParamIndex] = controller;
+
+            // Bind the Java-side ThreadLocal job context for the duration
+            // of the user method. See class javadoc on dispatchAsJob for
+            // why we don't also bind the Rust-side task-local.
+            JobContext.Snapshot snap = new JobContext.Snapshot(jobId, deadlineSecs);
+            return JobContext.withJob(snap, () -> invokeAndAutoComplete(fullArgs, controller));
+        } finally {
+            controller.close();
+        }
+    }
+
+    private Object invokeAndAutoComplete(Object[] fullArgs, JobController controller) throws Exception {
+        Object result;
+        try {
+            result = method.invoke(bean, fullArgs);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            // Best-effort failure report — the registry will sweep stale
+            // working rows on lease expiry, but reporting eagerly means
+            // the consumer's await() resolves with the right error
+            // sooner.
+            tryFail(controller, cause != null ? cause.toString() : "method invocation failed");
+            if (cause instanceof Exception ex) throw ex;
+            throw new RuntimeException(cause);
+        } catch (IllegalAccessException e) {
+            tryFail(controller, e.toString());
+            throw new RuntimeException("Method access denied: " + e.getMessage(), e);
+        }
+
+        // If the method returns a CompletableFuture, await it before
+        // deciding whether to auto-complete (matches the Python /
+        // TypeScript async semantics).
+        if (result instanceof CompletableFuture<?> future) {
+            try {
+                result = future.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                tryFail(controller, "async operation timed out after " + ASYNC_TIMEOUT_SECONDS + "s");
+                throw new RuntimeException("Async operation timed out after " + ASYNC_TIMEOUT_SECONDS + " seconds");
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                tryFail(controller, cause != null ? cause.toString() : e.toString());
+                if (cause instanceof Exception ex) throw ex;
+                throw new RuntimeException(cause);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                tryFail(controller, "async operation interrupted");
+                throw new RuntimeException("Async operation interrupted", e);
+            }
+        }
+
+        // Auto-complete iff the user didn't already close the row
+        // themselves. Matches Python's _run_and_autocomplete + TS's
+        // runWithJobContext.
+        try {
+            if (!controller.isTerminal()) {
+                controller.complete(result);
+            }
+        } catch (Exception e) {
+            log.warn("Auto-complete failed for job {}: {}", controller.jobId(), e.getMessage());
+            // Don't shadow the user's return value — the registry sweep
+            // is the ultimate backstop for stale `working` rows.
+        }
+        return result;
+    }
+
+    private static void tryFail(JobController controller, String reason) {
+        try {
+            if (!controller.isTerminal()) {
+                controller.fail(reason);
+            }
+        } catch (Exception ignored) {
+            // Best-effort — already logged the original cause.
+        }
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -488,7 +488,12 @@ public class MeshToolWrapper implements McpToolHandler {
                 try {
                     double secs = Double.parseDouble(timeoutHeader.trim());
                     if (Double.isFinite(secs) && secs > 0) {
-                        deadlineSecs = (long) secs;
+                        // Round, don't truncate. `(long) 0.7 == 0` would
+                        // collapse a sub-second budget into "immediate"
+                        // and bypass the `secs > 0` filter below; rounding
+                        // preserves at-least-the-budget semantics for
+                        // sub-second timeouts (PR review #874).
+                        deadlineSecs = Math.max(1L, Math.round(secs));
                     }
                 } catch (NumberFormatException nfe) {
                     log.debug("Invalid X-Mesh-Timeout header value '{}': {}", timeoutHeader, nfe.getMessage());

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -505,9 +505,17 @@ public class MeshToolWrapper implements McpToolHandler {
         // job pipeline: build a JobController bound to this job_id, set
         // both Java + native contexts, inject the controller at
         // meshJobParamIndex, auto-complete on successful return.
-        if (task && jobIdHeader != null && !jobIdHeader.isEmpty()
-                && meshJobParamIndex != null
-                && instanceId.get() != null && registryUrl.get() != null) {
+        //
+        // Gate is intentionally narrow — only `task=true` + a present
+        // `X-Mesh-Job-Id` header. Whether a JobController gets injected
+        // (requires meshJobParamIndex + instanceId + registryUrl) is
+        // decided INSIDE dispatchAsJob; if any of those is missing, we
+        // still bind the JobContext snapshot so outbound calls
+        // propagate the right job-id headers, but invoke the user
+        // method without the controller. The previous all-or-nothing
+        // gate silently skipped the wrap when the wiring was partial,
+        // leaving downstream calls headerless. (PR #891 review.)
+        if (task && jobIdHeader != null && !jobIdHeader.isEmpty()) {
             return dispatchAsJob(cleanArgs, jobIdHeader, deadlineSecs);
         }
 
@@ -676,6 +684,30 @@ public class MeshToolWrapper implements McpToolHandler {
             fullArgs[paramPos] = agent;
         }
 
+        // Decide whether we can build a JobController: we need a slot
+        // index AND both binding fields. If any piece is missing the
+        // job is still routed through the wrap (so outbound calls
+        // propagate the right headers via JobContext) but without the
+        // controller — see the gate-site javadoc. (PR #891 review.)
+        boolean canInjectController = meshJobParamIndex != null
+            && instanceId.get() != null
+            && registryUrl.get() != null;
+
+        if (!canInjectController) {
+            log.warn("Job dispatch for tool={} job={} is missing wiring " +
+                "(meshJobParamIndex={}, instanceId={}, registryUrl={}); " +
+                "binding JobContext only — controller NOT injected",
+                funcId, jobId,
+                meshJobParamIndex, instanceId.get(), registryUrl.get());
+            // Fill the MeshJob slot (if any) with null — user code that
+            // declares a MeshJob param tolerates null per DDDI.
+            if (meshJobParamIndex != null) {
+                fullArgs[meshJobParamIndex] = null;
+            }
+            JobContext.Snapshot snap = new JobContext.Snapshot(jobId, deadlineSecs);
+            return JobContext.withJob(snap, () -> invokeNoController(fullArgs));
+        }
+
         // Construct the producer controller. Free in finally.
         JobController controller = JobController.open(jobId, instanceId.get(), registryUrl.get());
         try {
@@ -690,6 +722,42 @@ public class MeshToolWrapper implements McpToolHandler {
         } finally {
             controller.close();
         }
+    }
+
+    /**
+     * Invoke the user method when we cannot construct a controller
+     * (missing wiring). Returns the user's result directly; no
+     * auto-complete because there's no controller to mark terminal.
+     * Matches the inbound non-job code path's invocation logic but
+     * stays inside the JobContext snapshot so outbound headers still
+     * carry the job id. (PR #891 review.)
+     */
+    private Object invokeNoController(Object[] fullArgs) throws Exception {
+        Object result;
+        try {
+            result = method.invoke(bean, fullArgs);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception ex) throw ex;
+            throw new RuntimeException(cause);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("Method access denied: " + e.getMessage(), e);
+        }
+        if (result instanceof CompletableFuture<?> future) {
+            try {
+                result = future.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                throw new RuntimeException("Async operation timed out after " + ASYNC_TIMEOUT_SECONDS + " seconds");
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof Exception ex) throw ex;
+                throw new RuntimeException(cause);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Async operation interrupted", e);
+            }
+        }
+        return result;
     }
 
     private Object invokeAndAutoComplete(Object[] fullArgs, JobController controller) throws Exception {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TraceContext.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TraceContext.java
@@ -55,6 +55,15 @@ public class TraceContext {
         if (!names.contains("x-mesh-timeout")) {
             names.add("x-mesh-timeout");
         }
+        // Phase B MeshJob substrate: x-mesh-job-id is captured here so the
+        // inbound MeshToolWrapper can dispatch task=true tools through the
+        // job pipeline (build a JobController + bind both Java/native
+        // contexts). Adding it to the propagate list also means outbound
+        // calls forward it to downstream task=true tools — matching the
+        // Python / TypeScript propagation behavior.
+        if (!names.contains("x-mesh-job-id")) {
+            names.add("x-mesh-job-id");
+        }
         PROPAGATE_HEADERS = Collections.unmodifiableList(names);
         PROPAGATE_HEADERS_CSV = String.join(",", PROPAGATE_HEADERS);
     }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/ClaimDispatcherTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/ClaimDispatcherTest.java
@@ -1,0 +1,151 @@
+package io.mcpmesh.spring;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link ClaimDispatcher}. Spins up a {@link MockWebServer}
+ * that pretends to be the registry's {@code /jobs/claim} endpoint so the
+ * dispatcher's HTTP loop is exercised end-to-end without needing a real
+ * registry.
+ *
+ * <p>Coverage matches Python's {@code test_claim_dispatcher.py} +
+ * TypeScript's {@code claim-dispatcher.spec.ts}:
+ * <ul>
+ *   <li>Empty claim response → loop backs off without invoking handler</li>
+ *   <li>Single-claim response → handler is invoked with the payload + a controller</li>
+ *   <li>{@code stop()} drains the loop and tolerates 0 timeout</li>
+ *   <li>Acquire-before-claim ordering — concurrent claims never exceed cap</li>
+ * </ul>
+ *
+ * <p>The handler test path uses {@code controller=null} via a stubbed
+ * {@code ClaimHandler} so we exercise the wiring, not the FFI controller
+ * (those are covered in the SDK-level JobController unit tests).
+ */
+class ClaimDispatcherTest {
+
+    private MockWebServer server;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (server != null) server.shutdown();
+    }
+
+    @Test
+    void emptyClaimResponse_doesNotInvokeHandler() throws Exception {
+        // Registry returns 204 No Content — dispatcher should treat as "no work".
+        for (int i = 0; i < 3; i++) {
+            server.enqueue(new MockResponse().setResponseCode(204));
+        }
+        AtomicInteger handlerCalls = new AtomicInteger(0);
+        ClaimDispatcher d = new ClaimDispatcher(
+            "test_cap",
+            "instance-1",
+            server.url("/").toString(),
+            (payload, controller) -> {
+                handlerCalls.incrementAndGet();
+                return "result";
+            }
+        );
+        d.start();
+        // Let the loop run a few cycles — backoff is 200ms+ so 800ms is enough
+        Thread.sleep(800);
+        d.stop(0);
+        assertEquals(0, handlerCalls.get(), "handler must not run when /jobs/claim returns 204");
+        assertTrue(server.getRequestCount() >= 1, "dispatcher must have polled at least once");
+    }
+
+    // Note: a "claimed job → handler invoked" end-to-end test would
+    // construct a real JobController via FFI inside dispatch(), which
+    // requires a live registry to PATCH terminal deltas to. That's
+    // covered in the integration suite (examples/jobs-java) — here we
+    // stay below the FFI boundary so the JVM doesn't risk crashing on
+    // a half-mocked registry response.
+
+    @Test
+    void claim_postsCorrectBody() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(204));
+        ClaimDispatcher d = new ClaimDispatcher(
+            "my_cap",
+            "my-instance",
+            server.url("/").toString(),
+            (payload, controller) -> null
+        );
+        d.start();
+        RecordedRequest req = server.takeRequest(2, TimeUnit.SECONDS);
+        d.stop(0);
+        assertNotNull(req, "dispatcher must POST to /jobs/claim");
+        assertEquals("/jobs/claim", req.getPath());
+        assertEquals("POST", req.getMethod());
+        String body = req.getBody().readUtf8();
+        assertTrue(body.contains("\"capability\":\"my_cap\""),
+            "claim body must carry capability; got: " + body);
+        assertTrue(body.contains("\"instance_id\":\"my-instance\""),
+            "claim body must carry instance_id; got: " + body);
+    }
+
+    @Test
+    void stop_isIdempotent() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(204));
+        ClaimDispatcher d = new ClaimDispatcher(
+            "test_cap",
+            "instance-1",
+            server.url("/").toString(),
+            (payload, controller) -> null
+        );
+        d.start();
+        Thread.sleep(100);
+        d.stop(0);
+        // Second stop must not throw or hang
+        assertDoesNotThrow(() -> d.stop(0));
+    }
+
+    @Test
+    void start_isIdempotent() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(204));
+        ClaimDispatcher d = new ClaimDispatcher(
+            "test_cap",
+            "instance-1",
+            server.url("/").toString(),
+            (payload, controller) -> null
+        );
+        d.start();
+        // Second start must be a no-op (no new loop spawned)
+        assertDoesNotThrow(d::start);
+        d.stop(0);
+    }
+
+    @Test
+    void constructor_validatesRequiredArgs() {
+        // capability
+        assertThrows(IllegalArgumentException.class,
+            () -> new ClaimDispatcher(null, "id", "http://x", (p, c) -> null));
+        assertThrows(IllegalArgumentException.class,
+            () -> new ClaimDispatcher("", "id", "http://x", (p, c) -> null));
+        // instanceId
+        assertThrows(IllegalArgumentException.class,
+            () -> new ClaimDispatcher("cap", null, "http://x", (p, c) -> null));
+        // registryUrl
+        assertThrows(IllegalArgumentException.class,
+            () -> new ClaimDispatcher("cap", "id", null, (p, c) -> null));
+        // handler
+        assertThrows(IllegalArgumentException.class,
+            () -> new ClaimDispatcher("cap", "id", "http://x", null));
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/JobCancelControllerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/JobCancelControllerTest.java
@@ -1,0 +1,43 @@
+package io.mcpmesh.spring;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the cancel HTTP route handler. Covers:
+ * <ul>
+ *   <li>Returns the {@code {"cancelled": ..., "jobId": ...}} envelope</li>
+ *   <li>Returns {@code cancelled=false} for an unknown jobId (no token in
+ *       the cancel registry — the registry sweep is the backstop).</li>
+ * </ul>
+ *
+ * <p>End-to-end behavior (cancel signal → in-flight handler abort) is
+ * exercised in the integration suite which spawns a real producer.
+ */
+class JobCancelControllerTest {
+
+    @Test
+    void cancel_returnsFalseForUnknownJobId() {
+        JobCancelController controller = new JobCancelController();
+        // Random UUID — no JobController has bound a token for this id.
+        String jobId = UUID.randomUUID().toString();
+        Map<String, Object> body = controller.cancelJob(jobId);
+
+        assertEquals(jobId, body.get("jobId"));
+        assertEquals(Boolean.FALSE, body.get("cancelled"),
+            "no active job → cancelled=false (registry will still mark cancelled)");
+    }
+
+    @Test
+    void cancel_responseShape_includesBothKeys() {
+        JobCancelController controller = new JobCancelController();
+        Map<String, Object> body = controller.cancelJob("some-id");
+        assertTrue(body.containsKey("cancelled"));
+        assertTrue(body.containsKey("jobId"));
+        assertEquals(2, body.size(), "response envelope is exactly {cancelled, jobId}");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/JobsHelperToolHandlerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/JobsHelperToolHandlerTest.java
@@ -1,0 +1,96 @@
+package io.mcpmesh.spring;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the three MeshJob helper tool handlers (Phase B). These
+ * tests cover the static surface (tool names, schema, validation) — the
+ * actual JobProxy round-trip is exercised in integration tests because
+ * it needs a live registry.
+ */
+class JobsHelperToolHandlerTest {
+
+    private static final String DUMMY_REGISTRY = "http://localhost:0/no-such";
+
+    @Test
+    void all_returnsThreeHandlersWithExpectedNames() {
+        List<JobsHelperToolHandler> handlers = JobsHelperToolHandler.all(DUMMY_REGISTRY);
+        assertEquals(3, handlers.size());
+
+        // Verify each handler reports the canonical __mesh_job_ name
+        assertEquals(JobsHelperToolHandler.TOOL_NAME_STATUS, handlers.get(0).getCapability());
+        assertEquals(JobsHelperToolHandler.TOOL_NAME_RESULT, handlers.get(1).getCapability());
+        assertEquals(JobsHelperToolHandler.TOOL_NAME_CANCEL, handlers.get(2).getCapability());
+    }
+
+    @Test
+    void status_inputSchemaRequiresJobIdString() {
+        JobsHelperToolHandler h = new JobsHelperToolHandler(JobsHelperToolHandler.Op.STATUS, DUMMY_REGISTRY);
+        Map<String, Object> schema = h.getInputSchema();
+        assertEquals("object", schema.get("type"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> props = (Map<String, Object>) schema.get("properties");
+        assertNotNull(props.get("job_id"));
+        assertNull(props.get("reason"), "status helper has no `reason` field");
+        @SuppressWarnings("unchecked")
+        List<String> required = (List<String>) schema.get("required");
+        assertTrue(required.contains("job_id"));
+    }
+
+    @Test
+    void cancel_inputSchemaIncludesOptionalReason() {
+        JobsHelperToolHandler h = new JobsHelperToolHandler(JobsHelperToolHandler.Op.CANCEL, DUMMY_REGISTRY);
+        Map<String, Object> schema = h.getInputSchema();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> props = (Map<String, Object>) schema.get("properties");
+        assertNotNull(props.get("reason"), "cancel helper has a `reason` field");
+        @SuppressWarnings("unchecked")
+        List<String> required = (List<String>) schema.get("required");
+        assertTrue(required.contains("job_id"));
+        assertFalse(required.contains("reason"), "reason must be optional");
+    }
+
+    @Test
+    void invoke_rejectsMissingJobId() {
+        JobsHelperToolHandler h = new JobsHelperToolHandler(JobsHelperToolHandler.Op.STATUS, DUMMY_REGISTRY);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> h.invoke(Map.of()));
+        assertTrue(e.getMessage().contains("job_id"));
+    }
+
+    @Test
+    void invoke_rejectsEmptyJobId() {
+        JobsHelperToolHandler h = new JobsHelperToolHandler(JobsHelperToolHandler.Op.STATUS, DUMMY_REGISTRY);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> h.invoke(Map.of("job_id", "")));
+        assertTrue(e.getMessage().contains("job_id"));
+    }
+
+    @Test
+    void invoke_rejectsNonStringJobId() {
+        JobsHelperToolHandler h = new JobsHelperToolHandler(JobsHelperToolHandler.Op.STATUS, DUMMY_REGISTRY);
+        assertThrows(IllegalArgumentException.class,
+            () -> h.invoke(Map.of("job_id", 123)));
+    }
+
+    @Test
+    void all_dependencyAndLlmCountsAreZero() {
+        for (JobsHelperToolHandler h : JobsHelperToolHandler.all(DUMMY_REGISTRY)) {
+            assertEquals(0, h.getDependencyCount(), "helper tools have no deps");
+            assertEquals(0, h.getLlmAgentCount(), "helper tools have no LLM agents");
+        }
+    }
+
+    @Test
+    void funcId_usesSyntheticPrefix() {
+        JobsHelperToolHandler h = new JobsHelperToolHandler(JobsHelperToolHandler.Op.STATUS, DUMMY_REGISTRY);
+        // Synthetic prefix avoids collisions with user-declared funcIds
+        assertTrue(h.getFuncId().startsWith("__mesh_jobs_helper."),
+            "funcId must use the synthetic helper prefix; got: " + h.getFuncId());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/JobsHelperToolsRegistrarTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/JobsHelperToolsRegistrarTest.java
@@ -1,0 +1,68 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.core.MeshObjectMappers;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the helper tool startup registrar (Phase B). Verifies
+ * the auto-registration on every agent + skip-on-no-registry behavior.
+ */
+class JobsHelperToolsRegistrarTest {
+
+    @Test
+    void register_addsThreeWrappersAndThreeSyntheticSpecs() {
+        MeshToolRegistry toolRegistry = new MeshToolRegistry();
+        MeshToolWrapperRegistry wrapperRegistry =
+            new MeshToolWrapperRegistry(new McpMeshToolProxyFactory());
+
+        JobsHelperToolsRegistrar.register(toolRegistry, wrapperRegistry, "http://localhost:8000");
+
+        // Three handlers in the wrapper registry
+        assertNotNull(wrapperRegistry.getHandlerByCapability(JobsHelperToolHandler.TOOL_NAME_STATUS));
+        assertNotNull(wrapperRegistry.getHandlerByCapability(JobsHelperToolHandler.TOOL_NAME_RESULT));
+        assertNotNull(wrapperRegistry.getHandlerByCapability(JobsHelperToolHandler.TOOL_NAME_CANCEL));
+
+        // Three synthetic ToolSpecs in the heartbeat catalog
+        List<AgentSpec.ToolSpec> specs = toolRegistry.getToolSpecs();
+        assertEquals(3, specs.size(), "expected 3 synthetic tool specs in heartbeat");
+
+        // All three have the framework_internal kwargs marker
+        for (AgentSpec.ToolSpec s : specs) {
+            assertNotNull(s.getKwargs(), "synthetic helper specs must carry kwargs");
+            assertTrue(s.getKwargs().contains("framework_internal"),
+                "kwargs must mark the spec framework-internal");
+        }
+    }
+
+    @Test
+    void register_isSkippedOnEmptyRegistryUrl() {
+        MeshToolRegistry toolRegistry = new MeshToolRegistry();
+        MeshToolWrapperRegistry wrapperRegistry =
+            new MeshToolWrapperRegistry(new McpMeshToolProxyFactory());
+
+        JobsHelperToolsRegistrar.register(toolRegistry, wrapperRegistry, "");
+
+        // No registry URL → no helpers registered (without a registry to
+        // talk to, the helpers can't function — same skip semantics as
+        // the Python and TS registrars).
+        assertNull(wrapperRegistry.getHandlerByCapability(JobsHelperToolHandler.TOOL_NAME_STATUS));
+        assertEquals(0, toolRegistry.getToolSpecs().size());
+    }
+
+    @Test
+    void register_isSkippedOnNullRegistryUrl() {
+        MeshToolRegistry toolRegistry = new MeshToolRegistry();
+        MeshToolWrapperRegistry wrapperRegistry =
+            new MeshToolWrapperRegistry(new McpMeshToolProxyFactory());
+
+        JobsHelperToolsRegistrar.register(toolRegistry, wrapperRegistry, null);
+
+        assertNull(wrapperRegistry.getHandlerByCapability(JobsHelperToolHandler.TOOL_NAME_STATUS));
+        assertEquals(0, toolRegistry.getToolSpecs().size());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshJobResolverTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshJobResolverTest.java
@@ -1,0 +1,223 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.types.McpMeshTool;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Cross-SDK contract tests for the MeshJob DDDI resolver. Mirrors:
+ * <ul>
+ *   <li>Python {@code tests/test_resolver_meshjob.py}</li>
+ *   <li>TypeScript {@code __tests__/resolver-meshjob.spec.ts}</li>
+ * </ul>
+ *
+ * <p>Each scenario number below maps to {@code MESHJOB_DDDI_CONTRACT.md} →
+ * "Equivalence across SDKs" checklist. If a test fails, the resolver
+ * implementation has diverged from the contract — fix the resolver, not
+ * the test.
+ */
+class MeshJobResolverTest {
+
+    // ---- Test fixtures (one method per scenario) ----------------------------
+    //
+    // Java's reflective resolver works against actual method signatures, so
+    // each scenario gets a tiny method with the corresponding parameter shape.
+    // The bodies are throwaway — only the signatures matter.
+
+    @SuppressWarnings("unused")
+    static class Fixtures {
+        // Scenario 1: MeshTool only
+        public void scenario1_meshToolOnly(
+            String userArg,
+            McpMeshTool<String> dep
+        ) {}
+
+        // Scenario 2: MeshJob only
+        public void scenario2_meshJobOnly(
+            String userArg,
+            MeshJob job
+        ) {}
+
+        // Scenario 3: both, MeshJob in the middle
+        public void scenario3_both_meshJobMiddle(
+            String userId,
+            McpMeshTool<String> weather,
+            MeshJob job,
+            McpMeshTool<String> flights
+        ) {}
+
+        // Scenario 4: neither
+        public void scenario4_neither(
+            String userArg,
+            int count
+        ) {}
+
+        // Scenario 5: MeshJob trailing
+        public void scenario5_meshJobTrailing(
+            String userArg,
+            McpMeshTool<String> dep,
+            MeshJob job
+        ) {}
+
+        // Scenario 6: multiple MeshJob → must reject
+        public void scenario6_multipleMeshJob(
+            String userArg,
+            MeshJob job1,
+            MeshJob job2
+        ) {}
+
+        // Bonus: zero parameters at all
+        public void scenarioZero_noParams() {}
+
+        // Bonus: a CompletableFuture-returning method (just to make sure
+        // return-type oddities don't trip the resolver — it only inspects
+        // parameters).
+        public CompletableFuture<Map<String, Object>> scenarioBonus_async(
+            String userArg,
+            MeshJob job,
+            McpMeshTool<Flow.Publisher<String>> stream
+        ) {
+            return CompletableFuture.completedFuture(Map.of());
+        }
+    }
+
+    private static Method find(String name) {
+        for (Method m : Fixtures.class.getDeclaredMethods()) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+        throw new AssertionError("Fixture method not found: " + name);
+    }
+
+    // ---- Contract tests -----------------------------------------------------
+
+    @Test
+    void scenario1_meshToolOnly_unchangedFromPriorBehavior() {
+        // Method with McpMeshTool only → unchanged from prior behavior:
+        // one mesh tool dep at signature position 1, no mesh job param.
+        MeshJobResolver.Resolved r = MeshJobResolver.resolve(find("scenario1_meshToolOnly"));
+        assertEquals(2, r.totalParameterCount());
+        assertEquals(1, r.meshToolCount());
+        assertEquals(1, r.meshToolPositions().get(0));
+        assertFalse(r.hasMeshJob());
+        assertTrue(r.meshJobParamIndex().isEmpty());
+    }
+
+    @Test
+    void scenario2_meshJobOnly_zeroToolsJobIndexRecorded() {
+        // Method with MeshJob only → MeshTool count = 0, MeshJob index recorded.
+        MeshJobResolver.Resolved r = MeshJobResolver.resolve(find("scenario2_meshJobOnly"));
+        assertEquals(2, r.totalParameterCount());
+        assertEquals(0, r.meshToolCount());
+        assertTrue(r.hasMeshJob());
+        assertEquals(1, r.meshJobParamIndex().orElseThrow());
+    }
+
+    @Test
+    void scenario3_both_meshJobInMiddle_meshToolPositionsCorrect() {
+        // Method with both, MeshJob in middle → MeshTool positions correct
+        // (skip MeshJob; positional counter for MeshTool unaffected by it).
+        MeshJobResolver.Resolved r =
+            MeshJobResolver.resolve(find("scenario3_both_meshJobMiddle"));
+        assertEquals(4, r.totalParameterCount());
+        assertEquals(2, r.meshToolCount(), "should pick up both MeshTool deps");
+        // MeshTool[0] is at signature position 1 (weather); MeshTool[1] is at
+        // signature position 3 (flights, NOT 2 — MeshJob at pos 2 is skipped).
+        assertEquals(1, r.meshToolPositions().get(0), "first MeshTool at sig pos 1");
+        assertEquals(3, r.meshToolPositions().get(1),
+            "second MeshTool at sig pos 3 (NOT 2 — MeshJob skipped per contract)");
+        assertTrue(r.hasMeshJob());
+        assertEquals(2, r.meshJobParamIndex().orElseThrow(),
+            "MeshJob recorded at signature position 2");
+    }
+
+    @Test
+    void scenario4_neither_noDddiMetadata() {
+        // Method with neither → no DDDI metadata.
+        MeshJobResolver.Resolved r = MeshJobResolver.resolve(find("scenario4_neither"));
+        assertEquals(2, r.totalParameterCount());
+        assertEquals(0, r.meshToolCount());
+        assertFalse(r.hasMeshJob());
+    }
+
+    @Test
+    void scenario5_meshJobTrailing_indexAtLastPosition() {
+        // Method with MeshJob trailing → meshJobParamIndex = last sig position.
+        MeshJobResolver.Resolved r =
+            MeshJobResolver.resolve(find("scenario5_meshJobTrailing"));
+        assertEquals(3, r.totalParameterCount());
+        assertEquals(1, r.meshToolCount(), "MeshTool at signature position 1");
+        assertEquals(1, r.meshToolPositions().get(0));
+        assertTrue(r.hasMeshJob());
+        assertEquals(2, r.meshJobParamIndex().orElseThrow(),
+            "MeshJob at last position (sig pos 2)");
+    }
+
+    @Test
+    void scenario6_multipleMeshJob_throwsAtResolveTime() {
+        // Method with two MeshJob params → throws IllegalStateException
+        // at resolve time (per contract: "Disallowed in Phase 1").
+        Method m = find("scenario6_multipleMeshJob");
+        IllegalStateException ex = assertThrows(
+            IllegalStateException.class,
+            () -> MeshJobResolver.resolve(m)
+        );
+        // Error message must reference the method name AND mention that
+        // a tool may declare at most one MeshJob — same as the contract's
+        // mandated wording.
+        assertTrue(ex.getMessage().contains("scenario6_multipleMeshJob"),
+            "error must reference the offending method, was: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("at most one MeshJob"),
+            "error must surface the contract clause, was: " + ex.getMessage());
+        // Both colliding positions should be mentioned so users can find
+        // the second occurrence — matches the Python error format.
+        assertTrue(ex.getMessage().contains("1") && ex.getMessage().contains("2"),
+            "error should mention both positions (1 and 2), was: " + ex.getMessage());
+    }
+
+    @Test
+    void zeroParameters_isHandledCleanly() {
+        // Edge case: methods with no params at all should not blow up.
+        MeshJobResolver.Resolved r = MeshJobResolver.resolve(find("scenarioZero_noParams"));
+        assertEquals(0, r.totalParameterCount());
+        assertEquals(0, r.meshToolCount());
+        assertFalse(r.hasMeshJob());
+    }
+
+    @Test
+    void resolverInspectsParametersOnly_returnTypeIrrelevant() {
+        // Make sure CompletableFuture / Flow.Publisher returns don't confuse
+        // the resolver — a regression here would mean the resolver was
+        // accidentally peeking at the return-type generic args.
+        MeshJobResolver.Resolved r = MeshJobResolver.resolve(find("scenarioBonus_async"));
+        assertEquals(3, r.totalParameterCount());
+        assertEquals(1, r.meshToolCount());
+        assertEquals(2, r.meshToolPositions().get(0),
+            "MeshTool at sig pos 2 (after String + MeshJob)");
+        assertTrue(r.hasMeshJob());
+        assertEquals(1, r.meshJobParamIndex().orElseThrow());
+    }
+
+    @Test
+    void nullMethod_throwsIllegalArgument() {
+        assertThrows(IllegalArgumentException.class,
+            () -> MeshJobResolver.resolve(null));
+    }
+
+    @Test
+    void resolved_meshToolPositions_isImmutable() {
+        // Defensive copy in the Resolved canonical constructor — callers
+        // mutating the returned list must NOT affect the resolver's result.
+        MeshJobResolver.Resolved r = MeshJobResolver.resolve(find("scenario1_meshToolOnly"));
+        assertThrows(UnsupportedOperationException.class,
+            () -> r.meshToolPositions().add(99));
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolRegistryTaskTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolRegistryTaskTest.java
@@ -1,0 +1,107 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.core.AgentSpec;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the Phase B {@code task} flag wiring on
+ * {@link MeshToolRegistry}.
+ *
+ * <p>Verifies the {@code task=true} flag flows from the {@link MeshTool}
+ * annotation into the registry's metadata AND into the heartbeat
+ * ToolSpec's {@code kwargs} JSON — matching Python's
+ * {@code rust_heartbeat.py} kwargs spread which carries the same flag
+ * through to the registry catalog.
+ */
+class MeshToolRegistryTaskTest {
+
+    static class TaskBean {
+        @MeshTool(capability = "task_cap", task = true)
+        public String taskMethod(@Param("input") String input) {
+            return input;
+        }
+
+        @MeshTool(capability = "regular_cap")
+        public String regularMethod(@Param("input") String input) {
+            return input;
+        }
+    }
+
+    private static Method find(String name) {
+        for (Method m : TaskBean.class.getDeclaredMethods()) {
+            if (m.getName().equals(name)) return m;
+        }
+        throw new AssertionError(name);
+    }
+
+    @Test
+    void registerTool_persistsTaskFlagInMetadata() throws Exception {
+        MeshToolRegistry reg = new MeshToolRegistry();
+        Object bean = new TaskBean();
+        reg.registerTool(bean, find("taskMethod"),
+            find("taskMethod").getAnnotation(MeshTool.class));
+
+        MeshToolRegistry.ToolMetadata meta = reg.getTool("task_cap");
+        assertNotNull(meta);
+        assertTrue(meta.task(), "task flag must round-trip into metadata");
+    }
+
+    @Test
+    void registerTool_regularMethodHasTaskFalse() throws Exception {
+        MeshToolRegistry reg = new MeshToolRegistry();
+        Object bean = new TaskBean();
+        reg.registerTool(bean, find("regularMethod"),
+            find("regularMethod").getAnnotation(MeshTool.class));
+
+        MeshToolRegistry.ToolMetadata meta = reg.getTool("regular_cap");
+        assertNotNull(meta);
+        assertFalse(meta.task(), "regular tool defaults to task=false");
+    }
+
+    @Test
+    void getToolSpecs_emitsTaskTrueInKwargsForTaskTools() throws Exception {
+        MeshToolRegistry reg = new MeshToolRegistry();
+        Object bean = new TaskBean();
+        reg.registerTool(bean, find("taskMethod"),
+            find("taskMethod").getAnnotation(MeshTool.class));
+
+        List<AgentSpec.ToolSpec> specs = reg.getToolSpecs();
+        AgentSpec.ToolSpec taskSpec = specs.stream()
+            .filter(s -> "task_cap".equals(s.getCapability()))
+            .findFirst()
+            .orElseThrow();
+        assertNotNull(taskSpec.getKwargs(), "task=true tool must carry kwargs");
+        assertTrue(taskSpec.getKwargs().contains("\"task\""),
+            "kwargs JSON must contain the `task` key");
+        assertTrue(taskSpec.getKwargs().contains("true"),
+            "kwargs JSON must record task=true");
+    }
+
+    @Test
+    void getToolSpecs_emitsNoKwargsForRegularTools() throws Exception {
+        MeshToolRegistry reg = new MeshToolRegistry();
+        Object bean = new TaskBean();
+        reg.registerTool(bean, find("regularMethod"),
+            find("regularMethod").getAnnotation(MeshTool.class));
+
+        AgentSpec.ToolSpec regularSpec = reg.getToolSpecs().get(0);
+        assertNull(regularSpec.getKwargs(),
+            "regular tools must not emit kwargs (matches Python's behavior — empty kwargs → null)");
+    }
+
+    @Test
+    void addSyntheticTool_appendsToHeartbeatCatalog() {
+        MeshToolRegistry reg = new MeshToolRegistry();
+        AgentSpec.ToolSpec synth = new AgentSpec.ToolSpec("__mesh_job_status", "__mesh_job_status");
+        reg.addSyntheticTool(synth);
+        assertEquals(1, reg.getToolSpecs().size());
+        assertEquals("__mesh_job_status", reg.getToolSpecs().get(0).getCapability());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperJobTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperJobTest.java
@@ -1,0 +1,190 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.JobController;
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshJobSubmitter;
+import io.mcpmesh.Param;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the Phase B MeshJob fields on {@link MeshToolWrapper}.
+ *
+ * <p>Covers the parts of the inbound dispatch wrapper that don't require
+ * a live Rust core (job param recognition, slot injection on non-job
+ * paths, getter contracts). The job-dispatch path itself (constructing
+ * a {@link JobController} via FFI + binding both contexts) is exercised
+ * end-to-end in the integration suite.
+ */
+class MeshToolWrapperJobTest {
+
+    @SuppressWarnings("unused")
+    static class Producer {
+        // task=true producer with a MeshJob slot — same shape as the
+        // long-task-provider example.
+        public Map<String, Object> generateReport(
+                @Param("user_id") String userId,
+                @Param(value = "sections", required = false) List<String> sections,
+                MeshJob job) {
+            return Map.of("user_id", userId, "report", List.of());
+        }
+
+        // No MeshJob slot — task=true is allowed but the slot is optional.
+        public String simpleTask(@Param("input") String input) {
+            return "ok:" + input;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class Consumer {
+        // Consumer-side: MeshJob slot + a declared dependency name.
+        public Map<String, Object> commissionReport(
+                @Param("user_id") String userId,
+                MeshJob generateReport) {
+            return Map.of();
+        }
+    }
+
+    private static Method find(Class<?> cls, String name) {
+        for (Method m : cls.getDeclaredMethods()) {
+            if (m.getName().equals(name)) return m;
+        }
+        throw new AssertionError("not found: " + name);
+    }
+
+    @Test
+    void taskWrapper_recordsTaskFlagAndMeshJobIndex() {
+        MeshToolWrapper w = new MeshToolWrapper(
+            "Producer.generateReport",
+            "generate_report",
+            "test",
+            new Producer(),
+            find(Producer.class, "generateReport"),
+            List.of(),
+            JsonMapper.builder().build(),
+            true
+        );
+        assertTrue(w.isTask(), "task flag must round-trip");
+        assertEquals(2, w.getMeshJobParamIndex(),
+            "MeshJob param sits at signature position 2 (after user_id + sections)");
+    }
+
+    @Test
+    void taskWrapper_meshJobParamIsNotInInputSchema() {
+        MeshToolWrapper w = new MeshToolWrapper(
+            "Producer.generateReport",
+            "generate_report",
+            "test",
+            new Producer(),
+            find(Producer.class, "generateReport"),
+            List.of(),
+            JsonMapper.builder().build(),
+            true
+        );
+        Map<String, Object> schema = w.getInputSchema();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties = (Map<String, Object>) schema.get("properties");
+        // user_id + sections → 2 props; MeshJob is exempt.
+        assertEquals(2, properties.size(),
+            "MeshJob param must be excluded from MCP input schema");
+        assertTrue(properties.containsKey("user_id"));
+        assertTrue(properties.containsKey("sections"));
+        assertFalse(properties.containsKey("job"));
+    }
+
+    @Test
+    void taskWrapper_withoutMeshJobSlot_isLegal() {
+        MeshToolWrapper w = new MeshToolWrapper(
+            "Producer.simpleTask",
+            "simple_task",
+            "test",
+            new Producer(),
+            find(Producer.class, "simpleTask"),
+            List.of(),
+            JsonMapper.builder().build(),
+            true
+        );
+        assertTrue(w.isTask());
+        assertNull(w.getMeshJobParamIndex(),
+            "task=true without a MeshJob slot must not synthesize one");
+    }
+
+    @Test
+    void nonTaskWrapper_isTaskReturnsFalse() {
+        MeshToolWrapper w = new MeshToolWrapper(
+            "Consumer.commissionReport",
+            "commission_report",
+            "test",
+            new Consumer(),
+            find(Consumer.class, "commissionReport"),
+            List.of("generate_report"),
+            JsonMapper.builder().build(),
+            false
+        );
+        assertFalse(w.isTask());
+        assertEquals(1, w.getMeshJobParamIndex(),
+            "consumer's MeshJob slot at signature position 1");
+    }
+
+    @Test
+    void invoke_withoutJobIdHeader_passesNullForMeshJobSlot() throws Exception {
+        // No X-Mesh-Job-Id and no submitter wired → MeshJob slot is null.
+        // The user method must tolerate null per MESHJOB_DDDI_CONTRACT.md.
+        MeshToolWrapper w = new MeshToolWrapper(
+            "Consumer.commissionReport",
+            "commission_report",
+            "test",
+            new Consumer(),
+            find(Consumer.class, "commissionReport"),
+            List.of("generate_report"),
+            JsonMapper.builder().build(),
+            false
+        );
+        // Direct invoke — no TraceContext set, so no propagated headers.
+        Object result = w.invoke(Map.of("user_id", "demo"));
+        assertNotNull(result);
+        // The Consumer method just returns Map.of(); no NPE means the
+        // null MeshJob slot was handled correctly.
+    }
+
+    @Test
+    void setJobBindingContext_isSafeWithNulls() {
+        MeshToolWrapper w = new MeshToolWrapper(
+            "Producer.simpleTask",
+            "simple_task",
+            "test",
+            new Producer(),
+            find(Producer.class, "simpleTask"),
+            List.of(),
+            JsonMapper.builder().build(),
+            true
+        );
+        // Both null is a no-op (defensive — in case the runtime hasn't
+        // resolved instance id / registry url yet).
+        assertDoesNotThrow(() -> w.setJobBindingContext(null, null));
+        assertDoesNotThrow(() -> w.setJobBindingContext("id", "http://x"));
+    }
+
+    @Test
+    void setJobSubmitter_acceptsSubmitterAndNull() {
+        MeshToolWrapper w = new MeshToolWrapper(
+            "Consumer.commissionReport",
+            "commission_report",
+            "test",
+            new Consumer(),
+            find(Consumer.class, "commissionReport"),
+            List.of("generate_report"),
+            JsonMapper.builder().build(),
+            false
+        );
+        MeshJobSubmitter submitter = new MeshJobSubmitter("generate_report", "consumer-1", "http://localhost:8000");
+        assertDoesNotThrow(() -> w.setJobSubmitter(submitter));
+        assertDoesNotThrow(() -> w.setJobSubmitter(null));
+    }
+}


### PR DESCRIPTION
Closes #874. Mirrors Python's PR #878 and TypeScript's PR #885 for the Java runtime. Integration tests + 3-way Python/TS/Java polyglot smoke land separately in #890.

## Summary

**C ABI bindings** (` src/runtime/core/src/jobs_ffi.rs`):
- 18 new ` mesh_job_*` / ` mesh_submit_job` / ` mesh_current_job` / ` mesh_cancel_active_job` / ` mesh_run_as_job` symbols using raw C ABI (manual marshalling, error via ` i32` return + thread-local ` mesh_last_error()`, sync-blocking via process-wide ` OnceLock<Runtime>` + ` block_on`)
- Updated cbindgen-regenerated header at ` src/runtime/core/include/mcp_mesh_core.h`
- Uniform ` <= 0.0 || !is_finite()` predicate for deadline validation across both ` mesh_job_proxy_wait` and ` mesh_run_as_job` (BLOCKER from review fixed)

**JNR-FFI bridge** (` mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java`):
- All 18 functions declared with JNR-FFI types; ` @Delegate`-annotated ` RunAsJobCallback` interface for the function-pointer arg

**Java SDK** (` mcp-mesh-sdk`):
- ` MeshJob` marker interface
- ` JobController` (producer side: ` updateProgress`, ` complete(Object)`, ` fail(String)`, ` isTerminal()`)
- ` JobProxy` (consumer side: ` await(double)` — ` Object.wait()` is ` final` so we use ` await`; ` status()`, ` cancel(String)`)
- ` MeshJobSubmitter` (` submit(...)` returns ` CompletableFuture<JobProxy>` for async composition)
- ` JobContext` (ThreadLocal-based ` withJob` + ` current` + native sync via ` mesh_current_job`)
- ` @MeshTool(task = true)` annotation field

**Spring Boot starter integration**:
- ` MeshToolWrapper.dispatchAsJob` — inbound MCP tool wrapper reads ` X-Mesh-Job-Id`, builds JobController, injects at ` meshJobParamIndex`, auto-completes on successful return
- ` ClaimDispatcher` — pure-Java pull-mode worker: ` Semaphore(4)`, acquire-before-claim ordering, bounded drain in ` stop()`, ` Future` self-removal from inflight set (W1 fix), ` Math.round + Math.max(1L, ...)` for fractional ` X-Mesh-Timeout` (W4 fix)
- ` JobCancelController` — Spring MVC ` @RestController` mounting ` POST /jobs/{jobId}/cancel`
- ` JobsHelperToolsRegistrar` — auto-registers ` __mesh_job_*` helpers on every Java agent
- ` JobsRuntimeManager` — ` SmartLifecycle` orchestrator wiring producers/consumers/dispatchers
- ` MeshJobResolver` — reflective DDDI implementation per ` MESHJOB_DDDI_CONTRACT.md`, standalone class for clean test seam

**Examples** (` examples/jobs-java/`):
- ` long-task-provider-java/` (port 9120)
- ` long-task-consumer-java/` (port 9121)

## Architectural decisions

- **C ABI manual marshalling**: errors via ` i32` return + thread-local ` mesh_last_error()`; opaque handles ` Box`-allocated, freed via dedicated ` mesh_*_free`
- **` JobProxy.await` not ` wait`**: ` Object.wait()` is ` final` in Java
- **Async submit**: ` CompletableFuture<JobProxy>` so DDDI callers can compose without blocking
- **DDDI resolver as standalone class**: clean test seam without Spring + native bridge weight
- **No ScopedValue** (preview API): sticking with ThreadLocal per Java 17 stable APIs
- **Java sync FFI nested-runtime constraint**: ` MeshToolWrapper.dispatchAsJob` and ` ClaimDispatcher` bind ONLY the Java-side ThreadLocal ` JobContext`, NOT the Rust-side ` with_job` task-local. Reason: nested ` block_on` panics. Documented inline; filed as **#889** follow-up. Consequence: cancel-registry binding inactive for Java-owned jobs — registry sweep is the backstop

## Review Notes

Independent code review found **1 BLOCKER + 6 WARNINGs + 5 INFOs**. **All 1 BLOCKER + 6 WARNINGs + 1 worth-fixing INFO addressed in commit ` 0f4929bb`**:

- BLOCKER: uniform deadline validation across ` jobs_ffi.rs` functions (was inconsistent ` is_sign_negative()` vs ` < 0.0`)
- W1: ` ClaimDispatcher` inflight Set memory leak (Future never removed; was holding full payload Map per claimed job indefinitely) → ` Future[1]` holder + ` finally` cleanup
- W2/W3: deleted dead code (` buildSnapshotJson`, ` JobController.fromHandle`)
- W4: ` Math.round(secs)` + floor of 1L for fractional ` X-Mesh-Timeout` (was ` (long)` truncation; ` 0.7s` became ` 0L`)
- W5: hoisted ` ObjectMapper` to ` static final` (was 6 mappers per startup)
- W6: ` addSyntheticTool` dedups by capability (was non-idempotent)
- INFO: replaced manual JSON string-concat with Jackson (was unsafe for special chars)

4 minor INFOs deferred (perf micro-opts, cosmetic constants, documented design tradeoffs).

## Substrate observations filed

- **#889** — Java cancel-registry binding inactive due to sync JNR-FFI nested-runtime constraint (specific to Java; Python/TS use async composition)

Closes #874

## Test plan

- [x] ` cargo test --features ffi --lib` — **388 passed** (386 baseline + 2 new validation tests)
- [x] ` mvn install -DskipTests=false` — all modules pass; **149 starter tests** + 124 spring-ai + 8 SDK + 5 SDK MeshJob, no failures
- [x] cbindgen-regenerated header includes all 18 new symbols
- [x] e2e smoke: Java consumer ↔ Java provider ` commission_report` returns assembled report
- [x] Helper tool reachable: ` __mesh_job_status` returns clean "job not found" for unknown ID
- [ ] CI green
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Phase B MeshJob support for long-running task workflows in Java Spring Boot agents.
  * Producers can now register long-running tasks with progress reporting and terminal completion.
  * Consumers can submit jobs, poll status, and await results with configurable timeouts.
  * Added built-in helper tools for job introspection: status queries, result retrieval, and job cancellation.
  * Included complete Java producer/consumer example with quick-start guide.

* **Documentation**
  * Added comprehensive README covering task workflow architecture, quick-start setup, expected behavior, and Phase B scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->