### PR TITLE
fix(a2a): consumer hardening — loop binding, lifecycle, multi-agent diag (#912)

### DIFF
--- a/src/runtime/python/mesh/_a2a_consumer.py
+++ b/src/runtime/python/mesh/_a2a_consumer.py
@@ -175,6 +175,10 @@ class A2AClient:
         # Drop the old reference and let GC handle it — closing an
         # AsyncClient from a different loop than its origin is undefined
         # behavior in httpx.
+        # Fork-after-import caveat: this swap is steady-state safe but does NOT
+        # protect coroutines mid-call holding the previous client when the loop
+        # transitions (e.g., os.fork after import). Drain in-flight work before
+        # forking, or use a per-process A2AClient instance.
         self._client = httpx.AsyncClient(timeout=httpx.Timeout(self.timeout_default))
         self._client_loop = loop
         return self._client
@@ -763,15 +767,19 @@ def _parse_sse_envelope(envelope: dict[str, Any], task_id: str) -> Optional[A2AE
 
 
 def _stream_finalizer(response_ref: "weakref.ref", task_id: str) -> None:
-    """Best-effort sync cleanup when an A2AStream is GC'd without explicit aclose.
-
-    httpx.Response carries a sync ``.close()`` that releases the connection
-    pool entry. We can't await ``aclose()`` from a finalizer (no event loop
-    is guaranteed during GC, and finalizers may run during interpreter
-    shutdown), so sync close is the best we can do. Emit a WARNING so the
-    user knows their stream lifecycle is wrong — under load this kind of
-    leak silently exhausts the httpx connection pool.
+    """Best-effort sync cleanup when an A2AStream is GC'd without
+    explicit aclose(). Warning fires unconditionally so the user sees
+    the leak even if the response was already collected. Sync close is
+    best-effort — ``httpx.Response.close()`` on an async-transport
+    response running from a finalizer (possibly on a torn-down loop)
+    may no-op rather than fully drain the async connection pool.
     """
+    logger.warning(
+        "A2AStream for task=%s was garbage-collected without explicit aclose(). "
+        "Use 'async with stream:' or 'await stream.aclose()' to release the "
+        "connection cleanly. Best-effort sync close attempted.",
+        task_id,
+    )
     response = response_ref()
     if response is None:
         return
@@ -779,12 +787,6 @@ def _stream_finalizer(response_ref: "weakref.ref", task_id: str) -> None:
         response.close()
     except Exception:
         pass
-    logger.warning(
-        "A2AStream for task=%s was garbage-collected without explicit aclose(). "
-        "Use 'async with stream:' or 'await stream.aclose()' to release the "
-        "connection cleanly. Best-effort sync close was performed.",
-        task_id,
-    )
 
 
 class A2AStream:

--- a/src/runtime/python/mesh/_a2a_consumer.py
+++ b/src/runtime/python/mesh/_a2a_consumer.py
@@ -25,11 +25,14 @@ typical ``task=True`` consumer pattern.
 from __future__ import annotations
 
 import asyncio
+import atexit
 import json
 import logging
 import os
+import threading
 import time
 import uuid
+import weakref
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Optional, TYPE_CHECKING
 
@@ -39,6 +42,42 @@ if TYPE_CHECKING:
     from .types import MeshJob
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Active A2AClient tracking — atexit drain (mirrors simple_shutdown.py pattern
+# for Rust agent handles). httpx.AsyncClient bound to a torn-down loop emits
+# noisy "Unclosed client" warnings at GC. We mark every live client closed at
+# interpreter exit so any in-flight user code raises cleanly; httpx's own GC
+# + the OS reclaim the actual sockets. No async aclose() in the atexit hook —
+# interpreter is finalizing and there's no guaranteed loop to await on.
+# ---------------------------------------------------------------------------
+_ACTIVE_CLIENTS: "weakref.WeakSet[A2AClient]" = weakref.WeakSet()
+_ATEXIT_LOCK = threading.Lock()
+_ATEXIT_HOOK_REGISTERED = False
+
+
+def _register_active_client(client: "A2AClient") -> None:
+    global _ATEXIT_HOOK_REGISTERED
+    with _ATEXIT_LOCK:
+        _ACTIVE_CLIENTS.add(client)
+        if not _ATEXIT_HOOK_REGISTERED:
+            atexit.register(_atexit_close_active_clients)
+            _ATEXIT_HOOK_REGISTERED = True
+
+
+def _atexit_close_active_clients() -> None:
+    """At interpreter exit: mark every living A2AClient closed so any
+    in-flight user code raises cleanly. We don't await aclose() here —
+    interpreter is finalizing and there's no guaranteed event loop to
+    drive the async close. httpx's own GC + the OS reclaim the sockets;
+    the explicit close-flag prevents post-finalize use of cached state.
+    """
+    for client in list(_ACTIVE_CLIENTS):
+        try:
+            client._closed = True
+        except Exception:
+            pass
 
 
 @dataclass
@@ -114,10 +153,30 @@ class A2AClient:
         self.poll_interval = poll_interval
         self.poll_interval_max = poll_interval_max
         self._client: Optional[httpx.AsyncClient] = None
+        self._client_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._closed: bool = False
+        _register_active_client(self)
 
     async def _http(self) -> httpx.AsyncClient:
-        if self._client is None or self._client.is_closed:
-            self._client = httpx.AsyncClient(timeout=httpx.Timeout(self.timeout_default))
+        if self._closed:
+            raise RuntimeError(
+                f"A2AClient(url={self.url!r}) is closed. "
+                "Create a new instance instead of reusing a closed one."
+            )
+        loop = asyncio.get_running_loop()
+        if (
+            self._client is not None
+            and self._client_loop is loop
+            and not self._client.is_closed
+        ):
+            return self._client
+        # Loop mismatch (fork-after-import, pytest-asyncio new-loop-per-test,
+        # or any other multi-loop scenario) OR no client yet OR client closed.
+        # Drop the old reference and let GC handle it — closing an
+        # AsyncClient from a different loop than its origin is undefined
+        # behavior in httpx.
+        self._client = httpx.AsyncClient(timeout=httpx.Timeout(self.timeout_default))
+        self._client_loop = loop
         return self._client
 
     def _headers(self) -> dict[str, str]:
@@ -316,8 +375,17 @@ class A2AClient:
         return A2AStream(response=response, task_id=task_id, _cm=cm)
 
     async def aclose(self) -> None:
+        self._closed = True
         if self._client and not self._client.is_closed:
-            await self._client.aclose()
+            try:
+                await self._client.aclose()
+            except Exception:
+                # Best-effort: a loop-mismatched close (e.g. pytest-asyncio
+                # tearing down a previous loop) can raise; the client is
+                # marked closed regardless so subsequent _http() raises.
+                pass
+        self._client = None
+        self._client_loop = None
 
 
 # ---------------------------------------------------------------------------
@@ -694,6 +762,31 @@ def _parse_sse_envelope(envelope: dict[str, Any], task_id: str) -> Optional[A2AE
     return None
 
 
+def _stream_finalizer(response_ref: "weakref.ref", task_id: str) -> None:
+    """Best-effort sync cleanup when an A2AStream is GC'd without explicit aclose.
+
+    httpx.Response carries a sync ``.close()`` that releases the connection
+    pool entry. We can't await ``aclose()`` from a finalizer (no event loop
+    is guaranteed during GC, and finalizers may run during interpreter
+    shutdown), so sync close is the best we can do. Emit a WARNING so the
+    user knows their stream lifecycle is wrong — under load this kind of
+    leak silently exhausts the httpx connection pool.
+    """
+    response = response_ref()
+    if response is None:
+        return
+    try:
+        response.close()
+    except Exception:
+        pass
+    logger.warning(
+        "A2AStream for task=%s was garbage-collected without explicit aclose(). "
+        "Use 'async with stream:' or 'await stream.aclose()' to release the "
+        "connection cleanly. Best-effort sync close was performed.",
+        task_id,
+    )
+
+
 class A2AStream:
     """Async iterator over parsed A2A SSE events.
 
@@ -719,6 +812,18 @@ class A2AStream:
         self._cm = _cm
         self._line_iter: Optional[AsyncIterator[str]] = None
         self._closed = False
+        # weakref.finalize fires when self is GC'd. Holding a weakref to the
+        # response (rather than the response directly) keeps the finalizer
+        # from extending the lifetime of self. aclose() detaches the
+        # finalizer on the explicit-close path so the leak warning only
+        # fires when the caller dropped the stream without iterating to
+        # completion or awaiting aclose.
+        self._finalizer = weakref.finalize(
+            self,
+            _stream_finalizer,
+            weakref.ref(response),
+            task_id,
+        )
 
     def __aiter__(self) -> "A2AStream":
         return self
@@ -804,6 +909,9 @@ class A2AStream:
         if self._closed:
             return
         self._closed = True
+        # Explicit close — detach the finalizer so the leak warning is
+        # suppressed for the well-behaved path.
+        self._finalizer.detach()
         if self._cm is not None:
             try:
                 await self._cm.__aexit__(None, None, None)

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -2270,11 +2270,12 @@ def _resolve_pending_consumer_self_tags(agent_name: str) -> None:
         if getattr(fn, "_mesh_a2a_consumer_pending_self_tag", False):
             pending.append(decorated)
             continue
-        consumer_meta = getattr(fn, "_mesh_a2a_consumer_metadata", None)
-        if isinstance(consumer_meta, dict):
-            cn = consumer_meta.get("consumer_name")
-            if cn and cn != _MESH_CONSUMER_SELF_SENTINEL:
-                already_resolved = True
+        # Use the explicit self-resolved marker rather than inferring from
+        # consumer_name, so a future explicit ``consumer_name=`` kwarg on
+        # @mesh.a2a_consumer (escape hatch for users who don't want the
+        # auto self-tag) doesn't false-fire the multi-agent warning.
+        if getattr(fn, "_mesh_a2a_consumer_self_resolved", False):
+            already_resolved = True
 
     if not pending:
         if already_resolved:
@@ -2312,6 +2313,10 @@ def _resolve_pending_consumer_self_tags(agent_name: str) -> None:
 
         try:
             fn._mesh_a2a_consumer_pending_self_tag = False
+            # Mark explicitly so future code can distinguish self-resolved
+            # (sentinel-substituted by this @mesh.agent) from explicit
+            # ``consumer_name=`` kwargs on @mesh.a2a_consumer.
+            fn._mesh_a2a_consumer_self_resolved = True
         except (AttributeError, TypeError):
             pass
 

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -2246,6 +2246,13 @@ def _resolve_pending_consumer_self_tags(agent_name: str) -> None:
     ``_mesh_a2a_consumer_metadata``) AND the registry's stored copy,
     because ``DecoratorRegistry.register_mesh_tool`` snapshots metadata
     via ``.copy()`` at decoration time.
+
+    Multi-``@mesh.agent`` diagnostic: if a second @mesh.agent runs in the
+    same process after a first has already resolved all consumer self-tags,
+    no pending tools remain and the substitution is a silent no-op. The
+    first @mesh.agent's name "wins" and binds to all consumer tools. Emit
+    a clear WARNING so users notice the implicit binding rather than
+    debugging by archaeology.
     """
     if not agent_name:
         return
@@ -2256,10 +2263,34 @@ def _resolve_pending_consumer_self_tags(agent_name: str) -> None:
                 tag_list[i] = agent_name
 
     registry_tools = DecoratorRegistry.get_mesh_tools()
+    pending: list[Any] = []
+    already_resolved = False
     for decorated in registry_tools.values():
         fn = decorated.function
-        if not getattr(fn, "_mesh_a2a_consumer_pending_self_tag", False):
+        if getattr(fn, "_mesh_a2a_consumer_pending_self_tag", False):
+            pending.append(decorated)
             continue
+        consumer_meta = getattr(fn, "_mesh_a2a_consumer_metadata", None)
+        if isinstance(consumer_meta, dict):
+            cn = consumer_meta.get("consumer_name")
+            if cn and cn != _MESH_CONSUMER_SELF_SENTINEL:
+                already_resolved = True
+
+    if not pending:
+        if already_resolved:
+            logger.warning(
+                "@mesh.agent(%r): consumer-name self-tag substitution found 0 pending "
+                "tools, but one or more @mesh.a2a_consumer tools have already been "
+                "resolved by a prior @mesh.agent in this process. The first @mesh.agent "
+                "wins and binds its name to all consumer tools. If multiple @mesh.agent "
+                "declarations are intentional, document which one owns each consumer "
+                "explicitly via consumer-name tags.",
+                agent_name,
+            )
+        return
+
+    for decorated in pending:
+        fn = decorated.function
 
         fn_meta = getattr(fn, "_mesh_tool_metadata", None)
         if isinstance(fn_meta, dict):

--- a/src/runtime/python/tests/unit/test_a2a_consumer_hardening.py
+++ b/src/runtime/python/tests/unit/test_a2a_consumer_hardening.py
@@ -222,6 +222,13 @@ def _register_consumer_tool(
 
     _fn.__name__ = name
     _fn._mesh_a2a_consumer_pending_self_tag = pending
+    # Simulate the marker stamped by _resolve_pending_consumer_self_tags when
+    # a prior @mesh.agent has already substituted the sentinel for this tool.
+    _fn._mesh_a2a_consumer_self_resolved = (
+        not pending
+        and bool(consumer_name)
+        and consumer_name != _MESH_CONSUMER_SELF_SENTINEL
+    )
     _fn._mesh_a2a_consumer_metadata = {
         "consumer_name": consumer_name,
         "tags": [consumer_name] if consumer_name else [],
@@ -293,6 +300,7 @@ def test_resolve_pending_does_substitute_when_pending(_clean_tools, caplog):
         == ["agent-1"]
     )
     assert fn._mesh_a2a_consumer_pending_self_tag is False
+    assert fn._mesh_a2a_consumer_self_resolved is True
     assert not any(
         "first @mesh.agent wins" in r.getMessage() for r in caplog.records
     )

--- a/src/runtime/python/tests/unit/test_a2a_consumer_hardening.py
+++ b/src/runtime/python/tests/unit/test_a2a_consumer_hardening.py
@@ -1,0 +1,308 @@
+"""Unit tests for the A2A consumer hardening fixes (issue #912).
+
+Covers the five follow-ups deferred from PR #913 + PR #914 reviews:
+
+    1. ``A2AClient._http`` per-loop client tracking (fork / new-loop safety).
+    2. Multi-``@mesh.agent`` diagnostic warning in
+       ``_resolve_pending_consumer_self_tags``.
+    3. Use-after-close raises ``RuntimeError`` from ``A2AClient._http``.
+    4. atexit hook flips ``_closed`` on every living A2AClient.
+    5. ``A2AStream`` GC without explicit aclose triggers a leak warning
+       via ``weakref.finalize``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import logging
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+import mesh
+from _mcp_mesh.engine.decorator_registry import DecoratedFunction, DecoratorRegistry
+from mesh._a2a_consumer import (
+    _ACTIVE_CLIENTS,
+    _atexit_close_active_clients,
+    A2AClient,
+    A2AStream,
+)
+from mesh.decorators import (
+    _MESH_CONSUMER_SELF_SENTINEL,
+    _resolve_pending_consumer_self_tags,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — per-loop httpx.AsyncClient caching
+# ---------------------------------------------------------------------------
+
+
+def test_a2a_client_per_loop_isolation():
+    """A new loop sees a fresh httpx.AsyncClient instance — the cached
+    one from a previous (closed) loop must NOT be reused."""
+    client = A2AClient(url="http://localhost", skill_id="x", timeout_default=5)
+
+    async def grab():
+        return await client._http()
+
+    loop_a = asyncio.new_event_loop()
+    loop_b = asyncio.new_event_loop()
+    try:
+        http_a = loop_a.run_until_complete(grab())
+        http_b = loop_b.run_until_complete(grab())
+    finally:
+        loop_a.close()
+        loop_b.close()
+
+    assert http_a is not http_b, (
+        "Per-loop tracking should produce distinct AsyncClient instances "
+        "across event loops"
+    )
+
+
+def test_a2a_client_same_loop_reuses_client():
+    """Within a single loop, repeated _http() calls share the same client."""
+    client = A2AClient(url="http://localhost", skill_id="x", timeout_default=5)
+
+    async def go():
+        c1 = await client._http()
+        c2 = await client._http()
+        return c1, c2
+
+    loop = asyncio.new_event_loop()
+    try:
+        c1, c2 = loop.run_until_complete(go())
+    finally:
+        loop.close()
+
+    assert c1 is c2
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — use-after-close raises
+# ---------------------------------------------------------------------------
+
+
+def test_a2a_client_raises_after_aclose():
+    """``_http()`` after ``aclose()`` must raise RuntimeError to surface
+    the lifecycle bug rather than silently rebuilding state."""
+    client = A2AClient(url="http://localhost", skill_id="x")
+
+    async def go():
+        await client._http()
+        await client.aclose()
+        with pytest.raises(RuntimeError, match="closed"):
+            await client._http()
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(go())
+    finally:
+        loop.close()
+
+
+def test_a2a_client_aclose_idempotent():
+    """``aclose()`` called twice does not raise."""
+    client = A2AClient(url="http://localhost", skill_id="x")
+
+    async def go():
+        await client._http()
+        await client.aclose()
+        await client.aclose()
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(go())
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Fix 4 — atexit hook marks live clients closed
+# ---------------------------------------------------------------------------
+
+
+def test_atexit_hook_flips_closed_flag_on_live_clients():
+    """Simulating the atexit drain marks every tracked client closed."""
+    client = A2AClient(url="http://localhost", skill_id="x")
+    assert client in _ACTIVE_CLIENTS
+    assert client._closed is False
+
+    _atexit_close_active_clients()
+
+    assert client._closed is True
+
+
+# ---------------------------------------------------------------------------
+# Fix 5 — A2AStream weakref.finalize warns on leak
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal httpx.Response stand-in for finalizer tests — only
+    ``close()`` is exercised."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_a2a_stream_gc_without_aclose_warns(caplog):
+    """Dropping a stream without aclose triggers the leak warning AND
+    invokes sync close on the underlying response."""
+    response = _FakeResponse()
+    with caplog.at_level(logging.WARNING, logger="mesh._a2a_consumer"):
+        stream = A2AStream(response=response, task_id="t-leak")
+        del stream
+        gc.collect()
+
+    assert response.closed, "finalizer should sync-close the response"
+    assert any(
+        "garbage-collected without explicit aclose" in r.getMessage()
+        for r in caplog.records
+    ), "expected leak warning, got: " + repr([r.getMessage() for r in caplog.records])
+
+
+def test_a2a_stream_explicit_aclose_suppresses_warning(caplog):
+    """Explicit ``aclose()`` detaches the finalizer — no warning fires
+    when the stream is later GC'd."""
+    response = _FakeResponse()
+
+    async def go():
+        stream = A2AStream(response=response, task_id="t-clean")
+        await stream.aclose()
+        return stream
+
+    loop = asyncio.new_event_loop()
+    try:
+        with caplog.at_level(logging.WARNING, logger="mesh._a2a_consumer"):
+            stream = loop.run_until_complete(go())
+            del stream
+            gc.collect()
+    finally:
+        loop.close()
+
+    assert not any(
+        "garbage-collected without explicit aclose" in r.getMessage()
+        for r in caplog.records
+    ), "explicit aclose() should suppress the leak warning"
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — multi-@mesh.agent diagnostic warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _clean_tools():
+    """Snapshot + restore the mesh-tools registry around the test so
+    the in-process global state doesn't leak."""
+    snapshot = DecoratorRegistry._mesh_tools.copy()
+    DecoratorRegistry._mesh_tools.clear()
+    yield
+    DecoratorRegistry._mesh_tools.clear()
+    DecoratorRegistry._mesh_tools.update(snapshot)
+
+
+def _register_consumer_tool(
+    *, name: str, pending: bool, consumer_name: str
+) -> None:
+    """Helper: register a fake @mesh.a2a_consumer-shaped tool in the
+    DecoratorRegistry. ``pending`` controls whether the resolution flag
+    is set (True = waiting for @mesh.agent), ``consumer_name`` controls
+    the resolved consumer-name field on the consumer metadata dict."""
+
+    def _fn() -> None:
+        pass
+
+    _fn.__name__ = name
+    _fn._mesh_a2a_consumer_pending_self_tag = pending
+    _fn._mesh_a2a_consumer_metadata = {
+        "consumer_name": consumer_name,
+        "tags": [consumer_name] if consumer_name else [],
+    }
+    _fn._mesh_tool_metadata = {
+        "tags": [consumer_name] if consumer_name else [],
+    }
+
+    DecoratorRegistry._mesh_tools[name] = DecoratedFunction(
+        decorator_type="mesh_tool",
+        function=_fn,
+        metadata={"tags": [consumer_name] if consumer_name else []},
+        registered_at=datetime.now(),
+    )
+
+
+def test_resolve_pending_warns_when_zero_pending_and_already_resolved(
+    _clean_tools, caplog
+):
+    """Second @mesh.agent in the same process logs a clear warning when
+    no pending tools remain but a prior resolution stamped a real name."""
+    _register_consumer_tool(
+        name="tool_already_resolved", pending=False, consumer_name="agent-1"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="mesh.decorators"):
+        _resolve_pending_consumer_self_tags("agent-2")
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("agent-2" in m and "first @mesh.agent wins" in m for m in msgs), (
+        "expected multi-agent warning, got: " + repr(msgs)
+    )
+
+
+def test_resolve_pending_silent_when_no_consumers_at_all(_clean_tools, caplog):
+    """No pending and no resolved consumers — no warning, no error."""
+    with caplog.at_level(logging.WARNING, logger="mesh.decorators"):
+        _resolve_pending_consumer_self_tags("agent-x")
+
+    assert not any(
+        "first @mesh.agent wins" in r.getMessage() for r in caplog.records
+    )
+
+
+def test_resolve_pending_does_substitute_when_pending(_clean_tools, caplog):
+    """A pending tool gets the sentinel swapped for the agent name AND
+    no diagnostic warning fires."""
+    _register_consumer_tool(
+        name="tool_pending",
+        pending=True,
+        consumer_name=_MESH_CONSUMER_SELF_SENTINEL,
+    )
+    # Re-stamp the tag list with the sentinel so the swap is observable.
+    fn = DecoratorRegistry._mesh_tools["tool_pending"].function
+    fn._mesh_a2a_consumer_metadata["tags"] = [_MESH_CONSUMER_SELF_SENTINEL]
+    fn._mesh_tool_metadata["tags"] = [_MESH_CONSUMER_SELF_SENTINEL]
+    DecoratorRegistry._mesh_tools["tool_pending"].metadata["tags"] = [
+        _MESH_CONSUMER_SELF_SENTINEL
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="mesh.decorators"):
+        _resolve_pending_consumer_self_tags("agent-1")
+
+    assert fn._mesh_a2a_consumer_metadata["consumer_name"] == "agent-1"
+    assert fn._mesh_a2a_consumer_metadata["tags"] == ["agent-1"]
+    assert fn._mesh_tool_metadata["tags"] == ["agent-1"]
+    assert (
+        DecoratorRegistry._mesh_tools["tool_pending"].metadata["tags"]
+        == ["agent-1"]
+    )
+    assert fn._mesh_a2a_consumer_pending_self_tag is False
+    assert not any(
+        "first @mesh.agent wins" in r.getMessage() for r in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# Smoke — public re-exports still resolve
+# ---------------------------------------------------------------------------
+
+
+def test_public_reexports_resolve():
+    assert mesh.A2AClient is A2AClient
+    assert mesh.A2AStream is A2AStream


### PR DESCRIPTION
## Summary

Five A2A consumer hardening fixes deferred from PR #913 (Phase 1) and PR #914 (Phase 3) reviews. All in issue #912.

### 1. `A2AClient` per-loop httpx client tracking
`httpx.AsyncClient` binds to the loop that first instantiated it. Failed in: multiprocessing fork-after-import, pytest-asyncio with new-loop-per-test, any cross-loop reuse. Fix: track `(client, loop)` together; on `_http()` if running loop differs, create fresh client. Old client abandoned to GC (closing across loops is undefined behavior in httpx).

### 2. Multi-`@mesh.agent`-per-process diagnostic warning
`_resolve_pending_consumer_self_tags` previously silently no-oped on the second `@mesh.agent` (first agent flips all pending flags to False). Now does a two-phase walk that detects "0 pending AND others already resolved" via a defensive `_mesh_a2a_consumer_self_resolved` marker, and logs a clear warning. Existing "first wins" semantic preserved — purely diagnostic.

### 3. `A2AClient` raises on use-after-close
`_http()` now raises `RuntimeError` when `_closed=True` (replaces silent revive that would spin up a fresh httpx client on demand).

### 4. atexit drain wired (mirrors `simple_shutdown.py` pattern)
Module-level `weakref.WeakSet` of active clients + lazy-registered atexit hook that flips `_closed=True` on each living client at interpreter exit. Does NOT attempt async `aclose()` — interpreter is finalizing, httpx GC + the OS reclaim sockets, the flag prevents post-finalize use of cached state.

### 5. `A2AStream` `weakref.finalize` for caller-dropped streams
Defense-in-depth for caller-dropped-without-aclose. Best-effort sync `response.close()` + warning log fires UNCONDITIONALLY using `task_id` (held strongly), so the leak warning surfaces even if the response was GC'd before/with the stream. Explicit `aclose()` detaches the finalizer.

## Review Notes

Independent review-agent pass found **0 BLOCKER, 4 WARNING, 2 INFO**. All 4 warnings + 0 of 2 infos applied as a follow-up commit (`d239c148`):

- `_stream_finalizer` now logs the leak warning UNCONDITIONALLY (was: silently suppressed if response already collected).
- Tightened the finalizer docstring to "best-effort sync close attempted" rather than overstating that it "releases the connection pool entry" — async-transport pool cleanup may need a live loop.
- `_resolve_pending_consumer_self_tags` now stamps `_mesh_a2a_consumer_self_resolved=True` and the multi-agent diagnostic walk checks for this marker. Future-proofs against a hypothetical explicit `consumer_name=` kwarg on `@mesh.a2a_consumer` (which would have made the inferred non-sentinel heuristic false-positive).
- Inline comment in `_http()` noting fork-after-import constraint.

INFO findings deferred (atexit DEBUG log level + test isolation monkeypatch) — both cosmetic.

Closes #912

## Test plan

- [x] 11 new focused unit tests in `test_a2a_consumer_hardening.py` cover each fix individually
- [x] 881/881 unit tests PASS (was 870 pre-PR; +11 from new module)
- [x] 11/11 `test_a2a_consumer_hardening.py` PASS in 0.09s
- [x] 12/12 src-tests PASS (image rebuild — both initial commit and after review fixes)
- [x] **7/7 uc25 at parallel 4 PASS — no regression on the existing suite** (both runs)
- [x] Smoke import: `mesh.A2AClient`, `mesh.A2AStream` resolve cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated spurious unclosed resource warnings during interpreter shutdown
  * Prevented event loop misuse errors by detecting and recreating clients when loops change
  * Added deterministic multi-agent decorator resolution with diagnostic warnings when conflicts are detected
  * Improved graceful error handling when attempting to use closed resources
  * Added automatic resource cleanup for streaming operations through garbage collection

* **Tests**
  * Comprehensive test coverage for resource lifecycle, event loop handling, and multi-agent scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/915)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->