### PR TITLE
feat(a2a): Python A2A consumer side — @mesh.a2a_consumer + A2AClient (#908)

### DIFF
--- a/examples/a2a/consumer_date_agent.py
+++ b/examples/a2a/consumer_date_agent.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+A2A consumer example — bridges the existing ``date_a2a_agent.py``
+``get-date`` skill into the mesh as a regular ``current-date``
+capability. This is the consumer side of the A2A bridge (issue #908):
+a mesh agent that calls OUT to an external A2A endpoint and
+re-publishes the skill as a normal mesh tool.
+
+The downstream mesh tool depending on ``current-date`` does not need
+to know it is talking to an A2A backend — mesh's existing
+capability+tag failover applies the moment a SECOND consumer
+(e.g. ``accuweather-bridge``) registers the same ``current-date``
+capability with a different consumer-name tag.
+
+Each consumer auto-tags its capability with the agent name (here
+``date-consumer``) so downstream resolvers can pin a specific
+backend via the dependency tag selector.
+
+Decorator order matters
+=======================
+
+``@mesh.agent`` MUST be the LAST decorator in the file. Its
+``auto_run=True`` path triggers the mcp_startup pipeline INLINE
+(uvicorn boot, registry handshake), which blocks the importing
+thread before any module-level code below it can run. Anything
+decorated AFTER ``@mesh.agent`` will silently fail to register.
+The ``@mesh.a2a_consumer`` self-tag is resolved lazily so the
+consumer can be declared above the agent without crashing the import.
+
+Prereqs (in three terminals)
+============================
+
+  # 1) Registry
+  meshctl start registry
+
+  # 2) Producer — the existing A2A surface
+  python examples/a2a/date_a2a_agent.py
+
+  # 3) This consumer — wraps the producer above, exposes mesh capability
+  python examples/a2a/consumer_date_agent.py
+
+Test
+====
+
+A downstream mesh tool consumes the capability normally:
+
+    @mesh.tool(capability="report", dependencies=[
+        {"capability": "current-date", "tags": ["date-consumer"]},
+    ])
+    async def report(current_date: McpMeshTool = None):
+        return await current_date()
+
+The dependency resolver routes the call to this consumer, which
+issues an outbound A2A ``tasks/send`` to the producer and returns
+the producer's artifact text.
+"""
+
+import json
+import os
+
+# Set MCP_MESH_HTTP_PORT BEFORE importing mesh so the framework's
+# display_config picks up the same port we'll bind to. Avoids the
+# producer's port (9090) and the registry's port (8000).
+HTTP_PORT = int(os.environ.setdefault("MCP_MESH_HTTP_PORT", "9201"))
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Date Consumer Bridge")
+
+
+@app.tool()
+@mesh.a2a_consumer(
+    capability="current-date",
+    a2a_url="http://localhost:9090/agents/date",
+    a2a_skill_id="get-date",
+    tags=["a2a-bridge"],
+)
+async def current_date(_a2a: mesh.A2AClient = None) -> dict:
+    """Return today's date by calling the upstream A2A get-date skill.
+
+    The producer-side handler returns ``{"date": "<iso-string>"}`` and
+    the A2A surface JSON-stringifies it into the artifact text part —
+    so we ``json.loads`` on the consumer side to recover the dict.
+    """
+    response = await _a2a.send(
+        message={"role": "user", "parts": [{"type": "text", "text": "now"}]},
+    )
+    return json.loads(response.artifact_text)
+
+
+# @mesh.agent MUST be last — see module docstring for why.
+@mesh.agent(name="date-consumer", http_port=HTTP_PORT)
+class DateConsumer:
+    """Mesh agent that bridges the date_a2a_agent's get-date skill."""
+
+    pass

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
@@ -417,12 +417,29 @@ def _build_agent_spec(context: dict[str, Any]) -> Any:
         else:
             kwargs_json = None
 
+        # Defensive: if @mesh.a2a_consumer's deferred self-tag sentinel
+        # survived to heartbeat time, the @mesh.agent decorator never
+        # ran (no agent in this process). Strip the sentinel so we
+        # don't publish a placeholder string to the registry, and warn
+        # the user that capability+tag failover by consumer name won't
+        # work.
+        published_tags = tool_metadata.get("tags", []) or []
+        if "__MESH_CONSUMER_SELF__" in published_tags:
+            published_tags = [t for t in published_tags if t != "__MESH_CONSUMER_SELF__"]
+            logger.warning(
+                f"@mesh.a2a_consumer tool '{tool_name}': consumer-name self "
+                "tag was never resolved (no @mesh.agent in this process at "
+                "heartbeat time). Publishing without auto-tag — failover by "
+                "consumer-name will not work. Declare a @mesh.agent in the "
+                "same module to enable it."
+            )
+
         tool_spec = core.ToolSpec(
             function_name=tool_name,
             capability=tool_metadata.get("capability", tool_name),
             version=tool_metadata.get("version", "1.0.0"),
             description=tool_metadata.get("description") or "",
-            tags=tool_metadata.get("tags", []),
+            tags=published_tags,
             dependencies=deps if deps else None,
             input_schema=input_schema_json,
             output_schema=output_schema_json,

--- a/src/runtime/python/mesh/__init__.py
+++ b/src/runtime/python/mesh/__init__.py
@@ -98,6 +98,20 @@ def __getattr__(name):
         return decorators.route
     elif name == "a2a":
         return decorators.a2a
+    elif name == "a2a_consumer":
+        return decorators.a2a_consumer
+    elif name == "A2AClient":
+        from ._a2a_consumer import A2AClient
+
+        return A2AClient
+    elif name == "A2ABearer":
+        from ._a2a_consumer import A2ABearer
+
+        return A2ABearer
+    elif name == "A2AResponse":
+        from ._a2a_consumer import A2AResponse
+
+        return A2AResponse
     elif name == "llm":
         return decorators.llm
     elif name == "llm_provider":

--- a/src/runtime/python/mesh/_a2a_consumer.py
+++ b/src/runtime/python/mesh/_a2a_consumer.py
@@ -114,11 +114,22 @@ class A2AClient:
         return h
 
     async def _post_jsonrpc(
-        self, method: str, params: dict[str, Any], rpc_id: int = 1
+        self,
+        method: str,
+        params: dict[str, Any],
+        rpc_id: int = 1,
+        request_timeout: Any = httpx.USE_CLIENT_DEFAULT,
     ) -> dict[str, Any]:
         client = await self._http()
         envelope = {"jsonrpc": "2.0", "id": rpc_id, "method": method, "params": params}
-        resp = await client.post(self.url, headers=self._headers(), json=envelope)
+        # Default sentinel preserves the AsyncClient construction-time timeout
+        # for callers that don't pass an override (passing `None` to httpx
+        # would disable the timeout entirely, not fall back to the default).
+        # send() passes the per-call remaining-deadline so individual calls
+        # (initial tasks/send + each tasks/get poll) honor the user override.
+        resp = await client.post(
+            self.url, headers=self._headers(), json=envelope, timeout=request_timeout
+        )
         resp.raise_for_status()
         body = resp.json()
         if "error" in body:
@@ -156,8 +167,12 @@ class A2AClient:
         if task_id is None:
             task_id = f"c-{uuid.uuid4().hex}"
 
+        remaining = max(0.001, deadline - time.monotonic())
         result = await self._post_jsonrpc(
-            "tasks/send", {"id": task_id, "message": message}, rpc_id=1
+            "tasks/send",
+            {"id": task_id, "message": message},
+            rpc_id=1,
+            request_timeout=remaining,
         )
         state = (result.get("status") or {}).get("state", "unknown")
 
@@ -167,8 +182,12 @@ class A2AClient:
         interval = self.poll_interval
         while time.monotonic() < deadline:
             await asyncio.sleep(interval)
+            remaining = max(0.001, deadline - time.monotonic())
             result = await self._post_jsonrpc(
-                "tasks/get", {"id": task_id}, rpc_id=2
+                "tasks/get",
+                {"id": task_id},
+                rpc_id=2,
+                request_timeout=remaining,
             )
             state = (result.get("status") or {}).get("state", "unknown")
             if state in ("completed", "failed", "canceled"):
@@ -183,7 +202,7 @@ class A2AClient:
     def _build_response(self, task_id: str, result: dict[str, Any]) -> A2AResponse:
         artifacts = result.get("artifacts") or []
         artifact_text = ""
-        if artifacts:
+        if artifacts and isinstance(artifacts[0], dict):
             parts = artifacts[0].get("parts") or []
             if parts and isinstance(parts[0], dict):
                 artifact_text = parts[0].get("text", "")

--- a/src/runtime/python/mesh/_a2a_consumer.py
+++ b/src/runtime/python/mesh/_a2a_consumer.py
@@ -1,0 +1,198 @@
+"""Consumer-side A2A primitives — A2AClient, A2ABearer, A2AResponse.
+
+The producer-side surface (``@mesh.a2a`` + ``mesh.a2a.mount``) lets a
+mesh agent expose a tool over A2A v1.0. This module is the mirror image:
+a thin async client a mesh agent uses to CALL an external A2A endpoint
+synchronously and re-publish the result as a regular mesh capability.
+
+Typical use is via the ``@mesh.a2a_consumer`` decorator (see
+``mesh.decorators.a2a_consumer``) which constructs a per-tool
+``A2AClient`` instance and injects it into the user function as the
+``_a2a`` keyword argument. Direct construction is supported for
+advanced cases (e.g. dynamic endpoint per call, custom polling).
+
+Phase 1 covers sync ``tasks/send`` + poll-until-terminal via
+``tasks/get``. Long-running submit/subscribe and SSE streaming are
+deferred to a later phase.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import httpx
+
+
+@dataclass
+class A2ABearer:
+    """Bearer-token credential for an outbound A2A call.
+
+    Provide either ``token`` (literal) or ``token_env`` (name of an env
+    var that holds the token). Resolution happens at header-build time
+    so rotating the env var between calls picks up the new value
+    without re-decorating the consumer. Raises ``RuntimeError`` if
+    neither source yields a value.
+    """
+
+    token_env: Optional[str] = None
+    token: Optional[str] = None
+
+    def header(self) -> dict[str, str]:
+        tok = self.token or (os.getenv(self.token_env) if self.token_env else None)
+        if not tok:
+            raise RuntimeError(
+                f"A2ABearer: no token available "
+                f"(token_env={self.token_env!r}, "
+                f"explicit_token={'set' if self.token else 'unset'})"
+            )
+        return {"Authorization": f"Bearer {tok}"}
+
+
+@dataclass
+class A2AResponse:
+    """Result of a synchronous ``A2AClient.send`` call.
+
+    ``artifact_text`` is the canonical sync return — the producer-side
+    surface places the handler's return value as
+    ``result.artifacts[0].parts[0].text`` and JSON-stringifies non-string
+    returns. Consumers that need the raw envelope (multi-artifact
+    responses, status messages, history) can read ``raw_task``.
+    """
+
+    artifact_text: str
+    state: str
+    task_id: str
+    raw_task: dict[str, Any]
+
+
+class A2AClient:
+    """Thin async A2A v1.0 client — sync ``tasks/send`` + poll until terminal.
+
+    One instance per (url, skill_id, auth) tuple — the ``@mesh.a2a_consumer``
+    decorator constructs one per decorated function and reuses it across
+    calls to amortize the underlying ``httpx.AsyncClient`` connection
+    pool. Direct construction is supported for users who need finer
+    control (e.g. dynamic URL per call).
+
+    ``send`` POSTs a JSON-RPC ``tasks/send`` request, then polls
+    ``tasks/get`` with exponential-ish backoff (capped at
+    ``poll_interval_max``) until the task reaches a terminal state
+    (``completed`` / ``failed`` / ``canceled``) or ``timeout`` elapses.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        skill_id: str,
+        auth: Optional[A2ABearer] = None,
+        timeout_default: float = 30.0,
+        poll_interval: float = 0.5,
+        poll_interval_max: float = 2.0,
+    ):
+        self.url = url.rstrip("/")
+        self.skill_id = skill_id
+        self.auth = auth
+        self.timeout_default = timeout_default
+        self.poll_interval = poll_interval
+        self.poll_interval_max = poll_interval_max
+        self._client: Optional[httpx.AsyncClient] = None
+
+    async def _http(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=httpx.Timeout(60.0))
+        return self._client
+
+    def _headers(self) -> dict[str, str]:
+        h = {"Content-Type": "application/json"}
+        if self.auth:
+            h.update(self.auth.header())
+        return h
+
+    async def _post_jsonrpc(
+        self, method: str, params: dict[str, Any], rpc_id: int = 1
+    ) -> dict[str, Any]:
+        client = await self._http()
+        envelope = {"jsonrpc": "2.0", "id": rpc_id, "method": method, "params": params}
+        resp = await client.post(self.url, headers=self._headers(), json=envelope)
+        resp.raise_for_status()
+        body = resp.json()
+        if "error" in body:
+            err = body["error"]
+            raise RuntimeError(
+                f"A2A error from {self.url}: "
+                f"{err.get('code')} {err.get('message')}"
+            )
+        return body.get("result", {})
+
+    async def send(
+        self,
+        message: dict[str, Any],
+        *,
+        task_id: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> A2AResponse:
+        """POST ``tasks/send`` and poll ``tasks/get`` until terminal.
+
+        ``message`` is the A2A v1.0 request message dict (typically
+        ``{"role": "user", "parts": [{"type": "text", "text": "..."}]}``).
+        Returns an ``A2AResponse`` whose ``artifact_text`` carries the
+        producer-side handler's return value (JSON-stringified for
+        non-string returns — match the producer convention with
+        ``json.loads`` on the consumer side when the upstream returns a
+        dict).
+
+        Raises ``TimeoutError`` if the task does not reach a terminal
+        state within ``timeout`` seconds (defaults to
+        ``timeout_default``). Raises ``RuntimeError`` for JSON-RPC error
+        envelopes from the producer.
+        """
+        timeout = timeout if timeout is not None else self.timeout_default
+        deadline = time.monotonic() + timeout
+        if task_id is None:
+            task_id = f"c-{int(time.time() * 1000)}-{os.urandom(3).hex()}"
+
+        result = await self._post_jsonrpc(
+            "tasks/send", {"id": task_id, "message": message}, rpc_id=1
+        )
+        state = (result.get("status") or {}).get("state", "unknown")
+
+        if state in ("completed", "failed", "canceled"):
+            return self._build_response(task_id, result)
+
+        interval = self.poll_interval
+        while time.monotonic() < deadline:
+            await asyncio.sleep(interval)
+            result = await self._post_jsonrpc(
+                "tasks/get", {"id": task_id}, rpc_id=2
+            )
+            state = (result.get("status") or {}).get("state", "unknown")
+            if state in ("completed", "failed", "canceled"):
+                return self._build_response(task_id, result)
+            interval = min(self.poll_interval_max, interval * 1.5)
+
+        raise TimeoutError(
+            f"A2A task {task_id!r} on {self.url} did not reach terminal "
+            f"state within {timeout}s (last state={state!r})"
+        )
+
+    def _build_response(self, task_id: str, result: dict[str, Any]) -> A2AResponse:
+        artifacts = result.get("artifacts") or []
+        artifact_text = ""
+        if artifacts:
+            parts = artifacts[0].get("parts") or []
+            if parts and isinstance(parts[0], dict):
+                artifact_text = parts[0].get("text", "")
+        return A2AResponse(
+            artifact_text=artifact_text,
+            state=(result.get("status") or {}).get("state", "unknown"),
+            task_id=task_id,
+            raw_task=result,
+        )
+
+    async def aclose(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()

--- a/src/runtime/python/mesh/_a2a_consumer.py
+++ b/src/runtime/python/mesh/_a2a_consumer.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import os
 import time
+import uuid
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -103,7 +104,7 @@ class A2AClient:
 
     async def _http(self) -> httpx.AsyncClient:
         if self._client is None or self._client.is_closed:
-            self._client = httpx.AsyncClient(timeout=httpx.Timeout(60.0))
+            self._client = httpx.AsyncClient(timeout=httpx.Timeout(self.timeout_default))
         return self._client
 
     def _headers(self) -> dict[str, str]:
@@ -153,7 +154,7 @@ class A2AClient:
         timeout = timeout if timeout is not None else self.timeout_default
         deadline = time.monotonic() + timeout
         if task_id is None:
-            task_id = f"c-{int(time.time() * 1000)}-{os.urandom(3).hex()}"
+            task_id = f"c-{uuid.uuid4().hex}"
 
         result = await self._post_jsonrpc(
             "tasks/send", {"id": task_id, "message": message}, rpc_id=1

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -26,6 +26,11 @@ _runtime_processor: Any | None = None
 # Shared agent ID for all functions in the same process
 _SHARED_AGENT_ID: str | None = None
 
+# Sentinel placeholder used by @mesh.a2a_consumer to mark tags that should
+# be substituted with the surrounding @mesh.agent name once it is known.
+# See _resolve_pending_consumer_self_tags below.
+_MESH_CONSUMER_SELF_SENTINEL = "__MESH_CONSUMER_SELF__"
+
 
 def _find_available_port() -> int:
     """
@@ -2116,6 +2121,9 @@ def a2a_consumer(
     user_tags = list(tags) if tags is not None else []
 
     def decorator(target: T) -> T:
+        # Coupled with the marker-propagation try/except at the bottom of this
+        # decorator — that block copies _mesh_a2a_consumer_metadata onto the DI
+        # wrapper returned by tool() so this guard catches re-decoration.
         if hasattr(target, "_mesh_a2a_consumer_metadata"):
             raise RuntimeError(
                 f"@mesh.a2a_consumer({capability!r}): function {target.__name__!r} is already "
@@ -2213,6 +2221,10 @@ def a2a_consumer(
         # ``tool()`` returns the DI wrapper; copy the consumer markers
         # across so post-substitution can find them via the registry's
         # stored function reference too.
+        # Propagate the consumer markers onto the DI wrapper returned by tool() —
+        # the registry stores the wrapper, not bridge, AND the double-decoration
+        # guard at the top of this decorator depends on these attributes being
+        # observable via hasattr(target, ...).
         try:
             wrapped._mesh_a2a_consumer_metadata = bridge._mesh_a2a_consumer_metadata
             wrapped._mesh_a2a_consumer_client = bridge._mesh_a2a_consumer_client
@@ -2223,9 +2235,6 @@ def a2a_consumer(
         return wrapped
 
     return decorator
-
-
-_MESH_CONSUMER_SELF_SENTINEL = "__MESH_CONSUMER_SELF__"
 
 
 def _resolve_pending_consumer_self_tags(agent_name: str) -> None:
@@ -2241,13 +2250,10 @@ def _resolve_pending_consumer_self_tags(agent_name: str) -> None:
     if not agent_name:
         return
 
-    def _swap(tag_list: list[str]) -> bool:
-        changed = False
+    def _swap(tag_list: list[str]) -> None:
         for i, t in enumerate(tag_list):
             if t == _MESH_CONSUMER_SELF_SENTINEL:
                 tag_list[i] = agent_name
-                changed = True
-        return changed
 
     registry_tools = DecoratorRegistry.get_mesh_tools()
     for decorated in registry_tools.values():

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -2100,6 +2100,11 @@ def a2a_consumer(
         for t in tags:
             if not isinstance(t, str):
                 raise ValueError("@mesh.a2a_consumer: all tags must be strings")
+            if t == _MESH_CONSUMER_SELF_SENTINEL:
+                raise ValueError(
+                    f"@mesh.a2a_consumer: tag {_MESH_CONSUMER_SELF_SENTINEL!r} is reserved "
+                    "for the framework's consumer-name auto-injection sentinel; do not supply it explicitly"
+                )
     if not isinstance(version, str):
         raise ValueError("@mesh.a2a_consumer: 'version' must be a string")
     if description is not None and not isinstance(description, str):
@@ -2111,6 +2116,13 @@ def a2a_consumer(
     user_tags = list(tags) if tags is not None else []
 
     def decorator(target: T) -> T:
+        if hasattr(target, "_mesh_a2a_consumer_metadata"):
+            raise RuntimeError(
+                f"@mesh.a2a_consumer({capability!r}): function {target.__name__!r} is already "
+                "decorated with @mesh.a2a_consumer; stacking the decorator orphans the inner "
+                "A2AClient. Apply @mesh.a2a_consumer exactly once per function."
+            )
+
         # Deferred resolution of the surrounding @mesh.agent name. The
         # convention is that @mesh.agent is the LAST decorator in the
         # file (its auto_run blocks the importing thread), so this

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -1385,6 +1385,12 @@ def agent(
         # Register with DecoratorRegistry for processor discovery
         DecoratorRegistry.register_mesh_agent(target, metadata)
 
+        # Resolve any @mesh.a2a_consumer self-tag sentinels now that we
+        # know the agent name. The convention puts @mesh.agent at the
+        # bottom of the file, so consumer decorators (above) ran first
+        # and stamped a placeholder; substitute it in-place here.
+        _resolve_pending_consumer_self_tags(name)
+
         # Trigger debounced processing
         _trigger_debounced_processing()
 
@@ -1990,6 +1996,275 @@ def a2a(
             return target
 
     return decorator
+
+
+def a2a_consumer(
+    *,
+    capability: str,
+    a2a_url: str,
+    a2a_skill_id: str | None = None,
+    tags: list[str] | None = None,
+    auth: Any | None = None,
+    version: str = "1.0.0",
+    description: str | None = None,
+    timeout: float = 30.0,
+    **kwargs: Any,
+) -> Callable[[T], T]:
+    """Bridge an external A2A v1.0 endpoint into a mesh capability (issue #908).
+
+    Wraps a user function as a regular ``@mesh.tool`` capability whose
+    body issues a synchronous ``tasks/send`` against an external A2A
+    backend. The decorator:
+
+    - Constructs a single ``A2AClient`` per decorator application (cached
+      in a closure, reused across calls).
+    - Injects the client as the ``_a2a`` keyword argument when the user
+      function declares it.
+    - Registers the capability with the surrounding ``@mesh.agent``'s
+      name automatically appended as a tag, so multiple consumer agents
+      bridging the same logical capability are distinguishable for mesh
+      capability+tag failover.
+
+    A consumer is NOT an A2A producer — registration goes through the
+    standard ``@mesh.tool`` path, not the ``api_startup`` / a2a-surface
+    pipeline.
+
+    Args:
+        capability: REQUIRED mesh capability name to register. Downstream
+            mesh tools depend on this string the same way they depend on
+            any other ``@mesh.tool`` capability.
+        a2a_url: REQUIRED full URL of the A2A endpoint (e.g.
+            ``http://host:port/agents/<skill>``).
+        a2a_skill_id: A2A skill identifier on the upstream side. Defaults
+            to ``capability`` when omitted. Recorded on the client for
+            future per-skill-discovery use; not yet sent on the wire
+            (Phase 1 only uses the URL itself).
+        tags: Extra mesh tags for the capability. The consumer agent's
+            name is automatically appended (or substituted in lazily
+            when no ``@mesh.agent`` is registered yet at decoration
+            time).
+        auth: ``A2ABearer`` instance for outbound bearer auth, or
+            ``None`` for unauthenticated calls.
+        version: Capability version (default ``"1.0.0"``).
+        description: Capability description; defaults to the function's
+            docstring.
+        timeout: Default timeout (seconds) for ``A2AClient.send`` calls
+            issued by this decorator. Per-call ``send(..., timeout=...)``
+            overrides the default.
+        **kwargs: Additional metadata stamped onto the underlying
+            ``@mesh.tool`` registration (passed through unchanged).
+
+    Returns:
+        The user function wrapped as a ``@mesh.tool``-style capability
+        with the ``A2AClient`` bound for ``_a2a`` injection.
+
+    Example:
+        @app.tool()
+        @mesh.a2a_consumer(
+            capability="current-date",
+            a2a_url="http://localhost:9090/agents/date",
+            a2a_skill_id="get-date",
+            tags=["a2a-bridge"],
+        )
+        async def current_date(_a2a: mesh.A2AClient = None) -> dict:
+            response = await _a2a.send(
+                message={"role": "user", "parts": [{"type": "text", "text": "now"}]},
+            )
+            return json.loads(response.artifact_text)
+    """
+    # Implementation lives in a private submodule (``_a2a_consumer``)
+    # so the public name ``mesh.a2a_consumer`` belongs to THIS decorator
+    # function. Importing from a public ``a2a_consumer`` submodule would
+    # set ``mesh.a2a_consumer`` to the module object as a Python import
+    # side effect, shadowing the decorator on subsequent attribute
+    # lookups in the same process.
+    from ._a2a_consumer import A2ABearer, A2AClient
+
+    if not isinstance(capability, str) or not capability:
+        raise ValueError(
+            "@mesh.a2a_consumer: 'capability' is required and must be a non-empty string"
+        )
+    if not isinstance(a2a_url, str) or not a2a_url:
+        raise ValueError(
+            "@mesh.a2a_consumer: 'a2a_url' is required and must be a non-empty string"
+        )
+    if a2a_skill_id is not None and not isinstance(a2a_skill_id, str):
+        raise ValueError("@mesh.a2a_consumer: 'a2a_skill_id' must be a string or None")
+    if auth is not None and not isinstance(auth, A2ABearer):
+        raise ValueError(
+            "@mesh.a2a_consumer: 'auth' must be a mesh.A2ABearer instance or None"
+        )
+    if tags is not None:
+        if not isinstance(tags, list):
+            raise ValueError("@mesh.a2a_consumer: 'tags' must be a list of strings")
+        for t in tags:
+            if not isinstance(t, str):
+                raise ValueError("@mesh.a2a_consumer: all tags must be strings")
+    if not isinstance(version, str):
+        raise ValueError("@mesh.a2a_consumer: 'version' must be a string")
+    if description is not None and not isinstance(description, str):
+        raise ValueError("@mesh.a2a_consumer: 'description' must be a string or None")
+    if not isinstance(timeout, (int, float)) or timeout <= 0:
+        raise ValueError("@mesh.a2a_consumer: 'timeout' must be a positive number")
+
+    final_skill_id = a2a_skill_id if a2a_skill_id else capability
+    user_tags = list(tags) if tags is not None else []
+
+    def decorator(target: T) -> T:
+        # Deferred resolution of the surrounding @mesh.agent name. The
+        # convention is that @mesh.agent is the LAST decorator in the
+        # file (its auto_run blocks the importing thread), so this
+        # consumer typically runs BEFORE the agent is registered. We
+        # stamp a sentinel here and let the @mesh.agent decorator
+        # substitute the real name once it knows it (see
+        # _resolve_pending_consumer_self_tags below).
+        merged_tags = list(user_tags)
+        if _MESH_CONSUMER_SELF_SENTINEL not in merged_tags:
+            merged_tags.append(_MESH_CONSUMER_SELF_SENTINEL)
+
+        client = A2AClient(
+            url=a2a_url,
+            skill_id=final_skill_id,
+            auth=auth,
+            timeout_default=float(timeout),
+        )
+
+        # Detect whether the user function declares the ``_a2a`` parameter.
+        # We require the literal name (NOT a prefix match) — anything
+        # broader would be too magical and surprise users who name
+        # parameters starting with ``_a``.
+        import inspect as _inspect
+
+        try:
+            sig = _inspect.signature(target)
+            wants_a2a = "_a2a" in sig.parameters
+        except (TypeError, ValueError):
+            wants_a2a = False
+
+        if asyncio.iscoroutinefunction(target):
+
+            @wraps(target)
+            async def bridge(*args: Any, **call_kwargs: Any) -> Any:
+                if wants_a2a and "_a2a" not in call_kwargs:
+                    call_kwargs["_a2a"] = client
+                return await target(*args, **call_kwargs)
+
+        else:
+
+            @wraps(target)
+            def bridge(*args: Any, **call_kwargs: Any) -> Any:
+                if wants_a2a and "_a2a" not in call_kwargs:
+                    call_kwargs["_a2a"] = client
+                return target(*args, **call_kwargs)
+
+        # Hide the user's ``_a2a`` parameter from the inner @mesh.tool
+        # signature analyzer — we bind it ourselves in ``bridge`` and the
+        # DI single-parameter heuristic would otherwise log a noisy
+        # "consider typing as McpMeshTool" warning AND attempt to inject
+        # a remote-capability proxy into the slot. The user-facing
+        # signature for FastMCP / the agent card stays clean too.
+        if wants_a2a:
+            user_sig = _inspect.signature(target)
+            cleaned_params = [
+                p for name, p in user_sig.parameters.items() if name != "_a2a"
+            ]
+            bridge.__signature__ = user_sig.replace(parameters=cleaned_params)
+
+        # Stamp marker so debugging / introspection can see this is a
+        # consumer-side bridge (parallels ``_mesh_a2a_metadata`` on the
+        # producer side). ``consumer_name`` starts as the sentinel and
+        # is rewritten in-place by ``_resolve_pending_consumer_self_tags``
+        # when @mesh.agent runs.
+        bridge._mesh_a2a_consumer_metadata = {
+            "capability": capability,
+            "a2a_url": a2a_url,
+            "a2a_skill_id": final_skill_id,
+            "tags": list(merged_tags),
+            "auth": "bearer" if isinstance(auth, A2ABearer) else None,
+            "consumer_name": _MESH_CONSUMER_SELF_SENTINEL,
+        }
+        bridge._mesh_a2a_consumer_client = client
+        bridge._mesh_a2a_consumer_pending_self_tag = True
+
+        # Route through the standard @mesh.tool registration path. This
+        # is the only registration the consumer needs — heartbeat
+        # publishes capability + tags via the regular mcp_startup
+        # pipeline; no a2a_startup involvement.
+        wrapped = tool(
+            capability=capability,
+            tags=merged_tags,
+            version=version,
+            description=description,
+            **kwargs,
+        )(bridge)
+
+        # ``tool()`` returns the DI wrapper; copy the consumer markers
+        # across so post-substitution can find them via the registry's
+        # stored function reference too.
+        try:
+            wrapped._mesh_a2a_consumer_metadata = bridge._mesh_a2a_consumer_metadata
+            wrapped._mesh_a2a_consumer_client = bridge._mesh_a2a_consumer_client
+            wrapped._mesh_a2a_consumer_pending_self_tag = True
+        except (AttributeError, TypeError):
+            pass
+
+        return wrapped
+
+    return decorator
+
+
+_MESH_CONSUMER_SELF_SENTINEL = "__MESH_CONSUMER_SELF__"
+
+
+def _resolve_pending_consumer_self_tags(agent_name: str) -> None:
+    """Substitute the deferred consumer-name sentinel with the real
+    @mesh.agent name across all registered tools and bridge functions.
+
+    Called from the @mesh.agent decorator once the agent name is known.
+    Walks both the function-level ``_mesh_tool_metadata`` (and
+    ``_mesh_a2a_consumer_metadata``) AND the registry's stored copy,
+    because ``DecoratorRegistry.register_mesh_tool`` snapshots metadata
+    via ``.copy()`` at decoration time.
+    """
+    if not agent_name:
+        return
+
+    def _swap(tag_list: list[str]) -> bool:
+        changed = False
+        for i, t in enumerate(tag_list):
+            if t == _MESH_CONSUMER_SELF_SENTINEL:
+                tag_list[i] = agent_name
+                changed = True
+        return changed
+
+    registry_tools = DecoratorRegistry.get_mesh_tools()
+    for decorated in registry_tools.values():
+        fn = decorated.function
+        if not getattr(fn, "_mesh_a2a_consumer_pending_self_tag", False):
+            continue
+
+        fn_meta = getattr(fn, "_mesh_tool_metadata", None)
+        if isinstance(fn_meta, dict):
+            tags = fn_meta.get("tags")
+            if isinstance(tags, list):
+                _swap(tags)
+
+        consumer_meta = getattr(fn, "_mesh_a2a_consumer_metadata", None)
+        if isinstance(consumer_meta, dict):
+            tags = consumer_meta.get("tags")
+            if isinstance(tags, list):
+                _swap(tags)
+            if consumer_meta.get("consumer_name") == _MESH_CONSUMER_SELF_SENTINEL:
+                consumer_meta["consumer_name"] = agent_name
+
+        registry_tags = decorated.metadata.get("tags") if isinstance(decorated.metadata, dict) else None
+        if isinstance(registry_tags, list):
+            _swap(registry_tags)
+
+        try:
+            fn._mesh_a2a_consumer_pending_self_tag = False
+        except (AttributeError, TypeError):
+            pass
 
 
 def _a2a_mount(*args: Any, **kwargs: Any):

--- a/tests/integration/suites/uc25_a2a_consumer_python/artifacts/caller-agent
+++ b/tests/integration/suites/uc25_a2a_consumer_python/artifacts/caller-agent
@@ -1,0 +1,1 @@
+../fixtures/caller-agent

--- a/tests/integration/suites/uc25_a2a_consumer_python/artifacts/consumer-date-agent
+++ b/tests/integration/suites/uc25_a2a_consumer_python/artifacts/consumer-date-agent
@@ -1,0 +1,1 @@
+../fixtures/consumer-date-agent

--- a/tests/integration/suites/uc25_a2a_consumer_python/artifacts/consumer-date-agent-b
+++ b/tests/integration/suites/uc25_a2a_consumer_python/artifacts/consumer-date-agent-b
@@ -1,0 +1,1 @@
+../fixtures/consumer-date-agent-b

--- a/tests/integration/suites/uc25_a2a_consumer_python/artifacts/date-a2a-agent
+++ b/tests/integration/suites/uc25_a2a_consumer_python/artifacts/date-a2a-agent
@@ -1,0 +1,1 @@
+../fixtures/date-a2a-agent

--- a/tests/integration/suites/uc25_a2a_consumer_python/artifacts/system-agent
+++ b/tests/integration/suites/uc25_a2a_consumer_python/artifacts/system-agent
@@ -1,0 +1,1 @@
+../fixtures/system-agent

--- a/tests/integration/suites/uc25_a2a_consumer_python/fixtures/caller-agent/main.py
+++ b/tests/integration/suites/uc25_a2a_consumer_python/fixtures/caller-agent/main.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Downstream caller fixture for uc25 (issue #908) — a regular mesh
+agent with three @mesh.tool functions all depending on the
+current-date capability that the A2A consumer publishes:
+
+  - get_formatted_date          : untagged dep (any consumer wins)
+  - get_formatted_date_primary  : tag-pinned to date-consumer
+  - get_formatted_date_alt      : tag-pinned to date-consumer-alt
+
+The untagged variant exercises auto-rewire on consumer death
+(tc03 failover); the tag-pinned variants prove the consumer-name
+auto-tag substitution actually makes consumers distinguishable
+for the resolver.
+"""
+
+import os
+
+HTTP_PORT = int(os.environ.setdefault("MCP_MESH_HTTP_PORT", "9203"))
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Date Caller")
+
+
+@app.tool()
+@mesh.tool(
+    capability="formatted-date",
+    dependencies=[{"capability": "current-date"}],
+)
+async def get_formatted_date(current_date: mesh.McpMeshTool = None) -> dict:
+    """Call any current-date provider — the resolver picks one of the
+    healthy consumers. Returns the producer's date payload."""
+    if current_date is None:
+        return {"error": "current_date dependency not resolved"}
+    return await current_date()
+
+
+@app.tool()
+@mesh.tool(
+    capability="formatted-date-primary",
+    dependencies=[
+        {"capability": "current-date", "tags": ["date-consumer"]},
+    ],
+)
+async def get_formatted_date_primary(
+    current_date: mesh.McpMeshTool = None,
+) -> dict:
+    """Pinned to the primary consumer (auto-tag = agent name)."""
+    if current_date is None:
+        return {"error": "current_date (date-consumer) dependency not resolved"}
+    return await current_date()
+
+
+@app.tool()
+@mesh.tool(
+    capability="formatted-date-alt",
+    dependencies=[
+        {"capability": "current-date", "tags": ["date-consumer-alt"]},
+    ],
+)
+async def get_formatted_date_alt(
+    current_date: mesh.McpMeshTool = None,
+) -> dict:
+    """Pinned to the alt consumer (auto-tag = agent name)."""
+    if current_date is None:
+        return {"error": "current_date (date-consumer-alt) dependency not resolved"}
+    return await current_date()
+
+
+# @mesh.agent MUST be last.
+@mesh.agent(name="date-caller", http_port=HTTP_PORT)
+class DateCaller:
+    """Downstream consumer that depends on the bridged current-date."""
+
+    pass

--- a/tests/integration/suites/uc25_a2a_consumer_python/fixtures/consumer-date-agent-b/main.py
+++ b/tests/integration/suites/uc25_a2a_consumer_python/fixtures/consumer-date-agent-b/main.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+Second A2A consumer fixture for uc25 tc03 (issue #908) — registers
+the SAME current-date capability with the SAME a2a-bridge tag, but
+under a different agent name (date-consumer-alt). The auto-injected
+consumer-name tag (date-consumer-alt) is what makes this consumer
+distinguishable from date-consumer for capability+tag failover.
+
+Bridges the same upstream date_a2a_agent get-date skill via
+localhost:9090 (single-container test environment).
+"""
+
+import json
+import os
+
+HTTP_PORT = int(os.environ.setdefault("MCP_MESH_HTTP_PORT", "9202"))
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Date Consumer Bridge (alt)")
+
+
+@app.tool()
+@mesh.a2a_consumer(
+    capability="current-date",
+    a2a_url="http://localhost:9090/agents/date",
+    a2a_skill_id="get-date",
+    tags=["a2a-bridge"],
+)
+async def current_date(_a2a: mesh.A2AClient = None) -> dict:
+    """Return today's date by calling the upstream A2A get-date skill."""
+    response = await _a2a.send(
+        message={"role": "user", "parts": [{"type": "text", "text": "now"}]},
+    )
+    return json.loads(response.artifact_text)
+
+
+# @mesh.agent MUST be last.
+@mesh.agent(name="date-consumer-alt", http_port=HTTP_PORT)
+class DateConsumerAlt:
+    """Second mesh agent bridging the same get-date skill under a
+    different consumer-name tag for failover/pinning tests."""
+
+    pass

--- a/tests/integration/suites/uc25_a2a_consumer_python/fixtures/consumer-date-agent/main.py
+++ b/tests/integration/suites/uc25_a2a_consumer_python/fixtures/consumer-date-agent/main.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+A2A consumer fixture for uc25 (issue #908) — bridges the existing
+date_a2a_agent.py get-date skill into the mesh as a regular
+current-date capability.
+
+Adapted from examples/a2a/consumer_date_agent.py — all agents in
+the tsuite container share the network namespace, so the upstream
+A2A endpoint is reachable on localhost (NOT a docker service name).
+
+Decorator order matters: @mesh.agent MUST be the LAST decorator so
+auto_run=True triggers the mcp_startup pipeline (uvicorn + registry
+handshake) AFTER the consumer is registered. The @mesh.a2a_consumer
+self-tag (agent name) is resolved lazily via the
+__MESH_CONSUMER_SELF__ sentinel so the consumer can be declared
+above the agent class without crashing the import.
+"""
+
+import json
+import os
+
+# Set MCP_MESH_HTTP_PORT BEFORE importing mesh so the framework's
+# display_config picks up the same port we'll bind to.
+HTTP_PORT = int(os.environ.setdefault("MCP_MESH_HTTP_PORT", "9201"))
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Date Consumer Bridge")
+
+
+@app.tool()
+@mesh.a2a_consumer(
+    capability="current-date",
+    a2a_url="http://localhost:9090/agents/date",
+    a2a_skill_id="get-date",
+    tags=["a2a-bridge"],
+)
+async def current_date(_a2a: mesh.A2AClient = None) -> dict:
+    """Return today's date by calling the upstream A2A get-date skill.
+
+    The producer-side handler returns {"date": "<iso-string>"} and the
+    A2A surface JSON-stringifies it into the artifact text part — so
+    we json.loads on the consumer side to recover the dict.
+    """
+    response = await _a2a.send(
+        message={"role": "user", "parts": [{"type": "text", "text": "now"}]},
+    )
+    return json.loads(response.artifact_text)
+
+
+# @mesh.agent MUST be last — see module docstring.
+@mesh.agent(name="date-consumer", http_port=HTTP_PORT)
+class DateConsumer:
+    """Mesh agent that bridges the date_a2a_agent's get-date skill."""
+
+    pass

--- a/tests/integration/suites/uc25_a2a_consumer_python/fixtures/date-a2a-agent/main.py
+++ b/tests/integration/suites/uc25_a2a_consumer_python/fixtures/date-a2a-agent/main.py
@@ -1,0 +1,1 @@
+../../../../../../examples/a2a/date_a2a_agent.py

--- a/tests/integration/suites/uc25_a2a_consumer_python/fixtures/system-agent/main.py
+++ b/tests/integration/suites/uc25_a2a_consumer_python/fixtures/system-agent/main.py
@@ -1,0 +1,1 @@
+../../../../../../examples/simple/system_agent.py

--- a/tests/integration/suites/uc25_a2a_consumer_python/routines.yaml
+++ b/tests/integration/suites/uc25_a2a_consumer_python/routines.yaml
@@ -1,0 +1,54 @@
+# UC-level routines for uc25_a2a_consumer_python (issue #908).
+#
+# Tests the consumer side of the A2A bridge: a mesh agent that calls
+# OUT to an external A2A backend and re-publishes the skill as a
+# regular mesh capability. Same fast-sweep registry timing as uc24
+# so failover (tc03) takes seconds, not minutes — DEFAULT_TIMEOUT_THRESHOLD
+# bounds how quickly the registry marks a stopped consumer unhealthy
+# so the surviving consumer can pick up subsequent calls.
+
+routines:
+  # Fast-sweep registry: short retention + tight health-check interval
+  # so consumer death (tc03) is detected within ~15s instead of the
+  # default 60s+ window. No MCP_MESH_PUBLIC_URL_PREFIX needed here —
+  # this suite never reads agent-card URLs (consumers register as
+  # mcp_agent, not a2a).
+  start_registry_consumer:
+    description: "Start the registry with fast-sweep timing for consumer health/failover tests"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: |
+          MCP_MESH_SWEEP_INTERVAL=10s \
+          MCP_MESH_RETENTION=10s \
+          MCP_MESH_HEALTH_CHECK_INTERVAL=5 \
+          DEFAULT_TIMEOUT_THRESHOLD=15 \
+            meshctl start --registry-only -d
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "registry ready after ${i}s"
+              # Verify the sweep override actually stamped its log line.
+              # If MCP_MESH_SWEEP_INTERVAL didn't take effect the suite
+              # must fail loudly here, not via slow per-test timeouts.
+              tail -n 200 ~/.mcp-mesh/logs/registry.log \
+                | grep -qE '\[sweep\] using MCP_MESH_SWEEP_INTERVAL' \
+                || { echo "FAIL: MCP_MESH_SWEEP_INTERVAL override did not take effect"; exit 1; }
+              echo "[setup] confirmed sweep override active"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: registry did not become ready in 20s"
+          tail -50 ~/.mcp-mesh/logs/registry.log 2>/dev/null || true
+          exit 1
+        capture: registry_start
+        timeout: 30
+
+  # Stop everything started by this test (agents + registry).
+  stop_all:
+    description: "Stop all mesh processes started by this test"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: meshctl stop 2>/dev/null || true
+        ignore_errors: true

--- a/tests/integration/suites/uc25_a2a_consumer_python/tc01_capability_and_tag_registration/test.yaml
+++ b/tests/integration/suites/uc25_a2a_consumer_python/tc01_capability_and_tag_registration/test.yaml
@@ -103,8 +103,8 @@ test:
 assertions:
   - expr: "${captured.agent_list} contains 'system-agent'"
     message: "system-agent should be registered"
-  - expr: "${captured.agent_list} contains 'date'"
-    message: "date-a2a-agent should be registered (name carries 'date')"
+  - expr: "${captured.agent_list} contains 'date-a2a-agent'"
+    message: "date-a2a-agent should be registered (meshctl derives the name from the source filename)"
   - expr: "${captured.agent_list} contains 'date-consumer'"
     message: "consumer-date-agent should be registered as 'date-consumer'"
 
@@ -117,12 +117,16 @@ assertions:
   - expr: "${captured.agents_response} contains '\"current-date\"'"
     message: "consumer should publish the current-date capability"
 
-  # BOTH tags must appear: the user-supplied a2a-bridge AND the
-  # auto-injected consumer-name (date-consumer). These substrings are
-  # unique enough in the response to assert against directly.
-  - expr: "${captured.agents_response} contains '\"a2a-bridge\"'"
+  # BOTH tags must appear scoped to the current-date capability under
+  # the date-consumer agent. We use the ${jq:captured.X:filter} operator
+  # (see uc02 tc22 / uc12 tc09 for the established pattern) to extract
+  # exactly the current-date capability's tags array — looser substring
+  # asserts on the raw response can pass even if the consumer-name tag
+  # injection didn't fire, since "date-consumer" also appears as the
+  # agent's name field.
+  - expr: "${jq:captured.agents_response:[.agents[] | select(.name==\"date-consumer\") | .capabilities[]? | select(.name==\"current-date\") | .tags[]]} contains 'a2a-bridge'"
     message: "current-date capability should carry the user-supplied a2a-bridge tag"
-  - expr: "${captured.agents_response} contains '\"date-consumer\"'"
+  - expr: "${jq:captured.agents_response:[.agents[] | select(.name==\"date-consumer\") | .capabilities[]? | select(.name==\"current-date\") | .tags[]]} contains 'date-consumer'"
     message: "current-date capability should carry the auto-injected consumer-name tag"
 
   # Defensive: the sentinel literal MUST NOT leak into anything the

--- a/tests/integration/suites/uc25_a2a_consumer_python/tc01_capability_and_tag_registration/test.yaml
+++ b/tests/integration/suites/uc25_a2a_consumer_python/tc01_capability_and_tag_registration/test.yaml
@@ -1,0 +1,137 @@
+# tc01_capability_and_tag_registration — A2A consumer registration smoke (Phase 1).
+#
+# Verifies the @mesh.a2a_consumer decorator publishes its capability
+# through the regular @mesh.tool registration path (NOT the A2A
+# api_startup pipeline) AND that the consumer-name auto-tag injection
+# works end-to-end:
+#
+#   - The consumer agent appears in /agents with agent_type=mcp_agent
+#     (it is a regular mesh agent that bridges A2A — NOT an A2A
+#     producer; only date-a2a-agent has agent_type=a2a here).
+#   - The current-date capability lives under the consumer's
+#     tools[*].capabilities array.
+#   - That capability's tags carry BOTH "a2a-bridge" (user-supplied)
+#     AND "date-consumer" (auto-injected from the surrounding
+#     @mesh.agent name via the __MESH_CONSUMER_SELF__ sentinel
+#     substitution in _resolve_pending_consumer_self_tags).
+#   - The sentinel string itself MUST NOT leak into the registered
+#     metadata — the defensive scrub in
+#     pipeline/mcp_heartbeat/rust_heartbeat.py is the safety net for
+#     the substitution path.
+#
+# Stack: registry + system-agent (date_service on 9100) +
+# date-a2a-agent (A2A surface on 9090) + consumer-date-agent
+# (consumer on 9201). The consumer reaches the producer over
+# localhost:9090 because all four processes share the tsuite
+# container's network namespace.
+
+name: "A2A consumer: capability + auto-tag registration"
+description: "@mesh.a2a_consumer registers current-date with a2a-bridge AND auto-injected consumer-name tag"
+tags:
+  - a2a
+  - python
+  - smoke
+  - issue-908
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/system-agent /workspace/
+      cp -rL /uc-artifacts/date-a2a-agent /workspace/
+      cp -rL /uc-artifacts/consumer-date-agent /workspace/
+
+  - name: "Install system-agent deps"
+    handler: pip-install
+    path: /workspace/system-agent
+
+  - name: "Install date-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/date-a2a-agent
+
+  - name: "Install consumer-date-agent deps"
+    handler: pip-install
+    path: /workspace/consumer-date-agent
+
+  - routine: start_registry_consumer
+
+  - name: "Start system-agent (port 9100, provides date_service)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start system-agent/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for system-agent registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start date-a2a-agent (port 9090)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start date-a2a-agent/main.py -d
+
+  - name: "Wait for date_service DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Start consumer-date-agent (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-date-agent/main.py -d
+
+  - name: "Wait for consumer registration heartbeat"
+    handler: wait
+    seconds: 18
+
+  - name: "Verify all 3 agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "GET /agents on the registry"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_response
+    timeout: 15
+
+assertions:
+  - expr: "${captured.agent_list} contains 'system-agent'"
+    message: "system-agent should be registered"
+  - expr: "${captured.agent_list} contains 'date'"
+    message: "date-a2a-agent should be registered (name carries 'date')"
+  - expr: "${captured.agent_list} contains 'date-consumer'"
+    message: "consumer-date-agent should be registered as 'date-consumer'"
+
+  # The consumer is a REGULAR mesh agent (mcp_agent), not an A2A
+  # producer. The /agents response carries all three; the substring
+  # match below is sufficient because we already checked the names
+  # above and only one mcp_agent type is consumer-shaped.
+  - expr: "${captured.agents_response} contains '\"name\":\"date-consumer\"'"
+    message: "/agents response should include the consumer agent record"
+  - expr: "${captured.agents_response} contains '\"current-date\"'"
+    message: "consumer should publish the current-date capability"
+
+  # BOTH tags must appear: the user-supplied a2a-bridge AND the
+  # auto-injected consumer-name (date-consumer). These substrings are
+  # unique enough in the response to assert against directly.
+  - expr: "${captured.agents_response} contains '\"a2a-bridge\"'"
+    message: "current-date capability should carry the user-supplied a2a-bridge tag"
+  - expr: "${captured.agents_response} contains '\"date-consumer\"'"
+    message: "current-date capability should carry the auto-injected consumer-name tag"
+
+  # Defensive: the sentinel literal MUST NOT leak into anything the
+  # registry returned — substitution in
+  # _resolve_pending_consumer_self_tags + the heartbeat scrub
+  # together guarantee this.
+  - expr: "${captured.agents_response} not contains '__MESH_CONSUMER_SELF__'"
+    message: "consumer-self sentinel must never appear in the registry response"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc25_a2a_consumer_python/tc02_end_to_end_dispatch_via_caller/test.yaml
+++ b/tests/integration/suites/uc25_a2a_consumer_python/tc02_end_to_end_dispatch_via_caller/test.yaml
@@ -1,0 +1,136 @@
+# tc02_end_to_end_dispatch_via_caller — full bridge round-trip.
+#
+# A downstream mesh tool depending on the bridged current-date
+# capability actually reaches the producer through the consumer's
+# A2A tasks/send call.
+#
+# Call chain:
+#   meshctl call date-caller:get_formatted_date
+#     -> caller resolves current-date dependency to consumer
+#     -> consumer's @mesh.a2a_consumer body issues outbound
+#        POST http://localhost:9090/agents/date  (tasks/send)
+#     -> date-a2a-agent's mounted handler resolves date_service
+#     -> system-agent's date_service returns the current time
+#     -> bubble back: producer artifact -> consumer json.loads
+#        -> caller returns the {"date": ...} dict
+#
+# Stack: registry + system-agent + date-a2a-agent + consumer-date-agent
+# + caller-agent (5 processes total). Wait windows mirror uc24's
+# DI-resolution timing — the caller needs both the consumer's
+# heartbeat AND the resolver's downstream rewire to converge before
+# the call can succeed.
+
+name: "A2A consumer: end-to-end dispatch via downstream caller"
+description: "Caller -> consumer A2A bridge -> producer -> system-agent round-trip returns the date payload"
+tags:
+  - a2a
+  - python
+  - smoke
+  - issue-908
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/system-agent /workspace/
+      cp -rL /uc-artifacts/date-a2a-agent /workspace/
+      cp -rL /uc-artifacts/consumer-date-agent /workspace/
+      cp -rL /uc-artifacts/caller-agent /workspace/
+
+  - name: "Install system-agent deps"
+    handler: pip-install
+    path: /workspace/system-agent
+
+  - name: "Install date-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/date-a2a-agent
+
+  - name: "Install consumer-date-agent deps"
+    handler: pip-install
+    path: /workspace/consumer-date-agent
+
+  - name: "Install caller-agent deps"
+    handler: pip-install
+    path: /workspace/caller-agent
+
+  - routine: start_registry_consumer
+
+  - name: "Start system-agent (port 9100, provides date_service)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start system-agent/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for system-agent registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start date-a2a-agent (port 9090)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start date-a2a-agent/main.py -d
+
+  - name: "Wait for date_service DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Start consumer-date-agent (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-date-agent/main.py -d
+
+  - name: "Wait for consumer registration heartbeat"
+    handler: wait
+    seconds: 18
+
+  - name: "Start caller-agent (port 9203)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start caller-agent/main.py -d
+
+  - name: "Wait for caller current-date DI resolution"
+    handler: wait
+    seconds: 25
+
+  - name: "Verify all 4 agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Invoke caller's get_formatted_date tool"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date '{}' 2>&1
+    capture: caller_response
+    timeout: 30
+
+assertions:
+  - expr: "${captured.agent_list} contains 'system-agent'"
+    message: "system-agent should be registered"
+  - expr: "${captured.agent_list} contains 'date-consumer'"
+    message: "consumer-date-agent should be registered"
+  - expr: "${captured.agent_list} contains 'date-caller'"
+    message: "caller-agent should be registered"
+
+  # The producer's date_service returns a timestamp; the A2A handler
+  # wraps it as {"date": "<ts>"} which the consumer json.loads back
+  # to a dict — meshctl call surfaces that dict in its output. We
+  # match the bare word `date` (the JSON key) which only appears in
+  # the successful payload, never in error envelopes.
+  - expr: "${captured.caller_response} contains 'date'"
+    message: "caller response should carry the {date: ...} payload from the producer"
+
+  # Defensive: confirm we did NOT hit the "dependency not resolved"
+  # short-circuit branch in the caller — that would mean the
+  # current-date dependency never wired up.
+  - expr: "${captured.caller_response} not contains 'dependency not resolved'"
+    message: "current_date dependency must be resolved by the time the call lands"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc25_a2a_consumer_python/tc03_multi_consumer_failover/test.yaml
+++ b/tests/integration/suites/uc25_a2a_consumer_python/tc03_multi_consumer_failover/test.yaml
@@ -1,0 +1,243 @@
+# tc03_multi_consumer_failover — multi-consumer registration + failover.
+#
+# Two A2A consumers register the SAME current-date capability with
+# the SAME a2a-bridge tag, but under DIFFERENT @mesh.agent names
+# (date-consumer / date-consumer-alt). The auto-injected
+# consumer-name tag is what makes the two registrations
+# distinguishable for capability+tag pinning AND for the resolver's
+# untagged failover path.
+#
+# Validation strategy (two phases):
+#
+#   Phase A — pinned distinguishability:
+#     With both consumers up, the caller's tag-pinned tools each
+#     resolve to a SPECIFIC consumer (proven by the pinned
+#     dependency selector matching the auto-injected consumer-name
+#     tag — if the substitution didn't work, neither pinned tool
+#     would resolve and the caller would short-circuit with
+#     "dependency not resolved").
+#
+#   Phase B — auto-rewire on consumer death:
+#     Stop the primary consumer (date-consumer). After the
+#     fast-sweep registry marks it unhealthy
+#     (DEFAULT_TIMEOUT_THRESHOLD=15 + HEALTH_CHECK_INTERVAL=5 set
+#     in start_registry_consumer), the caller's UNTAGGED
+#     get_formatted_date dep auto-rewires to the surviving
+#     date-consumer-alt and the call still succeeds. The pinned-alt
+#     tool also still works (its dep was always wired to the
+#     surviving consumer); the pinned-primary tool is expected to
+#     fail — but we don't assert on that here to keep the test
+#     deterministic.
+#
+# Stack: registry + system-agent + date-a2a-agent + consumer-date-agent
+# + consumer-date-agent-b + caller-agent (6 processes).
+
+name: "A2A consumer: multi-consumer registration + auto-rewire failover"
+description: "Two consumers register current-date with distinct auto-tags; tag-pinning works AND untagged dep auto-rewires when one consumer dies"
+tags:
+  - a2a
+  - python
+  - smoke
+  - issue-908
+timeout: 240
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/system-agent /workspace/
+      cp -rL /uc-artifacts/date-a2a-agent /workspace/
+      cp -rL /uc-artifacts/consumer-date-agent /workspace/
+      cp -rL /uc-artifacts/consumer-date-agent-b /workspace/
+      cp -rL /uc-artifacts/caller-agent /workspace/
+
+  - name: "Install system-agent deps"
+    handler: pip-install
+    path: /workspace/system-agent
+
+  - name: "Install date-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/date-a2a-agent
+
+  - name: "Install consumer-date-agent deps"
+    handler: pip-install
+    path: /workspace/consumer-date-agent
+
+  - name: "Install consumer-date-agent-b deps"
+    handler: pip-install
+    path: /workspace/consumer-date-agent-b
+
+  - name: "Install caller-agent deps"
+    handler: pip-install
+    path: /workspace/caller-agent
+
+  - routine: start_registry_consumer
+
+  - name: "Start system-agent (port 9100, provides date_service)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start system-agent/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for system-agent registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start date-a2a-agent (port 9090)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start date-a2a-agent/main.py -d
+
+  - name: "Wait for date_service DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Start consumer-date-agent (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-date-agent/main.py -d
+
+  - name: "Start consumer-date-agent-b (port 9202)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-date-agent-b/main.py -d
+
+  - name: "Wait for both consumers to heartbeat-register"
+    handler: wait
+    seconds: 18
+
+  - name: "Start caller-agent (port 9203)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start caller-agent/main.py -d
+
+  - name: "Wait for caller pinned + untagged DI resolution"
+    handler: wait
+    seconds: 25
+
+  - name: "Verify all 5 agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "GET /agents on the registry"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_response_pre
+    timeout: 15
+
+  # ===== Phase A: pinned distinguishability =====
+
+  - name: "Phase A: invoke pinned-primary tool (must hit date-consumer)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date_primary '{}' 2>&1
+    capture: pinned_primary_pre
+    timeout: 30
+
+  - name: "Phase A: invoke pinned-alt tool (must hit date-consumer-alt)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date_alt '{}' 2>&1
+    capture: pinned_alt_pre
+    timeout: 30
+
+  - name: "Phase A: invoke untagged tool (any healthy consumer wins)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date '{}' 2>&1
+    capture: untagged_pre
+    timeout: 30
+
+  # ===== Phase B: kill primary consumer, verify failover =====
+
+  - name: "Phase B: stop date-consumer (primary)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl stop consumer-date-agent 2>&1 || true
+    ignore_errors: true
+
+  # DEFAULT_TIMEOUT_THRESHOLD=15 + HEALTH_CHECK_INTERVAL=5 means the
+  # registry marks a non-heartbeating agent unhealthy in ~15-20s; the
+  # caller then needs another heartbeat round to pull a fresh
+  # dependency state. Bump the wait to 35s so the rewire is
+  # comfortably converged before we re-poll.
+  - name: "Phase B: wait for fast-sweep to mark primary unhealthy + caller rewire"
+    handler: wait
+    seconds: 35
+
+  - name: "Phase B: invoke pinned-alt tool again (should still succeed — its dep never moved)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date_alt '{}' 2>&1
+    capture: pinned_alt_post
+    timeout: 30
+
+  - name: "Phase B: invoke untagged tool again (auto-rewire to surviving date-consumer-alt)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date '{}' 2>&1
+    capture: untagged_post
+    timeout: 30
+
+assertions:
+  # ===== Setup sanity =====
+  - expr: "${captured.agent_list} contains 'date-consumer'"
+    message: "primary consumer should be registered"
+  - expr: "${captured.agent_list} contains 'date-consumer-alt'"
+    message: "alt consumer should be registered"
+  - expr: "${captured.agent_list} contains 'date-caller'"
+    message: "caller agent should be registered"
+
+  # Both auto-injected tags must be present in the registry response
+  # (proves the consumer-name self-tag substitution ran on BOTH
+  # consumers under different agent names).
+  - expr: "${captured.agents_response_pre} contains '\"date-consumer\"'"
+    message: "primary consumer-name tag should appear on its current-date capability"
+  - expr: "${captured.agents_response_pre} contains '\"date-consumer-alt\"'"
+    message: "alt consumer-name tag should appear on its current-date capability"
+  - expr: "${captured.agents_response_pre} not contains '__MESH_CONSUMER_SELF__'"
+    message: "consumer-self sentinel must never appear in the registry response"
+
+  # ===== Phase A: pinned distinguishability =====
+  # Each pinned tool returns the date payload — proves the
+  # consumer-name auto-tag actually let the resolver pick the
+  # specific bound consumer, not just any current-date provider.
+  - expr: "${captured.pinned_primary_pre} contains 'date'"
+    message: "pinned-primary tool should resolve to date-consumer and return the date payload"
+  - expr: "${captured.pinned_primary_pre} not contains 'dependency not resolved'"
+    message: "pinned-primary dependency must wire up before the call"
+  - expr: "${captured.pinned_alt_pre} contains 'date'"
+    message: "pinned-alt tool should resolve to date-consumer-alt and return the date payload"
+  - expr: "${captured.pinned_alt_pre} not contains 'dependency not resolved'"
+    message: "pinned-alt dependency must wire up before the call"
+  - expr: "${captured.untagged_pre} contains 'date'"
+    message: "untagged tool should resolve to either consumer and return the date payload"
+  - expr: "${captured.untagged_pre} not contains 'dependency not resolved'"
+    message: "untagged dependency must wire up before the call"
+
+  # ===== Phase B: failover =====
+  # Pinned-alt's dep was always wired to the surviving consumer, so
+  # it MUST still work post-kill — this isolates "did the surviving
+  # consumer keep functioning" from "did the resolver rewire".
+  - expr: "${captured.pinned_alt_post} contains 'date'"
+    message: "pinned-alt tool should still succeed after primary consumer is killed"
+  - expr: "${captured.pinned_alt_post} not contains 'dependency not resolved'"
+    message: "pinned-alt dep should remain wired after primary consumer death"
+
+  # The untagged tool USED to potentially go to either consumer; after
+  # primary dies, it must rewire to the survivor. This is the
+  # auto-rewire / failover path.
+  - expr: "${captured.untagged_post} contains 'date'"
+    message: "untagged tool should auto-rewire to the surviving consumer after primary death"
+  - expr: "${captured.untagged_post} not contains 'dependency not resolved'"
+    message: "untagged dep should auto-rewire (not orphan) when primary consumer dies"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

Phase 1 of the A2A consumer side. Mirror of `@mesh.llm_provider` but geared for the open-ended A2A universe — every backend is bespoke, so we expose a primitive (`A2AClient`) + decorator (`@mesh.a2a_consumer`) and let users wire the I/O mapping rather than ship per-vendor handlers.

The decorator wraps a function as a regular `@mesh.tool` capability whose body issues a synchronous `tasks/send` to an external A2A v1.0 endpoint and returns the parsed artifact text. It auto-injects the surrounding `@mesh.agent` name as a tag (deferred resolution via the `__MESH_CONSUMER_SELF__` sentinel substituted at `@mesh.agent` registration time, so decoration order is flexible) and binds an `A2AClient` instance into the user function as the `_a2a` kwarg when present.

The capability+tag failover that mesh already provides for any `@mesh.tool` now applies to A2A backends — multiple consumer agents bridging the same logical capability are distinguishable by their auto-injected consumer-name tag, enabling tag-pinning and auto-rewire on consumer death. **Federation across A2A providers without changes to the protocol itself.**

### Phase 1 scope (sync only)

- `@mesh.a2a_consumer` decorator with sentinel-based `consumer_name` substitution hook
- `A2AClient` (sync `tasks/send` + poll-until-terminal)
- `A2ABearer` auth helper (env-var-backed)
- `A2AResponse` dataclass
- Defensive sentinel scrub at heartbeat-publish time (warns if no `@mesh.agent` is found)
- Eat-our-own-dogfood example: `examples/a2a/consumer_date_agent.py` bridges `examples/a2a/date_a2a_agent.py`'s `get-date` skill into mesh capability `current-date`
- `uc25_a2a_consumer_python` integration suite (3/3 PASS at parallel 4):
  - tc01: capability + tag registration (sentinel substituted to consumer-name)
  - tc02: end-to-end dispatch via downstream caller
  - tc03: multi-consumer failover (tag-pinning + auto-rewire)

Long-running submit/subscribe + scaffolding deferred to #909, #910.

## Review Notes

Independent review-agent pass found 0 BLOCKER, 6 WARNING, 4 INFO. Four trivial hardening fixes shipped in the second commit (`b0b36e91`):

- Reject the `__MESH_CONSUMER_SELF__` literal as a user-supplied tag
- Reject double-application of `@mesh.a2a_consumer` on the same function
- Switch task_id from `time.time()*1000 + 3-byte random` to `uuid.uuid4().hex`
- Honor `timeout_default` in the underlying `httpx.AsyncClient` socket timeout

Architectural hardening deferred to #912: event-loop binding (per-loop httpx client dict), `aclose()` lifecycle wiring, multi-`@mesh.agent`-per-process diagnostic, silent revive after `aclose()`.

Closes #908

## Test plan

- [x] Manual smoke test — 5/5 goals pass (registry binary rebuilt, import OK, capability+tags right, MCP call returns date, fail-fast on producer kill)
- [x] `uc25_a2a_consumer_python` integration suite — 3/3 PASS at parallel 1
- [x] `uc25_a2a_consumer_python` integration suite — 3/3 PASS at parallel 4 (no flake)
- [x] `tests/src-tests` rebuild green (377s, 12/12 PASS) so the wheel baked into `tsuite-mesh:local` includes all changes
- [x] All 4 hardening fixes verified individually post-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added A2A consumer bridge functionality to expose external A2A services as mesh capabilities with automatic consumer-name tagging
  * Added support for multi-consumer failover scenarios with pinned capability resolution
  * Included example consumer bridge agent demonstrating integration with upstream A2A endpoints

* **Tests**
  * Added comprehensive integration test suite covering capability registration, end-to-end dispatch, and multi-consumer failover scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/913)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->