### PR TITLE
feat(meshjob): Python handler observes /jobs/:id/cancel

### DIFF
--- a/src/runtime/core/python/mcp_mesh_core/__init__.py
+++ b/src/runtime/core/python/mcp_mesh_core/__init__.py
@@ -130,3 +130,13 @@ __all__ = [
     "submit_job",
     "with_job_async",
 ]
+
+# Issue #882 Part A: optional re-export. Older `mcp-mesh-core` builds
+# may not export ``await_job_cancel`` — guarding the import keeps the
+# package importable so consumers can detect absence and use their
+# fallback path (see ``_mcp_mesh.engine.job_dispatch``).
+try:
+    from .mcp_mesh_core import await_job_cancel  # noqa: F401
+    __all__.append("await_job_cancel")
+except ImportError:
+    pass

--- a/src/runtime/core/src/jobs_py.rs
+++ b/src/runtime/core/src/jobs_py.rs
@@ -456,6 +456,41 @@ pub fn cancel_active_job_py(job_id: &str) -> bool {
     cancel_registry::cancel_active_job(job_id)
 }
 
+/// Await the cancel token bound for `job_id` in the process-wide
+/// cancel registry. Resolves when EITHER the token fires (explicit
+/// cancel via [`cancel_active_job_py`]) OR the registry unregisters
+/// the job naturally (ended without cancel — see
+/// [`crate::cancel_registry::JobCancelState::ended`]). Resolves
+/// immediately if the job is not currently registered (already
+/// terminal / never claimed).
+///
+/// Used by the SDK's job_dispatch wrapper to race the user's
+/// coroutine against cancel-token-fire — when cancel arrives, the
+/// dispatch wrapper cancels the user's asyncio task so
+/// `await asyncio.sleep` and similar propagate CancelledError
+/// naturally. Mirror of the TypeScript SDK's `awaitJobCancel(jobId)`
+/// napi and the C ABI `mesh_await_job_cancel`.
+///
+/// Returns a Python coroutine; callers `await` it on asyncio.
+#[pyfunction(name = "await_job_cancel")]
+pub fn await_job_cancel_py<'py>(
+    py: Python<'py>,
+    job_id: String,
+) -> PyResult<Bound<'py, PyAny>> {
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        // Snapshot both tokens once. None means "not registered" —
+        // resolve immediately so callers don't hang on stale jobs.
+        let Some((cancel, ended)) = cancel_registry::get_state(&job_id) else {
+            return Ok(());
+        };
+        tokio::select! {
+            _ = cancel.cancelled() => {},
+            _ = ended.cancelled() => {},
+        }
+        Ok::<(), pyo3::PyErr>(())
+    })
+}
+
 /// Run an awaitable Python callable inside a fresh
 /// [`crate::jobs::run_as_job`] scope so the cancel-registry entry under
 /// `job_id` is bound for the duration of the call (so the

--- a/src/runtime/core/src/lib.rs
+++ b/src/runtime/core/src/lib.rs
@@ -592,6 +592,7 @@ fn mcp_mesh_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(jobs_py::submit_job_py, m)?)?;
     m.add_function(wrap_pyfunction!(jobs_py::current_job_py, m)?)?;
     m.add_function(wrap_pyfunction!(jobs_py::cancel_active_job_py, m)?)?;
+    m.add_function(wrap_pyfunction!(jobs_py::await_job_cancel_py, m)?)?;
     m.add_function(wrap_pyfunction!(jobs_py::with_job_async_py, m)?)?;
 
     Ok(())

--- a/src/runtime/python/_mcp_mesh/engine/job_dispatch.py
+++ b/src/runtime/python/_mcp_mesh/engine/job_dispatch.py
@@ -31,6 +31,7 @@ can call into it without re-implementing the contract.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from typing import Any, Awaitable, Callable, Optional
@@ -38,6 +39,15 @@ from typing import Any, Awaitable, Callable, Optional
 from .job_context import CURRENT_JOB, JobContextSnapshot
 
 logger = logging.getLogger(__name__)
+
+
+# Cancel-watcher helper for issue #882 Part A. Older mcp-mesh-core
+# builds may not export this — degrade gracefully (handler runs to
+# natural completion as before, no cancel observability).
+try:
+    from mcp_mesh_core import await_job_cancel as _await_job_cancel
+except ImportError:
+    _await_job_cancel = None
 
 
 # Header names — lowercased to match how the FastMCP middleware stores
@@ -333,9 +343,114 @@ async def maybe_dispatch_as_job(
           - If the exception doesn't match retry_on, we propagate up
             through the wrapper chain (existing behaviour). The
             inbound HTTP path or registry sweep is the backstop.
+
+        Cancel observability (issue #882 Part A):
+          The user's coroutine is wrapped in an asyncio.Task and raced
+          against ``await_job_cancel(job_id)`` — a coroutine that
+          resolves when EITHER the cancel-registry token fires
+          (explicit cancel via ``POST /jobs/:id/cancel``) OR the
+          registry unregisters the job naturally (handler returned).
+          When cancel wins the race, the user task is cancelled so
+          ``await asyncio.sleep`` / network IO inside the handler
+          propagates ``CancelledError`` naturally — without this, a
+          handler napping in ``await asyncio.sleep(30)`` would not
+          observe a Tokio-side cancel token and would run to natural
+          completion despite the registry having flipped the row to
+          ``cancelled``. Mirrors the TS SDK's ``awaitJobCancel`` race
+          (PR #897) and the Java SDK's ``controller.isCancelled()``
+          poll (PR #891).
         """
         try:
-            result = await invoke(final_kwargs)
+            if _await_job_cancel is None:
+                result = await invoke(final_kwargs)
+            else:
+                user_task = asyncio.create_task(
+                    invoke(final_kwargs), name=f"mesh-job-{job_id}-user"
+                )
+                # ``_await_job_cancel`` is a pyo3-async helper that
+                # returns a Future (not a coroutine) — use
+                # ``ensure_future`` so we accept either shape (the
+                # Python-side fallback in some test mocks may return a
+                # coroutine instead).
+                cancel_watcher = asyncio.ensure_future(
+                    _await_job_cancel(job_id)
+                )
+                done, pending = await asyncio.wait(
+                    {user_task, cancel_watcher},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                # Prefer the user task whenever it's done — even if the
+                # cancel-watcher also completed in the same tick (e.g. the
+                # job was never registered, so the watcher resolved
+                # immediately on its first poll). This keeps the path
+                # deterministic for tests + for jobs that finish before
+                # the watcher gets to schedule.
+                if user_task.done():
+                    # Drain the watcher so it doesn't linger in the loop.
+                    if not cancel_watcher.done():
+                        cancel_watcher.cancel()
+                    try:
+                        await cancel_watcher
+                    except asyncio.CancelledError:
+                        pass
+                    if user_task.cancelled():
+                        # External cancel (loop shutdown, anyio CancelScope, signal) —
+                        # propagate so structured-concurrency semantics are preserved.
+                        # NOT the watcher-fired cancel path (that's the `else` branch).
+                        raise asyncio.CancelledError()
+                    user_exc = user_task.exception()
+                    if user_exc is not None:
+                        raise user_exc
+                    result = user_task.result()
+                else:
+                    # Cancel-watcher resolved before the user task.
+                    # Defensive: if the watcher resolved with an
+                    # exception (rare; would indicate a pyo3-runtime
+                    # issue, not a real cancel), DON'T cancel the user
+                    # task — log and let the user task continue to
+                    # natural completion. Calling .exception() also
+                    # consumes it so asyncio doesn't log "Task
+                    # exception was never retrieved" at GC time.
+                    watcher_exc = cancel_watcher.exception()
+                    if watcher_exc is not None:
+                        logger.warning(
+                            "job_dispatch: cancel-watcher for job=%s "
+                            "resolved with exception (%s); ignoring "
+                            "spurious signal and awaiting user task",
+                            job_id,
+                            watcher_exc,
+                        )
+                        await user_task
+                        if user_task.cancelled():
+                            raise asyncio.CancelledError()
+                        user_exc = user_task.exception()
+                        if user_exc is not None:
+                            raise user_exc
+                        result = user_task.result()
+                    else:
+                        # Cancel arrived first — abort the user's task
+                        # so `await asyncio.sleep` / network IO inside
+                        # the handler raises CancelledError. The
+                        # registry's CancelJob handler already flipped
+                        # the row to cancelled (the cancel route is
+                        # what fired the token), so there's nothing
+                        # for us to do beyond returning None.
+                        user_task.cancel()
+                        try:
+                            await user_task
+                        except asyncio.CancelledError:
+                            logger.info(
+                                "job_dispatch: user task for job=%s cancelled via "
+                                "cancel-watcher; registry owns terminal state",
+                                job_id,
+                            )
+                            return None
+                        # User caught CancelledError, did cleanup, and returned normally.
+                        # Honor their result — fall through to auto-complete logic with
+                        # the captured value. Note: a non-CancelledError exception falls
+                        # out to the outer `except Exception as exc:` block and runs the
+                        # existing retry_on / fail handling.
+                        result = user_task.result()
         except Exception as exc:
             # If the user already called complete/fail explicitly, leave
             # state alone — the user's terminal call is the source of truth.

--- a/src/runtime/python/tests/unit/test_meshjob_dispatch.py
+++ b/src/runtime/python/tests/unit/test_meshjob_dispatch.py
@@ -653,6 +653,123 @@ class TestRetryOnDispatch:
 
 
 # ===========================================================================
+# Cancel observability — issue #882 Part A
+#
+# When ``mcp_mesh_core.cancel_active_job(job_id)`` fires the registry's
+# cancel token (e.g. from ``POST /jobs/:id/cancel``), the user's
+# ``await asyncio.sleep`` must propagate ``CancelledError`` rather than
+# running to natural completion. The wrapper achieves this by racing the
+# user's task against ``await_job_cancel(job_id)`` and cancelling the
+# user task when the watcher resolves first.
+# ===========================================================================
+
+
+class TestCancelObservability:
+    """Mid-flight cancel via the registry interrupts the user's coroutine."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_active_job_aborts_running_handler(self, monkeypatch):
+        """``cancel_active_job(job_id)`` mid-flight → user task receives
+        ``CancelledError``, wrapper returns ``None``, fail()/release_lease()
+        are NOT called (registry's CancelJob handler owns the row state)."""
+        from mcp_mesh_core import cancel_active_job, with_job_async
+
+        from _mcp_mesh.engine.job_dispatch import maybe_dispatch_as_job
+        from _mcp_mesh.tracing.context import TraceContext
+
+        fn = _fixture_with_job
+        fn._mesh_tool_metadata = {"task": True}
+
+        job_id = "job-cancel-obs-1"
+        TraceContext.set_propagated_headers(
+            {"x-mesh-job-id": job_id, "x-mesh-timeout": "30"}
+        )
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://r:9999")
+        monkeypatch.setenv("MCP_MESH_AGENT_ID", "cancel-obs-agent")
+
+        try:
+            release_calls: list = []
+            fail_calls: list = []
+            complete_calls: list = []
+            cancelled_in_user = asyncio.Event()
+            ready = asyncio.Event()
+
+            class _FakeController:
+                def __init__(self, *a, **kw):
+                    self._terminal = False
+
+                async def is_terminal(self):
+                    return self._terminal
+
+                async def release_lease(self, reason=None):
+                    release_calls.append(reason)
+                    self._terminal = True
+
+                async def fail(self, error):
+                    fail_calls.append(error)
+                    self._terminal = True
+
+                async def complete(self, value):
+                    complete_calls.append(value)
+                    self._terminal = True
+
+            async def invoke(_kw):
+                # Simulate a long-running handler. We expect the cancel
+                # watcher to interrupt this before it returns naturally.
+                ready.set()  # Signal the test that the user task has started.
+                try:
+                    await asyncio.sleep(30)
+                except asyncio.CancelledError:
+                    cancelled_in_user.set()
+                    raise
+                return "should-not-reach"
+
+            with mock.patch(
+                "mcp_mesh_core.JobController", _FakeController, create=True
+            ):
+                # Run dispatch + fire cancel in parallel. The real
+                # ``with_job_async`` registers the job in the cancel
+                # registry, so ``cancel_active_job(job_id)`` from a
+                # sibling task will fire the watcher's token.
+                async def _firer():
+                    await ready.wait()
+                    # Yield a few times so the Rust-side `with_job_async`
+                    # finishes registering the job in the cancel registry
+                    # before we fire (the Python<->Tokio bridge can take
+                    # multiple ticks to thread through).
+                    for _ in range(5):
+                        await asyncio.sleep(0)
+                    fired = cancel_active_job(job_id)
+                    return fired
+
+                dispatch_task = asyncio.create_task(
+                    maybe_dispatch_as_job(fn, invoke, {"user": "x"})
+                )
+                firer_task = asyncio.create_task(_firer())
+
+                out, fired = await asyncio.gather(dispatch_task, firer_task)
+
+            # Wrapper returned cleanly with None (registry owns terminal).
+            assert out is None
+            # Cancel actually fired the registered token.
+            assert fired is True
+            # The user's coroutine observed CancelledError.
+            assert cancelled_in_user.is_set(), (
+                "user's await asyncio.sleep must propagate CancelledError "
+                "when cancel_active_job fires mid-flight"
+            )
+            # The wrapper did NOT call fail / release / complete — the
+            # registry's CancelJob handler is the source of truth for
+            # the cancelled row.
+            assert fail_calls == []
+            assert release_calls == []
+            assert complete_calls == []
+        finally:
+            TraceContext.set_propagated_headers({})
+            fn._mesh_tool_metadata = {"task": True}
+
+
+# ===========================================================================
 # MeshJobSubmitter — consumer-side handle
 # ===========================================================================
 

--- a/tests/integration/suites/uc21_meshjob/fixtures/long-task-provider/main.py
+++ b/tests/integration/suites/uc21_meshjob/fixtures/long-task-provider/main.py
@@ -244,11 +244,26 @@ async def runs_overlong(
     elapsed = 0.0
     step = 0.5
     total = max(float(seconds), step)
-    while elapsed < total:
-        await asyncio.sleep(step)
-        elapsed += step
-        if job is not None:
-            await job.update_progress(min(elapsed / total, 0.99), f"alive at {elapsed:.1f}s")
+    try:
+        while elapsed < total:
+            await asyncio.sleep(step)
+            elapsed += step
+            if job is not None:
+                await job.update_progress(min(elapsed / total, 0.99), f"alive at {elapsed:.1f}s")
+    except asyncio.CancelledError:
+        # Marker for issue #882 Part A — when the SDK's cancel-watcher
+        # races and cancels the user task on a registry-driven cancel,
+        # `await asyncio.sleep` raises CancelledError. Logging here
+        # gives integration tests a positive signal that the handler
+        # observed the cancel mid-flight (rather than just relying on
+        # the registry-side row state, which flips to cancelled even
+        # without Part A working).
+        print(
+            f"[runs_overlong] cancelled mid-flight at {elapsed:.1f}s "
+            f"user_id={user_id}",
+            flush=True,
+        )
+        raise
     payload = {"user_id": user_id, "elapsed": elapsed}
     if job is not None:
         await job.complete(payload)

--- a/tests/integration/suites/uc21_meshjob/tc06_cancel_alive_owner/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc06_cancel_alive_owner/test.yaml
@@ -99,6 +99,19 @@ test:
       meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
     capture: final_status
 
+  # Issue #882 Part A: confirm the producer's handler actually observed
+  # the cancel mid-flight. The runs_overlong fixture logs a marker when
+  # CancelledError is raised inside the loop — without Part A working,
+  # the asyncio.sleep wouldn't observe the Tokio cancel token, the
+  # handler would run to natural 30s completion, and this marker would
+  # NEVER appear in the producer log.
+  - name: "Read producer log"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl logs long-task-provider 2>&1 | tail -200 | grep "\[runs_overlong\] cancelled mid-flight" | grep "user_id=alice" || true
+    capture: producer_log
+
 assertions:
   - expr: "${captured.cancel_response} contains '\"ok\": true'"
     message: "__mesh_job_cancel should return ok:true"
@@ -111,6 +124,12 @@ assertions:
   # exact status-field shape "\"status\": \"completed\"" instead.
   - expr: "${captured.final_status} not contains '\"status\": \"completed\"'"
     message: "status field must NOT be completed — cancel happened before natural finish"
+  # Issue #882 Part A: positive signal that the user's coroutine
+  # observed CancelledError. Without the SDK's cancel-watcher race
+  # in job_dispatch.py, asyncio.sleep would not propagate the cancel
+  # and this marker would never be logged.
+  - expr: "${captured.producer_log} contains '[runs_overlong] cancelled mid-flight'"
+    message: "producer must log the CancelledError marker — proves handler aborted, not just registry-side row flip"
 
 post_run:
   - routine: stop_all


### PR DESCRIPTION
## Summary

Closes #882. When `mesh_cancel_active_job(job_id)` fires the Rust cancel token (e.g., from `POST /jobs/:id/cancel`), the user's `await asyncio.sleep` propagates `CancelledError` naturally and the handler aborts mid-flight.

### Approach

Python's natural `await` is cancellable via `asyncio.Task.cancel()` — so unlike Java (which polls `isCancelled()`) or TS (which uses `Promise.race` + AbortController), Python can race the user's coroutine against a cancel-watcher and cancel the loser. `await asyncio.sleep` and network IO propagate `CancelledError` automatically.

### Rust core

- New `await_job_cancel` pyfunction in `jobs_py.rs` — returns a Python coroutine that resolves on cancel-fire OR registry-unregister via `tokio::select!` on the `(cancel, ended)` token pair from `cancel_registry::get_state`. Mirror of the napi version (TS PR #897) and C ABI version (PR #899).
- `mcp_mesh_core/__init__.py` re-export is **guarded** via `try/except ImportError` so older native builds (without the symbol) don't break the entire package import. `__all__.append("await_job_cancel")` only on success.

### Python SDK

- `_run_and_autocomplete` in `job_dispatch.py` wraps the user's coroutine in `asyncio.create_task` and races against `await_job_cancel(job_id)` via `asyncio.wait FIRST_COMPLETED`. Module-top import with graceful degrade for older `mcp-mesh-core` builds (no-watcher fallback).
- Race winner handling:
  - `user_task.cancelled()` re-raises `CancelledError` for structured-concurrency / loop-shutdown propagation.
  - `cancel_watcher.exception()` non-None (rare, pyo3 runtime issue) → logs WARN, awaits user task to natural completion, runs auto-complete on result.
  - Cancel-watcher win → cancels user task; if user catches and re-raises, log + return None; if user swallows cancel and returns, honor the result and run auto-complete; non-Cancelled exceptions hit the existing `retry_on` / `fail` path.

### Tests

- New `TestCancelObservability` in `test_meshjob_dispatch.py` uses real `cancel_active_job` + `with_job_async`. Synchronization via `asyncio.Event` (no real-time sleeps) — deterministic across CI.
- `runs_overlong` Python fixture logs a `CancelledError` marker; `tc06` integration test greps the producer log anchored to `user_id` to avoid stale-line matches.

## Review Notes

Pre-merge review-agents flagged 6 warnings + 3 INFOs across two passes; **all 9 fixed**. Highlights:

- `user_task.cancelled()` defensive branch now re-raises `CancelledError` (was silent `return None`) — preserves structured-concurrency.
- "Unreachable" return None was reachable when user catches `CancelledError` and returns normally; now honors the user's result.
- `cancel_watcher.exception()` checked before deciding to cancel user task — defensive against pyo3 runtime issues.
- `__init__.py` re-export guarded so older native builds don't break package import.
- Watcher-drain `except` narrowed from broad `Exception` to `CancelledError` only.
- Unit test sync via `asyncio.Event` instead of `asyncio.sleep(0.1)` — deterministic.
- `tc06` marker grep anchored to `user_id` to avoid stale-line pollution.

## On Part B (deferred)

The original #882 issue also flagged a broader case: **upstream TCP-disconnect from the caller** not propagating as `CancelledError` (FastMCP / Starlette / uvicorn don't surface `request.is_disconnected()` as task cancellation). That requires either upstream FastMCP work or fragile mesh-internal interception of Starlette's request scope.

Decision: **defer until it surfaces in real workloads.** The handler-side cancel that this PR delivers covers the dominant case (users calling `__mesh_job_cancel` and expecting the handler to abort). If Part B becomes a production pain point, file a fresh issue with concrete repro and we'll revisit.

## Validation

- `cargo check --features python --no-default-features` clean
- `cargo test --lib --features python --no-default-features`: 386/386
- `pytest tests/unit/test_meshjob_dispatch.py`: 47/47 (46 + 1 new)
- `pytest tests/unit/`: 822/822

Closes #882
Refs #861 (parent), #897 (TS sibling), #899 (Java sibling)

## Test plan

- [ ] CI green
- [ ] Manual smoke: submit Python `task=true` handler running `await asyncio.sleep(30)`; cancel via `__mesh_job_cancel`; handler aborts within ~1s with `CancelledError` (vs running to natural 30s before this PR)
- [ ] `tc06_cancel_alive_owner` passes with the new marker-grep assertion proving handler observed cancel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for job handler cancellation observability. Running handlers now receive and can properly respond to cancellation signals during execution.

* **Bug Fixes**
  * Fixed cancellation signal propagation to job handlers. Long-running handlers now correctly receive cancellation notifications and abort execution instead of completing normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->