### PR TITLE
docs(meshjob): user-facing documentation + meshctl man page

### DIFF
--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -1,0 +1,529 @@
+# Long-Running Jobs
+
+> Submit-and-wait task execution that survives `tools/call` timeouts, replica
+> restarts, and consumer disconnects.
+
+A regular `tools/call` is a request-response pair on a single open HTTP/SSE
+connection. If the work takes minutes — generating a multi-section report,
+transcoding a video, running a long agentic loop — the client and server
+spend that whole time holding a socket open and gambling that nothing in
+between (load balancers, proxies, k8s pod restarts) drops the connection.
+**MeshJob** is a different primitive for that class of work: producers
+declare a tool as `task=true`, consumers `submit` and later `wait`, and the
+registry holds the durable state in between.
+
+## The problem
+
+`tools/call` is fine for sub-second to ~30s tools. For anything longer:
+
+- **Connection fragility.** Any hop (browser, ingress, mesh) drops idle
+  HTTP after 60–120s. The producer keeps computing; the consumer sees a
+  generic timeout and has no handle to recover.
+- **No backpressure.** The producer can't tell the consumer "I'm 60% done,
+  ETA 90 seconds." The consumer waits blind.
+- **No cancel.** A consumer that gives up has no way to tell the producer
+  to stop burning CPU.
+- **No retry semantics.** A transient upstream error (rate-limit, network
+  blip) on attempt 1 of a 5-minute job means restarting from scratch on the
+  consumer's clock.
+
+**Streaming** ([`streaming.md`](streaming.md)) solves the responsiveness
+problem when the work is a single text stream — chunks flow back over the
+already-open connection. **Jobs** solve the durability problem when the
+work is a discrete unit that needs to outlive the request: the connection
+closes, the producer keeps going, the consumer reconnects (or polls) for
+the result.
+
+## Solution: `task=true` opt-in
+
+Authors annotate the tool with `task=true` and accept an injected
+controller (`MeshJob`) that exposes `update_progress`, `complete`, and
+`fail`. Consumers declare a dependency on the producer's capability and
+type the parameter as `MeshJob` — the framework injects a
+`MeshJobSubmitter` (instead of the usual `McpMeshTool` proxy) at that
+slot. `submitter.submit(...)` returns a `JobProxy`; `proxy.wait(...)`
+polls the registry until the row is terminal.
+
+There's no global config knob. Whether a tool is a job is opt-in per
+tool by virtue of `task=true`. Plain `task=false` tools continue to be
+buffered request-response exactly as before.
+
+## Getting started
+
+A producer that emits progress updates and a consumer that submits-and-
+waits — the canonical end-to-end pattern. The full files live under
+[`examples/jobs/`](https://github.com/dhyansraj/mcp-mesh/tree/main/examples/jobs),
+[`examples/jobs-ts/`](https://github.com/dhyansraj/mcp-mesh/tree/main/examples/jobs-ts),
+and [`examples/jobs-java/`](https://github.com/dhyansraj/mcp-mesh/tree/main/examples/jobs-java).
+
+<!-- markdownlint-disable MD046 -->
+**Producer — declares a `task=true` capability:**
+
+=== "Python"
+
+    ```python
+    import asyncio
+    import mesh
+    from fastmcp import FastMCP
+    from mesh import MeshJob
+
+    app = FastMCP("Long Task Provider")
+
+    @app.tool()
+    @mesh.tool(capability="generate_report", task=True)
+    async def generate_report(
+        user_id: str,
+        sections: list[str],
+        job: MeshJob = None,
+    ) -> dict:
+        if job is not None:
+            await job.update_progress(0.0, "starting")
+        results = []
+        total = max(len(sections), 1)
+        for i, section in enumerate(sections):
+            await asyncio.sleep(2)
+            results.append({"section": section, "content": f"...{section}"})
+            if job is not None:
+                await job.update_progress((i + 1) / total, f"section {i+1}/{total}")
+        payload = {"user_id": user_id, "report": results}
+        if job is not None:
+            await job.complete(payload)
+        return payload
+
+    @mesh.agent(name="long-task-provider", http_port=9100, auto_run=True)
+    class LongTaskProvider: pass
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { FastMCP } from "fastmcp";
+    import { mesh, type MeshJob } from "@mcpmesh/sdk";
+    import { z } from "zod";
+
+    const server = new FastMCP({ name: "Long Task Provider (TS)", version: "1.0.0" });
+    const agent = mesh(server, { name: "long-task-provider-ts", httpPort: 9110 });
+
+    agent.addTool({
+      name: "generate_report",
+      capability: "generate_report",
+      task: true,
+      meshJobParamIndex: 1,         // job lands at sig pos 1 (after `args`)
+      parameters: z.object({
+        user_id: z.string(),
+        sections: z.array(z.string()),
+      }),
+      execute: async ({ user_id, sections }, job: MeshJob | null = null) => {
+        await job?.updateProgress?.(0.0, "starting");
+        const results: { section: string; content: string }[] = [];
+        const total = Math.max(sections.length, 1);
+        for (let i = 0; i < sections.length; i++) {
+          await new Promise((r) => setTimeout(r, 2000));
+          results.push({ section: sections[i], content: `...${sections[i]}` });
+          await job?.updateProgress?.((i + 1) / total, `section ${i+1}/${total}`);
+        }
+        const payload = { user_id, report: results };
+        await job?.complete?.(payload);
+        return payload;
+      },
+    });
+    ```
+
+=== "Java"
+
+    ```java
+    @MeshAgent(name = "long-task-provider-java", port = 9120)
+    @SpringBootApplication
+    public class LongTaskProviderApplication {
+
+      public static void main(String[] args) {
+        SpringApplication.run(LongTaskProviderApplication.class, args);
+      }
+
+      @MeshTool(capability = "generate_report", task = true)
+      public Map<String, Object> generateReport(
+          @Param("user_id") String userId,
+          @Param("sections") List<String> sections,
+          MeshJob job) throws InterruptedException {
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller != null) controller.updateProgress(0.0, "starting");
+        List<Map<String, String>> results = new ArrayList<>();
+        int total = Math.max(sections.size(), 1);
+        for (int i = 0; i < sections.size(); i++) {
+          Thread.sleep(2000);
+          results.add(Map.of("section", sections.get(i), "content", "..."));
+          if (controller != null) {
+            controller.updateProgress((i + 1.0) / total, "section " + (i+1) + "/" + total);
+          }
+        }
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        payload.put("report", results);
+        if (controller != null) controller.complete(payload);
+        return payload;
+      }
+    }
+    ```
+
+**Consumer — submits and waits:**
+
+=== "Python"
+
+    ```python
+    import mesh
+    from fastmcp import FastMCP
+    from mesh import MeshJob
+
+    app = FastMCP("Long Task Consumer")
+
+    @app.tool()
+    @mesh.tool(capability="commission_report", dependencies=["generate_report"])
+    async def commission_report(
+        user_id: str,
+        sections: list[str],
+        # Param name MUST match the dependency capability — that pairing
+        # is what makes the slot a MeshJobSubmitter (not a McpMeshTool proxy).
+        generate_report: MeshJob = None,
+    ) -> dict:
+        proxy = await generate_report.submit(
+            user_id=user_id, sections=sections, max_duration=60,
+        )
+        return await proxy.wait(timeout_secs=60)
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    agent.addTool({
+      name: "commission_report",
+      capability: "commission_report",
+      dependencies: [{ capability: "generate_report" }],
+      meshJobDepIndex: 0,            // dep[0] is task=true → MeshJobSubmitter
+      parameters: z.object({
+        user_id: z.string(),
+        sections: z.array(z.string()),
+      }),
+      execute: async (
+        { user_id, sections },
+        generateReport: MeshJob | null = null,
+      ) => {
+        const proxy = await generateReport!.submit!(
+          { user_id, sections },
+          { maxDuration: 60 },
+        );
+        return await proxy.wait!(60);
+      },
+    });
+    ```
+
+=== "Java"
+
+    ```java
+    @MeshTool(
+        capability = "commission_report",
+        dependencies = @Selector(capability = "generate_report"))
+    public Map<String, Object> commissionReport(
+        @Param("user_id") String userId,
+        @Param("sections") List<String> sections,
+        MeshJob generateReport) throws Exception {
+      MeshJobSubmitter submitter = (MeshJobSubmitter) generateReport;
+      Map<String, Object> payload = new LinkedHashMap<>();
+      payload.put("user_id", userId);
+      payload.put("sections", sections);
+      var opts = new MeshJobSubmitter.SubmitOptions(payload, null, 60, null, null);
+      try (JobProxy proxy = submitter.submit(opts).get()) {
+        return (Map<String, Object>) proxy.await(60.0);
+      }
+    }
+    ```
+<!-- markdownlint-enable MD046 -->
+
+`submit(...)` posts to the registry's `POST /jobs` and returns a
+`JobProxy` bound to the new `job_id`. `wait(...)` polls
+`GET /jobs/{id}` until the status is terminal (`completed`, `failed`,
+or `cancelled`) and returns the producer's `complete()` payload (or
+raises on failure / cancel / timeout).
+
+## Retry semantics
+
+A failed attempt does not mean a failed job. The mesh distinguishes
+**explicit failure** (the handler decided this is unrecoverable) from
+**transient failure** (the handler hit a retryable error class), and
+re-runs only the latter on a peer replica.
+
+### `max_retries` (Sidekiq/Celery convention)
+
+`max_retries` counts retries **beyond** the initial attempt. So
+`max_retries=3` means up to 4 total attempts. The default is conservative
+— check your runtime's per-tool default and set explicitly when in doubt.
+
+!!! warning "Retries restart from scratch"
+
+    There are no idempotency keys in v2.x. Every retry runs the handler
+    body from the top. If the work has external side effects (sending
+    email, charging a card, mutating a remote DB), make the handler
+    **idempotent** or design for at-least-once semantics — e.g.,
+    deterministic IDs the downstream can dedupe on, or a "claim → check →
+    execute → mark done" pattern keyed off the `job_id`.
+
+### `retry_on` (per-tool exception whitelist)
+
+`retry_on` is a per-tool list of exception classes that should be treated
+as transient. When the handler raises a matching exception, the SDK calls
+`releaseLease(reason)` instead of `fail(reason)`: the registry resets the
+owner, and a peer replica (or the same replica on the next claim cycle)
+re-runs the handler within ~5 seconds. Anything **not** in `retry_on`
+still goes through `fail()` and surfaces to the consumer immediately.
+
+The canonical pattern: a tool that calls a flakey upstream raises
+`OSError` / `IOException` / `TransientUpstreamError` on the first N
+attempts, succeeds on attempt N+1.
+
+<!-- markdownlint-disable MD046 -->
+=== "Python"
+
+    ```python
+    @app.tool()
+    @mesh.tool(
+        capability="report_with_transient_failures",
+        task=True,
+        retry_on=(OSError,),
+    )
+    async def report_with_transient_failures(
+        user_id: str,
+        transient_failures: int = 2,
+        job: MeshJob = None,
+    ) -> dict:
+        n = _bump_retry_counter()
+        if n <= transient_failures:
+            # SDK matches retry_on=(OSError,) → calls release_lease(),
+            # NOT fail() — the registry hands the job to a peer within ~5s.
+            raise OSError(f"simulated transient failure {n}/{transient_failures}")
+        payload = {"user_id": user_id, "succeeded_on_attempt": n}
+        if job is not None:
+            await job.complete(payload)
+        return payload
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    class TransientUpstreamError extends Error {}
+
+    agent.addTool({
+      name: "report_with_transient_failures",
+      capability: "report_with_transient_failures",
+      task: true,
+      meshJobParamIndex: 1,
+      retryOn: [TransientUpstreamError],
+      parameters: z.object({
+        user_id: z.string(),
+        transient_failures: z.number().default(2),
+      }),
+      execute: async (
+        { user_id, transient_failures },
+        job: MeshJob | null = null,
+      ) => {
+        const n = bumpRetryCounter();
+        if (n <= transient_failures) {
+          // retryOn match → SDK releases the lease; peer replica retries.
+          throw new TransientUpstreamError(`transient ${n}/${transient_failures}`);
+        }
+        const payload = { user_id, succeeded_on_attempt: n };
+        await job?.complete?.(payload);
+        return payload;
+      },
+    });
+    ```
+
+=== "Java"
+
+    ```java
+    @MeshTool(
+        capability = "report_with_transient_failures",
+        task = true,
+        retryOn = IOException.class)
+    public Map<String, Object> reportWithTransientFailures(
+        @Param("user_id") String userId,
+        @Param(value = "transient_failures", required = false) Integer transientFailures,
+        MeshJob job) throws IOException {
+      int target = transientFailures == null ? 2 : transientFailures;
+      int n = bumpRetryCounter();
+      if (n <= target) {
+        // retryOn=IOException matches → dispatch wrapper calls
+        // releaseLease(reason) instead of fail(reason).
+        throw new IOException("simulated transient failure " + n + "/" + target);
+      }
+      JobController controller = job instanceof JobController c ? c : null;
+      Map<String, Object> payload = new LinkedHashMap<>();
+      payload.put("user_id", userId);
+      payload.put("succeeded_on_attempt", n);
+      if (controller != null) controller.complete(payload);
+      return payload;
+    }
+    ```
+<!-- markdownlint-enable MD046 -->
+
+**Validation is loud.** `retry_on` requires `task=true`; misuse (string
+entries, non-`Error` classes) fails at registration so it surfaces at
+agent boot, not at retry time. Both `report_with_transient_failures`
+fixtures (Python `tests/integration/suites/uc21_meshjob/fixtures/long-task-provider/main.py`
+and Java `tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/`)
+exercise this end-to-end with a file-based attempt counter that lets
+the test assert "succeeded on attempt 3" deterministically.
+
+## Timeout propagation
+
+Jobs use the existing `X-Mesh-Timeout` header (#656) to carry a
+**per-attempt deadline** — relative seconds remaining for the current
+attempt, not an absolute timestamp. The provider runtime parses the
+header on inbound, stashes the deadline in an async-local primitive,
+and outbound proxies (any `McpMeshTool` call the handler makes) read
+the same primitive and attach `X-Mesh-Timeout: <remaining>` to their
+own downstream requests.
+
+| Runtime    | Async-local primitive                          |
+|------------|------------------------------------------------|
+| Python     | `contextvars.ContextVar("mesh_job_deadline")`  |
+| TypeScript | `AsyncLocalStorage`                            |
+| Java       | `ThreadLocal` (or `ScopedValue` for Loom)      |
+
+**Nested job cap.** When a parent job calls a child job, the child's
+deadline is `min(parent_remaining, child_requested)`. If the parent
+has 5 seconds left on its attempt and the child's `submit(...)`
+requests `max_duration=30`, the child gets 5 seconds. This is enforced
+at submission time so the child's runtime sees a single coherent
+deadline regardless of how deep the chain runs.
+
+The header is on the default `MCP_MESH_PROPAGATE_HEADERS` allowlist
+alongside `X-Mesh-Job-Id`, `X-Mesh-Trace-Id`, etc. — no per-agent
+configuration is needed for propagation to work. Tracing this in
+[Audit Trail](audit.md) shows the deadline shrinking as it walks the
+chain.
+
+## meshctl
+
+Three SDK-managed helper tools are exposed on every mesh agent for
+out-of-band job inspection. They are not separate `meshctl` subcommands
+— they are regular MCP tools, prefixed with `__mesh_job_` to mark them
+framework-internal, that you reach via `meshctl call`:
+
+```bash
+# Inspect status (registry returns the full job row)
+meshctl call <consumer>:__mesh_job_status \
+    '{"job_id":"01HXY..."}'
+
+# Pull just the terminal result + status (convenience over status)
+meshctl call <consumer>:__mesh_job_result \
+    '{"job_id":"01HXY..."}'
+
+# Cancel mid-flight (idempotent — already-terminal jobs return ok)
+meshctl call <consumer>:__mesh_job_cancel \
+    '{"job_id":"01HXY...","reason":"user requested"}'
+```
+
+Submission goes through the consumer's actual capability (e.g.
+`commission_report` in the example above), which is the wrapper that
+calls `submitter.submit(...)` internally. There is no
+`__mesh_job_submit` helper — kicking off a job always goes through a
+consumer tool, because the submitter needs to know which capability
+to route to and which retry / deadline policy to apply.
+
+The Dashboard also lists active jobs and exposes the same status /
+cancel actions over the registry HTTP API directly, useful when
+debugging from a browser instead of a shell.
+
+## Auth model
+
+`job_id` is a **presigned-URL-style capability**. Possession of a valid
+`job_id` (~122 bits of entropy from a UUID) grants full status / result
+/ cancel rights on that job, with no additional caller-identity check.
+Reads and writes against the registry's `/jobs/{id}` endpoints are not
+authenticated by design: the secret IS the URL fragment.
+
+!!! warning "Leak the id, leak the job"
+
+    Treat `job_id` like a presigned S3 URL. Anyone who learns it can
+    cancel the work or read the result, including any error payload it
+    surfaced. Don't log job ids to a system that has a wider audience
+    than the consumer that issued them. Don't return them to a
+    third-party browser unless you intend that party to control the
+    job. If a job carries sensitive payloads, scrub them out of the
+    `complete()` body too — the result lives in the registry until the
+    sweep cron expires it.
+
+In v2.x there is **no opt-in caller-identity verification**. Future
+work (tracked in `MESHJOB_DESIGN.org`) will add an optional SPIRE-
+based mode that matches the calling SVID against the job's submitter
+on cancel / status, for environments that need stricter isolation.
+
+## Architecture overview
+
+The **registry** is the durable substrate. It's a Go service backed by
+PostgreSQL (or SQLite for `--singlepass` dev mode); jobs live in a
+`jobs` table with `status`, `owner_instance_id`, `lease_expires_at`,
+`attempt_count`, `progress`, and `result` columns. A periodic sweep
+loop reaps orphaned jobs (owner crashed, lease expired) and enforces
+`total_deadline` as a separate safety net beyond the per-attempt
+`max_duration`. All status transitions land in the same Postgres row,
+so any consumer that holds the `job_id` sees the latest state on the
+next poll regardless of which replica owns the job.
+
+The **agent runtime** is a thin client. On the producer side, it
+maintains a claim queue per `task=true` capability (`UPDATE jobs SET
+owner_instance_id = $self WHERE capability = $cap AND status =
+'pending'` is the atomic claim), runs the handler with an injected
+`JobController`, and batches progress / terminal POSTs back to the
+registry on a tick interval (terminal calls flush immediately). Cancel
+signals bind a registry watcher to the in-flight handler's cancel
+token, so `proxy.cancel(...)` from any consumer fires the token on the
+owner replica and outbound HTTP proxies abort their requests too.
+
+**DDDI is the injection layer.** The producer's `MeshJob` parameter
+lands at `meshJobParamIndex` (Python and Java auto-detect it from the
+type annotation; TS declares it explicitly in `addTool`). The
+consumer's `MeshJob` parameter — typed identically, but on a slot
+named after a dependency capability — gets a `MeshJobSubmitter`
+instead of an `McpMeshTool` proxy: same DDDI lookup, different
+injection target based on the dep's `task=true` flag. Resolution,
+trust, and tag matching are unchanged from the regular tool path; the
+only difference is the runtime swaps the proxy class at the dep slot.
+For the full design rationale and lifecycle diagrams, see
+[`MESHJOB_DESIGN.org`](https://github.com/dhyansraj/mcp-mesh/blob/main/MESHJOB_DESIGN.org)
+and [`MESHJOB_DDDI_CONTRACT.md`](https://github.com/dhyansraj/mcp-mesh/blob/main/MESHJOB_DDDI_CONTRACT.md).
+
+## What it does NOT do (v2 limitations)
+
+- **No idempotency keys.** Retries restart the handler from scratch;
+  the SDK does not dedupe partial side effects. Make handlers
+  idempotent if at-least-once semantics are not acceptable.
+- **No caller-identity check on `job_id`.** Possession of the id is
+  the only auth. SPIRE-based opt-in is future work.
+- **No streaming-style chunked progress.** `update_progress(fraction,
+  message)` flushes through the registry on a batching tick. For
+  token-by-token feedback, use [streaming](streaming.md) instead — or
+  combine: a job that calls a streaming tool internally and reports
+  coarse progress via `update_progress`.
+- **No cross-runtime retry-on whitelist coercion.** Each runtime
+  matches its own native exception classes (Python `Exception`
+  subclasses, TS `Error` subclasses, Java `Throwable` subclasses).
+  A Python provider's `retry_on=(OSError,)` does not propagate to a
+  Java peer claiming the same capability — declare the whitelist
+  separately on each runtime that hosts the capability.
+
+## See Also
+
+- [Streaming](streaming.md) — token-by-token progress for the request-
+  response case where the work fits in a single SSE
+- [Audit Trail](audit.md) — `progressToken`, `X-Mesh-Job-Id`, and
+  `X-Mesh-Timeout` propagation through the audit pipeline
+- [DDDI](dddi.md) — Distributed Dynamic Dependency Injection overview;
+  explains how `MeshJob` slots are resolved
+- [`MESHJOB_DESIGN.org`](https://github.com/dhyansraj/mcp-mesh/blob/main/MESHJOB_DESIGN.org)
+  — full design doc with state machine, lifecycle, and SQL schema
+- [`MESHJOB_DDDI_CONTRACT.md`](https://github.com/dhyansraj/mcp-mesh/blob/main/MESHJOB_DDDI_CONTRACT.md)
+  — the cross-runtime injection contract every SDK implements
+- [`examples/jobs/`](https://github.com/dhyansraj/mcp-mesh/tree/main/examples/jobs),
+  [`examples/jobs-ts/`](https://github.com/dhyansraj/mcp-mesh/tree/main/examples/jobs-ts),
+  [`examples/jobs-java/`](https://github.com/dhyansraj/mcp-mesh/tree/main/examples/jobs-java)
+  — runnable producer + consumer pairs in all three runtimes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -228,6 +228,7 @@ nav:
       - Schema Matching: concepts/schema-matching.md
       - Audit Trail: concepts/audit.md
       - Streaming: concepts/streaming.md
+      - Long-Running Jobs: concepts/jobs.md
 
   - Multimodal:
       - Getting Started: multimodal/getting-started.md

--- a/src/core/cli/man/content.go
+++ b/src/core/cli/man/content.go
@@ -61,6 +61,14 @@ var guideRegistry = map[string]*Guide{
 		Title:       "Streaming",
 		Description: "Token-by-token text responses via MCP progress notifications (issue #645)",
 	},
+	"jobs": {
+		Name:                 "jobs",
+		Aliases:              []string{"meshjob", "long-running", "task", "background"},
+		Title:                "Long-Running Jobs (MeshJob)",
+		Description:          "DDDI-native primitive for tasks that outlast a tools/call request — submit, await, cancel, retry_on",
+		HasTypeScriptVariant: true,
+		HasJavaVariant:       true,
+	},
 	"decorators": {
 		Name:                 "decorators",
 		Aliases:              []string{"decorator"},
@@ -318,7 +326,7 @@ func ListGuides() []*Guide {
 	order := []string{
 		"quickstart", "prerequisites", "tutorial", "overview", "capabilities", "tags",
 		"schema-matching", "decorators",
-		"dependency-injection", "audit", "streaming", "health", "registry", "llm", "media", "multimodal",
+		"dependency-injection", "audit", "streaming", "jobs", "health", "registry", "llm", "media", "multimodal",
 		"proxies", "api", "environment", "deployment", "observability", "headers",
 		"testing", "scaffold", "cli", "security",
 	}

--- a/src/core/cli/man/content/jobs.md
+++ b/src/core/cli/man/content/jobs.md
@@ -1,0 +1,301 @@
+# Long-Running Jobs (MeshJob)
+
+> DDDI-native primitive for tasks that outlast a `tools/call` request — submit, await, cancel, retry_on
+
+## Why MeshJob
+
+`tools/call` is fine for sub-second to ~30s work. For anything longer (multi-section reports, video transcoding, long agentic loops), the consumer's HTTP socket is at the mercy of every load balancer, ingress, and pod restart between the two agents.
+
+**MeshJob** is the durable alternative:
+
+- Producer declares `task=True` on the tool — the SDK runs it under a
+  registry-backed claim/lease, with progress updates and explicit
+  `complete()` / `fail()` terminal states.
+- Consumer types a dependency parameter as `MeshJob` — DDDI swaps the
+  usual `McpMeshTool` proxy for a `MeshJobSubmitter` at that slot.
+- `submitter.submit(...)` posts to `POST /jobs` and returns a
+  `JobProxy` bound to the new job id. `proxy.wait(...)` polls
+  `GET /jobs/{id}` until terminal.
+
+Plain `task=False` tools continue to be buffered request-response — no
+behavior change for non-job tools.
+
+## Cheat sheet
+
+| Surface                    | Producer                          | Consumer                                |
+| -------------------------- | --------------------------------- | --------------------------------------- |
+| Decorator flag             | `@mesh.tool(task=True, ...)`      | (regular `@mesh.tool` w/ dependency)    |
+| Injected type              | `job: MeshJob = None`             | `<dep_name>: MeshJob = None`            |
+| Concrete injection         | `JobController` (or `None`)       | `MeshJobSubmitter`                      |
+| Progress                   | `await job.update_progress(f, m)` | (read via `__mesh_job_status`)          |
+| Terminal success           | `await job.complete(payload)`     | `await proxy.wait(timeout_secs=N)`      |
+| Terminal failure           | `await job.fail(reason)`          | `wait()` raises                         |
+| Transient retry            | `raise OSError(...)` w/ `retry_on=(OSError,)` | (registry hands to peer in ~5s) |
+| Cancel                     | (cancel token fires in handler)   | `await proxy.cancel(reason)`            |
+
+## Producer: `@mesh.tool(task=True)`
+
+```python
+import asyncio
+import mesh
+from fastmcp import FastMCP
+from mesh import MeshJob
+
+app = FastMCP("Long Task Provider")
+
+
+@app.tool()
+@mesh.tool(
+    capability="generate_report",
+    task=True,                              # opts the tool into MeshJob
+    description="Long-running report generator",
+)
+async def generate_report(
+    user_id: str,
+    sections: list[str],
+    job: MeshJob = None,                    # auto-injected by signature scan
+) -> dict:
+    if job is not None:
+        await job.update_progress(0.0, "starting")
+
+    results = []
+    total = max(len(sections), 1)
+    for i, section in enumerate(sections):
+        await asyncio.sleep(2)              # simulate work
+        results.append({"section": section, "content": f"...{section}"})
+        if job is not None:
+            await job.update_progress(
+                (i + 1) / total,
+                f"finished section {i+1}/{total}",
+            )
+
+    payload = {"user_id": user_id, "report": results}
+    if job is not None:
+        await job.complete(payload)         # explicit terminal flush
+    return payload
+
+
+@mesh.agent(name="long-task-provider", http_port=9100, auto_run=True)
+class LongTaskProvider:
+    pass
+```
+
+**Notes:**
+
+- `job: MeshJob = None` lands at the parameter position the SDK detects
+  by type annotation. It is `None` when the tool is invoked via a
+  regular `tools/call` (no `X-Mesh-Job-Id` header) — the function then
+  runs the fast path and just returns its result.
+- `complete()` / `fail()` flush past the batching tick immediately, so
+  the consumer's `wait(...)` sees the terminal state without latency.
+- `update_progress(fraction, message)` is batched to avoid hammering
+  the registry. For token-by-token feedback, see `meshctl man streaming`.
+
+## Consumer: `MeshJob`-typed dependency
+
+```python
+import mesh
+from fastmcp import FastMCP
+from mesh import MeshJob
+
+app = FastMCP("Long Task Consumer")
+
+
+@app.tool()
+@mesh.tool(
+    capability="commission_report",
+    # Param NAME must match the dependency capability — that pairing is
+    # what makes the slot a MeshJobSubmitter (instead of an McpMeshTool).
+    dependencies=["generate_report"],
+)
+async def commission_report(
+    user_id: str,
+    sections: list[str],
+    generate_report: MeshJob = None,        # injected MeshJobSubmitter
+) -> dict:
+    proxy = await generate_report.submit(
+        user_id=user_id,
+        sections=sections,
+        max_duration=60,                    # per-attempt soft timeout (seconds)
+    )
+    return await proxy.wait(timeout_secs=60)
+```
+
+**Notes:**
+
+- The SDK swaps `McpMeshTool` for `MeshJobSubmitter` at the slot
+  whose param name matches a dependency that points at a `task=True`
+  capability. Same DDDI lookup pipeline (resolution, trust, tags) —
+  only the proxy class differs.
+- `wait(timeout_secs=N)` returns the producer's `complete()` payload
+  on success; raises `JobFailedError`, `JobCancelledError`, or
+  `JobTimeoutError` on the other terminal states.
+
+## `submit(...)` options
+
+| Keyword            | Type             | Purpose                                                 |
+| ------------------ | ---------------- | ------------------------------------------------------- |
+| `**args`           | per-tool         | Forwarded as the tool's input arguments                 |
+| `max_duration`     | `int` (seconds)  | Per-attempt soft timeout (provider runtime + cron sweep)|
+| `max_retries`      | `int`            | Retries beyond initial attempt (Sidekiq convention)     |
+| `total_deadline`   | `int` (seconds)  | Hard ceiling across all attempts (registry enforces)    |
+| `owner_instance_id`| `str`            | Pin to a specific replica (rarely needed)               |
+
+## `retry_on` (per-tool exception whitelist)
+
+`retry_on` is a tuple of exception classes that should be treated as
+transient. When the handler raises a matching exception, the SDK calls
+`release_lease(reason)` instead of `fail(reason)` — the registry
+resets the owner and a peer replica re-runs the handler within ~5
+seconds. Anything **not** in `retry_on` still goes through `fail()`
+and surfaces to the consumer immediately.
+
+```python
+@app.tool()
+@mesh.tool(
+    capability="report_with_transient_failures",
+    task=True,
+    retry_on=(OSError,),                    # tuple of Exception subclasses
+)
+async def report_with_transient_failures(
+    user_id: str,
+    transient_failures: int = 2,
+    job: MeshJob = None,
+) -> dict:
+    n = _bump_retry_counter()
+    if n <= transient_failures:
+        # SDK matches retry_on=(OSError,) → release_lease(), NOT fail().
+        # The registry hands the job to a peer (or this replica's next
+        # claim cycle) within ~5 seconds.
+        raise OSError(f"simulated transient failure {n}/{transient_failures}")
+
+    payload = {"user_id": user_id, "succeeded_on_attempt": n}
+    if job is not None:
+        await job.complete(payload)
+    return payload
+```
+
+**Validation:**
+
+- `retry_on` requires `task=True` — registration fails at agent boot
+  otherwise. Same for non-`Exception` entries (strings, instances, etc).
+- Misuse surfaces at startup, not at retry time.
+
+**Combining with `max_retries`:**
+
+```python
+# Caller-side: at most 4 total attempts (1 initial + 3 retries)
+proxy = await generate_report.submit(
+    user_id="alice",
+    sections=["intro"],
+    max_duration=30,
+    max_retries=3,
+)
+```
+
+Retries restart the handler from scratch — there are no idempotency
+keys in v2.x. If the handler has external side effects, design for
+at-least-once: deterministic ids the downstream can dedupe on, or a
+"claim → check → execute → mark done" pattern keyed off `job_id`.
+
+## Cancellation
+
+```python
+# Consumer-side: cancel an in-flight job
+await proxy.cancel(reason="user requested abort")
+```
+
+The registry forwards the cancel to the owner replica via
+`POST /jobs/{id}/cancel` (auto-registered on every agent's FastAPI
+app). On the producer side, the in-process cancel token fires:
+
+- `asyncio.CancelledError` is raised at the next `await` point in the
+  handler.
+- Outbound `McpMeshTool` proxy calls abort their underlying HTTP
+  request (cancel propagates through `X-Mesh-Job-Id` header binding).
+
+The registry treats cancel as terminal (idempotent — already-terminal
+jobs return ok without re-firing).
+
+## Timeout propagation
+
+Jobs use the `X-Mesh-Timeout` header (#656) to carry a per-attempt
+deadline as **relative seconds remaining** for the current attempt
+(not an absolute timestamp). The producer runtime stashes the deadline
+in a `contextvars.ContextVar("mesh_job_deadline")`; outbound proxies
+read it back and attach a recomputed `X-Mesh-Timeout` to downstream
+requests.
+
+**Nested job cap:** when a parent job calls a child job, the child's
+deadline is `min(parent_remaining, child_requested)`. Enforced at
+submission time, so the child's runtime sees a single coherent
+deadline regardless of depth.
+
+The header is on the default `MCP_MESH_PROPAGATE_HEADERS` allowlist
+alongside `X-Mesh-Job-Id` and `X-Mesh-Trace-Id` — no per-agent
+configuration is needed.
+
+## Out-of-band inspection
+
+Three SDK-managed helper tools are auto-registered on every mesh
+agent. They are regular MCP tools (prefixed `__mesh_job_` to mark them
+framework-internal) — no separate `meshctl` subcommand:
+
+```bash
+# Inspect status (registry returns the full job row)
+meshctl call <consumer>:__mesh_job_status \
+    '{"job_id":"01HXY..."}'
+
+# Pull just the terminal result + status (convenience over status)
+meshctl call <consumer>:__mesh_job_result \
+    '{"job_id":"01HXY..."}'
+
+# Cancel mid-flight (idempotent — already-terminal jobs return ok)
+meshctl call <consumer>:__mesh_job_cancel \
+    '{"job_id":"01HXY...","reason":"user requested"}'
+```
+
+Submission goes through the consumer's actual capability (e.g.
+`commission_report`), not a dedicated `__mesh_job_submit` helper —
+the submitter needs the dependency context to know which capability
+to route to and which retry / deadline policy to apply.
+
+## Auth model
+
+`job_id` is a presigned-URL-style capability. Possession of a valid
+job id (~122 bits of entropy from a UUID) grants full status / result
+/ cancel rights on that job, with no additional caller-identity check.
+
+> **Leak the id, leak the job.** Treat `job_id` like a presigned S3
+> URL. Anyone who learns it can cancel the work or read the result,
+> including any error payload. Don't log job ids to a system that has
+> a wider audience than the consumer that issued them. If a job
+> carries sensitive payloads, scrub them out of `complete()` too —
+> the result lives in the registry until the sweep cron expires it.
+
+In v2.x there is no opt-in caller-identity verification. SPIRE-based
+mode is future work (tracked in `MESHJOB_DESIGN.org`).
+
+## v2 Limitations
+
+- **No idempotency keys.** Retries restart the handler from scratch.
+- **No caller-identity check on `job_id`.** Possession is the only auth.
+- **No streaming-style chunked progress.** Progress flushes on a
+  batching tick. For token-by-token feedback, see
+  `meshctl man streaming` — or combine: a job that calls a streaming
+  tool internally and reports coarse progress via `update_progress`.
+- **No cross-runtime `retry_on` coercion.** Each runtime matches its
+  own native exception classes. A Python `retry_on=(OSError,)` does
+  NOT propagate to a Java peer claiming the same capability — declare
+  the whitelist separately on each runtime that hosts the capability.
+
+## See Also
+
+- `meshctl man streaming` — token-by-token progress for the
+  request-response case where the work fits in a single SSE
+- `meshctl man audit` — `X-Mesh-Job-Id` + `X-Mesh-Timeout` propagation
+  through the audit pipeline
+- `meshctl man dependency-injection` — how DDDI resolves
+  `MeshJob`-typed slots
+- [`docs/concepts/jobs.md`](https://github.com/dhyansraj/mcp-mesh/blob/main/docs/concepts/jobs.md) — narrative concept doc with architecture overview
+- [`examples/jobs/`](https://github.com/dhyansraj/mcp-mesh/tree/main/examples/jobs) — runnable producer + consumer pair (Python)

--- a/src/core/cli/man/content/jobs_java.md
+++ b/src/core/cli/man/content/jobs_java.md
@@ -1,0 +1,398 @@
+# Long-Running Jobs (MeshJob — Java)
+
+> DDDI-native primitive for tasks that outlast a `tools/call` request — submit, await, cancel, retryOn
+
+## Why MeshJob
+
+`tools/call` is fine for sub-second to ~30s work. For anything longer (multi-section reports, video transcoding, long agentic loops), the consumer's HTTP socket is at the mercy of every load balancer, ingress, and pod restart between the two agents.
+
+**MeshJob** is the durable alternative:
+
+- Producer sets `task = true` on `@MeshTool` — the SDK runs the
+  method under a registry-backed claim/lease, with progress updates
+  and explicit `complete()` / `fail()` terminal states.
+- Consumer types a dependency parameter as `MeshJob` — DDDI swaps
+  the usual `McpMeshTool` proxy for a `MeshJobSubmitter` at that slot.
+- `submitter.submit(...)` posts to `POST /jobs` and returns a
+  `CompletableFuture<JobProxy>` bound to the new job id.
+  `proxy.await(timeoutSeconds)` polls `GET /jobs/{id}` until terminal.
+
+Plain `task = false` (default) tools continue to be buffered
+request-response — no behavior change for non-job tools.
+
+## Cheat sheet
+
+| Surface              | Producer                                    | Consumer                                           |
+| -------------------- | ------------------------------------------- | -------------------------------------------------- |
+| Annotation flag      | `@MeshTool(task = true)`                    | (regular `@MeshTool` w/ dependency)                |
+| Slot detection       | Auto from `MeshJob` parameter type          | Auto from `MeshJob` parameter type                 |
+| Injected type        | `MeshJob` (cast to `JobController`)         | `MeshJob` (cast to `MeshJobSubmitter`)             |
+| Concrete injection   | `JobController` (or `null`)                 | `MeshJobSubmitter`                                 |
+| Progress             | `controller.updateProgress(f, m)`           | (read via `__mesh_job_status`)                     |
+| Terminal success     | `controller.complete(payload)`              | `proxy.await(timeoutSeconds)`                      |
+| Terminal failure     | `controller.fail(reason)`                   | `await()` throws                                   |
+| Transient retry      | `throw new IOException(...)` w/ `retryOn`   | (registry hands to peer in ~5s)                    |
+| Cancel               | (cancel token fires in handler)             | `proxy.cancel(reason)`                             |
+
+## Producer: `@MeshTool(task = true)`
+
+```java
+package com.example.longtaskprovider;
+
+import io.mcpmesh.JobController;
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@MeshAgent(
+    name = "long-task-provider-java",
+    version = "1.0.0",
+    description = "MeshJob producer (Java)",
+    port = 9120
+)
+@SpringBootApplication
+public class LongTaskProviderApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(LongTaskProviderApplication.class, args);
+    }
+
+    @MeshTool(
+        capability = "generate_report",
+        task = true,                                // opts the tool into MeshJob
+        description = "Long-running report generator"
+    )
+    public Map<String, Object> generateReport(
+            @Param("user_id") String userId,
+            @Param(value = "sections", required = false) List<String> sections,
+            MeshJob job) throws InterruptedException {       // injected at this slot
+
+        if (sections == null) {
+            sections = List.of("default");
+        }
+        // The runtime injects a JobController when X-Mesh-Job-Id is set,
+        // or null when invoked via a regular tools/call (fast path).
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller != null) {
+            controller.updateProgress(0.0, "starting");
+        }
+
+        List<Map<String, String>> results = new ArrayList<>();
+        int total = Math.max(sections.size(), 1);
+        for (int i = 0; i < sections.size(); i++) {
+            Thread.sleep(2000);                     // simulate work
+            String section = sections.get(i);
+            Map<String, String> entry = new LinkedHashMap<>();
+            entry.put("section", section);
+            entry.put("content", "..." + section);
+            results.add(entry);
+            if (controller != null) {
+                controller.updateProgress(
+                    (i + 1.0) / total,
+                    "finished section " + (i + 1) + "/" + total);
+            }
+        }
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        payload.put("report", results);
+
+        if (controller != null) {
+            controller.complete(payload);           // explicit terminal flush
+        }
+        return payload;
+    }
+}
+```
+
+**Notes:**
+
+- The SDK auto-detects the `MeshJob` slot from the parameter type
+  signature — no `meshJobParamIndex` needed (Java has reflection).
+- `job` is `null` when the tool is invoked via a regular `tools/call`
+  (no `X-Mesh-Job-Id` header) — the function then runs the fast path.
+  Always check `job instanceof JobController` before downcasting.
+- `complete()` / `fail()` flush past the batching tick immediately,
+  so the consumer's `await(...)` sees the terminal state without
+  latency.
+- `updateProgress(fraction, message)` is batched. For token-by-token
+  feedback, see `meshctl man streaming --java`.
+
+## Consumer: `MeshJob`-typed dependency
+
+```java
+package com.example.longtaskconsumer;
+
+import io.mcpmesh.JobProxy;
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshJobSubmitter;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@MeshAgent(name = "long-task-consumer-java", port = 9121)
+@SpringBootApplication
+public class LongTaskConsumerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(LongTaskConsumerApplication.class, args);
+    }
+
+    @MeshTool(
+        capability = "commission_report",
+        description = "Commission a report and await its result",
+        dependencies = @Selector(capability = "generate_report")
+    )
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> commissionReport(
+            @Param("user_id") String userId,
+            @Param(value = "sections", required = false) List<String> sections,
+            MeshJob generateReport) throws Exception {
+
+        // The DI layer injects a MeshJobSubmitter (NOT an McpMeshTool proxy)
+        // because the dependency points at a task=true capability.
+        if (!(generateReport instanceof MeshJobSubmitter submitter)) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "submitter not injected");
+            return err;
+        }
+
+        if (sections == null) {
+            sections = List.of("intro", "analysis", "summary");
+        }
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", userId);
+        payload.put("sections", sections);
+
+        // SubmitOptions(args, ownerInstanceId, maxDuration, maxRetries, totalDeadline)
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            payload,
+            null,    // ownerInstanceId — let the registry route via claim
+            60,      // maxDuration seconds (per-attempt soft timeout)
+            null,    // maxRetries — accept default
+            null     // totalDeadline — unlimited
+        );
+
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            Object result = proxy.await(60.0);     // poll until terminal
+            if (result instanceof Map<?, ?> m) {
+                return (Map<String, Object>) m;
+            }
+            Map<String, Object> wrapped = new LinkedHashMap<>();
+            wrapped.put("result", result);
+            return wrapped;
+        }
+    }
+}
+```
+
+**Notes:**
+
+- `MeshJob` is the cross-runtime parameter marker; on the consumer
+  side it downcasts to `MeshJobSubmitter`, on the producer side to
+  `JobController`. Same DDDI lookup pipeline (resolution, trust,
+  tags) — only the proxy class differs.
+- `JobProxy` is `AutoCloseable` — use try-with-resources to ensure
+  the underlying poller releases its registry watcher.
+- `proxy.await(timeoutSeconds)` returns the producer's `complete()`
+  payload on success; throws `JobFailedException`,
+  `JobCancelledException`, or `JobTimeoutException` on the other
+  terminal states.
+
+## `SubmitOptions`
+
+```java
+public record SubmitOptions(
+    Object args,                  // Map of args forwarded to the tool
+    String ownerInstanceId,       // optional: pin to a replica
+    Integer maxDuration,          // per-attempt soft timeout (seconds)
+    Integer maxRetries,           // retries beyond initial attempt
+    Integer totalDeadline         // hard ceiling across attempts (seconds)
+) { }
+```
+
+## `retryOn` (per-tool exception whitelist)
+
+`retryOn` is a `Class<? extends Throwable>[]` of exception classes
+that should be treated as transient. When the handler throws a
+matching exception, the SDK calls `releaseLease(reason)` instead of
+`fail(reason)` — the registry resets the owner and a peer replica
+re-runs the handler within ~5 seconds. Anything **not** in `retryOn`
+still goes through `fail()` and surfaces to the consumer immediately.
+
+```java
+import java.io.IOException;
+
+@MeshTool(
+    capability = "report_with_transient_failures",
+    task = true,
+    retryOn = IOException.class                    // class literal (or array)
+)
+public Map<String, Object> reportWithTransientFailures(
+        @Param("user_id") String userId,
+        @Param(value = "transient_failures", required = false)
+            Integer transientFailures,
+        MeshJob job) throws IOException {
+
+    int target = transientFailures == null ? 2 : transientFailures;
+    int n = bumpRetryCounter();
+    if (n <= target) {
+        // retryOn=IOException.class matches → dispatch wrapper calls
+        // releaseLease(reason) instead of fail(reason). The registry
+        // hands the job to a peer (or this replica's next claim cycle)
+        // within ~5 seconds.
+        throw new IOException(
+            "simulated transient failure " + n + "/" + target);
+    }
+
+    JobController controller = job instanceof JobController c ? c : null;
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("user_id", userId);
+    payload.put("succeeded_on_attempt", n);
+    if (controller != null) {
+        controller.complete(payload);
+    }
+    return payload;
+}
+```
+
+**Multiple classes:**
+
+```java
+@MeshTool(
+    capability = "...",
+    task = true,
+    retryOn = { IOException.class, TimeoutException.class }
+)
+```
+
+**Validation:**
+
+- `retryOn` requires `task = true` — registration fails at agent boot
+  otherwise. Same for non-`Throwable` subclass entries (caught at
+  compile time via the bound).
+- Misuse surfaces at startup, not at retry time.
+
+Retries restart the handler from scratch — there are no idempotency
+keys in v2.x. If the handler has external side effects, design for
+at-least-once: deterministic ids the downstream can dedupe on, or a
+"claim → check → execute → mark done" pattern keyed off `job_id`.
+
+## Cancellation
+
+```java
+// Consumer-side: cancel an in-flight job
+proxy.cancel("user requested abort");
+```
+
+The registry forwards the cancel to the owner replica via
+`POST /jobs/{id}/cancel` (auto-registered on every agent's HTTP
+server). On the producer side, the cancel token fires:
+
+- Thread interrupt is signaled at the next `Thread.sleep` /
+  `Object.wait` / blocking I/O — the handler should propagate
+  `InterruptedException` rather than swallow it.
+- Outbound `McpMeshTool` proxy calls abort their underlying HTTP
+  request (cancel propagates through `X-Mesh-Job-Id` header binding).
+
+The registry treats cancel as terminal (idempotent — already-terminal
+jobs return ok without re-firing).
+
+## Timeout propagation
+
+Jobs use the `X-Mesh-Timeout` header (#656) to carry a per-attempt
+deadline as **relative seconds remaining** for the current attempt
+(not an absolute timestamp). The producer runtime stashes the deadline
+in a `ThreadLocal` (or `ScopedValue` under Loom); outbound proxies
+read it back and attach a recomputed `X-Mesh-Timeout` to downstream
+requests.
+
+**Nested job cap:** when a parent job calls a child job, the child's
+deadline is `min(parentRemaining, childRequested)`. Enforced at
+submission time, so the child's runtime sees a single coherent
+deadline regardless of depth.
+
+The header is on the default `MCP_MESH_PROPAGATE_HEADERS` allowlist
+alongside `X-Mesh-Job-Id` and `X-Mesh-Trace-Id` — no per-agent
+configuration is needed.
+
+## Out-of-band inspection
+
+Three SDK-managed helper tools are auto-registered on every mesh
+agent. They are regular MCP tools (prefixed `__mesh_job_` to mark them
+framework-internal):
+
+```bash
+# Inspect status (registry returns the full job row)
+meshctl call <consumer>:__mesh_job_status \
+    '{"job_id":"01HXY..."}'
+
+# Pull just the terminal result + status (convenience over status)
+meshctl call <consumer>:__mesh_job_result \
+    '{"job_id":"01HXY..."}'
+
+# Cancel mid-flight (idempotent — already-terminal jobs return ok)
+meshctl call <consumer>:__mesh_job_cancel \
+    '{"job_id":"01HXY...","reason":"user requested"}'
+```
+
+Submission goes through the consumer's actual capability (e.g.
+`commission_report`), not a dedicated `__mesh_job_submit` helper —
+the submitter needs the dependency context to know which capability
+to route to and which retry / deadline policy to apply.
+
+## Auth model
+
+`job_id` is a presigned-URL-style capability. Possession of a valid
+job id (~122 bits of entropy from a UUID) grants full status / result
+/ cancel rights on that job, with no additional caller-identity check.
+
+> **Leak the id, leak the job.** Treat `job_id` like a presigned S3
+> URL. Anyone who learns it can cancel the work or read the result,
+> including any error payload. Don't log job ids to a system that has
+> a wider audience than the consumer that issued them. If a job
+> carries sensitive payloads, scrub them out of `complete()` too —
+> the result lives in the registry until the sweep cron expires it.
+
+In v2.x there is no opt-in caller-identity verification. SPIRE-based
+mode is future work (tracked in `MESHJOB_DESIGN.org`).
+
+## v2 Limitations
+
+- **No idempotency keys.** Retries restart the handler from scratch.
+- **No caller-identity check on `job_id`.** Possession is the only auth.
+- **No streaming-style chunked progress.** Progress flushes on a
+  batching tick. For token-by-token feedback, see
+  `meshctl man streaming --java` — or combine: a job that calls a
+  streaming tool internally and reports coarse progress via
+  `updateProgress`.
+- **No cross-runtime `retryOn` coercion.** Each runtime matches its
+  own native exception classes. A Java
+  `retryOn = IOException.class` does NOT propagate to a Python or
+  TypeScript peer claiming the same capability — declare the
+  whitelist separately on each runtime that hosts the capability.
+
+## See Also
+
+- `meshctl man streaming --java` — token-by-token progress
+- `meshctl man audit` — `X-Mesh-Job-Id` + `X-Mesh-Timeout` propagation
+- `meshctl man dependency-injection --java` — how DDDI resolves
+  `MeshJob`-typed slots
+- [`docs/concepts/jobs.md`](https://github.com/dhyansraj/mcp-mesh/blob/main/docs/concepts/jobs.md) — narrative concept doc with architecture overview
+- [`examples/jobs-java/`](https://github.com/dhyansraj/mcp-mesh/tree/main/examples/jobs-java) — runnable producer + consumer pair (Java)

--- a/src/core/cli/man/content/jobs_typescript.md
+++ b/src/core/cli/man/content/jobs_typescript.md
@@ -1,0 +1,334 @@
+# Long-Running Jobs (MeshJob — TypeScript)
+
+> DDDI-native primitive for tasks that outlast a `tools/call` request — submit, await, cancel, retryOn
+
+## Why MeshJob
+
+`tools/call` is fine for sub-second to ~30s work. For anything longer (multi-section reports, video transcoding, long agentic loops), the consumer's HTTP socket is at the mercy of every load balancer, ingress, and pod restart between the two agents.
+
+**MeshJob** is the durable alternative:
+
+- Producer sets `task: true` on the tool — the SDK runs it under a
+  registry-backed claim/lease, with progress updates and explicit
+  `complete()` / `fail()` terminal states.
+- Consumer types a dependency parameter as `MeshJob | null` — DDDI
+  swaps the usual `McpMeshTool` proxy for a `MeshJobSubmitter` at that
+  slot.
+- `submitter.submit(...)` posts to `POST /jobs` and returns a
+  `JobProxy` bound to the new job id. `proxy.wait(...)` polls
+  `GET /jobs/{id}` until terminal.
+
+Plain `task: false` tools continue to be buffered request-response —
+no behavior change for non-job tools.
+
+## Cheat sheet
+
+| Surface              | Producer                                  | Consumer                                  |
+| -------------------- | ----------------------------------------- | ----------------------------------------- |
+| Tool flag            | `task: true`                              | (regular `addTool` w/ dependency)         |
+| Slot index           | `meshJobParamIndex: <pos>`                | `meshJobDepIndex: <dep-array-index>`      |
+| Injected type        | `job: MeshJob \| null = null`             | `<dep>: MeshJob \| null = null`           |
+| Concrete injection   | `JobController` (or `null`)               | `MeshJobSubmitter`                        |
+| Progress             | `await job?.updateProgress(f, m)`         | (read via `__mesh_job_status`)            |
+| Terminal success     | `await job?.complete(payload)`            | `await proxy.wait(timeoutSecs)`           |
+| Terminal failure     | `await job?.fail(reason)`                 | `wait()` rejects                          |
+| Transient retry      | `throw new TransientError(...)` w/ `retryOn` | (registry hands to peer in ~5s)        |
+| Cancel               | (cancel token fires in handler)           | `await proxy.cancel(reason)`              |
+
+## Producer: `task: true`
+
+```typescript
+import { FastMCP } from "fastmcp";
+import { mesh, type MeshJob } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const server = new FastMCP({
+  name: "Long Task Provider (TS)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "long-task-provider-ts",
+  httpPort: 9110,
+});
+
+agent.addTool({
+  name: "generate_report",
+  capability: "generate_report",
+  task: true,                              // opts the tool into MeshJob
+  // Position 0 is `args`, the MeshJob lands at position 1.
+  meshJobParamIndex: 1,
+  description: "Long-running report generator",
+  parameters: z.object({
+    user_id: z.string(),
+    sections: z.array(z.string()),
+  }),
+  execute: async (
+    { user_id, sections },
+    job: MeshJob | null = null,            // injected JobController (or null)
+  ) => {
+    if (job?.updateProgress) {
+      await job.updateProgress(0.0, "starting");
+    }
+    const results: { section: string; content: string }[] = [];
+    const total = Math.max(sections.length, 1);
+    for (let i = 0; i < sections.length; i++) {
+      await new Promise((r) => setTimeout(r, 2000));    // simulate work
+      results.push({
+        section: sections[i],
+        content: `...${sections[i]}`,
+      });
+      if (job?.updateProgress) {
+        await job.updateProgress(
+          (i + 1) / total,
+          `finished section ${i+1}/${total}`,
+        );
+      }
+    }
+    const payload = { user_id, report: results };
+    if (job?.complete) {
+      await job.complete(payload);         // explicit terminal flush
+    }
+    return payload;
+  },
+});
+```
+
+**Notes:**
+
+- Unlike Python (which auto-detects from the type annotation), TS
+  declares `meshJobParamIndex` explicitly because runtime type
+  reflection is not available. Position 0 is the `args` object;
+  position 1 is the first slot after that.
+- `job` is `null` when the tool is invoked via a regular `tools/call`
+  (no `X-Mesh-Job-Id` header) — the function then runs the fast path
+  and just returns its result.
+- `complete()` / `fail()` flush past the batching tick immediately, so
+  the consumer's `wait(...)` sees the terminal state without latency.
+- `updateProgress(fraction, message)` is batched. For token-by-token
+  feedback, see `meshctl man streaming --typescript`.
+
+## Consumer: `MeshJob`-typed dependency
+
+```typescript
+import { FastMCP } from "fastmcp";
+import { mesh, type MeshJob } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const server = new FastMCP({
+  name: "Long Task Consumer (TS)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "long-task-consumer-ts",
+  httpPort: 9111,
+});
+
+agent.addTool({
+  name: "commission_report",
+  capability: "commission_report",
+  dependencies: [{ capability: "generate_report" }],
+  // Replace dep[0]'s slot with a MeshJobSubmitter. Without this flag,
+  // the SDK injects a regular McpMeshTool proxy.
+  meshJobDepIndex: 0,
+  parameters: z.object({
+    user_id: z.string(),
+    sections: z.array(z.string()),
+  }),
+  execute: async (
+    { user_id, sections },
+    generateReport: MeshJob | null = null,
+  ) => {
+    if (!generateReport?.submit) {
+      return { error: "submitter not injected" };
+    }
+    const proxy = await generateReport.submit(
+      { user_id, sections },
+      { maxDuration: 60 },                 // per-attempt soft timeout
+    );
+    return await proxy.wait!(60);
+  },
+});
+```
+
+**Notes:**
+
+- `meshJobDepIndex: N` swaps `McpMeshTool` for `MeshJobSubmitter` at
+  the Nth dependency slot. Same DDDI lookup pipeline (resolution,
+  trust, tags) — only the proxy class differs.
+- `proxy.wait(timeoutSecs)` resolves with the producer's `complete()`
+  payload on success; rejects on `JobFailedError`,
+  `JobCancelledError`, or `JobTimeoutError`.
+
+## `submit(...)` options
+
+```typescript
+const proxy = await generateReport.submit(
+  { user_id, sections },                    // tool args
+  {
+    maxDuration: 60,                        // per-attempt soft timeout (sec)
+    maxRetries: 3,                          // retries beyond initial attempt
+    totalDeadline: 300,                     // hard ceiling across attempts (sec)
+    ownerInstanceId: undefined,             // optional: pin to a replica
+  },
+);
+```
+
+## `retryOn` (per-tool exception whitelist)
+
+`retryOn` is an array of `Error` subclass constructors that should be
+treated as transient. When the handler throws an instance of a matching
+class, the SDK calls `releaseLease(reason)` instead of `fail(reason)`
+— the registry resets the owner and a peer replica re-runs the handler
+within ~5 seconds. Anything **not** in `retryOn` still goes through
+`fail()` and surfaces to the consumer immediately.
+
+```typescript
+class TransientUpstreamError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TransientUpstreamError";
+  }
+}
+
+agent.addTool({
+  name: "report_with_transient_failures",
+  capability: "report_with_transient_failures",
+  task: true,
+  meshJobParamIndex: 1,
+  retryOn: [TransientUpstreamError],         // array of Error subclasses
+  parameters: z.object({
+    user_id: z.string(),
+    transient_failures: z.number().default(2),
+  }),
+  execute: async (
+    { user_id, transient_failures },
+    job: MeshJob | null = null,
+  ) => {
+    const n = bumpRetryCounter();
+    if (n <= transient_failures) {
+      // retryOn match → SDK releases the lease; peer replica retries.
+      throw new TransientUpstreamError(
+        `simulated transient failure ${n}/${transient_failures}`,
+      );
+    }
+    const payload = { user_id, succeeded_on_attempt: n };
+    if (job?.complete) await job.complete(payload);
+    return payload;
+  },
+});
+```
+
+**Validation:**
+
+- `retryOn` requires `task: true` — registration fails at agent boot
+  otherwise. Same for non-`Error`-subclass entries (strings,
+  instances, plain objects, etc).
+- Misuse surfaces at startup, not at retry time.
+
+Retries restart the handler from scratch — there are no idempotency
+keys in v2.x. If the handler has external side effects, design for
+at-least-once: deterministic ids the downstream can dedupe on, or a
+"claim → check → execute → mark done" pattern keyed off `job_id`.
+
+## Cancellation
+
+```typescript
+// Consumer-side: cancel an in-flight job
+await proxy.cancel("user requested abort");
+```
+
+The registry forwards the cancel to the owner replica via
+`POST /jobs/{id}/cancel` (auto-registered on every agent's HTTP
+server). On the producer side, the cancel token fires:
+
+- The `AbortSignal` exposed via `job?.signal` (if the handler
+  subscribed) is aborted.
+- Outbound `McpMeshTool` proxy calls abort their underlying `fetch`
+  (cancel propagates through `X-Mesh-Job-Id` binding).
+
+The registry treats cancel as terminal (idempotent — already-terminal
+jobs return ok without re-firing).
+
+## Timeout propagation
+
+Jobs use the `X-Mesh-Timeout` header (#656) to carry a per-attempt
+deadline as **relative seconds remaining** for the current attempt
+(not an absolute timestamp). The producer runtime stashes the deadline
+in `AsyncLocalStorage`; outbound proxies read it back and attach a
+recomputed `X-Mesh-Timeout` to downstream requests.
+
+**Nested job cap:** when a parent job calls a child job, the child's
+deadline is `min(parentRemaining, childRequested)`. Enforced at
+submission time, so the child's runtime sees a single coherent
+deadline regardless of depth.
+
+The header is on the default `MCP_MESH_PROPAGATE_HEADERS` allowlist
+alongside `X-Mesh-Job-Id` and `X-Mesh-Trace-Id` — no per-agent
+configuration is needed.
+
+## Out-of-band inspection
+
+Three SDK-managed helper tools are auto-registered on every mesh
+agent. They are regular MCP tools (prefixed `__mesh_job_` to mark them
+framework-internal):
+
+```bash
+# Inspect status (registry returns the full job row)
+meshctl call <consumer>:__mesh_job_status \
+    '{"job_id":"01HXY..."}'
+
+# Pull just the terminal result + status (convenience over status)
+meshctl call <consumer>:__mesh_job_result \
+    '{"job_id":"01HXY..."}'
+
+# Cancel mid-flight (idempotent — already-terminal jobs return ok)
+meshctl call <consumer>:__mesh_job_cancel \
+    '{"job_id":"01HXY...","reason":"user requested"}'
+```
+
+Submission goes through the consumer's actual capability (e.g.
+`commission_report`), not a dedicated `__mesh_job_submit` helper —
+the submitter needs the dependency context to know which capability
+to route to and which retry / deadline policy to apply.
+
+## Auth model
+
+`job_id` is a presigned-URL-style capability. Possession of a valid
+job id (~122 bits of entropy from a UUID) grants full status / result
+/ cancel rights on that job, with no additional caller-identity check.
+
+> **Leak the id, leak the job.** Treat `job_id` like a presigned S3
+> URL. Anyone who learns it can cancel the work or read the result,
+> including any error payload. Don't log job ids to a system that has
+> a wider audience than the consumer that issued them. If a job
+> carries sensitive payloads, scrub them out of `complete()` too —
+> the result lives in the registry until the sweep cron expires it.
+
+In v2.x there is no opt-in caller-identity verification. SPIRE-based
+mode is future work (tracked in `MESHJOB_DESIGN.org`).
+
+## v2 Limitations
+
+- **No idempotency keys.** Retries restart the handler from scratch.
+- **No caller-identity check on `job_id`.** Possession is the only auth.
+- **No streaming-style chunked progress.** Progress flushes on a
+  batching tick. For token-by-token feedback, see
+  `meshctl man streaming --typescript` — or combine: a job that calls
+  a streaming tool internally and reports coarse progress via
+  `updateProgress`.
+- **No cross-runtime `retryOn` coercion.** Each runtime matches its
+  own native exception classes. A TypeScript
+  `retryOn: [TransientUpstreamError]` does NOT propagate to a Python
+  or Java peer claiming the same capability — declare the whitelist
+  separately on each runtime that hosts the capability.
+
+## See Also
+
+- `meshctl man streaming --typescript` — token-by-token progress
+- `meshctl man audit` — `X-Mesh-Job-Id` + `X-Mesh-Timeout` propagation
+- `meshctl man dependency-injection --typescript` — how DDDI resolves
+  `MeshJob`-typed slots
+- [`docs/concepts/jobs.md`](https://github.com/dhyansraj/mcp-mesh/blob/main/docs/concepts/jobs.md) — narrative concept doc with architecture overview
+- [`examples/jobs-ts/`](https://github.com/dhyansraj/mcp-mesh/tree/main/examples/jobs-ts) — runnable producer + consumer pair (TypeScript)


### PR DESCRIPTION
## Summary

Closes #875. Final sub-issue of #861 — on merge, **the MeshJob substrate ships complete**.

### Concepts page (`docs/concepts/jobs.md`, 529 lines)

Modeled on `docs/concepts/streaming.md`. Covers all 6 issue-required sections with cross-runtime tabs:

- **Getting started** — producer + consumer in Python / TypeScript / Java, sourced from `examples/jobs*/` (copy-paste runnable).
- **Retry semantics** — `max_retries` Sidekiq/Celery convention (N retries beyond initial = N+1 attempts) + idempotency caveat; `retry_on` per-tool whitelist with examples in all 3 runtimes.
- **Timeout propagation** — `X-Mesh-Timeout` header, async-local primitives table (`contextvars` / `AsyncLocalStorage` / `ThreadLocal`), nested job cap `min(parent_remaining, child_requested)`.
- **meshctl helper tools** — `__mesh_job_status` / `__mesh_job_result` / `__mesh_job_cancel`. Submit goes through the consumer's wrapper.
- **Auth model** — `job_id` as presigned-URL capability, leak-the-id-leak-the-job warning, future SPIRE opt-in note.
- **Architecture overview** — registry / agent runtime / DDDI, with refs to `MESHJOB_DESIGN.org` and `MESHJOB_DDDI_CONTRACT.md`.

### meshctl man page (3 files + registry entry)

New `jobs` topic with aliases `meshjob`, `long-running`, `task`, `background`. Cheat-sheet style matching `decorators` / `streaming`. Content in `src/core/cli/man/content/jobs.md` (Python, 301 lines), `jobs_typescript.md` (334 lines), `jobs_java.md` (398 lines). Listed between `streaming` and `health` in `meshctl man --list` (sibling long-running primitives).

```
$ meshctl man jobs            # Python
$ meshctl man jobs -t         # TypeScript
$ meshctl man jobs -j         # Java
$ meshctl man --list | grep jobs
  jobs (meshjob, long-running, task, background)
```

## What's NOT in this PR

- **`RELEASE_NOTES.md`** — intentionally deferred to actual release time per project convention. The MeshJob v2.0 entry will reference #861, #896, #897, #898, #899, #901 then.

## Follow-ups noted (not fixed here)

- `examples/jobs/long-task-consumer/main.py` line 10 docstring: shows `proxy.wait(timeout=60)` but the call uses `timeout_secs=60`. Trivial doc fix, not blocking docs.
- TS uc22 fixture lacks a `report_with_transient_failures` parity equivalent. The `retryOn` API is implemented; only the integration fixture is missing it. Worth adding for cross-runtime test parity.

## Validation

- `go build -o /tmp/meshctl ./cmd/meshctl` clean
- `meshctl man jobs --raw` / `-t --raw` / `-j --raw` render with cross-link header
- All 4 aliases resolve to the canonical `jobs` topic
- `mkdocs build` (non-strict) clean

Closes #875
Closes #861 (parent — final sub-issue, MeshJob substrate ships complete)

## Test plan

- [ ] CI green (mkdocs build, Go build)
- [ ] `meshctl man jobs` renders correctly in a terminal
- [ ] `mkdocs serve` shows the new "Long-Running Jobs" entry under Concepts and renders the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)