### PR TITLE
feature: Java MeshJob integration tests + 3-way polyglot smoke + Maven cleanup

### DIFF
--- a/examples/java/basic-tool-agent/pom.xml
+++ b/examples/java/basic-tool-agent/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -58,11 +64,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/java/dependency-agent/pom.xml
+++ b/examples/java/dependency-agent/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -58,11 +64,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/java/direct-openai-agent/pom.xml
+++ b/examples/java/direct-openai-agent/pom.xml
@@ -25,6 +25,12 @@
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -62,10 +68,6 @@
     </dependencies>
 
     <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>

--- a/examples/java/employee-service/pom.xml
+++ b/examples/java/employee-service/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -54,11 +60,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/java/gemini-provider-agent/pom.xml
+++ b/examples/java/gemini-provider-agent/pom.xml
@@ -25,6 +25,12 @@
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -62,10 +68,6 @@
     </dependencies>
 
     <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>

--- a/examples/java/gpt-provider-agent/pom.xml
+++ b/examples/java/gpt-provider-agent/pom.xml
@@ -25,6 +25,12 @@
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -62,10 +68,6 @@
     </dependencies>
 
     <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>

--- a/examples/java/header-api/pom.xml
+++ b/examples/java/header-api/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -50,10 +56,4 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/java/health-block-test-agent/pom.xml
+++ b/examples/java/health-block-test-agent/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -58,11 +64,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/java/java-accurate-provider/pom.xml
+++ b/examples/java/java-accurate-provider/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -35,13 +41,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/examples/java/java-alpha-provider/pom.xml
+++ b/examples/java/java-alpha-provider/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -35,13 +41,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/examples/java/java-beta-provider/pom.xml
+++ b/examples/java/java-beta-provider/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -35,13 +41,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/examples/java/java-booking-consumer/pom.xml
+++ b/examples/java/java-booking-consumer/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -58,11 +64,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/java/java-calculator/pom.xml
+++ b/examples/java/java-calculator/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -58,11 +64,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/java/java-deprecated-provider/pom.xml
+++ b/examples/java/java-deprecated-provider/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -35,13 +41,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/examples/java/java-dual-consumer/pom.xml
+++ b/examples/java/java-dual-consumer/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -35,13 +41,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/examples/java/java-fast-provider/pom.xml
+++ b/examples/java/java-fast-provider/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -35,13 +41,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/examples/java/java-math-agent/pom.xml
+++ b/examples/java/java-math-agent/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -58,11 +64,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/java/java-schedule-agent/pom.xml
+++ b/examples/java/java-schedule-agent/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -58,11 +64,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/java/java-tag-consumer/pom.xml
+++ b/examples/java/java-tag-consumer/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -35,13 +41,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/examples/java/java-weather-agent/pom.xml
+++ b/examples/java/java-weather-agent/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -58,11 +64,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/java/llm-mesh-agent/pom.xml
+++ b/examples/java/llm-mesh-agent/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -71,12 +77,7 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
     <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>

--- a/examples/java/media-consumer-agent/pom.xml
+++ b/examples/java/media-consumer-agent/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -58,11 +64,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/java/media-producer-agent/pom.xml
+++ b/examples/java/media-producer-agent/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -65,11 +71,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/java/multijar-api-gateway/pom.xml
+++ b/examples/java/multijar-api-gateway/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -69,11 +75,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/java/multijar-payment-service/pom.xml
+++ b/examples/java/multijar-payment-service/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -68,11 +74,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/jobs-java/long-task-consumer-java/pom.xml
+++ b/examples/jobs-java/long-task-consumer-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -35,13 +41,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/examples/jobs-java/long-task-provider-java/pom.xml
+++ b/examples/jobs-java/long-task-provider-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -35,13 +41,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/examples/parallel-tools/consumer-claude-java/pom.xml
+++ b/examples/parallel-tools/consumer-claude-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -65,10 +71,6 @@
     </build>
 
     <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>

--- a/examples/parallel-tools/consumer-gemini-java/pom.xml
+++ b/examples/parallel-tools/consumer-gemini-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -65,10 +71,6 @@
     </build>
 
     <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>

--- a/examples/parallel-tools/consumer-openai-java/pom.xml
+++ b/examples/parallel-tools/consumer-openai-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -65,10 +71,6 @@
     </build>
 
     <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>

--- a/examples/parallel-tools/parallel-consumer-java/pom.xml
+++ b/examples/parallel-tools/parallel-consumer-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -72,10 +78,6 @@
     </build>
 
     <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>

--- a/examples/parallel-tools/slow-tool-java/pom.xml
+++ b/examples/parallel-tools/slow-tool-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -58,10 +64,4 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/examples/schema-corpus/java/pom.xml
+++ b/examples/schema-corpus/java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -39,13 +45,6 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/examples/schema/java/consumer/pom.xml
+++ b/examples/schema/java/consumer/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -39,13 +45,6 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/examples/schema/java/producer-bad/pom.xml
+++ b/examples/schema/java/producer-bad/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -35,13 +41,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/examples/schema/java/producer-good/pom.xml
+++ b/examples/schema/java/producer-good/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -39,13 +45,6 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/examples/toolcalls/analyst-java/pom.xml
+++ b/examples/toolcalls/analyst-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -72,10 +78,6 @@
     </build>
 
     <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>

--- a/examples/toolcalls/claude-provider-java/pom.xml
+++ b/examples/toolcalls/claude-provider-java/pom.xml
@@ -25,6 +25,12 @@
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -62,10 +68,6 @@
     </dependencies>
 
     <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>

--- a/examples/toolcalls/gemini-provider-java/pom.xml
+++ b/examples/toolcalls/gemini-provider-java/pom.xml
@@ -25,6 +25,12 @@
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -62,10 +68,6 @@
     </dependencies>
 
     <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>

--- a/examples/toolcalls/openai-provider-java/pom.xml
+++ b/examples/toolcalls/openai-provider-java/pom.xml
@@ -25,6 +25,12 @@
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -62,10 +68,6 @@
     </dependencies>
 
     <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>

--- a/examples/toolcalls/weather-tool-java/pom.xml
+++ b/examples/toolcalls/weather-tool-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -58,10 +64,4 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/java-slow-agent/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/java-slow-agent/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -58,11 +64,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/tests/integration/suites/uc05_meshctl/artifacts/java-non-mesh-app/pom.xml
+++ b/tests/integration/suites/uc05_meshctl/artifacts/java-non-mesh-app/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter (on classpath but not used as agent) -->
         <dependency>
@@ -51,11 +57,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-echo-java/pom.xml
+++ b/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-echo-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -48,10 +54,4 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-relay-java/pom.xml
+++ b/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-relay-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -48,10 +54,4 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/tests/integration/suites/uc12_registration_trust/artifacts/java-greeter/pom.xml
+++ b/tests/integration/suites/uc12_registration_trust/artifacts/java-greeter/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter -->
         <dependency>
@@ -58,11 +64,4 @@
         </plugins>
     </build>
 
-    <!-- Local repository for mcp-mesh artifacts (development) -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/tests/integration/suites/uc14_multimedia/tc31_download_media_java/artifacts/java-download-agent/pom.xml
+++ b/tests/integration/suites/uc14_multimedia/tc31_download_media_java/artifacts/java-download-agent/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -48,10 +54,4 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/tests/integration/suites/uc16_schema_filtering/artifacts/java-schema-agent/pom.xml
+++ b/tests/integration/suites/uc16_schema_filtering/artifacts/java-schema-agent/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -48,10 +54,4 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/tests/integration/suites/uc18_streaming/artifacts/streaming/java-stream-gateway/pom.xml
+++ b/tests/integration/suites/uc18_streaming/artifacts/streaming/java-stream-gateway/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <!-- MCP Mesh Spring Boot Starter (provides @MeshRoute + MeshSse) -->
         <dependency>
@@ -57,15 +63,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <!-- Local repository for mcp-mesh artifacts (development).
-         The maven-install handler also strips file:// repos and aligns
-         mcp-mesh.version to whatever is published in the container's
-         m2 cache, so this entry is harmless when running under tsuite. -->
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../../../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 </project>

--- a/tests/integration/suites/uc23_meshjob_java/artifacts/bystander-x-java
+++ b/tests/integration/suites/uc23_meshjob_java/artifacts/bystander-x-java
@@ -1,0 +1,1 @@
+../fixtures/bystander-x-java

--- a/tests/integration/suites/uc23_meshjob_java/artifacts/bystander-x-ts
+++ b/tests/integration/suites/uc23_meshjob_java/artifacts/bystander-x-ts
@@ -1,0 +1,1 @@
+../../uc22_meshjob_ts/fixtures/bystander-x-ts

--- a/tests/integration/suites/uc23_meshjob_java/artifacts/bystander-y-java
+++ b/tests/integration/suites/uc23_meshjob_java/artifacts/bystander-y-java
@@ -1,0 +1,1 @@
+../fixtures/bystander-y-java

--- a/tests/integration/suites/uc23_meshjob_java/artifacts/downstream-sleeper-java
+++ b/tests/integration/suites/uc23_meshjob_java/artifacts/downstream-sleeper-java
@@ -1,0 +1,1 @@
+../fixtures/downstream-sleeper-java

--- a/tests/integration/suites/uc23_meshjob_java/artifacts/long-task-consumer
+++ b/tests/integration/suites/uc23_meshjob_java/artifacts/long-task-consumer
@@ -1,0 +1,1 @@
+../../uc21_meshjob/fixtures/long-task-consumer

--- a/tests/integration/suites/uc23_meshjob_java/artifacts/long-task-consumer-java
+++ b/tests/integration/suites/uc23_meshjob_java/artifacts/long-task-consumer-java
@@ -1,0 +1,1 @@
+../fixtures/long-task-consumer-java

--- a/tests/integration/suites/uc23_meshjob_java/artifacts/long-task-consumer-ts
+++ b/tests/integration/suites/uc23_meshjob_java/artifacts/long-task-consumer-ts
@@ -1,0 +1,1 @@
+../../uc22_meshjob_ts/fixtures/long-task-consumer-ts

--- a/tests/integration/suites/uc23_meshjob_java/artifacts/long-task-provider
+++ b/tests/integration/suites/uc23_meshjob_java/artifacts/long-task-provider
@@ -1,0 +1,1 @@
+../../uc21_meshjob/fixtures/long-task-provider

--- a/tests/integration/suites/uc23_meshjob_java/artifacts/long-task-provider-java
+++ b/tests/integration/suites/uc23_meshjob_java/artifacts/long-task-provider-java
@@ -1,0 +1,1 @@
+../fixtures/long-task-provider-java

--- a/tests/integration/suites/uc23_meshjob_java/artifacts/long-task-provider-ts
+++ b/tests/integration/suites/uc23_meshjob_java/artifacts/long-task-provider-ts
@@ -1,0 +1,1 @@
+../../uc22_meshjob_ts/fixtures/long-task-provider-ts

--- a/tests/integration/suites/uc23_meshjob_java/artifacts/orchestrator-agent
+++ b/tests/integration/suites/uc23_meshjob_java/artifacts/orchestrator-agent
@@ -1,0 +1,1 @@
+../../uc21_meshjob/fixtures/orchestrator-agent

--- a/tests/integration/suites/uc23_meshjob_java/artifacts/orchestrator-agent-java
+++ b/tests/integration/suites/uc23_meshjob_java/artifacts/orchestrator-agent-java
@@ -1,0 +1,1 @@
+../fixtures/orchestrator-agent-java

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>bystander-x-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Bystander X (uc23 Java)</name>
+    <description>Bystander agent X (Java) — verifies third-party status reads (tc16).</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>local-maven-repo</id>
+            <url>file://${project.basedir}/../../../../../src/runtime/java/local-repo</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.bystanderx.BystanderXApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -35,13 +41,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/src/main/java/com/example/bystanderx/BystanderXApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/src/main/java/com/example/bystanderx/BystanderXApplication.java
@@ -1,0 +1,46 @@
+package com.example.bystanderx;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Bystander X (uc23 Java) — used by tc16 to verify third-party status reads.
+ *
+ * <p>Has no MeshJob deps and no task=true tools. The framework still
+ * auto-registers {@code __mesh_job_status} / {@code __mesh_job_result} /
+ * {@code __mesh_job_cancel} on every mesh agent, so the test can read
+ * job state from this agent for a job_id it did not submit.
+ *
+ * <p>Distinct fixture file (separate from bystander-y-java) so meshctl's
+ * "is this agent already running" check (which keys off
+ * {@code @MeshAgent(name=...)}) doesn't conflate the two instances.
+ */
+@MeshAgent(
+    name = "bystander-x-java",
+    version = "1.0.0",
+    description = "Bystander agent X (Java) — verifies third-party status reads (tc16).",
+    port = 9124
+)
+@SpringBootApplication
+public class BystanderXApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BystanderXApplication.class, args);
+    }
+
+    @MeshTool(
+        capability = "bystander_x_ping",
+        description = "Trivial tool — keeps bystander X alive in the registry."
+    )
+    public Map<String, Object> bystanderXPing() {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("ok", true);
+        response.put("agent", "bystander-x-java");
+        return response;
+    }
+}

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/src/main/resources/application.properties
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=9124
+mesh.agent.port=9124

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>bystander-y-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Bystander Y (uc23 Java)</name>
+    <description>Bystander agent Y (Java) — verifies third-party status reads (tc16).</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>local-maven-repo</id>
+            <url>file://${project.basedir}/../../../../../src/runtime/java/local-repo</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.bystandery.BystanderYApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -35,13 +41,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/src/main/java/com/example/bystandery/BystanderYApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/src/main/java/com/example/bystandery/BystanderYApplication.java
@@ -1,0 +1,41 @@
+package com.example.bystandery;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Bystander Y (uc23 Java) — used by tc16 to verify third-party status reads.
+ *
+ * <p>Mirror of bystander-x-java in every way except agent name; deployed
+ * alongside X so the test can prove BOTH agents (each with no involvement
+ * in the job) can read its state via the framework's helper tools.
+ */
+@MeshAgent(
+    name = "bystander-y-java",
+    version = "1.0.0",
+    description = "Bystander agent Y (Java) — verifies third-party status reads (tc16).",
+    port = 9125
+)
+@SpringBootApplication
+public class BystanderYApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BystanderYApplication.class, args);
+    }
+
+    @MeshTool(
+        capability = "bystander_y_ping",
+        description = "Trivial tool — keeps bystander Y alive in the registry."
+    )
+    public Map<String, Object> bystanderYPing() {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("ok", true);
+        response.put("agent", "bystander-y-java");
+        return response;
+    }
+}

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/src/main/resources/application.properties
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=9125
+mesh.agent.port=9125

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>downstream-sleeper-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Downstream Sleeper (uc23 Java)</name>
+    <description>Slow downstream tool used to verify mesh-job cancel propagation (Java).</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>local-maven-repo</id>
+            <url>file://${project.basedir}/../../../../../src/runtime/java/local-repo</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.downstreamsleeper.DownstreamSleeperApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -35,13 +41,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/src/main/java/com/example/downstreamsleeper/DownstreamSleeperApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/src/main/java/com/example/downstreamsleeper/DownstreamSleeperApplication.java
@@ -49,6 +49,9 @@ public class DownstreamSleeperApplication {
     public Map<String, Object> slowDownstream(
             @Param("user_id") String userId,
             @Param(value = "seconds", required = false) Integer seconds) {
+        if (seconds != null && seconds < 0) {
+            throw new IllegalArgumentException("seconds must be >= 0");
+        }
         int totalSecs = seconds == null ? 30 : seconds;
         System.err.println("[downstream-sleeper-java] starting " + totalSecs
                 + "s sleep for user=" + userId);

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/src/main/java/com/example/downstreamsleeper/DownstreamSleeperApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/src/main/java/com/example/downstreamsleeper/DownstreamSleeperApplication.java
@@ -1,0 +1,73 @@
+package com.example.downstreamsleeper;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Downstream sleeper agent (uc23 Java) — exercises cancel propagation.
+ *
+ * <p>Java port of uc21_meshjob/fixtures/downstream-sleeper/main.py and
+ * uc22_meshjob_ts/fixtures/downstream-sleeper-ts.
+ *
+ * <p>Provides {@code slow_downstream}, a regular (non-task) tool that
+ * sleeps for the requested number of seconds. The producer agent's
+ * {@code report_with_downstream_call} invokes this via the mesh proxy.
+ *
+ * <h2>Cancel-propagation gap</h2>
+ *
+ * <p>In a runtime where cancel propagates end-to-end, the producer's
+ * cancel token would abort the in-flight outbound HTTP, surfacing here
+ * as an {@link InterruptedException}. The Java SDK (per #889) currently
+ * cannot bind the cancel registry, so the cancel token never fires for
+ * Java-owned jobs — this sleep runs to natural completion regardless.
+ * Tests that exercise this path therefore assert ONLY registry-side
+ * correctness ({@code status=cancelled}), not the marker line below.
+ */
+@MeshAgent(
+    name = "downstream-sleeper-java",
+    version = "1.0.0",
+    description = "Slow downstream tool used to verify mesh-job cancel propagation (Java).",
+    port = 9122
+)
+@SpringBootApplication
+public class DownstreamSleeperApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DownstreamSleeperApplication.class, args);
+    }
+
+    @MeshTool(
+        capability = "slow_downstream",
+        description = "Sleeps for the requested number of seconds (regular tool, not task=true)."
+    )
+    public Map<String, Object> slowDownstream(
+            @Param("user_id") String userId,
+            @Param(value = "seconds", required = false) Integer seconds) {
+        int totalSecs = seconds == null ? 30 : seconds;
+        System.err.println("[downstream-sleeper-java] starting " + totalSecs
+                + "s sleep for user=" + userId);
+        try {
+            Thread.sleep(totalSecs * 1000L);
+        } catch (InterruptedException e) {
+            // UNREACHABLE in practice — the Java SDK does not surface
+            // inbound client-disconnect / cancel as interrupt today
+            // (parallel to TS uc22 fixture's documented gap).
+            System.err.println("[downstream-sleeper-java] sleep CANCELLED for user="
+                    + userId + " (cancel token fired)");
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("interrupted", e);
+        }
+        System.err.println("[downstream-sleeper-java] sleep completed for user="
+                + userId + " (NOT cancelled)");
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("user_id", userId);
+        result.put("slept", totalSecs);
+        return result;
+    }
+}

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/src/main/resources/application.properties
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=9122
+mesh.agent.port=9122

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/pom.xml
@@ -34,6 +34,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -45,13 +51,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  MeshJob test-suite consumer (uc23_meshjob_java) — Java port of
+  uc21_meshjob/fixtures/long-task-consumer/main.py and
+  uc22_meshjob_ts/fixtures/long-task-consumer-ts/.
+
+  Hosts several variants of the submit-and-await pattern so individual
+  tests can exercise behavioural knobs without forking new agents.
+  Capability names match the Python and TS fixtures so the polyglot
+  tests can call them interchangeably across runtimes.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>long-task-consumer-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>MeshJob Long-Task Consumer (uc23 Java)</name>
+    <description>MeshJob test consumer (uc23 Java) — multi-capability fixture for the integration suite.</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>local-maven-repo</id>
+            <url>file://${project.basedir}/../../../../../src/runtime/java/local-repo</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.longtaskconsumer.LongTaskConsumerApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
@@ -1,0 +1,335 @@
+package com.example.longtaskconsumer;
+
+import io.mcpmesh.JobProxy;
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshJobSubmitter;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * MeshJob test-suite consumer (uc23_meshjob_java) — Java port of
+ * uc21_meshjob/fixtures/long-task-consumer/main.py and
+ * uc22_meshjob_ts/fixtures/long-task-consumer-ts.
+ *
+ * <p>Hosts several variants of the submit-and-await pattern so
+ * individual test cases can exercise behavioural knobs without forking
+ * new agents. Capability names match the Python and TypeScript fixtures
+ * exactly so the polyglot tests (tc17–tc22) can call them
+ * interchangeably across runtimes.
+ *
+ * <h2>Wrappers</h2>
+ * <ul>
+ *   <li>{@code commission_report}        — submit + wait; returns terminal payload</li>
+ *   <li>{@code commission_with_options}  — submit + wait with caller-supplied
+ *                                          max_retries + total_deadline_secs</li>
+ *   <li>{@code commission_submit_only}   — submit and return job_id immediately</li>
+ *   <li>{@code commission_explicit_fail} — submits report_with_explicit_fail</li>
+ *   <li>{@code commission_crash}          — submits report_that_crashes</li>
+ *   <li>{@code commission_overlong}       — submits runs_overlong</li>
+ *   <li>{@code commission_downstream}     — submits report_with_downstream_call</li>
+ * </ul>
+ */
+@MeshAgent(
+    name = "long-task-consumer-java",
+    version = "1.0.0",
+    description = "MeshJob test consumer (uc23 Java) — multi-capability fixture for the integration suite.",
+    port = 9121
+)
+@SpringBootApplication
+public class LongTaskConsumerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(LongTaskConsumerApplication.class, args);
+    }
+
+    /**
+     * Convert relative seconds to a unix-epoch deadline. Returns null
+     * when the input is null (≡ "no deadline").
+     */
+    private static Long utcDeadlineFromRelative(Integer secs) {
+        if (secs == null) {
+            return null;
+        }
+        return (System.currentTimeMillis() / 1000L) + secs;
+    }
+
+    // -------------------------------------------------------------------
+    // Submit + wait — happy path baseline (tc01)
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "commission_report",
+        description = "Submit a generate_report job and wait up to 60s for the result.",
+        dependencies = @Selector(capability = "generate_report")
+    )
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> commissionReport(
+            @Param("user_id") String userId,
+            @Param(value = "sections", required = false) List<String> sections,
+            MeshJob generateReport) throws Exception {
+        if (!(generateReport instanceof MeshJobSubmitter submitter)) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "generate_report submitter not injected");
+            return err;
+        }
+        if (sections == null) {
+            sections = List.of("intro", "analysis", "summary");
+        }
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        payload.put("sections", sections);
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            payload, null, 60, null, null);
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            Object result = proxy.await(60.0);
+            if (result instanceof Map<?, ?> m) {
+                return (Map<String, Object>) m;
+            }
+            Map<String, Object> wrapped = new LinkedHashMap<>();
+            wrapped.put("result", result);
+            return wrapped;
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Submit + wait with caller-controlled retry / deadline knobs (tc13)
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "commission_with_options",
+        description = "Submit generate_report with caller-supplied max_retries / total_deadline_secs.",
+        dependencies = @Selector(capability = "generate_report")
+    )
+    public Map<String, Object> commissionWithOptions(
+            @Param("user_id") String userId,
+            @Param(value = "sections", required = false) List<String> sections,
+            @Param(value = "max_retries", required = false) Integer maxRetries,
+            @Param(value = "total_deadline_secs", required = false) Integer totalDeadlineSecs,
+            @Param(value = "wait_timeout_secs", required = false) Integer waitTimeoutSecs,
+            MeshJob generateReport) {
+        if (!(generateReport instanceof MeshJobSubmitter submitter)) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "generate_report submitter not injected");
+            return err;
+        }
+        if (sections == null) {
+            sections = List.of("intro", "analysis", "summary");
+        }
+        int retries = maxRetries == null ? 1 : maxRetries;
+        int waitSecs = waitTimeoutSecs == null ? 60 : waitTimeoutSecs;
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        payload.put("sections", sections);
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            payload, null, 60, retries, utcDeadlineFromRelative(totalDeadlineSecs));
+
+        String jobId;
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            jobId = proxy.jobId();
+            try {
+                Object result = proxy.await((double) waitSecs);
+                Map<String, Object> envelope = new LinkedHashMap<>();
+                envelope.put("job_id", jobId);
+                envelope.put("status", "completed");
+                envelope.put("result", result);
+                return envelope;
+            } catch (Exception e) {
+                Map<String, Object> envelope = new LinkedHashMap<>();
+                envelope.put("job_id", jobId);
+                envelope.put("status", "wait_raised");
+                envelope.put("error", e.getMessage());
+                return envelope;
+            }
+        } catch (Exception e) {
+            Map<String, Object> envelope = new LinkedHashMap<>();
+            envelope.put("job_id", null);
+            envelope.put("status", "submit_raised");
+            envelope.put("error", e.getMessage());
+            return envelope;
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Submit-only — return job_id immediately (tc02, tc06, tc10–tc12, tc14, tc16)
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "commission_submit_only",
+        description = "Submit generate_report and return the job_id without waiting.",
+        dependencies = @Selector(capability = "generate_report")
+    )
+    public Map<String, Object> commissionSubmitOnly(
+            @Param("user_id") String userId,
+            @Param(value = "sections", required = false) List<String> sections,
+            @Param(value = "max_retries", required = false) Integer maxRetries,
+            @Param(value = "max_duration", required = false) Integer maxDuration,
+            MeshJob generateReport) throws Exception {
+        if (!(generateReport instanceof MeshJobSubmitter submitter)) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "generate_report submitter not injected");
+            return err;
+        }
+        if (sections == null) {
+            sections = List.of("default");
+        }
+        int retries = maxRetries == null ? 1 : maxRetries;
+        int duration = maxDuration == null ? 60 : maxDuration;
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        payload.put("sections", sections);
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            payload, null, duration, retries, null);
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("job_id", proxy.jobId());
+            return response;
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Explicit-fail submitter (tc05)
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "commission_explicit_fail",
+        description = "Submit report_with_explicit_fail with caller-supplied max_retries.",
+        dependencies = @Selector(capability = "report_with_explicit_fail")
+    )
+    public Map<String, Object> commissionExplicitFail(
+            @Param("user_id") String userId,
+            @Param(value = "max_retries", required = false) Integer maxRetries,
+            @Param(value = "wait_timeout_secs", required = false) Integer waitTimeoutSecs,
+            MeshJob reportWithExplicitFail) {
+        if (!(reportWithExplicitFail instanceof MeshJobSubmitter submitter)) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "report_with_explicit_fail submitter not injected");
+            return err;
+        }
+        int retries = maxRetries == null ? 3 : maxRetries;
+        int waitSecs = waitTimeoutSecs == null ? 30 : waitTimeoutSecs;
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            payload, null, 30, retries, null);
+
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            String jobId = proxy.jobId();
+            try {
+                Object result = proxy.await((double) waitSecs);
+                Map<String, Object> envelope = new LinkedHashMap<>();
+                envelope.put("job_id", jobId);
+                envelope.put("status", "completed");
+                envelope.put("result", result);
+                return envelope;
+            } catch (Exception e) {
+                Map<String, Object> envelope = new LinkedHashMap<>();
+                envelope.put("job_id", jobId);
+                envelope.put("status", "wait_raised");
+                envelope.put("error", e.getMessage());
+                return envelope;
+            }
+        } catch (Exception e) {
+            Map<String, Object> envelope = new LinkedHashMap<>();
+            envelope.put("job_id", null);
+            envelope.put("status", "submit_raised");
+            envelope.put("error", e.getMessage());
+            return envelope;
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Crash submitter (tc12)
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "commission_crash",
+        description = "Submit report_that_crashes (always raises) with caller-supplied retry/deadline.",
+        dependencies = @Selector(capability = "report_that_crashes")
+    )
+    public Map<String, Object> commissionCrash(
+            @Param("user_id") String userId,
+            @Param(value = "max_retries", required = false) Integer maxRetries,
+            @Param(value = "total_deadline_secs", required = false) Integer totalDeadlineSecs,
+            MeshJob reportThatCrashes) throws Exception {
+        if (!(reportThatCrashes instanceof MeshJobSubmitter submitter)) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "report_that_crashes submitter not injected");
+            return err;
+        }
+        int retries = maxRetries == null ? 0 : maxRetries;
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            payload, null, 30, retries, utcDeadlineFromRelative(totalDeadlineSecs));
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("job_id", proxy.jobId());
+            return response;
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Overlong submitter (tc06, tc20)
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "commission_overlong",
+        description = "Submit runs_overlong and return the job_id (no wait).",
+        dependencies = @Selector(capability = "runs_overlong")
+    )
+    public Map<String, Object> commissionOverlong(
+            @Param("user_id") String userId,
+            @Param(value = "seconds", required = false) Integer seconds,
+            MeshJob runsOverlong) throws Exception {
+        if (!(runsOverlong instanceof MeshJobSubmitter submitter)) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "runs_overlong submitter not injected");
+            return err;
+        }
+        int secs = seconds == null ? 30 : seconds;
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        payload.put("seconds", secs);
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            payload, null, 120, null, null);
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("job_id", proxy.jobId());
+            return response;
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Downstream-call submitter (tc09)
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "commission_downstream",
+        description = "Submit report_with_downstream_call (provider calls slow_downstream) and return job_id.",
+        dependencies = @Selector(capability = "report_with_downstream_call")
+    )
+    public Map<String, Object> commissionDownstream(
+            @Param("user_id") String userId,
+            MeshJob reportWithDownstreamCall) throws Exception {
+        if (!(reportWithDownstreamCall instanceof MeshJobSubmitter submitter)) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "report_with_downstream_call submitter not injected");
+            return err;
+        }
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            payload, null, 120, null, null);
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("job_id", proxy.jobId());
+            return response;
+        }
+    }
+}

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/resources/application.properties
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+# Tomcat port for the Spring Boot HTTP server. Mesh's @MeshAgent(port=)
+# is the value advertised to the registry — it must match the actual
+# Tomcat port so other agents can route MCP calls to us.
+server.port=9121
+mesh.agent.port=9121

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  MeshJob test-suite producer (uc23_meshjob_java) — Java port of
+  uc21_meshjob/fixtures/long-task-provider/main.py and
+  uc22_meshjob_ts/fixtures/long-task-provider-ts/.
+
+  Hosts a small zoo of `task = true` capabilities, one per scenario the
+  suite needs to exercise. Same capability names as the Python and TS
+  fixtures so polyglot tests (tc17–tc22) can call them interchangeably.
+
+  Spring Boot version is intentionally 4.0.6 (newer than 4.0.5 in the
+  toolcalls examples) — addresses CVEs caught during the #891 review.
+
+  The local-repo path resolves the mcp-mesh-* artifacts the suite
+  builds via src-tests; tsuite's maven-install handler strips file://
+  repos and re-points to the container's pre-populated m2 cache.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>long-task-provider-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>MeshJob Long-Task Provider (uc23 Java)</name>
+    <description>MeshJob test producer (uc23 Java) — multi-capability fixture for the integration suite.</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>local-maven-repo</id>
+            <url>file://${project.basedir}/../../../../../src/runtime/java/local-repo</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.longtaskprovider.LongTaskProviderApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/pom.xml
@@ -10,10 +10,6 @@
 
   Spring Boot version is intentionally 4.0.6 (newer than 4.0.5 in the
   toolcalls examples) — addresses CVEs caught during the #891 review.
-
-  The local-repo path resolves the mcp-mesh-* artifacts the suite
-  builds via src-tests; tsuite's maven-install handler strips file://
-  repos and re-points to the container's pre-populated m2 cache.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -40,6 +36,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -51,13 +53,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
@@ -1,0 +1,375 @@
+package com.example.longtaskprovider;
+
+import io.mcpmesh.JobController;
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * MeshJob test-suite producer (uc23_meshjob_java) — Java port of
+ * uc21_meshjob/fixtures/long-task-provider/main.py and
+ * uc22_meshjob_ts/fixtures/long-task-provider-ts.
+ *
+ * <p>Hosts a small zoo of {@code task = true} capabilities, one per
+ * scenario the suite needs to exercise. Capability names mirror the
+ * Python and TypeScript fixtures exactly so the polyglot tests
+ * (tc17–tc22) can call them interchangeably across runtimes.
+ *
+ * <h2>Capabilities</h2>
+ * <ul>
+ *   <li>{@code generate_report}              — happy path, progress + complete</li>
+ *   <li>{@code report_with_explicit_complete} — explicit complete({...}) marker</li>
+ *   <li>{@code report_with_implicit_complete} — return value WITHOUT complete()</li>
+ *   <li>{@code report_with_explicit_fail}     — calls fail("reason")</li>
+ *   <li>{@code report_that_crashes}            — raises mid-attempt</li>
+ *   <li>{@code runs_overlong}                  — long sleep loop for cancel tests</li>
+ *   <li>{@code report_with_downstream_call}    — calls slow_downstream regular tool</li>
+ * </ul>
+ *
+ * <h2>Cancel limitation (#889)</h2>
+ *
+ * <p>Java's sync JNR-FFI bindings cannot bind the per-job cancel
+ * registry (would require a nested Tokio runtime which Tokio rejects).
+ * Tests that exercise mid-flight cancellation (tc06, tc09, tc22)
+ * therefore assert only the registry-side correctness — the row's
+ * {@code status} field flips to {@code cancelled} via the registry's
+ * route + sweep — but the producer's task body does NOT abort
+ * mid-flight; the loop runs to natural completion or until orphaned by
+ * the sweep. See {@code MeshToolWrapper.dispatchAsJob} javadoc.
+ */
+@MeshAgent(
+    name = "long-task-provider-java",
+    version = "1.0.0",
+    description = "MeshJob test producer (uc23 Java) — multi-capability fixture for the integration suite.",
+    port = 9120
+)
+@SpringBootApplication
+public class LongTaskProviderApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(LongTaskProviderApplication.class, args);
+    }
+
+    // -------------------------------------------------------------------
+    // Happy path — generate_report
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "generate_report",
+        task = true,
+        description = "Long-running multi-section report generator with progress."
+    )
+    public Map<String, Object> generateReport(
+            @Param("user_id") String userId,
+            @Param(value = "sections", required = false) List<String> sections,
+            MeshJob job) throws InterruptedException {
+        if (sections == null) {
+            sections = List.of("default");
+        }
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller != null) {
+            controller.updateProgress(0.0, "starting");
+        }
+
+        List<Map<String, String>> results = new ArrayList<>();
+        int total = Math.max(sections.size(), 1);
+        for (int i = 0; i < sections.size(); i++) {
+            Thread.sleep(2000);
+            String section = sections.get(i);
+            Map<String, String> entry = new LinkedHashMap<>();
+            entry.put("section", section);
+            entry.put("content", "Generated content for " + section);
+            results.add(entry);
+            if (controller != null) {
+                controller.updateProgress(
+                    (i + 1.0) / total,
+                    "finished section " + (i + 1) + "/" + total);
+            }
+        }
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        payload.put("report", results);
+
+        if (controller != null) {
+            controller.complete(payload);
+        }
+        return payload;
+    }
+
+    // -------------------------------------------------------------------
+    // Explicit complete with fixed marker payload (tc03)
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "report_with_explicit_complete",
+        task = true,
+        description = "Calls job.complete({...}) with a fixed marker payload."
+    )
+    public Map<String, Object> reportWithExplicitComplete(
+            @Param("user_id") String userId,
+            MeshJob job) throws InterruptedException {
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller != null) {
+            controller.updateProgress(0.5, "midpoint");
+            Thread.sleep(500);
+        }
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("explicit", true);
+        payload.put("marker", "X");
+        payload.put("user_id", userId);
+        if (controller != null) {
+            controller.complete(payload);
+        }
+        return payload;
+    }
+
+    // -------------------------------------------------------------------
+    // Implicit complete (auto-complete on return) (tc04)
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "report_with_implicit_complete",
+        task = true,
+        description = "Returns a value WITHOUT calling job.complete() — relies on auto-complete."
+    )
+    public Map<String, Object> reportWithImplicitComplete(
+            @Param("user_id") String userId,
+            MeshJob job) throws InterruptedException {
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller != null) {
+            controller.updateProgress(0.5, "halfway");
+            Thread.sleep(500);
+            controller.updateProgress(0.9, "almost done");
+        }
+        // Intentionally do NOT call complete() — runtime auto-complete should fire.
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("implicit", true);
+        payload.put("user_id", userId);
+        return payload;
+    }
+
+    // -------------------------------------------------------------------
+    // Explicit fail — no retry (tc05)
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "report_with_explicit_fail",
+        task = true,
+        description = "Calls job.fail('reason') — must NOT trigger retry even with max_retries > 0."
+    )
+    public Map<String, Object> reportWithExplicitFail(
+            @Param("user_id") String userId,
+            MeshJob job) throws InterruptedException {
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller != null) {
+            controller.updateProgress(0.1, "about to fail");
+            Thread.sleep(300);
+            controller.fail("explicit: not retryable");
+        }
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("failed", true);
+        payload.put("reason", "explicit: not retryable");
+        return payload;
+    }
+
+    // -------------------------------------------------------------------
+    // Crash on attempt (tc12)
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "report_that_crashes",
+        task = true,
+        description = "Always raises mid-attempt — drives crash-recovery / retry-exhaustion tests."
+    )
+    public Map<String, Object> reportThatCrashes(
+            @Param("user_id") String userId,
+            MeshJob job) throws InterruptedException {
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller != null) {
+            controller.updateProgress(0.1, "about to crash");
+            Thread.sleep(300);
+        }
+        throw new RuntimeException("simulated crash for crash-recovery test");
+    }
+
+    // -------------------------------------------------------------------
+    // Long-running task (tc06, tc09, tc10–tc13 use this via SIGKILL)
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "runs_overlong",
+        task = true,
+        description = "Sleeps for many small intervals so cancel / kill can land mid-flight."
+    )
+    public Map<String, Object> runsOverlong(
+            @Param("user_id") String userId,
+            @Param(value = "seconds", required = false) Integer seconds,
+            MeshJob job) throws InterruptedException {
+        int totalSecs = seconds == null ? 30 : seconds;
+        JobController controller = job instanceof JobController c ? c : null;
+        double elapsed = 0.0;
+        double step = 0.5;
+        double total = Math.max(totalSecs, step);
+        while (elapsed < total) {
+            Thread.sleep((long) (step * 1000));
+            elapsed += step;
+            if (controller != null) {
+                controller.updateProgress(
+                    Math.min(elapsed / total, 0.99),
+                    String.format("alive at %.1fs", elapsed));
+            }
+        }
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        payload.put("elapsed", elapsed);
+        if (controller != null) {
+            controller.complete(payload);
+        }
+        return payload;
+    }
+
+    // -------------------------------------------------------------------
+    // Job that calls a downstream regular tool (tc09)
+    //
+    // NOTE: Java's JobsRuntimeManager rejects task=true methods with
+    // McpMeshTool / @Selector dependencies (see exception in
+    // JobsRuntimeManager.validateProducerParams) — the claim path
+    // doesn't resolve those for task tools. Python and TS allow it.
+    // We work around by issuing the downstream HTTP call DIRECTLY via
+    // the mesh registry's proxy (registry forwards /proxy/{ip}:{port}
+    // to the agent's /mcp endpoint), exercising the same outbound HTTP
+    // path that the McpMeshTool wrapper would use, just minus the
+    // resolution layer. From the substrate's POV the cancel-propagation
+    // surface is identical (both go through the JVM's HTTP client).
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "report_with_downstream_call",
+        task = true,
+        description = "Calls a downstream regular tool that sleeps; cancel must abort the in-flight HTTP."
+    )
+    public Object reportWithDownstreamCall(
+            @Param("user_id") String userId,
+            MeshJob job) {
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller != null) {
+            controller.updateProgress(0.1, "calling downstream");
+        }
+        // Resolve the downstream agent via the registry's /agents API
+        // and call its /mcp endpoint directly. The registry proxy URL
+        // shape is /proxy/{host}:{port}/mcp.
+        String registryUrl = System.getenv().getOrDefault(
+            "MCP_MESH_REGISTRY_URL", "http://localhost:8000");
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+
+            // Discover the slow_downstream provider's instance.
+            HttpRequest agentsReq = HttpRequest.newBuilder()
+                .uri(URI.create(registryUrl + "/agents"))
+                .timeout(Duration.ofSeconds(5))
+                .GET()
+                .build();
+            HttpResponse<String> agentsResp = client.send(
+                agentsReq, HttpResponse.BodyHandlers.ofString());
+            String body = agentsResp.body();
+            String endpointMarker = "\"endpoint\":\"";
+            String slowDownstreamMarker = "\"name\":\"downstream-sleeper-java\"";
+            int nameIdx = body.indexOf(slowDownstreamMarker);
+            if (nameIdx < 0) {
+                // Try the polyglot variants if the Java sleeper isn't here.
+                slowDownstreamMarker = "\"name\":\"downstream-sleeper\"";
+                nameIdx = body.indexOf(slowDownstreamMarker);
+            }
+            if (nameIdx < 0) {
+                slowDownstreamMarker = "\"name\":\"downstream-sleeper-ts\"";
+                nameIdx = body.indexOf(slowDownstreamMarker);
+            }
+            if (nameIdx < 0) {
+                if (controller != null) {
+                    controller.fail("slow_downstream provider not registered");
+                }
+                return null;
+            }
+            // Walk back from the name to the enclosing endpoint field.
+            int endpointStart = body.indexOf(endpointMarker, Math.max(0, nameIdx - 800));
+            if (endpointStart < 0 || endpointStart > nameIdx) {
+                if (controller != null) {
+                    controller.fail("could not parse slow_downstream endpoint");
+                }
+                return null;
+            }
+            int valStart = endpointStart + endpointMarker.length();
+            int valEnd = body.indexOf("\"", valStart);
+            String agentEndpoint = body.substring(valStart, valEnd); // http://10.x.y.z:9122
+
+            // Call /mcp on that endpoint with a tools/call request.
+            //
+            // MCP tool name registration differs across runtimes:
+            //   - Python: capability == tool name (snake_case)
+            //   - TS:     capability == tool name (snake_case)
+            //   - Java:   tool name == @MeshTool method name (camelCase)
+            //
+            // To survive any of those, try the snake_case shape first
+            // (matches Python/TS), and if the agent reports "Unknown
+            // tool" / "Tool not found", retry with camelCase. This
+            // makes the provider portable across uc21/uc22/uc23
+            // sleepers without baking in the choice.
+            HttpResponse<String> callResp = invokeDownstream(
+                client, agentEndpoint, "slow_downstream", userId);
+            String respBody = callResp.body();
+            if (callResp.statusCode() == 200
+                && (respBody.contains("Unknown tool") || respBody.contains("Tool not found"))) {
+                // Java sleeper — retry with camelCase method name.
+                callResp = invokeDownstream(
+                    client, agentEndpoint, "slowDownstream", userId);
+            }
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("status_code", callResp.statusCode());
+            result.put("body", callResp.body());
+            if (controller != null) {
+                controller.complete(result);
+            }
+            return result;
+        } catch (IOException | InterruptedException e) {
+            if (controller != null) {
+                controller.fail("downstream call failed: " + e.getMessage());
+            }
+            Thread.currentThread().interrupt();
+            return null;
+        }
+    }
+
+    /**
+     * Issue a tools/call POST to the given agent endpoint with the
+     * specified tool name. Used by reportWithDownstreamCall to call
+     * slow_downstream / slowDownstream regardless of the downstream
+     * runtime's tool-naming convention.
+     */
+    private static HttpResponse<String> invokeDownstream(
+            HttpClient client,
+            String agentEndpoint,
+            String toolName,
+            String userId) throws IOException, InterruptedException {
+        String mcpBody = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
+            + "\"params\":{\"name\":\"" + toolName + "\",\"arguments\":"
+            + "{\"user_id\":\"" + userId + "\",\"seconds\":30}}}";
+        HttpRequest req = HttpRequest.newBuilder()
+            .uri(URI.create(agentEndpoint + "/mcp"))
+            .timeout(Duration.ofSeconds(60))
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .POST(HttpRequest.BodyPublishers.ofString(mcpBody))
+            .build();
+        return client.send(req, HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
@@ -333,11 +333,16 @@ public class LongTaskProviderApplication {
                 controller.complete(result);
             }
             return result;
-        } catch (IOException | InterruptedException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             if (controller != null) {
                 controller.fail("downstream call failed: " + e.getMessage());
             }
-            Thread.currentThread().interrupt();
+            return null;
+        } catch (IOException e) {
+            if (controller != null) {
+                controller.fail("downstream call failed: " + e.getMessage());
+            }
             return null;
         }
     }

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
@@ -1,5 +1,8 @@
 package com.example.longtaskprovider;
 
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 import io.mcpmesh.JobController;
 import io.mcpmesh.MeshAgent;
 import io.mcpmesh.MeshJob;
@@ -59,6 +62,8 @@ import java.util.Map;
 )
 @SpringBootApplication
 public class LongTaskProviderApplication {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     public static void main(String[] args) {
         SpringApplication.run(LongTaskProviderApplication.class, args);
@@ -281,36 +286,24 @@ public class LongTaskProviderApplication {
                 .build();
             HttpResponse<String> agentsResp = client.send(
                 agentsReq, HttpResponse.BodyHandlers.ofString());
-            String body = agentsResp.body();
-            String endpointMarker = "\"endpoint\":\"";
-            String slowDownstreamMarker = "\"name\":\"downstream-sleeper-java\"";
-            int nameIdx = body.indexOf(slowDownstreamMarker);
-            if (nameIdx < 0) {
-                // Try the polyglot variants if the Java sleeper isn't here.
-                slowDownstreamMarker = "\"name\":\"downstream-sleeper\"";
-                nameIdx = body.indexOf(slowDownstreamMarker);
+            // Parse the /agents response with Jackson — string-based
+            // indexOf scanning was brittle once the JSON object grew
+            // past the lookback window or agent ordering shifted, and
+            // could attribute the wrong endpoint to the matched name.
+            String agentEndpoint = null;
+            for (String candidate : List.of(
+                    "downstream-sleeper-java",
+                    "downstream-sleeper",
+                    "downstream-sleeper-ts")) {
+                agentEndpoint = findEndpointForAgentName(agentsResp.body(), candidate);
+                if (agentEndpoint != null) break;
             }
-            if (nameIdx < 0) {
-                slowDownstreamMarker = "\"name\":\"downstream-sleeper-ts\"";
-                nameIdx = body.indexOf(slowDownstreamMarker);
-            }
-            if (nameIdx < 0) {
+            if (agentEndpoint == null) {
                 if (controller != null) {
                     controller.fail("slow_downstream provider not registered");
                 }
                 return null;
             }
-            // Walk back from the name to the enclosing endpoint field.
-            int endpointStart = body.indexOf(endpointMarker, Math.max(0, nameIdx - 800));
-            if (endpointStart < 0 || endpointStart > nameIdx) {
-                if (controller != null) {
-                    controller.fail("could not parse slow_downstream endpoint");
-                }
-                return null;
-            }
-            int valStart = endpointStart + endpointMarker.length();
-            int valEnd = body.indexOf("\"", valStart);
-            String agentEndpoint = body.substring(valStart, valEnd); // http://10.x.y.z:9122
 
             // Call /mcp on that endpoint with a tools/call request.
             //
@@ -360,9 +353,19 @@ public class LongTaskProviderApplication {
             String agentEndpoint,
             String toolName,
             String userId) throws IOException, InterruptedException {
-        String mcpBody = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
-            + "\"params\":{\"name\":\"" + toolName + "\",\"arguments\":"
-            + "{\"user_id\":\"" + userId + "\",\"seconds\":30}}}";
+        // Build the JSON-RPC body via Jackson rather than string concat
+        // so the embedded user_id / tool name get properly escaped if
+        // they ever contain a quote, backslash, or control char.
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("jsonrpc", "2.0");
+        root.put("id", 1);
+        root.put("method", "tools/call");
+        ObjectNode params = root.putObject("params");
+        params.put("name", toolName);
+        ObjectNode args = params.putObject("arguments");
+        args.put("user_id", userId);
+        args.put("seconds", 30);
+        String mcpBody = MAPPER.writeValueAsString(root);
         HttpRequest req = HttpRequest.newBuilder()
             .uri(URI.create(agentEndpoint + "/mcp"))
             .timeout(Duration.ofSeconds(60))
@@ -371,5 +374,34 @@ public class LongTaskProviderApplication {
             .POST(HttpRequest.BodyPublishers.ofString(mcpBody))
             .build();
         return client.send(req, HttpResponse.BodyHandlers.ofString());
+    }
+
+    /**
+     * Find the {@code endpoint} field for the named agent in a
+     * registry {@code GET /agents} response body. Returns {@code null}
+     * if the agent isn't present or the response shape doesn't match.
+     *
+     * <p>Replaces an earlier indexOf-based scanner that could land on
+     * the wrong agent's endpoint when the JSON exceeded an 800-char
+     * lookback window or agent ordering shifted between requests.
+     */
+    private static String findEndpointForAgentName(String body, String agentName) {
+        try {
+            JsonNode root = MAPPER.readTree(body);
+            JsonNode agents = root.has("agents") ? root.get("agents") : root;
+            if (agents == null || !agents.isArray()) return null;
+            for (JsonNode agent : agents) {
+                JsonNode name = agent.get("name");
+                if (name != null && agentName.equals(name.asText())) {
+                    JsonNode endpoint = agent.get("endpoint");
+                    return endpoint != null && !endpoint.isNull() ? endpoint.asText() : null;
+                }
+            }
+            return null;
+        } catch (RuntimeException e) {
+            // Jackson 3.x throws unchecked JacksonException — return
+            // null so the caller falls through to controller.fail().
+            return null;
+        }
     }
 }

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/resources/application.properties
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+# Tomcat port for the Spring Boot HTTP server. Mesh's @MeshAgent(port=)
+# is the value advertised to the registry — it must match the actual
+# Tomcat port so consumer agents can route MCP calls to us.
+server.port=9120
+mesh.agent.port=9120

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>orchestrator-agent-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Orchestrator (uc23 Java)</name>
+    <description>Agent with no task tools and no mesh deps — verifies helper-tool auto-registration is universal (Java).</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>local-maven-repo</id>
+            <url>file://${project.basedir}/../../../../../src/runtime/java/local-repo</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.orchestrator.OrchestratorApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/pom.xml
@@ -24,6 +24,12 @@
         <mcp-mesh.version>1.4.1</mcp-mesh.version>
     </properties>
 
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
@@ -35,13 +41,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>local-maven-repo</id>
-            <url>file://${project.basedir}/../../../../../src/runtime/java/local-repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/src/main/java/com/example/orchestrator/OrchestratorApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/src/main/java/com/example/orchestrator/OrchestratorApplication.java
@@ -1,0 +1,43 @@
+package com.example.orchestrator;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Orchestrator agent (uc23 Java) — Java port of orchestrator-agent.
+ *
+ * <p>Has NO task=true tools and NO mesh deps. Used by tc14 to prove the
+ * three framework helper tools ({@code __mesh_job_status} /
+ * {@code __mesh_job_result} / {@code __mesh_job_cancel}) auto-register
+ * on every Java mesh agent regardless of whether that agent
+ * participates in the job lifecycle.
+ */
+@MeshAgent(
+    name = "orchestrator-agent-java",
+    version = "1.0.0",
+    description = "Agent with no task tools and no mesh deps — verifies helper-tool auto-registration is universal (Java).",
+    port = 9123
+)
+@SpringBootApplication
+public class OrchestratorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OrchestratorApplication.class, args);
+    }
+
+    @MeshTool(
+        capability = "orchestrator_ping",
+        description = "Trivial tool — only purpose is to keep the agent alive in the registry."
+    )
+    public Map<String, Object> orchestratorPing() {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("ok", true);
+        response.put("agent", "orchestrator-agent-java");
+        return response;
+    }
+}

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/src/main/resources/application.properties
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=9123
+mesh.agent.port=9123

--- a/tests/integration/suites/uc23_meshjob_java/routines.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/routines.yaml
@@ -1,0 +1,74 @@
+# UC-level routines for uc23_meshjob_java.
+#
+# Java port of the MeshJob suite — mirror of uc21_meshjob/routines.yaml
+# (Python) and uc22_meshjob_ts/routines.yaml (TypeScript). Same registry
+# knobs (MCP_MESH_SWEEP_INTERVAL=10s + retention/health) so
+# crash-recovery / orphan-reroute / deadline tests resolve in seconds
+# instead of the registry's 5-minute defaults.
+#
+# Identical to the Python and TS suites: the substrate's recovery +
+# deadline expiry paths are runtime-agnostic — they live entirely in the
+# registry (Go) — so the same env-var overrides apply regardless of
+# whether the producer/consumer is Python, TypeScript, or Java.
+
+routines:
+  # See uc21_meshjob/routines.yaml for the full chain-of-effects writeup
+  # of MCP_MESH_SWEEP_INTERVAL / RETENTION / HEALTH_CHECK_INTERVAL /
+  # DEFAULT_TIMEOUT_THRESHOLD. Numbers are intentionally identical to
+  # keep the suite-suite math (~35s end-to-end after a SIGKILL for
+  # orphan reset) the same across all three runtimes.
+  start_registry_with_fast_sweep:
+    description: "Start the mesh registry with all timing knobs cranked for fast recovery tests"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: |
+          MCP_MESH_SWEEP_INTERVAL=10s \
+          MCP_MESH_RETENTION=10s \
+          MCP_MESH_HEALTH_CHECK_INTERVAL=5 \
+          DEFAULT_TIMEOUT_THRESHOLD=15 \
+            meshctl start --registry-only -d
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "registry ready after ${i}s"
+              # Verify the sweep override actually stamped its log line.
+              # If MCP_MESH_SWEEP_INTERVAL didn't take effect the suite
+              # must fail loudly here, not via slow per-test timeouts.
+              # Tail the log so a stale match from an earlier run in the
+              # same shell session can't make a misconfigured current
+              # run look healthy.
+              tail -n 200 ~/.mcp-mesh/logs/registry.log \
+                | grep -qE '\[sweep\] using MCP_MESH_SWEEP_INTERVAL' \
+                || { echo "FAIL: MCP_MESH_SWEEP_INTERVAL override did not take effect"; exit 1; }
+              echo "[setup] confirmed sweep override active"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: registry did not become ready in 20s"
+          tail -50 ~/.mcp-mesh/logs/registry.log 2>/dev/null || true
+          exit 1
+        capture: registry_start
+        timeout: 30
+
+  # Stop everything started by this test (agents + registry).
+  stop_all:
+    description: "Stop all mesh processes started by this test"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: meshctl stop 2>/dev/null || true
+        ignore_errors: true
+
+  # Kill all Java agent processes whose cmdline mentions a target jar /
+  # main class. Used by the SIGKILL recovery tests (tc10, tc11, tc12,
+  # tc13) — `mvn spring-boot:run` spawns a Maven parent and a Java
+  # child; killing only one leaves the other alive and the agent keeps
+  # heartbeating. Pattern mirrors uc22's TS suite (tsx parent + node
+  # child) but matches Java cmdlines (mvn / surefire / java).
+  #
+  # Inputs come via env vars set by the test before invoking this
+  # routine (we can't pass params to a routine via the routine: shorthand
+  # without restructuring; tests just inline the kill loop directly).
+  # This routine is therefore informational — see test.yaml inline for
+  # the actual implementation.

--- a/tests/integration/suites/uc23_meshjob_java/tc01_submit_wait_happy_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc01_submit_wait_happy_java/test.yaml
@@ -1,0 +1,150 @@
+# tc01_submit_wait_happy_java — Java port of uc21/tc01 + uc22/tc01.
+#
+# Headline regression test for MeshJob Phase 1, Java runtime.
+#
+# Scenario:
+#   - Registry up with MCP_MESH_SWEEP_INTERVAL=10s
+#   - long-task-provider-java hosts generate_report (task=true)
+#   - long-task-consumer-java hosts commission_report (deps=["generate_report"])
+#   - Client invokes commission_report with sections=[intro, analysis, summary]
+#   - Consumer's submit() + await() returns the structured payload after ~6s
+#
+# Java cold-start is ~30s for Spring Boot — the post-start wait (60s) is
+# generous to absorb mvn dependency resolution + JVM warmup.
+
+name: "MeshJob Java: submit-and-wait happy path returns structured result"
+description: "Java producer + Java consumer: commission_report -> generate_report (3 sections) -> wait -> structured result"
+tags:
+  - meshjob
+  - smoke
+  - java
+  - issue-890
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9120)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  # Java cold-start is ~30s for Spring Boot; with the fast-sweep
+  # registry the agent can be marked unhealthy if the first heartbeat
+  # is delayed past DEFAULT_TIMEOUT_THRESHOLD=15s. Poll the /agents
+  # endpoint until status==healthy (recovers automatically once the
+  # JVM finishes booting and the heartbeat thread starts).
+  - name: "Wait for Java provider to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -s http://localhost:8000/agents | jq -r \
+          '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        if [ "$STATUS" = "healthy" ]; then
+          echo "provider healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: provider not healthy within 120s (last status='$STATUS')"
+      meshctl logs long-task-provider-java 2>&1 | tail -80 || true
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name=="long-task-provider-java")' || true
+      exit 1
+    timeout: 150
+
+  - name: "Start consumer (port 9121)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for Java consumer to be healthy + DI resolved"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # /agents.dependencies_resolved is a numeric count, not a bool —
+      # equals total_dependencies once every @Selector has a matched
+      # producer bound to the local proxy registry.
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents \
+          | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        STATUS=$(echo "$ROW" | jq -r '.status' 2>/dev/null)
+        RESOLVED=$(echo "$ROW" | jq -r '.dependencies_resolved' 2>/dev/null)
+        TOTAL=$(echo "$ROW" | jq -r '.total_dependencies' 2>/dev/null)
+        # Provider must also still be healthy — Java's slow startup
+        # can cause it to flap, and resolved deps might transiently
+        # drop. Assert end-state where both are healthy + all wired.
+        PSTATUS=$(curl -s http://localhost:8000/agents \
+          | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        if [ "$STATUS" = "healthy" ] && [ "$PSTATUS" = "healthy" ] \
+           && [ "$RESOLVED" = "$TOTAL" ] && [ "$TOTAL" != "0" ]; then
+          echo "consumer healthy with $RESOLVED/$TOTAL deps resolved after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: consumer not ready within 120s (status=$STATUS deps=$RESOLVED/$TOTAL provider_status=$PSTATUS)"
+      echo "=== consumer logs ==="
+      meshctl logs long-task-consumer-java 2>&1 | tail -50 || true
+      echo "=== provider logs ==="
+      meshctl logs long-task-provider-java 2>&1 | tail -50 || true
+      echo "=== /agents ==="
+      curl -s http://localhost:8000/agents | jq '.agents[] | {name, status, dependencies_resolved, total_dependencies, last_seen}'
+      exit 1
+    timeout: 150
+
+  - name: "Verify both agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Call commission_report — submit + wait the full job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_report '{"user_id": "alice", "sections": ["intro", "analysis", "summary"]}'
+    capture: commission_response
+    timeout: 90
+
+assertions:
+  - expr: "${captured.agent_list} contains 'long-task-provider-java'"
+    message: "Java provider should be registered"
+  - expr: "${captured.agent_list} contains 'long-task-consumer-java'"
+    message: "Java consumer should be registered"
+  - expr: "${captured.commission_response} not contains '\"isError\":true'"
+    message: "commission_report should NOT return an MCP error envelope"
+  # Java's Jackson serializer emits compact JSON without spaces, and the
+  # meshctl envelope JSON-escapes the inner text — match the escaped form.
+  - expr: "${captured.commission_response} contains 'alice'"
+    message: "result should echo the submitted user_id"
+  - expr: "${captured.commission_response} contains 'Generated content for intro'"
+    message: "result should include the intro section content"
+  - expr: "${captured.commission_response} contains 'Generated content for analysis'"
+    message: "result should include the analysis section content"
+  - expr: "${captured.commission_response} contains 'Generated content for summary'"
+    message: "result should include the summary section content"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc01_submit_wait_happy_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc01_submit_wait_happy_java/test.yaml
@@ -97,7 +97,7 @@ test:
         PSTATUS=$(curl -s http://localhost:8000/agents \
           | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
         if [ "$STATUS" = "healthy" ] && [ "$PSTATUS" = "healthy" ] \
-           && [ "$RESOLVED" = "$TOTAL" ] && [ "$TOTAL" != "0" ]; then
+           && [ "$RESOLVED" = "$TOTAL" ] && [ "$TOTAL" != "0" ] && [ "$TOTAL" != "null" ]; then
           echo "consumer healthy with $RESOLVED/$TOTAL deps resolved after ${i}x2s"
           exit 0
         fi

--- a/tests/integration/suites/uc23_meshjob_java/tc02_progress_visible_midflight_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc02_progress_visible_midflight_java/test.yaml
@@ -77,7 +77,7 @@ test:
         STATUS=$(echo "$ROW" | jq -r '.status' 2>/dev/null)
         RESOLVED=$(echo "$ROW" | jq -r '.dependencies_resolved' 2>/dev/null)
         TOTAL=$(echo "$ROW" | jq -r '.total_dependencies' 2>/dev/null)
-        if [ "$STATUS" = "healthy" ] && [ "$RESOLVED" = "$TOTAL" ] && [ "$TOTAL" != "0" ]; then
+        if [ "$STATUS" = "healthy" ] && [ "$RESOLVED" = "$TOTAL" ] && [ "$TOTAL" != "0" ] && [ "$TOTAL" != "null" ]; then
           echo "consumer ready ($RESOLVED/$TOTAL deps) after ${i}x2s"
           exit 0
         fi

--- a/tests/integration/suites/uc23_meshjob_java/tc02_progress_visible_midflight_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc02_progress_visible_midflight_java/test.yaml
@@ -1,0 +1,165 @@
+# tc02_progress_visible_midflight_java — Java port of uc21/tc02 + uc22/tc02.
+#
+# Submit a long-enough generate_report job (7 sections * 2s = 14s) and
+# poll __mesh_job_status mid-flight. Java's JobController emits
+# update_progress() after each section; deltas flow to the registry via
+# /jobs/batch on the batching tick. By the time at least one mid-flight
+# status read happens during a working interval, we should observe
+# progress > 0 AND status == "working".
+
+name: "MeshJob Java: mid-flight progress visible via __mesh_job_status"
+description: "Java submit long job, poll status mid-flight, observe progress advance through working->completed"
+tags:
+  - meshjob
+  - java
+  - issue-890
+  - progress
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9120)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for Java provider to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -s http://localhost:8000/agents | jq -r \
+          '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        if [ "$STATUS" = "healthy" ]; then
+          echo "provider healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: provider not healthy within 120s (last='$STATUS')"
+      meshctl logs long-task-provider-java 2>&1 | tail -50 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start consumer (port 9121)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for Java consumer + DI resolved"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents \
+          | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        STATUS=$(echo "$ROW" | jq -r '.status' 2>/dev/null)
+        RESOLVED=$(echo "$ROW" | jq -r '.dependencies_resolved' 2>/dev/null)
+        TOTAL=$(echo "$ROW" | jq -r '.total_dependencies' 2>/dev/null)
+        if [ "$STATUS" = "healthy" ] && [ "$RESOLVED" = "$TOTAL" ] && [ "$TOTAL" != "0" ]; then
+          echo "consumer ready ($RESOLVED/$TOTAL deps) after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: consumer not ready (status=$STATUS deps=$RESOLVED/$TOTAL)"
+      exit 1
+    timeout: 150
+
+  - name: "Submit generate_report (7 sections, ~14s) — get job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g"],"max_retries":1,"max_duration":60}' --raw
+    capture: submit_response
+    timeout: 30
+
+  - name: "Extract job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP='${captured.submit_response}'
+      JOB_ID=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+    capture: job_id_extract
+    timeout: 10
+
+  # Poll mid-flight: kick off after a 4s settle (claim + first
+  # iteration), then poll every 2s for 6 ticks. Producer takes
+  # ~14s for 7 sections, so this window straddles working at
+  # ~0.14, 0.28, 0.42, 0.57, 0.71, 0.85.
+  #
+  # Java helper uses snake_case `job_id` (matches Python's helper API,
+  # not TS's camelCase `jobId`).
+  - name: "Poll status 6x mid-flight"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "polling job_id=$JOB_ID"
+      sleep 4
+      for i in 1 2 3 4 5 6; do
+        echo "--- poll $i ---"
+        meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}" --raw 2>&1 || true
+        sleep 2
+      done
+    capture: midflight_polls
+    timeout: 45
+
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 12
+
+  - name: "Final status read"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}" --raw
+    capture: final_status
+    timeout: 15
+
+assertions:
+  - expr: "${captured.submit_response} contains 'job_id'"
+    message: "submit response should carry a job_id"
+  - expr: "${captured.midflight_polls} contains 'working'"
+    message: "at least one mid-flight poll should observe status=working"
+  # The captured JSON-escaped text from meshctl carries
+  # `\"progress\":0.<nonzero>` for working-state reads.
+  - expr: "${captured.midflight_polls} contains '\\\"progress\\\":0.'"
+    message: "at least one mid-flight poll should observe progress in (0, 1)"
+  - expr: "${captured.final_status} contains 'completed'"
+    message: "final status should be completed"
+  # Final progress is 1 (compact JSON serializes 1.0 as 1, no decimal).
+  - expr: "${captured.final_status} contains '\\\"progress\\\":1'"
+    message: "final progress should be 1"
+  - expr: "${captured.final_status} contains 'Generated content for a'"
+    message: "final result should include section a content"
+  - expr: "${captured.final_status} contains 'Generated content for g'"
+    message: "final result should include section g content (7 total)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc03_explicit_complete_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc03_explicit_complete_java/test.yaml
@@ -66,7 +66,7 @@ test:
       for i in $(seq 1 60); do
         ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
         STATUS=$(echo "$ROW" | jq -r '.status'); RESOLVED=$(echo "$ROW" | jq -r '.dependencies_resolved'); TOTAL=$(echo "$ROW" | jq -r '.total_dependencies')
-        [ "$STATUS" = "healthy" ] && [ "$RESOLVED" = "$TOTAL" ] && [ "$TOTAL" != "0" ] && { echo "consumer ready after ${i}x2s"; exit 0; }
+        [ "$STATUS" = "healthy" ] && [ "$RESOLVED" = "$TOTAL" ] && [ "$TOTAL" != "0" ] && [ "$TOTAL" != "null" ] && { echo "consumer ready after ${i}x2s"; exit 0; }
         sleep 2
       done
       echo "ERROR: consumer not ready"; exit 1

--- a/tests/integration/suites/uc23_meshjob_java/tc03_explicit_complete_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc03_explicit_complete_java/test.yaml
@@ -1,0 +1,119 @@
+# tc03_explicit_complete_java — Java port of uc21/tc03 + uc22/tc03.
+#
+# Producer fixture report_with_explicit_complete always calls
+# controller.complete({explicit:true, marker:"X", user_id}). Tests that
+# the runtime's auto-complete path is NOT exercised — the user's
+# explicit terminal payload must surface verbatim.
+
+name: "MeshJob Java: explicit job.complete() returns the user-supplied payload"
+description: "Java producer calls controller.complete({...}) with a fixed marker; consumer receives it verbatim"
+tags:
+  - meshjob
+  - java
+  - issue-890
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9120)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for Java provider to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -s http://localhost:8000/agents | jq -r \
+          '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$STATUS" = "healthy" ] && { echo "provider healthy after ${i}x2s"; exit 0; }
+        sleep 2
+      done
+      echo "ERROR: provider not healthy"; exit 1
+    timeout: 150
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for Java consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        STATUS=$(echo "$ROW" | jq -r '.status'); RESOLVED=$(echo "$ROW" | jq -r '.dependencies_resolved'); TOTAL=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$STATUS" = "healthy" ] && [ "$RESOLVED" = "$TOTAL" ] && [ "$TOTAL" != "0" ] && { echo "consumer ready after ${i}x2s"; exit 0; }
+        sleep 2
+      done
+      echo "ERROR: consumer not ready"; exit 1
+    timeout: 150
+
+  # Submit by direct registry POST so we hit report_with_explicit_complete
+  # (no consumer wrapper for it — same pattern as Python tc03 / TS tc03).
+  - name: "POST /jobs for report_with_explicit_complete"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:8000/jobs \
+        -H 'Content-Type: application/json' \
+        -d '{"capability":"report_with_explicit_complete","submitted_payload":{"user_id":"alice"},"submitted_by":"tc03","max_duration":30,"max_retries":1}'
+    capture: submit_resp
+    timeout: 15
+
+  - name: "Extract job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      echo "JOB_ID=${JOB_ID}"
+    capture: job_id_extract
+
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 12
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
+    capture: final_status
+
+assertions:
+  - expr: "${captured.final_status} contains 'completed'"
+    message: "status should be completed"
+  - expr: "${captured.final_status} contains '\\\"explicit\\\":true'"
+    message: "result must include the explicit:true marker from controller.complete() (not just the capability name)"
+  - expr: "${captured.final_status} contains 'marker'"
+    message: "result should include the marker key from controller.complete()"
+  - expr: "${captured.final_status} contains '\\\"X\\\"'"
+    message: "result should include the marker value 'X'"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc04_implicit_complete_on_return_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc04_implicit_complete_on_return_java/test.yaml
@@ -1,0 +1,112 @@
+# tc04_implicit_complete_on_return_java — Java port of uc21/tc04 + uc22/tc04.
+#
+# Producer fixture report_with_implicit_complete updates progress but
+# NEVER calls controller.complete(). The Java dispatch wrapper's
+# auto-complete path should observe the non-terminal isTerminal() probe
+# and flush the user's return value as the terminal payload.
+
+name: "MeshJob Java: handler returns without complete() — auto-complete fires"
+description: "Java producer doesn't call controller.complete; runtime auto-completes with the return value"
+tags:
+  - meshjob
+  - java
+  - issue-890
+  - auto-complete
+timeout: 300
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0
+        sleep 2
+      done
+      echo "ERROR provider not healthy"; exit 1
+    timeout: 150
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0
+        sleep 2
+      done
+      echo "ERROR consumer not ready"; exit 1
+    timeout: 150
+
+  - name: "POST /jobs for report_with_implicit_complete"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:8000/jobs \
+        -H 'Content-Type: application/json' \
+        -d '{"capability":"report_with_implicit_complete","submitted_payload":{"user_id":"alice"},"submitted_by":"tc04","max_duration":30,"max_retries":1}'
+    capture: submit_resp
+
+  - name: "Extract job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      echo "JOB_ID=${JOB_ID}"
+    capture: job_id_extract
+
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 12
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
+    capture: final_status
+
+assertions:
+  - expr: "${captured.final_status} contains '\\\"status\\\":\\\"completed\\\"'"
+    message: "status field should be completed via auto-complete path"
+  - expr: "${captured.final_status} contains '\\\"implicit\\\":true'"
+    message: "result must be the user's return value carrying implicit:true (not just the capability name)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc04_implicit_complete_on_return_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc04_implicit_complete_on_return_java/test.yaml
@@ -66,7 +66,7 @@ test:
       for i in $(seq 1 60); do
         ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
         S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
-        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0
         sleep 2
       done
       echo "ERROR consumer not ready"; exit 1

--- a/tests/integration/suites/uc23_meshjob_java/tc05_explicit_fail_no_retry_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc05_explicit_fail_no_retry_java/test.yaml
@@ -93,6 +93,22 @@ test:
       meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
     capture: final_status
 
+  # Whitespace-tolerant attempt_count check — JSON serializers may emit
+  # `"attempt_count": 1` (with space). Mirrors tc11's jq-based pattern
+  # from commit 2e0140cb. Read straight from registry to avoid the
+  # meshctl envelope (which would require fromjson gymnastics).
+  - name: "Verify attempt_count == 1 (explicit fail must NOT retry)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.commission_response}' | jq -r '.content[0].text | fromjson | .job_id')
+      COUNT=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.attempt_count')
+      if [ "$COUNT" != "1" ]; then
+        echo "ERROR: attempt_count=$COUNT (expected 1; explicit fail must NOT retry)"
+        exit 1
+      fi
+      echo "attempt_count=1 (correct, no retry)"
+
 assertions:
   - expr: "${captured.final_status} contains 'failed'"
     message: "status should be failed"
@@ -100,8 +116,6 @@ assertions:
     message: "error should preserve the exact reason from controller.fail()"
   - expr: "${captured.final_status} contains 'attempt_count'"
     message: "response should include attempt_count"
-  - expr: "${captured.final_status} contains '\\\"attempt_count\\\":1'"
-    message: "attempt_count must stay at 1 — explicit fail must NOT retry"
 
 post_run:
   - routine: stop_all

--- a/tests/integration/suites/uc23_meshjob_java/tc05_explicit_fail_no_retry_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc05_explicit_fail_no_retry_java/test.yaml
@@ -1,0 +1,108 @@
+# tc05_explicit_fail_no_retry_java — Java port of uc21/tc05 + uc22/tc05.
+#
+# Producer fixture report_with_explicit_fail always calls
+# controller.fail("explicit: not retryable"). Submitting with
+# max_retries=3 must NOT retry — the substrate must distinguish
+# "developer explicitly failed the job" from "agent crashed mid-attempt".
+
+name: "MeshJob Java: explicit job.fail() does not trigger retry"
+description: "Java producer calls controller.fail('reason'); registry must mark failed and NOT retry"
+tags:
+  - meshjob
+  - java
+  - issue-890
+  - retry
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; echo "ERROR provider"; exit 1
+    timeout: 150
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+      done; echo "ERROR consumer"; exit 1
+    timeout: 150
+
+  - name: "Submit explicit-fail job with max_retries=3"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_explicit_fail \
+        '{"user_id":"alice","max_retries":3,"wait_timeout_secs":20}' --raw
+    capture: commission_response
+    timeout: 45
+
+  # Even with max_retries=3, an explicit fail() must NOT trigger
+  # additional attempts. Wait long enough that any (incorrect) retry
+  # would have completed (~30s if retries fired).
+  - name: "Wait for any retries to settle"
+    handler: wait
+    seconds: 15
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.commission_response}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
+    capture: final_status
+
+assertions:
+  - expr: "${captured.final_status} contains 'failed'"
+    message: "status should be failed"
+  - expr: "${captured.final_status} contains 'explicit: not retryable'"
+    message: "error should preserve the exact reason from controller.fail()"
+  - expr: "${captured.final_status} contains 'attempt_count'"
+    message: "response should include attempt_count"
+  - expr: "${captured.final_status} contains '\\\"attempt_count\\\":1'"
+    message: "attempt_count must stay at 1 — explicit fail must NOT retry"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc05_explicit_fail_no_retry_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc05_explicit_fail_no_retry_java/test.yaml
@@ -64,7 +64,7 @@ test:
       for i in $(seq 1 60); do
         ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
         S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
-        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
       done; echo "ERROR consumer"; exit 1
     timeout: 150
 

--- a/tests/integration/suites/uc23_meshjob_java/tc06_cancel_alive_owner_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc06_cancel_alive_owner_java/test.yaml
@@ -1,0 +1,135 @@
+# tc06_cancel_alive_owner_java — Java port of uc21/tc06 + uc22/tc06.
+#
+# Submits an overlong job (~30s), waits 5s for the producer's claim
+# worker to take ownership, then calls __mesh_job_cancel.
+#
+# IMPORTANT — Java cancel limitation (#889):
+#
+# Per #889, Java's sync JNR-FFI bindings cannot bind the per-job cancel
+# registry table — the natural binding path requires nested Tokio
+# block_on which Tokio rejects. The substrate's cancel pipeline
+# therefore behaves as follows on a Java owner:
+#
+#   - registry's CancelJob handler succeeds and marks the row cancelled
+#   - registry POSTs /jobs/{id}/cancel to the owner Java replica
+#   - the Java cancel route returns {cancelled:false, jobId} because the
+#     local cancel-registry lookup misses (binding inactive)
+#   - the Java task body does NOT abort; runs_overlong continues to its
+#     natural end (~30s) — but the registry already marked cancelled, so
+#     the consumer's status read sees status=cancelled
+#
+# Assertion: status=cancelled in the registry. We do NOT assert that
+# the task aborted faster than its natural completion, because Java
+# cannot deliver that guarantee until #889 is fixed.
+
+name: "MeshJob Java: cancel registers as cancelled in registry (Java cancel-registry inactive per #889)"
+description: "Java submit overlong job, cancel mid-flight, observe cancelled status in registry. Does NOT assert mid-flight abort (see #889 inline)."
+tags:
+  - meshjob
+  - java
+  - issue-890
+  - issue-889
+  - cancel
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Submit a 30-second job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_overlong '{"user_id":"alice","seconds":30}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Wait 5s for claim + start"
+    handler: wait
+    seconds: 5
+
+  - name: "Cancel the job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+      meshctl call __mesh_job_cancel "{\"job_id\":\"${JOB_ID}\",\"reason\":\"tc06 client requested abort\"}"
+    capture: cancel_response
+    timeout: 15
+
+  - name: "Wait for cancel to settle in registry"
+    handler: wait
+    seconds: 8
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
+    capture: final_status
+
+assertions:
+  # Java helper returns {ok:true, job_id:...} (snake_case); compact JSON.
+  - expr: "${captured.cancel_response} contains '\\\"ok\\\":true'"
+    message: "__mesh_job_cancel response should include ok:true"
+  # Per #889 — the registry-side row flips to cancelled even though the
+  # Java owner's local cancel token didn't fire. This is the substantive
+  # signal we CAN test for Java today.
+  - expr: "${captured.final_status} contains '\\\"status\\\":\\\"cancelled\\\"'"
+    message: "registry-side status should be cancelled (Java cancel-registry binding inactive per #889; this still validates the registry's CancelJob path)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc06_cancel_alive_owner_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc06_cancel_alive_owner_java/test.yaml
@@ -82,7 +82,7 @@ test:
       for i in $(seq 1 60); do
         ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
         S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
-        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
       done; exit 1
     timeout: 150
 
@@ -97,6 +97,28 @@ test:
   - name: "Wait 5s for claim + start"
     handler: wait
     seconds: 5
+
+  # Per #889 the registry-side cancel handler always succeeds even if
+  # the producer never claimed. Without a pre-cancel progress check
+  # this test could pass for the wrong reason. Confirm the row
+  # recorded at least one progress emission before we cancel.
+  - name: "Confirm producer is in flight (progress > 0 before cancel)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      for i in $(seq 1 20); do
+        PROG=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.progress // 0')
+        if awk "BEGIN{exit !(${PROG} > 0)}"; then
+          echo "[pre-cancel] progress=${PROG} after ${i}s — producer is in flight"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: producer never recorded progress > 0 — cancel scenario invalid"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq .
+      exit 1
+    timeout: 30
 
   - name: "Cancel the job"
     handler: shell

--- a/tests/integration/suites/uc23_meshjob_java/tc07_cancel_orphan_no_owner_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc07_cancel_orphan_no_owner_java/test.yaml
@@ -1,0 +1,79 @@
+# tc07_cancel_orphan_no_owner_java — Java port of uc21/tc07 + uc22/tc07.
+#
+# Direct registry POST /jobs for a capability that NO running provider
+# hosts (ghost_capability). With no producer, the registry's claim path
+# never assigns owner_instance_id — row stays in working+owner=NULL.
+# Cancel that job, assert HTTP 200 with forwarded_to_instance_id == null.
+#
+# This test is runtime-agnostic — it talks to the registry directly.
+# We tag it as Java because it lives in the Java suite, but the
+# mechanism is identical to uc21/tc07 + uc22/tc07.
+
+name: "MeshJob Java: cancel for unowned/orphan job (no claim has happened)"
+description: "POST /jobs for a capability nobody hosts; cancel before claim; verify forwarded_to_instance_id is null"
+tags:
+  - meshjob
+  - java
+  - issue-890
+  - cancel
+timeout: 60
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Submit job for a capability nobody hosts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:8000/jobs \
+        -H 'Content-Type: application/json' \
+        -d '{"capability":"ghost_capability","submitted_payload":{"x":1},"submitted_by":"tc07","max_duration":30,"max_retries":0}'
+    capture: submit_resp
+    timeout: 10
+
+  - name: "Confirm the row is owner=NULL"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}"
+    capture: pre_cancel_status
+
+  - name: "Cancel via direct registry POST"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      curl -s -X POST "http://localhost:8000/jobs/${JOB_ID}/cancel" \
+        -H 'Content-Type: application/json' \
+        -d '{"reason":"tc07 unowned cancel"}' \
+        -w "\nHTTP_CODE=%{http_code}"
+    capture: cancel_response
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}"
+    capture: final_status
+
+assertions:
+  - expr: "${captured.pre_cancel_status} contains '\"owner_instance_id\":null'"
+    message: "row should have owner_instance_id=null (no provider for ghost_capability to claim it)"
+  - expr: "${captured.cancel_response} contains 'HTTP_CODE=200'"
+    message: "cancel HTTP should return 200"
+  - expr: "${captured.cancel_response} contains '\"forwarded_to_instance_id\":null'"
+    message: "no owner to forward to — forwarded_to_instance_id must be null"
+  - expr: "${captured.cancel_response} contains '\"status\":\"cancelled\"'"
+    message: "cancel response should report status:cancelled"
+  - expr: "${captured.final_status} contains '\"status\":\"cancelled\"'"
+    message: "final status row should be cancelled"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc08_cancel_already_terminal_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc08_cancel_already_terminal_java/test.yaml
@@ -1,0 +1,129 @@
+# tc08_cancel_already_terminal_java — Java port of uc21/tc08 + uc22/tc08.
+#
+# Submit a fast generate_report job and wait for it to complete. Then
+# attempt to cancel the now-completed job. Registry returns HTTP 409
+# with "job is already in a terminal state". The Java helper-tool
+# wrapper surfaces it through MCP as an isError envelope (the
+# JobProxy.cancel() throws which the wrapper marshals into
+# isError content).
+
+name: "MeshJob Java: cancel of already-terminal job returns 409 / structured error"
+description: "Java — complete a job, then cancel it; both registry HTTP and helper tool must reject as conflict"
+tags:
+  - meshjob
+  - java
+  - issue-890
+  - cancel
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Submit a quick job (submit-only) to capture job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["only"],"max_retries":1,"max_duration":30}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Wait for job to complete (~3s)"
+    handler: wait
+    seconds: 8
+
+  - name: "Confirm it is terminal"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.status'
+    capture: terminal_check
+
+  - name: "Direct registry cancel — expect HTTP 409"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      curl -s -X POST "http://localhost:8000/jobs/${JOB_ID}/cancel" \
+        -H 'Content-Type: application/json' -d '{}' \
+        -w "\nHTTP_CODE=%{http_code}"
+    capture: registry_cancel
+
+  - name: "Helper-tool cancel — expect MCP isError"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      meshctl call __mesh_job_cancel "{\"job_id\":\"${JOB_ID}\"}" 2>&1 || true
+    capture: helper_cancel
+
+assertions:
+  - expr: "${captured.terminal_check} contains 'completed'"
+    message: "job should have completed before cancel attempt"
+  - expr: "${captured.registry_cancel} contains 'HTTP_CODE=409'"
+    message: "direct registry cancel of completed job must return 409"
+  - expr: "${captured.registry_cancel} contains 'terminal'"
+    message: "registry 409 message should mention terminal state"
+  # Java helper tool surfaces the registry's 409 as a MeshException —
+  # JobProxy.cancel() throws, the handler logs+rethrows, MCP wraps as
+  # isError. The error message bubbles up containing "Conflict" or
+  # the body text.
+  - expr: "${captured.helper_cancel} icontains 'conflict'"
+    message: "helper-tool cancel should surface 409 conflict"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc08_cancel_already_terminal_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc08_cancel_already_terminal_java/test.yaml
@@ -66,7 +66,7 @@ test:
       for i in $(seq 1 60); do
         ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
         S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
-        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
       done; exit 1
     timeout: 150
 

--- a/tests/integration/suites/uc23_meshjob_java/tc09_cancel_aborts_outbound_http_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc09_cancel_aborts_outbound_http_java/test.yaml
@@ -120,7 +120,7 @@ test:
       for i in $(seq 1 60); do
         ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
         S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
-        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
       done; exit 1
     timeout: 150
 
@@ -135,6 +135,30 @@ test:
   - name: "Wait 6s — let producer pick up + flush first progress + enter downstream"
     handler: wait
     seconds: 6
+
+  # Per #889 the registry-side cancel handler always succeeds, so
+  # without a pre-cancel progress check this test could pass even if
+  # the producer never claimed the job or never reached the downstream
+  # call. Confirm the row recorded at least one progress emission
+  # before we cancel — proves the producer is genuinely in flight.
+  - name: "Confirm producer is in flight (progress > 0 before cancel)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      for i in $(seq 1 20); do
+        PROG=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.progress // 0')
+        # Bash's [[ ]] doesn't compare floats; use awk for a numeric > 0 check.
+        if awk "BEGIN{exit !(${PROG} > 0)}"; then
+          echo "[pre-cancel] progress=${PROG} after ${i}s — producer is in flight"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: producer never recorded progress > 0 — cancel scenario invalid"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq .
+      exit 1
+    timeout: 30
 
   - name: "Cancel the job"
     handler: shell

--- a/tests/integration/suites/uc23_meshjob_java/tc09_cancel_aborts_outbound_http_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc09_cancel_aborts_outbound_http_java/test.yaml
@@ -1,0 +1,172 @@
+# tc09_cancel_aborts_outbound_http_java — Java port of uc21/tc09 + uc22/tc09.
+#
+# Three-agent chain (all Java):
+#   consumer (commission_downstream)
+#     -> provider.report_with_downstream_call (task=true)
+#         -> downstream-sleeper-java.slow_downstream (sleeps 30s)
+#
+# After submit, wait briefly then cancel.
+#
+# IMPORTANT — Java has TWO documented limitations relevant here:
+#
+#   1. #889: Java cancel-registry binding inactive (sync JNR-FFI cannot
+#      bind nested Tokio runtime). The cancel route returns
+#      cancelled:false; the in-process cancel token never fires.
+#
+#   2. uc22/tc09 already documents that even with the cancel token
+#      firing, the inbound transport on the downstream agent must
+#      surface client-disconnect as a cancellation to the tool handler.
+#      The Java SDK does not yet propagate inbound cancel either —
+#      same gap as Python (#882) and TS (open follow-up).
+#
+# Producer fixture's report_with_downstream_call also can't use a
+# McpMeshTool dependency (Java SDK rejects task=true producers with
+# Selector deps; see provider source comment) — it issues a plain
+# HTTP POST to the sleeper's /mcp endpoint instead. Same outbound HTTP
+# surface, just minus the resolution-layer wrapper.
+#
+# What DOES work for Java today:
+#   - registry-side row flips to status=cancelled (registry route works)
+#
+# What does NOT work for Java today:
+#   - producer's local cancel token doesn't fire (#889)
+#   - downstream sleeper's marker line doesn't fire (#886-style)
+#   - the runs_overlong / downstream HTTP runs to natural completion
+#     until the producer hits a sweep or the registry pre-cancels
+#
+# This test asserts what's observable: registry-side status=cancelled.
+# The downstream-sleeper-java's marker is NOT asserted (parallel to
+# uc22/tc09's pattern for the cross-runtime gap).
+
+name: "MeshJob Java: cancel registers as cancelled in registry (downstream propagation gap per #889/#886)"
+description: "Java — provider calls slow_downstream(30s) via HTTP; cancel must result in cancelled status in registry. Producer-local + downstream propagation NOT asserted (Java #889 + cross-runtime #886-style)."
+tags:
+  - meshjob
+  - java
+  - issue-890
+  - issue-889
+  - cancel
+  - propagation
+timeout: 480
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+      cp -rL /uc-artifacts/downstream-sleeper-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - name: "Install sleeper deps"
+    handler: maven-install
+    path: /workspace/downstream-sleeper-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start downstream-sleeper-java (port 9122) FIRST"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start downstream-sleeper-java --env MCP_MESH_HTTP_PORT=9122 -d
+
+  - name: "Wait for sleeper healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="downstream-sleeper-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Start provider (port 9120)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Start consumer (port 9121)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Submit job that calls downstream"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_downstream '{"user_id":"alice"}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Wait 6s — let producer pick up + flush first progress + enter downstream"
+    handler: wait
+    seconds: 6
+
+  - name: "Cancel the job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+      meshctl call __mesh_job_cancel "{\"job_id\":\"${JOB_ID}\"}"
+    capture: cancel_response
+    timeout: 15
+
+  - name: "Wait for cancel to settle"
+    handler: wait
+    seconds: 10
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
+    capture: final_status
+
+assertions:
+  - expr: "${captured.cancel_response} contains '\\\"ok\\\":true'"
+    message: "cancel should ack with ok:true"
+  # Per #889 — registry-side row flips to cancelled (registry's
+  # CancelJob handler succeeds) even though Java's cancel-registry
+  # binding is inactive. This is the substantive signal we CAN test.
+  - expr: "${captured.final_status} contains '\\\"status\\\":\\\"cancelled\\\"'"
+    message: "registry-side status should be cancelled (Java cancel-registry inactive per #889; downstream HTTP NOT asserted aborted)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc10_crash_recovery_max_retries_1_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc10_crash_recovery_max_retries_1_java/test.yaml
@@ -1,0 +1,181 @@
+# tc10_crash_recovery_max_retries_1_java — Java port of uc21/tc10 + uc22/tc10.
+#
+# Submits a 14s job to a single Java provider+consumer pair, kills the
+# provider mid-flight (SIGKILL), then waits for the registry sweep to
+# detect the orphan and re-claim the row to a NEW provider replica.
+# With max_retries=1, attempt_count becomes 2 (initial + 1 retry).
+#
+# Java process tree: `meshctl start <dir>` → mvn (parent) → java (child).
+# Both must be killed; killing only one leaves the other alive and the
+# agent keeps heartbeating. Same pattern as uc22 TS (tsx parent + node
+# child) but matches Java cmdlines.
+
+name: "MeshJob Java: crash recovery with default max_retries=1 — orphan reclaim"
+description: "Java — submit, kill provider (mvn parent + java child), wait for sweep, start new provider, observe completion via retry"
+tags:
+  - meshjob
+  - java
+  - issue-890
+  - retry
+  - crash-recovery
+  - slow
+timeout: 480
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Submit job (7 sections, max_retries=1)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g"],"max_retries":1,"max_duration":60}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  # Java's claim worker polls less aggressively than Python (asyncio
+  # tight loop) or TS (event loop) — wait long enough for attempt 1 to
+  # be recorded against the row before SIGKILL. With max_duration=60s
+  # the lease covers the full kill+sweep window.
+  - name: "Wait 12s for the producer to claim + start (Java is slower)"
+    handler: wait
+    seconds: 12
+
+  - name: "Kill the provider mid-flight (SIGKILL — mvn parent + java child)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # Kill EVERY mvn/java process whose cmdline mentions the provider
+      # project — meshctl start spawns mvn (parent) which forks the
+      # JVM (child). Both must die.
+      MY_PID=$$
+      MY_PPID=$PPID
+      KILLED=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        case "$cmd" in
+          *long-task-provider-java*spring-boot:run*|*long-task-provider-java*classpath*|*LongTaskProviderApplication*|*long-task-provider-java/target/classes*)
+            kill -9 "$pid" 2>/dev/null && KILLED="$KILLED $pid"
+            ;;
+        esac
+      done
+      echo "killed PIDs:$KILLED"
+      if [ -z "$KILLED" ]; then
+        echo "ERROR: No provider processes were killed — recovery scenario invalid"
+        exit 1
+      fi
+      rm -f ~/.mcp-mesh/agents/long-task-provider-java/* 2>/dev/null || true
+    capture: kill_output
+
+  - name: "Wait for sweep to orphan the job (~35s end-to-end)"
+    handler: wait
+    seconds: 45
+
+  - name: "Confirm orphan is back in claimable state"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,owner_instance_id,attempt_count,error}'
+    capture: orphaned_check
+
+  - name: "Stale PID cleanup — meshctl still tracks the killed PID"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop long-task-provider-java 2>&1 || true
+      rm -f ~/.mcp-mesh/agents/long-task-provider-java/* 2>/dev/null || true
+      echo "stale entry cleared"
+
+  - name: "Start a fresh provider — same capability, new instance_id"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for fresh provider healthy + claim + run (Java cold-start ~30s + 14s job)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && { echo "ready after ${i}x2s"; sleep 25; exit 0; }
+        sleep 2
+      done; echo "ERROR fresh provider"; exit 1
+    timeout: 180
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,attempt_count,progress,error}'
+    capture: final_status
+
+assertions:
+  - expr: "${captured.orphaned_check} contains '\"owner_instance_id\": null'"
+    message: "after sweep, owner should be cleared (orphan re-claim path)"
+  - expr: "${captured.final_status} contains '\"status\": \"completed\"'"
+    message: "fresh provider should have completed the retried job"
+  - expr: "${captured.final_status} contains '\"attempt_count\": 2'"
+    message: "attempt_count should be 2 (initial + 1 retry)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc10_crash_recovery_max_retries_1_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc10_crash_recovery_max_retries_1_java/test.yaml
@@ -71,7 +71,7 @@ test:
       for i in $(seq 1 60); do
         ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
         S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
-        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
       done; exit 1
     timeout: 150
 
@@ -84,13 +84,29 @@ test:
     capture: submit_resp
     timeout: 30
 
-  # Java's claim worker polls less aggressively than Python (asyncio
-  # tight loop) or TS (event loop) — wait long enough for attempt 1 to
-  # be recorded against the row before SIGKILL. With max_duration=60s
-  # the lease covers the full kill+sweep window.
-  - name: "Wait 12s for the producer to claim + start (Java is slower)"
-    handler: wait
-    seconds: 12
+  # Poll until the producer has actually claimed the job rather than
+  # waiting a static 12s. owner_instance_id flipping non-null is the
+  # deterministic signal that attempt 1 has been recorded, so SIGKILL
+  # below cannot land before the claim worker writes attempt 1 → the
+  # orphan reset path can correctly increment to attempt 2 on retry.
+  - name: "Wait for the producer to claim the job (deterministic pre-kill)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      for i in $(seq 1 30); do
+        OWNER=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.owner_instance_id // empty')
+        if [ -n "$OWNER" ] && [ "$OWNER" != "null" ]; then
+          echo "[claim-confirmed] owner=$OWNER after ${i}s"
+          sleep 2
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: producer never claimed within 30s — recovery scenario invalid"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq .
+      exit 1
+    timeout: 45
 
   - name: "Kill the provider mid-flight (SIGKILL — mvn parent + java child)"
     handler: shell
@@ -149,16 +165,35 @@ test:
     workdir: /workspace
     command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
 
-  - name: "Wait for fresh provider healthy + claim + run (Java cold-start ~30s + 14s job)"
+  - name: "Wait for fresh provider to retry + complete the job (poll terminal status)"
     handler: shell
     workdir: /workspace
     command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      # First wait for the fresh provider to be healthy.
       for i in $(seq 1 60); do
         S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
-        [ "$S" = "healthy" ] && { echo "ready after ${i}x2s"; sleep 25; exit 0; }
+        [ "$S" = "healthy" ] && { echo "[provider-healthy] after ${i}x2s"; break; }
         sleep 2
-      done; echo "ERROR fresh provider"; exit 1
-    timeout: 180
+      done
+      [ "$S" = "healthy" ] || { echo "ERROR fresh provider not healthy"; exit 1; }
+      # Poll for terminal status instead of sleeping a fixed 25s — the
+      # retry path is faster than the worst-case wall-clock we used to
+      # bake in, and slow CI shouldn't have to be the limit.
+      for i in $(seq 1 60); do
+        STATUS=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.status')
+        case "$STATUS" in
+          completed|failed|cancelled)
+            echo "[terminal] status=$STATUS after ${i}s"
+            exit 0
+            ;;
+        esac
+        sleep 1
+      done
+      echo "ERROR: job never reached terminal status within 60s"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq .
+      exit 1
+    timeout: 240
 
   - name: "Read final status"
     handler: shell

--- a/tests/integration/suites/uc23_meshjob_java/tc11_max_retries_0_disables_retry_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc11_max_retries_0_disables_retry_java/test.yaml
@@ -1,0 +1,141 @@
+# tc11_max_retries_0_disables_retry_java — Java port of uc21/tc11 + uc22/tc11.
+#
+# With max_retries=0, the orphan path's check
+#   if attempt_count > max_retries => 1 > 0
+# trips after the crash → registry marks status=failed with the
+# canonical "orphaned: max retries exceeded" reason.
+
+name: "MeshJob Java: max_retries=0 disables retry — orphan goes straight to failed"
+description: "Java — kill provider mid-flight; with max_retries=0 the sweep marks failed instead of re-claiming"
+tags:
+  - meshjob
+  - java
+  - issue-890
+  - retry
+  - crash-recovery
+  - slow
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Submit job with max_retries=0"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g"],"max_retries":0,"max_duration":60}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  # See tc10 inline comment — Java needs longer pre-kill wait for the
+  # claim worker to record attempt 1 against the row.
+  - name: "Wait 12s for the producer to claim + start (Java is slower)"
+    handler: wait
+    seconds: 12
+
+  - name: "Kill the provider mid-flight (SIGKILL — mvn parent + java child)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      MY_PID=$$
+      MY_PPID=$PPID
+      KILLED=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        case "$cmd" in
+          *long-task-provider-java*spring-boot:run*|*long-task-provider-java*classpath*|*LongTaskProviderApplication*|*long-task-provider-java/target/classes*)
+            kill -9 "$pid" 2>/dev/null && KILLED="$KILLED $pid"
+            ;;
+        esac
+      done
+      echo "killed PIDs:$KILLED"
+      if [ -z "$KILLED" ]; then
+        echo "ERROR: No provider processes were killed — recovery scenario invalid"
+        exit 1
+      fi
+      rm -f ~/.mcp-mesh/agents/long-task-provider-java/* 2>/dev/null || true
+    capture: kill_output
+
+  - name: "Wait for health-monitor flip + sweep to mark failed (~35s end-to-end)"
+    handler: wait
+    seconds: 45
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,attempt_count,error,owner_instance_id}'
+    capture: final_status
+
+assertions:
+  - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
+    message: "max_retries=0 should mark failed after crash (no re-claim)"
+  - expr: "${captured.final_status} contains 'orphaned'"
+    message: "error should mention 'orphaned'"
+  - expr: "${captured.final_status} contains 'max retries exceeded'"
+    message: "error should mention 'max retries exceeded'"
+  - expr: "${captured.final_status} contains '\"attempt_count\": 1'"
+    message: "only one attempt counted — no retry"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc11_max_retries_0_disables_retry_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc11_max_retries_0_disables_retry_java/test.yaml
@@ -66,7 +66,7 @@ test:
       for i in $(seq 1 60); do
         ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
         S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
-        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
       done; exit 1
     timeout: 150
 
@@ -79,11 +79,31 @@ test:
     capture: submit_resp
     timeout: 30
 
-  # See tc10 inline comment — Java needs longer pre-kill wait for the
-  # claim worker to record attempt 1 against the row.
-  - name: "Wait 12s for the producer to claim + start (Java is slower)"
-    handler: wait
-    seconds: 12
+  # Poll until the producer has actually claimed the job rather than
+  # waiting a static 12s — on slow CI the claim worker could record
+  # attempt 1 after the SIGKILL window opened, leaving attempt_count=0
+  # and breaking the assertion. owner_instance_id flipping non-null
+  # is the deterministic signal that attempt 1 has been recorded.
+  - name: "Wait for the producer to claim the job (deterministic pre-kill)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      for i in $(seq 1 30); do
+        OWNER=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.owner_instance_id // empty')
+        if [ -n "$OWNER" ] && [ "$OWNER" != "null" ]; then
+          echo "[claim-confirmed] owner=$OWNER after ${i}s"
+          # Short beat so the claim worker has flushed attempt 1
+          # before SIGKILL closes the JVM.
+          sleep 2
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: producer never claimed within 30s — scenario invalid"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq .
+      exit 1
+    timeout: 45
 
   - name: "Kill the provider mid-flight (SIGKILL — mvn parent + java child)"
     handler: shell
@@ -126,6 +146,23 @@ test:
       curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,attempt_count,error,owner_instance_id}'
     capture: final_status
 
+  # Substring match on `"attempt_count": 1` was timing-fragile (could
+  # race with SIGKILL). The deterministic claim-confirm pre-kill above
+  # makes attempt_count>=1 guaranteed; this step asserts the inverse —
+  # no RETRY happened, i.e. attempt_count <= 1 — directly with jq so
+  # the test can't pass for the wrong reason.
+  - name: "Verify attempt_count <= 1 (no retry under max_retries=0)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      COUNT=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.attempt_count')
+      echo "attempt_count=${COUNT}"
+      if [ "$COUNT" -gt 1 ]; then
+        echo "ERROR: attempt_count=${COUNT} > 1 — max_retries=0 should disable retry"
+        exit 1
+      fi
+
 assertions:
   - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
     message: "max_retries=0 should mark failed after crash (no re-claim)"
@@ -133,8 +170,6 @@ assertions:
     message: "error should mention 'orphaned'"
   - expr: "${captured.final_status} contains 'max retries exceeded'"
     message: "error should mention 'max retries exceeded'"
-  - expr: "${captured.final_status} contains '\"attempt_count\": 1'"
-    message: "only one attempt counted — no retry"
 
 post_run:
   - routine: stop_all

--- a/tests/integration/suites/uc23_meshjob_java/tc12_max_retries_exhausted_marks_failed_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc12_max_retries_exhausted_marks_failed_java/test.yaml
@@ -1,0 +1,204 @@
+# tc12_max_retries_exhausted_marks_failed_java — Java port of uc21/tc12 + uc22/tc12.
+#
+# Two SIGKILL cycles with max_retries=1 leaves attempt_count=2,
+# max_retries=1 → orphan-reset path's check `attempt_count > max_retries`
+# (2 > 1) trips and marks failed with "orphaned: max retries exceeded".
+
+name: "MeshJob Java: retry budget exhausted via repeated crashes — marked failed"
+description: "Java — two crash + sweep cycles with max_retries=1; final attempt_count=2 > max_retries → exhausted"
+tags:
+  - meshjob
+  - java
+  - issue-890
+  - retry
+  - crash-recovery
+  - slow
+timeout: 600
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (round 1)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Submit job with max_retries=1"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g","h","i"],"max_retries":1,"max_duration":60}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  # See tc10 inline comment — Java needs longer pre-kill wait.
+  - name: "Wait 12s for claim (Java is slower)"
+    handler: wait
+    seconds: 12
+
+  - name: "Kill provider — round 1 (attempt 1 crashes)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      MY_PID=$$
+      MY_PPID=$PPID
+      KILLED=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        case "$cmd" in
+          *long-task-provider-java*spring-boot:run*|*long-task-provider-java*classpath*|*LongTaskProviderApplication*|*long-task-provider-java/target/classes*)
+            kill -9 "$pid" 2>/dev/null && KILLED="$KILLED $pid"
+            ;;
+        esac
+      done
+      echo "killed PIDs round 1:$KILLED"
+      if [ -z "$KILLED" ]; then
+        echo "ERROR: No provider processes were killed in round 1"
+        exit 1
+      fi
+      rm -f ~/.mcp-mesh/agents/long-task-provider-java/* 2>/dev/null || true
+    capture: kill1
+
+  - name: "Wait for sweep to reset orphan (~35s end-to-end)"
+    handler: wait
+    seconds: 45
+
+  - name: "Status after round 1 (should be working, owner=null)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,owner_instance_id,attempt_count}'
+    capture: after_round_1
+
+  - name: "Stale PID cleanup before round 2"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop long-task-provider-java 2>&1 || true
+      rm -f ~/.mcp-mesh/agents/long-task-provider-java/* 2>/dev/null || true
+      echo "stale entry cleared"
+
+  - name: "Start provider (round 2)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for round 2 healthy + claim"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && { sleep 5; exit 0; }
+        sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Kill provider — round 2 (attempt 2 crashes)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      MY_PID=$$
+      MY_PPID=$PPID
+      KILLED=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        case "$cmd" in
+          *long-task-provider-java*spring-boot:run*|*long-task-provider-java*classpath*|*LongTaskProviderApplication*|*long-task-provider-java/target/classes*)
+            kill -9 "$pid" 2>/dev/null && KILLED="$KILLED $pid"
+            ;;
+        esac
+      done
+      echo "killed PIDs round 2:$KILLED"
+      if [ -z "$KILLED" ]; then
+        echo "ERROR: No provider processes were killed in round 2"
+        exit 1
+      fi
+      rm -f ~/.mcp-mesh/agents/long-task-provider-java/* 2>/dev/null || true
+    capture: kill2
+
+  - name: "Wait for sweep to mark exhausted (~35s end-to-end)"
+    handler: wait
+    seconds: 45
+
+  - name: "Final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,owner_instance_id,attempt_count,error}'
+    capture: final_status
+
+assertions:
+  - expr: "${captured.after_round_1} contains '\"status\": \"working\"'"
+    message: "after round 1 sweep, status should still be working (orphan reset)"
+  - expr: "${captured.after_round_1} contains '\"owner_instance_id\": null'"
+    message: "after round 1 sweep, owner should be cleared"
+  - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
+    message: "after round 2 sweep with attempt_count > max_retries, must be failed"
+  - expr: "${captured.final_status} contains 'max retries exceeded'"
+    message: "error should mention max retries exceeded"
+  - expr: "${captured.final_status} contains '\"attempt_count\": 2'"
+    message: "attempt_count should be 2 (1 initial + 1 retry attempt) — budget exceeded"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc12_max_retries_exhausted_marks_failed_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc12_max_retries_exhausted_marks_failed_java/test.yaml
@@ -65,7 +65,7 @@ test:
       for i in $(seq 1 60); do
         ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
         S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
-        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
       done; exit 1
     timeout: 150
 
@@ -78,10 +78,28 @@ test:
     capture: submit_resp
     timeout: 30
 
-  # See tc10 inline comment — Java needs longer pre-kill wait.
-  - name: "Wait 12s for claim (Java is slower)"
-    handler: wait
-    seconds: 12
+  # Poll until the producer has actually claimed the job rather than
+  # waiting a static 12s — owner_instance_id flipping non-null is the
+  # deterministic signal that attempt 1 has been recorded against the
+  # row before SIGKILL closes the JVM.
+  - name: "Wait for the producer to claim the job (deterministic pre-kill, round 1)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      for i in $(seq 1 30); do
+        OWNER=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.owner_instance_id // empty')
+        if [ -n "$OWNER" ] && [ "$OWNER" != "null" ]; then
+          echo "[claim-confirmed-round1] owner=$OWNER after ${i}s"
+          sleep 2
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: producer never claimed within 30s (round 1) — scenario invalid"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq .
+      exit 1
+    timeout: 45
 
   - name: "Kill provider — round 1 (attempt 1 crashes)"
     handler: shell
@@ -136,16 +154,32 @@ test:
     workdir: /workspace
     command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
 
-  - name: "Wait for round 2 healthy + claim"
+  - name: "Wait for round 2 healthy + claim (deterministic — owner re-bound)"
     handler: shell
     workdir: /workspace
     command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      # First wait for the fresh provider to be healthy.
       for i in $(seq 1 60); do
         S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
-        [ "$S" = "healthy" ] && { sleep 5; exit 0; }
+        [ "$S" = "healthy" ] && break
         sleep 2
-      done; exit 1
-    timeout: 150
+      done
+      [ "$S" = "healthy" ] || { echo "ERROR: round 2 provider not healthy"; exit 1; }
+      # Then poll for re-claim (owner flips back to non-null).
+      for i in $(seq 1 30); do
+        OWNER=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.owner_instance_id // empty')
+        if [ -n "$OWNER" ] && [ "$OWNER" != "null" ]; then
+          echo "[claim-confirmed-round2] owner=$OWNER after ${i}s"
+          sleep 2
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: round 2 never re-claimed — scenario invalid"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq .
+      exit 1
+    timeout: 180
 
   - name: "Kill provider — round 2 (attempt 2 crashes)"
     handler: shell

--- a/tests/integration/suites/uc23_meshjob_java/tc13_total_deadline_expires_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc13_total_deadline_expires_java/test.yaml
@@ -1,0 +1,154 @@
+# tc13_total_deadline_expires_java — Java port of uc21/tc13 + uc22/tc13.
+#
+# Submits a job with total_deadline=now+5s and a generous max_retries=10.
+# Producer is killed mid-flight to make the row eligible for the orphan
+# path. ExpireDeadlinedJobs marks the row failed with reason
+# "deadline_exceeded" BEFORE orphan-reset can put it back in the pool.
+
+name: "MeshJob Java: total_deadline expiry overrides retry budget"
+description: "Java — deadline=now+5s with max_retries=10; deadline-sweep marks failed before any retry"
+tags:
+  - meshjob
+  - java
+  - issue-890
+  - retry
+  - deadline
+  - slow
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  # commission_with_options propagates total_deadline_secs (relative)
+  # → unix-epoch seconds for the Java submitter.
+  - name: "Submit with total_deadline=now+5s, max_retries=10"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_with_options \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g"],"max_retries":10,"total_deadline_secs":5,"wait_timeout_secs":2}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Capture job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+    capture: job_id_extract
+
+  - name: "Kill provider — make the row a candidate for orphan/deadline sweep"
+    handler: shell
+    workdir: /workspace
+    command: |
+      MY_PID=$$
+      MY_PPID=$PPID
+      KILLED=""
+      for p in /proc/[0-9]*; do
+        pid="${p##*/}"
+        [ "$pid" = "1" ] && continue
+        [ "$pid" = "$MY_PID" ] && continue
+        [ "$pid" = "$MY_PPID" ] && continue
+        [ -f "$p/cmdline" ] || continue
+        cmd=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null)
+        case "$cmd" in
+          *long-task-provider-java*spring-boot:run*|*long-task-provider-java*classpath*|*LongTaskProviderApplication*|*long-task-provider-java/target/classes*)
+            kill -9 "$pid" 2>/dev/null && KILLED="$KILLED $pid"
+            ;;
+        esac
+      done
+      echo "killed PIDs:$KILLED"
+      if [ -z "$KILLED" ]; then
+        echo "ERROR: No provider processes were killed — deadline scenario invalid"
+        exit 1
+      fi
+      rm -f ~/.mcp-mesh/agents/long-task-provider-java/* 2>/dev/null || true
+
+  - name: "Wait for deadline sweep"
+    handler: wait
+    seconds: 30
+
+  - name: "Final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,attempt_count,error,total_deadline,owner_instance_id}'
+    capture: final_status
+
+  - name: "Assert attempt_count <= 1 (deadline must prevent retries)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      COUNT=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.attempt_count')
+      if ! [ "$COUNT" -le 1 ] 2>/dev/null; then
+        echo "ERROR: attempt_count=$COUNT exceeds 1 — total_deadline should have prevented retry"
+        exit 1
+      fi
+      echo "attempt_count=$COUNT (<= 1, OK)"
+
+assertions:
+  - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
+    message: "deadline-expired job must be marked failed"
+  - expr: "${captured.final_status} contains 'deadline_exceeded'"
+    message: "error must be the canonical 'deadline_exceeded' reason — NOT 'orphaned'"
+  - expr: "${captured.final_status} not contains 'orphaned'"
+    message: "deadline path must take precedence over orphan-reset"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc13_total_deadline_expires_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc13_total_deadline_expires_java/test.yaml
@@ -66,7 +66,7 @@ test:
       for i in $(seq 1 60); do
         ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
         S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
-        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
       done; exit 1
     timeout: 150
 

--- a/tests/integration/suites/uc23_meshjob_java/tc14_helpers_on_every_agent_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc14_helpers_on_every_agent_java/test.yaml
@@ -79,7 +79,7 @@ test:
         OS=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="orchestrator-agent-java") | .status')
         CR=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .dependencies_resolved')
         CT=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .total_dependencies')
-        if [ "$PS" = "healthy" ] && [ "$CS" = "healthy" ] && [ "$OS" = "healthy" ] && [ "$CR" = "$CT" ] && [ "$CT" != "0" ]; then
+        if [ "$PS" = "healthy" ] && [ "$CS" = "healthy" ] && [ "$OS" = "healthy" ] && [ "$CR" = "$CT" ] && [ "$CT" != "0" ] && [ "$CT" != "null" ]; then
           echo "all 3 ready after ${i}x2s"
           exit 0
         fi

--- a/tests/integration/suites/uc23_meshjob_java/tc14_helpers_on_every_agent_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc14_helpers_on_every_agent_java/test.yaml
@@ -1,0 +1,191 @@
+# tc14_helpers_on_every_agent_java — Java port of uc21/tc14 + uc22/tc14.
+#
+# Three Java agents: producer (task=true only), consumer (deps + submit
+# wrapper), and orchestrator (no task tools, no deps — pure bystander).
+# All three should advertise __mesh_job_status, __mesh_job_result, and
+# __mesh_job_cancel via the registry.
+
+name: "MeshJob Java: helper tools auto-registered on every mesh agent"
+description: "Java — producer, consumer, and bystander all expose __mesh_job_* and return correct data"
+tags:
+  - meshjob
+  - java
+  - issue-890
+  - helpers
+timeout: 480
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+      cp -rL /uc-artifacts/orchestrator-agent-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - name: "Install orchestrator deps"
+    handler: maven-install
+    path: /workspace/orchestrator-agent-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Start orchestrator (no task tools, no deps)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start orchestrator-agent-java --env MCP_MESH_HTTP_PORT=9123 -d
+
+  - name: "Wait for all 3 to be healthy + consumer DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        AGENTS=$(curl -s http://localhost:8000/agents)
+        PS=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status')
+        CS=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .status')
+        OS=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="orchestrator-agent-java") | .status')
+        CR=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .dependencies_resolved')
+        CT=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .total_dependencies')
+        if [ "$PS" = "healthy" ] && [ "$CS" = "healthy" ] && [ "$OS" = "healthy" ] && [ "$CR" = "$CT" ] && [ "$CT" != "0" ]; then
+          echo "all 3 ready after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR — provider=$PS consumer=$CS orchestrator=$OS deps=$CR/$CT"; exit 1
+    timeout: 180
+
+  - name: "Capture full agent IDs"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl list 2>&1
+      echo "---"
+      curl -s http://localhost:8000/agents | jq -r '.agents[].id'
+    capture: agent_ids
+
+  - name: "Submit a job via consumer (1 section)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["only"],"max_retries":1,"max_duration":30}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 8
+
+  - name: "Call __mesh_job_status on PROVIDER"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .id')
+      echo "JOB_ID=${JOB_ID} AGENT=${AGENT}"
+      meshctl call "${AGENT}:__mesh_job_status" "{\"job_id\":\"${JOB_ID}\"}"
+    capture: status_on_provider
+
+  - name: "Call __mesh_job_result on CONSUMER"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .id')
+      meshctl call "${AGENT}:__mesh_job_result" "{\"job_id\":\"${JOB_ID}\"}"
+    capture: result_on_consumer
+
+  - name: "Call __mesh_job_status on ORCHESTRATOR (bystander)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="orchestrator-agent-java") | .id')
+      meshctl call "${AGENT}:__mesh_job_status" "{\"job_id\":\"${JOB_ID}\"}"
+    capture: status_on_orchestrator
+
+  - name: "Confirm helper tools auto-register on the orchestrator (bystander)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s http://localhost:8000/agents \
+        | jq -r '.agents[] | select(.name=="orchestrator-agent-java") | .capabilities[].function_name'
+    capture: orchestrator_tools
+
+  - name: "Assert owner_instance_id starts with provider agent name"
+    handler: shell
+    workdir: /workspace
+    command: |
+      OWNER=$(echo '${captured.status_on_orchestrator}' \
+        | jq -r '.content[0].text | fromjson | .owner_instance_id' 2>/dev/null)
+      echo "owner_instance_id=${OWNER}"
+      case "$OWNER" in
+        long-task-provider-java-*)
+          echo "OK"
+          ;;
+        *)
+          echo "ERROR: owner_instance_id should start with 'long-task-provider-java-' but got '$OWNER'"
+          exit 1
+          ;;
+      esac
+
+assertions:
+  - expr: "${captured.agent_ids} contains 'long-task-provider-java'"
+    message: "Java provider should be registered"
+  - expr: "${captured.agent_ids} contains 'long-task-consumer-java'"
+    message: "Java consumer should be registered"
+  - expr: "${captured.agent_ids} contains 'orchestrator-agent-java'"
+    message: "Java orchestrator (bystander) should be registered"
+  - expr: "${captured.status_on_provider} contains 'completed'"
+    message: "__mesh_job_status on provider should return the same completed state"
+  - expr: "${captured.result_on_consumer} contains 'completed'"
+    message: "__mesh_job_result on consumer should return terminal status=completed"
+  - expr: "${captured.status_on_orchestrator} contains 'completed'"
+    message: "__mesh_job_status on bystander orchestrator should also return completed"
+
+  # Auto-registration check: even the bystander orchestrator (no task
+  # tools, no MeshJob deps) advertises all three __mesh_job_* helpers.
+  - expr: "${captured.orchestrator_tools} contains '__mesh_job_status'"
+    message: "orchestrator (bystander) must auto-register __mesh_job_status"
+  - expr: "${captured.orchestrator_tools} contains '__mesh_job_result'"
+    message: "orchestrator (bystander) must auto-register __mesh_job_result"
+  - expr: "${captured.orchestrator_tools} contains '__mesh_job_cancel'"
+    message: "orchestrator (bystander) must auto-register __mesh_job_cancel"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc15_status_for_unknown_id_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc15_status_for_unknown_id_java/test.yaml
@@ -1,0 +1,95 @@
+# tc15_status_for_unknown_id_java — Java port of uc21/tc15 + uc22/tc15.
+#
+# Calls __mesh_job_status with a UUID that's not in the registry.
+# Registry returns HTTP 404 with "job not found: <id>". Java JobProxy
+# turns that into a MeshException; the helper-tool wrapper surfaces it
+# through MCP as an isError envelope.
+
+name: "MeshJob Java: __mesh_job_status with unknown job_id returns structured not-found"
+description: "Java — bogus UUID returns NotFound-shaped error (not a 500, not an auth error)"
+tags:
+  - meshjob
+  - java
+  - issue-890
+  - helpers
+  - errors
+timeout: 240
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/orchestrator-agent-java /workspace/
+
+  - name: "Install agent deps"
+    handler: maven-install
+    path: /workspace/orchestrator-agent-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start orchestrator agent (Java)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start orchestrator-agent-java --env MCP_MESH_HTTP_PORT=9123 -d
+
+  - name: "Wait for orchestrator healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="orchestrator-agent-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Direct registry GET — confirm 404 shape"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -w "\nHTTP_CODE=%{http_code}" \
+        "http://localhost:8000/jobs/00000000-0000-0000-0000-000000000000"
+    capture: registry_404
+
+  - name: "Helper tool with bogus job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call __mesh_job_status \
+        '{"job_id":"00000000-0000-0000-0000-000000000000"}' 2>&1 || true
+    capture: helper_response
+
+  - name: "Assert no auth-rejection phrasing (case-insensitive)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      LOWER=$(echo '${captured.helper_response}' | tr '[:upper:]' '[:lower:]')
+      if echo "$LOWER" | grep -q -E 'unauthorized|permission denied'; then
+        echo "ERROR: helper_response contains an auth-rejection phrase (job_id-as-capability auth must be open)"
+        echo "$LOWER"
+        exit 1
+      fi
+      echo "no auth-rejection phrasing detected"
+
+assertions:
+  - expr: "${captured.registry_404} contains 'HTTP_CODE=404'"
+    message: "registry GET /jobs/<bogus-id> should return HTTP 404"
+  - expr: "${captured.registry_404} icontains 'job not found'"
+    message: "registry 404 body should say 'job not found'"
+  # The Java helper tool surfaces NotFound through MCP either as a
+  # thrown error (meshctl call exits non-zero with stderr) or as an
+  # isError envelope — the error message bubbles up.
+  - expr: "${captured.helper_response} icontains 'not found'"
+    message: "helper-tool error should mention 'not found'"
+  - expr: "${captured.helper_response} not contains 'server error (HTTP 5'"
+    message: "must NOT surface as a 5xx server error"
+  - expr: "${captured.helper_response} not contains '500 Internal Server Error'"
+    message: "must NOT carry a literal HTTP 500 status line"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc16_third_party_can_read_status_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc16_third_party_can_read_status_java/test.yaml
@@ -94,7 +94,7 @@ test:
         CR=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .dependencies_resolved')
         CT=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .total_dependencies')
         if [ "$PS" = "healthy" ] && [ "$CS" = "healthy" ] && [ "$XS" = "healthy" ] && [ "$YS" = "healthy" ] \
-           && [ "$CR" = "$CT" ] && [ "$CT" != "0" ]; then
+           && [ "$CR" = "$CT" ] && [ "$CT" != "0" ] && [ "$CT" != "null" ]; then
           echo "all 4 ready after ${i}x2s"
           exit 0
         fi

--- a/tests/integration/suites/uc23_meshjob_java/tc16_third_party_can_read_status_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc16_third_party_can_read_status_java/test.yaml
@@ -1,0 +1,177 @@
+# tc16_third_party_can_read_status_java — Java port of uc21/tc16 + uc22/tc16.
+#
+# Four Java agents: producer, consumer (submits), and two bystanders X / Y
+# (no involvement). Bystanders are distinct fixtures with unique
+# @MeshAgent names so the registry sees two genuinely independent agents.
+# Submit a job via consumer; capture job_id. Call __mesh_job_status on
+# each bystander. Presigned-URL semantics: possession of the UUID = read.
+
+name: "MeshJob Java: third-party agents can read status by job_id (presigned-URL auth)"
+description: "Java — two unrelated bystanders read job status — no auth gating, only ID-as-capability"
+tags:
+  - meshjob
+  - java
+  - issue-890
+  - helpers
+  - auth
+timeout: 600
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+      cp -rL /uc-artifacts/bystander-x-java /workspace/
+      cp -rL /uc-artifacts/bystander-y-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - name: "Install bystander-x-java deps"
+    handler: maven-install
+    path: /workspace/bystander-x-java
+    timeout: 600
+
+  - name: "Install bystander-y-java deps"
+    handler: maven-install
+    path: /workspace/bystander-y-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Start bystander X"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start bystander-x-java --env MCP_MESH_HTTP_PORT=9124 -d
+
+  - name: "Start bystander Y"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start bystander-y-java --env MCP_MESH_HTTP_PORT=9125 -d
+
+  - name: "Wait for all 4 healthy + consumer DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        AGENTS=$(curl -s http://localhost:8000/agents)
+        PS=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status')
+        CS=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .status')
+        XS=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="bystander-x-java") | .status')
+        YS=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="bystander-y-java") | .status')
+        CR=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .dependencies_resolved')
+        CT=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .total_dependencies')
+        if [ "$PS" = "healthy" ] && [ "$CS" = "healthy" ] && [ "$XS" = "healthy" ] && [ "$YS" = "healthy" ] \
+           && [ "$CR" = "$CT" ] && [ "$CT" != "0" ]; then
+          echo "all 4 ready after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR — provider=$PS consumer=$CS X=$XS Y=$YS deps=$CR/$CT"
+      exit 1
+    timeout: 240
+
+  - name: "Confirm all 4 agents in registry"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s http://localhost:8000/agents | jq -r '.agents[].name' | sort
+    capture: agent_names
+
+  - name: "Submit job via consumer"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["one","two"],"max_retries":1,"max_duration":30}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 8
+
+  - name: "Bystander X reads status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="bystander-x-java") | .id')
+      echo "AGENT=${AGENT} JOB=${JOB_ID}"
+      meshctl call "${AGENT}:__mesh_job_status" "{\"job_id\":\"${JOB_ID}\"}"
+    capture: bystander_x_status
+
+  - name: "Bystander Y reads status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="bystander-y-java") | .id')
+      meshctl call "${AGENT}:__mesh_job_status" "{\"job_id\":\"${JOB_ID}\"}"
+    capture: bystander_y_status
+
+assertions:
+  - expr: "${captured.agent_names} contains 'long-task-provider-java'"
+    message: "Java provider should be registered"
+  - expr: "${captured.agent_names} contains 'long-task-consumer-java'"
+    message: "Java consumer should be registered"
+  - expr: "${captured.agent_names} contains 'bystander-x-java'"
+    message: "bystander-x-java should be registered"
+  - expr: "${captured.agent_names} contains 'bystander-y-java'"
+    message: "bystander-y-java should be registered"
+
+  - expr: "${captured.bystander_x_status} contains 'completed'"
+    message: "bystander-x-java should read the actual completed status (no auth gating)"
+  - expr: "${captured.bystander_y_status} contains 'completed'"
+    message: "bystander-y-java should read the actual completed status (no auth gating)"
+
+  - expr: "${captured.bystander_x_status} contains 'long-task-provider-java'"
+    message: "bystander-x-java's read should include the producer owner_instance_id"
+  - expr: "${captured.bystander_y_status} contains 'long-task-provider-java'"
+    message: "bystander-y-java's read should include the producer owner_instance_id"
+
+  - expr: "${captured.bystander_x_status} not contains 'unauthorized'"
+    message: "bystander-x-java must NOT see 'unauthorized'"
+  - expr: "${captured.bystander_x_status} not contains 'permission denied'"
+    message: "bystander-x-java must NOT see 'permission denied'"
+  - expr: "${captured.bystander_y_status} not contains 'unauthorized'"
+    message: "bystander-y-java must NOT see 'unauthorized'"
+  - expr: "${captured.bystander_y_status} not contains 'permission denied'"
+    message: "bystander-y-java must NOT see 'permission denied'"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc17_polyglot_java_consumer_python_provider/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc17_polyglot_java_consumer_python_provider/test.yaml
@@ -63,7 +63,7 @@ test:
       for i in $(seq 1 60); do
         ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
         S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
-        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
       done; exit 1
     timeout: 180
 

--- a/tests/integration/suites/uc23_meshjob_java/tc17_polyglot_java_consumer_python_provider/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc17_polyglot_java_consumer_python_provider/test.yaml
@@ -1,0 +1,99 @@
+# tc17_polyglot_java_consumer_python_provider — Java consumer ↔ Python provider.
+#
+# Validates that a Java MeshJobSubmitter can submit work to a Python
+# task=true tool. The Python provider's `generate_report` is the
+# upstream of choice (well-exercised in uc21). The Java consumer
+# (commission_report) issues submit + await via MeshJobSubmitter.
+#
+# Setup:
+#   - Python long-task-provider on port 9100 (capability: generate_report)
+#   - Java long-task-consumer-java on port 9121 (depends on generate_report)
+
+name: "MeshJob polyglot: Java consumer commissions Python provider"
+description: "Java MeshJobSubmitter -> Python task=true tool, end-to-end submit + await"
+tags:
+  - meshjob
+  - polyglot
+  - java
+  - python
+  - issue-890
+timeout: 480
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts (Python provider + Java consumer)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install Python provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install Java consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start Python provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for Python provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start Java consumer (port 9121)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for Java consumer + DI resolution"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 180
+
+  - name: "Verify both runtimes registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Call commission_report — Java consumer -> Python provider"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_report '{"user_id":"alice","sections":["intro","analysis"]}'
+    capture: commission_response
+    timeout: 90
+
+assertions:
+  - expr: "${captured.agent_list} contains 'long-task-provider'"
+    message: "Python provider should be registered"
+  - expr: "${captured.agent_list} contains 'long-task-consumer-java'"
+    message: "Java consumer should be registered"
+  # Result echoed verbatim from the Python complete() payload.
+  - expr: "${captured.commission_response} contains 'alice'"
+    message: "result should echo the submitted user_id"
+  - expr: "${captured.commission_response} contains 'Generated content for intro'"
+    message: "result should include the intro section content from Python provider"
+  - expr: "${captured.commission_response} contains 'Generated content for analysis'"
+    message: "result should include the analysis section content from Python provider"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc18_polyglot_java_consumer_ts_provider/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc18_polyglot_java_consumer_ts_provider/test.yaml
@@ -61,7 +61,7 @@ test:
       for i in $(seq 1 60); do
         ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
         S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
-        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
       done; exit 1
     timeout: 180
 

--- a/tests/integration/suites/uc23_meshjob_java/tc18_polyglot_java_consumer_ts_provider/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc18_polyglot_java_consumer_ts_provider/test.yaml
@@ -1,0 +1,97 @@
+# tc18_polyglot_java_consumer_ts_provider — Java consumer ↔ TS provider.
+#
+# Validates that a Java MeshJobSubmitter can submit work to a
+# TypeScript task=true tool. Reuses uc22's TS provider fixture.
+#
+# Setup:
+#   - TS long-task-provider-ts on port 9110 (capability: generate_report)
+#   - Java long-task-consumer-java on port 9121 (depends on generate_report)
+
+name: "MeshJob polyglot: Java consumer commissions TS provider"
+description: "Java MeshJobSubmitter -> TS addTool({task:true}), end-to-end submit + await"
+tags:
+  - meshjob
+  - polyglot
+  - java
+  - typescript
+  - issue-890
+timeout: 480
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts (TS provider + Java consumer)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install TS provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install Java consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start TS provider (port 9110)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Wait for TS provider"
+    handler: wait
+    seconds: 15
+
+  - name: "Start Java consumer (port 9121)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for Java consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 180
+
+  - name: "Verify both runtimes registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Call commission_report — Java consumer -> TS provider"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_report '{"user_id":"alice","sections":["intro","analysis"]}'
+    capture: commission_response
+    timeout: 90
+
+assertions:
+  - expr: "${captured.agent_list} contains 'long-task-provider-ts'"
+    message: "TS provider should be registered"
+  - expr: "${captured.agent_list} contains 'long-task-consumer-java'"
+    message: "Java consumer should be registered"
+  # Result echoed verbatim from the TS provider's complete() payload.
+  - expr: "${captured.commission_response} contains 'alice'"
+    message: "result should echo the submitted user_id"
+  - expr: "${captured.commission_response} contains 'Generated content for intro'"
+    message: "result should include the intro section content from TS provider"
+  - expr: "${captured.commission_response} contains 'Generated content for analysis'"
+    message: "result should include the analysis section content from TS provider"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc18_polyglot_java_consumer_ts_provider/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc18_polyglot_java_consumer_ts_provider/test.yaml
@@ -15,7 +15,7 @@ tags:
   - java
   - typescript
   - issue-890
-timeout: 480
+timeout: 720  # accommodate the 600s maven-install step + downstream test work
 
 pre_run:
   - routine: global.setup_for_typescript_agent

--- a/tests/integration/suites/uc23_meshjob_java/tc19_polyglot_python_consumer_java_provider/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc19_polyglot_python_consumer_java_provider/test.yaml
@@ -1,0 +1,97 @@
+# tc19_polyglot_python_consumer_java_provider — Python consumer ↔ Java provider.
+#
+# Reverse of tc17. Validates that a Python MeshJobSubmitter can submit
+# work to a Java task=true tool. Uses the Python uc21 long-task-consumer
+# fixture (commission_report) and the Java uc23 long-task-provider-java
+# fixture (generate_report).
+#
+# Setup:
+#   - Java long-task-provider-java on port 9120 (capability: generate_report)
+#   - Python long-task-consumer on port 9101 (depends on generate_report)
+
+name: "MeshJob polyglot: Python consumer commissions Java provider"
+description: "Python MeshJobSubmitter -> Java @MeshTool(task=true), end-to-end submit + await"
+tags:
+  - meshjob
+  - polyglot
+  - java
+  - python
+  - issue-890
+timeout: 480
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts (Java provider + Python consumer)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install Java provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install Python consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start Java provider (port 9120)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for Java provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Start Python consumer (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for Python consumer + DI resolution"
+    handler: wait
+    seconds: 22
+
+  - name: "Verify both runtimes registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Call commission_report — Python consumer -> Java provider"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_report '{"user_id":"alice","sections":["intro","analysis"]}'
+    capture: commission_response
+    timeout: 90
+
+assertions:
+  - expr: "${captured.agent_list} contains 'long-task-provider-java'"
+    message: "Java provider should be registered"
+  - expr: "${captured.agent_list} contains 'long-task-consumer'"
+    message: "Python consumer should be registered"
+  - expr: "${captured.commission_response} contains 'alice'"
+    message: "result should echo the submitted user_id"
+  - expr: "${captured.commission_response} contains 'Generated content for intro'"
+    message: "result should include the intro section content from Java provider"
+  - expr: "${captured.commission_response} contains 'Generated content for analysis'"
+    message: "result should include the analysis section content from Java provider"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc20_polyglot_ts_consumer_java_provider/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc20_polyglot_ts_consumer_java_provider/test.yaml
@@ -1,0 +1,95 @@
+# tc20_polyglot_ts_consumer_java_provider — TS consumer ↔ Java provider.
+#
+# Reverse of tc18. Validates that a TS MeshJobSubmitter can submit work
+# to a Java task=true tool.
+#
+# Setup:
+#   - Java long-task-provider-java on port 9120 (capability: generate_report)
+#   - TS long-task-consumer-ts on port 9111 (depends on generate_report)
+
+name: "MeshJob polyglot: TS consumer commissions Java provider"
+description: "TS MeshJobSubmitter -> Java @MeshTool(task=true), end-to-end submit + await"
+tags:
+  - meshjob
+  - polyglot
+  - java
+  - typescript
+  - issue-890
+timeout: 480
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts (Java provider + TS consumer)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+
+  - name: "Install Java provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install TS consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start Java provider (port 9120)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for Java provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Start TS consumer (port 9111)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 -d
+
+  - name: "Wait for TS consumer + DI"
+    handler: wait
+    seconds: 22
+
+  - name: "Verify both runtimes registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Call commission_report — TS consumer -> Java provider"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_report '{"user_id":"alice","sections":["intro","analysis"]}'
+    capture: commission_response
+    timeout: 90
+
+assertions:
+  - expr: "${captured.agent_list} contains 'long-task-provider-java'"
+    message: "Java provider should be registered"
+  - expr: "${captured.agent_list} contains 'long-task-consumer-ts'"
+    message: "TS consumer should be registered"
+  - expr: "${captured.commission_response} contains 'alice'"
+    message: "result should echo the submitted user_id"
+  - expr: "${captured.commission_response} contains 'Generated content for intro'"
+    message: "result should include the intro section content from Java provider"
+  - expr: "${captured.commission_response} contains 'Generated content for analysis'"
+    message: "result should include the analysis section content from Java provider"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc21_polyglot_3way_status_read/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc21_polyglot_3way_status_read/test.yaml
@@ -103,7 +103,7 @@ test:
         JCR=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .dependencies_resolved')
         JCT=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .total_dependencies')
         if [ "$JP" = "healthy" ] && [ "$JC" = "healthy" ] && [ "$PO" = "healthy" ] && [ "$TX" = "healthy" ] \
-           && [ "$JCR" = "$JCT" ] && [ "$JCT" != "0" ]; then
+           && [ "$JCR" = "$JCT" ] && [ "$JCT" != "0" ] && [ "$JCT" != "null" ]; then
           echo "all 4 ready after ${i}x2s"
           exit 0
         fi

--- a/tests/integration/suites/uc23_meshjob_java/tc21_polyglot_3way_status_read/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc21_polyglot_3way_status_read/test.yaml
@@ -1,0 +1,185 @@
+# tc21_polyglot_3way_status_read — All three runtimes simultaneously.
+#
+# Java provider + Java consumer submits a job; capture job_id; then
+# BOTH a Python orchestrator AND a TS bystander call __mesh_job_status
+# with that job_id. Confirms job_id-as-capability auth model + helper
+# tool routing across all 3 runtimes simultaneously.
+#
+# Java is the LAST runtime so all 3 SDKs are alive in the same suite.
+#
+# Setup:
+#   - Java long-task-provider-java (port 9120)  — task=true tools
+#   - Java long-task-consumer-java (port 9121)  — submits the job
+#   - Python orchestrator-agent     (port 9103) — pure bystander
+#   - TS bystander-x-ts             (port 9114) — pure bystander
+
+name: "MeshJob polyglot 3-way: Python and TS read status for Java-submitted job"
+description: "All 3 runtimes wired — Java consumer submits, Python + TS BOTH read job state via __mesh_job_status"
+tags:
+  - meshjob
+  - polyglot
+  - java
+  - python
+  - typescript
+  - issue-890
+  - helpers
+timeout: 600
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_typescript_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts (Java provider + Java consumer + Python orchestrator + TS bystander)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+      cp -rL /uc-artifacts/orchestrator-agent /workspace/
+      cp -rL /uc-artifacts/bystander-x-ts /workspace/
+
+  - name: "Install Java provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install Java consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - name: "Install Python orchestrator deps"
+    handler: pip-install
+    path: /workspace/orchestrator-agent
+
+  - name: "Install TS bystander deps"
+    handler: npm-install
+    path: /workspace/bystander-x-ts
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start Java provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for Java provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Start Java consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Start Python orchestrator (port 9103)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start orchestrator-agent/main.py --env MCP_MESH_HTTP_PORT=9103 -d
+
+  - name: "Start TS bystander (port 9114)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start bystander-x-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9114 -d
+
+  - name: "Wait for all 4 healthy + Java consumer DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        AGENTS=$(curl -s http://localhost:8000/agents)
+        JP=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status')
+        JC=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .status')
+        PO=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="orchestrator-agent") | .status')
+        TX=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="bystander-x-ts") | .status')
+        JCR=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .dependencies_resolved')
+        JCT=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .total_dependencies')
+        if [ "$JP" = "healthy" ] && [ "$JC" = "healthy" ] && [ "$PO" = "healthy" ] && [ "$TX" = "healthy" ] \
+           && [ "$JCR" = "$JCT" ] && [ "$JCT" != "0" ]; then
+          echo "all 4 ready after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR — JP=$JP JC=$JC PO=$PO TX=$TX deps=$JCR/$JCT"
+      exit 1
+    timeout: 240
+
+  - name: "Verify all 4 agents registered"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s http://localhost:8000/agents | jq -r '.agents[].name' | sort
+    capture: agent_names
+
+  - name: "Submit a quick job via Java consumer"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["only"],"max_retries":1,"max_duration":30}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Wait for completion"
+    handler: wait
+    seconds: 10
+
+  - name: "Call Python orchestrator's __mesh_job_status (snake_case job_id)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="orchestrator-agent") | .id')
+      echo "JOB_ID=${JOB_ID} AGENT=${AGENT}"
+      meshctl call "${AGENT}:__mesh_job_status" "{\"job_id\":\"${JOB_ID}\"}"
+    capture: status_from_python
+
+  - name: "Call TS bystander's __mesh_job_status (camelCase jobId)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="bystander-x-ts") | .id')
+      echo "JOB_ID=${JOB_ID} AGENT=${AGENT}"
+      meshctl call "${AGENT}:__mesh_job_status" "{\"jobId\":\"${JOB_ID}\"}"
+    capture: status_from_ts
+
+assertions:
+  - expr: "${captured.agent_names} contains 'long-task-provider-java'"
+    message: "Java provider should be registered"
+  - expr: "${captured.agent_names} contains 'long-task-consumer-java'"
+    message: "Java consumer should be registered"
+  - expr: "${captured.agent_names} contains 'orchestrator-agent'"
+    message: "Python orchestrator should be registered"
+  - expr: "${captured.agent_names} contains 'bystander-x-ts'"
+    message: "TS bystander should be registered"
+
+  # Python read returns the terminal state including completed.
+  - expr: "${captured.status_from_python} contains 'completed'"
+    message: "Python orchestrator should read terminal status for the Java-submitted job"
+  - expr: "${captured.status_from_python} contains 'long-task-provider-java'"
+    message: "Python's read should expose the Java provider's owner_instance_id"
+  - expr: "${captured.status_from_python} not contains 'unauthorized'"
+    message: "Python read must NOT see 'unauthorized' (ID-as-capability auth)"
+
+  # TS read also returns terminal state — proves the helper tool
+  # routes correctly across all 3 runtimes simultaneously.
+  - expr: "${captured.status_from_ts} contains 'completed'"
+    message: "TS bystander should read terminal status for the Java-submitted job"
+  - expr: "${captured.status_from_ts} contains 'long-task-provider-java'"
+    message: "TS bystander's read should expose the Java provider's owner_instance_id"
+  - expr: "${captured.status_from_ts} not contains 'unauthorized'"
+    message: "TS read must NOT see 'unauthorized' (ID-as-capability auth)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc22_polyglot_3way_cancel_documents_889/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc22_polyglot_3way_cancel_documents_889/test.yaml
@@ -102,7 +102,7 @@ test:
         JCR=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .dependencies_resolved')
         JCT=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .total_dependencies')
         if [ "$JP" = "healthy" ] && [ "$JC" = "healthy" ] && [ "$PO" = "healthy" ] \
-           && [ "$JCR" = "$JCT" ] && [ "$JCT" != "0" ]; then
+           && [ "$JCR" = "$JCT" ] && [ "$JCT" != "0" ] && [ "$JCT" != "null" ]; then
           echo "all 3 ready after ${i}x2s"
           exit 0
         fi

--- a/tests/integration/suites/uc23_meshjob_java/tc22_polyglot_3way_cancel_documents_889/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc22_polyglot_3way_cancel_documents_889/test.yaml
@@ -1,0 +1,173 @@
+# tc22_polyglot_3way_cancel_documents_889 — Documents Java cancel-registry gap.
+#
+# Java provider + Java consumer (running long job). Mid-flight, call
+# __mesh_job_cancel from a PYTHON agent.
+#
+# Per #889 — Java cancel-registry binding inactive (sync JNR-FFI cannot
+# bind nested Tokio runtime). The cancel pipeline behaves as follows:
+#
+#   1. Python orchestrator's __mesh_job_cancel calls JobProxy.cancel
+#      (Python SDK) which POSTs /jobs/{id}/cancel to the registry
+#   2. Registry's CancelJob handler succeeds, marks the row cancelled
+#   3. Registry forwards cancel to the Java provider's
+#      POST /jobs/:job_id/cancel route
+#   4. Java cancel route returns {cancelled:false, jobId} because the
+#      local cancel-registry lookup misses (the binding never happened
+#      for this job — see #889 / MeshToolWrapper.dispatchAsJob)
+#   5. Registry already wrote status=cancelled in step 2, so the
+#      consumer's status read still observes cancelled
+#   6. The Java task body continues running until natural completion
+#      or the registry's sweep marks orphaned
+#
+# Assertion: Python helper's cancel response is ok:true (registry-side
+# success), final status=cancelled (via the registry's CancelJob
+# handler, NOT via the Java owner's cancel token). This is exactly
+# what Java supports today.
+
+name: "MeshJob polyglot 3-way cancel: Python cancels Java-owned job (documents #889)"
+description: "Cross-runtime cancel — Python helper fires registry cancel; Java cancel route returns cancelled:false (#889) but registry-side row flips cancelled regardless"
+tags:
+  - meshjob
+  - polyglot
+  - java
+  - python
+  - issue-890
+  - issue-889
+  - cancel
+timeout: 480
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts (Java provider + Java consumer + Python orchestrator)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+      cp -rL /uc-artifacts/orchestrator-agent /workspace/
+
+  - name: "Install Java provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install Java consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - name: "Install Python orchestrator deps"
+    handler: pip-install
+    path: /workspace/orchestrator-agent
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start Java provider (port 9120)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for Java provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done; exit 1
+    timeout: 150
+
+  - name: "Start Java consumer (port 9121)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Start Python orchestrator (port 9103)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start orchestrator-agent/main.py --env MCP_MESH_HTTP_PORT=9103 -d
+
+  - name: "Wait for all 3 healthy + Java consumer DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        AGENTS=$(curl -s http://localhost:8000/agents)
+        JP=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status')
+        JC=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .status')
+        PO=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="orchestrator-agent") | .status')
+        JCR=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .dependencies_resolved')
+        JCT=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .total_dependencies')
+        if [ "$JP" = "healthy" ] && [ "$JC" = "healthy" ] && [ "$PO" = "healthy" ] \
+           && [ "$JCR" = "$JCT" ] && [ "$JCT" != "0" ]; then
+          echo "all 3 ready after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR — JP=$JP JC=$JC PO=$PO deps=$JCR/$JCT"
+      exit 1
+    timeout: 240
+
+  - name: "Submit 30-second overlong job via Java consumer"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_overlong '{"user_id":"alice","seconds":30}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Wait 5s for Java provider to claim + start"
+    handler: wait
+    seconds: 5
+
+  # Python helper: __mesh_job_cancel takes snake_case job_id.
+  - name: "Cancel via the Python orchestrator agent's helper tool"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="orchestrator-agent") | .id')
+      echo "JOB_ID=${JOB_ID} AGENT=${AGENT}"
+      if [ -z "$JOB_ID" ] || [ "$JOB_ID" = "null" ] || [ -z "$AGENT" ] || [ "$AGENT" = "null" ]; then
+        echo "ERROR: required vars empty — JOB_ID='$JOB_ID' AGENT='$AGENT'"
+        exit 1
+      fi
+      meshctl call "${AGENT}:__mesh_job_cancel" "{\"job_id\":\"${JOB_ID}\",\"reason\":\"tc22 python-initiated cancel of Java job\"}"
+    capture: cancel_response
+    timeout: 15
+
+  - name: "Wait for cancel to settle in registry"
+    handler: wait
+    seconds: 8
+
+  - name: "Read final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,owner_instance_id,error,progress}'
+    capture: final_status
+
+assertions:
+  # Python helper returns {"ok": True, "job_id": ...} (snake_case
+  # spaced JSON wrapping). The registry-side cancel succeeds even
+  # though the Java owner's local cancel token doesn't fire (#889).
+  - expr: "${captured.cancel_response} contains '\"ok\": true'"
+    message: "Python helper cancel should ack with ok:true (registry-side success)"
+  # Per #889 — registry's CancelJob handler writes status=cancelled
+  # directly. The cancel forward to the Java owner returns
+  # cancelled:false but the row is already updated.
+  - expr: "${captured.final_status} contains '\"status\": \"cancelled\"'"
+    message: "registry-side status should be cancelled (Python -> registry path works; Java cancel-registry inactive per #889)"
+  # Owner is the Java provider — proves the registry forwarded the
+  # cancel to the Java replica that holds the lease.
+  - expr: "${captured.final_status} contains 'long-task-provider-java'"
+    message: "owner_instance_id should be the Java provider — confirms Python -> Java forwarding path reached"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
Closes #890. Final test layer for the MeshJob substrate (#861). Plus opportunistic cleanup of dead `<repository>` references across 55 pom.xml files.

## Summary

### uc23_meshjob_java — 22 tests

**A. Happy path — Java↔Java (5)** — submit/wait, mid-flight progress, explicit complete, implicit complete, explicit fail
**B. Cancellation — Java↔Java (4)** — alive-owner forward, orphan direct, already-terminal 409, cancel-aborts-outbound (assertions scoped to registry-side per #889)
**C. Retry & recovery — Java↔Java (4)** — `max_retries=1` succeeds, `=0` disables, exhausted, `total_deadline` overrides
**F. Helper tools & auth — Java↔Java (3)** — helpers on every agent, unknown ID, third-party reads
**G. Polyglot — 3-way (6 NEW)**:
- ` tc17` Java consumer → Python provider
- ` tc18` Java consumer → TS provider
- ` tc19` Python consumer → Java provider
- ` tc20` TS consumer → Java provider
- ` tc21` 3-way status read (Java submits, Python orchestrator + TS bystander BOTH read)
- ` tc22` 3-way cancel — documents #889 (Java cancel-registry binding gap)

6 Java fixtures (multi-cap provider/consumer + sleeper + orchestrator + 2 bystanders); polyglot tests reuse uc21 (Python) + uc22 (TS) fixtures via relative symlinks.

### Maven cleanup — 55 pom.xml files

The `src/runtime/java/local-repo/` Maven `<repository>` reference was dead code: no automated mechanism populated it; builds were succeeding solely via Maven's `~/.m2/repository` fall-through. Stripped from 43 single-repo + 12 multi-repo poms (kept ` spring-milestones` where present). Added prereq comment to each touched pom: "run ` mvn install -DskipTests` from ` src/runtime/java/` first".

After this lands, the orphaned ` src/runtime/java/local-repo/` directory in any working tree can be ` rm -rf`'d cleanly.

## Architectural decisions / known limitations

- **#889 documented inline** in tc06/tc09/tc22 — Java's sync JNR-FFI nested-runtime constraint means cancel-registry binding is inactive for Java-owned jobs. Tests assert ONLY registry-side `status=cancelled`, not mid-flight task abort. Pre-cancel `progress > 0` confirmation added so the tests can't pass without the producer actually starting (review fix W4)
- **Java process tree kill** (tc10/tc11/tc12): matches `mvn spring-boot:run` parent + `java` child via `/proc` walk. Replaced fragile static-sleep pre-kill timing with poll-until-`owner_instance_id`-non-null deterministic claim confirmation (review fix W3)
- **Spring Boot version**: pinned to 4.0.6 in fixture poms (4.0.5 has CVEs per #891 fix history)
- **Jackson 3.x in Spring Boot 4** — uses ` tools.jackson.databind.*` package path, not ` com.fasterxml.jackson.databind.*`. Affects ` invokeDownstream`'s parsing helper

## Review Notes

Independent code review found **0 BLOCKERs, 4 WARNINGs, 4 INFOs**. **All 4 WARNINGs + 1 substantive INFO addressed in commit `2e0140cb`**:

- W1: Brittle ` indexOf` + 800-char-lookback JSON parsing → Jackson ` ObjectMapper.readTree` with proper iteration
- W2: ` jq -r` of absent fields emits ` null` → equality + non-zero checks both pass spuriously. Added `[ "$TOTAL" != "null" ]` guard to DI readiness loops across **18 test.yaml files** via batch perl edit
- W3: tc10/tc11/tc12 fragile ` attempt_count: 1` substring assertion + static pre-kill wait → poll-until-claim-confirmed loop + jq ` attempt_count <= 1` shell check
- W4 + tc06: Cancel test could pass without producer ever starting (per #889 registry-side cancel always succeeds) → added pre-cancel ` progress > 0` confirmation. Producer must have actually emitted at least one update before cancel lands

3 INFOs deferred (intentional fail-loud sweep grep, wasted consumer setup matches uc21/uc22 pattern, JSON string-concat addressed incidentally by W1).

## Substrate observations referenced

All known follow-ups from this work:

- **#877** — pyo3-async-runtimes panic during Python interpreter shutdown
- **#879** — handler-raised exceptions don't trigger retry (Sidekiq/Celery convention)
- **#880** — last `update_progress` clobbered by `complete()` in terminal-flush race
- **#882** — FastMCP-Python doesn't propagate client disconnect to handlers
- **#886** — TS proxy.ts outbound-HTTP cancel propagation gap
- **#887** — TS MCP envelope omits structuredContent
- **#889** — Java cancel-registry binding inactive (sync JNR-FFI nested-runtime)

None #861-blocking; all triageable independently.

Closes #890

## Test plan

- [x] `tsuite run --suite-path tests/integration --uc uc23_meshjob_java --parallel 1` — 22/22 pass, ~210s
- [x] `tsuite run --suite-path tests/integration --uc uc23_meshjob_java --parallel 4` — 22/22 pass, ~220s (post-fix)
- [x] Maven cleanup: `mvn -o compile` (offline) on a fixture passes — proves `~/.m2` fall-through works
- [x] tc01 still passes after Maven cleanup
- [x] All 137 repo poms still parse as valid XML
- [ ] CI green
- [ ] CodeRabbit review

After this lands, only **#875 (Documentation)** remains for **#861** to fully close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build configuration files with guidance on local artifact installation for development.

* **New Features**
  * Added comprehensive MeshJob integration test suite for Java runtime, including job submission, progress tracking, completion handling, cancellation, retry policies, deadline expiration, and polyglot scenarios across multiple runtimes.
  * Introduced new test fixtures and agents supporting job orchestration, status verification, and cross-runtime communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->