### PR TITLE
refactor(a2a): Java @A2AConsumer framework-injection pattern (#923)

### DIFF
--- a/examples/java/consumer-date-agent/src/main/java/com/example/dateconsumer/DateConsumerAgentApplication.java
+++ b/examples/java/consumer-date-agent/src/main/java/com/example/dateconsumer/DateConsumerAgentApplication.java
@@ -5,7 +5,6 @@ import io.mcpmesh.MeshTool;
 import io.mcpmesh.a2a.A2AClient;
 import io.mcpmesh.a2a.A2AConsumer;
 import io.mcpmesh.a2a.A2AResponse;
-import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -16,8 +15,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * A2A consumer example (issue #916 Phase 1) — Java port of
- * {@code examples/a2a/consumer_date_agent.py}.
+ * A2A consumer example (issue #923 — annotation-config form) — Java
+ * port of {@code examples/a2a/consumer_date_agent.py}.
  *
  * <p>Bridges the existing {@code examples/a2a/date_a2a_agent.py}
  * {@code get-date} skill into the mesh as a regular {@code current-date}
@@ -31,6 +30,11 @@ import java.util.Map;
  * {@link MeshAgent#name()} via {@link A2AConsumer} (here
  * {@code date-consumer}) so downstream resolvers can pin a specific
  * backend via the dependency tag selector.
+ *
+ * <p><b>Framework-injection (issue #923):</b> the {@link A2AClient} is
+ * provisioned by the Spring starter from the {@link A2AConsumer} fields
+ * and injected at the method's {@code A2AClient} parameter slot.
+ * Lifecycle (incl. close) is owned by the framework.
  *
  * <h2>Stack</h2>
  * <ul>
@@ -61,18 +65,6 @@ import java.util.Map;
 public class DateConsumerAgentApplication {
 
     private static final Logger log = LoggerFactory.getLogger(DateConsumerAgentApplication.class);
-
-    /**
-     * One reusable client per (url, skillId, auth) tuple — amortises
-     * the underlying {@link java.net.http.HttpClient} connection pool
-     * across calls. The producer is unauth in the example deployment
-     * so no {@code A2ABearer} is supplied.
-     */
-    private static final A2AClient A2A_CLIENT = new A2AClient(
-        "http://localhost:9090/agents/date",
-        "get-date"
-    );
-
     private static final ObjectMapper JSON = new ObjectMapper();
 
     public static void main(String[] args) {
@@ -83,16 +75,17 @@ public class DateConsumerAgentApplication {
     /**
      * Bridge the upstream A2A {@code get-date} skill onto the mesh as
      * the {@code current-date} capability. The {@link A2AConsumer}
-     * marker tells the runtime to inject the surrounding
-     * {@link MeshAgent#name()} as a tag, so this capability registers
-     * with tags {@code [a2a-bridge, date-consumer]}.
+     * carries the upstream config; the runtime constructs an
+     * {@link A2AClient} per unique config tuple and injects it at the
+     * {@code a2a} parameter slot here.
      *
      * <p>The producer-side handler returns
      * {@code {"date": "<iso-string>"}} and the A2A surface
      * JSON-stringifies it into the artifact text part — so we
      * {@code readValue} on the consumer side to recover the dict.
      *
-     * @return the producer's date payload as a Map
+     * @param a2a framework-injected A2AClient bound to the upstream.
+     * @return the producer's date payload as a Map.
      * @throws Exception on transport, JSON, or A2A protocol failure.
      */
     @MeshTool(
@@ -100,25 +93,17 @@ public class DateConsumerAgentApplication {
         description = "Get the current date by bridging the upstream A2A get-date skill",
         tags = {"a2a-bridge"}
     )
-    @A2AConsumer
-    public Map<String, Object> currentDate() throws Exception {
-        A2AResponse response = A2A_CLIENT.send(Map.of(
+    @A2AConsumer(
+        url = "http://localhost:9090/agents/date",
+        skillId = "get-date"
+    )
+    public Map<String, Object> currentDate(A2AClient a2a) throws Exception {
+        A2AResponse response = a2a.send(Map.of(
             "role", "user",
             "parts", List.of(Map.of("type", "text", "text", "now"))
         ));
         @SuppressWarnings("unchecked")
         Map<String, Object> payload = JSON.readValue(response.artifactText(), Map.class);
         return payload;
-    }
-
-    // On JDK 17 close() is cosmetic (see A2AClient Javadoc); JDK 21+ honors the AutoCloseable contract. Demonstrates proper lifecycle hygiene either way.
-    @PreDestroy
-    void releaseA2AClient() {
-        try {
-            A2A_CLIENT.close();
-        } catch (Exception e) {
-            // Best-effort — log but don't fail shutdown.
-            log.warn("Failed to close A2AClient during shutdown", e);
-        }
     }
 }

--- a/examples/java/consumer-report-agent-sse/src/main/java/com/example/reportconsumersse/ReportConsumerSseAgentApplication.java
+++ b/examples/java/consumer-report-agent-sse/src/main/java/com/example/reportconsumersse/ReportConsumerSseAgentApplication.java
@@ -8,7 +8,6 @@ import io.mcpmesh.Param;
 import io.mcpmesh.a2a.A2AClient;
 import io.mcpmesh.a2a.A2AConsumer;
 import io.mcpmesh.a2a.A2AStream;
-import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -20,8 +19,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * A2A consumer example (issue #910 / Phase 3, SSE variant) — Java
- * port of {@code examples/a2a/consumer_report_agent_sse.py}.
+ * A2A consumer example (issue #910 / Phase 3, SSE variant; refactored
+ * under #923) — Java port of {@code examples/a2a/consumer_report_agent_sse.py}.
  *
  * <p>Same end-to-end shape as
  * {@code com.example.reportconsumer.ReportConsumerAgentApplication}
@@ -50,12 +49,6 @@ import java.util.Map;
 public class ReportConsumerSseAgentApplication {
 
     private static final Logger log = LoggerFactory.getLogger(ReportConsumerSseAgentApplication.class);
-
-    private static final A2AClient A2A_CLIENT = new A2AClient(
-        "http://localhost:9091/agents/report",
-        "generate-report"
-    );
-
     private static final ObjectMapper JSON = new ObjectMapper();
 
     public static void main(String[] args) {
@@ -81,10 +74,14 @@ public class ReportConsumerSseAgentApplication {
         description = "Bridge upstream A2A generate-report skill via SSE as a mesh ``report_sse`` capability.",
         tags = {"a2a-bridge", "sse"}
     )
-    @A2AConsumer
+    @A2AConsumer(
+        url = "http://localhost:9091/agents/report",
+        skillId = "generate-report"
+    )
     public Object generateReportSse(
             @Param("user_id") String userId,
             @Param(value = "sections", required = false) List<String> sections,
+            A2AClient a2a,
             MeshJob job) throws Exception {
         if (sections == null || sections.isEmpty()) {
             sections = List.of("default");
@@ -96,18 +93,18 @@ public class ReportConsumerSseAgentApplication {
             // return the artifact text. The polling consumer falls back
             // to A2AClient.send() here; the SSE variant has no direct
             // equivalent so we drain the stream and toss progress.
-            return drainSyncFallback(message);
+            return drainSyncFallback(a2a, message);
         }
-        try (A2AStream stream = A2A_CLIENT.subscribe(message)) {
+        try (A2AStream stream = a2a.subscribe(message)) {
             return stream.bridge(controller);
         }
     }
 
-    private Object drainSyncFallback(Map<String, Object> message) throws Exception {
+    private Object drainSyncFallback(A2AClient a2a, Map<String, Object> message) throws Exception {
         // Synchronous tools/call path — no JobController to mirror to,
         // so just iterate the stream and return the first artifact's
         // parsed payload (or the raw text if it isn't JSON).
-        try (A2AStream stream = A2A_CLIENT.subscribe(message)) {
+        try (A2AStream stream = a2a.subscribe(message)) {
             for (var event : stream) {
                 if (event.kind() == io.mcpmesh.a2a.A2AEvent.Kind.ARTIFACT) {
                     String text = event.artifactText();
@@ -135,14 +132,5 @@ public class ReportConsumerSseAgentApplication {
                 "type", "text",
                 "text", JSON.writeValueAsString(argsPayload)))
         );
-    }
-
-    @PreDestroy
-    void releaseA2AClient() {
-        try {
-            A2A_CLIENT.close();
-        } catch (Exception e) {
-            log.warn("Failed to close A2AClient during shutdown", e);
-        }
     }
 }

--- a/examples/java/consumer-report-agent/src/main/java/com/example/reportconsumer/ReportConsumerAgentApplication.java
+++ b/examples/java/consumer-report-agent/src/main/java/com/example/reportconsumer/ReportConsumerAgentApplication.java
@@ -9,7 +9,6 @@ import io.mcpmesh.a2a.A2AClient;
 import io.mcpmesh.a2a.A2AConsumer;
 import io.mcpmesh.a2a.A2AJob;
 import io.mcpmesh.a2a.A2AResponse;
-import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -21,8 +20,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * A2A consumer example (issue #910 / Phase 3) — Java port of
- * {@code examples/a2a/consumer_report_agent.py}.
+ * A2A consumer example (issue #910 / Phase 3, refactored under #923) —
+ * Java port of {@code examples/a2a/consumer_report_agent.py}.
  *
  * <p>Bridges the existing {@code examples/a2a/report_a2a_agent.py}
  * {@code generate-report} skill onto the mesh as a long-running
@@ -81,17 +80,6 @@ import java.util.Map;
 public class ReportConsumerAgentApplication {
 
     private static final Logger log = LoggerFactory.getLogger(ReportConsumerAgentApplication.class);
-
-    /**
-     * One reusable client per (url, skillId, auth) tuple — amortises
-     * the underlying {@link java.net.http.HttpClient} connection pool
-     * across calls.
-     */
-    private static final A2AClient A2A_CLIENT = new A2AClient(
-        "http://localhost:9091/agents/report",
-        "generate-report"
-    );
-
     private static final ObjectMapper JSON = new ObjectMapper();
 
     public static void main(String[] args) {
@@ -104,7 +92,8 @@ public class ReportConsumerAgentApplication {
      * mesh as the {@code report} capability. The {@link MeshTool}
      * carries {@code task=true} so the framework injects a
      * {@link JobController} (via the {@link MeshJob} parameter) for
-     * long-running progress mirroring.
+     * long-running progress mirroring; {@link A2AConsumer} provisions
+     * the upstream client at the {@code a2a} parameter slot.
      *
      * @return the final artifact value as parsed JSON (typically a
      *         {@code Map<String,Object>} carrying the producer's
@@ -116,10 +105,14 @@ public class ReportConsumerAgentApplication {
         description = "Bridge upstream A2A generate-report skill onto the mesh as a long-running ``report`` capability.",
         tags = {"a2a-bridge"}
     )
-    @A2AConsumer
+    @A2AConsumer(
+        url = "http://localhost:9091/agents/report",
+        skillId = "generate-report"
+    )
     public Object generateReport(
             @Param("user_id") String userId,
             @Param(value = "sections", required = false) List<String> sections,
+            A2AClient a2a,
             MeshJob job) throws Exception {
         if (sections == null || sections.isEmpty()) {
             sections = List.of("default");
@@ -131,7 +124,7 @@ public class ReportConsumerAgentApplication {
             // contract where task=true tools must tolerate a null MeshJob.
             // Mirror the SSE sibling: parse the artifact text as JSON when
             // possible, fall back to raw text on parse failure.
-            A2AResponse response = A2A_CLIENT.send(message);
+            A2AResponse response = a2a.send(message);
             String text = response.artifactText();
             if (text == null || text.isEmpty()) {
                 return text == null ? "" : text;
@@ -142,7 +135,7 @@ public class ReportConsumerAgentApplication {
                 return text;
             }
         }
-        A2AJob a2aJob = A2A_CLIENT.submit(message);
+        A2AJob a2aJob = a2a.submit(message);
         return a2aJob.bridge(controller);
     }
 
@@ -156,14 +149,5 @@ public class ReportConsumerAgentApplication {
                 "type", "text",
                 "text", JSON.writeValueAsString(argsPayload)))
         );
-    }
-
-    @PreDestroy
-    void releaseA2AClient() {
-        try {
-            A2A_CLIENT.close();
-        } catch (Exception e) {
-            log.warn("Failed to close A2AClient during shutdown", e);
-        }
     }
 }

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AConsumer.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AConsumer.java
@@ -83,8 +83,15 @@ public @interface A2AConsumer {
      * <p>Supports Spring property placeholders, e.g.
      * {@code "${weather.a2a.url}"}, resolved against the Spring
      * {@code Environment} at boot.
+     *
+     * <p>Defaults to {@code ""} so that class files compiled against the
+     * pre-#923 marker-only annotation continue to load — the runtime
+     * surfaces a clear migration error in
+     * {@link io.mcpmesh.spring.A2AConsumerBeanPostProcessor} when the
+     * resolved value is blank, instead of throwing an opaque
+     * {@code IncompleteAnnotationException} at reflection time.
      */
-    String url();
+    String url() default "";
 
     /**
      * Optional: A2A skill ID. Defaults to the surrounding

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AConsumer.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AConsumer.java
@@ -10,32 +10,35 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a {@link MeshTool}-annotated method as an A2A consumer bridge.
+ * Marks a {@link MeshTool}-annotated method as an A2A consumer bridge
+ * AND carries the upstream A2A configuration.
  *
- * <p>Pure marker — the annotation itself carries no fields. Its sole
- * purpose is to opt the surrounding tool into the consumer-name
- * auto-tag injection path: at agent registration time the Spring
- * starter rewrites the tool's tag list to include the surrounding
- * {@link MeshAgent#name()}, making the bridged capability
- * distinguishable from sibling consumers (and pinnable from downstream
- * dependencies via the consumer name).
+ * <p>The Spring starter reads these fields at boot, constructs an
+ * {@link A2AClient} per unique {@code (url, skillId, auth, timeout)}
+ * tuple, and injects the cached client at the method's
+ * {@link A2AClient} parameter slot at invoke time. Mirrors Python's
+ * {@code @mesh.a2a_consumer(url=..., a2a_skill_id=..., auth=...)}
+ * decorator (issue #913) so Java, Python, and the upcoming TypeScript
+ * implementation (#917) share the same framework-injection shape.
  *
- * <p>Mirrors the Python runtime's {@code @mesh.a2a_consumer} surface
- * (issue #908), which auto-tags via the
- * {@code __MESH_CONSUMER_SELF__} sentinel substitution. Java keeps the
- * relationship explicit: the user constructs an {@link A2AClient}
- * inside the method body and places this annotation alongside
- * {@link MeshTool} so the post-processor knows to inject the auto-tag.
+ * <p>The marker also opts the surrounding tool into the consumer-name
+ * auto-tag injection path: at agent registration time the starter
+ * appends the surrounding {@link MeshAgent#name()} to the tool's tag
+ * list, making the bridged capability distinguishable from sibling
+ * consumers (and pinnable from downstream dependencies via the
+ * consumer name).
  *
  * <h2>Pattern</h2>
  * <pre>{@code
- * private static final A2AClient CLIENT = new A2AClient(
- *     "http://upstream.example.com/agents/date", "get-date");
- *
  * @MeshTool(capability = "current-date", tags = {"a2a-bridge"})
- * @A2AConsumer
- * public Map<String, Object> currentDate() throws Exception {
- *     A2AResponse r = CLIENT.send(Map.of(
+ * @A2AConsumer(
+ *     url = "http://upstream.example.com/agents/date",
+ *     skillId = "get-date",
+ *     authBearerEnv = "UPSTREAM_TOKEN",
+ *     timeoutSeconds = 30
+ * )
+ * public Map<String, Object> currentDate(A2AClient a2a) throws Exception {
+ *     A2AResponse r = a2a.send(Map.of(
  *         "role", "user",
  *         "parts", List.of(Map.of("type", "text", "text", "now"))));
  *     return new ObjectMapper().readValue(r.artifactText(), Map.class);
@@ -46,6 +49,15 @@ import java.lang.annotation.Target;
  * <ul>
  *   <li>Must be combined with {@link MeshTool} on the same method —
  *       a bare {@code @A2AConsumer} on a non-mesh method is a no-op.</li>
+ *   <li>The method MUST declare exactly one {@link A2AClient}
+ *       parameter — the framework injects the cached client at that
+ *       slot. Boot fails with a clear error otherwise.</li>
+ *   <li>{@link #url()} is required. The marker-only form (predating
+ *       issue #923) is rejected at boot with a migration message.</li>
+ *   <li>{@link #url()} supports Spring property placeholders, e.g.
+ *       {@code @A2AConsumer(url = "${weather.a2a.url}")}.</li>
+ *   <li>{@link #authBearerEnv()} and {@link #authBearerToken()} are
+ *       mutually exclusive — set zero or one, never both.</li>
  *   <li>The surrounding agent must declare {@link MeshAgent#name()}
  *       (or its env-var override) so the auto-tag has a value to
  *       substitute. A consumer-only / nameless agent skips the
@@ -56,4 +68,40 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface A2AConsumer {
+
+    /**
+     * Required: URL of the A2A endpoint to bridge.
+     *
+     * <p>Supports Spring property placeholders, e.g.
+     * {@code "${weather.a2a.url}"}, resolved against the Spring
+     * {@code Environment} at boot.
+     */
+    String url();
+
+    /**
+     * Optional: A2A skill ID. Defaults to the surrounding
+     * {@link MeshTool#capability()} when left empty.
+     */
+    String skillId() default "";
+
+    /**
+     * Optional: env-var name holding the bearer token for outbound
+     * auth. Resolved per call (so a rotated credential is honoured
+     * without restarting the agent). Mutually exclusive with
+     * {@link #authBearerToken()}.
+     */
+    String authBearerEnv() default "";
+
+    /**
+     * Optional: explicit bearer token for outbound auth. Rarely used;
+     * prefer {@link #authBearerEnv()} to avoid hardcoding credentials
+     * in source. Mutually exclusive with {@link #authBearerEnv()}.
+     */
+    String authBearerToken() default "";
+
+    /**
+     * Optional: per-call deadline (seconds) on the constructed
+     * {@link A2AClient}. Default 30. Must be {@code > 0}.
+     */
+    int timeoutSeconds() default 30;
 }

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AConsumer.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AConsumer.java
@@ -63,6 +63,14 @@ import java.lang.annotation.Target;
  *       substitute. A consumer-only / nameless agent skips the
  *       injection cleanly with a warning.</li>
  * </ul>
+ *
+ * <p><b>Lifecycle:</b> The framework owns the {@link A2AClient}'s
+ * lifecycle. Do not retain references to the injected client across
+ * Spring context shutdown — the framework's {@code @PreDestroy} hook
+ * closes all cached clients and may run before any user
+ * {@code @PreDestroy} that retained a reference. The injection is
+ * scoped to the method invocation; let the framework manage construction
+ * + close.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/A2AConsumerBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/A2AConsumerBeanPostProcessor.java
@@ -1,0 +1,298 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.a2a.A2ABearer;
+import io.mcpmesh.a2a.A2AClient;
+import io.mcpmesh.a2a.A2AConsumer;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.env.Environment;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Issue #923: scans Spring beans for {@code @A2AConsumer} methods,
+ * constructs an {@link A2AClient} per unique
+ * {@code (url, skillId, auth, timeoutSeconds)} tuple, and records a
+ * per-method binding so {@link MeshToolWrapper} can inject the cached
+ * client at the method's {@link A2AClient} parameter slot at invoke
+ * time.
+ *
+ * <p>This processor mirrors the framework-construction shape of
+ * Python's {@code @mesh.a2a_consumer} decorator (issue #913):
+ * configuration lives on the annotation, not in user-managed
+ * {@code static final} fields, and the runtime owns the
+ * {@link A2AClient} lifecycle (incl. {@link #shutdown shutdown} on
+ * Spring context close).
+ *
+ * <p><b>Why this is a separate processor:</b> {@link MeshToolBeanPostProcessor}
+ * is responsible for {@code @MeshTool} metadata and wrapper construction;
+ * binding A2A clients is an orthogonal concern that runs alongside it. The
+ * two processors share no state — wrapper-side injection consults
+ * {@link #bindingFor(Method)} on dispatch.
+ */
+public class A2AConsumerBeanPostProcessor implements BeanPostProcessor, Ordered {
+
+    private static final Logger log = LoggerFactory.getLogger(A2AConsumerBeanPostProcessor.class);
+
+    private final Environment environment;
+
+    private final Map<A2AClientKey, A2AClient> clientCache = new ConcurrentHashMap<>();
+    private final Map<Method, MethodBinding> bindings = new ConcurrentHashMap<>();
+
+    public A2AConsumerBeanPostProcessor(Environment environment) {
+        this.environment = environment;
+    }
+
+    /**
+     * Run BEFORE {@link MeshToolBeanPostProcessor} (which also visits
+     * each user bean) so the {@link MethodBinding} is in place by the
+     * time the {@link MeshToolWrapper} is constructed and asks for
+     * its A2A injection slot. Lower order = earlier; the default for
+     * the tool processor is the framework default ({@code LOWEST_PRECEDENCE}).
+     */
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        Class<?> targetClass = AopUtils.getTargetClass(bean);
+        ReflectionUtils.doWithMethods(targetClass, method -> {
+            A2AConsumer annotation = AnnotationUtils.findAnnotation(method, A2AConsumer.class);
+            if (annotation == null) {
+                return;
+            }
+            try {
+                processConsumerMethod(targetClass, method, annotation);
+            } catch (BeanInitializationException bie) {
+                throw bie;
+            } catch (RuntimeException re) {
+                throw new BeanInitializationException(
+                    "Failed to wire @A2AConsumer on " + targetClass.getName()
+                        + "#" + method.getName() + ": " + re.getMessage(), re);
+            }
+        });
+        return bean;
+    }
+
+    private void processConsumerMethod(Class<?> targetClass, Method method, A2AConsumer annotation) {
+        // Hard cutover (#923): the marker-only form is rejected with the
+        // exact migration message documented in the issue body.
+        String rawUrl = annotation.url();
+        if (rawUrl == null || rawUrl.isBlank()) {
+            throw new BeanInitializationException(
+                "@A2AConsumer on method " + method.getName() + "() requires the 'url' field. "
+                    + "The marker-only form was removed in #923 — see "
+                    + "https://github.com/dhyansraj/mcp-mesh/issues/923 for migration. "
+                    + "Set @A2AConsumer(url = \"...\", skillId = \"...\").");
+        }
+
+        String authEnv = annotation.authBearerEnv();
+        String authToken = annotation.authBearerToken();
+        boolean hasEnv = authEnv != null && !authEnv.isBlank();
+        boolean hasToken = authToken != null && !authToken.isBlank();
+        if (hasEnv && hasToken) {
+            throw new BeanInitializationException(
+                "@A2AConsumer on " + targetClass.getName() + "#" + method.getName()
+                    + ": authBearerEnv and authBearerToken are mutually exclusive — set zero or one, never both.");
+        }
+
+        int timeoutSeconds = annotation.timeoutSeconds();
+        if (timeoutSeconds <= 0) {
+            throw new BeanInitializationException(
+                "@A2AConsumer on " + targetClass.getName() + "#" + method.getName()
+                    + ": timeoutSeconds must be > 0 (got " + timeoutSeconds + ")");
+        }
+
+        // Resolve Spring property placeholders so users can write
+        // @A2AConsumer(url = "${weather.a2a.url}") and have the property
+        // value (env-overridable) flow into the underlying URL.
+        String resolvedUrl;
+        try {
+            resolvedUrl = environment.resolveRequiredPlaceholders(rawUrl);
+        } catch (IllegalArgumentException e) {
+            throw new BeanInitializationException(
+                "@A2AConsumer on " + targetClass.getName() + "#" + method.getName()
+                    + ": failed to resolve url placeholder '" + rawUrl + "': " + e.getMessage(), e);
+        }
+
+        // Default skillId to the surrounding @MeshTool capability when
+        // the user left it blank — matches the Python decorator's
+        // a2a_skill_id=None → capability default.
+        String skillId = annotation.skillId();
+        if (skillId == null || skillId.isBlank()) {
+            MeshTool meshTool = AnnotationUtils.findAnnotation(method, MeshTool.class);
+            if (meshTool != null && meshTool.capability() != null && !meshTool.capability().isBlank()) {
+                skillId = meshTool.capability();
+            } else {
+                skillId = "";
+            }
+        }
+
+        // Locate the (mandatory) A2AClient parameter slot. Without
+        // exactly one, the wrapper has no place to inject the client —
+        // surface a clear error rather than silently fail at first call.
+        int a2aParamIndex = findSingleA2AClientParam(targetClass, method);
+
+        AuthSpec authSpec = hasEnv ? AuthSpec.fromEnv(authEnv)
+            : hasToken ? AuthSpec.literal(authToken)
+            : AuthSpec.none();
+
+        A2AClientKey key = new A2AClientKey(resolvedUrl, skillId, authSpec, timeoutSeconds);
+        A2AClient client = clientCache.computeIfAbsent(key, k -> {
+            A2ABearer bearer = k.auth().toBearer();
+            A2AClient created = new A2AClient(k.url(), k.skillId(), bearer, Duration.ofSeconds(k.timeoutSeconds()));
+            log.info("@A2AConsumer: constructed A2AClient(url={}, skillId={}, auth={}, timeoutSeconds={})",
+                k.url(), k.skillId(), k.auth(), k.timeoutSeconds());
+            return created;
+        });
+
+        bindings.put(method, new MethodBinding(key, a2aParamIndex, client));
+        log.debug("@A2AConsumer wired: {}#{} → A2AClient(url={}) at paramIndex={}",
+            targetClass.getSimpleName(), method.getName(), resolvedUrl, a2aParamIndex);
+    }
+
+    private static int findSingleA2AClientParam(Class<?> targetClass, Method method) {
+        Parameter[] params = method.getParameters();
+        int found = -1;
+        for (int i = 0; i < params.length; i++) {
+            if (A2AClient.class.isAssignableFrom(params[i].getType())) {
+                if (found >= 0) {
+                    throw new BeanInitializationException(
+                        "@A2AConsumer on " + targetClass.getName() + "#" + method.getName()
+                            + ": method declares more than one A2AClient parameter; exactly one is required.");
+                }
+                found = i;
+            }
+        }
+        if (found < 0) {
+            throw new BeanInitializationException(
+                "@A2AConsumer on " + targetClass.getName() + "#" + method.getName()
+                    + ": method must declare exactly one A2AClient parameter — the framework injects the cached client at that slot.");
+        }
+        return found;
+    }
+
+    /**
+     * Look up the {@link MethodBinding} for a {@code @A2AConsumer}
+     * method. Returns {@code null} when the method was never processed
+     * (i.e. has no {@code @A2AConsumer} annotation).
+     */
+    public MethodBinding bindingFor(Method method) {
+        return bindings.get(method);
+    }
+
+    /** Test/diagnostics surface: cache size — used by unit tests to assert sharing. */
+    public int cacheSize() {
+        return clientCache.size();
+    }
+
+    /** Test/diagnostics surface: read-only snapshot of currently-bound methods. */
+    public Map<Method, MethodBinding> bindings() {
+        return Collections.unmodifiableMap(bindings);
+    }
+
+    /**
+     * Close every cached {@link A2AClient} when the surrounding Spring
+     * context shuts down. Replaces the user's manual {@code @PreDestroy}
+     * hook in the pre-#923 examples — the framework now owns the
+     * client lifecycle from boot to shutdown.
+     */
+    @PreDestroy
+    public void shutdown() {
+        for (Map.Entry<A2AClientKey, A2AClient> e : clientCache.entrySet()) {
+            try {
+                e.getValue().close();
+            } catch (Exception ex) {
+                // Best-effort — log but don't fail context shutdown.
+                log.warn("@A2AConsumer: failed to close A2AClient(url={}) during shutdown",
+                    e.getKey().url(), ex);
+            }
+        }
+        clientCache.clear();
+        bindings.clear();
+    }
+
+    /**
+     * Per-method binding captured at boot for the wrapper-side dispatcher.
+     *
+     * @param key            the cache key the client was registered under
+     *                       (kept for diagnostics + test assertions).
+     * @param a2aParamIndex  the position of the {@link A2AClient}
+     *                       parameter on the method signature.
+     * @param client         the cached {@link A2AClient} instance.
+     */
+    public record MethodBinding(A2AClientKey key, int a2aParamIndex, A2AClient client) {
+    }
+
+    /**
+     * Cache key distinguishing one {@link A2AClient} configuration from
+     * another. Two methods with identical {@code (url, skillId, auth,
+     * timeoutSeconds)} tuples share the same client instance — the
+     * Java HTTP connection pool is amortised across them.
+     */
+    public record A2AClientKey(String url, String skillId, AuthSpec auth, int timeoutSeconds) {
+        public A2AClientKey {
+            Objects.requireNonNull(url, "url");
+            Objects.requireNonNull(auth, "auth");
+            if (skillId == null) skillId = "";
+        }
+    }
+
+    /**
+     * Internal: serialised form of the optional bearer credential
+     * (env-var name OR literal token OR none) used as part of the
+     * {@link A2AClientKey} so credentials with different rotation
+     * surfaces don't accidentally share a cached client.
+     */
+    public record AuthSpec(String envName, String literal) {
+        private static final AuthSpec NONE = new AuthSpec(null, null);
+
+        public static AuthSpec none() {
+            return NONE;
+        }
+
+        public static AuthSpec fromEnv(String envName) {
+            return new AuthSpec(envName, null);
+        }
+
+        public static AuthSpec literal(String literal) {
+            return new AuthSpec(null, literal);
+        }
+
+        /** Build an {@link A2ABearer} from this spec, or {@code null} when no auth is configured. */
+        public A2ABearer toBearer() {
+            if (envName != null) return A2ABearer.fromEnv(envName);
+            if (literal != null) return A2ABearer.of(literal);
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            if (envName != null) return "env:" + envName;
+            if (literal != null) return "literal:<redacted>";
+            return "none";
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/A2AConsumerBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/A2AConsumerBeanPostProcessor.java
@@ -83,6 +83,14 @@ public class A2AConsumerBeanPostProcessor implements BeanPostProcessor, Ordered 
             if (annotation == null) {
                 return;
             }
+            // @A2AConsumer is meaningful only when paired with @MeshTool —
+            // a bare @A2AConsumer on a non-mesh method has nothing to
+            // bridge, so building an A2AClient here would just leak. Skip
+            // it cleanly rather than constructing an HttpClient that no
+            // dispatch path will ever consult.
+            if (AnnotationUtils.findAnnotation(method, MeshTool.class) == null) {
+                return;
+            }
             try {
                 processConsumerMethod(targetClass, method, annotation);
             } catch (BeanInitializationException bie) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/A2AConsumerBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/A2AConsumerBeanPostProcessor.java
@@ -97,8 +97,11 @@ public class A2AConsumerBeanPostProcessor implements BeanPostProcessor, Ordered 
     }
 
     private void processConsumerMethod(Class<?> targetClass, Method method, A2AConsumer annotation) {
-        // Hard cutover (#923): the marker-only form is rejected with the
-        // exact migration message documented in the issue body.
+        // Hard cutover (#923): the marker-only form (url defaulted to "")
+        // is rejected with the exact migration message documented in the
+        // issue body. A url that is non-blank at source level but
+        // resolves to blank via Spring placeholder substitution gets a
+        // distinct message that points at the property, not the migration.
         String rawUrl = annotation.url();
         if (rawUrl == null || rawUrl.isBlank()) {
             throw new BeanInitializationException(
@@ -136,17 +139,33 @@ public class A2AConsumerBeanPostProcessor implements BeanPostProcessor, Ordered 
                 "@A2AConsumer on " + targetClass.getName() + "#" + method.getName()
                     + ": failed to resolve url placeholder '" + rawUrl + "': " + e.getMessage(), e);
         }
+        if (resolvedUrl == null || resolvedUrl.isBlank()) {
+            // rawUrl was non-blank (would have been rejected above
+            // otherwise) but resolution yielded empty — typical cause is
+            // a placeholder like ${empty.prop:} resolving to "". Point
+            // at the property, not the marker-only migration.
+            throw new BeanInitializationException(
+                "@A2AConsumer on " + targetClass.getName() + "#" + method.getName()
+                    + ": url resolved to empty (raw=" + rawUrl + "). "
+                    + "Check that the Spring property is defined and non-blank.");
+        }
 
         // Default skillId to the surrounding @MeshTool capability when
         // the user left it blank — matches the Python decorator's
-        // a2a_skill_id=None → capability default.
+        // a2a_skill_id=None → capability default. If BOTH are blank,
+        // fail fast at boot rather than caching an empty skillId and
+        // having the first A2A call fail downstream with an opaque
+        // upstream error.
         String skillId = annotation.skillId();
         if (skillId == null || skillId.isBlank()) {
             MeshTool meshTool = AnnotationUtils.findAnnotation(method, MeshTool.class);
             if (meshTool != null && meshTool.capability() != null && !meshTool.capability().isBlank()) {
                 skillId = meshTool.capability();
             } else {
-                skillId = "";
+                throw new BeanInitializationException(
+                    "@A2AConsumer on method " + method.getName() + " requires a non-blank "
+                        + "skillId — neither @A2AConsumer(skillId=...) nor @MeshTool(capability=...) "
+                        + "carries a value. Set skillId on the @A2AConsumer annotation explicitly.");
             }
         }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
@@ -2,6 +2,7 @@ package io.mcpmesh.spring;
 
 import io.mcpmesh.JobController;
 import io.mcpmesh.MeshJobSubmitter;
+import io.mcpmesh.a2a.A2AClient;
 import io.mcpmesh.types.McpMeshTool;
 import io.mcpmesh.types.MeshLlmAgent;
 import org.slf4j.Logger;
@@ -56,6 +57,7 @@ public final class JobsRuntimeManager implements SmartLifecycle {
     private final MeshRuntime runtime;
     private final MeshToolRegistry toolRegistry;
     private final MeshToolWrapperRegistry wrapperRegistry;
+    private final A2AConsumerBeanPostProcessor a2aProcessor;
 
     private final Map<String, ClaimDispatcher> dispatchers = new ConcurrentHashMap<>();
     private final AtomicBoolean started = new AtomicBoolean(false);
@@ -65,9 +67,27 @@ public final class JobsRuntimeManager implements SmartLifecycle {
             MeshRuntime runtime,
             MeshToolRegistry toolRegistry,
             MeshToolWrapperRegistry wrapperRegistry) {
+        this(runtime, toolRegistry, wrapperRegistry, null);
+    }
+
+    /**
+     * Issue #923: includes the {@link A2AConsumerBeanPostProcessor} so
+     * the claim-path reflection invoker can fill {@link A2AClient}
+     * parameter slots on {@code task=true @A2AConsumer} methods.
+     * Without this, a long-running A2A bridge dispatched via the claim
+     * path would receive {@code a2a=null} and NPE on the first
+     * {@code a2a.send(...)} call. Pass {@code null} for environments
+     * without A2A consumer support.
+     */
+    public JobsRuntimeManager(
+            MeshRuntime runtime,
+            MeshToolRegistry toolRegistry,
+            MeshToolWrapperRegistry wrapperRegistry,
+            A2AConsumerBeanPostProcessor a2aProcessor) {
         this.runtime = runtime;
         this.toolRegistry = toolRegistry;
         this.wrapperRegistry = wrapperRegistry;
+        this.a2aProcessor = a2aProcessor;
     }
 
     @Override
@@ -255,12 +275,30 @@ public final class JobsRuntimeManager implements SmartLifecycle {
         Object bean = meta.bean();
         method.setAccessible(true);
 
+        // Issue #923: resolve the @A2AConsumer binding (if any) once per
+        // claim — the claim path doesn't hit MeshToolWrapper, so we
+        // can't piggy-back on its setA2AClientBinding wiring. The
+        // binding map is keyed by Method, so the lookup here uses the
+        // same Method instance the user method's reflection metadata
+        // exposes.
+        A2AConsumerBeanPostProcessor.MethodBinding a2aBinding =
+            a2aProcessor != null ? a2aProcessor.bindingFor(method) : null;
+
         Object[] fullArgs = new Object[method.getParameterCount()];
         java.lang.reflect.Parameter[] params = method.getParameters();
         for (int i = 0; i < params.length; i++) {
             Class<?> type = params[i].getType();
             if (io.mcpmesh.MeshJob.class.isAssignableFrom(type)) {
                 fullArgs[i] = controller;
+                continue;
+            }
+            if (A2AClient.class.isAssignableFrom(type)) {
+                // Issue #923: fill the @A2AConsumer-injected A2AClient
+                // slot on the claim path. Without this, a task=true
+                // @A2AConsumer bridge (e.g. uc27 report consumer) would
+                // NPE on the first a2a.send(...) call when dispatched
+                // via the claim path instead of inbound HTTP.
+                fullArgs[i] = a2aBinding != null ? a2aBinding.client() : null;
                 continue;
             }
             io.mcpmesh.Param paramAnn = params[i].getAnnotation(io.mcpmesh.Param.class);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
@@ -298,6 +298,12 @@ public final class JobsRuntimeManager implements SmartLifecycle {
                 // @A2AConsumer bridge (e.g. uc27 report consumer) would
                 // NPE on the first a2a.send(...) call when dispatched
                 // via the claim path instead of inbound HTTP.
+                if (a2aBinding == null) {
+                    log.warn("JobsRuntimeManager: method {} declares A2AClient parameter but no "
+                        + "A2AConsumerBeanPostProcessor binding exists. Tool will receive null and "
+                        + "likely NPE on first A2A call. Was the bean registered outside Spring's "
+                        + "BeanPostProcessor scan path?", meta.method().getName());
+                }
                 fullArgs[i] = a2aBinding != null ? a2aBinding.client() : null;
                 continue;
             }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -95,8 +95,26 @@ public class MeshAutoConfiguration {
     public static MeshToolBeanPostProcessor meshToolBeanPostProcessor(
             MeshToolRegistry registry,
             MeshToolWrapperRegistry wrapperRegistry,
-            ObjectMapper objectMapper) {
-        return new MeshToolBeanPostProcessor(registry, wrapperRegistry, objectMapper);
+            ObjectMapper objectMapper,
+            A2AConsumerBeanPostProcessor a2aConsumerBeanPostProcessor) {
+        return new MeshToolBeanPostProcessor(registry, wrapperRegistry, objectMapper,
+            a2aConsumerBeanPostProcessor);
+    }
+
+    /**
+     * Issue #923: scans @A2AConsumer methods at boot, constructs an
+     * A2AClient per unique (url, skillId, auth, timeout) tuple, and
+     * exposes a per-method binding for MeshToolWrapper to inject the
+     * cached client at the A2AClient parameter slot at invoke time.
+     *
+     * <p>Static factory so this processor is instantiated before user
+     * beans are created — the same pattern as MeshToolBeanPostProcessor.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public static A2AConsumerBeanPostProcessor a2aConsumerBeanPostProcessor(
+            org.springframework.core.env.Environment environment) {
+        return new A2AConsumerBeanPostProcessor(environment);
     }
 
     @Bean
@@ -227,8 +245,10 @@ public class MeshAutoConfiguration {
     public JobsRuntimeManager jobsRuntimeManager(
             MeshRuntime runtime,
             MeshToolRegistry toolRegistry,
-            MeshToolWrapperRegistry wrapperRegistry) {
-        return new JobsRuntimeManager(runtime, toolRegistry, wrapperRegistry);
+            MeshToolWrapperRegistry wrapperRegistry,
+            A2AConsumerBeanPostProcessor a2aConsumerBeanPostProcessor) {
+        return new JobsRuntimeManager(runtime, toolRegistry, wrapperRegistry,
+            a2aConsumerBeanPostProcessor);
     }
 
     private AgentSpec buildAgentSpec(

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.ReflectionUtils;
 
@@ -29,21 +30,50 @@ import java.util.List;
  * @see MeshToolWrapper
  * @see MeshToolWrapperRegistry
  */
-public class MeshToolBeanPostProcessor implements BeanPostProcessor {
+public class MeshToolBeanPostProcessor implements BeanPostProcessor, Ordered {
 
     private static final Logger log = LoggerFactory.getLogger(MeshToolBeanPostProcessor.class);
 
     private final MeshToolRegistry registry;
     private final MeshToolWrapperRegistry wrapperRegistry;
     private final ObjectMapper objectMapper;
+    private final A2AConsumerBeanPostProcessor a2aProcessor;
 
     public MeshToolBeanPostProcessor(
             MeshToolRegistry registry,
             MeshToolWrapperRegistry wrapperRegistry,
             ObjectMapper objectMapper) {
+        this(registry, wrapperRegistry, objectMapper, null);
+    }
+
+    /**
+     * Issue #923: includes the {@link A2AConsumerBeanPostProcessor} so
+     * each created {@link MeshToolWrapper} can be told which method
+     * has an A2AClient injection slot (and which client to inject).
+     * Pass {@code null} for environments without A2A consumer support.
+     */
+    public MeshToolBeanPostProcessor(
+            MeshToolRegistry registry,
+            MeshToolWrapperRegistry wrapperRegistry,
+            ObjectMapper objectMapper,
+            A2AConsumerBeanPostProcessor a2aProcessor) {
         this.registry = registry;
         this.wrapperRegistry = wrapperRegistry;
         this.objectMapper = objectMapper;
+        this.a2aProcessor = a2aProcessor;
+    }
+
+    /**
+     * Issue #923: run AFTER {@link A2AConsumerBeanPostProcessor} so that
+     * {@link A2AConsumerBeanPostProcessor#bindingFor(Method)} returns a
+     * non-null binding for {@code @A2AConsumer} methods by the time we
+     * construct the {@link MeshToolWrapper} and call
+     * {@link MeshToolWrapper#setA2AClientBinding}. Lowest precedence (= last)
+     * is the safe default — no other framework BPP needs to run after us.
+     */
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
     }
 
     @Override
@@ -121,6 +151,16 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor {
             annotation.task(),
             annotation.retryOn()
         );
+
+        // Issue #923: when @A2AConsumer wired this method, hand the
+        // wrapper the cached A2AClient + slot index so dispatch
+        // populates the parameter at invoke time.
+        if (a2aProcessor != null) {
+            A2AConsumerBeanPostProcessor.MethodBinding binding = a2aProcessor.bindingFor(method);
+            if (binding != null) {
+                wrapper.setA2AClientBinding(binding.a2aParamIndex(), binding.client());
+            }
+        }
 
         // Register with wrapper registry
         wrapperRegistry.registerWrapper(wrapper);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -9,6 +9,7 @@ import io.mcpmesh.MeshJob;
 import io.mcpmesh.MeshJobSubmitter;
 import io.mcpmesh.Param;
 import io.mcpmesh.a2a.A2AClient;
+import io.mcpmesh.a2a.A2AConsumer;
 import io.mcpmesh.core.MeshCore;
 import io.mcpmesh.spring.tracing.ExecutionTracer;
 import io.mcpmesh.spring.tracing.SpanScope;
@@ -244,6 +245,17 @@ public class MeshToolWrapper implements McpToolHandler {
                 // exactly-one at boot, but the wrapper rejects defensively
                 // in case the wrapper is constructed without going through
                 // it (e.g. unit tests).
+                if (!method.isAnnotationPresent(A2AConsumer.class)) {
+                    // An A2AClient parameter without @A2AConsumer has no
+                    // upstream URL/auth/timeout to bind to — the dispatch
+                    // wrapper would silently inject null and the user
+                    // method would NPE on the first call. Fail BOOT, not
+                    // runtime, so the misuse is visible immediately.
+                    throw new IllegalStateException(
+                        "MeshTool method " + method.getName() + " has an A2AClient parameter "
+                            + "but is not annotated with @A2AConsumer. A2AClient injection requires "
+                            + "@A2AConsumer to declare the upstream URL + auth config (issue #923).");
+                }
                 if (a2aClientParamIndex != null) {
                     throw new IllegalStateException(
                         "Method " + method.getName() + " declares more than one A2AClient parameter; "

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -8,6 +8,7 @@ import io.mcpmesh.JobController;
 import io.mcpmesh.MeshJob;
 import io.mcpmesh.MeshJobSubmitter;
 import io.mcpmesh.Param;
+import io.mcpmesh.a2a.A2AClient;
 import io.mcpmesh.core.MeshCore;
 import io.mcpmesh.spring.tracing.ExecutionTracer;
 import io.mcpmesh.spring.tracing.SpanScope;
@@ -104,6 +105,15 @@ public class MeshToolWrapper implements McpToolHandler {
     // wrapper doesn't need a hard dep on MeshRuntime at construction time).
     private final AtomicReference<String> instanceId = new AtomicReference<>();
     private final AtomicReference<String> registryUrl = new AtomicReference<>();
+
+    // Issue #923: @A2AConsumer-injected A2AClient. The slot index is
+    // captured at construction time by analyzeParameters (so the
+    // parameter is exempt from the MCP input schema). The client itself
+    // is bound lazily by MeshToolBeanPostProcessor once the
+    // A2AConsumerBeanPostProcessor has finished computing the cached
+    // instance for this method's (url, skillId, auth, timeout) tuple.
+    private Integer a2aClientParamIndex;
+    private final AtomicReference<A2AClient> a2aClient = new AtomicReference<>();
 
     private final ObjectMapper objectMapper;
 
@@ -224,6 +234,22 @@ public class MeshToolWrapper implements McpToolHandler {
                 // by the dispatch wrapper (JobController on inbound job
                 // dispatch, MeshJobSubmitter on consumer side). No @Param
                 // required; the param is exempt from the MCP input schema.
+                continue;
+            } else if (A2AClient.class.isAssignableFrom(type)) {
+                // Issue #923: @A2AConsumer-injected A2AClient slot. The
+                // index is captured here so the dispatch wrapper can
+                // populate it from the cached client; the parameter is
+                // exempt from the MCP input schema. Multiple A2AClient
+                // params are an error — the bean post-processor enforces
+                // exactly-one at boot, but the wrapper rejects defensively
+                // in case the wrapper is constructed without going through
+                // it (e.g. unit tests).
+                if (a2aClientParamIndex != null) {
+                    throw new IllegalStateException(
+                        "Method " + method.getName() + " declares more than one A2AClient parameter; "
+                            + "exactly one is required (issue #923).");
+                }
+                a2aClientParamIndex = i;
                 continue;
             } else if (McpMeshTool.class.isAssignableFrom(type)) {
                 // Mesh tool dependency - will be injected
@@ -392,6 +418,37 @@ public class MeshToolWrapper implements McpToolHandler {
     /** The position of the MeshJob param in the method signature, or null. */
     public Integer getMeshJobParamIndex() {
         return meshJobParamIndex;
+    }
+
+    /**
+     * Issue #923: bind the cached {@link A2AClient} that {@code @A2AConsumer}
+     * provisioned for this method. Called by {@link MeshToolBeanPostProcessor}
+     * once {@link A2AConsumerBeanPostProcessor} has finished computing the
+     * binding. Throws if the wrapper's analysed signature did not include
+     * an A2AClient slot — keeps the binding wiring honest.
+     *
+     * @param paramIndex slot index reported by the bean post-processor;
+     *                   must match the wrapper's own analysis.
+     * @param client     the cached client to inject at dispatch time.
+     */
+    public void setA2AClientBinding(int paramIndex, A2AClient client) {
+        if (a2aClientParamIndex == null) {
+            throw new IllegalStateException(
+                "Cannot bind A2AClient on " + funcId
+                    + ": method has no A2AClient parameter slot to inject into.");
+        }
+        if (a2aClientParamIndex != paramIndex) {
+            throw new IllegalStateException(
+                "A2AClient binding mismatch for " + funcId
+                    + ": wrapper analysed slot=" + a2aClientParamIndex
+                    + " but post-processor reported slot=" + paramIndex);
+        }
+        this.a2aClient.set(client);
+    }
+
+    /** The position of the A2AClient param in the method signature, or null. */
+    public Integer getA2AClientParamIndex() {
+        return a2aClientParamIndex;
     }
 
     // =========================================================================
@@ -579,6 +636,14 @@ public class MeshToolWrapper implements McpToolHandler {
             fullArgs[meshJobParamIndex] = submitter; // null when no submitter wired
         }
 
+        // Issue #923: fill the @A2AConsumer-injected A2AClient slot, if any.
+        // The bean post-processor has already validated the binding; the
+        // null-guard here is defensive (e.g. wrapper constructed without
+        // going through the post-processor in unit tests).
+        if (a2aClientParamIndex != null) {
+            fullArgs[a2aClientParamIndex] = a2aClient.get();
+        }
+
         // Fill McpMeshTool dependencies (null if unavailable for graceful degradation)
         for (int i = 0; i < meshToolPositions.size(); i++) {
             int paramPos = meshToolPositions.get(i);
@@ -721,6 +786,13 @@ public class MeshToolWrapper implements McpToolHandler {
                 }
             }
             fullArgs[paramPos] = agent;
+        }
+
+        // Issue #923: same A2AClient injection as the non-job path —
+        // needed so a task=true @A2AConsumer method (e.g. report bridge)
+        // receives the cached client when dispatched as a job.
+        if (a2aClientParamIndex != null) {
+            fullArgs[a2aClientParamIndex] = a2aClient.get();
         }
 
         // Decide whether we can build a JobController: we need a slot

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/A2AConsumerBeanPostProcessorTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/A2AConsumerBeanPostProcessorTest.java
@@ -4,13 +4,17 @@ import io.mcpmesh.MeshTool;
 import io.mcpmesh.a2a.A2AClient;
 import io.mcpmesh.a2a.A2AConsumer;
 import io.mcpmesh.spring.A2AConsumerBeanPostProcessor;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -55,6 +59,24 @@ class A2AConsumerBeanPostProcessorTest {
         @MeshTool(capability = "broken-timeout")
         @A2AConsumer(url = "http://x", timeoutSeconds = 0)
         public String brokenTimeout(A2AClient a2a) {
+            return "x";
+        }
+    }
+
+    public static class NegativeTimeoutBean {
+        @MeshTool(capability = "neg-timeout")
+        @A2AConsumer(url = "http://x", timeoutSeconds = -1)
+        public String negTimeout(A2AClient a2a) {
+            return "x";
+        }
+    }
+
+    public static class NoMeshToolBean {
+        // @A2AConsumer without @MeshTool — must be a no-op (skipped by
+        // the post-processor) so we don't construct an A2AClient that
+        // no dispatch path will ever consult.
+        @A2AConsumer(url = "http://x", skillId = "skill")
+        public String orphan(A2AClient a2a) {
             return "x";
         }
     }
@@ -119,17 +141,6 @@ class A2AConsumerBeanPostProcessorTest {
         }
     }
 
-    public static class BlankSkillAndBlankCapabilityBean {
-        // No @MeshTool annotation at all AND no @A2AConsumer skillId —
-        // must fail fast at boot rather than caching an empty skillId.
-        // (@MeshTool's capability() has no default, so the only path to
-        // a missing capability fallback is the missing-@MeshTool case.)
-        @A2AConsumer(url = "http://x/agents/y")
-        public String noSkill(A2AClient a2a) {
-            return "x";
-        }
-    }
-
     public static class ResolvedToBlankUrlBean {
         // Spring property defaulted to empty string — placeholder
         // resolves successfully but yields blank url. Distinct error
@@ -165,12 +176,33 @@ class A2AConsumerBeanPostProcessorTest {
         }
     }
 
-    private static A2AConsumerBeanPostProcessor newProcessor(Environment env) {
-        return new A2AConsumerBeanPostProcessor(env);
+    // Track every processor produced via newProcessor() so the
+    // @AfterEach cleanup hook can shutdown() each one. Each A2AClient
+    // owns a JDK HttpClient + selector thread pool; without explicit
+    // shutdown the pools accumulate across tests and risk an FD leak
+    // on long suites (CodeRabbit Fix 6).
+    private final List<A2AConsumerBeanPostProcessor> processors = new ArrayList<>();
+
+    private A2AConsumerBeanPostProcessor newProcessor(Environment env) {
+        A2AConsumerBeanPostProcessor proc = new A2AConsumerBeanPostProcessor(env);
+        processors.add(proc);
+        return proc;
     }
 
-    private static A2AConsumerBeanPostProcessor newProcessor() {
+    private A2AConsumerBeanPostProcessor newProcessor() {
         return newProcessor(new StandardEnvironment());
+    }
+
+    @AfterEach
+    void cleanupProcessors() {
+        for (A2AConsumerBeanPostProcessor proc : processors) {
+            try {
+                proc.shutdown();
+            } catch (Exception ignored) {
+                // best-effort cleanup
+            }
+        }
+        processors.clear();
     }
 
     // -------- Validation --------
@@ -202,10 +234,18 @@ class A2AConsumerBeanPostProcessorTest {
     @Test
     void boot_failsWhenTimeoutZeroOrNegative() {
         A2AConsumerBeanPostProcessor proc = newProcessor();
-        BeanInitializationException ex = assertThrows(BeanInitializationException.class,
+        BeanInitializationException ex1 = assertThrows(BeanInitializationException.class,
             () -> proc.postProcessAfterInitialization(new ZeroTimeoutBean(), "zero"));
-        assertTrue(ex.getMessage().contains("timeoutSeconds"),
-            "must call out invalid timeout, got: " + ex.getMessage());
+        assertTrue(ex1.getMessage().contains("timeoutSeconds"),
+            "must call out invalid timeout for zero, got: " + ex1.getMessage());
+
+        // Negative timeouts take the same code path as zero (timeoutSeconds <= 0)
+        // but cover them explicitly so a future split of the validation
+        // doesn't silently drop one branch.
+        BeanInitializationException ex2 = assertThrows(BeanInitializationException.class,
+            () -> proc.postProcessAfterInitialization(new NegativeTimeoutBean(), "negative"));
+        assertTrue(ex2.getMessage().contains("timeoutSeconds"),
+            "must call out invalid timeout for negative, got: " + ex2.getMessage());
     }
 
     @Test
@@ -224,6 +264,20 @@ class A2AConsumerBeanPostProcessorTest {
             () -> proc.postProcessAfterInitialization(new TwoClientParamsBean(), "two"));
         assertTrue(ex.getMessage().contains("more than one A2AClient"),
             "must reject the multi-slot signature, got: " + ex.getMessage());
+    }
+
+    @Test
+    void boot_skipsMethodWithoutMeshTool() {
+        // CodeRabbit Fix 2: an @A2AConsumer that is NOT paired with
+        // @MeshTool has nothing to bridge — the post-processor must
+        // skip it cleanly rather than construct an A2AClient that no
+        // dispatch path will ever consult.
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        proc.postProcessAfterInitialization(new NoMeshToolBean(), "orphan");
+        assertEquals(0, proc.cacheSize(),
+            "no-MeshTool method must NOT trigger A2AClient construction");
+        assertEquals(0, proc.bindings().size(),
+            "no-MeshTool method must NOT record a MethodBinding");
     }
 
     // -------- Wiring --------
@@ -281,21 +335,13 @@ class A2AConsumerBeanPostProcessorTest {
             "blank skillId must fall back to the @MeshTool capability (Python parity)");
     }
 
-    @Test
-    void boot_failsWhenBothSkillIdAndCapabilityBlank() {
-        // Fix 1: when neither @A2AConsumer(skillId) nor @MeshTool(capability)
-        // carries a value, fail fast at boot rather than caching an empty
-        // skillId and waiting for the first A2A call to fail downstream.
-        A2AConsumerBeanPostProcessor proc = newProcessor();
-        BeanInitializationException ex = assertThrows(BeanInitializationException.class,
-            () -> proc.postProcessAfterInitialization(new BlankSkillAndBlankCapabilityBean(), "noskill"));
-        assertTrue(ex.getMessage().contains("requires a non-blank"),
-            "must call out the non-blank skillId requirement, got: " + ex.getMessage());
-        assertTrue(ex.getMessage().contains("skillId"),
-            "must mention the skillId field by name, got: " + ex.getMessage());
-        assertTrue(ex.getMessage().contains("@MeshTool(capability"),
-            "must mention the capability fallback path, got: " + ex.getMessage());
-    }
+    // Note: a "blank skillId AND blank @MeshTool capability" scenario was
+    // previously asserted via a no-@MeshTool stub bean. With CodeRabbit
+    // Fix 2 the post-processor now early-returns for any @A2AConsumer
+    // without @MeshTool, so that scenario is no longer reachable from
+    // user code (@MeshTool.capability() has no default, so a present
+    // @MeshTool always carries a non-blank capability). The defensive
+    // validation in processConsumerMethod remains as belt-and-suspenders.
 
     @Test
     void boot_failsWhenUrlPlaceholderResolvesToBlank() {
@@ -392,6 +438,54 @@ class A2AConsumerBeanPostProcessorTest {
         assertEquals(0, proc.cacheSize(),
             "shutdown must drop cached A2AClient instances so the context can be GC'd");
         assertEquals(0, proc.bindings().size());
+    }
+
+    @Test
+    void shutdown_closesEachCachedA2AClient() throws Exception {
+        // CodeRabbit Fix 5: clearing the cache map is necessary but not
+        // sufficient — each cached A2AClient holds an HttpClient with
+        // its own selector + worker pool, and AutoCloseable.close() is
+        // the public lifecycle signal. Verify shutdown() actually flips
+        // the `closed` flag on every cached instance, not just drops
+        // them on the floor for the GC to (eventually) reach.
+        //
+        // A2AClient is `final`, so subclassing is impossible; we read
+        // the production `closed` field via reflection — which has the
+        // upside that this test covers the real production close path,
+        // not a test-double surrogate.
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        proc.postProcessAfterInitialization(new TwoMethodsDifferentConfigBean(), "diff");
+        assertEquals(2, proc.cacheSize(),
+            "two distinct configs should populate two cache entries before shutdown");
+
+        // Snapshot the cached clients before shutdown drops the map.
+        Method m1 = TwoMethodsDifferentConfigBean.class.getMethod("first", A2AClient.class);
+        Method m2 = TwoMethodsDifferentConfigBean.class.getMethod("second", A2AClient.class);
+        A2AClient client1 = proc.bindingFor(m1).client();
+        A2AClient client2 = proc.bindingFor(m2).client();
+        assertNotSame(client1, client2,
+            "two different urls must yield two distinct cached clients");
+        assertFalse(readClosedFlag(client1), "client1 must start un-closed");
+        assertFalse(readClosedFlag(client2), "client2 must start un-closed");
+
+        proc.shutdown();
+
+        assertTrue(readClosedFlag(client1),
+            "shutdown() must call close() on every cached A2AClient — client1 leaked");
+        assertTrue(readClosedFlag(client2),
+            "shutdown() must call close() on every cached A2AClient — client2 leaked");
+    }
+
+    /**
+     * Read the package-private {@code closed} flag on an {@link A2AClient}
+     * via reflection. The field is set by {@link A2AClient#close()}; reading
+     * it lets us verify the close path ran without subclassing the final
+     * class. Used by {@link #shutdown_closesEachCachedA2AClient()}.
+     */
+    private static boolean readClosedFlag(A2AClient client) throws Exception {
+        Field f = A2AClient.class.getDeclaredField("closed");
+        f.setAccessible(true);
+        return f.getBoolean(client);
     }
 
     // -------- Task=true wiring (uc27 tc04 regression cover) --------

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/A2AConsumerBeanPostProcessorTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/A2AConsumerBeanPostProcessorTest.java
@@ -119,6 +119,52 @@ class A2AConsumerBeanPostProcessorTest {
         }
     }
 
+    public static class BlankSkillAndBlankCapabilityBean {
+        // No @MeshTool annotation at all AND no @A2AConsumer skillId —
+        // must fail fast at boot rather than caching an empty skillId.
+        // (@MeshTool's capability() has no default, so the only path to
+        // a missing capability fallback is the missing-@MeshTool case.)
+        @A2AConsumer(url = "http://x/agents/y")
+        public String noSkill(A2AClient a2a) {
+            return "x";
+        }
+    }
+
+    public static class ResolvedToBlankUrlBean {
+        // Spring property defaulted to empty string — placeholder
+        // resolves successfully but yields blank url. Distinct error
+        // message from the marker-only migration path.
+        @MeshTool(capability = "blank-url")
+        @A2AConsumer(url = "${some.url:}", skillId = "x")
+        public String blank(A2AClient a2a) {
+            return "x";
+        }
+    }
+
+    public static class AuthlessBean {
+        @MeshTool(capability = "auth-none")
+        @A2AConsumer(url = "http://x/agents/y", skillId = "skill")
+        public String none(A2AClient a2a) {
+            return "x";
+        }
+    }
+
+    public static class AuthEnvBean {
+        @MeshTool(capability = "auth-env")
+        @A2AConsumer(url = "http://x/agents/y", skillId = "skill", authBearerEnv = "MY_TOKEN")
+        public String env(A2AClient a2a) {
+            return "x";
+        }
+    }
+
+    public static class AuthLiteralBean {
+        @MeshTool(capability = "auth-literal")
+        @A2AConsumer(url = "http://x/agents/y", skillId = "skill", authBearerToken = "literal")
+        public String literal(A2AClient a2a) {
+            return "x";
+        }
+    }
+
     private static A2AConsumerBeanPostProcessor newProcessor(Environment env) {
         return new A2AConsumerBeanPostProcessor(env);
     }
@@ -235,6 +281,42 @@ class A2AConsumerBeanPostProcessorTest {
             "blank skillId must fall back to the @MeshTool capability (Python parity)");
     }
 
+    @Test
+    void boot_failsWhenBothSkillIdAndCapabilityBlank() {
+        // Fix 1: when neither @A2AConsumer(skillId) nor @MeshTool(capability)
+        // carries a value, fail fast at boot rather than caching an empty
+        // skillId and waiting for the first A2A call to fail downstream.
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        BeanInitializationException ex = assertThrows(BeanInitializationException.class,
+            () -> proc.postProcessAfterInitialization(new BlankSkillAndBlankCapabilityBean(), "noskill"));
+        assertTrue(ex.getMessage().contains("requires a non-blank"),
+            "must call out the non-blank skillId requirement, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("skillId"),
+            "must mention the skillId field by name, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("@MeshTool(capability"),
+            "must mention the capability fallback path, got: " + ex.getMessage());
+    }
+
+    @Test
+    void boot_failsWhenUrlPlaceholderResolvesToBlank() {
+        // Fix 3: a placeholder like ${some.url:} that resolves to empty
+        // must surface a property-pointing message, NOT the marker-only
+        // migration message (which would mislead the user — they did
+        // set a url, the property is just empty).
+        MockEnvironment env = new MockEnvironment();
+        // Don't set any property — ${some.url:} default is "".
+        A2AConsumerBeanPostProcessor proc = newProcessor(env);
+        BeanInitializationException ex = assertThrows(BeanInitializationException.class,
+            () -> proc.postProcessAfterInitialization(new ResolvedToBlankUrlBean(), "blank"));
+        assertTrue(ex.getMessage().contains("resolved to empty"),
+            "must call out the blank resolution, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("Spring property"),
+            "must point at the property, not the migration link, got: " + ex.getMessage());
+        assertFalse(ex.getMessage().contains("#923"),
+            "must NOT show the marker-only migration message — the user did set a url, "
+                + "got: " + ex.getMessage());
+    }
+
     // -------- Caching --------
 
     @Test
@@ -262,6 +344,39 @@ class A2AConsumerBeanPostProcessorTest {
 
         assertEquals(2, proc.cacheSize(),
             "two methods with different urls must construct two A2AClient instances");
+    }
+
+    @Test
+    void cache_separatesA2AClientsByAuthSpec_evenWithIdenticalUrlAndSkill() throws Exception {
+        // Fix 5: two methods with identical (url, skillId, timeout) but
+        // DIFFERENT auth specs (none vs env vs literal) must produce
+        // distinct cached A2AClient instances. Closes the cache-key
+        // correctness gap where credentials with different rotation
+        // surfaces would otherwise collide.
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        proc.postProcessAfterInitialization(new AuthlessBean(), "none");
+        proc.postProcessAfterInitialization(new AuthEnvBean(), "env");
+        proc.postProcessAfterInitialization(new AuthLiteralBean(), "literal");
+
+        assertEquals(3, proc.cacheSize(),
+            "auth=none, auth=env, auth=literal must each get their own cached A2AClient — "
+                + "AuthSpec is part of the cache key");
+        assertEquals(3, proc.bindings().size(),
+            "each method must record its own binding");
+
+        // Pull the three clients and verify pairwise distinctness.
+        Method noneM = AuthlessBean.class.getMethod("none", A2AClient.class);
+        Method envM = AuthEnvBean.class.getMethod("env", A2AClient.class);
+        Method literalM = AuthLiteralBean.class.getMethod("literal", A2AClient.class);
+        A2AClient noneClient = proc.bindingFor(noneM).client();
+        A2AClient envClient = proc.bindingFor(envM).client();
+        A2AClient literalClient = proc.bindingFor(literalM).client();
+        assertNotSame(noneClient, envClient,
+            "auth=none and auth=env must NOT share a cached client");
+        assertNotSame(noneClient, literalClient,
+            "auth=none and auth=literal must NOT share a cached client");
+        assertNotSame(envClient, literalClient,
+            "auth=env and auth=literal must NOT share a cached client");
     }
 
     // -------- Lifecycle --------

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/A2AConsumerBeanPostProcessorTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/A2AConsumerBeanPostProcessorTest.java
@@ -1,0 +1,341 @@
+package io.mcpmesh.spring.a2a;
+
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.a2a.A2AClient;
+import io.mcpmesh.a2a.A2AConsumer;
+import io.mcpmesh.spring.A2AConsumerBeanPostProcessor;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #923: unit tests for {@link A2AConsumerBeanPostProcessor}.
+ *
+ * <p>Covers the boot-time validation, A2AClient caching, Spring
+ * property placeholder resolution, and the migration error fired when
+ * a method still uses the marker-only form.
+ */
+class A2AConsumerBeanPostProcessorTest {
+
+    // -------- Stub beans --------
+
+    public static class GoodBean {
+        @MeshTool(capability = "current-date", tags = {"a2a-bridge"})
+        @A2AConsumer(url = "http://localhost:9090/agents/date", skillId = "get-date")
+        public String currentDate(A2AClient a2a) {
+            return "ok";
+        }
+    }
+
+    public static class MarkerOnlyBean {
+        // Pre-#923 marker-only usage with no url() — must be rejected at boot.
+        @MeshTool(capability = "broken")
+        @A2AConsumer(url = "")
+        public String broken(A2AClient a2a) {
+            return "x";
+        }
+    }
+
+    public static class BothAuthBean {
+        @MeshTool(capability = "broken-auth")
+        @A2AConsumer(url = "http://x", authBearerEnv = "FOO", authBearerToken = "bar")
+        public String brokenAuth(A2AClient a2a) {
+            return "x";
+        }
+    }
+
+    public static class ZeroTimeoutBean {
+        @MeshTool(capability = "broken-timeout")
+        @A2AConsumer(url = "http://x", timeoutSeconds = 0)
+        public String brokenTimeout(A2AClient a2a) {
+            return "x";
+        }
+    }
+
+    public static class MissingClientParamBean {
+        @MeshTool(capability = "missing")
+        @A2AConsumer(url = "http://x")
+        public String missing() {
+            return "x";
+        }
+    }
+
+    public static class TwoClientParamsBean {
+        @MeshTool(capability = "two")
+        @A2AConsumer(url = "http://x")
+        public String two(A2AClient a, A2AClient b) {
+            return "x";
+        }
+    }
+
+    public static class PlaceholderBean {
+        @MeshTool(capability = "placeholder")
+        @A2AConsumer(url = "${weather.a2a.url}", skillId = "get-weather")
+        public String weather(A2AClient a2a) {
+            return "ok";
+        }
+    }
+
+    public static class TwoMethodsSameConfigBean {
+        @MeshTool(capability = "first")
+        @A2AConsumer(url = "http://x/agents/y", skillId = "skill")
+        public String first(A2AClient a2a) {
+            return "1";
+        }
+
+        @MeshTool(capability = "second")
+        @A2AConsumer(url = "http://x/agents/y", skillId = "skill")
+        public String second(A2AClient a2a) {
+            return "2";
+        }
+    }
+
+    public static class TwoMethodsDifferentConfigBean {
+        @MeshTool(capability = "first")
+        @A2AConsumer(url = "http://x/agents/y", skillId = "skill")
+        public String first(A2AClient a2a) {
+            return "1";
+        }
+
+        @MeshTool(capability = "second")
+        @A2AConsumer(url = "http://x/agents/z", skillId = "skill")
+        public String second(A2AClient a2a) {
+            return "2";
+        }
+    }
+
+    public static class CapabilityFallbackSkillBean {
+        @MeshTool(capability = "current-date")
+        @A2AConsumer(url = "http://x/agents/y")     // skillId left unset
+        public String currentDate(A2AClient a2a) {
+            return "ok";
+        }
+    }
+
+    private static A2AConsumerBeanPostProcessor newProcessor(Environment env) {
+        return new A2AConsumerBeanPostProcessor(env);
+    }
+
+    private static A2AConsumerBeanPostProcessor newProcessor() {
+        return newProcessor(new StandardEnvironment());
+    }
+
+    // -------- Validation --------
+
+    @Test
+    void boot_failsWithMigrationMessage_whenUrlMissing() {
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        BeanInitializationException ex = assertThrows(BeanInitializationException.class,
+            () -> proc.postProcessAfterInitialization(new MarkerOnlyBean(), "marker"));
+        // Migration message must spell out the issue link + example syntax
+        // so users who upgraded mid-PR get a real fix path, not a stack trace.
+        assertTrue(ex.getMessage().contains("requires the 'url' field"),
+            "must mention the missing url field, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("#923"),
+            "must reference the migration issue, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("@A2AConsumer(url"),
+            "must show the new annotation syntax, got: " + ex.getMessage());
+    }
+
+    @Test
+    void boot_failsWhenBothAuthFieldsSet() {
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        BeanInitializationException ex = assertThrows(BeanInitializationException.class,
+            () -> proc.postProcessAfterInitialization(new BothAuthBean(), "both"));
+        assertTrue(ex.getMessage().contains("mutually exclusive"),
+            "must call out auth field conflict, got: " + ex.getMessage());
+    }
+
+    @Test
+    void boot_failsWhenTimeoutZeroOrNegative() {
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        BeanInitializationException ex = assertThrows(BeanInitializationException.class,
+            () -> proc.postProcessAfterInitialization(new ZeroTimeoutBean(), "zero"));
+        assertTrue(ex.getMessage().contains("timeoutSeconds"),
+            "must call out invalid timeout, got: " + ex.getMessage());
+    }
+
+    @Test
+    void boot_failsWhenA2AClientParamMissing() {
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        BeanInitializationException ex = assertThrows(BeanInitializationException.class,
+            () -> proc.postProcessAfterInitialization(new MissingClientParamBean(), "missing"));
+        assertTrue(ex.getMessage().contains("A2AClient parameter"),
+            "must call out the missing injection slot, got: " + ex.getMessage());
+    }
+
+    @Test
+    void boot_failsWhenTwoA2AClientParamsDeclared() {
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        BeanInitializationException ex = assertThrows(BeanInitializationException.class,
+            () -> proc.postProcessAfterInitialization(new TwoClientParamsBean(), "two"));
+        assertTrue(ex.getMessage().contains("more than one A2AClient"),
+            "must reject the multi-slot signature, got: " + ex.getMessage());
+    }
+
+    // -------- Wiring --------
+
+    @Test
+    void boot_wiresGoodBean_andRecordsBinding() throws Exception {
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        proc.postProcessAfterInitialization(new GoodBean(), "good");
+
+        Method m = GoodBean.class.getMethod("currentDate", A2AClient.class);
+        A2AConsumerBeanPostProcessor.MethodBinding binding = proc.bindingFor(m);
+        assertNotNull(binding, "binding must be present after post-processing");
+        assertEquals(0, binding.a2aParamIndex(),
+            "A2AClient is the sole param at position 0");
+        assertNotNull(binding.client(), "cached A2AClient must be non-null");
+        assertEquals("http://localhost:9090/agents/date", binding.key().url());
+        assertEquals("get-date", binding.key().skillId());
+        assertEquals(30, binding.key().timeoutSeconds(),
+            "default timeout (30s) must round-trip into the key");
+    }
+
+    @Test
+    void boot_resolvesSpringPropertyPlaceholderInUrl() throws Exception {
+        MockEnvironment env = new MockEnvironment();
+        env.setProperty("weather.a2a.url", "http://upstream:9999/agents/weather");
+        A2AConsumerBeanPostProcessor proc = newProcessor(env);
+        proc.postProcessAfterInitialization(new PlaceholderBean(), "ph");
+
+        Method m = PlaceholderBean.class.getMethod("weather", A2AClient.class);
+        A2AConsumerBeanPostProcessor.MethodBinding binding = proc.bindingFor(m);
+        assertNotNull(binding);
+        assertEquals("http://upstream:9999/agents/weather", binding.key().url(),
+            "placeholder must be resolved against the Spring Environment");
+    }
+
+    @Test
+    void boot_failsWhenUrlPlaceholderUnresolved() {
+        // No property set — resolveRequiredPlaceholders should raise.
+        A2AConsumerBeanPostProcessor proc = newProcessor(new MockEnvironment());
+        BeanInitializationException ex = assertThrows(BeanInitializationException.class,
+            () -> proc.postProcessAfterInitialization(new PlaceholderBean(), "ph"));
+        assertTrue(ex.getMessage().contains("placeholder"),
+            "must call out the unresolved placeholder, got: " + ex.getMessage());
+    }
+
+    @Test
+    void boot_skillIdDefaultsToCapability_whenAnnotationSkillIdBlank() throws Exception {
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        proc.postProcessAfterInitialization(new CapabilityFallbackSkillBean(), "fallback");
+
+        Method m = CapabilityFallbackSkillBean.class.getMethod("currentDate", A2AClient.class);
+        A2AConsumerBeanPostProcessor.MethodBinding binding = proc.bindingFor(m);
+        assertNotNull(binding);
+        assertEquals("current-date", binding.key().skillId(),
+            "blank skillId must fall back to the @MeshTool capability (Python parity)");
+    }
+
+    // -------- Caching --------
+
+    @Test
+    void cache_sharesA2AClientAcrossMethodsWithIdenticalConfig() {
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        proc.postProcessAfterInitialization(new TwoMethodsSameConfigBean(), "same");
+
+        assertEquals(1, proc.cacheSize(),
+            "two methods with identical config must share a single cached A2AClient");
+        assertEquals(2, proc.bindings().size(),
+            "but each method gets its own MethodBinding entry");
+
+        // Both bindings reference the SAME A2AClient instance.
+        Map<java.lang.reflect.Method, A2AConsumerBeanPostProcessor.MethodBinding> bindings = proc.bindings();
+        A2AClient[] clients = bindings.values().stream()
+            .map(A2AConsumerBeanPostProcessor.MethodBinding::client)
+            .toArray(A2AClient[]::new);
+        assertSame(clients[0], clients[1], "shared config must yield shared A2AClient instance");
+    }
+
+    @Test
+    void cache_separatesA2AClientsByDifferentConfig() {
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        proc.postProcessAfterInitialization(new TwoMethodsDifferentConfigBean(), "diff");
+
+        assertEquals(2, proc.cacheSize(),
+            "two methods with different urls must construct two A2AClient instances");
+    }
+
+    // -------- Lifecycle --------
+
+    @Test
+    void shutdown_clearsCacheAndBindings() throws Exception {
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        proc.postProcessAfterInitialization(new GoodBean(), "good");
+        assertEquals(1, proc.cacheSize());
+        assertEquals(1, proc.bindings().size());
+
+        proc.shutdown();
+        assertEquals(0, proc.cacheSize(),
+            "shutdown must drop cached A2AClient instances so the context can be GC'd");
+        assertEquals(0, proc.bindings().size());
+    }
+
+    // -------- Task=true wiring (uc27 tc04 regression cover) --------
+
+    /**
+     * Mirror of the {@code consumer-report-agent-java} fixture's signature:
+     * {@code (@Param, @Param, A2AClient, MeshJob)} with {@code task=true}.
+     * Catches the regression seen in uc27 tc04 where the wrapper-side
+     * dispatch could not find the cached A2AClient on the task path.
+     */
+    public static class TaskBean {
+        @MeshTool(capability = "report", task = true, tags = {"a2a-bridge"})
+        @A2AConsumer(url = "http://localhost:9091/agents/report", skillId = "generate-report")
+        public Object generateReport(
+                @io.mcpmesh.Param("user_id") String userId,
+                @io.mcpmesh.Param(value = "sections", required = false) java.util.List<String> sections,
+                A2AClient a2a,
+                io.mcpmesh.MeshJob job) {
+            return java.util.Map.of();
+        }
+    }
+
+    @Test
+    void taskBean_bindingResolvesAtCorrectSlotIndex() throws Exception {
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        proc.postProcessAfterInitialization(new TaskBean(), "task");
+
+        Method m = TaskBean.class.getMethod("generateReport",
+            String.class, java.util.List.class, A2AClient.class, io.mcpmesh.MeshJob.class);
+        A2AConsumerBeanPostProcessor.MethodBinding binding = proc.bindingFor(m);
+        assertNotNull(binding,
+            "task=true @A2AConsumer methods must be wired exactly like non-task ones");
+        assertEquals(2, binding.a2aParamIndex(),
+            "A2AClient sits at signature position 2 (after the two @Param slots)");
+    }
+
+    @Test
+    void taskBean_methodLookupRoundTripsThroughReflectionUtils() throws Exception {
+        // Defensive cover for the failure mode where two BPPs see two
+        // different Method instances for "the same" method (would be a
+        // bug in a custom Map<Method,?> impl). With ReflectionUtils +
+        // ConcurrentHashMap (the production wiring) Method.equals is
+        // class+name+params, so .get returns the recorded binding.
+        A2AConsumerBeanPostProcessor proc = newProcessor();
+        TaskBean bean = new TaskBean();
+        proc.postProcessAfterInitialization(bean, "task");
+
+        // Walk methods the same way MeshToolBeanPostProcessor does and
+        // confirm the binding is found.
+        Class<?> targetClass = bean.getClass();
+        java.util.concurrent.atomic.AtomicReference<A2AConsumerBeanPostProcessor.MethodBinding> seen =
+            new java.util.concurrent.atomic.AtomicReference<>();
+        org.springframework.util.ReflectionUtils.doWithMethods(targetClass, method -> {
+            if ("generateReport".equals(method.getName())) {
+                seen.set(proc.bindingFor(method));
+            }
+        });
+        assertNotNull(seen.get(),
+            "binding lookup via ReflectionUtils.doWithMethods (the path the tool BPP uses) must "
+                + "return a non-null binding for the same method that A2A BPP recorded");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/A2AConsumerTagInjectionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/A2AConsumerTagInjectionTest.java
@@ -24,7 +24,7 @@ class A2AConsumerTagInjectionTest {
     public static class ConsumerBean {
 
         @MeshTool(capability = "current-date", tags = {"a2a-bridge"})
-        @A2AConsumer
+        @A2AConsumer(url = "http://localhost:9090/agents/date", skillId = "get-date")
         public String currentDate() {
             return "today";
         }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/JobsRuntimeManagerA2AInjectionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/JobsRuntimeManagerA2AInjectionTest.java
@@ -1,0 +1,123 @@
+package io.mcpmesh.spring.a2a;
+
+import io.mcpmesh.JobController;
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.a2a.A2AClient;
+import io.mcpmesh.a2a.A2AConsumer;
+import io.mcpmesh.spring.A2AConsumerBeanPostProcessor;
+import io.mcpmesh.spring.JobsRuntimeManager;
+import io.mcpmesh.spring.MeshToolRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.StandardEnvironment;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #923 regression cover: verify the claim-path reflection invoker
+ * in {@link JobsRuntimeManager} fills the {@link A2AClient} parameter
+ * slot for {@code task=true @A2AConsumer} producers. Without this,
+ * uc27 tc04/05/06/08 fail with {@code NullPointerException} on the
+ * first {@code a2a.send(...)} call (the claim path doesn't go through
+ * {@link io.mcpmesh.spring.MeshToolWrapper}, so its
+ * {@code setA2AClientBinding} wiring is bypassed).
+ */
+class JobsRuntimeManagerA2AInjectionTest {
+
+    /** Shape mirrors the uc27 consumer-report-agent-java fixture. */
+    public static class TaskBean {
+        final AtomicReference<A2AClient> received = new AtomicReference<>();
+
+        @MeshTool(capability = "report", task = true)
+        @A2AConsumer(url = "http://localhost:9091/agents/report", skillId = "generate-report")
+        public Object generateReport(
+                @Param("user_id") String userId,
+                @Param(value = "sections", required = false) List<String> sections,
+                A2AClient a2a,
+                MeshJob job) {
+            received.set(a2a);
+            return Map.of("user_id", userId, "sections", sections == null ? List.of() : sections);
+        }
+    }
+
+    @Test
+    void claimPath_injectsBoundA2AClientOnTaskBridge() throws Exception {
+        // 1. Stand up the A2A processor + wire the task bean.
+        A2AConsumerBeanPostProcessor a2a = new A2AConsumerBeanPostProcessor(new StandardEnvironment());
+        TaskBean bean = new TaskBean();
+        a2a.postProcessAfterInitialization(bean, "task");
+
+        // 2. Register the tool with MeshToolRegistry (mimics what
+        //    MeshToolBeanPostProcessor would do at boot).
+        MeshToolRegistry registry = new MeshToolRegistry();
+        Method method = TaskBean.class.getMethod("generateReport",
+            String.class, List.class, A2AClient.class, MeshJob.class);
+        registry.registerTool(bean, method, method.getAnnotation(MeshTool.class));
+
+        // 3. Build the JobsRuntimeManager — only the invokeViaReflection
+        //    path matters for this test; we don't start the full
+        //    SmartLifecycle.
+        JobsRuntimeManager mgr = new JobsRuntimeManager(
+            null, registry, null, a2a);
+
+        // 4. Drive invokeViaReflection through reflection (the method is
+        //    private, but visible to the test in the same module).
+        Method invokeMethod = JobsRuntimeManager.class.getDeclaredMethod(
+            "invokeViaReflection",
+            MeshToolRegistry.ToolMetadata.class,
+            Map.class,
+            JobController.class);
+        invokeMethod.setAccessible(true);
+
+        MeshToolRegistry.ToolMetadata meta = registry.getTool("report");
+        assertNotNull(meta);
+
+        Object result = invokeMethod.invoke(mgr, meta,
+            Map.of("user_id", "alice", "sections", List.of("intro")),
+            null);
+
+        assertNotNull(result);
+        // The smoking-gun assertion — without the claim-path injection
+        // fix, bean.received.get() is null and the user method NPEs on
+        // the first a2a.send(...).
+        assertNotNull(bean.received.get(),
+            "claim-path reflection invoker MUST inject the cached A2AClient at the bound slot — "
+                + "uc27 tc04/05/06/08 regression cover");
+    }
+
+    @Test
+    void claimPath_passesNullA2AClient_whenNoBinding() throws Exception {
+        // Defensive cover: a JobsRuntimeManager constructed without the
+        // A2A processor (e.g. legacy environments) must still invoke
+        // task-only methods without the slot, just leaving A2AClient
+        // params as null. Mirrors the McpMeshTool "Phase 1 limit" path.
+        MeshToolRegistry registry = new MeshToolRegistry();
+        TaskBean bean = new TaskBean();
+        Method method = TaskBean.class.getMethod("generateReport",
+            String.class, List.class, A2AClient.class, MeshJob.class);
+        registry.registerTool(bean, method, method.getAnnotation(MeshTool.class));
+
+        JobsRuntimeManager mgr = new JobsRuntimeManager(
+            null, registry, null, null);
+
+        Method invokeMethod = JobsRuntimeManager.class.getDeclaredMethod(
+            "invokeViaReflection",
+            MeshToolRegistry.ToolMetadata.class,
+            Map.class,
+            JobController.class);
+        invokeMethod.setAccessible(true);
+
+        MeshToolRegistry.ToolMetadata meta = registry.getTool("report");
+        Object result = invokeMethod.invoke(mgr, meta,
+            Map.of("user_id", "alice", "sections", List.of()), null);
+        assertNotNull(result);
+        assertNull(bean.received.get(),
+            "no A2A processor wired → A2AClient slot stays null (matches Phase 1 limit for other inject types)");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/MeshToolWrapperA2AInjectionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/MeshToolWrapperA2AInjectionTest.java
@@ -2,6 +2,7 @@ package io.mcpmesh.spring.a2a;
 
 import io.mcpmesh.Param;
 import io.mcpmesh.a2a.A2AClient;
+import io.mcpmesh.a2a.A2AConsumer;
 import io.mcpmesh.spring.MeshToolWrapper;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
@@ -25,6 +26,12 @@ class MeshToolWrapperA2AInjectionTest {
     static class Bridge {
         final AtomicReference<A2AClient> received = new AtomicReference<>();
 
+        // Annotation must be present at wrapper-construction time —
+        // CodeRabbit Fix 3 added a boot-time guard rejecting A2AClient
+        // params on methods without @A2AConsumer. The url here is
+        // unused by the wrapper (the post-processor owns config); we
+        // just need the marker so analyzeParameters lets the slot through.
+        @A2AConsumer(url = "http://localhost:9090/agents/date", skillId = "get-date")
         public Map<String, Object> currentDate(@Param("hint") String hint, A2AClient a2a) {
             received.set(a2a);
             return Map.of("hint", hint == null ? "" : hint);
@@ -144,5 +151,38 @@ class MeshToolWrapperA2AInjectionTest {
         } finally {
             client.close();
         }
+    }
+
+    /** A bean whose @MeshTool method has an A2AClient parameter but NO @A2AConsumer. */
+    @SuppressWarnings("unused")
+    static class A2AClientWithoutConsumerBean {
+        public String orphan(@Param("hint") String hint, A2AClient a2a) {
+            return hint;
+        }
+    }
+
+    @Test
+    void wrapper_rejectsA2AClientParamWithoutA2AConsumerAtBoot() {
+        // CodeRabbit Fix 3: an A2AClient parameter on a @MeshTool method
+        // that lacks @A2AConsumer has no upstream URL/auth/timeout to
+        // bind to. The dispatch wrapper would silently inject null and
+        // the user method would NPE on the first a2a.send(...) call.
+        // Fail BOOT (wrapper construction == registration time) so the
+        // misuse surfaces immediately.
+        A2AClientWithoutConsumerBean bean = new A2AClientWithoutConsumerBean();
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> new MeshToolWrapper(
+                "A2AClientWithoutConsumerBean.orphan",
+                "orphan",
+                "test",
+                bean,
+                find(A2AClientWithoutConsumerBean.class, "orphan"),
+                List.of(),
+                JsonMapper.builder().build()
+            ));
+        assertTrue(ex.getMessage().contains("@A2AConsumer"),
+            "must reference the missing @A2AConsumer annotation, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("A2AClient"),
+            "must mention the A2AClient parameter, got: " + ex.getMessage());
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/MeshToolWrapperA2AInjectionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/a2a/MeshToolWrapperA2AInjectionTest.java
@@ -1,0 +1,148 @@
+package io.mcpmesh.spring.a2a;
+
+import io.mcpmesh.Param;
+import io.mcpmesh.a2a.A2AClient;
+import io.mcpmesh.spring.MeshToolWrapper;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #923: verify that {@link MeshToolWrapper} recognises the
+ * {@link A2AClient} parameter slot, exempts it from the MCP input
+ * schema, and injects the bound client at dispatch time.
+ */
+class MeshToolWrapperA2AInjectionTest {
+
+    /** Sink bean — captures the injected A2AClient so the test can assert identity. */
+    @SuppressWarnings("unused")
+    static class Bridge {
+        final AtomicReference<A2AClient> received = new AtomicReference<>();
+
+        public Map<String, Object> currentDate(@Param("hint") String hint, A2AClient a2a) {
+            received.set(a2a);
+            return Map.of("hint", hint == null ? "" : hint);
+        }
+    }
+
+    private static Method find(Class<?> cls, String name) {
+        for (Method m : cls.getDeclaredMethods()) {
+            if (m.getName().equals(name)) return m;
+        }
+        throw new AssertionError("not found: " + name);
+    }
+
+    @Test
+    void wrapper_capturesA2AClientSlot_andExemptsItFromInputSchema() {
+        Bridge bridge = new Bridge();
+        MeshToolWrapper w = new MeshToolWrapper(
+            "Bridge.currentDate",
+            "current-date",
+            "test",
+            bridge,
+            find(Bridge.class, "currentDate"),
+            List.of(),
+            JsonMapper.builder().build()
+        );
+        // The A2AClient slot sits at signature position 1 (after @Param("hint")).
+        assertEquals(1, w.getA2AClientParamIndex(),
+            "wrapper must record the A2AClient slot index");
+
+        Map<String, Object> schema = w.getInputSchema();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties = (Map<String, Object>) schema.get("properties");
+        assertEquals(1, properties.size(),
+            "A2AClient param must be excluded from the MCP input schema");
+        assertTrue(properties.containsKey("hint"));
+        assertFalse(properties.containsKey("a2a"),
+            "injected A2AClient slot must not bleed into the MCP schema");
+    }
+
+    @Test
+    void wrapper_injectsBoundA2AClientAtDispatch() throws Exception {
+        Bridge bridge = new Bridge();
+        MeshToolWrapper w = new MeshToolWrapper(
+            "Bridge.currentDate",
+            "current-date",
+            "test",
+            bridge,
+            find(Bridge.class, "currentDate"),
+            List.of(),
+            JsonMapper.builder().build()
+        );
+        // The cached A2AClient that the bean post-processor would normally
+        // hand us. Real wiring goes through MeshToolBeanPostProcessor.
+        A2AClient expected = new A2AClient("http://localhost:9090/agents/date", "get-date");
+        try {
+            w.setA2AClientBinding(1, expected);
+
+            Object result = w.invoke(Map.of("hint", "now"));
+            assertNotNull(result);
+            assertSame(expected, bridge.received.get(),
+                "dispatch must pass the bound A2AClient through to the user method");
+        } finally {
+            expected.close();
+        }
+    }
+
+    @Test
+    void wrapper_setA2AClientBinding_rejectsSlotMismatch() {
+        Bridge bridge = new Bridge();
+        MeshToolWrapper w = new MeshToolWrapper(
+            "Bridge.currentDate",
+            "current-date",
+            "test",
+            bridge,
+            find(Bridge.class, "currentDate"),
+            List.of(),
+            JsonMapper.builder().build()
+        );
+        A2AClient client = new A2AClient("http://localhost:9090/agents/date", "get-date");
+        try {
+            // The wrapper analysed the slot at index 1; a post-processor
+            // claiming index 0 means the wiring drifted and we should fail
+            // loudly rather than silently inject into the wrong slot.
+            assertThrows(IllegalStateException.class,
+                () -> w.setA2AClientBinding(0, client));
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void wrapper_setA2AClientBinding_rejectsMethodWithoutSlot() {
+        // Method with no A2AClient param — wrapper must refuse to bind.
+        @SuppressWarnings("unused")
+        class PlainBean {
+            public String plain(@Param("x") String x) {
+                return x;
+            }
+        }
+        PlainBean bean = new PlainBean();
+        MeshToolWrapper w = new MeshToolWrapper(
+            "PlainBean.plain",
+            "plain",
+            "test",
+            bean,
+            find(PlainBean.class, "plain"),
+            List.of(),
+            JsonMapper.builder().build()
+        );
+        assertNull(w.getA2AClientParamIndex(),
+            "method without A2AClient param must report null slot index");
+        A2AClient client = new A2AClient("http://localhost:9090/agents/date", "get-date");
+        try {
+            assertThrows(IllegalStateException.class,
+                () -> w.setA2AClientBinding(0, client),
+                "binding must be rejected when the wrapper has no slot to inject into");
+        } finally {
+            client.close();
+        }
+    }
+}

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/src/main/java/com/example/dateconsumerjavab/ConsumerDateAgentBApplication.java
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/src/main/java/com/example/dateconsumerjavab/ConsumerDateAgentBApplication.java
@@ -16,7 +16,8 @@ import java.util.Map;
  * uc27 Java consumer (alt) — second bridge over the same date_a2a_agent
  * producer at localhost:9090, but registered under
  * date-consumer-alt so the auto-injected consumer-name tag
- * distinguishes it from date-consumer for failover (tc03).
+ * distinguishes it from date-consumer for failover (tc03). Refactored
+ * for issue #923 (annotation-config form).
  */
 @MeshAgent(
     name = "date-consumer-alt",
@@ -26,11 +27,6 @@ import java.util.Map;
 )
 @SpringBootApplication
 public class ConsumerDateAgentBApplication {
-
-    private static final A2AClient A2A_CLIENT = new A2AClient(
-        "http://localhost:9090/agents/date",
-        "get-date"
-    );
 
     private static final ObjectMapper JSON = new ObjectMapper();
 
@@ -43,9 +39,12 @@ public class ConsumerDateAgentBApplication {
         description = "Bridge upstream A2A get-date skill onto the mesh (alt consumer).",
         tags = {"a2a-bridge"}
     )
-    @A2AConsumer
-    public Map<String, Object> currentDate() throws Exception {
-        A2AResponse response = A2A_CLIENT.send(Map.of(
+    @A2AConsumer(
+        url = "http://localhost:9090/agents/date",
+        skillId = "get-date"
+    )
+    public Map<String, Object> currentDate(A2AClient a2a) throws Exception {
+        A2AResponse response = a2a.send(Map.of(
             "role", "user",
             "parts", List.of(Map.of("type", "text", "text", "now"))
         ));

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/src/main/java/com/example/dateconsumerjava/ConsumerDateAgentApplication.java
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/src/main/java/com/example/dateconsumerjava/ConsumerDateAgentApplication.java
@@ -13,9 +13,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * uc27_a2a_consumer_java fixture — bridges the existing
- * date_a2a_agent.py producer's get-date skill onto the mesh as a
- * current-date capability.
+ * uc27_a2a_consumer_java fixture (issue #923 — annotation-config form) —
+ * bridges the existing date_a2a_agent.py producer's get-date skill onto
+ * the mesh as a current-date capability.
  *
  * <p>All test agents share the tsuite container's network namespace,
  * so the upstream A2A endpoint is reachable on localhost:9090 (NOT a
@@ -30,11 +30,6 @@ import java.util.Map;
 @SpringBootApplication
 public class ConsumerDateAgentApplication {
 
-    private static final A2AClient A2A_CLIENT = new A2AClient(
-        "http://localhost:9090/agents/date",
-        "get-date"
-    );
-
     private static final ObjectMapper JSON = new ObjectMapper();
 
     public static void main(String[] args) {
@@ -46,9 +41,12 @@ public class ConsumerDateAgentApplication {
         description = "Bridge upstream A2A get-date skill onto the mesh.",
         tags = {"a2a-bridge"}
     )
-    @A2AConsumer
-    public Map<String, Object> currentDate() throws Exception {
-        A2AResponse response = A2A_CLIENT.send(Map.of(
+    @A2AConsumer(
+        url = "http://localhost:9090/agents/date",
+        skillId = "get-date"
+    )
+    public Map<String, Object> currentDate(A2AClient a2a) throws Exception {
+        A2AResponse response = a2a.send(Map.of(
             "role", "user",
             "parts", List.of(Map.of("type", "text", "text", "now"))
         ));

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java-sse/src/main/java/com/example/reportconsumerjavasse/ConsumerReportAgentJavaSseApplication.java
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java-sse/src/main/java/com/example/reportconsumerjavasse/ConsumerReportAgentJavaSseApplication.java
@@ -18,10 +18,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * uc27 Phase 3 fixture (SSE variant) — Java A2A SSE consumer that
- * bridges {@code report_a2a_agent.py}'s {@code generate-report} skill
- * onto the mesh as a long-running {@code report-sse} capability via
- * {@link A2AClient#subscribe} + {@link A2AStream#bridge}.
+ * uc27 Phase 3 fixture, SSE variant (refactored under #923) — Java
+ * A2A SSE consumer that bridges {@code report_a2a_agent.py}'s
+ * {@code generate-report} skill onto the mesh as a long-running
+ * {@code report-sse} capability via {@link A2AClient#subscribe} +
+ * {@link A2AStream#bridge}.
  *
  * <p>Auto-tag scheme: {@code capability="report-sse"},
  * {@code tags=[a2a-bridge, sse, report-consumer-sse]} (the third tag is
@@ -37,11 +38,6 @@ import java.util.Map;
 @SpringBootApplication
 public class ConsumerReportAgentJavaSseApplication {
 
-    private static final A2AClient A2A_CLIENT = new A2AClient(
-        "http://localhost:9091/agents/report",
-        "generate-report"
-    );
-
     private static final ObjectMapper JSON = new ObjectMapper();
 
     public static void main(String[] args) {
@@ -56,25 +52,29 @@ public class ConsumerReportAgentJavaSseApplication {
         description = "Bridge upstream A2A generate-report skill via SSE as report_sse capability.",
         tags = {"a2a-bridge", "sse"}
     )
-    @A2AConsumer
+    @A2AConsumer(
+        url = "http://localhost:9091/agents/report",
+        skillId = "generate-report"
+    )
     public Object generateReportSse(
             @Param("user_id") String userId,
             @Param(value = "sections", required = false) List<String> sections,
+            A2AClient a2a,
             MeshJob job) throws Exception {
         if (sections == null) {
             sections = List.of("default");
         }
         Map<String, Object> message = buildMessage(userId, sections);
         if (!(job instanceof JobController controller)) {
-            return drainSyncFallback(message);
+            return drainSyncFallback(a2a, message);
         }
-        try (A2AStream stream = A2A_CLIENT.subscribe(message)) {
+        try (A2AStream stream = a2a.subscribe(message)) {
             return stream.bridge(controller);
         }
     }
 
-    private Object drainSyncFallback(Map<String, Object> message) throws Exception {
-        try (A2AStream stream = A2A_CLIENT.subscribe(message)) {
+    private Object drainSyncFallback(A2AClient a2a, Map<String, Object> message) throws Exception {
+        try (A2AStream stream = a2a.subscribe(message)) {
             for (A2AEvent event : stream) {
                 if (event.kind() == A2AEvent.Kind.ARTIFACT) {
                     String text = event.artifactText();

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java/src/main/java/com/example/reportconsumerjava/ConsumerReportAgentJavaApplication.java
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java/src/main/java/com/example/reportconsumerjava/ConsumerReportAgentJavaApplication.java
@@ -18,9 +18,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * uc27 Phase 3 fixture — Java A2A consumer that bridges
- * {@code report_a2a_agent.py}'s {@code generate-report} skill onto the
- * mesh as a long-running {@code report} capability via
+ * uc27 Phase 3 fixture (refactored under #923) — Java A2A consumer that
+ * bridges {@code report_a2a_agent.py}'s {@code generate-report} skill onto
+ * the mesh as a long-running {@code report} capability via
  * {@link A2AClient#submit} + {@link A2AJob#bridge}.
  *
  * <p>Auto-tag scheme matches the Python uc25 consumer-report-agent:
@@ -37,11 +37,6 @@ import java.util.Map;
 @SpringBootApplication
 public class ConsumerReportAgentJavaApplication {
 
-    private static final A2AClient A2A_CLIENT = new A2AClient(
-        "http://localhost:9091/agents/report",
-        "generate-report"
-    );
-
     private static final ObjectMapper JSON = new ObjectMapper();
 
     public static void main(String[] args) {
@@ -54,17 +49,21 @@ public class ConsumerReportAgentJavaApplication {
         description = "Bridge upstream A2A generate-report skill onto the mesh as a long-running report capability.",
         tags = {"a2a-bridge"}
     )
-    @A2AConsumer
+    @A2AConsumer(
+        url = "http://localhost:9091/agents/report",
+        skillId = "generate-report"
+    )
     public Object generateReport(
             @Param("user_id") String userId,
             @Param(value = "sections", required = false) List<String> sections,
+            A2AClient a2a,
             MeshJob job) throws Exception {
         if (sections == null) {
             sections = List.of("default");
         }
         Map<String, Object> message = buildMessage(userId, sections);
         if (!(job instanceof JobController controller)) {
-            A2AResponse response = A2A_CLIENT.send(message);
+            A2AResponse response = a2a.send(message);
             String text = response.artifactText();
             if (text == null || text.isEmpty()) {
                 return text == null ? "" : text;
@@ -75,7 +74,7 @@ public class ConsumerReportAgentJavaApplication {
                 return text;
             }
         }
-        A2AJob a2aJob = A2A_CLIENT.submit(message);
+        A2AJob a2aJob = a2a.submit(message);
         return a2aJob.bridge(controller);
     }
 


### PR DESCRIPTION
## Summary

Refactor of the Java `@A2AConsumer` annotation from marker-only to config-bearing — framework now constructs + injects `A2AClient` via method parameter. Aligns Java with Python's `@mesh.a2a_consumer` pattern (PR #913) and sets the consistent design baseline for upcoming TypeScript implementation (#917).

```java
// Before (PRs #919 + #922)
private static final A2AClient A2A_CLIENT = new A2AClient(
    "http://upstream/agents/date", "get-date");

@MeshTool(capability = "current-date", tags = {"a2a-bridge"})
@A2AConsumer
public Map<String, Object> getCurrentDate() throws Exception {
    A2AResponse r = A2A_CLIENT.send(...);
}

@PreDestroy void release() { A2A_CLIENT.close(); }

// After (this PR)
@MeshTool(capability = "current-date", tags = {"a2a-bridge"})
@A2AConsumer(
    url = "http://upstream/agents/date",
    skillId = "get-date",
    authBearerEnv = "A2A_TOKEN"     // optional
)
public Map<String, Object> getCurrentDate(A2AClient a2a) throws Exception {
    A2AResponse r = a2a.send(...);   // framework-injected
}
// No @PreDestroy needed — framework owns A2AClient lifecycle
```

### Annotation refactor
- `@A2AConsumer.url()` — required, supports Spring placeholders
- `@A2AConsumer.skillId()` — defaults to @MeshTool.capability if empty
- `@A2AConsumer.authBearerEnv()` / `authBearerToken()` — mutually exclusive
- `@A2AConsumer.timeoutSeconds()` — default 30

### `A2AConsumerBeanPostProcessor` (NEW)
- Scans `@A2AConsumer` methods at boot; validates config
- Resolves Spring property placeholders in `url`
- Caches `A2AClient` instances per `(url, skillId, auth, timeout)` tuple — two methods sharing the same backend share one client
- `@PreDestroy` closes all cached clients (replaces user manual `@PreDestroy` hooks)
- Hard-cutover migration error: marker-only `@A2AConsumer` (no url) fails boot with a `BeanInitializationException` carrying a clear message + #923 link

### `MeshToolWrapper` integration
- `setA2AClientBinding()` — `A2AClient` parameter slot is exempt from MCP input schema generation, resolved at dispatch time
- `MeshToolBeanPostProcessor` ordered `LOWEST_PRECEDENCE` so A2A bindings exist before tool wrappers are constructed

### Critical fix discovered during integration
The `task=true` claim path goes through `JobsRuntimeManager.invokeViaReflection` (NOT `MeshToolWrapper`). Without extending it for `A2AClient` injection, uc27 tc04/05/06/08 NPE'd. Mirrors the existing `@Param`/`MeshJob` handling in the same reflection invoker.

### Hard cutover
- 3 examples migrated (consumer-date, consumer-report, consumer-report-sse): static fields removed, `A2AClient` parameter added, `@PreDestroy` hooks removed
- 4 uc27 fixtures migrated (consumer-date-agent-java + -b, consumer-report-agent-java + -sse): same pattern

## Review Notes

Independent review-agent pass found **0 BLOCKER, 5 WARNING, 6 INFO**. 4 warnings + 1 info applied as a follow-up commit (`5845f7e5`):

- `A2AConsumerBeanPostProcessor` now fails at boot when both `@A2AConsumer.skillId` and `@MeshTool.capability` are blank — was silently caching with `skillId=""` and failing at first call.
- `JobsRuntimeManager.invokeViaReflection` now logs WARN when `A2AClient` parameter exists but no binding is registered — surfaces "bean registered outside Spring's BPP scan path" misconfiguration instead of silent NPE.
- `A2AConsumerBeanPostProcessor` distinguishes raw `url=""` (default annotation value → marker-only migration message) from resolved-to-blank url (Spring placeholder substitution issue → "url cannot be blank, check property" message).
- `A2AConsumer` Javadoc grew a Lifecycle paragraph warning users not to retain `A2AClient` references across context shutdown.
- New test `cache_separatesA2AClientsByAuthSpec_evenWithIdenticalUrlAndSkill` verifies cache key correctness for the (none, env, literal) auth matrix.

5 INFO/WARNINGs verified INVALID/cosmetic and skipped:
- `LOWEST_PRECEDENCE` ordering change: intentional behavior change, release-note territory
- `AuthSpec.literal()` whitespace check, error message phrasing inconsistency, `ConcurrentHashMap` on single-threaded path, `setA2AClientBinding` double-binding, no boot summary log — all cosmetic / micro-cleanup

Closes #923

## Test plan

- [x] `mvn -pl mcp-mesh-sdk,mcp-mesh-spring-boot-starter compile` — clean
- [x] **42/42** mcp-mesh-sdk unit tests PASS (unchanged from PR #922)
- [x] **176/176** mcp-mesh-spring-boot-starter unit tests PASS (was 153 → +20 from initial refactor + 3 from review fixes)
- [x] **12/12** src-tests PASS (image rebuild)
- [x] **7/7** uc27 at parallel 4 PASS (tc01-tc06 + tc08; tc07 stays disabled per #920)
- [x] All 3 examples + 4 fixtures `mvn package` clean
- [x] Migration error verified: `@A2AConsumer` without `url()` fires `BeanInitializationException` with the migration message at boot

## Follow-up

After this lands: TypeScript A2A consumer (#917) implementation can match the consistent framework-injection pattern across all 3 runtimes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added A2A consumer annotation configuration with support for custom URLs, skill IDs, bearer authentication (environment or literal), and timeout settings.
  * Enabled Spring dependency injection support for A2A client lifecycle management.

* **Refactor**
  * Migrated all A2A consumer examples from static client instances to framework-managed dependency injection.
  * Simplified client lifecycle by delegating framework shutdown management instead of manual resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->