### PR TITLE
feat(a2a): Python v1 A2A surface adapter — Phase 1 + minimal Phase 2

### DIFF
--- a/A2A_SURFACE_DESIGN.org
+++ b/A2A_SURFACE_DESIGN.org
@@ -1,0 +1,610 @@
+#+TITLE: A2A Surface Adapter: Mesh Agents as A2A-Compliant Servers
+#+AUTHOR: mcp-mesh
+#+DATE: 2026-05-08
+#+TODO: TODO IN-PROGRESS | DONE BLOCKED
+#+OPTIONS: toc:3
+
+* Abstract
+
+Add an A2A (Agent-to-Agent) surface adapter to mcp-mesh, tracking issue
+#869. A2A is Google's open Agent-to-Agent protocol — a JSON-RPC 2.0 wire
+shape over HTTP with a discovery convention (=/.well-known/agent.json=) and
+a small set of task verbs (=tasks/send=, =tasks/get=, =tasks/cancel=,
+=tasks/sendSubscribe=, =tasks/resubscribe=). v1 of this work exposes
+existing mesh agents as A2A-compliant servers so that any A2A client
+(LangGraph agents, third-party orchestrators, partner systems) can call
+into the mesh without learning mesh-native protocols. Mesh stays mesh
+internally; A2A is a translation layer at the edge.
+
+The adapter is decorator-based (=@mesh.a2a=) and reuses three existing
+mesh primitives: DDDI injection (#861), MeshJob long-running tasks (post
+#861), and the registry's heartbeat-stamped metadata channel. No
+modifications to =@mesh.tool= are required.
+
+A2A protocol version pinned: *v1.0* (current latest as of 2026-05).
+Spec: https://a2a-protocol.org/latest/specification/
+Reference: https://github.com/a2aproject/A2A
+
+* Motivation
+
+A2A has reached meaningful adoption — 150+ organizations as of 2026,
+including LangChain/LangGraph integrations, multiple cloud-vendor agent
+runtimes, and a growing partner ecosystem. The protocol is intentionally
+minimal: agent cards for discovery, JSON-RPC for invocation, SSE for
+streaming. It does not (and does not try to) solve coordination,
+capability resolution, scheduling, or replication — exactly the layers
+mesh already owns.
+
+Critically, mesh has every primitive A2A's task lifecycle requires:
+
+| A2A concept                  | Mesh primitive                                        |
+|------------------------------+-------------------------------------------------------|
+| Agent card                   | =@mesh.tool= metadata + heartbeat-stamped FQDN        |
+| =tasks/send= (sync)          | Direct tool invocation via DDDI proxy                 |
+| =tasks/send= (long-running)  | =MeshJob.submit= (#861)                               |
+| =tasks/get=                  | =MeshJob.status= → registry =GET /jobs/{id}=          |
+| =tasks/cancel=               | =MeshJob.cancel= → registry-forwarded cancel          |
+| =tasks/sendSubscribe= (SSE)  | =MeshJob.update_progress= event stream                |
+| Discovery                    | Registry FQDN stamping + new =GET /a2a/agents=        |
+
+Strategic positioning: mesh stays protocol-independent. A2A is one of N
+possible surfaces — OpenAPI, gRPC, MCP-over-HTTP, and others can follow
+the same decorator pattern without entangling the core. The adapter
+proves the pattern; subsequent surfaces are mechanical.
+
+* Key Decisions
+
+** Decorator-based, not auto-mount
+=@mesh.a2a= is a route-style decorator analogous to =@mesh.route=. The
+function body is user-controlled; the decorator handles the A2A protocol
+envelope (agent card generation, JSON-RPC method routing, task lifecycle
+shaping). Mesh tools (=@mesh.tool=) stay completely untouched — no new
+flags, no new fields, no implicit A2A exposure. Operators opt in
+explicitly per-skill. Rationale: implicit exposure of every mesh tool to
+external A2A clients would be a security and surface-area footgun;
+decorator-based opt-in keeps the surface narrow and intentional.
+
+** DDDI-injected dependencies
+The =@mesh.a2a= function declares =dependencies=[...]= like any mesh
+tool. The decorator introspects the injected =McpMeshTool= proxy at call
+time:
+
+- If the underlying tool is =task=True= → wrap call in =MeshJob.submit=,
+  return A2A task with =state: working=; =tasks/get= polls registry;
+  =tasks/sendSubscribe= streams progress events as SSE.
+- If sync → invoke inline, return A2A task with =state: completed= and
+  the artifact embedded in the response.
+
+This means the adapter never has to introspect mesh-internal state
+machines directly. It composes cleanly on the existing DDDI substrate
+shipped in the MeshJob phase.
+
+** Per-skill agent cards as default
+Each =@mesh.a2a= function emits one agent card with one skill. The A2A
+spec allows multi-skill cards, but the spec has *no =skill_id= field on
+=tasks/send=* — multi-skill routing requires either LLM intent
+classification or off-spec convention. Per-skill is deterministic and
+matches mesh's explicit-tool, explicit-capability model. It also gives
+operators per-skill auth and FQDN granularity at zero extra cost.
+
+** LLM-backed multi-skill cards (deferred to v2)
+When the injected dependency is an =@mesh.llm= agent, the decorator
+could introspect the LLM's tool-filter set and emit a multi-skill card
+where the LLM itself becomes the dispatcher (intent → tool selection →
+invocation). This is a clean composition but introduces a new failure
+mode (LLM misroutes the skill). Defer to v2 to keep v1 surface area
+small and predictable.
+
+** Registry-driven FQDN discovery
+External A2A clients need a publicly addressable URL — mesh-internal
+capability resolution is invisible to them. The registry gains a new env
+var =MCP_MESH_PUBLIC_URL_PREFIX= (e.g., =https://agents.acme.com=). Each
+=@mesh.a2a(path="/agents/...")= decorator declares a path suffix; the
+registry computes =prefix + suffix= and stamps the FQDN onto the
+agent's heartbeat-stored metadata. A new registry endpoint
+=GET /a2a/agents= returns the public FQDN list for external discovery.
+Mesh-internal callers continue using capability-based resolution
+unchanged.
+
+** Auth scope for v1: bearer-token only
+The agent card's =authentication= field declares the scheme; the
+=@mesh.a2a= route handler validates the bearer header. Defer SPIRE /
+mTLS / OAuth flow to v2. Rationale: bearer token is the lowest-friction
+deployment story (matches Replicate, OpenAI, most SaaS APIs); mesh's
+internal trust boundary is already separate (SPIRE SVIDs for mesh-to-mesh).
+Conflating the two would slow shipping.
+
+** Runtime priority: Python first only
+v1 ships Python only. TypeScript and Java ports follow once Python
+validates the decorator surface and the registry plumbing. This matches
+the MeshJob rollout cadence (Rust core was uniform, language shims
+shipped sequentially) and avoids three-way coordination cost on a still-
+evolving design.
+
+** Consumer side deferred to v2
+=mesh.A2AProxy= (mesh agents *depending on* external A2A agents) is a
+separate architectural concern: it touches the DDDI resolver (new
+injectable type), the capability table (how do you list non-mesh
+capabilities?), and the wire (outbound A2A JSON-RPC client). Not in v1
+scope. v1 is producer-only.
+
+** Surface = thin translation, no state of its own
+The =@mesh.a2a= decorator owns no persistent state. It does not cache
+agent cards, does not maintain its own task table, does not duplicate
+MeshJob's progress storage. Every read terminates at either the
+registry or the underlying mesh-tool runtime. This keeps the adapter
+boring (= small, debuggable, swappable) and matches the mesh discipline
+established in the MeshJob design (=Status read path: all reads → registry=).
+
+** JSON-RPC single endpoint per A2A spec
+Per A2A v1.0, all task verbs (=tasks/send=, =tasks/get=, =tasks/cancel=,
+=tasks/sendSubscribe=, =tasks/resubscribe=) are JSON-RPC methods on a
+*single* HTTP endpoint, not separate URLs. The decorator mounts:
+
+- =GET  {path}/.well-known/agent.json= (discovery, plain HTTP)
+- =POST {path}= (JSON-RPC entry point for all verbs)
+
+A common implementer mistake is to expose =POST {path}/tasks/send= etc.
+as separate routes; the spec is explicit that the method name lives in
+the JSON-RPC envelope's =method= field.
+
+* Architecture
+
+** Layer map
+
+| Layer                                          | Where               | Notes                                              |
+|------------------------------------------------+---------------------+----------------------------------------------------|
+| =@mesh.a2a= decorator                          | runtime/python      | New module alongside =@mesh.route= / =@mesh.tool=  |
+| Agent card schema generator                    | runtime/python      | Reads tool input schema, emits A2A AgentCard JSON  |
+| JSON-RPC dispatcher (tasks/* verbs)            | runtime/python      | Mounts on FastMCP/route subsystem                  |
+| Bearer-token auth filter                       | runtime/python      | Per-route middleware                               |
+| FQDN stamping                                  | Go registry         | New env var + heartbeat metadata field             |
+| Public discovery endpoint =GET /a2a/agents=    | Go registry         | Reads heartbeat metadata, returns FQDN list        |
+| Long-running task routing                      | runtime/python      | Composes existing =MeshJob= primitive              |
+| SSE streaming                                  | runtime/python      | Wraps =MeshJob.update_progress= events             |
+
+** Producer-side flow (sync skill)
+
+#+BEGIN_SRC text
+External A2A client                Mesh agent (HTTP)             Registry
+       |                                  |                          |
+       | GET /agents/lookup/.well-known/agent.json                   |
+       |--------------------------------->|                          |
+       |     {200 AgentCard JSON}         |                          |
+       |<---------------------------------|                          |
+       |                                  |                          |
+       | POST /agents/lookup              |                          |
+       | { jsonrpc:"2.0",                 |                          |
+       |   method:"tasks/send",           |                          |
+       |   params:{ message:{...} } }     |                          |
+       |--------------------------------->|                          |
+       |                                  | (DDDI proxy → @mesh.tool |
+       |                                  |  quick_lookup invoked    |
+       |                                  |  inline — no MeshJob)    |
+       |   {200 task: state=completed,    |                          |
+       |        artifacts:[...]}          |                          |
+       |<---------------------------------|                          |
+#+END_SRC
+
+** Producer-side flow (long-running skill)
+
+#+BEGIN_SRC text
+External A2A client                Mesh agent (HTTP)             Registry
+       |                                  |                          |
+       | POST /agents/report-generator    |                          |
+       | { method:"tasks/send",           |                          |
+       |   params:{...} }                 |                          |
+       |--------------------------------->|                          |
+       |                                  | DDDI proxy detects       |
+       |                                  | task=True → MeshJob.submit
+       |                                  |------------------------->| POST /jobs
+       |                                  |<-------------------------| {job_id}
+       |   {200 task: state=working,      |                          |
+       |        id="job-uuid"}            |                          |
+       |<---------------------------------|                          |
+       |                                  |                          |
+       | POST /agents/report-generator    |                          |
+       | { method:"tasks/get",            |                          |
+       |   params:{id:"job-uuid"} }       |                          |
+       |--------------------------------->|                          |
+       |                                  | MeshJob.status           |
+       |                                  |------------------------->| GET /jobs/{id}
+       |                                  |<-------------------------| {status,progress}
+       |   {200 task: state=working,      |                          |
+       |        progress:0.4}             |                          |
+       |<---------------------------------|                          |
+#+END_SRC
+
+** Discovery flow
+
+#+BEGIN_SRC text
+Mesh agent boot:
+  1. @mesh.a2a(path="/agents/lookup", ...) registers locally
+  2. Heartbeat to registry includes a2a_paths=["/agents/lookup", ...]
+  3. Registry computes FQDN = MCP_MESH_PUBLIC_URL_PREFIX + path
+  4. Registry stores FQDN list on agent's heartbeat metadata
+
+External A2A client discovery:
+  1. GET https://registry.acme.com/a2a/agents
+       → [{name, fqdn, agent_card_url, description}, ...]
+  2. GET https://agents.acme.com/agents/lookup/.well-known/agent.json
+       → AgentCard JSON
+  3. POST https://agents.acme.com/agents/lookup
+       → JSON-RPC tasks/send
+#+END_SRC
+
+* Registry-Side Agent Typing
+
+** Background — current state
+
+Today the registry's =agent_type= enum has two values: =mcp_agent=
+(default) and =api=. They live in the OpenAPI spec at
+=api/mcp-mesh-registry.openapi.yaml= and surface in the generated Go
+code at =src/core/registry/generated/server.go=. The =api= type already
+gets special handling in registry status hooks and auto-resolve logic —
+establishing precedent for type-driven branching.
+
+#+BEGIN_SRC go
+// src/core/registry/generated/server.go:39
+const (
+    AgentInfoAgentTypeApi      AgentInfoAgentType = "api"
+    AgentInfoAgentTypeMcpAgent AgentInfoAgentType = "mcp_agent"
+)
+#+END_SRC
+
+** Proposal — add =a2a= as a third type
+
+Single-value enum stays exclusive (one type per agent record). An
+A2A-exposing agent registers as =agent_type=a2a=. It can still hold
+capabilities (mesh tools) AND new A2A-specific surfaces — the type tells
+the registry "in addition to the usual mesh-tool handling, this agent
+has A2A surfaces; compute FQDNs and expose via the A2A discovery
+endpoint."
+
+OpenAPI diff:
+
+#+BEGIN_SRC yaml
+agent_type:
+  type: string
+  enum: [mcp_agent, api, a2a]   # NEW: a2a
+  default: "mcp_agent"
+#+END_SRC
+
+** Heartbeat schema discriminator
+
+Heartbeat payload accepts type-specific fields via discriminator
+(matches the existing =oneOf= pattern in OpenAPI):
+
+#+BEGIN_SRC yaml
+A2AHeartbeat:
+  type: object
+  required: [agent_id, agent_type, surfaces]
+  properties:
+    agent_id: { ... }
+    agent_type: { const: "a2a" }
+    capabilities: { ... }              # mesh tools still allowed
+    surfaces:                          # NEW: A2A-specific
+      type: array
+      items:
+        type: object
+        required: [path, skill_id]
+        properties:
+          path: { type: string }       # "/agents/report-generator"
+          skill_id: { type: string }
+          description: { type: string }
+          input_modes: { type: array, items: { type: string } }
+          output_modes: { type: array, items: { type: string } }
+          tags: { type: array, items: { type: string } }
+#+END_SRC
+
+** Heartbeat response — registry-stamped FQDN
+
+The registry computes =MCP_MESH_PUBLIC_URL_PREFIX + path= per surface
+and returns it in the heartbeat response so agents never need to know
+their own public hostname:
+
+#+BEGIN_SRC yaml
+A2AHeartbeatResponse:
+  type: object
+  properties:
+    surfaces:
+      items:
+        type: object
+        properties:
+          path: { type: string }
+          skill_id: { type: string }
+          public_url:                  # registry-computed
+            type: string
+            example: "https://agents.acme.com/agents/report-generator"
+          agent_card_url:              # convenience
+            type: string
+            example: "https://agents.acme.com/agents/report-generator/.well-known/agent.json"
+#+END_SRC
+
+** Why this shape
+
+- *Single registration*: agent registers once with =type=a2a=;
+  capability + surface metadata coexist on the same record. No duplicate
+  records, no two-step registration flow.
+- *Registry owns FQDN*: agents declare path suffixes in
+  =@mesh.a2a(path=...)= decorators; the registry concatenates with
+  =MCP_MESH_PUBLIC_URL_PREFIX= and returns the full URL. Agents never
+  need to know their public hostname (load-balancer / ingress concern).
+- *Type-driven discovery*: =GET /agents?type=a2a= filters;
+  =GET /a2a/agents= is the external A2A client discovery endpoint that
+  returns FQDNs per surface.
+- *Forward-compatible*: adding =grpc=, =openapi=, or other surface types
+  tomorrow follows the same pattern — new enum value + new =oneOf=
+  branch + new URL prefix env var.
+- *Backwards compatible*: existing =mcp_agent= and =api= agents are
+  untouched. Default stays =mcp_agent=.
+
+** Multi-skill grouping (forward-pointer)
+
+The =surfaces= array naturally supports the per-skill agent card model.
+Each =@mesh.a2a= decorator emits one surface entry. External A2A
+clients see N agent cards (one per skill).
+
+For the v2 LLM-backed multi-skill model, the same =surfaces= array can
+hold a =group_id= field; the registry would aggregate same-group
+surfaces into one logical agent card on the discovery endpoint. No
+schema rework needed — purely additive.
+
+*** Action items
+**** TODO Add =a2a= to AgentInfoAgentType enum in =api/mcp-mesh-registry.openapi.yaml=
+**** TODO Regenerate Go bindings: =make generate=
+**** TODO Add A2A heartbeat discriminator schema (=oneOf= branch with =surfaces= array)
+**** TODO Add A2A heartbeat response (FQDN stamping) — registry concatenates =MCP_MESH_PUBLIC_URL_PREFIX=
+**** TODO Add =MCP_MESH_PUBLIC_URL_PREFIX= env var to registry config (cli + docs)
+**** TODO Add =GET /a2a/agents= discovery endpoint returning surface FQDNs by agent
+**** TODO Update =GET /agents?type=a2a= filter handling (Ent query already supports type filter)
+**** TODO Status hooks: extend the existing api-type special-casing to handle =a2a= (likely no-op for now but verify)
+
+* API Surface (Python v1)
+
+** Canonical example
+
+#+BEGIN_SRC python
+import mesh
+from fastmcp import FastMCP
+from mesh import MeshJob, McpMeshTool
+
+@mesh.agent(name="long-task-provider", http_port=9100)
+class LongTaskProviderAgent:
+    pass
+
+app = FastMCP("Long Task Provider")
+
+# Mesh tools — completely standard, no A2A awareness
+@app.tool()
+@mesh.tool(capability="generate_report", task=True)
+async def generate_report(user_id: str, sections: list[str], job: MeshJob = None):
+    await job.update_progress(0.1, "fetching user")
+    # ... long work ...
+    await job.update_progress(0.9, "rendering")
+    return {"report_url": "https://..."}
+
+@app.tool()
+@mesh.tool(capability="quick_lookup")
+async def quick_lookup(user_id: str) -> dict:
+    return {"name": "Alice", "id": user_id}
+
+# A2A surface — separate, explicit, DDDI-injected
+@mesh.a2a(
+    path="/agents/report-generator",
+    description="Generate a long-form report",
+    dependencies=["generate_report"],
+)
+async def report_generator_a2a(payload: dict, generate_report: McpMeshTool = None):
+    return await generate_report(**payload)
+
+@mesh.a2a(
+    path="/agents/lookup",
+    description="Fetch a user record by id",
+    dependencies=["quick_lookup"],
+)
+async def lookup_a2a(payload: dict, quick_lookup: McpMeshTool = None):
+    return await quick_lookup(**payload)
+#+END_SRC
+
+** Auto-generated endpoints per =@mesh.a2a= decorator
+
+| Method | Path                              | Purpose                                                    |
+|--------+-----------------------------------+------------------------------------------------------------|
+| GET    | ={path}/.well-known/agent.json=   | A2A AgentCard, generated from decorator + dep input schema |
+| POST   | ={path}=                          | JSON-RPC 2.0 entry point for all =tasks/*= verbs           |
+
+** JSON-RPC methods handled on =POST {path}=
+
+| JSON-RPC method        | Maps to                                       | Notes                                  |
+|------------------------+-----------------------------------------------+----------------------------------------|
+| =tasks/send=           | inline call OR =MeshJob.submit=               | Branch on dep =task= flag              |
+| =tasks/get=            | =MeshJob.status= (long-running) / cached      | Reads registry =GET /jobs/{id}=        |
+| =tasks/cancel=         | =MeshJob.cancel=                              | Registry forwards to owner replica     |
+| =tasks/sendSubscribe=  | submit + SSE stream of progress + terminal    | Phase 3                                |
+| =tasks/resubscribe=    | re-attach SSE to in-flight task               | Phase 3                                |
+
+** AgentCard generation
+
+The decorator builds the AgentCard at registration time from:
+
+- =name= ← decorator =name= or function name
+- =description= ← decorator =description=
+- =url= ← registry-stamped FQDN (or empty placeholder pre-stamp)
+- =skills= ← single skill derived from the dependency's =@mesh.tool= input schema
+- =authentication= ← bearer scheme (v1)
+- =capabilities.streaming= ← =true= iff dep is =task=True= (Phase 3)
+
+* Phase 1 — Skeleton & Agent Card (~400 LOC)
+
+Goal: ship the decorator surface, agent-card generation, and discovery
+endpoint mounting. =tasks/*= verbs return =Method not implemented=. End-
+to-end discovery works; invocation lands in Phase 2.
+
+** Decorator & card generation
+*** TODO Add =@mesh.a2a= decorator to =src/runtime/python/mesh/decorators.py=
+*** TODO Decorator metadata model (path, description, dependencies, name)
+*** TODO Agent card schema generator: reads dep =@mesh.tool= input schema, emits A2A AgentCard JSON
+*** TODO Mount =GET {path}/.well-known/agent.json= via existing =mesh.route= mechanism
+*** TODO Mount =POST {path}= JSON-RPC handler (returns =Method not implemented= for now)
+*** TODO Bearer-token auth scaffold — read header, no enforcement yet (Phase 2 enforces)
+
+** Tests
+*** TODO Unit: card generation for sync tool
+*** TODO Unit: card generation for =task=True= tool (capabilities.streaming=true)
+*** TODO Unit: card schema validates against A2A v1.0 JSON schema
+*** TODO Unit: =POST {path}= returns proper JSON-RPC error envelope for unimplemented methods
+
+** Discovery (cross-phase, started here)
+*** TODO Add =MCP_MESH_PUBLIC_URL_PREFIX= env var to registry config
+*** TODO Heartbeat field for =a2a_paths: []string=
+*** TODO Registry stamps FQDN per path on heartbeat receipt
+*** TODO New endpoint =GET /a2a/agents= returns FQDN list
+
+** Acceptance
+- External A2A client can fetch =agent.json= from a deployed mesh agent
+- Card schema validates against A2A v1.0 JSON schema
+- =GET /a2a/agents= lists deployed A2A surfaces with public FQDNs
+- =POST {path}= returns well-formed JSON-RPC =Method not implemented=
+
+* Phase 2 — Sync + Long-Running Task Routing (~400 LOC)
+
+Goal: implement =tasks/send=, =tasks/get=, =tasks/cancel=. End-to-end
+external A2A client can submit a sync task and a long-running task and
+observe correct A2A-shaped responses.
+
+** Task verb routing
+*** TODO =tasks/send= dispatcher: introspect dep, route to inline OR =MeshJob.submit=
+*** TODO Build A2A =Task= response object from inline result (state=completed)
+*** TODO Build A2A =Task= response object from =MeshJob= submission (state=working)
+*** TODO =tasks/get=: =MeshJob.status= → A2A =Task= shape with progress mapping
+*** TODO =tasks/cancel=: =MeshJob.cancel= passthrough; A2A =state: cancelled= response
+*** TODO Map mesh job states to A2A states:
+    =working= → =working=,
+    =completed= → =completed=,
+    =failed= → =failed=,
+    =cancelled= → =cancelled=
+*** TODO Bearer-token auth enforcement (rejects 401 with A2A-shaped error)
+*** TODO Map A2A =Message= request shape → mesh tool args (one-to-one for v1)
+
+** Error mapping
+*** TODO Tool exception → A2A =state: failed= with =error= field
+*** TODO Timeout → A2A =state: failed= with =timeout= reason
+*** TODO Auth failure → JSON-RPC error code per A2A spec
+*** TODO Bad payload → JSON-RPC =Invalid params= error
+
+** Tests
+*** TODO Unit: sync tasks/send → state=completed roundtrip
+*** TODO Unit: long-running tasks/send → state=working + job-id passthrough
+*** TODO Unit: tasks/get state mapping for each MeshJob status
+*** TODO Unit: tasks/cancel propagates to MeshJob.cancel
+*** TODO Unit: bearer-token enforcement (401 on missing/invalid)
+*** TODO Integration: external A2A client end-to-end submit + poll + complete (long-running)
+*** TODO Integration: external A2A client end-to-end submit + immediate complete (sync)
+*** TODO Integration: cancel mid-execution; verify A2A state transition
+
+** Acceptance
+- External A2A client can submit a sync task and receive a complete result
+- External A2A client can submit a long-running task, poll =tasks/get=,
+  observe state transitions, and read the final artifact
+- =tasks/cancel= cleanly stops in-flight work
+- Bearer-token auth blocks unauthenticated callers
+
+* Phase 3 — Streaming via sendSubscribe (~200 LOC)
+
+Goal: SSE streaming of progress events. External A2A client can
+=tasks/sendSubscribe= and observe progress + terminal events as
+Server-Sent Events.
+
+** SSE plumbing
+*** TODO =tasks/sendSubscribe=: submit job + open SSE response stream
+*** TODO Subscribe to =MeshJob.update_progress= events from registry/owner
+*** TODO Emit =TaskStatusUpdateEvent= per progress tick
+*** TODO Emit =TaskArtifactUpdateEvent= on terminal complete
+*** TODO Emit terminal =TaskStatusUpdateEvent= (=final: true=) on completion/failure/cancel
+*** TODO =tasks/resubscribe=: re-attach SSE to in-flight task; replay current state
+
+** Reliability
+*** TODO SSE keepalive heartbeat (avoid proxy timeouts)
+*** TODO Client disconnect cleanup (does not cancel underlying job — A2A spec semantics)
+*** TODO Backpressure: drop progress events if client is slow (favor terminal delivery)
+
+** Tests
+*** TODO Unit: SSE event-shape conformance to A2A v1.0
+*** TODO Integration: client subscribes, observes N progress events, observes terminal
+*** TODO Integration: client disconnects mid-stream, job continues, resubscribe works
+*** TODO Integration: failure mid-stream → terminal failed event delivered
+
+** Acceptance
+- External A2A client can stream a long-running task end-to-end
+- Resubscribe after disconnect recovers the live state
+- Terminal events always delivered (or recoverable via tasks/get fallback)
+
+* Out of Scope for v1
+
+Explicitly *not* in v1; deferred to v2 or later:
+
+- TypeScript and Java SDKs (Python-only first)
+- Consumer side: =mesh.A2AProxy= for depending on external A2A agents
+- Multi-skill grouping in a single agent card
+- LLM-backed multi-skill cards (=@mesh.llm= as A2A dispatcher)
+- Auth schemes beyond bearer-token (no SPIRE / mTLS / OAuth flow)
+- Multi-turn =state: input-required= dialogues (no clean mesh primitive)
+- Push notifications / webhooks for task completion
+- gRPC variant of A2A (spec supports it; we focus on HTTP+JSON)
+- Signed agent cards (A2A v1.0 introduced these but they require key
+  management infrastructure; defer)
+- A2A's =Message= attachment / file upload semantics beyond inline JSON
+- Per-skill rate limiting / quota
+- Federated discovery (multi-registry A2A directory)
+
+* Open Questions
+
+To verify during implementation:
+
+- A2A v1.0's exact JSON-RPC method names and parameter shapes — read the
+  official spec carefully when starting Phase 1; the spec has shifted on
+  =tasks/*= naming during 2025
+- Agent-card schema for =inputModes= / =outputModes= when our tool only
+  handles JSON — likely =["application/json"]= for both, but verify
+- How to express =tags= on a skill — pull from mesh tool's =tags= field
+  if present, otherwise default to ={capability_name}=?
+- SSE event-shape: =TaskStatusUpdateEvent= vs =TaskArtifactUpdateEvent= —
+  decide which to emit on =update_progress= vs final result; spec allows
+  both during a stream
+- Bearer-token validation: match an existing mesh auth header convention
+  (=Authorization: Bearer ...= is the obvious choice) or define a new
+  one? Likely just standard Authorization header.
+- Registry env var name: =MCP_MESH_PUBLIC_URL_PREFIX= is one option;
+  check existing registry env var conventions for naming alignment
+- A2A error code mapping: spec defines its own JSON-RPC error code
+  ranges; map mesh exception types to those codes consistently
+- =tasks/get= caching: if registry calls are hot, do we add a TTL cache
+  on the adapter? Default to no-cache (matches MeshJob discipline) and
+  measure
+- Multi-skill auth scoping: when v2 adds multi-skill cards, does each
+  skill get its own bearer secret or one card-wide secret?
+- Streaming reconnect window: how long do we hold task state after a
+  client disconnects before resubscribe is impossible? MeshJob already
+  has terminal retention semantics — reuse those.
+
+* References
+
+- Issue #869 — A2A surface adapter (parent issue for this design)
+- Issue #861 — MeshJob long-running tasks (substrate dependency)
+- A2A protocol specification: https://a2a-protocol.org/latest/specification/
+- A2A protocol GitHub: https://github.com/a2aproject/A2A
+- A2A samples: https://github.com/a2aproject/a2a-samples
+- =MESHJOB_DESIGN.org= — architectural precedent for a similar feature
+  (decorator-driven, DDDI-injected, registry-coordinated)
+- =MESHJOB_DDDI_CONTRACT.md= — DDDI mechanics that =@mesh.a2a= injection
+  composes on top of
+
+* Status & Changelog
+
+** 2026-05-08
+- Initial design committed
+- Tracks GitHub issue #869 (A2A surface adapter)
+- Depends on #861 (MeshJob substrate, shipped Phase 1)
+- v1 scope: Python-only producer side; Phases 1–3 outlined
+- v2 scope captured in "Out of Scope" section for traceability

--- a/api/mcp-mesh-registry.openapi.yaml
+++ b/api/mcp-mesh-registry.openapi.yaml
@@ -43,6 +43,8 @@ tags:
     description: Canonical schema registry (issue #547)
   - name: jobs
     description: Long-running job coordination (MeshJob — see MESHJOB_DESIGN.org)
+  - name: a2a
+    description: A2A (Agent-to-Agent) surface discovery (see A2A_SURFACE_DESIGN.org)
 paths:
   /health:
     get:
@@ -554,6 +556,33 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /a2a/agents:
+    get:
+      tags: [a2a]
+      summary: List A2A-exposed agents and their public URLs
+      description: |
+        Returns the FQDN-stamped surface list for every registered a2a-typed
+        agent. External A2A clients use this endpoint to discover where to
+        fetch agent cards (`{public_url}/.well-known/agent.json`) and where
+        to POST JSON-RPC `tasks/*` requests.
+
+        🤖 AI NOTE: Mesh-internal callers continue to use capability-based
+        resolution; this endpoint is purely the external discovery surface.
+      operationId: listA2AAgents
+      responses:
+        "200":
+          description: List of A2A surfaces with registry-stamped FQDNs
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/A2AAgentsListResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /events:
     get:
       tags: [events]
@@ -752,7 +781,8 @@ components:
       description: |
         Service registration request with flattened structure.
         Used by both /agents/register and /heartbeat endpoints.
-        Supports both agents (agent_type=mcp_agent) and API services (agent_type=api).
+        Supports mesh agents (agent_type=mcp_agent), API services (agent_type=api),
+        and A2A-exposing agents (agent_type=a2a).
       properties:
         agent_id:
           type: string
@@ -763,10 +793,14 @@ components:
           description: Unique identifier for the agent
         agent_type:
           type: string
-          enum: [mcp_agent, api]
+          enum: [mcp_agent, api, a2a]
           default: "mcp_agent"
           example: "mcp_agent"
-          description: Type of service - mcp_agent provides capabilities, api consumes them
+          description: |
+            Type of service:
+            - mcp_agent: provides mesh capabilities (default)
+            - api: API-style consumer
+            - a2a: exposes A2A (Agent-to-Agent) surfaces; populates the optional surfaces field
         runtime:
           type: string
           enum: [python, typescript, java]
@@ -812,6 +846,55 @@ components:
           description: |
             Array of tools provided by this agent (@mesh.tool functions).
             Tools can optionally include llm_filter if decorated with @mesh.llm.
+        surfaces:
+          type: array
+          items:
+            $ref: "#/components/schemas/A2ASurface"
+          description: |
+            A2A surface declarations. Optional; only populated when agent_type=a2a.
+            Each surface corresponds to one @mesh.a2a decorator and carries the
+            path suffix + skill metadata the registry needs to compute the public
+            FQDN (path is concatenated with MCP_MESH_PUBLIC_URL_PREFIX).
+
+    A2ASurface:
+      type: object
+      required: [path, skill_id]
+      description: |
+        A single A2A (Agent-to-Agent) surface registered by an a2a-typed agent.
+        Carries the per-skill metadata an external A2A client needs to discover
+        and call this surface, plus the path suffix the registry uses to build
+        the publicly addressable URL.
+      properties:
+        path:
+          type: string
+          example: "/agents/report-generator"
+          description: URL path suffix for the A2A surface (e.g., /agents/report-generator)
+        skill_id:
+          type: string
+          example: "generate-report"
+          description: A2A skill identifier (kebab-case canonical)
+        name:
+          type: string
+          example: "Report Generator"
+          description: Human-readable skill name for the agent card
+        description:
+          type: string
+          example: "Generate a long-form report"
+          description: Free-form skill description shown on the agent card
+        input_modes:
+          type: array
+          items: { type: string }
+          default: ["application/json"]
+          description: A2A inputModes for this skill
+        output_modes:
+          type: array
+          items: { type: string }
+          default: ["application/json"]
+          description: A2A outputModes for this skill
+        tags:
+          type: array
+          items: { type: string }
+          description: Skill tags surfaced on the agent card
 
     MeshToolRegistration:
       type: object
@@ -1322,6 +1405,62 @@ components:
               tags: ["claude", "sonnet", "production"]
               version: "1.0.0"
               status: "available"
+        surfaces:
+          type: array
+          items:
+            $ref: "#/components/schemas/A2ASurfaceResponse"
+          description: |
+            Registry-stamped A2A surface metadata. Populated only when the
+            request was for an a2a-typed agent and the request body included
+            a `surfaces` array. The registry concatenates the configured
+            MCP_MESH_PUBLIC_URL_PREFIX with each surface's path to produce
+            the publicly addressable URL — so the agent never needs to know
+            its own external hostname.
+
+    A2ASurfaceResponse:
+      type: object
+      required: [path, skill_id]
+      description: |
+        Registry-computed A2A surface response entry. Echoes the surface's
+        declared path + skill_id and adds the FQDN-stamped public_url and
+        agent_card_url derived from MCP_MESH_PUBLIC_URL_PREFIX.
+      properties:
+        path:
+          type: string
+          example: "/agents/report-generator"
+          description: Path suffix as declared by the agent
+        skill_id:
+          type: string
+          example: "generate-report"
+          description: A2A skill identifier
+        public_url:
+          type: string
+          example: "https://agents.acme.com/agents/report-generator"
+          description: |
+            Registry-computed public URL: MCP_MESH_PUBLIC_URL_PREFIX + path.
+            Empty string when MCP_MESH_PUBLIC_URL_PREFIX is unset (registry
+            logs a warn-once telling operators to configure the prefix).
+        agent_card_url:
+          type: string
+          example: "https://agents.acme.com/agents/report-generator/.well-known/agent.json"
+          description: |
+            Convenience URL pointing at the surface's A2A agent card
+            (public_url + "/.well-known/agent.json"). Empty when
+            MCP_MESH_PUBLIC_URL_PREFIX is unset.
+
+    A2AAgentsListResponse:
+      type: object
+      required: [surfaces]
+      description: |
+        Response shape for GET /a2a/agents. The `surfaces` array is a flat
+        list of every A2A surface across all a2a-typed agents — clients use
+        public_url + agent_card_url to discover and call into surfaces.
+      properties:
+        surfaces:
+          type: array
+          items:
+            $ref: "#/components/schemas/A2ASurfaceResponse"
+          description: All A2A surfaces with registry-stamped public URLs
 
     # Core response schemas
     HealthResponse:
@@ -1634,9 +1773,13 @@ components:
           example: "hello-world"
         agent_type:
           type: string
-          enum: [mcp_agent, api]
+          enum: [mcp_agent, api, a2a]
           example: "mcp_agent"
-          description: Type of service - mcp_agent provides capabilities, api consumes them
+          description: |
+            Type of service:
+            - mcp_agent: provides mesh capabilities (default)
+            - api: API-style consumer (no capability advertisement)
+            - a2a: exposes A2A (Agent-to-Agent) surfaces in addition to standard mesh handling
         runtime:
           type: string
           enum: [python, typescript, java]

--- a/examples/a2a/README.md
+++ b/examples/a2a/README.md
@@ -1,0 +1,187 @@
+# A2A Surface Example — `date-a2a-agent`
+
+A minimal agent that exposes the existing `examples/simple/system_agent`
+`date_service` capability via the A2A v1.0 protocol surface using the new
+user-controlled mounting pattern:
+
+```python
+from fastapi import FastAPI
+import mesh
+from mesh.types import McpMeshTool
+
+app = FastAPI()  # ← user owns the app
+
+@mesh.a2a.mount(
+    app,
+    path="/agents/date",
+    dependencies=["date_service"],
+    skill_id="get-date",
+    skill_name="Get Date",
+    tags=["system", "date"],
+)
+async def date_a2a(payload: dict, date_service: McpMeshTool = None):
+    return {"date": await date_service()}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=9090)
+```
+
+`mesh.a2a.mount()` mirrors the `@mesh.route` UX — the user owns both the
+FastAPI app AND the uvicorn lifecycle, and the mesh runtime drives
+dependency injection + registry registration on top:
+
+| Concern | Handled by |
+|---|---|
+| Owning the FastAPI app | **You** (`app = FastAPI()`) |
+| Running the HTTP server | **You** (`uvicorn.run(app, ...)` in `__main__`) |
+| DI dependency resolution | `mesh.a2a.mount(...)` (same machinery as `@mesh.route`) |
+| `GET /…/.well-known/agent.json` (agent card) | `mesh.a2a.mount(...)` (auto-mounted) |
+| `POST /…` (JSON-RPC tasks/* entry) | `mesh.a2a.mount(...)` (auto-mounted) |
+| Heartbeat → registry registration (`agent_type=a2a` + surfaces) | mesh runtime |
+
+There is no `@mesh.agent` here — the `a2a_startup` pipeline (NOT
+`api_startup`) detects `@mesh.a2a` markers in the `DecoratorRegistry`
+and emits an `agent_type=a2a` heartbeat to the registry. The
+`api_startup` pipeline is exclusively for `@mesh.route`-decorated
+services. See `_mcp_mesh/pipeline/a2a_startup/` and
+`_mcp_mesh/pipeline/api_startup/` for the two independent pipeline
+modules.
+
+## Prereqs
+
+You'll want three terminals:
+
+```bash
+# Terminal 1: Registry
+meshctl start registry
+
+# Terminal 2: Provider — exposes date_service
+python examples/simple/system_agent.py
+
+# Terminal 3: This A2A agent (user-driven uvicorn)
+python examples/a2a/date_a2a_agent.py
+```
+
+## Test the A2A surface
+
+### Agent card
+
+```bash
+curl http://localhost:9090/agents/date/.well-known/agent.json | jq
+```
+
+Expected (abbreviated):
+
+```json
+{
+  "name": "date-a2a-agent",
+  "description": "date-a2a-agent",
+  "version": "1.0.0",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "defaultInputModes": ["application/json"],
+  "defaultOutputModes": ["application/json"],
+  "skills": [
+    {
+      "id": "get-date",
+      "name": "Get Date",
+      "description": "Get current date/time via A2A protocol",
+      "tags": ["system", "date"],
+      "inputModes": ["application/json"],
+      "outputModes": ["application/json"]
+    }
+  ],
+  "url": "http://localhost:9090/agents/date",
+  "authentication": { "schemes": [] }
+}
+```
+
+### JSON-RPC `tasks/send` (Phase 2: dispatches into handler)
+
+```bash
+curl -X POST http://localhost:9090/agents/date \
+     -H 'Content-Type: application/json' \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"t1","message":{"role":"user","parts":[]}}}'
+```
+
+Expected (sync handler dispatch — A2A v1.0 `Task` envelope):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "id": "t1",
+    "sessionId": "t1",
+    "status": {
+      "state": "completed",
+      "timestamp": "2026-05-09T12:34:56.789Z"
+    },
+    "artifacts": [
+      {
+        "name": "result",
+        "parts": [
+          {"type": "text", "text": "{\"date\": \"2026-05-09T12:34:56Z\"}"}
+        ],
+        "index": 0
+      }
+    ],
+    "history": [
+      {"role": "user", "parts": []}
+    ]
+  }
+}
+```
+
+The handler return value (e.g. `{"date": "..."}`) is JSON-stringified into
+the single artifact's `text` part. String returns are used verbatim. If the
+handler raises, the response is still a JSON-RPC `result` but with
+`status.state = "failed"` and the exception text under
+`status.message.parts[0].text` — per A2A v1.0, handler failures are Task
+failures, not JSON-RPC errors.
+
+### Other `tasks/*` methods (Phase 3 territory)
+
+`tasks/get`, `tasks/cancel`, `tasks/sendSubscribe`, and `tasks/send` for
+underlying tools decorated with `@mesh.tool(task=True)` still return
+`-32601 Method not implemented`. Those land in Phase 3 once the MeshJob
+lifecycle is wired into the long-running task envelope.
+
+## Public URL stamping
+
+The agent card's `url` field reflects how external clients reach the
+JSON-RPC entry point. There are two paths:
+
+1. **Registry-stamped (production):** Set
+   `MCP_MESH_PUBLIC_URL_PREFIX=https://agents.acme.com` on the registry.
+   On each heartbeat, the registry returns
+   `surfaces[].public_url = https://agents.acme.com/agents/date`, which
+   is cached in the agent process and surfaced on the card.
+2. **Local fallback (dev/CI):** When the cache is empty (first request
+   before the first heartbeat round-trip, or the env var is unset), the
+   card falls back to `http://{http_host}:{http_port}{path}` — e.g.
+   `http://localhost:9090/agents/date`.
+
+## Authentication (`auth="bearer"`)
+
+Add `auth="bearer"` to `mesh.a2a.mount(...)` to enforce header-presence
+checks on the JSON-RPC entry. Phase 1 only verifies the
+`Authorization: Bearer <token>` header is present and well-formed — token
+validation (signature/issuer/audience) is Phase-2+ scope. Requests
+missing the header receive a `401` with a JSON-RPC-shaped error envelope
+(`code: -32001`).
+
+## Where to read the design
+
+- `A2A_SURFACE_DESIGN.org` — full design doc with phasing rationale
+- `mesh/a2a.py` — Python helper module (`mount`, public-URL cache,
+  card/RPC endpoint builders)
+- `mesh/decorators.py` — bare `@mesh.a2a` decorator (DI + metadata only)
+- `_mcp_mesh/engine/a2a_surfaces.py` — shared registry-shape collector
+  used by all three heartbeat paths (mcp_startup Python, mcp_startup
+  Rust, api_startup Rust)

--- a/examples/a2a/date_a2a_agent.py
+++ b/examples/a2a/date_a2a_agent.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+A2A example agent — exposes the existing examples/simple/system_agent
+``date_service`` capability via the A2A v1.0 protocol surface.
+
+This demonstrates the user-controlled FastAPI mounting pattern with
+``mesh.a2a.mount(app, ...)``. The user owns the FastAPI app AND owns
+the uvicorn lifecycle — same shape as ``examples/simple/fastapi_app.py``
+with ``@mesh.route``. The mesh ``api_startup`` pipeline picks up the
+mounted A2A surface from the DecoratorRegistry and registers the agent
+with the registry as ``agent_type=a2a`` (with the surfaces array
+populated) on each heartbeat round-trip.
+
+The helper wires both companion routes the A2A protocol requires:
+
+    GET  /agents/date/.well-known/agent.json   (agent card)
+    POST /agents/date                          (JSON-RPC tasks/* entry)
+
+Phase 2 dispatches sync ``tasks/send`` into the user's handler and wraps
+the return value in an A2A v1.0 ``Task`` envelope. Other ``tasks/*``
+methods (``tasks/get``, ``tasks/cancel``, ``tasks/sendSubscribe``) and
+``tasks/send`` for ``task=True`` underlying tools still return
+``-32601 Method not implemented`` — Phase 3 territory.
+
+Prereqs (in three terminals)
+============================
+
+  # 1) Registry
+  meshctl start registry
+
+  # 2) Provider — exposes date_service (from examples/simple)
+  python examples/simple/system_agent.py
+
+  # 3) This A2A surface — exposes date_service via A2A
+  python examples/a2a/date_a2a_agent.py
+
+Test the A2A surface
+====================
+
+  # Agent card — registry stamps the public ``url`` field when
+  # MCP_MESH_PUBLIC_URL_PREFIX is set on the registry; otherwise the
+  # card uses the local fallback http://localhost:9090/agents/date.
+  curl http://localhost:9090/agents/date/.well-known/agent.json | jq
+
+  # JSON-RPC tasks/send (Phase 2: dispatches into the handler and
+  # returns an A2A v1.0 Task envelope under jsonrpc.result).
+  curl -X POST http://localhost:9090/agents/date \\
+       -H 'Content-Type: application/json' \\
+       -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"t1","message":{"role":"user","parts":[]}}}'
+"""
+
+import os
+
+# Set MCP_MESH_HTTP_PORT BEFORE importing mesh so the framework's
+# display_config picks up the same port we'll bind uvicorn to. Without
+# this, the agent card's `url` field falls back to the framework
+# default (8080) instead of the actual uvicorn port (9090).
+HTTP_PORT = int(os.environ.setdefault("MCP_MESH_HTTP_PORT", "9090"))
+
+import mesh
+from fastapi import FastAPI
+from mesh.types import McpMeshTool
+
+# User-owned FastAPI app — same pattern as @mesh.route examples
+# (see examples/simple/fastapi_app.py). NO @mesh.agent decorator;
+# the user owns the uvicorn lifecycle (see __main__ below).
+app = FastAPI(title="Date A2A Agent")
+
+
+@mesh.a2a.mount(
+    app,
+    path="/agents/date",
+    dependencies=["date_service"],
+    description="Get current date/time via A2A protocol",
+    skill_id="get-date",
+    skill_name="Get Date",
+    tags=["system", "date"],
+)
+async def date_a2a(payload: dict, date_service: McpMeshTool = None):
+    """A2A handler. Phase 2's JSON-RPC entry dispatches ``tasks/send``
+    into this body and wraps the return value in an A2A v1.0 ``Task``
+    envelope (artifact 0 carries the JSON-stringified return). The
+    ``payload`` argument is the A2A request ``message`` dict
+    (``{"role": "user", "parts": [...]}``); for the date example we
+    ignore it and just call the underlying mesh dependency.
+    """
+    if date_service is None:
+        return {"error": "date_service not yet resolved"}
+    result = await date_service()
+    return {"date": result}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    print(f"🌐 Date A2A Agent on http://localhost:{HTTP_PORT}")
+    print(f"    Card:     GET  http://localhost:{HTTP_PORT}/agents/date/.well-known/agent.json")
+    print(f"    JSON-RPC: POST http://localhost:{HTTP_PORT}/agents/date")
+    print()
+    uvicorn.run(app, host="0.0.0.0", port=HTTP_PORT, log_level="info")

--- a/examples/jobs/long-task-consumer/main.py
+++ b/examples/jobs/long-task-consumer/main.py
@@ -7,7 +7,7 @@ Demonstrates the consumer-side dispatch surface:
     @mesh.tool(capability="commission_report", dependencies=["generate_report"])
     async def commission_report(..., generate_report: MeshJob = None):
         proxy = await generate_report.submit(...)
-        return await proxy.wait(timeout=60)
+        return await proxy.wait(timeout_secs=60)
 
 The DI layer sees the ``MeshJob``-typed parameter whose name matches
 the declared dependency capability and injects a

--- a/src/core/ent/agent.go
+++ b/src/core/ent/agent.go
@@ -3,6 +3,7 @@
 package ent
 
 import (
+	"encoding/json"
 	"fmt"
 	"mcp-mesh/src/core/ent/agent"
 	"strings"
@@ -18,7 +19,7 @@ type Agent struct {
 	// ID of the ent.
 	// Unique identifier for the agent
 	ID string `json:"id,omitempty"`
-	// Type of agent
+	// Type of agent (mcp_agent | mesh_tool | decorator_agent | api | a2a)
 	AgentType agent.AgentType `json:"agent_type,omitempty"`
 	// SDK runtime: python, typescript, or java
 	Runtime agent.Runtime `json:"runtime,omitempty"`
@@ -46,6 +47,8 @@ type Agent struct {
 	LastFullRefresh time.Time `json:"last_full_refresh,omitempty"`
 	// Entity ID from TLS certificate verification
 	EntityID *string `json:"entity_id,omitempty"`
+	// A2A surface metadata (path, skill_id, description, etc.) — populated for a2a-typed agents only. JSON for v1 simplicity; promote to entity if query patterns demand it later.
+	A2aSurfaces []map[string]interface{} `json:"a2a_surfaces,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the AgentQuery when eager-loading is set.
 	Edges        AgentEdges `json:"edges"`
@@ -119,6 +122,8 @@ func (*Agent) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
+		case agent.FieldA2aSurfaces:
+			values[i] = new([]byte)
 		case agent.FieldHTTPPort, agent.FieldTotalDependencies, agent.FieldDependenciesResolved:
 			values[i] = new(sql.NullInt64)
 		case agent.FieldID, agent.FieldAgentType, agent.FieldRuntime, agent.FieldName, agent.FieldVersion, agent.FieldHTTPHost, agent.FieldNamespace, agent.FieldStatus, agent.FieldEntityID:
@@ -231,6 +236,14 @@ func (a *Agent) assignValues(columns []string, values []any) error {
 				a.EntityID = new(string)
 				*a.EntityID = value.String
 			}
+		case agent.FieldA2aSurfaces:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field a2a_surfaces", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &a.A2aSurfaces); err != nil {
+					return fmt.Errorf("unmarshal field a2a_surfaces: %w", err)
+				}
+			}
 		default:
 			a.selectValues.Set(columns[i], values[i])
 		}
@@ -335,6 +348,9 @@ func (a *Agent) String() string {
 		builder.WriteString("entity_id=")
 		builder.WriteString(*v)
 	}
+	builder.WriteString(", ")
+	builder.WriteString("a2a_surfaces=")
+	builder.WriteString(fmt.Sprintf("%v", a.A2aSurfaces))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/src/core/ent/agent/agent.go
+++ b/src/core/ent/agent/agent.go
@@ -43,6 +43,8 @@ const (
 	FieldLastFullRefresh = "last_full_refresh"
 	// FieldEntityID holds the string denoting the entity_id field in the database.
 	FieldEntityID = "entity_id"
+	// FieldA2aSurfaces holds the string denoting the a2a_surfaces field in the database.
+	FieldA2aSurfaces = "a2a_surfaces"
 	// EdgeCapabilities holds the string denoting the capabilities edge name in mutations.
 	EdgeCapabilities = "capabilities"
 	// EdgeEvents holds the string denoting the events edge name in mutations.
@@ -119,6 +121,7 @@ var Columns = []string{
 	FieldUpdatedAt,
 	FieldLastFullRefresh,
 	FieldEntityID,
+	FieldA2aSurfaces,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -158,6 +161,7 @@ const (
 	AgentTypeMeshTool       AgentType = "mesh_tool"
 	AgentTypeDecoratorAgent AgentType = "decorator_agent"
 	AgentTypeAPI            AgentType = "api"
+	AgentTypeA2a            AgentType = "a2a"
 )
 
 func (at AgentType) String() string {
@@ -167,7 +171,7 @@ func (at AgentType) String() string {
 // AgentTypeValidator is a validator for the "agent_type" field enum values. It is called by the builders before save.
 func AgentTypeValidator(at AgentType) error {
 	switch at {
-	case AgentTypeMcpAgent, AgentTypeMeshTool, AgentTypeDecoratorAgent, AgentTypeAPI:
+	case AgentTypeMcpAgent, AgentTypeMeshTool, AgentTypeDecoratorAgent, AgentTypeAPI, AgentTypeA2a:
 		return nil
 	default:
 		return fmt.Errorf("agent: invalid enum value for agent_type field: %q", at)

--- a/src/core/ent/agent/where.go
+++ b/src/core/ent/agent/where.go
@@ -795,6 +795,16 @@ func EntityIDContainsFold(v string) predicate.Agent {
 	return predicate.Agent(sql.FieldContainsFold(FieldEntityID, v))
 }
 
+// A2aSurfacesIsNil applies the IsNil predicate on the "a2a_surfaces" field.
+func A2aSurfacesIsNil() predicate.Agent {
+	return predicate.Agent(sql.FieldIsNull(FieldA2aSurfaces))
+}
+
+// A2aSurfacesNotNil applies the NotNil predicate on the "a2a_surfaces" field.
+func A2aSurfacesNotNil() predicate.Agent {
+	return predicate.Agent(sql.FieldNotNull(FieldA2aSurfaces))
+}
+
 // HasCapabilities applies the HasEdge predicate on the "capabilities" edge.
 func HasCapabilities() predicate.Agent {
 	return predicate.Agent(func(s *sql.Selector) {

--- a/src/core/ent/agent_create.go
+++ b/src/core/ent/agent_create.go
@@ -213,6 +213,12 @@ func (ac *AgentCreate) SetNillableEntityID(s *string) *AgentCreate {
 	return ac
 }
 
+// SetA2aSurfaces sets the "a2a_surfaces" field.
+func (ac *AgentCreate) SetA2aSurfaces(m []map[string]interface{}) *AgentCreate {
+	ac.mutation.SetA2aSurfaces(m)
+	return ac
+}
+
 // SetID sets the "id" field.
 func (ac *AgentCreate) SetID(s string) *AgentCreate {
 	ac.mutation.SetID(s)
@@ -501,6 +507,10 @@ func (ac *AgentCreate) createSpec() (*Agent, *sqlgraph.CreateSpec) {
 	if value, ok := ac.mutation.EntityID(); ok {
 		_spec.SetField(agent.FieldEntityID, field.TypeString, value)
 		_node.EntityID = &value
+	}
+	if value, ok := ac.mutation.A2aSurfaces(); ok {
+		_spec.SetField(agent.FieldA2aSurfaces, field.TypeJSON, value)
+		_node.A2aSurfaces = value
 	}
 	if nodes := ac.mutation.CapabilitiesIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/src/core/ent/agent_update.go
+++ b/src/core/ent/agent_update.go
@@ -17,6 +17,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
 )
 
@@ -263,6 +264,24 @@ func (au *AgentUpdate) SetNillableEntityID(s *string) *AgentUpdate {
 // ClearEntityID clears the value of the "entity_id" field.
 func (au *AgentUpdate) ClearEntityID() *AgentUpdate {
 	au.mutation.ClearEntityID()
+	return au
+}
+
+// SetA2aSurfaces sets the "a2a_surfaces" field.
+func (au *AgentUpdate) SetA2aSurfaces(m []map[string]interface{}) *AgentUpdate {
+	au.mutation.SetA2aSurfaces(m)
+	return au
+}
+
+// AppendA2aSurfaces appends m to the "a2a_surfaces" field.
+func (au *AgentUpdate) AppendA2aSurfaces(m []map[string]interface{}) *AgentUpdate {
+	au.mutation.AppendA2aSurfaces(m)
+	return au
+}
+
+// ClearA2aSurfaces clears the value of the "a2a_surfaces" field.
+func (au *AgentUpdate) ClearA2aSurfaces() *AgentUpdate {
+	au.mutation.ClearA2aSurfaces()
 	return au
 }
 
@@ -572,6 +591,17 @@ func (au *AgentUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if au.mutation.EntityIDCleared() {
 		_spec.ClearField(agent.FieldEntityID, field.TypeString)
+	}
+	if value, ok := au.mutation.A2aSurfaces(); ok {
+		_spec.SetField(agent.FieldA2aSurfaces, field.TypeJSON, value)
+	}
+	if value, ok := au.mutation.AppendedA2aSurfaces(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, agent.FieldA2aSurfaces, value)
+		})
+	}
+	if au.mutation.A2aSurfacesCleared() {
+		_spec.ClearField(agent.FieldA2aSurfaces, field.TypeJSON)
 	}
 	if au.mutation.CapabilitiesCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1051,6 +1081,24 @@ func (auo *AgentUpdateOne) ClearEntityID() *AgentUpdateOne {
 	return auo
 }
 
+// SetA2aSurfaces sets the "a2a_surfaces" field.
+func (auo *AgentUpdateOne) SetA2aSurfaces(m []map[string]interface{}) *AgentUpdateOne {
+	auo.mutation.SetA2aSurfaces(m)
+	return auo
+}
+
+// AppendA2aSurfaces appends m to the "a2a_surfaces" field.
+func (auo *AgentUpdateOne) AppendA2aSurfaces(m []map[string]interface{}) *AgentUpdateOne {
+	auo.mutation.AppendA2aSurfaces(m)
+	return auo
+}
+
+// ClearA2aSurfaces clears the value of the "a2a_surfaces" field.
+func (auo *AgentUpdateOne) ClearA2aSurfaces() *AgentUpdateOne {
+	auo.mutation.ClearA2aSurfaces()
+	return auo
+}
+
 // AddCapabilityIDs adds the "capabilities" edge to the Capability entity by IDs.
 func (auo *AgentUpdateOne) AddCapabilityIDs(ids ...int) *AgentUpdateOne {
 	auo.mutation.AddCapabilityIDs(ids...)
@@ -1387,6 +1435,17 @@ func (auo *AgentUpdateOne) sqlSave(ctx context.Context) (_node *Agent, err error
 	}
 	if auo.mutation.EntityIDCleared() {
 		_spec.ClearField(agent.FieldEntityID, field.TypeString)
+	}
+	if value, ok := auo.mutation.A2aSurfaces(); ok {
+		_spec.SetField(agent.FieldA2aSurfaces, field.TypeJSON, value)
+	}
+	if value, ok := auo.mutation.AppendedA2aSurfaces(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, agent.FieldA2aSurfaces, value)
+		})
+	}
+	if auo.mutation.A2aSurfacesCleared() {
+		_spec.ClearField(agent.FieldA2aSurfaces, field.TypeJSON)
 	}
 	if auo.mutation.CapabilitiesCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/src/core/ent/migrate/schema.go
+++ b/src/core/ent/migrate/schema.go
@@ -11,7 +11,7 @@ var (
 	// AgentsColumns holds the columns for the "agents" table.
 	AgentsColumns = []*schema.Column{
 		{Name: "agent_id", Type: field.TypeString},
-		{Name: "agent_type", Type: field.TypeEnum, Enums: []string{"mcp_agent", "mesh_tool", "decorator_agent", "api"}, Default: "mcp_agent"},
+		{Name: "agent_type", Type: field.TypeEnum, Enums: []string{"mcp_agent", "mesh_tool", "decorator_agent", "api", "a2a"}, Default: "mcp_agent"},
 		{Name: "runtime", Type: field.TypeEnum, Nullable: true, Enums: []string{"python", "typescript", "java"}, Default: "python"},
 		{Name: "name", Type: field.TypeString},
 		{Name: "version", Type: field.TypeString, Nullable: true},
@@ -25,6 +25,7 @@ var (
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "last_full_refresh", Type: field.TypeTime},
 		{Name: "entity_id", Type: field.TypeString, Nullable: true},
+		{Name: "a2a_surfaces", Type: field.TypeJSON, Nullable: true},
 	}
 	// AgentsTable holds the schema information for the "agents" table.
 	AgentsTable = &schema.Table{

--- a/src/core/ent/mutation.go
+++ b/src/core/ent/mutation.go
@@ -64,6 +64,8 @@ type AgentMutation struct {
 	updated_at                      *time.Time
 	last_full_refresh               *time.Time
 	entity_id                       *string
+	a2a_surfaces                    *[]map[string]interface{}
+	appenda2a_surfaces              []map[string]interface{}
 	clearedFields                   map[string]struct{}
 	capabilities                    map[int]struct{}
 	removedcapabilities             map[int]struct{}
@@ -819,6 +821,71 @@ func (m *AgentMutation) ResetEntityID() {
 	delete(m.clearedFields, agent.FieldEntityID)
 }
 
+// SetA2aSurfaces sets the "a2a_surfaces" field.
+func (m *AgentMutation) SetA2aSurfaces(value []map[string]interface{}) {
+	m.a2a_surfaces = &value
+	m.appenda2a_surfaces = nil
+}
+
+// A2aSurfaces returns the value of the "a2a_surfaces" field in the mutation.
+func (m *AgentMutation) A2aSurfaces() (r []map[string]interface{}, exists bool) {
+	v := m.a2a_surfaces
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldA2aSurfaces returns the old "a2a_surfaces" field's value of the Agent entity.
+// If the Agent object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AgentMutation) OldA2aSurfaces(ctx context.Context) (v []map[string]interface{}, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldA2aSurfaces is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldA2aSurfaces requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldA2aSurfaces: %w", err)
+	}
+	return oldValue.A2aSurfaces, nil
+}
+
+// AppendA2aSurfaces adds value to the "a2a_surfaces" field.
+func (m *AgentMutation) AppendA2aSurfaces(value []map[string]interface{}) {
+	m.appenda2a_surfaces = append(m.appenda2a_surfaces, value...)
+}
+
+// AppendedA2aSurfaces returns the list of values that were appended to the "a2a_surfaces" field in this mutation.
+func (m *AgentMutation) AppendedA2aSurfaces() ([]map[string]interface{}, bool) {
+	if len(m.appenda2a_surfaces) == 0 {
+		return nil, false
+	}
+	return m.appenda2a_surfaces, true
+}
+
+// ClearA2aSurfaces clears the value of the "a2a_surfaces" field.
+func (m *AgentMutation) ClearA2aSurfaces() {
+	m.a2a_surfaces = nil
+	m.appenda2a_surfaces = nil
+	m.clearedFields[agent.FieldA2aSurfaces] = struct{}{}
+}
+
+// A2aSurfacesCleared returns if the "a2a_surfaces" field was cleared in this mutation.
+func (m *AgentMutation) A2aSurfacesCleared() bool {
+	_, ok := m.clearedFields[agent.FieldA2aSurfaces]
+	return ok
+}
+
+// ResetA2aSurfaces resets all changes to the "a2a_surfaces" field.
+func (m *AgentMutation) ResetA2aSurfaces() {
+	m.a2a_surfaces = nil
+	m.appenda2a_surfaces = nil
+	delete(m.clearedFields, agent.FieldA2aSurfaces)
+}
+
 // AddCapabilityIDs adds the "capabilities" edge to the Capability entity by ids.
 func (m *AgentMutation) AddCapabilityIDs(ids ...int) {
 	if m.capabilities == nil {
@@ -1123,7 +1190,7 @@ func (m *AgentMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *AgentMutation) Fields() []string {
-	fields := make([]string, 0, 14)
+	fields := make([]string, 0, 15)
 	if m.agent_type != nil {
 		fields = append(fields, agent.FieldAgentType)
 	}
@@ -1166,6 +1233,9 @@ func (m *AgentMutation) Fields() []string {
 	if m.entity_id != nil {
 		fields = append(fields, agent.FieldEntityID)
 	}
+	if m.a2a_surfaces != nil {
+		fields = append(fields, agent.FieldA2aSurfaces)
+	}
 	return fields
 }
 
@@ -1202,6 +1272,8 @@ func (m *AgentMutation) Field(name string) (ent.Value, bool) {
 		return m.LastFullRefresh()
 	case agent.FieldEntityID:
 		return m.EntityID()
+	case agent.FieldA2aSurfaces:
+		return m.A2aSurfaces()
 	}
 	return nil, false
 }
@@ -1239,6 +1311,8 @@ func (m *AgentMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldLastFullRefresh(ctx)
 	case agent.FieldEntityID:
 		return m.OldEntityID(ctx)
+	case agent.FieldA2aSurfaces:
+		return m.OldA2aSurfaces(ctx)
 	}
 	return nil, fmt.Errorf("unknown Agent field %s", name)
 }
@@ -1346,6 +1420,13 @@ func (m *AgentMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetEntityID(v)
 		return nil
+	case agent.FieldA2aSurfaces:
+		v, ok := value.([]map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetA2aSurfaces(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Agent field %s", name)
 }
@@ -1430,6 +1511,9 @@ func (m *AgentMutation) ClearedFields() []string {
 	if m.FieldCleared(agent.FieldEntityID) {
 		fields = append(fields, agent.FieldEntityID)
 	}
+	if m.FieldCleared(agent.FieldA2aSurfaces) {
+		fields = append(fields, agent.FieldA2aSurfaces)
+	}
 	return fields
 }
 
@@ -1458,6 +1542,9 @@ func (m *AgentMutation) ClearField(name string) error {
 		return nil
 	case agent.FieldEntityID:
 		m.ClearEntityID()
+		return nil
+	case agent.FieldA2aSurfaces:
+		m.ClearA2aSurfaces()
 		return nil
 	}
 	return fmt.Errorf("unknown Agent nullable field %s", name)
@@ -1508,6 +1595,9 @@ func (m *AgentMutation) ResetField(name string) error {
 		return nil
 	case agent.FieldEntityID:
 		m.ResetEntityID()
+		return nil
+	case agent.FieldA2aSurfaces:
+		m.ResetA2aSurfaces()
 		return nil
 	}
 	return fmt.Errorf("unknown Agent field %s", name)

--- a/src/core/ent/schema/agent.go
+++ b/src/core/ent/schema/agent.go
@@ -22,9 +22,9 @@ func (Agent) Fields() []ent.Field {
 			StorageKey("agent_id").
 			Comment("Unique identifier for the agent"),
 		field.Enum("agent_type").
-			Values("mcp_agent", "mesh_tool", "decorator_agent", "api").
+			Values("mcp_agent", "mesh_tool", "decorator_agent", "api", "a2a").
 			Default("mcp_agent").
-			Comment("Type of agent"),
+			Comment("Type of agent (mcp_agent | mesh_tool | decorator_agent | api | a2a)"),
 		field.Enum("runtime").
 			Values("python", "typescript", "java").
 			Default("python").
@@ -68,6 +68,9 @@ func (Agent) Fields() []ent.Field {
 			Optional().
 			Nillable().
 			Comment("Entity ID from TLS certificate verification"),
+		field.JSON("a2a_surfaces", []map[string]interface{}{}).
+			Optional().
+			Comment("A2A surface metadata (path, skill_id, description, etc.) — populated for a2a-typed agents only. JSON for v1 simplicity; promote to entity if query patterns demand it later."),
 	}
 }
 

--- a/src/core/registry/a2a_endpoint_test.go
+++ b/src/core/registry/a2a_endpoint_test.go
@@ -1,0 +1,300 @@
+// A2A surface tests (issue #903 / Phase 1A).
+//
+// Covers:
+//   - Registration of an a2a-typed agent with `surfaces` array persists
+//     A2aSurfaces JSON on the agent record.
+//   - Heartbeat returns the surfaces back with stamped public_url +
+//     agent_card_url derived from MCP_MESH_PUBLIC_URL_PREFIX.
+//   - GET /a2a/agents flattens every a2a-typed agent's surfaces into a
+//     single response with FQDN-stamped URLs.
+//   - When MCP_MESH_PUBLIC_URL_PREFIX is unset, public_url / agent_card_url
+//     are emitted as empty (not as relative paths) — operator visibility
+//     comes via warn-once log, not via response shape.
+
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"mcp-mesh/src/core/ent/agent"
+	"mcp-mesh/src/core/registry/generated"
+)
+
+// a2aRegistrationFixture returns a minimal but realistic a2a-typed agent
+// registration request with two surfaces. Mirrors the canonical Python
+// example in A2A_SURFACE_DESIGN.org so tests stay aligned with the
+// design-time semantics.
+func a2aRegistrationFixture(agentID string) *AgentRegistrationRequest {
+	return &AgentRegistrationRequest{
+		AgentID: agentID,
+		Metadata: map[string]interface{}{
+			"agent_type": "a2a",
+			"name":       agentID,
+			"http_host":  "0.0.0.0",
+			"http_port":  float64(9100),
+			"namespace":  "default",
+			"tools": []interface{}{
+				map[string]interface{}{
+					"function_name": "report_generator_a2a",
+					"capability":    "a2a.report-generator",
+				},
+			},
+			"surfaces": []interface{}{
+				map[string]interface{}{
+					"path":         "/agents/report-generator",
+					"skill_id":     "generate-report",
+					"name":         "Report Generator",
+					"description":  "Generate a long-form report",
+					"input_modes":  []interface{}{"application/json"},
+					"output_modes": []interface{}{"application/json"},
+					"tags":         []interface{}{"reporting"},
+				},
+				map[string]interface{}{
+					"path":     "/agents/lookup",
+					"skill_id": "quick-lookup",
+					"name":     "Quick Lookup",
+				},
+			},
+		},
+	}
+}
+
+func TestA2ARegistrationPersistsSurfaces(t *testing.T) {
+	service := setupTestService(t)
+
+	req := a2aRegistrationFixture("a2a-test-agent")
+	_, err := service.RegisterAgent(req)
+	require.NoError(t, err)
+
+	// Read back via Ent and verify a2a_surfaces JSON survived the round-trip.
+	a, err := service.entDB.Agent.Query().
+		Where(agent.IDEQ("a2a-test-agent")).
+		Only(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "a2a", a.AgentType.String())
+	require.Len(t, a.A2aSurfaces, 2)
+	assert.Equal(t, "/agents/report-generator", a.A2aSurfaces[0]["path"])
+	assert.Equal(t, "generate-report", a.A2aSurfaces[0]["skill_id"])
+	assert.Equal(t, "Report Generator", a.A2aSurfaces[0]["name"])
+	assert.Equal(t, "/agents/lookup", a.A2aSurfaces[1]["path"])
+	assert.Equal(t, "quick-lookup", a.A2aSurfaces[1]["skill_id"])
+}
+
+func TestA2AHeartbeatReturnsStampedURLs(t *testing.T) {
+	t.Setenv("MCP_MESH_PUBLIC_URL_PREFIX", "https://agents.acme.com")
+
+	service := setupTestService(t)
+
+	// Register first.
+	regReq := a2aRegistrationFixture("a2a-stamp-agent")
+	_, err := service.RegisterAgent(regReq)
+	require.NoError(t, err)
+
+	// Heartbeat should echo surfaces back with stamped URLs.
+	hbReq := &HeartbeatRequest{
+		AgentID:  "a2a-stamp-agent",
+		Status:   "healthy",
+		Metadata: regReq.Metadata,
+	}
+	hbResp, err := service.UpdateHeartbeat(hbReq)
+	require.NoError(t, err)
+	require.NotNil(t, hbResp)
+	require.Len(t, hbResp.A2ASurfaces, 2)
+
+	// Build the wire-shape (mirrors what SendHeartbeat does) and assert the
+	// FQDN stamping.
+	stamped := buildA2ASurfaceResponses(hbResp.A2ASurfaces)
+	require.Len(t, stamped, 2)
+
+	assert.Equal(t, "/agents/report-generator", stamped[0].Path)
+	assert.Equal(t, "generate-report", stamped[0].SkillId)
+	require.NotNil(t, stamped[0].PublicUrl)
+	require.NotNil(t, stamped[0].AgentCardUrl)
+	assert.Equal(t, "https://agents.acme.com/agents/report-generator", *stamped[0].PublicUrl)
+	assert.Equal(t,
+		"https://agents.acme.com/agents/report-generator/.well-known/agent.json",
+		*stamped[0].AgentCardUrl)
+}
+
+func TestA2AHeartbeatWithoutPublicURLPrefix(t *testing.T) {
+	// Explicitly clear the env var to test the unset path. The warn-once
+	// behavior is process-lifetime; we don't assert on the log line here
+	// (no test logger plumb yet) — just confirm the URL fields stay empty
+	// rather than collapsing to relative paths or panicking.
+	t.Setenv("MCP_MESH_PUBLIC_URL_PREFIX", "")
+
+	service := setupTestService(t)
+
+	regReq := a2aRegistrationFixture("a2a-unset-prefix-agent")
+	_, err := service.RegisterAgent(regReq)
+	require.NoError(t, err)
+
+	hbReq := &HeartbeatRequest{
+		AgentID:  "a2a-unset-prefix-agent",
+		Status:   "healthy",
+		Metadata: regReq.Metadata,
+	}
+	hbResp, err := service.UpdateHeartbeat(hbReq)
+	require.NoError(t, err)
+	require.Len(t, hbResp.A2ASurfaces, 2)
+
+	stamped := buildA2ASurfaceResponses(hbResp.A2ASurfaces)
+	require.Len(t, stamped, 2)
+	// Path + skill_id always echoed.
+	assert.Equal(t, "/agents/report-generator", stamped[0].Path)
+	// URL fields nil-pointer when prefix is empty (omitted from JSON).
+	assert.Nil(t, stamped[0].PublicUrl)
+	assert.Nil(t, stamped[0].AgentCardUrl)
+}
+
+// TestA2AListAgentsEndpoint exercises the GET /a2a/agents discovery
+// endpoint via a real gin router so the wire shape is validated end-to-end
+// (not just the in-process service-layer call).
+func TestA2AListAgentsEndpoint(t *testing.T) {
+	t.Setenv("MCP_MESH_PUBLIC_URL_PREFIX", "https://agents.acme.com/")
+
+	service := setupTestService(t)
+	handlers := NewEntBusinessLogicHandlers(service)
+
+	// Register one a2a agent and one mcp_agent — the discovery endpoint
+	// should only surface the a2a agent.
+	_, err := service.RegisterAgent(a2aRegistrationFixture("a2a-discovery-agent"))
+	require.NoError(t, err)
+	_, err = service.RegisterAgent(&AgentRegistrationRequest{
+		AgentID: "regular-mesh-agent",
+		Metadata: map[string]interface{}{
+			"agent_type": "mcp_agent",
+			"name":       "regular-mesh-agent",
+			"tools": []interface{}{
+				map[string]interface{}{
+					"function_name": "say_hi",
+					"capability":    "greet",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Wire the handler into a real gin router so we exercise the
+	// generated.RegisterHandlers path too.
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	generated.RegisterHandlers(router, handlers)
+
+	w := httptest.NewRecorder()
+	httpReq, err := http.NewRequest(http.MethodGet, "/a2a/agents", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	router.ServeHTTP(w, httpReq)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp generated.A2AAgentsListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Surfaces, 2, "only the two a2a surfaces should be listed")
+
+	// Spot-check stamped URLs (trailing-slash on prefix is trimmed).
+	paths := map[string]generated.A2ASurfaceResponse{}
+	for _, s := range resp.Surfaces {
+		paths[s.Path] = s
+	}
+	report, ok := paths["/agents/report-generator"]
+	require.True(t, ok)
+	require.NotNil(t, report.PublicUrl)
+	assert.Equal(t, "https://agents.acme.com/agents/report-generator", *report.PublicUrl)
+	require.NotNil(t, report.AgentCardUrl)
+	assert.Equal(t,
+		"https://agents.acme.com/agents/report-generator/.well-known/agent.json",
+		*report.AgentCardUrl)
+	assert.Equal(t, "generate-report", report.SkillId)
+
+	lookup, ok := paths["/agents/lookup"]
+	require.True(t, ok)
+	assert.Equal(t, "quick-lookup", lookup.SkillId)
+}
+
+// TestA2AListAgentsEndpointEmpty verifies the endpoint returns an empty
+// (non-nil) surfaces array when no a2a agents are registered. This matches
+// the OpenAPI required-field contract.
+func TestA2AListAgentsEndpointEmpty(t *testing.T) {
+	service := setupTestService(t)
+	handlers := NewEntBusinessLogicHandlers(service)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	generated.RegisterHandlers(router, handlers)
+
+	w := httptest.NewRecorder()
+	httpReq, err := http.NewRequest(http.MethodGet, "/a2a/agents", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	router.ServeHTTP(w, httpReq)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp generated.A2AAgentsListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotNil(t, resp.Surfaces)
+	assert.Len(t, resp.Surfaces, 0)
+}
+
+// TestExtractSurfacesFromMetadata sanity-checks the input-shape tolerance
+// of extractSurfacesFromMetadata. Inbound surfaces can arrive as either
+// []interface{} (typical JSON unmarshal path) or []map[string]interface{}
+// (if the caller pre-shaped them); both must work.
+func TestExtractSurfacesFromMetadata(t *testing.T) {
+	t.Run("absent", func(t *testing.T) {
+		assert.Nil(t, extractSurfacesFromMetadata(map[string]interface{}{}))
+	})
+	t.Run("nil", func(t *testing.T) {
+		assert.Nil(t, extractSurfacesFromMetadata(map[string]interface{}{"surfaces": nil}))
+	})
+	t.Run("interface_slice", func(t *testing.T) {
+		out := extractSurfacesFromMetadata(map[string]interface{}{
+			"surfaces": []interface{}{
+				map[string]interface{}{"path": "/x", "skill_id": "s1"},
+			},
+		})
+		require.Len(t, out, 1)
+		assert.Equal(t, "/x", out[0]["path"])
+	})
+	t.Run("map_slice", func(t *testing.T) {
+		out := extractSurfacesFromMetadata(map[string]interface{}{
+			"surfaces": []map[string]interface{}{
+				{"path": "/y", "skill_id": "s2"},
+			},
+		})
+		require.Len(t, out, 1)
+		assert.Equal(t, "/y", out[0]["path"])
+	})
+}
+
+// TestComputeA2ASurfaceURLs covers the URL-stamping helper in isolation:
+// trailing-slash trimming, prefix-unset behavior, and missing-leading-slash
+// path normalization.
+func TestComputeA2ASurfaceURLs(t *testing.T) {
+	t.Run("with_trailing_slash_in_prefix", func(t *testing.T) {
+		t.Setenv("MCP_MESH_PUBLIC_URL_PREFIX", "https://agents.acme.com/")
+		pub, card := computeA2ASurfaceURLs("/agents/x")
+		assert.Equal(t, "https://agents.acme.com/agents/x", pub)
+		assert.Equal(t, "https://agents.acme.com/agents/x/.well-known/agent.json", card)
+	})
+	t.Run("path_missing_leading_slash", func(t *testing.T) {
+		t.Setenv("MCP_MESH_PUBLIC_URL_PREFIX", "https://agents.acme.com")
+		pub, _ := computeA2ASurfaceURLs("agents/y")
+		assert.Equal(t, "https://agents.acme.com/agents/y", pub)
+	})
+	t.Run("prefix_unset", func(t *testing.T) {
+		t.Setenv("MCP_MESH_PUBLIC_URL_PREFIX", "")
+		pub, card := computeA2ASurfaceURLs("/agents/z")
+		assert.Equal(t, "", pub)
+		assert.Equal(t, "", card)
+	})
+}

--- a/src/core/registry/ent_handlers.go
+++ b/src/core/registry/ent_handlers.go
@@ -339,6 +339,16 @@ func (h *EntBusinessLogicHandlers) SendHeartbeat(c *gin.Context) {
 		response["llm_providers"] = llmProvidersMap
 	}
 
+	// Include A2A surfaces with stamped FQDNs when present (issue #903).
+	// Triggers the warn-once if MCP_MESH_PUBLIC_URL_PREFIX is unset for an
+	// a2a registration so operators see the misconfiguration.
+	if len(serviceResp.A2ASurfaces) > 0 {
+		h.maybeWarnPublicURLPrefixUnset()
+		if surfacesResp := buildA2ASurfaceResponses(serviceResp.A2ASurfaces); surfacesResp != nil {
+			response["surfaces"] = surfacesResp
+		}
+	}
+
 	c.JSON(http.StatusOK, response)
 }
 
@@ -510,6 +520,36 @@ func ConvertMeshAgentRegistrationToMap(reg generated.MeshAgentRegistration) map[
 		}
 	}
 	result["tools"] = toolsData
+
+	// A2A surfaces (issue #903 / A2A_SURFACE_DESIGN.org). Forwarded as
+	// []map[string]interface{} so the service layer can persist directly to
+	// the Ent JSON field. Omitted entirely when not present.
+	if reg.Surfaces != nil {
+		surfaces := make([]map[string]interface{}, 0, len(*reg.Surfaces))
+		for _, s := range *reg.Surfaces {
+			entry := map[string]interface{}{
+				"path":     s.Path,
+				"skill_id": s.SkillId,
+			}
+			if s.Name != nil {
+				entry["name"] = *s.Name
+			}
+			if s.Description != nil {
+				entry["description"] = *s.Description
+			}
+			if s.InputModes != nil {
+				entry["input_modes"] = *s.InputModes
+			}
+			if s.OutputModes != nil {
+				entry["output_modes"] = *s.OutputModes
+			}
+			if s.Tags != nil {
+				entry["tags"] = *s.Tags
+			}
+			surfaces = append(surfaces, entry)
+		}
+		result["surfaces"] = surfaces
+	}
 
 	return result
 }

--- a/src/core/registry/ent_handlers_a2a.go
+++ b/src/core/registry/ent_handlers_a2a.go
@@ -1,0 +1,195 @@
+// A2A surface handlers and helpers.
+//
+// Phase 1A of issue #903 — see A2A_SURFACE_DESIGN.org. The Registry exposes
+// A2A surfaces declared by a2a-typed agents (one entry per @mesh.a2a
+// decorator). Two surfaces are exposed at this layer:
+//
+//   1. Persistence: a2a-typed agents send a `surfaces: [{path, skill_id, ...}]`
+//      array on register/heartbeat. The handler stores the array as-is on the
+//      agent's a2a_surfaces JSON field (Ent schema/agent.go).
+//   2. Discovery: GET /a2a/agents returns every stored surface flattened with
+//      registry-computed FQDNs (MCP_MESH_PUBLIC_URL_PREFIX + path).
+//
+// The actual A2A protocol envelope (agent card JSON, JSON-RPC tasks/* verbs,
+// SSE) lives on the agent side (Phase 1B+). The registry is a discovery
+// directory; nothing here knows about A2A wire shape beyond URL stamping.
+
+package registry
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"mcp-mesh/src/core/ent"
+	"mcp-mesh/src/core/ent/agent"
+	"mcp-mesh/src/core/registry/generated"
+)
+
+// publicURLPrefixWarnOnce ensures we log the "MCP_MESH_PUBLIC_URL_PREFIX is
+// unset" warning at most once per registry process, even if many a2a agents
+// register before the operator notices the misconfiguration.
+var publicURLPrefixWarnOnce sync.Once
+
+// publicURLPrefix returns the configured MCP_MESH_PUBLIC_URL_PREFIX with any
+// trailing slash trimmed. When unset, returns "" — callers treat empty as
+// "no FQDN available; emit empty public_url / agent_card_url" rather than
+// rejecting the registration. The first time this is observed during an a2a
+// flow, ``warnIfMissing`` triggers a warn-once log via the supplied logger
+// hook so operators see the misconfiguration without burying it.
+func publicURLPrefix() string {
+	return strings.TrimRight(os.Getenv("MCP_MESH_PUBLIC_URL_PREFIX"), "/")
+}
+
+// computeA2ASurfaceURLs returns (public_url, agent_card_url) for a single
+// surface path. Both are empty when MCP_MESH_PUBLIC_URL_PREFIX is unset.
+func computeA2ASurfaceURLs(path string) (string, string) {
+	prefix := publicURLPrefix()
+	if prefix == "" {
+		return "", ""
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	publicURL := prefix + path
+	cardURL := publicURL + "/.well-known/agent.json"
+	return publicURL, cardURL
+}
+
+// extractSurfacesFromMetadata pulls the optional ``surfaces`` array out of a
+// register/heartbeat metadata map and returns it in the canonical
+// []map[string]interface{} shape expected by the Ent JSON field.
+//
+// Tolerant to absence and to slightly-different inbound shapes
+// ([]interface{} vs []map[string]interface{}) so callers don't have to care
+// whether the request came from the generated wrapper or a hand-built map.
+func extractSurfacesFromMetadata(metadata map[string]interface{}) []map[string]interface{} {
+	raw, ok := metadata["surfaces"]
+	if !ok || raw == nil {
+		return nil
+	}
+
+	switch arr := raw.(type) {
+	case []map[string]interface{}:
+		return arr
+	case []interface{}:
+		out := make([]map[string]interface{}, 0, len(arr))
+		for _, item := range arr {
+			if m, ok := item.(map[string]interface{}); ok {
+				out = append(out, m)
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	}
+	return nil
+}
+
+// buildA2ASurfaceResponses converts the stored a2a_surfaces JSON shape
+// (`[]map[string]interface{}`) into the wire response shape
+// (`[]A2ASurfaceResponse`) with URLs stamped from MCP_MESH_PUBLIC_URL_PREFIX.
+//
+// Returns nil for a nil/empty input so callers can use the result directly
+// in optional response fields.
+func buildA2ASurfaceResponses(surfaces []map[string]interface{}) []generated.A2ASurfaceResponse {
+	if len(surfaces) == 0 {
+		return nil
+	}
+	out := make([]generated.A2ASurfaceResponse, 0, len(surfaces))
+	for _, s := range surfaces {
+		path, _ := s["path"].(string)
+		skillID, _ := s["skill_id"].(string)
+		if path == "" || skillID == "" {
+			continue
+		}
+		publicURL, cardURL := computeA2ASurfaceURLs(path)
+		entry := generated.A2ASurfaceResponse{
+			Path:    path,
+			SkillId: skillID,
+		}
+		if publicURL != "" {
+			entry.PublicUrl = &publicURL
+			entry.AgentCardUrl = &cardURL
+		}
+		out = append(out, entry)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// maybeWarnPublicURLPrefixUnset emits a single registry-lifetime warning when
+// an a2a-typed agent registers without MCP_MESH_PUBLIC_URL_PREFIX configured.
+// Called from the register/heartbeat path so the warning lands in the logs at
+// the moment the misconfiguration becomes visible.
+func (h *EntBusinessLogicHandlers) maybeWarnPublicURLPrefixUnset() {
+	if publicURLPrefix() != "" {
+		return
+	}
+	publicURLPrefixWarnOnce.Do(func() {
+		if h.entService != nil && h.entService.logger != nil {
+			h.entService.logger.Warning(
+				"a2a-typed agent registered but MCP_MESH_PUBLIC_URL_PREFIX is unset; " +
+					"public_url and agent_card_url will be empty until the operator sets it " +
+					"(see A2A_SURFACE_DESIGN.org > Registry-Driven FQDN Discovery)")
+		}
+	})
+}
+
+// ListA2AAgents implements GET /a2a/agents — the external A2A client
+// discovery endpoint. Walks every a2a-typed agent, flattens their
+// a2a_surfaces JSON arrays, stamps FQDNs from MCP_MESH_PUBLIC_URL_PREFIX, and
+// returns the result as a single ``surfaces`` list.
+//
+// Mesh-internal capability resolution stays untouched; this endpoint is the
+// purely external face of the A2A discovery model.
+func (h *EntBusinessLogicHandlers) ListA2AAgents(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	agents, err := h.entService.entDB.Agent.Query().
+		Where(agent.AgentTypeEQ(agent.AgentTypeA2a)).
+		All(ctx)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, generated.ErrorResponse{
+			Error:     "failed to query a2a agents: " + err.Error(),
+			Timestamp: time.Now().UTC(),
+		})
+		return
+	}
+
+	all := make([]generated.A2ASurfaceResponse, 0)
+	for _, a := range agents {
+		all = append(all, buildA2ASurfaceResponses(a.A2aSurfaces)...)
+	}
+
+	c.JSON(http.StatusOK, generated.A2AAgentsListResponse{
+		Surfaces: all,
+	})
+}
+
+// listA2ASurfacesForAgent fetches the a2a_surfaces JSON for a single agent.
+// Used by the heartbeat-response path so the response carries the freshly-
+// stamped surface URLs without re-querying through the typed Ent struct
+// path. Returns (nil, nil) if the agent has no surfaces or doesn't exist.
+func (s *EntService) listA2ASurfacesForAgent(ctx context.Context, agentID string) ([]map[string]interface{}, error) {
+	a, err := s.entDB.Agent.Query().Where(agent.IDEQ(agentID)).Only(ctx)
+	if err != nil {
+		// Honour the doc contract: a missing agent is not an error to
+		// the caller — return (nil, nil) so the heartbeat-response path
+		// just emits no surfaces. The previous code returned the raw
+		// not-found error, which conflated "row missing" with "DB
+		// failure" and surfaced misleading 5xx-style errors upstream.
+		if ent.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return a.A2aSurfaces, nil
+}

--- a/src/core/registry/ent_handlers_test.go
+++ b/src/core/registry/ent_handlers_test.go
@@ -332,6 +332,10 @@ func (h *TestHandlers) ReleaseJob(c *gin.Context, jobId string) {
 	c.JSON(http.StatusNotImplemented, gin.H{"error": "not implemented"})
 }
 
+func (h *TestHandlers) ListA2AAgents(c *gin.Context) {
+	c.JSON(http.StatusNotImplemented, gin.H{"error": "not implemented"})
+}
+
 // TestHealthMonitor tests the background health monitoring functionality
 func TestHealthMonitor(t *testing.T) {
 	tests := []struct {

--- a/src/core/registry/ent_service.go
+++ b/src/core/registry/ent_service.go
@@ -225,6 +225,14 @@ type HeartbeatResponse struct {
 	DependenciesResolved map[string][]*DependencyResolution        `json:"dependencies_resolved,omitempty"`
 	LLMTools             map[string][]LLMToolInfo                  `json:"llm_tools,omitempty"`
 	LLMProviders         map[string]*generated.ResolvedLLMProvider `json:"llm_providers,omitempty"`
+
+	// A2ASurfaces is the registry-stamped surface list returned to a2a-typed
+	// agents. The handler builds the wire-shape `[]A2ASurfaceResponse` from
+	// this on the way out (see SendHeartbeat). Populated only when the
+	// request was for an a2a-typed agent that included a surfaces array;
+	// nil otherwise so the JSON `surfaces` field stays omitted from the
+	// response payload for non-a2a flows.
+	A2ASurfaces []map[string]interface{} `json:"-"`
 }
 
 // EntService provides registry operations using Ent ORM instead of raw SQL
@@ -417,6 +425,13 @@ func (s *EntService) RegisterAgent(req *AgentRegistrationRequest) (*AgentRegistr
 	// Extract agent metadata
 	meta := extractAgentMetadata(req.AgentID, req.Metadata)
 
+	// A2A surfaces (issue #903). Pulled here so the agent create/update path
+	// can persist them on the agent's a2a_surfaces JSON field. Empty / nil
+	// when the request isn't a2a-typed or didn't carry a surfaces array —
+	// in that case we skip the JSON SetA2aSurfaces call entirely (the
+	// optional Ent field stays unset).
+	surfaces := extractSurfacesFromMetadata(req.Metadata)
+
 	// Start a transaction for atomicity
 	err := s.entDB.Transaction(ctx, func(tx *ent.Tx) error {
 		// Upsert the agent
@@ -440,6 +455,9 @@ func (s *EntService) RegisterAgent(req *AgentRegistrationRequest) (*AgentRegistr
 		}
 		if req.EntityID != "" {
 			agentCreate = agentCreate.SetEntityID(req.EntityID)
+		}
+		if surfaces != nil {
+			agentCreate = agentCreate.SetA2aSurfaces(surfaces)
 		}
 
 		// Check if agent already exists and update or create
@@ -486,6 +504,9 @@ func (s *EntService) RegisterAgent(req *AgentRegistrationRequest) (*AgentRegistr
 			}
 			if req.EntityID != "" {
 				updateBuilder = updateBuilder.SetEntityID(req.EntityID)
+			}
+			if surfaces != nil {
+				updateBuilder = updateBuilder.SetA2aSurfaces(surfaces)
 			}
 
 			existingAgent, err = updateBuilder.Save(ctx)
@@ -1184,6 +1205,11 @@ func (s *EntService) UpdateHeartbeat(req *HeartbeatRequest) (*HeartbeatResponse,
 					llmProviders = make(map[string]*generated.ResolvedLLMProvider)
 				}
 
+				// A2A surfaces (issue #903): for heartbeat-time first
+				// registration, fetch the persisted JSON back so the response
+				// carries the freshly-stamped surface URLs.
+				a2aSurfaces, _ := s.listA2ASurfacesForAgent(ctx, req.AgentID)
+
 				return &HeartbeatResponse{
 					Status:               regResp.Status,
 					Timestamp:            now.Format(time.RFC3339),
@@ -1192,6 +1218,7 @@ func (s *EntService) UpdateHeartbeat(req *HeartbeatRequest) (*HeartbeatResponse,
 					DependenciesResolved: regResp.DependenciesResolved,
 					LLMTools:             llmTools,
 					LLMProviders:         llmProviders,
+					A2ASurfaces:          a2aSurfaces,
 				}, nil
 			}
 
@@ -1257,6 +1284,13 @@ func (s *EntService) UpdateHeartbeat(req *HeartbeatRequest) (*HeartbeatResponse,
 				}
 				if req.EntityID != "" {
 					updateBuilder = updateBuilder.SetEntityID(req.EntityID)
+				}
+
+				// A2A surfaces (issue #903). Apply only when the heartbeat
+				// carries a `surfaces` array — otherwise a non-a2a heartbeat
+				// would clobber a previously-stored surfaces list to nil.
+				if hbSurfaces := extractSurfacesFromMetadata(req.Metadata); hbSurfaces != nil {
+					updateBuilder = updateBuilder.SetA2aSurfaces(hbSurfaces)
 				}
 
 				existingAgent, err = updateBuilder.Save(ctx)
@@ -1482,6 +1516,7 @@ func (s *EntService) UpdateHeartbeat(req *HeartbeatRequest) (*HeartbeatResponse,
 				DependenciesResolved: dependenciesResolved,
 				LLMTools:             llmTools,
 				LLMProviders:         llmProviders,
+				A2ASurfaces:          existingAgent.A2aSurfaces,
 			}, nil
 		}
 	}

--- a/src/core/registry/generated/server.go
+++ b/src/core/registry/generated/server.go
@@ -36,6 +36,7 @@ import (
 
 // Defines values for AgentInfoAgentType.
 const (
+	AgentInfoAgentTypeA2a      AgentInfoAgentType = "a2a"
 	AgentInfoAgentTypeApi      AgentInfoAgentType = "api"
 	AgentInfoAgentTypeMcpAgent AgentInfoAgentType = "mcp_agent"
 )
@@ -152,6 +153,7 @@ const (
 
 // Defines values for MeshAgentRegistrationAgentType.
 const (
+	A2a      MeshAgentRegistrationAgentType = "a2a"
 	Api      MeshAgentRegistrationAgentType = "api"
 	McpAgent MeshAgentRegistrationAgentType = "mcp_agent"
 )
@@ -233,9 +235,68 @@ const (
 	Update               ListEventsParamsType = "update"
 )
 
+// A2AAgentsListResponse Response shape for GET /a2a/agents. The `surfaces` array is a flat
+// list of every A2A surface across all a2a-typed agents — clients use
+// public_url + agent_card_url to discover and call into surfaces.
+type A2AAgentsListResponse struct {
+	// Surfaces All A2A surfaces with registry-stamped public URLs
+	Surfaces []A2ASurfaceResponse `json:"surfaces"`
+}
+
+// A2ASurface A single A2A (Agent-to-Agent) surface registered by an a2a-typed agent.
+// Carries the per-skill metadata an external A2A client needs to discover
+// and call this surface, plus the path suffix the registry uses to build
+// the publicly addressable URL.
+type A2ASurface struct {
+	// Description Free-form skill description shown on the agent card
+	Description *string `json:"description,omitempty"`
+
+	// InputModes A2A inputModes for this skill
+	InputModes *[]string `json:"input_modes,omitempty"`
+
+	// Name Human-readable skill name for the agent card
+	Name *string `json:"name,omitempty"`
+
+	// OutputModes A2A outputModes for this skill
+	OutputModes *[]string `json:"output_modes,omitempty"`
+
+	// Path URL path suffix for the A2A surface (e.g., /agents/report-generator)
+	Path string `json:"path"`
+
+	// SkillId A2A skill identifier (kebab-case canonical)
+	SkillId string `json:"skill_id"`
+
+	// Tags Skill tags surfaced on the agent card
+	Tags *[]string `json:"tags,omitempty"`
+}
+
+// A2ASurfaceResponse Registry-computed A2A surface response entry. Echoes the surface's
+// declared path + skill_id and adds the FQDN-stamped public_url and
+// agent_card_url derived from MCP_MESH_PUBLIC_URL_PREFIX.
+type A2ASurfaceResponse struct {
+	// AgentCardUrl Convenience URL pointing at the surface's A2A agent card
+	// (public_url + "/.well-known/agent.json"). Empty when
+	// MCP_MESH_PUBLIC_URL_PREFIX is unset.
+	AgentCardUrl *string `json:"agent_card_url,omitempty"`
+
+	// Path Path suffix as declared by the agent
+	Path string `json:"path"`
+
+	// PublicUrl Registry-computed public URL: MCP_MESH_PUBLIC_URL_PREFIX + path.
+	// Empty string when MCP_MESH_PUBLIC_URL_PREFIX is unset (registry
+	// logs a warn-once telling operators to configure the prefix).
+	PublicUrl *string `json:"public_url,omitempty"`
+
+	// SkillId A2A skill identifier
+	SkillId string `json:"skill_id"`
+}
+
 // AgentInfo defines model for AgentInfo.
 type AgentInfo struct {
-	// AgentType Type of service - mcp_agent provides capabilities, api consumes them
+	// AgentType Type of service:
+	// - mcp_agent: provides mesh capabilities (default)
+	// - api: API-style consumer (no capability advertisement)
+	// - a2a: exposes A2A (Agent-to-Agent) surfaces in addition to standard mesh handling
 	AgentType    AgentInfoAgentType `json:"agent_type"`
 	Capabilities []CapabilityInfo   `json:"capabilities"`
 
@@ -272,7 +333,10 @@ type AgentInfo struct {
 	Version           *string `json:"version,omitempty"`
 }
 
-// AgentInfoAgentType Type of service - mcp_agent provides capabilities, api consumes them
+// AgentInfoAgentType Type of service:
+// - mcp_agent: provides mesh capabilities (default)
+// - api: API-style consumer (no capability advertisement)
+// - a2a: exposes A2A (Agent-to-Agent) surfaces in addition to standard mesh handling
 type AgentInfoAgentType string
 
 // AgentInfoRuntime SDK runtime language (python, typescript, or java)
@@ -1006,12 +1070,16 @@ type MeshAgentRegisterMetadataAgentType string
 
 // MeshAgentRegistration Service registration request with flattened structure.
 // Used by both /agents/register and /heartbeat endpoints.
-// Supports both agents (agent_type=mcp_agent) and API services (agent_type=api).
+// Supports mesh agents (agent_type=mcp_agent), API services (agent_type=api),
+// and A2A-exposing agents (agent_type=a2a).
 type MeshAgentRegistration struct {
 	// AgentId Unique identifier for the agent
 	AgentId string `json:"agent_id"`
 
-	// AgentType Type of service - mcp_agent provides capabilities, api consumes them
+	// AgentType Type of service:
+	// - mcp_agent: provides mesh capabilities (default)
+	// - api: API-style consumer
+	// - a2a: exposes A2A (Agent-to-Agent) surfaces; populates the optional surfaces field
 	AgentType *MeshAgentRegistrationAgentType `json:"agent_type,omitempty"`
 
 	// HttpHost HTTP host for agent endpoint
@@ -1029,6 +1097,12 @@ type MeshAgentRegistration struct {
 	// Runtime SDK runtime language (python, typescript, or java)
 	Runtime *MeshAgentRegistrationRuntime `json:"runtime,omitempty"`
 
+	// Surfaces A2A surface declarations. Optional; only populated when agent_type=a2a.
+	// Each surface corresponds to one @mesh.a2a decorator and carries the
+	// path suffix + skill metadata the registry needs to compute the public
+	// FQDN (path is concatenated with MCP_MESH_PUBLIC_URL_PREFIX).
+	Surfaces *[]A2ASurface `json:"surfaces,omitempty"`
+
 	// Timestamp Registration/heartbeat timestamp
 	Timestamp *time.Time `json:"timestamp,omitempty"`
 
@@ -1040,7 +1114,10 @@ type MeshAgentRegistration struct {
 	Version *string `json:"version,omitempty"`
 }
 
-// MeshAgentRegistrationAgentType Type of service - mcp_agent provides capabilities, api consumes them
+// MeshAgentRegistrationAgentType Type of service:
+// - mcp_agent: provides mesh capabilities (default)
+// - api: API-style consumer
+// - a2a: exposes A2A (Agent-to-Agent) surfaces; populates the optional surfaces field
 type MeshAgentRegistrationAgentType string
 
 // MeshAgentRegistrationRuntime SDK runtime language (python, typescript, or java)
@@ -1080,10 +1157,18 @@ type MeshRegistrationResponse struct {
 	// Enables LLM agents to receive auto-filtered, up-to-date tool lists based on llm_filter in tool registration.
 	// 🤖 AI NOTE: This is populated only when tool includes llm_filter.
 	// Registry applies filtering logic and returns matching tools with full schemas.
-	LlmTools  *map[string][]LLMToolInfo      `json:"llm_tools,omitempty"`
-	Message   string                         `json:"message"`
-	Status    MeshRegistrationResponseStatus `json:"status"`
-	Timestamp time.Time                      `json:"timestamp"`
+	LlmTools *map[string][]LLMToolInfo      `json:"llm_tools,omitempty"`
+	Message  string                         `json:"message"`
+	Status   MeshRegistrationResponseStatus `json:"status"`
+
+	// Surfaces Registry-stamped A2A surface metadata. Populated only when the
+	// request was for an a2a-typed agent and the request body included
+	// a `surfaces` array. The registry concatenates the configured
+	// MCP_MESH_PUBLIC_URL_PREFIX with each surface's path to produce
+	// the publicly addressable URL — so the agent never needs to know
+	// its own external hostname.
+	Surfaces  *[]A2ASurfaceResponse `json:"surfaces,omitempty"`
+	Timestamp time.Time             `json:"timestamp"`
 }
 
 // MeshRegistrationResponseDependenciesResolvedStatus Current status of the dependency
@@ -1875,6 +1960,9 @@ type ServerInterface interface {
 	// Registry root information
 	// (GET /)
 	GetRoot(c *gin.Context)
+	// List A2A-exposed agents and their public URLs
+	// (GET /a2a/agents)
+	ListA2AAgents(c *gin.Context)
 	// List all registered agents
 	// (GET /agents)
 	ListAgents(c *gin.Context)
@@ -1942,6 +2030,19 @@ func (siw *ServerInterfaceWrapper) GetRoot(c *gin.Context) {
 	}
 
 	siw.Handler.GetRoot(c)
+}
+
+// ListA2AAgents operation middleware
+func (siw *ServerInterfaceWrapper) ListA2AAgents(c *gin.Context) {
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.ListA2AAgents(c)
 }
 
 // ListAgents operation middleware
@@ -2283,6 +2384,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	}
 
 	router.GET(options.BaseURL+"/", wrapper.GetRoot)
+	router.GET(options.BaseURL+"/a2a/agents", wrapper.ListA2AAgents)
 	router.GET(options.BaseURL+"/agents", wrapper.ListAgents)
 	router.DELETE(options.BaseURL+"/agents/:agent_id", wrapper.UnregisterAgent)
 	router.GET(options.BaseURL+"/events", wrapper.ListEvents)
@@ -2303,264 +2405,287 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+y93W4cOZY/+CpEzgCVmspMpeSPKqtQwKhlV5Xc/lpL7h50pVdiRjAzaUeSUSRDcnbB",
-	"g77axWIvFpgZ7MXe7F7MQ+zz1AvsPsIfPIdkML7yQ7Zsz3T1RaOsjCAZ5OHhOYe/8zu/9hK5zKVgwuje",
-	"0a+9nCq6ZIYp+Ne/PGV68VhOT9OfGE2Zsn9LmU4Uzw2XonfU+wMXqSZUEC6mshApyZVMi4SpoeYpI+wd",
-	"Swr7KDGSUKJzlvAZT8gbOSVKXo8m4owZMl0Rs2BEF9MlN4aprzRZMr2wbb1bESmILAy2ntAs098RxWjq",
-	"3poI3+NXmhgpM3KtaJ4zZXuccpFC0+47SCKFUTLL8Gd4PZFKscTYIY3IGVNXTA3nTDBFDUsHROb0l4LZ",
-	"p5OM21ki/VevTh8OM/6WDci0MBMhpCHaKJ6YbEWuaMZT++reaCJ6gx63s7TA2Rv0BF2y3lHvX4Z2QMPH",
-	"cjo8TXuDnk4WbEnt7LJ3dJln9pnxwYM702/ZwfCb5JAOv0nuzYYPpnfo8A69O3sw/TY5SA9Zb9Azq9w+",
-	"bfsX89779wNctHO+ZLIwXcv2gqmhnUuSMppmXDDCBdEskXY1++wd14aLOfmH+/fu743ICyVzOrcfRa44",
-	"nQiqVyIZZjKhGcwoe2fITMklTDVNDL9idjq/swt4xVOmiCqE4UtGZpRneiJmVBvCZ4S9SxhLWToiJ3bN",
-	"UkINuT8eay8RIACb59F9bPtE3hkPeksu+LJY9o4OwoRxYdicqd57O2X4Goj88ZwJcypmEnaDkjlThjP4",
-	"idqfLvD9+oSer3JG5Ixopq54wsiQLJP8At7ws6BJQnM65Rm3DQ4IzbmdPV0smbZfu+wNekzYUf7cCy/3",
-	"Bj2a897rQSQZ8Y+15R/04j4q8/BzQwb8sOaKMVjuWSES+yPNuFn1Bj3/7ws33fBgOfv+PTsMOtd23Clb",
-	"SrsMMuE0s6O+Ykpjdwej8Wjcez/oHMaMKnbNsmzzMKRMpytWDsS/udNAXg963LAlTNI/KjbrHfX+Yb9U",
-	"hvtOJvZP/ISuQCrehzmnStEVTLlidm9cUNOUiz8vmCAoBtdUkxlX2hDF5lwbppjd++W6Ho4P7w7HB8PD",
-	"8fnB+Ojw3tF4/Bf7+VItbdM9q1aGdhu1rXvKciZSJhLO9IViWmZXLG2O51mxnDJlJTV+gZgFNWRBrxiZ",
-	"MiZIeD8a3p1oG42b2ygawQr7B72vm0N4wrWxA0D1498h0TukP5VmEUZBqEhJIfw/9+JR/fxrKfErN0cX",
-	"bhPCfkpzyYWdvYUx+dH+/sE3h6ODb0fj0b2jB+MHBy3iRQXNVn9lF9fcLC6YUDxZLHGz2Y1njxgrg8xc",
-	"JIVSoBFwSbyyw715wVO7Pitt2HIIfxk+mN47HH+TPrByaagptO3sivKMTjMWyS6+ZP9gG35tt0zlG68Z",
-	"NQumos/c/hNCx+V8Rj27lnuvt94dD8MCvgzr17VPysWIzzm3LnCaLKQ2R9+OxwdtEs6E4WYF81oXqUfw",
-	"Ezl9iMfQ+ZMzkli9PeMJNYxcMYX/aQ2RvmaGXNttubTPcU2YsAtQlasejGeYsqu2oeAYom9gWSaH11Jl",
-	"advjGdXmQjMmWjaDPQkXjCozZdQQu+La0GW+RjHcGR/dvbe9Ysiy5UUQza035pMnT6PTO9qaM6nIP1vr",
-	"bJRly/BIbUs2t12S0SJlQ//80YPx4bhFcPWSKnPhxLe647Js2bHJam0P6TQ5OLzTG/QU+6XgiqUXle2D",
-	"DYXfvOzjn7/GxuyJ0bJHt94WT548deea2rwv7ArZj9xtdcDW7V6ZGc/MFutiLbFlkqOGOvp2/C2sCrxb",
-	"nTUrXrHGwUeWMrWfMmXaXCypSRa7remWWtQP0nU/ZPfHd+7dm92PH1832A9cyXMps82riF+7g1ZwNnFz",
-	"pc8e/jEYzBkV84LOGennK7OQYkBsO/j0gEhF3tAruhdZjviY6w+f6w169qmqEVl5rjIuP1u/hjYXjGZm",
-	"YU2xlM0VTeHMKET5ZzmbWSei2kP5c6MLIw3NLmILpMWits8Q0W6v+N2LjgLXxNvDoft7m8yVYBDGS4a2",
-	"YZtX5Xu088FTb3sOYqcgTF101NUM8tZP7zLeXodxyOkblhg7anBPnjJDU2rozVyUMFXe12B6EfyJ2LdA",
-	"O8T9s+qBxK9sdEHa9Vj8lD9HYD3RWu6PrXQvpWJVey/2OoLdH2/mprDVNmpT7Ga0yEzv6OfXgy6dC0Oq",
-	"SGA0PjIkushzqYwmYLhqbgdLcAgazFdrghFcRl39nqrFWjP1uFU2LZYhBiiymqEmBXs+a/H0znA8kbE9",
-	"XZXzvyJOlMv1rVnR9Sn9tUfTlKOL9iKSvxnNNKvP4Uv75VHX1iYl9oNgXpZelAc1SY6nof49L/3uX/cN",
-	"furq4mAf1DlNWGXtw3/Vh/88x+8k4b2WozV6uyl+sHa/djULM2GPbjgmCRyiKN2RjDTXfReBjzRdxyDc",
-	"ExCOMIryqirtTYrx+A77fjvlGC1cU4G9bt2P0ZjqQzx2O6/8WzwwJ9ghgNGpkmLXo60D/zt59fIJ6Tvb",
-	"aEDsf2j4L7tAJuXyaH+/6ids775ccTSLzEIxvZBZWhHAg8NxXfQeuTdIeCOK0sWDgHfXxbgG7jC+sH9R",
-	"VzSrdH2n0fNP8DRJFix5S/w7HZ1DfI2+w77v3B9vHIo3lGpdFksqhorR1NpnTuM2NnXVpFrSd0+YmJtF",
-	"7+j+XejW//Pgwzf+cRiB2/VSEanmVPC/0oYgrtn/miWFso6ri5S22HvuiTKWKlXToNlOx3QeZfg5QdtY",
-	"v3guVcu3/NzDgLr7uzZgL++kcAzGYzsk/X5D3Fz8dqOc398oWxVV51fY6622CfEvDHY2Atvsv1LEIpXT",
-	"aca9hDCgol7ztZlybdGOV4L/UjDCUyYMn3GmYEUh9t4Qmh02TE6NYcp28D//TId/PR7+ZTx8cDF8/fU/",
-	"toncMrJB2ybW/076GZvTZEUwWmEVqWDXeL+Df7L6tLRc1vliVePX2iHrnn7K9CKaZ6bKN187IcVQS4t9",
-	"US7Mxw/J1OQorHM0p/HoOsVHW+v0JdO5FJp1yM8a+7sMQhP36JYecXlD0hYLl0XbKVt35kKPYUYPN/lr",
-	"lfW6tYWwY8Jv2LQGJ1QkLHssp9YaZdqsMa8SeDRDeVKMailG5A8yXZElXZEpI2yZm5XdGnSqmTCjhjWM",
-	"LzW7+EExNrTf6poludVn2thFzaSYwyWs1QzxEEYVSS40xAXhG1jaOkvrvr0Uv/oe0kWGzlP9+6Gr5jfO",
-	"pLqmKmXphZEXXGhj32pVgM+vBVPEPxJ9H96x+HaIkaQviiwjfEYkvGN/p5m1MlZw9bkvVb6ggqV71Ump",
-	"hxQVyzOe0OGhVfJFhjGkI6MKtjaAsm4bPZbTM3ywLoju/Xahq1xGNTb9Wlu6ZmJFP9plwlkMtns8G5tv",
-	"ChtzUAsCNq6h6JL5Tv2jeAkVLkshrNMxIH8RucHiy7LlhXPWtovy/YAP16LmOwR7u+3bkzWuahTS2PBF",
-	"Wxh65+Baa7j5tHoA/e3uyWy5K72ha7ne3oom4IONrrKBqpy1bpmM8uVjOdWdevrYyCVPiOZinrFhYp/3",
-	"Wgosq0LA31hK3siptrYpjeZytFPoIpoFgJTYvq6lems7qqqgPKPiwiieb5aKtcryJaouYq27ZQ671/e8",
-	"nc67s2kA3QGA6tA2rE7XSfK8MIks1QXOmfsa8tvf/sOdniCTZMmo0ERInFRQ9z7m37JQuKzNLu2ArJma",
-	"rYhfeodISWiW2SkMh08/g3khEA48sMLxYkE1IwdwomyHMMAuHstpc4vV59aNuHMqsZmmiDvpBuCVLpKE",
-	"aT0rsuj7uEAloWQh0qGVu+Z8uUm/6DDyXuUAfAprA48ROjNMOQXkhW69E8fbVyR2ePxSMEWEvLaHux61",
-	"Xn4yqtkFe5dzxXQrQOOV4O8Iy2WywEth27J1UOBN4t4cdR/70biX9N1FWpT+XBNy5WdGyxne9VqvN0Ze",
-	"UU0USyRYLxIH80ZO9+pztnksHkuXXuR0lUkKU9oetcUmanaltZqommvyNUHQFRwfplAI0sLmh4jpkopY",
-	"XUFX0RJ4sWy7OWmObVATrVbxBpTNOnv7RQV66DW4kcHVIRSW9o2c3lxp44qQa55lDt1o3W5q9cGN9fdH",
-	"EBzhv1Kt8PPdcQwKEoNpNM8zzjS5Mx5rbMg9U7V979QjeNsJvmJG1S9UDgad6CP3OAi5zL1u54IbTjOv",
-	"QSaif8ZT9pb/sn/CMqZW+y+Z/qVgJJHiyuoCKfZG5KH70gPy2//6b1Y4l1IbcjgRcNWGSkeT/kFo/Wty",
-	"AP0DtDRRVC/23ZTujcgZsyIzEWMrOCnXYCrj07ZHxbIV6dfGSaTIVg7vWQZlNzm04JFscHScBzkipzOi",
-	"mRmERSY5FzpII2BZuS7xte7sBjjMRABADbAveaEXZClTBnIRALckV2wY4Fa2VUPVnNn5OJ0Ribt1MBGN",
-	"IRNtqDKaPHv15Anc59DQ9bLQxh3WV5ySfWs77cO/J6KfW/0SxlFolrr4qvXGiGJKwr4SKbH6YTilme0w",
-	"xRFrDQtfne4PdNmCSpq27P9Tf9ifPvSS6l4Ilw7VvS9VsmAQQWJhHAeb9cAtKG0jfUjA6WmjVvud2rq8",
-	"nkZUcKtEDq0BPAU4BCPR8RmgxDRRUmsAqrhtXpmdg2/ujPF/m3XLOtOy7RiprOOGU2RN5AJ+cZYLjewl",
-	"xK1H0cHmOdK2jR2qnGrN5wLdiNiYAUB5LQDx7exwepfdp8OD5E46vMvuzYYP6Hg6PEgO0zvs7uwevT9t",
-	"M3i2UCpBmhXTdmApodqFR3wcGWGqTruNcHd762gi/Mnq9AK5bHR6SWo7vKoWJqJVL5Apm0kVJQ185D3+",
-	"gWEZtF26YzMPreFGjVQNjMba+HgihaFcgCYBRKxrhXCBQUx0dG+I8yB9uygpVSn/K0bEAsJjrxVvvj3S",
-	"PIy0Jch8DM6YQ6v9cwkXKT9PRxkD8EvAKm2JO3Xt+ED0kotTfPFgPfL0417/+r8iwje6bRkiBLH1FvLv",
-	"6PbzS7yQq4ju5p3c6W+8ElZ/p8HTQNmEqQIYEAqF3i/dD5GS/RLs6wekRxNx5gFEYWjDKdX+bqZy5mBE",
-	"L2dqGCKnMTIJdeZt3CV2yfgt3Sputf3rV4Lrr/WcR/jpbvTirsK3rRU5H9evn9nhLCB0ap0/6iM6LdrV",
-	"WtNONG7q58aAPHAtogZvErjeAXT3cC3QMxrHVgfFWXT8lckKvV1xSD+UW207KBJsUiszEfbtAy9KWle3",
-	"djpcgDQgAPHjXSegTlhzhRAJguv74yDU/LTvJx/j9qA614OqO1GR0PYt6tdxXXpgq8Ud3MY4IRAi8Yua",
-	"fETxo5DOcDOc7UkXvhYWsr3TaCF3Wr9u++qRt6yMtJauYIlxmbetuSOtcLrDTSfF9i7ycXiyNMBRn9ZG",
-	"1Fj90nuoTTOmLxD8vdyq8fQ6IzvO9SpE/K8Aq69Y35XcsLWGVTygPzkspxtJSOJpnufbbZroNIssqLV+",
-	"UEdKWGPHfDDGt4ZT3qDtuqXUX9+WjkAffF4+68o77E4n3FXDh5MFJx21QucOXZeduCHIHNJu6iN4evIC",
-	"s4kEHDailJmNs9CSwNPouCWjp3P+UT+ePtzcc1dm5Rq3v8PMiFNPSZTBsWnTRhmU22/bLU7cIPkBrLkB",
-	"FI5potvr611OxTX7/JFSUnXjz1JmKM/0jfUzs80T30pL//BAy4kD7y2Z1nRe1RanAsgZiJdDhz9sXabb",
-	"Bpvh4DdhzB5dWVv2J66NVKstIpZRLEmxJHIcV4RdOXRbTQW3X+WWFzX4HlHMFEpUM8IPN+ZYuU47MYj4",
-	"+wBvbNyIIfa4rXXvkJormKh2TGJ94q8qKL+2WUf0e7dk+wOnNc7Lk9ib7tWiaUNrng/9ouyirp5fMYUR",
-	"dbegiOhvKqwNyXqvN0l7h3kDIezbyE8ucpetiXDvLjDuiuCDXVkI1cSD8UZweGsXN3ctwjKUTdQ+rBoM",
-	"8DLUIX8YIYoiT9u6GhhEi8M5Si4r4aM1EcWPZWRXA9xUpF5Y14W0u4lLPjzlDxJZdjyKKjkwCtCs3cdQ",
-	"WwhcrNwZ5s6iCsB6qxyKj3sCtW21jlv/j50wW8+BXXvobfK00Ea8ufrbIkO52wUK/a2N5kU7uNs86uBr",
-	"aZfQX0vRuYWoQ3doYbURyQoWapTfGRmrO3hg28UJdvWtjhNT0JJQCMdre7AnaeTo7HIQf3SHf2vZqxvq",
-	"bUnmG2z2tTHP0hX180T9NV7AhlRyoJc0z7mYjybi//+///P/JMen5OTl6fnpyfGTI/IC+AUCj0GhPaS7",
-	"Ji5c2LHZTguAD7r7i8bIvUFf0T5hn4HxyK9Yuh2hgbvR73knoqIVyh8/vVsQ1Ev14gA/vW1BW9GeAARB",
-	"qEIiFdzvl3khHGGF3o78SpPLN3KqL4lpB8luAH2WngIMGdfY9r2gGsmkHMJ03zXE0grSYeOx8zmBeR0u",
-	"5g+UZ4ViPudGCnI5ozxj6eWodi+KiJgLz3O3DUzhMwNIgKso3FFugsw67WdfIlOr+N0uLi/3ARtSw/8c",
-	"Pnjw4MHdbfA/N0XwupgU9v6VbqJ566P5ZrvRfASkZnDgrFPPNKF6yPV3NYzm78jMJjLz2Ir9RHgcOQAl",
-	"rhc8Y+SyoqMI0BUk35Po4y+/Q+gSAgyHHmCorxnLyZKqt5pwQ3ATEykSNhFtjbJKm7cA+AzYLCfA2QpE",
-	"NwSF7cYPKW0hL+VWsthyJefKnoMtSYfUJX8R/9CAjEfj3/7279YdqGj30d3oHJxlEsJtgS6gNmUdY8K0",
-	"0XhMF5E10JUQuahCavyrREjDqtOkGVVgspJZxucLcPM2Tg96hLu5lOdMLTlMGwIW4eRIpB2GsYcHKUf/",
-	"+Oz5M8cXQ/ohQI+d7q1JR2hzo7aEu8XoyW31LJy4VBNHgdmmWQHnuS5B4VYRt58CY3ujxIjNUNvj3TC2",
-	"pC8Bm7v3scC24HO0ORbbZHBUj56aaG2B030sp3+w9kQn+OpE0ozpxBlDzndAsyNAYzwzdMjWalq3KcsM",
-	"1e1HuW0YfwdfKM+z1dY5XY/l9KF9dSM0cVOicyXZLNoDZsE0c8PbXuvvkscXj2zgJ2r9WnVdUNjZRPNQ",
-	"YjJfi5uRJMw6B+spa2ExKvlraDFVNc9GqlrF7NjbOvPrjk/gtaz1oXRl5TdDvmv5ak6H+X7xS1oz1roy",
-	"/V+ir4GxhsxQULuhvT4bzUfkUkhzAVbG5YBcGnfa2P+2P8xkIdLLvdF29HZuHJuDCPV4hV/HaJY7hAY3",
-	"SHeuIn6n33r2P6RgyNP+XGQrMuMsSzXJFdNgOyvm9EA6mohLPCsvCdeQFMrFfFZkkKmDx9clarPvy/P3",
-	"O3IJDt9l+dRE+Me8g9eCrtzOS+xDo7Ls2LVYs9mKXBvF6PKiGjC6kdvYSJoEWAFMKqT36I/jMnZbij4j",
-	"dNa0GGtm4v1Payb6gW1vJE6lfPspTUR8OViKDekpxXZXc5Bm2RZcO5Fh2EAoPGPXLvw5sH6IUVRo+D4u",
-	"5s3BtKiXDoVw1hFytXKc8RlLVgnQKlLDRiTMFPxbw/aPjOlBiMkMCBXpRFw6FhIwtC+5yAtz4YcFWoIS",
-	"IcXQlDZ6oX1n6Oi54OG1VG8xvl1tBO6UXfdwU2V7BxPK9dt69xqTRxztRKxYoWj2mX8IEZ7hrZO1FzM2",
-	"x78tZWo/BAjpS5pgiMv6Vr5PeWIGlfCgj/za6fGR/Qo59ES4yIVIHUjAutK6RFJxQWIyDXtoObQC6O8o",
-	"ePzs+fmjI3K+CJTcGnqqf0j/ajy6PzogM0at2b3XppJvgiwjfbPKeUKtVTHpZdly0qtRggND9MfNs3j2",
-	"waySm5G7VWZJRCbbyYIEiKOJGJKJbW/SI98HvDX+9Wv/51yxGVPh70P/d/YuyYrU/rmKTXIs2oPe19Mi",
-	"nQNXy1Do2fVHggX/qcFXSfqaLa8wfcFxit0Gf2VlvzbhjQ1YjoeVcTGTsBaVTdtvEqlbaT5byGtNrhc8",
-	"WVSfL+tIlLm6Ehe2ivWsaINWk+UWoJAdFO83xkOCnJYzFBJjqrGbOrn4ZwBBol74RLjHTrL7FvOjhf1+",
-	"G2UY6cGvsmz51Q20YI1d/6PgHRsE/dsrkq673BfNCge3jADdgL1sW7O1F7pV4qoW3j2ZuZOlxUSgorm/",
-	"ouyS0UQ8Wk5ZmjoWKS6gjhbS4Uf5aENS+QxrS/FlnvGEu7JQOYXLGLu9RhMR0FawzAyrdmmC6W52ZDjc",
-	"RHHDFKcVywJ/YynJuA6mBb7vzYo2dTfrmJ4GF/nK9aBH5IQKMmV1Lu9+zWjQexMhVYXeu8Zw3eRW1rWL",
-	"g0YNG5kUDtPtib/zdNYb9Gh6BTQIvdfvB71rNr3AyHWDNTyRyyUV6QVegyLO1Fe5kMmutOF1M6nFUMnT",
-	"2QV7Z6yXJ1UrYXgLJ7hbZ5itso8BzNwgnrqb5rB5FIMvTBEZVuUMf8wMKTp3SZv4adbY6utiqllpfdXI",
-	"7OvrekvW0S2yea8NblaqhMTmMIViXbWDH+UBOANgOq3u8vPmzFSaZZPeETkVYHZC+Bt3f7BuqVjVNQi+",
-	"WtYosS08Fww7yO2D0dk3hQxROscW9/Ddf7KvHGdZSSbmuuUC3ZM+nwu4zcWu9yoOI35spUbKP9UODKxd",
-	"1uR1s/N8ATUZq/MX1F5jFl/4Ao5B/LGVMGAjSd9ObxWg0zjjQ/MbDjBUBmuOpnbb+MR5yrgIES40WMlY",
-	"Gi93B5FbcU3YFVMr45YaHhSMpRChL4T1Lw3Q0LhakchlY7u44pRYGy9X0sgEDqIP0yvWTUUJcoyVazXi",
-	"xvTY7Xk7odOYvDOaMSAYj8fxCMdAgFc8LriAJ/OLhz9YkWX6g0jz7QDiucUynW0+Qp7OqqWGWmQ+L8xZ",
-	"KONYCwSdPX9Gzso0e5z/ULIUb0qdBziaCDspJfCsKiEhsdj+Q3qm3rKt2hldj/m7tb3gS0D2xpuzNVjz",
-	"5wUzC6w66l4lzNtWro0wGVMpM0aFU6DsIqdWbBq2K7VWBkIk/TJus11de2sC++Uf3l5TNd8RN/0CirYm",
-	"Usz43CFlyrUq68H2HbBjgICPAcGwNxfzAWEmGdn1e0G1Rh/XUS08PXmBzdsGmVggKRQWZiVTtqBXXKrG",
-	"ykEHHr92x5rTrqewVm4svaP747Zp2OCoYvCosgEydsWyqk71EoNH/oebHTH2zT5dpXQtDRzsz/XO8Urn",
-	"Vghewdf4YPqOWk52nGwfq4YN/PrtVbu2jtCY0m3ScZTGne61GA2erNcM7nra4jJtDtinisq0FnhrxmSa",
-	"Fd/WHIDuQ0owaYtLUCvB1tXj7qZhoTELbWvjqvJb1zi2tfO3+PSQmbnTRvtvFxX7fKnBa8oFdo9gS9EP",
-	"F/lhn8tsJ7nvCkWdV8s5ft4w1JqAU3dVjQ4rsUJdVFqfoVgliFfEdaQ/hOyMZtd0paPa2+EmDJT0h1Ke",
-	"7cIjtoYmzOez7cYRdtxOChYaCyX8PiEv2NbXVeBMdtPE4RHaYCnxn7QV5Koam4zLvWyIUnwUjrLDHcg0",
-	"InKynp+bLfZaF+zcpx1XdponJYPzYpZRY5hgqbWyi8QUio0m4pXGqb45WRm8iS+Sfvlt35ccg9DM8YtT",
-	"Xxi/+hzN+d7t8ZXdWu2jukLyMhPrjnY15WaBDCMVFSpexFmSA0Jz7mIg4MAC00NTdw16NOc7aDBrFV4s",
-	"pEdU+pGPR+NWef/p/PwFsY+XNclIlHZWdlo20N6llZdKl+PWruxjLV2R/hhvsq0arRz21qD9CEXmSN8N",
-	"DKGeTvz2/quzL1ZKDPtOQ+XfL6rq8JbluPZvtVb6hxxT3k9E39EZVNqqt3N4K6EixJmyFeEuhF3WqLEm",
-	"bXkJV7XzUUne4Bh0Z8YnOQJ35pNaf/LFH7AF90mg3awcg458IGSJwqGodzhwTqSYcbUMTJynD3chUPg9",
-	"y/v3LO//flneLUA9vlyylFfpLqPcbs1MkXdkdlfQgev2xnoiIBx6rRZXLZpBIZ+xilaA+iDuuytoqxYQ",
-	"5WgiXsi8yEBDl1Byd4flbqji72nE/F42cJWtqEq3mQMmolz5fUPnet+p348FnoyC5ckCc79KjdMNOaqA",
-	"DhCeU+79DbAw3MpWzSVM6wvottyO1diFwy4EUKG2qsOgEveVal9Hh5g7iVpLF5ZXm9to4S1qxnVVwtxO",
-	"9AKgBWQo83Ua7NKhXzWaiEfRejpnC4QWGA8ILYwc+mYGpMiHRg4hBzs0GYFrYnND+KTCqJ5Bq0BxTfKt",
-	"xB5bjsXcJzSXiIhMznlSAfWEHeAC6eCxFlnmCLV1h4zWYTP1K9fa0bP9RWhThhvXlrVbygbaaNOl3Ue6",
-	"sCvv56o3WG5zVa+c/Daq3Q21bZw6oCjGGjWCD/bPcDpesykIb5XlqTmb2NIOE/pLwdSqJYpemyt87HXn",
-	"BZ5L9L24ZtNoOsJ32T+3Tcbr99vSkcQBT9jUcabaf2dmkkF5XHRZ81ZVxsyw1YDWDmkPEW9nC6KRVNyv",
-	"0URMBN7bYMiKPH9JqNVEghpuT98rTolgWDDXam7Ew/88CSOa9Ab2n+i42n9MIh930nv9GksOHhH/Ajl+",
-	"9tD7zba78uk91/SMavumf/FNoY2HIxD/KzF0/pHyGj6EMfddDhl8uDFPqJCCJzTbDRAQl0HG94mw8pdB",
-	"RZIGpGMBPB2Y1hhSRezIrPGFCb2hGuPLIpRduAhtqpJ8xMXP1FdQVyGjcNCucjYRkDA58PnCL1YpFYYn",
-	"cMOYkRxxB1Y2wAEvRa7vh4bxy9FotLfnk2p8HqKRc8R6wEEGh9tTmbJaXo2/XZaFCXnKeiKuF1Iz+8eg",
-	"DsOsk1QyLb4yRFPD9WxV/0IcWnS53KSqqyznT1S3nFBnPx0f3rtPFlQDu0uHBLigbRk11Qt6eO/+0c/j",
-	"4QM6nL3+9f7d9+0FHvx0tPSMQmAtLWq4E2C7IEcTQciQIJLyKMzWV9rNkys1htyngAl0maHxBPkdpkOo",
-	"j2i2hFXXe64Do3hijtD2wNv7vjWfhlJZs5cLzSDP7YoNHGpVSa2HPmhmv5UoltF3sAZ7E/F8yY0jvbID",
-	"sge/fstzJ7ENrGhZX87T13hIy141Aw1nAsxlO+LWvLIvPg9pRMI1wkalbI1gHM3Rbrr5++3UcvX63r/S",
-	"G7QHNl+3g6eboOdtb/9ff5Ho3vLc3nzV+zS+162WJhk5vOLvlUm+kMok0ThvsRrJliXab4IwjEjC8XU8",
-	"xpvSJlUrUDBvIhTjS80qMBFxgwOSFNrI5YXjfKnAFWlhFiELGNGLdY+18oj/qmqT9rF/GR6/OB3+KXgg",
-	"V4eYTNWJX3TJ3t75u3uvzVf5aFVeXKH4q4NbwxB+snovm9Vd123776pud1W3wQH8+1J5OyHcw6VGHeWO",
-	"fm6Auh8XRg7nTDA3PqsQw7uazwWEe+0C/kC1eXryIsJ/VOOKEUZ+Ia/DPUrId9gAjPdzvgGvFQmtt2rh",
-	"YzLYprqgWadV27FGRhK/AFsAjbeCv0crdUPf92QblzesE/RHjn84f/QSnBG4d8EQ/sPTam7Cdp7wiJxI",
-	"YZgwQ5qmimm34NF3WSdwNBE+zOs8JgyVhrLMVT8nUs3Blm/3N2v9bHQ22+YbkpWW1JBJz/mYSO+4YO/Q",
-	"1J309kYERJnqiUga3/uWrTDrCUjkUCE5rltyfi3joDM8QZdsImBEC3rFAmAKL+0BdmRHhUtVCVDfwBv+",
-	"3fq5feunvJe4YdiqlhBQizrCTUi5g/U6CMdDNuOCVdMGQK8GDeyS2SjEeYmRdmWMVFij2eqNAZnJLJPX",
-	"8E6Z+e1rj8bwvk13rVvcb8VXqXFMareZfEmvu3UeXgKRK5oVbOuTzb0EERcqhMSoV3S6kf0yprdP/iJT",
-	"sk8e0+StBmF/5RVbyqbFfM7F/DvUfEHpAAdnvzUMt2cX+XpBjS+G7QJ6XKTsHUMrensV2drFbZ4x2OGI",
-	"nDHWqm+3GOdWurw9hLmNMr+pMkW5/TNVgot5C6TjWRkgvnYPERcGnvTwuLX7rGXej4iddxzbWaFmNImi",
-	"w4nJHEpkRB4tc7PCW1zQC0KGrmoIrs31P3532rZy2poVoLoJBavFsEbkSeAUc1Wu+v7ubgDJJf6/IR9x",
-	"IqhinugWbt2X1DialOnKA4UWUr7VuPiurLmhhpFkQcUcahuULtAwyvbw/ZfgmYAWG0SImoso5QXHw1wN",
-	"fmcGul8RvV04c+/SiyktUm4udwNc1/FlIGswXIh1G+Dv6ILErWGnwR53hunyWZmDv7cTEu9DaoXi9wbE",
-	"QB8pHQdEZum+iMjwQFCqto9g1xcB1VLWoRn0ZJaWP5R/9vyf7sL1AiWn1T2BUW3ws6oiH3lbXrp7g17A",
-	"R8LIc64AyQYMiS67KDwaf4Cyxy6LK+eWQlv9a1eCUtTwjVmiUCziI24IybehthywpQdI+bAlM7fDbVyL",
-	"Sf6zZ8BG0ZAJXNmkt1RRPFrpQXt58XbVCGUPHstpJ4uycyPVUPOUkSuZFcJQtXL1EhQ2MCInNMvgwu0y",
-	"IgW+hHu3iSjzXP211WWD6f7SK5E3ckp++9t/+KYJ1xMBTw8BV9S/O75DpFkwdc11O7XfWsLkMFBeEoh/",
-	"h/eDOMxKYYh4hNtzKG9N2VtTY54HFk0OvOdOGFI4gCX7ta8URsyCmokwis/nCA5bhMXYG5GXwEhcpqB6",
-	"1lq8ZIR55LOJiF4ihufo3Ct5TaQ9IC7jSgYIiKqWQah5cb3nZ1BZ88gDd9F4n7l03O2ppDdJ6hqgd5EB",
-	"WxONBDWIqOdFdeyclz6a4bjMJsIxT4P0xdT1rgUkguD23zQFsuGpnb6hK7Fgz1E6ETljyOnOEzqqM/ni",
-	"1M/gktktzVQWIrXjTKhmE3G9YIr5dbDbqUKafgnjoRmOYA6WhjXuqJiI6nKBfeHXFvj3rdynpM9HbOTS",
-	"ku25Ra2ryNIJFor4SpMFFWlmP4FyzdK9AdHSGqmzQgFiwVPJW8sil1pzOH5F6oUpEHdZSfGTyN4taKGN",
-	"l5idqgeFmm6uago8NiLPpGFH4QNTyTR59vyccJEotvRWyESgwNsFhZkHFWQ/lOTULOC1ETlfMOdc+hKm",
-	"BBbBvu/jPe4Bu+tgNjUz3qDC9uCX3IfcwO8T8noYRAeL3FQ3zOEmEvKdCzR0IbKqc9y+v5ro6HYyhAYK",
-	"uk7N00REnyDwAosRCJZYHaZWBCwlI53FTKgLPNld5l5nyFpDs0xjFgAvqWhvhxZ2GzN3TcH07bkXd8ms",
-	"2I529ibVzOlNaXq2pfK8SfwyxNVaApFNVpjbpII5jGKHB4c3Zn5xclPZNQ1agBrOfcMV0W5ZKVF+y245",
-	"KR+vZnkQuWQdK80mAP8u0QmRtnHu20XA3/bDWsAiOSi0DyAizg/bj27CAljMSKJZxhKoyKVkriC1xX/l",
-	"T+4UhbTM3PClixJb5e5YdlzgsgwRlAMooJzTE27YkydPv9JkzsxFHJft75XRurQAZFhe8pRWsPoncrmU",
-	"Lniqj8ikR4VZKJnzBNFQMmeCcvzvuZTzjOF/J9Kege6ZLKNL6tBTDrpo/9UM5Jetb5bgHcJHQXY+mDso",
-	"SpWKnKT2EjZOglpPS54sIkDObvBkoLaMcqBcwLNMaqhQYIDEOGVo9QPeiH5WzO8XDxxs5doZ9PCKILu1",
-	"KOcG3N3OgDs3BXHF8HLqW8VSyjX1hAM/Q0v8M5BWHr84LYkcqvO4j4Gd3qC3H8eDHC3EjnTLZYH8G1e/",
-	"j6JEhRAdmaYfUJK63A/l/EecO36O2hYCLzUeCfCVtshMdshkq8jLGyZ3YceEr5BV2/Sbqq36m2xwNHlU",
-	"VaH/2//2nyTjSw4k+BtcEGykE4vtRjfAwo2KJUCpw5XempSlnKtVe6JcfVnciAa9bm+m3mZ3wH9jxoH9",
-	"wFWjOG55q2d9dIeqcHPh6+S6FtBXTlpQFhOBF1dwI/ZdBB0oB+VeI461SC+ogsKbEB5oJyi9lRvCtgs/",
-	"d9HRWgnQBT/h0qkmz9Z9BgGJ0qC2pl9YtF4sOggL3iz22+8N9252ZeggLRdS8TlvK7rlof3W/8fPiqIA",
-	"le+3Xzgip6W3TF2xqd/+9h9tsJSUpUWOKUCY2fBLAXcq2KMTBh8qqsL/15BtWGv/rZDXYnPKOUz2IBKp",
-	"xnRUhKB1I7YjmHczmOJGWgwnT+mFvQ6IYFdMOct973db6XPZSp8pI+Fc0YTBVW9bzdCUX/G0oBmxrpa/",
-	"mkG8kLuwPzt7tENQ6NjdeFJDSgBKeQFa+cprqd4y1V5zNJEK7kq5FO1lHkOGXPkgOX3oCogij5f9pLe1",
-	"FbUzN3y3+us33z5oJx8xlGc7hmdgcoce40R8G3XEpyv4dnivLHMWp6dS/TYKengWthvdYEZrGelA28OF",
-	"NlRhsS34ZxiW+3dcjQv+EEpy4ZJj0LzjArMSHqn31mCRhAIXFzqn7Qv8Agtg2N8Rd2SNCz4tQJ4UTaxp",
-	"uOBMUZUsVlXiwJyKITbfxRa4+ZYy3Nh/7GvKQQ9Wp/WbYas2yg/iOKYsk2LeQA5AYy6qOkzZ7O69+7td",
-	"jYbRVNOU1yQnvweYKhqRYKcnoFnYkvLMfvtiRYWib/55bv8wSuSypK54aH8jL+kbe+qqzEVP9dH+/pyb",
-	"RTG1T+9DA1rRN/ve/2lyQ5xIha5ZQN76SO1TphckcCm4YwmSmn/7v/6f/+///T8IOXl5en56cvyE/PD8",
-	"JTk+JQ8f/enRk+cvHr08O3Ko3uc5E0DAV4Etpg6KaA2Mk+cvH5GT58/OXx6fnJMpM9eMCfKjLC98qEh9",
-	"vQCMsGoYhI/Q/+HRT8d/On3+krx89eTRGWRQP3v0p0cvyVKmfOZyBmz/EAaRhSHsnasPU2imMMZ2RTP7",
-	"4umMGKaNhltIAmXHmEhCAXTbyoDM+DuykoUiCSTWCmkQu5uzxLZxLFZkqhiFgo0OeoO3PnQ2Y4lBnqgf",
-	"ZfxdkDGwZAKhhNo2cx6G7e4StSxU4pRSYRawTHZqfbgZ5+Tf/3fiT8SfuDZSrWBGruAAPCKnrtZ9WGxY",
-	"CsxntDZXxhPm/EknaE9PzxsiJnMmcDgjqeb77iW9b58FnWBgRzWF6PjFaa+N8QFjhTnvHfXujMajO2hQ",
-	"L+D02AdgPzNtNhVSeEyp5gmJsJDlpRGUYwgRiJhGsn7FE2CZ/ob5CsLITGPRb5GWVxkp14m8YmqFljFW",
-	"s+NSnKa9o96PzLyU0gCYBp1i+IrD8djvcmc/ADkJboj9N+4KXweA61q6oTgWA0qklbKuMhOgunSxXFK1",
-	"ih9RUpoaZ4bnpnAxmdf2TR+J6VqKH5lB5KGcwU2cQzpkq5iQInDKtM79dEVOnpxiK66GkLuvC1Z5iVlr",
-	"m/knXJtjT+J7a5OPPdi+1i2Br+3U+PraOsBzWEe9/mC5ED4KFi3E/q/+WHnvCokz02LG/GiPJCxVXSKp",
-	"CPXwwEBV4PfOaCJOwOvS9qFJBL+a9NzpidUUcpnJ+cqpN2unsZLywq9tOB28dgdNBGvtbhZwFHM3SKIX",
-	"hUnltSD9s9Mfzx+9fLp/dvrj6bNzoK7w46piyvAWBOADZRIRDqc+StDvgShMsaVV+h7R7drsC+lzEAAM",
-	"D0jHIXked3DNs4zMmSGH48My8CUFEeydIT89On7ozeYWGX0VJvTYXfCWiTUtRbDQB4jNGEkqkLh24GNR",
-	"8NQZbNw2AxQ+wXSIbifqaRHlFtiFk/b968Z+u9vlz5SjrzPUvB/07uJ7H2WfAl5o3RZ1NKfSylAhUtv/",
-	"vY+oJzb2f+pvX6xlxRRByp2qevD71+0UP3mqrqorGgKxh52q+n8qmFpV6UBwKy3QXvAlWp1X6KlCpv4x",
-	"u/gDX3j39CEWS6vQH46CQq+Bf7EglDVqzESkrVjklCXcGgc6iotSTS5bvKRLsj8Rl61Iz0sHwAR9tA5o",
-	"HW4bBgTBpwNXxb2CwZ6IAD0dEESe7kHolWZaEmB+wuJICyWL+cI5G85cgDEgfgzjtQEKJNg102YIob2u",
-	"A+3RlWelX6cnXB5OZY385kdiqrD73U+lEH9+TG7Dx+r+vLIOQ40S1C2tqaYSwn36XsdMRHrwhnpvzUCr",
-	"fKB9xTJ2Rd151YoV7hplozpCGOrG0TzFEvZEhHsbP0vSCWFHn3CBU+krBP/ujaPS+PfG4+iS56B5ydNy",
-	"MnxEDQsf47ycdZoWH4yY/kLlFI2nzifV+lc04ykqjSir9os8fsA6dRdv1cPCEyW6WSxPInf44EnkPIhN",
-	"/ltoGp/3ACN7rqBrF/knLd7DeaxtiV7IIktdCMCl6sG3aVKIDBIb46PP6gpVZNZll2+ZiOA4EHEr8tK4",
-	"deSRXFg/pcP1+8nfY9+a1GMP27l/mnjl3OH9uQlPFix52+b5wVGQ7rxyLq02BFyClTyV6Sqa4ocyecvU",
-	"/h+/1ZWROOG6tkb2cKhzB8msr/uZ1ayO0FOTHx+dEydwZAp94hDhGswNKKIzdZV1K90eVbskDo8IVWsX",
-	"Upujb8fjseujZfl/YjRdu/4bl4n0/czZUe9ts2r1Vzrc9/JEt2ec1KZrPAG4aXefZiK1dhiXKU8iJnOo",
-	"L8aR8axBeG6nMDqY0WzQW3iGZ1YRabuWECHjLlTV6KA5IPu2X9gMvbvoHYdXd5OXyCVcc2dcMEJn5Qe7",
-	"/W7bCuCJwC/bSqVepyUvGafdR0M40HmNUr0lQGxBMylYbVBcE+v4DkIYAO6LygnHlD4fx2qRvTMmrOwF",
-	"q815oH+Q6WoLzRNny5fMy7WcNqQtrvPeRlQataSpkNlU4nQ7AbB3xu+Bh2w7FdhemabTxSunEfPntGOU",
-	"X1JDqK7Iyl7DJ35/i6q8s85Ay6f8FJURAOrlNu/5M9gx1cmtaayWGlyVkghdHmx4oBbmaj+MnvD5wlwz",
-	"+/9V1ViWcnHnkj+PAApZGVZOV5mkKWC9FUTuZlTHogNIW1cABa+6i+nwYEw0S6RIPygi5g9TqEHjRprI",
-	"lOHR1Reyen5CROpwPCbP/3hEnsl613pA3jKWg+62xm4ckNL46iE5ThKWG5YekfPq2+mA5Jj3ArofJurF",
-	"87Pzqq69ezAmP0rBjsgrBHzgNId3gxaDc7z5/r3xHeLrRr0qAeJH5UUBWGwDMqXJWyJnM8/YrVYtuu8H",
-	"qk3YHifOlNktrBZHAZs1br6s0Nq4jVygIQVOAsHxrrCcWKUzfIHCMXwsp3pdjshQJzJnKWZG2V1RCJ+S",
-	"9kZONaHXlJtwPQZf/5UmcyWh3sJfmJJkn9ApMNN+T4QkuZNKexyOyAlF1gNDDsZjtKjLaQpe5kHFy2yB",
-	"EoJ6OhwfttU1rEt3l1j/vUzT3YNxW12zdbsYXdM7ayzY2m6tnQJ2fzo93OFvVJT/GzfZ7VaqzxkOo9OE",
-	"EsGuSSbFfOjQupAZiCoDvFs9EW1ZwX2kXcky+4rLq9zDpL1gmbkopEZkpm1XyWvrA16GXE8kWYhrCgBh",
-	"gdZ8LlhKeNriu5xgyqTL84tIhSGxzJNdodlHLg3Vb78/VwW7nAise6AJF1fyLcMExGfPzyH298659E9P",
-	"XvircpJyxRKTrUbkkft5IvxvmjEUUDhprMl5CWbevp2US/I1WbAsdwlFus3jxUuZx3K6s8m5nRkS2vc5",
-	"5C2WyGM5xTS/qPDgFmbcwW0MstteCqP0Rd+tOHr5TD+b+eYBXs7+ibb6pxlHUCFWd1jVHOeLtbm/1l2D",
-	"/f5GxnUUQGmU+mN/ChWXN2uRvNALZs0tmjGdsJR4GJddpH0o+gf2WMoyQxHjaL03qchSKlQIkLUur4UO",
-	"RHDov4aW0BmEVUfFavepAIgGwHNLO57AsEEqjCaXGdXmIpxQF9RgqvwltHKBgXlt/zwRkIdIgderSBZ4",
-	"7rSonec+U1lei0jpkSVdWYN2yY370hF5GL7YfaWQSFyAFzsVRYq3GrlUDsV+qdgbMD4u25TGGXT0WE7/",
-	"4Mpi34bm8M2vURwnYdGtWvcrjJz8DsLvFXNgdPik/mH5Dd0bCB7wCVwsJX0tl8x/jF1W4BGcMog24KLs",
-	"fTZtg+L9X0DXoIgS6kYsZ5GIrNE6YPRtoXVczjyW+zRy6bI0Md3f6peK/RgqU8z5FRMTUcZfRuQM5HTo",
-	"iAfsiSILkQ6N4rljOkHqEGBYSaRAXE6C+SE5QPDgyhJY2ZBA7NJ1felKs2GWgJAYwgKSiDIQ1fcXbk6J",
-	"IRwO7MG9LVzfY/h48urFw+PzR2Q0GpGXj85fvXx2+uzHskACfAjmP1wrjm4lYuTOQE02LbtBSdbQoLkY",
-	"EMVmioHaB0UK4BJgbiFlJhNwT4Cbz4zxFiWI6TvjvUXnkwNDBSHsHUsK46+XsK64TNv81RM7v+BS3JLR",
-	"5Ntfp/vKLISvUe7syD+LlouG27134aGIqMNhq0nf7xMnq3RFpozYh1afT815GpAvXs0d13UPFVXVs0bX",
-	"/fpGTn1cbu3tnt0OQNVmIkiH3U7gN43IceYpDIH9RhPD1JILathEAGzWbn8IgsWqjMJVrlU3aEoPgezG",
-	"qj+DWfV10+e4MAuXeW8bzKXWTIMRJmfkEj/mkvT/9eDwcDjlhrx6dfpwLxC1xDr3mfXP1TBBnXHFVFxi",
-	"se1SEP2jtREpuPtQw+A02vmJ4lN9GE17zAmHvjbitGVQ6WMZLa0b2JFHhIX/5Hgv64HV0F5fqqNDU79j",
-	"yunavBP3E6u7s27742mFOekSHwfuKCrSAeEz7xqUNFNwtBueZYRm/IoNwNO4psrXN8ImaEn0ngHGyxAt",
-	"CRfDWQZRebAcEioInUplRhNxAu95oA5EH8KuwZQn7BQJiQGuQh3Nm88kcMxtYaBo7Vj9oQ1FRkwG1/0h",
-	"lPNLwRRnbfhjr6ou3cex9MLI2KL4XhRZ5pivwhxNBC8Js1K7aH1P6yVVvqDOVdLXjOV7gfkrCZ8OnzgR",
-	"WKQy9aWIVYnMvm4NucD7X6ZKuQVbxn/tGlsmLvFWSqPjxbtVy6Uc3IbAj99ppA+xn7IQexA4u/wgVXuf",
-	"XzHeHT/4tL37TcQFof74R6OADezk2dE55fYF622n1KiINN92NtS+43LrVt3PK7rOMxDyLHAQasKNc2iI",
-	"hKBxiE/DGSLrBIKgjz3FYHm/5oJYQdNVOftsI/DYkGV8Dk5SSSPZB4Cdiw+VFQH6eOsvBRQsvNzDoJdV",
-	"rlZlyhkQ+nm/CQ4mz2gIALACGKydaoSFKNI5M0SKiQBzFYmAIZVRaCDgsu8XytU8PHv4R8fy5hn97FwI",
-	"yBmYiOBR2MkoBFxYckH+9Z4mfbg5LW+AE5oykbA9oiikA5gFdXwN/4oBOWMydx0MIcFrwKEZ+hYT6fFI",
-	"GMJpgBSBcKxZgxWT6pwvjNHCI5JkjKpW77YjCDiYiIzRK9Ykdnz17OSn42c/Pnrobjy6WAUr9KTRpnSu",
-	"NEvtZ1X5U+HTnv/wA1rlEog/7elNlyx4a0DvWWjE2qeymGZsCCPbGzi5sxuzALwMOgJHdj4IGXr+TCCw",
-	"JL/9L//mHQV7xOtSxAduyDBnLB3gHY22bRBHqeljKJCkgTMQhUr6WBTBfU/5zFeuDSuWRpJpsczrs+vK",
-	"N1a4No+8LYVEm+wdxyyy+sKU9gN2c4nZ6qRCt9lvMGp6B7PQC1wTA37S8bOH2EzLvvVmlRvA3sDPJO4a",
-	"yDokRrph+A0I1/dI8Pr9pBeoNhHOTDXbOyJIhYGHrWfRv8QtDkNxynxAlhxBmI29gPt56FpHMIZZbI4d",
-	"ddACP311dk62YgW2I6xS/taFu+QGBtDF3fEDv7BgTJXWXziz+u608o1Qu3Jcu4j8HsI9OolFa/LxXRuz",
-	"qB01kosGohm/0b6H2CE+2v/6YI98jXQursO+kEOZ7w1sC5C0ei29Ml1wyJUYwt3nJa7mpeO5wKiYI/2N",
-	"6q93EPza1kPFmyAy+yhSeKZ/56qXIR9M2YrVQYRU5oAgWs4woOm05r+RrSCQksT378IubrJrtwb5MKoJ",
-	"HweRvpDV46zjTxnna6FZbrW3HKst0k9AUp47BY5IlWW5rvXDae5EpxAO9YHOl1SDVmJkEniRJwL1dV0C",
-	"cY9bQ4fZPRBpZzJlMxlednJsrY0BWDUsJZHSrPA1D4LOAK7YL+j+9+6nNK/LwLtPo68aIUAyyjXY0b/7",
-	"RZFfBCJdPWy+ZN8oXH21ui7ufAIbzVvxQzA7UAXstftQEYHcxgh0kwOryoHXoGGLc6JPtS4Y+Yd7d79p",
-	"SW2EhPXh0A3GWeehNg92kvLZ7LIrxe8ssM6tPbea2VyhnpxP5xrtns+FqLEIQ/Y5M7rauQ1bJK/KEAhL",
-	"4ChhvtQcqpDzXCeti++T/V8q4r3/64LqxXb3LMk21bjCVXKgAFxgHca1Yh5LspW4GbMmNiBdrO8HfNB0",
-	"IqCAvuK68zIkkP6tFfZtafdajDRHLbcV/nY7qr5PJPOOo3KttH/6NHnX+ReeJ89MCdpp0EIit3aQp/YN",
-	"55hj28XxibTNpeyKZTJfxumQFW6cRrJYr5mU63PeiilTgsWMFvWm/N9dS6/DsDtxuA5eC6lb6N7HfLt+",
-	"f2BeWHNkHdkaSyroHPzTGs5dt31dG1kL0rh40pyylUpF6GZbL9vpCfpZyOev0sPENALAN7BXduXSUpud",
-	"nNSFpeQC4VYdlk14WWm28aQOPU6kVCkXrqrAU6YXj13lIc0Yefro7KfHz/9w8fDR2emPz0ZSzfcqLqbu",
-	"vX/9/n8EAAD//4ZPvhYbHQEA",
+	"H4sIAAAAAAAC/+y923IbOZcu+CoI9o4oqoukKPnwl1VREa2S5bLcPqgl+e+OLnooMBMkYScB/gBSMv8K",
+	"d/TVTEzMxUTsvWMu5mbmYj/EPM//AjOPMIG1ACTyxINsubx3V11UWMlMHBcW1vFbv3USuVhKwYTRnaPf",
+	"Okuq6IIZpuCvf3nF9PyFnJylzxlNmbLPUqYTxZeGS9E56vzMRaoJFYSLicxFSpZKpnnCVF/zlBH2kSW5",
+	"fZUYSSjRS5bwKU/IezkhSt4ORuKSGTJZETNnROeTBTeGqe80WTA9t219XBEpiMwNtp7QLNM/EsVo6r4a",
+	"Cd/jd5oYKTNyq+hyyZTtccJFCk27eZBECqNkluHP8HkilWKJsUMakEumbpjqz5hgihqW9ohc0r/kzL6d",
+	"ZNyuEum+fXv2tJ/xD6xHJrkZCSEN0UbxxGQrckMzntpP9wYj0el1uF2lOa5eryPognWOOv/StwPqv5CT",
+	"/lna6XV0MmcLaleXfaSLZWbfGR48eTD5gR30/5Qc0v6fkkfT/pPJA9p/QB9On0x+SA7SQ9bpdcxqad+2",
+	"/YtZ59OnHm7aFV8wmZu2bTtnqm/XkqSMphkXjHBBNEuk3c0u+8i14WJG/u7xo8d7A3Ku5JLO7KTIDacj",
+	"QfVKJP1MJjSDFWUfDZkquYClponhN8wu5492A294yhRRuTB8wciU8kyPxJRqQ/iUsI8JYylLB+TE7llK",
+	"qCGPh0PtKQIIYPM6usk2L+SDYa+z4IIv8kXn6CAsGBeGzZjqfLJLhp8ByR8fHh/P7D6/5NpcML2UQrP6",
+	"AvpfiJ7TJSNTqcgvp1dknx7SfQrfD8jVnJFrnaspTZi+JlQpuiJcE0qmGTUjkXFtiJwSdsPUihwfHhP3",
+	"MqGJkloTu0H0kPbtkFOCzZK//ft/DaSYa0v/+STjyThXGfkeXxonVKXwwEiScp3IG6YIdeeHcGGk70rj",
+	"6i6VXDJlOIM18L/Vp32cZfFANbnlZk4Um3Ft1KqvDV3YoeKQyNuLl9punWELaOs/KTbtHHX+br/gOftu",
+	"6fePD48vsdGw6J/CZsHSAXEr9pecK5Z2jn4thvkuvCgn71li7JdFew2zIJqLWcZgKl3Y7r6RffjHXtgE",
+	"nBVTDFgNFdWtGIzECVWKM420anneB55lZMEMTamh9hv20TAlKK4abhsRjKU63pqRCHtj5lz7EfTIMstd",
+	"49TMic6nU/4R/vYrbikAmprkPEtHAt6Fxc9WhKapYlrTScbsVjTtdGldqsv0TDHWn0q1IDiv6Fei5/JW",
+	"WNYMR94uB7FE1+lFHOwXx0UJJZkUM2xKsaVUps647Alf5ma8kKkf2pTmmbEbTZfLjCfUdrz/XkthN7yy",
+	"o4fHBL5/ZT+H44graQcek2Ct1zKFec5SXYrn+YKKvr12YDVxPeyrrqvWNbiA6RK3FFI1TVzm5vNmjg18",
+	"9tQtkdWn/vbiZYn8/IRjftVlg9mgRxzn28c99reoVHulJWl7q2lpYBJjnjacYds9bANPmTB8ypki3Q9s",
+	"Qif9hGpGEiqk4AnNyr37q73fToiGzhpY3yV0Zn/z004b6X/b9a4wM1j8aMLredq6i8nxYstjc3tlxxul",
+	"/LXFhFGrATlN5tLxL/fKd3okUpZk1PI92PfviR8UXCE0TfGDZ//09HWF48OdQ0U6EpV7KGWK37AUpYRX",
+	"J+fjV6eXz8fnb39+eXYyfnvxcnx+cfrs7F+aWFS5pfqET6S4YYIzkQCXI0vJBQgv1JTnBQtRbNVIdEs3",
+	"56izP7hlWdb/IOStQCId2DM36uwNyOliaVbkds7ESLSP397uudDM4EQKqpsbs9RH+140oMmCDRK5aDsK",
+	"LSNpItbmQ3seHViqSdhQJ1dBk3c+lMWybUN+hSxwtGbnyfdAbIORwJXG3mDByRbrTbr+RhyJTM6sjHVL",
+	"lehLSxWGZZltzFKVnRNcmIkUUz7LFXOCJpvyj3ufuW2fz8F2Y1V3YSF25GdiKkHZazho+EV1rFerJbOi",
+	"qmbqhifsaCT6ZJEsx/DNkZfzndqW0CWd8IzbhknX3WZ79hO65Efk+Pysr80qY3YPdL6wfFvI4isruNzY",
+	"YWm2sAIZfHhIjwj7uJRW3FkntWmryNA05V7p1IaKlKoUhzanwqo7M9xnYVWCXzthIp1ehy65/f8htatX",
+	"bEX8Sm2L4/mWVI9fa8fSr9NMMQZMapqLxP5I7cQ7vY7/e+w0HHixUHj8dx1/S/3aSdlC2l2XCaeZHfUN",
+	"Uxq7OxgMB8POp17rMKZUMctpNg9DynSyYsVA/Jc7DeTdlrrASSAFoNQGUSVRzKqjY2rqtPrPlmcgn7+l",
+	"mky50iYS5ktH7HB4+LA/POgfDq8OhkeHj46Gw3+105dqYZvuWE2+bzXXpn1P2ZKJlImEMz1WTMvshjWc",
+	"89f5YsKUPT3xB8TMqSFzesPIhDFBwvfR8B5EmuuwrrlGI1hh/2BqaZBdXjpNEzV+/w2JviHdiQRNDkcB",
+	"N30u/J8lEerX3wqKX7k1GjvGAKcqhSvYsc+j/f2DPx0ODn4YDAePjp4Mnxw0kBcVNFv9lY2tNjlmQvFk",
+	"vsDDZg+ekTIDdmjGSa4UcCncEm9fwLMJXLajV9qwRR+e9J9MHh0O/5Q+sXRpqMm17eyG8syK8RHt4kf2",
+	"gW34nT0ypTneMmrmTEXT3H4KoeNiPaOeXcudd1ufjqdhAy/C/rWdk2Izfqtca0f7+2DAmUttjn4YDg+a",
+	"KNxeS2bVeHudwk/k7CnKdFcvL0limfbUqiuM3DCF/7RsuGtvaLjKF/Y9rgkTdgPKdNWB8fRTdtOoHaaV",
+	"ObAsk/1bqbK06fWMajPWjDWotS+pNmTOqDITZmVEvmAgxa5hDA+GRw8fbc8YsmwxDqS59cF8+fJVZDCL",
+	"jqbVuP7BXl+DLFuEVypHsn7skozmKev794+eDA+HDYSrF1SZsSPf8onLskXLIau03aeT5ODwQaeQR8al",
+	"44MNhd887ePj77Exe2M0nNGtj8XLl6/cvaY2nwu7Q3aSu+0OmJfbd2bKM7PFvkypNotkiRzq6IfhD7Ar",
+	"8G151Sx5xRwHX1nI1E5lwrQZL6hJ5rvt6ZZc1A/Sdd9nj4cPHj2aPo5fXzfYz9zJKymzzbvobTVbcwVn",
+	"hm5Q7p/+Y7BRZ1TMcjpjpLtcmbkUPWLbwbd7RCrynt7QvUh+xNdcf/hep9exb5WFyNJ7ZSXBrdZvoc05",
+	"o5mZW1EsZTNFU7gzclE8ltNpxgUr91D8XDc+SEOzcSyBNEj59h0imuUVf3pRh+S6rkQ+2iSuBIEw3jKU",
+	"DTfpNjz1smcvVlTC0kVXXUUgb5x6m/DWqjK9cjbdu6lNYam8xsH0POgTsW6Bcoj7s6yBxJ9sVEGa+VhJ",
+	"MXPHGI3bIC13h5a6F1KxsrwXax1B7n+3i2WxTnbewlmzZwaeC0MqUWA0PtInOl9arVgTEFw1t4N1ZgMN",
+	"4qsVwQhuoy7PpyyxVkQ9bplNg2SI2nhWEdSkYG+mDZreJY4nErYnq1jFdaRc7G9Fiq4u6W8dr9TS7Dyi",
+	"vynNNKuu4YWdedQ1OGnAcmnXxbsnapa2eBnqdh13+tfNwS9dlRzsi3oZXDFu78O/qsN/s8R5kvBdw9Ua",
+	"fb2lATc0Cythr264JglcokjdEY3U930Xgo84Xcsg3BtgAzGK8oo9bpQPhw/YT9sxx2jj6gzsXeN5XOP2",
+	"OXYnr3gWD8wRdjBgtLKkWPVo6sD/DkbbrpONesSb3OCm1Sbl8mh/f69mldtOfbnhKBaZuWJ6LrO0RIAH",
+	"h8Mq6Z26L0j4InKMx4OAb9e5lXvuMh7bJ+qGZqWuH9R6fg5vk2TOkg/Ef9PSObi06Ufs+8Hj4cahbOXU",
+	"Qo5bO9RlkWpBP75kYmbmnaPHD6Fb/+fB5x/84zACd+qlIlLNqOB/pTVCXHP+NUtyZRVXF5zQIO+5N4rw",
+	"BakarOJb8ZjWqwynE7iN1YtnUjXM5dcOxrC459qAvLwTwzEYAtFC6Y9r5OZCJjbS+eONtFVidX6HPd9q",
+	"WhD/QW9nIbBJ/itILGI5rWKcc09Qz/maRLkma8dbwf+Ss9jVWPL73vXALKkxTNkO/qdfaf+vx/1/Hfaf",
+	"jPvvvv9PTSS3iGTQpoUNcQfdjM1osiJorbCMVLBbNIDjI8tPC8llbVhGSfi1csi6t18xPY/Wmaniy3eO",
+	"SNHU0uY3QnvRFzfJVOgo7HO0pvHoWsmnFhTUQD9r5O8oosS9um1wTPDaNNnCZd50y1aVudBjWNHDTfpa",
+	"ab/ubSPsmHAOm/bghIqEZS/kxEqjTJs14lUCr2ZIT4pRLcWA/CzTFVnQFZkwwsDNaLn+RDNhBjVpGD9a",
+	"FxWDb5Cl5Wfa2E3NpJhB3KPlDPEQBiVKzjXYBWEOLG1cpXVzXxOTlmeoPFXnD13V5ziV6paqlKVjI8dc",
+	"aGO/amSAb24FU8S/Es0PfSy+HWIk6Yo8ywifEgnf2N9pZqWMFUQb7ku1nFPB0r3yolRNiopB6Ev/0DL5",
+	"PEMb0pFROVtrQFl3jF7IySW+WAslw8fNRFdyRtUO/VpZuiJixRFUcupWMcju8Wps9hTW1qBiBKy5oeiC",
+	"+U79q+iECt5bMOu0DMg7IjdIfFm2GDtlbTsr3zN8uWI138HY2y7fnqxRVSOTxoYZbSHoXYFqrcHzafkA",
+	"6tvti9ngK72jarle3ooW4LOFrqKBMp01HpmM8sULOdGtfPrYyAVPXBhmP7Hvey4FklUu4BlLyXs5QZ9+",
+	"tJaDnUwX0SpAFLft61aqD7ajMgtaZlSMjeLLzVSxllleIOsiVrpbLOH0+p6343kPNg2g3QBQHtqG3Wm7",
+	"Sd7kJpEFu8A1c7OBAGS8PTGiecGo0ERIXFRg997m37BRuK31Lu2ArJiarYjfeheslFAM3wmXTzeDdSFg",
+	"DjywxHE+p5qRA7hRtoswwC5eyMnGwDw/4talxGbag4zfywnReZIwrad5Fs2PC2QSSuYi7Vu6q6+XW/Rx",
+	"i5D3dgm5BmFv4DVCp4a5KNBAdOuVON68I7HC47eCKSLkrb3c9aDR+cmoZmP2cckV040BGm8F/0jYUiZz",
+	"dArblq2CAl8S9+Wg/dqPxr2gH8dpXuhz9SwHvzJaTtHXa7XeONmBaqJYIkF6cfGc7+Vkr7pmm8fi01fS",
+	"8ZKuMklhSZuttthERa60UhNVM02+J5jnANeHyRXmRWDzfUyjkIpYXkFX0RZ4smzynNTH1quQViN5Q5TN",
+	"Onn7vJTt4zm4kUHVIRS29r2c3J1p446QW55lLqHIqt3U8oM78+8vQDhCRokPdvruOgYGicY0CN9mmjwY",
+	"DjU25KPhBmV73nBXYrPjV8yoqkPloNcafeReByKXS8/bueCG08xzkJHoXvKUfeB/2T9hGVOr/Qum/5JD",
+	"rN6N5QVS7A3IUzfTA/K3/+U/W+JcSG3I4UiAqw2Zjibdg9D69+QA+odsrkRRPd93S7o3IJfMksxIDF1O",
+	"BIjK+LbtUbFsRbqVcRIpslU1XvNgk0ILGskGRcdpkANyNiWamV6Ra7HkQgdqhPQxrouUNnd3QzjMSECA",
+	"GsS+LHM9JwuZMqCLkONGlor1Q7iVbdVQNWN2Pc6mROJp7Y1EbchEG6qMJq/fvnyJAdmh60Wujbusbzgl",
+	"+1Z22oe/Idg5y4px5Jqlzr5qtTGimJJwrkRKLH/oT2hmO0xxxFrDxlfCYz9PZQssadJw/s/8ZX/21FOq",
+	"+yA4HcpnX6pkzsCCxMI4DjbzgXtg2kZ6k4Dj00at9lu5deGexkS8RorsWwF4AuEQjETXZ8jeixLG3DEv",
+	"rc7Bnx4M8b/NvGWdaNl0jZT2ccMtsjGbDiUXGslLmCoaWQfr90jTMXaJnFRrPhOoRpQSRd6+PXtaMUD8",
+	"MD2cPGSPaf8geZD2H7JH0/4TOpz0D5LD9AF7OH1EH08a03c2M5VAzYppO7CUUO3MI96OjGGqjrsN8HR7",
+	"6Wgk/M3q+AK5rnV6TSonvMwWRqKRL5AJm0oV5el+4TP+mWYZlF3abTNPreBGjVS1GI219vFECkO5AE4C",
+	"EbGuFcIFGjFR0b1jnAfp+phz/le0iIUIj73GqPPtI83DSJtSM0EZc9Fq/1CEixTT01GSLvwSYpW2jDt1",
+	"7XhD9IKLM/zwYH3k6Zd1//qnGOEbeVv6GILY6IX8D+T9/BYdciXS3XySW/WNt8Ly7zRoGkibsFQQBlRk",
+	"5nj1Q6Rkvwj29QPSg5G49AFEYWj9CdXeN1O6c9Cit2SqHyyncWRSe9ra5/oS22j8nryKWx3/qktwvVvP",
+	"aYRfz6MXdxXmtpbkvF2/emeHu4DQiVX+qLfoNHBXK0070rirnhsH5IFqETV4F8P1DkF3T9cGekbj2Oqi",
+	"uIyuvyJZobNrHNKz4qhtF4oEh9TSTBT79pmOksbdrdwOY6AGDED8cu6EkMfd5kKICMH1/WUi1Pyy7ydf",
+	"wntQXuteWZ0oUWjzEfX7uC5lsVHiDmojHlM8XGCJn1foI7IfhXSGu8XZnrTF18JGNncabeRO+9cuX516",
+	"yQqzXAVLjAO7acwdaQynO9x0U2yvIh+HNyNgjAnGHpVGVNv9QnuoLDOmLxD8vTiq8fI6ITvO9cpF/FcI",
+	"qy9J36XcsLWCVTygP7tYTjeSkMRTv8+3OzTRbRZJUGv1oJaUsNqJ+ewY30qc8gZu106l3n1bKAJd0Hn5",
+	"tC3vsD2dcFcOH24WXHTkCq0ndF124gYjc0i7qY7g1ck5ZhMBhogUBc1sXIWGBJ56hn49o6d1/ZE/nj3d",
+	"3HNbZuUatb9FzIhTT0mUwbHp0EYZlNsf2y1u3ED5IVhzQ1A4poneGexj7a245pyfKiVVe/xZygzlmb4z",
+	"f2a2eeJbaegfXmi4ceC7BdOazsrc4kwAHhrxdOjiDxu36b6DzXDwm2LMTm+sLPucayPVaguLZWRLUiyJ",
+	"FMcVYTcuuq3CgptduYWjBr8jiplciXJG+OHGHCvXaWsMIv7eQ4+NGzHYHreV7j3CByxUc0xideFvSlF+",
+	"TauO0e/tlO0vnEY7L09YG4TGIln2rXje95uyC7t6c8MUWtTdhmJEf51hbUjWe7eJ2lvEGzBh30d+cr50",
+	"2ZoY7t0K4kLwxbYshHLiwXBjcHhjF3dXLcI2FE1UJlY2BngaaqE/tBBFlqdtVQ00osXmHCUXJfPRGovi",
+	"lxKyywZuKlJPrOtM2u3AJZ+f8geJLDteRaUcGAXRrO3XUJMJXKzcHebuIt3ZNYfiy95ATUetxev/pRNm",
+	"qzmway+9TZoWyoh3Z39bZCi3q0Chv7XWvOgEt4tHLXgtzRT6W0E692B1aDctrDZGsoKEGuV3RsLqDhrY",
+	"dnaCXXWr48TktAAUwvHaHuxNGik6u1zEX1zh35r2qoJ6U5L5Bpl9rc2zUEX9OlHvxguxIaUc6AVdLrmY",
+	"DUbi//u//tv/QY7PyMnF2dXZyfHLI3IO+AIBxwChQcGAWyYXLuzYbKc5hA86/0Vt5F6gL3GfcM5AeOQ3",
+	"LN0O0MB59DteiShxheLHr68WBPZSdhzg1Js2tDHaEwJBMFQhkQr8+0VeCBcl0NbvNLl+Lyf6mpjmINkN",
+	"QZ+FpgBDxj22fc+pRjApF2G67xpiaSnSYeO183sG5rWomM8oz3LFfM6NFOR6SnnG0utBxS+KETFjDy29",
+	"TZjC7xxAAlhFwUe5KWTWcT/7EZlYxu9OceHch9iQSvzP4ZMnT5483Cb+564RvM4mhb1/p+vRvNXR/Gm7",
+	"0XyBSM2gwFmlnmlCdZ/rHysxmn9EZtYjM48t2Y+EjyOHQInbOc8YuS7xKAJwBclPJJr89Y8YuoQBhn0f",
+	"YKhvGVuSBVUfNOGG4CEmUiRsJJoaZaU27yHgM8RmOQLOVkC6wShsD35IaQt5KfeSxbZUcqbsPdiQdEhd",
+	"8hfxL/XIcDD827//F6sOlLj74GF0D04zCea2ABdQWbKWMWHaaDymcSQNtCVEzsshNf5TIqRh5WXSjCoQ",
+	"Wck047M5qHkblwc1wt1UyiumFhyWDQMW4eZIpB2GsZcHKUb/4vLNa4cXQ7rBQI+d7q1JR2hSo7YMd4uj",
+	"J7fls3DjUk0cBGYTZ4U4z3UJCvcacfs1YmzvlBixOdT2eLcYW9KVEJu796WCbUHnaFIstsngKF89FdLa",
+	"Ik73hZz8bOWJ1uCrE0kzphMnDDndAcWOEBrji7GEbK1BQ82BzFDdfJXbhvF30IWWy2y1dU7XCzl5aj/d",
+	"GJq4KdG5lGwWnQEzZ5q54W3P9XfJ44tH1vMLtX6v2hwUdjVRPJSYzNegZiQJs8rBesha2IxS/hpKTGXO",
+	"sxGqVjE79qbO/L7jG+iWtTqULu385pDvSr6a42G+X5xJY8ZaW6b/BeoaaGvIDAW2G9qDmgfkWkgzBinj",
+	"ukeujbtt7L/tD1OZi/R6b7AdvJ0bx2YjQtVe4fcxWuUWosED0p6riPP0R8/+QwqGpZHeiGxFppxlqSZL",
+	"xTTIzoo5PpAORuIa78prwjUkhXIxm+YZZOrg9XWN3Oyn4v79kVyDwnddvDUS/jWv4DVEV26nJXahUVl0",
+	"7FqsyGz5UhvF6GJcNhjdSW2sJU1CWAEsKqT36C+jMrZLij4jdFqXGCti4uOvKyb6gW0vJE6k/PA1RUT8",
+	"OEiKNeopyHZXcZBm2RZYO5FgWItQeM1unfmzZ/UQo6jQMD8uZvXBNLCXFoZw2WJytXSc8SlLVgnAKlLD",
+	"BiSsFPyt4fhHwnQv2GR6WATk2qGQgKB9jfV9/LCusRKWkKJvChk9176zEkL/rVQf0L5dbgR8yq578FTZ",
+	"3kGEcv02+l5j8IijnYAVSxDNPvMPQ4Sn6HWy8mLGZvhsIVM7EQCkL2CCwS7rW/kp5YnplWs6OcuvXR5v",
+	"2S+BQ7vqKghyCUECVpXWRSQVFyQG09BF2Rfg35Hx+PWbq9MjcjUPkNwaeqpOpHszHDweHJApo1bs3mti",
+	"yXeJLCNds1ryhFqpYtTJssWoU4EEB4ToL5tn8fqzUSU3R+6WkSUxMjmUH4HqGSPb3qhDfgrx1vj0e/94",
+	"qdiUqfC875+zj0mWp/ZxOTbJoWj3Ot9P8nQGWC19oae3Xygs+M81vErS1Wxxg+kLDlPsPvArS+e1Ht5Y",
+	"C8vxYWVcTCXsRenQdutA6paaL+fyVpPbOU/m5feLOhJFrq7EjS3Hepa4QaPIcg+hkC0Q73eOhwQ6LVYo",
+	"JMaUbTdVcPHfIQgS+cJXintsBbtvED8a0O+3YYYRH/wuyxbf3YELVtD1v0i8Yw2gf3tG0ubLPa9XOLjn",
+	"CNANsZdNe7bWoVsGrmrA3ZOZu1kaRAQq6ucryi6B+lcTlqYORYoLKF2LcPhRPlqflKZhZSm+WGY84a4S",
+	"65KCM8Yer8FIhGgr2GaGhXI1wXQ3OzIcbqK4YYrTkmSBv7GUQLlSJ1rg916saGJ305blqWGRr1wPekBO",
+	"qCATVsXy7laEBr03ElKV4L0rCNd1bGVdcRzUatjIJHcx3R74e5lOO70OTW8ABqHz7lOvc8smY7Rc11DD",
+	"E7lYUJGO0Q2Kcaa+yoVMdoUNr4pJDYLKMp2O2UdjtbzGwmO/NWGCu32G1Sr66MHK9eKlu2sOm49i8IUp",
+	"IsGqWOEvmSFFZy5pE6dmha2uzieaFdJXBcy+uq/3JB3dI5r3WuNmqUpILA5TKNZVufiRHgAzAJbT8i6/",
+	"bk5MpVk26hyRMwFiJ5i/8fQH6ZaKVZWD4KdFjRLbwhvBsIOlfTG6+yaQIUpn2OIefvv39pPjLCvAxFy3",
+	"XKB60uUzAd5c7HqvpDDiZEs1Uv6+cmFg7bI6rptd5zGUQS+vX2B7tVU89zXTA/ljK2HARpKuXd5ygE7t",
+	"jg/Nb7jAkBmsuZqaZeMTpynjJkRxoUFKxnp8S3cRuR3XWJ/auK2GF0MF41xY/dIADE1Rwth1ccMpsTLe",
+	"UkkjE7iIPo+vWDUVKcghVq7liBvTY7fH7YROY/DOaMUAYDwexymOgQCueFxwAW/m86fPLMky/Vmg+XYA",
+	"8dpiZfwmHWGZTsulhpoLL1+GyukVQ9Dlm9fkskizx/X3FK/RU+o0wMFI2EUpAs/KFBISi+0f0iP1Fm1V",
+	"7uiqzd/t7ZgvILI3PpyNxpp/njMzx0L/7lPCvGzl2giLMZEyY1Q4BsrGa6qquhBJv43bHFfX3hrDfvHg",
+	"wy1Vsx3jps+V/LgKFU2LMw17FaBdSNcFdvQw4KNH0OzNxaxHmEkGdv/Oqdao4zqohVcn59i8bZCJOYJC",
+	"uUrmEzanN1yq2s5BBz5+7YEVp11PYa/cWDpHj4dNy7BBUUXjUekAZOyGVWo9e4rBK//zxY449s2+XYZ0",
+	"LQQc7M/1ztGlcy8Ar6BrfDZ8RyUnO062j1nDBnz95qpdW1toTKE26dhK4273io0Gb9ZbBr6eJrtMkwL2",
+	"tawyjQXe6jaZesW3NRegm0gRTNqgElRKsLX1uLtomGvMQttauCr91jaObeX8LaYeMjN3Omj/w1nFfr/U",
+	"4DXlAttHsCXpB0d+OOcy24nu20xRV+Vyjr+vGWqNwam9qkaLlFiCLiqkz1CsEsgrwjrSnwN2RrNbutIF",
+	"xlnhCQMm/bmQZ7vgiK2BCfP5bLthhB03g4KFxkIJv6+IC7a1uwqUyXaYOLxCayglfkpbhVyVbZNxuZcN",
+	"VoovglF2uAOYRgRO1vFrs8VZaws792nHpZPmQcngvphm1BgmWGql7DwxuWKDkXircanvDlYGJws/JN1i",
+	"bj8VGIM9cnx+5iv1l1+iS77XGwnbz/HhcR8K6ofozsqrh3Tv/nDN7q1GUpVxedqKeUwzO3MLBlav8PZR",
+	"URwDFr5UQbPrUwbsJ3TJj+zC97VZZcyZUpiCnw7pEYG1ZtquO+kChfWN7MM/9ojO1ZQmTP9IlnKZZxBc",
+	"AZkcXkn2L6ADv2TqimdGl9z+/5DuwGCt0DqeSx/w6RdsOBg2HsfnV1fnxL5elEwjUVZc0WnRQHOXlpxL",
+	"XQ4bu7KvNXRFukN0tFsuX5JFrLz9BWrghd3FSFRH9Xv/vYNDliog+05DYeJvqyiyo/mGO+zw2J8IK41n",
+	"FBmwHhCP3v0jxhP605Ri/GGZvQ1G4pQm89BSIhU6tNC0KYUD+hvQQxphxKKdU0H8NyS4LKmxjUyn/CP5",
+	"nugPPIuQrkqBPcFsaq/S3GAZpWU+yXgyEs/+6elr0oXGuLb8I6GGiaKezKuT8/Gr08vn4/O3P788Oxm/",
+	"vXg5Pr84fXb2L45Pb1dJ7PD4Eue7MQO+vUDb/r1Wz/8cwcVbDtCa4ERsbRfoCr5KqAhMNVsR7pwaRdUi",
+	"q+QUbtmy5rfDMjc5bb+OULQzwth6WSiewBZoOAGItSQYOTiKkDcMYpLeQbQ4kWLK1SJgs5493QVS44+8",
+	"/z/y/v/Hy/tvCN3kiwVLeRkANcr218zky5Zc/1K86LqzsR4aCodeqc5WsW9RyHAtx69AxRg371L8XUNY",
+	"7WAkzsO9XiQXOK+m81nG86lZgS9qkbaNcbbuMIcomWLn9w2d6X3Hfr9UOG3kPknmmA1YcJz2ILRSGAoG",
+	"bBVnf0OgIB5ly+YSpvUYui2OY9ma5aJZQpiptqzDIBP3tYvfRZeYu4kai1kWzu5tuPAWVQTbaqNuR3oh",
+	"xAloKPOVO+zWoWZsRcVoP526DEQLGBiE5kb2fTM9ki+tcgdZ+aHJKNwqFjeETzONKlw0EhTXkTi7juyx",
+	"5ZjMfYp7ESOTyRlPSmFe4QQ41wrYMPIscxDruoVGq4FUVSd85erZ3jVep+GaI7vit67Fn21y434hF27h",
+	"sS37NN3hKjsh/TGqeAubDk41xCyOPquZo+xjuB1v2QSIt4z7VV9NbGmHBf1LztSqwa9SWSt87V2rS9el",
+	"fo9v2SRajjAv+7hpMd592hagJjaBw6GOcxfvF6umXWO9CIXCrK7EwPwWFE9/CAak8V6L67+4YruECkIP",
+	"ad+OwMvE9jihtomvTmQaFJx0JCi59sO7RmFjQK5i5TTSONH45OMJ7NftyidyChYp0t9psnQnzGUDj0Sh",
+	"6GYrQtNU2Z2bZAyqf0BdLBmJz4LdMFVoyx+EvB0JbqBkDmEfDVOCZmCEsjR1J+036DJfBQduF8ihXnHr",
+	"tyll9saLIZ/Lluod8pkiQN6GUGVS0qIHIzES6JBFWzR5c0FoBpthuBWibjglgmElbLuWmOjy6yiMaNTp",
+	"2T/R5GP/GEXWoVHn3TusJXpE/Afk+PVTb3Gy3RVv77mmp1TbL/2H73NtfJwR8b8SQ2dfKGHpc6CwPy4h",
+	"NRf56wkVUvCEZrtF+sT1zfF7Iiz9ZVBqqBarNQcAHsxXDjlgdmRWhsazGcqsXuShnso4tKkKVCFv0f5O",
+	"O5ublZdWSzYSkAnd80AA56uUCsMTCB3IyBIDiixtgB2lILmuHxpa5AaDwd6ez5bzCcZGzjCIC7gMyCiv",
+	"ZMoqCXM+bETmJgAQ6JG4nUvN7MNwq4VVJ6lkWnxniKaG6+mqOkMcWhQ1UsegLG3nc6obBI3L58eHjx6T",
+	"OdUA29RCAc7LUrg59JwePnp89Ouw/4T2p+9+e/zwU3PlFr8cDT0jEVgWSA13BGw35GgkCOkTDJE+Cqv1",
+	"nXbr5GoIIqgxBPu6lO94gfwJK1wgRLMF7Lrecx0YxRNzhCIkhuV0rRTcl8pqL1xoBgmsN6znwtGV1Lrv",
+	"zc12rkSxjH6EPdgbiTcLbhyanR2QvRf0B750FFsLAi8KR3pcKh+rtldOLcWVAK3HjrgxYfSbTzAckOAf",
+	"3MiUrS6DoznajTf/tB1bLsfl+E86vWaXwLvmrIh6NsO2YT3vvsmw/eLe3hzD8SoO2CjXHBq4QOQ/Sg59",
+	"IyWHonHeY5kh6G7z6t8ldDhC/8fP8RqvU5tUjRHAy3rocRytUI44xoDgHklybeRi7MCcSnHINDfzkN6P",
+	"YclVw0PpFT+rcpP2tX/pH5+f9f8cFMmbQ8ySbA1MdigOXod/+KhJ5fxi5ZtStpCdXufm4N6Cg79aIafN",
+	"7K4tjOYPVrc7q9ugAP7HYnk7pa4E31Q1fQX13JDDcpwb2Z8xwdz4LEMM32o+E2C1txv4jGrz6uQ8Cuwq",
+	"m4ej5Je5vA3usJDItCHjxa/5hkDMiGi9VAuTyeCY6pxmrVJtyx4ZSfwGbJFBsFVeS7RTd9R9T7ZRecM+",
+	"QX/k+NnV6QUoI+A+Q0/M07Ny0tF2mvCAnEhhmDB9Z7/CD6J5WSVwMBLeWu80JrR4h3rrZT0nYs1Blm/W",
+	"Nyv9bFQ2m9YbshAX1JBRx+mYiNs6Zx9R1B119gYESJnqkUhq8/3AVpjOCOiQyJAciDW5upWx7wDeoAs2",
+	"EjCiOb1hIRISYy8gTtCOCreq5Ge4gzb8h/Rz/9JP4V66o9mqkulTsTqCvbs4wXpdJM5TNuWClfOBgK8G",
+	"DuwMyBTM9cRIuzNGKiy+bvlGj0xllslb+KaAdPBFheO43U0u8y3clLFHPLZJ7baSF/S2neehL4/c0Cxn",
+	"W99s7iOwuFAhJFq9otuN7Bc2vX3yrzIl++QFTT5oIPa3nrGlbJLPZlzMfkTOF5gOgOt2G81we3aTb+fU",
+	"eC+HM+hxkbKPDKXo7VlkYxf3ecdghwNyyVgjv91inFvx8mYT5jbM/K7MFOn2n6kSXMwa/FmvCwPxrXuJ",
+	"ODPwqIPXrT1nDet+ROy649icL6awDicmc8E+A3K6WJoVOuOBLwgZuqp4fDYX9vlDadtKaauXdmtHCi1X",
+	"uRuQlwEs0JWv63oXbA+yxvy/IdF4JKhiHsEagicW1Dj8o8nKx3vNpfygo8hdRAYkyZyKGRQtKVSgfpTG",
+	"5fsvYqBC0F8vCowaR7lsOB6G+MheDHS/YsRv7sS9a0+mNE+5ud4tQ6IaJgi0BsMFWzc4XmVbZOMa2Cns",
+	"cecAdz4twDX2dgqo/JwiwDjfEPjRRazWHpFZui8ilEsglLLsI9jtOAQnFQWmeh2ZpcUPxWMP7OscrmOk",
+	"nEb1BEa1Qc8qk3ykbXnq7vQ6IcwVRr7kCgISAfrUpQ2GV+MJKHvtsrgkdkG05adtmYdRw3eGf0OyiK+4",
+	"PmTVh6KRUAYhJGP0G1LuW9TGtaHl/+yh7ZE0ZAIum/RLRZQ3VaP0+WBxHPTaCmkXDOqZvJCTVnh0p0aq",
+	"vuYpIzcyy4WhauUKoShsYEBOaJaBw+06Qvu+Br/bSBQJ7N5tdV0rYXHtmch7OYHYCdc04Xok4O0+RI90",
+	"Hw4fEGnmTN1y3YzZuRYJPQyUF5UBfkT/IA6zVPElHuH24OhbY3FX2JgHeEaRA/3cCUNsFpBkv/clAImZ",
+	"UzMSRvHZDGP85mEz9gbkAqDGi9xyD0eNTkZYRz7F+BW/zIYvUblX8pZIe0FcxyVKMK6tXN+kosV13lxC",
+	"ydwjH3+NwvvU5dlvjxG/iVLXxOvnGcCw0YhQA4l6wGMHu3vtrRkOpHAkHKQ8UF9ck8K1gAgv3P5NU0AR",
+	"n9jl67vaKfYepSOxZAyLNfCEDqoQ3bj0U3Ayu62ZyFykdpwJ1WwkbudMMb8P9jiVqiFcw3hohiOYgaRh",
+	"hTsqRqK8XSBf+L2FwhqW7lPS5QM2cHgD9t6iVlVk6QgrwHynyZyKNLNToFyzdK9HtLRC6jRXELHga0RY",
+	"yWIpteZw/YrUE1NA5LOU4heRfZzTXBtPMTuVBQvFGl05JHhtQF5Lw47CBFPJNHn95opwkSi28FLISCDB",
+	"2w2FlQcWZCeKsVz2M4wXQ+XS1yYmsAn2e2/vcS/YUwerqZnxAhW2B78svckN9D4hb/uBdLB6VfnAHG6q",
+	"LrBz5ZW2iKzyGjefr3qQezPKSS2YvYq5VQ9sP8HAC6wyIlhieZhaEUwlk05iJtQZnuwpc58zhKOiWaYx",
+	"mYMXGNP3g/e8jZhbjqS/I6jqLgky2+FJ75AsU8HCuAP+1rYYvXexXwa7WoMhsg73dJ8YT4eR7fDg8M6Q",
+	"To5uSqemhvdRSVfY4CLaLbkoSlPaLbVoKwyQrUwRgeSSdXBTm/IwdrFOiLSpmIbdBPxtP+wFbJKLaPcG",
+	"RIzzw/YjT1gIFjOSaJaxBErtKblUkKHkZ/nc3aKQ0Lw0fOGsxJa5O/gsZ7gsTATFAHKAL3jJDXv58tV3",
+	"msyYGcd22e5eYa1Lc4gMWxYAxKWUixO5WEhnPNVHZNShwsyVXPIEo6HkkgnK8d8zKWcZw38n0t6B7p0s",
+	"owvqoqdc6KL9q27IL1rfTME7mI8C7Xw2KFiU8RYpSc21qRwFNd6WPJlHATm7hScDZm2UyuYMnkVuSgnb",
+	"BijGMUPLH9Aj+rvG/H7zgYONIFq9DroIsnuzcm6Iu9s54M4tQTGGeOkbyVLKNYXCA/BKg/0zoNEen58V",
+	"CC3lddxHw06n19mP7UEO72VHHHVHa6VUhEWy7FuZre/ViA15LYWVKBeiJWH4M2rNF+ehWP8ITMuvUdNG",
+	"oFPjVICutEWCuYtMtoy88DA5hx0TvvRd5dBvKqPsPdmgaPKoXEr3b//rfyMZX3CobrFBBcFGWmOx3eh6",
+	"WJFVsQSwsrjSW6MtFWu1as53rG6LG1Gv067NVNtsN/hvzDiwE1zVql4XXj2ro7uoCrcWvgC2awF15aQh",
+	"ymIk0HEFHrEfo9CBYlDuM+LgyPScKqioC+aBZuThe/EQNjn8nKOjscSnM36C06lCz5DsZQkkymbbGkVj",
+	"3uhYdCEs6FnsNvsN9+7mMnQhLWOp+Iw3VdPzof1W/8dpRVaA0vztDAfkrNCWqasi97d//69NYSkpS/Ml",
+	"pgBhZsNfcvCpYI+OGLypqBz+vwamxkr7H4S8FZuRA2CxexFJ1ZajRASNB7E5gnk3gSlupEFw8lh92GvP",
+	"5dnhnPb+kJV+L1npd8pIuFI0YeDqbSoGnPIbnuY0I1bV8q4ZjBdyDvvLy9MdjELHzuNJDSkCUAoHaGmW",
+	"t1J9YKq5mDCgNGXAFZrrt4YMueJFcvbUVQbG1Fg7pQ+VHbUr1/+4+uuffnjSjCFjKM92NM/A4vZ9jBPx",
+	"bVQjPl0lx8NHRf3COMuY6g+R0cPDK97JgxntZcQDbQ9jbajCKnrwZxiW+zsuswcPQq093HI0mrc4MEvm",
+	"kWpvNXhYqFwz1kvavMHnWNnG/o5xR1a44JMc6EnRxIqGc84UVcl8VUYEXVLRx+bbYEA3eymDx/5Luyl7",
+	"HdidxjnDUa3VFcVxTFgmxawWOQCNOatqP2XTh48e7+YaDaMppymvSU7+BGGqKESCnJ4AZ2ELyjM79/mK",
+	"CkXf/8PMPhgkclEgkDy1v5EL+t7euipz1lN9tL8/42aeT+zb+9CAVvT9vtd/6hAfJ1KhahYib72l9hXT",
+	"cxIgMdy1BEnNf/s//+//9//53wk5uTi7Ojs5fkmevbkgx2fk6emfT1++OT+9uDxyUb1vlkwAuGYpbDF1",
+	"oYhWwDh5c3FKTt68vro4PrkiE2ZuGRPkF1k4fKhIfSEQtLBqGIS30P98+vz4z2dvLsjF25enl5BB/fr0",
+	"z6cXZCFTPnU5A7Z/MIPI3BD20RV+yjVTaGO7oZn98GxKDNNGgxeSQD1BJhKEpXKt9MiUfyQrmSuSQGKt",
+	"kAZjd5cssW0cixWZKEahEqsLvUGvD51OWWIQ7usXGc8LMgYWTGAoobbNXIVhO1+ilrlKHFPKzRy2yS6t",
+	"NzfjmvyX/434G/E510aqFazIDVyAR+RMcMOd8A+bDVuB+YxW5sp4wpw+6Qjt1dlVjcTkkgkczkCq2b77",
+	"SO/bd4EnGDhRdSI6Pj/rNAF3oK1wyTtHnQeD4eABCtRzuD32IbCfmSaZCpFYJlTzhESxkIXTCOqsBAtE",
+	"jA9bdfGEsEzvYb4BMzLTWM1fpIUrI+U6kTdMrVAyxjKVXIqztHPU+YWZCykNBNOgUgyzOBwO/Sl38gNg",
+	"zOCB2H/vXPg6BLiuRY2KbTHARJqxM0qQJp8AbmOxoGoVv6KkNBXoEw8x4mwy7+yX+/SQemvMpu2wxPrs",
+	"n56+DtAdHrYj4ARBfZwYcSRAc7hKrQNy6kErjg+P/bG359Ux8giRze8Gcf5tORJTZhKH+UsSqlJNute/",
+	"IZrGOFfZp/3BLcuyPugqOKuB3YHrPdhnaGckjCTnby6vQFXtX5yfkGt7Eev9v78OgHwNZGTpvR8Mq3DJ",
+	"KwCnNFzkkCdiJ1EImpiHPRJFON6PlSlyTZY5ZGZj1IZrOhChX94mYnzJtTk+PD72mOX3RpKhE9vjOtr0",
+	"1ewiOBeX/6CqiC+WhrRlDo++4EAhjGTdAM/83tkLjymCgDbl0wOTCHjQARTeI8pw5aBbyNuLlzo6UYAz",
+	"jMdp/VH6hRk8LXIKjm0XOJSVD82MrWFlkxU5eXmGrbhae879HZTcguZaaef+CWcnqqnNvmlj7ILVX4x2",
+	"wRmVo43Y/81LaZ9wM6zk3rAtVsIDWKQoQheghRDH3yN/eFIejMQJGDEsaZBRFM046jhhFKsOLWUmZysn",
+	"LVi1hxUIMn5vg7DlhSW42GGvnaMORzFzgyR6nptU3grSvTz75er04tX+5dkvZ6+vAAnGj6scoolORYjG",
+	"KXLycDjVUYK4FOATFVtYGconSLg2u0L6lB7ILYHA4T55E3dwy7OMzJghh8PDwo4sBRHsoyHPT4+fenbb",
+	"QKNvw4Ieu3iJIk+toVgkqtSxViBJKcK0OY44z3nq9B9umwFgsyCJR86+apZRcQR2wWT/9K523h62mQeK",
+	"0Vdxuz71Og/xu6/DNx3etrQ0lIv0m+Tb/vy6k+IXT1UlnxKHwFDeVlb9T7m9g0sRaniU5ih++1Lmzsji",
+	"kXcm/jW7+T1foP7sKRYVLYHCDgJDr8TSY+FEqyOYkUgbQ/tTlnAra+vIzUA1uW4wOlyT/ZG4bgycvnbx",
+	"zMCP1uUtBOddj2Asd49gKHcppWEkQiR3j2Ag9x54MmimJQE8PCwiOFcyn83L8hCMAcMx0f0RIusEu2Xa",
+	"9MFS3nahnd746i3r+IRLayvtkT/8CNcXTr/7qSDi3z/EvWayaJ9eUa+oApTsttaUM3MhPGWvZSUiPnhH",
+	"vrdmoGWU5K5iGbuh7r5qDL1vG2WtilAY6sbRvKIf+SJfEBHcoH6VpCPClj7BH1rqK9jSHw2hDAJ6SR8N",
+	"h5HP9KDuM224Gb4gh4XJOKPBOk6LL0b4p6HCmMZb56ty/Rua8RSZRpSk/u2qDc6PXb4sPHysW8XiJnKX",
+	"D95ETiHfpH+HpvF9H69n7xW0lETqfoP2cFXSPvVc5lnqLGou8xXmpkkuMsgTjq8+yytUnq3IRMkPTETR",
+	"bWDAzpeFcOsgdbmwekqLJeW5Dwu5N6rHHrazpmjimXOLMcUteDJnyYcmQwpcBenOO+ey1IP9MkjJE5mu",
+	"oiV+KpMPTO3/4w+6NBJHXLdWyO739dJFOFf3/dJyVgdzrMkvp1fEERyZQJ84RPAquwFFIM+uAn2p26Ny",
+	"l8SF90J197nU5uiH4XDo+mjY/ueMpmv3f+M2ka5fOTvqvW12rfpJizWsuNHtHSe1aRtPiIO2p08zkVo5",
+	"jMuUJ1F9B6jDyRFAsFYGwi5hdDGj2KC30AwvLSPSdi/B4Myd5bfWQX1A9mu/sRlqd9E3Lv0jgOAuIGok",
+	"44IROi0m7M67bSvEIgXU7cYCE9ViDQUOv5s0WNed1ijVBwI4MTSTglUGxTWxim8vmAHA/VosOGbIerNw",
+	"A+1dMmFpL0htTgP9WaarLThPDD5R4NFXUkQRzL2KBh4h01RyEEOiYBH23hpP/mD4CWD9tmOBzRXcWlW8",
+	"YhkxHVW7OhsLagjVJVrZq+nEn+6RlbdWX2mYyvOouAoA0jdpz7+DHFNe3ArHaqhVWSoU06bBhhcqZq7m",
+	"y+gln83NLbP/L7PGoqaYu5f8fQSRxaVhLekqkzSF1AkFlrsp1THpQOC6q8SFkSP5pH8wJJolUqSfZRHz",
+	"lykUQ3MjTWTK8OrqClm+P8EidTgckjf/eERey2rXukc+MLYE3m2F3dggpfHTQ3KcJGxpWHpErspfpz2y",
+	"xDQy4P2wUOBUKPHahwdD8osU7Ii8xfgpXObwbeBicI/Xv380fEB8fcW3Rb7FUeF3A4mtRyY0+UDkdOrr",
+	"GKhVA+97RrUJx+PEiTK7mdViK2C92Nq3ZVobNmF11KjAUSAo3iXQIPD3nCNx9F/IiV6XctXXiVyyFBMN",
+	"7anIhc/wfC8nmtBbyk3wNsPsv9NkpiRUoflXpiTZJ3QCQM8/ESHJ0lGlvQ4H5IQiiIghB8MhStTFMgUt",
+	"86CkZTZE5gJ7OhweNtX/rVJ3G1n/R1mmhwfDprqe604xqqYP1kiwldNauQXs+XR8uEXfKDH/926xm6VU",
+	"n4IfRqcJJYLdkkyKWd8Fv0OiLbIM0G71SDQl2XcRxSjL7CcuTXmvUjPBWSFdIUDbrpK3Vge8DqnTiFkS",
+	"V1oB/A+t+UywlPC0QXc5wQxklzYbYXRDnqbHjkOxD/24P12pnF2PBFaD0YSLG/mBYT7v6zdXYPvzrtZX",
+	"J+fBBZ1yxRKTrQoP9Uj43zRjSKBw01iR8xrEvH27KNfkezJn2dLl5+kmjRedMi/kZGeRczsxJLTvIRka",
+	"JJEXcoJZs1GB3i3EuIP7GGS7vBRG6VLngRw9faa/m/jm4yWd/BMd9a8zjsBCLO+wrDlOv2xSf626Buf9",
+	"vYyrywDTKPjH/oSaZL4FF1nmes6suEUzphOWEh8VaTdpH6rPgjyWssy4wixWe5OKLKRChgAgEPJW6ICr",
+	"iPpraAmVQdh1ZKz2nAqIeIJo90KOJzBsoAqjyXVGtRmHG2pMDSJPXEMrYzTMa/t4JCBIhQJMXp7M8d5p",
+	"YDtvfOK/vBUR0yMLurIC7YIbN9MBeRpm7GYpJOKAoGOnxEjRq7GUyiWFXCv2HoSP6yamcQkdvZCTn2GT",
+	"7odz+ObXMI6TsOmWrfsdxhIXLiPGM+YAkPJV9cNiDu0HCF7w+ZAsJV0tF8xPxm4rwHJOGFgbcFP2fjdu",
+	"g+T93wGvQRIl1I1YTiMSWcN1QOjbgus4CAqsO23kwiU9I3qG5S8l+TEUepnxGyZGorC/DMgl0Gnf4XjY",
+	"G0XmIu0bxZcOOAiReACwKJEC43ISTLdaQkQruCwB5BDx+K5d166GlEu6ERJNWIC5Uhiiut7h5pgYRpeC",
+	"PLi3hep7DJMnb8+fHl+dksFgQC5Or95evD57/UtRbwQmgulEt4qjWokhp5fAJuuSXa/APqmhxvSIYlPF",
+	"gO0DI4XgEgh7I0ViIEC5gJrPjPESJZDpR+O1RaeTA+ALIewjS3Lj3UsgpVltvUlosusLKsU9CU2+/XW8",
+	"r0jq+R7pzo78d+Fy0XDbzy68FOHeuFQF0vXnxNEqXZEJI/al1e/H5jyqzjfP5o6rvIeKMutZw+t+ey8n",
+	"3i63MboWkA9NFNJhjxPoTQNynHlEUACT0sQwteCCGjYSECBrjz8YwWJWRsGVa9kNitJ9wI6y7M8gSEVV",
+	"9DnOzdwBWdgGl1JrpkEIk1NyjZO5Jt1/Ozg87E+4IW/fnj3dC7hHMc99bfVz1cdQWXLDVFx4tskpiPrR",
+	"WosU+D5UPyiNdn0i+1QXRtNsc8Khr7U4bWlU+lJCS+MBdlgsYeO/eryX1cAq0V7fqqJDU39iiuXafBL3",
+	"E8u7s3b541UJiOwaXwcoNirSHuFTrxoUqG1wtRueZYRm/Ib1QNO4hQh1BwFtm6BF3YQMYrwM0ZJw0Z9m",
+	"YJUHySGhgtCJVGYwEifwnQ/UAetDODWYQYidhgKRCpUbl7ViD5wDQgwDRWnH8g9tKALMMnD3B1POX3Km",
+	"OGuKP/as6tpNjqVjI2OJ4ieRZ9l1qNaJazQSvMCfS+2mdT1KnlTLOXWqkr5lbLkXgPSSMHWY4khg6d7U",
+	"F2hXRaLDbaPJBb7/NlnKPcgyfrZrZJm4YmJBjQ5m8l4ll2JwGww//qSRLth+3IAzSNtGgrPbD1S19/sz",
+	"xofDJ1+3d3+IuCDUX/8oFLCeXTw7OsfcvmG+7ZgaFRHn206G2nfQiO2s+02J13lAT54FSE9NuHEKDZFg",
+	"NA72abhDZBWPE/ixR+ws/GvOiBU4XRkC0zYCr/VZxmegJBWorF0IsHP2oaLARhe9/lJA/c/rPTR6WeZq",
+	"WaacAj6m15vgYvIAoRAAlgMgvGONsBF5OmOGSDESIK4irjZkBgsNeHb2+1y5EqKXT//RgSZ6gEy7FgJy",
+	"BkYiaBR2MXIBDksuyL890qQLntPCA5zQlImE7RFFIR3AzKmDP/k3NMgZkzl3MJgEbyEOzdAPiEuBV0If",
+	"boNQPVkxK7BijqrThdFaeESSjFHVqN22GAF7I5ExesPqOKlvX588P379y+lT5/FoA+ksof1Gh9Kp0iy1",
+	"0yrDEcPU3jx7hlK5BBxde3vTBQvaGqDl5hpj7VOZTzLWh5Ht9Rzd2YOZQ7wMKgJHdj0I6Xs4WsCDJX/7",
+	"n/+zVxTsFa8LEu+5IcOasbSHPhpt2yAOodbbUCBJA1cgMpV0scaIm0/xzneuDUuWRpJJvlhWV9dVQy1B",
+	"1x55WQpxa9lHjkmZ1Y0p5Afs5hrBH0gJvbZbA6j1Cmau57gnBvSk49dPsZmGc+vFKjeAvZ5fSTw1kMQL",
+	"mYgwDH8AwX2PeMk/jToBuRbDmalme0cEkWXwsvVFKa7xiMNQHDPvkQXHIMzaWcDz3HetYzCGmW+2HbWg",
+	"bL96e3lFtgLZtiMsI2hXibuA2oagi4fDJ35jQZgqpL9wZ3XdbeUboXbnuHYW+T0M92jF6a3Qx49NQL12",
+	"1IjVG3Cb/EH7CWyH+Gr3+4M98j2iI7kOu0L25XKvZ1uAHPBb6ZnpnEOuRB98n9e4m9cONgatYg5Du1S0",
+	"vhEv27YeCkgFktlHksI7/UdXDBDhlYpWLA8ipLQGBKPlDAPUWyv+G9kYBFJgYv+HkIvrYPWNRj60asLk",
+	"wNIXsnqcdPw17XwNqOWN8pYDiUY0F0jKc7fAESmDlle5frjNHenkwkV9oPIlVa8RZ5wEmPGRQH5dpUA8",
+	"41bQYfYMRNyZTNhUho8dHVtpowdSDUtJxDRL8Oe9wDMAevkb8v8+/JridWF496gUZSEEMHu5Bjn6D70o",
+	"0ouApMuXzbesGwXXV6Pq4u4nkNG8FN8HsQNZwF6zDhXhMW60QNch5cqQkjVUwzgn+kzrnJG/e/TwTw2p",
+	"jZCw3u+7wTjpPJS6wk5SPp1et6X4XQYQx7X3Vj2bK5Rn9Olcg93zuTBqLIoh+z0zupqhQhsorwy4CVvg",
+	"EJa+1RyqkPNcxYCM/cn+SYm893+bUz3fzs+SbFPcLriSA6LmHMuariXzmJItxSFkCUS6WN0P4NXpSNhl",
+	"pIrrVmdIwNBcS+zbolg2CGkOqXGr+NvtkC+/Es07yNe11P710+Rd5994njwzRdBODWUVoeoDPTUfOAfE",
+	"3EyOL6VtLmU3LJPLRZwOWYKaqiWLdepJuT7nLZ8wJViMaFFtyj93Lb0Lw26Nw3XhtZC6hep9DF/tzwfm",
+	"hdVH1pKtsaCCzkA/rcS566bZNYG1IIyLh/8pWikVWK+3ddEMT9DNQj5/GR4mhhEAvIG9oiuXllrv5KRK",
+	"LAUWCLfssGjC00q9jZfV0ONESpVy4Yp0vGJ6/sIV8tKMkVenl89fvPl5/PT08uyX1wOpZnslFbOpi+PD",
+	"Y9KFDeob2Yd/7AWYqgJZqWvbPz48Hl++vXh2fHLa3Ac9pJ1P7z79/wEAAP//3g/Q0BkwAQA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/src/core/registry/status_hooks.go
+++ b/src/core/registry/status_hooks.go
@@ -125,7 +125,10 @@ func handleAgentStatusChange(ctx context.Context, m *ent.AgentMutation, config *
 			}
 		}
 
-		// Create the appropriate registry event in the same transaction (skip for API services)
+		// Create the appropriate registry event in the same transaction (skip for API services).
+		// Note: a2a-typed agents still generate lifecycle events because they can hold
+		// mesh capabilities alongside their A2A surfaces (see A2A_SURFACE_DESIGN.org —
+		// "agent_type=a2a" is additive over mesh-tool handling).
 		if oldAgent.AgentType.String() != "api" {
 			eventType := getEventTypeForStatusChange(oldStatus, newStatus)
 			eventData := createEventDataForStatusChange(oldStatus, newStatus)

--- a/src/runtime/core/src/registry.rs
+++ b/src/runtime/core/src/registry.rs
@@ -305,6 +305,13 @@ pub struct HeartbeatRequest {
     pub tools: Vec<ToolRegistration>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub llm_agents: Vec<LlmAgentRegistration>,
+    /// A2A surfaces (issue #903 / A2A_SURFACE_DESIGN.org). Optional —
+    /// populated only when the agent has at least one `@mesh.a2a` decorator.
+    /// Forwarded as a JSON value so the Rust core doesn't need to model the
+    /// surface schema; the registry's `MeshAgentRegistration` deserializer
+    /// reshapes this into typed `A2ASurface` entries.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub surfaces: Option<serde_json::Value>,
 }
 
 impl HeartbeatRequest {
@@ -399,6 +406,16 @@ impl HeartbeatRequest {
             runtime: spec.runtime.as_api_str().to_string(),
             tools,
             llm_agents,
+            // Issue #903 Phase 1B: forward A2A surfaces verbatim so the
+            // registry can persist them and stamp FQDNs. The SDK passes
+            // a JSON string from Python (because pyclass(get_all, set_all)
+            // can't host a `serde_json::Value` field directly); parse it
+            // here before sending so the wire shape matches the registry's
+            // typed `MeshAgentRegistration.surfaces` deserializer.
+            surfaces: spec
+                .surfaces
+                .as_ref()
+                .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok()),
         }
     }
 }

--- a/src/runtime/core/src/spec.rs
+++ b/src/runtime/core/src/spec.rs
@@ -319,6 +319,11 @@ pub enum AgentType {
     McpAgent = 0,
     /// API service that only consumes capabilities (e.g., FastAPI, Express)
     Api = 1,
+    /// A2A (Agent-to-Agent) surface — exposes JSON-RPC tasks/* endpoints and an
+    /// agent card under MCP_MESH_PUBLIC_URL_PREFIX. Issue #903 / A2A_SURFACE_DESIGN.org.
+    /// May still expose mesh tools (capabilities) — the type just signals to the registry
+    /// that it should additionally compute FQDNs from the optional `surfaces` field.
+    A2a = 2,
 }
 
 #[cfg(feature = "python")]
@@ -340,6 +345,7 @@ impl AgentType {
         match self {
             Self::McpAgent => "mcp_agent",
             Self::Api => "api",
+            Self::A2a => "a2a",
         }
     }
 
@@ -347,6 +353,7 @@ impl AgentType {
     pub fn from_str(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "api" => Self::Api,
+            "a2a" => Self::A2a,
             _ => Self::McpAgent,
         }
     }
@@ -450,6 +457,16 @@ pub struct AgentSpec {
 
     /// Heartbeat interval in seconds
     pub heartbeat_interval: u64,
+
+    /// A2A surfaces (issue #903 / A2A_SURFACE_DESIGN.org). Optional — populated
+    /// only when `agent_type=A2a` and the SDK has at least one `@mesh.a2a`-style
+    /// decorator. Stored as a JSON-encoded string to keep the field py-class
+    /// compatible (`pyclass(get_all, set_all)` requires fields convertible
+    /// to/from PyAny — `serde_json::Value` is not). The Python side passes
+    /// `json.dumps([{path, skill_id, ...}, ...])`; `from_spec` re-parses
+    /// before forwarding to the registry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub surfaces: Option<String>,
 }
 
 #[cfg(feature = "python")]
@@ -469,7 +486,8 @@ impl AgentSpec {
         tools=None,
         llm_agents=None,
         heartbeat_interval=5,
-        agent_id=None
+        agent_id=None,
+        surfaces=None
     ))]
     #[allow(clippy::too_many_arguments)]
     pub fn py_new(
@@ -486,8 +504,13 @@ impl AgentSpec {
         llm_agents: Option<Vec<LlmAgentSpec>>,
         heartbeat_interval: u64,
         agent_id: Option<String>,
+        // Issue #903 Phase 1B: A2A surfaces JSON passthrough. Accepts a JSON
+        // string from Python (built by `_build_agent_spec`) so we don't need
+        // to model `A2ASurface` as a pyclass on the Rust side — the registry
+        // is the only consumer of the shape.
+        surfaces: Option<String>,
     ) -> Self {
-        Self::new(
+        let mut spec = Self::new(
             name,
             registry_url,
             version,
@@ -501,7 +524,11 @@ impl AgentSpec {
             llm_agents,
             heartbeat_interval,
             agent_id,
-        )
+        );
+        // Empty string is treated as absent so the wire stays clean
+        // (registry's `surfaces` is omitted via `skip_serializing_if`).
+        spec.surfaces = surfaces.filter(|s| !s.trim().is_empty());
+        spec
     }
 
     fn __repr__(&self) -> String {
@@ -553,6 +580,7 @@ impl AgentSpec {
             tools: tools.unwrap_or_default(),
             llm_agents: llm_agents.unwrap_or_default(),
             heartbeat_interval,
+            surfaces: None,
         }
     }
 
@@ -761,6 +789,34 @@ mod tests {
         assert_eq!(spec.agent_type.as_api_str(), "api");
         assert_eq!(spec.runtime, RuntimeType::TypeScript);
         assert_eq!(spec.runtime.as_api_str(), "typescript");
+    }
+
+    #[test]
+    fn test_agent_type_a2a() {
+        // Issue #903 Phase 1B: A2A surface adapter agent type. The string
+        // form must round-trip via from_str/as_api_str so the registry sees
+        // exactly "a2a" on the wire.
+        assert_eq!(AgentType::from_str("a2a"), AgentType::A2a);
+        assert_eq!(AgentType::A2a.as_api_str(), "a2a");
+
+        let spec = AgentSpec::new(
+            "report-generator".to_string(),
+            "http://localhost:8100".to_string(),
+            "1.0.0".to_string(),
+            "".to_string(),
+            0,
+            "localhost".to_string(),
+            "default".to_string(),
+            Some("a2a".to_string()),
+            None,
+            None,
+            None,
+            5,
+            None,
+        );
+
+        assert_eq!(spec.agent_type, AgentType::A2a);
+        assert!(spec.surfaces.is_none());
     }
 
     #[test]

--- a/src/runtime/python/_mcp_mesh/engine/a2a_card.py
+++ b/src/runtime/python/_mcp_mesh/engine/a2a_card.py
@@ -1,0 +1,111 @@
+"""A2A v1.0 AgentCard JSON generator (issue #903 Phase 1B).
+
+Builds the JSON body returned from ``GET {path}/.well-known/agent.json`` for
+each ``@mesh.a2a`` decorated function. The card shape follows the A2A v1.0
+specification at https://a2a-protocol.org/latest/specification/.
+
+Phase 1B emits one card per surface with one skill (per the design doc's
+"Per-skill agent cards as default" decision). Multi-skill grouping is v2.
+
+The card is intentionally minimal — we populate the fields the A2A v1.0 spec
+requires plus the optional fields we have data for from the decorator
+metadata. We deliberately leave optional fields empty rather than fabricate
+values (e.g., ``provider``, ``documentationUrl``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def build_agent_card(
+    *,
+    name: str,
+    description: str | None,
+    version: str,
+    public_url: str | None,
+    skill_id: str,
+    skill_name: str,
+    skill_description: str | None,
+    input_modes: list[str],
+    output_modes: list[str],
+    tags: list[str],
+    streaming: bool,
+    bearer_auth: bool,
+    underlying_tool_input_schema: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Build an A2A v1.0 AgentCard dict.
+
+    Args:
+        name: Agent display name (typically the @mesh.agent name).
+        description: Agent-level description (free-form).
+        version: Agent version string (semver).
+        public_url: Registry-stamped public FQDN for ``POST {path}``
+            (the JSON-RPC tasks/* entry point). May be ``None`` when
+            ``MCP_MESH_PUBLIC_URL_PREFIX`` is unset on the registry —
+            in that case the card omits the ``url`` field so external
+            clients fail loudly rather than silently follow an empty URL.
+        skill_id: A2A skill identifier (kebab-case).
+        skill_name: Human-readable skill name.
+        skill_description: Skill-level description.
+        input_modes: A2A inputModes (e.g. ``["application/json"]``).
+        output_modes: A2A outputModes (e.g. ``["application/json"]``).
+        tags: Skill tags surfaced on the card.
+        streaming: ``True`` when the underlying mesh tool is
+            ``task=True`` — flips ``capabilities.streaming``.
+        bearer_auth: ``True`` when the surface declared
+            ``auth="bearer"`` — affects ``authentication.schemes``.
+        underlying_tool_input_schema: JSON Schema for the underlying
+            mesh tool's input. When present, embedded as
+            ``skills[0].metadata.input_schema`` so an A2A client can
+            inspect the parameter shape without out-of-band knowledge.
+            Optional in the A2A spec.
+
+    Returns:
+        A dict that serializes to the A2A v1.0 AgentCard JSON shape.
+    """
+    skill: dict[str, Any] = {
+        "id": skill_id,
+        "name": skill_name,
+        "description": skill_description or skill_name,
+        "tags": tags,
+        "inputModes": input_modes,
+        "outputModes": output_modes,
+    }
+
+    if underlying_tool_input_schema is not None:
+        # The A2A v1.0 spec doesn't reserve a canonical "input schema" slot
+        # on Skill; we expose it under a metadata bag so the card stays
+        # spec-compliant while still carrying the shape downstream tooling
+        # (LangGraph etc.) typically wants.
+        skill["metadata"] = {"input_schema": underlying_tool_input_schema}
+
+    card: dict[str, Any] = {
+        "name": name,
+        "description": description or name,
+        "version": version,
+        "capabilities": {
+            "streaming": bool(streaming),
+            "pushNotifications": False,
+            "stateTransitionHistory": False,
+        },
+        "defaultInputModes": input_modes,
+        "defaultOutputModes": output_modes,
+        "skills": [skill],
+    }
+
+    if public_url:
+        card["url"] = public_url
+
+    if bearer_auth:
+        # A2A v1.0 spec: authentication.schemes is a list of scheme names.
+        # For bearer-token, the conventional value is "bearer".
+        card["authentication"] = {"schemes": ["bearer"]}
+    else:
+        # A2A v1.0 has no "none" scheme — only real scheme names like
+        # "bearer", "oauth2", etc. Emit an empty schemes list so clients
+        # see "no schemes advertised" (i.e., unauthenticated) rather
+        # than rejecting an unknown scheme name.
+        card["authentication"] = {"schemes": []}
+
+    return card

--- a/src/runtime/python/_mcp_mesh/engine/a2a_surfaces.py
+++ b/src/runtime/python/_mcp_mesh/engine/a2a_surfaces.py
@@ -1,0 +1,69 @@
+"""Shared collector for ``@mesh.a2a`` surface metadata (issue #903 Phase 1B refactor).
+
+The same registry-bound surfaces shape is consumed by THREE heartbeat paths:
+
+  * ``mcp_startup/heartbeat_preparation.py`` — legacy Python heartbeat
+    payload builder (sends dict directly).
+  * ``mcp_heartbeat/rust_heartbeat.py`` — Rust-backed heartbeat (sends
+    JSON string via ``AgentSpec.surfaces``).
+  * ``api_heartbeat/rust_api_heartbeat.py`` — Rust-backed heartbeat for
+    pure ``@mesh.route`` / ``mesh.a2a.mount`` (no ``@mesh.agent``) FastAPI
+    apps. Same JSON shape as the mcp_heartbeat path.
+
+The shape MUST stay in sync across all three or the registry's
+``MeshAgentRegistration.surfaces`` JSONB column will land mixed shapes
+across agent types — making the GET ``/a2a/agents`` listing fragile.
+Centralizing the construction here makes any future field additions a
+single-point edit.
+
+The output is the shape persisted on the registry's ``a2a_surfaces`` JSON
+field (see Go ``MeshAgentRegistration.surfaces`` and the OpenAPI
+``A2ASurface`` schema).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Module-level import (rather than late) so unit tests can patch
+# ``_mcp_mesh.engine.a2a_surfaces.DecoratorRegistry`` directly. The
+# circular-import worry doesn't apply here in practice — by the time
+# any heartbeat path imports this module, ``decorator_registry`` is
+# fully initialised (see test sweep on the fix #5 commit).
+from .decorator_registry import DecoratorRegistry
+
+
+def collect_a2a_surfaces() -> list[dict[str, Any]]:
+    """Return the registry-bound surfaces array for all ``@mesh.a2a`` decorators.
+
+    Reads ``DecoratorRegistry.get_all_by_type("mesh_a2a")`` and projects each
+    entry to the registry shape. Returns ``[]`` when no surfaces are
+    declared — callers decide whether to omit the field on the wire.
+
+    Optional fields (``name``, ``description``, ``input_modes``,
+    ``output_modes``, ``tags``) are only populated when set on the decorator
+    so the registry's OpenAPI defaults aren't overridden with empty values.
+    """
+    a2a_funcs = DecoratorRegistry.get_all_by_type("mesh_a2a")
+    if not a2a_funcs:
+        return []
+
+    surfaces: list[dict[str, Any]] = []
+    for _, decorated in a2a_funcs.items():
+        md = decorated.metadata or {}
+        entry: dict[str, Any] = {
+            "path": md["path"],
+            "skill_id": md["skill_id"],
+        }
+        if md.get("skill_name"):
+            entry["name"] = md["skill_name"]
+        if md.get("description"):
+            entry["description"] = md["description"]
+        if md.get("input_modes"):
+            entry["input_modes"] = list(md["input_modes"])
+        if md.get("output_modes"):
+            entry["output_modes"] = list(md["output_modes"])
+        if md.get("tags"):
+            entry["tags"] = list(md["tags"])
+        surfaces.append(entry)
+    return surfaces

--- a/src/runtime/python/_mcp_mesh/pipeline/a2a_heartbeat/__init__.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/a2a_heartbeat/__init__.py
@@ -1,0 +1,27 @@
+"""
+A2A heartbeat pipeline for FastAPI integration (issue #903 Phase 1B).
+
+Sibling pipeline to ``api_heartbeat`` (handles ``@mesh.route`` services)
+and ``mcp_heartbeat`` (handles ``@mesh.agent`` agents).
+
+Provides periodic service registration and health monitoring for
+FastAPI applications hosting ``@mesh.a2a`` / ``mesh.a2a.mount``
+surfaces. Emits ``agent_type="a2a"`` + the ``surfaces`` JSON array on
+each heartbeat round-trip so the registry stamps FQDNs and surfaces
+the agent on ``GET /a2a/agents``.
+
+Uses Rust core for registry communication, dependency resolution, and
+deregistration — same pattern as ``api_heartbeat``.
+"""
+
+from .a2a_lifespan_integration import (a2a_heartbeat_lifespan_task,
+                                        create_a2a_lifespan_handler,
+                                        integrate_a2a_heartbeat_with_fastapi)
+from .rust_a2a_heartbeat import rust_a2a_heartbeat_task
+
+__all__ = [
+    "a2a_heartbeat_lifespan_task",
+    "create_a2a_lifespan_handler",
+    "integrate_a2a_heartbeat_with_fastapi",
+    "rust_a2a_heartbeat_task",
+]

--- a/src/runtime/python/_mcp_mesh/pipeline/a2a_heartbeat/a2a_lifespan_integration.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/a2a_heartbeat/a2a_lifespan_integration.py
@@ -1,10 +1,10 @@
 """
-FastAPI lifespan integration for API heartbeat pipeline.
+FastAPI lifespan integration for A2A heartbeat pipeline.
 
-Handles the execution of API heartbeat as a background task
-during FastAPI application lifespan for @mesh.route decorator services.
-
-Uses the Rust core for registry communication.
+Mirrors ``api_heartbeat/api_lifespan_integration.py`` for the A2A flow.
+Wires the ``rust_a2a_heartbeat_task`` as a FastAPI lifespan background
+task so the user's ``uvicorn.run(app)`` automatically participates in
+the mesh's heartbeat round-trips.
 """
 
 import asyncio
@@ -14,40 +14,38 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-async def api_heartbeat_lifespan_task(heartbeat_config: dict[str, Any]) -> None:
+async def a2a_heartbeat_lifespan_task(heartbeat_config: dict[str, Any]) -> None:
     """
-    API heartbeat task that runs in FastAPI lifespan.
+    A2A heartbeat task that runs in FastAPI lifespan.
 
     Uses Rust-backed heartbeat for registry communication.
 
     Args:
         heartbeat_config: Configuration containing service_id, interval,
-                         and context for API heartbeat execution
+                         and context (with ``a2a_surfaces``) for A2A heartbeat.
     """
-    service_id = heartbeat_config.get("service_id", "unknown-api-service")
+    service_id = heartbeat_config.get("service_id", "unknown-a2a-service")
     standalone_mode = heartbeat_config.get("standalone_mode", False)
 
-    # Check if running in standalone mode
     if standalone_mode:
         logger.info(
-            f"💓 API heartbeat in standalone mode for service '{service_id}' "
-            f"(no registry communication)"
+            f"💓 A2A heartbeat in standalone mode for service '{service_id}' "
+            "(no registry communication)"
         )
         return
 
-    # Use Rust-backed heartbeat
-    from .rust_api_heartbeat import rust_api_heartbeat_task
+    from .rust_a2a_heartbeat import rust_a2a_heartbeat_task
 
-    logger.info(f"💓 Using Rust-backed heartbeat for API service '{service_id}'")
-    await rust_api_heartbeat_task(heartbeat_config)
+    logger.info(f"💓 Using Rust-backed heartbeat for A2A service '{service_id}'")
+    await rust_a2a_heartbeat_task(heartbeat_config)
 
 
-def create_api_lifespan_handler(heartbeat_config: dict[str, Any]) -> Any:
+def create_a2a_lifespan_handler(heartbeat_config: dict[str, Any]) -> Any:
     """
-    Create a FastAPI lifespan context manager that runs API heartbeat.
+    Create a FastAPI lifespan context manager that runs A2A heartbeat.
 
     Args:
-        heartbeat_config: Configuration for API heartbeat execution
+        heartbeat_config: Configuration for A2A heartbeat execution
 
     Returns:
         Async context manager for FastAPI lifespan
@@ -55,39 +53,38 @@ def create_api_lifespan_handler(heartbeat_config: dict[str, Any]) -> Any:
     from contextlib import asynccontextmanager
 
     @asynccontextmanager
-    async def api_lifespan(app):
-        """FastAPI lifespan context manager with API heartbeat integration."""
+    async def a2a_lifespan(app):
+        """FastAPI lifespan context manager with A2A heartbeat integration."""
         service_id = heartbeat_config.get("service_id", "unknown")
-        logger.info(f"🚀 Starting FastAPI lifespan for service '{service_id}'")
+        logger.info(f"🚀 Starting FastAPI lifespan for A2A service '{service_id}'")
 
-        # Start API heartbeat task
         heartbeat_task = asyncio.create_task(
-            api_heartbeat_lifespan_task(heartbeat_config)
+            a2a_heartbeat_lifespan_task(heartbeat_config)
         )
 
         try:
-            # Yield control to FastAPI
             yield
         finally:
-            # Cleanup: cancel heartbeat task
-            logger.info(f"🛑 Shutting down FastAPI lifespan for service '{service_id}'")
+            logger.info(
+                f"🛑 Shutting down FastAPI lifespan for A2A service '{service_id}'"
+            )
             heartbeat_task.cancel()
 
             try:
                 await heartbeat_task
             except asyncio.CancelledError:
                 logger.info(
-                    f"✅ API heartbeat task cancelled for service '{service_id}'"
+                    f"✅ A2A heartbeat task cancelled for service '{service_id}'"
                 )
 
-    return api_lifespan
+    return a2a_lifespan
 
 
-def integrate_api_heartbeat_with_fastapi(
+def integrate_a2a_heartbeat_with_fastapi(
     fastapi_app: Any, heartbeat_config: dict[str, Any]
 ) -> None:
     """
-    Integrate API heartbeat with FastAPI lifespan events.
+    Integrate A2A heartbeat with FastAPI lifespan events.
 
     Args:
         fastapi_app: FastAPI application instance
@@ -109,14 +106,14 @@ def integrate_api_heartbeat_with_fastapi(
             else None
         )
 
-        api_lifespan = create_api_lifespan_handler(heartbeat_config)
+        a2a_lifespan = create_a2a_lifespan_handler(heartbeat_config)
 
         if existing_lifespan is not None:
             from contextlib import asynccontextmanager
 
             logger.warning(
                 f"⚠️ FastAPI app already has lifespan handler - "
-                f"composing API heartbeat with user's lifespan for service '{service_id}'"
+                f"composing A2A heartbeat with user's lifespan for service '{service_id}'"
             )
 
             @asynccontextmanager
@@ -126,20 +123,20 @@ def integrate_api_heartbeat_with_fastapi(
                 # don't tear down the registry connection while user code
                 # still expects it.
                 async with existing_lifespan(app):
-                    async with api_lifespan(app):
+                    async with a2a_lifespan(app):
                         yield
 
             fastapi_app.router.lifespan_context = composed_lifespan
         else:
-            fastapi_app.router.lifespan_context = api_lifespan
+            fastapi_app.router.lifespan_context = a2a_lifespan
 
         logger.info(
-            f"🔗 API heartbeat integrated with FastAPI lifespan for service '{service_id}'"
+            f"🔗 A2A heartbeat integrated with FastAPI lifespan for service '{service_id}'"
         )
 
     except Exception as e:
         logger.error(
-            f"❌ Failed to integrate API heartbeat with FastAPI lifespan "
+            f"❌ Failed to integrate A2A heartbeat with FastAPI lifespan "
             f"for service '{service_id}': {e}"
         )
         raise

--- a/src/runtime/python/_mcp_mesh/pipeline/a2a_heartbeat/rust_a2a_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/a2a_heartbeat/rust_a2a_heartbeat.py
@@ -1,0 +1,525 @@
+"""
+Rust-backed heartbeat implementation for A2A services (issue #903 Phase 1B).
+
+Sibling of ``api_heartbeat/rust_api_heartbeat.py`` (which handles
+``@mesh.route`` services). Both delegate registry communication to the
+Rust core; the difference is the AgentSpec shape:
+
+  * API services: ``agent_type="api"``, no ``surfaces`` field.
+  * A2A services: ``agent_type="a2a"`` + ``surfaces=<json>`` array.
+
+The dependency-change handler reuses the dependency-injector path
+(mirrors ``mcp_heartbeat/rust_heartbeat.py``) because ``@mesh.a2a``
+wires DI via ``injector.create_injection_wrapper`` — i.e., A2A
+handlers live in the global injector's function registry, NOT in the
+``DecoratorRegistry.get_all_route_wrappers()`` mapping that
+``rust_api_heartbeat`` walks.
+"""
+
+import asyncio
+import json
+import logging
+import re
+from typing import Any, Optional
+
+# Matches the registry/SDK convention of "{base}-{8-hex-chars}" at the end
+# of a service_id. Used to strip the suffix and recover the base name.
+_A2A_SERVICE_ID_SUFFIX_RE = re.compile(r"-[0-9a-f]{8}$")
+
+logger = logging.getLogger(__name__)
+
+# Lazy import to avoid ImportError if Rust core not built
+_rust_core = None
+
+
+def _get_rust_core():
+    """Lazy import of Rust core module."""
+    global _rust_core
+    if _rust_core is None:
+        try:
+            import mcp_mesh_core
+
+            _rust_core = mcp_mesh_core
+            logger.debug("Rust core module loaded successfully for A2A heartbeat")
+        except ImportError as e:
+            logger.warning(f"Rust core not available for A2A heartbeat: {e}")
+            raise
+    return _rust_core
+
+
+def _build_a2a_agent_spec(context: dict[str, Any], service_id: Optional[str] = None) -> Any:
+    """
+    Build AgentSpec from A2A service context.
+
+    Emits ``agent_type="a2a"`` and serializes the surfaces array onto
+    the Rust AgentSpec's ``surfaces`` field (JSON string). Same shape
+    as the mcp-startup rust_heartbeat path uses for ``@mesh.agent`` +
+    ``@mesh.a2a`` agents — guarantees the registry's
+    ``MeshAgentRegistration.surfaces`` JSONB column lands a consistent
+    shape regardless of which entry-point the agent uses.
+
+    Args:
+        context: Pipeline context (with ``a2a_surfaces``, ``display_config``,
+                 ``agent_config``).
+        service_id: Service ID from heartbeat config (passed explicitly).
+    """
+    core = _get_rust_core()
+
+    if not service_id:
+        service_id = context.get("service_id") or context.get(
+            "agent_id", "unknown-a2a-service"
+        )
+    display_config = context.get("display_config", {})
+    # Prefer pipeline-context override (test seams), fall back to the
+    # DecoratorRegistry's resolved config so the FastAPI app title +
+    # any update_agent_config(...) writes from a2a_server_setup.py
+    # land in the heartbeat. Without this fallback, base_name strips
+    # the service_id suffix and produces names like "a2a" instead of
+    # the actual app title.
+    agent_config = context.get("agent_config")
+    if not agent_config:
+        from ...engine.decorator_registry import DecoratorRegistry
+
+        agent_config = DecoratorRegistry.get_resolved_agent_config() or {}
+
+    from ...shared.config_resolver import get_config_value
+    from ...shared.defaults import MeshDefaults
+
+    registry_url = get_config_value(
+        "MCP_MESH_REGISTRY_URL",
+        override=agent_config.get("registry_url"),
+    )
+
+    heartbeat_interval = int(
+        get_config_value(
+            "MCP_MESH_HEALTH_INTERVAL",
+            override=agent_config.get("health_interval"),
+            default=MeshDefaults.HEALTH_INTERVAL,
+        )
+    )
+
+    http_host = display_config.get("display_host", "127.0.0.1")
+    http_port = display_config.get("display_port", 8080)
+    namespace = agent_config.get("namespace", "default")
+    version = agent_config.get("version", "1.0.0")
+
+    # Build tool specs for A2A surfaces. Each surface's underlying handler
+    # may declare cross-agent dependencies (e.g., ``date_service``); we
+    # surface those so the Rust core resolves them and the injector wires
+    # the proxies on dependency_available events. The function_name is the
+    # surface's skill_id so the registry can correlate updates.
+    from ...engine.decorator_registry import DecoratorRegistry
+
+    tools = []
+    a2a_decorators = DecoratorRegistry.get_all_by_type("mesh_a2a")
+    for func_id, decorated in a2a_decorators.items():
+        meta = decorated.metadata or {}
+        deps_meta = meta.get("dependencies") or []
+
+        deps = []
+        for dep in deps_meta:
+            cap = dep.get("capability") if isinstance(dep, dict) else dep
+            if not cap:
+                continue
+            dep_tags = dep.get("tags", []) if isinstance(dep, dict) else []
+            dep_version = dep.get("version") if isinstance(dep, dict) else None
+            dep_spec = core.DependencySpec(
+                capability=cap,
+                tags=json.dumps(dep_tags),
+                version=dep_version,
+            )
+            deps.append(dep_spec)
+
+        if not deps:
+            continue
+
+        skill_id = meta.get("skill_id", func_id)
+        tool_spec = core.ToolSpec(
+            function_name=skill_id,
+            capability="",  # A2A surfaces consume capabilities, not provide them
+            version="1.0.0",
+            description=meta.get("description") or "",
+            tags=meta.get("tags") or [],
+            dependencies=deps if deps else None,
+            input_schema=None,
+            llm_filter=None,
+            llm_provider=None,
+        )
+        tools.append(tool_spec)
+
+    # Derive base name from service_id (strip the "-{uuid8}" suffix if present).
+    base_name = agent_config.get("name")
+    if not base_name:
+        stripped = _A2A_SERVICE_ID_SUFFIX_RE.sub("", service_id)
+        base_name = stripped if stripped != service_id else service_id
+
+    # Surfaces JSON is the centerpiece — the registry consumes it to
+    # populate the ``MeshAgentRegistration.surfaces`` JSONB column and
+    # stamp FQDNs onto each surface's public_url before responding.
+    a2a_surfaces = context.get("a2a_surfaces")
+    if not a2a_surfaces:
+        try:
+            from ...engine.a2a_surfaces import collect_a2a_surfaces
+
+            a2a_surfaces = collect_a2a_surfaces()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(f"Could not collect a2a surfaces: {e}")
+            a2a_surfaces = []
+
+    surfaces_json = json.dumps(a2a_surfaces) if a2a_surfaces else None
+
+    spec_kwargs: dict[str, Any] = dict(
+        name=base_name,
+        registry_url=registry_url,
+        version=version,
+        description="",
+        http_port=http_port,
+        http_host=http_host,
+        namespace=namespace,
+        agent_type="a2a",
+        tools=tools if tools else None,
+        llm_agents=None,
+        heartbeat_interval=heartbeat_interval,
+        agent_id=service_id,
+    )
+    if surfaces_json is not None:
+        spec_kwargs["surfaces"] = surfaces_json
+
+    spec = core.AgentSpec(**spec_kwargs)
+
+    logger.info(
+        f"Built A2A AgentSpec: name={base_name}, agent_id={service_id}, "
+        f"agent_type=a2a, surfaces={len(a2a_surfaces)}, "
+        f"tools_with_deps={len(tools)}, registry={registry_url}"
+    )
+
+    return spec
+
+
+async def _handle_a2a_mesh_event(event: Any, context: dict[str, Any]) -> None:
+    """
+    Handle a mesh event from the Rust core for A2A services.
+
+    Dispatches to the dependency-injector path because ``@mesh.a2a``
+    wires DI via ``injector.create_injection_wrapper`` (functions live
+    in the global injector's function registry).
+    """
+    event_type = event.event_type
+
+    if event_type == "agent_registered":
+        logger.info(f"A2A service registered with ID: {event.agent_id}")
+
+    elif event_type == "registration_failed":
+        logger.error(f"A2A service registration failed: {event.error}")
+
+    elif event_type == "dependency_available":
+        await _handle_a2a_dependency_change(
+            capability=event.capability,
+            endpoint=event.endpoint,
+            function_name=event.function_name,
+            agent_id=event.agent_id,
+            available=True,
+            context=context,
+            producer_kwargs=getattr(event, "kwargs", None),
+        )
+
+    elif event_type == "dependency_changed":
+        await _handle_a2a_dependency_change(
+            capability=event.capability,
+            endpoint=event.endpoint,
+            function_name=event.function_name,
+            agent_id=event.agent_id,
+            available=True,
+            context=context,
+            producer_kwargs=getattr(event, "kwargs", None),
+        )
+
+    elif event_type == "dependency_unavailable":
+        await _handle_a2a_dependency_change(
+            capability=event.capability,
+            endpoint=None,
+            function_name=None,
+            agent_id=None,
+            available=False,
+            context=context,
+            producer_kwargs=None,
+        )
+
+    elif event_type == "llm_tools_updated":
+        logger.debug(
+            f"LLM tools update for A2A service (ignored): {event.function_id}"
+        )
+
+    elif event_type == "health_check_due":
+        logger.debug("Health check due for A2A service (not implemented yet)")
+
+    elif event_type == "registry_disconnected":
+        logger.warning(f"Registry disconnected for A2A service: {event.reason}")
+
+    elif event_type == "shutdown":
+        logger.info("Rust core shutdown event received for A2A service")
+
+    else:
+        logger.debug(f"Unhandled event type for A2A service: {event_type}")
+
+
+async def _handle_a2a_dependency_change(
+    capability: str,
+    endpoint: Optional[str],
+    function_name: Optional[str],
+    agent_id: Optional[str],
+    available: bool,
+    context: dict[str, Any],
+    producer_kwargs: Optional[str] = None,
+) -> None:
+    """
+    Handle dependency availability change for A2A services.
+
+    Walks ``DecoratorRegistry.get_all_by_type("mesh_a2a")`` and updates
+    each surface's underlying injection wrapper via
+    ``_mesh_update_dependency``. ``producer_kwargs`` is the producer's
+    @mesh.tool kwargs (JSON string) so the proxy honours producer-side
+    streaming/timeout config.
+    """
+    logger.info(
+        f"A2A dependency change: {capability} -> "
+        f"{'available' if available else 'unavailable'} "
+        f"at {endpoint}/{function_name}"
+    )
+
+    from ...engine.decorator_registry import DecoratorRegistry
+    from ...engine.unified_mcp_proxy import EnhancedUnifiedMCPProxy
+
+    parsed_producer_kwargs: dict = {}
+    if producer_kwargs:
+        try:
+            parsed = json.loads(producer_kwargs)
+        except (TypeError, ValueError) as e:
+            logger.warning(
+                f"Could not parse producer kwargs for {capability}: {e}; "
+                f"falling back to empty config"
+            )
+        else:
+            if isinstance(parsed, dict):
+                parsed_producer_kwargs = parsed
+            elif parsed is not None:
+                logger.warning(
+                    f"Producer kwargs for {capability} parsed to "
+                    f"{type(parsed).__name__}, expected dict; "
+                    "falling back to empty config"
+                )
+
+    a2a_decorators = DecoratorRegistry.get_all_by_type("mesh_a2a")
+
+    for func_id, decorated in a2a_decorators.items():
+        meta = decorated.metadata or {}
+        deps_meta = meta.get("dependencies") or []
+        # Locate the active wrapper. The decorator stamps
+        # ``_mesh_injection_wrapper`` on the original target after wrapping.
+        target = decorated.function
+        wrapper = getattr(target, "_mesh_injection_wrapper", None) or target
+
+        if not hasattr(wrapper, "_mesh_update_dependency"):
+            continue
+
+        for dep_index, dep in enumerate(deps_meta):
+            dep_cap = dep.get("capability") if isinstance(dep, dict) else dep
+            if dep_cap != capability:
+                continue
+
+            if not available:
+                wrapper._mesh_update_dependency(dep_index, None)
+                logger.info(
+                    f"Cleared dependency '{capability}' at index {dep_index} "
+                    f"for A2A surface '{func_id}'"
+                )
+                continue
+
+            current_service_id = context.get("service_id") or context.get("agent_id")
+            if not current_service_id:
+                from ...shared.config_resolver import get_config_value
+
+                current_service_id = get_config_value("MCP_MESH_AGENT_ID")
+
+            is_self_dependency = (
+                current_service_id and agent_id and current_service_id == agent_id
+            )
+
+            if is_self_dependency:
+                from ...engine.self_dependency_proxy import SelfDependencyProxy
+
+                mesh_tools = DecoratorRegistry.get_mesh_tools()
+                wrapper_func = mesh_tools.get(function_name)
+
+                if wrapper_func:
+                    proxy = SelfDependencyProxy(
+                        wrapper_func.function, function_name
+                    )
+                    logger.debug(
+                        f"Created SelfDependencyProxy for A2A surface '{func_id}' "
+                        f"dependency '{capability}'"
+                    )
+                else:
+                    proxy = EnhancedUnifiedMCPProxy(
+                        endpoint,
+                        function_name,
+                        kwargs_config=dict(parsed_producer_kwargs),
+                    )
+                    logger.debug(
+                        f"Created EnhancedUnifiedMCPProxy (fallback) for A2A "
+                        f"surface '{func_id}' dependency '{capability}'"
+                    )
+            else:
+                proxy = EnhancedUnifiedMCPProxy(
+                    endpoint,
+                    function_name,
+                    kwargs_config=dict(parsed_producer_kwargs),
+                )
+                logger.debug(
+                    f"Created EnhancedUnifiedMCPProxy for A2A surface '{func_id}' "
+                    f"dependency '{capability}' -> {endpoint}"
+                )
+
+            wrapper._mesh_update_dependency(dep_index, proxy)
+            logger.info(
+                f"Updated dependency '{capability}' at index {dep_index} "
+                f"for A2A surface '{func_id}' -> {endpoint}/{function_name}"
+            )
+
+
+async def rust_a2a_heartbeat_task(heartbeat_config: dict[str, Any]) -> None:
+    """
+    Rust-backed heartbeat task for A2A services that runs in FastAPI lifespan.
+
+    Drop-in replacement for ``a2a_heartbeat_lifespan_task``. Mirrors
+    ``rust_api_heartbeat_task`` for the A2A flow.
+
+    Args:
+        heartbeat_config: Configuration containing service_id, interval,
+                         and context (with ``a2a_surfaces``).
+    """
+    service_id = heartbeat_config.get("service_id", "unknown-a2a-service")
+    context = heartbeat_config.get("context", {})
+    standalone_mode = heartbeat_config.get("standalone_mode", False)
+
+    if standalone_mode:
+        logger.info(
+            f"Rust A2A heartbeat in standalone mode for service '{service_id}' "
+            "(no registry communication)"
+        )
+        return
+
+    try:
+        core = _get_rust_core()
+    except ImportError as e:
+        logger.error(
+            f"Rust core not available for A2A service '{service_id}': {e}. "
+            "The mcp_mesh_core module must be built and installed."
+        )
+        raise RuntimeError(
+            f"Rust core (mcp_mesh_core) is required but not available: {e}"
+        ) from e
+
+    logger.info(f"Starting Rust-backed heartbeat for A2A service '{service_id}'")
+
+    handle = None
+    try:
+        spec = _build_a2a_agent_spec(context, service_id=service_id)
+
+        handle = core.start_agent(spec)
+        logger.info(f"Rust core started for A2A service '{service_id}'")
+
+        # Track this handle in the process-wide registry so atexit can drain
+        # it before Py_Finalize. Closes the pyo3-async-runtimes
+        # Python::attach race during abnormal exits. See issue #877.
+        try:
+            from ...shared.simple_shutdown import register_rust_agent_handle
+
+            register_rust_agent_handle(handle)
+        except Exception as e:  # pragma: no cover - never block startup
+            logger.debug(f"Could not register handle for atexit drain: {e}")
+
+        # Track consecutive failures from ``handle.next_event()`` /
+        # ``_handle_a2a_mesh_event`` so a persistently-failing event
+        # source doesn't tight-loop on logger.error. Backoff is
+        # exponential per attempt and capped; on too many in a row we
+        # surface the failure to the caller instead of swallowing it
+        # forever.
+        consecutive_failures = 0
+        MAX_CONSECUTIVE = 10
+
+        while True:
+            try:
+                from ...shared.simple_shutdown import should_stop_heartbeat
+
+                if should_stop_heartbeat():
+                    logger.info(
+                        f"Stopping Rust A2A heartbeat for service '{service_id}' due to shutdown"
+                    )
+                    handle.shutdown()
+                    break
+            except ImportError:
+                pass
+
+            try:
+                try:
+                    event = await asyncio.wait_for(handle.next_event(), timeout=1.0)
+                except TimeoutError:
+                    continue
+
+                if event.event_type == "shutdown":
+                    logger.info(f"Rust core shutdown for A2A service '{service_id}'")
+                    break
+
+                await _handle_a2a_mesh_event(event, context)
+                consecutive_failures = 0
+
+            except Exception as e:
+                consecutive_failures += 1
+                logger.error(
+                    f"Error handling Rust event for A2A service "
+                    f"({consecutive_failures}/{MAX_CONSECUTIVE}): {e}"
+                )
+                if consecutive_failures >= MAX_CONSECUTIVE:
+                    logger.error(
+                        f"Rust A2A event loop exiting after {MAX_CONSECUTIVE} "
+                        f"consecutive failures for service '{service_id}'"
+                    )
+                    raise
+                # Exponential backoff capped at 5s so we don't burn CPU
+                # while still recovering quickly from transient blips.
+                backoff = min(0.5 * (2 ** (consecutive_failures - 1)), 5.0)
+                try:
+                    await asyncio.sleep(backoff)
+                except asyncio.CancelledError:
+                    raise
+
+    except asyncio.CancelledError:
+        logger.info(f"Rust A2A heartbeat task cancelled for service '{service_id}'")
+        raise
+    except Exception as e:
+        logger.error(f"Rust A2A heartbeat failed for service '{service_id}': {e}")
+        raise
+    finally:
+        if handle is not None:
+            try:
+                handle.shutdown()
+                try:
+                    await asyncio.sleep(0.2)
+                except (asyncio.CancelledError, RuntimeError):
+                    import time
+
+                    time.sleep(0.2)
+                logger.debug(
+                    f"Rust core shutdown complete for A2A service '{service_id}'"
+                )
+                try:
+                    from ...shared.simple_shutdown import (
+                        unregister_rust_agent_handle,
+                    )
+
+                    unregister_rust_agent_handle(handle)
+                except Exception:
+                    pass
+            except Exception as e:
+                logger.warning(f"Error during Rust core shutdown for A2A service: {e}")

--- a/src/runtime/python/_mcp_mesh/pipeline/a2a_startup/__init__.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/a2a_startup/__init__.py
@@ -1,0 +1,33 @@
+"""
+A2A Startup pipeline components for MCP Mesh (issue #903 Phase 1B).
+
+Handles ``@mesh.a2a`` / ``mesh.a2a.mount`` surface registration on a
+user-owned FastAPI app. Sibling pipeline to ``api_startup`` (which
+handles ``@mesh.route``) and ``mcp_startup`` (which handles
+``@mesh.agent`` / ``@mesh.tool``).
+
+The A2A pipeline differs from ``api_startup`` in two ways:
+
+  * There are no ``@mesh.route`` decorators to collect — the
+    ``mesh.a2a.mount`` helper has already wired the agent-card and
+    JSON-RPC routes onto the user's FastAPI app at module import time.
+  * Dependency injection is performed by ``@mesh.a2a`` itself (mirrors
+    ``@mesh.route``), so no ``RouteIntegrationStep`` is needed.
+
+The pipeline therefore reduces to: discover the user's FastAPI app,
+attach tracing middleware, and prepare the heartbeat metadata
+(``service_type=a2a`` + the ``surfaces`` array sent on each registry
+heartbeat round-trip).
+"""
+
+from .a2a_pipeline import A2APipeline
+from .a2a_server_setup import A2AServerSetupStep
+from .a2a_surface_collection import A2ASurfaceCollectionStep
+from .fastapi_discovery import A2AFastAPIDiscoveryStep
+
+__all__ = [
+    "A2APipeline",
+    "A2AServerSetupStep",
+    "A2ASurfaceCollectionStep",
+    "A2AFastAPIDiscoveryStep",
+]

--- a/src/runtime/python/_mcp_mesh/pipeline/a2a_startup/a2a_pipeline.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/a2a_startup/a2a_pipeline.py
@@ -1,0 +1,69 @@
+"""
+A2A pipeline for MCP Mesh A2A surface integration (issue #903 Phase 1B).
+
+Sibling pipeline to ``APIPipeline`` (handles ``@mesh.route``) and the
+mcp-startup ``StartupPipeline`` (handles ``@mesh.agent`` / ``@mesh.tool``).
+Triggered when the user has declared ``@mesh.a2a`` or
+``mesh.a2a.mount(...)`` surfaces — the user owns the FastAPI app AND
+the uvicorn lifecycle, mesh handles discovery + heartbeat + DI bookkeeping.
+
+Pipeline shape:
+
+  1. A2A surface collection      (read ``mesh_a2a`` markers from registry)
+  2. FastAPI app discovery       (locate the user's FastAPI instance)
+  3. Tracing middleware          (attach distributed-tracing middleware)
+  4. A2A server setup            (heartbeat config + ``service_type=a2a``)
+
+DI is wired by the ``@mesh.a2a`` decorator itself at module import (mirrors
+``@mesh.route``), so this pipeline has no equivalent of
+``RouteIntegrationStep``.
+"""
+
+import logging
+
+from ..api_startup.middleware_integration import \
+    TracingMiddlewareIntegrationStep
+from ..shared.mesh_pipeline import MeshPipeline
+from .a2a_server_setup import A2AServerSetupStep
+from .a2a_surface_collection import A2ASurfaceCollectionStep
+from .fastapi_discovery import A2AFastAPIDiscoveryStep
+
+logger = logging.getLogger(__name__)
+
+
+class A2APipeline(MeshPipeline):
+    """
+    Specialized pipeline for A2A surface operations.
+
+    Executes the A2A integration steps in sequence:
+    1. A2A surface collection (read ``mesh_a2a`` markers)
+    2. FastAPI app discovery (locate the user's FastAPI instance)
+    3. Tracing middleware integration (shared with api_startup)
+    4. A2A server setup (heartbeat metadata + ``service_type=a2a``)
+
+    Like ``APIPipeline``, this is a consumer-style pipeline:
+    - No FastAPI server is created (user owns the app + uvicorn).
+    - DI is already wired by ``@mesh.a2a`` at module import.
+    - The pipeline only contributes registration metadata + heartbeat.
+    """
+
+    def __init__(self, name: str = "a2a-pipeline"):
+        super().__init__(name=name)
+        self._setup_a2a_steps()
+
+    def _setup_a2a_steps(self) -> None:
+        """Setup the A2A pipeline steps."""
+        steps = [
+            A2ASurfaceCollectionStep(),  # Collect mesh_a2a markers
+            A2AFastAPIDiscoveryStep(),  # Find user's FastAPI app
+            TracingMiddlewareIntegrationStep(),  # Add tracing middleware
+            A2AServerSetupStep(),  # Heartbeat + service_type=a2a
+        ]
+
+        self.add_steps(steps)
+        self.logger.debug(f"A2A pipeline configured with {len(steps)} steps")
+
+        self.logger.info(
+            "🌐 [DEBUG] A2A Pipeline initialized: surface registration for @mesh.a2a decorators"
+        )
+        self.logger.debug(f"📋 Pipeline steps: {[step.name for step in steps]}")

--- a/src/runtime/python/_mcp_mesh/pipeline/a2a_startup/a2a_server_setup.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/a2a_startup/a2a_server_setup.py
@@ -1,0 +1,385 @@
+"""
+A2A server setup step (issue #903 Phase 1B).
+
+Mirrors ``api_startup/api_server_setup.py`` for the A2A flow. Prepares
+heartbeat config + service-registration metadata for a user-owned
+FastAPI app that has declared ``@mesh.a2a`` / ``mesh.a2a.mount``
+surfaces. This step does NOT create or modify the FastAPI app — it
+only computes the registration shape the heartbeat task ships to the
+registry on each round-trip.
+"""
+
+import logging
+import uuid
+from typing import Any, Dict, List, Optional
+
+from ...shared.config_resolver import ValidationRule, get_config_value
+from ...shared.host_resolver import HostResolver
+from ...shared.slug import slugify_service_name
+from ..shared import PipelineResult, PipelineStatus, PipelineStep
+
+
+class A2AServerSetupStep(PipelineStep):
+    """
+    Minimal A2A server setup for FastAPI integration.
+
+    Mirrors ``APIServerSetupStep`` but always emits ``service_type="a2a"``
+    and pre-seeds the heartbeat context with the ``a2a_surfaces`` array
+    so the rust a2a-heartbeat AgentSpec builder has zero work to do.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="a2a-server-setup",
+            required=True,
+            description="Prepare binding config + service registration for A2A FastAPI app",
+        )
+
+    async def execute(self, context: dict[str, Any]) -> PipelineResult:
+        """Setup A2A server configuration."""
+        self.logger.debug("Setting up A2A server configuration...")
+
+        result = PipelineResult(message="A2A server setup completed")
+
+        try:
+            fastapi_apps = context.get("fastapi_apps", {})
+            a2a_surfaces: List[Dict[str, Any]] = context.get("a2a_surfaces", [])
+
+            if not fastapi_apps:
+                result.status = PipelineStatus.FAILED
+                result.message = "No FastAPI applications found"
+                result.add_error("Cannot setup A2A server without existing FastAPI app")
+                self.logger.error(
+                    "❌ No FastAPI applications found. A2A pipeline requires "
+                    "an existing FastAPI app with @mesh.a2a / mesh.a2a.mount surfaces."
+                )
+                return result
+
+            if not a2a_surfaces:
+                result.status = PipelineStatus.FAILED
+                result.message = "No A2A surfaces found"
+                result.add_error(
+                    "A2A pipeline executed without any registered @mesh.a2a surfaces"
+                )
+                self.logger.error(
+                    "❌ A2A server setup requires at least one @mesh.a2a surface."
+                )
+                return result
+
+            if len(fastapi_apps) > 1:
+                self.logger.warning(
+                    f"⚠️ Multiple FastAPI apps found ({len(fastapi_apps)}), "
+                    "using the first one. Multi-app support coming in future."
+                )
+
+            primary_app_id = list(fastapi_apps.keys())[0]
+            primary_app_info = fastapi_apps[primary_app_id]
+            primary_app = primary_app_info["instance"]
+
+            self.logger.info(
+                f"🎯 Using FastAPI app: '{primary_app_info['title']}' as primary A2A host"
+            )
+
+            display_config = self._prepare_display_config()
+            service_metadata = self._prepare_service_metadata(
+                primary_app_info, a2a_surfaces, display_config
+            )
+            heartbeat_config = self._prepare_heartbeat_config(
+                primary_app_info, display_config, service_metadata, a2a_surfaces
+            )
+
+            result.add_context("primary_fastapi_app", primary_app)
+            result.add_context("fastapi_app", primary_app)
+            result.add_context("a2a_display_config", display_config)
+            result.add_context("display_config", display_config)
+            result.add_context("a2a_service_metadata", service_metadata)
+            result.add_context("service_type", "a2a")
+            result.add_context("heartbeat_config", heartbeat_config)
+            result.add_context("a2a_surfaces", a2a_surfaces)
+
+            result.message = (
+                f"A2A server config prepared for '{primary_app_info['title']}' "
+                f"with {len(a2a_surfaces)} surface(s)"
+            )
+
+            self.logger.info(
+                f"✅ A2A server setup: {primary_app_info['title']} ready "
+                f"({len(a2a_surfaces)} surface(s); registry display: "
+                f"{display_config['display_host']}:{display_config['display_port']})"
+            )
+            self.logger.info(
+                f"🌐 A2A surfaces detected: {len(a2a_surfaces)} surface(s); "
+                "service_type='a2a'"
+            )
+
+        except Exception as e:
+            result.status = PipelineStatus.FAILED
+            result.message = f"A2A server setup failed: {e}"
+            result.add_error(str(e))
+            self.logger.error(f"❌ A2A server setup failed: {e}")
+
+        return result
+
+    def _prepare_display_config(self) -> Dict[str, Any]:
+        """
+        Prepare display configuration for service registration.
+
+        For A2A, the display host:port is what the registry advertises on
+        the agent-card ``url`` (subject to MCP_MESH_PUBLIC_URL_PREFIX
+        rewriting on the registry side). The user controls actual uvicorn
+        binding separately.
+        """
+        external_host = HostResolver.get_external_host()
+
+        display_port = get_config_value(
+            "MCP_MESH_HTTP_PORT",
+            default=8080,
+            rule=ValidationRule.PORT_RULE,
+        )
+
+        display_host = get_config_value(
+            "MCP_MESH_HTTP_HOST",
+            default=external_host,
+            rule=ValidationRule.STRING_RULE,
+        )
+
+        display_config = {
+            "display_host": display_host,
+            "display_port": display_port,
+            "external_host": external_host,
+        }
+
+        self.logger.debug(
+            f"📍 Display config: {display_host}:{display_port} "
+            "(for registry display only - user controls actual uvicorn binding)"
+        )
+
+        return display_config
+
+    def _prepare_service_metadata(
+        self,
+        app_info: Dict[str, Any],
+        a2a_surfaces: List[Dict[str, Any]],
+        display_config: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """
+        Prepare service registration metadata for the registry.
+
+        Always emits ``service_type="a2a"``. The ``capabilities`` list is
+        derived from the A2A surfaces (one entry per skill).
+        """
+        capabilities = []
+        for surface in a2a_surfaces:
+            capabilities.append(
+                {
+                    "name": surface.get("skill_id", "unknown"),
+                    "type": "a2a_surface",
+                    "path": surface.get("path"),
+                }
+            )
+
+        service_metadata = {
+            "service_name": app_info.get("title", "FastAPI A2A Service"),
+            "service_version": app_info.get("version", "1.0.0"),
+            "service_type": "a2a",
+            "capabilities": capabilities,
+            "total_surfaces": len(a2a_surfaces),
+            "framework": "fastapi",
+            "integration_method": "mesh_a2a_mount",
+            "display_host": display_config["display_host"],
+            "display_port": display_config["display_port"],
+            "external_host": display_config["external_host"],
+        }
+
+        self.logger.debug(
+            f"📋 Service metadata: {service_metadata['service_name']} "
+            f"({len(capabilities)} A2A skill(s))"
+        )
+
+        return service_metadata
+
+    def _prepare_heartbeat_config(
+        self,
+        app_info: Dict[str, Any],
+        display_config: Dict[str, Any],
+        service_metadata: Dict[str, Any],
+        a2a_surfaces: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """
+        Prepare heartbeat configuration for A2A service.
+
+        The surfaces array is pre-seeded into the heartbeat context so
+        the rust a2a-heartbeat AgentSpec builder doesn't need to re-walk
+        the DecoratorRegistry (the integrate path merges additional
+        pipeline context on top of this seed).
+        """
+        service_id = self._get_or_generate_a2a_service_id(app_info)
+
+        from ...shared.defaults import MeshDefaults
+
+        heartbeat_interval = get_config_value(
+            "MCP_MESH_HEALTH_INTERVAL",
+            default=MeshDefaults.HEALTH_INTERVAL,
+            rule=ValidationRule.NONZERO_RULE,
+        )
+
+        standalone_mode = get_config_value(
+            "MCP_MESH_STANDALONE",
+            default=False,
+            rule=ValidationRule.TRUTHY_RULE,
+        )
+
+        seed_context: Dict[str, Any] = {"a2a_surfaces": list(a2a_surfaces)}
+
+        heartbeat_config = {
+            "service_id": service_id,
+            "interval": heartbeat_interval,
+            "standalone_mode": standalone_mode,
+            "context": seed_context,
+        }
+
+        try:
+            from ...engine.decorator_registry import DecoratorRegistry
+
+            # Slugify the FastAPI app title so it matches the registry's
+            # name validation (lowercase alphanumeric + hyphens only).
+            # "Date A2A Agent" → "date-a2a-agent". Non-ASCII chars (e.g.
+            # "Café A2A ☕") are stripped to hyphens so registry validation
+            # doesn't reject the resulting name. Helper is shared with the
+            # API pipeline + ``_generate_a2a_service_id`` to keep the four
+            # call sites consistent.
+            raw_title = app_info.get("title")
+            slug_name = slugify_service_name(raw_title, "a2a-service")
+
+            # Plumb the discovered host/port into agent_config so the
+            # card endpoint's local-fallback URL builder can produce
+            # `http://{host}:{port}{path}` (env-var-derived defaults
+            # would otherwise miss the user's actual uvicorn port).
+            update = {"agent_id": service_id, "name": slug_name}
+            if display_config.get("display_host"):
+                update["http_host"] = display_config["display_host"]
+            if display_config.get("display_port"):
+                update["http_port"] = display_config["display_port"]
+            DecoratorRegistry.update_agent_config(update)
+
+            self.logger.debug(
+                f"🔧 Stored A2A service ID '{service_id}' (name='{slug_name}', from title='{raw_title}') in decorator registry"
+            )
+        except Exception as e:
+            self.logger.warning(
+                f"⚠️ Failed to store A2A service ID in decorator registry: {e}"
+            )
+
+        self.logger.info(
+            f"💓 A2A heartbeat config created: service_id='{service_id}', "
+            f"interval={heartbeat_interval}s, standalone={standalone_mode}"
+        )
+
+        return heartbeat_config
+
+    def _generate_a2a_service_id(
+        self, app_info: Optional[Dict[str, Any]] = None
+    ) -> str:
+        """
+        Generate A2A service ID using the same priority logic as MCP/API agents.
+
+        Priority order:
+        1. ``MCP_MESH_AGENT_ID`` environment variable — pinned ID, used
+           verbatim with no slug or UUID suffix. This is how operators
+           opt into a stable, externally-managed identity (e.g. Helm
+           chart parameter).
+        2. ``MCP_MESH_A2A_NAME`` environment variable
+        3. ``MCP_MESH_AGENT_NAME`` environment variable (fallback)
+        4. FastAPI app title slug (stable across restarts — without this
+           the default ``a2a-{uuid8}`` would create a fresh registry entry
+           every restart, leaving stale records).
+        5. Default to ``"a2a-{uuid8}"``.
+        """
+        # ``MCP_MESH_AGENT_ID`` is the pinned-ID escape hatch — when set
+        # we honour it verbatim (no slug, no UUID suffix). Operators use
+        # this when the registry identity is managed externally (Helm
+        # values, Terraform, etc.) and must be stable across restarts.
+        pinned_id = get_config_value(
+            "MCP_MESH_AGENT_ID",
+            default=None,
+            rule=ValidationRule.STRING_RULE,
+        )
+        if pinned_id:
+            self.logger.debug(
+                f"Using pinned A2A service ID from MCP_MESH_AGENT_ID: '{pinned_id}'"
+            )
+            return pinned_id
+
+        a2a_name = get_config_value(
+            "MCP_MESH_A2A_NAME",
+            default=None,
+            rule=ValidationRule.STRING_RULE,
+        )
+
+        if not a2a_name:
+            a2a_name = get_config_value(
+                "MCP_MESH_AGENT_NAME",
+                default=None,
+                rule=ValidationRule.STRING_RULE,
+            )
+
+        # Fall back to the FastAPI app title for a stable identity across
+        # restarts (the cached-config reuse logic at
+        # ``_get_or_generate_a2a_service_id`` will then hit on subsequent
+        # runs since the resulting service_id contains "a2a-" or "-a2a-").
+        if not a2a_name and app_info and app_info.get("title"):
+            a2a_name = app_info["title"]
+
+        # Use the shared slug helper — the empty-fallback ("") is the
+        # sentinel that triggers the "a2a-{uuid8}" branch below.
+        cleaned_name = slugify_service_name(a2a_name, "")
+
+        uuid_suffix = str(uuid.uuid4())[:8]
+
+        if not cleaned_name:
+            service_id = f"a2a-{uuid_suffix}"
+        elif "a2a" in cleaned_name.lower():
+            service_id = f"{cleaned_name}-{uuid_suffix}"
+        else:
+            service_id = f"{cleaned_name}-a2a-{uuid_suffix}"
+
+        self.logger.debug(
+            f"Generated A2A service ID: '{service_id}' from name source: '{a2a_name}'"
+        )
+
+        return service_id
+
+    def _get_or_generate_a2a_service_id(
+        self, app_info: Optional[Dict[str, Any]] = None
+    ) -> str:
+        """
+        Get existing service ID from decorator registry or generate a new one.
+        """
+        try:
+            from ...engine.decorator_registry import DecoratorRegistry
+
+            current_config = DecoratorRegistry.get_resolved_agent_config()
+            existing_id = current_config.get("agent_id", "")
+
+            is_a2a_format = (
+                existing_id.startswith("a2a-")
+                or "-a2a-" in existing_id
+            )
+
+            if existing_id and is_a2a_format:
+                self.logger.info(
+                    f"🔄 Reusing existing A2A service ID: '{existing_id}'"
+                )
+                return existing_id
+
+            new_id = self._generate_a2a_service_id(app_info)
+            self.logger.info(
+                f"🆕 Generated new A2A service ID: '{new_id}'"
+            )
+            return new_id
+
+        except Exception as e:
+            self.logger.warning(
+                f"⚠️ Error checking existing service ID, generating new one: {e}"
+            )
+            return self._generate_a2a_service_id(app_info)

--- a/src/runtime/python/_mcp_mesh/pipeline/a2a_startup/a2a_surface_collection.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/a2a_startup/a2a_surface_collection.py
@@ -1,0 +1,64 @@
+"""
+A2A surface collection step.
+
+Reads ``@mesh.a2a`` markers from the DecoratorRegistry and emits the
+shared surfaces array (registry shape) onto the pipeline context. This
+mirrors ``api_startup/route_collection.py`` for the A2A flow.
+"""
+
+import logging
+from typing import Any
+
+from ...engine.a2a_surfaces import collect_a2a_surfaces
+from ...engine.decorator_registry import DecoratorRegistry
+from ..shared import PipelineResult, PipelineStatus, PipelineStep
+
+
+class A2ASurfaceCollectionStep(PipelineStep):
+    """
+    Collects all registered ``@mesh.a2a`` decorators from DecoratorRegistry.
+
+    Stamps both the raw decorator dict (``mesh_a2a_decorators``) and the
+    registry-shape surfaces array (``a2a_surfaces``) onto the context for
+    downstream steps and the heartbeat AgentSpec builder.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="a2a-surface-collection",
+            required=True,
+            description="Collect all registered @mesh.a2a / mesh.a2a.mount surfaces",
+        )
+
+    async def execute(self, context: dict[str, Any]) -> PipelineResult:
+        """Collect A2A surface decorators from registry."""
+        self.logger.debug("Collecting A2A surfaces from DecoratorRegistry...")
+
+        result = PipelineResult(message="A2A surface collection completed")
+
+        try:
+            mesh_a2a_decorators = DecoratorRegistry.get_all_by_type("mesh_a2a")
+            a2a_surfaces = collect_a2a_surfaces()
+
+            result.add_context("mesh_a2a_decorators", mesh_a2a_decorators)
+            result.add_context("a2a_surfaces", a2a_surfaces)
+            result.add_context("a2a_surface_count", len(a2a_surfaces))
+
+            result.message = f"Collected {len(a2a_surfaces)} A2A surface(s)"
+
+            self.logger.info(
+                f"🌐 Collected decorators: {len(a2a_surfaces)} @mesh.a2a surface(s)"
+            )
+
+            if len(a2a_surfaces) == 0:
+                result.status = PipelineStatus.SKIPPED
+                result.message = "No A2A surfaces found to process"
+                self.logger.warning("⚠️ No A2A surfaces found in registry")
+
+        except Exception as e:
+            result.status = PipelineStatus.FAILED
+            result.message = f"Failed to collect A2A surfaces: {e}"
+            result.add_error(str(e))
+            self.logger.error(f"❌ A2A surface collection failed: {e}")
+
+        return result

--- a/src/runtime/python/_mcp_mesh/pipeline/a2a_startup/fastapi_discovery.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/a2a_startup/fastapi_discovery.py
@@ -1,0 +1,142 @@
+"""
+FastAPI app discovery for the A2A pipeline.
+
+Mirrors ``api_startup/fastapi_discovery.py`` but gates on
+``mesh_a2a_decorators`` instead of ``mesh_routes`` — the A2A pipeline
+runs when the user has declared ``@mesh.a2a`` / ``mesh.a2a.mount`` but
+no ``@mesh.route`` decorators.
+
+The ``mesh.a2a.mount(...)`` helper has already attached the agent-card
++ JSON-RPC routes to the user's FastAPI app and applied DI to the
+underlying handler at module import time. This step only locates the
+app instance so the heartbeat config can ship the correct binding info
+to the registry.
+"""
+
+import logging
+from typing import Any
+
+from ...shared.server_discovery import ServerDiscoveryUtil
+from ..shared import PipelineResult, PipelineStatus, PipelineStep
+
+
+class A2AFastAPIDiscoveryStep(PipelineStep):
+    """
+    Discovers existing FastAPI application instances for the A2A pipeline.
+
+    Same discovery mechanism as ``FastAPIAppDiscoveryStep`` (via
+    ``ServerDiscoveryUtil``), but gates on the presence of
+    ``@mesh.a2a`` surfaces instead of ``@mesh.route`` handlers.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="a2a-fastapi-discovery",
+            required=True,
+            description="Discover existing FastAPI application instances for A2A surfaces",
+        )
+
+    async def execute(self, context: dict[str, Any]) -> PipelineResult:
+        """Discover FastAPI applications hosting A2A surfaces."""
+        self.logger.debug("Discovering FastAPI applications for A2A surfaces...")
+
+        result = PipelineResult(message="A2A FastAPI discovery completed")
+
+        try:
+            mesh_a2a_decorators = context.get("mesh_a2a_decorators", {})
+
+            if not mesh_a2a_decorators:
+                result.status = PipelineStatus.SKIPPED
+                result.message = "No @mesh.a2a surfaces found"
+                self.logger.info("⚠️ No @mesh.a2a surfaces found to process")
+                return result
+
+            fastapi_apps = ServerDiscoveryUtil.discover_fastapi_instances()
+
+            if not fastapi_apps:
+                result.status = PipelineStatus.FAILED
+                result.message = "No FastAPI applications found"
+                result.add_error("No FastAPI applications discovered in runtime")
+                self.logger.error(
+                    "❌ No FastAPI applications found. @mesh.a2a / mesh.a2a.mount "
+                    "requires an existing FastAPI app instance — please create a "
+                    "FastAPI app before declaring A2A surfaces."
+                )
+                return result
+
+            # Filter discovered apps to those that actually host an A2A
+            # surface. Without this, multi-app runtimes (e.g. an unrelated
+            # FastAPI app for admin / metrics in the same process) would
+            # cause us to pick an arbitrary app — possibly one without any
+            # of the routes ``mesh.a2a.mount(...)`` registered, leading
+            # to "no surfaces visible" mysteries downstream.
+            #
+            # An app "hosts" a surface when one of its routes' paths
+            # matches a configured ``@mesh.a2a`` ``path`` — either the
+            # raw RPC path or the agent-card discovery suffix.
+            wanted_paths: set = set()
+            for decorated in mesh_a2a_decorators.values():
+                meta = getattr(decorated, "metadata", None) or {}
+                p = meta.get("path")
+                if not p:
+                    continue
+                rpc_path = p.rstrip("/") or "/"
+                card_path = p.rstrip("/") + "/.well-known/agent.json"
+                wanted_paths.add(rpc_path)
+                wanted_paths.add(card_path)
+
+            filtered_apps: dict = {}
+            for app_id, app_info in fastapi_apps.items():
+                app = app_info.get("instance")
+                if app is None:
+                    continue
+                app_route_paths = {
+                    getattr(r, "path", None) for r in app.router.routes
+                }
+                if app_route_paths & wanted_paths:
+                    filtered_apps[app_id] = app_info
+
+            if not filtered_apps:
+                result.status = PipelineStatus.FAILED
+                result.message = (
+                    "No FastAPI app hosts any @mesh.a2a surface route"
+                )
+                result.add_error(
+                    "Discovered FastAPI app(s) but none had a route matching "
+                    "the @mesh.a2a / mesh.a2a.mount path(s) — did mount() run "
+                    "before pipeline execution?"
+                )
+                self.logger.error(
+                    f"❌ A2A FastAPI discovery: found {len(fastapi_apps)} app(s) "
+                    f"but none host any of the {len(wanted_paths)} expected "
+                    "A2A route path(s)."
+                )
+                return result
+
+            result.add_context("fastapi_apps", filtered_apps)
+            result.add_context("discovered_app_count", len(filtered_apps))
+
+            result.message = (
+                f"Discovered {len(filtered_apps)} FastAPI app(s) hosting "
+                f"{len(mesh_a2a_decorators)} @mesh.a2a surface(s)"
+            )
+
+            self.logger.info(
+                f"📦 A2A FastAPI Discovery: {len(filtered_apps)} app(s) hosting "
+                f"A2A surfaces (of {len(fastapi_apps)} total app(s) in runtime), "
+                f"{len(mesh_a2a_decorators)} A2A surface(s)"
+            )
+
+            for app_id, app_info in filtered_apps.items():
+                self.logger.debug(
+                    f"  App '{app_info.get('title', 'Unknown')}' ({app_id}): "
+                    f"{len(app_info.get('routes', []))} total route(s)"
+                )
+
+        except Exception as e:
+            result.status = PipelineStatus.FAILED
+            result.message = f"A2A FastAPI discovery failed: {e}"
+            result.add_error(str(e))
+            self.logger.error(f"❌ A2A FastAPI discovery failed: {e}")
+
+        return result

--- a/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/rust_api_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/rust_api_heartbeat.py
@@ -65,7 +65,17 @@ def _build_api_agent_spec(context: dict[str, Any], service_id: str = None) -> An
             "agent_id", "unknown-api-service"
         )
     display_config = context.get("display_config", {})
-    agent_config = context.get("agent_config", {})
+    # Prefer pipeline-context override (test seams), fall back to the
+    # DecoratorRegistry's resolved config so the FastAPI app title +
+    # any update_agent_config(...) writes from api_server_setup.py
+    # land in the heartbeat. Without this fallback, base_name strips
+    # the service_id suffix and produces names like "api" instead of
+    # the actual app title.
+    agent_config = context.get("agent_config")
+    if not agent_config:
+        from ...engine.decorator_registry import DecoratorRegistry
+
+        agent_config = DecoratorRegistry.get_resolved_agent_config() or {}
 
     # Get registry URL
     from ...shared.config_resolver import get_config_value

--- a/src/runtime/python/_mcp_mesh/pipeline/api_startup/api_server_setup.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_startup/api_server_setup.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 from ...shared.config_resolver import ValidationRule, get_config_value
 from ...shared.defaults import MeshDefaults
 from ...shared.host_resolver import HostResolver
+from ...shared.slug import slugify_service_name
 from ..shared import PipelineResult, PipelineStatus, PipelineStep
 
 
@@ -251,12 +252,29 @@ class APIServerSetupStep(PipelineStep):
         try:
             from ...engine.decorator_registry import DecoratorRegistry
 
-            DecoratorRegistry.update_agent_config(
-                {"agent_id": service_id, "name": app_info.get("title", "api-service")}
-            )
+            # Slugify the FastAPI app title so it matches the registry's
+            # name validation (lowercase alphanumeric + hyphens only).
+            # "MCP Mesh FastAPI Example" → "mcp-mesh-fastapi-example".
+            # Non-ASCII chars (e.g. "Café API ☕") are stripped to hyphens
+            # so registry validation doesn't reject the resulting name.
+            # Helper is shared with the A2A pipeline + service-id
+            # generators to keep the four call sites consistent.
+            raw_title = app_info.get("title")
+            slug_name = slugify_service_name(raw_title, "api-service")
+
+            # Plumb the discovered host/port into agent_config so any
+            # downstream consumer (telemetry, fallback URL builders)
+            # has the user's actual uvicorn bind info instead of the
+            # env-var-derived defaults.
+            update = {"agent_id": service_id, "name": slug_name}
+            if display_config.get("display_host"):
+                update["http_host"] = display_config["display_host"]
+            if display_config.get("display_port"):
+                update["http_port"] = display_config["display_port"]
+            DecoratorRegistry.update_agent_config(update)
 
             self.logger.debug(
-                f"🔧 Stored API service ID '{service_id}' in decorator registry for telemetry"
+                f"🔧 Stored API service ID '{service_id}' (name='{slug_name}', from title='{raw_title}') in decorator registry"
             )
         except Exception as e:
             self.logger.warning(
@@ -304,12 +322,9 @@ class APIServerSetupStep(PipelineStep):
                 rule=ValidationRule.STRING_RULE,
             )
 
-        # Clean the service name if provided
-        if api_name:
-            cleaned_name = api_name.lower().replace(" ", "-").replace("_", "-")
-            cleaned_name = "-".join(part for part in cleaned_name.split("-") if part)
-        else:
-            cleaned_name = ""
+        # Clean the service name if provided. Empty fallback is the
+        # sentinel that triggers the "api-{uuid8}" branch below.
+        cleaned_name = slugify_service_name(api_name, "")
 
         # Generate UUID suffix
         uuid_suffix = str(uuid.uuid4())[:8]

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
@@ -466,6 +466,15 @@ def _build_agent_spec(context: dict[str, Any]) -> Any:
     # synthetic configs where @mesh.agent(name=...) wasn't used.
     base_name = agent_config.get("name") or agent_id
 
+    # Issue #903 Phase 1B: gather @mesh.a2a surfaces. Presence flips
+    # agent_type to "a2a" so the registry computes FQDNs and surfaces
+    # this agent on GET /a2a/agents. The Rust core ships the surfaces
+    # JSON string verbatim to the registry's `MeshAgentRegistration.surfaces`
+    # field. Mesh tools coexist with A2A surfaces.
+    a2a_surfaces = _build_a2a_surfaces_for_rust()
+    agent_type = "a2a" if a2a_surfaces else None
+    surfaces_json = json.dumps(a2a_surfaces) if a2a_surfaces else None
+
     # Create AgentSpec
     spec = core.AgentSpec(
         name=base_name,
@@ -475,18 +484,35 @@ def _build_agent_spec(context: dict[str, Any]) -> Any:
         http_port=http_port,
         http_host=http_host,
         namespace=namespace,
+        agent_type=agent_type,
         tools=tools if tools else None,
         llm_agents=llm_agents if llm_agents else None,
         heartbeat_interval=heartbeat_interval,
         agent_id=agent_id,
+        surfaces=surfaces_json,
     )
 
     logger.info(
-        f"Built AgentSpec: name={base_name}, agent_id={agent_id}, tools={len(tools)}, "
-        f"llm_agents={len(llm_agents)}, registry={registry_url}"
+        f"Built AgentSpec: name={base_name}, agent_id={agent_id}, "
+        f"agent_type={agent_type or 'mcp_agent'}, tools={len(tools)}, "
+        f"llm_agents={len(llm_agents)}, surfaces={len(a2a_surfaces)}, "
+        f"registry={registry_url}"
     )
 
     return spec
+
+
+def _build_a2a_surfaces_for_rust() -> list[dict[str, Any]]:
+    """Collect ``@mesh.a2a`` surfaces in the registry-bound shape (issue #903 Phase 1B).
+
+    Thin wrapper around :func:`a2a_surfaces.collect_a2a_surfaces` so the
+    legacy Python heartbeat path, the Rust-backed mcp heartbeat, and the
+    Rust-backed api heartbeat all emit identical JSON. See
+    ``_mcp_mesh.engine.a2a_surfaces`` for shape rationale.
+    """
+    from ...engine.a2a_surfaces import collect_a2a_surfaces
+
+    return collect_a2a_surfaces()
 
 
 async def _handle_mesh_event(event: Any, context: dict[str, Any]) -> None:

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/heartbeat_preparation.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/heartbeat_preparation.py
@@ -52,9 +52,14 @@ class HeartbeatPreparationStep(PipelineStep):
             # Build tools list for registration (with FastMCP schemas)
             tools_list = self._build_tools_list(mesh_tools, fastmcp_servers)
 
+            # Issue #903 Phase 1B: gather @mesh.a2a surfaces for the
+            # registry. Presence flips agent_type to "a2a" so the registry
+            # stamps FQDNs and surfaces this agent on GET /a2a/agents.
+            a2a_surfaces = self._build_a2a_surfaces()
+
             # Build agent registration payload
             registration_data = self._build_registration_payload(
-                agent_id, agent_config, tools_list
+                agent_id, agent_config, tools_list, a2a_surfaces
             )
 
             # Build health status for heartbeat
@@ -331,11 +336,28 @@ class HeartbeatPreparationStep(PipelineStep):
 
         return debug_info
 
+    def _build_a2a_surfaces(self) -> list[dict[str, Any]]:
+        """Collect ``@mesh.a2a`` surface metadata for heartbeat (issue #903 Phase 1B).
+
+        Thin delegating wrapper over
+        :func:`_mcp_mesh.engine.a2a_surfaces.collect_a2a_surfaces` (the
+        single source of truth — also used by the Rust-backed mcp_heartbeat
+        and api_heartbeat paths). Kept as an instance method so call sites
+        in this class don't change, but unit tests that previously patched
+        ``_mcp_mesh.pipeline.mcp_startup.heartbeat_preparation.DecoratorRegistry``
+        for ``get_all_by_type`` should now patch
+        ``_mcp_mesh.engine.a2a_surfaces.DecoratorRegistry`` instead.
+        """
+        from ...engine.a2a_surfaces import collect_a2a_surfaces
+
+        return collect_a2a_surfaces()
+
     def _build_registration_payload(
         self,
         agent_id: str,
         agent_config: dict[str, Any],
         tools_list: list[dict[str, Any]],
+        a2a_surfaces: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Build agent registration payload."""
         from ...shared.host_resolver import HostResolver
@@ -346,9 +368,15 @@ class HeartbeatPreparationStep(PipelineStep):
         # configured only via @mesh.tool with no @mesh.agent(name=...)).
         base_name = agent_config.get("name") or agent_id
 
-        return {
+        # Issue #903 Phase 1B: presence of @mesh.a2a surfaces flips the
+        # agent_type to "a2a" so the registry computes FQDNs and exposes
+        # this agent via GET /a2a/agents. Mesh tools coexist with A2A
+        # surfaces — agent_type=a2a does NOT mean "no mesh tools".
+        agent_type = "a2a" if a2a_surfaces else "mcp_agent"
+
+        payload: dict[str, Any] = {
             "agent_id": agent_id,
-            "agent_type": "mcp_agent",
+            "agent_type": agent_type,
             "name": base_name,
             "version": agent_config.get("version", "1.0.0"),
             "http_host": HostResolver.get_external_host(),
@@ -357,6 +385,9 @@ class HeartbeatPreparationStep(PipelineStep):
             "namespace": agent_config.get("namespace", "default"),
             "tools": tools_list,
         }
+        if a2a_surfaces:
+            payload["surfaces"] = a2a_surfaces
+        return payload
 
     def _extract_capabilities(self, tools_list: list[dict[str, Any]]) -> list[str]:
         """Extract capabilities from tools list."""

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_orchestrator.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_orchestrator.py
@@ -92,8 +92,9 @@ class DebounceCoordinator:
 
         Returns:
             "mcp": Only MCP agents/tools found
-            "api": Only API routes found
-            "mixed": Both MCP and API decorators found (throws exception)
+            "api": Only @mesh.route decorators found
+            "a2a": Only @mesh.a2a / mesh.a2a.mount surfaces found
+            "mixed": Conflicting decorator families coexist (throws exception)
             "none": No decorators found
         """
         from ...engine.decorator_registry import DecoratorRegistry
@@ -101,22 +102,32 @@ class DebounceCoordinator:
         agents = DecoratorRegistry.get_mesh_agents()
         tools = DecoratorRegistry.get_mesh_tools()
         routes = DecoratorRegistry.get_all_by_type("mesh_route")
+        a2a_surfaces = DecoratorRegistry.get_all_by_type("mesh_a2a")
 
         has_mcp = len(agents) > 0 or len(tools) > 0
         has_api = len(routes) > 0
+        has_a2a = len(a2a_surfaces) > 0
 
         self.logger.debug(
-            f"🔍 Pipeline type detection: MCP={has_mcp} ({len(agents)} agents, {len(tools)} tools), API={has_api} ({len(routes)} routes)"
+            f"🔍 Pipeline type detection: MCP={has_mcp} ({len(agents)} agents, {len(tools)} tools), "
+            f"API={has_api} ({len(routes)} routes), "
+            f"A2A={has_a2a} ({len(a2a_surfaces)} surfaces)"
         )
 
-        if has_api and has_mcp:
+        # Mixed-mode: MCP cannot coexist with @mesh.route or @mesh.a2a
+        # in the same process. @mesh.route + @mesh.a2a coexisting is also
+        # a mixed-mode error (each owns the user's FastAPI app + heartbeat).
+        active_families = sum([has_mcp, has_api, has_a2a])
+        if active_families > 1:
             return "mixed"
-        elif has_api:
+
+        if has_api:
             return "api"
-        elif has_mcp:
+        if has_a2a:
+            return "a2a"
+        if has_mcp:
             return "mcp"
-        else:
-            return "none"
+        return "none"
 
     def _execute_processing(self) -> None:
         """Execute the processing (called by timer)."""
@@ -139,9 +150,10 @@ class DebounceCoordinator:
 
             if pipeline_type == "mixed":
                 error_msg = (
-                    "❌ Mixed mode not supported: Cannot use @mesh.route decorators "
-                    "together with @mesh.tool/@mesh.agent decorators in the same process. "
-                    "Please use either MCP agent decorators OR API route decorators, not both."
+                    "❌ Mixed mode not supported: @mesh.tool/@mesh.agent, "
+                    "@mesh.route, and @mesh.a2a / mesh.a2a.mount decorator "
+                    "families cannot be combined in the same process. "
+                    "Please use exactly one family per process."
                 )
                 self.logger.error(error_msg)
                 raise RuntimeError(error_msg)
@@ -168,8 +180,29 @@ class DebounceCoordinator:
                 elif pipeline_type == "api":
                     # Phase 1: Run async API pipeline setup
                     result = asyncio.run(orchestrator.process_api_once())
+                elif pipeline_type == "a2a":
+                    # Phase 1: Run async A2A pipeline setup
+                    result = asyncio.run(orchestrator.process_a2a_once())
                 else:
                     raise RuntimeError(f"Unsupported pipeline type: {pipeline_type}")
+
+                # Fail fast on pipeline failure — proceeding to "DI complete" /
+                # heartbeat startup with a failed pipeline would silently leave
+                # the agent half-initialised (no surfaces mounted, no heartbeat
+                # spec, etc.) while the user's uvicorn happily serves an
+                # empty/broken app. Surface the error and abort.
+                if result.get("status") == "failed":
+                    err_detail = result.get("message") or "unknown error"
+                    errors = result.get("errors") or []
+                    if errors:
+                        err_detail = f"{err_detail}: {errors}"
+                    self.logger.error(
+                        f"❌ {pipeline_type.upper()} pipeline failed during startup; "
+                        f"aborting: {err_detail}"
+                    )
+                    raise RuntimeError(
+                        f"{pipeline_type.upper()} pipeline failed: {err_detail}"
+                    )
 
                 # Phase 2: Extract FastAPI app and start synchronous server
                 pipeline_context = result.get("context", {}).get("pipeline_context", {})
@@ -194,6 +227,24 @@ class DebounceCoordinator:
                     )
                     self.logger.info(
                         "✅ API dependency injection complete - user's FastAPI server can now start"
+                    )
+                    return  # Don't block - let user's uvicorn run
+                elif pipeline_type == "a2a":
+                    # For A2A services, mirror the API path: setup heartbeat
+                    # in background and let user's uvicorn drive the lifecycle.
+                    from ..a2a_heartbeat.a2a_lifespan_integration import (
+                        a2a_heartbeat_lifespan_task,
+                    )
+
+                    self._setup_heartbeat_background(
+                        heartbeat_config,
+                        pipeline_context,
+                        a2a_heartbeat_lifespan_task,
+                        id_field="service_id",
+                        label="A2A service",
+                    )
+                    self.logger.info(
+                        "✅ A2A dependency injection complete - user's FastAPI server can now start"
                     )
                     return  # Don't block - let user's uvicorn run
                 elif fastapi_app and binding_config:
@@ -299,8 +350,24 @@ class DebounceCoordinator:
                     result = asyncio.run(orchestrator.process_once())
                 elif pipeline_type == "api":
                     result = asyncio.run(orchestrator.process_api_once())
+                elif pipeline_type == "a2a":
+                    result = asyncio.run(orchestrator.process_a2a_once())
                 else:
                     raise RuntimeError(f"Unsupported pipeline type: {pipeline_type}")
+
+                # Mirror the auto-run branch: surface pipeline failures so
+                # tests / debug runs don't report success on a broken setup.
+                if result.get("status") == "failed":
+                    err_detail = result.get("message") or "unknown error"
+                    errors = result.get("errors") or []
+                    if errors:
+                        err_detail = f"{err_detail}: {errors}"
+                    self.logger.error(
+                        f"❌ {pipeline_type.upper()} pipeline failed in single-execution mode: {err_detail}"
+                    )
+                    raise RuntimeError(
+                        f"{pipeline_type.upper()} pipeline failed: {err_detail}"
+                    )
 
                 self.logger.info("✅ Pipeline execution completed, exiting")
 
@@ -510,6 +577,42 @@ class MeshOrchestrator:
 
         except Exception as e:
             error_msg = f"API pipeline execution failed: {e}"
+            self.logger.error(f"❌ {error_msg}")
+
+            return {
+                "status": "failed",
+                "message": error_msg,
+                "errors": [str(e)],
+                "context": {},
+                "timestamp": "unknown",
+            }
+
+    async def process_a2a_once(self) -> dict:
+        """
+        Execute the A2A pipeline once for @mesh.a2a / mesh.a2a.mount surfaces.
+
+        Issue #903 Phase 1B. Handles FastAPI app discovery, tracing
+        middleware integration, and heartbeat config preparation for an
+        A2A-only flow (sibling to ``process_api_once`` and ``process_once``).
+        """
+        self.logger.info(f"🚀 Starting A2A pipeline execution: {self.name}")
+
+        try:
+            from ..a2a_startup import A2APipeline
+
+            a2a_pipeline = A2APipeline(name=f"{self.name}-a2a")
+            result = await a2a_pipeline.execute()
+
+            return {
+                "status": result.status.value,
+                "message": result.message,
+                "errors": result.errors,
+                "context": result.context,
+                "timestamp": result.timestamp.isoformat(),
+            }
+
+        except Exception as e:
+            error_msg = f"A2A pipeline execution failed: {e}"
             self.logger.error(f"❌ {error_msg}")
 
             return {

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_pipeline.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_pipeline.py
@@ -60,6 +60,12 @@ class StartupPipeline(MeshPipeline):
             # Phase 1 MeshJob: spawn one Python claim worker per
             # @mesh.tool(task=True) handler (skipped when no task tools).
             JobsClaimWorkersStep(),
+            # Issue #903 Phase 1B: A2A discovery + JSON-RPC routes are
+            # NOT auto-mounted here — users opt in by calling
+            # ``mesh.a2a.mount(app, path=...)`` on their own FastAPI
+            # app (mirrors the @mesh.route UX). Heartbeat preparation
+            # still picks up the @mesh.a2a metadata and emits
+            # agent_type=a2a + the surfaces array on registration.
             # Note: Registry connection is handled in heartbeat pipeline for retry behavior
             # Note: FastAPI server will be started with uvicorn.run() after pipeline (or reused if discovered)
         ]

--- a/src/runtime/python/_mcp_mesh/shared/slug.py
+++ b/src/runtime/python/_mcp_mesh/shared/slug.py
@@ -1,0 +1,40 @@
+"""Shared slug helper for service / agent IDs.
+
+Both ``api_server_setup`` and ``a2a_server_setup`` derive a kebab-case
+service name from the FastAPI app title (or env-var override) so the
+registry's name validation (lowercase alphanumeric + hyphens only)
+accepts the result. The transformation is identical in both pipelines
+and was previously inlined in four call sites — this module is the
+single source of truth.
+"""
+
+from __future__ import annotations
+
+import re
+
+_NON_SLUG_CHAR_RE = re.compile(r"[^a-z0-9-]+")
+
+
+def slugify_service_name(raw_name: str | None, fallback: str) -> str:
+    """Return a registry-safe slug derived from ``raw_name``.
+
+    Lowercases, converts spaces and underscores to hyphens, strips any
+    remaining non ``[a-z0-9-]`` characters (including non-ASCII like
+    emoji), collapses runs of hyphens, and falls back to ``fallback``
+    when the result would otherwise be empty (e.g. all-emoji input).
+
+    Args:
+        raw_name: The candidate name (typically the FastAPI app title
+            or an env-var override). ``None`` and empty strings yield
+            ``fallback`` directly.
+        fallback: The slug to return when ``raw_name`` is empty or
+            slugifies to an empty string. Pipeline-specific defaults:
+            ``"a2a-service"`` for the A2A pipeline, ``"api-service"``
+            for the API pipeline.
+    """
+    if not raw_name:
+        return fallback
+    slug = raw_name.lower().replace(" ", "-").replace("_", "-")
+    slug = _NON_SLUG_CHAR_RE.sub("-", slug)
+    slug = "-".join(part for part in slug.split("-") if part)
+    return slug or fallback

--- a/src/runtime/python/mesh/__init__.py
+++ b/src/runtime/python/mesh/__init__.py
@@ -96,6 +96,8 @@ def __getattr__(name):
         return decorators.agent
     elif name == "route":
         return decorators.route
+    elif name == "a2a":
+        return decorators.a2a
     elif name == "llm":
         return decorators.llm
     elif name == "llm_provider":

--- a/src/runtime/python/mesh/a2a.py
+++ b/src/runtime/python/mesh/a2a.py
@@ -1,0 +1,728 @@
+"""User-facing A2A surface helpers (issue #903 Phase 1B / Phase 2).
+
+Two complementary entry points:
+
+* ``@mesh.a2a(path=..., dependencies=[...])`` — decorator that stamps
+  ``_mesh_a2a_metadata`` on the function and wires DDDI dependency
+  injection (mirrors ``@mesh.route``). Pure metadata + DI; does NOT
+  mount any FastAPI routes. Imported from ``mesh.decorators`` and
+  re-exposed here under the ``mesh.a2a`` callable so users can write
+  ``@mesh.a2a(...)`` for advanced cases (multi-app fan-out, custom
+  mounting, library-style integrations).
+
+* ``mesh.a2a.mount(app, *, path=..., dependencies=[...])`` — the
+  recommended entry point. Mirrors the ``@mesh.route`` UX: the user
+  owns the FastAPI app, the helper applies ``@mesh.a2a`` AND mounts
+  the two companion routes the A2A protocol surface needs:
+
+    GET  ``{path}/.well-known/agent.json``  → A2A AgentCard
+    POST ``{path}``                         → JSON-RPC 2.0 entry point
+
+Phase 2 (this module) dispatches sync ``tasks/send`` into the user
+handler and wraps the result in an A2A v1.0 ``Task`` envelope. Other
+``tasks/*`` methods (``tasks/get``, ``tasks/cancel``,
+``tasks/sendSubscribe``) and ``tasks/send`` for ``task=True``
+underlying tools still return JSON-RPC ``Method not implemented`` —
+those land in Phase 3 once the MeshJob lifecycle is wired.
+
+Public URL caching
+==================
+Each surface caches the registry-stamped public URL (delivered on the
+heartbeat response under ``surfaces[].public_url``) on a module-level
+dict keyed by ``(path, skill_id)``. The agent-card endpoint reads
+this cache so the card's ``url`` field reflects the public FQDN. When
+the cache is empty (e.g., first request before the first heartbeat
+round-trip, or ``MCP_MESH_PUBLIC_URL_PREFIX`` unset), the URL falls
+back to the agent's local ``http_host:http_port + path`` — sufficient
+for local development and integration tests.
+
+NOTE: we deliberately avoid ``from __future__ import annotations`` in
+this module — FastAPI's Dependant builder calls ``inspect.signature``
+and stringified annotations cause it to misclassify ``request: Request``
+as a query parameter (yielding 422 on every POST).
+"""
+
+import json as _json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Optional
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+
+# Module-level cache of the registry-stamped public URLs, keyed by
+# (path, skill_id). Populated by :func:`update_public_url_cache` from the
+# heartbeat-response handler; read by the agent-card endpoint at request
+# time. Process-local — not persisted.
+_PUBLIC_URL_CACHE: Dict[tuple, str] = {}
+
+
+# Tracks already-mounted A2A surfaces keyed by ``(id(app), path)`` so a
+# duplicate ``mount(app, path=X, ...)`` call raises instead of silently
+# splitting into two DecoratorRegistry entries (heartbeat would report 2
+# surfaces) plus a single reachable route. Keying by ``id(app)`` allows
+# the same path on different FastAPI app instances (e.g. multiple test apps).
+_MOUNTED_A2A_PATHS: set = set()
+
+
+def update_public_url_cache(path: str, skill_id: str, public_url: Optional[str]) -> None:
+    """Cache (or clear) a registry-stamped public URL for one A2A surface.
+
+    Called from the heartbeat-response handler when the registry returns
+    ``surfaces[].public_url``. Empty/None clears the cache entry so the
+    agent-card endpoint falls back to the local host:port.
+    """
+    key = (path, skill_id)
+    if public_url:
+        _PUBLIC_URL_CACHE[key] = public_url
+    else:
+        _PUBLIC_URL_CACHE.pop(key, None)
+
+
+def get_cached_public_url(path: str, skill_id: str) -> Optional[str]:
+    """Return the registry-stamped public URL for a surface, if cached."""
+    return _PUBLIC_URL_CACHE.get((path, skill_id))
+
+
+def _local_fallback_url(agent_config: dict, path: str) -> str:
+    """Build a host:port + path URL for local-development fallback.
+
+    Used when the registry hasn't stamped a public URL yet (or
+    ``MCP_MESH_PUBLIC_URL_PREFIX`` is unset). Not addressable from
+    outside the local network — appropriate only for dev/CI.
+    """
+    host = agent_config.get("http_host") or "localhost"
+    port = agent_config.get("http_port") or 0
+    if port:
+        return f"http://{host}:{port}{path}"
+    return f"http://{host}{path}"
+
+
+def _resolve_agent_config() -> dict:
+    """Best-effort lookup of the resolved @mesh.agent config at mount time.
+
+    Falls back to an empty dict — the agent-card endpoint then uses
+    ``localhost`` for the fallback URL. Once the heartbeat round-trip
+    populates the public-URL cache, the fallback path stops mattering.
+    """
+    try:
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+        return DecoratorRegistry.get_resolved_agent_config() or {}
+    except Exception:
+        return {}
+
+
+def _underlying_tool_is_task(metadata: dict) -> bool:
+    """Return True iff the underlying mesh tool dep is task=True.
+
+    Best-effort: looks up the dependency's capability in the
+    DecoratorRegistry's mesh_tools and checks the producer-side
+    ``task`` flag stamped by ``@mesh.tool(task=True)``. Returns
+    False when the dep is missing, multi-dep, or the tool isn't
+    locally registered (cross-agent dep).
+    """
+    try:
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+    except Exception:
+        return False
+
+    deps = metadata.get("dependencies") or []
+    if len(deps) != 1:
+        return False
+    cap = deps[0].get("capability")
+    if not cap:
+        return False
+    for _, decorated in DecoratorRegistry.get_mesh_tools().items():
+        tool_meta = decorated.metadata or {}
+        if tool_meta.get("capability") == cap and tool_meta.get("task"):
+            return True
+    return False
+
+
+def _underlying_tool_input_schema(metadata: dict) -> Optional[dict]:
+    """Return the underlying mesh tool's input schema if available."""
+    try:
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.utils.fastmcp_schema_extractor import (
+            FastMCPSchemaExtractor,
+        )
+    except Exception:
+        return None
+
+    deps = metadata.get("dependencies") or []
+    if len(deps) != 1:
+        return None
+    cap = deps[0].get("capability")
+    if not cap:
+        return None
+    for _, decorated in DecoratorRegistry.get_mesh_tools().items():
+        tool_meta = decorated.metadata or {}
+        if tool_meta.get("capability") == cap:
+            schema = tool_meta.get("input_schema")
+            if schema:
+                return schema
+            try:
+                return FastMCPSchemaExtractor.extract_input_schema(decorated.function)
+            except Exception:
+                return None
+    return None
+
+
+def _make_card_endpoint(
+    *,
+    metadata: dict,
+    agent_config_provider: Callable[[], dict],
+):
+    """Build a FastAPI endpoint coroutine returning the AgentCard JSON.
+
+    ``agent_config_provider`` is called lazily on each request so the
+    card picks up agent config that may not have been resolved yet at
+    mount time (mount() is typically called at module import, before
+    the @mesh.agent class is processed).
+    """
+    from _mcp_mesh.engine.a2a_card import build_agent_card
+
+    path = metadata["path"]
+    skill_id = metadata["skill_id"]
+
+    async def get_agent_card() -> dict:
+        agent_config = agent_config_provider() or {}
+        agent_name = (
+            agent_config.get("name")
+            or agent_config.get("agent_id")
+            or "agent"
+        )
+        agent_version = agent_config.get("version", "1.0.0")
+        agent_description = agent_config.get("description")
+
+        cached = get_cached_public_url(path, skill_id)
+        public_url = cached or _local_fallback_url(agent_config, path)
+
+        streaming = _underlying_tool_is_task(metadata)
+        input_schema = _underlying_tool_input_schema(metadata)
+        bearer_auth = metadata.get("auth") == "bearer"
+
+        return build_agent_card(
+            name=agent_name,
+            description=agent_description,
+            version=agent_version,
+            public_url=public_url,
+            skill_id=skill_id,
+            skill_name=metadata.get("skill_name") or skill_id,
+            skill_description=metadata.get("description"),
+            input_modes=metadata.get("input_modes") or ["application/json"],
+            output_modes=metadata.get("output_modes") or ["application/json"],
+            tags=metadata.get("tags") or [],
+            streaming=streaming,
+            bearer_auth=bearer_auth,
+            underlying_tool_input_schema=input_schema,
+        )
+
+    return get_agent_card
+
+
+def _utc_now_iso() -> str:
+    """Return current UTC time in A2A v1.0 ``...Z`` ISO-8601 form."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _build_completed_task(
+    task_id: str,
+    session_id: str,
+    request_message: Optional[dict],
+    result: Any,
+) -> dict:
+    """Build an A2A v1.0 ``Task`` with ``state=completed``.
+
+    The user-handler return value becomes the single ``result`` artifact's
+    text part. Non-string results are JSON-stringified so the artifact's
+    ``text`` field stays string-typed per the A2A v1.0 ``TextPart`` shape.
+    Non-JSON-serializable types (datetime, Decimal, Path, dataclass, set,
+    etc.) are coerced best-effort via ``default=str`` so a handler that
+    returns one of these doesn't crash the JSON-RPC entry — the user's
+    try/except is honoured by routing exceptions through ``state=failed``,
+    not bubbling them up as 500s.
+    """
+    text = result if isinstance(result, str) else _json.dumps(result, default=str)
+    return {
+        "id": task_id,
+        "sessionId": session_id,
+        "status": {
+            "state": "completed",
+            "timestamp": _utc_now_iso(),
+        },
+        "artifacts": [
+            {
+                "name": "result",
+                "parts": [{"type": "text", "text": text}],
+                "index": 0,
+            }
+        ],
+        "history": [request_message] if request_message else [],
+    }
+
+
+def _build_failed_task(
+    task_id: str,
+    session_id: str,
+    request_message: Optional[dict],
+    error_msg: str,
+) -> dict:
+    """Build an A2A v1.0 ``Task`` with ``state=failed``.
+
+    Per A2A v1.0, handler exceptions become a ``failed`` task (NOT a
+    JSON-RPC error). JSON-RPC errors are reserved for protocol-level
+    issues like bad request shape or missing method.
+    """
+    return {
+        "id": task_id,
+        "sessionId": session_id,
+        "status": {
+            "state": "failed",
+            "timestamp": _utc_now_iso(),
+            "message": {
+                "role": "agent",
+                "parts": [{"type": "text", "text": error_msg}],
+            },
+        },
+        "artifacts": [],
+        "history": [request_message] if request_message else [],
+    }
+
+
+def _jsonrpc_success(req_id: Any, result_obj: Any) -> JSONResponse:
+    return JSONResponse(
+        status_code=200,
+        content={"jsonrpc": "2.0", "id": req_id, "result": result_obj},
+    )
+
+
+def _jsonrpc_error(
+    req_id: Any,
+    code: int,
+    message: str,
+    *,
+    status_code: int = 200,
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": code, "message": message},
+        },
+    )
+
+
+async def _handle_tasks_send(
+    *,
+    req_id: Any,
+    params: dict,
+    user_handler: Callable[..., Any],
+    metadata: dict,
+) -> JSONResponse:
+    """Phase 2 sync-only ``tasks/send`` dispatch.
+
+    Calls the user's ``@mesh.a2a`` handler with the A2A ``message`` dict
+    as the positional payload. Dependency injection (e.g. ``date_service``)
+    is wired by the decorator wrapper, so deps land via keyword args at
+    call time.
+
+    Long-running surfaces (underlying mesh tool was ``@mesh.tool(task=True)``)
+    fall back to ``Method not implemented`` until Phase 3 wires the
+    MeshJob lifecycle into ``tasks/send`` + ``tasks/sendSubscribe``.
+    """
+    if _underlying_tool_is_task(metadata):
+        return _jsonrpc_error(
+            req_id,
+            -32601,
+            (
+                "Method not implemented: 'tasks/send' for task=True "
+                "underlying tools requires Phase 3 (MeshJob lifecycle). "
+                "Sync handlers are supported today."
+            ),
+        )
+
+    if not isinstance(params, dict):
+        params = {}
+
+    task_id = params.get("id") or str(uuid.uuid4())
+    session_id = params.get("sessionId") or task_id
+    message = params.get("message") if isinstance(params.get("message"), dict) else {}
+
+    # Pass the full A2A message dict to the user's handler so user code
+    # can introspect parts/role as needed. The handler is responsible for
+    # translating message → its dependency-call shape.
+    try:
+        import inspect
+
+        result = user_handler(message)
+        if inspect.isawaitable(result):
+            result = await result
+    except Exception as exc:
+        # Per A2A v1.0: handler exceptions surface as Task.state=failed,
+        # NOT as a JSON-RPC -3260x error.
+        logger.warning(
+            "A2A tasks/send handler raised on %s: %s",
+            metadata.get("path"),
+            exc,
+        )
+        return _jsonrpc_success(
+            req_id,
+            _build_failed_task(task_id, session_id, message or None, str(exc)),
+        )
+
+    return _jsonrpc_success(
+        req_id,
+        _build_completed_task(task_id, session_id, message or None, result),
+    )
+
+
+def _make_rpc_endpoint(*, metadata: dict, user_handler: Callable[..., Any]):
+    """Build a FastAPI endpoint coroutine for the JSON-RPC entry point.
+
+    Phase 2 dispatches sync ``tasks/send`` into ``user_handler`` and
+    wraps the return value in an A2A v1.0 ``Task`` envelope. All other
+    ``tasks/*`` methods still return JSON-RPC ``Method not implemented``
+    (Phase 3 territory).
+
+    Honours the decorator's ``auth="bearer"`` setting at the header-
+    presence level only — token validation (signature/issuer/audience)
+    is Phase-2+ scope.
+    """
+    bearer_auth = metadata.get("auth") == "bearer"
+
+    async def jsonrpc_entry(request: Request) -> JSONResponse:
+        if bearer_auth:
+            authz = request.headers.get("authorization") or ""
+            if not authz.lower().startswith("bearer "):
+                return JSONResponse(
+                    status_code=401,
+                    content={
+                        "jsonrpc": "2.0",
+                        "error": {
+                            "code": -32001,
+                            "message": (
+                                "Authentication required: missing "
+                                "Authorization: Bearer <token> header"
+                            ),
+                        },
+                        "id": None,
+                    },
+                )
+            # Reject "Bearer " (or "Bearer ...empty/whitespace token...") —
+            # accepting a prefix-only header would let any client past the
+            # auth gate without supplying a real token.
+            parts = authz.split(" ", 1)
+            if len(parts) != 2 or not parts[1].strip():
+                return JSONResponse(
+                    status_code=401,
+                    content={
+                        "jsonrpc": "2.0",
+                        "error": {
+                            "code": -32001,
+                            "message": (
+                                "Authentication required: empty bearer token "
+                                "in Authorization header"
+                            ),
+                        },
+                        "id": None,
+                    },
+                )
+
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "jsonrpc": "2.0",
+                    "error": {
+                        "code": -32700,
+                        "message": "Parse error: request body is not valid JSON",
+                    },
+                    "id": None,
+                },
+            )
+
+        req_id = None
+        method = None
+        params: dict = {}
+        if isinstance(body, dict):
+            req_id = body.get("id")
+            method = body.get("method")
+            raw_params = body.get("params")
+            if isinstance(raw_params, dict):
+                params = raw_params
+
+        if method == "tasks/send":
+            return await _handle_tasks_send(
+                req_id=req_id,
+                params=params,
+                user_handler=user_handler,
+                metadata=metadata,
+            )
+
+        # All other tasks/* methods land in Phase 3.
+        return _jsonrpc_error(
+            req_id,
+            -32601,
+            (
+                f"Method not implemented: {method!r}. "
+                "Phase 2 wires sync 'tasks/send' only — long-running "
+                "and streaming methods (tasks/sendSubscribe, tasks/get, "
+                "tasks/cancel) land in Phase 3 (see A2A_SURFACE_DESIGN.org)."
+            ),
+        )
+
+    return jsonrpc_entry
+
+
+def mount(
+    app: FastAPI,
+    *,
+    path: str,
+    dependencies: Optional[list] = None,
+    description: Optional[str] = None,
+    skill_id: Optional[str] = None,
+    skill_name: Optional[str] = None,
+    input_modes: Optional[list] = None,
+    output_modes: Optional[list] = None,
+    tags: Optional[list] = None,
+    auth: Optional[str] = None,
+    **kwargs: Any,
+) -> Callable[[Callable], Callable]:
+    """Mount an A2A surface on the user's FastAPI ``app``.
+
+    Mirrors the ``@mesh.route`` UX: the user owns the FastAPI app,
+    this helper applies ``@mesh.a2a`` (DI + metadata stamping) AND
+    registers the two routes A2A v1.0 requires:
+
+      * ``GET  {path}/.well-known/agent.json`` — agent card
+      * ``POST {path}``                        — JSON-RPC tasks/* entry
+
+    Phase 1 returns ``Method not implemented`` for every ``tasks/*``
+    JSON-RPC method; Phase 2 wires actual task routing.
+
+    Args:
+        app: User-owned ``FastAPI`` application instance.
+        path: REQUIRED URL path prefix for this surface (must start
+            with ``/``), e.g. ``/agents/report-generator``. The
+            registry concatenates ``MCP_MESH_PUBLIC_URL_PREFIX`` with
+            this path to compute the public FQDN stamped on the card.
+        dependencies: Optional list of mesh capabilities to inject
+            (same shape as ``@mesh.tool`` deps). For v1, typically a
+            single capability — the user's handler may declare more
+            but multi-skill grouping in a single card is v2 scope.
+        description: Free-form skill description shown on the agent
+            card. Defaults to the function's docstring when not set.
+        skill_id: A2A skill identifier (kebab-case canonical). When
+            unset, derived from the path's last segment.
+        skill_name: Human-readable skill name. When unset, derived
+            from ``skill_id`` (TitleCase).
+        input_modes: A2A inputModes (default ``["application/json"]``).
+        output_modes: A2A outputModes (default ``["application/json"]``).
+        tags: Skill tags surfaced on the agent card.
+        auth: Authentication scheme. v1 accepts ``"bearer"`` or ``None``
+            (no auth). Anything else raises ``ValueError`` —  broader
+            schemes (SPIRE/mTLS/OAuth) land in v2.
+        **kwargs: Additional metadata stamped onto the surface.
+
+    Returns:
+        A decorator that:
+          1. Applies ``@mesh.a2a(...)`` to the user's handler function
+             (DI + metadata stamping).
+          2. Mounts the agent-card and JSON-RPC routes on ``app``.
+          3. Returns the wrapped function so the user's variable points
+             to a usable callable (e.g., for direct unit tests).
+
+    Example:
+        from fastapi import FastAPI
+        import mesh
+        from mesh.types import McpMeshTool
+
+        app = FastAPI()
+
+        @mesh.a2a.mount(
+            app,
+            path="/agents/date",
+            dependencies=["date_service"],
+        )
+        async def date_a2a(payload: dict, date_service: McpMeshTool = None):
+            return await date_service()
+    """
+    if not isinstance(app, FastAPI):
+        raise ValueError(
+            "mesh.a2a.mount requires a FastAPI app instance as the first argument"
+        )
+
+    # Reject duplicate mounts on the same (app, path) pair — silently
+    # accepting the second call would add another `mesh_a2a` entry to the
+    # DecoratorRegistry (heartbeat reports 2 surfaces) while only one
+    # endpoint stays reachable, since route registration short-circuits
+    # on path collision below.
+    #
+    # NOTE: do NOT add ``dup_key`` to ``_MOUNTED_A2A_PATHS`` here — if any
+    # validation or route registration in the inner ``decorator`` raises,
+    # the key would leak and block legitimate retries on the same path.
+    # Add it on the success path at the end of ``decorator`` instead.
+    dup_key = (id(app), (path or "").rstrip("/") or "/")
+    if dup_key in _MOUNTED_A2A_PATHS:
+        raise ValueError(
+            f"mesh.a2a.mount: path {dup_key[1]!r} is already mounted on this "
+            "FastAPI app. A2A surfaces must have unique paths per app."
+        )
+
+    # Late-bind the decorator import to avoid circular import at module load.
+    from .decorators import a2a as a2a_decorator
+
+    def decorator(target: Callable) -> Callable:
+        # Apply @mesh.a2a(...) for DI + metadata stamping. The decorator
+        # registers the surface in DecoratorRegistry under "mesh_a2a" so
+        # heartbeat preparation picks it up and emits agent_type=a2a.
+        wrapped = a2a_decorator(
+            path=path,
+            description=description,
+            dependencies=dependencies,
+            skill_id=skill_id,
+            skill_name=skill_name,
+            input_modes=input_modes,
+            output_modes=output_modes,
+            tags=tags,
+            auth=auth,
+            **kwargs,
+        )(target)
+
+        # The decorator stamps the (possibly-derived) final metadata on
+        # the wrapper. Use that as the source of truth for the routes.
+        metadata = getattr(wrapped, "_mesh_a2a_metadata", None)
+        if metadata is None:
+            # The DI wrapper failed and we got the raw target back;
+            # pull metadata directly from the target.
+            metadata = getattr(target, "_mesh_a2a_metadata", None)
+        if metadata is None:
+            # Nothing to mount — decorator failed catastrophically. Log
+            # and return the (un)wrapped function so the caller's import
+            # doesn't blow up.
+            logger.error(
+                "mesh.a2a.mount: @mesh.a2a metadata missing on %s; "
+                "skipping route registration",
+                getattr(target, "__name__", target),
+            )
+            return wrapped
+
+        skill_id_resolved = metadata["skill_id"]
+        path_resolved = metadata["path"]
+
+        card_path = path_resolved.rstrip("/") + "/.well-known/agent.json"
+        rpc_path = path_resolved.rstrip("/") or "/"
+
+        # Map existing paths to their endpoint callables so we can
+        # distinguish a legitimate idempotent re-mount (same endpoint
+        # function — typical in test fixtures that call ``mount()``
+        # multiple times against a fresh ``_MOUNTED_A2A_PATHS``) from a
+        # foreign route hijacking the path. Silently skipping on path
+        # collision would let a hostile/typo'd route own ``card_path`` /
+        # ``rpc_path`` while heartbeat still advertises the surface for
+        # this agent — clients would then call the wrong handler.
+        existing_endpoints: dict = {}
+        for r in app.router.routes:
+            r_path = getattr(r, "path", None)
+            if r_path is not None:
+                existing_endpoints[r_path] = getattr(r, "endpoint", None)
+
+        card_endpoint = _make_card_endpoint(
+            metadata=metadata,
+            agent_config_provider=_resolve_agent_config,
+        )
+        rpc_endpoint = _make_rpc_endpoint(metadata=metadata, user_handler=wrapped)
+
+        added_paths: list = []
+        if card_path not in existing_endpoints:
+            app.add_api_route(
+                path=card_path,
+                endpoint=card_endpoint,
+                methods=["GET"],
+                tags=["a2a"],
+                summary=f"A2A AgentCard for skill '{skill_id_resolved}'",
+            )
+            added_paths.append(card_path)
+            logger.debug(
+                "Mounted A2A card route GET %s (skill=%s)",
+                card_path, skill_id_resolved,
+            )
+        elif existing_endpoints[card_path] is card_endpoint:
+            # Identical callable already wired (e.g., test fixture re-mount
+            # after wiping ``_MOUNTED_A2A_PATHS``) — safe to skip.
+            logger.debug(
+                "A2A card route %s already registered with identical endpoint; skipping",
+                card_path,
+            )
+        else:
+            raise RuntimeError(
+                f"mesh.a2a.mount: cannot mount A2A card route at {card_path!r} — "
+                "the path is already registered with a different endpoint. "
+                "Refusing to silently let a foreign route own this path while "
+                "the agent's heartbeat advertises it as an A2A surface."
+            )
+
+        if rpc_path not in existing_endpoints:
+            app.add_api_route(
+                path=rpc_path,
+                endpoint=rpc_endpoint,
+                methods=["POST"],
+                tags=["a2a"],
+                summary=f"A2A JSON-RPC entry point for skill '{skill_id_resolved}'",
+            )
+            added_paths.append(rpc_path)
+            logger.debug(
+                "Mounted A2A RPC route POST %s (skill=%s)",
+                rpc_path, skill_id_resolved,
+            )
+        elif existing_endpoints[rpc_path] is rpc_endpoint:
+            logger.debug(
+                "A2A RPC route %s already registered with identical endpoint; skipping",
+                rpc_path,
+            )
+        else:
+            raise RuntimeError(
+                f"mesh.a2a.mount: cannot mount A2A JSON-RPC route at {rpc_path!r} — "
+                "the path is already registered with a different endpoint. "
+                "Refusing to silently let a foreign route own this path while "
+                "the agent's heartbeat advertises it as an A2A surface."
+            )
+
+        # Move the newly-added routes to the FRONT of the router so the
+        # FastMCP catch-all (mounted at "" by FastAPIServerSetupStep)
+        # doesn't shadow them. Mirrors jobs_cancel_route.py #bug 4.
+        # Starlette resolves routes in registration order and Mount("")
+        # matches every path — explicit routes added AFTER the mount
+        # would yield 404 without this re-ordering.
+        if added_paths:
+            head: list = []
+            rest: list = []
+            for r in app.router.routes:
+                if getattr(r, "path", None) in added_paths:
+                    head.append(r)
+                else:
+                    rest.append(r)
+            app.router.routes[:] = head + rest
+
+        logger.info(
+            "🌐 Mounted A2A surface: %s (skill=%s, %d route(s))",
+            path_resolved, skill_id_resolved, len(added_paths),
+        )
+
+        # Validation + route registration succeeded — only NOW record the
+        # (app, path) pair so a future re-mount on the same pair raises.
+        # Adding before this point would leak the key on validation
+        # failures and block legitimate retries.
+        _MOUNTED_A2A_PATHS.add(dup_key)
+        return wrapped
+
+    return decorator

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -1717,6 +1717,305 @@ def route(
     return decorator
 
 
+def _derive_a2a_skill_id_from_path(path: str) -> str:
+    """Derive a default skill_id from an A2A path's last segment.
+
+    ``/agents/report-generator`` → ``report-generator``. Falls back to
+    ``"default"`` for degenerate inputs (just ``/`` or empty after strip).
+    Issue #903 / A2A_SURFACE_DESIGN.org > "API Surface (Python v1)".
+    """
+    last = path.rstrip("/").rsplit("/", 1)[-1].strip()
+    return last or "default"
+
+
+def _derive_a2a_skill_name_from_id(skill_id: str) -> str:
+    """Derive a TitleCase skill name from a skill_id.
+
+    ``report-generator`` → ``Report Generator``. Splits on ``-`` and ``_``.
+    """
+    parts = [p for p in skill_id.replace("_", "-").split("-") if p]
+    return " ".join(p.capitalize() for p in parts) if parts else skill_id
+
+
+def a2a(
+    *,
+    path: str,
+    description: str | None = None,
+    dependencies: list[str] | list[dict[str, Any]] | None = None,
+    skill_id: str | None = None,
+    skill_name: str | None = None,
+    input_modes: list[str] | None = None,
+    output_modes: list[str] | None = None,
+    tags: list[str] | None = None,
+    auth: str | None = None,
+    **kwargs: Any,
+) -> Callable[[T], T]:
+    """A2A (Agent-to-Agent) surface decorator (issue #903 Phase 1B).
+
+    Exposes a function as an A2A v1.0 protocol surface. Each decorated
+    function becomes one agent card with one skill, mounted at
+    ``GET {path}/.well-known/agent.json`` (discovery) and
+    ``POST {path}`` (JSON-RPC tasks/* entry point). The function body is
+    user-controlled and may declare DDDI dependencies (typically a single
+    underlying ``@mesh.tool`` capability).
+
+    Phase 1: discovery + agent-card generation only. ``tasks/*`` JSON-RPC
+    methods return ``Method not implemented``. Phase 2 wires actual task
+    routing.
+
+    Args:
+        path: REQUIRED URL path suffix for this surface (must start with
+            ``/``), e.g. ``/agents/report-generator``. The registry
+            concatenates ``MCP_MESH_PUBLIC_URL_PREFIX`` with this path
+            to compute the public FQDN.
+        description: Free-form skill description shown on the agent card.
+            Defaults to the function's docstring when not set.
+        dependencies: Optional list of mesh capabilities to inject (same
+            shape as ``@mesh.tool`` deps). For v1, typically a single
+            capability — multi-skill grouping is v2 (see design doc
+            "LLM-backed multi-skill cards" section).
+        skill_id: A2A skill identifier (kebab-case canonical). When unset,
+            derived from the path's last segment.
+        skill_name: Human-readable skill name. When unset, derived from
+            ``skill_id`` (TitleCase).
+        input_modes: A2A inputModes for this skill (default
+            ``["application/json"]``).
+        output_modes: A2A outputModes for this skill (default
+            ``["application/json"]``).
+        tags: Skill tags surfaced on the agent card.
+        auth: Authentication scheme. v1 accepts ``"bearer"`` or ``None``
+            (no auth). Anything else raises ``ValueError`` — broader auth
+            schemes (SPIRE/mTLS/OAuth) land in v2.
+        **kwargs: Additional metadata stamped onto the surface registration.
+
+    Returns:
+        The decorated function with ``_mesh_a2a_metadata`` attached and
+        DI wiring applied (mirrors ``@mesh.route``).
+
+    Example:
+        @mesh.a2a(
+            path="/agents/report-generator",
+            description="Generate a long-form report",
+            dependencies=["generate_report"],
+            auth="bearer",
+        )
+        async def report_generator_a2a(
+            payload: dict,
+            generate_report: McpMeshTool = None,
+        ):
+            return await generate_report(**payload)
+    """
+
+    def decorator(target: T) -> T:
+        # Validate path (REQUIRED, must start with /)
+        if not isinstance(path, str) or not path:
+            raise ValueError("path is required for @mesh.a2a and must be a non-empty string")
+        if not path.startswith("/"):
+            raise ValueError(
+                f"@mesh.a2a path must start with '/' (got {path!r})"
+            )
+
+        # Validate auth — v1 scope only allows "bearer" or None.
+        if auth is not None:
+            if not isinstance(auth, str):
+                raise ValueError("auth must be a string or None")
+            if auth != "bearer":
+                raise ValueError(
+                    f"@mesh.a2a auth={auth!r} is not supported in v1; "
+                    "only 'bearer' or None are valid. Broader auth schemes "
+                    "(SPIRE/mTLS/OAuth) are v2 scope."
+                )
+
+        if description is not None and not isinstance(description, str):
+            raise ValueError("description must be a string or None")
+
+        if skill_id is not None and not isinstance(skill_id, str):
+            raise ValueError("skill_id must be a string or None")
+
+        if skill_name is not None and not isinstance(skill_name, str):
+            raise ValueError("skill_name must be a string or None")
+
+        # Validate input/output modes
+        for field_name, value in (("input_modes", input_modes), ("output_modes", output_modes)):
+            if value is not None:
+                if not isinstance(value, list):
+                    raise ValueError(f"{field_name} must be a list of strings")
+                for entry in value:
+                    if not isinstance(entry, str):
+                        raise ValueError(f"all {field_name} entries must be strings")
+
+        # Validate tags
+        if tags is not None:
+            if not isinstance(tags, list):
+                raise ValueError("tags must be a list of strings")
+            for tag in tags:
+                if not isinstance(tag, str):
+                    raise ValueError("all tags must be strings")
+
+        # Validate and process dependencies (mirrors @mesh.route shape).
+        if dependencies is not None:
+            if not isinstance(dependencies, list):
+                raise ValueError("dependencies must be a list")
+
+            validated_dependencies = []
+            for dep in dependencies:
+                if isinstance(dep, str):
+                    validated_dependencies.append({"capability": dep, "tags": []})
+                elif isinstance(dep, dict):
+                    if "capability" not in dep:
+                        raise ValueError("dependency must have 'capability' field")
+                    if not isinstance(dep["capability"], str):
+                        raise ValueError("dependency capability must be a string")
+                    # Mirror @mesh.tool's tag validation — tags is a list
+                    # whose elements are either strings (AND-tags) or
+                    # nested lists of strings (OR-groups). Without this
+                    # check, malformed shapes (ints, nested ints, dicts)
+                    # would silently propagate to the registry and only
+                    # surface as confusing resolver mismatches at
+                    # capability-binding time.
+                    dep_tags = dep.get("tags", [])
+                    if not isinstance(dep_tags, list):
+                        raise ValueError("dependency tags must be a list")
+                    for tag in dep_tags:
+                        if isinstance(tag, str):
+                            continue
+                        elif isinstance(tag, list):
+                            for inner_tag in tag:
+                                if not isinstance(inner_tag, str):
+                                    raise ValueError(
+                                        "OR alternative tags must be strings"
+                                    )
+                        else:
+                            raise ValueError(
+                                "tags must be strings or arrays of strings (OR alternatives)"
+                            )
+                    dep_version = dep.get("version")
+                    if dep_version is not None and not isinstance(dep_version, str):
+                        raise ValueError("dependency version must be a string")
+                    dep_dict = {
+                        "capability": dep["capability"],
+                        "tags": dep_tags,
+                    }
+                    if dep_version is not None:
+                        dep_dict["version"] = dep_version
+                    validated_dependencies.append(dep_dict)
+                else:
+                    raise ValueError("dependencies must be strings or dictionaries")
+        else:
+            validated_dependencies = []
+
+        if len(validated_dependencies) > 1:
+            # v1 emits a single agent card per surface with one skill. Multi-
+            # dep is permitted (the user's function can fan out internally)
+            # but multi-skill grouping is reserved for v2 (see design doc).
+            logger.warning(
+                f"@mesh.a2a({path}) declares {len(validated_dependencies)} "
+                "dependencies; v1 emits one agent card per surface with one "
+                "skill. Multi-skill grouping in a single card is v2 scope."
+            )
+
+        # Derive defaults for skill_id and skill_name when not provided.
+        final_skill_id = skill_id if skill_id else _derive_a2a_skill_id_from_path(path)
+        final_skill_name = (
+            skill_name if skill_name else _derive_a2a_skill_name_from_id(final_skill_id)
+        )
+
+        final_input_modes = (
+            list(input_modes) if input_modes is not None else ["application/json"]
+        )
+        final_output_modes = (
+            list(output_modes) if output_modes is not None else ["application/json"]
+        )
+        final_tags = list(tags) if tags is not None else []
+
+        final_description = description
+        if final_description is None:
+            doc = getattr(target, "__doc__", None)
+            if doc:
+                final_description = doc.strip().split("\n")[0]
+
+        # Build A2A surface metadata. Stamped onto the function so the
+        # pipeline (heartbeat preparation + FastAPI route mount step) can
+        # discover it.
+        metadata = {
+            "path": path,
+            "skill_id": final_skill_id,
+            "skill_name": final_skill_name,
+            "description": final_description,
+            "input_modes": final_input_modes,
+            "output_modes": final_output_modes,
+            "tags": final_tags,
+            "auth": auth,
+            "dependencies": validated_dependencies,
+            **kwargs,
+        }
+
+        target._mesh_a2a_metadata = metadata
+
+        # Register with DecoratorRegistry under a custom decorator type so
+        # the pipeline can discover @mesh.a2a-decorated functions.
+        DecoratorRegistry.register_custom_decorator("mesh_a2a", target, metadata)
+
+        try:
+            _add_tracing_middleware_immediately()
+        except Exception as e:
+            logger.debug(f"Failed to add immediate tracing middleware for a2a: {e}")
+
+        logger.debug(
+            f"🌐 A2A surface registered: path={path}, skill_id={final_skill_id}, "
+            f"deps={len(validated_dependencies)}, auth={auth!r}"
+        )
+
+        # Wrap with DI injector when there are dependencies (mirrors @mesh.route).
+        try:
+            from _mcp_mesh.engine.dependency_injector import get_global_injector
+
+            dependency_names = [dep["capability"] for dep in validated_dependencies]
+            injector = get_global_injector()
+            wrapped = injector.create_injection_wrapper(target, dependency_names)
+
+            # Preserve metadata on wrapper so the route-mount step finds it
+            # regardless of which reference it has.
+            wrapped._mesh_a2a_metadata = metadata
+            target._mesh_injection_wrapper = wrapped
+            wrapped._mesh_is_injection_wrapper = True
+
+            _trigger_debounced_processing()
+            return wrapped
+        except Exception as e:
+            logger.error(
+                f"A2A dependency injection setup failed for {target.__name__}: {e}"
+            )
+            _trigger_debounced_processing()
+            return target
+
+    return decorator
+
+
+def _a2a_mount(*args: Any, **kwargs: Any):
+    """Attribute alias for ``mesh.a2a.mount`` (see ``mesh.a2a.mount``).
+
+    The implementation lives in ``mesh.a2a`` to keep the FastAPI import
+    out of ``mesh.decorators`` (which is loaded eagerly by ``import mesh``
+    and shouldn't pull FastAPI for users that only need ``@mesh.tool``).
+
+    Imports via ``importlib`` rather than ``from . import a2a`` because
+    the ``mesh`` package's ``__getattr__`` shadows ``a2a`` with the
+    decorator function — a plain ``from`` import would resolve
+    ``a2a`` to ``_a2a_mount`` itself and recurse.
+    """
+    import importlib
+
+    a2a_module = importlib.import_module("mesh.a2a")
+    return a2a_module.mount(*args, **kwargs)
+
+
+# Expose ``mount`` as an attribute of the ``a2a`` decorator so users can
+# write ``@mesh.a2a.mount(app, path=...)`` while still keeping
+# ``@mesh.a2a(path=...)`` callable as a plain decorator.
+a2a.mount = _a2a_mount  # type: ignore[attr-defined]
+
+
 def _add_tracing_middleware_immediately():
     """
     Request tracing middleware injection using monkey-patch approach.

--- a/src/runtime/python/tests/unit/test_a2a_decorator.py
+++ b/src/runtime/python/tests/unit/test_a2a_decorator.py
@@ -1,0 +1,739 @@
+"""Unit tests for the @mesh.a2a decorator + mesh.a2a.mount helper +
+agent card generator + heartbeat plumbing introduced in Phase 1B of
+issue #903.
+
+See A2A_SURFACE_DESIGN.org for the full design — these tests cover the
+Python runtime surface only:
+
+  * Decorator validation (path required, auth restrictions, dep shape)
+  * Decorator-only path: stamps metadata, does NOT mount any routes
+  * mesh.a2a.mount(): registers card + JSON-RPC routes on the user's app
+  * Agent card generator: A2A v1.0 shape for sync vs streaming surfaces
+  * Heartbeat preparation: agent_type=a2a + surfaces array shape
+  * Phase-1B JSON-RPC route: returns Method-not-implemented for tasks/*
+  * Public-URL cache contract used by the agent-card endpoint
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mesh
+from _mcp_mesh.engine.a2a_card import build_agent_card
+from _mcp_mesh.engine.decorator_registry import DecoratedFunction, DecoratorRegistry
+from _mcp_mesh.pipeline.mcp_startup.heartbeat_preparation import (
+    HeartbeatPreparationStep,
+)
+from _mcp_mesh.pipeline.shared import PipelineStatus
+
+
+# Each test wipes the custom-decorator slot so registrations across tests
+# don't leak — DecoratorRegistry is process-global by design.
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    DecoratorRegistry._custom_decorators.pop("mesh_a2a", None)
+    yield
+    DecoratorRegistry._custom_decorators.pop("mesh_a2a", None)
+
+
+class TestA2ADecoratorValidation:
+    """Decorator-time validation: path, auth, multi-dep warning."""
+
+    def test_path_is_required(self):
+        with pytest.raises(TypeError):
+            # Missing required keyword arg.
+            @mesh.a2a()  # type: ignore[call-arg]
+            def f():
+                pass
+
+    def test_path_must_start_with_slash(self):
+        with pytest.raises(ValueError, match="must start with"):
+
+            @mesh.a2a(path="agents/foo")
+            def f():
+                pass
+
+    def test_empty_path_rejected(self):
+        with pytest.raises(ValueError):
+
+            @mesh.a2a(path="")
+            def f():
+                pass
+
+    def test_auth_bearer_accepted(self):
+        @mesh.a2a(path="/agents/foo", auth="bearer")
+        def f():
+            pass
+
+        # Resolve to underlying registered function (decorator may wrap).
+        registered = DecoratorRegistry.get_all_by_type("mesh_a2a")
+        assert "f" in registered
+        assert registered["f"].metadata["auth"] == "bearer"
+
+    def test_auth_none_accepted(self):
+        @mesh.a2a(path="/agents/foo")
+        def f():
+            pass
+
+        registered = DecoratorRegistry.get_all_by_type("mesh_a2a")
+        assert registered["f"].metadata["auth"] is None
+
+    def test_auth_other_scheme_rejected(self):
+        with pytest.raises(ValueError, match="not supported in v1"):
+
+            @mesh.a2a(path="/agents/foo", auth="oauth2")
+            def f():
+                pass
+
+    def test_skill_id_derived_from_path(self):
+        @mesh.a2a(path="/agents/report-generator")
+        def f():
+            pass
+
+        registered = DecoratorRegistry.get_all_by_type("mesh_a2a")
+        assert registered["f"].metadata["skill_id"] == "report-generator"
+
+    def test_skill_name_titlecased_from_skill_id(self):
+        @mesh.a2a(path="/agents/quick-lookup")
+        def f():
+            pass
+
+        registered = DecoratorRegistry.get_all_by_type("mesh_a2a")
+        assert registered["f"].metadata["skill_name"] == "Quick Lookup"
+
+    def test_default_input_output_modes_application_json(self):
+        @mesh.a2a(path="/agents/foo")
+        def f():
+            pass
+
+        md = DecoratorRegistry.get_all_by_type("mesh_a2a")["f"].metadata
+        assert md["input_modes"] == ["application/json"]
+        assert md["output_modes"] == ["application/json"]
+
+
+class TestDecoratorOnlyDoesNotMount:
+    """Bare ``@mesh.a2a`` stamps metadata but does NOT touch any FastAPI app.
+
+    This is the key UX guarantee of the refactor: the decorator is now
+    a pure metadata + DI primitive (mirroring ``@mesh.route``), and route
+    mounting is opt-in via ``mesh.a2a.mount(app, ...)``.
+    """
+
+    def test_decorator_alone_registers_metadata_only(self):
+        @mesh.a2a(path="/agents/bare", description="Bare surface")
+        def bare_a2a(payload: dict):
+            return {"ok": True}
+
+        registered = DecoratorRegistry.get_all_by_type("mesh_a2a")
+        assert "bare_a2a" in registered
+        md = registered["bare_a2a"].metadata
+        assert md["path"] == "/agents/bare"
+        assert md["description"] == "Bare surface"
+        # The wrapper carries the metadata too (so the heartbeat path
+        # can find it regardless of which reference the registry holds).
+        assert hasattr(bare_a2a, "_mesh_a2a_metadata")
+
+
+class TestA2AMountHelper:
+    """``mesh.a2a.mount(app, ...)`` — the recommended user-facing entry."""
+
+    def test_mount_is_attached_to_decorator(self):
+        # Public surface: ``mesh.a2a.mount`` must be callable.
+        assert callable(mesh.a2a.mount)
+
+    def test_mount_registers_card_and_jsonrpc_routes(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        app = FastAPI()
+
+        @mesh.a2a.mount(
+            app,
+            path="/agents/lookup",
+            description="User lookup",
+            tags=["users"],
+        )
+        async def lookup_a2a(payload: dict):
+            return {"ok": True}
+
+        with TestClient(app) as client:
+            r = client.get("/agents/lookup/.well-known/agent.json")
+            assert r.status_code == 200
+            card = r.json()
+            assert card["skills"][0]["id"] == "lookup"
+            assert card["skills"][0]["tags"] == ["users"]
+            # No bearer auth declared → schemes=[] (A2A v1.0 has no "none"
+            # scheme; an empty list means "no advertised schemes").
+            assert card["authentication"]["schemes"] == []
+
+            # Phase 2: tasks/send dispatches into the handler and
+            # wraps the result in an A2A v1.0 Task envelope.
+            req = {
+                "jsonrpc": "2.0",
+                "method": "tasks/send",
+                "params": {"id": "t-lookup-1", "message": {"role": "user", "parts": []}},
+                "id": "req-1",
+            }
+            r = client.post("/agents/lookup", json=req)
+            assert r.status_code == 200
+            envelope = r.json()
+            assert envelope["jsonrpc"] == "2.0"
+            assert envelope["id"] == "req-1"
+            assert "error" not in envelope
+            task = envelope["result"]
+            assert task["id"] == "t-lookup-1"
+            assert task["status"]["state"] == "completed"
+
+            # Other tasks/* still return Method-not-implemented.
+            other = {
+                "jsonrpc": "2.0",
+                "method": "tasks/get",
+                "params": {"id": "t-lookup-1"},
+                "id": "req-2",
+            }
+            r = client.post("/agents/lookup", json=other)
+            assert r.status_code == 200
+            envelope = r.json()
+            assert envelope["error"]["code"] == -32601
+            assert "Method not implemented" in envelope["error"]["message"]
+
+    def test_mount_records_metadata_for_heartbeat(self):
+        # mount() should still register the surface in the
+        # DecoratorRegistry so HeartbeatPreparationStep emits
+        # agent_type=a2a + surfaces array.
+        from fastapi import FastAPI
+
+        app = FastAPI()
+
+        @mesh.a2a.mount(
+            app,
+            path="/agents/metric",
+            skill_id="metric",
+            skill_name="Metric Surface",
+        )
+        async def metric_a2a(payload: dict):
+            return payload
+
+        registered = DecoratorRegistry.get_all_by_type("mesh_a2a")
+        assert "metric_a2a" in registered
+        md = registered["metric_a2a"].metadata
+        assert md["path"] == "/agents/metric"
+        assert md["skill_id"] == "metric"
+        assert md["skill_name"] == "Metric Surface"
+
+    def test_mount_returns_callable_for_direct_invocation(self):
+        # The decorator returns the wrapped function so the user can
+        # still hold a reference to a usable callable (handy for unit
+        # tests that exercise the handler directly without HTTP).
+        from fastapi import FastAPI
+
+        app = FastAPI()
+
+        @mesh.a2a.mount(app, path="/agents/echo")
+        async def echo(payload: dict):
+            return {"echoed": payload}
+
+        assert callable(echo)
+
+    def test_mount_bearer_auth_rejects_missing_header(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        app = FastAPI()
+
+        @mesh.a2a.mount(app, path="/agents/secure", auth="bearer")
+        async def secure(payload: dict):
+            return {}
+
+        with TestClient(app) as client:
+            r = client.post(
+                "/agents/secure",
+                json={"jsonrpc": "2.0", "method": "tasks/send", "id": 1},
+            )
+            assert r.status_code == 401
+            assert r.json()["error"]["code"] == -32001
+
+            r = client.post(
+                "/agents/secure",
+                headers={"Authorization": "Bearer abc"},
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "tasks/send",
+                    "params": {"id": "t-sec-1", "message": {"role": "user", "parts": []}},
+                    "id": 1,
+                },
+            )
+            assert r.status_code == 200
+            envelope = r.json()
+            # With a valid bearer header, Phase 2 dispatches tasks/send.
+            assert "error" not in envelope
+            assert envelope["result"]["status"]["state"] == "completed"
+
+    def test_mount_rejects_non_fastapi_app(self):
+        # Catch the easy mistake of forgetting ``app`` and passing
+        # something else as the first positional arg.
+        with pytest.raises(ValueError, match="FastAPI"):
+            mesh.a2a.mount("not-an-app", path="/agents/oops")  # type: ignore[arg-type]
+
+
+class TestAgentCardGenerator:
+    """build_agent_card shape conformance to A2A v1.0."""
+
+    def test_sync_card_has_streaming_false(self):
+        card = build_agent_card(
+            name="lookup-svc",
+            description="User lookup",
+            version="1.0.0",
+            public_url="https://agents.acme.com/agents/lookup",
+            skill_id="lookup",
+            skill_name="Lookup",
+            skill_description="Lookup a user",
+            input_modes=["application/json"],
+            output_modes=["application/json"],
+            tags=["users"],
+            streaming=False,
+            bearer_auth=False,
+        )
+
+        assert card["name"] == "lookup-svc"
+        assert card["version"] == "1.0.0"
+        assert card["url"] == "https://agents.acme.com/agents/lookup"
+        assert card["capabilities"]["streaming"] is False
+        assert card["capabilities"]["pushNotifications"] is False
+        assert card["capabilities"]["stateTransitionHistory"] is False
+        assert card["defaultInputModes"] == ["application/json"]
+        assert card["defaultOutputModes"] == ["application/json"]
+        assert len(card["skills"]) == 1
+        skill = card["skills"][0]
+        assert skill["id"] == "lookup"
+        assert skill["name"] == "Lookup"
+        assert skill["description"] == "Lookup a user"
+        assert skill["tags"] == ["users"]
+        # No bearer → schemes=[] (A2A v1.0 has no "none" scheme).
+        assert card["authentication"]["schemes"] == []
+
+    def test_streaming_card_flips_capabilities(self):
+        card = build_agent_card(
+            name="report-svc",
+            description=None,
+            version="2.0.0",
+            public_url="https://agents.acme.com/agents/report-generator",
+            skill_id="generate-report",
+            skill_name="Generate Report",
+            skill_description=None,
+            input_modes=["application/json"],
+            output_modes=["application/json"],
+            tags=[],
+            streaming=True,
+            bearer_auth=True,
+        )
+
+        assert card["capabilities"]["streaming"] is True
+        assert card["authentication"]["schemes"] == ["bearer"]
+        # Description fallback to name when not set.
+        assert card["description"] == "report-svc"
+        # Skill description falls back to skill_name when not set.
+        assert card["skills"][0]["description"] == "Generate Report"
+
+    def test_card_omits_url_when_public_url_empty(self):
+        card = build_agent_card(
+            name="x",
+            description="x",
+            version="1.0.0",
+            public_url=None,
+            skill_id="x",
+            skill_name="X",
+            skill_description="x",
+            input_modes=["application/json"],
+            output_modes=["application/json"],
+            tags=[],
+            streaming=False,
+            bearer_auth=False,
+        )
+        # Per design: when MCP_MESH_PUBLIC_URL_PREFIX is unset and registry
+        # hasn't stamped a public URL, omit the field rather than emit ''.
+        assert "url" not in card
+
+    def test_card_includes_underlying_input_schema_in_metadata(self):
+        schema = {"type": "object", "properties": {"user_id": {"type": "string"}}}
+        card = build_agent_card(
+            name="x",
+            description="x",
+            version="1.0.0",
+            public_url="https://x/y",
+            skill_id="s",
+            skill_name="S",
+            skill_description=None,
+            input_modes=["application/json"],
+            output_modes=["application/json"],
+            tags=[],
+            streaming=False,
+            bearer_auth=False,
+            underlying_tool_input_schema=schema,
+        )
+        # The A2A v1.0 spec doesn't reserve a slot for tool input schema on
+        # Skill — we expose it under skill.metadata so the card stays
+        # spec-clean while still carrying the shape downstream.
+        assert card["skills"][0]["metadata"]["input_schema"] == schema
+
+
+class TestHeartbeatPreparationWithSurfaces:
+    """HeartbeatPreparationStep flips agent_type and emits surfaces."""
+
+    @pytest.fixture
+    def agent_config(self):
+        return {
+            "agent_id": "report-agent-1",
+            "name": "report-agent",
+            "version": "1.0.0",
+            "http_host": "0.0.0.0",
+            "http_port": 9100,
+            "namespace": "default",
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_a2a_keeps_mcp_agent_type(self, agent_config):
+        step = HeartbeatPreparationStep()
+        # _build_a2a_surfaces now delegates to engine.a2a_surfaces; patch
+        # both the local DecoratorRegistry symbol (used for tools/config)
+        # and the engine-level one (used by collect_a2a_surfaces).
+        with patch(
+            "_mcp_mesh.pipeline.mcp_startup.heartbeat_preparation.DecoratorRegistry"
+        ) as mock_registry, patch(
+            "_mcp_mesh.engine.a2a_surfaces.DecoratorRegistry"
+        ) as mock_surfaces_registry:
+            mock_registry.get_mesh_tools.return_value = {}
+            mock_registry.get_mesh_llm_agents.return_value = {}
+            mock_registry.get_resolved_agent_config.return_value = agent_config
+            mock_registry.get_all_by_type.return_value = {}
+            mock_surfaces_registry.get_all_by_type.return_value = {}
+
+            result = await step.execute({})
+            assert result.status == PipelineStatus.SUCCESS
+            payload = result.context["registration_data"]
+            assert payload["agent_type"] == "mcp_agent"
+            assert "surfaces" not in payload
+
+    @pytest.mark.asyncio
+    async def test_a2a_decorator_flips_agent_type_and_emits_surfaces(
+        self, agent_config
+    ):
+        # Build a fake mesh_a2a registration directly on the registry so the
+        # heartbeat-prep step picks it up. We deliberately don't go through
+        # the @mesh.a2a decorator here to keep the test surface minimal —
+        # the decorator path is exercised in TestA2ADecoratorValidation.
+        fake_func = MagicMock()
+        fake_func.__name__ = "report_a2a"
+        decorated = DecoratedFunction(
+            decorator_type="mesh_a2a",
+            function=fake_func,
+            metadata={
+                "path": "/agents/report-generator",
+                "skill_id": "generate-report",
+                "skill_name": "Generate Report",
+                "description": "Long-form report",
+                "input_modes": ["application/json"],
+                "output_modes": ["application/json"],
+                "tags": ["reports"],
+                "auth": "bearer",
+                "dependencies": [{"capability": "generate_report", "tags": []}],
+            },
+            registered_at=datetime.now(),
+        )
+
+        step = HeartbeatPreparationStep()
+        # See note in test_no_a2a_keeps_mcp_agent_type: surfaces collection
+        # now lives in engine.a2a_surfaces, so patch both registries.
+        with patch(
+            "_mcp_mesh.pipeline.mcp_startup.heartbeat_preparation.DecoratorRegistry"
+        ) as mock_registry, patch(
+            "_mcp_mesh.engine.a2a_surfaces.DecoratorRegistry"
+        ) as mock_surfaces_registry:
+            mock_registry.get_mesh_tools.return_value = {}
+            mock_registry.get_mesh_llm_agents.return_value = {}
+            mock_registry.get_resolved_agent_config.return_value = agent_config
+            mock_registry.get_all_by_type.return_value = {"report_a2a": decorated}
+            mock_surfaces_registry.get_all_by_type.return_value = {
+                "report_a2a": decorated
+            }
+
+            result = await step.execute({})
+            assert result.status == PipelineStatus.SUCCESS
+
+            payload = result.context["registration_data"]
+            assert payload["agent_type"] == "a2a"
+            assert "surfaces" in payload
+            surfaces = payload["surfaces"]
+            assert len(surfaces) == 1
+            entry = surfaces[0]
+            assert entry["path"] == "/agents/report-generator"
+            assert entry["skill_id"] == "generate-report"
+            assert entry["name"] == "Generate Report"
+            assert entry["description"] == "Long-form report"
+            assert entry["input_modes"] == ["application/json"]
+            assert entry["output_modes"] == ["application/json"]
+            assert entry["tags"] == ["reports"]
+
+
+class TestA2APublicUrlCache:
+    """Public URL cache contract for the agent-card endpoint."""
+
+    def test_update_and_get_cache(self):
+        from mesh.a2a import (
+            get_cached_public_url,
+            update_public_url_cache,
+        )
+
+        path = "/agents/cache-test"
+        skill = "cache-test"
+        try:
+            assert get_cached_public_url(path, skill) is None
+            update_public_url_cache(path, skill, "https://agents.acme.com" + path)
+            assert (
+                get_cached_public_url(path, skill)
+                == "https://agents.acme.com" + path
+            )
+            # Empty/None clears the entry.
+            update_public_url_cache(path, skill, None)
+            assert get_cached_public_url(path, skill) is None
+        finally:
+            update_public_url_cache(path, skill, None)
+
+
+class TestA2ATasksSendDispatch:
+    """Phase 2: sync tasks/send dispatches into the @mesh.a2a handler
+    and wraps the result in an A2A v1.0 Task envelope.
+
+    Long-running (task=True underlying), tasks/get, tasks/cancel, and
+    tasks/sendSubscribe still return JSON-RPC -32601 (Phase 3 territory).
+    """
+
+    def _client(self, mount_kwargs: dict, handler):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        app = FastAPI()
+        mesh.a2a.mount(app, **mount_kwargs)(handler)
+        return TestClient(app)
+
+    def test_tasks_send_returns_completed_task_for_sync_handler(self):
+        async def handler(payload: dict):
+            return {"date": "2026-05-09T12:34:56Z"}
+
+        with self._client({"path": "/agents/date"}, handler) as client:
+            req = {
+                "jsonrpc": "2.0",
+                "id": "req-42",
+                "method": "tasks/send",
+                "params": {
+                    "id": "task-abc",
+                    "sessionId": "sess-xyz",
+                    "message": {"role": "user", "parts": []},
+                },
+            }
+            r = client.post("/agents/date", json=req)
+            assert r.status_code == 200
+            envelope = r.json()
+            assert envelope["jsonrpc"] == "2.0"
+            assert envelope["id"] == "req-42"
+            assert "error" not in envelope
+
+            task = envelope["result"]
+            assert task["id"] == "task-abc"
+            assert task["sessionId"] == "sess-xyz"
+            assert task["status"]["state"] == "completed"
+            assert task["status"]["timestamp"].endswith("Z")
+            assert len(task["artifacts"]) == 1
+            artifact = task["artifacts"][0]
+            assert artifact["name"] == "result"
+            assert artifact["index"] == 0
+            assert len(artifact["parts"]) == 1
+            part = artifact["parts"][0]
+            assert part["type"] == "text"
+            # Non-string handler results are JSON-stringified.
+            import json as _json
+
+            assert _json.loads(part["text"]) == {"date": "2026-05-09T12:34:56Z"}
+            # History echoes the request message.
+            assert task["history"] == [{"role": "user", "parts": []}]
+
+    def test_tasks_send_string_result_used_verbatim(self):
+        async def handler(payload: dict):
+            return "hello world"
+
+        with self._client({"path": "/agents/echo"}, handler) as client:
+            r = client.post(
+                "/agents/echo",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 7,
+                    "method": "tasks/send",
+                    "params": {
+                        "id": "t1",
+                        "message": {"role": "user", "parts": []},
+                    },
+                },
+            )
+            envelope = r.json()
+            text = envelope["result"]["artifacts"][0]["parts"][0]["text"]
+            # String results are NOT JSON-encoded (no surrounding quotes).
+            assert text == "hello world"
+
+    def test_tasks_send_handler_exception_yields_failed_task(self):
+        async def handler(payload: dict):
+            raise RuntimeError("boom: dependency timed out")
+
+        with self._client({"path": "/agents/fail"}, handler) as client:
+            r = client.post(
+                "/agents/fail",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "req-99",
+                    "method": "tasks/send",
+                    "params": {
+                        "id": "task-fail",
+                        "message": {"role": "user", "parts": []},
+                    },
+                },
+            )
+            assert r.status_code == 200
+            envelope = r.json()
+            # Per A2A v1.0: handler failure is a failed Task, NOT a
+            # JSON-RPC error.
+            assert "error" not in envelope
+            task = envelope["result"]
+            assert task["id"] == "task-fail"
+            assert task["status"]["state"] == "failed"
+            assert task["artifacts"] == []
+            err_text = task["status"]["message"]["parts"][0]["text"]
+            assert "boom" in err_text
+
+    def test_tasks_send_session_id_defaults_to_task_id(self):
+        async def handler(payload: dict):
+            return {"ok": True}
+
+        with self._client({"path": "/agents/sess"}, handler) as client:
+            r = client.post(
+                "/agents/sess",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tasks/send",
+                    "params": {
+                        "id": "only-task-id",
+                        # sessionId omitted on purpose.
+                        "message": {"role": "user", "parts": []},
+                    },
+                },
+            )
+            task = r.json()["result"]
+            assert task["id"] == "only-task-id"
+            assert task["sessionId"] == "only-task-id"
+
+    def test_tasks_send_missing_task_id_gets_uuid(self):
+        async def handler(payload: dict):
+            return {"ok": True}
+
+        with self._client({"path": "/agents/auto"}, handler) as client:
+            r = client.post(
+                "/agents/auto",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tasks/send",
+                    "params": {"message": {"role": "user", "parts": []}},
+                },
+            )
+            task = r.json()["result"]
+            # Real UUID4 (not just 36-char string — guards against any
+            # future "use a deterministic placeholder" regression).
+            import uuid
+
+            parsed = uuid.UUID(task["id"])
+            assert parsed.version == 4
+            assert task["sessionId"] == task["id"]
+
+    def test_tasks_send_handler_receives_message_dict(self):
+        captured: dict = {}
+
+        async def handler(payload: dict):
+            captured["payload"] = payload
+            return {"got_role": payload.get("role")}
+
+        with self._client({"path": "/agents/cap"}, handler) as client:
+            r = client.post(
+                "/agents/cap",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tasks/send",
+                    "params": {
+                        "id": "t1",
+                        "message": {
+                            "role": "user",
+                            "parts": [{"type": "text", "text": "hi"}],
+                        },
+                    },
+                },
+            )
+            assert r.status_code == 200
+            assert captured["payload"]["role"] == "user"
+            assert captured["payload"]["parts"][0]["text"] == "hi"
+            import json as _json
+
+            artifact_text = r.json()["result"]["artifacts"][0]["parts"][0]["text"]
+            assert _json.loads(artifact_text) == {"got_role": "user"}
+
+    def test_other_tasks_methods_still_method_not_implemented(self):
+        async def handler(payload: dict):
+            return {}
+
+        with self._client({"path": "/agents/x"}, handler) as client:
+            for method in ("tasks/get", "tasks/cancel", "tasks/sendSubscribe"):
+                r = client.post(
+                    "/agents/x",
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": method,
+                        "method": method,
+                        "params": {},
+                    },
+                )
+                assert r.status_code == 200
+                envelope = r.json()
+                assert envelope["id"] == method
+                assert envelope["error"]["code"] == -32601
+                assert "Method not implemented" in envelope["error"]["message"]
+
+    def test_tasks_send_falls_back_when_underlying_is_task_true(self):
+        # Mock _underlying_tool_is_task to simulate a task=True dep.
+        from mesh import a2a as a2a_mod
+
+        async def handler(payload: dict):
+            # Should NOT be invoked — Phase 3 territory.
+            raise AssertionError("handler should not run for task=True deps")
+
+        with patch.object(a2a_mod, "_underlying_tool_is_task", return_value=True):
+            with self._client(
+                {"path": "/agents/long", "dependencies": ["long_tool"]},
+                handler,
+            ) as client:
+                r = client.post(
+                    "/agents/long",
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": "req-1",
+                        "method": "tasks/send",
+                        "params": {
+                            "id": "t-long",
+                            "message": {"role": "user", "parts": []},
+                        },
+                    },
+                )
+                envelope = r.json()
+                assert envelope["error"]["code"] == -32601
+                assert "Phase 3" in envelope["error"]["message"]

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/src/index.ts
@@ -16,6 +16,8 @@
  *   - commission_crash            — submits report_that_crashes
  *   - commission_overlong         — submits runs_overlong
  *   - commission_downstream       — submits report_with_downstream_call
+ *   - commission_transient_failures — submits report_with_transient_failures
+ *                                     (#894 retryOn integration test driver)
  */
 import { FastMCP, mesh, type MeshJob } from "@mcpmesh/sdk";
 import { z } from "zod";
@@ -278,6 +280,50 @@ agent.addTool({
       { maxDuration: 120 },
     );
     return { job_id: (proxy as { jobId?: string }).jobId ?? null };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Transient-failures submitter — submits report_with_transient_failures (#894 tc23)
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "commission_transient_failures",
+  capability: "commission_transient_failures",
+  dependencies: [{ capability: "report_with_transient_failures" }],
+  meshJobDepIndex: 0,
+  description:
+    "Submit report_with_transient_failures with caller-supplied max_retries.",
+  parameters: z.object({
+    user_id: z.string(),
+    max_retries: z.number().int().default(3),
+    transient_failures: z.number().int().default(2),
+    wait_timeout_secs: z.number().int().default(30),
+  }),
+  execute: async (
+    { user_id, max_retries, transient_failures, wait_timeout_secs },
+    reportWithTransientFailures: MeshJob | null = null,
+  ) => {
+    if (!reportWithTransientFailures?.submit) {
+      return { error: "report_with_transient_failures submitter not injected" };
+    }
+    const proxy = await reportWithTransientFailures.submit(
+      { user_id, transient_failures },
+      { maxDuration: 30, maxRetries: max_retries },
+    );
+    const job_id = (proxy as { jobId?: string }).jobId ?? null;
+    if (!proxy.wait) {
+      return { job_id, status: "submitted", result: null };
+    }
+    try {
+      const result = await proxy.wait(wait_timeout_secs);
+      return { job_id, status: "completed", result };
+    } catch (e) {
+      return {
+        job_id,
+        status: "wait_raised",
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
   },
 });
 

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/src/index.ts
@@ -15,11 +15,14 @@
  *   - report_with_implicit_complete     — return value WITHOUT complete()
  *   - report_with_explicit_fail         — calls fail("reason")
  *   - report_that_crashes               — raises mid-attempt
+ *   - report_with_transient_failures    — throws TransientError on first N
+ *                                         attempts, succeeds on N+1 (retryOn)
  *   - runs_overlong                     — long sleep loop for cancel tests
  *   - report_with_downstream_call       — calls slow_downstream regular tool
  */
 import { FastMCP, mesh, type MeshJob, type McpMeshTool } from "@mcpmesh/sdk";
 import { z } from "zod";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
 
 const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9110", 10);
 
@@ -162,6 +165,74 @@ agent.addTool({
       await new Promise((r) => setTimeout(r, 300));
     }
     throw new Error("simulated crash for crash-recovery test");
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Transient-failure path — exercises retryOn (#894) (tc23 mirror)
+// ---------------------------------------------------------------------------
+//
+// Mirrors Python's report_with_transient_failures
+// (uc21_meshjob/fixtures/long-task-provider/main.py) and Java's
+// reportWithTransientFailures (uc23_meshjob_java/...). The handler is
+// declared with retryOn: [TransientError]: when the body throws
+// TransientError the dispatch wrapper calls JobController.releaseLease
+// (NOT fail), so the registry resets owner_instance_id and the next
+// claim cycle re-runs the handler — proving the fast-retry path
+// engaged rather than waiting for lease expiry.
+//
+// File-based counter shared with the Python fixture so the same
+// integration assertions (attempt_count=3) work cross-runtime.
+// ---------------------------------------------------------------------------
+class TransientError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TransientError";
+  }
+}
+
+const RETRY_COUNTER_PATH = "/tmp/mesh-retry-on-counter";
+
+function bumpRetryCounter(): number {
+  let n = 0;
+  if (existsSync(RETRY_COUNTER_PATH)) {
+    const body = readFileSync(RETRY_COUNTER_PATH, "utf8").trim();
+    n = body === "" ? 0 : parseInt(body, 10);
+    if (Number.isNaN(n)) n = 0;
+  }
+  n += 1;
+  writeFileSync(RETRY_COUNTER_PATH, String(n), "utf8");
+  return n;
+}
+
+agent.addTool({
+  name: "report_with_transient_failures",
+  capability: "report_with_transient_failures",
+  task: true,
+  meshJobParamIndex: 1,
+  retryOn: [TransientError],
+  description:
+    "Throws TransientError on the first N attempts, succeeds on N+1 — exercises retryOn (#894).",
+  parameters: z.object({
+    user_id: z.string(),
+    transient_failures: z.number().int().default(2),
+  }),
+  execute: async (
+    { user_id, transient_failures },
+    job: MeshJob | null = null,
+  ) => {
+    if (job?.updateProgress) {
+      await job.updateProgress(0.1, "checking transient counter");
+    }
+    const n = bumpRetryCounter();
+    if (n <= transient_failures) {
+      throw new TransientError(`simulated transient failure ${n}/${transient_failures}`);
+    }
+    const payload = { user_id, succeeded_on_attempt: n };
+    if (job?.complete) {
+      await job.complete(payload);
+    }
+    return payload;
   },
 });
 


### PR DESCRIPTION
## Summary

Closes #903 (Python v1 of #869). Adds a Google A2A v1.0 protocol surface adapter that exposes mesh tools as A2A-compatible agents discoverable at `/.well-known/agent.json`. Three sibling pipelines now exist: `mcp_startup` (FastMCP) / `api_startup` (REST) / `a2a_startup` (A2A) — each owning its own protocol surface; mesh tools stay protocol-agnostic.

## DX

User-controlled FastAPI mounting via `mesh.a2a.mount(app, ...)`, mirroring the established `@mesh.route` pattern. The user owns the FastAPI app and uvicorn lifecycle; mesh handles the A2A protocol envelope + DI.

```python
app = FastAPI(title="Date A2A Agent")

@mesh.a2a.mount(app, path="/agents/date", dependencies=["date_service"])
async def date_a2a(payload: dict, date_service: McpMeshTool = None):
    return await date_service()

uvicorn.run(app, port=9090)
```

End-to-end live test:

```bash
$ curl -X POST http://localhost:9090/agents/date \
    -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"t1","message":{"role":"user","parts":[]}}}'
{
  "result": {
    "id": "t1", "sessionId": "t1",
    "status": {"state": "completed", "timestamp": "..."},
    "artifacts": [{"name": "result", "parts": [{"type": "text", "text": "{\"date\": \"...\"}"}], "index": 0}]
  }
}
```

## Architecture

- **Registry**: new `agent_type=a2a` enum, `surfaces` JSONB field, `GET /a2a/agents` discovery endpoint, FQDN stamping via `MCP_MESH_PUBLIC_URL_PREFIX`
- **`a2a_startup` pipeline**: sibling to `api_startup` and `mcp_startup`. Detects `mesh_a2a` markers, slugifies FastAPI title for stable agent identity, populates surfaces array
- **`@mesh.a2a` + `mount()`**: pure DI decorator + user-controlled mount helper (no auto-mount). Duplicate path raises `ValueError`
- **Phase 2 minimal `tasks/send`**: invokes user handler via DDDI, wraps result in A2A v1.0 Task envelope. Sync only; long-running (`task=True`) underlying defers to Phase 3
- **Rust core**: `AgentType::A2a` variant + `surfaces` JSON passthrough on `AgentSpec`

## Review Notes

Pre-merge review-agent flagged 3 BLOCKERS + 6 WARNINGS + 2 INFOs. **Fixed all 3 blockers and 4 of 6 warnings**:

- ✓ **Non-string handler return crashed JSON-RPC** — `json.dumps(default=str)` coerces non-serializable returns
- ✓ **Slugifier passed non-ASCII through** — added `re.sub(r'[^a-z0-9-]+', '-', ...)`. Same fix in api_startup (was newly vulnerable from this PR's parity edit)
- ✓ **Stale registry entries on restart** — service_id now derives from slugified title for stable identity
- ✓ **Duplicate `mount()` calls silently diverged** — now raises `ValueError`
- ✓ **`_build_a2a_surfaces` duplication** — collapsed to delegating wrapper
- ✓ **Bearer auth empty-token bypass** — rejects empty token after prefix

## Deferred (documented for Phase 3)

The remaining BLOCKER + 2 WARNINGS need architectural work that doesn't block this PR's value delivery:

- **Card endpoint URL falls back to local** (BLOCKER): heartbeat-response `surfaces[].public_url` isn't wired to `update_public_url_cache`. Needs a new Rust `MeshEvent` variant. **Mitigation**: external A2A clients should use `GET /a2a/agents` for FQDN discovery (which IS correctly stamped today via `MCP_MESH_PUBLIC_URL_PREFIX`).
- **`_underlying_tool_is_task()` blind to remote deps** (WARNING): consults only local `DecoratorRegistry`. For cross-agent deps (the canonical A2A use case), returns False — a remote `task=True` tool would dispatch sync. Needs injector proxy metadata to fix cleanly.
- **`MCP_MESH_HTTP_PORT` import-order footgun** (WARNING): must be set before `import mesh`. Production scripts loading `.env` after imports may hit this. The example uses `os.environ.setdefault` pre-import as the workaround pattern.

## Out of scope (per #903)

- TypeScript and Java SDKs (Python only for v1)
- Consumer side (`mesh.A2AProxy` for depending on external A2A agents)
- LLM-backed multi-skill agent cards
- Auth schemes beyond bearer (OAuth, mTLS, SPIRE)
- Multi-turn `state: input-required`
- Push notifications / webhooks
- Signed agent cards
- gRPC variant
- `tasks/sendSubscribe` SSE streaming + `tasks/get`/`cancel` + `task=True` MeshJob lifecycle (Phase 3)

## Validation

- `go test -short ./src/core/registry/...` clean (incl. 7 new A2A tests)
- `cargo test --lib --features python --no-default-features` clean
- `pytest tests/unit/`: **853 passed** (incl. 31 new A2A tests covering decorator validation, mount(), card generation, tasks/send dispatch, bearer auth, public URL cache, heartbeat surfaces emission, dispatch failure modes)
- Live end-to-end: registry + system_agent + date_a2a_agent + curl `tasks/send` → A2A → mesh DI → date_service → date string in Task artifact

Closes #903
Refs #869 (parent A2A surface adapter umbrella), #861 (MeshJob substrate dependency)

## Test plan

- [ ] CI green
- [ ] Manual smoke (per `examples/a2a/README.md`):
  - Start registry: `MCP_MESH_PUBLIC_URL_PREFIX=https://agents.acme.com /tmp/mcp-mesh-registry`
  - Start provider: `python examples/simple/system_agent.py`
  - Start A2A agent: `python examples/a2a/date_a2a_agent.py`
  - `curl http://localhost:9090/agents/date/.well-known/agent.json` returns A2A v1.0 card
  - `curl -X POST http://localhost:9090/agents/date -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"t1","message":{"role":"user","parts":[]}}}'` returns Task with `state=completed` and the date in the artifact
  - `curl http://localhost:8000/a2a/agents` returns FQDN-stamped surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `@mesh.a2a` decorator and `mesh.a2a.mount()` helper to expose agent capabilities via A2A v1.0 HTTP/JSON-RPC protocol with bearer authentication support.
  * Added A2A agent discovery endpoint in registry with surface metadata and public URL stamping via `MCP_MESH_PUBLIC_URL_PREFIX`.
  * Added A2A heartbeat lifecycle integration and agent card generation for A2A surfaces.

* **Documentation**
  * Added A2A surface design specification and working example with FastAPI implementation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/904)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->