### PR TITLE
feat(a2a): TypeScript A2A consumer (#917) + structuredContent fix (#925)

### DIFF
--- a/examples/typescript/consumer-date-agent/index.ts
+++ b/examples/typescript/consumer-date-agent/index.ts
@@ -1,0 +1,87 @@
+/**
+ * TypeScript A2A consumer example (issue #917) — port of
+ * `examples/a2a/consumer_date_agent.py` and
+ * `examples/java/consumer-date-agent`.
+ *
+ * Bridges the existing `examples/a2a/date_a2a_agent.py` `get-date`
+ * skill into the mesh as a regular `current-date` capability. A
+ * downstream mesh tool depending on `current-date` does not need to
+ * know it is talking to an A2A backend — mesh's existing capability +
+ * tag failover applies the moment a SECOND consumer (Python or Java)
+ * registers the same `current-date` capability with a different
+ * consumer-name tag.
+ *
+ * Each consumer auto-tags its capability with the surrounding agent
+ * name (here `date-consumer-ts`) so downstream resolvers can pin a
+ * specific backend via the dependency tag selector.
+ *
+ * Framework injection (matches Python's `@mesh.a2a_consumer` and
+ * Java's `@A2AConsumer`): `a2aConfig` carries the upstream config;
+ * the framework constructs an `A2AClient` per unique tuple and
+ * injects it as the trailing argument of `execute`.
+ *
+ * Stack
+ * =====
+ *   1) Registry — `meshctl start --registry-only`
+ *   2) System agent (Python) — provides `date_service`
+ *   3) Date A2A surface (Python) — exposes `get-date` via A2A on
+ *      `http://localhost:9090/agents/date`
+ *   4) This TS consumer — bridges the get-date skill onto the mesh as
+ *      `current-date` (port 9201)
+ *
+ * Run
+ * ===
+ *   cd examples/typescript/consumer-date-agent
+ *   npm install
+ *   npx tsx index.ts
+ */
+import { FastMCP, mesh, type A2AClient } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9201", 10);
+
+const server = new FastMCP({
+  name: "Date Consumer Bridge (TS)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "date-consumer-ts",
+  httpPort: HTTP_PORT,
+  description:
+    "TypeScript A2A consumer bridge — re-publishes the date_a2a_agent get-date skill as a mesh current-date capability.",
+});
+
+agent.addTool({
+  name: "current_date",
+  capability: "current-date",
+  tags: ["a2a-bridge"],
+  description:
+    "Get the current date by bridging the upstream A2A get-date skill.",
+  parameters: z.object({}),
+  a2aConfig: {
+    url: "http://localhost:9090/agents/date",
+    skillId: "get-date",
+  },
+  execute: async (_args, ..._injected) => {
+    // The framework injects an `A2AClient` at the trailing slot when
+    // `a2aConfig` is set on this tool. Pull + assert here so the rest
+    // of the body is statically typed.
+    const a2a = _injected[_injected.length - 1] as A2AClient | null;
+    if (!a2a) {
+      throw new Error("A2AClient was not injected — did you set a2aConfig?");
+    }
+    const r = await a2a.send({
+      role: "user",
+      parts: [{ type: "text", text: "now" }],
+    });
+    // The producer-side handler returns `{"date": "<iso-string>"}` and
+    // the A2A surface JSON-stringifies it into the artifact text part —
+    // so we JSON.parse on the consumer side to recover the dict.
+    return JSON.parse(r.artifactText);
+  },
+});
+
+console.log(
+  `date-consumer-ts agent defined on port ${HTTP_PORT}. Waiting for auto-start...`,
+);

--- a/examples/typescript/consumer-date-agent/index.ts
+++ b/examples/typescript/consumer-date-agent/index.ts
@@ -64,10 +64,10 @@ agent.addTool({
     skillId: "get-date",
   },
   execute: async (_args, ..._injected) => {
-    // The framework injects an `A2AClient` at the trailing slot when
-    // `a2aConfig` is set on this tool. Pull + assert here so the rest
-    // of the body is statically typed.
-    const a2a = _injected[_injected.length - 1] as A2AClient | null;
+    // The framework injects an `A2AClient` at slot 0 when `a2aConfig`
+    // is set on this tool (no other injection sources are wired here).
+    // Pull + assert here so the rest of the body is statically typed.
+    const a2a = _injected[0] as A2AClient | null;
     if (!a2a) {
       throw new Error("A2AClient was not injected — did you set a2aConfig?");
     }
@@ -78,7 +78,12 @@ agent.addTool({
     // The producer-side handler returns `{"date": "<iso-string>"}` and
     // the A2A surface JSON-stringifies it into the artifact text part —
     // so we JSON.parse on the consumer side to recover the dict.
-    return JSON.parse(r.artifactText);
+    if (!r.artifactText) return "";
+    try {
+      return JSON.parse(r.artifactText);
+    } catch {
+      return r.artifactText;
+    }
   },
 });
 

--- a/examples/typescript/consumer-date-agent/package.json
+++ b/examples/typescript/consumer-date-agent/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "consumer-date-agent-ts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "TypeScript A2A consumer example — bridges date_a2a_agent.py get-date as a mesh current-date capability.",
+  "scripts": {
+    "start": "tsx index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/typescript/consumer-date-agent/tsconfig.json
+++ b/examples/typescript/consumer-date-agent/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/typescript/consumer-report-agent-sse/index.ts
+++ b/examples/typescript/consumer-report-agent-sse/index.ts
@@ -33,7 +33,7 @@ import {
   mesh,
   type A2AClient,
   type MeshJob,
-  JobController,
+  type JobController,
 } from "@mcpmesh/sdk";
 import { z } from "zod";
 

--- a/examples/typescript/consumer-report-agent-sse/index.ts
+++ b/examples/typescript/consumer-report-agent-sse/index.ts
@@ -103,7 +103,10 @@ agent.addTool({
       } finally {
         await stream.aclose();
       }
-      return "";
+      // Surface a real failure mode — the SSE stream completed without
+      // ever yielding an artifact event. Returning "" silently here
+      // would mask producer-side bugs from sync callers.
+      throw new Error("No artifact received from SSE stream");
     }
     const stream = await a2a.subscribe(message);
     return await stream.bridge(job as JobController);

--- a/examples/typescript/consumer-report-agent-sse/index.ts
+++ b/examples/typescript/consumer-report-agent-sse/index.ts
@@ -1,0 +1,115 @@
+/**
+ * TypeScript A2A consumer example (SSE) — port of
+ * `examples/a2a/consumer_report_agent_sse.py` and
+ * `examples/java/consumer-report-agent-sse`.
+ *
+ * Same end-to-end shape as the polling sibling but uses
+ * `A2AClient.subscribe` (SSE) instead of poll-based submit + bridge.
+ * Validates the `A2AStream` async iterator + `A2AStream.bridge()`
+ * helper end-to-end.
+ *
+ * Cancel propagation note
+ * =======================
+ *
+ * Per A2A v1.0, client disconnect is a transient signal — the
+ * producer continues running unless explicitly canceled.
+ * `A2AStream.bridge` therefore does NOT POST `tasks/cancel` upstream
+ * when the mesh-side job is cancelled (it just closes the SSE
+ * connection). Users who need cancel propagation should use the
+ * polling `consumer-report-agent` (which races
+ * `awaitJobCancel(jobId)` against the polling sleep and POSTs
+ * `tasks/cancel`).
+ *
+ * Stack same as the polling variant — uses port 9212 to coexist.
+ *
+ * Run
+ * ===
+ *   cd examples/typescript/consumer-report-agent-sse
+ *   npm install
+ *   npx tsx index.ts
+ */
+import {
+  FastMCP,
+  mesh,
+  type A2AClient,
+  type MeshJob,
+  JobController,
+} from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9212", 10);
+
+const server = new FastMCP({
+  name: "Report Consumer Bridge (TS, SSE)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "report-consumer-sse-ts",
+  httpPort: HTTP_PORT,
+  description:
+    "TypeScript A2A consumer (SSE) — bridges generate-report via the A2A SSE stream as the mesh `report_sse` capability.",
+});
+
+agent.addTool({
+  name: "report_sse",
+  // Underscore form (`report_sse`) matches the existing Python
+  // caller-agent-report fixture's `report_sse` dependency name —
+  // makes the TS example a drop-in replacement for the Python
+  // `consumer_report_agent_sse.py` without re-wiring downstream callers.
+  capability: "report_sse",
+  task: true,
+  tags: ["a2a-bridge", "sse"],
+  description:
+    "Bridge upstream A2A generate-report skill via SSE as a mesh `report_sse` capability.",
+  parameters: z.object({
+    user_id: z.string(),
+    sections: z.array(z.string()),
+  }),
+  meshJobParamIndex: 1,
+  a2aConfig: {
+    url: "http://localhost:9091/agents/report",
+    skillId: "generate-report",
+  },
+  execute: async ({ user_id, sections }, ..._injected) => {
+    // Positional layout (set by the framework):
+    //   _injected[0] = JobController | null   (from meshJobParamIndex)
+    //   _injected[1] = A2AClient              (from a2aConfig)
+    const job = _injected[0] as MeshJob | null;
+    const a2a = _injected[1] as A2AClient;
+    const message = {
+      role: "user",
+      parts: [
+        {
+          type: "text",
+          text: JSON.stringify({ user_id, sections }),
+        },
+      ],
+    };
+    // Sync tools/call fallback — drain the stream and surface the
+    // first artifact's parsed payload (or the raw text).
+    if (!job || typeof (job as JobController).updateProgress !== "function") {
+      const stream = await a2a.subscribe(message);
+      try {
+        for await (const event of stream) {
+          if (event.kind === "artifact" && event.artifactText) {
+            try {
+              return JSON.parse(event.artifactText);
+            } catch {
+              return event.artifactText;
+            }
+          }
+        }
+      } finally {
+        await stream.aclose();
+      }
+      return "";
+    }
+    const stream = await a2a.subscribe(message);
+    return await stream.bridge(job as JobController);
+  },
+});
+
+console.log(
+  `report-consumer-sse-ts (SSE bridge) defined on port ${HTTP_PORT}. Waiting for auto-start...`,
+);

--- a/examples/typescript/consumer-report-agent-sse/package.json
+++ b/examples/typescript/consumer-report-agent-sse/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "consumer-report-agent-sse-ts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "TypeScript A2A consumer (SSE) — bridges report_a2a_agent.py generate-report as a mesh report_sse capability via tasks/sendSubscribe.",
+  "scripts": {
+    "start": "tsx index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/typescript/consumer-report-agent-sse/tsconfig.json
+++ b/examples/typescript/consumer-report-agent-sse/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/typescript/consumer-report-agent/index.ts
+++ b/examples/typescript/consumer-report-agent/index.ts
@@ -101,7 +101,7 @@ agent.addTool({
     // controller arrives — fall back to a simple sync send + parse.
     if (!job || typeof (job as JobController).updateProgress !== "function") {
       const r = await a2a.send(message);
-      if (!r.artifactText) return r.artifactText;
+      if (!r.artifactText) return "";
       try {
         return JSON.parse(r.artifactText);
       } catch {

--- a/examples/typescript/consumer-report-agent/index.ts
+++ b/examples/typescript/consumer-report-agent/index.ts
@@ -48,7 +48,7 @@ import {
   mesh,
   type A2AClient,
   type MeshJob,
-  JobController,
+  type JobController,
 } from "@mcpmesh/sdk";
 import { z } from "zod";
 

--- a/examples/typescript/consumer-report-agent/index.ts
+++ b/examples/typescript/consumer-report-agent/index.ts
@@ -1,0 +1,118 @@
+/**
+ * TypeScript A2A consumer example (long-running) — port of
+ * `examples/a2a/consumer_report_agent.py` and
+ * `examples/java/consumer-report-agent`.
+ *
+ * Bridges the existing `examples/a2a/report_a2a_agent.py`
+ * `generate-report` skill onto the mesh as a long-running `report`
+ * capability that downstream callers consume via the standard
+ * MeshJob interface — they have no idea the actual work is happening
+ * on an external A2A backend.
+ *
+ * Bridging pattern
+ * ================
+ *
+ * The `task: true` body issues a non-blocking `A2AClient.submit`
+ * against the upstream A2A surface, then hands the returned
+ * `A2AJob` to `bridge(job)` which polls the A2A backend, mirrors
+ * progress into the framework-injected `JobController`, and returns
+ * the final artifact value (the producer's report payload). The mesh
+ * `task: true` wrapper takes that return and calls
+ * `controller.complete(...)` itself.
+ *
+ * Cancel semantics
+ * ================
+ *
+ * `A2AJob.bridge` races each iteration's sleep against
+ * `awaitJobCancel(jobId)` so a mesh-side cancel arriving DURING a
+ * sleep wakes the bridge immediately. On detection it POSTs
+ * `tasks/cancel` upstream so the A2A producer stops billing for the
+ * work, then throws `A2AJobCanceledError`.
+ *
+ * Stack
+ * =====
+ *   1) Registry — `meshctl start --registry-only`
+ *   2) Long-task provider (Python) — produces the report
+ *   3) Report A2A surface (Python) — exposes generate-report via A2A
+ *   4) This TS consumer — bridges A2A back into the mesh as
+ *      `report` (port 9211)
+ *
+ * Run
+ * ===
+ *   cd examples/typescript/consumer-report-agent
+ *   npm install
+ *   npx tsx index.ts
+ */
+import {
+  FastMCP,
+  mesh,
+  type A2AClient,
+  type MeshJob,
+  JobController,
+} from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9211", 10);
+
+const server = new FastMCP({
+  name: "Report Consumer Bridge (TS, polling)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "report-consumer-ts",
+  httpPort: HTTP_PORT,
+  description:
+    "TypeScript A2A consumer (long-running) — bridges the report_a2a_agent.py generate-report skill as a mesh `report` capability.",
+});
+
+agent.addTool({
+  name: "report",
+  capability: "report",
+  task: true,
+  tags: ["a2a-bridge"],
+  description:
+    "Bridge upstream A2A generate-report skill onto the mesh as a long-running `report` capability.",
+  parameters: z.object({
+    user_id: z.string(),
+    sections: z.array(z.string()),
+  }),
+  meshJobParamIndex: 1,
+  a2aConfig: {
+    url: "http://localhost:9091/agents/report",
+    skillId: "generate-report",
+  },
+  execute: async ({ user_id, sections }, ..._injected) => {
+    // Positional layout (set by the framework):
+    //   _injected[0] = JobController | null   (from meshJobParamIndex)
+    //   _injected[1] = A2AClient              (from a2aConfig)
+    const job = _injected[0] as MeshJob | null;
+    const a2a = _injected[1] as A2AClient;
+    const message = {
+      role: "user",
+      parts: [
+        {
+          type: "text",
+          text: JSON.stringify({ user_id, sections }),
+        },
+      ],
+    };
+    // When invoked as a synchronous tools/call (no X-Mesh-Job-Id), no
+    // controller arrives — fall back to a simple sync send + parse.
+    if (!job || typeof (job as JobController).updateProgress !== "function") {
+      const r = await a2a.send(message);
+      if (!r.artifactText) return r.artifactText;
+      try {
+        return JSON.parse(r.artifactText);
+      } catch {
+        return r.artifactText;
+      }
+    }
+    const a2aJob = await a2a.submit(message);
+    return await a2aJob.bridge(job as JobController);
+  },
+});
+
+console.log(
+  `report-consumer-ts (polling bridge) defined on port ${HTTP_PORT}. Waiting for auto-start...`,
+);

--- a/examples/typescript/consumer-report-agent/package.json
+++ b/examples/typescript/consumer-report-agent/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "consumer-report-agent-ts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "TypeScript A2A consumer (long-running) — bridges report_a2a_agent.py generate-report as a mesh report capability via A2A polling + bridge.",
+  "scripts": {
+    "start": "tsx index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/typescript/consumer-report-agent/tsconfig.json
+++ b/examples/typescript/consumer-report-agent/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/src/runtime/typescript/src/__tests__/a2a/a2a-bearer.spec.ts
+++ b/src/runtime/typescript/src/__tests__/a2a/a2a-bearer.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for A2ABearer (issue #917).
+ *
+ * Mirrors Java's A2ABearerTest + Python's TestA2ABearer:
+ *   - rejects null/empty/whitespace tokens;
+ *   - mutual exclusion of token vs tokenEnv;
+ *   - rotation: env-var changes between calls take effect.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { A2ABearer } from "../../a2a/a2a-bearer.js";
+import { A2AAuthError } from "../../a2a/errors.js";
+
+describe("A2ABearer", () => {
+  const ENV_VAR = "A2A_BEARER_TEST_TOKEN";
+  const originalEnv = process.env[ENV_VAR];
+
+  beforeEach(() => {
+    delete process.env[ENV_VAR];
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env[ENV_VAR];
+    else process.env[ENV_VAR] = originalEnv;
+  });
+
+  it("constructs from a literal token", () => {
+    const b = new A2ABearer({ token: "abc123" });
+    expect(b.authorizationHeader()).toBe("Bearer abc123");
+  });
+
+  it("constructs from an env var and resolves at call time", () => {
+    const b = new A2ABearer({ tokenEnv: ENV_VAR });
+    process.env[ENV_VAR] = "from-env";
+    expect(b.authorizationHeader()).toBe("Bearer from-env");
+    // Rotation between calls should be honoured.
+    process.env[ENV_VAR] = "rotated";
+    expect(b.authorizationHeader()).toBe("Bearer rotated");
+  });
+
+  it("throws when neither token nor tokenEnv is supplied", () => {
+    expect(() => new A2ABearer({})).toThrow(A2AAuthError);
+  });
+
+  it("throws when both token and tokenEnv are supplied", () => {
+    expect(() => new A2ABearer({ token: "x", tokenEnv: "Y" })).toThrow(
+      A2AAuthError,
+    );
+  });
+
+  it("throws on blank literal token", () => {
+    expect(() => new A2ABearer({ token: "   " })).toThrow(A2AAuthError);
+  });
+
+  it("throws on blank tokenEnv name", () => {
+    expect(() => new A2ABearer({ tokenEnv: "   " })).toThrow(A2AAuthError);
+  });
+
+  it("throws at call time when env var resolves to empty", () => {
+    const b = new A2ABearer({ tokenEnv: ENV_VAR });
+    process.env[ENV_VAR] = "";
+    expect(() => b.authorizationHeader()).toThrow(A2AAuthError);
+  });
+
+  it("throws at call time when env var is unset", () => {
+    const b = new A2ABearer({ tokenEnv: ENV_VAR });
+    expect(() => b.authorizationHeader()).toThrow(A2AAuthError);
+  });
+});

--- a/src/runtime/typescript/src/__tests__/a2a/a2a-client.spec.ts
+++ b/src/runtime/typescript/src/__tests__/a2a/a2a-client.spec.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for A2AClient (issue #917).
+ *
+ * Each test spins up a tiny http.Server bound to 127.0.0.1:<random
+ * port> so we exercise the full undici fetch path including JSON-RPC
+ * envelope build, polling backoff, error/timeout surfacing, and bearer
+ * header injection.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as http from "node:http";
+import { AddressInfo } from "node:net";
+import {
+  A2AClient,
+  isCanceledState,
+  isTerminalState,
+} from "../../a2a/a2a-client.js";
+import {
+  A2AError,
+  A2ATimeoutError,
+} from "../../a2a/errors.js";
+import { A2ABearer } from "../../a2a/a2a-bearer.js";
+
+interface TestServer {
+  port: number;
+  url: string;
+  /** All received envelopes — assert against this in tests. */
+  envelopes: Array<{ method: string; params: unknown; auth?: string }>;
+  /** Reset between tests so no cross-test leakage. */
+  reset: () => void;
+  close: () => Promise<void>;
+}
+
+function startServer(
+  handler: (req: {
+    method: string;
+    params: Record<string, unknown>;
+    rpcId: number;
+    headers: http.IncomingHttpHeaders;
+  }) => unknown,
+): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const envelopes: TestServer["envelopes"] = [];
+    const server = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        let envelope: Record<string, unknown>;
+        try {
+          envelope = JSON.parse(body);
+        } catch {
+          res.statusCode = 400;
+          res.end("invalid json");
+          return;
+        }
+        const method = String(envelope.method ?? "");
+        const params =
+          (envelope.params as Record<string, unknown>) ?? ({} as Record<string, unknown>);
+        const rpcId = Number(envelope.id ?? 0);
+        const auth = req.headers["authorization"];
+        envelopes.push({ method, params, auth: typeof auth === "string" ? auth : undefined });
+
+        let result: unknown;
+        try {
+          result = handler({ method, params, rpcId, headers: req.headers });
+        } catch (err) {
+          res.statusCode = 500;
+          res.end((err as Error).message);
+          return;
+        }
+        if (result === "__SERVER_ERROR__") {
+          res.statusCode = 500;
+          res.end("server error");
+          return;
+        }
+        if (result === "__MALFORMED_JSON__") {
+          res.setHeader("Content-Type", "application/json");
+          res.end("not-json{{{");
+          return;
+        }
+        if (result === "__NO_RESULT_NO_ERROR__") {
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ jsonrpc: "2.0", id: rpcId }));
+          return;
+        }
+        if (
+          result &&
+          typeof result === "object" &&
+          (result as Record<string, unknown>).__rpcError
+        ) {
+          res.setHeader("Content-Type", "application/json");
+          res.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: rpcId,
+              error: (result as Record<string, unknown>).__rpcError,
+            }),
+          );
+          return;
+        }
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ jsonrpc: "2.0", id: rpcId, result }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        port,
+        url: `http://127.0.0.1:${port}/agents/test`,
+        envelopes,
+        reset: () => {
+          envelopes.length = 0;
+        },
+        close: () =>
+          new Promise<void>((resolveClose, rejectClose) => {
+            server.close((err) => (err ? rejectClose(err) : resolveClose()));
+          }),
+      });
+    });
+  });
+}
+
+describe("isTerminalState / isCanceledState", () => {
+  it("recognises completed/failed/canceled/cancelled (case-insensitive)", () => {
+    for (const s of [
+      "completed",
+      "Completed",
+      "FAILED",
+      "canceled",
+      "Cancelled",
+    ]) {
+      expect(isTerminalState(s)).toBe(true);
+    }
+    expect(isTerminalState("working")).toBe(false);
+    expect(isTerminalState(undefined)).toBe(false);
+    expect(isTerminalState(null)).toBe(false);
+  });
+
+  it("isCanceledState accepts both spellings", () => {
+    expect(isCanceledState("canceled")).toBe(true);
+    expect(isCanceledState("CANCELLED")).toBe(true);
+    expect(isCanceledState("failed")).toBe(false);
+    expect(isCanceledState(undefined)).toBe(false);
+  });
+});
+
+describe("A2AClient.send", () => {
+  let server: TestServer;
+
+  beforeEach(async () => {
+    // each test installs its own handler via reset+swap below
+  });
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it("sends a tasks/send envelope and returns the artifact text on terminal completed", async () => {
+    server = await startServer(({ method, params }) => {
+      expect(method).toBe("tasks/send");
+      expect((params as { id: string }).id).toMatch(/^c-/);
+      return {
+        status: { state: "completed" },
+        artifacts: [
+          { parts: [{ type: "text", text: '{"date":"2026-05-10"}' }] },
+        ],
+      };
+    });
+    const client = new A2AClient({ url: server.url, skillId: "get-date" });
+    const r = await client.send({
+      role: "user",
+      parts: [{ type: "text", text: "now" }],
+    });
+    expect(r.state).toBe("completed");
+    expect(r.artifactText).toBe('{"date":"2026-05-10"}');
+    expect(r.taskId).toMatch(/^c-/);
+    expect(server.envelopes).toHaveLength(1);
+  });
+
+  it("polls tasks/get with backoff until terminal", async () => {
+    let pollCount = 0;
+    server = await startServer(({ method }) => {
+      if (method === "tasks/send") {
+        return { status: { state: "working" } };
+      }
+      if (method === "tasks/get") {
+        pollCount += 1;
+        if (pollCount < 2) return { status: { state: "working" } };
+        return {
+          status: { state: "completed" },
+          artifacts: [{ parts: [{ type: "text", text: "ok" }] }],
+        };
+      }
+      return null;
+    });
+    const client = new A2AClient({
+      url: server.url,
+      skillId: "x",
+      pollIntervalMs: 10,
+      pollIntervalMaxMs: 50,
+    });
+    const r = await client.send({ role: "user", parts: [] });
+    expect(r.artifactText).toBe("ok");
+    expect(server.envelopes.map((e) => e.method)).toEqual([
+      "tasks/send",
+      "tasks/get",
+      "tasks/get",
+    ]);
+  });
+
+  it("times out when no terminal state arrives", async () => {
+    server = await startServer(() => ({ status: { state: "working" } }));
+    const client = new A2AClient({
+      url: server.url,
+      skillId: "x",
+      pollIntervalMs: 10,
+      pollIntervalMaxMs: 30,
+    });
+    await expect(
+      client.send({ role: "user", parts: [] }, { timeoutMs: 100 }),
+    ).rejects.toBeInstanceOf(A2ATimeoutError);
+  });
+
+  it("surfaces JSON-RPC error envelopes as A2AError", async () => {
+    server = await startServer(() => ({
+      __rpcError: { code: -32602, message: "bad params" },
+    }));
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    await expect(
+      client.send({ role: "user", parts: [] }),
+    ).rejects.toThrow(/A2A error from .*: -32602 bad params/);
+  });
+
+  it("surfaces malformed JSON-RPC (no result, no error) as A2AError fast-fail", async () => {
+    server = await startServer(() => "__NO_RESULT_NO_ERROR__");
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    await expect(
+      client.send({ role: "user", parts: [] }),
+    ).rejects.toThrow(/malformed JSON-RPC envelope/);
+  });
+
+  it("surfaces malformed JSON body as A2AError", async () => {
+    server = await startServer(() => "__MALFORMED_JSON__");
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    await expect(
+      client.send({ role: "user", parts: [] }),
+    ).rejects.toThrow(/malformed JSON/);
+  });
+
+  it("injects Authorization header when auth is configured", async () => {
+    server = await startServer(() => ({
+      status: { state: "completed" },
+      artifacts: [{ parts: [{ type: "text", text: "ok" }] }],
+    }));
+    const client = new A2AClient({
+      url: server.url,
+      skillId: "x",
+      auth: new A2ABearer({ token: "secret123" }),
+    });
+    await client.send({ role: "user", parts: [] });
+    expect(server.envelopes[0].auth).toBe("Bearer secret123");
+  });
+
+  it("treats config.auth as a bearer config shorthand", async () => {
+    server = await startServer(() => ({
+      status: { state: "completed" },
+      artifacts: [{ parts: [{ type: "text", text: "ok" }] }],
+    }));
+    const client = new A2AClient({
+      url: server.url,
+      skillId: "x",
+      auth: { token: "literal-token" },
+    });
+    await client.send({ role: "user", parts: [] });
+    expect(server.envelopes[0].auth).toBe("Bearer literal-token");
+  });
+
+  it("rejects use after close()", async () => {
+    server = await startServer(() => ({ status: { state: "completed" } }));
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    await client.close();
+    await expect(
+      client.send({ role: "user", parts: [] }),
+    ).rejects.toThrow(/closed/);
+  });
+
+  it("trims trailing slashes from the configured URL", async () => {
+    server = await startServer(() => ({ status: { state: "completed" } }));
+    const client = new A2AClient({
+      url: server.url + "///",
+      skillId: "x",
+    });
+    expect(client.url).toBe(server.url);
+  });
+});
+
+describe("A2AClient.submit", () => {
+  let server: TestServer;
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it("returns A2AJob without polling", async () => {
+    server = await startServer(({ method }) => {
+      if (method === "tasks/send") {
+        return { status: { state: "working" } };
+      }
+      throw new Error(`unexpected ${method}`);
+    });
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const job = await client.submit({ role: "user", parts: [] });
+    expect(job.taskId).toMatch(/^c-/);
+    expect(job.initialState).toBe("working");
+    expect(server.envelopes).toHaveLength(1);
+  });
+
+  it("returns A2AJob with terminal initial state when producer responds immediately", async () => {
+    server = await startServer(() => ({
+      status: { state: "completed" },
+      artifacts: [{ parts: [{ type: "text", text: '{"x":1}' }] }],
+    }));
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const job = await client.submit({ role: "user", parts: [] });
+    expect(job.initialState).toBe("completed");
+  });
+});
+
+describe("A2AClient construction", () => {
+  it("throws on empty url", () => {
+    expect(() => new A2AClient({ url: "", skillId: "x" })).toThrow(A2AError);
+  });
+  it("throws on non-positive timeoutMs", () => {
+    expect(
+      () => new A2AClient({ url: "http://x", skillId: "x", timeoutMs: 0 }),
+    ).toThrow(A2AError);
+    expect(
+      () => new A2AClient({ url: "http://x", skillId: "x", timeoutMs: -1 }),
+    ).toThrow(A2AError);
+  });
+});

--- a/src/runtime/typescript/src/__tests__/a2a/a2a-client.spec.ts
+++ b/src/runtime/typescript/src/__tests__/a2a/a2a-client.spec.ts
@@ -325,6 +325,61 @@ describe("A2AClient.submit", () => {
   });
 });
 
+describe("A2AClient.tasksCancel", () => {
+  let server: TestServer;
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it("succeeds against a producer that returns {jsonrpc,id} (no result, no error)", async () => {
+    server = await startServer(({ method }) => {
+      if (method === "tasks/send") return { status: { state: "working" } };
+      if (method === "tasks/cancel") return "__NO_RESULT_NO_ERROR__";
+      return { status: { state: "working" } };
+    });
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const job = await client.submit({ role: "user", parts: [] });
+    // Should not throw — tasks/cancel uses result-or-error mode.
+    await expect(job.cancel("ok")).resolves.toBeUndefined();
+    expect(server.envelopes.some((e) => e.method === "tasks/cancel")).toBe(true);
+  });
+});
+
+describe("A2AClient JSON-RPC id uniqueness", () => {
+  let server: TestServer;
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it("emits a unique JSON-RPC id per request (per-instance monotonic counter)", async () => {
+    let pollCount = 0;
+    const ids: number[] = [];
+    server = await startServer(({ method, rpcId }) => {
+      ids.push(rpcId);
+      if (method === "tasks/send") return { status: { state: "working" } };
+      if (method === "tasks/get") {
+        pollCount += 1;
+        if (pollCount < 3) return { status: { state: "working" } };
+        return {
+          status: { state: "completed" },
+          artifacts: [{ parts: [{ type: "text", text: "ok" }] }],
+        };
+      }
+      return null;
+    });
+    const client = new A2AClient({
+      url: server.url,
+      skillId: "x",
+      pollIntervalMs: 5,
+      pollIntervalMaxMs: 20,
+    });
+    await client.send({ role: "user", parts: [] });
+    // Send + 3 polls = 4 envelopes, all with distinct ids.
+    expect(ids).toHaveLength(4);
+    expect(new Set(ids).size).toBe(4);
+  });
+});
+
 describe("A2AClient construction", () => {
   it("throws on empty url", () => {
     expect(() => new A2AClient({ url: "", skillId: "x" })).toThrow(A2AError);

--- a/src/runtime/typescript/src/__tests__/a2a/a2a-job.spec.ts
+++ b/src/runtime/typescript/src/__tests__/a2a/a2a-job.spec.ts
@@ -172,10 +172,14 @@ describe("A2AJob.bridge", () => {
     ]);
     server.responses.set("tasks/cancel", [{ status: { state: "canceled" } }]);
 
-    // Resolve cancel signal after a short delay so bridge enters poll loop first.
-    awaitJobCancelMock.mockReturnValue(
-      new Promise((resolve) => setTimeout(resolve, 30)),
-    );
+    // Resolver-controlled cancel — eliminates the previous timing-
+    // sensitive setTimeout(30ms). We trigger it explicitly after the
+    // bridge has had a chance to enter its poll loop (one tick).
+    let cancelResolve!: () => void;
+    const cancelPromise = new Promise<void>((r) => {
+      cancelResolve = r;
+    });
+    awaitJobCancelMock.mockReturnValue(cancelPromise);
 
     const client = new A2AClient({
       url: server.url,
@@ -184,9 +188,12 @@ describe("A2AJob.bridge", () => {
       pollIntervalMaxMs: 20,
     });
     const job = await client.submit({ role: "user", parts: [] });
-    await expect(job.bridge(makeMockController())).rejects.toBeInstanceOf(
-      A2AJobCanceledError,
-    );
+    const bridgePromise = job.bridge(makeMockController());
+    // Yield once so bridge attaches its .then on cancelPromise + enters
+    // the poll loop, then explicitly fire the cancel signal.
+    await Promise.resolve();
+    cancelResolve();
+    await expect(bridgePromise).rejects.toBeInstanceOf(A2AJobCanceledError);
     // The bridge MUST have POSTed tasks/cancel upstream.
     expect(server.envelopes.some((e) => e.method === "tasks/cancel")).toBe(true);
   });

--- a/src/runtime/typescript/src/__tests__/a2a/a2a-job.spec.ts
+++ b/src/runtime/typescript/src/__tests__/a2a/a2a-job.spec.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for A2AJob (issue #917).
+ *
+ * Avoids binding a real napi JobController — we mock @mcpmesh/core's
+ * `awaitJobCancel` and pass a hand-rolled controller object whose
+ * `updateProgress` we can spy on.
+ */
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import * as http from "node:http";
+import { AddressInfo } from "node:net";
+
+// Mock @mcpmesh/core's awaitJobCancel so we can simulate cancel
+// without binding a real napi cancel registry.
+vi.mock("@mcpmesh/core", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@mcpmesh/core");
+  return {
+    ...actual,
+    awaitJobCancel: vi.fn().mockReturnValue(new Promise(() => {})),
+  };
+});
+
+import { awaitJobCancel } from "@mcpmesh/core";
+import { A2AClient } from "../../a2a/a2a-client.js";
+import {
+  A2AJobCanceledError,
+  A2AJobFailedError,
+} from "../../a2a/errors.js";
+
+const awaitJobCancelMock = awaitJobCancel as unknown as ReturnType<typeof vi.fn>;
+
+interface TestServer {
+  url: string;
+  /** Per-method response queue. Each entry is consumed in order. */
+  responses: Map<string, Array<unknown>>;
+  /** All received envelopes — assert against this in tests. */
+  envelopes: Array<{ method: string; params: unknown }>;
+  close: () => Promise<void>;
+}
+
+function startServer(): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const responses = new Map<string, Array<unknown>>();
+    const envelopes: TestServer["envelopes"] = [];
+    const server = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => (body += chunk));
+      req.on("end", () => {
+        const env = JSON.parse(body);
+        envelopes.push({ method: env.method, params: env.params });
+        const queue = responses.get(env.method) ?? [];
+        const next = queue.shift() ?? { status: { state: "working" } };
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ jsonrpc: "2.0", id: env.id, result: next }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}/agents/test`,
+        responses,
+        envelopes,
+        close: () =>
+          new Promise<void>((rs, rj) =>
+            server.close((err) => (err ? rj(err) : rs())),
+          ),
+      });
+    });
+  });
+}
+
+function makeMockController(jobId = "job-test") {
+  return {
+    jobId,
+    updateProgress: vi.fn().mockResolvedValue(undefined),
+    complete: vi.fn().mockResolvedValue(undefined),
+    fail: vi.fn().mockResolvedValue(undefined),
+    isTerminal: vi.fn().mockResolvedValue(false),
+    releaseLease: vi.fn().mockResolvedValue(undefined),
+  } as unknown as import("@mcpmesh/core").JobController & {
+    updateProgress: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("A2AJob.bridge", () => {
+  let server: TestServer;
+
+  beforeEach(() => {
+    awaitJobCancelMock.mockReset();
+    awaitJobCancelMock.mockReturnValue(new Promise(() => {}));
+  });
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it("polls until terminal then returns the parsed artifact", async () => {
+    server = await startServer();
+    server.responses.set("tasks/send", [{ status: { state: "working" } }]);
+    server.responses.set("tasks/get", [
+      {
+        status: { state: "working" },
+        metadata: { progress: 0.3 },
+      },
+      {
+        status: { state: "completed" },
+        artifacts: [{ parts: [{ text: '{"section":"intro"}' }] }],
+      },
+    ]);
+    const client = new A2AClient({
+      url: server.url,
+      skillId: "x",
+      pollIntervalMs: 5,
+      pollIntervalMaxMs: 20,
+    });
+    const job = await client.submit({ role: "user", parts: [] });
+    const ctrl = makeMockController();
+    const value = await job.bridge(ctrl);
+    expect(value).toEqual({ section: "intro" });
+    expect(
+      (ctrl as unknown as { updateProgress: ReturnType<typeof vi.fn> })
+        .updateProgress,
+    ).toHaveBeenCalledWith(0.3, null);
+  });
+
+  it("throws A2AJobFailedError on terminal failed", async () => {
+    server = await startServer();
+    server.responses.set("tasks/send", [
+      {
+        status: {
+          state: "failed",
+          message: { parts: [{ text: "boom" }] },
+        },
+      },
+    ]);
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const job = await client.submit({ role: "user", parts: [] });
+    await expect(job.bridge(makeMockController())).rejects.toBeInstanceOf(
+      A2AJobFailedError,
+    );
+  });
+
+  it("throws A2AJobCanceledError on terminal canceled", async () => {
+    server = await startServer();
+    server.responses.set("tasks/send", [
+      {
+        status: {
+          state: "canceled",
+          message: { parts: [{ text: "user-cancel" }] },
+        },
+      },
+    ]);
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const job = await client.submit({ role: "user", parts: [] });
+    await expect(job.bridge(makeMockController())).rejects.toBeInstanceOf(
+      A2AJobCanceledError,
+    );
+  });
+
+  it("propagates mesh-side cancel: POSTs tasks/cancel + throws A2AJobCanceledError", async () => {
+    server = await startServer();
+    server.responses.set("tasks/send", [{ status: { state: "working" } }]);
+    server.responses.set("tasks/get", [
+      { status: { state: "working" } },
+      { status: { state: "working" } },
+      { status: { state: "working" } },
+    ]);
+    server.responses.set("tasks/cancel", [{ status: { state: "canceled" } }]);
+
+    // Resolve cancel signal after a short delay so bridge enters poll loop first.
+    awaitJobCancelMock.mockReturnValue(
+      new Promise((resolve) => setTimeout(resolve, 30)),
+    );
+
+    const client = new A2AClient({
+      url: server.url,
+      skillId: "x",
+      pollIntervalMs: 10,
+      pollIntervalMaxMs: 20,
+    });
+    const job = await client.submit({ role: "user", parts: [] });
+    await expect(job.bridge(makeMockController())).rejects.toBeInstanceOf(
+      A2AJobCanceledError,
+    );
+    // The bridge MUST have POSTed tasks/cancel upstream.
+    expect(server.envelopes.some((e) => e.method === "tasks/cancel")).toBe(true);
+  });
+
+  it("surfaces transport failure as A2AJobFailedError + best-effort upstream cancel", async () => {
+    server = await startServer();
+    server.responses.set("tasks/send", [{ status: { state: "working" } }]);
+    server.responses.set("tasks/cancel", [{ status: { state: "canceled" } }]);
+    const client = new A2AClient({
+      url: server.url,
+      skillId: "x",
+      pollIntervalMs: 5,
+    });
+    const job = await client.submit({ role: "user", parts: [] });
+    await server.close(); // Force tasks/get to fail
+    server = { ...server, close: async () => {} };
+    await expect(job.bridge(makeMockController())).rejects.toBeInstanceOf(
+      A2AJobFailedError,
+    );
+  });
+});
+
+describe("A2AJob.cancel", () => {
+  let server: TestServer;
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it("POSTs tasks/cancel with the supplied reason", async () => {
+    server = await startServer();
+    server.responses.set("tasks/send", [{ status: { state: "working" } }]);
+    server.responses.set("tasks/cancel", [{ status: { state: "canceled" } }]);
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const job = await client.submit({ role: "user", parts: [] });
+    await job.cancel("why");
+    const cancelEnv = server.envelopes.find((e) => e.method === "tasks/cancel");
+    expect(cancelEnv).toBeDefined();
+    expect((cancelEnv?.params as { reason?: string }).reason).toBe("why");
+  });
+
+  it("swallows transport errors (best-effort)", async () => {
+    server = await startServer();
+    server.responses.set("tasks/send", [{ status: { state: "working" } }]);
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const job = await client.submit({ role: "user", parts: [] });
+    await server.close();
+    server = { ...server, close: async () => {} };
+    // Should not throw.
+    await job.cancel("after-close");
+  });
+});
+
+describe("A2AJob.wait", () => {
+  let server: TestServer;
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it("returns A2AResponse on completed terminal", async () => {
+    server = await startServer();
+    server.responses.set("tasks/send", [{ status: { state: "working" } }]);
+    server.responses.set("tasks/get", [
+      {
+        status: { state: "completed" },
+        artifacts: [{ parts: [{ text: "ok" }] }],
+      },
+    ]);
+    const client = new A2AClient({
+      url: server.url,
+      skillId: "x",
+      pollIntervalMs: 5,
+    });
+    const job = await client.submit({ role: "user", parts: [] });
+    const r = await job.wait();
+    expect(r.state).toBe("completed");
+    expect(r.artifactText).toBe("ok");
+  });
+
+  it("short-circuits on initial terminal state", async () => {
+    server = await startServer();
+    server.responses.set("tasks/send", [
+      {
+        status: { state: "completed" },
+        artifacts: [{ parts: [{ text: "ok" }] }],
+      },
+    ]);
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const job = await client.submit({ role: "user", parts: [] });
+    const r = await job.wait();
+    expect(r.state).toBe("completed");
+    // Only the initial submit envelope — no tasks/get.
+    expect(server.envelopes.filter((e) => e.method === "tasks/get")).toHaveLength(0);
+  });
+});
+
+describe("A2AJob.status (raw envelope)", () => {
+  let server: TestServer;
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it("returns the live envelope for the configured task", async () => {
+    server = await startServer();
+    server.responses.set("tasks/send", [{ status: { state: "working" } }]);
+    server.responses.set("tasks/get", [
+      { status: { state: "working" }, metadata: { progress: 0.5 } },
+    ]);
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const job = await client.submit({ role: "user", parts: [] });
+    const result = await job.status();
+    expect(
+      ((result as Record<string, unknown>).status as { state: string }).state,
+    ).toBe("working");
+  });
+});

--- a/src/runtime/typescript/src/__tests__/a2a/a2a-stream.spec.ts
+++ b/src/runtime/typescript/src/__tests__/a2a/a2a-stream.spec.ts
@@ -274,7 +274,7 @@ describe("A2AStream.bridge", () => {
     );
   });
 
-  it("throws A2AJobFailedError when stream ends without an artifact", async () => {
+  it("returns empty string on terminal completed with no artifact (parity with A2AJob)", async () => {
     server = await startSseServer([
       [
         sse({
@@ -283,6 +283,28 @@ describe("A2AStream.bridge", () => {
           result: {
             status: { state: "completed" },
             final: true,
+          },
+        }),
+      ],
+    ]);
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const stream = await client.subscribe({ role: "user", parts: [] });
+    const value = await stream.bridge(makeMockController());
+    expect(value).toBe("");
+  });
+
+  it("throws A2AJobFailedError when stream ends with no terminal state and no artifact", async () => {
+    server = await startSseServer([
+      [
+        sse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            status: {
+              state: "working",
+              message: { parts: [{ text: "still going" }] },
+            },
+            metadata: { progress: 0.1 },
           },
         }),
       ],

--- a/src/runtime/typescript/src/__tests__/a2a/a2a-stream.spec.ts
+++ b/src/runtime/typescript/src/__tests__/a2a/a2a-stream.spec.ts
@@ -1,0 +1,296 @@
+/**
+ * Tests for A2AStream + A2AClient.subscribe (issue #917).
+ *
+ * Spins up a tiny SSE producer over node:http that pushes a sequence
+ * of `data: { ... }` frames (status + artifact + final) so we exercise
+ * the full SSE line parser + JobController bridge.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import * as http from "node:http";
+import { AddressInfo } from "node:net";
+import { A2AClient } from "../../a2a/a2a-client.js";
+import {
+  A2AJobCanceledError,
+  A2AJobFailedError,
+} from "../../a2a/errors.js";
+
+interface SseServer {
+  url: string;
+  close: () => Promise<void>;
+}
+
+function startSseServer(frames: string[][]): Promise<SseServer> {
+  return new Promise((resolve) => {
+    const server = http.createServer((_req, res) => {
+      res.setHeader("Content-Type", "text/event-stream");
+      res.setHeader("Cache-Control", "no-cache");
+      // Push frames one at a time with small gaps so the consumer sees
+      // a true streaming response (not a single buffered write).
+      let i = 0;
+      const writeNext = () => {
+        if (i >= frames.length) {
+          res.end();
+          return;
+        }
+        const lines = frames[i++];
+        for (const l of lines) {
+          res.write(l + "\n");
+        }
+        res.write("\n"); // event boundary
+        setTimeout(writeNext, 5);
+      };
+      writeNext();
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}/agents/test`,
+        close: () =>
+          new Promise<void>((rs, rj) =>
+            server.close((err) => (err ? rj(err) : rs())),
+          ),
+      });
+    });
+  });
+}
+
+function makeMockController(jobId = "job-test") {
+  return {
+    jobId,
+    updateProgress: vi.fn().mockResolvedValue(undefined),
+    complete: vi.fn().mockResolvedValue(undefined),
+    fail: vi.fn().mockResolvedValue(undefined),
+    isTerminal: vi.fn().mockResolvedValue(false),
+    releaseLease: vi.fn().mockResolvedValue(undefined),
+  } as unknown as import("@mcpmesh/core").JobController & {
+    updateProgress: ReturnType<typeof vi.fn>;
+  };
+}
+
+const sse = (envelope: object) =>
+  `data: ${JSON.stringify(envelope)}`;
+
+describe("A2AStream iterator", () => {
+  let server: SseServer;
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it("yields parsed status and artifact events", async () => {
+    server = await startSseServer([
+      [
+        sse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            status: {
+              state: "working",
+              message: { parts: [{ text: "warming up" }] },
+            },
+            metadata: { progress: 0.1 },
+          },
+        }),
+      ],
+      [
+        sse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            artifact: { parts: [{ text: '{"x":1}' }] },
+          },
+        }),
+      ],
+      [
+        sse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            status: { state: "completed" },
+            final: true,
+          },
+        }),
+      ],
+    ]);
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const stream = await client.subscribe({ role: "user", parts: [] });
+    const events: Array<{
+      kind: string;
+      state?: string;
+      progress?: number;
+      message?: string;
+      artifactText?: string;
+      final: boolean;
+    }> = [];
+    for await (const e of stream) {
+      events.push({
+        kind: e.kind,
+        state: e.state,
+        progress: e.progress,
+        message: e.message,
+        artifactText: e.artifactText,
+        final: e.final,
+      });
+    }
+    expect(events.map((e) => e.kind)).toEqual([
+      "status",
+      "artifact",
+      "status",
+    ]);
+    expect(events[0].progress).toBe(0.1);
+    expect(events[0].message).toBe("warming up");
+    expect(events[1].artifactText).toBe('{"x":1}');
+    expect(events[2].state).toBe("completed");
+    expect(events[2].final).toBe(true);
+  });
+
+  it("ignores SSE comment + non-data lines", async () => {
+    server = await startSseServer([
+      [": keepalive", "id: 1", "event: message"],
+      [
+        sse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            status: { state: "completed" },
+            final: true,
+          },
+        }),
+      ],
+    ]);
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const stream = await client.subscribe({ role: "user", parts: [] });
+    const events = [];
+    for await (const e of stream) events.push(e);
+    expect(events).toHaveLength(1);
+    expect(events[0].state).toBe("completed");
+  });
+});
+
+describe("A2AStream.bridge", () => {
+  let server: SseServer;
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it("mirrors progress + returns the artifact value", async () => {
+    server = await startSseServer([
+      [
+        sse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            status: {
+              state: "working",
+              message: { parts: [{ text: "step1" }] },
+            },
+            metadata: { progress: 0.25 },
+          },
+        }),
+      ],
+      [
+        sse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            status: {
+              state: "working",
+              message: { parts: [{ text: "step2" }] },
+            },
+            metadata: { progress: 0.75 },
+          },
+        }),
+      ],
+      [
+        sse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            artifact: { parts: [{ text: '{"sections":["a","b"]}' }] },
+          },
+        }),
+      ],
+      [
+        sse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { status: { state: "completed" }, final: true },
+        }),
+      ],
+    ]);
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const stream = await client.subscribe({ role: "user", parts: [] });
+    const ctrl = makeMockController();
+    const value = await stream.bridge(ctrl);
+    expect(value).toEqual({ sections: ["a", "b"] });
+    expect(
+      (ctrl as unknown as { updateProgress: ReturnType<typeof vi.fn> })
+        .updateProgress.mock.calls.length,
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it("throws A2AJobFailedError when terminal state is failed", async () => {
+    server = await startSseServer([
+      [
+        sse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            status: {
+              state: "failed",
+              message: { parts: [{ text: "boom" }] },
+            },
+            final: true,
+          },
+        }),
+      ],
+    ]);
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const stream = await client.subscribe({ role: "user", parts: [] });
+    await expect(stream.bridge(makeMockController())).rejects.toBeInstanceOf(
+      A2AJobFailedError,
+    );
+  });
+
+  it("throws A2AJobCanceledError when terminal state is canceled", async () => {
+    server = await startSseServer([
+      [
+        sse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            status: {
+              state: "canceled",
+              message: { parts: [{ text: "user cancel" }] },
+            },
+            final: true,
+          },
+        }),
+      ],
+    ]);
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const stream = await client.subscribe({ role: "user", parts: [] });
+    await expect(stream.bridge(makeMockController())).rejects.toBeInstanceOf(
+      A2AJobCanceledError,
+    );
+  });
+
+  it("throws A2AJobFailedError when stream ends without an artifact", async () => {
+    server = await startSseServer([
+      [
+        sse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            status: { state: "completed" },
+            final: true,
+          },
+        }),
+      ],
+    ]);
+    const client = new A2AClient({ url: server.url, skillId: "x" });
+    const stream = await client.subscribe({ role: "user", parts: [] });
+    await expect(stream.bridge(makeMockController())).rejects.toThrow(
+      /ended without artifact/,
+    );
+  });
+});

--- a/src/runtime/typescript/src/__tests__/a2a/agent-a2a-config.spec.ts
+++ b/src/runtime/typescript/src/__tests__/a2a/agent-a2a-config.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for `addTool({ a2aConfig: ... })` integration in agent.ts
+ * (issue #917).
+ *
+ * Targets the registration-time validation, A2AClient cache, and
+ * heartbeat-build auto-tag injection. Doesn't bind to a real registry
+ * — `_autoStart` is stubbed out, and we reach into the agent's
+ * private fields to assert the cache state.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { z } from "zod";
+import { MeshAgent } from "../../agent.js";
+import { A2AClient } from "../../a2a/a2a-client.js";
+
+function makeFastMCPStub() {
+  return {
+    addTool: vi.fn(),
+    start: vi.fn(),
+    getApp: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+let autoStartSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+beforeEach(() => {
+  autoStartSpy = vi
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .spyOn(MeshAgent.prototype as any, "_autoStart")
+    .mockImplementation(async () => {
+      /* no-op */
+    });
+});
+
+afterEach(() => {
+  if (autoStartSpy) {
+    autoStartSpy.mockRestore();
+    autoStartSpy = null;
+  }
+});
+
+function newAgent(name = "date-consumer"): MeshAgent {
+  return new MeshAgent(makeFastMCPStub(), { name, httpPort: 0 });
+}
+
+describe("addTool({ a2aConfig }) — registration-time validation", () => {
+  it("rejects empty url", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad",
+        capability: "x",
+        parameters: z.object({}),
+        a2aConfig: { url: "" },
+        execute: async () => "ok",
+      }),
+    ).toThrow(/url must be a non-empty string/);
+  });
+
+  it("rejects non-positive timeoutMs", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad",
+        capability: "x",
+        parameters: z.object({}),
+        a2aConfig: { url: "http://x", timeoutMs: 0 },
+        execute: async () => "ok",
+      }),
+    ).toThrow(/timeoutMs.*must be > 0/);
+  });
+
+  it("accepts a valid a2aConfig and registers the tool", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "current-date",
+        capability: "current-date",
+        tags: ["a2a-bridge"],
+        parameters: z.object({}),
+        a2aConfig: {
+          url: "http://localhost:9090/agents/date",
+          skillId: "get-date",
+        },
+        execute: async (_args, _a2a) => "ok",
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("A2AClient cache", () => {
+  it("returns the same A2AClient for two tools sharing the same config tuple", () => {
+    const agent = newAgent();
+    agent.addTool({
+      name: "tool-a",
+      capability: "current-date",
+      parameters: z.object({}),
+      a2aConfig: { url: "http://localhost:9090/agents/date", skillId: "get-date" },
+      execute: async () => "ok",
+    });
+    agent.addTool({
+      name: "tool-b",
+      capability: "alt-date",
+      parameters: z.object({}),
+      a2aConfig: { url: "http://localhost:9090/agents/date", skillId: "get-date" },
+      execute: async () => "ok",
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache = (agent as any)._a2aClients as Map<string, A2AClient>;
+    expect(cache.size).toBe(1);
+    const onlyEntry = [...cache.values()][0];
+    expect(onlyEntry).toBeInstanceOf(A2AClient);
+  });
+
+  it("returns separate clients for different urls", () => {
+    const agent = newAgent();
+    agent.addTool({
+      name: "tool-a",
+      capability: "x",
+      parameters: z.object({}),
+      a2aConfig: { url: "http://a/agents/x", skillId: "x" },
+      execute: async () => "ok",
+    });
+    agent.addTool({
+      name: "tool-b",
+      capability: "x",
+      parameters: z.object({}),
+      a2aConfig: { url: "http://b/agents/x", skillId: "x" },
+      execute: async () => "ok",
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache = (agent as any)._a2aClients as Map<string, A2AClient>;
+    expect(cache.size).toBe(2);
+  });
+});
+
+describe("auto-tag injection at heartbeat-build time", () => {
+  it("appends the agent name to the tool's tags when a2aConfig is set", async () => {
+    const agent = newAgent("my-consumer");
+    agent.addTool({
+      name: "current-date",
+      capability: "current-date",
+      tags: ["a2a-bridge"],
+      parameters: z.object({}),
+      a2aConfig: { url: "http://x/agents/y", skillId: "y" },
+      execute: async () => "ok",
+    });
+    // Reach into private state to inspect what heartbeat-build will ship.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tools = (agent as any).tools as Map<string, { tags: string[]; a2aConsumer?: boolean; a2aAgentName?: string }>;
+    const meta = tools.get("current-date");
+    expect(meta?.a2aConsumer).toBe(true);
+    expect(meta?.a2aAgentName).toBe("my-consumer");
+    // The original tags array stored in meta is unchanged (defensive copy
+    // happens inside the heartbeat path); the on-the-wire tags receive
+    // the auto-tag.
+    expect(meta?.tags).toEqual(["a2a-bridge"]);
+  });
+
+  it("does NOT mark a2aConsumer when a2aConfig is absent", () => {
+    const agent = newAgent();
+    agent.addTool({
+      name: "plain",
+      capability: "plain",
+      parameters: z.object({}),
+      execute: async () => "ok",
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tools = (agent as any).tools as Map<string, { a2aConsumer?: boolean }>;
+    expect(tools.get("plain")?.a2aConsumer).toBeFalsy();
+  });
+});

--- a/src/runtime/typescript/src/__tests__/a2a/agent-a2a-config.spec.ts
+++ b/src/runtime/typescript/src/__tests__/a2a/agent-a2a-config.spec.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { z } from "zod";
 import { MeshAgent } from "../../agent.js";
 import { A2AClient } from "../../a2a/a2a-client.js";
+import { A2ABearer } from "../../a2a/a2a-bearer.js";
 
 function makeFastMCPStub() {
   return {
@@ -131,6 +132,60 @@ describe("A2AClient cache", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const cache = (agent as any)._a2aClients as Map<string, A2AClient>;
     expect(cache.size).toBe(2);
+  });
+
+  it("cache_distinguishesA2AClientsByDistinctBearerInstances", () => {
+    // Regression for the BLOCKER: two A2ABearer instances holding
+    // distinct literal tokens MUST NOT collide in the A2AClient cache.
+    // Pre-fix the cache key used `Object.prototype.hasOwnProperty.call`
+    // against `tokenEnv` — which always returned true because A2ABearer
+    // assigns both fields unconditionally — so both bearers hashed to
+    // `env:` and tool-B's outbound HTTP would carry tool-A's secret.
+    const agent = newAgent();
+    const bearerA = new A2ABearer({ token: "secret-A" });
+    const bearerB = new A2ABearer({ token: "secret-B" });
+    agent.addTool({
+      name: "tool-a",
+      capability: "x",
+      parameters: z.object({}),
+      a2aConfig: { url: "http://x/agents/x", skillId: "x", auth: bearerA },
+      execute: async () => "ok",
+    });
+    agent.addTool({
+      name: "tool-b",
+      capability: "x",
+      parameters: z.object({}),
+      a2aConfig: { url: "http://x/agents/x", skillId: "x", auth: bearerB },
+      execute: async () => "ok",
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache = (agent as any)._a2aClients as Map<string, A2AClient>;
+    expect(cache.size).toBe(2);
+  });
+
+  it("reuses one A2AClient when the SAME A2ABearer instance is shared", () => {
+    // Counterpart to the above — sharing one bearer reference across
+    // multiple tools SHOULD hit the cache (the desired connection-pool
+    // sharing behaviour). Identity-based keying preserves this.
+    const agent = newAgent();
+    const sharedBearer = new A2ABearer({ tokenEnv: "MY_TOKEN" });
+    agent.addTool({
+      name: "tool-a",
+      capability: "x",
+      parameters: z.object({}),
+      a2aConfig: { url: "http://x/agents/x", skillId: "x", auth: sharedBearer },
+      execute: async () => "ok",
+    });
+    agent.addTool({
+      name: "tool-b",
+      capability: "x",
+      parameters: z.object({}),
+      a2aConfig: { url: "http://x/agents/x", skillId: "x", auth: sharedBearer },
+      execute: async () => "ok",
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache = (agent as any)._a2aClients as Map<string, A2AClient>;
+    expect(cache.size).toBe(1);
   });
 });
 

--- a/src/runtime/typescript/src/__tests__/a2a/agent-a2a-config.spec.ts
+++ b/src/runtime/typescript/src/__tests__/a2a/agent-a2a-config.spec.ts
@@ -68,7 +68,76 @@ describe("addTool({ a2aConfig }) — registration-time validation", () => {
         a2aConfig: { url: "http://x", timeoutMs: 0 },
         execute: async () => "ok",
       }),
-    ).toThrow(/timeoutMs.*must be > 0/);
+    ).toThrow(/timeoutMs.*must be a finite positive number/);
+  });
+
+  it("rejects Infinity timeoutMs", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad",
+        capability: "x",
+        parameters: z.object({}),
+        a2aConfig: { url: "http://x", timeoutMs: Number.POSITIVE_INFINITY },
+        execute: async () => "ok",
+      }),
+    ).toThrow(/timeoutMs.*must be a finite positive number/);
+  });
+
+  it("rejects NaN timeoutMs", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad",
+        capability: "x",
+        parameters: z.object({}),
+        a2aConfig: { url: "http://x", timeoutMs: Number.NaN },
+        execute: async () => "ok",
+      }),
+    ).toThrow(/timeoutMs.*must be a finite positive number/);
+  });
+
+  it("rejects negative timeoutMs", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad",
+        capability: "x",
+        parameters: z.object({}),
+        a2aConfig: { url: "http://x", timeoutMs: -100 },
+        execute: async () => "ok",
+      }),
+    ).toThrow(/timeoutMs.*must be a finite positive number/);
+  });
+
+  it("rejects non-positive pollIntervalMs", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad",
+        capability: "x",
+        parameters: z.object({}),
+        a2aConfig: { url: "http://x", pollIntervalMs: 0 },
+        execute: async () => "ok",
+      }),
+    ).toThrow(/pollIntervalMs.*must be a finite positive number/);
+  });
+
+  it("rejects pollIntervalMaxMs < pollIntervalMs", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad",
+        capability: "x",
+        parameters: z.object({}),
+        a2aConfig: {
+          url: "http://x",
+          pollIntervalMs: 500,
+          pollIntervalMaxMs: 100,
+        },
+        execute: async () => "ok",
+      }),
+    ).toThrow(/pollIntervalMaxMs.*must be >= pollIntervalMs/);
   });
 
   it("accepts a valid a2aConfig and registers the tool", () => {

--- a/src/runtime/typescript/src/__tests__/agent-add-tool.spec.ts
+++ b/src/runtime/typescript/src/__tests__/agent-add-tool.spec.ts
@@ -390,3 +390,178 @@ describe("addTool — W4 worker-isolation force-disable warning", () => {
     expect(isolationCall).toBeUndefined();
   });
 });
+
+// =============================================================================
+// Regression for #925 — wrappedExecute MUST return a bare string for object
+// results, NOT an envelope with `structuredContent`. FastMCP TS validates
+// the tool-result via ContentResultZodSchema.strict(), which rejects unknown
+// keys at the server-side dispatcher BEFORE the response leaves the process.
+// PR #897 originally added `structuredContent` for Python-FastMCP parity,
+// but it broke uc26 tc02/tc03 (Python caller -> TS sync tool with object
+// return). Field is part of the MCP spec; re-enable when FastMCP TS upstream
+// accepts it.
+// =============================================================================
+
+describe("addTool — #925 wrappedExecute return shape (no structuredContent)", () => {
+  // Mirror FastMCP TS's strict ContentResultZodSchema so the test is
+  // self-contained and breaks loudly if anyone re-introduces
+  // `structuredContent` (or any other unknown key) into the wrapped
+  // execute return value.
+  const StrictContentResultSchema = z
+    .object({
+      content: z.array(
+        z.object({
+          type: z.literal("text"),
+          text: z.string(),
+        }),
+      ),
+      isError: z.boolean().optional(),
+    })
+    .strict();
+
+  // Mimics FastMCP's `tool.execute()` dispatch path: when the wrapped
+  // execute returns a bare string, FastMCP wraps it as
+  // {content: [{type: "text", text: <string>}]} and validates with
+  // ContentResultZodSchema.strict().
+  function fastmcpDispatch(maybeStringResult: unknown): unknown {
+    if (maybeStringResult === undefined || maybeStringResult === null) {
+      return StrictContentResultSchema.parse({ content: [] });
+    } else if (typeof maybeStringResult === "string") {
+      return StrictContentResultSchema.parse({
+        content: [{ text: maybeStringResult, type: "text" }],
+      });
+    } else if (
+      typeof maybeStringResult === "object" &&
+      "type" in (maybeStringResult as Record<string, unknown>)
+    ) {
+      return StrictContentResultSchema.parse({ content: [maybeStringResult] });
+    } else {
+      return StrictContentResultSchema.parse(maybeStringResult);
+    }
+  }
+
+  // Capture the wrapped execute fn that MeshAgent registers with
+  // FastMCP so the test can drive it directly (no worker pool, no HTTP).
+  function captureWrappedExecute() {
+    let wrapped: ((args: unknown) => Promise<unknown>) | null = null;
+    const stub = {
+      addTool: vi.fn((tool: { execute: (a: unknown) => Promise<unknown> }) => {
+        wrapped = tool.execute;
+      }),
+      start: vi.fn(),
+      getApp: vi.fn(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const agent = new MeshAgent(stub, {
+      name: "test-agent-925",
+      httpPort: 0,
+    });
+    return { agent, getWrapped: () => wrapped };
+  }
+
+  // Force-disable worker isolation so the test exercises the inline
+  // path. Worker dispatch can't be trivially serialised over the
+  // worker_threads boundary in a unit test harness — the inline branch
+  // is the same return-shape codepath, just without the postMessage hop.
+  const originalIsolation = process.env.MCP_MESH_TOOL_ISOLATION;
+  beforeEach(() => {
+    process.env.MCP_MESH_TOOL_ISOLATION = "false";
+  });
+  afterEach(() => {
+    if (originalIsolation === undefined) {
+      delete process.env.MCP_MESH_TOOL_ISOLATION;
+    } else {
+      process.env.MCP_MESH_TOOL_ISOLATION = originalIsolation;
+    }
+  });
+
+  it("returns a bare JSON-stringified string (NOT an envelope) for object results", async () => {
+    const { agent, getWrapped } = captureWrappedExecute();
+    agent.addTool({
+      name: "object-tool",
+      parameters: z.object({}),
+      execute: async () => ({ foo: "bar", n: 42 }),
+    });
+    const wrapped = getWrapped();
+    expect(wrapped).not.toBeNull();
+    const result = await wrapped!({});
+    expect(typeof result).toBe("string");
+    expect(result).toBe('{"foo":"bar","n":42}');
+    // No structuredContent key — the return value is a primitive string.
+    expect(result).not.toHaveProperty("structuredContent");
+    expect(result).not.toHaveProperty("content");
+  });
+
+  it("returns a bare string unchanged for string results", async () => {
+    const { agent, getWrapped } = captureWrappedExecute();
+    agent.addTool({
+      name: "string-tool",
+      parameters: z.object({}),
+      execute: async () => "hello",
+    });
+    const result = await getWrapped()!({});
+    expect(result).toBe("hello");
+  });
+
+  it("returns an empty string for null/undefined results", async () => {
+    const { agent, getWrapped } = captureWrappedExecute();
+    agent.addTool({
+      name: "null-tool",
+      parameters: z.object({}),
+      execute: async () => null,
+    });
+    expect(await getWrapped()!({})).toBe("");
+
+    const { agent: agent2, getWrapped: getWrapped2 } = captureWrappedExecute();
+    agent2.addTool({
+      name: "undef-tool",
+      parameters: z.object({}),
+      execute: async () => undefined,
+    });
+    expect(await getWrapped2()!({})).toBe("");
+  });
+
+  it("FastMCP-style dispatch validates without ContentResultZodSchema error (object return)", async () => {
+    const { agent, getWrapped } = captureWrappedExecute();
+    agent.addTool({
+      name: "object-tool-strict",
+      parameters: z.object({}),
+      execute: async () => ({ foo: "bar" }),
+    });
+    const result = await getWrapped()!({});
+    // Simulating FastMCP's strict-schema validation must not throw.
+    let dispatched: unknown;
+    expect(() => {
+      dispatched = fastmcpDispatch(result);
+    }).not.toThrow();
+    expect(dispatched).toEqual({
+      content: [{ type: "text", text: '{"foo":"bar"}' }],
+    });
+  });
+
+  it("FastMCP-style dispatch validates without error for arrays and numbers", async () => {
+    const { agent, getWrapped } = captureWrappedExecute();
+    agent.addTool({
+      name: "array-tool",
+      parameters: z.object({}),
+      execute: async () => [1, 2, 3],
+    });
+    const arrResult = await getWrapped()!({});
+    expect(() => fastmcpDispatch(arrResult)).not.toThrow();
+    expect(fastmcpDispatch(arrResult)).toEqual({
+      content: [{ type: "text", text: "[1,2,3]" }],
+    });
+
+    const { agent: agent2, getWrapped: getWrapped2 } = captureWrappedExecute();
+    agent2.addTool({
+      name: "number-tool",
+      parameters: z.object({}),
+      execute: async () => 42,
+    });
+    const numResult = await getWrapped2()!({});
+    expect(() => fastmcpDispatch(numResult)).not.toThrow();
+    expect(fastmcpDispatch(numResult)).toEqual({
+      content: [{ type: "text", text: "42" }],
+    });
+  });
+});

--- a/src/runtime/typescript/src/a2a/a2a-bearer.ts
+++ b/src/runtime/typescript/src/a2a/a2a-bearer.ts
@@ -1,0 +1,79 @@
+/**
+ * Bearer-token credential for an outbound A2A call (issue #917).
+ *
+ * Provide either `token` (literal) or `tokenEnv` (the name of an
+ * environment variable). Resolution happens at header-build time so
+ * rotating the env var between calls picks up the new value without
+ * reconstructing the surrounding A2AClient. Mirrors
+ * `mesh._a2a_consumer.A2ABearer` (Python) and `io.mcpmesh.a2a.A2ABearer`
+ * (Java).
+ */
+import { A2AAuthError } from "./errors.js";
+
+export interface A2ABearerConfig {
+  /** Literal bearer token. Mutually exclusive with `tokenEnv`. */
+  token?: string;
+  /** Env-var name to read the token from on each call. Mutually exclusive with `token`. */
+  tokenEnv?: string;
+}
+
+export class A2ABearer {
+  private readonly token?: string;
+  private readonly tokenEnv?: string;
+
+  constructor(config: A2ABearerConfig) {
+    if (!config.token && !config.tokenEnv) {
+      throw new A2AAuthError(
+        "A2ABearer: must specify either 'token' or 'tokenEnv'",
+      );
+    }
+    if (config.token && config.tokenEnv) {
+      throw new A2AAuthError(
+        "A2ABearer: 'token' and 'tokenEnv' are mutually exclusive",
+      );
+    }
+    if (config.token !== undefined && config.token.trim() === "") {
+      throw new A2AAuthError("A2ABearer: 'token' must be non-blank");
+    }
+    if (config.tokenEnv !== undefined && config.tokenEnv.trim() === "") {
+      throw new A2AAuthError("A2ABearer: 'tokenEnv' must be non-blank");
+    }
+    this.token = config.token;
+    this.tokenEnv = config.tokenEnv;
+  }
+
+  /**
+   * Build the value for the `Authorization` header at call time.
+   *
+   * Reads the env var (when configured) on every call so a rotated
+   * credential is honoured mid-process.
+   */
+  authorizationHeader(): string {
+    let resolved = this.token;
+    if (resolved === undefined && this.tokenEnv) {
+      resolved = process.env[this.tokenEnv];
+    }
+    if (!resolved || resolved.trim() === "") {
+      throw new A2AAuthError(
+        `A2ABearer: no token resolved (token=${this.token ? "set" : "unset"}, ` +
+          `tokenEnv=${this.tokenEnv ?? "<unset>"})`,
+      );
+    }
+    return `Bearer ${resolved}`;
+  }
+}
+
+/**
+ * Helper: normalise the user-friendly union (`A2ABearer | A2ABearerConfig`)
+ * into a concrete `A2ABearer` instance, or `undefined` for "no auth".
+ *
+ * Lets the consumer-side `addTool({ a2aConfig: { auth: { tokenEnv: "X" } } })`
+ * shortcut work without forcing the user to `new A2ABearer(...)` every time.
+ */
+export function resolveBearer(
+  auth: A2ABearer | A2ABearerConfig | undefined,
+): A2ABearer | undefined {
+  if (auth === undefined) return undefined;
+  if (auth instanceof A2ABearer) return auth;
+  return new A2ABearer(auth);
+}

--- a/src/runtime/typescript/src/a2a/a2a-client.ts
+++ b/src/runtime/typescript/src/a2a/a2a-client.ts
@@ -1,0 +1,525 @@
+/**
+ * Thin A2A v1.0 client — sync `tasks/send` + non-blocking `submit` +
+ * SSE `subscribe` (issue #917).
+ *
+ * One instance per (url, skillId, auth, timeout) tuple — the framework
+ * caches and re-uses clients across tool invocations so the underlying
+ * undici connection pool is amortised. Mirrors
+ * `mesh._a2a_consumer.A2AClient` (Python) and
+ * `io.mcpmesh.a2a.A2AClient` (Java) — same JSON-RPC envelope shape +
+ * polling backoff + auth header semantics.
+ */
+import { randomUUID } from "node:crypto";
+import { getDispatcher } from "../http-pool.js";
+import {
+  A2ABearer,
+  type A2ABearerConfig,
+  resolveBearer,
+} from "./a2a-bearer.js";
+import {
+  A2AAuthError,
+  A2AError,
+  A2ATimeoutError,
+} from "./errors.js";
+import { A2AJob } from "./a2a-job.js";
+import { A2AStream } from "./a2a-stream.js";
+
+/** Default per-call deadline for `send`. */
+export const DEFAULT_TIMEOUT_MS = 30_000;
+/** Initial poll interval for `tasks/get` (ms). */
+export const DEFAULT_POLL_INTERVAL_MS = 500;
+/** Capped poll interval for `tasks/get` (ms). */
+export const DEFAULT_POLL_INTERVAL_MAX_MS = 2_000;
+/** Multiplier applied between consecutive polls. */
+export const POLL_BACKOFF_FACTOR = 1.5;
+
+const _TERMINAL_STATES = new Set([
+  "completed",
+  "failed",
+  "canceled",
+  // A2A v1.0 uses US "canceled"; mesh JobController uses UK "cancelled".
+  // Accept both so a heterogeneous deployment doesn't get stuck polling.
+  "cancelled",
+]);
+
+export function isTerminalState(state: string | undefined | null): boolean {
+  return state != null && _TERMINAL_STATES.has(state.toLowerCase());
+}
+
+/** A2A v1.0 message dict — `{ role, parts: [...] }` shape. */
+export type A2AMessage = Record<string, unknown>;
+
+export interface A2AClientConfig {
+  /** A2A endpoint URL. Trailing slashes are stripped. */
+  url: string;
+  /** Skill ID to invoke on the upstream. */
+  skillId: string;
+  /** Bearer credential (instance or config). */
+  auth?: A2ABearer | A2ABearerConfig;
+  /** Per-call deadline for `send` (ms). Default 30_000. */
+  timeoutMs?: number;
+  /** Initial backoff between `tasks/get` polls (ms). Default 500. */
+  pollIntervalMs?: number;
+  /** Cap on the backoff between polls (ms). Default 2_000. */
+  pollIntervalMaxMs?: number;
+}
+
+/** Result of a synchronous `A2AClient.send`. */
+export interface A2AResponse {
+  /** First artifact's first text part — the canonical sync return. */
+  artifactText: string;
+  /** Final lifecycle state (typically "completed"). */
+  state: string;
+  /** Consumer-generated task ID echoed back by the producer. */
+  taskId: string;
+  /** Full Task envelope (status, artifacts, metadata, history). */
+  rawTask: Record<string, unknown>;
+}
+
+/** Raw task envelope returned by `A2AJob.status` etc. */
+export type A2ATaskEnvelope = Record<string, unknown>;
+
+interface JsonRpcEnvelope {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+/** Sentinel that controls whether `_postJsonRpc` asserts a `result` field. */
+type JsonRpcAcceptShape = "result-required" | "result-or-error";
+
+export class A2AClient {
+  readonly url: string;
+  readonly skillId: string;
+  readonly auth?: A2ABearer;
+  readonly timeoutMs: number;
+  readonly pollIntervalMs: number;
+  readonly pollIntervalMaxMs: number;
+  private closed = false;
+
+  constructor(config: A2AClientConfig) {
+    if (!config.url || config.url.trim() === "") {
+      throw new A2AError("A2AClient: url must be non-empty");
+    }
+    if (config.timeoutMs !== undefined && config.timeoutMs <= 0) {
+      throw new A2AError("A2AClient: timeoutMs must be > 0");
+    }
+    // Trim trailing slashes to match Python's url.rstrip("/") and Java's
+    // trim loop — keeps the on-the-wire URL stable regardless of how
+    // the user wrote the constructor argument.
+    let trimmed = config.url;
+    while (trimmed.endsWith("/")) {
+      trimmed = trimmed.slice(0, -1);
+    }
+    this.url = trimmed;
+    this.skillId = config.skillId;
+    this.auth = resolveBearer(config.auth);
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.pollIntervalMaxMs =
+      config.pollIntervalMaxMs ?? DEFAULT_POLL_INTERVAL_MAX_MS;
+  }
+
+  /**
+   * POST `tasks/send` and poll `tasks/get` until terminal.
+   *
+   * `message` is the A2A v1.0 request message dict — typically
+   * `{ role: "user", parts: [{ type: "text", text: "..." }] }`.
+   * Returns an `A2AResponse` whose `artifactText` carries the
+   * producer-side handler's return value (JSON-stringified for
+   * non-string returns; consumers `JSON.parse` when the upstream
+   * returns a dict).
+   */
+  async send(
+    message: A2AMessage,
+    options?: { taskId?: string; timeoutMs?: number },
+  ): Promise<A2AResponse> {
+    this._ensureOpen();
+    if (message == null) {
+      throw new A2AError("A2AClient.send: message must be non-null");
+    }
+    const timeoutMs = options?.timeoutMs ?? this.timeoutMs;
+    if (timeoutMs <= 0) {
+      throw new A2AError("A2AClient.send: timeoutMs must be > 0");
+    }
+    const taskId = options?.taskId ?? this._newTaskId();
+    const deadline = Date.now() + timeoutMs;
+
+    let result = await this._postJsonRpc(
+      "tasks/send",
+      { id: taskId, message },
+      1,
+      Math.max(1, deadline - Date.now()),
+    );
+    let state = readState(result);
+    if (isTerminalState(state)) {
+      return this._buildResponse(taskId, result);
+    }
+
+    let intervalMs = this.pollIntervalMs;
+    while (Date.now() < deadline) {
+      await sleep(Math.min(intervalMs, Math.max(1, deadline - Date.now())));
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      result = await this._postJsonRpc(
+        "tasks/get",
+        { id: taskId },
+        2,
+        remaining,
+      );
+      state = readState(result);
+      if (isTerminalState(state)) {
+        return this._buildResponse(taskId, result);
+      }
+      intervalMs = Math.min(
+        this.pollIntervalMaxMs,
+        Math.floor(intervalMs * POLL_BACKOFF_FACTOR),
+      );
+    }
+
+    throw new A2ATimeoutError(
+      `A2A task '${taskId}' on ${this.url} did not reach terminal state ` +
+        `within ${timeoutMs}ms (last state='${state}')`,
+    );
+  }
+
+  /**
+   * POST `tasks/send` and return an `A2AJob` handle WITHOUT polling.
+   *
+   * Use this when the surrounding `addTool({ task: true, ... })` body
+   * wants explicit control over when to poll — typically via
+   * `A2AJob.bridge(jobController)` which mirrors progress into the
+   * framework-injected `JobController`.
+   */
+  async submit(
+    message: A2AMessage,
+    options?: { taskId?: string },
+  ): Promise<A2AJob> {
+    this._ensureOpen();
+    if (message == null) {
+      throw new A2AError("A2AClient.submit: message must be non-null");
+    }
+    const taskId = options?.taskId ?? this._newTaskId();
+    const result = await this._postJsonRpc(
+      "tasks/send",
+      { id: taskId, message },
+      1,
+      this.timeoutMs,
+    );
+    const state = readState(result);
+    return new A2AJob(this, taskId, state, result);
+  }
+
+  /**
+   * POST `tasks/sendSubscribe` and return an `A2AStream` of parsed events.
+   *
+   * The returned stream MUST be either iterated to completion (the
+   * terminal `final=true` frame closes it) OR explicitly closed via
+   * `await using` / `await stream.aclose()` to release the underlying
+   * connection.
+   */
+  async subscribe(
+    message: A2AMessage,
+    options?: { taskId?: string },
+  ): Promise<A2AStream> {
+    this._ensureOpen();
+    if (message == null) {
+      throw new A2AError("A2AClient.subscribe: message must be non-null");
+    }
+    const taskId = options?.taskId ?? this._newTaskId();
+    const envelope: JsonRpcEnvelope = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tasks/sendSubscribe",
+      params: { id: taskId, message },
+    };
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+    };
+    if (this.auth) {
+      headers["Authorization"] = this.auth.authorizationHeader();
+    }
+
+    let response: Response;
+    try {
+      // No request timeout on the SSE call — the stream lifetime is
+      // dictated by the producer, not a per-request deadline. The
+      // dispatcher's keep-alive still applies to the initial handshake.
+      response = await fetch(this.url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(envelope),
+        // undici extension: dispatcher is honoured for connection pooling.
+        dispatcher: getDispatcher(this.url),
+      });
+    } catch (err) {
+      throw new A2AError(
+        `A2A tasks/sendSubscribe ${this.url} transport failure: ` +
+          `${(err as Error)?.message ?? String(err)}`,
+        err,
+      );
+    }
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new A2AError(
+        `A2A tasks/sendSubscribe ${this.url} HTTP ${response.status}: ` +
+          truncate(body, 256),
+      );
+    }
+    if (!response.body) {
+      throw new A2AError(
+        `A2A tasks/sendSubscribe ${this.url} returned no response body`,
+      );
+    }
+    return new A2AStream(response, taskId);
+  }
+
+  /**
+   * Lifecycle marker (forward-compat).
+   *
+   * The undici Agent pool is shared process-wide via `closeHttpPool()`
+   * — there's no per-client connection state to tear down. We mark
+   * `closed = true` so subsequent `send`/`submit`/`subscribe` raise
+   * cleanly (matches Python's `_closed` flag behaviour).
+   */
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+
+  // --- internal API used by A2AJob / A2AStream -----------------------------
+
+  /** Internal: POST `tasks/get` for the supplied task ID. */
+  async tasksGet(taskId: string): Promise<A2ATaskEnvelope> {
+    this._ensureOpen();
+    return this._postJsonRpc("tasks/get", { id: taskId }, 2, this.timeoutMs);
+  }
+
+  /** Internal: POST `tasks/cancel`. Best-effort; transport errors swallowed by caller. */
+  async tasksCancel(taskId: string, reason?: string): Promise<void> {
+    this._ensureOpen();
+    const params: Record<string, unknown> = { id: taskId };
+    if (reason !== undefined) params.reason = reason;
+    await this._postJsonRpc("tasks/cancel", params, 3, this.timeoutMs);
+  }
+
+  /** Internal: build an `A2AResponse` from a Task envelope. */
+  buildResponse(taskId: string, result: A2ATaskEnvelope): A2AResponse {
+    return this._buildResponse(taskId, result);
+  }
+
+  // --- helpers -------------------------------------------------------------
+
+  private _newTaskId(): string {
+    return `c-${randomUUID().replace(/-/g, "")}`;
+  }
+
+  private _ensureOpen(): void {
+    if (this.closed) {
+      throw new A2AError(
+        `A2AClient(url=${this.url}) is closed; create a new instance instead.`,
+      );
+    }
+  }
+
+  private async _postJsonRpc(
+    method: string,
+    params: Record<string, unknown>,
+    rpcId: number,
+    timeoutMs: number,
+    accept: JsonRpcAcceptShape = "result-required",
+  ): Promise<A2ATaskEnvelope> {
+    const envelope: JsonRpcEnvelope = {
+      jsonrpc: "2.0",
+      id: rpcId,
+      method,
+      params,
+    };
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    };
+    if (this.auth) {
+      try {
+        headers["Authorization"] = this.auth.authorizationHeader();
+      } catch (err) {
+        if (err instanceof A2AAuthError) throw err;
+        throw new A2AAuthError(
+          `A2A ${method} ${this.url}: failed to resolve bearer header: ` +
+            `${(err as Error)?.message ?? String(err)}`,
+          err,
+        );
+      }
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    let response: Response;
+    try {
+      response = await fetch(this.url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(envelope),
+        signal: controller.signal,
+        // undici extension: dispatcher is honoured for connection pooling.
+        dispatcher: getDispatcher(this.url),
+      });
+    } catch (err) {
+      if ((err as { name?: string })?.name === "AbortError") {
+        throw new A2ATimeoutError(
+          `A2A ${method} ${this.url} timed out after ${timeoutMs}ms`,
+          err,
+        );
+      }
+      throw new A2AError(
+        `A2A ${method} ${this.url} transport failure: ` +
+          `${(err as Error)?.message ?? String(err)}`,
+        err,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+
+    const body = await response.text();
+    if (!response.ok) {
+      throw new A2AError(
+        `A2A ${method} ${this.url} HTTP ${response.status}: ` +
+          truncate(body, 256),
+      );
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(body);
+    } catch (err) {
+      throw new A2AError(
+        `A2A ${method} ${this.url} returned malformed JSON: ` +
+          truncate(body, 256),
+        err,
+      );
+    }
+    if (parsed == null || typeof parsed !== "object") {
+      throw new A2AError(`A2A ${method} ${this.url} returned empty body`);
+    }
+    const obj = parsed as Record<string, unknown>;
+    if (obj.error != null) {
+      const err = obj.error as Record<string, unknown>;
+      const code = err.code !== undefined ? String(err.code) : "?";
+      const msg =
+        err.message !== undefined ? String(err.message) : "<no message>";
+      throw new A2AError(`A2A error from ${this.url}: ${code} ${msg}`);
+    }
+    if (obj.result === undefined || obj.result === null) {
+      if (accept === "result-or-error") {
+        return {} as A2ATaskEnvelope;
+      }
+      // A producer that returns {"jsonrpc":"2.0","id":1} (no result and
+      // no error) is malformed JSON-RPC. Coercing this to an empty
+      // object would make `readState()` return "unknown" and the
+      // polling loop spin until the user-supplied deadline. Fail fast
+      // with a clear message instead — matches Java parity.
+      throw new A2AError(
+        `A2A ${method} ${this.url} response has neither 'result' nor 'error' ` +
+          `field — malformed JSON-RPC envelope: ${truncate(body, 256)}`,
+      );
+    }
+    return obj.result as A2ATaskEnvelope;
+  }
+
+  private _buildResponse(
+    taskId: string,
+    result: A2ATaskEnvelope,
+  ): A2AResponse {
+    return {
+      artifactText: extractArtifactText(result),
+      state: readState(result),
+      taskId,
+      rawTask: result,
+    };
+  }
+}
+
+// --- exported helpers (used by A2AJob + A2AStream) ----------------------------
+
+export function readState(result: A2ATaskEnvelope | undefined | null): string {
+  if (!result || typeof result !== "object") return "unknown";
+  const status = (result as Record<string, unknown>).status as
+    | Record<string, unknown>
+    | undefined;
+  if (!status || typeof status !== "object") return "unknown";
+  const state = status.state;
+  if (typeof state !== "string") return "unknown";
+  return state;
+}
+
+export function extractArtifactText(result: A2ATaskEnvelope): string {
+  const artifacts = (result as Record<string, unknown>).artifacts;
+  if (!Array.isArray(artifacts) || artifacts.length === 0) return "";
+  const first = artifacts[0];
+  if (!first || typeof first !== "object") return "";
+  const parts = (first as Record<string, unknown>).parts;
+  if (!Array.isArray(parts) || parts.length === 0) return "";
+  const firstPart = parts[0];
+  if (!firstPart || typeof firstPart !== "object") return "";
+  const text = (firstPart as Record<string, unknown>).text;
+  return typeof text === "string" ? text : "";
+}
+
+export function readStatusMessage(result: A2ATaskEnvelope): string | undefined {
+  const status = (result as Record<string, unknown>).status as
+    | Record<string, unknown>
+    | undefined;
+  if (!status || typeof status !== "object") return undefined;
+  const msg = status.message;
+  if (!msg || typeof msg !== "object") return undefined;
+  const parts = (msg as Record<string, unknown>).parts;
+  if (!Array.isArray(parts) || parts.length === 0) return undefined;
+  const firstPart = parts[0];
+  if (!firstPart || typeof firstPart !== "object") return undefined;
+  const text = (firstPart as Record<string, unknown>).text;
+  return typeof text === "string" ? text : undefined;
+}
+
+export function readProgress(result: A2ATaskEnvelope): number | undefined {
+  const metadata = (result as Record<string, unknown>).metadata as
+    | Record<string, unknown>
+    | undefined;
+  if (!metadata || typeof metadata !== "object") return undefined;
+  const progress = metadata.progress;
+  if (progress === undefined || progress === null) return undefined;
+  if (typeof progress === "number" && Number.isFinite(progress)) {
+    return progress;
+  }
+  // Tolerate stringified numerics — some producers JSON-encode metadata
+  // fields as strings.
+  if (typeof progress === "string") {
+    const n = Number.parseFloat(progress);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
+}
+
+export function maybeJsonParse(text: string): unknown {
+  if (!text) return text;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+export function isCanceledState(state: string | undefined | null): boolean {
+  if (!state) return false;
+  const s = state.toLowerCase();
+  return s === "canceled" || s === "cancelled";
+}
+
+function truncate(s: string | undefined | null, max: number): string {
+  if (s == null) return "";
+  return s.length <= max ? s : s.slice(0, max) + "...";
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/runtime/typescript/src/a2a/a2a-client.ts
+++ b/src/runtime/typescript/src/a2a/a2a-client.ts
@@ -97,6 +97,10 @@ export class A2AClient {
   readonly pollIntervalMs: number;
   readonly pollIntervalMaxMs: number;
   private closed = false;
+  // JSON-RPC requires a unique id per request — a per-instance monotonic
+  // counter is the spec-conforming choice. Some servers/middleware
+  // enforce this, so don't reuse `2` across every tasks/get poll.
+  private nextRpcId = 1;
 
   constructor(config: A2AClientConfig) {
     if (!config.url || config.url.trim() === "") {
@@ -149,7 +153,6 @@ export class A2AClient {
     let result = await this._postJsonRpc(
       "tasks/send",
       { id: taskId, message },
-      1,
       Math.max(1, deadline - Date.now()),
     );
     let state = readState(result);
@@ -165,7 +168,6 @@ export class A2AClient {
       result = await this._postJsonRpc(
         "tasks/get",
         { id: taskId },
-        2,
         remaining,
       );
       state = readState(result);
@@ -204,7 +206,6 @@ export class A2AClient {
     const result = await this._postJsonRpc(
       "tasks/send",
       { id: taskId, message },
-      1,
       this.timeoutMs,
     );
     const state = readState(result);
@@ -230,7 +231,7 @@ export class A2AClient {
     const taskId = options?.taskId ?? this._newTaskId();
     const envelope: JsonRpcEnvelope = {
       jsonrpc: "2.0",
-      id: 1,
+      id: this.nextRpcId++,
       method: "tasks/sendSubscribe",
       params: { id: taskId, message },
     };
@@ -294,7 +295,7 @@ export class A2AClient {
   /** Internal: POST `tasks/get` for the supplied task ID. */
   async tasksGet(taskId: string): Promise<A2ATaskEnvelope> {
     this._ensureOpen();
-    return this._postJsonRpc("tasks/get", { id: taskId }, 2, this.timeoutMs);
+    return this._postJsonRpc("tasks/get", { id: taskId }, this.timeoutMs);
   }
 
   /** Internal: POST `tasks/cancel`. Best-effort; transport errors swallowed by caller. */
@@ -302,7 +303,16 @@ export class A2AClient {
     this._ensureOpen();
     const params: Record<string, unknown> = { id: taskId };
     if (reason !== undefined) params.reason = reason;
-    await this._postJsonRpc("tasks/cancel", params, 3, this.timeoutMs);
+    // A2A spec-conforming producers may return `{jsonrpc:"2.0",id:N}` for
+    // tasks/cancel (no result, no error) — accept that envelope shape so
+    // we don't false-fail the cancel on producers that don't echo a Task
+    // body back.
+    await this._postJsonRpc(
+      "tasks/cancel",
+      params,
+      this.timeoutMs,
+      "result-or-error",
+    );
   }
 
   /** Internal: build an `A2AResponse` from a Task envelope. */
@@ -327,13 +337,12 @@ export class A2AClient {
   private async _postJsonRpc(
     method: string,
     params: Record<string, unknown>,
-    rpcId: number,
     timeoutMs: number,
     accept: JsonRpcAcceptShape = "result-required",
   ): Promise<A2ATaskEnvelope> {
     const envelope: JsonRpcEnvelope = {
       jsonrpc: "2.0",
-      id: rpcId,
+      id: this.nextRpcId++,
       method,
       params,
     };

--- a/src/runtime/typescript/src/a2a/a2a-event.ts
+++ b/src/runtime/typescript/src/a2a/a2a-event.ts
@@ -1,0 +1,26 @@
+/**
+ * Parsed A2A v1.0 SSE event surface (issue #917).
+ *
+ * One event per `tasks/sendSubscribe` SSE frame after the JSON-RPC
+ * envelope is decoded. Mirrors `mesh._a2a_consumer.A2AEvent` (Python)
+ * and `io.mcpmesh.a2a.A2AEvent` (Java).
+ */
+
+export type A2AEventKind = "status" | "artifact";
+
+export interface A2AEvent {
+  /** "status" for TaskStatusUpdateEvent frames; "artifact" for TaskArtifactUpdateEvent frames. */
+  kind: A2AEventKind;
+  /** Lifecycle state (status frames only). */
+  state?: string;
+  /** Normalized progress in [0, 1] (status frames only, when present). */
+  progress?: number;
+  /** Status message text (status frames only, when present). */
+  message?: string;
+  /** Artifact text (artifact frames only). */
+  artifactText?: string;
+  /** True on the terminal status frame. */
+  final: boolean;
+  /** Full JSON-RPC envelope for advanced consumers. */
+  raw: unknown;
+}

--- a/src/runtime/typescript/src/a2a/a2a-job.ts
+++ b/src/runtime/typescript/src/a2a/a2a-job.ts
@@ -143,13 +143,27 @@ export class A2AJob {
     }
 
     let cancelObserved = false;
+    // ONE shared AbortController fans out the cancelPromise resolution
+    // to every per-iteration `raceSleep` listener. Without this the
+    // polling loop would attach a fresh `.then` to cancelPromise on
+    // every iteration — for a 30-min job at sub-second polling that's
+    // hundreds of accumulated handlers on a never-resolving promise,
+    // i.e. linear memory creep. AbortController makes the fan-out O(1).
+    const cancelAbort = new AbortController();
     cancelPromise
       .then(() => {
         cancelObserved = true;
+        cancelAbort.abort();
       })
-      .catch(() => {
-        // awaitJobCancel resolves on cancel/end OR rejects only when
-        // the napi binding fails — treat as no cancel.
+      .catch((err: unknown) => {
+        // awaitJobCancel resolves on cancel/end and only rejects when
+        // the napi binding itself fails. That's a real diagnostic
+        // signal (binding loss mid-job) — log at WARN so it surfaces
+        // without throwing into the polling loop.
+        console.warn(
+          `[a2a-job] bridge: awaitJobCancel observer failed for task ` +
+            `${this.taskId}: ${(err as Error)?.message ?? String(err)}`,
+        );
       });
 
     let intervalMs = this.client.pollIntervalMs;
@@ -186,7 +200,7 @@ export class A2AJob {
       // Race the sleep against the cancel signal — if cancel fires
       // mid-sleep we wake immediately and propagate on the next loop
       // iteration without wasting one more `tasks/get` round trip.
-      await raceSleep(intervalMs, cancelPromise);
+      await raceSleep(intervalMs, cancelAbort.signal);
       intervalMs = Math.min(
         this.client.pollIntervalMaxMs,
         Math.floor(intervalMs * POLL_BACKOFF_FACTOR),
@@ -282,20 +296,27 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Sleep for `ms` OR until `cancelPromise` resolves — whichever is
- * first. The cancel promise resolving wakes us early; the timer is
- * cleared in either path so we don't leak handles.
+ * Sleep for `ms` OR until `signal` aborts — whichever is first. The
+ * abort wakes us early; the timer is cleared in either path so we
+ * don't leak handles. Uses an `AbortSignal` instead of a raw promise
+ * so the polling loop can attach ONE upstream listener (the
+ * AbortController) and fan out to per-iteration `raceSleep` calls
+ * without accumulating handlers on a long-running cancelPromise.
  */
-function raceSleep(ms: number, cancelPromise: Promise<void>): Promise<void> {
+function raceSleep(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
-    let settled = false;
-    const finish = () => {
-      if (settled) return;
-      settled = true;
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const onAbort = () => {
       clearTimeout(timer);
       resolve();
     };
-    const timer = setTimeout(finish, ms);
-    cancelPromise.then(finish, finish);
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
   });
 }

--- a/src/runtime/typescript/src/a2a/a2a-job.ts
+++ b/src/runtime/typescript/src/a2a/a2a-job.ts
@@ -1,0 +1,301 @@
+/**
+ * Handle to a long-running A2A task — returned by `A2AClient.submit`
+ * (issue #917).
+ *
+ * Provides direct task lifecycle methods (`status`, `wait`, `cancel`)
+ * AND a convenience `bridge(jobController)` that mirrors A2A polling
+ * state into a mesh `JobController` for the typical
+ * `addTool({ task: true, a2aConfig: { ... } })` consumer pattern.
+ *
+ * Mirrors `mesh._a2a_consumer.A2AJob` (Python) and
+ * `io.mcpmesh.a2a.A2AJob` (Java).
+ */
+import { JobController, awaitJobCancel } from "@mcpmesh/core";
+import {
+  A2AClient,
+  type A2AResponse,
+  type A2ATaskEnvelope,
+  POLL_BACKOFF_FACTOR,
+  extractArtifactText,
+  isCanceledState,
+  isTerminalState,
+  maybeJsonParse,
+  readProgress,
+  readState,
+  readStatusMessage,
+} from "./a2a-client.js";
+import {
+  A2AJobCanceledError,
+  A2AJobFailedError,
+} from "./errors.js";
+
+export class A2AJob {
+  private readonly client: A2AClient;
+  readonly taskId: string;
+  readonly initialState: string;
+  private readonly initialResult: A2ATaskEnvelope;
+
+  constructor(
+    client: A2AClient,
+    taskId: string,
+    initialState: string,
+    initialResult: A2ATaskEnvelope,
+  ) {
+    this.client = client;
+    this.taskId = taskId;
+    this.initialState = initialState;
+    this.initialResult = initialResult;
+  }
+
+  /** POST `tasks/get` once and return the raw `result` envelope. */
+  async status(): Promise<A2ATaskEnvelope> {
+    return this.client.tasksGet(this.taskId);
+  }
+
+  /**
+   * POST `tasks/cancel`. Idempotent — already-terminal tasks should
+   * return cleanly per A2A v1.0; transport-level errors are logged
+   * and swallowed so callers can still raise `A2AJobCanceledError`
+   * or similar.
+   */
+  async cancel(reason?: string): Promise<void> {
+    try {
+      await this.client.tasksCancel(this.taskId, reason);
+    } catch (err) {
+      // Mirror the Python+Java posture (best-effort): the remote may
+      // have already terminated the task. Log and move on so callers
+      // can still raise A2AJobCanceledError or similar.
+      console.info(
+        `A2A tasks/cancel: remote raised for task ${this.taskId} on ` +
+          `${this.client.url} (may already be terminal): ` +
+          `${(err as Error)?.message ?? String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Poll `tasks/get` until terminal; return `A2AResponse` on completed.
+   *
+   * Throws `A2AJobFailedError` on `state=failed`,
+   * `A2AJobCanceledError` on `state=canceled`, `A2ATimeoutError` if
+   * the deadline elapses.
+   */
+  async wait(timeoutMs?: number): Promise<A2AResponse> {
+    const timeout = timeoutMs ?? this.client.timeoutMs;
+    if (timeout <= 0) {
+      throw new Error("A2AJob.wait: timeoutMs must be > 0");
+    }
+
+    if (isTerminalState(this.initialState)) {
+      return this._terminalToResponseOrThrow(this.initialResult);
+    }
+
+    const deadline = Date.now() + timeout;
+    let intervalMs = this.client.pollIntervalMs;
+    while (Date.now() < deadline) {
+      await sleep(Math.min(intervalMs, Math.max(1, deadline - Date.now())));
+      if (Date.now() >= deadline) break;
+      const result = await this.status();
+      const state = readState(result);
+      if (isTerminalState(state)) {
+        return this._terminalToResponseOrThrow(result);
+      }
+      intervalMs = Math.min(
+        this.client.pollIntervalMaxMs,
+        Math.floor(intervalMs * POLL_BACKOFF_FACTOR),
+      );
+    }
+
+    const { A2ATimeoutError } = await import("./errors.js");
+    throw new A2ATimeoutError(
+      `A2A task '${this.taskId}' on ${this.client.url} did not reach ` +
+        `terminal state within ${timeout}ms`,
+    );
+  }
+
+  /**
+   * Mirror A2A polling into the supplied `JobController` until terminal.
+   * Returns the final artifact value: parsed JSON when the artifact
+   * text is valid JSON, otherwise the raw text. Empty artifacts return
+   * an empty string.
+   *
+   * Cancel handling: races each iteration's sleep against
+   * `awaitJobCancel(jobId)` so a mesh-side cancel arriving DURING a
+   * sleep wakes us immediately instead of waiting for the next poll
+   * boundary. On detection POSTs `tasks/cancel` upstream so the
+   * producer stops billing for the work, then throws
+   * `A2AJobCanceledError` so the framework's `task: true` wrapper
+   * records a canceled outcome.
+   */
+  async bridge(controller: JobController): Promise<unknown> {
+    if (controller == null) {
+      throw new Error("A2AJob.bridge: controller must be non-null");
+    }
+    const jobId = controller.jobId;
+    const cancelPromise = awaitJobCancel(jobId);
+
+    const mirrorState = { lastProgress: undefined as number | undefined, lastMessage: undefined as string | undefined };
+    if (this.initialResult) {
+      await this._mirrorProgress(controller, this.initialResult, mirrorState);
+    }
+    if (isTerminalState(this.initialState)) {
+      return this._terminalToArtifactOrThrow(this.initialResult);
+    }
+
+    let cancelObserved = false;
+    cancelPromise
+      .then(() => {
+        cancelObserved = true;
+      })
+      .catch(() => {
+        // awaitJobCancel resolves on cancel/end OR rejects only when
+        // the napi binding fails — treat as no cancel.
+      });
+
+    let intervalMs = this.client.pollIntervalMs;
+    while (true) {
+      if (cancelObserved) {
+        await this._propagateCancelUpstream("mesh-side cancel");
+        throw new A2AJobCanceledError(
+          `A2A task ${this.taskId} canceled by mesh-side request`,
+        );
+      }
+
+      let result: A2ATaskEnvelope;
+      try {
+        result = await this.status();
+      } catch (err) {
+        // tasks/get itself failed (network error, HTTP 5xx, malformed
+        // envelope, ...). The upstream producer is almost certainly
+        // still running — best-effort POST tasks/cancel so it stops
+        // billing for work whose result we'll never observe.
+        await this._propagateCancelUpstream("consumer poll failed");
+        throw new A2AJobFailedError(
+          `A2A status poll failed for task ${this.taskId}: ` +
+            `${(err as Error)?.message ?? String(err)}`,
+          err,
+        );
+      }
+
+      const state = readState(result);
+      await this._mirrorProgress(controller, result, mirrorState);
+      if (isTerminalState(state)) {
+        return this._terminalToArtifactOrThrow(result);
+      }
+
+      // Race the sleep against the cancel signal — if cancel fires
+      // mid-sleep we wake immediately and propagate on the next loop
+      // iteration without wasting one more `tasks/get` round trip.
+      await raceSleep(intervalMs, cancelPromise);
+      intervalMs = Math.min(
+        this.client.pollIntervalMaxMs,
+        Math.floor(intervalMs * POLL_BACKOFF_FACTOR),
+      );
+    }
+  }
+
+  // --- helpers -------------------------------------------------------------
+
+  private async _mirrorProgress(
+    controller: JobController,
+    result: A2ATaskEnvelope,
+    state: { lastProgress: number | undefined; lastMessage: string | undefined },
+  ): Promise<void> {
+    const progress = readProgress(result);
+    const message = readStatusMessage(result);
+    if (progress === undefined && message === undefined) {
+      return;
+    }
+    if (progress === state.lastProgress && message === state.lastMessage) {
+      return;
+    }
+    // Coerce missing progress to last-known or 0.0 — the controller
+    // requires a number, but the consumer surface allows message-only
+    // events. Clamp to [0, 1] — updateProgress expects a normalized
+    // fraction; raw A2A producer progress values are advisory.
+    const rawP =
+      progress !== undefined
+        ? progress
+        : state.lastProgress !== undefined
+          ? state.lastProgress
+          : 0.0;
+    const clamped = Math.min(1.0, Math.max(0.0, rawP));
+    try {
+      await controller.updateProgress(clamped, message ?? null);
+    } catch (err) {
+      // Do NOT advance lastProgress / lastMessage on delivery failure
+      // — leaving them stale ensures the next poll's equality check
+      // sees a delta and retries the update.
+      console.warn(
+        `[a2a-job] bridge: controller.updateProgress failed ` +
+          `(task=${this.taskId}, progress=${progress}, msg=${message}) — ` +
+          `will retry on next poll: ${(err as Error)?.message ?? String(err)}`,
+      );
+      return;
+    }
+    if (progress !== undefined) state.lastProgress = progress;
+    state.lastMessage = message;
+  }
+
+  private async _propagateCancelUpstream(reason: string): Promise<void> {
+    try {
+      await this.client.tasksCancel(this.taskId, reason);
+    } catch (err) {
+      console.debug(
+        `[a2a-job] bridge: upstream cancel after ${reason} also failed ` +
+          `(task=${this.taskId}): ${(err as Error)?.message ?? String(err)}`,
+      );
+    }
+  }
+
+  private _terminalToResponseOrThrow(result: A2ATaskEnvelope): A2AResponse {
+    const state = readState(result);
+    if (state.toLowerCase() === "completed") {
+      return this.client.buildResponse(this.taskId, result);
+    }
+    const msg =
+      readStatusMessage(result) ?? `A2A task ${this.taskId} state=${state}`;
+    if (isCanceledState(state)) {
+      throw new A2AJobCanceledError(msg);
+    }
+    throw new A2AJobFailedError(msg);
+  }
+
+  private _terminalToArtifactOrThrow(result: A2ATaskEnvelope): unknown {
+    const state = readState(result);
+    if (state.toLowerCase() === "completed") {
+      const text = extractArtifactText(result);
+      if (!text) return text;
+      return maybeJsonParse(text);
+    }
+    const msg =
+      readStatusMessage(result) ?? `A2A task ${this.taskId} state=${state}`;
+    if (isCanceledState(state)) {
+      throw new A2AJobCanceledError(msg);
+    }
+    throw new A2AJobFailedError(msg);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Sleep for `ms` OR until `cancelPromise` resolves — whichever is
+ * first. The cancel promise resolving wakes us early; the timer is
+ * cleared in either path so we don't leak handles.
+ */
+function raceSleep(ms: number, cancelPromise: Promise<void>): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(finish, ms);
+    cancelPromise.then(finish, finish);
+  });
+}

--- a/src/runtime/typescript/src/a2a/a2a-job.ts
+++ b/src/runtime/typescript/src/a2a/a2a-job.ts
@@ -27,6 +27,7 @@ import {
 import {
   A2AJobCanceledError,
   A2AJobFailedError,
+  A2ATimeoutError,
 } from "./errors.js";
 
 export class A2AJob {
@@ -106,7 +107,6 @@ export class A2AJob {
       );
     }
 
-    const { A2ATimeoutError } = await import("./errors.js");
     throw new A2ATimeoutError(
       `A2A task '${this.taskId}' on ${this.client.url} did not reach ` +
         `terminal state within ${timeout}ms`,
@@ -156,14 +156,19 @@ export class A2AJob {
         cancelAbort.abort();
       })
       .catch((err: unknown) => {
-        // awaitJobCancel resolves on cancel/end and only rejects when
-        // the napi binding itself fails. That's a real diagnostic
-        // signal (binding loss mid-job) — log at WARN so it surfaces
-        // without throwing into the polling loop.
+        // awaitJobCancel rejects only when the napi binding itself
+        // fails (binding loss mid-job). If we ignored the rejection
+        // the polling loop would never observe a cancel signal and
+        // could poll the A2A backend until the user-supplied deadline.
+        // Treat as a degraded-but-recoverable cancel signal so the
+        // bridge fails fast and propagates `tasks/cancel` upstream.
         console.warn(
           `[a2a-job] bridge: awaitJobCancel observer failed for task ` +
-            `${this.taskId}: ${(err as Error)?.message ?? String(err)}`,
+            `${this.taskId} (treating as degraded cancel): ` +
+            `${(err as Error)?.message ?? String(err)}`,
         );
+        cancelObserved = true;
+        cancelAbort.abort();
       });
 
     let intervalMs = this.client.pollIntervalMs;

--- a/src/runtime/typescript/src/a2a/a2a-stream.ts
+++ b/src/runtime/typescript/src/a2a/a2a-stream.ts
@@ -126,6 +126,12 @@ export class A2AStream implements AsyncIterable<A2AEvent> {
           terminalMessage ?? `A2A task ${this.taskId} failed`,
         );
       }
+      // Parity with A2AJob._terminalToArtifactOrThrow — completed
+      // with no artifact event seen returns "" rather than throwing,
+      // matching the polling-bridge semantics.
+      if (lower === "completed" && !sawArtifact) {
+        return "";
+      }
     }
     if (!sawArtifact) {
       throw new A2AJobFailedError(

--- a/src/runtime/typescript/src/a2a/a2a-stream.ts
+++ b/src/runtime/typescript/src/a2a/a2a-stream.ts
@@ -1,0 +1,318 @@
+/**
+ * Async iterator over parsed A2A SSE events — returned by
+ * `A2AClient.subscribe` (issue #917).
+ *
+ * Implements `AsyncIterable<A2AEvent>` so callers can write
+ * `for await (const event of stream) { ... }` idiomatically.
+ * Implements TC39 `Symbol.asyncDispose` (Node 20+) for `await using`,
+ * AND exposes `aclose()` as a manual fallback for older runtimes.
+ *
+ * Per A2A v1.0, client disconnect is a transient signal — the producer
+ * continues running unless explicitly canceled. `bridge` therefore does
+ * NOT POST `tasks/cancel` upstream when the mesh-side job is cancelled
+ * (it just closes the SSE connection). Users who need cancel
+ * propagation should use `submit` + `A2AJob.bridge` instead, which
+ * polls for cancel between iterations and propagates upstream.
+ *
+ * Mirrors `mesh._a2a_consumer.A2AStream` (Python) and
+ * `io.mcpmesh.a2a.A2AStream` (Java).
+ */
+import { JobController } from "@mcpmesh/core";
+import type { A2AEvent } from "./a2a-event.js";
+import {
+  A2AJobCanceledError,
+  A2AJobFailedError,
+} from "./errors.js";
+import { maybeJsonParse } from "./a2a-client.js";
+
+const ASYNC_DISPOSE: typeof Symbol.asyncDispose | symbol =
+  (Symbol as { asyncDispose?: symbol }).asyncDispose ??
+  Symbol.for("Symbol.asyncDispose");
+
+export class A2AStream implements AsyncIterable<A2AEvent> {
+  private readonly response: Response;
+  readonly taskId: string;
+  private closed = false;
+  private reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
+  constructor(response: Response, taskId: string) {
+    this.response = response;
+    this.taskId = taskId;
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<A2AEvent> {
+    return this._iterate();
+  }
+
+  /**
+   * TC39 explicit-resource-management hook — Node 20+ supports
+   * `await using stream = await client.subscribe(...)`. The fallback
+   * below uses Symbol.for so older runtimes still surface a usable
+   * symbol on the prototype (idempotent close).
+   */
+  async [ASYNC_DISPOSE as typeof Symbol.asyncDispose](): Promise<void> {
+    await this.aclose();
+  }
+
+  /** Mirror events into a JobController; return the final artifact value. */
+  async bridge(controller: JobController): Promise<unknown> {
+    if (controller == null) {
+      throw new Error("A2AStream.bridge: controller must be non-null");
+    }
+    let lastProgress: number | undefined;
+    let lastMessage: string | undefined;
+    let artifactValue: unknown = "";
+    let sawArtifact = false;
+    let terminalState: string | undefined;
+    let terminalMessage: string | undefined;
+
+    try {
+      for await (const event of this) {
+        if (event.kind === "artifact") {
+          const text = event.artifactText ?? "";
+          artifactValue = !text ? text : maybeJsonParse(text);
+          sawArtifact = true;
+          continue;
+        }
+        if (event.progress !== undefined || event.message !== undefined) {
+          const changed =
+            event.progress !== lastProgress || event.message !== lastMessage;
+          if (changed) {
+            const rawP =
+              event.progress !== undefined
+                ? event.progress
+                : lastProgress !== undefined
+                  ? lastProgress
+                  : 0.0;
+            const clamped = Math.min(1.0, Math.max(0.0, rawP));
+            try {
+              await controller.updateProgress(clamped, event.message ?? null);
+              if (event.progress !== undefined) lastProgress = event.progress;
+              lastMessage = event.message;
+            } catch (err) {
+              // Do NOT advance lastProgress / lastMessage on delivery
+              // failure — leaving them stale ensures the next event
+              // still passes the equality check and retries.
+              console.warn(
+                `[a2a-stream] bridge: controller.updateProgress failed ` +
+                  `(task=${this.taskId}, progress=${event.progress}, ` +
+                  `msg=${event.message}) — will retry on next event: ` +
+                  `${(err as Error)?.message ?? String(err)}`,
+              );
+            }
+          }
+        }
+        if (event.final) {
+          terminalState = event.state;
+          terminalMessage = event.message;
+          break;
+        }
+      }
+    } finally {
+      // Ensure the SSE stream is closed on any exit path (normal
+      // completion, throw, etc.). aclose() is idempotent.
+      await this.aclose();
+    }
+
+    if (terminalState) {
+      const lower = terminalState.toLowerCase();
+      if (lower === "canceled" || lower === "cancelled") {
+        throw new A2AJobCanceledError(
+          terminalMessage ?? `A2A task ${this.taskId} canceled`,
+        );
+      }
+      if (lower === "failed") {
+        throw new A2AJobFailedError(
+          terminalMessage ?? `A2A task ${this.taskId} failed`,
+        );
+      }
+    }
+    if (!sawArtifact) {
+      throw new A2AJobFailedError(
+        `A2A subscribe stream ${this.taskId} ended without artifact`,
+      );
+    }
+    return artifactValue;
+  }
+
+  /**
+   * Explicit close — releases the reader lock + cancels the
+   * underlying ReadableStream so the undici Agent reclaims the
+   * connection promptly. Idempotent.
+   */
+  async aclose(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      if (this.reader) {
+        try {
+          await this.reader.cancel();
+        } catch {
+          // best-effort
+        }
+        try {
+          this.reader.releaseLock();
+        } catch {
+          // best-effort
+        }
+        this.reader = null;
+      } else if (this.response.body) {
+        try {
+          await this.response.body.cancel();
+        } catch {
+          // best-effort
+        }
+      }
+    } catch {
+      // swallow — close is best-effort
+    }
+  }
+
+  private async *_iterate(): AsyncGenerator<A2AEvent> {
+    if (this.closed) return;
+    if (!this.response.body) {
+      throw new A2AJobFailedError(
+        `A2AStream(${this.taskId}): response body is null`,
+      );
+    }
+    if (!this.reader) {
+      this.reader = this.response.body.getReader();
+    }
+    const reader = this.reader;
+    const decoder = new TextDecoder("utf-8");
+    let pending = "";
+    const dataBuf: string[] = [];
+
+    const flushEvent = (): A2AEvent | null => {
+      if (dataBuf.length === 0) return null;
+      const payload = dataBuf.join("\n");
+      dataBuf.length = 0;
+      let envelope: unknown;
+      try {
+        envelope = JSON.parse(payload);
+      } catch {
+        // Skip non-JSON SSE frames silently — matches Python behavior.
+        return null;
+      }
+      return parseSseEnvelope(envelope);
+    };
+
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        pending += decoder.decode(value, { stream: true });
+        let nlIdx: number;
+        while ((nlIdx = pending.search(/\r\n|\n/)) !== -1) {
+          // Accept both LF and CRLF line endings.
+          const isCrLf =
+            pending.charCodeAt(nlIdx) === 13 &&
+            pending.charCodeAt(nlIdx + 1) === 10;
+          const line = pending.slice(0, nlIdx);
+          pending = pending.slice(nlIdx + (isCrLf ? 2 : 1));
+          if (line === "") {
+            const event = flushEvent();
+            if (event !== null) {
+              yield event;
+              if (event.final) {
+                await this.aclose();
+                return;
+              }
+            }
+            continue;
+          }
+          if (line.startsWith(":")) {
+            // SSE comment / keepalive — ignore.
+            continue;
+          }
+          if (line.startsWith("data:")) {
+            // Strip "data:" prefix and one optional space.
+            let payload = line.slice(5);
+            if (payload.startsWith(" ")) payload = payload.slice(1);
+            dataBuf.push(payload);
+            continue;
+          }
+          // event:/id:/retry:/unknown — ignore for v1.0.
+        }
+      }
+      // Stream ended without a trailing blank — flush any pending frame.
+      pending += decoder.decode();
+      if (pending.length > 0 && pending.startsWith("data:")) {
+        let payload = pending.slice(5);
+        if (payload.startsWith(" ")) payload = payload.slice(1);
+        dataBuf.push(payload);
+      }
+      const tail = flushEvent();
+      if (tail !== null) {
+        yield tail;
+      }
+    } finally {
+      await this.aclose();
+    }
+  }
+}
+
+function parseSseEnvelope(envelope: unknown): A2AEvent | null {
+  if (!envelope || typeof envelope !== "object") return null;
+  const result = (envelope as Record<string, unknown>).result;
+  if (!result || typeof result !== "object") return null;
+  const r = result as Record<string, unknown>;
+
+  // ARTIFACT events have the "artifact" key.
+  const artifact = r.artifact;
+  if (artifact && typeof artifact === "object") {
+    const text = extractFirstTextPart(artifact as Record<string, unknown>) ?? "";
+    return {
+      kind: "artifact",
+      artifactText: text,
+      final: false,
+      raw: envelope,
+    };
+  }
+
+  // STATUS events have the "status" key.
+  const status = r.status;
+  if (status && typeof status === "object") {
+    const statusObj = status as Record<string, unknown>;
+    const stateRaw = statusObj.state;
+    const state = typeof stateRaw === "string" ? stateRaw : undefined;
+    const msgObj = statusObj.message;
+    let message: string | undefined;
+    if (msgObj && typeof msgObj === "object") {
+      message = extractFirstTextPart(msgObj as Record<string, unknown>);
+    }
+    let progress: number | undefined;
+    const metadata = r.metadata;
+    if (metadata && typeof metadata === "object") {
+      const p = (metadata as Record<string, unknown>).progress;
+      if (typeof p === "number" && Number.isFinite(p)) progress = p;
+      else if (typeof p === "string") {
+        const n = Number.parseFloat(p);
+        if (Number.isFinite(n)) progress = n;
+      }
+    }
+    const finalRaw = r.final;
+    const final = finalRaw === true;
+    return {
+      kind: "status",
+      state,
+      progress,
+      message,
+      final,
+      raw: envelope,
+    };
+  }
+
+  return null;
+}
+
+function extractFirstTextPart(
+  container: Record<string, unknown>,
+): string | undefined {
+  const parts = container.parts;
+  if (!Array.isArray(parts) || parts.length === 0) return undefined;
+  const first = parts[0];
+  if (!first || typeof first !== "object") return undefined;
+  const text = (first as Record<string, unknown>).text;
+  return typeof text === "string" ? text : undefined;
+}

--- a/src/runtime/typescript/src/a2a/errors.ts
+++ b/src/runtime/typescript/src/a2a/errors.ts
@@ -1,0 +1,50 @@
+/**
+ * Error hierarchy for the A2A consumer surface (issue #917).
+ *
+ * Mirrors `_a2a_consumer.A2AJobFailed` / `A2AJobCanceled` (Python) and
+ * `A2AException` / `A2AJobFailedException` / `A2AJobCanceledException`
+ * (Java). Each subclass sets `name` explicitly so `instanceof` works
+ * across module boundaries (ES module dual-loading, multiple SDK
+ * copies under monorepo workspaces).
+ */
+export class A2AError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = "A2AError";
+  }
+}
+
+export class A2ATimeoutError extends A2AError {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause);
+    this.name = "A2ATimeoutError";
+  }
+}
+
+export class A2AAuthError extends A2AError {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause);
+    this.name = "A2AAuthError";
+  }
+}
+
+export class A2AJobError extends A2AError {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause);
+    this.name = "A2AJobError";
+  }
+}
+
+export class A2AJobFailedError extends A2AJobError {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause);
+    this.name = "A2AJobFailedError";
+  }
+}
+
+export class A2AJobCanceledError extends A2AJobError {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause);
+    this.name = "A2AJobCanceledError";
+  }
+}

--- a/src/runtime/typescript/src/a2a/index.ts
+++ b/src/runtime/typescript/src/a2a/index.ts
@@ -1,0 +1,30 @@
+/**
+ * A2A consumer surface barrel — re-exports the public types and
+ * runtime classes the SDK consumer reaches for via
+ * `import { A2AClient, A2ABearer } from "@mcpmesh/sdk"` (issue #917).
+ */
+export {
+  A2AClient,
+  type A2AClientConfig,
+  type A2AMessage,
+  type A2AResponse,
+  type A2ATaskEnvelope,
+  DEFAULT_TIMEOUT_MS,
+  DEFAULT_POLL_INTERVAL_MS,
+  DEFAULT_POLL_INTERVAL_MAX_MS,
+  POLL_BACKOFF_FACTOR,
+  isTerminalState,
+  isCanceledState,
+} from "./a2a-client.js";
+export { A2AJob } from "./a2a-job.js";
+export { A2AStream } from "./a2a-stream.js";
+export type { A2AEvent, A2AEventKind } from "./a2a-event.js";
+export { A2ABearer, type A2ABearerConfig } from "./a2a-bearer.js";
+export {
+  A2AError,
+  A2ATimeoutError,
+  A2AAuthError,
+  A2AJobError,
+  A2AJobFailedError,
+  A2AJobCanceledError,
+} from "./errors.js";

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -213,6 +213,17 @@ export class MeshAgent {
    */
   private _a2aClients: Map<string, A2AClient> = new Map();
 
+  /**
+   * Issue #917: stable opaque IDs for `A2ABearer` instances used in
+   * the A2AClient cache key. Bearer fields are private so we cannot
+   * fingerprint by content (would also be a security risk — two
+   * tools with distinct literal tokens must NEVER share a cache
+   * entry). Identity-based keying is the safe default. `WeakMap`
+   * lets bearers be GC'd when the registering tool is removed.
+   */
+  private _bearerIds: WeakMap<A2ABearer, string> = new WeakMap();
+  private _nextBearerId = 0;
+
   constructor(server: FastMCP, config: AgentConfig) {
     if (_isWorkerMode) {
       // Worker thread: skip ALL init. Only addTool() runs (in worker-mode
@@ -898,18 +909,18 @@ export class MeshAgent {
    * Issue #917: build an `A2ABearer` (or undefined) from the
    * user-friendly auth config supported on `MeshA2AConfig.auth`. The
    * config can be either an `{ token, tokenEnv }` shorthand object OR
-   * an instance that already exposes `authorizationHeader()` (e.g. a
-   * pre-built `A2ABearer` the user constructed manually).
+   * a pre-built `A2ABearer` instance the user constructed manually.
+   *
+   * Tightened to `instanceof A2ABearer` so a stray `{ token,
+   * authorizationHeader: () => ... }` object cannot duck-type its way
+   * past A2ABearer's validation (which catches blank tokens and
+   * mutually-exclusive `token`/`tokenEnv`).
    */
   private _buildBearerFromConfig(
     auth: import("./types.js").MeshA2AConfig["auth"],
   ): A2ABearer | undefined {
     if (auth === undefined) return undefined;
-    if (typeof (auth as { authorizationHeader?: unknown })
-      .authorizationHeader === "function") {
-      // Already an A2ABearer (or duck-typed equivalent) — pass through.
-      return auth as A2ABearer;
-    }
+    if (auth instanceof A2ABearer) return auth;
     return new A2ABearer(auth as { token?: string; tokenEnv?: string });
   }
 
@@ -918,23 +929,35 @@ export class MeshAgent {
    * multiple consumer tools targeting the same backend share one
    * outbound connection pool. Auth instances participate in the cache
    * key by reference (same `A2ABearer` ref → same client); two
-   * separately-constructed bearers pointing at the same env var get
-   * separate clients (rare; correctness-preserving).
+   * separately-constructed bearers — even ones holding identical
+   * tokens — get separate clients. Identity-based keying is the safe
+   * default: A2ABearer's private fields make content-fingerprinting
+   * impossible from outside, and a content-derived key risks leaking
+   * tool-A's bearer onto tool-B's outbound traffic.
    */
+  private _bearerCacheKey(
+    bearer: A2ABearer | import("./a2a/a2a-bearer.js").A2ABearerConfig | undefined,
+  ): string {
+    if (!bearer) return "none";
+    // A2AClientConfig.auth permits a raw A2ABearerConfig too, but the
+    // call site below always normalises via `_buildBearerFromConfig`
+    // first, so in practice we only ever see real A2ABearer instances.
+    // Defensively pass-through the config-shape case as a content-free
+    // fallback key — never collide with the bearer-id namespace.
+    if (!(bearer instanceof A2ABearer)) return "raw-config";
+    let id = this._bearerIds.get(bearer);
+    if (id === undefined) {
+      id = `bearer-${this._nextBearerId++}`;
+      this._bearerIds.set(bearer, id);
+    }
+    return id;
+  }
+
   private _getOrBuildA2AClient(config: A2AClientConfig): A2AClient {
-    const authKey = config.auth
-      ? Object.prototype.hasOwnProperty.call(config.auth, "tokenEnv")
-        ? `env:${(config.auth as { tokenEnv?: string }).tokenEnv ?? ""}`
-        : `lit:${
-            (config.auth as { token?: string }).token === undefined
-              ? "?"
-              : "set"
-          }`
-      : "none";
     const key = [
       config.url,
       config.skillId,
-      authKey,
+      this._bearerCacheKey(config.auth),
       config.timeoutMs ?? "default",
       config.pollIntervalMs ?? "default",
       config.pollIntervalMaxMs ?? "default",

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -69,6 +69,11 @@ import { findAndSetBasePath } from "./template.js";
 import { getTlsOptions, getTlsConfigCached, prepareTls, cleanupTls } from "./tls-config.js";
 import { closeHttpPool } from "./http-pool.js";
 import { dispatch as poolDispatch, closePool } from "./tool-worker-pool.js";
+import {
+  A2AClient,
+  A2ABearer,
+  type A2AClientConfig,
+} from "./a2a/index.js";
 
 /**
  * Globally-set symbol that user agent code can check to detect whether it
@@ -199,6 +204,14 @@ export class MeshAgent {
    * that own no task=true tools.
    */
   private _claimDispatchers: ClaimDispatcher[] = [];
+
+  /**
+   * Issue #917: cache of `A2AClient` instances keyed by their
+   * `(url, skillId, auth, timeoutMs)` tuple so multiple consumer
+   * tools targeting the same backend share one outbound connection
+   * pool. Closed via `close()` on agent shutdown.
+   */
+  private _a2aClients: Map<string, A2AClient> = new Map();
 
   constructor(server: FastMCP, config: AgentConfig) {
     if (_isWorkerMode) {
@@ -380,6 +393,37 @@ export class MeshAgent {
       }
     }
 
+    // Issue #917: validate a2aConfig at registration time so misuse fails
+    // loud BEFORE the agent talks to the registry. Match the Python
+    // `mesh.a2a_consumer` and Java `@A2AConsumer` startup-time checks.
+    let a2aClient: A2AClient | null = null;
+    if (def.a2aConfig !== undefined) {
+      const cfg = def.a2aConfig;
+      if (!cfg.url || cfg.url.trim() === "") {
+        throw new Error(
+          `addTool({ a2aConfig }) for tool '${toolName}': url must be ` +
+            `a non-empty string.`,
+        );
+      }
+      if (cfg.timeoutMs !== undefined && cfg.timeoutMs <= 0) {
+        throw new Error(
+          `addTool({ a2aConfig }) for tool '${toolName}': timeoutMs ` +
+            `must be > 0 (got ${cfg.timeoutMs}).`,
+        );
+      }
+      if (!this._workerMode) {
+        const skillId = cfg.skillId ?? def.capability ?? toolName;
+        a2aClient = this._getOrBuildA2AClient({
+          url: cfg.url,
+          skillId,
+          auth: this._buildBearerFromConfig(cfg.auth),
+          timeoutMs: cfg.timeoutMs,
+          pollIntervalMs: cfg.pollIntervalMs,
+          pollIntervalMaxMs: cfg.pollIntervalMaxMs,
+        });
+      }
+    }
+
     // Worker mode: register the raw execute fn in the worker tool map and
     // skip FastMCP registration, dependency wiring, and metadata storage.
     // The worker entry will look up tools by name when handling dispatched
@@ -434,13 +478,7 @@ export class MeshAgent {
     // Create wrapper that injects dependencies positionally and handles tracing
     const wrappedExecute = async (
       args: z.infer<T>,
-    ): Promise<
-      | string
-      | {
-          content: Array<{ type: "text"; text: string }>;
-          structuredContent?: unknown;
-        }
-    > => {
+    ): Promise<string> => {
       // Build positional deps array using composite keys (toolName:dep_index)
       // Phase 1 MeshJob substrate (consumer-side): if meshJobDepIndex is
       // set, swap the McpMeshTool proxy at that slot for a
@@ -524,9 +562,16 @@ export class MeshAgent {
       // long-running by definition and benefit less from isolation
       // (their wall-clock time is dominated by the user's `await`s,
       // not CPU bursts that block the event loop).
+      // Issue #917: A2A consumer tools force-disable isolation along
+      // with job-bound tools. The framework-injected `A2AClient` wraps
+      // an undici dispatcher handle that cannot be cleanly serialised
+      // across the worker_threads boundary; running inline keeps the
+      // cached client + connection pool intact across calls.
+      const isA2aBound = a2aClient !== null;
       const isJobBound = isTaskTool || meshJobDepIndex !== undefined;
       const isolationEnabled =
         !isJobBound &&
+        !isA2aBound &&
         (process.env.MCP_MESH_TOOL_ISOLATION ?? "true").toLowerCase() !== "false";
 
       try {
@@ -617,6 +662,14 @@ export class MeshAgent {
                   controller,
                   meshJobParamIndex,
                 );
+                // Issue #917: append the framework-cached A2AClient as
+                // the trailing positional arg when this tool declares
+                // a2aConfig. Mirrors the producer-side JobController
+                // splice — A2AClient never participates in the
+                // ordered-deps math, it always lands last.
+                if (a2aClient !== null) {
+                  callArgs.push(a2aClient);
+                }
                 return await runWithJobContext(
                   jobId,
                   deadlineSecs,
@@ -628,26 +681,33 @@ export class MeshAgent {
                   retryOn,
                 );
               }
+              if (a2aClient !== null) {
+                return await (execute as (...a: unknown[]) => unknown)(
+                  cleanArgs,
+                  ...(depsArray as (McpMeshTool | null)[]),
+                  a2aClient,
+                );
+              }
               return await execute(cleanArgs, ...(depsArray as (McpMeshTool | null)[]));
             });
           });
         }
 
-        // Auto-serialize non-string results (like Python SDK does)
-        // This allows users to return natural types (numbers, objects, arrays)
-        // without manually calling JSON.stringify() or String()
+        // Auto-serialize non-string results (like Python SDK does).
+        // NOTE: structuredContent removed in #917 — FastMCP TS rejects it via
+        // strict zod schema (ContentResultZodSchema.strict()) even though
+        // the field is part of the MCP spec. Re-enable when FastMCP TS
+        // upstream accepts the field. Tracked in #925.
         if (typeof result === "string") {
           return result;
         } else if (result === undefined || result === null) {
           return "";
         } else {
-          // Emit MCP envelope with both content[0].text (JSON string) and
-          // structuredContent (parsed object) for parity with Python FastMCP.
-          const text = JSON.stringify(result);
-          return {
-            content: [{ type: "text", text }],
-            structuredContent: result,
-          };
+          // Return JSON-stringified text only — every consumer parses
+          // content[0].text back into an object anyway. FastMCP TS will
+          // auto-build {content: [{type: "text", text: <string>}]} from
+          // this bare string return, satisfying its strict schema.
+          return JSON.stringify(result);
         }
       } catch (err) {
         success = false;
@@ -725,6 +785,12 @@ export class MeshAgent {
           controller,
           meshJobParamIndex,
         );
+        // Issue #917: A2A consumer tools dispatched via the claim
+        // path get the same trailing A2AClient argument as the
+        // inbound HTTP path.
+        if (a2aClient !== null) {
+          callArgs.push(a2aClient);
+        }
         return await (execute as (...a: unknown[]) => unknown)(...callArgs);
       };
       this._taskHandlers.set(capability, { handler, retryOn });
@@ -757,6 +823,13 @@ export class MeshAgent {
       task: def.task === true,
       meshJobParamIndex: def.meshJobParamIndex,
       meshJobDepIndex: def.meshJobDepIndex,
+      // Issue #917: A2A consumer marker so heartbeat-build appends the
+      // surrounding agent name to the tag list before shipping to the
+      // registry. Captured here at addTool time so a downstream rename
+      // of `this.config.name` doesn't desync the registered tag.
+      a2aConsumer: def.a2aConfig !== undefined,
+      a2aAgentName:
+        def.a2aConfig !== undefined ? this.config.name : undefined,
     });
 
     return this;
@@ -819,6 +892,58 @@ export class MeshAgent {
     }
 
     return this;
+  }
+
+  /**
+   * Issue #917: build an `A2ABearer` (or undefined) from the
+   * user-friendly auth config supported on `MeshA2AConfig.auth`. The
+   * config can be either an `{ token, tokenEnv }` shorthand object OR
+   * an instance that already exposes `authorizationHeader()` (e.g. a
+   * pre-built `A2ABearer` the user constructed manually).
+   */
+  private _buildBearerFromConfig(
+    auth: import("./types.js").MeshA2AConfig["auth"],
+  ): A2ABearer | undefined {
+    if (auth === undefined) return undefined;
+    if (typeof (auth as { authorizationHeader?: unknown })
+      .authorizationHeader === "function") {
+      // Already an A2ABearer (or duck-typed equivalent) — pass through.
+      return auth as A2ABearer;
+    }
+    return new A2ABearer(auth as { token?: string; tokenEnv?: string });
+  }
+
+  /**
+   * Issue #917: cache `A2AClient` instances by their config tuple so
+   * multiple consumer tools targeting the same backend share one
+   * outbound connection pool. Auth instances participate in the cache
+   * key by reference (same `A2ABearer` ref → same client); two
+   * separately-constructed bearers pointing at the same env var get
+   * separate clients (rare; correctness-preserving).
+   */
+  private _getOrBuildA2AClient(config: A2AClientConfig): A2AClient {
+    const authKey = config.auth
+      ? Object.prototype.hasOwnProperty.call(config.auth, "tokenEnv")
+        ? `env:${(config.auth as { tokenEnv?: string }).tokenEnv ?? ""}`
+        : `lit:${
+            (config.auth as { token?: string }).token === undefined
+              ? "?"
+              : "set"
+          }`
+      : "none";
+    const key = [
+      config.url,
+      config.skillId,
+      authKey,
+      config.timeoutMs ?? "default",
+      config.pollIntervalMs ?? "default",
+      config.pollIntervalMaxMs ?? "default",
+    ].join("|");
+    const existing = this._a2aClients.get(key);
+    if (existing) return existing;
+    const client = new A2AClient(config);
+    this._a2aClients.set(key, client);
+    return client;
   }
 
   /**
@@ -1188,11 +1313,29 @@ export class MeshAgent {
           combinedWarnings.push(...r.warnings);
         }
 
+        // Issue #917: when this tool was registered with a2aConfig,
+        // append the consumer agent's name to the tag list (defensive
+        // copy — never mutate meta.tags). Skips when the agent has
+        // no name (consumer-only / nameless agent) or when the tag
+        // already appears, mirrors Java's
+        // MeshToolRegistry.injectConsumerNameTags semantics.
+        let effectiveTags = meta.tags;
+        if (meta.a2aConsumer) {
+          const agentName = meta.a2aAgentName;
+          if (
+            agentName &&
+            agentName.trim() !== "" &&
+            !meta.tags.includes(agentName)
+          ) {
+            effectiveTags = [...meta.tags, agentName];
+          }
+        }
+
         return {
           functionName: name,
           capability: meta.capability,
           version: meta.version,
-          tags: meta.tags,
+          tags: effectiveTags,
           description: meta.description,
           // Pass dependencies to Rust core for registry resolution
           // Note: tags may contain nested arrays for OR alternatives (TagSpec[])
@@ -1552,6 +1695,17 @@ export class MeshAgent {
       }
     }
     this._claimDispatchers = [];
+    // Issue #917: mark all cached A2AClients closed so any in-flight
+    // user code raises cleanly instead of reusing a torn-down instance.
+    // The undici Agent pool is shared via closeHttpPool() below.
+    for (const client of this._a2aClients.values()) {
+      try {
+        await client.close();
+      } catch (err) {
+        console.warn("[mesh-a2a] Error closing A2AClient:", err);
+      }
+    }
+    this._a2aClients.clear();
     try {
       await closeHttpPool();
     } catch (err) {

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -416,10 +416,44 @@ export class MeshAgent {
             `a non-empty string.`,
         );
       }
-      if (cfg.timeoutMs !== undefined && cfg.timeoutMs <= 0) {
+      if (cfg.timeoutMs !== undefined) {
+        if (!Number.isFinite(cfg.timeoutMs) || cfg.timeoutMs <= 0) {
+          throw new Error(
+            `addTool({ a2aConfig }) for tool '${toolName}': timeoutMs ` +
+              `must be a finite positive number (got ${cfg.timeoutMs}).`,
+          );
+        }
+      }
+      if (cfg.pollIntervalMs !== undefined) {
+        if (!Number.isFinite(cfg.pollIntervalMs) || cfg.pollIntervalMs <= 0) {
+          throw new Error(
+            `addTool({ a2aConfig }) for tool '${toolName}': ` +
+              `pollIntervalMs must be a finite positive number ` +
+              `(got ${cfg.pollIntervalMs}).`,
+          );
+        }
+      }
+      if (cfg.pollIntervalMaxMs !== undefined) {
+        if (
+          !Number.isFinite(cfg.pollIntervalMaxMs) ||
+          cfg.pollIntervalMaxMs <= 0
+        ) {
+          throw new Error(
+            `addTool({ a2aConfig }) for tool '${toolName}': ` +
+              `pollIntervalMaxMs must be a finite positive number ` +
+              `(got ${cfg.pollIntervalMaxMs}).`,
+          );
+        }
+      }
+      if (
+        cfg.pollIntervalMs !== undefined &&
+        cfg.pollIntervalMaxMs !== undefined &&
+        cfg.pollIntervalMaxMs < cfg.pollIntervalMs
+      ) {
         throw new Error(
-          `addTool({ a2aConfig }) for tool '${toolName}': timeoutMs ` +
-            `must be > 0 (got ${cfg.timeoutMs}).`,
+          `addTool({ a2aConfig }) for tool '${toolName}': ` +
+            `pollIntervalMaxMs (${cfg.pollIntervalMaxMs}) must be >= ` +
+            `pollIntervalMs (${cfg.pollIntervalMs}).`,
         );
       }
       if (!this._workerMode) {
@@ -1720,14 +1754,15 @@ export class MeshAgent {
     this._claimDispatchers = [];
     // Issue #917: mark all cached A2AClients closed so any in-flight
     // user code raises cleanly instead of reusing a torn-down instance.
-    // The undici Agent pool is shared via closeHttpPool() below.
-    for (const client of this._a2aClients.values()) {
-      try {
-        await client.close();
-      } catch (err) {
+    // Close in parallel so one slow client doesn't block the others —
+    // the undici Agent pool is shared via closeHttpPool() below.
+    const closePromises = Array.from(this._a2aClients.values()).map((client) =>
+      client.close().catch((err) => {
         console.warn("[mesh-a2a] Error closing A2AClient:", err);
-      }
-    }
+        return null;
+      }),
+    );
+    await Promise.allSettled(closePromises);
     this._a2aClients.clear();
     try {
       await closeHttpPool();

--- a/src/runtime/typescript/src/index.ts
+++ b/src/runtime/typescript/src/index.ts
@@ -305,6 +305,30 @@ export { registerCancelRoute } from "./jobs-cancel-route.js";
 // from a known job_id).
 export { JobController, JobProxy } from "@mcpmesh/core";
 
+// A2A consumer surface (issue #917) — sync send / non-blocking submit /
+// SSE subscribe + bridge. The framework constructs A2AClient instances
+// from `addTool({ a2aConfig: {...} })` and injects them into execute;
+// users only reach for these classes directly in advanced scenarios.
+export {
+  A2AClient,
+  A2AJob,
+  A2AStream,
+  A2ABearer,
+  A2AError,
+  A2ATimeoutError,
+  A2AAuthError,
+  A2AJobError,
+  A2AJobFailedError,
+  A2AJobCanceledError,
+  type A2AClientConfig,
+  type A2ABearerConfig,
+  type A2AMessage,
+  type A2AResponse,
+  type A2ATaskEnvelope,
+  type A2AEvent,
+  type A2AEventKind,
+} from "./a2a/index.js";
+
 // Types
 export type {
   AgentConfig,
@@ -352,6 +376,8 @@ export type {
   LlmProviderConfig,
   // Media parameter types
   MediaParamMeta,
+  // A2A consumer config (issue #917)
+  MeshA2AConfig,
 } from "./types.js";
 
 // Default export for convenience

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -275,6 +275,40 @@ export interface DependencyKwargs {
 }
 
 /**
+ * Per-tool A2A bridge configuration (issue #917).
+ *
+ * When set on a `MeshToolDef`, the framework constructs a per-config
+ * `A2AClient` and injects it into the user's `execute` function as the
+ * LAST positional argument (after the standard dependency proxies and
+ * — for `task: true` tools — after the `JobController`). Multiple
+ * tools sharing the same `(url, skillId, auth, timeoutMs)` tuple share
+ * one cached client so the underlying undici connection pool is
+ * amortised.
+ *
+ * The presence of `a2aConfig` ALSO opts the tool into auto-tag
+ * injection: at heartbeat-build time the framework appends the
+ * surrounding agent name to the tool's tags array so downstream
+ * resolvers can pin a specific bridge via the tag selector. Mirrors
+ * Python's `@mesh.a2a_consumer` and Java's `@A2AConsumer`.
+ */
+export interface MeshA2AConfig {
+  /** Required: A2A endpoint URL. Trailing slashes are stripped. */
+  url: string;
+  /** Optional: skill ID to invoke. Defaults to the tool's `capability`. */
+  skillId?: string;
+  /** Optional: bearer credential (instance or `{ tokenEnv }` / `{ token }` config). */
+  auth?:
+    | { token?: string; tokenEnv?: string }
+    | { authorizationHeader: () => string };
+  /** Optional: per-call deadline (ms). Default 30_000. */
+  timeoutMs?: number;
+  /** Optional: initial backoff between `tasks/get` polls (ms). Default 500. */
+  pollIntervalMs?: number;
+  /** Optional: cap on the backoff between polls (ms). Default 2_000. */
+  pollIntervalMaxMs?: number;
+}
+
+/**
  * Tool definition for MeshAgent.
  */
 export interface MeshToolDef<T extends z.ZodType = z.ZodType> {
@@ -449,6 +483,13 @@ export interface MeshToolDef<T extends z.ZodType = z.ZodType> {
    */
   dependencyKwargs?: DependencyKwargs[];
   /**
+   * Issue #917: A2A bridge configuration. When set, the framework
+   * constructs a cached `A2AClient` and injects it at the trailing
+   * positional slot of `execute` (after deps + JobController). Also
+   * opts the tool into consumer-name auto-tag injection.
+   */
+  a2aConfig?: MeshA2AConfig;
+  /**
    * Tool implementation.
    *
    * Returns any serializable value - the SDK auto-converts to string:
@@ -596,6 +637,14 @@ export interface ToolMeta {
    * whose slot should hold a MeshJobSubmitter (instead of a regular
    * McpMeshTool proxy). */
   meshJobDepIndex?: number;
+  /** Issue #917: A2A bridge marker — when true, the heartbeat-build
+   * pass appends the surrounding agent name to the tool's tags before
+   * the registry sees them. */
+  a2aConsumer?: boolean;
+  /** Issue #917: agent name captured at addTool time so the heartbeat
+   * pass injects the correct value (in case the agent is renamed via
+   * env between addTool and heartbeat). */
+  a2aAgentName?: string;
 }
 
 // ============================================================================

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/caller-agent
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/caller-agent
@@ -1,0 +1,1 @@
+../fixtures/caller-agent

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/caller-agent-report
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/caller-agent-report
@@ -1,0 +1,1 @@
+../fixtures/caller-agent-report

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/consumer-date-agent-ts
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/consumer-date-agent-ts
@@ -1,0 +1,1 @@
+../fixtures/consumer-date-agent-ts

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/consumer-date-agent-ts-b
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/consumer-date-agent-ts-b
@@ -1,0 +1,1 @@
+../fixtures/consumer-date-agent-ts-b

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/consumer-report-agent-ts
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/consumer-report-agent-ts
@@ -1,0 +1,1 @@
+../fixtures/consumer-report-agent-ts

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/consumer-report-agent-ts-sse
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/consumer-report-agent-ts-sse
@@ -1,0 +1,1 @@
+../fixtures/consumer-report-agent-ts-sse

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/date-a2a-agent
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/date-a2a-agent
@@ -1,0 +1,1 @@
+../fixtures/date-a2a-agent

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/long-task-provider
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/long-task-provider
@@ -1,0 +1,1 @@
+../fixtures/long-task-provider

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/report-a2a-agent
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/report-a2a-agent
@@ -1,0 +1,1 @@
+../fixtures/report-a2a-agent

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/system-agent
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/artifacts/system-agent
@@ -1,0 +1,1 @@
+../fixtures/system-agent

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/caller-agent
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/caller-agent
@@ -1,0 +1,1 @@
+../../uc25_a2a_consumer_python/fixtures/caller-agent

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/caller-agent-report
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/caller-agent-report
@@ -1,0 +1,1 @@
+../../uc25_a2a_consumer_python/fixtures/caller-agent-report

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "consumer-date-agent-ts-b",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "uc26 TS A2A consumer (alt) — second bridge for failover tests.",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^1.4.1",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/src/index.ts
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/src/index.ts
@@ -41,7 +41,12 @@ agent.addTool({
       role: "user",
       parts: [{ type: "text", text: "now" }],
     });
-    return JSON.parse(r.artifactText);
+    if (!r.artifactText) return "";
+    try {
+      return JSON.parse(r.artifactText);
+    } catch {
+      return r.artifactText;
+    }
   },
 });
 

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/src/index.ts
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/src/index.ts
@@ -1,0 +1,50 @@
+/**
+ * uc26 TS consumer (alt) — second bridge over the same date_a2a_agent
+ * producer at localhost:9090, but registered under
+ * `date-consumer-ts-alt` so the auto-injected consumer-name tag (via
+ * `a2aConfig`) distinguishes it from `date-consumer-ts` for failover
+ * (tc03).
+ */
+import { FastMCP, mesh, type A2AClient } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9202", 10);
+
+const server = new FastMCP({
+  name: "Date Consumer Bridge (TS alt, uc26)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "date-consumer-alt",
+  httpPort: HTTP_PORT,
+  description:
+    "uc26 TS A2A consumer (alt) — second bridge for failover tests.",
+});
+
+agent.addTool({
+  name: "current_date",
+  capability: "current-date",
+  tags: ["a2a-bridge"],
+  description: "Bridge upstream A2A get-date skill onto the mesh (alt).",
+  parameters: z.object({}),
+  a2aConfig: {
+    url: "http://localhost:9090/agents/date",
+    skillId: "get-date",
+  },
+  execute: async (_args, ..._injected) => {
+    const a2a = _injected[_injected.length - 1] as A2AClient | null;
+    if (!a2a) {
+      throw new Error("A2AClient was not injected — did you set a2aConfig?");
+    }
+    const r = await a2a.send({
+      role: "user",
+      parts: [{ type: "text", text: "now" }],
+    });
+    return JSON.parse(r.artifactText);
+  },
+});
+
+console.log(
+  `consumer-date-agent-ts-alt (uc26) defined on port ${HTTP_PORT}. Waiting for auto-start...`,
+);

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/tsconfig.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "consumer-date-agent-ts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "uc26 TypeScript A2A consumer fixture — bridges date_a2a_agent.py get-date as the current-date capability.",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^1.4.1",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/src/index.ts
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/src/index.ts
@@ -43,7 +43,12 @@ agent.addTool({
       role: "user",
       parts: [{ type: "text", text: "now" }],
     });
-    return JSON.parse(r.artifactText);
+    if (!r.artifactText) return "";
+    try {
+      return JSON.parse(r.artifactText);
+    } catch {
+      return r.artifactText;
+    }
   },
 });
 

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/src/index.ts
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/src/index.ts
@@ -1,0 +1,52 @@
+/**
+ * uc26_a2a_consumer_typescript fixture (issue #917) — bridges the
+ * existing date_a2a_agent.py producer's get-date skill onto the mesh
+ * as a current-date capability.
+ *
+ * All test agents share the tsuite container's network namespace, so
+ * the upstream A2A endpoint is reachable on localhost:9090 (NOT a
+ * docker service name).
+ */
+import { FastMCP, mesh, type A2AClient } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9201", 10);
+
+const server = new FastMCP({
+  name: "Date Consumer Bridge (TS, uc26)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "date-consumer",
+  httpPort: HTTP_PORT,
+  description:
+    "uc26 TS A2A consumer fixture — bridges date_a2a_agent.py get-date as current-date.",
+});
+
+agent.addTool({
+  name: "current_date",
+  capability: "current-date",
+  tags: ["a2a-bridge"],
+  description: "Bridge upstream A2A get-date skill onto the mesh.",
+  parameters: z.object({}),
+  a2aConfig: {
+    url: "http://localhost:9090/agents/date",
+    skillId: "get-date",
+  },
+  execute: async (_args, ..._injected) => {
+    const a2a = _injected[_injected.length - 1] as A2AClient | null;
+    if (!a2a) {
+      throw new Error("A2AClient was not injected — did you set a2aConfig?");
+    }
+    const r = await a2a.send({
+      role: "user",
+      parts: [{ type: "text", text: "now" }],
+    });
+    return JSON.parse(r.artifactText);
+  },
+});
+
+console.log(
+  `consumer-date-agent-ts (uc26) defined on port ${HTTP_PORT}. Waiting for auto-start...`,
+);

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/tsconfig.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "consumer-report-agent-ts-sse",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "uc26 TS A2A consumer (SSE bridge) — bridges generate-report via tasks/sendSubscribe as the report_sse capability.",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^1.4.1",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/src/index.ts
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/src/index.ts
@@ -10,7 +10,7 @@ import {
   mesh,
   type A2AClient,
   type MeshJob,
-  JobController,
+  type JobController,
 } from "@mcpmesh/sdk";
 import { z } from "zod";
 

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/src/index.ts
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/src/index.ts
@@ -1,0 +1,83 @@
+/**
+ * uc26 TS A2A consumer (SSE bridge) — bridges report_a2a_agent.py
+ * generate-report via the A2A tasks/sendSubscribe SSE stream as the
+ * mesh `report_sse` capability. Underscore form matches the existing
+ * caller-agent-report Python fixture so the test driver doesn't need
+ * to be re-wired.
+ */
+import {
+  FastMCP,
+  mesh,
+  type A2AClient,
+  type MeshJob,
+  JobController,
+} from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9212", 10);
+
+const server = new FastMCP({
+  name: "Report Consumer Bridge (TS, SSE, uc26)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "report-consumer-sse",
+  httpPort: HTTP_PORT,
+  description:
+    "uc26 TS A2A consumer (SSE) — bridges generate-report via the A2A SSE stream as `report_sse`.",
+});
+
+agent.addTool({
+  name: "report_sse",
+  capability: "report_sse",
+  task: true,
+  tags: ["a2a-bridge", "sse"],
+  description:
+    "Bridge upstream A2A generate-report skill via SSE as a mesh `report_sse` capability.",
+  parameters: z.object({
+    user_id: z.string(),
+    sections: z.array(z.string()),
+  }),
+  meshJobParamIndex: 1,
+  a2aConfig: {
+    url: "http://localhost:9091/agents/report",
+    skillId: "generate-report",
+  },
+  execute: async ({ user_id, sections }, ..._injected) => {
+    const job = _injected[0] as MeshJob | null;
+    const a2a = _injected[1] as A2AClient;
+    const message = {
+      role: "user",
+      parts: [
+        {
+          type: "text",
+          text: JSON.stringify({ user_id, sections }),
+        },
+      ],
+    };
+    if (!job || typeof (job as JobController).updateProgress !== "function") {
+      const stream = await a2a.subscribe(message);
+      try {
+        for await (const event of stream) {
+          if (event.kind === "artifact" && event.artifactText) {
+            try {
+              return JSON.parse(event.artifactText);
+            } catch {
+              return event.artifactText;
+            }
+          }
+        }
+      } finally {
+        await stream.aclose();
+      }
+      return "";
+    }
+    const stream = await a2a.subscribe(message);
+    return await stream.bridge(job as JobController);
+  },
+});
+
+console.log(
+  `consumer-report-agent-ts-sse (uc26) defined on port ${HTTP_PORT}.`,
+);

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/tsconfig.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "consumer-report-agent-ts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "uc26 TS A2A consumer (long-running polling) — bridges report_a2a_agent.py generate-report as the report capability.",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^1.4.1",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/src/index.ts
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/src/index.ts
@@ -1,0 +1,74 @@
+/**
+ * uc26 TS A2A consumer (long-running polling bridge) — bridges
+ * report_a2a_agent.py generate-report onto the mesh as the `report`
+ * capability so the existing Python caller-agent-report fixture can
+ * drive it without re-wiring.
+ */
+import {
+  FastMCP,
+  mesh,
+  type A2AClient,
+  type MeshJob,
+  JobController,
+} from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const HTTP_PORT = parseInt(process.env.MCP_MESH_HTTP_PORT ?? "9211", 10);
+
+const server = new FastMCP({
+  name: "Report Consumer Bridge (TS, polling, uc26)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "report-consumer",
+  httpPort: HTTP_PORT,
+  description:
+    "uc26 TS A2A consumer (polling) — bridges report_a2a_agent.py generate-report as `report`.",
+});
+
+agent.addTool({
+  name: "report",
+  capability: "report",
+  task: true,
+  tags: ["a2a-bridge"],
+  description:
+    "Bridge upstream A2A generate-report skill onto the mesh as a long-running `report` capability.",
+  parameters: z.object({
+    user_id: z.string(),
+    sections: z.array(z.string()),
+  }),
+  meshJobParamIndex: 1,
+  a2aConfig: {
+    url: "http://localhost:9091/agents/report",
+    skillId: "generate-report",
+  },
+  execute: async ({ user_id, sections }, ..._injected) => {
+    const job = _injected[0] as MeshJob | null;
+    const a2a = _injected[1] as A2AClient;
+    const message = {
+      role: "user",
+      parts: [
+        {
+          type: "text",
+          text: JSON.stringify({ user_id, sections }),
+        },
+      ],
+    };
+    if (!job || typeof (job as JobController).updateProgress !== "function") {
+      const r = await a2a.send(message);
+      if (!r.artifactText) return r.artifactText;
+      try {
+        return JSON.parse(r.artifactText);
+      } catch {
+        return r.artifactText;
+      }
+    }
+    const a2aJob = await a2a.submit(message);
+    return await a2aJob.bridge(job as JobController);
+  },
+});
+
+console.log(
+  `consumer-report-agent-ts (uc26, polling bridge) defined on port ${HTTP_PORT}.`,
+);

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/src/index.ts
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/src/index.ts
@@ -9,7 +9,7 @@ import {
   mesh,
   type A2AClient,
   type MeshJob,
-  JobController,
+  type JobController,
 } from "@mcpmesh/sdk";
 import { z } from "zod";
 

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/tsconfig.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/date-a2a-agent
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/date-a2a-agent
@@ -1,0 +1,1 @@
+../../uc25_a2a_consumer_python/fixtures/date-a2a-agent

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/long-task-provider
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/long-task-provider
@@ -1,0 +1,1 @@
+../../uc25_a2a_consumer_python/fixtures/long-task-provider

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/report-a2a-agent
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/report-a2a-agent
@@ -1,0 +1,1 @@
+../../uc25_a2a_consumer_python/fixtures/report-a2a-agent

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/system-agent
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/system-agent
@@ -1,0 +1,1 @@
+../../uc25_a2a_consumer_python/fixtures/system-agent

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/routines.yaml
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/routines.yaml
@@ -1,0 +1,54 @@
+# UC-level routines for uc26_a2a_consumer_typescript (issue #917).
+#
+# TypeScript port of uc25_a2a_consumer_python / uc27_a2a_consumer_java:
+# tests the consumer side of the A2A bridge using the TS runtime's
+# `addTool({ a2aConfig: ... })` framework-injection pattern. The
+# producer (date_a2a_agent.py / report_a2a_agent.py) and the
+# downstream caller (caller-agent / caller-agent-report) remain
+# Python — this suite exercises TS consumer registration + auto-tag
+# injection + outbound A2A round-trip + multi-consumer failover.
+#
+# Same fast-sweep registry timing as uc25/uc27 so failover (tc03)
+# takes seconds, not minutes — DEFAULT_TIMEOUT_THRESHOLD bounds how
+# quickly the registry marks a stopped consumer unhealthy so the
+# surviving consumer can pick up subsequent calls.
+
+routines:
+  start_registry_consumer:
+    description: "Start the registry with fast-sweep timing for consumer health/failover tests"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: |
+          MCP_MESH_SWEEP_INTERVAL=10s \
+          MCP_MESH_RETENTION=10s \
+          MCP_MESH_HEALTH_CHECK_INTERVAL=5 \
+          DEFAULT_TIMEOUT_THRESHOLD=15 \
+            meshctl start --registry-only -d
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "registry ready after ${i}s"
+              # Verify the sweep override actually stamped its log line.
+              # If MCP_MESH_SWEEP_INTERVAL didn't take effect the suite
+              # must fail loudly here, not via slow per-test timeouts.
+              tail -n 200 ~/.mcp-mesh/logs/registry.log \
+                | grep -qE '\[sweep\] using MCP_MESH_SWEEP_INTERVAL' \
+                || { echo "FAIL: MCP_MESH_SWEEP_INTERVAL override did not take effect"; exit 1; }
+              echo "[setup] confirmed sweep override active"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: registry did not become ready in 20s"
+          tail -50 ~/.mcp-mesh/logs/registry.log 2>/dev/null || true
+          exit 1
+        capture: registry_start
+        timeout: 30
+
+  stop_all:
+    description: "Stop all mesh processes started by this test"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: meshctl stop 2>/dev/null || true
+        ignore_errors: true

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/tc01_capability_and_tag_registration/test.yaml
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/tc01_capability_and_tag_registration/test.yaml
@@ -1,0 +1,150 @@
+# tc01_capability_and_tag_registration — TS A2A consumer registration smoke (issue #917).
+#
+# TypeScript port of uc25 tc01 / uc27 tc01. Verifies that
+# `addTool({ a2aConfig: ... })` pairs with the regular registration
+# path AND that the consumer-name auto-tag injection works
+# end-to-end:
+#
+#   - The consumer agent appears in /agents with agent_type=mcp_agent
+#     (it is a regular mesh agent that bridges A2A — NOT an A2A
+#     producer; only date-a2a-agent has agent_type=a2a here).
+#   - The current-date capability lives under the consumer's
+#     tools[*].capabilities array.
+#   - That capability's tags carry BOTH "a2a-bridge" (user-supplied
+#     via the addTool tags field) AND "date-consumer" (auto-injected
+#     from the surrounding agent name via the heartbeat-build pass —
+#     TS equivalent of Python's _resolve_pending_consumer_self_tags
+#     and Java's MeshToolRegistry.injectConsumerNameTags).
+#
+# Stack: registry + system-agent (Python, date_service on 9100) +
+# date-a2a-agent (Python A2A surface on 9090) +
+# consumer-date-agent-ts (TS consumer on 9201). The TS consumer
+# reaches the Python producer over localhost:9090 because all four
+# processes share the tsuite container's network namespace.
+
+name: "A2A consumer (TS): capability + auto-tag registration"
+description: "addTool({ a2aConfig }) publishes current-date with a2a-bridge AND auto-injected consumer-name tag"
+tags:
+  - a2a
+  - typescript
+  - smoke
+  - issue-917
+timeout: 600
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/system-agent /workspace/
+      cp -rL /uc-artifacts/date-a2a-agent /workspace/
+      cp -rL /uc-artifacts/consumer-date-agent-ts /workspace/
+
+  - name: "Install system-agent deps"
+    handler: pip-install
+    path: /workspace/system-agent
+
+  - name: "Install date-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/date-a2a-agent
+
+  - name: "Install consumer-date-agent-ts deps"
+    handler: npm-install
+    path: /workspace/consumer-date-agent-ts
+
+  - routine: start_registry_consumer
+
+  - name: "Start system-agent (port 9100, provides date_service)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start system-agent/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for system-agent registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start date-a2a-agent (port 9090)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start date-a2a-agent/main.py -d
+
+  - name: "Wait for date_service DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Start consumer-date-agent-ts (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-date-agent-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9201 -d
+
+  # TS cold-start is faster than Java (~5-10s for tsx), but with the
+  # fast-sweep registry the agent can still be marked unhealthy if
+  # the first heartbeat is delayed past DEFAULT_TIMEOUT_THRESHOLD=15s.
+  # Poll the /agents endpoint until status==healthy.
+  - name: "Wait for TS consumer to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null | jq -r \
+          '.agents[] | select(.name=="date-consumer") | .status' 2>/dev/null || echo "")
+        if [ "$STATUS" = "healthy" ]; then
+          echo "TS consumer healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: TS consumer not healthy within 120s (last status='$STATUS')"
+      meshctl logs consumer-date-agent-ts 2>&1 | tail -80 || true
+      curl -fsS --max-time 10 http://localhost:8000/agents | jq '.agents[] | select(.name=="date-consumer")' || true
+      exit 1
+    timeout: 150
+
+  - name: "Verify all 3 agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "GET /agents on the registry"
+    handler: shell
+    workdir: /workspace
+    command: curl -fsS --max-time 10 http://localhost:8000/agents
+    capture: agents_response
+    timeout: 15
+
+assertions:
+  - expr: "${captured.agent_list} contains 'system-agent'"
+    message: "system-agent should be registered"
+  - expr: "${captured.agent_list} contains 'date-a2a-agent'"
+    message: "date-a2a-agent should be registered (meshctl derives the name from the source filename)"
+  - expr: "${captured.agent_list} contains 'date-consumer'"
+    message: "TS consumer-date-agent-ts should be registered as 'date-consumer' (from mesh({ name: ... }))"
+
+  # The consumer is a REGULAR mesh agent (mcp_agent), not an A2A
+  # producer. The /agents response carries all three; the substring
+  # match below is sufficient because we already checked the names
+  # above and only one mcp_agent type is consumer-shaped.
+  - expr: "${captured.agents_response} contains '\"name\":\"date-consumer\"'"
+    message: "/agents response should include the TS consumer agent record"
+  - expr: "${captured.agents_response} contains '\"current-date\"'"
+    message: "TS consumer should publish the current-date capability"
+
+  # BOTH tags must appear scoped to the current-date capability under
+  # the date-consumer agent. Use jq to extract exactly the
+  # current-date capability's tags array — looser substring asserts on
+  # the raw response can pass even if the consumer-name tag injection
+  # didn't fire, since "date-consumer" also appears as the agent's
+  # name field.
+  - expr: "${jq:captured.agents_response:[.agents[] | select(.name==\"date-consumer\") | .capabilities[]? | select(.name==\"current-date\") | .tags[]]} contains 'a2a-bridge'"
+    message: "current-date capability should carry the user-supplied a2a-bridge tag"
+  - expr: "${jq:captured.agents_response:[.agents[] | select(.name==\"date-consumer\") | .capabilities[]? | select(.name==\"current-date\") | .tags[]]} contains 'date-consumer'"
+    message: "current-date capability should carry the auto-injected consumer-name tag (TS a2aConfig)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/tc02_end_to_end_dispatch_via_caller/test.yaml
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/tc02_end_to_end_dispatch_via_caller/test.yaml
@@ -1,0 +1,149 @@
+# tc02_end_to_end_dispatch_via_caller — full bridge round-trip (TS consumer).
+#
+# TypeScript port of uc25 tc02 / uc27 tc02. A downstream Python mesh
+# tool depending on the bridged current-date capability actually
+# reaches the producer through the TS consumer's outbound A2A
+# tasks/send call.
+#
+# Call chain:
+#   meshctl call date-caller:get_formatted_date
+#     -> caller resolves current-date dependency to TS consumer
+#     -> consumer's addTool body issues outbound
+#        POST http://localhost:9090/agents/date  (tasks/send via fetch + undici)
+#     -> date-a2a-agent's mounted handler resolves date_service
+#     -> system-agent's date_service returns the current time
+#     -> bubble back: producer artifact -> TS consumer JSON.parse
+#        -> caller returns the {"date": ...} dict
+#
+# Stack: registry + system-agent (Python) + date-a2a-agent (Python) +
+# consumer-date-agent-ts (TS) + caller-agent (Python). 5 processes.
+
+name: "A2A consumer (TS): end-to-end dispatch via downstream caller"
+description: "Caller -> TS A2A consumer bridge -> producer -> system-agent round-trip returns the date payload"
+tags:
+  - a2a
+  - typescript
+  - smoke
+  - issue-917
+timeout: 600
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/system-agent /workspace/
+      cp -rL /uc-artifacts/date-a2a-agent /workspace/
+      cp -rL /uc-artifacts/consumer-date-agent-ts /workspace/
+      cp -rL /uc-artifacts/caller-agent /workspace/
+
+  - name: "Install system-agent deps"
+    handler: pip-install
+    path: /workspace/system-agent
+
+  - name: "Install date-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/date-a2a-agent
+
+  - name: "Install consumer-date-agent-ts deps"
+    handler: npm-install
+    path: /workspace/consumer-date-agent-ts
+
+  - name: "Install caller-agent deps"
+    handler: pip-install
+    path: /workspace/caller-agent
+
+  - routine: start_registry_consumer
+
+  - name: "Start system-agent (port 9100, provides date_service)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start system-agent/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for system-agent registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start date-a2a-agent (port 9090)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start date-a2a-agent/main.py -d
+
+  - name: "Wait for date_service DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Start consumer-date-agent-ts (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-date-agent-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9201 -d
+
+  - name: "Wait for TS consumer to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null | jq -r \
+          '.agents[] | select(.name=="date-consumer") | .status' 2>/dev/null || echo "")
+        if [ "$STATUS" = "healthy" ]; then
+          echo "TS consumer healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: TS consumer not healthy within 120s (last status='$STATUS')"
+      meshctl logs consumer-date-agent-ts 2>&1 | tail -80 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start caller-agent (port 9203)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start caller-agent/main.py -d
+
+  - name: "Wait for caller current-date DI resolution"
+    handler: wait
+    seconds: 25
+
+  - name: "Verify all 4 agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Invoke caller's get_formatted_date tool"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date '{}' 2>&1
+    capture: caller_response
+    timeout: 30
+
+assertions:
+  - expr: "${captured.agent_list} contains 'system-agent'"
+    message: "system-agent should be registered"
+  - expr: "${captured.agent_list} contains 'date-consumer'"
+    message: "TS consumer-date-agent-ts should be registered as 'date-consumer'"
+  - expr: "${captured.agent_list} contains 'date-caller'"
+    message: "caller-agent should be registered"
+
+  # The producer's date_service returns a timestamp; the A2A handler
+  # wraps it as {"date": "<ts>"} which the TS consumer's JSON.parse
+  # surfaces back to a Map — meshctl call surfaces the dict in its
+  # output. We match the bare JSON key '"date":' which only appears
+  # in the successful payload, never in error envelopes.
+  - expr: "${captured.caller_response} contains '\"date\":'"
+    message: "caller response should carry the JSON 'date' key from the bridge"
+
+  # Defensive: confirm we did NOT hit the "dependency not resolved"
+  # short-circuit branch in the caller — that would mean the
+  # current-date dependency never wired up to the TS consumer.
+  - expr: "${captured.caller_response} not contains 'dependency not resolved'"
+    message: "current_date dependency must be resolved by the time the call lands"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/tc03_multi_consumer_failover/test.yaml
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/tc03_multi_consumer_failover/test.yaml
@@ -1,0 +1,245 @@
+# tc03_multi_consumer_failover — multi-consumer registration + failover (TS).
+#
+# TypeScript port of uc25 tc03 / uc27 tc03. Two TS A2A consumers
+# register the SAME current-date capability with the SAME a2a-bridge
+# tag, but under DIFFERENT agent names (date-consumer /
+# date-consumer-alt). The auto-injected consumer-name tag (via
+# `addTool({ a2aConfig })`) is what makes the two registrations
+# distinguishable for capability+tag pinning AND for the resolver's
+# untagged failover path.
+#
+# Validation strategy (two phases):
+#
+#   Phase A — pinned distinguishability:
+#     With both TS consumers up, the caller's tag-pinned tools each
+#     resolve to a SPECIFIC consumer (proven by the pinned dependency
+#     selector matching the auto-injected consumer-name tag — if the
+#     TS injection didn't work, neither pinned tool would resolve and
+#     the caller would short-circuit with "dependency not resolved").
+#
+#   Phase B — auto-rewire on consumer death:
+#     Stop the primary TS consumer (date-consumer). After the
+#     fast-sweep registry marks it unhealthy, the caller's UNTAGGED
+#     get_formatted_date dep auto-rewires to the surviving
+#     date-consumer-alt and the call still succeeds.
+#
+# Stack: registry + system-agent + date-a2a-agent + 2 TS consumers +
+# caller-agent (6 processes). Two tsx processes to boot — modest
+# timeout vs. Java's 1500s.
+
+name: "A2A consumer (TS): multi-consumer registration + auto-rewire failover"
+description: "Two TS consumers register current-date with distinct auto-tags; tag-pinning works AND untagged dep auto-rewires when one consumer dies"
+tags:
+  - a2a
+  - typescript
+  - smoke
+  - issue-917
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/system-agent /workspace/
+      cp -rL /uc-artifacts/date-a2a-agent /workspace/
+      cp -rL /uc-artifacts/consumer-date-agent-ts /workspace/
+      cp -rL /uc-artifacts/consumer-date-agent-ts-b /workspace/
+      cp -rL /uc-artifacts/caller-agent /workspace/
+
+  - name: "Install system-agent deps"
+    handler: pip-install
+    path: /workspace/system-agent
+
+  - name: "Install date-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/date-a2a-agent
+
+  - name: "Install TS consumer (primary) deps"
+    handler: npm-install
+    path: /workspace/consumer-date-agent-ts
+
+  - name: "Install TS consumer (alt) deps"
+    handler: npm-install
+    path: /workspace/consumer-date-agent-ts-b
+
+  - name: "Install caller-agent deps"
+    handler: pip-install
+    path: /workspace/caller-agent
+
+  - routine: start_registry_consumer
+
+  - name: "Start system-agent (port 9100, provides date_service)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start system-agent/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for system-agent registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start date-a2a-agent (port 9090)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start date-a2a-agent/main.py -d
+
+  - name: "Wait for date_service DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Start consumer-date-agent-ts (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-date-agent-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9201 -d
+
+  - name: "Start consumer-date-agent-ts-b (port 9202)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-date-agent-ts-b/src/index.ts --env MCP_MESH_HTTP_PORT=9202 -d
+
+  - name: "Wait for both TS consumers to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S1=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null | jq -r \
+          '.agents[] | select(.name=="date-consumer") | .status' 2>/dev/null || echo "")
+        S2=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null | jq -r \
+          '.agents[] | select(.name=="date-consumer-alt") | .status' 2>/dev/null || echo "")
+        if [ "$S1" = "healthy" ] && [ "$S2" = "healthy" ]; then
+          echo "both TS consumers healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: consumers not healthy within 120s (primary='$S1', alt='$S2')"
+      meshctl logs consumer-date-agent-ts 2>&1 | tail -50 || true
+      meshctl logs consumer-date-agent-ts-b 2>&1 | tail -50 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start caller-agent (port 9203)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start caller-agent/main.py -d
+
+  - name: "Wait for caller pinned + untagged DI resolution"
+    handler: wait
+    seconds: 25
+
+  - name: "Verify all 5 agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "GET /agents on the registry"
+    handler: shell
+    workdir: /workspace
+    command: curl -fsS --max-time 10 http://localhost:8000/agents
+    capture: agents_response_pre
+    timeout: 15
+
+  # ===== Phase A: pinned distinguishability =====
+
+  - name: "Phase A: invoke pinned-primary tool (must hit date-consumer)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date_primary '{}' 2>&1
+    capture: pinned_primary_pre
+    timeout: 30
+
+  - name: "Phase A: invoke pinned-alt tool (must hit date-consumer-alt)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date_alt '{}' 2>&1
+    capture: pinned_alt_pre
+    timeout: 30
+
+  - name: "Phase A: invoke untagged tool (any healthy consumer wins)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date '{}' 2>&1
+    capture: untagged_pre
+    timeout: 30
+
+  # ===== Phase B: kill primary consumer, verify failover =====
+
+  - name: "Phase B: stop date-consumer (primary)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl stop consumer-date-agent-ts 2>&1 || true
+    ignore_errors: true
+
+  # DEFAULT_TIMEOUT_THRESHOLD=15 + HEALTH_CHECK_INTERVAL=5 means the
+  # registry marks a non-heartbeating agent unhealthy in ~15-20s; the
+  # caller then needs another heartbeat round to pull a fresh
+  # dependency state. Bump the wait to 35s so the rewire is
+  # comfortably converged before we re-poll.
+  - name: "Phase B: wait for fast-sweep to mark primary unhealthy + caller rewire"
+    handler: wait
+    seconds: 35
+
+  - name: "Phase B: invoke pinned-alt tool again (should still succeed — its dep never moved)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date_alt '{}' 2>&1
+    capture: pinned_alt_post
+    timeout: 30
+
+  - name: "Phase B: invoke untagged tool again (auto-rewire to surviving date-consumer-alt)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call date-caller:get_formatted_date '{}' 2>&1
+    capture: untagged_post
+    timeout: 30
+
+assertions:
+  # ===== Setup sanity =====
+  - expr: "${captured.agent_list} contains 'date-consumer'"
+    message: "primary TS consumer should be registered"
+  - expr: "${captured.agent_list} contains 'date-consumer-alt'"
+    message: "alt TS consumer should be registered"
+  - expr: "${captured.agent_list} contains 'date-caller'"
+    message: "caller agent should be registered"
+
+  # Both auto-injected tags must be present in the registry response
+  # (proves the TS consumer-name auto-tag injection ran on BOTH
+  # consumers under different agent names).
+  - expr: "${captured.agents_response_pre} contains '\"date-consumer\"'"
+    message: "primary consumer-name tag should appear on its current-date capability"
+  - expr: "${captured.agents_response_pre} contains '\"date-consumer-alt\"'"
+    message: "alt consumer-name tag should appear on its current-date capability"
+
+  # ===== Phase A: pinned distinguishability =====
+  - expr: "${captured.pinned_primary_pre} contains '\"date\":'"
+    message: "pinned-primary tool should carry the JSON 'date' key from the bridge"
+  - expr: "${captured.pinned_primary_pre} not contains 'dependency not resolved'"
+    message: "pinned-primary dependency must wire up before the call"
+  - expr: "${captured.pinned_alt_pre} contains '\"date\":'"
+    message: "pinned-alt tool should carry the JSON 'date' key from the bridge"
+  - expr: "${captured.pinned_alt_pre} not contains 'dependency not resolved'"
+    message: "pinned-alt dependency must wire up before the call"
+  - expr: "${captured.untagged_pre} contains '\"date\":'"
+    message: "untagged tool should carry the JSON 'date' key from the bridge"
+  - expr: "${captured.untagged_pre} not contains 'dependency not resolved'"
+    message: "untagged dependency must wire up before the call"
+
+  # ===== Phase B: failover =====
+  - expr: "${captured.pinned_alt_post} contains '\"date\":'"
+    message: "pinned-alt tool should still carry the JSON 'date' key after primary TS consumer is killed"
+  - expr: "${captured.pinned_alt_post} not contains 'dependency not resolved'"
+    message: "pinned-alt dep should remain wired after primary consumer death"
+
+  - expr: "${captured.untagged_post} contains '\"date\":'"
+    message: "untagged tool should carry the JSON 'date' key after auto-rewire to surviving consumer"
+  - expr: "${captured.untagged_post} not contains 'dependency not resolved'"
+    message: "untagged dep should auto-rewire (not orphan) when primary TS consumer dies"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/tc04_long_running_bridge_end_to_end/test.yaml
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/tc04_long_running_bridge_end_to_end/test.yaml
@@ -1,0 +1,185 @@
+# tc04_long_running_bridge_end_to_end — Phase 3 happy path (TS).
+#
+# TypeScript port of uc25 tc04 / uc27 tc04. A downstream Python caller
+# submits a long-running mesh job against the TS consumer's bridged
+# `report` capability and awaits the result via the standard MeshJob
+# interface. The TS consumer's task=true body forwards the work to the
+# upstream Python A2A producer via A2AClient.submit(), then mirrors A2A
+# polling state into the framework-injected JobController via
+# A2AJob.bridge(controller). The caller has no idea the work is happening
+# on an A2A backend — and crucially, no idea the bridge is TypeScript.
+#
+# Stack (5 processes):
+#   1) registry
+#   2) long-task-provider (Python, port 9100) — task=True provider
+#   3) report-a2a-agent   (Python, port 9091) — A2A surface
+#   4) consumer-report-agent-ts (TS, port 9211) — bridges into mesh
+#   5) caller-agent-report (Python, port 9213) — exercises the bridge
+#
+# Asserts:
+#   - All 4 mesh agents register.
+#   - Final mesh job status = completed; producer's report payload
+#     bubbles back through TS consumer bridge to the caller.
+
+name: "A2A consumer (TS) Phase 3: long-running bridge end-to-end"
+description: "Python caller -> TS A2A consumer bridge (poll) -> Python A2A surface -> Python producer; final artifact flows back via JobController.complete()"
+tags:
+  - a2a
+  - typescript
+  - smoke
+  - issue-917
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/report-a2a-agent /workspace/
+      cp -rL /uc-artifacts/consumer-report-agent-ts /workspace/
+      cp -rL /uc-artifacts/caller-agent-report /workspace/
+
+  - name: "Install long-task-provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install report-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/report-a2a-agent
+
+  - name: "Install consumer-report-agent-ts deps"
+    handler: npm-install
+    path: /workspace/consumer-report-agent-ts
+
+  - name: "Install caller-agent-report deps"
+    handler: pip-install
+    path: /workspace/caller-agent-report
+
+  - routine: start_registry_consumer
+
+  - name: "Start long-task-provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py -d
+
+  - name: "Wait for long-task-provider registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start report-a2a-agent (port 9091)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start report-a2a-agent/main.py -d
+
+  - name: "Wait for generate_report DI resolution into the A2A surface"
+    handler: wait
+    seconds: 18
+
+  - name: "Start consumer-report-agent-ts (port 9211)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-report-agent-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9211 -d
+
+  - name: "Wait for TS consumer to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null | jq -r \
+          '.agents[] | select(.name=="report-consumer") | .status' 2>/dev/null || echo "")
+        if [ "$STATUS" = "healthy" ]; then
+          echo "TS consumer healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: TS consumer not healthy within 120s (last status='$STATUS')"
+      meshctl logs consumer-report-agent-ts 2>&1 | tail -80 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start caller-agent-report (port 9213)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start caller-agent-report/main.py -d
+
+  - name: "Wait for caller report-dep DI resolution"
+    handler: wait
+    seconds: 25
+
+  - name: "Verify all 4 mesh agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  # Submit-then-poll so the registry's HTTP proxy upstream-timeout doesn't
+  # bite the nested-task chain (mirrors uc25 tc04's pattern).
+  - name: "Submit report job via commission_report_async — return job_id immediately"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_report_async '{"user_id": "alice", "sections": ["intro", "analysis", "summary"]}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  # Nominal timing mirrors uc25 tc04 / uc27 tc04: ~5s consumer claim
+  # + ~5s producer claim + ~6s compute + bridge overhead ~= 20s. Wide
+  # buffer for parallel mode.
+  - name: "Wait for the TS bridge to drive the job to terminal"
+    handler: wait
+    seconds: 40
+
+  - name: "Read final mesh job status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
+    capture: commission_response
+    timeout: 30
+
+assertions:
+  - expr: "${captured.agent_list} contains 'long-task-provider'"
+    message: "long-task-provider should be registered"
+  - expr: "${captured.agent_list} contains 'report-a2a-agent'"
+    message: "report-a2a-agent should be registered"
+  - expr: "${captured.agent_list} contains 'report-consumer'"
+    message: "TS consumer-report-agent-ts should be registered as 'report-consumer'"
+  - expr: "${captured.agent_list} contains 'report-caller'"
+    message: "caller-agent-report should be registered as 'report-caller'"
+
+  - expr: "${captured.submit_resp} contains 'job_id'"
+    message: "submit response should carry a job_id"
+  - expr: "${captured.submit_resp} not contains 'submitter not injected'"
+    message: "report MeshJob submitter must be injected at the caller"
+
+  - expr: "${captured.commission_response} not contains '\"isError\": true'"
+    message: "__mesh_job_status should not return an MCP error envelope"
+
+  # Final status MUST be completed — the TS bridge drove the job to
+  # completion within the wait window.
+  - expr: "${captured.commission_response} contains '\"status\": \"completed\"'"
+    message: "final mesh job status should be completed (TS bridge drove it terminal)"
+
+  # Producer's complete() payload bubbles all the way back through the
+  # A2A artifact -> TS consumer JobController -> mesh registry. The
+  # canonical "Generated content for X" markers from the Python producer
+  # are the proof that the producer's tool body actually ran end-to-end.
+  - expr: "${captured.commission_response} contains 'Generated content for intro'"
+    message: "result should include the producer's intro section"
+  - expr: "${captured.commission_response} contains 'Generated content for analysis'"
+    message: "result should include the producer's analysis section"
+  - expr: "${captured.commission_response} contains 'Generated content for summary'"
+    message: "result should include the producer's summary section"
+  - expr: "${captured.commission_response} contains '\"user_id\": \"alice\"'"
+    message: "result should echo the submitted user_id"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/tc05_cancel_propagates_upstream/test.yaml
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/tc05_cancel_propagates_upstream/test.yaml
@@ -1,0 +1,166 @@
+# tc05_cancel_propagates_upstream — mesh cancel reaches A2A producer (TS).
+#
+# TypeScript port of uc25 tc05 / uc27 tc05. Caller submits a long-running
+# mesh job via the bridged `report` capability, then mid-flight calls
+# __mesh_job_cancel. The mesh job's cancel-token flips; A2AJob.bridge
+# races each iteration's sleep against awaitJobCancel(jobId) and wakes
+# immediately on cancel. It then POSTs `tasks/cancel` upstream so the
+# Python A2A producer aborts, throws A2AJobCanceledError, and the mesh
+# wrapper records the canceled outcome.
+#
+# Validation strategy mirrors uc25 tc05 / uc27 tc05:
+#   - Cancel response carries ok=true.
+#   - Final mesh job status is "cancelled" (NOT completed).
+
+name: "A2A consumer (TS) Phase 3: cancel propagates upstream and aborts the job"
+description: "Caller cancels mid-flight; TS bridge propagates tasks/cancel upstream; final mesh job state=cancelled"
+tags:
+  - a2a
+  - typescript
+  - smoke
+  - issue-917
+  - cancel
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/report-a2a-agent /workspace/
+      cp -rL /uc-artifacts/consumer-report-agent-ts /workspace/
+      cp -rL /uc-artifacts/caller-agent-report /workspace/
+
+  - name: "Install long-task-provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install report-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/report-a2a-agent
+
+  - name: "Install consumer-report-agent-ts deps"
+    handler: npm-install
+    path: /workspace/consumer-report-agent-ts
+
+  - name: "Install caller-agent-report deps"
+    handler: pip-install
+    path: /workspace/caller-agent-report
+
+  - routine: start_registry_consumer
+
+  - name: "Start long-task-provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py -d
+
+  - name: "Wait for long-task-provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start report-a2a-agent (port 9091)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start report-a2a-agent/main.py -d
+
+  - name: "Wait for generate_report DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Start consumer-report-agent-ts (port 9211)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-report-agent-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9211 -d
+
+  - name: "Wait for TS consumer to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null | jq -r \
+          '.agents[] | select(.name=="report-consumer") | .status' 2>/dev/null || echo "")
+        if [ "$STATUS" = "healthy" ]; then
+          echo "TS consumer healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: TS consumer not healthy within 120s (last status='$STATUS')"
+      meshctl logs consumer-report-agent-ts 2>&1 | tail -80 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start caller-agent-report (port 9213)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start caller-agent-report/main.py -d
+
+  - name: "Wait for caller report-dep DI resolution"
+    handler: wait
+    seconds: 25
+
+  # 8 sections × ~2s each = ~16s natural runtime — wide cancel window.
+  - name: "Submit long-running report job (~16s) — return job_id immediately"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_report_async '{"user_id":"alice","sections":["a","b","c","d","e","f","g","h"],"max_duration":120}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  # Let the consumer's bridge enter its polling loop AND the upstream
+  # producer claim + start its first sleep. TS startup is faster than
+  # Java — 4s buffer is enough.
+  - name: "Wait for bridge to enter polling loop"
+    handler: wait
+    seconds: 4
+
+  - name: "Cancel the mesh job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      echo "JOB_ID=${JOB_ID}"
+      meshctl call __mesh_job_cancel "{\"job_id\":\"${JOB_ID}\",\"reason\":\"tc05 client requested abort\"}"
+    capture: cancel_response
+    timeout: 30
+
+  # Allow cancel to propagate end-to-end:
+  #   wrapper sets cancel-token -> awaitJobCancel resolves ->
+  #   raceSleep wakes -> POST tasks/cancel upstream -> producer aborts
+  #   inner mesh job -> bridge throws A2AJobCanceledError -> wrapper
+  #   records canceled. TS races inside the sleep so the worst case is
+  #   one outstanding tasks/get's timeout (~30s); typical case ~0.5s.
+  - name: "Wait for cancel to settle through the bridge"
+    handler: wait
+    seconds: 8
+
+  - name: "Read final mesh job status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
+    capture: final_status
+    timeout: 30
+
+assertions:
+  - expr: "${captured.cancel_response} contains '\"ok\": true'"
+    message: "__mesh_job_cancel should return ok:true"
+
+  # The mesh job MUST end as cancelled, not completed — proves the TS
+  # bridge actually aborted the work before natural finish.
+  - expr: "${captured.final_status} contains '\"status\": \"cancelled\"'"
+    message: "final mesh job status field should equal cancelled"
+
+  - expr: "${captured.final_status} not contains '\"status\": \"completed\"'"
+    message: "status field must not be completed — cancel happened before natural finish"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/tc05_cancel_propagates_upstream/test.yaml
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/tc05_cancel_propagates_upstream/test.yaml
@@ -125,6 +125,11 @@ test:
     workdir: /workspace
     command: |
       JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      if [ -z "$JOB_ID" ] || [ "$JOB_ID" = "null" ]; then
+        echo "ERROR: failed to extract JOB_ID from submit response"
+        echo "submit_resp was: ${captured.submit_resp}"
+        exit 1
+      fi
       echo "JOB_ID=${JOB_ID}"
       meshctl call __mesh_job_cancel "{\"job_id\":\"${JOB_ID}\",\"reason\":\"tc05 client requested abort\"}"
     capture: cancel_response
@@ -145,6 +150,11 @@ test:
     workdir: /workspace
     command: |
       JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      if [ -z "$JOB_ID" ] || [ "$JOB_ID" = "null" ]; then
+        echo "ERROR: failed to extract JOB_ID from submit response"
+        echo "submit_resp was: ${captured.submit_resp}"
+        exit 1
+      fi
       meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
     capture: final_status
     timeout: 30

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/tc06_sse_subscribe_bridge_end_to_end/test.yaml
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/tc06_sse_subscribe_bridge_end_to_end/test.yaml
@@ -1,0 +1,176 @@
+# tc06_sse_subscribe_bridge_end_to_end — Phase 3 SSE happy path (TS).
+#
+# TypeScript port of uc25 tc06 / uc27 tc06. Same shape as uc26 tc04 but
+# the TS consumer uses A2AClient.subscribe() (SSE) instead of poll-based
+# submit/bridge. Validates A2AStream + A2AStream.bridge() helper end-to-end.
+#
+# Stack (5 processes):
+#   1) registry
+#   2) long-task-provider (Python, port 9100)
+#   3) report-a2a-agent   (Python, port 9091)
+#   4) consumer-report-agent-ts-sse (TS, port 9212) — bridges via SSE
+#   5) caller-agent-report (Python, port 9213) — depends on report-sse
+
+name: "A2A consumer (TS) Phase 3: SSE subscribe bridge end-to-end"
+description: "Caller -> SSE-based TS consumer bridge -> Python A2A surface -> Python producer; A2AStream.bridge mirrors events into JobController; final artifact returned to caller"
+tags:
+  - a2a
+  - typescript
+  - smoke
+  - issue-917
+  - sse
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/report-a2a-agent /workspace/
+      cp -rL /uc-artifacts/consumer-report-agent-ts-sse /workspace/
+      cp -rL /uc-artifacts/caller-agent-report /workspace/
+
+  - name: "Install long-task-provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install report-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/report-a2a-agent
+
+  - name: "Install consumer-report-agent-ts-sse deps"
+    handler: npm-install
+    path: /workspace/consumer-report-agent-ts-sse
+
+  - name: "Install caller-agent-report deps"
+    handler: pip-install
+    path: /workspace/caller-agent-report
+
+  - routine: start_registry_consumer
+
+  - name: "Start long-task-provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py -d
+
+  - name: "Wait for long-task-provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start report-a2a-agent (port 9091)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start report-a2a-agent/main.py -d
+
+  - name: "Wait for generate_report DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Start consumer-report-agent-ts-sse (port 9212)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-report-agent-ts-sse/src/index.ts --env MCP_MESH_HTTP_PORT=9212 -d
+
+  - name: "Wait for TS SSE consumer to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null | jq -r \
+          '.agents[] | select(.name=="report-consumer-sse") | .status' 2>/dev/null || echo "")
+        if [ "$STATUS" = "healthy" ]; then
+          echo "TS SSE consumer healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: TS SSE consumer not healthy within 120s (last status='$STATUS')"
+      meshctl logs consumer-report-agent-ts-sse 2>&1 | tail -80 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start caller-agent-report (port 9213)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start caller-agent-report/main.py -d
+
+  - name: "Wait for caller report-sse DI resolution"
+    handler: wait
+    seconds: 25
+
+  - name: "Verify all 4 mesh agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  # TS SSE fixture registers capability "report_sse" (underscore) —
+  # matches the existing Python caller-agent-report's report_sse
+  # dependency name so we can reuse the uc25 caller fixture without
+  # changes.
+
+  - name: "Submit report job via commission_report_sse_async — return job_id immediately"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_report_sse_async '{"user_id": "alice", "sections": ["intro", "analysis", "summary"]}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  # SSE bridge consistently lags polling-bridge by 5-10s due to the
+  # long-lived stream negotiation; under parallel mode add ~10s slack.
+  - name: "Wait for the SSE bridge to drive the job to terminal"
+    handler: wait
+    seconds: 50
+
+  - name: "Read final mesh job status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
+    capture: commission_response
+    timeout: 30
+
+assertions:
+  - expr: "${captured.agent_list} contains 'long-task-provider'"
+    message: "long-task-provider should be registered"
+  - expr: "${captured.agent_list} contains 'report-a2a-agent'"
+    message: "report-a2a-agent should be registered"
+  - expr: "${captured.agent_list} contains 'report-consumer-sse'"
+    message: "TS SSE consumer should be registered as 'report-consumer-sse'"
+  - expr: "${captured.agent_list} contains 'report-caller'"
+    message: "caller-agent-report should be registered as 'report-caller'"
+
+  - expr: "${captured.submit_resp} contains 'job_id'"
+    message: "submit response should carry a job_id"
+  - expr: "${captured.submit_resp} not contains 'submitter not injected'"
+    message: "report_sse MeshJob submitter must be injected at the caller"
+
+  - expr: "${captured.commission_response} not contains '\"isError\": true'"
+    message: "__mesh_job_status should not return an MCP error envelope"
+
+  # Final status MUST be completed — the SSE bridge drove it terminal.
+  - expr: "${captured.commission_response} contains '\"status\": \"completed\"'"
+    message: "final mesh job status should be completed (TS SSE bridge drove it terminal)"
+
+  # Producer's complete() payload bubbles through the A2A SSE artifact
+  # event -> TS consumer SSE bridge -> mesh JobController. Same canonical
+  # markers as tc04.
+  - expr: "${captured.commission_response} contains 'Generated content for intro'"
+    message: "result should include the intro section via the SSE bridge"
+  - expr: "${captured.commission_response} contains 'Generated content for analysis'"
+    message: "result should include the analysis section via the SSE bridge"
+  - expr: "${captured.commission_response} contains 'Generated content for summary'"
+    message: "result should include the summary section via the SSE bridge"
+  - expr: "${captured.commission_response} contains '\"user_id\": \"alice\"'"
+    message: "result should echo the submitted user_id"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/tc08_polyglot_ts_a2a_consumer_python_a2a_provider/test.yaml
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/tc08_polyglot_ts_a2a_consumer_python_a2a_provider/test.yaml
@@ -1,0 +1,164 @@
+# tc08_polyglot_ts_a2a_consumer_python_a2a_provider — explicit
+# polyglot smoke for issue #917 Phase 3.
+#
+# While tc04/tc05/tc06 ARE all polyglot by construction (TS consumer +
+# Python A2A surface + Python producer + Python caller), this dedicated
+# test is tagged "polyglot" so it shows up in the polyglot tag filter
+# alongside uc23 tc17-tc22 (the MeshJob polyglot matrix) and uc27 tc08
+# (Java polyglot). Validates the same shape as tc04 but is the
+# canonical entry-point for "TS A2A consumer can bridge a Python A2A
+# producer end-to-end".
+#
+# Stack identical to tc04 — caller submits + waits, asserts the
+# producer's payload bubbles all the way back through the TS bridge.
+
+name: "MeshA2A polyglot: TS A2A consumer commissions Python A2A provider"
+description: "TS A2AClient.submit + A2AJob.bridge -> Python A2A surface -> Python long-task-provider; Python caller observes completed report"
+tags:
+  - a2a
+  - typescript
+  - python
+  - polyglot
+  - issue-917
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts (Python provider + A2A surface + TS consumer + Python caller)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/report-a2a-agent /workspace/
+      cp -rL /uc-artifacts/consumer-report-agent-ts /workspace/
+      cp -rL /uc-artifacts/caller-agent-report /workspace/
+
+  - name: "Install long-task-provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install report-a2a-agent deps"
+    handler: pip-install
+    path: /workspace/report-a2a-agent
+
+  - name: "Install consumer-report-agent-ts deps"
+    handler: npm-install
+    path: /workspace/consumer-report-agent-ts
+
+  - name: "Install caller-agent-report deps"
+    handler: pip-install
+    path: /workspace/caller-agent-report
+
+  - routine: start_registry_consumer
+
+  - name: "Start Python long-task-provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py -d
+
+  - name: "Wait for Python provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start Python report-a2a-agent (port 9091)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start report-a2a-agent/main.py -d
+
+  - name: "Wait for generate_report DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Start TS consumer-report-agent-ts (port 9211)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-report-agent-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9211 -d
+
+  - name: "Wait for TS consumer to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null | jq -r \
+          '.agents[] | select(.name=="report-consumer") | .status' 2>/dev/null || echo "")
+        if [ "$STATUS" = "healthy" ]; then
+          echo "TS consumer healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: TS consumer not healthy within 120s (last status='$STATUS')"
+      meshctl logs consumer-report-agent-ts 2>&1 | tail -80 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start Python caller-agent-report (port 9213)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start caller-agent-report/main.py -d
+
+  - name: "Wait for caller report-dep DI resolution"
+    handler: wait
+    seconds: 25
+
+  - name: "Verify all 4 agents registered (polyglot stack)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Submit report job via Python caller's commission_report_async"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_report_async '{"user_id":"polyglot","sections":["intro","analysis"]}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  # Same nominal timing as tc04 — 2 sections × ~2s = ~4s compute +
+  # nested claim cycles ~10s + TS startup slack.
+  - name: "Wait for TS bridge to drive the polyglot job to terminal"
+    handler: wait
+    seconds: 30
+
+  - name: "Read final mesh job status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      meshctl call __mesh_job_status "{\"job_id\":\"${JOB_ID}\"}"
+    capture: commission_response
+    timeout: 30
+
+assertions:
+  - expr: "${captured.agent_list} contains 'long-task-provider'"
+    message: "Python long-task-provider should be registered"
+  - expr: "${captured.agent_list} contains 'report-a2a-agent'"
+    message: "Python report-a2a-agent should be registered"
+  - expr: "${captured.agent_list} contains 'report-consumer'"
+    message: "TS consumer-report-agent-ts should be registered as 'report-consumer'"
+  - expr: "${captured.agent_list} contains 'report-caller'"
+    message: "Python caller-agent-report should be registered as 'report-caller'"
+
+  - expr: "${captured.submit_resp} contains 'job_id'"
+    message: "Python caller MUST receive a job_id from the TS-bridged report capability"
+
+  - expr: "${captured.commission_response} contains '\"status\": \"completed\"'"
+    message: "polyglot end-to-end MUST drive the job to completed"
+
+  # Producer's payload makes it all the way back: Python producer ->
+  # Python A2A surface -> TS A2AClient -> TS A2AJob.bridge ->
+  # TS JobController.complete -> registry -> Python caller's status read.
+  - expr: "${captured.commission_response} contains 'Generated content for intro'"
+    message: "polyglot path MUST surface the Python producer's intro section"
+  - expr: "${captured.commission_response} contains 'Generated content for analysis'"
+    message: "polyglot path MUST surface the Python producer's analysis section"
+  - expr: "${captured.commission_response} contains '\"user_id\": \"polyglot\"'"
+    message: "polyglot path MUST round-trip the user_id field through every hop"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

Third runtime port of the A2A consumer arc — closes #917. Mirrors Python (#913+#914+#915) and Java (#919+#922+#924) implementations in idiomatic TypeScript. Single PR covers sync `send()` + long-running `submit()` + SSE `subscribe()` + framework-injected `A2AClient` + auto-tag + 3 examples + uc26 7-test suite + polyglot smoke.

```typescript
// Sync bridge
agent.addTool({
  name: "current_date",
  capability: "current-date",
  tags: ["a2a-bridge"],
  a2aConfig: {
    url: "http://localhost:9090/agents/date",
    skillId: "get-date",
    auth: { tokenEnv: "A2A_BEARER_TOKEN" },     // optional
  },
  execute: async (_args, ..._injected) => {
    const a2a = _injected[0] as A2AClient;        // framework-injected
    const r = await a2a.send({ message: {...} });
    return JSON.parse(r.artifactText);
  },
});

// Long-running with task=true
execute: async ({ user_id, sections }, ..._injected) => {
  const a2a = _injected[0] as A2AClient;
  const job = _injected[1] as JobController;
  const a2aJob = await a2a.submit({ message: {...} });
  return await a2aJob.bridge(job);    // mirrors A2A polling -> JobController
}

// SSE bridge
execute: async (_args, ..._injected) => {
  const a2a = _injected[0] as A2AClient;
  const job = _injected[1] as JobController;
  const stream = await a2a.subscribe({ message: {...} });
  return await stream.bridge(job);
}
```

Framework-injection model matches Python's `@mesh.a2a_consumer` and Java's refactored `@A2AConsumer` — `a2aConfig` carries config, framework constructs `A2AClient` and injects as last positional argument.

The injected-positional cast pattern is a TypeScript constraint: widening `MeshToolDef.execute`'s rest-arg union to include `A2AClient` would break every existing user agent's typed dependency parameters (`McpMeshTool | null = null` pattern). Examples + fixtures document the cast clearly.

### TS-idiomatic cancel detection
`A2AJob.bridge()` races each polling sleep against `awaitJobCancel(jobId)` via a shared `AbortController` — strictly better than Java's poll-between-iterations because cancel arriving DURING a sleep wakes immediately, not at the next iteration boundary. Mirrors Python's `asyncio.shield + CancelledError` semantics.

### SDK additions
`src/runtime/typescript/src/a2a/`:
- `A2AClient` — sync send + non-blocking submit + SSE subscribe via native fetch + undici Agents
- `A2AJob` — `status() / wait() / cancel() / bridge(JobController)`
- `A2AStream` — `AsyncIterable<A2AEvent>` + `AsyncDisposable` + `bridge()`. Custom SSE parser uses native ReadableStream + line-buffered TextDecoder
- `A2AEvent` type, `A2ABearer` auth, 6 error classes
- 47 new vitest tests + 2 BLOCKER regression tests = **561/561** unit tests pass

### agent.ts integration
- `a2aConfig` field on `MeshToolDef`
- A2AClient cache keyed by `(url, skillId, bearer-id, timeout, ...)` via `WeakMap<A2ABearer, string>` for **identity-based bearer keying** (security-critical — see Review Notes)
- Auto-tag: agent name appended to tool tags at heartbeat-build (defensive copy, idempotent via includes() check)
- Worker isolation force-disabled for A2A-bound tools (A2AClient needs main event loop's networking + cancel-watch handles)
- Cached A2AClient instances close on agent shutdown

### Bundled `structuredContent` fix (#925)
PR #897 added `structuredContent` to TS SDK envelope for Python-FastMCP parity. The MCP spec defines it as valid for tool results, but FastMCP TS validates with strict zod (`ContentResultZodSchema.strict()`) that rejects unknown keys at the dispatcher BEFORE the response leaves the process. uc26 tc02/tc03 are the FIRST tests in the project to exercise the Python-caller → TS-synchronous-tool-with-object-return path and surfaced the regression. Fix: drop `structuredContent` from wrapped execute, return JSON-stringified text only. 5 regression tests in `agent-add-tool.spec.ts`. Long-term re-enable tracked in #925 pending FastMCP TS upstream patch.

### Integration tests
`uc26_a2a_consumer_typescript`: tc01-tc06 + tc08 polyglot. tc07 deliberately omitted — same `meshctl` SIGTERM issue as Java, blocked by #920.

## Review Notes

Independent review-agent pass found **1 BLOCKER, 4 WARNINGs, 4 INFOs**. ALL BLOCKER + 3 WARNINGs + 2 trivial INFOs applied as a follow-up commit (`ae103b81`):

- **BLOCKER (security)**: A2AClient cache silently mixed up bearer tokens. `A2ABearer`'s constructor unconditionally assigns both `token` + `tokenEnv` fields → `hasOwnProperty("tokenEnv") === true` for EVERY bearer → cache key collapsed to `env:` for all bearers → tool-A's A2AClient (built with secret-A) was hit by tool-B's lookup → **tool-B's outbound HTTP carried secret-A**. Fixed via WeakMap-by-identity keying. New regression test `cache_distinguishesA2AClientsByDistinctBearerInstances` asserts two distinct bearers create two distinct clients; sibling test asserts shared bearers hit the cache.
- **WARNING**: `A2AJob.cancelPromise` observer swallowed napi rejection silently → now logs at `console.warn` for diagnostic surfacing.
- **WARNING**: `raceSleep` attached `cancelPromise.then(...)` per poll iteration → O(N) listener accumulation on long jobs. Replaced with shared `AbortController` per `bridge()` call → O(1) handlers across job lifetime.
- **WARNING**: `JobController` import-as-value used only as type → switched to `import type` in 4 files (2 examples + 2 fixtures).
- **INFO**: `_buildBearerFromConfig` tightened from duck-typing to `instanceof A2ABearer`.
- **INFO**: `agent.ts` cache-key comment expanded to explain security rationale.

1 WARNING deferred to follow-up #926 (`A2AStream` multi-iteration race — sibling of Java's deferred #921). 2 INFOs (deadline edge case, image link note) acceptable.

Closes #917
Closes #925

## Test plan

- [x] `cd src/runtime/typescript && npm run build` — clean
- [x] **561/561** TS SDK unit tests PASS (was 553 → +6 from new A2A code + structuredContent regression + 2 BLOCKER regression tests)
- [x] **12/12** src-tests PASS (image rebuilt twice — once for original PR, once for review fixes)
- [x] **7/7 uc26 at parallel 4 PASS** — including tc02/tc03 (was 5/7 before structuredContent fix; was 7/7 after; still 7/7 after BLOCKER fix)
- [x] All 3 examples + 4 fixtures `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added TypeScript A2A consumer support with classes for synchronous task execution, asynchronous job handling, and SSE-based streaming.
  * Introduced bearer token authentication for A2A connections with environment variable support.
  * Added new TypeScript examples demonstrating A2A consumer patterns including date-based and report-based consumers.
  * Extended tool configuration to support A2A upstream bridging via `a2aConfig` parameter.
  * Enabled automatic agent name tagging for A2A consumer discovery in the registry.

* **Tests**
  * Added comprehensive test coverage for A2A consumer client, job handling, streaming, and bearer authentication.
  * Added integration test suite covering capability registration, end-to-end dispatch, multi-consumer failover, long-running bridges, cancellation propagation, and polyglot scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/927)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->