### PR TITLE
feat(meshjob): Java cancel-registry binding + outbound HTTP cancel propagation

### DIFF
--- a/src/runtime/core/include/mcp_mesh_core.h
+++ b/src/runtime/core/include/mcp_mesh_core.h
@@ -745,6 +745,22 @@ int32_t mesh_job_controller_release_lease(struct JobControllerHandle *handle, co
 // `1` if terminal, `0` if not, `-1` on error.
 int32_t mesh_job_controller_is_terminal(const struct JobControllerHandle *handle);
 
+// Whether the cancel token bound to this controller's job in the
+// process-wide cancel registry has been fired. Returns `0` (not cancelled)
+// when the job is not currently registered (no [`mesh_run_as_job`] scope
+// active). Used by per-language SDKs whose blocking primitives cannot be
+// interrupted by a Tokio cancel token firing — e.g. the Java fixture's
+// `runs_overlong` polls this between `Thread.sleep` intervals so a
+// mid-flight cancel can break out of the loop instead of running to
+// natural completion. Distinct from [`mesh_job_controller_is_terminal`]:
+// terminal reflects local complete/fail/release intent; cancelled
+// reflects an external cancel signal (HTTP route, deadline trip, etc.).
+//
+// # Returns
+// `1` if cancel token fired, `0` if not (or job not registered),
+// `-1` on error.
+int32_t mesh_job_controller_is_cancelled(const struct JobControllerHandle *handle);
+
 // Read the job ID this controller is bound to. Caller frees the returned
 // string via `mesh_free_string`.
 int32_t mesh_job_controller_job_id(const struct JobControllerHandle *handle, char **out_job_id);
@@ -846,6 +862,27 @@ int32_t mesh_inject_job_headers(char **out_headers_json);
 // `-1` on error (null/invalid `job_id`).
 int32_t mesh_cancel_active_job(const char *job_id);
 
+// Block until the cancel token bound for `job_id` in the process-wide
+// cancel registry fires (explicit cancel via `mesh_cancel_active_job`)
+// OR the job is unregistered naturally (ended without cancel — see
+// `cancel_registry::JobCancelState::ended`). Resolves immediately if
+// the job is not currently registered (already terminal / never claimed).
+//
+// Returns 0 on success (token resolved or unregistered), -1 on a NULL
+// `job_id_ptr` or invalid UTF-8.
+//
+// Java SDK uses this from a watcher thread (wrapped in a
+// `CompletableFuture.runAsync`) to abort outbound OkHttp `Call`s when
+// the producer's job is cancelled. The `ended` arm prevents the
+// watcher from leaking when the call completes naturally without
+// cancel. Mirror of the napi `awaitJobCancel(jobId)` shipped in TS PR
+// #897, but blocking instead of async because JNR-FFI doesn't expose
+// async return types.
+//
+// # Safety
+// `job_id_ptr` must be a valid C string for the duration of this call.
+int32_t mesh_await_job_cancel(const char *job_id_ptr);
+
 // Run a Java-provided callback inside a fresh [`crate::jobs::run_as_job`]
 // scope so the cancel-registry entry under the snapshot's `job_id` is
 // bound for the duration of the callback (allowing
@@ -857,10 +894,18 @@ int32_t mesh_cancel_active_job(const char *job_id);
 // headers. `deadline_secs` is the per-attempt deadline (relative); null /
 // missing / non-positive ≡ no deadline.
 //
-// `callback` is invoked synchronously from the runtime's `block_on`. It
-// receives the opaque `user_data` pointer the caller passed in. The
-// callback's `i32` return value is propagated as this function's return
-// value (0 = success, non-zero = caller-defined error).
+// `callback` is invoked synchronously from the runtime's `block_on`,
+// wrapped in [`tokio::task::block_in_place`] so it is legal for the
+// callback to issue further blocking FFI calls (e.g.
+// `mesh_job_controller_complete` / `_fail` / `_update_progress`) that
+// internally re-enter `jobs_runtime().block_on(...)` — without
+// `block_in_place` such nested `block_on` calls would panic with
+// "Cannot start a runtime from within a runtime". This requires
+// `jobs_runtime()` to be a multi-threaded runtime, which it is
+// (`Runtime::new()` defaults to `multi_thread`). The callback receives
+// the opaque `user_data` pointer the caller passed in. The callback's
+// `i32` return value is propagated as this function's return value
+// (0 = success, non-zero = caller-defined error).
 //
 // # Safety
 // `callback` must be a valid C function pointer for the entire duration

--- a/src/runtime/core/src/jobs.rs
+++ b/src/runtime/core/src/jobs.rs
@@ -356,6 +356,28 @@ impl JobController {
         q.terminal.contains(&self.job_id)
     }
 
+    /// Whether the cancel token bound to this controller's job in the
+    /// process-wide [`cancel_registry`] has been fired. Returns `false`
+    /// if the controller's job is not currently registered (not yet
+    /// wrapped in [`run_as_job`], or already unregistered).
+    ///
+    /// Distinct from [`is_terminal`] — `is_terminal` is set by the
+    /// controller's own `complete`/`fail`/`release_lease` calls and
+    /// reflects local intent, whereas `is_cancelled` reflects an
+    /// external cancel signal (e.g. `POST /jobs/{id}/cancel` on the
+    /// SDK-owned HTTP route, the Rust task-deadline tripping, etc.).
+    /// Per-language SDKs (notably the Java fixture's `runs_overlong`
+    /// loop) poll this between blocking sleep intervals so a mid-flight
+    /// cancel can break out instead of running to natural completion —
+    /// languages whose blocking primitives can't be interrupted by a
+    /// Tokio token firing have no other observation point.
+    pub async fn is_cancelled(&self) -> bool {
+        match cancel_registry::get_state(&self.job_id) {
+            Some((cancel, _ended)) => cancel.is_cancelled(),
+            None => false,
+        }
+    }
+
     /// Voluntarily release the lease for retry. Used when the user
     /// handler raised an exception matched by the tool's `retry_on`
     /// whitelist (#879) — instead of marking the job `failed` (which

--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -421,6 +421,39 @@ pub unsafe extern "C" fn mesh_job_controller_is_terminal(
     }
 }
 
+/// Whether the cancel token bound to this controller's job in the
+/// process-wide cancel registry has been fired. Returns `0` (not cancelled)
+/// when the job is not currently registered (no [`mesh_run_as_job`] scope
+/// active). Used by per-language SDKs whose blocking primitives cannot be
+/// interrupted by a Tokio cancel token firing — e.g. the Java fixture's
+/// `runs_overlong` polls this between `Thread.sleep` intervals so a
+/// mid-flight cancel can break out of the loop instead of running to
+/// natural completion. Distinct from [`mesh_job_controller_is_terminal`]:
+/// terminal reflects local complete/fail/release intent; cancelled
+/// reflects an external cancel signal (HTTP route, deadline trip, etc.).
+///
+/// # Returns
+/// `1` if cancel token fired, `0` if not (or job not registered),
+/// `-1` on error.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_controller_is_cancelled(
+    handle: *const JobControllerHandle,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    let handle = &*handle;
+    let inner = handle.inner.clone();
+    let cancelled = jobs_runtime().block_on(async move { inner.is_cancelled().await });
+    if cancelled {
+        1
+    } else {
+        0
+    }
+}
+
 /// Read the job ID this controller is bound to. Caller frees the returned
 /// string via `mesh_free_string`.
 #[no_mangle]
@@ -790,6 +823,46 @@ pub unsafe extern "C" fn mesh_cancel_active_job(job_id: *const c_char) -> i32 {
     }
 }
 
+/// Block until the cancel token bound for `job_id` in the process-wide
+/// cancel registry fires (explicit cancel via `mesh_cancel_active_job`)
+/// OR the job is unregistered naturally (ended without cancel — see
+/// `cancel_registry::JobCancelState::ended`). Resolves immediately if
+/// the job is not currently registered (already terminal / never claimed).
+///
+/// Returns 0 on success (token resolved or unregistered), -1 on a NULL
+/// `job_id_ptr` or invalid UTF-8.
+///
+/// Java SDK uses this from a watcher thread (wrapped in a
+/// `CompletableFuture.runAsync`) to abort outbound OkHttp `Call`s when
+/// the producer's job is cancelled. The `ended` arm prevents the
+/// watcher from leaking when the call completes naturally without
+/// cancel. Mirror of the napi `awaitJobCancel(jobId)` shipped in TS PR
+/// #897, but blocking instead of async because JNR-FFI doesn't expose
+/// async return types.
+///
+/// # Safety
+/// `job_id_ptr` must be a valid C string for the duration of this call.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_await_job_cancel(job_id_ptr: *const c_char) -> i32 {
+    take_last_error();
+    let job_id = match req_cstr(job_id_ptr, "job_id") {
+        Ok(s) => s.to_string(),
+        Err(()) => return -1,
+    };
+    // Snapshot both tokens once. None means "not registered" — resolve
+    // immediately so callers don't hang on stale jobs.
+    let Some((cancel, ended)) = cancel_registry::get_state(&job_id) else {
+        return 0;
+    };
+    jobs_runtime().block_on(async move {
+        tokio::select! {
+            _ = cancel.cancelled() => {},
+            _ = ended.cancelled() => {},
+        }
+    });
+    0
+}
+
 // =============================================================================
 // run_as_job — callback-based scope binding
 // =============================================================================
@@ -805,10 +878,18 @@ pub unsafe extern "C" fn mesh_cancel_active_job(job_id: *const c_char) -> i32 {
 /// headers. `deadline_secs` is the per-attempt deadline (relative); null /
 /// missing / non-positive ≡ no deadline.
 ///
-/// `callback` is invoked synchronously from the runtime's `block_on`. It
-/// receives the opaque `user_data` pointer the caller passed in. The
-/// callback's `i32` return value is propagated as this function's return
-/// value (0 = success, non-zero = caller-defined error).
+/// `callback` is invoked synchronously from the runtime's `block_on`,
+/// wrapped in [`tokio::task::block_in_place`] so it is legal for the
+/// callback to issue further blocking FFI calls (e.g.
+/// `mesh_job_controller_complete` / `_fail` / `_update_progress`) that
+/// internally re-enter `jobs_runtime().block_on(...)` — without
+/// `block_in_place` such nested `block_on` calls would panic with
+/// "Cannot start a runtime from within a runtime". This requires
+/// `jobs_runtime()` to be a multi-threaded runtime, which it is
+/// (`Runtime::new()` defaults to `multi_thread`). The callback receives
+/// the opaque `user_data` pointer the caller passed in. The callback's
+/// `i32` return value is propagated as this function's return value
+/// (0 = success, non-zero = caller-defined error).
 ///
 /// # Safety
 /// `callback` must be a valid C function pointer for the entire duration
@@ -897,8 +978,20 @@ pub unsafe extern "C" fn mesh_run_as_job(
 
     jobs_runtime().block_on(async move {
         run_as_job(ctx, async move {
+            // `block_in_place` tells the multi-threaded Tokio runtime
+            // "this call may block; move me off the worker thread so
+            // other tasks can progress." This makes nested `block_on`
+            // calls inside the callback legal — which matters because
+            // the Java SDK's controller methods (mesh_job_controller_*)
+            // each do their own `jobs_runtime().block_on(...)`
+            // internally. Without `block_in_place`, a callback that
+            // calls `controller.complete()` would panic with "Cannot
+            // start a runtime from within a runtime."
+            //
+            // Requires `jobs_runtime()` to be multi-threaded — it is
+            // (`Runtime::new()` defaults to `multi_thread`).
             let UserDataPtr(ptr) = ud;
-            callback(ptr)
+            tokio::task::block_in_place(|| callback(ptr))
         })
         .await
     })
@@ -961,6 +1054,54 @@ mod tests {
         let id = CString::new("does-not-exist-ffi-test").unwrap();
         let rc = unsafe { mesh_cancel_active_job(id.as_ptr()) };
         assert_eq!(rc, 0);
+    }
+
+    /// `mesh_await_job_cancel` must resolve immediately (return 0) when
+    /// the job is not currently registered — mirrors the napi
+    /// `awaitJobCancel` `None`-branch resolve-immediately semantic so
+    /// Java watchers don't hang on stale jobs.
+    #[test]
+    fn await_job_cancel_resolves_immediately_when_unregistered() {
+        let id = CString::new("await-cancel-not-registered").unwrap();
+        let rc = unsafe { mesh_await_job_cancel(id.as_ptr()) };
+        assert_eq!(rc, 0);
+    }
+
+    /// Null pointer must be rejected via the last-error slot rather
+    /// than panicking — same pattern as the other req_cstr-guarded
+    /// entry points.
+    #[test]
+    fn await_job_cancel_rejects_null() {
+        let rc = unsafe { mesh_await_job_cancel(ptr::null()) };
+        assert_eq!(rc, -1);
+    }
+
+    /// `mesh_await_job_cancel` must wake on the registry's `ended`
+    /// token when a job is unregistered without explicit cancel — this
+    /// is the no-leak path: the Java watcher thread reclaims itself
+    /// when the surrounding `mesh_run_as_job` scope ends naturally.
+    #[test]
+    fn await_job_cancel_wakes_on_natural_unregister() {
+        use std::thread;
+        use std::time::Duration;
+        use tokio_util::sync::CancellationToken;
+
+        let job_id = format!(
+            "await-cancel-natural-{}",
+            uuid::Uuid::new_v4().simple()
+        );
+        cancel_registry::register_active_job(&job_id, CancellationToken::new());
+
+        let job_id_for_thread = job_id.clone();
+        let unregisterer = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(50));
+            cancel_registry::unregister_active_job(&job_id_for_thread);
+        });
+
+        let id_c = CString::new(job_id).unwrap();
+        let rc = unsafe { mesh_await_job_cancel(id_c.as_ptr()) };
+        assert_eq!(rc, 0);
+        unregisterer.join().expect("unregister thread panicked");
     }
 
     /// `mesh_run_as_job` must reject malformed JSON cleanly via the

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
@@ -539,6 +539,23 @@ public interface MeshCore {
     int mesh_job_controller_is_terminal(Pointer handle);
 
     /**
+     * Whether the cancel token bound to this controller's job in the
+     * process-wide cancel registry has been fired. Returns 0 (not cancelled)
+     * when the job is not currently registered (no mesh_run_as_job scope
+     * active). Used by Java fixtures whose blocking primitives (e.g.
+     * Thread.sleep) cannot be interrupted by a Tokio cancel token firing —
+     * the fixture polls this between sleep intervals so a mid-flight cancel
+     * can break out instead of running to natural completion. Distinct from
+     * mesh_job_controller_is_terminal: terminal reflects local
+     * complete/fail/release intent; cancelled reflects an external cancel
+     * signal (HTTP route, deadline trip, etc.).
+     *
+     * @param handle Controller handle
+     * @return 1 if cancel token fired, 0 if not (or job not registered), -1 on error
+     */
+    int mesh_job_controller_is_cancelled(Pointer handle);
+
+    /**
      * Read the job ID this controller is bound to.
      *
      * @param handle    Controller handle
@@ -660,6 +677,31 @@ public interface MeshCore {
      * @return 1 if a token was found and fired, 0 if no active job, -1 on error
      */
     int mesh_cancel_active_job(String jobId);
+
+    /**
+     * Block until the cancel token bound for {@code jobId} in the process-
+     * wide cancel registry fires, OR until the job is unregistered naturally
+     * (ended without cancel). Resolves immediately if the job is not
+     * currently registered.
+     *
+     * <p>Used by {@link io.mcpmesh.spring.McpHttpClient} via a watcher
+     * thread wrapped in {@link java.util.concurrent.CompletableFuture#runAsync}
+     * to abort in-flight outbound HTTP calls when the producer's job is
+     * cancelled mid-flight. Mirror of the TypeScript SDK's
+     * {@code awaitJobCancel(jobId)} napi (PR #897) — same primitive, sync
+     * because JNR-FFI doesn't expose async returns.
+     *
+     * <p>This call BLOCKS the calling thread until the token fires; callers
+     * must invoke it on a dedicated daemon thread (e.g., via
+     * {@link java.util.concurrent.CompletableFuture#runAsync}). The watcher
+     * future MUST be cancelled in a {@code finally} block so it doesn't leak
+     * if the outbound call completes naturally.
+     *
+     * @param jobId the job ID whose cancel token to await
+     * @return 0 on success (token resolved or job unregistered), -1 on
+     *         invalid input (see {@link #mesh_last_error})
+     */
+    int mesh_await_job_cancel(String jobId);
 
     /**
      * Callback type for {@link MeshCore#mesh_run_as_job}. The callback is

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
@@ -220,14 +220,54 @@ public final class JobController implements MeshJob, AutoCloseable {
     }
 
     /**
+     * Whether the cancel token bound to this controller's job in the Rust
+     * cancel registry has been fired. Returns {@code false} when the job is
+     * not currently registered (e.g. no enclosing {@code mesh_run_as_job}
+     * scope active — should not happen for handlers driven by the dispatch
+     * wrapper, but is the safe default).
+     *
+     * <p>Distinct from {@link #isTerminal}: terminal reflects local
+     * {@code complete}/{@code fail}/{@code releaseLease} intent set by
+     * <em>this</em> controller; cancelled reflects an <em>external</em>
+     * cancel signal — typically {@code POST /jobs/{id}/cancel} hitting the
+     * SDK-owned HTTP route, but also the per-attempt deadline tripping or
+     * any other cancel-token holder in the Rust runtime.
+     *
+     * <p>Java's {@link Thread#sleep} cannot be interrupted by a Tokio
+     * token firing, so long-running task handlers MUST poll this method
+     * between sleep intervals to observe mid-flight cancel — the
+     * registry-side row will already have flipped to {@code cancelled} via
+     * the cancel route's atomic update; without polling, the handler runs
+     * to natural completion and the registry's terminal state is whatever
+     * the handler eventually wrote (the cancel marker survives in row
+     * status / history but {@code final_progress} reflects the natural
+     * loop endpoint, not the cancel point). Mirrors Python's
+     * {@code asyncio.sleep} which observes cancel via the future and TS's
+     * {@code AbortSignal}-aware sleep.
+     *
+     * @return true if the cancel token has fired, false otherwise
+     * @throws MeshException if the native call fails
+     */
+    public boolean isCancelled() {
+        synchronized (lock) {
+            ensureOpen();
+            int rc = core.mesh_job_controller_is_cancelled(handle);
+            if (rc < 0) {
+                throw new MeshException("mesh_job_controller_is_cancelled failed: " + lastError(core));
+            }
+            return rc == 1;
+        }
+    }
+
+    /**
      * Free the underlying native handle and stop the background batching
      * tick (with a final flush). Idempotent — repeated calls are no-ops.
      */
     @Override
     public void close() {
         // Hold `lock` across the free so any in-flight FFI call
-        // (updateProgress / complete / fail / isTerminal) finishes
-        // before we drop the handle. The `closed` flag preserves
+        // (updateProgress / complete / fail / isTerminal / isCancelled)
+        // finishes before we drop the handle. The `closed` flag preserves
         // idempotent semantics for repeated close() calls; it's still
         // checked inside the lock by `ensureOpen` so a thread that
         // wins the race observes the closed state.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ClaimDispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ClaimDispatcher.java
@@ -2,6 +2,7 @@ package io.mcpmesh.spring;
 
 import io.mcpmesh.JobContext;
 import io.mcpmesh.JobController;
+import io.mcpmesh.core.MeshCore;
 import io.mcpmesh.core.MeshObjectMappers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -446,16 +447,20 @@ public final class ClaimDispatcher implements AutoCloseable {
         }
 
         try {
-            // Bind the Java-side ThreadLocal job context for the user
-            // method's duration. We intentionally do NOT call
-            // mesh_run_as_job here for the same reason as the inbound
-            // wrapper — see MeshToolWrapper.dispatchAsJob class javadoc.
-            // (Rust task-local + cancel-registry binding is Phase B-
-            // deferred; the registry sweep is the backstop on cancel.)
+            // Bind both the Rust-side cancel registry (via mesh_run_as_job)
+            // and the Java-side ThreadLocal job context (via
+            // JobContext.withJob) for the user method's duration. The
+            // Rust callback wrapper applies tokio::task::block_in_place
+            // so nested mesh_job_controller_* block_on calls are legal.
+            // See MeshToolWrapper.dispatchAsJob class javadoc for the
+            // full rationale (resolved via #889).
             JobContext.Snapshot snap = new JobContext.Snapshot(jobId, deadlineSecs);
             try {
-                JobContext.withJob(snap, () -> {
-                    runHandler(payload, controller);
+                runAsJobWithRegistryBinding(jobId, deadlineSecs, () -> {
+                    JobContext.withJob(snap, () -> {
+                        runHandler(payload, controller);
+                        return null;
+                    });
                     return null;
                 });
             } catch (Throwable t) {
@@ -620,6 +625,75 @@ public final class ClaimDispatcher implements AutoCloseable {
             }
         } catch (Exception e) {
             log.warn("[mesh-claim] /jobs/batch fail-fast for job={} raised: {}", jobId, e.getMessage());
+        }
+    }
+
+    /**
+     * Wrap a Java {@link java.util.concurrent.Callable} in
+     * {@link MeshCore#mesh_run_as_job} so the Rust cancel-registry entry
+     * for {@code jobId} is bound while the callable runs. Mirrors the
+     * inbound wrapper's helper (see
+     * {@link MeshToolWrapper#dispatchAsJob} class javadoc; resolved via
+     * #889). Throwables raised by the body callable are captured in a
+     * closure-captured holder and rethrown after {@code mesh_run_as_job}
+     * returns, preserving the original exception type — the C ABI's
+     * {@code int} return is too coarse to carry exception identity.
+     *
+     * <p>Snapshot serialization is a precondition, NOT part of the body:
+     * a Jackson failure inside {@link #buildRunAsJobSnapshot} (extremely
+     * unlikely given the trivial two-scalar map shape) propagates as
+     * {@link IllegalStateException} to the caller and never reaches the
+     * native FFI. The unified rethrow logic only covers exceptions raised
+     * inside the user-supplied callable.
+     */
+    private Object runAsJobWithRegistryBinding(
+            String jobId, Long deadlineSecs, java.util.concurrent.Callable<Object> body)
+            throws Exception {
+        String snapshotJson = buildRunAsJobSnapshot(jobId, deadlineSecs);
+        Object[] resultBox = new Object[1];
+        Throwable[] thrownBox = new Throwable[1];
+        MeshCore core = MeshCore.load();
+        int rc = core.mesh_run_as_job(snapshotJson, userData -> {
+            try {
+                resultBox[0] = body.call();
+                return 0;
+            } catch (Throwable t) {
+                thrownBox[0] = t;
+                return -1;
+            }
+        }, null);
+        if (thrownBox[0] != null) {
+            if (thrownBox[0] instanceof Exception ex) throw ex;
+            if (thrownBox[0] instanceof Error err) throw err;
+            throw new RuntimeException(thrownBox[0]);
+        }
+        if (rc != 0) {
+            throw new RuntimeException(
+                "mesh_run_as_job failed (rc=" + rc + ") for job=" + jobId
+                + ": " + readLastError(core));
+        }
+        return resultBox[0];
+    }
+
+    private static String buildRunAsJobSnapshot(String jobId, Long deadlineSecs) {
+        try {
+            java.util.Map<String, Object> snap = new java.util.LinkedHashMap<>();
+            snap.put("job_id", jobId);
+            snap.put("deadline_secs", deadlineSecs);
+            return MAPPER.writeValueAsString(snap);
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                "failed to serialize mesh_run_as_job snapshot for job=" + jobId, e);
+        }
+    }
+
+    private static String readLastError(MeshCore core) {
+        jnr.ffi.Pointer err = core.mesh_last_error();
+        if (err == null) return "<no error>";
+        try {
+            return err.getString(0);
+        } finally {
+            core.mesh_free_string(err);
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpHttpClient.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpHttpClient.java
@@ -3,6 +3,8 @@ package io.mcpmesh.spring;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+import io.mcpmesh.JobContext;
+import io.mcpmesh.core.MeshCore;
 import io.mcpmesh.core.MeshCoreBridge;
 import io.mcpmesh.core.MeshObjectMappers;
 import io.mcpmesh.spring.tracing.TraceContext;
@@ -82,6 +84,77 @@ public class McpHttpClient {
         LAST_CALL_METRICS.remove();
     }
 
+    /**
+     * Daemon executor for outbound HTTP cancel watchers (#900). One thread
+     * per concurrent in-flight job (NOT per outbound call — see
+     * {@link JobCancelWatcher} below). Daemon so it never blocks JVM
+     * shutdown. Watchers exit when {@link MeshCore#mesh_await_job_cancel}
+     * returns (cancel fired OR job unregistered naturally). Mirror of TS
+     * PR #897's outbound abort wiring.
+     */
+    private static final java.util.concurrent.ExecutorService JOB_CANCEL_WATCHER_EXECUTOR =
+        java.util.concurrent.Executors.newCachedThreadPool(r -> {
+            Thread t = new Thread(r, "mesh-job-cancel-watcher");
+            t.setDaemon(true);
+            return t;
+        });
+
+    /**
+     * Per-job cancel watcher (#900 follow-up). When a producer's task=true
+     * handler makes multiple outbound HTTP calls, we want exactly ONE
+     * watcher thread blocked in native mesh_await_job_cancel(jobId) — not
+     * N threads, one per call. Each outbound call subscribes its
+     * Call.cancel() runnable; when the underlying token fires, all
+     * subscribers run. The map auto-removes the entry on watcher exit so
+     * a fresh job under the same id (re-claim path) gets a fresh watcher.
+     *
+     * <p>Per-job, not per-call: native mesh_await_job_cancel is sync and
+     * uninterruptible from Java; spawning one thread per call would leak
+     * N stuck native threads until the job ends. The shared-watcher design
+     * caps thread cost at 1 per concurrent in-flight job.
+     */
+    private static final java.util.concurrent.ConcurrentMap<String, JobCancelWatcher>
+        ACTIVE_WATCHERS = new java.util.concurrent.ConcurrentHashMap<>();
+
+    private static final class JobCancelWatcher {
+        private final java.util.List<Runnable> subscribers =
+            new java.util.concurrent.CopyOnWriteArrayList<>();
+
+        JobCancelWatcher(String jobId) {
+            // `self` capture lets us use ConcurrentHashMap.remove(K, V)
+            // below — identity-aware removal so a watcher that finished
+            // can't accidentally evict a newer watcher installed under
+            // the same jobId in the post-cancel-pre-handler-end window.
+            final JobCancelWatcher self = this;
+            java.util.concurrent.CompletableFuture.runAsync(() -> {
+                try {
+                    MeshCore.load().mesh_await_job_cancel(jobId);
+                    // Token fired (cancel) OR job unregistered (natural
+                    // end). Either way, run all subscribers; on the
+                    // natural-end path the call.cancel() invocations are
+                    // no-ops because the calls have already completed.
+                    for (Runnable r : subscribers) {
+                        try {
+                            r.run();
+                        } catch (Exception swallow) {
+                            log.debug("Subscriber threw: {}", swallow.toString());
+                        }
+                    }
+                } catch (Exception e) {
+                    // Swallow Exception — Errors propagate (let the JVM
+                    // handle OOM/StackOverflow). The natural-completion
+                    // path remains the backstop on watcher failure.
+                    log.debug("Job cancel watcher for {} caught: {}", jobId, e.toString());
+                } finally {
+                    ACTIVE_WATCHERS.remove(jobId, self);
+                }
+            }, JOB_CANCEL_WATCHER_EXECUTOR);
+        }
+
+        void subscribe(Runnable r) { subscribers.add(r); }
+        void unsubscribe(Runnable r) { subscribers.remove(r); }
+    }
+
     private final OkHttpClient httpClient;
     private final ObjectMapper objectMapper;
 
@@ -111,6 +184,75 @@ public class McpHttpClient {
 
         this.httpClient = builder.build();
         this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Wrap an OkHttp {@link Call#execute()} with cancel-watcher wiring so
+     * outbound HTTP calls abort when the producer's job is cancelled (#900).
+     *
+     * <p>If a {@link JobContext} is active on the calling thread, spawns a
+     * watcher on {@link #JOB_CANCEL_WATCHER_EXECUTOR} that blocks on
+     * {@link MeshCore#mesh_await_job_cancel} until either:
+     * <ul>
+     *   <li>the cancel token fires (POST /jobs/{id}/cancel forwarded by the
+     *       registry) — the watcher invokes {@link Call#cancel()} which races
+     *       with {@code execute()} and surfaces as
+     *       {@link java.io.InterruptedIOException} below; OR</li>
+     *   <li>the job is unregistered naturally (handler returned without
+     *       cancel) — the watcher exits without calling {@code cancel()}.</li>
+     * </ul>
+     * The {@code finally} block also cancels the watcher future to bound
+     * its lifetime: the {@code mesh_await_job_cancel} call will return
+     * promptly via the registry's {@code ended} token when the surrounding
+     * {@code mesh_run_as_job} scope tears down.
+     *
+     * <p>If no job context is active, this method is a thin pass-through to
+     * {@code call.execute()} with zero overhead.
+     *
+     * <p>Mirror of TypeScript PR #897's {@code awaitJobCancel} +
+     * {@code AbortController} wiring in {@code proxy.ts}.
+     *
+     * @param call OkHttp Call to execute (must not have been executed yet)
+     * @return the {@link Response} on natural success; caller is responsible
+     *         for try-with-resources
+     * @throws java.io.InterruptedIOException when cancellation races with
+     *         execute() — surfaces as an interruption signal so the
+     *         dispatch wrapper sees it as a cancel rather than an HTTP
+     *         error
+     * @throws IOException for any other transport failure
+     */
+    private Response executeWithJobCancelWatcher(Call call) throws IOException {
+        JobContext.Snapshot job = JobContext.current();
+        Runnable subscriber = null;
+        JobCancelWatcher watcher = null;
+        if (job != null && job.jobId != null) {
+            String jobId = job.jobId;
+            watcher = ACTIVE_WATCHERS.computeIfAbsent(jobId, JobCancelWatcher::new);
+            subscriber = () -> {
+                if (!call.isCanceled()) {
+                    call.cancel();
+                }
+            };
+            watcher.subscribe(subscriber);
+        }
+        try {
+            return call.execute();
+        } catch (java.io.IOException e) {
+            // OkHttp throws IOException("Canceled") when Call.cancel()
+            // races with execute(). Re-classify as a cancellation so the
+            // dispatch wrapper sees an InterruptedIOException-like signal
+            // rather than an HTTP error.
+            if (call.isCanceled()) {
+                throw new java.io.InterruptedIOException(
+                    "outbound HTTP call cancelled via mesh job cancel: "
+                        + e.getMessage());
+            }
+            throw e;
+        } finally {
+            if (watcher != null && subscriber != null) {
+                watcher.unsubscribe(subscriber);
+            }
+        }
     }
 
     /**
@@ -293,7 +435,12 @@ public class McpHttpClient {
                 .writeTimeout(effectiveTimeoutSecs + 10, TimeUnit.SECONDS)
                 .build();
 
-            try (Response response = perCallClient.newCall(httpRequest).execute()) {
+            // executeWithJobCancelWatcher (#900) wires a daemon watcher on
+            // the active job's cancel token (no-op if no job context) so a
+            // mid-flight cancel aborts the in-flight HTTP call instead of
+            // letting it run to its read timeout.
+            Call call = perCallClient.newCall(httpRequest);
+            try (Response response = executeWithJobCancelWatcher(call)) {
                 if (!response.isSuccessful()) {
                     throw new MeshToolCallException(functionName, functionName,
                         "HTTP " + response.code() + ": " + response.message());
@@ -799,7 +946,10 @@ public class McpHttpClient {
                 return;
             }
 
-            try (Response response = call.execute()) {
+            // executeWithJobCancelWatcher (#900) — same wiring as the
+            // buffered callTool path: outbound SSE stream is aborted if
+            // the producer's job is cancelled mid-flight.
+            try (Response response = executeWithJobCancelWatcher(call)) {
                 if (!response.isSuccessful()) {
                     upstreamError = new MeshToolCallException(functionName, functionName,
                         "HTTP " + response.code() + ": " + response.message());
@@ -977,7 +1127,13 @@ public class McpHttpClient {
                 .header("Accept", "application/json, text/event-stream")
                 .build();
 
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            // executeWithJobCancelWatcher (#900) — listTools is normally
+            // a discovery call outside any job scope (helper is a pass-
+            // through when no JobContext is active), but if a user code
+            // path ever invokes it from a task=true handler the cancel
+            // wiring is consistent with the other call sites.
+            Call call = httpClient.newCall(httpRequest);
+            try (Response response = executeWithJobCancelWatcher(call)) {
                 if (!response.isSuccessful()) {
                     log.warn("Failed to list tools at {}: HTTP {}", endpoint, response.code());
                     return null;

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -8,6 +8,7 @@ import io.mcpmesh.JobController;
 import io.mcpmesh.MeshJob;
 import io.mcpmesh.MeshJobSubmitter;
 import io.mcpmesh.Param;
+import io.mcpmesh.core.MeshCore;
 import io.mcpmesh.spring.tracing.ExecutionTracer;
 import io.mcpmesh.spring.tracing.SpanScope;
 import io.mcpmesh.spring.tracing.TraceContext;
@@ -671,18 +672,20 @@ public class MeshToolWrapper implements McpToolHandler {
      * if not already terminal, then propagates the exception so the MCP
      * SDK surfaces it as a tool-call error.
      *
-     * <p><b>Why no {@code mesh_run_as_job} on the Java sync path?</b>
-     * The Rust {@code mesh_run_as_job} wraps its callback in
-     * {@code jobs_runtime().block_on}; calling any
-     * {@code mesh_job_controller_*} (which also block_on internally)
-     * from inside that callback panics with a "Cannot start a runtime
-     * from within a runtime" Tokio error. The Python and TypeScript
-     * SDKs use {@code with_job} (async) so the callback's awaits don't
-     * nest block_ons — Java's only synchronous JNR-FFI bindings can't
-     * compose the same way. Cancel-registry binding for the Java path
-     * is therefore Phase B-deferred (the registry sweep is the
-     * backstop); user code sees an interrupted thread on cancel via
-     * {@link Thread#interrupt} once Phase 2 wires that up.
+     * <p><b>How the Java sync path binds the Rust cancel registry:</b>
+     * The dispatch wraps the user invocation in {@code mesh_run_as_job}
+     * (a C-ABI export that internally calls {@code run_as_job} and binds
+     * the cancel registry entry for the job ID). The Rust side wraps the
+     * callback in {@code tokio::task::block_in_place} so nested
+     * {@code block_on} calls from inside the callback (e.g.
+     * {@code mesh_job_controller_complete}) don't panic. This makes
+     * {@code POST /jobs/{id}/cancel} fire the in-flight cancel token
+     * immediately, matching Python and TypeScript behaviour. The
+     * Java-side {@link JobContext} ThreadLocal is still bound on top
+     * because the Rust task-local isn't visible to Java code in the
+     * callback — user code's {@code JobContext.current()} reads and
+     * outbound-header injection both depend on the ThreadLocal mirror.
+     * Resolved via #889.
      *
      * <p>Mirrors (Java-adapted):
      * <ul>
@@ -741,7 +744,8 @@ public class MeshToolWrapper implements McpToolHandler {
                 fullArgs[meshJobParamIndex] = null;
             }
             JobContext.Snapshot snap = new JobContext.Snapshot(jobId, deadlineSecs);
-            return JobContext.withJob(snap, () -> invokeNoController(fullArgs));
+            return runAsJobWithRegistryBinding(jobId, deadlineSecs,
+                () -> JobContext.withJob(snap, () -> invokeNoController(fullArgs)));
         }
 
         // Construct the producer controller. Free in finally.
@@ -750,13 +754,113 @@ public class MeshToolWrapper implements McpToolHandler {
             // Inject the controller at the MeshJob slot
             fullArgs[meshJobParamIndex] = controller;
 
-            // Bind the Java-side ThreadLocal job context for the duration
-            // of the user method. See class javadoc on dispatchAsJob for
-            // why we don't also bind the Rust-side task-local.
+            // Bind both the Rust-side cancel registry (via mesh_run_as_job)
+            // and the Java-side ThreadLocal job context (via JobContext.withJob)
+            // for the duration of the user method. See class javadoc on
+            // dispatchAsJob for the rationale (resolved via #889).
             JobContext.Snapshot snap = new JobContext.Snapshot(jobId, deadlineSecs);
-            return JobContext.withJob(snap, () -> invokeAndAutoComplete(fullArgs, controller));
+            try {
+                return runAsJobWithRegistryBinding(jobId, deadlineSecs,
+                    () -> JobContext.withJob(snap, () -> invokeAndAutoComplete(fullArgs, controller)));
+            } catch (Throwable t) {
+                // Defensive: runAsJobWithRegistryBinding can throw BEFORE
+                // invokeAndAutoComplete runs (snapshot serialization or
+                // mesh_run_as_job rc != 0 path). The row was claimed
+                // (status=working); without a terminal call here it would
+                // sit in working until lease expiry. Mark failed best-effort
+                // before rethrowing so the consumer's await() resolves
+                // promptly. tryFail is no-op when already terminal (e.g.
+                // invokeAndAutoComplete ran and the helper already
+                // reported), so the double-cover is safe.
+                tryFail(controller, "dispatch error before user method: " +
+                    (t.getMessage() != null ? t.getMessage() : t.getClass().getSimpleName()));
+                throw t;
+            }
         } finally {
             controller.close();
+        }
+    }
+
+    /**
+     * Wrap a Java {@link Callable} in {@link MeshCore#mesh_run_as_job} so
+     * the Rust cancel-registry entry for {@code jobId} is bound while the
+     * callable runs. {@code POST /jobs/{jobId}/cancel} can then fire the
+     * in-flight cancel token via {@code mesh_cancel_active_job} — the
+     * Java-only path previously skipped this binding (Phase A of #889).
+     *
+     * <p>Throwables raised by the body callable are captured in a closure-
+     * captured holder and rethrown after {@code mesh_run_as_job} returns,
+     * preserving the original exception type for the auto-complete logic
+     * ({@code retryOn} matching, etc.) — the Rust callback's {@code int}
+     * return is too coarse to carry exception identity.
+     *
+     * <p>Snapshot serialization is a precondition, NOT part of the body:
+     * a Jackson failure inside {@link #buildRunAsJobSnapshot} (extremely
+     * unlikely given the trivial two-scalar map shape) propagates as
+     * {@link IllegalStateException} to the caller and never reaches the
+     * native FFI. The unified rethrow logic only covers exceptions raised
+     * inside the user-supplied callable.
+     */
+    private Object runAsJobWithRegistryBinding(
+            String jobId, Long deadlineSecs, java.util.concurrent.Callable<Object> body)
+            throws Exception {
+        String snapshotJson = buildRunAsJobSnapshot(jobId, deadlineSecs);
+        Object[] resultBox = new Object[1];
+        Throwable[] thrownBox = new Throwable[1];
+        MeshCore core = MeshCore.load();
+        int rc = core.mesh_run_as_job(snapshotJson, userData -> {
+            // Inside mesh_run_as_job's run_as_job scope on a Tokio worker
+            // thread (block_in_place applied on the Rust side so nested
+            // controller block_on calls are legal).
+            try {
+                resultBox[0] = body.call();
+                return 0;
+            } catch (Throwable t) {
+                thrownBox[0] = t;
+                return -1;
+            }
+        }, null);
+        if (thrownBox[0] != null) {
+            if (thrownBox[0] instanceof Exception ex) throw ex;
+            if (thrownBox[0] instanceof Error err) throw err;
+            throw new RuntimeException(thrownBox[0]);
+        }
+        if (rc != 0) {
+            throw new RuntimeException(
+                "mesh_run_as_job failed (rc=" + rc + ") for job=" + jobId
+                + ": " + readLastError(core));
+        }
+        return resultBox[0];
+    }
+
+    /**
+     * Build the {@code mesh_run_as_job} snapshot payload:
+     * {@code {"job_id": "...", "deadline_secs": <number>|null}}.
+     */
+    private String buildRunAsJobSnapshot(String jobId, Long deadlineSecs) {
+        try {
+            Map<String, Object> snap = new LinkedHashMap<>();
+            snap.put("job_id", jobId);
+            snap.put("deadline_secs", deadlineSecs);
+            return objectMapper.writeValueAsString(snap);
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                "failed to serialize mesh_run_as_job snapshot for job=" + jobId, e);
+        }
+    }
+
+    /**
+     * Drain {@code mesh_last_error} into a Java string for diagnostic use,
+     * freeing the native pointer. Returns {@code "<no error>"} when the
+     * last-error slot is empty.
+     */
+    private static String readLastError(MeshCore core) {
+        jnr.ffi.Pointer err = core.mesh_last_error();
+        if (err == null) return "<no error>";
+        try {
+            return err.getString(0);
+        } finally {
+            core.mesh_free_string(err);
         }
     }
 

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
@@ -276,6 +276,70 @@ public class LongTaskConsumerApplication {
     }
 
     // -------------------------------------------------------------------
+    // Transient-failures submitter (tc23 — exercises @MeshTool(retryOn=...))
+    // -------------------------------------------------------------------
+    //
+    // Mirrors Python's commission_transient_failures
+    // (uc21_meshjob/fixtures/long-task-consumer/main.py). Submits a
+    // report_with_transient_failures job with caller-supplied max_retries
+    // and waits for terminal — the captured payload exposes
+    // succeeded_on_attempt so the test asserts attempt_count == 3.
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "commission_transient_failures",
+        description = "Submit report_with_transient_failures with caller-supplied max_retries.",
+        dependencies = @Selector(capability = "report_with_transient_failures")
+    )
+    public Map<String, Object> commissionTransientFailures(
+            @Param("user_id") String userId,
+            @Param(value = "max_retries", required = false) Integer maxRetries,
+            @Param(value = "transient_failures", required = false) Integer transientFailures,
+            @Param(value = "wait_timeout_secs", required = false) Integer waitTimeoutSecs,
+            MeshJob reportWithTransientFailures) {
+        if (!(reportWithTransientFailures instanceof MeshJobSubmitter submitter)) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "report_with_transient_failures submitter not injected");
+            return err;
+        }
+        int retries = maxRetries == null ? 3 : maxRetries;
+        int targetTransient = transientFailures == null ? 2 : transientFailures;
+        int waitSecs = waitTimeoutSecs == null ? 30 : waitTimeoutSecs;
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        payload.put("transient_failures", targetTransient);
+        // max_duration=30s mirrors Python — keeps the per-attempt budget
+        // tight so a slow-path lease-expiry recovery would push past the
+        // 30s wall-clock guard the test asserts.
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            payload, null, 30, retries, null);
+
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            String jobId = proxy.jobId();
+            try {
+                Object result = proxy.await((double) waitSecs);
+                Map<String, Object> envelope = new LinkedHashMap<>();
+                envelope.put("job_id", jobId);
+                envelope.put("status", "completed");
+                envelope.put("result", result);
+                return envelope;
+            } catch (Exception e) {
+                Map<String, Object> envelope = new LinkedHashMap<>();
+                envelope.put("job_id", jobId);
+                envelope.put("status", "wait_raised");
+                envelope.put("error", e.getMessage());
+                return envelope;
+            }
+        } catch (Exception e) {
+            Map<String, Object> envelope = new LinkedHashMap<>();
+            envelope.put("job_id", null);
+            envelope.put("status", "submit_raised");
+            envelope.put("error", e.getMessage());
+            return envelope;
+        }
+    }
+
+    // -------------------------------------------------------------------
     // Overlong submitter (tc06, tc20)
     // -------------------------------------------------------------------
     @MeshTool(

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
@@ -12,10 +12,17 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -208,6 +215,95 @@ public class LongTaskProviderApplication {
     }
 
     // -------------------------------------------------------------------
+    // Transient-failure path — exercises @MeshTool(retryOn=...) (#895) (tc23)
+    // -------------------------------------------------------------------
+    //
+    // Mirrors Python's report_with_transient_failures
+    // (uc21_meshjob/fixtures/long-task-provider/main.py). The handler is
+    // annotated with retryOn={IOException.class}: when the body throws
+    // IOException the dispatch wrapper calls JobController.releaseLease
+    // (NOT fail), so the registry resets owner_instance_id and the next
+    // claim cycle re-runs the handler — proving the fast-retry path
+    // engaged rather than waiting for lease expiry.
+    //
+    // The attempt counter lives at /tmp/mesh-retry-on-counter so it
+    // survives across attempts even if the runtime ever hands the next
+    // claim to a peer replica. Single-process here; the file pattern
+    // matches Python so the assertions (attempt_count=3) remain
+    // language-agnostic.
+    // -------------------------------------------------------------------
+    private static final Path RETRY_COUNTER_PATH = Paths.get("/tmp/mesh-retry-on-counter");
+
+    /**
+     * Atomic-ish file-based counter shared across attempts. Returns the
+     * NEW (post-increment) value so the handler can decide whether this
+     * attempt is in the transient-failure window or the success window.
+     *
+     * <p>Uses {@link FileLock} so concurrent claims (would-be peers in a
+     * future scaled scenario) don't lose updates. Mirrors Python's
+     * {@code _bump_retry_counter} which uses a plain read-modify-write.
+     */
+    private static int bumpRetryCounter() throws IOException {
+        // Ensure the file exists before opening read-write so the first
+        // call doesn't see a FileNotFoundException.
+        if (!Files.exists(RETRY_COUNTER_PATH)) {
+            Files.write(RETRY_COUNTER_PATH, "0".getBytes(StandardCharsets.UTF_8));
+        }
+        try (RandomAccessFile raf = new RandomAccessFile(RETRY_COUNTER_PATH.toFile(), "rw");
+             FileChannel ch = raf.getChannel();
+             FileLock ignored = ch.lock()) {
+            // Read from the locked raf — Files.readAllBytes would open a
+            // separate FD and bypass the lock.
+            long len = raf.length();
+            String body = "0";
+            if (len > 0) {
+                byte[] buf = new byte[(int) len];
+                raf.seek(0);
+                raf.readFully(buf);
+                body = new String(buf, StandardCharsets.UTF_8).trim();
+            }
+            int n = body.isEmpty() ? 0 : Integer.parseInt(body);
+            n += 1;
+            raf.setLength(0);
+            raf.seek(0);
+            raf.write(Integer.toString(n).getBytes(StandardCharsets.UTF_8));
+            return n;
+        }
+    }
+
+    @MeshTool(
+        capability = "report_with_transient_failures",
+        task = true,
+        retryOn = IOException.class,
+        description = "Raises IOException on the first N attempts, succeeds on N+1 — exercises retryOn (#895)."
+    )
+    public Map<String, Object> reportWithTransientFailures(
+            @Param("user_id") String userId,
+            @Param(value = "transient_failures", required = false) Integer transientFailures,
+            MeshJob job) throws IOException {
+        int targetTransient = transientFailures == null ? 2 : transientFailures;
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller != null) {
+            controller.updateProgress(0.1, "checking transient counter");
+        }
+        int n = bumpRetryCounter();
+        if (n <= targetTransient) {
+            // Match Python's message shape so log-grep based debugging
+            // is uniform across runtimes. retryOn=IOException matches
+            // here -> dispatch wrapper calls releaseLease(reason).
+            throw new IOException(
+                "simulated transient failure " + n + "/" + targetTransient);
+        }
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        payload.put("succeeded_on_attempt", n);
+        if (controller != null) {
+            controller.complete(payload);
+        }
+        return payload;
+    }
+
+    // -------------------------------------------------------------------
     // Long-running task (tc06, tc09, tc10–tc13 use this via SIGKILL)
     // -------------------------------------------------------------------
     @MeshTool(
@@ -224,9 +320,24 @@ public class LongTaskProviderApplication {
         double elapsed = 0.0;
         double step = 0.5;
         double total = Math.max(totalSecs, step);
+        boolean cancelled = false;
         while (elapsed < total) {
             Thread.sleep((long) (step * 1000));
             elapsed += step;
+            // Poll the cancel-registry state between sleeps so a
+            // mid-flight POST /jobs/{id}/cancel breaks out of the loop
+            // promptly. Java's Thread.sleep can't be interrupted by a
+            // Tokio token firing the way Python's asyncio.sleep can,
+            // so this poll IS our cancellation observation point. Once
+            // observed, we skip the trailing updateProgress and the
+            // complete() below — the cancel route has already flipped
+            // the registry row to terminal `cancelled`, so any further
+            // delta from this defunct attempt would either be rejected
+            // as not_owner or stomp on the cancel marker.
+            if (controller != null && controller.isCancelled()) {
+                cancelled = true;
+                break;
+            }
             if (controller != null) {
                 controller.updateProgress(
                     Math.min(elapsed / total, 0.99),
@@ -236,7 +347,8 @@ public class LongTaskProviderApplication {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("user_id", userId);
         payload.put("elapsed", elapsed);
-        if (controller != null) {
+        payload.put("cancelled", cancelled);
+        if (controller != null && !cancelled) {
             controller.complete(payload);
         }
         return payload;

--- a/tests/integration/suites/uc23_meshjob_java/tc06_cancel_alive_owner_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc06_cancel_alive_owner_java/test.yaml
@@ -3,27 +3,31 @@
 # Submits an overlong job (~30s), waits 5s for the producer's claim
 # worker to take ownership, then calls __mesh_job_cancel.
 #
-# IMPORTANT — Java cancel limitation (#889):
+# Post-#889 cancel pipeline (Java owner):
 #
-# Per #889, Java's sync JNR-FFI bindings cannot bind the per-job cancel
-# registry table — the natural binding path requires nested Tokio
-# block_on which Tokio rejects. The substrate's cancel pipeline
-# therefore behaves as follows on a Java owner:
+#   1. Registry's CancelJob handler succeeds and marks the row cancelled.
+#   2. Registry POSTs /jobs/{id}/cancel to the Java provider's local
+#      route.
+#   3. Java cancel route returns {cancelled: true, jobId} because Phase
+#      A wires mesh_run_as_job to bind the per-job cancel-registry
+#      token; mesh_cancel_active_job finds the bound token and fires it.
+#   4. The runs_overlong handler observes the cancel token (via
+#      JobController.is_terminal()) and breaks out of its sleep loop
+#      before the natural ~30s completion.
 #
-#   - registry's CancelJob handler succeeds and marks the row cancelled
-#   - registry POSTs /jobs/{id}/cancel to the owner Java replica
-#   - the Java cancel route returns {cancelled:false, jobId} because the
-#     local cancel-registry lookup misses (binding inactive)
-#   - the Java task body does NOT abort; runs_overlong continues to its
-#     natural end (~30s) — but the registry already marked cancelled, so
-#     the consumer's status read sees status=cancelled
-#
-# Assertion: status=cancelled in the registry. We do NOT assert that
-# the task aborted faster than its natural completion, because Java
-# cannot deliver that guarantee until #889 is fixed.
+# Assertions (all post-#889):
+#   - registry-side status=cancelled
+#   - cancel-to-cancelled wall clock < 10s (registry-side write is
+#     synchronous; this guards against pathological cases)
+#   - final progress < 0.95 — proves the handler aborted before its
+#     natural completion. The runs_overlong loop reaches progress=0.99
+#     when it runs to completion, so progress < 0.95 means cancel
+#     fired and the loop broke out early. Without Phase A, the handler
+#     would run to completion and progress would land at ~0.99 even
+#     though the registry-side row says cancelled.
 
-name: "MeshJob Java: cancel registers as cancelled in registry (Java cancel-registry inactive per #889)"
-description: "Java submit overlong job, cancel mid-flight, observe cancelled status in registry. Does NOT assert mid-flight abort (see #889 inline)."
+name: "MeshJob Java: cancel propagates through Java cancel-registry binding"
+description: "Java submit overlong job, cancel mid-flight; the Java provider's local cancel-registry binding (Phase A) fires the token and aborts the handler before natural completion"
 tags:
   - meshjob
   - java
@@ -67,7 +71,7 @@ test:
       for i in $(seq 1 60); do
         S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
         [ "$S" = "healthy" ] && exit 0; sleep 2
-      done; exit 1
+      done; echo "ERROR provider"; exit 1
     timeout: 150
 
   - name: "Start consumer"
@@ -83,7 +87,7 @@ test:
         ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
         S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
         [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
-      done; exit 1
+      done; echo "ERROR consumer"; exit 1
     timeout: 150
 
   - name: "Submit a 30-second job"
@@ -98,10 +102,9 @@ test:
     handler: wait
     seconds: 5
 
-  # Per #889 the registry-side cancel handler always succeeds even if
-  # the producer never claimed. Without a pre-cancel progress check
-  # this test could pass for the wrong reason. Confirm the row
-  # recorded at least one progress emission before we cancel.
+  # Confirm the producer is in flight (progress > 0) before cancel.
+  # Without this, a cancel landing pre-claim would mark the row
+  # cancelled trivially and pass the test for the wrong reason.
   - name: "Confirm producer is in flight (progress > 0 before cancel)"
     handler: shell
     workdir: /workspace
@@ -120,6 +123,12 @@ test:
       exit 1
     timeout: 30
 
+  - name: "Capture wall-clock just before cancel"
+    handler: shell
+    workdir: /workspace
+    command: date +%s
+    capture: ts_cancel_start
+
   - name: "Cancel the job"
     handler: shell
     workdir: /workspace
@@ -130,11 +139,42 @@ test:
     capture: cancel_response
     timeout: 15
 
-  - name: "Wait for cancel to settle in registry"
-    handler: wait
-    seconds: 8
+  # Poll until status flips to cancelled, capture elapsed time. The
+  # registry-side row flip happens synchronously inside CancelJob, so
+  # this lower-bounds at the registry RTT — typically <2s. The guard
+  # below is at <10s to leave slack for slow CI.
+  - name: "Poll until status=cancelled, capture elapsed time"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      START='${captured.ts_cancel_start}'
+      START_NUM=$(echo "$START" | tr -d -c '0-9')
+      for i in $(seq 1 15); do
+        S=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.status' 2>/dev/null)
+        if [ "$S" = "cancelled" ]; then
+          NOW=$(date +%s)
+          echo "cancel_elapsed=$((NOW - START_NUM))"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: status never flipped to cancelled within 15s (last=$S)"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq .
+      exit 1
+    capture: cancel_elapsed
+    timeout: 30
 
-  - name: "Read final status"
+  # Wait a few seconds AFTER cancel observes the row flip, so any
+  # in-flight progress updates from the (now-defunct) Java handler
+  # have a chance to land. With Phase A active, the handler should
+  # have aborted via the cancel token; without it, progress would
+  # keep climbing toward 0.99 (natural runs_overlong endpoint).
+  - name: "Wait 5s for any post-cancel progress to settle"
+    handler: wait
+    seconds: 5
+
+  - name: "Read final status (capture progress for the abort-vs-natural check)"
     handler: shell
     workdir: /workspace
     command: |
@@ -142,15 +182,64 @@ test:
       meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
     capture: final_status
 
+  - name: "Capture raw progress field for assertion arithmetic"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.progress // 0'
+    capture: final_progress
+
+  # Wall-clock guard — with Phase A's cancel-registry binding active,
+  # cancel propagation completes <10s typical. Larger elapsed values
+  # indicate a regression to the slow path (sweep-driven recovery).
+  - name: "Assert cancel-to-cancelled elapsed < 10s (proves fast cancel path)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      ELAPSED=$(echo '${captured.cancel_elapsed}' | grep -oE 'cancel_elapsed=[0-9]+' | sed 's/cancel_elapsed=//')
+      if [ -z "$ELAPSED" ]; then
+        echo "ERROR: could not extract cancel_elapsed from: ${captured.cancel_elapsed}"
+        exit 1
+      fi
+      if [ "$ELAPSED" -ge 10 ]; then
+        echo "ERROR: cancel_elapsed=${ELAPSED}s >= 10s — cancel forwarding may have regressed"
+        exit 1
+      fi
+      echo "OK: cancel_elapsed=${ELAPSED}s < 10s (fast cancel path active)"
+
+  # Progress guard — runs_overlong's loop ticks updateProgress at
+  # min(elapsed/total, 0.99) each ~0.5s. If the handler aborts
+  # mid-flight (cancel token fired), progress will be well below 0.99.
+  # If the handler ran to natural completion (cancel ineffective on
+  # the handler), progress lands at 0.99. <0.95 is a tight enough
+  # threshold to flag a regression while leaving room for the handler
+  # to emit a few more progress points after cancel-token-set but
+  # before the loop re-checks isTerminal().
+  - name: "Assert final progress < 0.95 (handler aborted before natural completion)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      P='${captured.final_progress}'
+      P_TRIM=$(echo "$P" | tr -d ' \t\n\r')
+      if [ -z "$P_TRIM" ] || [ "$P_TRIM" = "null" ]; then
+        echo "ERROR: empty/null progress: '$P'"
+        exit 1
+      fi
+      if awk "BEGIN{exit !(${P_TRIM} >= 0.95)}"; then
+        echo "ERROR: final progress=${P_TRIM} >= 0.95 — handler likely ran to completion (Phase A binding regressed)"
+        exit 1
+      fi
+      echo "OK: final progress=${P_TRIM} < 0.95 (handler aborted via cancel token)"
+
 assertions:
   # Java helper returns {ok:true, job_id:...} (snake_case); compact JSON.
   - expr: "${captured.cancel_response} contains '\\\"ok\\\":true'"
     message: "__mesh_job_cancel response should include ok:true"
-  # Per #889 — the registry-side row flips to cancelled even though the
-  # Java owner's local cancel token didn't fire. This is the substantive
-  # signal we CAN test for Java today.
+  # Registry-side status flip (works irrespective of Phase A — guard
+  # against catastrophic regression of the registry's CancelJob path).
   - expr: "${captured.final_status} contains '\\\"status\\\":\\\"cancelled\\\"'"
-    message: "registry-side status should be cancelled (Java cancel-registry binding inactive per #889; this still validates the registry's CancelJob path)"
+    message: "registry-side status should be cancelled"
 
 post_run:
   - routine: stop_all

--- a/tests/integration/suites/uc23_meshjob_java/tc09_cancel_aborts_outbound_http_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc09_cancel_aborts_outbound_http_java/test.yaml
@@ -7,44 +7,63 @@
 #
 # After submit, wait briefly then cancel.
 #
-# IMPORTANT — Java has TWO documented limitations relevant here:
+# IMPORTANT — outbound-HTTP cancel propagation, post-#900:
 #
-#   1. #889: Java cancel-registry binding inactive (sync JNR-FFI cannot
-#      bind nested Tokio runtime). The cancel route returns
-#      cancelled:false; the in-process cancel token never fires.
+# #889 (Phase A) fixed the producer-local cancel-registry binding —
+# the Java handler's cancel token now DOES fire when the registry
+# forwards a cancel (see tc06 / tc22 which assert this directly).
 #
-#   2. uc22/tc09 already documents that even with the cancel token
-#      firing, the inbound transport on the downstream agent must
-#      surface client-disconnect as a cancellation to the tool handler.
-#      The Java SDK does not yet propagate inbound cancel either —
-#      same gap as Python (#882) and TS (open follow-up).
+# #900 (this PR) wires the producer-side outbound abort hook into
+# {@link io.mcpmesh.spring.McpHttpClient}: a daemon watcher thread
+# blocks on {@code mesh_await_job_cancel} for the duration of each
+# OkHttp Call.execute() and aborts the call when the producer's
+# cancel token fires. Mirror of TypeScript PR #897. So when a Java
+# task=true handler issues outbound work via the SDK's McpHttpClient
+# (the McpMeshTool proxy path), cancel now propagates end-to-end on
+# the producer side.
 #
-# Producer fixture's report_with_downstream_call also can't use a
+# This test, however, exercises a DIFFERENT outbound surface:
+# producer fixture's report_with_downstream_call can't use a
 # McpMeshTool dependency (Java SDK rejects task=true producers with
-# Selector deps; see provider source comment) — it issues a plain
-# HTTP POST to the sleeper's /mcp endpoint instead. Same outbound HTTP
-# surface, just minus the resolution-layer wrapper.
+# Selector deps; see provider source comment), so it falls back to a
+# plain {@code java.net.http.HttpClient} send() against the sleeper's
+# /mcp endpoint. The #900 wiring is bound to OkHttp Calls inside
+# McpHttpClient — it does NOT instrument the JDK's java.net.http
+# HttpClient. So tc09 still does NOT observe a producer-side outbound
+# abort here (the substrate IS fixed for the McpHttpClient code path
+# — uc23/tc06 / tc22 cover the registry-side flip; a follow-up
+# fixture variant could exercise the McpHttpClient path with a
+# regular-tool dep on the consumer side to drive the abort end-to-end).
 #
-# What DOES work for Java today:
+# Downstream-side observability (sleeper's slowDownstream waking up
+# mid-sleep) requires the downstream handler to poll isCancelled() the
+# same way runsOverlong does — that's a downstream-side concern
+# orthogonal to #900 (#886-style cross-runtime gap). Not asserted here.
+#
+# What DOES work for Java today (post-#889 + post-#900):
 #   - registry-side row flips to status=cancelled (registry route works)
+#   - producer's local cancel token fires (#889 Phase A — see tc06/tc22)
+#   - producer's McpHttpClient outbound calls abort on cancel (#900)
 #
-# What does NOT work for Java today:
-#   - producer's local cancel token doesn't fire (#889)
-#   - downstream sleeper's marker line doesn't fire (#886-style)
-#   - the runs_overlong / downstream HTTP runs to natural completion
-#     until the producer hits a sweep or the registry pre-cancels
+# What still does NOT propagate in tc09 specifically:
+#   - producer fixture uses java.net.http.HttpClient (not McpHttpClient),
+#     so the #900 wiring doesn't apply — this is a fixture-level gap,
+#     not a substrate gap. A follow-up fixture variant using the
+#     McpHttpClient code path would close this.
+#   - downstream sleeper's slowDownstream handler doesn't poll
+#     isCancelled(), so it sleeps to natural completion (#886-style).
 #
-# This test asserts what's observable: registry-side status=cancelled.
-# The downstream-sleeper-java's marker is NOT asserted (parallel to
-# uc22/tc09's pattern for the cross-runtime gap).
+# This test asserts the registry-side row flip + cancel-elapsed wall
+# clock guard (parity with tc06's <10s threshold).
 
-name: "MeshJob Java: cancel registers as cancelled in registry (downstream propagation gap per #889/#886)"
-description: "Java — provider calls slow_downstream(30s) via HTTP; cancel must result in cancelled status in registry. Producer-local + downstream propagation NOT asserted (Java #889 + cross-runtime #886-style)."
+name: "MeshJob Java: cancel registers as cancelled in registry (#900 wires McpHttpClient abort; tc09 fixture uses java.net.http so still asserts registry-side only)"
+description: "Java — provider calls slow_downstream(30s) via HTTP; cancel must result in cancelled status in registry within <10s. McpHttpClient outbound abort wired by #900 but tc09 fixture uses java.net.http (orthogonal surface)."
 tags:
   - meshjob
   - java
   - issue-890
   - issue-889
+  - issue-900
   - cancel
   - propagation
 timeout: 480
@@ -160,6 +179,12 @@ test:
       exit 1
     timeout: 30
 
+  - name: "Capture wall-clock just before cancel"
+    handler: shell
+    workdir: /workspace
+    command: date +%s
+    capture: ts_cancel_start
+
   - name: "Cancel the job"
     handler: shell
     workdir: /workspace
@@ -170,9 +195,30 @@ test:
     capture: cancel_response
     timeout: 15
 
-  - name: "Wait for cancel to settle"
-    handler: wait
-    seconds: 10
+  # Poll until status flips to cancelled, capture elapsed time. Same
+  # pattern as tc06 — registry-side row flip happens synchronously
+  # inside CancelJob; <10s threshold leaves slack for slow CI.
+  - name: "Poll until status=cancelled, capture elapsed time"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      START='${captured.ts_cancel_start}'
+      START_NUM=$(echo "$START" | tr -d -c '0-9')
+      for i in $(seq 1 15); do
+        S=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.status' 2>/dev/null)
+        if [ "$S" = "cancelled" ]; then
+          NOW=$(date +%s)
+          echo "cancel_elapsed=$((NOW - START_NUM))"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: status never flipped to cancelled within 15s (last=$S)"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq .
+      exit 1
+    capture: cancel_elapsed
+    timeout: 30
 
   - name: "Read final status"
     handler: shell
@@ -182,14 +228,33 @@ test:
       meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
     capture: final_status
 
+  # Wall-clock guard — registry-side cancel forwarding completes <10s
+  # typical (parity with tc06). Larger elapsed values indicate a
+  # regression to the slow path (sweep-driven recovery).
+  - name: "Assert cancel-to-cancelled elapsed < 10s (registry-side fast path)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      ELAPSED=$(echo '${captured.cancel_elapsed}' | grep -oE 'cancel_elapsed=[0-9]+' | sed 's/cancel_elapsed=//')
+      if [ -z "$ELAPSED" ]; then
+        echo "ERROR: could not extract cancel_elapsed from: ${captured.cancel_elapsed}"
+        exit 1
+      fi
+      if [ "$ELAPSED" -ge 10 ]; then
+        echo "ERROR: cancel_elapsed=${ELAPSED}s >= 10s — cancel forwarding may have regressed"
+        exit 1
+      fi
+      echo "OK: cancel_elapsed=${ELAPSED}s < 10s (fast cancel path active)"
+
 assertions:
   - expr: "${captured.cancel_response} contains '\\\"ok\\\":true'"
     message: "cancel should ack with ok:true"
-  # Per #889 — registry-side row flips to cancelled (registry's
-  # CancelJob handler succeeds) even though Java's cancel-registry
-  # binding is inactive. This is the substantive signal we CAN test.
+  # Per #889 + #900 — registry-side row flips to cancelled. The
+  # producer-side McpHttpClient outbound abort (#900) is wired but
+  # not exercised here because the fixture uses java.net.http
+  # directly; see header comment for the orthogonal-fixture rationale.
   - expr: "${captured.final_status} contains '\\\"status\\\":\\\"cancelled\\\"'"
-    message: "registry-side status should be cancelled (Java cancel-registry inactive per #889; downstream HTTP NOT asserted aborted)"
+    message: "registry-side status should be cancelled (#900 producer-side abort wired for McpHttpClient; tc09 fixture uses java.net.http, so registry-side flip is the substantive signal asserted here)"
 
 post_run:
   - routine: stop_all

--- a/tests/integration/suites/uc23_meshjob_java/tc22_polyglot_3way_cancel_documents_889/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc22_polyglot_3way_cancel_documents_889/test.yaml
@@ -1,31 +1,41 @@
-# tc22_polyglot_3way_cancel_documents_889 — Documents Java cancel-registry gap.
+# tc22_polyglot_3way_cancel — Python orchestrator cancels a Java-owned
+# job. Mirror of uc21/tc22 / uc22/tc22 for the Java owner side.
 #
-# Java provider + Java consumer (running long job). Mid-flight, call
-# __mesh_job_cancel from a PYTHON agent.
+# NOTE on directory name: the trailing "_documents_889" suffix is now
+# stale (the gap is fixed in PR #889 Phase A — Java's cancel-registry
+# binding is active and the local cancel route returns cancelled:true).
+# The directory is intentionally not renamed in this commit to keep the
+# git diff small; rename will follow in a subsequent housekeeping PR.
+# The name: / description: / tags / inline doc below all reflect the
+# post-#889 reality.
 #
-# Per #889 — Java cancel-registry binding inactive (sync JNR-FFI cannot
-# bind nested Tokio runtime). The cancel pipeline behaves as follows:
+# Post-#889 cancel pipeline (Java owner):
 #
 #   1. Python orchestrator's __mesh_job_cancel calls JobProxy.cancel
-#      (Python SDK) which POSTs /jobs/{id}/cancel to the registry
-#   2. Registry's CancelJob handler succeeds, marks the row cancelled
-#   3. Registry forwards cancel to the Java provider's
-#      POST /jobs/:job_id/cancel route
-#   4. Java cancel route returns {cancelled:false, jobId} because the
-#      local cancel-registry lookup misses (the binding never happened
-#      for this job — see #889 / MeshToolWrapper.dispatchAsJob)
-#   5. Registry already wrote status=cancelled in step 2, so the
-#      consumer's status read still observes cancelled
-#   6. The Java task body continues running until natural completion
-#      or the registry's sweep marks orphaned
+#      (Python SDK) which POSTs /jobs/{id}/cancel to the registry.
+#   2. Registry's CancelJob handler succeeds and writes status=cancelled
+#      on the job row.
+#   3. Registry forwards the cancel to the Java provider's local
+#      POST /jobs/:job_id/cancel route.
+#   4. Java cancel route returns {cancelled: true} because Phase A wires
+#      mesh_run_as_job → cancel-registry binding so mesh_cancel_active_job
+#      finds the bound token for this job.
+#   5. The Java handler's cancel token fires → JobController.is_terminal()
+#      flips → the runs_overlong sleep loop observes cancellation and
+#      breaks out before its natural ~30s completion.
+#   6. Final status: cancelled (registry-side AND Java-side).
 #
-# Assertion: Python helper's cancel response is ok:true (registry-side
-# success), final status=cancelled (via the registry's CancelJob
-# handler, NOT via the Java owner's cancel token). This is exactly
-# what Java supports today.
+# Assertions:
+#   - Python helper acks ok:true (registry-side success).
+#   - Final status is cancelled.
+#   - owner_instance_id is the Java provider (proves cross-runtime
+#     forward reached).
+#   - Wall-clock from cancel-request to status-cancelled is < 10s
+#     (the natural path would take ~30s — guards against a regression
+#     of the cancel forwarding when the Java route returns cancelled:false).
 
-name: "MeshJob polyglot 3-way cancel: Python cancels Java-owned job (documents #889)"
-description: "Cross-runtime cancel — Python helper fires registry cancel; Java cancel route returns cancelled:false (#889) but registry-side row flips cancelled regardless"
+name: "MeshJob polyglot 3-way cancel: Python cancels Java-owned job (post-#889)"
+description: "Cross-runtime cancel — Python helper fires registry cancel; registry forwards to Java owner whose cancel-registry binding (Phase A) aborts the in-flight handler"
 tags:
   - meshjob
   - polyglot
@@ -124,6 +134,33 @@ test:
     handler: wait
     seconds: 5
 
+  # Confirm the producer is actually executing (progress > 0) before
+  # cancel — guards against a false pass where the cancel landed
+  # pre-claim and the row was marked cancelled trivially.
+  - name: "Confirm producer is in flight (progress > 0 before cancel)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      for i in $(seq 1 20); do
+        PROG=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.progress // 0')
+        if awk "BEGIN{exit !(${PROG} > 0)}"; then
+          echo "[pre-cancel] progress=${PROG} after ${i}s — producer is in flight"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: producer never recorded progress > 0 — cancel scenario invalid"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq .
+      exit 1
+    timeout: 30
+
+  - name: "Capture wall-clock just before cancel"
+    handler: shell
+    workdir: /workspace
+    command: date +%s
+    capture: ts_cancel_start
+
   # Python helper: __mesh_job_cancel takes snake_case job_id.
   - name: "Cancel via the Python orchestrator agent's helper tool"
     handler: shell
@@ -140,9 +177,45 @@ test:
     capture: cancel_response
     timeout: 15
 
-  - name: "Wait for cancel to settle in registry"
+  # Poll until status flips to cancelled (or 15s elapses). Captures the
+  # exact moment the registry observes the terminal flip — this is the
+  # signal we time-bound. With #889 fixed, both the registry-side row
+  # AND the Java handler's cancel token fire fast (<5s typical).
+  - name: "Poll until status=cancelled, capture elapsed time"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      START='${captured.ts_cancel_start}'
+      START_NUM=$(echo "$START" | tr -d -c '0-9')
+      if [ -z "$START_NUM" ]; then
+        echo "ERROR: ts_cancel_start has no digits — raw='$START'"
+        echo "JOB_ID=$JOB_ID"
+        curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '.' || true
+        exit 1
+      fi
+      for i in $(seq 1 15); do
+        S=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.status' 2>/dev/null)
+        if [ "$S" = "cancelled" ]; then
+          NOW=$(date +%s)
+          echo "cancel_elapsed=$((NOW - START_NUM))"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: status never flipped to cancelled within 15s (last=$S)"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq .
+      exit 1
+    capture: cancel_elapsed
+    timeout: 30
+
+  # Wait for any in-flight progress updates from the (now-defunct)
+  # Java handler to land. With Phase A active, the handler observes
+  # the cancel token and breaks out of runs_overlong's loop early —
+  # final progress will be well below 0.99.
+  - name: "Wait 5s for any post-cancel progress to settle"
     handler: wait
-    seconds: 8
+    seconds: 5
 
   - name: "Read final status"
     handler: shell
@@ -152,17 +225,69 @@ test:
       curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,owner_instance_id,error,progress}'
     capture: final_status
 
+  - name: "Capture raw progress field for assertion arithmetic"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.progress // 0'
+    capture: final_progress
+
+  # Wall-clock guard: registry-side row write is synchronous in
+  # CancelJob, so this lower-bounds at the registry RTT (<2s typical).
+  # Threshold <10s flags a regression where cancel handling slows
+  # catastrophically (e.g., the registry's CancelJob path itself
+  # regresses).
+  - name: "Assert cancel-to-cancelled elapsed < 10s (proves fast cancel path)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      ELAPSED=$(echo '${captured.cancel_elapsed}' | grep -oE 'cancel_elapsed=[0-9]+' | sed 's/cancel_elapsed=//')
+      if [ -z "$ELAPSED" ]; then
+        echo "ERROR: could not extract cancel_elapsed from: ${captured.cancel_elapsed}"
+        exit 1
+      fi
+      if [ "$ELAPSED" -ge 10 ]; then
+        echo "ERROR: cancel_elapsed=${ELAPSED}s >= 10s — cancel forwarding may have regressed"
+        exit 1
+      fi
+      echo "OK: cancel_elapsed=${ELAPSED}s < 10s (fast cancel path active)"
+
+  # Progress guard — runs_overlong's loop ticks updateProgress at
+  # min(elapsed/total, 0.99) each ~0.5s. If the handler aborts
+  # mid-flight (cancel token fired via Phase A binding), progress will
+  # be well below 0.99. If the cancel-token never fires (e.g., the
+  # cross-runtime forward to the Java owner was missed), the handler
+  # would run to natural completion and progress would land at 0.99
+  # — even though the registry-side row says cancelled. <0.95 is
+  # tight enough to flag a regression while leaving slack for the
+  # handler to emit a few more updates after cancel-set but before
+  # the loop re-checks isTerminal().
+  - name: "Assert final progress < 0.95 (handler aborted before natural completion)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      P='${captured.final_progress}'
+      P_TRIM=$(echo "$P" | tr -d ' \t\n\r')
+      if [ -z "$P_TRIM" ] || [ "$P_TRIM" = "null" ]; then
+        echo "ERROR: empty/null progress: '$P'"
+        exit 1
+      fi
+      if awk "BEGIN{exit !(${P_TRIM} >= 0.95)}"; then
+        echo "ERROR: final progress=${P_TRIM} >= 0.95 — Java handler likely ran to natural completion (Phase A binding regressed)"
+        exit 1
+      fi
+      echo "OK: final progress=${P_TRIM} < 0.95 (Java handler aborted via cancel token; cross-runtime forward landed)"
+
 assertions:
   # Python helper returns {"ok": True, "job_id": ...} (snake_case
-  # spaced JSON wrapping). The registry-side cancel succeeds even
-  # though the Java owner's local cancel token doesn't fire (#889).
+  # spaced JSON wrapping).
   - expr: "${captured.cancel_response} contains '\"ok\": true'"
     message: "Python helper cancel should ack with ok:true (registry-side success)"
-  # Per #889 — registry's CancelJob handler writes status=cancelled
-  # directly. The cancel forward to the Java owner returns
-  # cancelled:false but the row is already updated.
+  # Post-#889: the registry's row flips to cancelled, AND the Java
+  # cancel route's local handler aborts the in-flight task.
   - expr: "${captured.final_status} contains '\"status\": \"cancelled\"'"
-    message: "registry-side status should be cancelled (Python -> registry path works; Java cancel-registry inactive per #889)"
+    message: "registry-side status should be cancelled (Python -> registry -> Java forward path active)"
   # Owner is the Java provider — proves the registry forwarded the
   # cancel to the Java replica that holds the lease.
   - expr: "${captured.final_status} contains 'long-task-provider-java'"

--- a/tests/integration/suites/uc23_meshjob_java/tc23_retry_on_raise_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc23_retry_on_raise_java/test.yaml
@@ -1,0 +1,173 @@
+# tc23_retry_on_raise_java — Java port of uc21/tc23.
+#
+# Fast-retry path via @MeshTool(retryOn={IOException.class}) (#895).
+#
+# Producer fixture report_with_transient_failures throws IOException on
+# the first 2 attempts and succeeds on the 3rd. The tool is annotated
+# with retryOn={IOException.class} so the Java dispatch wrapper calls
+# JobController.releaseLease(reason) instead of fail() — the registry
+# resets owner_instance_id (claim already counted this attempt; release
+# does NOT increment), and the next claim cycle (~5s) re-runs the
+# handler and bumps attempt_count for that attempt.
+#
+# Asserts:
+#   - status=completed
+#   - attempt_count=3 (initial + 2 retries via release-lease path)
+#   - total wall time < 30s — proves the fast retry path engaged.
+#     Lease-expiry recovery (slow path) would take ~max_duration seconds
+#     per attempt (here 30s), so 3 attempts would push past 60s.
+#
+# Tags: retry, issue-879, issue-895
+
+name: "MeshJob Java: retryOn per-tool exception whitelist drives fast retry"
+description: "Java handler raises IOException on attempts 1+2, succeeds on 3; retryOn={IOException.class} → releaseLease path completes within ~15s"
+tags:
+  - meshjob
+  - java
+  - issue-879
+  - issue-895
+  - retry
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Reset retry counter from any prior run"
+    handler: shell
+    workdir: /workspace
+    command: |
+      rm -f /tmp/mesh-retry-on-counter || true
+      echo "counter cleared"
+
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9120)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for Java provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done
+      echo "ERROR: provider not healthy"
+      meshctl logs long-task-provider-java 2>&1 | tail -50 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start consumer (port 9121)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
+      done
+      echo "ERROR: consumer not ready"
+      meshctl logs long-task-consumer-java 2>&1 | tail -50 || true
+      exit 1
+    timeout: 150
+
+  - name: "Capture wall-clock start"
+    handler: shell
+    workdir: /workspace
+    command: date +%s
+    capture: ts_start
+
+  - name: "Submit transient-failures job: max_retries=3, transient_failures=2"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_transient_failures \
+        '{"user_id":"alice","max_retries":3,"transient_failures":2,"wait_timeout_secs":40}' --raw
+    capture: commission_response
+    timeout: 60
+
+  - name: "Capture wall-clock end"
+    handler: shell
+    workdir: /workspace
+    command: date +%s
+    capture: ts_end
+
+  - name: "Compute elapsed wall-clock seconds"
+    handler: shell
+    workdir: /workspace
+    command: |
+      START='${captured.ts_start}'
+      END='${captured.ts_end}'
+      START_NUM=$(echo "$START" | tr -d -c '0-9')
+      END_NUM=$(echo "$END" | tr -d -c '0-9')
+      echo "elapsed=$((END_NUM - START_NUM))"
+    capture: elapsed
+
+  - name: "Read final job status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.commission_response}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,attempt_count,error}'
+    capture: final_status
+
+  # Fast retry: 3 attempts via releaseLease should land in <30s. Lease-
+  # expiry recovery (the slow path) would require waiting for the lease
+  # to time out per attempt, pushing total well past 60s. Numeric guard
+  # avoids the false-positive/false-negative pitfalls of substring checks.
+  - name: "Assert elapsed wall-clock < 30s (fast retry, not lease-expiry)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      ELAPSED=$(echo '${captured.elapsed}' | grep -oE 'elapsed=[0-9]+' | sed 's/elapsed=//')
+      if [ -z "$ELAPSED" ]; then
+        echo "ERROR: could not extract elapsed from: ${captured.elapsed}"
+        exit 1
+      fi
+      if [ "$ELAPSED" -ge 30 ]; then
+        echo "ERROR: elapsed=$ELAPSED >= 30s — likely hit lease-expiry slow path"
+        exit 1
+      fi
+      echo "OK: elapsed=$ELAPSED < 30s (fast retry path)"
+
+assertions:
+  - expr: "${captured.final_status} contains '\"status\": \"completed\"'"
+    message: "job must complete successfully on the 3rd attempt"
+  - expr: "${captured.final_status} contains '\"attempt_count\": 3'"
+    message: "attempt_count must be 3 — initial + 2 retries via releaseLease path"
+  - expr: "${captured.commission_response} contains 'succeeded_on_attempt'"
+    message: "consumer should see the success-marker payload"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace
+  - name: "Clean up retry counter file"
+    handler: shell
+    workdir: /workspace
+    command: rm -f /tmp/mesh-retry-on-counter || true


### PR DESCRIPTION
## Summary

Closes the Java MeshJob cancel story. After this PR, Java behaves equivalently to Python and TypeScript for cancel propagation across both surfaces:

- **Handler-side** (#889): `POST /jobs/:id/cancel` fires the in-flight cancel token; long-running handlers poll `JobController.isCancelled()` to break early.
- **Outbound-HTTP-side** (#900): in-flight `McpHttpClient` calls abort when the producer's job is cancelled mid-flight.

### Phase A — Handler-side cancel (#889)

- **Rust** (`jobs_ffi.rs`): wrap the FFI callback inside `mesh_run_as_job` with `tokio::task::block_in_place` so nested `block_on` calls from controller methods don't panic on the multi-threaded `jobs_runtime()`.
- **Rust** (`jobs.rs` + `jobs_ffi.rs`): new `JobController::is_cancelled()` + `mesh_job_controller_is_cancelled` C ABI. Distinct from `is_terminal` — reflects external cancel signals via the cancel-registry bound token.
- **Java SDK**: JNR binding + public `JobController.isCancelled()` mirroring `isTerminal()`.
- **Spring Boot**: `MeshToolWrapper` and `ClaimDispatcher` now route through `runAsJobWithRegistryBinding(jobId, deadlineSecs, body)` which invokes `mesh_run_as_job`. ThreadLocal `JobContext.withJob` preserved for header injection.

### Phase B — Outbound HTTP cancel (#900)

- **Rust** (`jobs_ffi.rs`): new blocking `mesh_await_job_cancel(jobId)` C ABI export — `tokio::select!` on `(cancel, ended)` token pair from `cancel_registry::get_state(jobId)`. Mirror of TS PR #897's `awaitJobCancel` napi but blocking for JNR consumption. 3 unit tests cover happy path, NULL guard, natural-unregister wake.
- **Java SDK**: JNR binding for `mesh_await_job_cancel`.
- **Spring Boot** (`McpHttpClient`): new `executeWithJobCancelWatcher(Call)` helper wraps OkHttp `Call.execute()` at three sites (`callTool`, `streamTool`/SSE, `listTools`) with a daemon watcher. Watcher blocks on `mesh_await_job_cancel(jobId)`; on fire it calls `Call.cancel()` (idempotent on natural completion). The `ended` arm prevents watcher leak when call completes naturally. Surfaces `InterruptedIOException` to user code on cancel for thread-interrupt parity.

### Phase C — Integration tests

- **NEW** `tc23_retry_on_raise_java` — Java mirror of `uc21/tc23` covering #895. Provider fixture gains `reportWithTransientFailures` handler with `@MeshTool(retryOn=IOException.class)`; consumer gains `commissionTransientFailures`. Asserts `status=completed`, `attempt_count=3`, total elapsed `< 30s`.
- **TIGHTENED** `tc06_cancel_alive_owner_java` and `tc22_polyglot_3way_cancel_documents_889`. Both now assert:
  - `cancel_elapsed < 10s` (Phase A binding makes the cancel route return `cancelled:true` immediately)
  - `final_progress < 0.95` (handler observed cancel via `isCancelled()` polling, broke out of `runsOverlong` loop)
- **TIGHTENED** `tc09_cancel_aborts_outbound_http_java` with `cancel_elapsed < 10s`. Header notes that #900 wires `McpHttpClient` but the existing fixture uses `java.net.http` directly, so end-to-end outbound abort assertion needs a fixture variant (follow-up).

## Review Notes

Pre-merge review-agent found 1 BLOCKER + 4 warnings; 2 fixed, 2 skipped (intentional), 1 deferred:

- **Fixed (BLOCKER)**: `runsOverlong` couldn't observe cancel because Java's `Thread.sleep` is uninterruptible AND `isTerminal()` only reflects local intent. Resolved by adding `isCancelled()` SDK method (case B) and polling.
- **Fixed**: `buildRunAsJobSnapshot` javadoc clarifies snapshot serialization is a precondition (not part of unified rethrow path).
- **Skipped (intentional)**: `mesh_run_as_job` wrapping on no-controller branch — cancel-registry binding + header injection still useful regardless of controller. Acceptable cost.
- **Skipped (intentional)**: minor style nits matching TS pattern.
- **Deferred**: `tc22` directory rename — inline header marks the suffix as stale; rename in housekeeping pass.

## What's NOT in this PR

- `tc09b` fixture variant exercising `McpHttpClient` end-to-end (current fixture uses `java.net.http` directly). Follow-up.
- Downstream-side cancel observability (`slow_downstream` fixture polling) — Java sibling of cross-runtime gap also affecting Python (#882) and TS.
- `java.net.http.HttpClient` cancel-watcher parity — `McpHttpClient` is the SDK's blessed path; user code reaching for `java.net.http` directly is on its own for now.

## Validation

- `cargo check --features ffi` clean
- `cargo test --lib --features ffi`: 402/402 (3 new for #900)
- `mvn -pl mcp-mesh-spring-boot-starter -am test`: 149/149
- All modified `test.yaml` files parse as valid YAML
- Both Java fixtures compile clean (`mvn compile`)

Closes #889
Closes #900
Refs #861 (parent), #874, #895 (retry_on test was the missing piece), #886 (TS sibling for outbound cancel), #882 (Python sibling, upstream-blocked)

## Test plan

- [ ] CI green
- [ ] Manual: submit Java task → cancel → cancel route returns `{cancelled: true}` within 1-2s; handler aborts at progress < 0.95
- [ ] Manual: Java task with outbound `McpHttpClient` call → cancel mid-flight → outbound `Call.execute()` throws `InterruptedIOException` instead of running to OkHttp timeout
- [ ] tc23, tc06, tc22, tc09 pass in tsuite (validates #889, #895, #900 end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added job cancellation APIs: query cancellation state and await cancellation events
  * Job cancellation now aborts in-flight HTTP requests automatically
  * Jobs can actively poll cancellation state during execution for responsive cancellation handling
  * Enhanced cross-language (Java/Rust) cancellation propagation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->