### PR TITLE
fix(meshjob): flush_terminal progress_message + Python shutdown drain

### DIFF
--- a/src/runtime/core/src/jobs.rs
+++ b/src/runtime/core/src/jobs.rs
@@ -321,18 +321,21 @@ impl JobController {
         // docs for the invariant).
         //
         // BEFORE we drop the pending entry, harvest its `progress_message`
-        // (if any) and fold it into the terminal delta — `complete`/`fail`
-        // don't take a message arg, so without this the registry's
-        // `progress_message` column would still reflect whatever the last
-        // batching-tick flush wrote (e.g. "section 6/7" when the user's
-        // last update_progress was "section 7/7"). See issue #880.
+        // and `progress` (if any) and fold them into the terminal delta —
+        // `complete`/`fail` don't take a message arg, and `fail()` leaves
+        // `progress=None`, so without this the registry's `progress_message`
+        // and `progress` columns would still reflect whatever the last
+        // batching-tick flush wrote (e.g. "section 6/7" / 0.5 when the
+        // user's last update_progress was "section 7/7" / 0.99 immediately
+        // before fail()). See issue #880.
         {
             let mut q = self.queue.lock().await;
-            if delta.progress_message.is_none() {
-                if let Some(pending) = q.pending.get(&self.job_id) {
-                    if let Some(msg) = pending.progress_message.clone() {
-                        delta.progress_message = Some(msg);
-                    }
+            if let Some(pending) = q.pending.get(&self.job_id) {
+                if delta.progress_message.is_none() {
+                    delta.progress_message = pending.progress_message.clone();
+                }
+                if delta.progress.is_none() {
+                    delta.progress = pending.progress;
                 }
             }
             q.mark_terminal(&self.job_id);
@@ -1079,6 +1082,64 @@ mod tests {
         // And the mock-applied state reflects it (registry would too).
         let job = backend.get_job(&resp.id).await.unwrap();
         assert_eq!(job.progress_message.as_deref(), Some("section 7/7"));
+    }
+
+    #[tokio::test]
+    async fn fail_preserves_last_progress_from_pending() {
+        // Issue #880 (follow-up): fail() builds a terminal delta with
+        // `progress: None`, so without harvesting the pending progress
+        // value we'd lose the last numeric progress (e.g. 0.99) along
+        // with the message when the batching tick hadn't fired yet.
+        let backend = MockBackend::new();
+        let queue = new_coalescing_queue();
+        let resp = backend
+            .create_job(CreateJobRequest {
+                capability: "cap".into(),
+                submitted_payload: serde_json::json!({}),
+                submitted_by: "inst-1".into(),
+                max_retries: None,
+                max_duration: None,
+                total_deadline: None,
+                owner_instance_id: None,
+            })
+            .await
+            .unwrap();
+        let ctrl = JobController::new(
+            resp.id.clone(),
+            "inst-1".to_string(),
+            backend.clone() as Arc<dyn TaskBackend>,
+            queue.clone(),
+        );
+
+        // Last update_progress before fail is the "last word".
+        ctrl.update_progress(0.5, Some("section 6/7".into())).await;
+        ctrl.update_progress(0.99, Some("section 7/7".into())).await;
+        // No batching tick runs in this test — pending still has 7/7 / 0.99.
+        ctrl.fail("backend exploded").await.unwrap();
+
+        // Backend received exactly one batch (the terminal one), and the
+        // terminal delta carries BOTH the last progress_message and the
+        // last numeric progress.
+        assert_eq!(backend.batch_count(), 1);
+        let (_, deltas) = backend.last_batch().unwrap();
+        assert_eq!(deltas.len(), 1);
+        assert!(deltas[0].is_terminal());
+        assert_eq!(deltas[0].status, Some(JobStatus::Failed));
+        assert_eq!(
+            deltas[0].progress_message.as_deref(),
+            Some("section 7/7"),
+            "terminal fail() delta must carry the last update_progress message",
+        );
+        assert_eq!(
+            deltas[0].progress,
+            Some(0.99),
+            "terminal fail() delta must carry the last update_progress numeric value",
+        );
+
+        // Mock-applied state reflects it (registry would too).
+        let job = backend.get_job(&resp.id).await.unwrap();
+        assert_eq!(job.progress_message.as_deref(), Some("section 7/7"));
+        assert_eq!(job.progress, Some(0.99));
     }
 
     #[tokio::test]

--- a/src/runtime/core/src/jobs.rs
+++ b/src/runtime/core/src/jobs.rs
@@ -309,7 +309,7 @@ impl JobController {
         self.flush_terminal(delta).await
     }
 
-    async fn flush_terminal(&self, delta: JobDelta) -> Result<(), JobError> {
+    async fn flush_terminal(&self, mut delta: JobDelta) -> Result<(), JobError> {
         // Mark the job terminal in the queue BEFORE dropping the lock —
         // this both removes any pending non-terminal delta (the terminal
         // supersedes it) and slams the door on any racing
@@ -319,8 +319,22 @@ impl JobController {
         // next batching-tick flush would push stale progress AFTER a
         // terminal status was already on the wire (see CoalescingQueue
         // docs for the invariant).
+        //
+        // BEFORE we drop the pending entry, harvest its `progress_message`
+        // (if any) and fold it into the terminal delta — `complete`/`fail`
+        // don't take a message arg, so without this the registry's
+        // `progress_message` column would still reflect whatever the last
+        // batching-tick flush wrote (e.g. "section 6/7" when the user's
+        // last update_progress was "section 7/7"). See issue #880.
         {
             let mut q = self.queue.lock().await;
+            if delta.progress_message.is_none() {
+                if let Some(pending) = q.pending.get(&self.job_id) {
+                    if let Some(msg) = pending.progress_message.clone() {
+                        delta.progress_message = Some(msg);
+                    }
+                }
+            }
             q.mark_terminal(&self.job_id);
         }
         self.backend
@@ -1014,6 +1028,57 @@ mod tests {
         let job = backend.get_job(&resp.id).await.unwrap();
         assert_eq!(job.status, JobStatus::Completed);
         assert_eq!(job.result, Some(serde_json::json!({"ans": 42})));
+    }
+
+    #[tokio::test]
+    async fn complete_preserves_last_progress_message_from_pending() {
+        // Issue #880: complete() must fold the pending progress_message
+        // into the terminal delta so the registry's progress_message
+        // column reflects the LAST update_progress call, not the one
+        // that happened to flush via the batching tick most recently.
+        let backend = MockBackend::new();
+        let queue = new_coalescing_queue();
+        let resp = backend
+            .create_job(CreateJobRequest {
+                capability: "cap".into(),
+                submitted_payload: serde_json::json!({}),
+                submitted_by: "inst-1".into(),
+                max_retries: None,
+                max_duration: None,
+                total_deadline: None,
+                owner_instance_id: None,
+            })
+            .await
+            .unwrap();
+        let ctrl = JobController::new(
+            resp.id.clone(),
+            "inst-1".to_string(),
+            backend.clone() as Arc<dyn TaskBackend>,
+            queue.clone(),
+        );
+
+        // Two progress updates, the second is the "last word".
+        ctrl.update_progress(0.5, Some("section 6/7".into())).await;
+        ctrl.update_progress(1.0, Some("section 7/7".into())).await;
+        // No batching tick runs in this test — pending still has 7/7.
+        ctrl.complete(serde_json::json!({"ans": 42})).await.unwrap();
+
+        // Backend received exactly one batch (the terminal one), and
+        // the terminal delta carries progress_message="section 7/7".
+        assert_eq!(backend.batch_count(), 1);
+        let (_, deltas) = backend.last_batch().unwrap();
+        assert_eq!(deltas.len(), 1);
+        assert!(deltas[0].is_terminal());
+        assert_eq!(deltas[0].status, Some(JobStatus::Completed));
+        assert_eq!(
+            deltas[0].progress_message.as_deref(),
+            Some("section 7/7"),
+            "terminal delta must carry the last update_progress message",
+        );
+
+        // And the mock-applied state reflects it (registry would too).
+        let job = backend.get_job(&resp.id).await.unwrap();
+        assert_eq!(job.progress_message.as_deref(), Some("section 7/7"));
     }
 
     #[tokio::test]

--- a/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/rust_api_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/rust_api_heartbeat.py
@@ -423,6 +423,17 @@ async def rust_api_heartbeat_task(heartbeat_config: dict[str, Any]) -> None:
         handle = core.start_agent(spec)
         logger.info(f"Rust core started for API service '{service_id}'")
 
+        # Track this handle in the process-wide registry so atexit can
+        # drain it before Py_Finalize. Closes the pyo3-async-runtimes
+        # Python::attach race during abnormal exits (uvicorn bind fail,
+        # unhandled startup exception). See issue #877.
+        try:
+            from ...shared.simple_shutdown import register_rust_agent_handle
+
+            register_rust_agent_handle(handle)
+        except Exception as e:  # pragma: no cover - never block startup
+            logger.debug(f"Could not register handle for atexit drain: {e}")
+
         # Event loop - process events from Rust core
         while True:
             # Check for Python shutdown signal
@@ -485,3 +496,14 @@ async def rust_api_heartbeat_task(heartbeat_config: dict[str, Any]) -> None:
                 )
             except Exception as e:
                 logger.warning(f"Error during Rust core shutdown for API service: {e}")
+            finally:
+                # Drained on the normal path — drop from atexit registry so
+                # the hook doesn't double-shutdown. Best-effort.
+                try:
+                    from ...shared.simple_shutdown import (
+                        unregister_rust_agent_handle,
+                    )
+
+                    unregister_rust_agent_handle(handle)
+                except Exception:
+                    pass

--- a/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/rust_api_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/rust_api_heartbeat.py
@@ -494,11 +494,11 @@ async def rust_api_heartbeat_task(heartbeat_config: dict[str, Any]) -> None:
                 logger.debug(
                     f"Rust core shutdown complete for API service '{service_id}'"
                 )
-            except Exception as e:
-                logger.warning(f"Error during Rust core shutdown for API service: {e}")
-            finally:
-                # Drained on the normal path — drop from atexit registry so
-                # the hook doesn't double-shutdown. Best-effort.
+                # Only drop from atexit registry on the success path. If
+                # shutdown() raised, leave the handle registered so the
+                # atexit hook can retry — `AgentHandle.shutdown` is
+                # idempotent (sets a flag + try_send on a channel), so a
+                # second call from atexit is safe. Best-effort.
                 try:
                     from ...shared.simple_shutdown import (
                         unregister_rust_agent_handle,
@@ -507,3 +507,5 @@ async def rust_api_heartbeat_task(heartbeat_config: dict[str, Any]) -> None:
                     unregister_rust_agent_handle(handle)
                 except Exception:
                     pass
+            except Exception as e:
+                logger.warning(f"Error during Rust core shutdown for API service: {e}")

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
@@ -1074,11 +1074,11 @@ async def rust_heartbeat_task(heartbeat_config: dict[str, Any]) -> None:
 
                     time.sleep(0.2)
                 logger.debug(f"Rust core shutdown complete for agent '{agent_id}'")
-            except Exception as e:
-                logger.warning(f"Error during Rust core shutdown: {e}")
-            finally:
-                # Drained on the normal path — drop from atexit registry so
-                # the hook doesn't double-shutdown. Best-effort.
+                # Only drop from atexit registry on the success path. If
+                # shutdown() raised, leave the handle registered so the
+                # atexit hook can retry — `AgentHandle.shutdown` is
+                # idempotent (sets a flag + try_send on a channel), so a
+                # second call from atexit is safe. Best-effort.
                 try:
                     from ...shared.simple_shutdown import (
                         unregister_rust_agent_handle,
@@ -1087,3 +1087,5 @@ async def rust_heartbeat_task(heartbeat_config: dict[str, Any]) -> None:
                     unregister_rust_agent_handle(handle)
                 except Exception:
                     pass
+            except Exception as e:
+                logger.warning(f"Error during Rust core shutdown: {e}")

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
@@ -991,6 +991,17 @@ async def rust_heartbeat_task(heartbeat_config: dict[str, Any]) -> None:
         handle = core.start_agent(spec)
         logger.info(f"Rust core started for agent '{agent_id}'")
 
+        # Track this handle in the process-wide registry so atexit can
+        # drain it before Py_Finalize. Closes the pyo3-async-runtimes
+        # Python::attach race during abnormal exits (uvicorn bind fail,
+        # unhandled startup exception). See issue #877.
+        try:
+            from ...shared.simple_shutdown import register_rust_agent_handle
+
+            register_rust_agent_handle(handle)
+        except Exception as e:  # pragma: no cover - never block startup
+            logger.debug(f"Could not register handle for atexit drain: {e}")
+
         # Phase 1 MeshJob substrate: start claim dispatchers on this
         # heartbeat loop (long-lived), not the transient pipeline loop
         # or the racy uvicorn-lifespan loop. See helper docstring for
@@ -1065,3 +1076,14 @@ async def rust_heartbeat_task(heartbeat_config: dict[str, Any]) -> None:
                 logger.debug(f"Rust core shutdown complete for agent '{agent_id}'")
             except Exception as e:
                 logger.warning(f"Error during Rust core shutdown: {e}")
+            finally:
+                # Drained on the normal path — drop from atexit registry so
+                # the hook doesn't double-shutdown. Best-effort.
+                try:
+                    from ...shared.simple_shutdown import (
+                        unregister_rust_agent_handle,
+                    )
+
+                    unregister_rust_agent_handle(handle)
+                except Exception:
+                    pass

--- a/src/runtime/python/_mcp_mesh/shared/simple_shutdown.py
+++ b/src/runtime/python/_mcp_mesh/shared/simple_shutdown.py
@@ -5,12 +5,133 @@ Provides clean shutdown via FastAPI lifespan events and basic signal handling.
 The Rust core handles actual deregistration from the registry.
 """
 
+import atexit
 import logging
 import signal
+import threading
+import time
 from contextlib import asynccontextmanager
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
+
+# =============================================================================
+# Active Rust agent-handle registry (issue #877)
+# =============================================================================
+#
+# The Rust core spawns a tokio runtime in a background thread. After futures
+# resolve, pyo3-async-runtimes does `spawn_blocking(|| Python::attach(...))`
+# to write the result back. If Python's interpreter has begun finalizing
+# (e.g. uvicorn failed to bind, sys.exit, unhandled exception in startup) and
+# a tokio worker happens to wake up at that moment, it tries to attach to a
+# torn-down interpreter and panics with "interpreter is not initialized".
+#
+# The cure: drain the Rust dispatcher BEFORE Python finalizes. We register
+# every live AgentHandle in this process-wide list and an atexit hook calls
+# `handle.shutdown()` on each. atexit fires before Py_Finalize tears down the
+# interpreter, so the Rust thread sees the shutdown signal and exits before
+# anyone tries to Python::attach against a dying interpreter.
+#
+# Best-effort: if shutdown raises (handle already shut down, channel closed,
+# whatever) we swallow it — we're inside atexit, the process is going away,
+# nothing useful can be done with the error.
+_active_handles_lock = threading.Lock()
+_active_handles: list = []
+_atexit_installed = False
+
+# Per-handle bound for the atexit drain. If a handle is wedged (Rust dispatcher
+# stuck, backend slow), we don't want it to block process exit. Shutdowns are
+# run concurrently in daemon threads so the total wait stays bounded by this
+# value rather than N * timeout when many handles are registered.
+_PER_HANDLE_SHUTDOWN_TIMEOUT_SECS = 2.0
+
+
+def _safe_shutdown(h: Any) -> None:
+    """Best-effort shutdown for a single handle — swallow errors at exit."""
+    try:
+        h.shutdown()
+    except Exception:
+        # Best-effort during interpreter shutdown — the channel may be
+        # closed, the runtime already gone, etc. Nothing we can do.
+        pass
+
+
+def register_rust_agent_handle(handle: Any) -> None:
+    """Track a Rust core AgentHandle so atexit can drain it before Py_Finalize.
+
+    Called by the heartbeat lifespan tasks immediately after `start_agent()`
+    returns. Idempotent on repeat: a handle registered twice is only kept
+    once. See module docstring for the race this closes.
+    """
+    global _atexit_installed
+    if handle is None:
+        return
+    with _active_handles_lock:
+        # Identity check (handle is a PyO3 object — list doesn't need __eq__).
+        if not any(h is handle for h in _active_handles):
+            _active_handles.append(handle)
+        if not _atexit_installed:
+            atexit.register(_atexit_shutdown_active_handles)
+            _atexit_installed = True
+            logger.debug("Registered atexit hook to drain Rust agent handles")
+
+
+def unregister_rust_agent_handle(handle: Any) -> None:
+    """Drop a handle from the registry (e.g. normal shutdown already drained it).
+
+    Best-effort: if the handle isn't in the list (already removed, never
+    registered), we silently no-op.
+    """
+    if handle is None:
+        return
+    with _active_handles_lock:
+        # Identity-based filter so we don't depend on __eq__ semantics of the
+        # PyO3 wrapper.
+        _active_handles[:] = [h for h in _active_handles if h is not handle]
+
+
+def _atexit_shutdown_active_handles() -> None:
+    """atexit hook: drain every still-live Rust handle before Py_Finalize.
+
+    Runs at interpreter shutdown — under abnormal exits (uvicorn bind fail,
+    unhandled startup error) the normal shutdown path in the heartbeat task
+    never gets a chance to fire, leaving the Rust tokio runtime live. That
+    runtime can then race with interpreter finalization and panic in the
+    pyo3-async-runtimes Python::attach codepath. Calling shutdown() here
+    signals the Rust core to drain its dispatcher and join its background
+    thread before the interpreter goes away.
+    """
+    with _active_handles_lock:
+        handles = list(_active_handles)
+        _active_handles.clear()
+    if not handles:
+        return
+    # Run each handle's shutdown in its own daemon thread with a bounded join.
+    # Concurrent dispatch keeps the total wall-clock bound at
+    # _PER_HANDLE_SHUTDOWN_TIMEOUT_SECS even when several handles are live.
+    # daemon=True ensures a genuinely-stuck shutdown thread can't block
+    # interpreter teardown — Python tears daemons down on exit.
+    threads = [
+        threading.Thread(
+            target=_safe_shutdown,
+            args=(h,),
+            daemon=True,
+            name=f"mesh-atexit-shutdown-{id(h)}",
+        )
+        for h in handles
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=_PER_HANDLE_SHUTDOWN_TIMEOUT_SECS)
+    # Brief grace window so the Rust dispatcher thread sees the signal and
+    # tears down its tokio runtime before atexit returns and Py_Finalize
+    # starts. Matches the 200ms used in the normal-path teardown in
+    # rust_heartbeat.py / rust_api_heartbeat.py.
+    try:
+        time.sleep(0.2)
+    except Exception:
+        pass
 
 
 class SimpleShutdownCoordinator:


### PR DESCRIPTION
Two surgical substrate fixes from the MeshJob follow-up backlog. Single-commit bundle.

## Summary

### #880 — `flush_terminal` preserves last `progress_message`

**Symptom**: producer's last `update_progress(1.0, "section 7/7")` was clobbered when `complete(result)` flushed the terminal delta — final registry state showed the previously-flushed value (e.g., `"section 6/7"`) instead.

**Root cause**: `JobController::flush_terminal` posted the terminal delta with `status=completed, progress=1.0, result=...` but no `progress_message`. The pending delta in the queue was dropped before its message could be flushed.

**Fix** (` src/runtime/core/src/jobs.rs`): inside the same lock that calls ` mark_terminal`, peek the pending entry for ` self.job_id` and harvest its ` progress_message` if the terminal delta doesn't already have one. Single-lock atomic — no extra round trips, no race with concurrent ` update_progress` (which acquires the same lock).

**Backward-compat**: `if delta.progress_message.is_none()` guard means an explicit message on a future ` complete()`/` fail()` API would still win; harvest is fallback only.

**Test added**: ` complete_preserves_last_progress_message_from_pending` — sequences two ` update_progress` calls + ` complete()` without batching tick spinning, asserts terminal delta carries the LAST message.

### #877 — Python atexit drain of Rust handle before Py_Finalize

**Symptom**: when Python interpreter starts shutting down (uvicorn fails to bind, ` sys.exit`, etc.) while the Rust core's tokio runtime still has tasks in flight, a ` tokio-rt-worker` thread tries ` Python::attach` via ` pyo3_async_runtimes` and panics with "interpreter is not initialized".

**Root cause**: latent race in ` pyo3-async-runtimes 0.27.0::generic.rs:641-657`. After a future returned by ` future_into_py` resolves, it does ` spawn_blocking(|| Python::attach(...))`. If ` Py_IsInitialized() == 0` (interpreter finalizing), assertion panics.

**Fix** (Python-side; cleaner than the Rust ` OnceLock<AgentHandle>` sketch in the issue body — fewer moving parts, reuses existing PyO3-exposed ` AgentHandle.shutdown`):

- New ` simple_shutdown.py` module: identity-based registry of live ` AgentHandle` instances + atexit hook
- Atexit hook runs each handle's ` .shutdown()` in a **daemon thread with bounded ` join(timeout=2.0s)`** — concurrent fan-out so total wall-clock is ` O(timeout)` not ` O(N * timeout)`. Daemon threads ensure a wedged shutdown can't block interpreter teardown
- ` rust_heartbeat.py` + ` rust_api_heartbeat.py`: register handle right after ` core.start_agent(spec)`; unregister in normal-path ` finally` so atexit doesn't double-shutdown

## Review Notes

Independent code review found 0 BLOCKERs, 1 WARNING (forward-looking sequential shutdown), 2 INFOs. **WARNING addressed in this PR** by switching to concurrent daemon threads with bounded ` join(timeout=...)`.

## Validation

- Rust: 378 tests pass (1 new — ` complete_preserves_last_progress_message_from_pending`)
- Python: 814 tests pass after wheel rebuild + reinstall
- **Smoke test for #880**: 7-section ` commission_report` end-to-end. Post-completion ` __mesh_job_status` shows ` progress_message: "finished section 7/7"` (was ` "6/7"` pre-fix).
- **#877 manual repro**: documented in issue; subprocess + interpreter-finalize harness too heavy for automated coverage

Closes #880
Closes #877

## Test plan

- [x] ` cargo test --features python --lib` — 378 pass (+1 new)
- [x] ` pytest tests/` — 814 pass
- [x] e2e smoke for #880 — last progress_message preserved post-completion
- [x] Manual repro for #877 documented in issue
- [ ] CI green
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Job completion now preserves the most recent progress message and progress state even if batching hasn’t flushed.

* **Reliability Improvements**
  * Background Rust agent handles are now registered/unregistered with a process-wide shutdown drain to avoid double-shutdown and reduce risk of hangs during abnormal exits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->