### PR TITLE
feat(meshjob): TS bundle — retry_on, outbound cancel, structuredContent

### DIFF
--- a/src/runtime/core/src/cancel_registry.rs
+++ b/src/runtime/core/src/cancel_registry.rs
@@ -15,7 +15,7 @@
 //! register/run/unregister dance in a panic-safe manner.
 //!
 //! # Concurrency model
-//! Backed by a `std::sync::Mutex<HashMap<String, CancellationToken>>` held
+//! Backed by a `std::sync::Mutex<HashMap<String, JobCancelState>>` held
 //! behind a `OnceLock` (matches `tracing_publish.rs`, `tls.rs`, etc.).
 //! Critical sections are short — clone-and-drop — so contention is not a
 //! concern at the scale of in-flight jobs per process.
@@ -25,10 +25,20 @@ use std::sync::{Mutex, OnceLock};
 
 use tokio_util::sync::CancellationToken;
 
-/// Process-wide map of active job ID → cancel token.
-static REGISTRY: OnceLock<Mutex<HashMap<String, CancellationToken>>> = OnceLock::new();
+/// Per-job state held by the cancel registry. The two tokens are
+/// distinct: `cancel` is fired by user-initiated cancel (the existing
+/// behaviour); `ended` is fired by the registry itself when
+/// `unregister_active_job` runs, so awaiters that need to clean up
+/// when the job finishes naturally (without cancel) can do so.
+pub struct JobCancelState {
+    pub cancel: CancellationToken,
+    pub ended: CancellationToken,
+}
 
-fn registry() -> &'static Mutex<HashMap<String, CancellationToken>> {
+/// Process-wide map of active job ID → per-job cancel state.
+static REGISTRY: OnceLock<Mutex<HashMap<String, JobCancelState>>> = OnceLock::new();
+
+fn registry() -> &'static Mutex<HashMap<String, JobCancelState>> {
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
@@ -37,10 +47,17 @@ fn registry() -> &'static Mutex<HashMap<String, CancellationToken>> {
 /// If a prior entry exists (e.g. previous attempt was never unregistered),
 /// it is silently overwritten — the latest registration wins. The old
 /// token is dropped, which does NOT fire it (cancellation requires an
-/// explicit `.cancel()` call).
+/// explicit `.cancel()` call). The companion `ended` token is freshly
+/// constructed inside the registry for each registration; it fires only
+/// on `unregister_active_job` so awaiters can wake up when a job ends
+/// naturally (without explicit cancel).
 pub fn register_active_job(job_id: &str, token: CancellationToken) {
+    let state = JobCancelState {
+        cancel: token,
+        ended: CancellationToken::new(),
+    };
     let mut map = registry().lock().expect("cancel_registry mutex poisoned");
-    map.insert(job_id.to_string(), token);
+    map.insert(job_id.to_string(), state);
 }
 
 /// Fire the cancel token for the given job ID, if one is registered.
@@ -50,10 +67,13 @@ pub fn register_active_job(job_id: &str, token: CancellationToken) {
 /// an already-cancelled token are no-ops on the token side, but only the
 /// first call returns `true` (subsequent calls still return `true` while
 /// the entry exists; once unregistered, returns `false`).
+///
+/// This does NOT fire the `ended` token — `ended` is reserved for
+/// natural lifecycle teardown via [`unregister_active_job`].
 pub fn cancel_active_job(job_id: &str) -> bool {
     let token = {
         let map = registry().lock().expect("cancel_registry mutex poisoned");
-        map.get(job_id).cloned()
+        map.get(job_id).map(|s| s.cancel.clone())
     };
     match token {
         Some(t) => {
@@ -65,12 +85,22 @@ pub fn cancel_active_job(job_id: &str) -> bool {
 }
 
 /// Remove the registry entry for the given job ID. Safe to call even if
-/// no entry exists. The associated token is NOT cancelled by this call —
-/// callers that want both behaviors should call [`cancel_active_job`]
-/// first.
+/// no entry exists. The associated `cancel` token is NOT cancelled by
+/// this call — callers that want both behaviors should call
+/// [`cancel_active_job`] first. The `ended` token IS fired before the
+/// entry is removed, so awaiters tracking natural job termination wake
+/// up promptly (used by the napi `await_job_cancel` path so per-call
+/// listeners don't leak when a job finishes without explicit cancel).
 pub fn unregister_active_job(job_id: &str) {
-    let mut map = registry().lock().expect("cancel_registry mutex poisoned");
-    map.remove(job_id);
+    let ended = {
+        let mut map = registry().lock().expect("cancel_registry mutex poisoned");
+        let ended = map.get(job_id).map(|s| s.ended.clone());
+        map.remove(job_id);
+        ended
+    };
+    if let Some(t) = ended {
+        t.cancel();
+    }
 }
 
 /// Number of active job entries currently registered. For diagnostics
@@ -78,6 +108,21 @@ pub fn unregister_active_job(job_id: &str) {
 /// hold the lock across other work.
 pub fn active_job_count() -> usize {
     registry().lock().expect("cancel_registry mutex poisoned").len()
+}
+
+/// Snapshot both per-job tokens (cancel, ended) without firing either.
+/// Used by the napi `await_job_cancel` accessor so callers in non-Rust
+/// runtimes can race their outbound work against EITHER the in-flight
+/// job's cancel signal OR its natural-termination signal — without this,
+/// an `awaitJobCancel(...)` future on a job that finishes normally would
+/// hang forever (its sole resolve path would be explicit cancel) and
+/// leak one Rust task + one JS Promise per outbound call. Returns `None`
+/// if the job is not currently registered (already terminal / never
+/// claimed) — callers should treat `None` as "no cancellation possible
+/// from here" and resolve immediately.
+pub fn get_state(job_id: &str) -> Option<(CancellationToken, CancellationToken)> {
+    let map = registry().lock().expect("cancel_registry mutex poisoned");
+    map.get(job_id).map(|s| (s.cancel.clone(), s.ended.clone()))
 }
 
 #[cfg(test)]
@@ -140,6 +185,70 @@ mod tests {
         assert!(fired);
         assert!(second.is_cancelled());
         assert!(!first.is_cancelled(), "first token should NOT be fired");
+
+        unregister_active_job(&id);
+    }
+
+    #[test]
+    fn get_state_returns_clones_for_registered_job() {
+        let id = unique_id("get-state");
+        let token = CancellationToken::new();
+        register_active_job(&id, token.clone());
+
+        let (cancel, ended) = get_state(&id).expect("state should be present");
+        // Cancel snapshot is a clone of the token the caller registered —
+        // firing it fires the original (and vice versa) since
+        // `CancellationToken::clone` shares the same underlying state.
+        assert!(!cancel.is_cancelled());
+        assert!(!ended.is_cancelled());
+        cancel.cancel();
+        assert!(token.is_cancelled(), "original token should also fire");
+        assert!(!ended.is_cancelled(), "ended must remain un-fired");
+
+        unregister_active_job(&id);
+    }
+
+    #[test]
+    fn get_state_returns_none_for_unregistered_job() {
+        let id = unique_id("get-state-missing");
+        assert!(get_state(&id).is_none());
+    }
+
+    #[test]
+    fn get_state_after_unregister_returns_none() {
+        let id = unique_id("get-state-ephemeral");
+        register_active_job(&id, CancellationToken::new());
+        assert!(get_state(&id).is_some());
+        unregister_active_job(&id);
+        assert!(get_state(&id).is_none());
+    }
+
+    #[test]
+    fn get_ended_token_fires_on_unregister() {
+        let id = unique_id("ended-on-unregister");
+        register_active_job(&id, CancellationToken::new());
+        let (_cancel, ended) = get_state(&id).expect("state should be present");
+        assert!(!ended.is_cancelled());
+        unregister_active_job(&id);
+        assert!(
+            ended.is_cancelled(),
+            "ended token must fire when job is unregistered (natural end)"
+        );
+    }
+
+    #[test]
+    fn get_cancel_token_isolated_from_ended() {
+        let id = unique_id("cancel-isolated-from-ended");
+        register_active_job(&id, CancellationToken::new());
+        let (cancel, ended) = get_state(&id).expect("state should be present");
+
+        // Firing cancel must NOT fire ended — they are distinct tokens.
+        cancel.cancel();
+        assert!(cancel.is_cancelled());
+        assert!(
+            !ended.is_cancelled(),
+            "ended must remain un-fired when only cancel is fired"
+        );
 
         unregister_active_job(&id);
     }

--- a/src/runtime/core/src/jobs_napi.rs
+++ b/src/runtime/core/src/jobs_napi.rs
@@ -219,6 +219,27 @@ impl JsJobController {
     pub async fn is_terminal(&self) -> bool {
         self.inner.is_terminal().await
     }
+
+    /// Voluntarily release the lease so a peer replica can re-claim and
+    /// retry. Used by the TS dispatch wrapper when a handler raises a
+    /// retryOn-matched exception (issue #894): instead of marking the row
+    /// terminal=failed, the SDK calls `releaseLease` so the registry resets
+    /// `owner_instance_id` and a peer replica picks up the row within ~5s
+    /// via the HEAD-heartbeat path. Note: release does NOT increment
+    /// `attempt_count` — the claim that picked the row up already counted
+    /// this attempt; the next claim will count the next attempt.
+    ///
+    /// Marks terminal locally before the backend call to fence racing
+    /// progress updates from the now-defunct attempt (mirror of
+    /// `JobController::release_lease` in Rust core).
+    #[napi]
+    pub async fn release_lease(&self, reason: Option<String>) -> Result<()> {
+        self.inner
+            .release_lease(reason)
+            .await
+            .map_err(job_error_to_napi)?;
+        Ok(())
+    }
 }
 
 // =============================================================================
@@ -408,6 +429,47 @@ pub fn inject_job_headers_napi() -> Option<JsJobHeaders> {
 #[napi(js_name = "cancelActiveJob")]
 pub fn cancel_active_job_napi(job_id: String) -> bool {
     cancel_registry::cancel_active_job(&job_id)
+}
+
+// =============================================================================
+// await_job_cancel
+// =============================================================================
+
+/// Await the cancel token registered for `jobId` in the process-wide
+/// cancel registry. Resolves when the token fires (i.e.
+/// [`cancel_active_job_napi`] was called for this `jobId`), or
+/// immediately if no token is currently registered (already terminal /
+/// never claimed) — callers don't hang on stale jobs.
+///
+/// Used by the TS proxy to wire outbound `AbortController`s to the
+/// active job's cancel token: when the registry's
+/// `POST /jobs/{job_id}/cancel` route fires the token, the proxy aborts
+/// in-flight outbound `fetch()` requests so cancel propagates to
+/// downstream calls instead of stalling on socket reads. Without this,
+/// the producer-side cancel only flips `JobController.is_terminal()`
+/// after the outer await returns — outbound HTTP work the handler
+/// kicked off keeps running in the background.
+///
+/// napi-rs maps `pub async fn -> ()` to `Promise<void>` on the JS side.
+///
+/// Resolves on EITHER explicit cancel OR the registry's natural-end
+/// signal. Without the latter, futures awaiting a job that finishes
+/// without an explicit cancel would hang forever (the snapshot Arc
+/// keeps the cancel token alive past `unregister_active_job`), leaking
+/// one Rust task + one JS Promise per outbound call. With the `ended`
+/// signal, awaiters wake when the registry tears down the entry.
+#[napi(js_name = "awaitJobCancel")]
+pub async fn await_job_cancel_napi(job_id: String) {
+    // Snapshot both tokens under the registry lock once. If the job is
+    // not registered (already terminal / never claimed), resolve
+    // immediately so callers don't hang on stale jobs.
+    let Some((cancel, ended)) = cancel_registry::get_state(&job_id) else {
+        return;
+    };
+    tokio::select! {
+        _ = cancel.cancelled() => {},
+        _ = ended.cancelled() => {},
+    }
 }
 
 // =============================================================================

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -181,8 +181,18 @@ export class MeshAgent {
    * the local handler without re-traversing the tools map. Populated
    * by addTool() at registration time; consumed by _autoStart() to
    * spawn one dispatcher per task tool.
+   *
+   * Issue #894: also carries the per-tool retryOn whitelist so the
+   * dispatcher can pass it into `runWithJobContext` for the
+   * release-lease-on-retry-eligible-throw path.
    */
-  private _taskHandlers: Map<string, ClaimHandler> = new Map();
+  private _taskHandlers: Map<
+    string,
+    {
+      handler: ClaimHandler;
+      retryOn?: ReadonlyArray<new (...args: unknown[]) => Error>;
+    }
+  > = new Map();
   /**
    * Active claim dispatchers (one per task=true capability). Started
    * during _autoStart(); stopped during shutdown(). Empty for agents
@@ -323,6 +333,53 @@ export class MeshAgent {
       }
     }
 
+    // Issue #894: validate retryOn at registration so misuse fails loud
+    // before the agent talks to the registry. Mirror Python's
+    // `mesh.decorators` validation in spirit:
+    //   - retryOn requires task: true (without the job dispatch wrapper
+    //     there's no controller to release a lease on, so the kwarg is
+    //     meaningless);
+    //   - entries must be Error constructor classes (typeof === "function").
+    // We don't filter control-flow exceptions like Python's
+    // KeyboardInterrupt / asyncio.CancelledError — JavaScript has no
+    // direct equivalent, and AbortError-style cancellation is a legitimate
+    // retry trigger for some users. They get to choose.
+    if (def.retryOn !== undefined) {
+      if (def.task !== true) {
+        throw new Error(
+          `addTool({ retryOn }) for tool '${toolName}': retryOn is only ` +
+            `valid with task: true; remove retryOn or set task: true.`,
+        );
+      }
+      if (!Array.isArray(def.retryOn)) {
+        throw new Error(
+          `addTool({ retryOn }) for tool '${toolName}': retryOn must be ` +
+            `an array of Error constructor classes (e.g., [TypeError, MyError]).`,
+        );
+      }
+      for (const entry of def.retryOn) {
+        // Must be a function that has a prototype (i.e. an actual class
+        // or a `function` declaration — not an arrow function), AND must
+        // either be Error itself or a subclass. Arrow functions have
+        // `prototype === undefined`, so `entry.prototype instanceof Error`
+        // is `false` for them — they're rejected by the second check.
+        // Without this, `err instanceof <arrow>` at dispatch time would
+        // throw `TypeError: Right-hand side of instanceof is not callable`.
+        if (typeof entry !== "function") {
+          throw new Error(
+            `addTool({ retryOn }) for tool '${toolName}': retryOn entries ` +
+              `must be Error constructor classes (functions); got: ${String(entry)}`,
+          );
+        }
+        if (entry !== Error && !(entry.prototype instanceof Error)) {
+          throw new Error(
+            `addTool({ retryOn }) for tool '${toolName}': retryOn entries ` +
+              `must extend Error (or be Error itself); got: ${String(entry)}`,
+          );
+        }
+      }
+    }
+
     // Worker mode: register the raw execute fn in the worker tool map and
     // skip FastMCP registration, dependency wiring, and metadata storage.
     // The worker entry will look up tools by name when handling dispatched
@@ -346,6 +403,11 @@ export class MeshAgent {
     const isTaskTool = def.task === true;
     const meshJobDepIndex = def.meshJobDepIndex;
     const meshJobParamIndex = def.meshJobParamIndex;
+    // Issue #894: per-tool retryOn whitelist threaded into both
+    // dispatch paths (inbound HTTP wrapper below + ClaimHandler
+    // registered in this.taskHandlers). Captured here so the closure
+    // sees a stable reference even if def is mutated post-registration.
+    const retryOn = def.retryOn;
 
     // Phase 1 MeshJob substrate: when a job-bound tool exists AND the
     // user explicitly opted into worker isolation via env, log a single
@@ -370,7 +432,15 @@ export class MeshAgent {
     }
 
     // Create wrapper that injects dependencies positionally and handles tracing
-    const wrappedExecute = async (args: z.infer<T>): Promise<string> => {
+    const wrappedExecute = async (
+      args: z.infer<T>,
+    ): Promise<
+      | string
+      | {
+          content: Array<{ type: "text"; text: string }>;
+          structuredContent?: unknown;
+        }
+    > => {
       // Build positional deps array using composite keys (toolName:dep_index)
       // Phase 1 MeshJob substrate (consumer-side): if meshJobDepIndex is
       // set, swap the McpMeshTool proxy at that slot for a
@@ -547,10 +617,15 @@ export class MeshAgent {
                   controller,
                   meshJobParamIndex,
                 );
-                return await runWithJobContext(jobId, deadlineSecs, controller, () =>
-                  Promise.resolve(
-                    (execute as (...a: unknown[]) => unknown)(...callArgs),
-                  ),
+                return await runWithJobContext(
+                  jobId,
+                  deadlineSecs,
+                  controller,
+                  () =>
+                    Promise.resolve(
+                      (execute as (...a: unknown[]) => unknown)(...callArgs),
+                    ),
+                  retryOn,
                 );
               }
               return await execute(cleanArgs, ...(depsArray as (McpMeshTool | null)[]));
@@ -566,7 +641,13 @@ export class MeshAgent {
         } else if (result === undefined || result === null) {
           return "";
         } else {
-          return JSON.stringify(result);
+          // Emit MCP envelope with both content[0].text (JSON string) and
+          // structuredContent (parsed object) for parity with Python FastMCP.
+          const text = JSON.stringify(result);
+          return {
+            content: [{ type: "text", text }],
+            structuredContent: result,
+          };
         }
       } catch (err) {
         success = false;
@@ -625,7 +706,7 @@ export class MeshAgent {
     // needed) and bypasses FastMCP's tool-call serialisation.
     if (isTaskTool) {
       const capability = def.capability ?? toolName;
-      this._taskHandlers.set(capability, async (payload, controller) => {
+      const handler: ClaimHandler = async (payload, controller) => {
         const liveDeps: (McpMeshTool | MeshJobSubmitter | null)[] = normalizedDeps.map(
           (dep, depIndex) => {
             if (depIndex === meshJobDepIndex) {
@@ -645,7 +726,8 @@ export class MeshAgent {
           meshJobParamIndex,
         );
         return await (execute as (...a: unknown[]) => unknown)(...callArgs);
-      });
+      };
+      this._taskHandlers.set(capability, { handler, retryOn });
     }
 
     // Store mesh metadata with JSON Schema for LLM tool resolution
@@ -948,12 +1030,13 @@ export class MeshAgent {
   private startClaimDispatchers(): void {
     if (!this.config.registryUrl) return;
     if (this._taskHandlers.size === 0) return;
-    for (const [capability, handler] of this._taskHandlers.entries()) {
+    for (const [capability, entry] of this._taskHandlers.entries()) {
       const dispatcher = new ClaimDispatcher(
         capability,
         this.agentId,
         this.config.registryUrl,
-        handler,
+        entry.handler,
+        entry.retryOn,
       );
       dispatcher.start();
       this._claimDispatchers.push(dispatcher);

--- a/src/runtime/typescript/src/claim-dispatcher.ts
+++ b/src/runtime/typescript/src/claim-dispatcher.ts
@@ -70,6 +70,15 @@ export class ClaimDispatcher {
   readonly instanceId: string;
   readonly registryUrl: string;
   private readonly handler: ClaimHandler;
+  /**
+   * Issue #894: per-tool retryOn whitelist. When the handler raises an
+   * Error matching one of the constructor classes, the dispatch wrapper
+   * calls `controller.releaseLease(reason)` instead of `fail(reason)`
+   * so a peer replica can re-claim within ~5s. Threaded straight through
+   * to `runWithJobContext`. `undefined` / `[]` disables retry (existing
+   * fail-on-throw behaviour).
+   */
+  private readonly retryOn?: ReadonlyArray<new (...args: unknown[]) => Error>;
 
   private _stopped = false;
   private _loopPromise: Promise<void> | null = null;
@@ -115,11 +124,13 @@ export class ClaimDispatcher {
     instanceId: string,
     registryUrl: string,
     handler: ClaimHandler,
+    retryOn?: ReadonlyArray<new (...args: unknown[]) => Error>,
   ) {
     this.capability = capability;
     this.instanceId = instanceId;
     this.registryUrl = registryUrl;
     this.handler = handler;
+    this.retryOn = retryOn;
   }
 
   /** Spawn the polling loop. Idempotent. */
@@ -421,8 +432,12 @@ export class ClaimDispatcher {
 
     try {
       await runWithPropagatedHeaders(headers, () =>
-        runWithJobContext(jobId, deadlineSecs, controller, () =>
-          this.handler(payload, controller),
+        runWithJobContext(
+          jobId,
+          deadlineSecs,
+          controller,
+          () => this.handler(payload, controller),
+          this.retryOn,
         ),
       );
     } catch (err) {

--- a/src/runtime/typescript/src/inbound-job-dispatch.ts
+++ b/src/runtime/typescript/src/inbound-job-dispatch.ts
@@ -120,12 +120,19 @@ function isJsonSafe(value: unknown): boolean {
  * @param invoke - Thunk that runs the user function and returns its
  *   result. The caller has already overlaid the controller into the
  *   user function's args at `meshJobParamIndex`.
+ * @param retryOn - Issue #894: per-tool retry-eligible exception
+ *   whitelist. When the user thunk raises an Error matching one of the
+ *   constructor classes, the wrapper calls `controller.releaseLease`
+ *   instead of `controller.fail` so a peer replica can re-claim within
+ *   ~5s. `undefined` / `[]` disables retry (existing fail-on-throw
+ *   behaviour). Match check is `err instanceof cls`.
  */
 export async function runWithJobContext<T>(
   jobId: string | null,
   deadlineSecs: number | null,
   controller: JobController | null,
   invoke: () => Promise<T>,
+  retryOn?: ReadonlyArray<new (...args: unknown[]) => Error>,
 ): Promise<T> {
   if (!jobId || !controller) {
     // Not a job — run directly.
@@ -152,20 +159,83 @@ export async function runWithJobContext<T>(
   // wraps non-safe values for `controller.complete(...)`.
   let captured: T;
   let didCapture = false;
+  // Issue #894: when retryOn matches we suppress the user's exception
+  // and the wrapper returns the default value of T (undefined). The
+  // claim-dispatch path is the primary consumer; it ignores the return
+  // value when re-claim happens. Inbound HTTP path is a no-op for
+  // retryOn since headers-driven invocations don't auto-retry on the
+  // producer side anyway.
+  let suppressed = false;
   const runAndAutoComplete = async (): Promise<null> => {
     try {
       captured = await invoke();
       didCapture = true;
     } catch (err) {
-      // Best-effort terminal report so the registry doesn't have to
-      // wait on the lease expiry to mark the row failed.
+      // Step 1: probe is_terminal — if user already called complete/fail,
+      // their terminal call is the source of truth; leave the row alone
+      // and propagate.
+      let alreadyTerminal = false;
       try {
-        const alreadyTerminal = await controller.isTerminal();
-        if (!alreadyTerminal) {
-          await controller.fail(
-            err instanceof Error ? err.message : String(err),
+        alreadyTerminal = await controller.isTerminal();
+      } catch {
+        // Probe failed; treat as not-terminal so we still attempt a
+        // best-effort terminal report below.
+      }
+      if (alreadyTerminal) throw err;
+
+      // Step 2 (issue #894): retryOn match → releaseLease so a peer
+      // replica can re-claim within ~5s. Suppress the exception on
+      // success — the job lifecycle becomes the registry's responsibility.
+      if (
+        retryOn &&
+        retryOn.length > 0 &&
+        err instanceof Error &&
+        retryOn.some((cls) => err instanceof cls)
+      ) {
+        const reason = `${err.constructor.name}: ${err.message}`;
+        try {
+          await controller.releaseLease(reason);
+          suppressed = true;
+          return null;
+        } catch (releaseErr) {
+          // releaseLease failed — fall back to fail() so the row
+          // doesn't sit in `working` until lease expiry. Best-effort;
+          // swallow any further failure (the registry's lease sweeper
+          // is the ultimate backstop). Log for parity with Python
+          // (`job_dispatch.py:365-383`) so operators can correlate
+          // unexpected fail-rows with the underlying release failure.
+          console.warn(
+            `[mesh-jobs] release_lease failed for job=${jobId} (${
+              releaseErr instanceof Error
+                ? releaseErr.message
+                : String(releaseErr)
+            }); falling back to fail()`,
           );
+          try {
+            await controller.fail(
+              `retry-eligible ${reason}; release_lease failed: ${
+                releaseErr instanceof Error
+                  ? releaseErr.message
+                  : String(releaseErr)
+              }`,
+            );
+          } catch (failErr) {
+            console.debug(
+              `[mesh-jobs] fallback fail() also failed for job=${jobId}:`,
+              failErr,
+            );
+          }
+          suppressed = true;
+          return null;
         }
+      }
+
+      // Step 3: non-retryable → existing behaviour (best-effort fail()
+      // then propagate).
+      try {
+        await controller.fail(
+          err instanceof Error ? err.message : String(err),
+        );
       } catch {
         // Swallow — the registry sweep is the ultimate backstop.
       }
@@ -205,6 +275,16 @@ export async function runWithJobContext<T>(
     const body = runAndAutoComplete();
     await withJobAsync(jobId, deadlineSecs, body);
     if (!didCapture) {
+      if (suppressed) {
+        // Issue #894: the user threw a retryOn-matched exception and the
+        // wrapper called releaseLease() (or its fail() fallback). The
+        // lifecycle is now the registry's concern — return undefined to
+        // unwind. wrappedExecute (agent.ts) maps undefined/null to the
+        // empty string "" before FastMCP serialises the response, which
+        // is benign here because the registry's row state (working/failed)
+        // is what consumers poll on, not the inbound HTTP body.
+        return undefined as unknown as T;
+      }
       // Defensive: the body resolved without setting `captured` —
       // should be unreachable since runAndAutoComplete only returns
       // after invoke() succeeds (which sets captured), but guard

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -17,6 +17,8 @@ import {
 } from "./tracing.js";
 import { isTimeoutError } from "./timeout-utils.js";
 import { getDispatcher } from "./http-pool.js";
+import { currentJob } from "./job-context.js";
+import { awaitJobCancel } from "@mcpmesh/core";
 
 /** Options for callMcpTool, derived from DependencyKwargs. */
 export interface CallOptions {
@@ -314,6 +316,32 @@ export async function callMcpTool(
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), effectiveTimeout);
 
+      // Wire per-job cancel propagation (#886). When the handler executing
+      // this outbound call is running under a MeshJob context AND the
+      // registry forwards a cancel via POST /jobs/{id}/cancel, fire the
+      // outbound AbortController so in-flight fetch is cancelled instead
+      // of stalling on socket reads. Fire-and-forget — the listener races
+      // against fetch completion / timeout; whichever wins, the others
+      // become no-ops (`controller.abort()` is idempotent and the dangling
+      // Promise resolves immediately once the registry entry is gone).
+      const jobSnap = currentJob();
+      if (jobSnap?.jobId) {
+        awaitJobCancel(jobSnap.jobId)
+          .then(() => {
+            if (!controller.signal.aborted) {
+              controller.abort();
+            }
+          })
+          .catch(() => {
+            // Defensive: napi rejection here would be unusual (the Rust
+            // implementation only awaits a CancellationToken), but a
+            // runtime shutdown mid-await could surface one. Swallow —
+            // the worst case is that the outbound fetch isn't proactively
+            // aborted, and the existing timeout / fetch-completion path
+            // still applies.
+          });
+      }
+
       // Build headers: custom headers first, then protocol-required headers override
       const headers: Record<string, string> = {
         ...(options.customHeaders ?? {}),
@@ -535,6 +563,28 @@ export async function* streamMcpTool(
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), effectiveTimeout);
+
+  // Wire per-job cancel propagation (#886). See callMcpTool above for
+  // rationale; same pattern applied to the streaming path so a cancel
+  // arriving mid-stream aborts the SSE reader instead of waiting for
+  // the next chunk / streamTimeout (default 300s).
+  const jobSnap = currentJob();
+  if (jobSnap?.jobId) {
+    awaitJobCancel(jobSnap.jobId)
+      .then(() => {
+        if (!controller.signal.aborted) {
+          controller.abort();
+        }
+      })
+      .catch(() => {
+        // Defensive: napi rejection here would be unusual (the Rust
+        // implementation only awaits a CancellationToken), but a
+        // runtime shutdown mid-await could surface one. Swallow — the
+        // worst case is that the outbound fetch isn't proactively
+        // aborted, and the existing timeout / fetch-completion path
+        // still applies.
+      });
+  }
 
   // Build headers — FastMCP stateless HTTP requires BOTH content types in
   // Accept (it returns SSE for streaming responses; missing application/json

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -393,6 +393,41 @@ export interface MeshToolDef<T extends z.ZodType = z.ZodType> {
    */
   meshJobDepIndex?: number;
   /**
+   * Issue #894: per-tool retry-eligible exception whitelist.
+   *
+   * When a `task: true` handler raises an Error whose constructor matches
+   * one of the entries (`err instanceof cls`), the dispatch wrapper calls
+   * `controller.releaseLease(reason)` instead of `controller.fail(reason)`.
+   * The registry then resets `owner_instance_id` so a peer replica can
+   * re-claim within ~5s — useful for transient failures (network blips,
+   * upstream unavailable) where the next attempt on a different replica
+   * is likely to succeed.
+   *
+   * Constraints (validated at `addTool` time):
+   *
+   *   - requires `task: true` (no-op for synchronous tools — non-job
+   *     handlers don't have a controller, so retry has no meaning);
+   *   - entries must be Error constructor classes (functions); anything
+   *     else throws at registration.
+   *
+   * Default: `undefined` (no retry-eligible exceptions; all raises mark
+   * the row failed). Empty array is equivalent.
+   *
+   * @example
+   * ```ts
+   * agent.addTool({
+   *   task: true,
+   *   retryOn: [TransientUpstreamError, AbortError],
+   *   execute: async (args, job: MeshJob | null = null) => {
+   *     // If this throws TransientUpstreamError, the registry will
+   *     // hand the job to a peer replica within ~5s.
+   *     return await callFlakeyApi(args);
+   *   },
+   * });
+   * ```
+   */
+  retryOn?: Array<new (...args: unknown[]) => Error>;
+  /**
    * Dependencies required by this tool.
    * Injected positionally as McpMeshTool params after args.
    *


### PR DESCRIPTION
## Summary

Three TS-side MeshJob follow-ups from #861, bundled into one PR because they share the napi surface and the dispatch wrappers.

- **#887** TS FastMCP `tools/call` now emits `structuredContent` alongside `content[0].text` for JSON-shaped returns — parity with Python.
- **#894** TS `retry_on` per-tool exception whitelist (mirrors Python's #879). New `releaseLease` napi + decoration validation + dispatch wiring in both `inbound-job-dispatch.ts` and `claim-dispatcher.ts`.
- **#886** TS proxy outbound-HTTP cancel propagation. New `awaitJobCancel(jobId)` napi races a per-job `(cancel, ended)` token pair, so listeners resolve on natural job termination instead of leaking. `proxy.ts` wires `AbortController` to both call sites.

## Review Notes

Pre-merge review-agent flagged a BLOCKER + 4 warnings, all fixed in this PR:

- BLOCKER: `awaitJobCancel` future would hang forever when a job ends without explicit cancel → leaked one Rust task + one JS Promise per outbound call. Fixed by splitting registry state into `(cancel, ended)` tokens; `unregister_active_job` fires `ended`. `awaitJobCancel` resolves on either via `tokio::select!`.
- `.catch()` on fire-and-forget Promise in proxy.ts so napi rejection isn't an unhandled rejection.
- `retryOn` validation tightened: entries must `=== Error || prototype instanceof Error` (rejects arrow functions).
- Corrected misleading FastMCP-undefined comment.
- Console warn/debug on fail() fallback for Python parity observability.

## What's NOT in this PR

- Integration tests (tc09 strict assertions for #886 cancel propagation). Existing `uc22_meshjob_ts/tc09` notes the gap with an inline comment; tightening the assertion is a follow-up once this lands.
- Java retry_on (#895) and Java cancel binding (#889) — separate Java bundle.

## Validation

- `cargo check --features typescript,spire --no-default-features` clean
- `cargo test --lib cancel_registry`: 11/11 (5 new tests)
- `cargo test --lib jobs_napi`: 3/3
- napi rebuild produces `releaseLease` + `awaitJobCancel` on the regenerated `index.d.ts`
- `tsc --noEmit` clean
- `vitest`: 507/507

Closes #887
Closes #894
Closes #886

Refs #861 (parent), #882 (Python sibling for #886).

## Test plan

- [ ] CI green
- [ ] Integration suite `uc22_meshjob_ts/tc23_retry_on_raise_ts` (mirror of tc23) verifies retry_on end-to-end (will land in a follow-up int-tests PR if not already covered)
- [ ] Manual smoke: `task: true` handler raising a `retryOn`-matched error → registry shows status=working with attempt_count incremented; peer re-claims within ~5s
- [ ] Manual smoke: outbound mesh proxy call inside a `task: true` handler → cancel via `__mesh_job_cancel` aborts the in-flight fetch instead of waiting for natural completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)