### PR TITLE
feat(a2a): Phase 2-leftover + Phase 3 — long-running tasks + SSE streaming

### DIFF
--- a/examples/a2a/report_a2a_agent.py
+++ b/examples/a2a/report_a2a_agent.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+A2A example agent for LONG-RUNNING tasks (Phase 3 — SSE streaming).
+
+Exposes ``examples/jobs/long-task-provider``'s ``generate_report``
+``task=True`` capability via the A2A v1.0 protocol surface, demonstrating:
+
+- ``tasks/send`` returns immediately with ``state=working`` and a task id
+- ``tasks/get`` polls the task and returns the current state + progress
+- ``tasks/cancel`` cancels the underlying mesh job mid-flight
+- ``tasks/sendSubscribe`` opens an SSE stream of TaskStatusUpdateEvent /
+  TaskArtifactUpdateEvent envelopes per A2A v1.0
+- ``tasks/resubscribe`` re-attaches an SSE stream to an in-flight task
+
+The framework introspects the user handler's return value: when it's a
+``mcp_mesh_core.JobProxy``, the surface routes the task lifecycle through
+``MeshJob.{status, cancel, wait}``. When it's a plain dict/string, the
+surface treats the task as sync (state=completed inline).
+
+Prereqs (in three terminals)
+============================
+
+  # 1) Registry
+  /tmp/mcp-mesh-registry  # or `meshctl start registry`
+
+  # 2) Long-running provider — exposes generate_report (task=True)
+  python examples/jobs/long-task-provider/main.py
+
+  # 3) This A2A surface — exposes generate_report via A2A
+  python examples/a2a/report_a2a_agent.py
+
+Test
+====
+
+  # Submit and poll
+  TASK_ID=$(curl -s -X POST http://localhost:9091/agents/report \\
+    -H 'Content-Type: application/json' \\
+    -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"r1","message":{"role":"user","parts":[{"type":"text","text":"{\\"user_id\\":\\"alice\\",\\"sections\\":[\\"intro\\",\\"body\\",\\"summary\\"]}"}]}}}' \\
+    | jq -r '.result.id')
+  curl -s -X POST http://localhost:9091/agents/report \\
+    -H 'Content-Type: application/json' \\
+    -d "{\\"jsonrpc\\":\\"2.0\\",\\"id\\":2,\\"method\\":\\"tasks/get\\",\\"params\\":{\\"id\\":\\"$TASK_ID\\"}}"
+
+  # Stream via SSE
+  curl -N -X POST http://localhost:9091/agents/report \\
+    -H 'Content-Type: application/json' \\
+    -d '{"jsonrpc":"2.0","id":3,"method":"tasks/sendSubscribe","params":{"id":"s1","message":{"role":"user","parts":[{"type":"text","text":"{\\"user_id\\":\\"alice\\",\\"sections\\":[\\"intro\\",\\"body\\"]}"}]}}}'
+"""
+
+import json
+import os
+
+# Set MCP_MESH_HTTP_PORT BEFORE importing mesh so display_config picks
+# up the same port we'll bind uvicorn to.
+HTTP_PORT = int(os.environ.setdefault("MCP_MESH_HTTP_PORT", "9091"))
+
+import mesh
+from fastapi import FastAPI
+from mesh import MeshJob
+
+app = FastAPI(title="Report A2A Agent")
+
+
+@mesh.a2a.mount(
+    app,
+    path="/agents/report",
+    dependencies=["generate_report"],
+    description="Generate a long-form report via A2A (task=True streaming)",
+    skill_id="generate-report",
+    skill_name="Generate Report",
+    tags=["reports", "long-running"],
+)
+async def report_a2a(payload: dict, generate_report: MeshJob = None):
+    """A2A handler that submits a long-running mesh job and returns the
+    JobProxy. The framework wraps the proxy as A2A state=working with a
+    fresh task_id; tasks/get/cancel/sendSubscribe/resubscribe operate on
+    the parked proxy via the underlying MeshJob lifecycle.
+    """
+    if generate_report is None:
+        # Raising surfaces as A2A state=failed. Returning a dict here would
+        # incorrectly wrap the unresolved-dependency case as state=completed
+        # with an error payload — misleading per the protocol.
+        raise RuntimeError(
+            "generate_report dependency not yet resolved by mesh DI"
+        )
+
+    # The A2A request `message` carries the user payload as a text part
+    # with JSON-encoded args. Real-world clients can use any parts shape;
+    # for this example we parse `parts[0].text` as JSON.
+    args = {}
+    parts = payload.get("parts") or []
+    if parts and parts[0].get("type") == "text":
+        try:
+            args = json.loads(parts[0].get("text") or "{}")
+        except json.JSONDecodeError:
+            args = {}
+
+    user_id = args.get("user_id", "anon")
+    sections = args.get("sections") or ["overview"]
+
+    proxy = await generate_report.submit(
+        user_id=user_id,
+        sections=sections,
+    )
+    # Returning the JobProxy switches the framework into long-running mode:
+    # state=working response, task parked in _A2A_TASK_STORE for tasks/get,
+    # tasks/cancel, tasks/sendSubscribe, tasks/resubscribe.
+    return proxy
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    print(f"📊 Report A2A Agent on http://localhost:{HTTP_PORT}")
+    print(f"    Card:        GET  http://localhost:{HTTP_PORT}/agents/report/.well-known/agent.json")
+    print(f"    JSON-RPC:    POST http://localhost:{HTTP_PORT}/agents/report")
+    print(f"    SSE stream:  POST http://localhost:{HTTP_PORT}/agents/report  (method: tasks/sendSubscribe)")
+    print()
+    uvicorn.run(app, host="0.0.0.0", port=HTTP_PORT, log_level="info")

--- a/src/runtime/python/mesh/a2a.py
+++ b/src/runtime/python/mesh/a2a.py
@@ -1,4 +1,4 @@
-"""User-facing A2A surface helpers (issue #903 Phase 1B / Phase 2).
+"""User-facing A2A surface helpers (issue #903 Phase 1B / Phase 2 / Phase 3).
 
 Two complementary entry points:
 
@@ -19,11 +19,24 @@ Two complementary entry points:
     POST ``{path}``                         → JSON-RPC 2.0 entry point
 
 Phase 2 (this module) dispatches sync ``tasks/send`` into the user
-handler and wraps the result in an A2A v1.0 ``Task`` envelope. Other
-``tasks/*`` methods (``tasks/get``, ``tasks/cancel``,
-``tasks/sendSubscribe``) and ``tasks/send`` for ``task=True``
-underlying tools still return JSON-RPC ``Method not implemented`` —
-those land in Phase 3 once the MeshJob lifecycle is wired.
+handler and wraps the result in an A2A v1.0 ``Task`` envelope.
+
+Phase 2-leftover wires the long-running task lifecycle: when the user
+handler returns a ``mcp_mesh_core.JobProxy`` (i.e., the handler called
+``await meshjob_dep.submit(...)``), the framework treats the call as
+long-running — stores the proxy in a process-local map keyed by A2A
+``task_id``, and exposes ``tasks/get`` / ``tasks/cancel`` against that
+proxy. Detecting long-running via the *return value* (rather than the
+metadata-driven ``_underlying_tool_is_task`` helper) is intentional:
+the helper can't see cross-agent deps, but the return-value pattern
+works uniformly for local *and* remote ``task=True`` deps.
+
+Phase 3 wires SSE streaming via ``tasks/sendSubscribe`` and
+``tasks/resubscribe`` — the same dispatch as ``tasks/send`` but the
+response is a ``StreamingResponse`` of A2A v1.0 ``TaskStatusUpdateEvent``
+/ ``TaskArtifactUpdateEvent`` JSON-RPC envelopes. Per spec, client
+disconnect does NOT cancel the underlying job; the client may rejoin
+via ``tasks/resubscribe``.
 
 Public URL caching
 ==================
@@ -42,16 +55,148 @@ and stringified annotations cause it to misclassify ``request: Request``
 as a query parameter (yielding 422 on every POST).
 """
 
+import asyncio
 import json as _json
 import logging
+import time
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, Optional
+from typing import Any, AsyncIterator, Callable, Dict, Optional
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Long-running task store
+# ---------------------------------------------------------------------------
+#
+# Shape: ``{ task_id (str) -> { "proxy": JobProxy, "terminal_at": float|None } }``
+#
+# - ``proxy`` is a ``mcp_mesh_core.JobProxy`` returned from the user
+#   handler when it submitted a ``MeshJob``. Keeping the proxy lets
+#   ``tasks/get`` / ``tasks/cancel`` / ``tasks/resubscribe`` poll +
+#   cancel the underlying mesh job without re-resolving.
+# - ``terminal_at`` is the monotonic-clock timestamp when the task was
+#   first observed in a terminal state (``completed`` / ``failed`` /
+#   ``cancelled``). ``None`` while still working. Used by the sweep to
+#   evict entries older than ``_TERMINAL_GRACE_SECS`` so the store
+#   doesn't grow unbounded for long-lived agents.
+#
+# The store is process-local — A2A surfaces do not currently share state
+# across replicas. A client that connected to replica A and then
+# reconnects (via ``tasks/resubscribe``) to replica B would get an
+# unknown-task error. Cross-replica sharing is out of scope for v1.
+_A2A_TASK_STORE: Dict[str, dict] = {}
+
+# Evict terminal-state entries from ``_A2A_TASK_STORE`` after this many
+# seconds. Five minutes balances "give the client time to fetch the
+# final result" against "don't keep references to dead Rust JobProxy
+# objects forever".
+_TERMINAL_GRACE_SECS = 300.0
+
+
+# A2A v1.0 spec uses a single-l ``"canceled"`` (US spelling); the mesh
+# job lifecycle uses double-l ``"cancelled"`` (UK spelling, matches the
+# Rust ``JobStatus::Cancelled`` variant). Translate at the boundary.
+_MESH_TO_A2A_STATE = {
+    "working": "working",
+    "completed": "completed",
+    "failed": "failed",
+    "cancelled": "canceled",
+}
+
+
+def _map_mesh_state(mesh_status: Optional[str]) -> str:
+    """Translate a mesh job status string to its A2A v1.0 equivalent.
+
+    Unknown / unset statuses fall back to ``"working"`` — preserves the
+    invariant that we never emit an A2A state outside the spec's
+    enumerated set, even if the registry adds a new internal status
+    we haven't mapped yet.
+    """
+    if not mesh_status:
+        return "working"
+    return _MESH_TO_A2A_STATE.get(mesh_status, "working")
+
+
+def _is_job_proxy(value: Any) -> bool:
+    """Return True iff ``value`` is a ``mcp_mesh_core.JobProxy`` instance.
+
+    Lazy import: ``mcp_mesh_core`` is a Rust extension that may not be
+    available in pure-Python test environments. When the import fails
+    we fall back to ``False`` — handlers in test envs that mock the
+    proxy can still use the duck-typed helpers via ``isinstance`` checks
+    against their mock class. Production agents always have the
+    extension installed.
+    """
+    try:
+        from mcp_mesh_core import JobProxy  # type: ignore[attr-defined]
+    except Exception:
+        return False
+    return isinstance(value, JobProxy)
+
+
+def _sweep_terminal_tasks(now: Optional[float] = None) -> None:
+    """Evict entries from ``_A2A_TASK_STORE`` whose terminal_at is older
+    than ``_TERMINAL_GRACE_SECS`` ago. Best-effort housekeeping called
+    on each store access — keeps the dict bounded for long-lived agents
+    without requiring a background sweeper task.
+    """
+    if not _A2A_TASK_STORE:
+        return
+    now = now if now is not None else time.monotonic()
+    expired = [
+        tid
+        for tid, entry in _A2A_TASK_STORE.items()
+        if entry.get("terminal_at") is not None
+        and (now - entry["terminal_at"]) > _TERMINAL_GRACE_SECS
+    ]
+    for tid in expired:
+        _A2A_TASK_STORE.pop(tid, None)
+
+
+def _store_task(
+    task_id: str,
+    proxy: Any,
+    *,
+    request_message: Optional[dict] = None,
+    session_id: Optional[str] = None,
+) -> None:
+    """Register a long-running task → proxy mapping for later lookups.
+
+    Sweeps terminal entries first, then rejects duplicates: if ``task_id``
+    already maps to an in-flight task, raises ``ValueError`` rather than
+    silently overwriting (which would orphan the prior ``JobProxy`` and
+    leave the originating client unable to poll/cancel its task).
+
+    Persists ``request_message`` and ``session_id`` alongside the proxy
+    so ``tasks/get`` envelopes can echo the originating request in the
+    A2A ``history`` field (which is otherwise empty for polled lookups).
+    """
+    _sweep_terminal_tasks()
+    if task_id in _A2A_TASK_STORE:
+        raise ValueError(
+            f"A2A task id {task_id!r} is already in use; pick a fresh "
+            "id or wait for the existing task to terminate (entries are "
+            f"swept after {_TERMINAL_GRACE_SECS}s in terminal state)"
+        )
+    _A2A_TASK_STORE[task_id] = {
+        "proxy": proxy,
+        "terminal_at": None,
+        "request_message": request_message,
+        "session_id": session_id,
+    }
+
+
+def _mark_terminal(task_id: str) -> None:
+    """Record that ``task_id`` reached a terminal state, starting the
+    eviction grace window. No-op if the task isn't in the store."""
+    entry = _A2A_TASK_STORE.get(task_id)
+    if entry is not None and entry.get("terminal_at") is None:
+        entry["terminal_at"] = time.monotonic()
 
 
 # Module-level cache of the registry-stamped public URLs, keyed by
@@ -203,7 +348,14 @@ def _make_card_endpoint(
         cached = get_cached_public_url(path, skill_id)
         public_url = cached or _local_fallback_url(agent_config, path)
 
-        streaming = _underlying_tool_is_task(metadata)
+        # Per A2A v1.0 spec, capabilities.streaming = "supports
+        # tasks/sendSubscribe + tasks/resubscribe". The mount() helper
+        # ALWAYS wires both routes (sync handlers stream a single
+        # artifact + terminal event; long-running stream progress +
+        # artifact + terminal). So streaming is always advertised true.
+        # _underlying_tool_is_task remains as a documented fallback for
+        # debug/diagnostic builds that disable the SSE handlers.
+        streaming = True or _underlying_tool_is_task(metadata)
         input_schema = _underlying_tool_input_schema(metadata)
         bearer_auth = metadata.get("auth") == "bearer"
 
@@ -295,6 +447,109 @@ def _build_failed_task(
     }
 
 
+def _build_working_task(
+    task_id: str,
+    session_id: str,
+    request_message: Optional[dict],
+    *,
+    progress: Optional[Any] = None,
+    progress_message: Optional[str] = None,
+) -> dict:
+    """Build an A2A v1.0 ``Task`` envelope with ``state=working``.
+
+    Returned synchronously from ``tasks/send`` once the user handler
+    has dispatched the underlying mesh job and handed us back a
+    ``JobProxy`` — the framework owns lifecycle from this point on.
+    The artifacts list is empty because the job hasn't produced one yet;
+    the client either polls ``tasks/get`` for terminal status or
+    subscribes via ``tasks/sendSubscribe`` for incremental updates.
+    """
+    status: dict = {"state": "working", "timestamp": _utc_now_iso()}
+    if progress_message:
+        status["message"] = {
+            "role": "agent",
+            "parts": [{"type": "text", "text": progress_message}],
+        }
+    envelope: dict = {
+        "id": task_id,
+        "sessionId": session_id,
+        "status": status,
+        "artifacts": [],
+        "history": [request_message] if request_message else [],
+    }
+    if progress is not None:
+        envelope["metadata"] = {"progress": progress}
+    return envelope
+
+
+def _build_task_from_status(
+    task_id: str,
+    session_id: str,
+    request_message: Optional[dict],
+    status: dict,
+    *,
+    final_result: Any = None,
+    has_final_result: bool = False,
+) -> dict:
+    """Build an A2A v1.0 ``Task`` envelope from a ``JobProxy.status()`` dict.
+
+    ``status`` is the dict the mesh registry returns — keys include
+    ``status`` (working/completed/failed/cancelled), ``progress``,
+    ``progress_message``, ``error``, etc. We map mesh→A2A states and
+    fold ``error``/``progress_message`` into the A2A status.message
+    when present.
+
+    ``final_result`` is only populated when the caller already invoked
+    ``proxy.wait()`` and got a value back (i.e., the job is completed).
+    For ``tasks/get`` we don't block on ``wait()`` — terminal-state
+    callers that want the artifact should subscribe via SSE instead.
+    """
+    mesh_state = status.get("status") or "working"
+    a2a_state = _map_mesh_state(mesh_state)
+
+    a2a_status: dict = {"state": a2a_state, "timestamp": _utc_now_iso()}
+
+    msg_text = None
+    if a2a_state == "failed":
+        msg_text = status.get("error") or status.get("progress_message")
+    else:
+        msg_text = status.get("progress_message")
+    if msg_text:
+        a2a_status["message"] = {
+            "role": "agent",
+            "parts": [{"type": "text", "text": str(msg_text)}],
+        }
+
+    artifacts: list = []
+    if has_final_result and a2a_state == "completed":
+        text = (
+            final_result
+            if isinstance(final_result, str)
+            else _json.dumps(final_result, default=str)
+        )
+        artifacts.append(
+            {
+                "name": "result",
+                "parts": [{"type": "text", "text": text}],
+                "index": 0,
+            }
+        )
+
+    envelope: dict = {
+        "id": task_id,
+        "sessionId": session_id,
+        "status": a2a_status,
+        "artifacts": artifacts,
+        "history": [request_message] if request_message else [],
+    }
+
+    progress = status.get("progress")
+    if progress is not None:
+        envelope["metadata"] = {"progress": progress}
+
+    return envelope
+
+
 def _jsonrpc_success(req_id: Any, result_obj: Any) -> JSONResponse:
     return JSONResponse(
         status_code=200,
@@ -319,6 +574,41 @@ def _jsonrpc_error(
     )
 
 
+def _extract_task_inputs(params: dict) -> tuple[str, str, dict]:
+    """Pull (task_id, session_id, message) out of JSON-RPC ``params``.
+
+    Centralised so all four handlers (send / sendSubscribe / get /
+    cancel / resubscribe) follow the same defaulting rules: missing
+    task_id → fresh UUID4, missing sessionId → reuse task_id, missing
+    or non-dict message → empty dict.
+    """
+    if not isinstance(params, dict):
+        params = {}
+    task_id = params.get("id") or str(uuid.uuid4())
+    session_id = params.get("sessionId") or task_id
+    raw_message = params.get("message")
+    message = raw_message if isinstance(raw_message, dict) else {}
+    return task_id, session_id, message
+
+
+async def _invoke_user_handler(
+    user_handler: Callable[..., Any], message: dict
+) -> Any:
+    """Call the user handler, awaiting if it returned a coroutine.
+
+    Handler errors propagate to the caller — each tasks/* handler wraps
+    this call in its own try/except to translate exceptions into the
+    A2A v1.0 ``state=failed`` envelope (or the SSE failed event for
+    ``sendSubscribe``).
+    """
+    import inspect
+
+    result = user_handler(message)
+    if inspect.isawaitable(result):
+        result = await result
+    return result
+
+
 async def _handle_tasks_send(
     *,
     req_id: Any,
@@ -326,44 +616,28 @@ async def _handle_tasks_send(
     user_handler: Callable[..., Any],
     metadata: dict,
 ) -> JSONResponse:
-    """Phase 2 sync-only ``tasks/send`` dispatch.
+    """Phase 2 / 2-leftover ``tasks/send`` dispatch.
 
     Calls the user's ``@mesh.a2a`` handler with the A2A ``message`` dict
-    as the positional payload. Dependency injection (e.g. ``date_service``)
-    is wired by the decorator wrapper, so deps land via keyword args at
-    call time.
+    as the positional payload. Dependency injection (e.g. ``date_service``,
+    ``MeshJob`` submitters) is wired by the decorator wrapper.
 
-    Long-running surfaces (underlying mesh tool was ``@mesh.tool(task=True)``)
-    fall back to ``Method not implemented`` until Phase 3 wires the
-    MeshJob lifecycle into ``tasks/send`` + ``tasks/sendSubscribe``.
+    Sync vs long-running detection: introspect the *return value*, not
+    the metadata. If the handler returned a ``mcp_mesh_core.JobProxy``
+    instance, the user submitted a mesh job via ``MeshJob.submit(...)``
+    → store the proxy and respond with ``state=working``. Otherwise the
+    return value is the synchronous result → wrap as ``state=completed``.
+
+    Detecting via return value (rather than the local-only
+    ``_underlying_tool_is_task`` helper) is the canonical pattern because
+    it works for cross-agent ``task=True`` deps too — the helper can't
+    see remote tool metadata, but the JobProxy class membership is
+    unambiguous.
     """
-    if _underlying_tool_is_task(metadata):
-        return _jsonrpc_error(
-            req_id,
-            -32601,
-            (
-                "Method not implemented: 'tasks/send' for task=True "
-                "underlying tools requires Phase 3 (MeshJob lifecycle). "
-                "Sync handlers are supported today."
-            ),
-        )
+    task_id, session_id, message = _extract_task_inputs(params)
 
-    if not isinstance(params, dict):
-        params = {}
-
-    task_id = params.get("id") or str(uuid.uuid4())
-    session_id = params.get("sessionId") or task_id
-    message = params.get("message") if isinstance(params.get("message"), dict) else {}
-
-    # Pass the full A2A message dict to the user's handler so user code
-    # can introspect parts/role as needed. The handler is responsible for
-    # translating message → its dependency-call shape.
     try:
-        import inspect
-
-        result = user_handler(message)
-        if inspect.isawaitable(result):
-            result = await result
+        result = await _invoke_user_handler(user_handler, message)
     except Exception as exc:
         # Per A2A v1.0: handler exceptions surface as Task.state=failed,
         # NOT as a JSON-RPC -3260x error.
@@ -377,19 +651,567 @@ async def _handle_tasks_send(
             _build_failed_task(task_id, session_id, message or None, str(exc)),
         )
 
+    if _is_job_proxy(result):
+        # Long-running: park the proxy in the task store, return the
+        # working envelope. The client polls tasks/get / subscribes via
+        # tasks/sendSubscribe / tasks/resubscribe to track progress.
+        try:
+            _store_task(
+                task_id,
+                result,
+                request_message=message or None,
+                session_id=session_id,
+            )
+        except ValueError as exc:
+            return _jsonrpc_error(req_id, -32602, str(exc))
+        logger.info(
+            "A2A tasks/send: long-running task started "
+            "(task_id=%s, mesh_job_id=%s, path=%s)",
+            task_id,
+            getattr(result, "job_id", "<unknown>"),
+            metadata.get("path"),
+        )
+        return _jsonrpc_success(
+            req_id,
+            _build_working_task(task_id, session_id, message or None),
+        )
+
     return _jsonrpc_success(
         req_id,
         _build_completed_task(task_id, session_id, message or None, result),
     )
 
 
+async def _handle_tasks_get(
+    *,
+    req_id: Any,
+    params: dict,
+) -> JSONResponse:
+    """Look up a long-running A2A task by id and return its current Task envelope.
+
+    The task must have been minted by an earlier ``tasks/send`` /
+    ``tasks/sendSubscribe`` call on this process — long-running task
+    state is process-local (see ``_A2A_TASK_STORE`` doc for the
+    cross-replica caveat).
+
+    Unknown task ids surface as JSON-RPC -32602 (Invalid params) per the
+    A2A v1.0 convention — the spec doesn't dedicate an error code to
+    "task not found" so we reuse the closest standard code.
+    """
+    _sweep_terminal_tasks()
+
+    if not isinstance(params, dict):
+        params = {}
+    task_id = params.get("id")
+    if not task_id:
+        return _jsonrpc_error(
+            req_id, -32602, "Invalid params: 'id' is required for tasks/get"
+        )
+
+    entry = _A2A_TASK_STORE.get(task_id)
+    if entry is None:
+        return _jsonrpc_error(
+            req_id, -32602, f"Unknown task id: {task_id}"
+        )
+
+    proxy = entry["proxy"]
+    try:
+        status = await proxy.status()
+    except Exception as exc:
+        logger.warning(
+            "A2A tasks/get: proxy.status() raised for task %s: %s", task_id, exc
+        )
+        # Surface as a working task with the error in the message — we
+        # can't reliably tell from a status() failure whether the underlying
+        # job is dead or just transiently unreachable.
+        return _jsonrpc_success(
+            req_id,
+            _build_working_task(
+                task_id,
+                params.get("sessionId") or task_id,
+                None,
+                progress_message=f"status unavailable: {exc}",
+            ),
+        )
+
+    if not isinstance(status, dict):
+        status = {}
+
+    mesh_state = status.get("status") or "working"
+    if mesh_state in ("completed", "failed", "cancelled"):
+        _mark_terminal(task_id)
+
+    # On terminal=completed, fetch the final result via proxy.wait() so the
+    # A2A Task envelope carries the result as an artifact[0]. SSE delivers
+    # this via TaskArtifactUpdateEvent; non-streaming tasks/get callers
+    # need it embedded inline. Use a tight timeout so we don't block on a
+    # job that the registry believes is completed but whose payload is
+    # transiently unreachable — fall back to no artifact in that case.
+    final_result: Any = None
+    has_final_result = False
+    if mesh_state == "completed":
+        try:
+            final_result = await proxy.wait(timeout_secs=1)
+            has_final_result = True
+        except Exception as exc:
+            logger.debug(
+                "A2A tasks/get: proxy.wait() failed for completed task %s: %s",
+                task_id,
+                exc,
+            )
+
+    # Echo the original request_message in the A2A history field if we
+    # captured it at submit time (otherwise empty per existing behavior).
+    envelope = _build_task_from_status(
+        task_id,
+        entry.get("session_id") or params.get("sessionId") or task_id,
+        entry.get("request_message"),
+        status,
+        final_result=final_result,
+        has_final_result=has_final_result,
+    )
+    return _jsonrpc_success(req_id, envelope)
+
+
+async def _handle_tasks_cancel(
+    *,
+    req_id: Any,
+    params: dict,
+) -> JSONResponse:
+    """Cancel a long-running A2A task via its underlying mesh ``JobProxy``.
+
+    Best-effort: cancel exceptions are logged and swallowed because the
+    registry may have already terminated the job (e.g., it just finished
+    on the producer side). We always re-fetch ``proxy.status()`` after
+    the cancel attempt so the response reflects the latest state the
+    client should trust.
+    """
+    _sweep_terminal_tasks()
+
+    if not isinstance(params, dict):
+        params = {}
+    task_id = params.get("id")
+    if not task_id:
+        return _jsonrpc_error(
+            req_id, -32602, "Invalid params: 'id' is required for tasks/cancel"
+        )
+
+    entry = _A2A_TASK_STORE.get(task_id)
+    if entry is None:
+        return _jsonrpc_error(
+            req_id, -32602, f"Unknown task id: {task_id}"
+        )
+
+    proxy = entry["proxy"]
+    reason = params.get("reason")
+    try:
+        await proxy.cancel(reason=reason) if reason is not None else await proxy.cancel()
+    except Exception as exc:
+        logger.info(
+            "A2A tasks/cancel: proxy.cancel() raised for task %s "
+            "(may already be terminal): %s",
+            task_id,
+            exc,
+        )
+
+    try:
+        status = await proxy.status()
+    except Exception as exc:
+        logger.warning(
+            "A2A tasks/cancel: proxy.status() raised post-cancel for task %s: %s",
+            task_id,
+            exc,
+        )
+        status = {"status": "cancelled"}
+
+    if not isinstance(status, dict):
+        status = {"status": "cancelled"}
+
+    mesh_state = status.get("status") or "cancelled"
+    if mesh_state in ("completed", "failed", "cancelled"):
+        _mark_terminal(task_id)
+
+    envelope = _build_task_from_status(
+        task_id,
+        entry.get("session_id") or task_id,
+        entry.get("request_message"),
+        status,
+    )
+    return _jsonrpc_success(req_id, envelope)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — SSE streaming (tasks/sendSubscribe + tasks/resubscribe)
+# ---------------------------------------------------------------------------
+
+# Headers we attach to every SSE response. ``X-Accel-Buffering: no``
+# tells nginx not to buffer the stream; ``Cache-Control: no-cache``
+# stops intermediaries from caching mid-flight events; keep-alive lets
+# clients hold the connection open across keepalives.
+_A2A_SSE_HEADERS = {
+    "Cache-Control": "no-cache",
+    "X-Accel-Buffering": "no",
+    "Connection": "keep-alive",
+}
+
+# Polling cadence for the long-running SSE generator. One second is
+# fast enough for a human-perceptible "this is making progress" feel
+# without hammering the registry. The keepalive interval guards against
+# proxy-layer idle timeouts (most defaults are 30-60s).
+_SSE_POLL_INTERVAL_SECS = 1.0
+_SSE_KEEPALIVE_SECS = 15.0
+
+
+def _sse_event(payload: dict) -> str:
+    """Format a JSON payload as one SSE ``data:`` frame.
+
+    SSE frames are terminated by a blank line (``\\n\\n``); the JSON
+    body goes after a single ``data: `` prefix. We do NOT split across
+    multiple ``data:`` lines because the A2A v1.0 events are compact
+    JSON (one object per frame).
+    """
+    return f"data: {_json.dumps(payload, default=str)}\n\n"
+
+
+def _status_update_event(
+    req_id: Any,
+    task_id: str,
+    a2a_state: str,
+    message_text: Optional[str],
+    *,
+    final: bool,
+    progress: Optional[Any] = None,
+) -> dict:
+    """Build an A2A v1.0 ``TaskStatusUpdateEvent`` wrapped in a JSON-RPC envelope.
+
+    The ``final`` flag tells the client this is the terminal event for
+    the task — the client closes its SSE connection on ``final=True``.
+    """
+    status: dict = {"state": a2a_state, "timestamp": _utc_now_iso()}
+    if message_text:
+        status["message"] = {
+            "role": "agent",
+            "parts": [{"type": "text", "text": str(message_text)}],
+        }
+    result: dict = {
+        "id": task_id,
+        "status": status,
+        "final": final,
+    }
+    if progress is not None:
+        result["metadata"] = {"progress": progress}
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _artifact_update_event(req_id: Any, task_id: str, value: Any) -> dict:
+    """Build an A2A v1.0 ``TaskArtifactUpdateEvent`` wrapped in JSON-RPC.
+
+    ``value`` is whatever ``proxy.wait()`` returned for the underlying
+    job. Strings ride verbatim in the text part; everything else gets
+    JSON-stringified so the part stays string-typed per the v1.0
+    ``TextPart`` shape.
+    """
+    text = value if isinstance(value, str) else _json.dumps(value, default=str)
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {
+            "id": task_id,
+            "artifact": {
+                "name": "result",
+                "parts": [{"type": "text", "text": text}],
+                "index": 0,
+            },
+        },
+    }
+
+
+async def _stream_completed_only(
+    req_id: Any, task_id: str, _session_id: str, _message: dict, value: Any
+) -> AsyncIterator[str]:
+    """SSE stream for a sync handler return: emit one terminal event + done.
+
+    Used when ``tasks/sendSubscribe`` runs against a sync handler. We
+    fold the handler's return value into a single artifact event and
+    follow it with a final status event so the client sees both the
+    payload and the explicit completion signal before the stream closes.
+    """
+    yield _sse_event(_artifact_update_event(req_id, task_id, value))
+    yield _sse_event(
+        _status_update_event(req_id, task_id, "completed", None, final=True)
+    )
+
+
+async def _stream_failed_only(
+    req_id: Any, task_id: str, _session_id: str, _message: dict, error: str
+) -> AsyncIterator[str]:
+    """SSE stream for a handler that raised: emit one terminal failed event.
+
+    Mirrors the JSON-RPC ``state=failed`` envelope but as a single SSE
+    frame followed by stream close. No artifact event because there's
+    no result payload to carry.
+    """
+    yield _sse_event(
+        _status_update_event(req_id, task_id, "failed", error, final=True)
+    )
+
+
+async def _stream_long_running(
+    req_id: Any, task_id: str, _session_id: str, _message: dict, proxy: Any
+) -> AsyncIterator[str]:
+    """SSE stream for a JobProxy: emit working → progress → terminal events.
+
+    Loop invariants:
+      1. Always emit an initial ``state=working`` event so the client
+         confirms the subscription is live before any polling latency.
+      2. Emit a status-update only when ``progress`` or
+         ``progress_message`` actually changed — natural backpressure
+         that drops redundant events without an explicit queue.
+      3. Emit an SSE comment (``: keepalive\\n\\n``) every
+         ``_SSE_KEEPALIVE_SECS`` of inactivity to defeat proxy-layer
+         idle timeouts. Comments are ignored by SSE parsers.
+      4. On terminal state, attempt ``proxy.wait()`` for the result and
+         emit it as an artifact event, then the final status event,
+         then exit.
+      5. On client disconnect (``CancelledError`` raised mid-yield), do
+         NOT call ``proxy.cancel()`` — the A2A spec is explicit that
+         disconnect is a transient condition and the underlying job
+         keeps running. The client may rejoin via ``tasks/resubscribe``.
+    """
+    # Initial event so the client sees an immediate "subscribed" signal
+    # before the first poll. Seed last_progress/last_message to ``None``
+    # so the first poll only re-emits if the registry actually reported
+    # *real* progress — otherwise the immediate "still working with no
+    # progress" status would emit a redundant duplicate of this initial
+    # event.
+    yield _sse_event(
+        _status_update_event(req_id, task_id, "working", None, final=False)
+    )
+
+    last_progress: Any = None
+    last_message: Any = None
+    last_event_time = time.monotonic()
+
+    try:
+        while True:
+            try:
+                status = await proxy.status()
+            except Exception as exc:
+                logger.warning(
+                    "A2A SSE poll: proxy.status() raised for task %s: %s",
+                    task_id,
+                    exc,
+                )
+                yield _sse_event(
+                    _status_update_event(
+                        req_id, task_id, "failed", f"status unavailable: {exc}",
+                        final=True,
+                    )
+                )
+                _mark_terminal(task_id)
+                return
+
+            if not isinstance(status, dict):
+                status = {}
+
+            mesh_state = status.get("status") or "working"
+
+            if mesh_state in ("completed", "failed", "cancelled"):
+                # Emit artifact + final status, then exit. ``proxy.wait()``
+                # returns the result for completed jobs; for failed/cancelled
+                # it raises — we surface the error text in the status message.
+                if mesh_state == "completed":
+                    try:
+                        result = await proxy.wait(timeout_secs=1)
+                        yield _sse_event(
+                            _artifact_update_event(req_id, task_id, result)
+                        )
+                    except Exception as exc:
+                        logger.debug(
+                            "A2A SSE poll: proxy.wait() raised on completed "
+                            "task %s: %s",
+                            task_id,
+                            exc,
+                        )
+                final_msg = None
+                if mesh_state == "failed":
+                    final_msg = status.get("error") or status.get("progress_message")
+                elif mesh_state == "cancelled":
+                    final_msg = status.get("progress_message")
+                yield _sse_event(
+                    _status_update_event(
+                        req_id,
+                        task_id,
+                        _map_mesh_state(mesh_state),
+                        final_msg,
+                        final=True,
+                    )
+                )
+                _mark_terminal(task_id)
+                return
+
+            progress = status.get("progress")
+            progress_message = status.get("progress_message")
+            now = time.monotonic()
+
+            if progress != last_progress or progress_message != last_message:
+                yield _sse_event(
+                    _status_update_event(
+                        req_id,
+                        task_id,
+                        "working",
+                        progress_message,
+                        final=False,
+                        progress=progress,
+                    )
+                )
+                last_progress = progress
+                last_message = progress_message
+                last_event_time = now
+            elif (now - last_event_time) > _SSE_KEEPALIVE_SECS:
+                # No state change in a while — emit an SSE comment to
+                # keep intermediaries from idling the connection out.
+                # SSE comments start with ``:`` and are ignored by
+                # parsers but reset the proxy's keepalive timer.
+                yield ": keepalive\n\n"
+                last_event_time = now
+
+            await asyncio.sleep(_SSE_POLL_INTERVAL_SECS)
+    except asyncio.CancelledError:
+        # Client disconnected. Per A2A v1.0 this MUST NOT cancel the
+        # underlying mesh job — the client may rejoin via tasks/resubscribe.
+        logger.debug(
+            "A2A SSE poll: client disconnected for task %s; "
+            "underlying mesh job continues",
+            task_id,
+        )
+        raise
+
+
+def _sse_response(generator: AsyncIterator[str]) -> StreamingResponse:
+    """Wrap an async generator of SSE frames in a ``StreamingResponse``.
+
+    ``media_type="text/event-stream"`` is the SSE content type per
+    HTML5; the headers defeat common proxy/CDN buffering that would
+    otherwise break streaming end-to-end.
+    """
+    return StreamingResponse(
+        generator,
+        media_type="text/event-stream",
+        headers=_A2A_SSE_HEADERS,
+    )
+
+
+async def _handle_tasks_send_subscribe(
+    *,
+    req_id: Any,
+    params: dict,
+    user_handler: Callable[..., Any],
+    metadata: dict,
+) -> Any:
+    """Phase 3 ``tasks/sendSubscribe`` dispatch — same as send, SSE response.
+
+    The user handler runs to completion (or raises) BEFORE the SSE
+    stream opens, so the framework knows whether to spin up the long-
+    running poll loop or just emit a single completed event. Doing the
+    handler invocation eagerly (rather than inside the generator) keeps
+    handler exceptions out of the streaming codepath where they'd be
+    invisible to the FastAPI exception handler chain.
+    """
+    task_id, session_id, message = _extract_task_inputs(params)
+
+    try:
+        result = await _invoke_user_handler(user_handler, message)
+    except Exception as exc:
+        logger.warning(
+            "A2A tasks/sendSubscribe handler raised on %s: %s",
+            metadata.get("path"),
+            exc,
+        )
+        return _sse_response(
+            _stream_failed_only(req_id, task_id, session_id, message, str(exc))
+        )
+
+    if _is_job_proxy(result):
+        try:
+            _store_task(
+                task_id,
+                result,
+                request_message=message,
+                session_id=session_id,
+            )
+        except ValueError as exc:
+            # Duplicate task_id — surface as a single SSE failed event
+            # so the SSE client sees a structured A2A failure rather
+            # than an opaque HTTP error.
+            return _sse_response(
+                _stream_failed_only(req_id, task_id, session_id, message, str(exc))
+            )
+        logger.info(
+            "A2A tasks/sendSubscribe: long-running stream started "
+            "(task_id=%s, mesh_job_id=%s, path=%s)",
+            task_id,
+            getattr(result, "job_id", "<unknown>"),
+            metadata.get("path"),
+        )
+        return _sse_response(
+            _stream_long_running(req_id, task_id, session_id, message, result)
+        )
+
+    return _sse_response(
+        _stream_completed_only(req_id, task_id, session_id, message, result)
+    )
+
+
+async def _handle_tasks_resubscribe(
+    *,
+    req_id: Any,
+    params: dict,
+) -> Any:
+    """Re-attach an SSE stream to an existing long-running task.
+
+    Idempotent: returns the same poll-loop generator as the original
+    ``tasks/sendSubscribe`` call would. The client re-receives the
+    initial ``working`` event, then catches up to live progress from
+    the registry's current view (we don't replay old events because
+    we don't store them — clients that need replay should rely on
+    ``tasks/get`` for the current snapshot).
+    """
+    _sweep_terminal_tasks()
+
+    if not isinstance(params, dict):
+        params = {}
+    task_id = params.get("id")
+    if not task_id:
+        return _jsonrpc_error(
+            req_id, -32602, "Invalid params: 'id' is required for tasks/resubscribe"
+        )
+
+    entry = _A2A_TASK_STORE.get(task_id)
+    if entry is None:
+        return _jsonrpc_error(
+            req_id, -32602, f"Unknown task id: {task_id}"
+        )
+
+    proxy = entry["proxy"]
+    return _sse_response(
+        _stream_long_running(req_id, task_id, task_id, {}, proxy)
+    )
+
+
 def _make_rpc_endpoint(*, metadata: dict, user_handler: Callable[..., Any]):
     """Build a FastAPI endpoint coroutine for the JSON-RPC entry point.
 
-    Phase 2 dispatches sync ``tasks/send`` into ``user_handler`` and
-    wraps the return value in an A2A v1.0 ``Task`` envelope. All other
-    ``tasks/*`` methods still return JSON-RPC ``Method not implemented``
-    (Phase 3 territory).
+    Dispatch table:
+      - ``tasks/send`` → sync result (state=completed) OR JobProxy
+        return (state=working, parked in ``_A2A_TASK_STORE``).
+      - ``tasks/get`` → look up parked task, return current Task envelope.
+      - ``tasks/cancel`` → call ``proxy.cancel()``, return updated Task.
+      - ``tasks/sendSubscribe`` → same dispatch as ``tasks/send`` but
+        the response is an SSE stream of ``TaskStatusUpdateEvent`` /
+        ``TaskArtifactUpdateEvent`` JSON-RPC envelopes.
+      - ``tasks/resubscribe`` → re-attach SSE to an existing parked task.
+      - Anything else → JSON-RPC -32601 ``Method not implemented``.
 
     Honours the decorator's ``auth="bearer"`` setting at the header-
     presence level only — token validation (signature/issuer/audience)
@@ -468,15 +1290,30 @@ def _make_rpc_endpoint(*, metadata: dict, user_handler: Callable[..., Any]):
                 metadata=metadata,
             )
 
-        # All other tasks/* methods land in Phase 3.
+        if method == "tasks/get":
+            return await _handle_tasks_get(req_id=req_id, params=params)
+
+        if method == "tasks/cancel":
+            return await _handle_tasks_cancel(req_id=req_id, params=params)
+
+        if method == "tasks/sendSubscribe":
+            return await _handle_tasks_send_subscribe(
+                req_id=req_id,
+                params=params,
+                user_handler=user_handler,
+                metadata=metadata,
+            )
+
+        if method == "tasks/resubscribe":
+            return await _handle_tasks_resubscribe(req_id=req_id, params=params)
+
         return _jsonrpc_error(
             req_id,
             -32601,
             (
                 f"Method not implemented: {method!r}. "
-                "Phase 2 wires sync 'tasks/send' only — long-running "
-                "and streaming methods (tasks/sendSubscribe, tasks/get, "
-                "tasks/cancel) land in Phase 3 (see A2A_SURFACE_DESIGN.org)."
+                "Supported A2A v1.0 methods: tasks/send, tasks/get, "
+                "tasks/cancel, tasks/sendSubscribe, tasks/resubscribe."
             ),
         )
 

--- a/src/runtime/python/tests/unit/test_a2a_decorator.py
+++ b/src/runtime/python/tests/unit/test_a2a_decorator.py
@@ -188,7 +188,9 @@ class TestA2AMountHelper:
             assert task["id"] == "t-lookup-1"
             assert task["status"]["state"] == "completed"
 
-            # Other tasks/* still return Method-not-implemented.
+            # tasks/get against a sync (non-stored) task id returns
+            # -32602 (Unknown task id) — sync tasks don't go into the
+            # long-running task store.
             other = {
                 "jsonrpc": "2.0",
                 "method": "tasks/get",
@@ -197,6 +199,19 @@ class TestA2AMountHelper:
             }
             r = client.post("/agents/lookup", json=other)
             assert r.status_code == 200
+            envelope = r.json()
+            assert envelope["error"]["code"] == -32602
+            assert "Unknown task id" in envelope["error"]["message"]
+
+            # Truly-unimplemented method (not in dispatch table) still
+            # surfaces as -32601.
+            unsupported = {
+                "jsonrpc": "2.0",
+                "method": "tasks/listSupportedSkills",
+                "params": {},
+                "id": "req-3",
+            }
+            r = client.post("/agents/lookup", json=unsupported)
             envelope = r.json()
             assert envelope["error"]["code"] == -32601
             assert "Method not implemented" in envelope["error"]["message"]
@@ -688,12 +703,15 @@ class TestA2ATasksSendDispatch:
             artifact_text = r.json()["result"]["artifacts"][0]["parts"][0]["text"]
             assert _json.loads(artifact_text) == {"got_role": "user"}
 
-    def test_other_tasks_methods_still_method_not_implemented(self):
+    def test_unsupported_methods_return_method_not_implemented(self):
         async def handler(payload: dict):
             return {}
 
         with self._client({"path": "/agents/x"}, handler) as client:
-            for method in ("tasks/get", "tasks/cancel", "tasks/sendSubscribe"):
+            # Methods outside the supported A2A v1.0 set still surface
+            # JSON-RPC -32601. The dispatch table covers tasks/send,
+            # tasks/get, tasks/cancel, tasks/sendSubscribe, tasks/resubscribe.
+            for method in ("tasks/list", "tasks/wait", "agent/info"):
                 r = client.post(
                     "/agents/x",
                     json={
@@ -709,31 +727,648 @@ class TestA2ATasksSendDispatch:
                 assert envelope["error"]["code"] == -32601
                 assert "Method not implemented" in envelope["error"]["message"]
 
-    def test_tasks_send_falls_back_when_underlying_is_task_true(self):
-        # Mock _underlying_tool_is_task to simulate a task=True dep.
-        from mesh import a2a as a2a_mod
+    # NOTE: the old "Phase 3 not implemented" guard was driven by
+    # ``_underlying_tool_is_task`` metadata. Phase 2-leftover replaces
+    # that with return-value introspection (handler returns a JobProxy
+    # → state=working). Coverage for the long-running path now lives in
+    # ``TestA2ALongRunningTasksLifecycle`` below.
+
+
+# ---------------------------------------------------------------------------
+# Phase 2-leftover + Phase 3 — long-running tasks + SSE streaming
+# ---------------------------------------------------------------------------
+
+
+class _FakeJobProxy:
+    """Duck-typed stand-in for ``mcp_mesh_core.JobProxy`` used in unit tests.
+
+    The real ``JobProxy`` is a Rust class; in CI we want to drive the
+    A2A surface without actually submitting jobs to a registry. We
+    monkey-patch ``mesh.a2a._is_job_proxy`` to recognise this class so
+    the framework treats handler returns of this type as long-running
+    (state=working).
+
+    Mirrors the ``JobProxy`` contract:
+      - ``job_id`` attribute
+      - ``async status()`` returning a dict
+      - ``async cancel(reason=None)``
+      - ``async wait(timeout_secs=None)`` returning the result
+        or raising on failure / cancellation
+    """
+
+    def __init__(
+        self,
+        *,
+        job_id: str = "job-fake-1",
+        status_seq: list | None = None,
+        wait_result: Any = None,
+        wait_raises: BaseException | None = None,
+    ) -> None:
+        self.job_id = job_id
+        # status() returns successive entries from this list — last entry
+        # is "sticky" (returned forever after the list is exhausted).
+        self._status_seq = list(status_seq) if status_seq else [{"status": "working"}]
+        self._status_idx = 0
+        self._wait_result = wait_result
+        self._wait_raises = wait_raises
+        self.cancel_calls: list = []
+
+    async def status(self) -> dict:
+        idx = min(self._status_idx, len(self._status_seq) - 1)
+        self._status_idx += 1
+        return dict(self._status_seq[idx])
+
+    async def cancel(self, reason: Any = None) -> None:
+        self.cancel_calls.append(reason)
+
+    async def wait(self, timeout_secs: Any = None) -> Any:
+        if self._wait_raises is not None:
+            raise self._wait_raises
+        return self._wait_result
+
+
+@pytest.fixture
+def patch_is_job_proxy():
+    """Make the framework recognise ``_FakeJobProxy`` as a JobProxy."""
+    import mesh.a2a as a2a_mod
+
+    original = a2a_mod._is_job_proxy
+
+    def _recognise_fake(value: Any) -> bool:
+        return isinstance(value, _FakeJobProxy)
+
+    a2a_mod._is_job_proxy = _recognise_fake
+    try:
+        yield
+    finally:
+        a2a_mod._is_job_proxy = original
+
+
+@pytest.fixture
+def _reset_a2a_task_store():
+    """Wipe the long-running task store between tests that exercise the
+    long-running tasks/* lifecycle.
+
+    NOT autouse: importing ``mesh.a2a`` as a module pollutes
+    ``sys.modules`` and shadows the ``mesh.__getattr__`` shim that
+    serves the ``mesh.a2a(...)`` decorator-callable. Tests that hit
+    the task store opt in via this fixture; tests that only call
+    ``mesh.a2a(...)`` / ``mesh.a2a.mount(...)`` skip it so the shim
+    keeps working.
+    """
+    import sys
+
+    a2a_mod = sys.modules.get("mesh.a2a")
+    if a2a_mod is not None:
+        a2a_mod._A2A_TASK_STORE.clear()
+    yield
+    a2a_mod = sys.modules.get("mesh.a2a")
+    if a2a_mod is not None:
+        a2a_mod._A2A_TASK_STORE.clear()
+
+
+class TestMeshToA2AStateMapping:
+    """The mesh→A2A state translation must use A2A v1.0 spelling.
+
+    A2A v1.0 spec uses the US single-l ``"canceled"``; mesh internally
+    uses UK double-l ``"cancelled"``. The mapper must translate at the
+    boundary so wire payloads conform to the spec exactly.
+    """
+
+    def test_cancelled_maps_to_single_l_canceled(self):
+        from mesh.a2a import _map_mesh_state
+
+        assert _map_mesh_state("cancelled") == "canceled"
+
+    def test_terminal_states_pass_through(self):
+        from mesh.a2a import _map_mesh_state
+
+        assert _map_mesh_state("completed") == "completed"
+        assert _map_mesh_state("failed") == "failed"
+        assert _map_mesh_state("working") == "working"
+
+    def test_unknown_state_falls_back_to_working(self):
+        from mesh.a2a import _map_mesh_state
+
+        assert _map_mesh_state("queued") == "working"
+        assert _map_mesh_state(None) == "working"
+        assert _map_mesh_state("") == "working"
+
+
+@pytest.mark.usefixtures("_reset_a2a_task_store")
+class TestA2ALongRunningTasksLifecycle:
+    """Phase 2-leftover: handler returns JobProxy → working envelope.
+
+    Covers:
+      * tasks/send: JobProxy return → state=working, parked in store
+      * tasks/get: returns current state from JobProxy.status()
+      * tasks/get: unknown task_id → -32602
+      * tasks/cancel: invokes JobProxy.cancel() and returns updated state
+      * tasks/cancel: unknown task_id → -32602
+    """
+
+    def _client(self, mount_kwargs: dict, handler):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        app = FastAPI()
+        mesh.a2a.mount(app, **mount_kwargs)(handler)
+        return TestClient(app)
+
+    def test_tasks_send_returns_working_when_handler_returns_jobproxy(
+        self, patch_is_job_proxy
+    ):
+        proxy = _FakeJobProxy(job_id="job-r1", status_seq=[{"status": "working"}])
 
         async def handler(payload: dict):
-            # Should NOT be invoked — Phase 3 territory.
-            raise AssertionError("handler should not run for task=True deps")
+            return proxy
 
-        with patch.object(a2a_mod, "_underlying_tool_is_task", return_value=True):
-            with self._client(
-                {"path": "/agents/long", "dependencies": ["long_tool"]},
-                handler,
-            ) as client:
-                r = client.post(
-                    "/agents/long",
-                    json={
-                        "jsonrpc": "2.0",
-                        "id": "req-1",
-                        "method": "tasks/send",
-                        "params": {
-                            "id": "t-long",
-                            "message": {"role": "user", "parts": []},
-                        },
+        with self._client({"path": "/agents/r1"}, handler) as client:
+            r = client.post(
+                "/agents/r1",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "req-1",
+                    "method": "tasks/send",
+                    "params": {
+                        "id": "task-r1",
+                        "message": {"role": "user", "parts": []},
                     },
-                )
-                envelope = r.json()
-                assert envelope["error"]["code"] == -32601
-                assert "Phase 3" in envelope["error"]["message"]
+                },
+            )
+        assert r.status_code == 200
+        envelope = r.json()
+        assert envelope["id"] == "req-1"
+        task = envelope["result"]
+        assert task["id"] == "task-r1"
+        assert task["status"]["state"] == "working"
+        # Working envelopes carry no artifacts yet.
+        assert task["artifacts"] == []
+
+        # Proxy was parked in the store keyed by the task_id.
+        import mesh.a2a as a2a_mod
+
+        assert "task-r1" in a2a_mod._A2A_TASK_STORE
+        assert a2a_mod._A2A_TASK_STORE["task-r1"]["proxy"] is proxy
+
+    def test_tasks_get_returns_current_state_from_jobproxy(self, patch_is_job_proxy):
+        # tasks/send stores the proxy without calling status(); tasks/get
+        # makes the first (and only, for this test) status() call.
+        proxy = _FakeJobProxy(
+            status_seq=[
+                {
+                    "status": "working",
+                    "progress": 0.45,
+                    "progress_message": "halfway",
+                },
+            ],
+        )
+
+        async def handler(payload: dict):
+            return proxy
+
+        with self._client({"path": "/agents/r2"}, handler) as client:
+            client.post(
+                "/agents/r2",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "send",
+                    "method": "tasks/send",
+                    "params": {"id": "task-r2", "message": {}},
+                },
+            )
+            r = client.post(
+                "/agents/r2",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "get",
+                    "method": "tasks/get",
+                    "params": {"id": "task-r2"},
+                },
+            )
+        assert r.status_code == 200
+        envelope = r.json()
+        task = envelope["result"]
+        assert task["id"] == "task-r2"
+        assert task["status"]["state"] == "working"
+        assert task["status"]["message"]["parts"][0]["text"] == "halfway"
+        assert task["metadata"]["progress"] == 0.45
+
+    def test_tasks_get_unknown_task_id_returns_invalid_params(self):
+        async def handler(payload: dict):
+            return {"x": 1}
+
+        with self._client({"path": "/agents/r3"}, handler) as client:
+            r = client.post(
+                "/agents/r3",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "get",
+                    "method": "tasks/get",
+                    "params": {"id": "does-not-exist"},
+                },
+            )
+        envelope = r.json()
+        assert envelope["error"]["code"] == -32602
+        assert "Unknown task id" in envelope["error"]["message"]
+
+    def test_tasks_cancel_calls_proxy_cancel_and_returns_state(
+        self, patch_is_job_proxy
+    ):
+        # tasks/send stores the proxy (no status() call); tasks/cancel
+        # invokes cancel() then status() — that single status() call
+        # returns the post-cancel state.
+        proxy = _FakeJobProxy(
+            status_seq=[
+                {"status": "cancelled", "progress_message": "user requested"},
+            ],
+        )
+
+        async def handler(payload: dict):
+            return proxy
+
+        with self._client({"path": "/agents/r4"}, handler) as client:
+            client.post(
+                "/agents/r4",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "send",
+                    "method": "tasks/send",
+                    "params": {"id": "task-r4", "message": {}},
+                },
+            )
+            r = client.post(
+                "/agents/r4",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "cancel",
+                    "method": "tasks/cancel",
+                    "params": {"id": "task-r4", "reason": "user requested"},
+                },
+            )
+        assert r.status_code == 200
+        envelope = r.json()
+        task = envelope["result"]
+        # Mesh "cancelled" must surface as A2A v1.0 single-l "canceled".
+        assert task["status"]["state"] == "canceled"
+        # Cancel invocation captured.
+        assert proxy.cancel_calls == ["user requested"]
+
+    def test_tasks_cancel_unknown_task_id_returns_invalid_params(self):
+        async def handler(payload: dict):
+            return {"x": 1}
+
+        with self._client({"path": "/agents/r5"}, handler) as client:
+            r = client.post(
+                "/agents/r5",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "cancel",
+                    "method": "tasks/cancel",
+                    "params": {"id": "no-such-task"},
+                },
+            )
+        envelope = r.json()
+        assert envelope["error"]["code"] == -32602
+
+    def test_tasks_cancel_swallows_proxy_cancel_exception(
+        self, patch_is_job_proxy
+    ):
+        # Registry may have already terminated the job by the time the
+        # client cancels — proxy.cancel() raising should NOT bubble up
+        # as a JSON-RPC error.
+        class _RaisingCancelProxy(_FakeJobProxy):
+            async def cancel(self, reason=None):
+                raise RuntimeError("already terminal")
+
+        proxy = _RaisingCancelProxy(status_seq=[{"status": "completed"}])
+
+        async def handler(payload: dict):
+            return proxy
+
+        with self._client({"path": "/agents/r6"}, handler) as client:
+            client.post(
+                "/agents/r6",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "send",
+                    "method": "tasks/send",
+                    "params": {"id": "task-r6", "message": {}},
+                },
+            )
+            r = client.post(
+                "/agents/r6",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "cancel",
+                    "method": "tasks/cancel",
+                    "params": {"id": "task-r6"},
+                },
+            )
+        envelope = r.json()
+        assert "error" not in envelope
+        # Status is whatever the post-cancel proxy.status() returned.
+        assert envelope["result"]["status"]["state"] == "completed"
+
+
+def _parse_sse_events(body: str) -> list[dict]:
+    """Parse an SSE response body into a list of decoded JSON payloads.
+
+    Skips comment frames (lines starting with ``:``) and the SSE-spec
+    blank-line separators. Each ``data: {...}`` line yields one dict.
+    """
+    events: list[dict] = []
+    for chunk in body.split("\n\n"):
+        chunk = chunk.strip()
+        if not chunk or chunk.startswith(":"):
+            continue
+        if chunk.startswith("data:"):
+            payload = chunk[len("data:"):].strip()
+            if payload:
+                import json as _j
+
+                events.append(_j.loads(payload))
+    return events
+
+
+@pytest.mark.usefixtures("_reset_a2a_task_store")
+class TestA2ASseStreaming:
+    """Phase 3: tasks/sendSubscribe + tasks/resubscribe over SSE."""
+
+    def _client(self, mount_kwargs: dict, handler):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        app = FastAPI()
+        mesh.a2a.mount(app, **mount_kwargs)(handler)
+        return TestClient(app)
+
+    def test_sse_response_carries_event_stream_headers(self):
+        async def handler(payload: dict):
+            return {"ok": True}
+
+        with self._client({"path": "/agents/s1"}, handler) as client:
+            r = client.post(
+                "/agents/s1",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "req",
+                    "method": "tasks/sendSubscribe",
+                    "params": {"id": "task-s1", "message": {}},
+                },
+            )
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith("text/event-stream")
+        assert r.headers["cache-control"] == "no-cache"
+        # X-Accel-Buffering avoids nginx-side stream buffering.
+        assert r.headers["x-accel-buffering"] == "no"
+
+    def test_sse_sync_handler_emits_artifact_then_completed(self):
+        async def handler(payload: dict):
+            return {"date": "2026-05-09"}
+
+        with self._client({"path": "/agents/s2"}, handler) as client:
+            r = client.post(
+                "/agents/s2",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "req-s2",
+                    "method": "tasks/sendSubscribe",
+                    "params": {
+                        "id": "task-s2",
+                        "message": {"role": "user", "parts": []},
+                    },
+                },
+            )
+        events = _parse_sse_events(r.text)
+        assert len(events) == 2
+        # First event: TaskArtifactUpdateEvent carrying the result.
+        artifact_evt = events[0]
+        assert artifact_evt["jsonrpc"] == "2.0"
+        assert artifact_evt["id"] == "req-s2"
+        artifact = artifact_evt["result"]["artifact"]
+        assert artifact["name"] == "result"
+        assert artifact["index"] == 0
+        import json as _j
+
+        assert _j.loads(artifact["parts"][0]["text"]) == {"date": "2026-05-09"}
+        # Second event: terminal status update with final=True.
+        status_evt = events[1]
+        assert status_evt["result"]["id"] == "task-s2"
+        assert status_evt["result"]["status"]["state"] == "completed"
+        assert status_evt["result"]["final"] is True
+
+    def test_sse_handler_exception_emits_single_failed_event(self):
+        async def handler(payload: dict):
+            raise RuntimeError("boom in handler")
+
+        with self._client({"path": "/agents/s3"}, handler) as client:
+            r = client.post(
+                "/agents/s3",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "req-s3",
+                    "method": "tasks/sendSubscribe",
+                    "params": {"id": "task-s3", "message": {}},
+                },
+            )
+        events = _parse_sse_events(r.text)
+        assert len(events) == 1
+        evt = events[0]
+        assert evt["result"]["status"]["state"] == "failed"
+        assert evt["result"]["final"] is True
+        assert "boom in handler" in evt["result"]["status"]["message"]["parts"][0]["text"]
+
+    def test_sse_long_running_emits_initial_working_then_terminal(
+        self, patch_is_job_proxy, monkeypatch
+    ):
+        # Drop poll/keepalive intervals so the test runs in <1s rather
+        # than waiting on real wall-clock seconds.
+        import mesh.a2a as a2a_mod
+
+        monkeypatch.setattr(a2a_mod, "_SSE_POLL_INTERVAL_SECS", 0.01)
+
+        proxy = _FakeJobProxy(
+            status_seq=[
+                {"status": "working"},
+                {"status": "working", "progress": 0.5, "progress_message": "halfway"},
+                {"status": "completed"},
+            ],
+            wait_result={"final": "value"},
+        )
+
+        async def handler(payload: dict):
+            return proxy
+
+        with self._client({"path": "/agents/s4"}, handler) as client:
+            r = client.post(
+                "/agents/s4",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "req-s4",
+                    "method": "tasks/sendSubscribe",
+                    "params": {"id": "task-s4", "message": {}},
+                },
+            )
+        events = _parse_sse_events(r.text)
+        # Expected sequence:
+        #   [0] initial working (no progress yet)
+        #   [1] working with progress=0.5 + "halfway" message
+        #   [2] terminal artifact event
+        #   [3] terminal completed status (final=True)
+        assert len(events) == 4
+
+        assert events[0]["result"]["status"]["state"] == "working"
+        assert events[0]["result"]["final"] is False
+
+        assert events[1]["result"]["status"]["state"] == "working"
+        assert events[1]["result"]["metadata"]["progress"] == 0.5
+        assert (
+            events[1]["result"]["status"]["message"]["parts"][0]["text"] == "halfway"
+        )
+
+        # Artifact event has no ``status`` key but does have ``artifact``.
+        assert "artifact" in events[2]["result"]
+        import json as _j
+
+        assert _j.loads(
+            events[2]["result"]["artifact"]["parts"][0]["text"]
+        ) == {"final": "value"}
+
+        assert events[3]["result"]["status"]["state"] == "completed"
+        assert events[3]["result"]["final"] is True
+
+    def test_sse_long_running_failed_emits_terminal_failed(
+        self, patch_is_job_proxy, monkeypatch
+    ):
+        import mesh.a2a as a2a_mod
+
+        monkeypatch.setattr(a2a_mod, "_SSE_POLL_INTERVAL_SECS", 0.01)
+
+        proxy = _FakeJobProxy(
+            status_seq=[
+                {"status": "working"},
+                {"status": "failed", "error": "downstream exploded"},
+            ],
+        )
+
+        async def handler(payload: dict):
+            return proxy
+
+        with self._client({"path": "/agents/s5"}, handler) as client:
+            r = client.post(
+                "/agents/s5",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "req-s5",
+                    "method": "tasks/sendSubscribe",
+                    "params": {"id": "task-s5", "message": {}},
+                },
+            )
+        events = _parse_sse_events(r.text)
+        assert events[0]["result"]["status"]["state"] == "working"
+        terminal = events[-1]
+        assert terminal["result"]["status"]["state"] == "failed"
+        assert terminal["result"]["final"] is True
+        # Error text propagated into the status.message text part.
+        msg_text = terminal["result"]["status"]["message"]["parts"][0]["text"]
+        assert "downstream exploded" in msg_text
+
+    def test_resubscribe_unknown_task_id_returns_invalid_params(self):
+        async def handler(payload: dict):
+            return {"x": 1}
+
+        with self._client({"path": "/agents/s6"}, handler) as client:
+            r = client.post(
+                "/agents/s6",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "resub",
+                    "method": "tasks/resubscribe",
+                    "params": {"id": "no-such-task"},
+                },
+            )
+        envelope = r.json()
+        assert envelope["error"]["code"] == -32602
+
+    def test_resubscribe_reattaches_to_existing_task(
+        self, patch_is_job_proxy, monkeypatch
+    ):
+        import mesh.a2a as a2a_mod
+
+        monkeypatch.setattr(a2a_mod, "_SSE_POLL_INTERVAL_SECS", 0.01)
+
+        proxy = _FakeJobProxy(
+            status_seq=[
+                {"status": "working"},
+                {"status": "completed"},
+            ],
+            wait_result="ok",
+        )
+
+        async def handler(payload: dict):
+            return proxy
+
+        with self._client({"path": "/agents/s7"}, handler) as client:
+            # First, send to register the task in the store.
+            client.post(
+                "/agents/s7",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "send",
+                    "method": "tasks/send",
+                    "params": {"id": "task-s7", "message": {}},
+                },
+            )
+            # Then resubscribe — should find the parked proxy.
+            r = client.post(
+                "/agents/s7",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "resub",
+                    "method": "tasks/resubscribe",
+                    "params": {"id": "task-s7"},
+                },
+            )
+        events = _parse_sse_events(r.text)
+        # Must see at least the initial working + a terminal event.
+        states = [e["result"].get("status", {}).get("state") for e in events]
+        assert "working" in states
+        assert states[-1] == "completed"
+        assert events[-1]["result"]["final"] is True
+
+
+@pytest.mark.usefixtures("_reset_a2a_task_store")
+class TestA2ATaskStoreEviction:
+    """Terminal-state grace-window cleanup keeps the task store bounded."""
+
+    def test_mark_terminal_then_sweep_evicts_after_grace_window(
+        self, patch_is_job_proxy, monkeypatch
+    ):
+        import mesh.a2a as a2a_mod
+
+        proxy = _FakeJobProxy()
+        a2a_mod._store_task("evict-me", proxy)
+        a2a_mod._mark_terminal("evict-me")
+
+        # No sweep yet — entry still present.
+        assert "evict-me" in a2a_mod._A2A_TASK_STORE
+
+        # Force the entry's terminal_at to be old enough to evict, then
+        # sweep with a future "now" so it's outside the grace window.
+        monkeypatch.setattr(a2a_mod, "_TERMINAL_GRACE_SECS", 1.0)
+        future = a2a_mod._A2A_TASK_STORE["evict-me"]["terminal_at"] + 100.0
+        a2a_mod._sweep_terminal_tasks(now=future)
+
+        assert "evict-me" not in a2a_mod._A2A_TASK_STORE
+
+    def test_working_entries_are_not_evicted(self, patch_is_job_proxy):
+        import time
+
+        import mesh.a2a as a2a_mod
+
+        proxy = _FakeJobProxy()
+        a2a_mod._store_task("keep-me", proxy)
+        # No mark_terminal — terminal_at stays None.
+        a2a_mod._sweep_terminal_tasks(now=time.monotonic() + 10000.0)
+        assert "keep-me" in a2a_mod._A2A_TASK_STORE

--- a/tests/integration/suites/uc24_a2a_python/artifacts/date-a2a-agent
+++ b/tests/integration/suites/uc24_a2a_python/artifacts/date-a2a-agent
@@ -1,0 +1,1 @@
+../fixtures/date-a2a-agent

--- a/tests/integration/suites/uc24_a2a_python/artifacts/long-task-provider
+++ b/tests/integration/suites/uc24_a2a_python/artifacts/long-task-provider
@@ -1,0 +1,1 @@
+../fixtures/long-task-provider

--- a/tests/integration/suites/uc24_a2a_python/artifacts/report-a2a-agent
+++ b/tests/integration/suites/uc24_a2a_python/artifacts/report-a2a-agent
@@ -1,0 +1,1 @@
+../fixtures/report-a2a-agent

--- a/tests/integration/suites/uc24_a2a_python/artifacts/system-agent
+++ b/tests/integration/suites/uc24_a2a_python/artifacts/system-agent
@@ -1,0 +1,1 @@
+../fixtures/system-agent

--- a/tests/integration/suites/uc24_a2a_python/fixtures/date-a2a-agent/main.py
+++ b/tests/integration/suites/uc24_a2a_python/fixtures/date-a2a-agent/main.py
@@ -1,0 +1,1 @@
+../../../../../../examples/a2a/date_a2a_agent.py

--- a/tests/integration/suites/uc24_a2a_python/fixtures/long-task-provider/main.py
+++ b/tests/integration/suites/uc24_a2a_python/fixtures/long-task-provider/main.py
@@ -1,0 +1,1 @@
+../../../../../../examples/jobs/long-task-provider/main.py

--- a/tests/integration/suites/uc24_a2a_python/fixtures/report-a2a-agent/main.py
+++ b/tests/integration/suites/uc24_a2a_python/fixtures/report-a2a-agent/main.py
@@ -1,0 +1,1 @@
+../../../../../../examples/a2a/report_a2a_agent.py

--- a/tests/integration/suites/uc24_a2a_python/fixtures/system-agent/main.py
+++ b/tests/integration/suites/uc24_a2a_python/fixtures/system-agent/main.py
@@ -1,0 +1,1 @@
+../../../../../../examples/simple/system_agent.py

--- a/tests/integration/suites/uc24_a2a_python/routines.yaml
+++ b/tests/integration/suites/uc24_a2a_python/routines.yaml
@@ -1,0 +1,60 @@
+# UC-level routines for uc24_a2a_python.
+#
+# A2A surfaces register on heartbeat with agent_type=a2a; the registry
+# stamps the agent-card public URL using MCP_MESH_PUBLIC_URL_PREFIX (set
+# below). Long-running A2A tasks (tc06/tc07/tc11) flow through the
+# MeshJob substrate, so we inherit the same fast-sweep timing knobs the
+# meshjob suite uses (uc21/routines.yaml) — short retention + frequent
+# sweep tick keep recovery / orphan / cancel paths bounded to seconds
+# instead of minutes.
+#
+# MCP_MESH_PUBLIC_URL_PREFIX is read on the *registry* side at startup;
+# exporting it inline in front of `meshctl start --registry-only` works
+# because meshctl inherits os.Environ() from the shell and forwards it
+# to the registry binary it exec's.
+
+routines:
+  # Same fast-sweep registry as uc21, plus MCP_MESH_PUBLIC_URL_PREFIX so
+  # the agent-card endpoint stamps a stable public FQDN on the card. The
+  # A2A tests don't actually need to reach that URL; we just need the
+  # ``url`` field present so card-shape assertions stay deterministic.
+  start_registry_a2a:
+    description: "Start the registry with fast-sweep timing AND MCP_MESH_PUBLIC_URL_PREFIX for A2A card stamping"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: |
+          MCP_MESH_PUBLIC_URL_PREFIX=https://test.example.com \
+          MCP_MESH_SWEEP_INTERVAL=10s \
+          MCP_MESH_RETENTION=10s \
+          MCP_MESH_HEALTH_CHECK_INTERVAL=5 \
+          DEFAULT_TIMEOUT_THRESHOLD=15 \
+            meshctl start --registry-only -d
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "registry ready after ${i}s"
+              # Verify the sweep override actually stamped its log line.
+              # If MCP_MESH_SWEEP_INTERVAL didn't take effect the suite
+              # must fail loudly here, not via slow per-test timeouts.
+              tail -n 200 ~/.mcp-mesh/logs/registry.log \
+                | grep -qE '\[sweep\] using MCP_MESH_SWEEP_INTERVAL' \
+                || { echo "FAIL: MCP_MESH_SWEEP_INTERVAL override did not take effect"; exit 1; }
+              echo "[setup] confirmed sweep override active"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: registry did not become ready in 20s"
+          tail -50 ~/.mcp-mesh/logs/registry.log 2>/dev/null || true
+          exit 1
+        capture: registry_start
+        timeout: 30
+
+  # Stop everything started by this test (agents + registry).
+  stop_all:
+    description: "Stop all mesh processes started by this test"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: meshctl stop 2>/dev/null || true
+        ignore_errors: true

--- a/tests/integration/suites/uc24_a2a_python/tc01_card_discovery_sync/test.yaml
+++ b/tests/integration/suites/uc24_a2a_python/tc01_card_discovery_sync/test.yaml
@@ -1,0 +1,100 @@
+# tc01_card_discovery_sync — A2A agent card endpoint smoke (Phase 1B).
+#
+# Verifies the GET {path}/.well-known/agent.json endpoint returns a
+# valid A2A v1.0 AgentCard for a sync skill. The date_a2a surface wraps
+# system-agent's date_service capability — sync (no task=True), so the
+# card's capabilities.streaming should be false.
+#
+# Setup: registry + system-agent (provides date_service on port 9100)
+# + date-a2a-agent (port 9090, baked via os.environ.setdefault). The
+# system-agent example bakes http_port=9091 in @mesh.agent; we override
+# to 9100 via MCP_MESH_HTTP_PORT to avoid colliding with report_a2a's
+# 9091 in other tests AND to give the A2A surface clean ownership of
+# 9090/9091. Per config_resolver.py, ENV > decorator default.
+
+name: "A2A: agent card discovery (sync skill)"
+description: "GET /agents/date/.well-known/agent.json returns valid A2A v1.0 card with streaming=false"
+tags:
+  - a2a
+  - python
+  - smoke
+  - issue-869
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/system-agent /workspace/
+      cp -rL /uc-artifacts/date-a2a-agent /workspace/
+
+  - name: "Install system-agent deps"
+    handler: pip-install
+    path: /workspace/system-agent
+
+  - name: "Install date-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/date-a2a-agent
+
+  - routine: start_registry_a2a
+
+  - name: "Start system-agent (port 9100, provides date_service)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start system-agent/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for system-agent registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start date-a2a-agent (port 9090)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start date-a2a-agent/main.py -d
+
+  - name: "Wait for A2A surface heartbeat + card cache"
+    handler: wait
+    seconds: 18
+
+  - name: "Verify both agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Fetch agent card"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:9090/agents/date/.well-known/agent.json
+    capture: card_response
+    timeout: 15
+
+assertions:
+  - expr: "${captured.agent_list} contains 'system-agent'"
+    message: "system-agent should be registered"
+  - expr: "${captured.agent_list} contains 'date'"
+    message: "date-a2a agent should be registered (name carries 'date')"
+  - expr: "${captured.card_response} contains '\"name\"'"
+    message: "card should carry a name field"
+  - expr: "${captured.card_response} contains '\"skills\"'"
+    message: "card should carry a skills array"
+  - expr: "${captured.card_response} contains '\"id\":\"get-date\"'"
+    message: "card should expose the get-date skill id"
+  # mount() ALWAYS wires tasks/sendSubscribe + tasks/resubscribe so per
+  # A2A v1.0 capabilities.streaming is advertised true regardless of
+  # whether the underlying tool is task=True (sync handlers stream a
+  # single artifact + terminal event).
+  - expr: "${captured.card_response} contains '\"streaming\":true'"
+    message: "card should advertise streaming=true (sendSubscribe + resubscribe always wired)"
+  - expr: "${captured.card_response} contains '\"capabilities\"'"
+    message: "card should carry a capabilities block"
+  - expr: "${captured.card_response} contains '\"defaultInputModes\"'"
+    message: "card should carry defaultInputModes (A2A v1.0 required)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc24_a2a_python/tc04_tasks_send_sync_completed/test.yaml
+++ b/tests/integration/suites/uc24_a2a_python/tc04_tasks_send_sync_completed/test.yaml
@@ -1,0 +1,86 @@
+# tc04_tasks_send_sync_completed — Phase 2 sync dispatch.
+#
+# JSON-RPC tasks/send dispatches into the user handler; the framework
+# wraps the return value in an A2A v1.0 Task envelope with state=completed.
+# The date_a2a handler returns {"date": <result-of-date_service>} so the
+# artifact[0].parts[0].text carries the JSON-stringified dict — checking
+# the substring '"date"' confirms the round-trip succeeded.
+
+name: "A2A: tasks/send sync handler returns state=completed"
+description: "POST tasks/send to date_a2a returns Task envelope with state=completed and artifact carrying the date result"
+tags:
+  - a2a
+  - python
+  - smoke
+  - issue-869
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/system-agent /workspace/
+      cp -rL /uc-artifacts/date-a2a-agent /workspace/
+
+  - name: "Install system-agent deps"
+    handler: pip-install
+    path: /workspace/system-agent
+
+  - name: "Install date-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/date-a2a-agent
+
+  - routine: start_registry_a2a
+
+  - name: "Start system-agent (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start system-agent/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for system-agent registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start date-a2a-agent (port 9090)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start date-a2a-agent/main.py -d
+
+  - name: "Wait for date_service DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "POST tasks/send to date_a2a"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:9090/agents/date \
+        -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"t1","message":{"role":"user","parts":[{"type":"text","text":"now"}]}}}'
+    capture: task_response
+    timeout: 15
+
+assertions:
+  - expr: "${captured.task_response} contains '\"state\":\"completed\"'"
+    message: "sync handler should yield state=completed"
+  - expr: "${captured.task_response} contains '\"id\":\"t1\"'"
+    message: "envelope should echo the submitted task id"
+  - expr: "${captured.task_response} contains '\"sessionId\":\"t1\"'"
+    message: "sessionId should default to task id"
+  - expr: "${captured.task_response} contains '\"artifacts\"'"
+    message: "envelope should carry artifacts array"
+  - expr: "${captured.task_response} contains '\"name\":\"result\"'"
+    message: "artifact[0].name should be 'result'"
+  # The artifact text is a JSON-stringified payload embedded as a quoted
+  # string (so {"date": ...} appears escaped as \"date\"). Just match the
+  # bare word "date" — that substring appears once, inside the artifact.
+  - expr: "${captured.task_response} contains 'date'"
+    message: "artifact text should carry the JSON-stringified {date: ...} payload"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc24_a2a_python/tc06_tasks_send_long_running_working/test.yaml
+++ b/tests/integration/suites/uc24_a2a_python/tc06_tasks_send_long_running_working/test.yaml
@@ -1,0 +1,84 @@
+# tc06_tasks_send_long_running_working — Phase 2-leftover long-running.
+#
+# When the user handler returns a JobProxy (i.e., it submitted a mesh
+# job via the injected MeshJob dep), the framework parks the proxy in
+# _A2A_TASK_STORE (mesh/a2a.py) and responds with state=working
+# immediately. The artifact list is empty because the underlying job
+# hasn't produced a result yet — the client polls tasks/get (tc07) or
+# subscribes via SSE (tc11) for that.
+#
+# Setup: long-task-provider (9100, baked via @mesh.agent) provides
+# generate_report (task=True). report-a2a-agent (9091, set via
+# os.environ.setdefault) wraps it as the A2A surface.
+
+name: "A2A: tasks/send long-running returns state=working"
+description: "POST tasks/send to report_a2a (task=True dep) returns Task envelope with state=working and empty artifacts"
+tags:
+  - a2a
+  - python
+  - smoke
+  - issue-869
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/report-a2a-agent /workspace/
+
+  - name: "Install long-task-provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install report-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/report-a2a-agent
+
+  - routine: start_registry_a2a
+
+  - name: "Start long-task-provider (port 9100, baked into @mesh.agent)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py -d
+
+  - name: "Wait for provider registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start report-a2a-agent (port 9091)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start report-a2a-agent/main.py -d
+
+  - name: "Wait for generate_report DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "POST tasks/send to report_a2a — submits long-running job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:9091/agents/report \
+        -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"r1","message":{"role":"user","parts":[{"type":"text","text":"{\"user_id\": \"alice\", \"sections\": [\"intro\", \"body\", \"summary\"]}"}]}}}'
+    capture: task_response
+    timeout: 15
+
+assertions:
+  - expr: "${captured.task_response} contains '\"state\":\"working\"'"
+    message: "long-running submit should yield state=working"
+  - expr: "${captured.task_response} contains '\"id\":\"r1\"'"
+    message: "envelope should echo the submitted task id"
+  - expr: "${captured.task_response} contains '\"sessionId\":\"r1\"'"
+    message: "sessionId should default to task id"
+  - expr: "${captured.task_response} contains '\"artifacts\":[]'"
+    message: "no artifact on initial long-running submit"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc24_a2a_python/tc07_tasks_get_progression_to_completed/test.yaml
+++ b/tests/integration/suites/uc24_a2a_python/tc07_tasks_get_progression_to_completed/test.yaml
@@ -1,0 +1,110 @@
+# tc07_tasks_get_progression_to_completed — Phase 2-leftover lifecycle.
+#
+# Submit a long-running A2A task, wait for it to terminate, then call
+# tasks/get to fetch the final Task envelope. The framework's tasks/get
+# handler (mesh/a2a.py::_handle_tasks_get) calls proxy.wait(timeout_secs=1)
+# on completed tasks and folds the result into artifact[0] — the artifact
+# text carries the full generate_report payload (user_id + 3 sections).
+#
+# The 12s wait between submit and tasks/get covers: ~2s claim latency +
+# 3 sections * ~2s each + ~2s slack. Generate_report's terminal
+# job.complete() flushes past the batch tick so status flips before the
+# wait window closes.
+
+name: "A2A: tasks/get returns completed with full report artifact"
+description: "Submit long-running A2A task -> wait -> tasks/get returns state=completed with the full report payload as artifact[0]"
+tags:
+  - a2a
+  - python
+  - smoke
+  - issue-869
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/report-a2a-agent /workspace/
+
+  - name: "Install long-task-provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install report-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/report-a2a-agent
+
+  - routine: start_registry_a2a
+
+  - name: "Start long-task-provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start report-a2a-agent (port 9091)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start report-a2a-agent/main.py -d
+
+  - name: "Wait for DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "POST tasks/send (capture task id from response)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=$(curl -s -X POST http://localhost:9091/agents/report \
+        -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"g1","message":{"role":"user","parts":[{"type":"text","text":"{\"user_id\": \"alice\", \"sections\": [\"intro\", \"body\", \"summary\"]}"}]}}}')
+      echo "$RESP"
+      TASK_ID=$(echo "$RESP" | jq -r '.result.id')
+      echo "TASK_ID=${TASK_ID}"
+    capture: send_response
+    timeout: 15
+
+  - name: "Wait for the long-running job to complete (3 sections * ~2s + claim slack)"
+    handler: wait
+    seconds: 12
+
+  - name: "POST tasks/get for the same task id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      TASK_ID=$(echo '${captured.send_response}' | grep '^TASK_ID=' | cut -d= -f2)
+      curl -s -X POST http://localhost:9091/agents/report \
+        -H 'Content-Type: application/json' \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tasks/get\",\"params\":{\"id\":\"${TASK_ID}\"}}"
+    capture: final_get
+    timeout: 15
+
+assertions:
+  - expr: "${captured.final_get} contains '\"state\":\"completed\"'"
+    message: "tasks/get should observe terminal completed state"
+  - expr: "${captured.final_get} contains '\"name\":\"result\"'"
+    message: "completed task should carry artifact[0].name='result'"
+  - expr: "${captured.final_get} contains 'report'"
+    message: "artifact text should embed the report payload"
+  - expr: "${captured.final_get} contains 'intro'"
+    message: "report should include the intro section"
+  - expr: "${captured.final_get} contains 'body'"
+    message: "report should include the body section"
+  - expr: "${captured.final_get} contains 'summary'"
+    message: "report should include the summary section"
+  - expr: "${captured.final_get} contains 'Generated content for'"
+    message: "report should carry the canonical generate_report marker"
+  - expr: "${captured.final_get} contains '\"progress\":1.0'"
+    message: "completed task should report progress=1.0"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc24_a2a_python/tc11_tasks_send_subscribe_long_running_sse/test.yaml
+++ b/tests/integration/suites/uc24_a2a_python/tc11_tasks_send_subscribe_long_running_sse/test.yaml
@@ -1,0 +1,98 @@
+# tc11_tasks_send_subscribe_long_running_sse — Phase 3 SSE streaming.
+#
+# tasks/sendSubscribe dispatches the same as tasks/send but the response
+# is an SSE stream of TaskStatusUpdateEvent + TaskArtifactUpdateEvent
+# JSON-RPC envelopes (mesh/a2a.py::_stream_long_running). For a
+# long-running JobProxy return, the stream sequence is:
+#
+#   1. initial state=working event (final=false) — confirms subscription
+#   2. zero-or-more progress events (working, progress=N, final=false)
+#      — emitted only when progress / progress_message actually changed
+#   3. terminal artifact event (TaskArtifactUpdateEvent — carries result)
+#   4. terminal status event (state=completed, final=true) — closes stream
+#
+# We use a 2-section job (~4s + slight overhead) and -m 20 on curl to
+# cap the consumption window; the stream closes on its own at final=true.
+
+name: "A2A: tasks/sendSubscribe streams working -> progress -> artifact -> completed"
+description: "POST tasks/sendSubscribe to report_a2a opens an SSE stream that progresses to a terminal completed event"
+tags:
+  - a2a
+  - python
+  - smoke
+  - issue-869
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/report-a2a-agent /workspace/
+
+  - name: "Install long-task-provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install report-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/report-a2a-agent
+
+  - routine: start_registry_a2a
+
+  - name: "Start long-task-provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start report-a2a-agent (port 9091)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start report-a2a-agent/main.py -d
+
+  - name: "Wait for DI resolution"
+    handler: wait
+    seconds: 18
+
+  # -N disables curl output buffering (otherwise the stream is held in
+  # the curl buffer until the stream closes anyway, but -N keeps stderr
+  # visible as the stream advances). -m 20 caps the SSE consumption at
+  # 20s so a stuck stream fails fast — the 2-section job runs ~4s and
+  # the stream closes on the terminal final=true event.
+  - name: "POST tasks/sendSubscribe and consume SSE stream"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -N -m 20 -s -X POST http://localhost:9091/agents/report \
+        -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","id":99,"method":"tasks/sendSubscribe","params":{"id":"s1","message":{"role":"user","parts":[{"type":"text","text":"{\"user_id\": \"bob\", \"sections\": [\"a\", \"b\"]}"}]}}}'
+    capture: sse_stream
+    timeout: 30
+
+assertions:
+  - expr: "${captured.sse_stream} contains '\"state\": \"working\"'"
+    message: "SSE stream should emit an initial state=working event"
+  - expr: "${captured.sse_stream} contains '\"final\": false'"
+    message: "non-terminal events should carry final=false"
+  - expr: "${captured.sse_stream} contains '\"progress\"'"
+    message: "SSE stream should emit at least one progress event"
+  - expr: "${captured.sse_stream} contains '\"artifact\"'"
+    message: "SSE stream should emit a terminal artifact event"
+  - expr: "${captured.sse_stream} contains 'Generated content for'"
+    message: "artifact event should embed the generate_report marker text"
+  - expr: "${captured.sse_stream} contains '\"state\": \"completed\"'"
+    message: "SSE stream should emit a terminal state=completed status event"
+  - expr: "${captured.sse_stream} contains '\"final\": true'"
+    message: "terminal status event should carry final=true"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

Builds on PR #904 (Phase 1 + Phase 2 minimal sync `tasks/send`) to complete A2A v1.0 method coverage:
- **Phase 2 leftover**: long-running task lifecycle (`tasks/get`, `tasks/cancel`, `tasks/send` for `task=True` deps via `JobProxy`)
- **Phase 3**: SSE streaming (`tasks/sendSubscribe`, `tasks/resubscribe`)

## Architectural shift — long-running detection by return value

PR #904's `_underlying_tool_is_task()` helper was blind to cross-agent deps (consults only local `DecoratorRegistry` — flagged in #904 review). This PR sidesteps the limitation by introspecting the user handler's **return value**:

```python
@mesh.a2a.mount(app, path="/agents/report", dependencies=["generate_report"])
async def report_a2a(payload: dict, generate_report: MeshJob = None):
    proxy = await generate_report.submit(**parse(payload))
    return proxy   # JobProxy → framework wraps as A2A state=working
```

Returns:
- `JobProxy` → state=working, parked in store, lifecycle via `proxy.{status,cancel,wait}`
- `dict` / `str` / anything else → state=completed (existing sync path from #904)

Works regardless of whether the underlying mesh tool is local or remote, since `JobProxy` is the canonical return type from `MeshJob.submit()` in both cases.

## JSON-RPC dispatch

| Method | Behavior |
|--------|----------|
| `tasks/send` | Sync (state=completed) or long-running (state=working with task_id) |
| `tasks/get` | `JobProxy.status()` → A2A Task envelope; on terminal=completed, also fetches `proxy.wait()` for the result artifact |
| `tasks/cancel` | `JobProxy.cancel()` → updated envelope (best-effort; swallows exception if already terminal) |
| `tasks/sendSubscribe` | SSE stream of `TaskStatusUpdateEvent` / `TaskArtifactUpdateEvent` |
| `tasks/resubscribe` | Re-attach SSE to in-flight task via store lookup |
| Other | JSON-RPC -32601 |

State mapping: `cancelled` → `canceled` (A2A spec uses single-l).

## Task store

Process-local `_A2A_TASK_STORE: dict[task_id, {proxy, terminal_at}]`. Terminal entries swept after 5min grace window on every store access. Memory bounded.

## SSE design

- `StreamingResponse` with `text/event-stream`, `Cache-Control: no-cache`, `X-Accel-Buffering: no`
- Polling generator: `proxy.status()` at 1s intervals, **only emits when state actually changes** (natural backpressure)
- Keepalive SSE comment every 15s (proxy timeout protection)
- Client disconnect (`asyncio.CancelledError`) does **NOT** call `proxy.cancel()` — A2A v1.0 semantics: job continues, client may rejoin via `resubscribe`
- On terminal: emit `TaskArtifactUpdateEvent` with `proxy.wait()` result, then final `TaskStatusUpdateEvent` with `final=true`
- `status()` failure mid-stream → single terminal failed event

## Example

`examples/a2a/report_a2a_agent.py` — long-running A2A surface depending on `generate_report` (`task=True`) from `examples/jobs/long-task-provider`. Demonstrates the JobProxy-return pattern with curl-able `tasks/send`/`get`/`cancel`/`sendSubscribe`.

## Validation

**Unit tests**: 870/870 (incl. 18 new across `TestMeshToA2AStateMapping`, `TestA2ALongRunningTasksLifecycle`, `TestA2ASseStreaming`, `TestA2ATaskStoreEviction`).

**Live end-to-end** against fresh registry + `examples/jobs/long-task-provider` + `examples/a2a/report_a2a_agent`:

```
=== tasks/send ===
{"result": {"id": "g1", "status": {"state": "working", ...}, "artifacts": []}}

=== tasks/get (terminal) ===
{"result": {"id": "g1", "status": {"state": "completed", "message": {"role": "agent", "parts": [{"text": "finished section 2/2"}]}},
            "artifacts": [{"name": "result", "parts": [{"text": "{\"report\": [...full content...], \"user_id\": \"alice\"}"}], "index": 0}],
            "metadata": {"progress": 1.0}}}

=== tasks/sendSubscribe (SSE) ===
data: {"result": {"status": {"state": "working"}, "final": false}}
data: {"result": {"status": {"state": "working", "message": {"text": "finished section 1/2"}}, "metadata": {"progress": 0.5}, "final": false}}
data: {"result": {"artifact": {"parts": [{"text": "{\"report\": [...], \"user_id\": \"bob\"}"}]}}}
data: {"result": {"status": {"state": "completed"}, "final": true}}

=== tasks/cancel ===
{"result": {"status": {"state": "canceled"}}}
```

## Deferred (separate work)

- **Public URL cache wiring** (heartbeat-response `surfaces[].public_url` → `update_public_url_cache`). Needs new Rust `MeshEvent::SurfacesResolved` variant. Card endpoint still uses local-fallback URL; external A2A clients should use `GET /a2a/agents` for FQDN discovery.
- **`_underlying_tool_is_task` remote-dep awareness** — the return-value introspection added here makes the helper less critical for the canonical flow but it remains a documented limitation.
- **`tasks/pushNotification`** subscriptions (A2A optional capability)
- **TS + Java SDKs** for the A2A surface

Refs #869 (parent A2A umbrella). Builds on #904.

## Test plan

- [ ] CI green
- [ ] Manual smoke (per `examples/a2a/report_a2a_agent.py` README block):
  - Start registry, `examples/jobs/long-task-provider/main.py`, `examples/a2a/report_a2a_agent.py`
  - `tasks/send` → state=working with task_id
  - `tasks/get` mid-flight → state=working
  - `tasks/get` terminal → state=completed with full result in `artifacts[0]`
  - `tasks/sendSubscribe` (curl -N) → SSE stream of working → progress → artifact → terminal
  - `tasks/cancel` → state=canceled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full support for long-running A2A tasks with lifecycle states (working/completed/failed) and SSE streaming for real-time updates.
  * New A2A endpoints for task status retrieval, cancellation, subscribe/resubscribe streaming, and send semantics for async jobs.
  * Added an example agent demonstrating long-running report generation.

* **Tests**
  * Expanded unit and integration suites covering long-running flows, SSE subscriptions, task progression, eviction, and error cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/905)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->