### PR TITLE
feat(a2a): Java A2A consumer Phase 1 — sync send + auto-tag (#916)

### DIFF
--- a/examples/java/consumer-date-agent/pom.xml
+++ b/examples/java/consumer-date-agent/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  A2A consumer example (issue #916 Phase 1) — bridges the existing
+  ``examples/a2a/date_a2a_agent.py`` ``get-date`` skill into the mesh
+  as a regular ``current-date`` capability. Java port of
+  ``examples/a2a/consumer_date_agent.py``.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>consumer-date-agent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>A2A Consumer Date Agent (Java)</name>
+    <description>Java A2A consumer bridge — wraps the date_a2a_agent.py producer as a mesh current-date capability.</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.dateconsumer.DateConsumerAgentApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/java/consumer-date-agent/src/main/java/com/example/dateconsumer/DateConsumerAgentApplication.java
+++ b/examples/java/consumer-date-agent/src/main/java/com/example/dateconsumer/DateConsumerAgentApplication.java
@@ -5,6 +5,7 @@ import io.mcpmesh.MeshTool;
 import io.mcpmesh.a2a.A2AClient;
 import io.mcpmesh.a2a.A2AConsumer;
 import io.mcpmesh.a2a.A2AResponse;
+import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -108,5 +109,16 @@ public class DateConsumerAgentApplication {
         @SuppressWarnings("unchecked")
         Map<String, Object> payload = JSON.readValue(response.artifactText(), Map.class);
         return payload;
+    }
+
+    // On JDK 17 close() is cosmetic (see A2AClient Javadoc); JDK 21+ honors the AutoCloseable contract. Demonstrates proper lifecycle hygiene either way.
+    @PreDestroy
+    void releaseA2AClient() {
+        try {
+            A2A_CLIENT.close();
+        } catch (Exception e) {
+            // Best-effort — log but don't fail shutdown.
+            log.warn("Failed to close A2AClient during shutdown", e);
+        }
     }
 }

--- a/examples/java/consumer-date-agent/src/main/java/com/example/dateconsumer/DateConsumerAgentApplication.java
+++ b/examples/java/consumer-date-agent/src/main/java/com/example/dateconsumer/DateConsumerAgentApplication.java
@@ -1,0 +1,112 @@
+package com.example.dateconsumer;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.a2a.A2AClient;
+import io.mcpmesh.a2a.A2AConsumer;
+import io.mcpmesh.a2a.A2AResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A2A consumer example (issue #916 Phase 1) — Java port of
+ * {@code examples/a2a/consumer_date_agent.py}.
+ *
+ * <p>Bridges the existing {@code examples/a2a/date_a2a_agent.py}
+ * {@code get-date} skill into the mesh as a regular {@code current-date}
+ * capability. A downstream mesh tool depending on {@code current-date}
+ * does not need to know it is talking to an A2A backend — mesh's
+ * existing capability+tag failover applies the moment a SECOND consumer
+ * (e.g. a TypeScript or Python bridge) registers the same
+ * {@code current-date} capability with a different consumer-name tag.
+ *
+ * <p>Each consumer auto-tags its capability with the surrounding
+ * {@link MeshAgent#name()} via {@link A2AConsumer} (here
+ * {@code date-consumer}) so downstream resolvers can pin a specific
+ * backend via the dependency tag selector.
+ *
+ * <h2>Stack</h2>
+ * <ul>
+ *   <li>Registry — {@code meshctl start --registry-only}</li>
+ *   <li>System agent (Python) — provides {@code date_service}</li>
+ *   <li>Date A2A surface (Python) — exposes get-date via A2A on
+ *       {@code http://localhost:9090/agents/date}</li>
+ *   <li>This Java consumer — bridges the get-date skill onto the mesh
+ *       as {@code current-date}</li>
+ * </ul>
+ *
+ * <h2>Run</h2>
+ * <pre>
+ * # in src/runtime/java
+ * mvn install -DskipTests
+ *
+ * # in examples/java/consumer-date-agent
+ * mvn spring-boot:run
+ * </pre>
+ */
+@MeshAgent(
+    name = "date-consumer",
+    version = "1.0.0",
+    description = "Java A2A consumer bridge — re-publishes the date_a2a_agent get-date skill as a mesh current-date capability.",
+    port = 9201
+)
+@SpringBootApplication
+public class DateConsumerAgentApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(DateConsumerAgentApplication.class);
+
+    /**
+     * One reusable client per (url, skillId, auth) tuple — amortises
+     * the underlying {@link java.net.http.HttpClient} connection pool
+     * across calls. The producer is unauth in the example deployment
+     * so no {@code A2ABearer} is supplied.
+     */
+    private static final A2AClient A2A_CLIENT = new A2AClient(
+        "http://localhost:9090/agents/date",
+        "get-date"
+    );
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    public static void main(String[] args) {
+        log.info("Starting Java A2A Consumer (date-consumer)...");
+        SpringApplication.run(DateConsumerAgentApplication.class, args);
+    }
+
+    /**
+     * Bridge the upstream A2A {@code get-date} skill onto the mesh as
+     * the {@code current-date} capability. The {@link A2AConsumer}
+     * marker tells the runtime to inject the surrounding
+     * {@link MeshAgent#name()} as a tag, so this capability registers
+     * with tags {@code [a2a-bridge, date-consumer]}.
+     *
+     * <p>The producer-side handler returns
+     * {@code {"date": "<iso-string>"}} and the A2A surface
+     * JSON-stringifies it into the artifact text part — so we
+     * {@code readValue} on the consumer side to recover the dict.
+     *
+     * @return the producer's date payload as a Map
+     * @throws Exception on transport, JSON, or A2A protocol failure.
+     */
+    @MeshTool(
+        capability = "current-date",
+        description = "Get the current date by bridging the upstream A2A get-date skill",
+        tags = {"a2a-bridge"}
+    )
+    @A2AConsumer
+    public Map<String, Object> currentDate() throws Exception {
+        A2AResponse response = A2A_CLIENT.send(Map.of(
+            "role", "user",
+            "parts", List.of(Map.of("type", "text", "text", "now"))
+        ));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> payload = JSON.readValue(response.artifactText(), Map.class);
+        return payload;
+    }
+}

--- a/examples/java/consumer-date-agent/src/main/resources/application.yml
+++ b/examples/java/consumer-date-agent/src/main/resources/application.yml
@@ -1,0 +1,26 @@
+# MCP Mesh A2A consumer date agent (Java) — issue #916 Phase 1.
+#
+# Mirrors examples/a2a/consumer_date_agent.py. Override at runtime via:
+#   MCP_MESH_REGISTRY_URL - Registry URL
+#   MCP_MESH_HTTP_PORT    - Agent HTTP port
+#   MCP_MESH_AGENT_NAME   - Agent name (becomes the auto-injected
+#                            consumer-name tag for @A2AConsumer tools)
+
+spring:
+  application:
+    name: consumer-date-agent
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9201}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:date-consumer}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    io.mcpmesh: INFO
+    com.example.dateconsumer: DEBUG

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AAuthException.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AAuthException.java
@@ -1,0 +1,22 @@
+package io.mcpmesh.a2a;
+
+/**
+ * Raised by {@link A2ABearer#authorizationHeader()} when neither the
+ * literal token nor the configured environment variable yields a
+ * non-empty bearer value at call time.
+ *
+ * <p>Distinct from the generic {@link A2AException} so callers that wire
+ * a credential at boot can surface a clearer "credential missing /
+ * misconfigured" error to operators instead of a generic protocol
+ * failure.
+ */
+public final class A2AAuthException extends A2AException {
+
+    public A2AAuthException(String message) {
+        super(message);
+    }
+
+    public A2AAuthException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2ABearer.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2ABearer.java
@@ -33,11 +33,11 @@ public final class A2ABearer {
     /**
      * Use a literal bearer token.
      *
-     * @param token the bearer credential, must be non-null and non-empty
+     * @param token the bearer credential, must be non-null and non-blank
      */
     public static A2ABearer of(String token) {
-        if (token == null || token.isEmpty()) {
-            throw new IllegalArgumentException("A2ABearer.of: token must be non-empty");
+        if (token == null || token.trim().isEmpty()) {
+            throw new IllegalArgumentException("A2ABearer.of: token must be non-blank");
         }
         return new A2ABearer(token, null);
     }
@@ -46,11 +46,11 @@ public final class A2ABearer {
      * Resolve the bearer token from the named environment variable on
      * each call.
      *
-     * @param envVar the environment variable name, must be non-null and non-empty
+     * @param envVar the environment variable name, must be non-null and non-blank
      */
     public static A2ABearer fromEnv(String envVar) {
-        if (envVar == null || envVar.isEmpty()) {
-            throw new IllegalArgumentException("A2ABearer.fromEnv: envVar must be non-empty");
+        if (envVar == null || envVar.trim().isEmpty()) {
+            throw new IllegalArgumentException("A2ABearer.fromEnv: envVar must be non-blank");
         }
         return new A2ABearer(null, envVar);
     }
@@ -61,14 +61,14 @@ public final class A2ABearer {
      * @return the {@code Bearer <token>} string suitable for
      *         {@code Authorization} headers.
      * @throws A2AAuthException if neither the literal token nor the
-     *         configured env var resolves to a non-empty value.
+     *         configured env var resolves to a non-blank value.
      */
     public String authorizationHeader() {
         String resolved = token;
         if (resolved == null && tokenEnv != null) {
             resolved = System.getenv(tokenEnv);
         }
-        if (resolved == null || resolved.isEmpty()) {
+        if (resolved == null || resolved.trim().isEmpty()) {
             throw new A2AAuthException(
                 "A2ABearer: no token available (token_env="
                     + (tokenEnv == null ? "<unset>" : "'" + tokenEnv + "'")

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2ABearer.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2ABearer.java
@@ -1,0 +1,81 @@
+package io.mcpmesh.a2a;
+
+/**
+ * Bearer-token credential for an outbound A2A call.
+ *
+ * <p>Provide either a literal token via {@link #of(String)} or the name
+ * of an environment variable via {@link #fromEnv(String)}. The header is
+ * resolved at call time (per request, just before the HTTP send) so
+ * rotating the env var between calls picks up the new value without
+ * reconstructing the surrounding {@link A2AClient}.
+ *
+ * <p>Mirrors {@code mesh._a2a_consumer.A2ABearer} from the Python
+ * runtime (issue #908 Phase 1).
+ *
+ * <h2>Example</h2>
+ * <pre>{@code
+ * A2AClient client = new A2AClient(
+ *     "http://upstream.example.com/agents/date",
+ *     "get-date",
+ *     A2ABearer.fromEnv("UPSTREAM_TOKEN"));
+ * }</pre>
+ */
+public final class A2ABearer {
+
+    private final String token;
+    private final String tokenEnv;
+
+    private A2ABearer(String token, String tokenEnv) {
+        this.token = token;
+        this.tokenEnv = tokenEnv;
+    }
+
+    /**
+     * Use a literal bearer token.
+     *
+     * @param token the bearer credential, must be non-null and non-empty
+     */
+    public static A2ABearer of(String token) {
+        if (token == null || token.isEmpty()) {
+            throw new IllegalArgumentException("A2ABearer.of: token must be non-empty");
+        }
+        return new A2ABearer(token, null);
+    }
+
+    /**
+     * Resolve the bearer token from the named environment variable on
+     * each call.
+     *
+     * @param envVar the environment variable name, must be non-null and non-empty
+     */
+    public static A2ABearer fromEnv(String envVar) {
+        if (envVar == null || envVar.isEmpty()) {
+            throw new IllegalArgumentException("A2ABearer.fromEnv: envVar must be non-empty");
+        }
+        return new A2ABearer(null, envVar);
+    }
+
+    /**
+     * Build the {@code Authorization} header value at call time.
+     *
+     * @return the {@code Bearer <token>} string suitable for
+     *         {@code Authorization} headers.
+     * @throws A2AAuthException if neither the literal token nor the
+     *         configured env var resolves to a non-empty value.
+     */
+    public String authorizationHeader() {
+        String resolved = token;
+        if (resolved == null && tokenEnv != null) {
+            resolved = System.getenv(tokenEnv);
+        }
+        if (resolved == null || resolved.isEmpty()) {
+            throw new A2AAuthException(
+                "A2ABearer: no token available (token_env="
+                    + (tokenEnv == null ? "<unset>" : "'" + tokenEnv + "'")
+                    + ", explicit_token="
+                    + (token != null ? "set" : "unset")
+                    + ")");
+        }
+        return "Bearer " + resolved;
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AClient.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AClient.java
@@ -1,0 +1,377 @@
+package io.mcpmesh.a2a;
+
+import io.mcpmesh.core.MeshObjectMappers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Thin A2A v1.0 client — sync {@code tasks/send} + poll until terminal.
+ *
+ * <p>Phase 1 surface (issue #916): one synchronous {@link #send} call
+ * that POSTs a JSON-RPC {@code tasks/send} request, then polls
+ * {@code tasks/get} with exponential backoff (capped at
+ * {@code pollIntervalMaxMs}) until the task reaches a terminal state
+ * ({@code completed} / {@code failed} / {@code canceled}, case-insensitive
+ * for the US/UK spelling) or the user-supplied timeout elapses.
+ *
+ * <p>One instance per (url, skillId, auth) tuple — a typical Spring
+ * agent constructs one per {@code @MeshTool} method (with {@code static}
+ * lifetime) so the underlying {@link HttpClient}'s connection pool is
+ * amortized across calls.
+ *
+ * <p>Mirrors {@code mesh._a2a_consumer.A2AClient} from the Python
+ * runtime. Phase 3 ({@code submit} / {@code subscribe} / SSE) is
+ * deferred to a follow-up PR.
+ *
+ * <h2>Example</h2>
+ * <pre>{@code
+ * private static final A2AClient CLIENT = new A2AClient(
+ *     "http://upstream.example.com/agents/date",
+ *     "get-date");
+ *
+ * @MeshTool(capability = "current-date", tags = {"a2a-bridge"})
+ * @A2AConsumer
+ * public Map<String, Object> currentDate() throws Exception {
+ *     A2AResponse r = CLIENT.send(Map.of(
+ *         "role", "user",
+ *         "parts", List.of(Map.of("type", "text", "text", "now"))
+ *     ));
+ *     return new ObjectMapper().readValue(r.artifactText(), Map.class);
+ * }
+ * }</pre>
+ */
+public final class A2AClient implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(A2AClient.class);
+
+    /** Default per-call deadline for {@link #send}. */
+    public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+
+    /** Initial backoff between {@code tasks/get} polls. */
+    static final long DEFAULT_POLL_INTERVAL_MS = 500L;
+    /** Cap on the backoff between {@code tasks/get} polls. */
+    static final long DEFAULT_POLL_INTERVAL_MAX_MS = 2000L;
+    /** Backoff multiplier between consecutive {@code tasks/get} polls. */
+    static final double POLL_BACKOFF_FACTOR = 1.5d;
+
+    private final URI url;
+    private final String skillId;
+    private final A2ABearer auth;
+    private final Duration defaultTimeout;
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final long pollIntervalMs;
+    private final long pollIntervalMaxMs;
+    private volatile boolean closed;
+
+    public A2AClient(String url, String skillId) {
+        this(url, skillId, null, DEFAULT_TIMEOUT);
+    }
+
+    public A2AClient(String url, String skillId, A2ABearer auth) {
+        this(url, skillId, auth, DEFAULT_TIMEOUT);
+    }
+
+    public A2AClient(String url, String skillId, A2ABearer auth, Duration defaultTimeout) {
+        if (url == null || url.isEmpty()) {
+            throw new IllegalArgumentException("A2AClient: url must be non-empty");
+        }
+        if (defaultTimeout == null || defaultTimeout.isZero() || defaultTimeout.isNegative()) {
+            throw new IllegalArgumentException("A2AClient: defaultTimeout must be > 0");
+        }
+        // Trim trailing slashes to match the Python runtime's url.rstrip("/")
+        // — keeps the on-the-wire URL stable regardless of how the user
+        // wrote the constructor argument.
+        String trimmed = url;
+        while (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        this.url = URI.create(trimmed);
+        this.skillId = skillId;
+        this.auth = auth;
+        this.defaultTimeout = defaultTimeout;
+        this.objectMapper = MeshObjectMappers.create();
+        this.pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
+        this.pollIntervalMaxMs = DEFAULT_POLL_INTERVAL_MAX_MS;
+        // connectTimeout is the TCP-handshake budget; the per-call
+        // request timeout is set on each HttpRequest below using the
+        // user-supplied or default deadline.
+        this.httpClient = HttpClient.newBuilder()
+            .connectTimeout(defaultTimeout)
+            .build();
+    }
+
+    /** The configured A2A endpoint. */
+    public URI url() {
+        return url;
+    }
+
+    /** The configured skill ID, or {@code null} if unset. */
+    public String skillId() {
+        return skillId;
+    }
+
+    /**
+     * POST {@code tasks/send} and poll {@code tasks/get} until terminal
+     * using the client's default timeout.
+     *
+     * @param message A2A v1.0 request message dict (typically
+     *                {@code {"role":"user","parts":[{"type":"text","text":"..."}]}})
+     * @return an {@link A2AResponse} carrying the artifact text + raw envelope.
+     * @throws A2AException        on JSON-RPC error envelope, transport
+     *                             failure, or malformed response.
+     * @throws A2ATimeoutException if no terminal state arrives within
+     *                             the deadline.
+     */
+    public A2AResponse send(Map<String, Object> message) {
+        return send(message, defaultTimeout);
+    }
+
+    /**
+     * POST {@code tasks/send} and poll {@code tasks/get} until terminal
+     * using the supplied deadline.
+     *
+     * @param message     A2A v1.0 request message dict.
+     * @param callTimeout per-call deadline override (must be > 0).
+     */
+    public A2AResponse send(Map<String, Object> message, Duration callTimeout) {
+        if (closed) {
+            throw new A2AException(
+                "A2AClient(url=" + url + ") is closed; create a new instance instead.");
+        }
+        if (message == null) {
+            throw new IllegalArgumentException("A2AClient.send: message must be non-null");
+        }
+        if (callTimeout == null || callTimeout.isZero() || callTimeout.isNegative()) {
+            throw new IllegalArgumentException("A2AClient.send: callTimeout must be > 0");
+        }
+
+        String taskId = "c-" + UUID.randomUUID().toString().replace("-", "");
+        long deadlineNanos = System.nanoTime() + callTimeout.toNanos();
+
+        ObjectNode params = objectMapper.createObjectNode();
+        params.put("id", taskId);
+        params.set("message", objectMapper.valueToTree(message));
+
+        Duration remaining = remainingOrMin(deadlineNanos);
+        JsonNode result = postJsonRpc("tasks/send", params, 1, remaining);
+        String state = readState(result);
+
+        if (isTerminal(state)) {
+            return buildResponse(taskId, result);
+        }
+
+        long intervalMs = pollIntervalMs;
+        ObjectNode getParams = objectMapper.createObjectNode();
+        getParams.put("id", taskId);
+
+        while (System.nanoTime() < deadlineNanos) {
+            sleepInterruptibly(intervalMs);
+            // Re-check the deadline AFTER the sleep so a long sleep
+            // does not push the next tasks/get past the user's
+            // deadline. Bail out cleanly to surface the polling-level
+            // timeout rather than the per-call HTTP timeout (which has
+            // a less helpful message).
+            long remainingNs = deadlineNanos - System.nanoTime();
+            if (remainingNs <= 0) {
+                break;
+            }
+            remaining = Duration.ofNanos(remainingNs);
+            result = postJsonRpc("tasks/get", getParams, 2, remaining);
+            state = readState(result);
+            if (isTerminal(state)) {
+                return buildResponse(taskId, result);
+            }
+            intervalMs = Math.min(pollIntervalMaxMs, (long) (intervalMs * POLL_BACKOFF_FACTOR));
+        }
+
+        throw new A2ATimeoutException(
+            "A2A task '" + taskId + "' on " + url
+                + " did not reach terminal state within " + callTimeout
+                + " (last state='" + state + "')");
+    }
+
+    @Override
+    public void close() {
+        // Java's HttpClient does not expose a shutdown hook prior to
+        // JDK 21; the JVM reclaims pooled connections on GC. We mark
+        // the client closed so subsequent send() calls raise rather
+        // than reuse a torn-down instance.
+        closed = true;
+    }
+
+    /**
+     * Internal: POST one JSON-RPC envelope and return the {@code result}
+     * node. Surfaces JSON-RPC error envelopes as {@link A2AException}.
+     */
+    private JsonNode postJsonRpc(String method, ObjectNode params, int rpcId, Duration timeout) {
+        ObjectNode envelope = objectMapper.createObjectNode();
+        envelope.put("jsonrpc", "2.0");
+        envelope.put("id", rpcId);
+        envelope.put("method", method);
+        envelope.set("params", params);
+
+        String body;
+        try {
+            body = objectMapper.writeValueAsString(envelope);
+        } catch (Exception e) {
+            throw new A2AException("Failed to serialize JSON-RPC envelope for " + method, e);
+        }
+
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+            .uri(url)
+            .timeout(timeout)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body));
+        if (auth != null) {
+            // A2ABearer.authorizationHeader resolves the env-var or
+            // literal at call time so a rotated credential is honoured
+            // mid-process.
+            builder.header("Authorization", auth.authorizationHeader());
+        }
+
+        HttpResponse<String> response;
+        try {
+            response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+        } catch (java.net.http.HttpTimeoutException e) {
+            throw new A2ATimeoutException(
+                "A2A " + method + " " + url + " timed out after " + timeout, e);
+        } catch (IOException e) {
+            throw new A2AException("A2A " + method + " " + url + " transport failure: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new A2AException("A2A " + method + " " + url + " interrupted", e);
+        }
+
+        int status = response.statusCode();
+        String responseBody = response.body();
+        if (status >= 400) {
+            // Mirror httpx.raise_for_status — surface the upstream's
+            // body in the exception so operators can debug the call
+            // without re-running with a packet capture.
+            throw new A2AException(
+                "A2A " + method + " " + url + " HTTP " + status + ": " + truncate(responseBody, 256));
+        }
+
+        JsonNode parsed;
+        try {
+            parsed = objectMapper.readTree(responseBody);
+        } catch (Exception e) {
+            throw new A2AException(
+                "A2A " + method + " " + url + " returned malformed JSON: " + truncate(responseBody, 256), e);
+        }
+        if (parsed == null || parsed.isMissingNode() || parsed.isNull()) {
+            throw new A2AException(
+                "A2A " + method + " " + url + " returned empty body");
+        }
+        if (parsed.has("error") && !parsed.get("error").isNull()) {
+            JsonNode err = parsed.get("error");
+            String code = err.has("code") ? err.get("code").asString() : "?";
+            String message = err.has("message") ? err.get("message").asString() : "<no message>";
+            throw new A2AException("A2A error from " + url + ": " + code + " " + message);
+        }
+
+        JsonNode result = parsed.get("result");
+        if (result == null || result.isMissingNode() || result.isNull()) {
+            return objectMapper.createObjectNode();
+        }
+        return result;
+    }
+
+    /** Pull the task lifecycle state from {@code result.status.state}. */
+    private static String readState(JsonNode result) {
+        if (result == null) {
+            return "unknown";
+        }
+        JsonNode status = result.get("status");
+        if (status == null || status.isMissingNode() || status.isNull()) {
+            return "unknown";
+        }
+        JsonNode state = status.get("state");
+        if (state == null || state.isMissingNode() || state.isNull()) {
+            return "unknown";
+        }
+        return state.asString();
+    }
+
+    /**
+     * Accept both A2A v1.0's US "canceled" and the mesh JobController's
+     * UK "cancelled" so a heterogeneous deployment doesn't get stuck
+     * polling on a mismatched terminal state.
+     */
+    private static boolean isTerminal(String state) {
+        if (state == null) {
+            return false;
+        }
+        String s = state.toLowerCase(Locale.ROOT);
+        return s.equals("completed") || s.equals("failed") || s.equals("canceled") || s.equals("cancelled");
+    }
+
+    private A2AResponse buildResponse(String taskId, JsonNode result) {
+        String artifactText = "";
+        JsonNode artifacts = result.get("artifacts");
+        if (artifacts instanceof ArrayNode array && !array.isEmpty()) {
+            JsonNode first = array.get(0);
+            if (first != null && first.isObject()) {
+                JsonNode parts = first.get("parts");
+                if (parts instanceof ArrayNode partsArr && !partsArr.isEmpty()) {
+                    JsonNode firstPart = partsArr.get(0);
+                    if (firstPart != null && firstPart.isObject()) {
+                        JsonNode text = firstPart.get("text");
+                        if (text != null && !text.isNull()) {
+                            artifactText = text.asString();
+                        }
+                    }
+                }
+            }
+        }
+        return new A2AResponse(artifactText, readState(result), taskId, result);
+    }
+
+    /**
+     * Remaining budget clamped to a 1ms minimum so the very first
+     * tasks/send call (issued before the polling loop) always has a
+     * positive timeout — even when the user-supplied deadline has
+     * already elapsed by the time we get here. The polling loop checks
+     * the deadline directly (without the 1ms floor) so it surfaces a
+     * polling-level A2ATimeoutException instead of a per-call HTTP one.
+     */
+    private static Duration remainingOrMin(long deadlineNanos) {
+        long remainingNs = deadlineNanos - System.nanoTime();
+        if (remainingNs <= 0) {
+            return Duration.ofMillis(1);
+        }
+        return Duration.ofNanos(remainingNs);
+    }
+
+    private static void sleepInterruptibly(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new A2AException("A2AClient poll loop interrupted", e);
+        }
+    }
+
+    private static String truncate(String s, int max) {
+        if (s == null) {
+            return "";
+        }
+        return s.length() <= max ? s : s.substring(0, max) + "...";
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AClient.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AClient.java
@@ -37,6 +37,15 @@ import java.util.UUID;
  * runtime. Phase 3 ({@code submit} / {@code subscribe} / SSE) is
  * deferred to a follow-up PR.
  *
+ * <p><b>Lifecycle on JDK 17:</b> This class implements {@link AutoCloseable}
+ * for forward-compatibility, but the underlying {@link java.net.http.HttpClient}
+ * does not expose a shutdown hook prior to JDK 21. Calling {@link #close()}
+ * marks this instance closed (subsequent operations throw {@link A2AException})
+ * but the HttpClient's internal selector and worker threads remain alive
+ * until garbage collection. For long-running test suites or containers that
+ * create and discard many instances, prefer holding a single shared
+ * {@code A2AClient} instance for the process lifetime.
+ *
  * <h2>Example</h2>
  * <pre>{@code
  * private static final A2AClient CLIENT = new A2AClient(
@@ -288,7 +297,15 @@ public final class A2AClient implements AutoCloseable {
 
         JsonNode result = parsed.get("result");
         if (result == null || result.isMissingNode() || result.isNull()) {
-            return objectMapper.createObjectNode();
+            // A producer that returns {"jsonrpc":"2.0","id":1} (no result
+            // and no error) is malformed JSON-RPC. Coercing this to an
+            // empty object would make readState() return "unknown" and
+            // the polling loop spin until the user-supplied deadline.
+            // Fail fast with a clear message instead.
+            throw new A2AException(
+                "A2A " + method + " " + url
+                    + " response has neither 'result' nor 'error' field — malformed JSON-RPC envelope: "
+                    + truncate(responseBody, 256));
         }
         return result;
     }

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AConsumer.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AConsumer.java
@@ -1,0 +1,59 @@
+package io.mcpmesh.a2a;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@link MeshTool}-annotated method as an A2A consumer bridge.
+ *
+ * <p>Pure marker — the annotation itself carries no fields. Its sole
+ * purpose is to opt the surrounding tool into the consumer-name
+ * auto-tag injection path: at agent registration time the Spring
+ * starter rewrites the tool's tag list to include the surrounding
+ * {@link MeshAgent#name()}, making the bridged capability
+ * distinguishable from sibling consumers (and pinnable from downstream
+ * dependencies via the consumer name).
+ *
+ * <p>Mirrors the Python runtime's {@code @mesh.a2a_consumer} surface
+ * (issue #908), which auto-tags via the
+ * {@code __MESH_CONSUMER_SELF__} sentinel substitution. Java keeps the
+ * relationship explicit: the user constructs an {@link A2AClient}
+ * inside the method body and places this annotation alongside
+ * {@link MeshTool} so the post-processor knows to inject the auto-tag.
+ *
+ * <h2>Pattern</h2>
+ * <pre>{@code
+ * private static final A2AClient CLIENT = new A2AClient(
+ *     "http://upstream.example.com/agents/date", "get-date");
+ *
+ * @MeshTool(capability = "current-date", tags = {"a2a-bridge"})
+ * @A2AConsumer
+ * public Map<String, Object> currentDate() throws Exception {
+ *     A2AResponse r = CLIENT.send(Map.of(
+ *         "role", "user",
+ *         "parts", List.of(Map.of("type", "text", "text", "now"))));
+ *     return new ObjectMapper().readValue(r.artifactText(), Map.class);
+ * }
+ * }</pre>
+ *
+ * <p>Usage rules:
+ * <ul>
+ *   <li>Must be combined with {@link MeshTool} on the same method —
+ *       a bare {@code @A2AConsumer} on a non-mesh method is a no-op.</li>
+ *   <li>The surrounding agent must declare {@link MeshAgent#name()}
+ *       (or its env-var override) so the auto-tag has a value to
+ *       substitute. A consumer-only / nameless agent skips the
+ *       injection cleanly with a warning.</li>
+ * </ul>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface A2AConsumer {
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AException.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AException.java
@@ -1,0 +1,26 @@
+package io.mcpmesh.a2a;
+
+/**
+ * Base exception type for failures encountered by the A2A consumer client
+ * (see {@link A2AClient}).
+ *
+ * <p>Mirrors the Python runtime's {@code RuntimeError} surface from
+ * {@code mesh._a2a_consumer}: protocol-level errors (JSON-RPC error
+ * envelopes, malformed responses, transport failures) bubble up as
+ * {@code A2AException}; auth and timeout get dedicated subclasses
+ * ({@link A2AAuthException}, {@link A2ATimeoutException}) so callers can
+ * branch on them with regular {@code try / catch} blocks.
+ *
+ * <p>Unchecked because the rest of the mesh SDK favours {@link RuntimeException}
+ * subtypes (see {@code io.mcpmesh.types.MeshToolCallException}).
+ */
+public class A2AException extends RuntimeException {
+
+    public A2AException(String message) {
+        super(message);
+    }
+
+    public A2AException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AResponse.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AResponse.java
@@ -18,6 +18,26 @@ import tools.jackson.databind.JsonNode;
  * the producer echoed back.
  *
  * <p>Mirrors {@code mesh._a2a_consumer.A2AResponse}.
+ *
+ * @param artifactText canonical sync return value (text part of the
+ *                     first artifact); empty string when the producer
+ *                     emitted no artifacts.
+ * @param state        terminal lifecycle state from the {@code Task}
+ *                     envelope (typically {@code completed} /
+ *                     {@code failed} / {@code canceled}).
+ * @param taskId       consumer-generated task ID echoed back by the
+ *                     producer.
+ * @param rawTask      the full A2A v1.0 Task envelope's {@code result}
+ *                     field — useful for advanced consumers that need
+ *                     fields beyond the parsed convenience properties
+ *                     ({@code artifactText}, {@code state}, {@code taskId}).
+ *                     <p><b>Sharing semantics:</b> Despite the enclosing
+ *                     record being immutable, this {@link JsonNode} is the
+ *                     live parse tree owned by {@link A2AClient}. Treat it
+ *                     as read-only — any mutation (e.g.
+ *                     {@code ((ObjectNode) rawTask).put(...)}) leaks into
+ *                     other consumers of the same response. Deep-copy via
+ *                     {@code rawTask.deepCopy()} if mutation is required.
  */
 public record A2AResponse(
     String artifactText,

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AResponse.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AResponse.java
@@ -1,0 +1,28 @@
+package io.mcpmesh.a2a;
+
+import tools.jackson.databind.JsonNode;
+
+/**
+ * Result of a synchronous {@link A2AClient#send} call.
+ *
+ * <p>{@code artifactText} is the canonical sync return — the
+ * producer-side surface places the handler's return value as
+ * {@code result.artifacts[0].parts[0].text} (JSON-stringified for
+ * non-string returns). Consumers that need the raw envelope
+ * (multi-artifact responses, status messages, history) can read
+ * {@link #rawTask()}.
+ *
+ * <p>{@code state} is the lifecycle state from the terminal {@code Task}
+ * envelope (typically one of {@code completed} / {@code failed} /
+ * {@code canceled}); {@code taskId} is the consumer-generated ID that
+ * the producer echoed back.
+ *
+ * <p>Mirrors {@code mesh._a2a_consumer.A2AResponse}.
+ */
+public record A2AResponse(
+    String artifactText,
+    String state,
+    String taskId,
+    JsonNode rawTask
+) {
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2ATimeoutException.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2ATimeoutException.java
@@ -1,0 +1,20 @@
+package io.mcpmesh.a2a;
+
+/**
+ * Raised by {@link A2AClient#send} when a polled task does not reach a
+ * terminal state ({@code completed} / {@code failed} / {@code canceled})
+ * within the user-supplied timeout.
+ *
+ * <p>Equivalent to the Python runtime's {@code TimeoutError} surface from
+ * {@code mesh._a2a_consumer}.
+ */
+public final class A2ATimeoutException extends A2AException {
+
+    public A2ATimeoutException(String message) {
+        super(message);
+    }
+
+    public A2ATimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/a2a/A2ABearerTest.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/a2a/A2ABearerTest.java
@@ -1,0 +1,40 @@
+package io.mcpmesh.a2a;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link A2ABearer} covering both literal and env-var
+ * resolution paths and the no-credential failure mode.
+ */
+class A2ABearerTest {
+
+    @Test
+    void of_buildsHeaderFromLiteralToken() {
+        A2ABearer bearer = A2ABearer.of("abc123");
+        assertEquals("Bearer abc123", bearer.authorizationHeader());
+    }
+
+    @Test
+    void of_rejectsBlankLiteral() {
+        assertThrows(IllegalArgumentException.class, () -> A2ABearer.of(""));
+        assertThrows(IllegalArgumentException.class, () -> A2ABearer.of(null));
+    }
+
+    @Test
+    void fromEnv_rejectsBlankName() {
+        assertThrows(IllegalArgumentException.class, () -> A2ABearer.fromEnv(""));
+        assertThrows(IllegalArgumentException.class, () -> A2ABearer.fromEnv(null));
+    }
+
+    @Test
+    void fromEnv_unsetEnvVar_throwsAuthException() {
+        // System.getenv("DEFINITELY_UNSET_A2A_BEARER_TEST_VAR") is null
+        // in any sane test environment.
+        A2ABearer bearer = A2ABearer.fromEnv("DEFINITELY_UNSET_A2A_BEARER_TEST_VAR");
+        A2AAuthException thrown = assertThrows(A2AAuthException.class, bearer::authorizationHeader);
+        assertTrue(thrown.getMessage().contains("DEFINITELY_UNSET_A2A_BEARER_TEST_VAR"),
+            "exception message should name the missing env var: " + thrown.getMessage());
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/a2a/A2ABearerTest.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/a2a/A2ABearerTest.java
@@ -2,6 +2,8 @@ package io.mcpmesh.a2a;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -23,18 +25,32 @@ class A2ABearerTest {
     }
 
     @Test
+    void of_whitespaceToken_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> A2ABearer.of("   "));
+        assertThrows(IllegalArgumentException.class, () -> A2ABearer.of("\t\n"));
+    }
+
+    @Test
     void fromEnv_rejectsBlankName() {
         assertThrows(IllegalArgumentException.class, () -> A2ABearer.fromEnv(""));
         assertThrows(IllegalArgumentException.class, () -> A2ABearer.fromEnv(null));
     }
 
     @Test
+    void fromEnv_whitespaceName_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> A2ABearer.fromEnv("   "));
+        assertThrows(IllegalArgumentException.class, () -> A2ABearer.fromEnv("\t\n"));
+    }
+
+    @Test
     void fromEnv_unsetEnvVar_throwsAuthException() {
-        // System.getenv("DEFINITELY_UNSET_A2A_BEARER_TEST_VAR") is null
-        // in any sane test environment.
-        A2ABearer bearer = A2ABearer.fromEnv("DEFINITELY_UNSET_A2A_BEARER_TEST_VAR");
+        // Generate a unique env var name per invocation so the test is
+        // immune to a stray export of the historical fixed name.
+        String uniqueVar = "DEFINITELY_UNSET_A2A_BEARER_TEST_VAR_"
+            + UUID.randomUUID().toString().replace("-", "");
+        A2ABearer bearer = A2ABearer.fromEnv(uniqueVar);
         A2AAuthException thrown = assertThrows(A2AAuthException.class, bearer::authorizationHeader);
-        assertTrue(thrown.getMessage().contains("DEFINITELY_UNSET_A2A_BEARER_TEST_VAR"),
+        assertTrue(thrown.getMessage().contains(uniqueVar),
             "exception message should name the missing env var: " + thrown.getMessage());
     }
 }

--- a/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/a2a/A2AClientTest.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/a2a/A2AClientTest.java
@@ -1,0 +1,242 @@
+package io.mcpmesh.a2a;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link A2AClient}. Spins up a tiny in-process HTTP
+ * server (JDK's {@code com.sun.net.httpserver.HttpServer}) so the
+ * client tests don't pull in OkHttp / MockWebServer (the SDK module
+ * cannot depend on them — that would create a cycle with
+ * {@code mcp-mesh-spring-boot-starter}, see issue #916 design notes).
+ */
+class A2AClientTest {
+
+    private HttpServer server;
+    private int port;
+
+    @BeforeEach
+    void startServer() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        port = server.getAddress().getPort();
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    private String url() {
+        return "http://127.0.0.1:" + port + "/agents/test";
+    }
+
+    private void mount(String path, HttpHandler handler) {
+        server.createContext(path, handler);
+    }
+
+    private static String readBody(HttpExchange ex) throws IOException {
+        try (InputStream in = ex.getRequestBody()) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static void respond(HttpExchange ex, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        ex.getResponseHeaders().add("Content-Type", "application/json");
+        ex.sendResponseHeaders(status, bytes.length);
+        try (OutputStream out = ex.getResponseBody()) {
+            out.write(bytes);
+        }
+    }
+
+    @Test
+    void send_terminalOnFirstResponse_returnsArtifactText() {
+        mount("/agents/test", ex -> respond(ex, 200, """
+            {"jsonrpc":"2.0","id":1,"result":{
+              "status":{"state":"completed"},
+              "artifacts":[{"parts":[{"type":"text","text":"hello"}]}]
+            }}
+            """));
+
+        try (A2AClient client = new A2AClient(url(), "demo-skill")) {
+            A2AResponse resp = client.send(Map.of(
+                "role", "user",
+                "parts", List.of(Map.of("type", "text", "text", "ping"))));
+            assertEquals("hello", resp.artifactText());
+            assertEquals("completed", resp.state());
+            assertNotNull(resp.taskId());
+            assertTrue(resp.taskId().startsWith("c-"));
+            assertNotNull(resp.rawTask());
+        }
+    }
+
+    @Test
+    void send_pollsUntilTerminal() {
+        AtomicInteger calls = new AtomicInteger(0);
+        mount("/agents/test", ex -> {
+            int n = calls.incrementAndGet();
+            String body = readBody(ex);
+            // First call should be tasks/send, subsequent are tasks/get.
+            if (n == 1) {
+                assertTrue(body.contains("tasks/send"), "first call must be tasks/send");
+                respond(ex, 200, """
+                    {"jsonrpc":"2.0","id":1,"result":{
+                      "status":{"state":"working"},
+                      "artifacts":[]
+                    }}
+                    """);
+                return;
+            }
+            assertTrue(body.contains("tasks/get"), "follow-up calls must be tasks/get");
+            if (n < 3) {
+                respond(ex, 200, """
+                    {"jsonrpc":"2.0","id":2,"result":{
+                      "status":{"state":"working"},
+                      "artifacts":[]
+                    }}
+                    """);
+                return;
+            }
+            respond(ex, 200, """
+                {"jsonrpc":"2.0","id":2,"result":{
+                  "status":{"state":"completed"},
+                  "artifacts":[{"parts":[{"type":"text","text":"done"}]}]
+                }}
+                """);
+        });
+
+        try (A2AClient client = new A2AClient(url(), "demo")) {
+            A2AResponse resp = client.send(Map.of("role", "user", "parts", List.of()));
+            assertEquals("done", resp.artifactText());
+            assertEquals("completed", resp.state());
+            assertTrue(calls.get() >= 3, "expected at least 3 calls (1 send + >=2 polls), got " + calls.get());
+        }
+    }
+
+    @Test
+    void send_jsonRpcErrorEnvelope_throwsA2AException() {
+        mount("/agents/test", ex -> respond(ex, 200, """
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not implemented"}}
+            """));
+
+        try (A2AClient client = new A2AClient(url(), "demo")) {
+            A2AException thrown = assertThrows(A2AException.class,
+                () -> client.send(Map.of("role", "user", "parts", List.of())));
+            assertTrue(thrown.getMessage().contains("Method not implemented"),
+                "exception should surface upstream error message: " + thrown.getMessage());
+        }
+    }
+
+    @Test
+    void send_httpErrorStatus_throwsA2AException() {
+        mount("/agents/test", ex -> respond(ex, 500, "internal server error"));
+
+        try (A2AClient client = new A2AClient(url(), "demo")) {
+            A2AException thrown = assertThrows(A2AException.class,
+                () -> client.send(Map.of("role", "user", "parts", List.of())));
+            assertTrue(thrown.getMessage().contains("HTTP 500"),
+                "exception should mention HTTP 500: " + thrown.getMessage());
+        }
+    }
+
+    @Test
+    void send_neverReachesTerminal_throwsTimeout() {
+        // Always reply with state=working so the client polls until the
+        // user-supplied 1s deadline elapses, then surfaces TimeoutException.
+        mount("/agents/test", ex -> respond(ex, 200, """
+            {"jsonrpc":"2.0","id":1,"result":{
+              "status":{"state":"working"},
+              "artifacts":[]
+            }}
+            """));
+
+        try (A2AClient client = new A2AClient(url(), "demo")) {
+            A2ATimeoutException thrown = assertThrows(A2ATimeoutException.class,
+                () -> client.send(Map.of("role", "user", "parts", List.of()), Duration.ofSeconds(1)));
+            assertTrue(thrown.getMessage().contains("did not reach terminal"),
+                thrown.getMessage());
+        }
+    }
+
+    @Test
+    void send_bearerHeader_isInjected() {
+        AtomicReference<String> seenAuth = new AtomicReference<>();
+        mount("/agents/test", ex -> {
+            seenAuth.set(ex.getRequestHeaders().getFirst("Authorization"));
+            respond(ex, 200, """
+                {"jsonrpc":"2.0","id":1,"result":{
+                  "status":{"state":"completed"},
+                  "artifacts":[{"parts":[{"type":"text","text":"ok"}]}]
+                }}
+                """);
+        });
+
+        try (A2AClient client = new A2AClient(url(), "demo", A2ABearer.of("secret-token"))) {
+            client.send(Map.of("role", "user", "parts", List.of()));
+            assertEquals("Bearer secret-token", seenAuth.get(),
+                "outbound request must carry Authorization: Bearer <token>");
+        }
+    }
+
+    @Test
+    void send_terminalCanceled_caseInsensitive_includesUkSpelling() {
+        mount("/agents/test", ex -> respond(ex, 200, """
+            {"jsonrpc":"2.0","id":1,"result":{
+              "status":{"state":"Cancelled"},
+              "artifacts":[]
+            }}
+            """));
+
+        try (A2AClient client = new A2AClient(url(), "demo")) {
+            A2AResponse resp = client.send(Map.of("role", "user", "parts", List.of()));
+            assertEquals("Cancelled", resp.state(),
+                "client must short-circuit on the UK spelling 'cancelled' too");
+        }
+    }
+
+    @Test
+    void send_afterClose_throws() {
+        mount("/agents/test", ex -> respond(ex, 200, """
+            {"jsonrpc":"2.0","id":1,"result":{"status":{"state":"completed"},"artifacts":[]}}
+            """));
+
+        A2AClient client = new A2AClient(url(), "demo");
+        client.close();
+        A2AException ex = assertThrows(A2AException.class,
+            () -> client.send(Map.of("role", "user", "parts", List.of())));
+        assertTrue(ex.getMessage().contains("closed"));
+    }
+
+    @Test
+    void constructor_rejectsBlankUrl() {
+        assertThrows(IllegalArgumentException.class, () -> new A2AClient("", "demo"));
+        assertThrows(IllegalArgumentException.class, () -> new A2AClient(null, "demo"));
+    }
+
+    @Test
+    void send_rejectsNullMessage() {
+        try (A2AClient client = new A2AClient(url(), "demo")) {
+            assertThrows(IllegalArgumentException.class, () -> client.send(null));
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/a2a/A2AClientTest.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/a2a/A2AClientTest.java
@@ -134,6 +134,25 @@ class A2AClientTest {
     }
 
     @Test
+    void send_responseMissingResultAndError_throwsException() {
+        // A producer that returns a JSON-RPC envelope with neither
+        // 'result' nor 'error' is malformed. The client must surface
+        // this as A2AException immediately rather than coercing the
+        // missing 'result' to an empty object and spinning the polling
+        // loop until the user-supplied deadline elapses.
+        mount("/agents/test", ex -> respond(ex, 200, """
+            {"jsonrpc":"2.0","id":1}
+            """));
+
+        try (A2AClient client = new A2AClient(url(), "demo")) {
+            A2AException thrown = assertThrows(A2AException.class,
+                () -> client.send(Map.of("role", "user", "parts", List.of())));
+            assertTrue(thrown.getMessage().contains("malformed JSON-RPC envelope"),
+                "exception should call out malformed envelope: " + thrown.getMessage());
+        }
+    }
+
+    @Test
     void send_jsonRpcErrorEnvelope_throwsA2AException() {
         mount("/agents/test", ex -> respond(ex, 200, """
             {"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not implemented"}}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -325,6 +325,21 @@ public class MeshAutoConfiguration {
             log.warn("Failed to register MeshJob helper tools at startup", e);
         }
 
+        // Issue #916 Phase 1: inject the surrounding @MeshAgent name as
+        // a tag on every @A2AConsumer-annotated tool BEFORE
+        // toolRegistry.getToolSpecs() snapshots the catalog. Mirrors
+        // Python's _resolve_pending_consumer_self_tags substitution —
+        // makes a bridged capability distinguishable from sibling
+        // consumers in the registry, so downstream dependencies can
+        // pin a specific bridge by tag and untagged dependencies still
+        // auto-fail-over when one bridge dies.
+        try {
+            toolRegistry.injectConsumerNameTags(name);
+        } catch (Exception e) {
+            log.warn("Failed to inject @A2AConsumer auto-tags for agent '{}': {}",
+                name, e.getMessage());
+        }
+
         // Add tools from registry (dependencies are embedded in tool specs)
         List<AgentSpec.ToolSpec> allTools = new ArrayList<>(toolRegistry.getToolSpecs());
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
@@ -5,6 +5,7 @@ import io.mcpmesh.MeshTool;
 import io.mcpmesh.Param;
 import io.mcpmesh.SchemaMode;
 import io.mcpmesh.Selector;
+import io.mcpmesh.a2a.A2AConsumer;
 import io.mcpmesh.core.AgentSpec;
 import io.mcpmesh.core.MeshCoreBridge;
 import org.slf4j.Logger;
@@ -47,7 +48,12 @@ public class MeshToolRegistry {
             capability,
             annotation.description(),
             annotation.version(),
-            Arrays.asList(annotation.tags()),
+            // Mutable list so the @A2AConsumer auto-tag injector
+            // (issue #916) can append the surrounding agent name once
+            // the @MeshAgent has been resolved. Kept as List<String>
+            // on the record so existing readers (heartbeat builder,
+            // tests) are unaffected.
+            new ArrayList<>(Arrays.asList(annotation.tags())),
             extractDependencies(annotation.dependencies()),
             extractInputSchema(method),
             outputType,
@@ -214,6 +220,70 @@ public class MeshToolRegistry {
      */
     public Collection<ToolMetadata> getAllTools() {
         return Collections.unmodifiableCollection(tools.values());
+    }
+
+    /**
+     * Issue #916 Phase 1: append the surrounding {@code @MeshAgent} name
+     * as a tag on every tool also annotated with
+     * {@link io.mcpmesh.a2a.A2AConsumer @A2AConsumer}, idempotent.
+     *
+     * <p>Called from {@code MeshAutoConfiguration.buildAgentSpec} once
+     * the agent name is resolved (env override, properties, or the
+     * annotation literal) but BEFORE {@link #getToolSpecs()} is read
+     * into the heartbeat catalog. Skipped silently when {@code agentName}
+     * is null/blank — the consumer-only / nameless mode of the runtime
+     * never reaches this code path with a real name, so we leave the
+     * tool tags untouched and let the call go up unmodified.
+     *
+     * <p>Java equivalent of Python's
+     * {@code _resolve_pending_consumer_self_tags} (mesh.decorators):
+     * the annotation marker substitutes for the
+     * {@code __MESH_CONSUMER_SELF__} sentinel, and this method takes
+     * the role of the deferred substitution pass.
+     *
+     * @param agentName the resolved {@code @MeshAgent} name; no-op when
+     *                  null or blank.
+     */
+    public void injectConsumerNameTags(String agentName) {
+        if (agentName == null || agentName.isBlank()) {
+            return;
+        }
+        for (ToolMetadata meta : tools.values()) {
+            java.lang.reflect.Method method = meta.method();
+            if (method == null) {
+                continue;
+            }
+            if (!method.isAnnotationPresent(A2AConsumer.class)) {
+                continue;
+            }
+            List<String> current = meta.tags();
+            if (current == null) {
+                continue;
+            }
+            // Idempotent: skip when the tag is already there. Repeated
+            // calls (e.g. test refresh, context restart) must not
+            // accumulate duplicates in the heartbeat tag list.
+            if (current.contains(agentName)) {
+                log.debug("@A2AConsumer tool '{}': consumer-name tag '{}' already present, skipping",
+                    meta.capability(), agentName);
+                continue;
+            }
+            try {
+                current.add(agentName);
+                log.info("@A2AConsumer tool '{}': injected consumer-name tag '{}'",
+                    meta.capability(), agentName);
+            } catch (UnsupportedOperationException e) {
+                // Defensive: registerTool builds a mutable ArrayList,
+                // but external callers using ToolMetadata's public
+                // constructor could supply an immutable list. Surface
+                // a warning instead of crashing the agent.
+                log.warn("@A2AConsumer tool '{}': tags list is immutable, cannot inject "
+                        + "consumer-name auto-tag '{}' — the tool will be missing this tag "
+                        + "in the registry. Construct ToolMetadata with a mutable List<String> "
+                        + "(e.g. new ArrayList<>(...)) to enable auto-tag injection.",
+                    meta.capability(), agentName);
+            }
+        }
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
@@ -130,7 +130,12 @@ public class MeshToolRegistry {
             spec.setCapability(meta.capability());
             spec.setDescription(meta.description());
             spec.setVersion(meta.version());
-            spec.setTags(meta.tags());
+            // Defensive copy: meta.tags() is the registry's mutable
+            // source-of-truth (mutated by injectConsumerNameTags). Aliasing
+            // it into the emitted ToolSpec would let downstream consumers
+            // mutate the registry, and would expose a concurrent-iterate
+            // window to the heartbeat thread while autoconfig appends.
+            spec.setTags(new ArrayList<>(meta.tags()));
 
             // Convert input schema Map to JSON string. The input schema is built
             // from @Param annotations only, so mesh DI parameters (McpMeshTool /

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/A2AConsumerTagInjectionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/A2AConsumerTagInjectionTest.java
@@ -1,0 +1,126 @@
+package io.mcpmesh.spring.a2a;
+
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.a2a.A2AConsumer;
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.spring.MeshToolRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #916 Phase 1: verify that
+ * {@link MeshToolRegistry#injectConsumerNameTags} appends the
+ * surrounding {@code @MeshAgent} name to every {@code @A2AConsumer}
+ * tool's tag list (and to those tools only), is idempotent across
+ * repeated invocations, and skips cleanly when the agent name is
+ * blank or the tool is missing the marker annotation.
+ */
+class A2AConsumerTagInjectionTest {
+
+    /** Stub bean exposing one consumer-marked + one plain mesh tool. */
+    public static class ConsumerBean {
+
+        @MeshTool(capability = "current-date", tags = {"a2a-bridge"})
+        @A2AConsumer
+        public String currentDate() {
+            return "today";
+        }
+
+        @MeshTool(capability = "plain-tool", tags = {"plain"})
+        public String plainTool() {
+            return "ok";
+        }
+    }
+
+    @Test
+    void injectConsumerNameTags_appendsAgentNameToConsumerToolOnly() throws Exception {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        ConsumerBean bean = new ConsumerBean();
+        registry.registerTool(
+            bean,
+            ConsumerBean.class.getMethod("currentDate"),
+            ConsumerBean.class.getMethod("currentDate").getAnnotation(MeshTool.class));
+        registry.registerTool(
+            bean,
+            ConsumerBean.class.getMethod("plainTool"),
+            ConsumerBean.class.getMethod("plainTool").getAnnotation(MeshTool.class));
+
+        registry.injectConsumerNameTags("date-consumer");
+
+        MeshToolRegistry.ToolMetadata consumerMeta = registry.getTool("current-date");
+        assertNotNull(consumerMeta);
+        assertTrue(consumerMeta.tags().contains("a2a-bridge"),
+            "user-supplied tag should still be present");
+        assertTrue(consumerMeta.tags().contains("date-consumer"),
+            "consumer-name auto-tag should be injected");
+
+        MeshToolRegistry.ToolMetadata plainMeta = registry.getTool("plain-tool");
+        assertNotNull(plainMeta);
+        assertFalse(plainMeta.tags().contains("date-consumer"),
+            "plain @MeshTool without @A2AConsumer must NOT receive the auto-tag");
+    }
+
+    @Test
+    void injectConsumerNameTags_isIdempotent() throws Exception {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        ConsumerBean bean = new ConsumerBean();
+        registry.registerTool(
+            bean,
+            ConsumerBean.class.getMethod("currentDate"),
+            ConsumerBean.class.getMethod("currentDate").getAnnotation(MeshTool.class));
+
+        registry.injectConsumerNameTags("date-consumer");
+        registry.injectConsumerNameTags("date-consumer");
+        registry.injectConsumerNameTags("date-consumer");
+
+        List<String> tags = registry.getTool("current-date").tags();
+        long agentTagCount = tags.stream().filter("date-consumer"::equals).count();
+        assertEquals(1, agentTagCount,
+            "auto-tag injection must be idempotent — repeated calls should not duplicate the tag");
+    }
+
+    @Test
+    void injectConsumerNameTags_skipsBlankAgentName() throws Exception {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        ConsumerBean bean = new ConsumerBean();
+        registry.registerTool(
+            bean,
+            ConsumerBean.class.getMethod("currentDate"),
+            ConsumerBean.class.getMethod("currentDate").getAnnotation(MeshTool.class));
+
+        registry.injectConsumerNameTags("");
+        registry.injectConsumerNameTags(null);
+        registry.injectConsumerNameTags("   ");
+
+        List<String> tags = registry.getTool("current-date").tags();
+        assertEquals(List.of("a2a-bridge"), tags,
+            "blank/null agent name should leave tags untouched (consumer-only mode)");
+    }
+
+    @Test
+    void injectConsumerNameTags_propagatesToHeartbeatToolSpecs() throws Exception {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        ConsumerBean bean = new ConsumerBean();
+        registry.registerTool(
+            bean,
+            ConsumerBean.class.getMethod("currentDate"),
+            ConsumerBean.class.getMethod("currentDate").getAnnotation(MeshTool.class));
+
+        registry.injectConsumerNameTags("date-consumer");
+
+        // Confirm the auto-tag flows through to the AgentSpec.ToolSpec
+        // emitted in the heartbeat — this is what the registry actually
+        // sees, and what the resolver uses for capability+tag matching.
+        AgentSpec.ToolSpec spec = registry.getToolSpecs().stream()
+            .filter(s -> "current-date".equals(s.getCapability()))
+            .findFirst()
+            .orElseThrow();
+        assertTrue(spec.getTags().contains("a2a-bridge"),
+            "heartbeat ToolSpec must keep the user-supplied tag");
+        assertTrue(spec.getTags().contains("date-consumer"),
+            "heartbeat ToolSpec must include the auto-injected consumer-name tag");
+    }
+}

--- a/tests/integration/suites/uc27_a2a_consumer_java/artifacts/caller-agent
+++ b/tests/integration/suites/uc27_a2a_consumer_java/artifacts/caller-agent
@@ -1,0 +1,1 @@
+../fixtures/caller-agent

--- a/tests/integration/suites/uc27_a2a_consumer_java/artifacts/consumer-date-agent-java
+++ b/tests/integration/suites/uc27_a2a_consumer_java/artifacts/consumer-date-agent-java
@@ -1,0 +1,1 @@
+../fixtures/consumer-date-agent-java

--- a/tests/integration/suites/uc27_a2a_consumer_java/artifacts/consumer-date-agent-java-b
+++ b/tests/integration/suites/uc27_a2a_consumer_java/artifacts/consumer-date-agent-java-b
@@ -1,0 +1,1 @@
+../fixtures/consumer-date-agent-java-b

--- a/tests/integration/suites/uc27_a2a_consumer_java/artifacts/date-a2a-agent
+++ b/tests/integration/suites/uc27_a2a_consumer_java/artifacts/date-a2a-agent
@@ -1,0 +1,1 @@
+../fixtures/date-a2a-agent

--- a/tests/integration/suites/uc27_a2a_consumer_java/artifacts/system-agent
+++ b/tests/integration/suites/uc27_a2a_consumer_java/artifacts/system-agent
@@ -1,0 +1,1 @@
+../fixtures/system-agent

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/caller-agent
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/caller-agent
@@ -1,0 +1,1 @@
+../../uc25_a2a_consumer_python/fixtures/caller-agent

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Second uc27 Java consumer fixture (issue #916 Phase 1) — registers
+  the SAME current-date capability with the SAME a2a-bridge tag, but
+  under a different agent name (date-consumer-alt). The auto-injected
+  consumer-name tag is what makes this consumer distinguishable from
+  consumer-date-agent-java for capability+tag failover.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>consumer-date-agent-java-b</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>A2A Consumer Date Agent (uc27 Java alt)</name>
+    <description>uc27 Java A2A consumer (alt) — second bridge for tc03 multi-consumer failover.</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.dateconsumerjavab.ConsumerDateAgentBApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/src/main/java/com/example/dateconsumerjavab/ConsumerDateAgentBApplication.java
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/src/main/java/com/example/dateconsumerjavab/ConsumerDateAgentBApplication.java
@@ -1,0 +1,56 @@
+package com.example.dateconsumerjavab;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.a2a.A2AClient;
+import io.mcpmesh.a2a.A2AConsumer;
+import io.mcpmesh.a2a.A2AResponse;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * uc27 Java consumer (alt) — second bridge over the same date_a2a_agent
+ * producer at localhost:9090, but registered under
+ * date-consumer-alt so the auto-injected consumer-name tag
+ * distinguishes it from date-consumer for failover (tc03).
+ */
+@MeshAgent(
+    name = "date-consumer-alt",
+    version = "1.0.0",
+    description = "uc27 Java A2A consumer (alt) — second bridge for failover tests.",
+    port = 9202
+)
+@SpringBootApplication
+public class ConsumerDateAgentBApplication {
+
+    private static final A2AClient A2A_CLIENT = new A2AClient(
+        "http://localhost:9090/agents/date",
+        "get-date"
+    );
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    public static void main(String[] args) {
+        SpringApplication.run(ConsumerDateAgentBApplication.class, args);
+    }
+
+    @MeshTool(
+        capability = "current-date",
+        description = "Bridge upstream A2A get-date skill onto the mesh (alt consumer).",
+        tags = {"a2a-bridge"}
+    )
+    @A2AConsumer
+    public Map<String, Object> currentDate() throws Exception {
+        A2AResponse response = A2A_CLIENT.send(Map.of(
+            "role", "user",
+            "parts", List.of(Map.of("type", "text", "text", "now"))
+        ));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> payload = JSON.readValue(response.artifactText(), Map.class);
+        return payload;
+    }
+}

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/src/main/resources/application.yml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: consumer-date-agent-java-b
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9202}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:date-consumer-alt}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    io.mcpmesh: INFO
+    com.example: DEBUG

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  uc27_a2a_consumer_java fixture — Java A2A consumer (issue #916 Phase 1).
+  Java port of the Python uc25 consumer-date-agent fixture; bridges the
+  same date_a2a_agent.py producer (localhost:9090/agents/date) onto the
+  mesh as the current-date capability.
+
+  Capability + auto-tag scheme matches the Python side EXACTLY so the
+  uc27 tests assert the same shape:
+      capability = "current-date"
+      tags       = ["a2a-bridge", "date-consumer"]
+  The "date-consumer" tag is auto-injected via @A2AConsumer at
+  registration time (see MeshToolRegistry.injectConsumerNameTags).
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>consumer-date-agent-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>A2A Consumer Date Agent (uc27 Java)</name>
+    <description>uc27 Java A2A consumer fixture — bridges date_a2a_agent.py get-date as the current-date mesh capability.</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.dateconsumerjava.ConsumerDateAgentApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/src/main/java/com/example/dateconsumerjava/ConsumerDateAgentApplication.java
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/src/main/java/com/example/dateconsumerjava/ConsumerDateAgentApplication.java
@@ -1,0 +1,59 @@
+package com.example.dateconsumerjava;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.a2a.A2AClient;
+import io.mcpmesh.a2a.A2AConsumer;
+import io.mcpmesh.a2a.A2AResponse;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * uc27_a2a_consumer_java fixture — bridges the existing
+ * date_a2a_agent.py producer's get-date skill onto the mesh as a
+ * current-date capability.
+ *
+ * <p>All test agents share the tsuite container's network namespace,
+ * so the upstream A2A endpoint is reachable on localhost:9090 (NOT a
+ * docker service name).
+ */
+@MeshAgent(
+    name = "date-consumer",
+    version = "1.0.0",
+    description = "Java A2A consumer fixture — bridges date_a2a_agent.py get-date as current-date.",
+    port = 9201
+)
+@SpringBootApplication
+public class ConsumerDateAgentApplication {
+
+    private static final A2AClient A2A_CLIENT = new A2AClient(
+        "http://localhost:9090/agents/date",
+        "get-date"
+    );
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    public static void main(String[] args) {
+        SpringApplication.run(ConsumerDateAgentApplication.class, args);
+    }
+
+    @MeshTool(
+        capability = "current-date",
+        description = "Bridge upstream A2A get-date skill onto the mesh.",
+        tags = {"a2a-bridge"}
+    )
+    @A2AConsumer
+    public Map<String, Object> currentDate() throws Exception {
+        A2AResponse response = A2A_CLIENT.send(Map.of(
+            "role", "user",
+            "parts", List.of(Map.of("type", "text", "text", "now"))
+        ));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> payload = JSON.readValue(response.artifactText(), Map.class);
+        return payload;
+    }
+}

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/src/main/resources/application.yml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: consumer-date-agent-java
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9201}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:date-consumer}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    io.mcpmesh: INFO
+    com.example: DEBUG

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/date-a2a-agent
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/date-a2a-agent
@@ -1,0 +1,1 @@
+../../uc25_a2a_consumer_python/fixtures/date-a2a-agent

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/system-agent
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/system-agent
@@ -1,0 +1,1 @@
+../../uc25_a2a_consumer_python/fixtures/system-agent

--- a/tests/integration/suites/uc27_a2a_consumer_java/routines.yaml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/routines.yaml
@@ -1,0 +1,52 @@
+# UC-level routines for uc27_a2a_consumer_java (issue #916 Phase 1).
+#
+# Java port of uc25_a2a_consumer_python: tests the consumer side of the
+# A2A bridge using the Java runtime's @A2AConsumer annotation. The
+# producer (date_a2a_agent.py) and the downstream caller (caller-agent)
+# remain Python — this suite exercises Java consumer registration +
+# tag injection + outbound A2A round-trip + multi-consumer failover.
+#
+# Same fast-sweep registry timing as uc25 so failover (tc03) takes
+# seconds, not minutes — DEFAULT_TIMEOUT_THRESHOLD bounds how quickly
+# the registry marks a stopped consumer unhealthy so the surviving
+# consumer can pick up subsequent calls.
+
+routines:
+  start_registry_consumer:
+    description: "Start the registry with fast-sweep timing for consumer health/failover tests"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: |
+          MCP_MESH_SWEEP_INTERVAL=10s \
+          MCP_MESH_RETENTION=10s \
+          MCP_MESH_HEALTH_CHECK_INTERVAL=5 \
+          DEFAULT_TIMEOUT_THRESHOLD=15 \
+            meshctl start --registry-only -d
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "registry ready after ${i}s"
+              # Verify the sweep override actually stamped its log line.
+              # If MCP_MESH_SWEEP_INTERVAL didn't take effect the suite
+              # must fail loudly here, not via slow per-test timeouts.
+              tail -n 200 ~/.mcp-mesh/logs/registry.log \
+                | grep -qE '\[sweep\] using MCP_MESH_SWEEP_INTERVAL' \
+                || { echo "FAIL: MCP_MESH_SWEEP_INTERVAL override did not take effect"; exit 1; }
+              echo "[setup] confirmed sweep override active"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: registry did not become ready in 20s"
+          tail -50 ~/.mcp-mesh/logs/registry.log 2>/dev/null || true
+          exit 1
+        capture: registry_start
+        timeout: 30
+
+  stop_all:
+    description: "Stop all mesh processes started by this test"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: meshctl stop 2>/dev/null || true
+        ignore_errors: true

--- a/tests/integration/suites/uc27_a2a_consumer_java/tc01_capability_and_tag_registration/test.yaml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/tc01_capability_and_tag_registration/test.yaml
@@ -1,0 +1,153 @@
+# tc01_capability_and_tag_registration — Java A2A consumer registration smoke (issue #916 Phase 1).
+#
+# Java port of uc25 tc01. Verifies the Java @A2AConsumer marker
+# annotation pairs with @MeshTool to publish the capability through the
+# regular registration path AND that the consumer-name auto-tag
+# injection works end-to-end:
+#
+#   - The consumer agent appears in /agents with agent_type=mcp_agent
+#     (it is a regular mesh agent that bridges A2A — NOT an A2A
+#     producer; only date-a2a-agent has agent_type=a2a here).
+#   - The current-date capability lives under the consumer's
+#     tools[*].capabilities array.
+#   - That capability's tags carry BOTH "a2a-bridge" (user-supplied
+#     via the @MeshTool tags field) AND "date-consumer" (auto-injected
+#     from the surrounding @MeshAgent name via
+#     MeshToolRegistry.injectConsumerNameTags() at heartbeat-build
+#     time — Java equivalent of Python's
+#     _resolve_pending_consumer_self_tags substitution).
+#
+# Stack: registry + system-agent (Python, date_service on 9100) +
+# date-a2a-agent (Python A2A surface on 9090) +
+# consumer-date-agent-java (Java consumer on 9201). The Java consumer
+# reaches the Python producer over localhost:9090 because all four
+# processes share the tsuite container's network namespace.
+
+name: "A2A consumer (Java): capability + auto-tag registration"
+description: "@A2AConsumer Java marker + @MeshTool publish current-date with a2a-bridge AND auto-injected consumer-name tag"
+tags:
+  - a2a
+  - java
+  - smoke
+  - issue-916
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/system-agent /workspace/
+      cp -rL /uc-artifacts/date-a2a-agent /workspace/
+      cp -rL /uc-artifacts/consumer-date-agent-java /workspace/
+
+  - name: "Install system-agent deps"
+    handler: pip-install
+    path: /workspace/system-agent
+
+  - name: "Install date-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/date-a2a-agent
+
+  - name: "Install consumer-date-agent-java deps"
+    handler: maven-install
+    path: /workspace/consumer-date-agent-java
+    timeout: 600
+
+  - routine: start_registry_consumer
+
+  - name: "Start system-agent (port 9100, provides date_service)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start system-agent/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for system-agent registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start date-a2a-agent (port 9090)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start date-a2a-agent/main.py -d
+
+  - name: "Wait for date_service DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Start consumer-date-agent-java (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-date-agent-java --env MCP_MESH_HTTP_PORT=9201 -d
+
+  # Java cold-start is ~30s for Spring Boot; with the fast-sweep
+  # registry the agent can be marked unhealthy if the first heartbeat
+  # is delayed past DEFAULT_TIMEOUT_THRESHOLD=15s. Poll the /agents
+  # endpoint until status==healthy (recovers automatically once the
+  # JVM finishes booting and the heartbeat thread starts).
+  - name: "Wait for Java consumer to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -s http://localhost:8000/agents | jq -r \
+          '.agents[] | select(.name=="date-consumer") | .status' 2>/dev/null)
+        if [ "$STATUS" = "healthy" ]; then
+          echo "Java consumer healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Java consumer not healthy within 120s (last status='$STATUS')"
+      meshctl logs consumer-date-agent-java 2>&1 | tail -80 || true
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name=="date-consumer")' || true
+      exit 1
+    timeout: 150
+
+  - name: "Verify all 3 agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "GET /agents on the registry"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_response
+    timeout: 15
+
+assertions:
+  - expr: "${captured.agent_list} contains 'system-agent'"
+    message: "system-agent should be registered"
+  - expr: "${captured.agent_list} contains 'date-a2a-agent'"
+    message: "date-a2a-agent should be registered (meshctl derives the name from the source filename)"
+  - expr: "${captured.agent_list} contains 'date-consumer'"
+    message: "Java consumer-date-agent-java should be registered as 'date-consumer' (from @MeshAgent(name=...))"
+
+  # The consumer is a REGULAR mesh agent (mcp_agent), not an A2A
+  # producer. The /agents response carries all three; the substring
+  # match below is sufficient because we already checked the names
+  # above and only one mcp_agent type is consumer-shaped.
+  - expr: "${captured.agents_response} contains '\"name\":\"date-consumer\"'"
+    message: "/agents response should include the Java consumer agent record"
+  - expr: "${captured.agents_response} contains '\"current-date\"'"
+    message: "Java consumer should publish the current-date capability"
+
+  # BOTH tags must appear scoped to the current-date capability under
+  # the date-consumer agent. We use the ${jq:captured.X:filter} operator
+  # to extract exactly the current-date capability's tags array — looser
+  # substring asserts on the raw response can pass even if the
+  # consumer-name tag injection didn't fire, since "date-consumer" also
+  # appears as the agent's name field.
+  - expr: "${jq:captured.agents_response:[.agents[] | select(.name==\"date-consumer\") | .capabilities[]? | select(.name==\"current-date\") | .tags[]]} contains 'a2a-bridge'"
+    message: "current-date capability should carry the user-supplied a2a-bridge tag"
+  - expr: "${jq:captured.agents_response:[.agents[] | select(.name==\"date-consumer\") | .capabilities[]? | select(.name==\"current-date\") | .tags[]]} contains 'date-consumer'"
+    message: "current-date capability should carry the auto-injected consumer-name tag (Java @A2AConsumer)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc27_a2a_consumer_java/tc01_capability_and_tag_registration/test.yaml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/tc01_capability_and_tag_registration/test.yaml
@@ -30,7 +30,7 @@ tags:
   - java
   - smoke
   - issue-916
-timeout: 360
+timeout: 900
 
 pre_run:
   - routine: global.setup_for_python_agent
@@ -93,8 +93,8 @@ test:
     workdir: /workspace
     command: |
       for i in $(seq 1 60); do
-        STATUS=$(curl -s http://localhost:8000/agents | jq -r \
-          '.agents[] | select(.name=="date-consumer") | .status' 2>/dev/null)
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null | jq -r \
+          '.agents[] | select(.name=="date-consumer") | .status' 2>/dev/null || echo "")
         if [ "$STATUS" = "healthy" ]; then
           echo "Java consumer healthy after ${i}x2s"
           exit 0
@@ -103,7 +103,7 @@ test:
       done
       echo "ERROR: Java consumer not healthy within 120s (last status='$STATUS')"
       meshctl logs consumer-date-agent-java 2>&1 | tail -80 || true
-      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name=="date-consumer")' || true
+      curl -fsS --max-time 10 http://localhost:8000/agents | jq '.agents[] | select(.name=="date-consumer")' || true
       exit 1
     timeout: 150
 
@@ -116,7 +116,7 @@ test:
   - name: "GET /agents on the registry"
     handler: shell
     workdir: /workspace
-    command: curl -s http://localhost:8000/agents
+    command: curl -fsS --max-time 10 http://localhost:8000/agents
     capture: agents_response
     timeout: 15
 

--- a/tests/integration/suites/uc27_a2a_consumer_java/tc02_end_to_end_dispatch_via_caller/test.yaml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/tc02_end_to_end_dispatch_via_caller/test.yaml
@@ -1,0 +1,149 @@
+# tc02_end_to_end_dispatch_via_caller — full bridge round-trip (Java consumer).
+#
+# Java port of uc25 tc02. A downstream Python mesh tool depending on the
+# bridged current-date capability actually reaches the producer through
+# the JAVA consumer's outbound A2A tasks/send call.
+#
+# Call chain:
+#   meshctl call date-caller:get_formatted_date
+#     -> caller resolves current-date dependency to JAVA consumer
+#     -> consumer's @MeshTool body issues outbound
+#        POST http://localhost:9090/agents/date  (tasks/send via java.net.http.HttpClient)
+#     -> date-a2a-agent's mounted handler resolves date_service
+#     -> system-agent's date_service returns the current time
+#     -> bubble back: producer artifact -> Java consumer json mapper
+#        -> caller returns the {"date": ...} dict
+#
+# Stack: registry + system-agent (Python) + date-a2a-agent (Python) +
+# consumer-date-agent-java (Java) + caller-agent (Python). 5 processes.
+
+name: "A2A consumer (Java): end-to-end dispatch via downstream caller"
+description: "Caller -> Java A2A consumer bridge -> producer -> system-agent round-trip returns the date payload"
+tags:
+  - a2a
+  - java
+  - smoke
+  - issue-916
+timeout: 420
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/system-agent /workspace/
+      cp -rL /uc-artifacts/date-a2a-agent /workspace/
+      cp -rL /uc-artifacts/consumer-date-agent-java /workspace/
+      cp -rL /uc-artifacts/caller-agent /workspace/
+
+  - name: "Install system-agent deps"
+    handler: pip-install
+    path: /workspace/system-agent
+
+  - name: "Install date-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/date-a2a-agent
+
+  - name: "Install consumer-date-agent-java deps"
+    handler: maven-install
+    path: /workspace/consumer-date-agent-java
+    timeout: 600
+
+  - name: "Install caller-agent deps"
+    handler: pip-install
+    path: /workspace/caller-agent
+
+  - routine: start_registry_consumer
+
+  - name: "Start system-agent (port 9100, provides date_service)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start system-agent/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for system-agent registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start date-a2a-agent (port 9090)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start date-a2a-agent/main.py -d
+
+  - name: "Wait for date_service DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Start consumer-date-agent-java (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-date-agent-java --env MCP_MESH_HTTP_PORT=9201 -d
+
+  - name: "Wait for Java consumer to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -s http://localhost:8000/agents | jq -r \
+          '.agents[] | select(.name=="date-consumer") | .status' 2>/dev/null)
+        if [ "$STATUS" = "healthy" ]; then
+          echo "Java consumer healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Java consumer not healthy within 120s (last status='$STATUS')"
+      meshctl logs consumer-date-agent-java 2>&1 | tail -80 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start caller-agent (port 9203)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start caller-agent/main.py -d
+
+  - name: "Wait for caller current-date DI resolution"
+    handler: wait
+    seconds: 25
+
+  - name: "Verify all 4 agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Invoke caller's get_formatted_date tool"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date '{}' 2>&1
+    capture: caller_response
+    timeout: 30
+
+assertions:
+  - expr: "${captured.agent_list} contains 'system-agent'"
+    message: "system-agent should be registered"
+  - expr: "${captured.agent_list} contains 'date-consumer'"
+    message: "Java consumer-date-agent-java should be registered as 'date-consumer'"
+  - expr: "${captured.agent_list} contains 'date-caller'"
+    message: "caller-agent should be registered"
+
+  # The producer's date_service returns a timestamp; the A2A handler
+  # wraps it as {"date": "<ts>"} which the Java consumer's Jackson
+  # readValue parses back to a Map — meshctl call surfaces the dict in
+  # its output. We match the bare word `date` (the JSON key) which only
+  # appears in the successful payload, never in error envelopes.
+  - expr: "${captured.caller_response} contains 'date'"
+    message: "caller response should carry the {date: ...} payload from the producer"
+
+  # Defensive: confirm we did NOT hit the "dependency not resolved"
+  # short-circuit branch in the caller — that would mean the
+  # current-date dependency never wired up to the Java consumer.
+  - expr: "${captured.caller_response} not contains 'dependency not resolved'"
+    message: "current_date dependency must be resolved by the time the call lands"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc27_a2a_consumer_java/tc02_end_to_end_dispatch_via_caller/test.yaml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/tc02_end_to_end_dispatch_via_caller/test.yaml
@@ -24,7 +24,7 @@ tags:
   - java
   - smoke
   - issue-916
-timeout: 420
+timeout: 900
 
 pre_run:
   - routine: global.setup_for_python_agent
@@ -87,8 +87,8 @@ test:
     workdir: /workspace
     command: |
       for i in $(seq 1 60); do
-        STATUS=$(curl -s http://localhost:8000/agents | jq -r \
-          '.agents[] | select(.name=="date-consumer") | .status' 2>/dev/null)
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null | jq -r \
+          '.agents[] | select(.name=="date-consumer") | .status' 2>/dev/null || echo "")
         if [ "$STATUS" = "healthy" ]; then
           echo "Java consumer healthy after ${i}x2s"
           exit 0
@@ -135,8 +135,8 @@ assertions:
   # readValue parses back to a Map — meshctl call surfaces the dict in
   # its output. We match the bare word `date` (the JSON key) which only
   # appears in the successful payload, never in error envelopes.
-  - expr: "${captured.caller_response} contains 'date'"
-    message: "caller response should carry the {date: ...} payload from the producer"
+  - expr: "${captured.caller_response} contains '\"date\":'"
+    message: "caller response should carry the JSON 'date' key from the bridge"
 
   # Defensive: confirm we did NOT hit the "dependency not resolved"
   # short-circuit branch in the caller — that would mean the

--- a/tests/integration/suites/uc27_a2a_consumer_java/tc03_multi_consumer_failover/test.yaml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/tc03_multi_consumer_failover/test.yaml
@@ -1,0 +1,246 @@
+# tc03_multi_consumer_failover — multi-consumer registration + failover (Java).
+#
+# Java port of uc25 tc03. Two JAVA A2A consumers register the SAME
+# current-date capability with the SAME a2a-bridge tag, but under
+# DIFFERENT @MeshAgent names (date-consumer / date-consumer-alt). The
+# auto-injected consumer-name tag (via @A2AConsumer) is what makes the
+# two registrations distinguishable for capability+tag pinning AND for
+# the resolver's untagged failover path.
+#
+# Validation strategy (two phases):
+#
+#   Phase A — pinned distinguishability:
+#     With both Java consumers up, the caller's tag-pinned tools each
+#     resolve to a SPECIFIC consumer (proven by the pinned dependency
+#     selector matching the auto-injected consumer-name tag — if the
+#     Java injection didn't work, neither pinned tool would resolve
+#     and the caller would short-circuit with "dependency not resolved").
+#
+#   Phase B — auto-rewire on consumer death:
+#     Stop the primary Java consumer (date-consumer). After the
+#     fast-sweep registry marks it unhealthy, the caller's UNTAGGED
+#     get_formatted_date dep auto-rewires to the surviving
+#     date-consumer-alt and the call still succeeds.
+#
+# Stack: registry + system-agent + date-a2a-agent + 2 JAVA consumers +
+# caller-agent (6 processes). Two slow Java JVMs to boot — generous
+# timeout.
+
+name: "A2A consumer (Java): multi-consumer registration + auto-rewire failover"
+description: "Two Java consumers register current-date with distinct auto-tags; tag-pinning works AND untagged dep auto-rewires when one consumer dies"
+tags:
+  - a2a
+  - java
+  - smoke
+  - issue-916
+timeout: 600
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/system-agent /workspace/
+      cp -rL /uc-artifacts/date-a2a-agent /workspace/
+      cp -rL /uc-artifacts/consumer-date-agent-java /workspace/
+      cp -rL /uc-artifacts/consumer-date-agent-java-b /workspace/
+      cp -rL /uc-artifacts/caller-agent /workspace/
+
+  - name: "Install system-agent deps"
+    handler: pip-install
+    path: /workspace/system-agent
+
+  - name: "Install date-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/date-a2a-agent
+
+  - name: "Install Java consumer (primary) deps"
+    handler: maven-install
+    path: /workspace/consumer-date-agent-java
+    timeout: 600
+
+  - name: "Install Java consumer (alt) deps"
+    handler: maven-install
+    path: /workspace/consumer-date-agent-java-b
+    timeout: 600
+
+  - name: "Install caller-agent deps"
+    handler: pip-install
+    path: /workspace/caller-agent
+
+  - routine: start_registry_consumer
+
+  - name: "Start system-agent (port 9100, provides date_service)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start system-agent/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for system-agent registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start date-a2a-agent (port 9090)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start date-a2a-agent/main.py -d
+
+  - name: "Wait for date_service DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Start consumer-date-agent-java (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-date-agent-java --env MCP_MESH_HTTP_PORT=9201 -d
+
+  - name: "Start consumer-date-agent-java-b (port 9202)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-date-agent-java-b --env MCP_MESH_HTTP_PORT=9202 -d
+
+  - name: "Wait for both Java consumers to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S1=$(curl -s http://localhost:8000/agents | jq -r \
+          '.agents[] | select(.name=="date-consumer") | .status' 2>/dev/null)
+        S2=$(curl -s http://localhost:8000/agents | jq -r \
+          '.agents[] | select(.name=="date-consumer-alt") | .status' 2>/dev/null)
+        if [ "$S1" = "healthy" ] && [ "$S2" = "healthy" ]; then
+          echo "both Java consumers healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: consumers not healthy within 120s (primary='$S1', alt='$S2')"
+      meshctl logs consumer-date-agent-java 2>&1 | tail -50 || true
+      meshctl logs consumer-date-agent-java-b 2>&1 | tail -50 || true
+      exit 1
+    timeout: 180
+
+  - name: "Start caller-agent (port 9203)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start caller-agent/main.py -d
+
+  - name: "Wait for caller pinned + untagged DI resolution"
+    handler: wait
+    seconds: 25
+
+  - name: "Verify all 5 agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "GET /agents on the registry"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_response_pre
+    timeout: 15
+
+  # ===== Phase A: pinned distinguishability =====
+
+  - name: "Phase A: invoke pinned-primary tool (must hit date-consumer)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date_primary '{}' 2>&1
+    capture: pinned_primary_pre
+    timeout: 30
+
+  - name: "Phase A: invoke pinned-alt tool (must hit date-consumer-alt)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date_alt '{}' 2>&1
+    capture: pinned_alt_pre
+    timeout: 30
+
+  - name: "Phase A: invoke untagged tool (any healthy consumer wins)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date '{}' 2>&1
+    capture: untagged_pre
+    timeout: 30
+
+  # ===== Phase B: kill primary consumer, verify failover =====
+
+  - name: "Phase B: stop date-consumer (primary)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl stop consumer-date-agent-java 2>&1 || true
+    ignore_errors: true
+
+  # DEFAULT_TIMEOUT_THRESHOLD=15 + HEALTH_CHECK_INTERVAL=5 means the
+  # registry marks a non-heartbeating agent unhealthy in ~15-20s; the
+  # caller then needs another heartbeat round to pull a fresh
+  # dependency state. Bump the wait to 35s so the rewire is
+  # comfortably converged before we re-poll.
+  - name: "Phase B: wait for fast-sweep to mark primary unhealthy + caller rewire"
+    handler: wait
+    seconds: 35
+
+  - name: "Phase B: invoke pinned-alt tool again (should still succeed — its dep never moved)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date_alt '{}' 2>&1
+    capture: pinned_alt_post
+    timeout: 30
+
+  - name: "Phase B: invoke untagged tool again (auto-rewire to surviving date-consumer-alt)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date '{}' 2>&1
+    capture: untagged_post
+    timeout: 30
+
+assertions:
+  # ===== Setup sanity =====
+  - expr: "${captured.agent_list} contains 'date-consumer'"
+    message: "primary Java consumer should be registered"
+  - expr: "${captured.agent_list} contains 'date-consumer-alt'"
+    message: "alt Java consumer should be registered"
+  - expr: "${captured.agent_list} contains 'date-caller'"
+    message: "caller agent should be registered"
+
+  # Both auto-injected tags must be present in the registry response
+  # (proves the Java consumer-name auto-tag injection ran on BOTH
+  # consumers under different agent names).
+  - expr: "${captured.agents_response_pre} contains '\"date-consumer\"'"
+    message: "primary consumer-name tag should appear on its current-date capability"
+  - expr: "${captured.agents_response_pre} contains '\"date-consumer-alt\"'"
+    message: "alt consumer-name tag should appear on its current-date capability"
+
+  # ===== Phase A: pinned distinguishability =====
+  - expr: "${captured.pinned_primary_pre} contains 'date'"
+    message: "pinned-primary tool should resolve to date-consumer and return the date payload"
+  - expr: "${captured.pinned_primary_pre} not contains 'dependency not resolved'"
+    message: "pinned-primary dependency must wire up before the call"
+  - expr: "${captured.pinned_alt_pre} contains 'date'"
+    message: "pinned-alt tool should resolve to date-consumer-alt and return the date payload"
+  - expr: "${captured.pinned_alt_pre} not contains 'dependency not resolved'"
+    message: "pinned-alt dependency must wire up before the call"
+  - expr: "${captured.untagged_pre} contains 'date'"
+    message: "untagged tool should resolve to either consumer and return the date payload"
+  - expr: "${captured.untagged_pre} not contains 'dependency not resolved'"
+    message: "untagged dependency must wire up before the call"
+
+  # ===== Phase B: failover =====
+  - expr: "${captured.pinned_alt_post} contains 'date'"
+    message: "pinned-alt tool should still succeed after primary Java consumer is killed"
+  - expr: "${captured.pinned_alt_post} not contains 'dependency not resolved'"
+    message: "pinned-alt dep should remain wired after primary consumer death"
+
+  - expr: "${captured.untagged_post} contains 'date'"
+    message: "untagged tool should auto-rewire to the surviving consumer after primary death"
+  - expr: "${captured.untagged_post} not contains 'dependency not resolved'"
+    message: "untagged dep should auto-rewire (not orphan) when primary Java consumer dies"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc27_a2a_consumer_java/tc03_multi_consumer_failover/test.yaml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/tc03_multi_consumer_failover/test.yaml
@@ -33,7 +33,7 @@ tags:
   - java
   - smoke
   - issue-916
-timeout: 600
+timeout: 1500
 
 pre_run:
   - routine: global.setup_for_python_agent
@@ -107,10 +107,10 @@ test:
     workdir: /workspace
     command: |
       for i in $(seq 1 60); do
-        S1=$(curl -s http://localhost:8000/agents | jq -r \
-          '.agents[] | select(.name=="date-consumer") | .status' 2>/dev/null)
-        S2=$(curl -s http://localhost:8000/agents | jq -r \
-          '.agents[] | select(.name=="date-consumer-alt") | .status' 2>/dev/null)
+        S1=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null | jq -r \
+          '.agents[] | select(.name=="date-consumer") | .status' 2>/dev/null || echo "")
+        S2=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null | jq -r \
+          '.agents[] | select(.name=="date-consumer-alt") | .status' 2>/dev/null || echo "")
         if [ "$S1" = "healthy" ] && [ "$S2" = "healthy" ]; then
           echo "both Java consumers healthy after ${i}x2s"
           exit 0
@@ -141,7 +141,7 @@ test:
   - name: "GET /agents on the registry"
     handler: shell
     workdir: /workspace
-    command: curl -s http://localhost:8000/agents
+    command: curl -fsS --max-time 10 http://localhost:8000/agents
     capture: agents_response_pre
     timeout: 15
 
@@ -217,27 +217,27 @@ assertions:
     message: "alt consumer-name tag should appear on its current-date capability"
 
   # ===== Phase A: pinned distinguishability =====
-  - expr: "${captured.pinned_primary_pre} contains 'date'"
-    message: "pinned-primary tool should resolve to date-consumer and return the date payload"
+  - expr: "${captured.pinned_primary_pre} contains '\"date\":'"
+    message: "pinned-primary tool should carry the JSON 'date' key from the bridge"
   - expr: "${captured.pinned_primary_pre} not contains 'dependency not resolved'"
     message: "pinned-primary dependency must wire up before the call"
-  - expr: "${captured.pinned_alt_pre} contains 'date'"
-    message: "pinned-alt tool should resolve to date-consumer-alt and return the date payload"
+  - expr: "${captured.pinned_alt_pre} contains '\"date\":'"
+    message: "pinned-alt tool should carry the JSON 'date' key from the bridge"
   - expr: "${captured.pinned_alt_pre} not contains 'dependency not resolved'"
     message: "pinned-alt dependency must wire up before the call"
-  - expr: "${captured.untagged_pre} contains 'date'"
-    message: "untagged tool should resolve to either consumer and return the date payload"
+  - expr: "${captured.untagged_pre} contains '\"date\":'"
+    message: "untagged tool should carry the JSON 'date' key from the bridge"
   - expr: "${captured.untagged_pre} not contains 'dependency not resolved'"
     message: "untagged dependency must wire up before the call"
 
   # ===== Phase B: failover =====
-  - expr: "${captured.pinned_alt_post} contains 'date'"
-    message: "pinned-alt tool should still succeed after primary Java consumer is killed"
+  - expr: "${captured.pinned_alt_post} contains '\"date\":'"
+    message: "pinned-alt tool should still carry the JSON 'date' key after primary Java consumer is killed"
   - expr: "${captured.pinned_alt_post} not contains 'dependency not resolved'"
     message: "pinned-alt dep should remain wired after primary consumer death"
 
-  - expr: "${captured.untagged_post} contains 'date'"
-    message: "untagged tool should auto-rewire to the surviving consumer after primary death"
+  - expr: "${captured.untagged_post} contains '\"date\":'"
+    message: "untagged tool should carry the JSON 'date' key after auto-rewire to surviving consumer"
   - expr: "${captured.untagged_post} not contains 'dependency not resolved'"
     message: "untagged dep should auto-rewire (not orphan) when primary Java consumer dies"
 


### PR DESCRIPTION
## Summary

First non-Python runtime port of the A2A consumer side. Mirrors the Python design from PR #913 (Phase 1 sync) in idiomatic Java, sitting on the existing Java SDK substrate (PR #891) and tsuite Java test infrastructure (PR #892). **Phase 1 of 2** for #916 — Phase 3 (long-running + SSE) ships in a follow-up PR.

User-facing surface (idiomatic Java — explicit construction, no Spring magic):

```java
@SpringBootApplication
@MeshAgent(name = "date-consumer", port = 9201)
public class DateConsumerAgent {
    private static final A2AClient CLIENT = new A2AClient(
        "http://upstream/agents/date", "get-date");

    @MeshTool(capability = "current-date", tags = {"a2a-bridge"})
    @A2AConsumer
    public Map<String, Object> getCurrentDate() throws Exception {
        A2AResponse r = CLIENT.send(Map.of(
            "role", "user",
            "parts", List.of(Map.of("type", "text", "text", "now"))
        ));
        return MAPPER.readValue(r.artifactText(), Map.class);
    }
}
```

The `@A2AConsumer` marker pairs with `@MeshTool` to opt the tool into consumer-name auto-tag injection. Capability registers with both the user-supplied tags AND the surrounding `@MeshAgent` name as a tag, enabling capability+tag failover across multiple Java consumers bridging the same logical capability — exactly like Python.

### Phase 1 scope (sync only)

- `io.mcpmesh.a2a.A2AClient` — sync `tasks/send` + poll-until-terminal using `java.net.http.HttpClient` (JDK 11+, no OkHttp dependency to avoid `mcp-mesh-sdk` → `mcp-mesh-spring-boot-starter` cycle)
- `io.mcpmesh.a2a.A2ABearer` — call-time-resolved bearer credential (env-var or explicit token; rotates between calls)
- `io.mcpmesh.a2a.A2AResponse` — record carrying `artifactText`, `state`, `taskId`, `rawTask` (Jackson 3 `JsonNode`)
- `io.mcpmesh.a2a.A2AException` + `A2ATimeoutException` + `A2AAuthException` — `RuntimeException` hierarchy
- `io.mcpmesh.a2a.A2AConsumer` — pure marker annotation
- `MeshToolRegistry.injectConsumerNameTags(agentName)` — appends `@MeshAgent` name to `@A2AConsumer`-marked tool tag lists, idempotent. Hooked from `MeshAutoConfiguration.buildAgentSpec` between agent-name resolution and `getToolSpecs()` — only point that runs BEFORE the inaugural heartbeat (an `ApplicationListener<ContextRefreshedEvent>` would have fired AFTER and missed the initial registration)
- `examples/java/consumer-date-agent` — eat-our-own-dogfood example bridging `examples/a2a/date_a2a_agent.py` over `localhost:9090`
- `uc27_a2a_consumer_java` integration suite (3/3 PASS at parallel 4): capability+tag registration, end-to-end dispatch via downstream caller, multi-consumer failover (tag-pinning + auto-rewire)

### Bug fix during testing

`A2AClient.send`'s polling loop was using a per-call timeout helper that always returned at least 1ms, masking the polling deadline check. Split the helper — keep the 1ms-floor for the initial `tasks/send` (HTTP timeout must always be positive even if user-supplied deadline already elapsed at construction), but check the deadline directly in the polling loop so a fully-elapsed deadline surfaces the polling-level `A2ATimeoutException` with the user-friendly "did not reach terminal state" message rather than a per-call HTTP timeout. Regression test `send_neverReachesTerminal_throwsTimeout` catches it.

## Review Notes

Independent review-agent pass found **0 BLOCKER, 5 WARNING, 6 INFO**. 4 of 5 warnings applied as a follow-up commit (`28daad14`):

- `MeshToolRegistry.getToolSpecs()` defensive-copies tag list into `ToolSpec.setTags(new ArrayList<>(meta.tags()))` — was aliasing the registry's mutable source-of-truth, future concurrent-modification footgun
- `A2AClient.postJsonRpc` throws `A2AException` when response carries neither `result` nor `error` — was silently coercing missing result to empty object, polling spun until timeout instead of failing fast
- Class-level Javadoc on `A2AClient` documents the JDK 17 lifecycle limitation (`close()` is cosmetic; JDK 21+ has real `HttpClient.close()`)
- `@param` Javadoc on `A2AResponse.rawTask` calls out the sharing semantics (record is immutable but JsonNode is the live parse tree — treat as read-only)

1 WARNING + 6 INFOs verified INVALID and skipped:
- WARNING (backoff cap one step late): intentional Python parity (same `min(cap, current * 1.5)` formula in `_a2a_consumer.py:209`)
- 6 INFOs: pure style (`replaceAll` vs `while`, `JsonNode.path()` chains, `ObjectMapper` duplication in examples)

Refs #916 (Phase 1 of 2 — Phase 3 long-running follows in a separate PR)

## Test plan

- [x] `mvn -pl mcp-mesh-sdk,mcp-mesh-spring-boot-starter compile` — clean
- [x] **15/15** mcp-mesh-sdk unit tests PASS (was 14; +1 regression test for fail-fast on malformed JSON-RPC)
- [x] **153/153** mcp-mesh-spring-boot-starter unit tests PASS (149 existing + 4 new `A2AConsumerTagInjectionTest`)
- [x] **12/12** src-tests PASS (image rebuilt with new Java SDK)
- [x] **3/3** uc27 integration tests PASS at parallel 4
- [x] Both Java fixtures + example build cleanly to runnable Spring Boot uber-jars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added A2A consumer support for Java applications, enabling synchronous calls to upstream A2A services with bearer token authentication and configurable timeout handling.
* Added example consumer application demonstrating A2A service integration.
* Added automatic consumer agent name tagging for A2A bridge tools in Spring Boot applications.

## Tests
* Added integration test suites validating A2A consumer registration, end-to-end dispatch, and multi-consumer failover scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/919)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->