### PR TITLE
feat(meshjob): Java retry_on per-tool exception whitelist

### DIFF
--- a/src/runtime/core/include/mcp_mesh_core.h
+++ b/src/runtime/core/include/mcp_mesh_core.h
@@ -723,6 +723,22 @@ int32_t mesh_job_controller_complete(struct JobControllerHandle *handle, const c
 // Mark the job failed with the given error reason. Flushes immediately.
 int32_t mesh_job_controller_fail(struct JobControllerHandle *handle, const char *error);
 
+// Voluntarily release the lease so a peer replica can re-claim and
+// retry. Used by the Java SDK dispatch wrapper when a handler raises
+// a retryOn-matched exception (#895). `reason` may be NULL for
+// "no reason given"; an empty string is passed through as `Some("")`
+// for parity with `mesh_job_proxy_cancel`.
+//
+// See [`crate::jobs::JobController::release_lease`] for full semantics.
+// Note: release does NOT increment `attempt_count` — the claim that
+// picked the row up already counted this attempt; the next claim will
+// count the next attempt.
+//
+// Marks the controller terminal locally before the backend call so
+// racing `update_progress` from this defunct attempt is fenced (mirror
+// of Python's / TS's release_lease contract).
+int32_t mesh_job_controller_release_lease(struct JobControllerHandle *handle, const char *reason);
+
 // Whether `complete` / `fail` has already been called on this controller.
 //
 // # Returns
@@ -785,8 +801,11 @@ int32_t mesh_job_proxy_status(struct JobProxyHandle *handle, char **out_job_json
 // `result` (JSON-encoded) to `*out_result_json`; caller frees via
 // `mesh_free_string`.
 //
-// `timeout_secs`: wall-clock timeout. Use a negative value (e.g. `-1`)
-// for "no timeout" (matches the Python / napi-rs `Optional<f64>` shape).
+// `timeout_secs`: wall-clock timeout. Any value `<= 0.0` (including
+// `-0.0` and negatives such as `-1`) means "no timeout"; non-finite
+// values (NaN, ±Inf) also fall back to "no timeout". Matches the
+// Python / napi-rs `Optional<f64>` shape and keeps the same policy
+// as [`mesh_run_as_job`] for consistency.
 int32_t mesh_job_proxy_wait(struct JobProxyHandle *handle,
                             double timeout_secs,
                             char **out_result_json);

--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -360,6 +360,44 @@ pub unsafe extern "C" fn mesh_job_controller_fail(
         .unwrap_or_else(jobs_set_err)
 }
 
+/// Voluntarily release the lease so a peer replica can re-claim and
+/// retry. Used by the Java SDK dispatch wrapper when a handler raises
+/// a retryOn-matched exception (#895). `reason` may be NULL for
+/// "no reason given"; an empty string is passed through as `Some("")`
+/// for parity with `mesh_job_proxy_cancel`.
+///
+/// See [`crate::jobs::JobController::release_lease`] for full semantics.
+/// Note: release does NOT increment `attempt_count` — the claim that
+/// picked the row up already counted this attempt; the next claim will
+/// count the next attempt.
+///
+/// Marks the controller terminal locally before the backend call so
+/// racing `update_progress` from this defunct attempt is fenced (mirror
+/// of Python's / TS's release_lease contract).
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_controller_release_lease(
+    handle: *mut JobControllerHandle,
+    reason: *const c_char,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    let handle = &*handle;
+    // `reason` is optional — NULL means "no reason given". Empty string
+    // is passed through as `Some("")` for parity with `mesh_job_proxy_cancel`.
+    let reason_opt: Option<String> = match opt_cstr(reason, "reason") {
+        Ok(opt) => opt.map(str::to_string),
+        Err(()) => return -1,
+    };
+    let inner = handle.inner.clone();
+    jobs_runtime()
+        .block_on(async move { inner.release_lease(reason_opt).await })
+        .map(|_| 0)
+        .unwrap_or_else(jobs_set_err)
+}
+
 /// Whether `complete` / `fail` has already been called on this controller.
 ///
 /// # Returns

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
@@ -513,6 +513,24 @@ public interface MeshCore {
     int mesh_job_controller_fail(Pointer handle, String error);
 
     /**
+     * Voluntarily release the lease so a peer replica can re-claim and
+     * retry (issue #895). Used by the Java dispatch wrapper when a
+     * {@code task=true} handler raises a {@link io.mcpmesh.MeshTool#retryOn()}-
+     * matched exception. The registry resets {@code owner_instance_id} on
+     * receipt so a peer replica picks up the row within ~5s.
+     *
+     * <p>Note: release does NOT increment {@code attempt_count} — the claim
+     * that picked the row up already counted this attempt; the next claim
+     * will count the next attempt. Marks terminal locally before the backend
+     * call to fence racing progress updates from the now-defunct attempt.
+     *
+     * @param handle Controller handle
+     * @param reason Optional reason (may be null or empty for "no reason given")
+     * @return 0 on success, -1 on error
+     */
+    int mesh_job_controller_release_lease(Pointer handle, String reason);
+
+    /**
      * Whether complete / fail has already been called on this controller.
      *
      * @param handle Controller handle

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
@@ -171,6 +171,35 @@ public final class JobController implements MeshJob, AutoCloseable {
     }
 
     /**
+     * Voluntarily release the lease so a peer replica can re-claim this job
+     * and retry. Used by the dispatch wrappers when a handler raises a
+     * {@link io.mcpmesh.MeshTool#retryOn()}-matched exception (#895).
+     *
+     * <p>The registry resets {@code owner_instance_id} on receipt so a peer
+     * replica picks up the row within ~5s via the HEAD-heartbeat path.
+     * Release does NOT increment {@code attempt_count} — the claim that
+     * picked the row up already counted this attempt; the next claim will
+     * count the next attempt.
+     *
+     * <p>Marks terminal locally before the backend call so racing
+     * {@link #updateProgress} from this defunct attempt is fenced (mirror
+     * of Python's / TS's {@code controller.release_lease} contract).
+     *
+     * @param reason short human-readable reason (may be {@code null}
+     *               or empty for "no reason given").
+     * @throws MeshException if the controller is closed or the native call fails
+     */
+    public void releaseLease(String reason) {
+        synchronized (lock) {
+            ensureOpen();
+            int rc = core.mesh_job_controller_release_lease(handle, reason);
+            if (rc != 0) {
+                throw new MeshException("mesh_job_controller_release_lease failed: " + lastError(core));
+            }
+        }
+    }
+
+    /**
      * Whether {@link #complete} / {@link #fail} has already been called on
      * this controller. The dispatch wrapper uses this to decide whether a
      * returning user method needs an auto-{@code complete} (the

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshTool.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshTool.java
@@ -178,4 +178,35 @@ public @interface MeshTool {
      * }</pre>
      */
     boolean task() default false;
+
+    /**
+     * Issue #895: per-tool retry-eligible exception whitelist.
+     *
+     * <p>When a {@code task = true} handler raises a {@link Throwable} whose
+     * class is a subtype of one of the entries (checked via
+     * {@code cls.isInstance(thrown)}), the dispatch wrapper calls
+     * {@code JobController.releaseLease(reason)} instead of
+     * {@code JobController.fail(reason)}. The registry then resets
+     * {@code owner_instance_id} so a peer replica can re-claim within ~5s
+     * — useful for transient failures (network blips, upstream
+     * unavailable) where the next attempt on a different replica is
+     * likely to succeed.
+     *
+     * <p>Constraints (validated at registration via the bean
+     * post-processor, see {@link io.mcpmesh.spring.MeshToolBeanPostProcessor}):
+     * <ul>
+     *   <li>requires {@code task = true} — synchronous tools have no
+     *       controller, so retry has no meaning;
+     *   <li>entries must be {@link Throwable} subclasses (the annotation
+     *       processor enforces this via {@code Class<? extends Throwable>}).
+     * </ul>
+     *
+     * <p>Default: empty array (no retry-eligible exceptions; all raises
+     * mark the row failed via the existing {@code controller.fail()}
+     * behaviour).
+     *
+     * @return the set of {@link Throwable} subclasses that trigger
+     *         release-and-retry on raise.
+     */
+    Class<? extends Throwable>[] retryOn() default {};
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ClaimDispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ClaimDispatcher.java
@@ -96,6 +96,15 @@ public final class ClaimDispatcher implements AutoCloseable {
     private final String instanceId;
     private final String registryUrl;
     private final ClaimHandler handler;
+    /**
+     * Issue #895: per-tool retry-eligible exception whitelist read from
+     * the producer's {@code @MeshTool(retryOn=...)}. When the handler
+     * raises a Throwable matching one of these classes, the dispatcher
+     * calls {@link JobController#releaseLease(String)} instead of
+     * {@link JobController#fail(String)} so a peer replica can re-claim
+     * the job within ~5s. Always non-null (zero-length when not set).
+     */
+    private final Class<? extends Throwable>[] retryOn;
 
     private final Semaphore permits = new Semaphore(MAX_CONCURRENT_DISPATCHES);
     private final AtomicBoolean stopped = new AtomicBoolean(false);
@@ -119,6 +128,23 @@ public final class ClaimDispatcher implements AutoCloseable {
     private Future<?> loopFuture;
 
     public ClaimDispatcher(String capability, String instanceId, String registryUrl, ClaimHandler handler) {
+        this(capability, instanceId, registryUrl, handler, EMPTY_RETRY_ON);
+    }
+
+    /**
+     * Construct a dispatcher with an explicit {@code retryOn} whitelist
+     * (issue #895). When the handler raises a Throwable matching one of
+     * the entries, the dispatcher calls
+     * {@link JobController#releaseLease(String)} instead of
+     * {@link JobController#fail(String)} so a peer replica can re-claim
+     * the job within ~5s.
+     *
+     * @param retryOn Per-tool retry-eligible exception classes from
+     *                {@link io.mcpmesh.MeshTool#retryOn()}. May be null
+     *                or empty for "no retry-eligible exceptions".
+     */
+    public ClaimDispatcher(String capability, String instanceId, String registryUrl,
+                           ClaimHandler handler, Class<? extends Throwable>[] retryOn) {
         if (capability == null || capability.isEmpty()) {
             throw new IllegalArgumentException("capability is required");
         }
@@ -135,6 +161,7 @@ public final class ClaimDispatcher implements AutoCloseable {
         this.instanceId = instanceId;
         this.registryUrl = stripTrailingSlash(registryUrl);
         this.handler = handler;
+        this.retryOn = retryOn != null ? retryOn : EMPTY_RETRY_ON;
         this.loopExecutor = Executors.newSingleThreadExecutor(named("mesh-claim-loop-" + capability));
         this.dispatchExecutor = Executors.newFixedThreadPool(MAX_CONCURRENT_DISPATCHES,
             named("mesh-claim-dispatch-" + capability));
@@ -142,6 +169,11 @@ public final class ClaimDispatcher implements AutoCloseable {
             .connectTimeout(Duration.ofSeconds(CLAIM_HTTP_TIMEOUT_SECS))
             .build();
     }
+
+    /** Issue #895: shared empty retryOn array — sentinel for "no retry-eligible exceptions". */
+    @SuppressWarnings("unchecked")
+    private static final Class<? extends Throwable>[] EMPTY_RETRY_ON =
+        (Class<? extends Throwable>[]) new Class<?>[0];
 
     /** Spawn the polling loop. Idempotent. */
     public synchronized void start() {
@@ -467,8 +499,18 @@ public final class ClaimDispatcher implements AutoCloseable {
         Object result;
         try {
             result = handler.handle(payload, controller);
-        } catch (Exception e) {
-            tryFail(controller, e.toString());
+        } catch (Throwable t) {
+            // Issue #895: retryOn-aware terminal handling. Mirrors Python
+            // `_run_and_autocomplete` (job_dispatch.py:336-386) and TS
+            // `runWithJobContext` (inbound-job-dispatch.ts:160-225). On a
+            // suppressed (retryOn-matched) exception we just return — the
+            // registry now owns the row's lifecycle. On non-matching, we
+            // already best-effort fail()ed inside the helper; swallow
+            // here too so the dispatch task ends without leaking the
+            // exception into the executor's uncaught handler (would just
+            // log noise; the controller already reflects the terminal
+            // state).
+            handleRetryOrFail(controller, t);
             return;
         }
         // Auto-complete iff the user didn't already close the row.
@@ -489,6 +531,64 @@ public final class ClaimDispatcher implements AutoCloseable {
         } catch (Exception ignored) {
             // Best-effort.
         }
+    }
+
+    /**
+     * Issue #895 — retryOn-aware terminal reporter for the claim path.
+     *
+     * <p>Mirrors {@link MeshToolWrapper}'s {@code handleRetryOrFail} (and
+     * Python {@code _run_and_autocomplete}: probe is_terminal → retryOn
+     * match triggers releaseLease → fall back to fail() on release
+     * failure → non-matching does best-effort fail()). Returns without
+     * propagating; the caller (runHandler) treats handler exceptions as
+     * already-reported once this returns.
+     */
+    private void handleRetryOrFail(JobController controller, Throwable cause) {
+        // Step 1: probe is_terminal — user may have already called
+        // complete()/fail(); their terminal call is the source of truth.
+        boolean alreadyTerminal = false;
+        try {
+            alreadyTerminal = controller.isTerminal();
+        } catch (Throwable probeErr) {
+            log.debug("[mesh-claim] is_terminal probe failed for job={}: {}",
+                controller.jobId(), probeErr.toString());
+        }
+        if (alreadyTerminal) {
+            return;
+        }
+
+        // Step 2 (issue #895): retryOn match → releaseLease (suppress) or
+        // fail() fallback.
+        if (retryOn != null && retryOn.length > 0) {
+            for (Class<? extends Throwable> cls : retryOn) {
+                if (cls.isInstance(cause)) {
+                    String reason = cause.getClass().getSimpleName() +
+                        ": " + cause.getMessage();
+                    try {
+                        controller.releaseLease(reason);
+                        log.info("[mesh-claim] retryOn match for job={} ({}); released lease for fast retry",
+                            controller.jobId(), reason);
+                        return;
+                    } catch (Throwable releaseErr) {
+                        log.warn("[mesh-claim] release_lease failed for job={} ({}); falling back to fail()",
+                            controller.jobId(), releaseErr.toString());
+                        try {
+                            controller.fail(
+                                "retry-eligible " + reason +
+                                "; release_lease failed: " + releaseErr.getMessage()
+                            );
+                        } catch (Throwable failErr) {
+                            log.debug("[mesh-claim] fallback fail() also failed for job={}: {}",
+                                controller.jobId(), failErr.toString());
+                        }
+                        return;
+                    }
+                }
+            }
+        }
+
+        // Step 3: non-retryable → existing best-effort fail() behaviour.
+        tryFail(controller, cause.toString());
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
@@ -125,16 +125,20 @@ public final class JobsRuntimeManager implements SmartLifecycle {
             wrapper.setJobBindingContext(instanceId, registryUrl);
 
             // Spawn a ClaimDispatcher that invokes the same method via reflection.
+            // Issue #895: thread the @MeshTool(retryOn=...) whitelist through so
+            // the claim-path matches the inbound-HTTP-path's release-and-retry
+            // semantics.
             ClaimDispatcher dispatcher = new ClaimDispatcher(
                 meta.capability(),
                 instanceId,
                 registryUrl,
-                (payload, controller) -> invokeViaReflection(meta, payload, controller)
+                (payload, controller) -> invokeViaReflection(meta, payload, controller),
+                meta.retryOn()
             );
             dispatcher.start();
             dispatchers.put(meta.capability(), dispatcher);
-            log.info("MeshJob producer wired: capability={} (wrapper={}, dispatcher started)",
-                meta.capability(), wrapper.getFuncId());
+            log.info("MeshJob producer wired: capability={} (wrapper={}, dispatcher started, retryOn={})",
+                meta.capability(), wrapper.getFuncId(), meta.retryOn().length);
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
@@ -62,6 +62,18 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor {
             if (annotation != null) {
                 log.debug("Found @MeshTool on {}.{}", targetClass.getSimpleName(), method.getName());
 
+                // Issue #895: retryOn requires task=true (no controller without it,
+                // so release-and-retry has no meaning). The Throwable-subclass
+                // bound is enforced at compile-time by the annotation field
+                // type (Class<? extends Throwable>), so no runtime check needed.
+                Class<? extends Throwable>[] retryOn = annotation.retryOn();
+                if (retryOn.length > 0 && !annotation.task()) {
+                    throw new IllegalStateException(
+                        "@MeshTool(retryOn = ...) on '" + targetClass.getName() +
+                        "#" + method.getName() + "' requires task = true; " +
+                        "remove retryOn or set task = true.");
+                }
+
                 // Register with legacy registry (for agent spec generation)
                 registry.registerTool(bean, method, annotation);
 
@@ -96,6 +108,8 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor {
         // Create wrapper. Phase B MeshJob substrate: the `task` flag controls
         // whether inbound calls bearing X-Mesh-Job-Id dispatch through the
         // job pipeline (JobController injection + auto-complete).
+        // Issue #895: retryOn whitelist drives release-and-retry on the
+        // task-dispatch path inside the wrapper.
         MeshToolWrapper wrapper = new MeshToolWrapper(
             funcId,
             annotation.capability(),
@@ -104,7 +118,8 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor {
             method,
             dependencyNames,
             objectMapper,
-            annotation.task()
+            annotation.task(),
+            annotation.retryOn()
         );
 
         // Register with wrapper registry

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
@@ -56,12 +56,18 @@ public class MeshToolRegistry {
             // Phase B MeshJob substrate: surfaced via kwargs JSON so the
             // registry / consumer SDK knows this is a task=true producer.
             annotation.task(),
+            // Issue #895: per-tool retry-eligible exception whitelist. The
+            // bean post-processor has already validated `retryOn requires
+            // task=true` before this call, so we only need to capture it
+            // here for downstream dispatch wiring.
+            annotation.retryOn(),
             bean,
             method
         );
 
         tools.put(capability, metadata);
-        log.info("Registered mesh tool: {} ({}, task={})", capability, method, annotation.task());
+        log.info("Registered mesh tool: {} ({}, task={}, retryOn={})",
+            capability, method, annotation.task(), annotation.retryOn().length);
     }
 
     // Phase B MeshJob substrate: synthetic tool specs registered outside
@@ -386,6 +392,11 @@ public class MeshToolRegistry {
      * <p>{@code outputSchemaStrict} mirrors {@link MeshTool#outputSchemaStrict()} —
      * when false, BLOCK verdicts for this tool are demoted to WARN instead of
      * refusing startup (issue #547 Phase 4).
+     *
+     * <p>{@code retryOn} mirrors {@link MeshTool#retryOn()} (issue #895) — the
+     * per-tool exception whitelist that triggers release-and-retry instead of
+     * fail() when a {@code task=true} handler raises. Always non-null (defaults
+     * to a zero-length array).
      */
     public record ToolMetadata(
         String capability,
@@ -397,6 +408,7 @@ public class MeshToolRegistry {
         Class<?> outputType,
         boolean outputSchemaStrict,
         boolean task,
+        Class<? extends Throwable>[] retryOn,
         Object bean,
         Method method
     ) {
@@ -414,8 +426,30 @@ public class MeshToolRegistry {
                 Object bean,
                 Method method) {
             this(capability, description, version, tags, dependencies, inputSchema,
-                outputType, outputSchemaStrict, false, bean, method);
+                outputType, outputSchemaStrict, false, EMPTY_RETRY_ON, bean, method);
         }
+
+        // Backward-compatible 11-arg constructor for callers that adopted
+        // the `task` flag but predate the issue #895 retryOn field.
+        public ToolMetadata(
+                String capability,
+                String description,
+                String version,
+                List<String> tags,
+                List<DependencyInfo> dependencies,
+                Map<String, Object> inputSchema,
+                Class<?> outputType,
+                boolean outputSchemaStrict,
+                boolean task,
+                Object bean,
+                Method method) {
+            this(capability, description, version, tags, dependencies, inputSchema,
+                outputType, outputSchemaStrict, task, EMPTY_RETRY_ON, bean, method);
+        }
+
+        @SuppressWarnings("unchecked")
+        private static final Class<? extends Throwable>[] EMPTY_RETRY_ON =
+            (Class<? extends Throwable>[]) new Class<?>[0];
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -53,6 +53,10 @@ public class MeshToolWrapper implements McpToolHandler {
     private static final Logger log = LoggerFactory.getLogger(MeshToolWrapper.class);
     private static final long ASYNC_TIMEOUT_SECONDS = 30;
     private static final SchemaGenerator SCHEMA_GENERATOR = MeshSchemaSupport.generator();
+    /** Issue #895: shared empty {@code retryOn} array — sentinel for "no retry-eligible exceptions". */
+    @SuppressWarnings("unchecked")
+    private static final Class<? extends Throwable>[] EMPTY_RETRY_ON =
+        (Class<? extends Throwable>[]) new Class<?>[0];
 
     private final String funcId;
     private final String capability;
@@ -60,6 +64,15 @@ public class MeshToolWrapper implements McpToolHandler {
     private final Object bean;
     private final Method method;
     private final boolean task;
+    /**
+     * Issue #895: per-tool retry-eligible exception whitelist read from
+     * {@code @MeshTool(retryOn=...)}. When a handler raises a Throwable
+     * matching one of these classes, the dispatch wrapper calls
+     * {@link JobController#releaseLease(String)} instead of
+     * {@link JobController#fail(String)} so a peer replica can re-claim
+     * the job within ~5s. Always non-null (zero-length when not set).
+     */
+    private final Class<? extends Throwable>[] retryOn;
 
     // Parameter metadata
     private final List<ParamInfo> mcpParams;           // MCP-exposed parameters (with @Param)
@@ -131,6 +144,28 @@ public class MeshToolWrapper implements McpToolHandler {
             List<String> dependencyNames,
             ObjectMapper objectMapper,
             boolean task) {
+        this(funcId, capability, description, bean, method, dependencyNames,
+            objectMapper, task, EMPTY_RETRY_ON);
+    }
+
+    /**
+     * Create a wrapper for a @MeshTool annotated method, with explicit
+     * task flag and {@code retryOn} whitelist (issue #895).
+     *
+     * @param retryOn Per-tool retry-eligible exception classes from
+     *                {@link io.mcpmesh.MeshTool#retryOn()}. May be null
+     *                or empty for "no retry-eligible exceptions".
+     */
+    public MeshToolWrapper(
+            String funcId,
+            String capability,
+            String description,
+            Object bean,
+            Method method,
+            List<String> dependencyNames,
+            ObjectMapper objectMapper,
+            boolean task,
+            Class<? extends Throwable>[] retryOn) {
 
         this.funcId = funcId;
         this.capability = capability;
@@ -138,6 +173,7 @@ public class MeshToolWrapper implements McpToolHandler {
         this.bean = bean;
         this.method = method;
         this.task = task;
+        this.retryOn = retryOn != null ? retryOn : EMPTY_RETRY_ON;
         this.dependencyNames = dependencyNames != null ? dependencyNames : List.of();
         this.objectMapper = objectMapper;
 
@@ -766,11 +802,25 @@ public class MeshToolWrapper implements McpToolHandler {
             result = method.invoke(bean, fullArgs);
         } catch (InvocationTargetException e) {
             Throwable cause = e.getCause();
-            // Best-effort failure report — the registry will sweep stale
-            // working rows on lease expiry, but reporting eagerly means
-            // the consumer's await() resolves with the right error
-            // sooner.
-            tryFail(controller, cause != null ? cause.toString() : "method invocation failed");
+            // Issue #895: retryOn-aware exception handling. Mirrors Python
+            // `_run_and_autocomplete` (job_dispatch.py:336-386) and TS
+            // `runWithJobContext` (inbound-job-dispatch.ts:160-225):
+            //   1) probe is_terminal — user's terminal call wins;
+            //   2) retryOn match → releaseLease (suppress on success,
+            //      fall back to fail() on release failure);
+            //   3) non-matching → existing best-effort fail() then rethrow.
+            if (cause != null && handleRetryOrFail(controller, cause)) {
+                // Suppressed by retryOn — registry now owns the row's
+                // lifecycle (peer replica re-claims within ~5s).
+                return null;
+            }
+            // cause==null path: nothing to match against retryOn, so preserve
+            // the original best-effort failure-report with the helpful
+            // "method invocation failed" literal and rethrow `e` unchanged.
+            if (cause == null) {
+                tryFail(controller, "method invocation failed");
+                throw e;
+            }
             if (cause instanceof Exception ex) throw ex;
             throw new RuntimeException(cause);
         } catch (IllegalAccessException e) {
@@ -788,8 +838,15 @@ public class MeshToolWrapper implements McpToolHandler {
                 tryFail(controller, "async operation timed out after " + ASYNC_TIMEOUT_SECONDS + "s");
                 throw new RuntimeException("Async operation timed out after " + ASYNC_TIMEOUT_SECONDS + " seconds");
             } catch (ExecutionException e) {
+                // Issue #895: same retryOn-aware handling as the synchronous
+                // throw path — a CompletableFuture that completes
+                // exceptionally with a retry-eligible cause should also
+                // release the lease.
                 Throwable cause = e.getCause();
-                tryFail(controller, cause != null ? cause.toString() : e.toString());
+                if (cause == null) cause = e;
+                if (handleRetryOrFail(controller, cause)) {
+                    return null;
+                }
                 if (cause instanceof Exception ex) throw ex;
                 throw new RuntimeException(cause);
             } catch (InterruptedException e) {
@@ -822,6 +879,71 @@ public class MeshToolWrapper implements McpToolHandler {
         } catch (Exception ignored) {
             // Best-effort — already logged the original cause.
         }
+    }
+
+    /**
+     * Issue #895 — central retryOn-aware terminal handler shared between
+     * the synchronous-throw path and the {@link CompletableFuture}-failure
+     * path of {@link #invokeAndAutoComplete}. Mirrors the canonical Python
+     * pattern in {@code _run_and_autocomplete} (job_dispatch.py:336-386).
+     *
+     * <p>Returns {@code true} when the exception was suppressed (caller
+     * should return {@code null} as the dispatch result; the registry
+     * now owns the row's lifecycle). Returns {@code false} when the
+     * caller must propagate {@code cause} — either because the user
+     * already terminated the controller, no retryOn entry matched, or
+     * the {@code releaseLease} call failed and we fell back to {@code fail()}.
+     */
+    private boolean handleRetryOrFail(JobController controller, Throwable cause) {
+        // Step 1: probe is_terminal — user may have already called
+        // complete()/fail(); their terminal call is the source of truth.
+        boolean alreadyTerminal = false;
+        try {
+            alreadyTerminal = controller.isTerminal();
+        } catch (Throwable probeErr) {
+            // probe failed; fall through to default best-effort report.
+            log.debug("[mesh-jobs] is_terminal probe failed for job={}: {}",
+                controller.jobId(), probeErr.toString());
+        }
+        if (alreadyTerminal) {
+            // Already terminal: user owns the outcome. Don't double-fail.
+            return false;
+        }
+
+        // Step 2 (issue #895): retryOn match → releaseLease (suppress) or
+        // fail() fallback → suppress. Non-matching falls through.
+        if (retryOn != null && retryOn.length > 0) {
+            for (Class<? extends Throwable> cls : retryOn) {
+                if (cls.isInstance(cause)) {
+                    String reason = cause.getClass().getSimpleName() +
+                        ": " + cause.getMessage();
+                    try {
+                        controller.releaseLease(reason);
+                        log.info("[mesh-jobs] retryOn match for job={} ({}); released lease for fast retry",
+                            controller.jobId(), reason);
+                        return true;
+                    } catch (Throwable releaseErr) {
+                        log.warn("[mesh-jobs] release_lease failed for job={} ({}); falling back to fail()",
+                            controller.jobId(), releaseErr.toString());
+                        try {
+                            controller.fail(
+                                "retry-eligible " + reason +
+                                "; release_lease failed: " + releaseErr.getMessage()
+                            );
+                        } catch (Throwable failErr) {
+                            log.debug("[mesh-jobs] fallback fail() also failed for job={}: {}",
+                                controller.jobId(), failErr.toString());
+                        }
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // Step 3: non-retryable → existing behaviour (best-effort fail
+        // then propagate). Caller propagates the cause.
+        tryFail(controller, cause.toString());
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary

Java mirror of Python's #879 (PR #896) and TypeScript's #894 (PR #897). When a `@MeshTool(task=true, retryOn={...})` handler throws a Throwable matching one of the listed classes, the dispatch wrapper calls `JobController.releaseLease(reason)` instead of `fail(reason)`. The registry resets `owner_instance_id` and a peer replica re-claims within ~5s.

### Key pieces

- **New C ABI export** `mesh_job_controller_release_lease` in `jobs_ffi.rs` (delegates to existing `JobController::release_lease` in `jobs.rs`).
- **Java SDK**: `@MeshTool.retryOn()` annotation field typed `Class<? extends Throwable>[]`; `JobController.releaseLease(reason)` Java method.
- **Spring Boot starter**: `handleRetryOrFail(controller, cause)` helper centralises retryOn dispatch in both `MeshToolWrapper` (sync + async paths) and `ClaimDispatcher`. Mirrors Python's `_run_and_autocomplete` (job_dispatch.py:336-386) line-for-line.
- **Validation**: `MeshToolBeanPostProcessor` rejects `retryOn != []` when `task=false` at registration time.

## Review Notes

Pre-merge review-agent flagged 3 warnings; 2 fixed, 1 skipped:

- **Fixed** Sync-throw `cause==null` reason regression — preserved the legacy `"method invocation failed"` literal when `InvocationTargetException.getCause()` returns null.
- **Fixed** `release_lease` empty-string handling diverged from `mesh_job_controller_cancel`. Now both pass empty string through as `Some("")`.
- **Skipped (parity)** `handleRetryOrFail` swallowing `is_terminal` probe exceptions and proceeding into retryOn match — matches Python exactly. Probe failure is logged at debug level. Local heuristic divergence would create a parity gap.

INFOs (cosmetic / cbindgen header noise / null-message format) skipped.

Backward-compat constructor overloads on `MeshToolWrapper`, `ClaimDispatcher`, and `MeshToolRegistry.ToolMetadata` keep existing call sites working without churn.

## What's NOT in this PR

- Java cancel-registry binding (#889) — separate PR. Requires `block_in_place` wrap + JNR-FFI callback bridge so Java can invoke `mesh_run_as_job`. Substantial enough to warrant its own scope.
- Integration test `uc23_meshjob_java/tc23_retry_on_raise_java` — follow-up int-tests PR (mirror of `uc21/tc23` and `uc22/tc23`).

## Validation

- `cargo check --features ffi` clean
- `cargo test --lib --features ffi jobs_ffi`: 13/13
- `mvn -pl mcp-mesh-spring-boot-starter -am test`: 149/149, BUILD SUCCESS

Closes #895
Refs #861 (parent), #879 (Python), #894 (TS), #889 (Java cancel-binding follow-up)

## Test plan

- [ ] CI green
- [ ] Manual smoke: `@MeshTool(task=true, retryOn=IOException.class)` handler throws `IOException` → registry shows `status=working` with incremented `attempt_count`; peer replica re-claims within ~5s
- [ ] Manual smoke: `@MeshTool(retryOn=IOException.class)` without `task=true` → application startup fails with `IllegalStateException` from `MeshToolBeanPostProcessor`
- [ ] Follow-up int-tests PR covers the polyglot scenario (TS consumer → Java provider with retry_on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for releasing job leases to enable peer replica re-claiming after transient failures
  * New `@MeshTool(retryOn=...)` annotation attribute to declare exception types that should trigger lease release and retry
  * New `JobController.releaseLease()` method for manual lease release with optional reason
  * Automatic retry handling: jobs encountering configured exception types now release leases instead of failing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->