### PR TITLE
feat(a2a): Java A2A producer — @MeshA2A annotation for Spring Boot apps

### DIFF
--- a/docs/a2a/overview.md
+++ b/docs/a2a/overview.md
@@ -6,7 +6,7 @@ MCP Mesh implements the [A2A v1.0 protocol](https://a2a-protocol.org/latest/spec
 
 The A2A v1.0 spec defines an HTTP + JSON-RPC envelope for cross-vendor agent calls. It deliberately stops at the protocol — capability discovery is per-card, there is no resolver, no failover, no DDDI. MCP Mesh adds those layers around A2A:
 
-- **Producer** (Python only today): `@mesh.a2a` builds the agent card automatically from `@mesh.tool` metadata; `mesh.a2a.mount(app, ...)` attaches both `/.well-known/agent.json` and the JSON-RPC entrypoint to a user-owned FastAPI app. Sync, long-running (`task=True`), and SSE handlers are all supported.
+- **Producer** (Python, Java today; TypeScript tracked in [#933](https://github.com/dhyanraj/mcp-mesh/issues/933)): the producer entry builds the agent card automatically from declared metadata and attaches both `/.well-known/agent.json` and the JSON-RPC entrypoint to a user-owned hosting framework — `mesh.a2a.mount(app, ...)` on FastAPI in Python, `@MeshA2A` on a Spring Boot bean in Java. Sync, long-running (`task=True`/`task=true`), and SSE handlers are all supported.
 - **Consumer** (Python, Java, TypeScript): a mesh capability whose body issues outbound `tasks/send` / `tasks/sendSubscribe` against a foreign A2A backend. The bridge re-publishes the upstream skill as a normal mesh capability — downstream callers do not need to know they are talking to A2A.
 
 ## The strategic value-add
@@ -20,15 +20,15 @@ Once a foreign A2A backend is bridged into the mesh as a capability, every mesh 
 
 ## Producer vs consumer
 
-| Aspect            | Producer                                              | Consumer                                                    |
-| ----------------- | ----------------------------------------------------- | ----------------------------------------------------------- |
-| Direction         | Mesh tool exposed AS A2A                              | External A2A skill bridged INTO mesh                        |
-| Decorator/marker  | `@mesh.a2a` + `mesh.a2a.mount(app, ...)` (Python)     | `@mesh.a2a_consumer` (Py) / `@A2AConsumer` (Java) / `a2aConfig` (TS) |
-| Runtime support   | Python                                                | Python, Java, TypeScript                                    |
-| Card / discovery  | Auto-generated at `/.well-known/agent.json`           | Card fetched once at scaffold time (or `--offline`)         |
-| Long-running      | Return `JobProxy`; framework parks the task           | `task=True` body submits + `bridge(JobController)`          |
-| SSE               | `tasks/sendSubscribe` handler returns `JobProxy`      | `A2AClient.subscribe(...)` + `stream.bridge(JobController)` |
-| Auth              | Bearer enforcement on the JSON-RPC route              | `A2ABearer` / `authBearerEnv` / `tokenEnv`                  |
+| Aspect            | Producer                                                                                  | Consumer                                                    |
+| ----------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| Direction         | Mesh tool exposed AS A2A                                                                  | External A2A skill bridged INTO mesh                        |
+| Decorator/marker  | `mesh.a2a.mount(app, ...)` (Py) / `@MeshA2A` (Java)                                       | `@mesh.a2a_consumer` (Py) / `@A2AConsumer` (Java) / `a2aConfig` (TS) |
+| Runtime support   | Python, Java (TypeScript tracked in [#933](https://github.com/dhyanraj/mcp-mesh/issues/933)) | Python, Java, TypeScript                                    |
+| Card / discovery  | Auto-generated at `/.well-known/agent.json`                                               | Card fetched once at scaffold time (or `--offline`)         |
+| Long-running      | Return `JobProxy`; framework parks the task                                               | `task=True` body submits + `bridge(JobController)`          |
+| SSE               | `tasks/sendSubscribe` handler returns `JobProxy`                                          | `A2AClient.subscribe(...)` + `stream.bridge(JobController)` |
+| Auth              | Bearer enforcement on the JSON-RPC route                                                  | `A2ABearer` / `authBearerEnv` / `tokenEnv`                  |
 
 ## A one-liner consumer
 
@@ -70,7 +70,7 @@ The consumer agent is a regular `@mesh.tool` capability whose body happens to wr
 
 - **A2A v1.0 protocol semantics.** Wire format, JSON-RPC envelopes, task lifecycle states — see the [A2A v1.0 spec](https://a2a-protocol.org/latest/specification/) and [JSON-RPC 2.0](https://www.jsonrpc.org/specification).
 - **Authentication schemes beyond bearer.** OAuth / mTLS are future work — Phase 1 ships bearer only ([Authentication](authentication.md)).
-- **Cross-runtime producer.** Java and TypeScript producer support is future work ([Producer (Python)](producer.md) header).
+- **TypeScript producer.** Tracked in [issue #933](https://github.com/dhyanraj/mcp-mesh/issues/933); Python and Java producers ship today ([Producer](producer.md) header).
 
 ## See also
 

--- a/docs/a2a/producer.md
+++ b/docs/a2a/producer.md
@@ -174,6 +174,7 @@ When the underlying work is long-running (`task=True` in the dependency graph), 
 
     import java.util.LinkedHashMap;
     import java.util.Map;
+    import java.util.concurrent.TimeUnit;
 
     @MeshAgent(name = "report-a2a-agent", port = 9091)
     @SpringBootApplication
@@ -208,7 +209,11 @@ When the underlying work is long-running (`task=True` in the dependency graph), 
                 Map<String, Object> payload = new LinkedHashMap<>();
                 payload.put("user_id", "alice");
                 payload.put("sections", java.util.List.of("intro", "body"));
-                JobProxy proxy = submitter.submit(payload).get();
+                // Bounded wait — submit() is a registry round-trip, NOT the
+                // long job itself. 30s is comfortable headroom; anything
+                // longer is a registry/provider problem and should surface
+                // as a failed A2A task rather than an indefinite hang.
+                JobProxy proxy = submitter.submit(payload).get(30, TimeUnit.SECONDS);
                 return proxy; // long-running mode trigger
             }
         }

--- a/docs/a2a/producer.md
+++ b/docs/a2a/producer.md
@@ -1,51 +1,109 @@
-# A2A Producer (Python)
+# A2A Producer
 
 Expose mesh tools to external A2A clients via the A2A v1.0 protocol surface.
 
-!!! info "Python only (today)"
-    Producer support ships in the Python runtime only. Java and TypeScript producer support is future work — track the A2A consumer arc for the Java/TS sides ([Consumer Quick Start](consumer-quickstart.md)).
+!!! info "Python and Java today; TypeScript is future work"
+    Producer support ships in the Python and Java runtimes. TypeScript producer support is tracked in [issue #933](https://github.com/dhyanraj/mcp-mesh/issues/933). Java consumers can still bridge a TS-hosted A2A backend via [`@A2AConsumer`](consumer-quickstart.md) in the meantime.
 
 ## Decoration and mounting
 
-A producer agent's handler is decorated/mounted via the unified entry point `@mesh.a2a.mount(app, path="/agents/<skill>", ...)`, which simultaneously:
+A producer agent's handler is decorated/mounted via a runtime-native entry point that simultaneously **stamps metadata** (skill id, name, description, tags, dependencies) and **attaches routes** (the JSON-RPC entry at `path` AND `/.well-known/agent.json` at `path/.well-known/agent.json`). The two-piece pattern is intentionally the same shape as `@mesh.route` / `@MeshRoute` for HTTP routes — same hosting framework, same lifecycle ownership, same DDDI for declared dependencies. The difference is that the producer entry registers the agent with the registry as `agent_type=a2a` (with the surfaces array populated), so other mesh agents and external scaffolding tools can discover the agent's A2A skills.
 
-1. **Stamps metadata** — applies `@mesh.a2a(...)` to the function for DI + A2A registration (capability, dependencies, skill_id, skill_name, tags). Dependencies on other mesh capabilities are declared on the decorator the same way they would be on `@mesh.tool`.
-2. **Attaches routes** — mounts both the JSON-RPC entry route at `path` AND the `/.well-known/agent.json` card route on the user-owned FastAPI app. The user owns the uvicorn lifecycle (no `@mesh.agent` decorator on the producer file).
+=== "Python"
 
-The standalone `@mesh.a2a(...)` decorator is also exposed for advanced cases (multi-app fan-out, custom mounting), but the recommended path for typical producer agents is `@mesh.a2a.mount(...)`. This is intentionally the same shape as `@mesh.route` for HTTP routes — same FastAPI mounting, same uvicorn ownership, same DDDI for declared dependencies. The difference is that `mesh.a2a.mount` registers the agent with the registry as `agent_type=a2a` (with the surfaces array populated), so other mesh agents and external scaffolding tools can discover the agent's A2A skills.
+    `@mesh.a2a.mount(app, path="/agents/<skill>", ...)` on a user-owned FastAPI app. The user owns the uvicorn lifecycle (no `@mesh.agent` decorator on the producer file).
+
+    The standalone `@mesh.a2a(...)` decorator is also exposed for advanced cases (multi-app fan-out, custom mounting), but the recommended path for typical producer agents is `@mesh.a2a.mount(...)`.
+
+=== "Java"
+
+    `@MeshA2A(path = "/agents/<skill>", ...)` on a Spring Boot bean method (sibling to `@MeshRoute`). The framework auto-mounts both routes on the application's `DispatcherServlet` — the user owns the Spring Boot lifecycle (`SpringApplication.run(...)`).
+
+    Mesh dependencies are declared via `@MeshDependency` entries on the annotation and injected at `@MeshInject` parameter slots, identical to the `@MeshRoute` DDDI path.
 
 ## Sync handler
 
 The simplest case — the upstream returns within seconds, so there is no parking. The handler returns a value; the framework wraps it as an A2A v1.0 `Task` envelope with `state=completed`, placing the JSON-stringified return as `result.artifacts[0].parts[0].text`.
 
-```python
-import mesh
-from fastapi import FastAPI
-from mesh.types import McpMeshTool
+=== "Python"
 
-app = FastAPI(title="Date A2A Agent")
+    ```python
+    import mesh
+    from fastapi import FastAPI
+    from mesh.types import McpMeshTool
 
-
-@mesh.a2a.mount(
-    app,
-    path="/agents/date",
-    dependencies=["date_service"],
-    description="Get current date/time via A2A protocol",
-    skill_id="get-date",
-    skill_name="Get Date",
-    tags=["system", "date"],
-)
-async def date_a2a(payload: dict, date_service: McpMeshTool = None):
-    if date_service is None:
-        return {"error": "date_service not yet resolved"}
-    result = await date_service()
-    return {"date": result}
+    app = FastAPI(title="Date A2A Agent")
 
 
-if __name__ == "__main__":
-    import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=9090, log_level="info")
-```
+    @mesh.a2a.mount(
+        app,
+        path="/agents/date",
+        dependencies=["date_service"],
+        description="Get current date/time via A2A protocol",
+        skill_id="get-date",
+        skill_name="Get Date",
+        tags=["system", "date"],
+    )
+    async def date_a2a(payload: dict, date_service: McpMeshTool = None):
+        if date_service is None:
+            return {"error": "date_service not yet resolved"}
+        result = await date_service()
+        return {"date": result}
+
+
+    if __name__ == "__main__":
+        import uvicorn
+        uvicorn.run(app, host="0.0.0.0", port=9090, log_level="info")
+    ```
+
+=== "Java"
+
+    ```java
+    package com.example.dateproducer;
+
+    import io.mcpmesh.MeshAgent;
+    import io.mcpmesh.spring.web.MeshA2A;
+    import io.mcpmesh.spring.web.MeshDependency;
+    import io.mcpmesh.spring.web.MeshInject;
+    import io.mcpmesh.types.McpMeshTool;
+    import org.springframework.boot.SpringApplication;
+    import org.springframework.boot.autoconfigure.SpringBootApplication;
+    import org.springframework.stereotype.Component;
+
+    import java.util.Map;
+
+    @MeshAgent(name = "date-a2a-agent", port = 9090)
+    @SpringBootApplication
+    public class ProducerDateAgentApplication {
+
+        public static void main(String[] args) {
+            SpringApplication.run(ProducerDateAgentApplication.class, args);
+        }
+
+        @Component
+        static class DateSkill {
+
+            @MeshA2A(
+                path = "/agents/date",
+                skillId = "get-date",
+                skillName = "Get Date",
+                description = "Get current date/time via A2A protocol",
+                tags = {"system", "date"},
+                dependencies = {
+                    @MeshDependency(capability = "date_service")
+                }
+            )
+            public Map<String, Object> getDate(
+                    Map<String, Object> message,
+                    @MeshInject("date_service") McpMeshTool dateService) {
+                if (dateService == null) {
+                    return Map.of("error", "date_service not yet resolved");
+                }
+                return Map.of("date", dateService.call(Map.of()));
+            }
+        }
+    }
+    ```
 
 Two routes are now live on port 9090:
 
@@ -54,48 +112,108 @@ Two routes are now live on port 9090:
 | `GET  /agents/date/.well-known/agent.json` | Auto-generated agent card (capabilities, skills, auth schemes) |
 | `POST /agents/date`                        | JSON-RPC entry — dispatches `tasks/*` methods |
 
-The card is built at agent registration time from the `@mesh.tool` metadata of declared dependencies and the `mesh.a2a.mount(...)` parameters (`skill_id`, `skill_name`, `description`, `tags`). Source: `src/runtime/python/_mcp_mesh/engine/a2a_card.py`.
+The card is built at agent registration time from the `@mesh.tool` / `@MeshA2A` metadata of declared dependencies and the producer-entry parameters (`skill_id`, `skill_name`, `description`, `tags`). Source: `src/runtime/python/_mcp_mesh/engine/a2a_card.py` (Python), `src/runtime/java/mcp-mesh-spring-boot-starter/.../MeshA2ACardBuilder.java` (Java).
 
 ## Long-running handler (`task=True`)
 
-When the underlying work is long-running (`task=True` in the dependency graph), the handler returns a `JobProxy` instead of a value. The framework parks the proxy in `_A2A_TASK_STORE` and responds to the inbound `tasks/send` immediately with `state=working` and a fresh task id. Subsequent `tasks/get` and `tasks/cancel` calls operate on the parked proxy via the underlying `MeshJob` lifecycle.
+When the underlying work is long-running (`task=True` in the dependency graph), the handler returns a `JobProxy` instead of a value. The framework parks the proxy in the A2A task store and responds to the inbound `tasks/send` immediately with `state=working` and a fresh task id. Subsequent `tasks/get` and `tasks/cancel` calls operate on the parked proxy via the underlying `MeshJob` lifecycle.
 
-```python
-import json
-import mesh
-from fastapi import FastAPI
-from mesh import MeshJob
+=== "Python"
 
-app = FastAPI(title="Report A2A Agent")
+    ```python
+    import json
+    import mesh
+    from fastapi import FastAPI
+    from mesh import MeshJob
+
+    app = FastAPI(title="Report A2A Agent")
 
 
-@mesh.a2a.mount(
-    app,
-    path="/agents/report",
-    dependencies=["generate_report"],
-    description="Generate a long-form report via A2A (task=True streaming)",
-    skill_id="generate-report",
-    skill_name="Generate Report",
-    tags=["reports", "long-running"],
-)
-async def report_a2a(payload: dict, generate_report: MeshJob = None):
-    if generate_report is None:
-        raise RuntimeError("generate_report dependency not yet resolved by mesh DI")
-
-    args = {}
-    parts = payload.get("parts") or []
-    if parts and parts[0].get("type") == "text":
-        try:
-            args = json.loads(parts[0].get("text") or "{}")
-        except json.JSONDecodeError:
-            args = {}
-
-    proxy = await generate_report.submit(
-        user_id=args.get("user_id", "anon"),
-        sections=args.get("sections") or ["overview"],
+    @mesh.a2a.mount(
+        app,
+        path="/agents/report",
+        dependencies=["generate_report"],
+        description="Generate a long-form report via A2A (task=True streaming)",
+        skill_id="generate-report",
+        skill_name="Generate Report",
+        tags=["reports", "long-running"],
     )
-    return proxy
-```
+    async def report_a2a(payload: dict, generate_report: MeshJob = None):
+        if generate_report is None:
+            raise RuntimeError("generate_report dependency not yet resolved by mesh DI")
+
+        args = {}
+        parts = payload.get("parts") or []
+        if parts and parts[0].get("type") == "text":
+            try:
+                args = json.loads(parts[0].get("text") or "{}")
+            except json.JSONDecodeError:
+                args = {}
+
+        proxy = await generate_report.submit(
+            user_id=args.get("user_id", "anon"),
+            sections=args.get("sections") or ["overview"],
+        )
+        return proxy
+    ```
+
+=== "Java"
+
+    ```java
+    package com.example.reportproducer;
+
+    import io.mcpmesh.JobProxy;
+    import io.mcpmesh.MeshAgent;
+    import io.mcpmesh.MeshJobSubmitter;
+    import io.mcpmesh.spring.MeshRuntime;
+    import io.mcpmesh.spring.web.MeshA2A;
+    import org.springframework.beans.factory.annotation.Autowired;
+    import org.springframework.boot.SpringApplication;
+    import org.springframework.boot.autoconfigure.SpringBootApplication;
+    import org.springframework.stereotype.Component;
+
+    import java.util.LinkedHashMap;
+    import java.util.Map;
+
+    @MeshAgent(name = "report-a2a-agent", port = 9091)
+    @SpringBootApplication
+    public class ProducerReportAgentApplication {
+
+        public static void main(String[] args) {
+            SpringApplication.run(ProducerReportAgentApplication.class, args);
+        }
+
+        @Component
+        static class ReportSkill {
+
+            @Autowired
+            private MeshRuntime meshRuntime;
+
+            @MeshA2A(
+                path = "/agents/report",
+                skillId = "generate-report",
+                skillName = "Generate Report",
+                description = "Generate a long-form report via A2A (task=True streaming)",
+                tags = {"reports", "long-running"}
+            )
+            public Object generateReport(Map<String, Object> message) throws Exception {
+                // @MeshA2A injects McpMeshTool proxies at parameter slots but does
+                // not (today) auto-wire MeshJobSubmitter — construct it inline from
+                // the autowired MeshRuntime. Cheap to construct, stateless after.
+                String registryUrl = meshRuntime.getAgentSpec().getRegistryUrl();
+                String agentId = meshRuntime.getAgentSpec().getAgentId();
+                MeshJobSubmitter submitter =
+                    new MeshJobSubmitter("generate_report", agentId, registryUrl);
+
+                Map<String, Object> payload = new LinkedHashMap<>();
+                payload.put("user_id", "alice");
+                payload.put("sections", java.util.List.of("intro", "body"));
+                JobProxy proxy = submitter.submit(payload).get();
+                return proxy; // long-running mode trigger
+            }
+        }
+    }
+    ```
 
 Returning the `JobProxy` switches the framework into long-running mode:
 
@@ -112,18 +230,20 @@ The producer-side handler does NOT need to be SSE-aware — write it once for `t
 
 ## Mixed-mode rejection
 
-A single Python process may NOT host both `@mesh.tool`-style capabilities and a `mesh.a2a.mount(...)` surface. The framework raises a clear error at agent boot if both are present in the same process — they have different registration paths (`@mesh.tool` goes through the standard heartbeat; `mesh.a2a.mount` registers the agent as `agent_type=a2a`), and the agent card cannot represent both shapes coherently.
+A single Python process may NOT host both `@mesh.tool`-style capabilities and a `mesh.a2a.mount(...)` surface. The framework raises a clear error at agent boot if both are present in the same process — they have different registration paths (`@mesh.tool` goes through the standard heartbeat; `mesh.a2a.mount` registers the agent as `agent_type=a2a`), and the agent card cannot represent both shapes coherently. The Java runtime allows `@MeshTool` and `@MeshA2A` to coexist in the same Spring Boot app (the registration paths share a heartbeat), but the agent advertises `agent_type=a2a` as soon as one `@MeshA2A` surface is present.
 
-If you need both: split into two agents (one `@mesh.tool`-style provider for the underlying capability, one A2A-surface agent that depends on it via `dependencies=[...]`). The `report_a2a_agent` example above is exactly this pattern — it depends on `generate_report` (provided by a separate `task=True` agent) and exposes it via A2A.
+If you need both runtimes' parallel semantics, split into two agents (one `@mesh.tool`/`@MeshTool` provider for the underlying capability, one A2A-surface agent that depends on it via the producer-entry's dependencies). The `report_a2a_agent` example above is exactly this pattern — it depends on `generate_report` (provided by a separate `task=True` agent) and exposes it via A2A.
 
 ## Authentication
 
-The producer side enforces bearer auth at the JSON-RPC route. Configure the expected token via the `auth=` parameter on `mesh.a2a.mount(...)` (Phase 1 ships bearer only — OAuth / mTLS are future work). Card auth schemes are auto-published in `/.well-known/agent.json` so consumers can scaffold against them. See [Authentication](authentication.md).
+The producer side enforces bearer auth at the JSON-RPC route. Configure the expected token via `auth="bearer"` on `mesh.a2a.mount(...)` / `@MeshA2A(...)` (Phase 1 ships bearer only — OAuth / mTLS are future work). Card auth schemes are auto-published in `/.well-known/agent.json` so consumers can scaffold against them. See [Authentication](authentication.md).
 
 ## Working examples
 
-- `examples/a2a/date_a2a_agent.py` — sync handler bridging the `date_service` capability
-- `examples/a2a/report_a2a_agent.py` — long-running + SSE handler bridging `generate_report` (`task=True`)
+- `examples/a2a/date_a2a_agent.py` — Python sync handler bridging the `date_service` capability
+- `examples/a2a/report_a2a_agent.py` — Python long-running + SSE handler bridging `generate_report` (`task=True`)
+- `examples/java/producer-date-agent/` — Java sync handler bridging the `date_service` capability via `@MeshA2A`
+- `examples/java/producer-report-agent/` — Java long-running + SSE handler bridging `generate_report` (`task=true`) via `@MeshA2A`
 
 ## See also
 

--- a/docs/a2a/surfaces-spec.md
+++ b/docs/a2a/surfaces-spec.md
@@ -1,0 +1,1170 @@
+# A2A Producer Spec (Conformance)
+
+This document codifies the on-the-wire contract that every mcp-mesh A2A
+**producer** implementation must honour, regardless of host language. It is the
+written form of behaviour currently encoded only in the Python source under
+`src/runtime/python/mesh/a2a.py` and `src/runtime/python/_mcp_mesh/engine/`.
+
+The audience is a developer building a producer SDK in a new runtime (Java,
+TypeScript, Rust, ...) who needs to emit wire-compatible cards, JSON-RPC
+responses, and SSE streams without having to read the Python source. The
+existing consumer-side parsers — `mesh._a2a_consumer.A2AStream` (Python),
+`src/runtime/typescript/src/a2a/a2a-stream.ts` (TS), and
+`io.mcpmesh.a2a.A2AStream` (Java) — are the de-facto verification harnesses:
+anything they parse, your producer must emit.
+
+Every numbered claim below cites the file:line it was derived from. If you find
+the source and this doc disagree, the source is authoritative — please open an
+issue.
+
+---
+
+## 1. Overview
+
+An **A2A producer** is a user-owned HTTP service that exposes one or more
+"skills" over the A2A v1.0 protocol (`https://a2a-protocol.org/latest/specification/`).
+Each skill is reachable at a producer-chosen path prefix `{path}` via two
+endpoints:
+
+| Method | URL                                  | Purpose                              |
+|--------|--------------------------------------|--------------------------------------|
+| `GET`  | `{path}/.well-known/agent.json`      | Returns the A2A v1.0 AgentCard JSON  |
+| `POST` | `{path}`                             | JSON-RPC 2.0 entry point for `tasks/*` methods |
+
+The producer registers itself with the mcp-mesh registry on its normal
+heartbeat envelope by setting `agent_type=a2a` and emitting an `a2a_surfaces[]`
+array (Section 2). The registry stores the array verbatim in an unconstrained
+JSONB column (`a2a_surfaces`, `src/core/ent/schema/agent.go:71-73`) and stamps
+each surface with a public FQDN derived from `MCP_MESH_PUBLIC_URL_PREFIX +
+path` (`src/core/registry/ent_handlers_a2a.go:48-61`). External A2A clients
+discover producers through `GET /a2a/agents`, which flattens every
+`a2a_surfaces[]` entry across every registered producer
+(`src/core/registry/ent_handlers_a2a.go:146-175`).
+
+This document specifies the **wire formats** the producer must emit:
+
+- the `a2a_surfaces[]` heartbeat shape (Section 2);
+- the AgentCard JSON returned from `/.well-known/agent.json` (Section 3);
+- the JSON-RPC envelopes for the five A2A v1.0 task methods (Section 4);
+- the SSE event framing and JSON shapes (Section 5);
+- the bearer-auth gate (Section 6);
+- the task lifecycle state machine (Section 7);
+- the conformance checklist (Section 9).
+
+It does **not** specify how the producer is configured, how dependencies are
+injected into the user handler, how task storage is implemented across
+replicas, or how the host HTTP framework is constructed. Those concerns are
+runtime-implementation choices.
+
+### Concept mapping across runtimes
+
+The user-facing API differs by language, but all three forms expand to the same
+wire contract:
+
+| Concept                       | Python                          | Java (planned, issue #932) | TypeScript (planned, issue #933) |
+|-------------------------------|---------------------------------|----------------------------|----------------------------------|
+| Decorator-level metadata stamp | `@mesh.a2a(path=...)`           | `@MeshA2A(path=...)`       | `mesh.a2a({path: ...})` (functional helper) |
+| Mount + DI                    | `mesh.a2a.mount(app, path=...)` | annotation processor       | `mesh.a2a()` returns a router    |
+| Source-of-truth file          | `src/runtime/python/mesh/a2a.py` | (TBD)                      | (TBD)                            |
+
+> The Python implementation is the de-facto reference. New runtimes must match
+> wire shape, NOT implementation structure.
+
+---
+
+## 2. `a2a_surfaces[]` JSON shape (registry heartbeat)
+
+### 2.1 Shape
+
+`a2a_surfaces[]` is a JSON array. Each entry describes one A2A skill the
+producer exposes. The canonical builder is
+`_mcp_mesh.engine.a2a_surfaces.collect_a2a_surfaces`
+(`src/runtime/python/_mcp_mesh/engine/a2a_surfaces.py:36-69`); the OpenAPI
+schema is `A2ASurface` in `api/mcp-mesh-registry.openapi.yaml:859-897`.
+
+| Field          | JSON type        | Required? | Semantics                                                                                  |
+|----------------|------------------|-----------|--------------------------------------------------------------------------------------------|
+| `path`         | string           | YES       | URL path prefix for this surface; must start with `/`. Example: `/agents/report-generator`. |
+| `skill_id`     | string           | YES       | A2A skill identifier, kebab-case canonical. Example: `generate-report`.                    |
+| `name`         | string           | NO        | Human-readable skill name. Only emitted when set on the decorator.                         |
+| `description`  | string           | NO        | Free-form skill description.                                                               |
+| `input_modes`  | string[]         | NO        | A2A inputModes. Defaults applied **at card-render time**, not at heartbeat emit time.      |
+| `output_modes` | string[]         | NO        | A2A outputModes. Same defaulting behaviour as `input_modes`.                               |
+| `tags`         | string[]         | NO        | Skill tags surfaced on the agent card.                                                     |
+
+The producer MUST omit optional fields rather than emit empty strings, empty
+arrays, or `null`. Reason: the registry's OpenAPI defaults
+(`input_modes: ["application/json"]`, `output_modes: ["application/json"]`)
+would be overridden with empty values if the producer emitted them
+unconditionally (`a2a_surfaces.py:44-46` is explicit about this).
+
+> ⚠️ **Implementation note**: the registry **does NOT validate** this shape on
+> ingest. The Ent schema declares the column as
+> `field.JSON("a2a_surfaces", []map[string]interface{}{}).Optional()`
+> (`src/core/ent/schema/agent.go:71-73`); the only post-load validation in
+> `buildA2ASurfaceResponses` is a check that `path` and `skill_id` are both
+> non-empty strings (`ent_handlers_a2a.go:106-110`). Any extra fields you
+> emit will be persisted and round-tripped but ignored by consumers. The
+> contract is producer ↔ consumer; the registry is a pass-through directory.
+
+### 2.2 Worked example
+
+A producer that exposes two skills (`generate-report` and `summarize`) on the
+same agent would emit:
+
+```json
+{
+  "agent_id": "report-agent-abc123",
+  "agent_type": "a2a",
+  "name": "report-agent",
+  "version": "1.0.0",
+  "http_host": "10.0.0.42",
+  "http_port": 8080,
+  "namespace": "default",
+  "timestamp": "2026-05-11T12:34:56Z",
+  "tools": [],
+  "surfaces": [
+    {
+      "path": "/agents/report-generator",
+      "skill_id": "generate-report",
+      "name": "Report Generator",
+      "description": "Generate a long-form report from structured input",
+      "input_modes": ["application/json"],
+      "output_modes": ["application/json"],
+      "tags": ["reports", "v1"]
+    },
+    {
+      "path": "/agents/summarizer",
+      "skill_id": "summarize"
+    }
+  ]
+}
+```
+
+Note that the second entry only carries the two required fields — all defaults
+materialise during card render, not on the heartbeat.
+
+### 2.3 When the producer emits this
+
+The producer SDK MUST set `agent_type = "a2a"` on the heartbeat **iff** the
+process has at least one registered `@MeshA2A` / `mesh.a2a()` surface. When the
+array is empty, `agent_type` falls back to `"mcp_agent"`
+(`heartbeat_preparation.py:375`). An agent can carry both regular `@mesh.tool`
+capabilities and A2A surfaces in the same heartbeat — `agent_type=a2a` does NOT
+mean "no mesh tools" (`heartbeat_preparation.py:372-374`).
+
+The `surfaces` key on the heartbeat envelope is OPTIONAL when empty; emit it
+only when the array has at least one entry (`heartbeat_preparation.py:388-389`).
+
+### 2.4 Registry response — public URL stamping
+
+On every heartbeat response, the registry returns a `surfaces[]` array of
+`A2ASurfaceResponse` objects (OpenAPI schema at
+`api/mcp-mesh-registry.openapi.yaml:1420-1449`):
+
+```json
+{
+  "surfaces": [
+    {
+      "path": "/agents/report-generator",
+      "skill_id": "generate-report",
+      "public_url": "https://agents.acme.com/agents/report-generator",
+      "agent_card_url": "https://agents.acme.com/agents/report-generator/.well-known/agent.json"
+    }
+  ]
+}
+```
+
+`public_url` and `agent_card_url` are empty strings when
+`MCP_MESH_PUBLIC_URL_PREFIX` is unset on the registry
+(`ent_handlers_a2a.go:50-61`); the registry logs a warn-once when that happens
+(`ent_handlers_a2a.go:128-144`). The producer SHOULD cache the stamped
+`public_url` per `(path, skill_id)` so the agent card returned from
+`/.well-known/agent.json` advertises the externally reachable FQDN rather than
+the local `http_host:http_port` (Python reference:
+`mesh/a2a.py:202-233`, `mesh/a2a.py:236-247`). When the cache is empty (first
+request before the first heartbeat round-trip, or
+`MCP_MESH_PUBLIC_URL_PREFIX` unset), fall back to
+`http://{http_host}:{http_port}{path}` — sufficient for local dev/CI
+(`mesh/a2a.py:236-247`).
+
+---
+
+## 3. Agent card (`/.well-known/agent.json`)
+
+### 3.1 URL pattern
+
+```
+GET {path}/.well-known/agent.json
+```
+
+Trailing-slash handling: the producer SHOULD treat
+`{path}` and `{path}/` as equivalent and serve the same card at both
+(`mesh/a2a.py:1459-1460` strips the trailing slash before constructing the
+card path).
+
+### 3.2 Card shape
+
+The card follows the A2A v1.0 AgentCard schema. mcp-mesh does not redefine it;
+it populates a curated subset. The canonical builder is
+`_mcp_mesh.engine.a2a_card.build_agent_card`
+(`src/runtime/python/_mcp_mesh/engine/a2a_card.py:21-111`).
+
+| Field                                | Producer behaviour                                                                                                            |
+|--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| `name` (top-level)                   | MUST emit. Defaults to `@mesh.agent(name=...)` value, falling back to `agent_id`, falling back to literal `"agent"`. (`a2a.py:340-344`) |
+| `description` (top-level)            | MUST emit. Falls back to `name` when no description is configured. (`a2a_card.py:84-85`)                                      |
+| `version`                            | MUST emit. Defaults to `"1.0.0"`. (`a2a.py:345`)                                                                              |
+| `url`                                | SHOULD emit. The producer's public `POST {path}` URL (registry-stamped public_url, with local-fallback when unset). MUST be **omitted** rather than emitted as an empty string when no URL is available — clients should fail loudly. (`a2a_card.py:97-98`) |
+| `capabilities.streaming`             | MUST emit `true`. Phase 3 always advertises streaming because `mount()` always wires both `tasks/sendSubscribe` and `tasks/resubscribe`, even for sync handlers (which stream a single artifact + terminal status). (`a2a.py:351-358`) |
+| `capabilities.pushNotifications`     | MUST emit `false`. Not supported in v1. (`a2a_card.py:89`)                                                                    |
+| `capabilities.stateTransitionHistory`| MUST emit `false`. Not supported in v1. (`a2a_card.py:90`)                                                                    |
+| `defaultInputModes`                  | MUST emit. Defaults to `["application/json"]`. Mirror of skill's `inputModes`. (`a2a.py:370-371`, `a2a_card.py:92`)            |
+| `defaultOutputModes`                 | MUST emit. Defaults to `["application/json"]`. Mirror of skill's `outputModes`. (`a2a.py:370-371`, `a2a_card.py:93`)           |
+| `skills`                             | MUST emit. v1 emits exactly one skill per card (`a2a_card.py:94`); multi-skill grouping is v2 scope.                          |
+| `skills[0].id`                       | MUST emit. The `skill_id`. (`a2a_card.py:67-68`)                                                                              |
+| `skills[0].name`                     | MUST emit. The `skill_name`; defaults to `skill_id` when unset. (`a2a.py:368`, `a2a_card.py:69`)                              |
+| `skills[0].description`              | MUST emit. Defaults to `skill_name` when no description is set. (`a2a_card.py:70`)                                            |
+| `skills[0].tags`                     | MUST emit (may be empty array). (`a2a_card.py:71`)                                                                            |
+| `skills[0].inputModes`               | MUST emit. (`a2a_card.py:72`)                                                                                                 |
+| `skills[0].outputModes`              | MUST emit. (`a2a_card.py:73`)                                                                                                 |
+| `skills[0].metadata.input_schema`    | SHOULD emit when the underlying tool's input schema is known. Optional in A2A v1.0; exposed under a metadata bag so the card stays spec-compliant. (`a2a_card.py:76-81`) |
+| `authentication.schemes`             | MUST emit. `["bearer"]` when `auth="bearer"` is configured; `[]` (empty array, NOT `"none"`) otherwise. A2A v1.0 has no `"none"` scheme. (`a2a_card.py:100-109`) |
+| `provider`, `documentationUrl`, ... | MUST NOT emit unless the producer has real values. Do not fabricate empty strings. (`a2a_card.py:11-13`)                       |
+
+### 3.3 Worked example
+
+```json
+{
+  "name": "report-agent",
+  "description": "Long-form report generation agent",
+  "version": "1.0.0",
+  "url": "https://agents.acme.com/agents/report-generator",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "defaultInputModes": ["application/json"],
+  "defaultOutputModes": ["application/json"],
+  "skills": [
+    {
+      "id": "generate-report",
+      "name": "Report Generator",
+      "description": "Generate a long-form report from structured input",
+      "tags": ["reports", "v1"],
+      "inputModes": ["application/json"],
+      "outputModes": ["application/json"],
+      "metadata": {
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "topic": {"type": "string"},
+            "max_words": {"type": "integer"}
+          },
+          "required": ["topic"]
+        }
+      }
+    }
+  ],
+  "authentication": {
+    "schemes": ["bearer"]
+  }
+}
+```
+
+---
+
+## 4. JSON-RPC method set
+
+The single `POST {path}` endpoint is a JSON-RPC 2.0 entry point with a fixed
+dispatch table. The reference dispatcher is
+`mesh/a2a.py:1202-1320`.
+
+### 4.1 Common request envelope
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": <client-chosen request id>,
+  "method": "tasks/<verb>",
+  "params": { ... }
+}
+```
+
+- `id` MAY be any JSON value the client picks. The producer MUST echo it back
+  in both success and error responses (`a2a.py:553-557`, `a2a.py:560-574`).
+- Malformed request bodies (non-JSON) return HTTP 400 + JSON-RPC error
+  `-32700 "Parse error"` (`a2a.py:1262-1273`).
+- Unknown methods return HTTP 200 + JSON-RPC error `-32601 "Method not
+  implemented: ..."` (`a2a.py:1310-1318`).
+
+### 4.2 Common task input extraction
+
+For `tasks/send` and `tasks/sendSubscribe`, the producer extracts three values
+from `params` (`a2a.py:577-591`):
+
+| Field          | Default when missing                              |
+|----------------|---------------------------------------------------|
+| `params.id`         | Fresh UUID4 string                          |
+| `params.sessionId`  | Same value as `task_id`                     |
+| `params.message`    | `{}` (empty object); non-dict values coerced |
+
+### 4.3 `tasks/send`
+
+**Synchronous request → returns a complete `Task` envelope.**
+
+#### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tasks/send",
+  "params": {
+    "id": "c-abc123",
+    "sessionId": "c-abc123",
+    "message": {
+      "role": "user",
+      "parts": [{"type": "text", "text": "Write a report on coffee."}]
+    }
+  }
+}
+```
+
+#### Response — sync handler (state=completed)
+
+When the user handler returns a value directly (no long-running submission),
+the producer wraps the return value as a single text-part artifact
+(`a2a.py:386-419`). Non-string returns are JSON-stringified with
+`default=str` so unusual types (datetime, Decimal, dataclass, set) coerce
+best-effort (`a2a.py:402-403`).
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "id": "c-abc123",
+    "sessionId": "c-abc123",
+    "status": {
+      "state": "completed",
+      "timestamp": "2026-05-11T12:34:56Z"
+    },
+    "artifacts": [
+      {
+        "name": "result",
+        "parts": [{"type": "text", "text": "Coffee is a beverage..."}],
+        "index": 0
+      }
+    ],
+    "history": [
+      {"role": "user", "parts": [{"type": "text", "text": "Write a report on coffee."}]}
+    ]
+  }
+}
+```
+
+#### Response — long-running handler (state=working)
+
+When the handler dispatches a background job (Python: returns a `JobProxy`
+instance), the producer parks the job in its task store and responds
+immediately with `state="working"` and an empty `artifacts[]`
+(`a2a.py:450-482`, `a2a.py:654-682`). The client then polls `tasks/get` or
+subscribes via `tasks/sendSubscribe`/`tasks/resubscribe`.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "id": "c-abc123",
+    "sessionId": "c-abc123",
+    "status": {
+      "state": "working",
+      "timestamp": "2026-05-11T12:34:56Z"
+    },
+    "artifacts": [],
+    "history": [
+      {"role": "user", "parts": [{"type": "text", "text": "..."}]}
+    ]
+  }
+}
+```
+
+> ⚠️ **Implementation note**: Python detects "long-running" by checking the
+> handler return type for `mcp_mesh_core.JobProxy` (`a2a.py:125-139`,
+> `a2a.py:654`). New runtimes need an equivalent type-based signal — do NOT
+> rely on the underlying tool's `task=True` metadata, because cross-agent
+> dependencies make that flag invisible (`a2a.py:265-289` documents why).
+
+#### Response — handler raised (state=failed)
+
+Per A2A v1.0, handler exceptions become `state=failed` Tasks, NOT JSON-RPC
+errors. JSON-RPC errors are reserved for protocol-level issues
+(`a2a.py:422-447`, `a2a.py:641-652`).
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "id": "c-abc123",
+    "sessionId": "c-abc123",
+    "status": {
+      "state": "failed",
+      "timestamp": "2026-05-11T12:34:56Z",
+      "message": {
+        "role": "agent",
+        "parts": [{"type": "text", "text": "Topic required"}]
+      }
+    },
+    "artifacts": [],
+    "history": [ ... ]
+  }
+}
+```
+
+#### Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant C as A2A Client
+    participant P as Producer (POST {path})
+    participant H as User Handler
+
+    C->>P: POST {jsonrpc, id, method=tasks/send, params={id, message}}
+    P->>P: extract (task_id, session_id, message); default id=UUID4
+    P->>H: invoke handler with message
+    alt handler returns value
+        H-->>P: return value
+        P-->>C: 200 {result: Task with state=completed, artifact[0]=result}
+    else handler returns JobProxy
+        H-->>P: return JobProxy (background job dispatched)
+        P->>P: store (task_id → proxy) in process-local map
+        P-->>C: 200 {result: Task with state=working, artifacts=[]}
+    else handler raises
+        H-->>P: raise Exception
+        P-->>C: 200 {result: Task with state=failed, status.message=error}
+    end
+```
+
+#### Idempotency and duplicate task IDs
+
+A duplicate `task_id` for an in-flight task returns JSON-RPC error `-32602
+"A2A task id ... is already in use"` (`a2a.py:180-185`, `a2a.py:665-666`).
+Terminal-state entries are evicted from the store 300 seconds after first
+reaching a terminal state (`a2a.py:94-98`, `a2a.py:142-158`), so reuse is
+permitted after the grace window.
+
+### 4.4 `tasks/get`
+
+**Look up an already-parked long-running task and return its current Task envelope.**
+
+#### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tasks/get",
+  "params": { "id": "c-abc123" }
+}
+```
+
+#### Response
+
+Same `Task` shape as `tasks/send`. The producer pulls the current mesh-side
+status from the parked proxy, translates the mesh status to an A2A state
+(Section 7.2), and includes a `result` artifact only when the state is
+`completed` AND the producer can synchronously fetch the final value
+(`a2a.py:750-762`).
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "id": "c-abc123",
+    "sessionId": "c-abc123",
+    "status": {
+      "state": "working",
+      "timestamp": "2026-05-11T12:34:57Z",
+      "message": {
+        "role": "agent",
+        "parts": [{"type": "text", "text": "Drafting outline..."}]
+      }
+    },
+    "artifacts": [],
+    "history": [ ... ],
+    "metadata": { "progress": 0.25 }
+  }
+}
+```
+
+When the status fetch fails transiently, the producer SHOULD return a
+`state=working` envelope with the error text in `status.message` rather than
+a JSON-RPC error, because the registry's transient unreachability is not
+authoritative evidence the job is dead (`a2a.py:718-735`).
+
+#### Errors
+
+- Missing `params.id` → `-32602 "Invalid params: 'id' is required for
+  tasks/get"` (`a2a.py:706-709`).
+- Unknown `task_id` (not in the store) → `-32602 "Unknown task id: ..."`
+  (`a2a.py:712-715`). A2A v1.0 has no dedicated error code for "task not
+  found", so `-32602 Invalid params` is the convention.
+
+### 4.5 `tasks/cancel`
+
+**Cancel a parked task. Idempotent; best-effort.**
+
+#### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tasks/cancel",
+  "params": {
+    "id": "c-abc123",
+    "reason": "user pressed stop"
+  }
+}
+```
+
+#### Response
+
+Same `Task` shape, post-cancel. Cancel exceptions on the underlying job are
+logged and swallowed because the job may have already completed
+(`a2a.py:807-815`). The response reflects whatever state the producer can
+read **after** the cancel attempt; when the post-cancel status fetch also
+fails, the producer falls back to emitting `state=canceled` synthetically
+(`a2a.py:817-826`).
+
+If both `JobProxy.cancel()` AND `JobProxy.status()` throw (double-failure),
+producers MUST synthesize a `state=canceled` envelope rather than propagating
+the underlying exceptions. This protects A2A callers from JobProxy
+implementation details.
+
+For a non-terminal task record where the producer has lost its `JobProxy`
+reference (defensive edge case), producers MUST synthesize a `state=canceled`
+envelope rather than returning an error. This is best-effort cancel semantics.
+
+#### Errors
+
+- Missing `params.id` → `-32602 "Invalid params: 'id' is required for
+  tasks/cancel"`.
+- Unknown `task_id` → `-32602 "Unknown task id: ..."`.
+
+### 4.6 `tasks/sendSubscribe`
+
+**Same dispatch as `tasks/send`, but the response is an SSE stream of
+JSON-RPC envelopes.**
+
+See Section 5 for the SSE event shape. The producer invokes the user handler
+**before** the SSE stream opens (`a2a.py:1115-1124`) so handler exceptions
+become a single `state=failed` SSE event (`a2a.py:945-956`), not an opaque
+HTTP error mid-stream.
+
+#### Request shape
+
+Identical to `tasks/send` (Section 4.3).
+
+#### Response shape
+
+HTTP response with:
+
+- `Content-Type: text/event-stream`
+- `Cache-Control: no-cache`
+- `X-Accel-Buffering: no` (defeats nginx buffering)
+- `Connection: keep-alive`
+
+(`a2a.py:851-855`)
+
+The body is a stream of SSE `data:` frames carrying JSON-RPC envelopes
+(Section 5).
+
+#### Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant C as A2A Client
+    participant P as Producer
+    participant H as User Handler
+    participant J as Job (background)
+
+    C->>P: POST {method=tasks/sendSubscribe, params={id, message}}
+    P->>H: invoke handler (synchronously, before opening stream)
+    alt handler returns value (sync)
+        H-->>P: return value
+        P-->>C: 200 SSE: data: {artifact event}\n\n
+        P-->>C: SSE: data: {status state=completed, final=true}\n\n
+        P-->>C: [close stream]
+    else handler returns JobProxy
+        H-->>P: return JobProxy
+        P-->>C: 200 SSE: data: {status state=working, final=false}\n\n
+        loop poll every 1s
+            P->>J: status()
+            J-->>P: {status, progress?, progress_message?}
+            opt progress or message changed
+                P-->>C: SSE: data: {status state=working, progress, message}\n\n
+            end
+            opt no change for >15s
+                P-->>C: SSE: : keepalive\n\n
+            end
+        end
+        J-->>P: status = completed
+        P->>J: wait(timeout=1)
+        J-->>P: result value
+        P-->>C: SSE: data: {artifact event}\n\n
+        P-->>C: SSE: data: {status state=completed, final=true}\n\n
+        P-->>C: [close stream]
+    else handler raised
+        H-->>P: raise
+        P-->>C: 200 SSE: data: {status state=failed, final=true}\n\n
+        P-->>C: [close stream]
+    end
+```
+
+### 4.7 `tasks/resubscribe`
+
+**Re-attach an SSE stream to an already-parked task. Idempotent.**
+
+#### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "tasks/resubscribe",
+  "params": { "id": "c-abc123" }
+}
+```
+
+#### Response
+
+Same SSE response shape as `tasks/sendSubscribe`. The producer immediately
+emits an initial `state=working` event (so the client confirms the
+subscription is live), then catches up to the current registry status on the
+next poll (`a2a.py:1166-1199`, `a2a.py:986-989`).
+
+For a non-terminal task record where the producer has lost its `JobProxy`
+reference (impossible-but-handled state), producers MUST emit a single
+`state=failed` terminal frame and close, rather than hanging the SSE
+connection or returning ambiguous status.
+
+> ⚠️ **Implementation note**: the Python producer does **NOT** replay events
+> the client missed while disconnected. Clients that need a snapshot should
+> call `tasks/get` first (`a2a.py:1175-1178`).
+
+#### Errors
+
+- Missing `params.id` → `-32602 "Invalid params: 'id' is required for
+  tasks/resubscribe"`.
+- Unknown `task_id` → `-32602 "Unknown task id: ..."` (returned as a
+  JSON-RPC error response, NOT an SSE event, because the connection has not
+  been promoted to `text/event-stream` yet).
+
+### 4.8 Parking semantics for long-running tasks
+
+| Property             | Value                                                                                 |
+|----------------------|---------------------------------------------------------------------------------------|
+| Store location       | Process-local in-memory map keyed by `task_id` (`a2a.py:92`).                          |
+| Cross-replica share  | NONE. A client that subscribed on replica A and resubscribes to replica B gets `-32602 "Unknown task id"` (`a2a.py:88-91`). Producers SHOULD document this limitation. |
+| Stored values        | `proxy` (handle to the underlying job), `terminal_at` (monotonic timestamp when first observed in a terminal state, or null), `request_message`, `session_id` (`a2a.py:186-191`). |
+| Terminal eviction    | Entries are evicted 300 seconds after `terminal_at` is set. The sweep runs lazily on every store access; no background sweeper is required (`a2a.py:94-98`, `a2a.py:142-158`). |
+
+---
+
+## 5. SSE event shape
+
+### 5.1 Framing
+
+The producer emits HTML5 Server-Sent Events with:
+
+- `Content-Type: text/event-stream`;
+- one event per `data: <json>\n\n` block (single line of JSON per frame,
+  terminated by blank line) (`a2a.py:865-873`);
+- SSE comments (lines starting with `:`) for keepalives (`a2a.py:1071-1077`).
+
+The producer SHOULD emit:
+
+- `Cache-Control: no-cache`
+- `X-Accel-Buffering: no`
+- `Connection: keep-alive`
+
+(`a2a.py:851-855`)
+
+> ⚠️ **Implementation note — parser tolerance**: the consumer parsers in
+> Python, TypeScript, and Java all accept BOTH `\n` and `\r\n` line endings
+> (`a2a-stream.ts:212-218`, `A2AStream.java:73-77` via `BufferedReader`,
+> Python via `aiter_lines()`). They all accept the `data:` prefix with OR
+> without a single leading space (`a2a-stream.ts:236-237`,
+> `A2AStream.java:308-311`, `_a2a_consumer.py:903-905`). Producers SHOULD
+> emit `data: <json>\n\n` (with space, LF endings) for maximum portability.
+
+Every SSE event body is a complete JSON-RPC envelope, wrapped in `data: ...`
+(`a2a.py:865-873`).
+
+### 5.2 Event types
+
+There are exactly **two** A2A v1.0 event kinds the producer emits inside the
+`result` field of the JSON-RPC envelope:
+
+#### Status update event (`TaskStatusUpdateEvent`)
+
+Identified by the presence of a `status` key on `result`. Reference builder:
+`_status_update_event` (`a2a.py:876-903`).
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "id": "c-abc123",
+    "status": {
+      "state": "working",
+      "timestamp": "2026-05-11T12:34:57Z",
+      "message": {
+        "role": "agent",
+        "parts": [{"type": "text", "text": "Drafting outline..."}]
+      }
+    },
+    "final": false,
+    "metadata": { "progress": 0.25 }
+  }
+}
+```
+
+| Field                | Required? | Notes                                                                          |
+|----------------------|-----------|--------------------------------------------------------------------------------|
+| `result.id`          | YES       | The A2A task id.                                                               |
+| `result.status.state`| YES       | One of `working`, `completed`, `failed`, `canceled` (Section 7.1).             |
+| `result.status.timestamp` | YES  | UTC ISO-8601 with `Z` suffix (NOT `+00:00`) (`a2a.py:381-383`).                |
+| `result.status.message`   | NO   | A2A `Message` shape with `role: "agent"` and a single text part.               |
+| `result.final`       | YES       | `true` only on the terminal event for the task; client closes the stream on `final=true`. |
+| `result.metadata.progress` | NO  | Numeric progress indicator. Advisory; consumers clamp to `[0.0, 1.0]` before forwarding to mesh JobControllers (`_a2a_consumer.py:631-633`, `a2a-stream.ts:84-87`, `A2AStream.java:142-143`). |
+
+#### Artifact update event (`TaskArtifactUpdateEvent`)
+
+Identified by the presence of an `artifact` key on `result`. Reference
+builder: `_artifact_update_event` (`a2a.py:906-926`).
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "id": "c-abc123",
+    "artifact": {
+      "name": "result",
+      "parts": [{"type": "text", "text": "Coffee is a beverage..."}],
+      "index": 0
+    }
+  }
+}
+```
+
+| Field                       | Required? | Notes                                                                |
+|-----------------------------|-----------|----------------------------------------------------------------------|
+| `result.id`                 | YES       | The A2A task id.                                                     |
+| `result.artifact.name`      | YES       | The literal string `"result"` for the canonical single-artifact case.|
+| `result.artifact.parts`     | YES       | Array of A2A `Part` objects. Producer emits a single `TextPart` with `type: "text"` and `text: <string>`. |
+| `result.artifact.index`     | YES       | `0` for the single-artifact case. (`a2a.py:411-417`)                  |
+
+> The producer JSON-stringifies non-string handler returns into the
+> `text` field (`a2a.py:403`, `a2a.py:914`). Consumers reverse this with
+> `json.loads` / `JSON.parse` and fall back to the raw text on parse failure
+> (`_a2a_consumer.py:459-479`, `a2a-stream.ts:73`, `A2AStream.java:206-219`).
+
+### 5.3 Stream ordering and terminal semantics
+
+For a **sync** handler over `tasks/sendSubscribe`
+(`_stream_completed_only`, `a2a.py:929-942`):
+
+1. one artifact event;
+2. one status event with `state=completed`, `final=true`;
+3. close stream.
+
+For a **failed** handler (any sendSubscribe handler that raised, or any
+long-running path that observed a terminal `failed`/`canceled` mesh state):
+
+1. one status event with `state ∈ {failed, canceled}`, `final=true`;
+2. close stream.
+
+For a **long-running** handler (`_stream_long_running`, `a2a.py:959-1088`):
+
+1. an initial status event with `state=working`, `final=false`;
+2. zero or more status events with `state=working` carrying
+   `metadata.progress` and/or `status.message`. The producer suppresses
+   redundant events when both `progress` and `progress_message` are
+   unchanged from the previous emission (`a2a.py:1057-1070`);
+3. zero or more SSE comment frames (`: keepalive\n\n`) every
+   `_SSE_KEEPALIVE_SECS` (15s) when no real event has been emitted in that
+   window (`a2a.py:1071-1077`);
+4. on `completed`: one artifact event (best-effort — if `proxy.wait()` fails
+   the producer skips the artifact and proceeds to the terminal status);
+   followed by one status event with `state=completed`, `final=true`.
+   (`a2a.py:1019-1051`)
+5. on `failed` or `canceled`: one status event with the corresponding state
+   and `final=true`. (`a2a.py:1036-1049`)
+6. close stream.
+
+### 5.4 Reconnection semantics
+
+A client that loses its SSE connection mid-stream MUST NOT assume the task
+is dead. Per A2A v1.0, disconnect is transient; the producer keeps the
+underlying job running (`a2a.py:1080-1088`). The client rejoins via
+`tasks/resubscribe`, which emits a fresh `state=working` event and resumes
+polling from the current registry view (Section 4.7).
+
+### 5.5 Terminal state semantics
+
+| State       | Trigger                                                              | Consumer expectation                                                |
+|-------------|----------------------------------------------------------------------|---------------------------------------------------------------------|
+| `completed` | Job finished successfully.                                           | Artifact event was (or will be) emitted; result available.          |
+| `failed`    | Job raised, OR producer-side cancel reached the job before completion with an error message. | No artifact. `status.message` carries the error text when available.|
+| `canceled`  | Job cancelled (mesh-side cancel or A2A `tasks/cancel`).              | No artifact. `status.message` MAY carry a reason.                   |
+
+> ⚠️ **Spelling**: A2A v1.0 uses **US spelling `"canceled"`**. The mesh job
+> substrate uses **UK spelling `"cancelled"`**. The producer MUST translate
+> at the boundary (`a2a.py:101-122`). Consumers accept both spellings
+> (`_a2a_consumer.py:449-456`, `a2a-stream.ts:117-119`, `A2AStream.java:170-173`).
+
+---
+
+## 6. Auth gate
+
+### 6.1 Card advertisement
+
+When the surface is configured with `auth="bearer"`, the agent card
+advertises:
+
+```json
+"authentication": { "schemes": ["bearer"] }
+```
+
+When unset, the card advertises an empty schemes list (NOT a `"none"`
+scheme — A2A v1.0 has no such scheme):
+
+```json
+"authentication": { "schemes": [] }
+```
+
+(`a2a_card.py:100-109`)
+
+The producer MUST re-emit the same `auth` scheme on every card render so
+external clients can negotiate authentication without out-of-band coordination.
+
+### 6.2 Gate enforcement (Phase 1)
+
+The gate is enforced on the `POST {path}` entry point only — the agent card
+endpoint (`GET .../.well-known/agent.json`) is always public so clients can
+discover the authentication scheme without first authenticating
+(`a2a.py:1222-1259`).
+
+Phase 1 semantics:
+
+1. The producer MUST require an `Authorization: Bearer <token>` header.
+2. The producer MUST reject headers that:
+   - are missing entirely;
+   - have a non-`Bearer` scheme (case-insensitive prefix check);
+   - have an empty token after the `Bearer ` prefix (whitespace-only counts as empty).
+3. The producer MUST NOT validate the token value (no signature check, no
+   issuer/audience check, no expiry check). Value-level validation is
+   Phase 2+ scope. (`a2a.py:1216-1218`, `a2a.py:1222-1259`)
+
+### 6.3 Error shape
+
+When the gate rejects a request, the producer returns HTTP **401** with a
+JSON-RPC error envelope. The error code is `-32001` and the `id` is
+`null` (the request body has not been parsed at this point, so the client's
+request id is unavailable):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "error": {
+    "code": -32001,
+    "message": "Authentication required: missing Authorization: Bearer <token> header"
+  },
+  "id": null
+}
+```
+
+For empty-token cases the message is:
+
+```text
+Authentication required: empty bearer token in Authorization header
+```
+
+(`a2a.py:1225-1239`, `a2a.py:1243-1258`)
+
+> ⚠️ **Implementation note**: `-32001` is **not** a JSON-RPC reserved code —
+> it sits in the implementation-defined `-32000` to `-32099` server-error
+> range. New runtimes MUST use the same code for parity with existing
+> consumers that may special-case it.
+
+---
+
+## 7. Task lifecycle state machine
+
+### 7.1 A2A v1.0 states
+
+The producer MUST emit only these four states in `status.state`:
+
+```mermaid
+stateDiagram-v2
+    [*] --> submitted: tasks/send received
+    submitted --> working: handler returned JobProxy (long-running)
+    submitted --> completed: handler returned a value (sync)
+    submitted --> failed: handler raised
+    working --> working: progress update (status.message and/or metadata.progress changed)
+    working --> completed: job finished
+    working --> failed: job raised
+    working --> canceled: tasks/cancel OR mesh-side cancel
+    completed --> [*]
+    failed --> [*]
+    canceled --> [*]
+```
+
+> ⚠️ **Implementation note**: the A2A v1.0 spec includes a `submitted` state
+> as the conceptual starting point. The Python producer does not currently
+> emit a status event with `state="submitted"` — sync handlers go directly
+> to `completed`/`failed`, long-running handlers go directly to `working`.
+> New runtimes SHOULD match this behaviour. Treat `submitted` as a
+> diagram-only conceptual state.
+
+### 7.2 Mesh → A2A state translation
+
+The mesh job substrate uses these internal statuses; the producer translates
+them at the boundary (`a2a.py:104-122`):
+
+| Mesh status   | A2A state     |
+|---------------|---------------|
+| `working`     | `working`     |
+| `completed`   | `completed`   |
+| `failed`      | `failed`      |
+| `cancelled`   | `canceled`    |
+| anything else | `working` (fallback — never emit an A2A state outside the enumerated set)|
+
+### 7.3 Cancellation flows
+
+There are three ways a long-running task can transition to `canceled`:
+
+| Source                  | Behaviour                                                                                                               |
+|-------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| A2A `tasks/cancel`      | The producer invokes the underlying job's cancel method. Best-effort: exceptions are logged and swallowed because the job may have already terminated (`a2a.py:807-815`). |
+| Mesh-side cancel        | The job substrate cancels the job autonomously (e.g., due to a parent agent cancelling). The producer's status poll sees `cancelled` on the next iteration and emits the terminal event. |
+| Both                    | The mesh substrate is idempotent; double-cancel is safe.                                                                  |
+
+Client-side SSE disconnect is **NOT** a cancel. The producer MUST keep the
+underlying job running on `CancelledError` from the SSE generator
+(`a2a.py:1080-1088`).
+
+### 7.4 State that survives across `tasks/resubscribe`
+
+The producer's task store retains:
+
+- the underlying job handle;
+- the originating `session_id`;
+- the originating `request_message` (so `tasks/get` can echo it in
+  `history`).
+
+The producer does NOT retain past SSE events; replay is not supported
+(`a2a.py:1175-1178`).
+
+---
+
+## 8. Registry registration envelope
+
+### 8.1 Heartbeat envelope shape
+
+A user-owned A2A producer app sends the same heartbeat envelope as a regular
+`@mesh.agent` agent, with two differences:
+
+1. `agent_type` is set to `"a2a"` instead of `"mcp_agent"`.
+2. A `surfaces` array is included (Section 2).
+
+Both differences are conditional on the process having registered at least
+one A2A surface (`heartbeat_preparation.py:371-389`). Producers with zero
+surfaces fall back to `agent_type="mcp_agent"` and omit `surfaces`.
+
+`tools[]` is still emitted as usual; A2A surfaces and `@mesh.tool`
+capabilities coexist in the same agent
+(`heartbeat_preparation.py:372-374`). Producers that have only A2A surfaces
+and no mesh tools still emit `tools: []`.
+
+### 8.2 Heartbeat response — public URL cache update
+
+On each heartbeat response, the registry returns a `surfaces[]` array of
+`A2ASurfaceResponse` entries (Section 2.4). The producer SHOULD update its
+public-URL cache keyed by `(path, skill_id)` so subsequent agent-card
+renders advertise the externally reachable FQDN
+(`mesh/a2a.py:217-228`).
+
+### 8.3 Reusing the `@mesh.route` heartbeat machinery
+
+In the Python reference implementation, a producer that uses
+`mesh.a2a.mount(app, ...)` for a "user-owned FastAPI app" is heartbeated by
+the same machinery that drives `@mesh.route` agents — the
+`api_heartbeat/rust_api_heartbeat.py` path
+(`_mcp_mesh/engine/a2a_surfaces.py:9-12`). New runtimes should align with
+the equivalent local "route-style" heartbeat surface, NOT invent a separate
+heartbeat path for A2A surfaces.
+
+---
+
+## 9. Conformance checklist
+
+A new producer runtime MUST satisfy every item below.
+
+### Heartbeat
+- [ ] When at least one A2A surface is registered, heartbeat envelope contains `agent_type=a2a`.
+- [ ] When at least one A2A surface is registered, heartbeat envelope contains a `surfaces[]` array with one entry per surface.
+- [ ] Each `surfaces[]` entry contains `path` (string starting with `/`) and `skill_id` (kebab-case string).
+- [ ] Optional fields (`name`, `description`, `input_modes`, `output_modes`, `tags`) are emitted only when set on the decorator/annotation — never as empty strings or empty arrays.
+- [ ] When no A2A surfaces are registered, the producer falls back to `agent_type=mcp_agent` and omits `surfaces`.
+- [ ] On heartbeat response, the producer caches each `surfaces[].public_url` keyed by `(path, skill_id)`.
+
+### Agent card (`GET {path}/.well-known/agent.json`)
+- [ ] Returns HTTP 200 with `application/json`.
+- [ ] Card is reachable WITHOUT authentication regardless of the surface's `auth` setting.
+- [ ] Top-level fields: `name`, `description`, `version`, `capabilities`, `defaultInputModes`, `defaultOutputModes`, `skills` are all present.
+- [ ] `capabilities.streaming` is `true`.
+- [ ] `capabilities.pushNotifications` and `capabilities.stateTransitionHistory` are both `false`.
+- [ ] `skills[]` contains exactly one entry per card.
+- [ ] `skills[0]` carries `id`, `name`, `description`, `tags`, `inputModes`, `outputModes`.
+- [ ] When `auth="bearer"`, `authentication.schemes` is `["bearer"]`.
+- [ ] When auth is unset, `authentication.schemes` is `[]` (empty array, never `["none"]`).
+- [ ] `url` is omitted (not emitted as empty string) when no public URL is available.
+- [ ] Trailing-slash request `{path}/.well-known/agent.json` and slash-less `{path}/.well-known/agent.json` both work.
+
+### JSON-RPC `POST {path}` dispatch
+- [ ] Non-JSON request body returns HTTP 400 with JSON-RPC error code `-32700`.
+- [ ] Unknown method returns HTTP 200 with JSON-RPC error code `-32601` and message starting with `Method not implemented`.
+- [ ] Echoes `request.id` in every response (success and error).
+
+### `tasks/send`
+- [ ] Missing `params.id` → producer generates a UUID4.
+- [ ] Sync handler return → JSON-RPC success with `result.status.state=completed`, one artifact in `result.artifacts[]`, `result.history` echoing the request message.
+- [ ] Long-running handler return → JSON-RPC success with `result.status.state=working`, empty `artifacts[]`, the task parked for subsequent `tasks/get`/`tasks/cancel`/`tasks/resubscribe`.
+- [ ] Handler raises → JSON-RPC success with `result.status.state=failed`, error text in `result.status.message.parts[0].text`.
+- [ ] Non-string handler returns are JSON-stringified into `artifacts[0].parts[0].text`.
+- [ ] Duplicate in-flight `task_id` → JSON-RPC error `-32602` with message indicating the id is in use.
+
+### `tasks/get`
+- [ ] Missing `params.id` → JSON-RPC error `-32602`.
+- [ ] Unknown `task_id` → JSON-RPC error `-32602`.
+- [ ] Known `task_id` → JSON-RPC success with current `Task` envelope, A2A state translated from mesh state.
+- [ ] On `state=completed`, `result.artifacts[]` contains the final result when synchronously available.
+- [ ] On `status` poll failure (transient), returns `state=working` with error in `status.message`, NOT a JSON-RPC error.
+
+### `tasks/cancel`
+- [ ] Missing `params.id` → JSON-RPC error `-32602`.
+- [ ] Unknown `task_id` → JSON-RPC error `-32602`.
+- [ ] Idempotent: cancelling an already-terminal task returns the current `Task` envelope cleanly.
+- [ ] Underlying cancel exceptions are swallowed; the response always reflects the latest readable state.
+
+### `tasks/sendSubscribe` (SSE)
+- [ ] Response is `Content-Type: text/event-stream`.
+- [ ] Response includes `Cache-Control: no-cache`, `X-Accel-Buffering: no`, `Connection: keep-alive`.
+- [ ] Each frame is `data: <json>\n\n` (data prefix + space + JSON + blank line).
+- [ ] SSE comments (`: keepalive\n\n`) are emitted every 15s of inactivity during long-running streams.
+- [ ] Handler is invoked **before** the SSE stream opens; handler exceptions surface as a single SSE failed event, not an HTTP-level error.
+- [ ] Sync handler return → one artifact event, then one `final=true` status event with `state=completed`.
+- [ ] Long-running handler → initial `state=working` event with `final=false`; subsequent `state=working` events on actual progress/message change; one artifact event + one `final=true` terminal status event on completion.
+- [ ] On client disconnect (CancelledError), the underlying job continues running.
+- [ ] Each SSE event body is a valid JSON-RPC envelope (`jsonrpc: "2.0"`, `id`, `result`).
+- [ ] `metadata.progress` is emitted as a number (not stringified) when known.
+
+### `tasks/resubscribe`
+- [ ] Missing `params.id` → JSON-RPC error `-32602` (returned as standard JSON-RPC response, not SSE).
+- [ ] Unknown `task_id` → JSON-RPC error `-32602`.
+- [ ] Known `task_id` → SSE response identical in shape to the original `sendSubscribe` stream.
+- [ ] Initial event is `state=working`, `final=false` (no replay of past events).
+
+### Auth gate
+- [ ] When `auth="bearer"`, missing `Authorization` header → HTTP 401 with JSON-RPC error `-32001`, `id=null`.
+- [ ] When `auth="bearer"`, non-`Bearer` scheme → HTTP 401 with JSON-RPC error `-32001`.
+- [ ] When `auth="bearer"`, empty token after `Bearer ` prefix → HTTP 401 with JSON-RPC error `-32001`.
+- [ ] Phase 1: token VALUE is NOT validated — any non-empty token passes the gate.
+- [ ] The agent-card endpoint is reachable without auth even when `auth="bearer"`.
+
+### State / spelling
+- [ ] Emitted A2A states are exactly one of: `working`, `completed`, `failed`, `canceled` (US spelling).
+- [ ] Mesh-side `cancelled` (UK) is translated to A2A `canceled` (US) at the boundary.
+- [ ] `status.timestamp` is UTC ISO-8601 with a `Z` suffix (NOT `+00:00`).
+
+### Terminal-state eviction
+- [ ] Tasks observed in a terminal state are evicted from the in-memory store after a grace window (Python default: 300s).
+- [ ] Eviction does not require a background sweeper task; lazy sweeping on every store access is sufficient.
+
+---
+
+## Appendix A: Cross-runtime parser implications
+
+The consumer-side parsers in Java
+(`src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AStream.java`)
+and TypeScript (`src/runtime/typescript/src/a2a/a2a-stream.ts`) impose a
+slightly tighter contract than the Python producer documents in
+docstrings. New producers SHOULD honour the tighter contract:
+
+| Aspect                              | Python producer (today)         | TS/Java consumer expectation                                       |
+|-------------------------------------|---------------------------------|---------------------------------------------------------------------|
+| `result.id` on SSE events            | Always emitted                  | Read but not validated; consumer keys off the task id supplied at subscribe time. Producers MAY safely omit if they want, but SHOULD include for debuggability. |
+| `result.metadata.progress` type      | Number (JSON-stringified via `_json.dumps`) | TS accepts numbers and numeric strings (`a2a-stream.ts:294-298`); Java accepts numbers and numeric strings (`A2AStream.java:380-389`). Producers MUST prefer numbers. |
+| `parts[0].type` on text parts        | Always `"text"`                 | Both consumers ignore the `type` field entirely — they read `parts[0].text` directly. Producers MUST still emit `type: "text"` for forward compatibility. |
+| Final-event `final` field            | `true` (boolean)                | TS: `r.final === true` strict comparison (`a2a-stream.ts:300-301`). Java: `asBoolean(false)` (`A2AStream.java:392-394`). Producers MUST emit a real boolean, NOT the string `"true"`. |
+| Multiple `data:` continuation lines  | NOT emitted (single line per frame) | All three consumers join multi-line `data:` with `\n` per SSE spec. Producers MAY emit multi-line frames; v1.0 producer convention is single-line. |
+| Artifact event with empty parts      | Always has parts                | TS treats missing/empty parts as empty string artifact (`a2a-stream.ts:270`); Java same (`A2AStream.java:355-358`). Producers SHOULD always include parts. |
+
+---
+
+## Appendix B: Open questions / ambiguity flags
+
+This appendix collects places where the Python implementation is ambiguous
+or under-documented and new runtimes should pick a deliberate stance.
+
+1. **Multi-skill cards.** The current Python implementation emits one card
+   per surface with exactly one skill (`a2a_card.py:8-9`). Multi-skill
+   grouping under a single card is explicitly v2. New runtimes MUST match —
+   do not group skills.
+
+2. **`submitted` state emission.** A2A v1.0 mentions a `submitted` state but
+   the Python producer never emits a status event with that state — sync
+   handlers jump directly to `completed`/`failed`, long-running handlers
+   jump directly to `working`. New runtimes SHOULD match for consumer
+   parity but the spec does not formally forbid emitting `submitted`.
+
+3. **Cross-replica task sharing.** The Python task store is process-local;
+   `tasks/get`/`tasks/cancel`/`tasks/resubscribe` against a task owned by a
+   different replica return `-32602 Unknown task id`. New runtimes inherit
+   this limitation — cross-replica sharing is out of scope for v1.
+
+4. **Auth token validation.** Phase 1 enforces header **presence** only;
+   the token value is not inspected. Producers MUST NOT add signature
+   validation, issuer checks, or audience checks in Phase 1 — those land
+   in Phase 2 and require coordinated spec updates.
+
+5. **Idempotency window for terminal task IDs.** The Python producer
+   evicts terminal-state entries 300s after `terminal_at`. Reusing a
+   `task_id` within that window returns `-32602 already in use`; outside
+   it succeeds. New runtimes SHOULD use the same 300s window for parity,
+   though clients MUST NOT depend on the exact value.
+
+6. **`history` field semantics.** The producer echoes the originating
+   request message into `result.history[]` when known (`a2a.py:418`,
+   `a2a.py:446`, `a2a.py:478`, `a2a.py:543`). The A2A v1.0 spec allows
+   richer history shapes (multiple turns, agent responses); the v1 producer
+   emits at most one entry. New runtimes MUST match for consumer parity.
+
+7. **`session_id` semantics.** The Python producer defaults `sessionId` to
+   the `task_id` when missing (`a2a.py:588`), but does not otherwise act on
+   the value. Producers SHOULD echo the client-supplied `sessionId` into
+   responses but do not need to maintain session-scoped state.
+
+8. **Streaming of multi-artifact returns.** v1 emits exactly one artifact
+   (`name: "result"`, `index: 0`). Multi-artifact returns are not
+   currently supported. New runtimes MUST emit a single artifact for v1.

--- a/docs/a2a/surfaces-spec.md
+++ b/docs/a2a/surfaces-spec.md
@@ -61,11 +61,11 @@ runtime-implementation choices.
 The user-facing API differs by language, but all three forms expand to the same
 wire contract:
 
-| Concept                       | Python                          | Java (planned, issue #932) | TypeScript (planned, issue #933) |
+| Concept                       | Python                          | Java (implemented)         | TypeScript (planned, issue #933) |
 |-------------------------------|---------------------------------|----------------------------|----------------------------------|
 | Decorator-level metadata stamp | `@mesh.a2a(path=...)`           | `@MeshA2A(path=...)`       | `mesh.a2a({path: ...})` (functional helper) |
 | Mount + DI                    | `mesh.a2a.mount(app, path=...)` | annotation processor       | `mesh.a2a()` returns a router    |
-| Source-of-truth file          | `src/runtime/python/mesh/a2a.py` | (TBD)                      | (TBD)                            |
+| Source-of-truth file          | `src/runtime/python/mesh/a2a.py` | `src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/` | (TBD)                            |
 
 > The Python implementation is the de-facto reference. New runtimes must match
 > wire shape, NOT implementation structure.
@@ -1039,7 +1039,7 @@ A new producer runtime MUST satisfy every item below.
 - [ ] When `auth="bearer"`, `authentication.schemes` is `["bearer"]`.
 - [ ] When auth is unset, `authentication.schemes` is `[]` (empty array, never `["none"]`).
 - [ ] `url` is omitted (not emitted as empty string) when no public URL is available.
-- [ ] Trailing-slash request `{path}/.well-known/agent.json` and slash-less `{path}/.well-known/agent.json` both work.
+- [ ] Trailing-slash request `{path}/.well-known/agent.json/` and slash-less `{path}/.well-known/agent.json` both work.
 
 ### JSON-RPC `POST {path}` dispatch
 - [ ] Non-JSON request body returns HTTP 400 with JSON-RPC error code `-32700`.

--- a/examples/java/producer-date-agent/pom.xml
+++ b/examples/java/producer-date-agent/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  A2A producer example (issue #932 Chunk 1C) — Java port of
+  ``examples/a2a/date_a2a_agent.py``. Exposes a ``get-date`` skill via
+  the A2A v1.0 protocol surface using ``@MeshA2A`` on a Spring Boot
+  controller method. Sibling to ``examples/java/consumer-date-agent``
+  (which goes the other way — bridges an external A2A surface back into
+  the mesh as a regular tool).
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>producer-date-agent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>A2A Producer Date Agent (Java)</name>
+    <description>Java A2A producer — exposes a get-date skill via the A2A v1.0 protocol surface using @MeshA2A.</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.dateproducer.ProducerDateAgentApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/java/producer-date-agent/src/main/java/com/example/dateproducer/ProducerDateAgentApplication.java
+++ b/examples/java/producer-date-agent/src/main/java/com/example/dateproducer/ProducerDateAgentApplication.java
@@ -1,0 +1,142 @@
+package com.example.dateproducer;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.spring.web.MeshA2A;
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshInject;
+import io.mcpmesh.types.McpMeshTool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A2A producer example (issue #932 Chunk 1C) — Java port of
+ * {@code examples/a2a/date_a2a_agent.py}.
+ *
+ * <p>Exposes a {@code get-date} skill via the A2A v1.0 protocol surface
+ * using {@link MeshA2A} on a Spring Boot bean method. The Spring Boot
+ * starter mounts both companion routes the A2A protocol requires:
+ *
+ * <pre>
+ *   GET  /agents/date/.well-known/agent.json   (agent card)
+ *   POST /agents/date                          (JSON-RPC tasks/* entry)
+ * </pre>
+ *
+ * <p>The {@code @MeshA2A} method is the Java equivalent of Python's
+ * {@code @mesh.a2a.mount(app, path=...)} decorator: it carries the
+ * skill-level metadata (skill id, name, description, tags) AND wires
+ * the JSON-RPC dispatch table for {@code tasks/send}, {@code tasks/get},
+ * {@code tasks/cancel}, {@code tasks/sendSubscribe},
+ * {@code tasks/resubscribe} at {@code POST /agents/date}. Return values
+ * are wrapped as an A2A v1.0 {@code Task} envelope with
+ * {@code state=completed}; handler exceptions become {@code state=failed}.
+ *
+ * <p>The mesh dependency on {@code date_service} demonstrates DDDI
+ * inside an A2A handler: at request time the framework resolves the
+ * {@link McpMeshTool} proxy through {@link MeshDependency} and injects
+ * it at the {@link MeshInject} parameter slot — same wiring used by
+ * {@code @MeshRoute}.
+ *
+ * <h2>Stack</h2>
+ *
+ * <ul>
+ *   <li>Registry — {@code meshctl start --registry-only}</li>
+ *   <li>System agent (Python) — provides {@code date_service} on port 9100</li>
+ *   <li>This Java producer — exposes {@code get-date} via A2A on port 9090</li>
+ * </ul>
+ *
+ * <h2>Run</h2>
+ * <pre>
+ * # in src/runtime/java (build the starter)
+ * mvn install -DskipTests
+ *
+ * # in examples/java/producer-date-agent
+ * mvn spring-boot:run
+ *
+ * # test the agent card
+ * curl http://localhost:9090/agents/date/.well-known/agent.json | jq
+ *
+ * # test the JSON-RPC tasks/send entry
+ * curl -X POST http://localhost:9090/agents/date \
+ *      -H 'Content-Type: application/json' \
+ *      -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send",
+ *           "params":{"id":"t1","message":{"role":"user",
+ *           "parts":[{"type":"text","text":"now"}]}}}'
+ * </pre>
+ */
+@MeshAgent(
+    name = "date-a2a-agent",
+    version = "1.0.0",
+    description = "Java A2A producer — exposes a get-date skill via the A2A v1.0 protocol surface.",
+    port = 9090
+)
+@SpringBootApplication
+public class ProducerDateAgentApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(ProducerDateAgentApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting Java A2A Producer (date-a2a-agent)...");
+        SpringApplication.run(ProducerDateAgentApplication.class, args);
+    }
+
+    /**
+     * The skill handler. Bean-scoped (not on the
+     * {@code @SpringBootApplication} class) so {@code @Component} scanning
+     * picks it up the same way {@code @MeshRoute} bean post-processors
+     * do for the other examples.
+     */
+    @Component
+    static class DateSkill {
+
+        /**
+         * Handle inbound A2A {@code tasks/send} (and {@code tasks/get},
+         * {@code tasks/cancel}, {@code tasks/sendSubscribe},
+         * {@code tasks/resubscribe} — same handler, the framework picks
+         * the right envelope shape based on the inbound method).
+         *
+         * <p>The framework passes the inbound A2A {@code message} dict
+         * ({@code {"role": "user", "parts": [...]}}) at the {@code Map}
+         * parameter slot. For the date example we ignore it and just
+         * call the upstream {@code date_service} mesh dependency.
+         *
+         * @param message    inbound A2A request message (ignored here)
+         * @param dateService framework-injected mesh tool proxy
+         * @return a map that becomes the A2A artifact text payload
+         *         (JSON-stringified into {@code parts[0].text})
+         * @throws Exception on upstream failure (becomes state=failed)
+         */
+        @MeshA2A(
+            path = "/agents/date",
+            skillId = "get-date",
+            skillName = "Get Date",
+            description = "Get current date/time via A2A protocol",
+            tags = {"system", "date"},
+            dependencies = {
+                @MeshDependency(capability = "date_service")
+            }
+        )
+        public Map<String, Object> getDate(
+                Map<String, Object> message,
+                @MeshInject("date_service") McpMeshTool dateService) throws Exception {
+            Map<String, Object> payload = new LinkedHashMap<>();
+            if (dateService == null) {
+                // Defer-resolution: dependency not yet wired by mesh DI.
+                // Returning a sentinel keeps the example runnable solo
+                // (sync handler return → state=completed envelope).
+                payload.put("date", Instant.now().toString());
+                payload.put("note", "date_service not yet resolved — returning local fallback");
+                return payload;
+            }
+            Object result = dateService.call(Map.of());
+            payload.put("date", result);
+            return payload;
+        }
+    }
+}

--- a/examples/java/producer-date-agent/src/main/resources/application.yml
+++ b/examples/java/producer-date-agent/src/main/resources/application.yml
@@ -1,0 +1,26 @@
+# MCP Mesh A2A producer date agent (Java) — issue #932 Chunk 1C.
+#
+# Mirrors examples/a2a/date_a2a_agent.py. Override at runtime via:
+#   MCP_MESH_REGISTRY_URL - Registry URL
+#   MCP_MESH_HTTP_PORT    - Agent HTTP port (also where the agent card lives)
+#   MCP_MESH_AGENT_NAME   - Agent name (registers as agent_type=a2a once
+#                           the @MeshA2A surface is discovered at boot)
+
+spring:
+  application:
+    name: producer-date-agent
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9090}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:date-a2a-agent}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    io.mcpmesh: INFO
+    com.example.dateproducer: DEBUG

--- a/examples/java/producer-report-agent/pom.xml
+++ b/examples/java/producer-report-agent/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  A2A producer example for LONG-RUNNING tasks (issue #932 Chunk 1C) —
+  Java port of ``examples/a2a/report_a2a_agent.py``. Exposes a
+  ``generate-report`` skill via the A2A v1.0 protocol surface using
+  ``@MeshA2A`` on a Spring Boot bean method. Returns a ``JobProxy`` to
+  hand the long-running task off to the framework, which parks it in
+  the A2A task store and services ``tasks/get``, ``tasks/cancel``,
+  ``tasks/sendSubscribe``, ``tasks/resubscribe`` for the lifetime of
+  the underlying mesh job.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>producer-report-agent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>A2A Producer Report Agent (Java, long-running)</name>
+    <description>Java A2A producer (long-running) — exposes generate-report via the A2A v1.0 protocol surface.</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.reportproducer.ProducerReportAgentApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/java/producer-report-agent/src/main/java/com/example/reportproducer/ProducerReportAgentApplication.java
+++ b/examples/java/producer-report-agent/src/main/java/com/example/reportproducer/ProducerReportAgentApplication.java
@@ -1,0 +1,229 @@
+package com.example.reportproducer;
+
+import io.mcpmesh.JobProxy;
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshJobSubmitter;
+import io.mcpmesh.spring.MeshRuntime;
+import io.mcpmesh.spring.web.MeshA2A;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A2A producer example for LONG-RUNNING tasks (issue #932 Chunk 1C) —
+ * Java port of {@code examples/a2a/report_a2a_agent.py}.
+ *
+ * <p>Exposes a {@code generate-report} skill via the A2A v1.0 protocol
+ * surface. The handler submits work to a {@code task=true} mesh
+ * capability (here {@code generate_report}, served by the existing
+ * {@code examples/jobs/long-task-provider} Python agent) and returns
+ * the resulting {@link JobProxy}. The framework switches into
+ * long-running mode:
+ *
+ * <ul>
+ *   <li>The inbound {@code tasks/send} returns {@code state=working}
+ *       immediately with a fresh task id.</li>
+ *   <li>The task is parked in the A2A task store keyed by that id.</li>
+ *   <li>Subsequent {@code tasks/get} polls the parked proxy via
+ *       {@link JobProxy#status()}.</li>
+ *   <li>{@code tasks/cancel} calls {@link JobProxy#cancel(String)},
+ *       propagating through to the underlying mesh job.</li>
+ *   <li>{@code tasks/sendSubscribe} opens an SSE stream of
+ *       {@code TaskStatusUpdateEvent} + {@code TaskArtifactUpdateEvent}
+ *       envelopes sourced from the parked proxy's status updates.</li>
+ * </ul>
+ *
+ * <h2>MeshJobSubmitter wiring</h2>
+ *
+ * <p>{@code @MeshA2A} handlers receive {@link io.mcpmesh.types.McpMeshTool}
+ * proxies at parameter slots but the framework does not (today) inject
+ * a {@link MeshJobSubmitter} via the {@code dependencies} array — that
+ * auto-wiring is reserved for {@code @MeshTool}-decorated consumers.
+ * For long-running producers we construct the submitter manually from
+ * the autowired {@link MeshRuntime}: it carries both the registry URL
+ * and the local agent id (the {@code submitted_by} identity recorded
+ * on every new job row). The submitter is cheap to construct (no I/O
+ * until {@link MeshJobSubmitter#submit(java.util.Map)} fires) and
+ * stateless after construction.
+ *
+ * <h2>Stack</h2>
+ *
+ * <ul>
+ *   <li>Registry — {@code meshctl start --registry-only}</li>
+ *   <li>Long-task provider (Python) — provides
+ *       {@code generate_report} ({@code task=true}) on port 9100</li>
+ *   <li>This Java producer — exposes {@code generate-report} via A2A
+ *       on port 9091</li>
+ * </ul>
+ *
+ * <h2>Run</h2>
+ * <pre>
+ * # in src/runtime/java (build the starter)
+ * mvn install -DskipTests
+ *
+ * # in examples/java/producer-report-agent
+ * mvn spring-boot:run
+ *
+ * # submit + poll
+ * TASK_ID=$(curl -s -X POST http://localhost:9091/agents/report \
+ *   -H 'Content-Type: application/json' \
+ *   -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send",
+ *        "params":{"id":"r1","message":{"role":"user",
+ *        "parts":[{"type":"text",
+ *        "text":"{\"user_id\":\"alice\",\"sections\":[\"intro\",\"body\"]}"}]}}}' \
+ *   | jq -r '.result.id')
+ *
+ * curl -s -X POST http://localhost:9091/agents/report \
+ *   -H 'Content-Type: application/json' \
+ *   -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tasks/get\",\"params\":{\"id\":\"$TASK_ID\"}}"
+ *
+ * # stream via SSE
+ * curl -N -X POST http://localhost:9091/agents/report \
+ *   -H 'Accept: text/event-stream' \
+ *   -H 'Content-Type: application/json' \
+ *   -d '{"jsonrpc":"2.0","id":3,"method":"tasks/sendSubscribe",
+ *        "params":{"id":"s1","message":{"role":"user",
+ *        "parts":[{"type":"text",
+ *        "text":"{\"user_id\":\"alice\",\"sections\":[\"intro\",\"body\"]}"}]}}}'
+ * </pre>
+ */
+@MeshAgent(
+    name = "report-a2a-agent",
+    version = "1.0.0",
+    description = "Java A2A producer (long-running) — bridges generate_report task=true via the A2A v1.0 protocol surface.",
+    port = 9091
+)
+@SpringBootApplication
+public class ProducerReportAgentApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(ProducerReportAgentApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting Java A2A Producer (report-a2a-agent, long-running)...");
+        SpringApplication.run(ProducerReportAgentApplication.class, args);
+    }
+
+    @Component
+    static class ReportSkill {
+
+        private static final ObjectMapper JSON = new ObjectMapper();
+
+        /**
+         * Reference to the MeshRuntime — we read the registry URL and
+         * the local agent id from {@link MeshRuntime#getAgentSpec()} at
+         * request time. Autowiring (rather than constructor injection)
+         * keeps the component decoupled from runtime construction order
+         * (the runtime bean is created late, after auto-config).
+         *
+         * <p><strong>Why {@code @Lazy}.</strong> The user-level workaround
+         * of injecting {@link MeshRuntime} into a {@code @Component} to
+         * construct a {@code MeshJobSubmitter} by hand creates a bean-
+         * creation cycle in Spring 6+: {@code MeshRuntime#buildAgentSpec}
+         * eagerly walks {@code @Component} beans → finds this
+         * {@code ReportSkill} (currently in creation) → cycle. The
+         * {@code @Lazy} annotation tells Spring to inject a CGLIB proxy
+         * that defers actual runtime resolution to first method call (at
+         * request time, not at construction time), so the
+         * {@code ReportSkill -> MeshRuntime} edge of the dependency graph
+         * is broken structurally — regardless of which side is constructed
+         * first. Same fix pattern as {@code MeshHealthController} in
+         * {@code MeshAutoConfiguration}.
+         *
+         * <p>The cleaner long-term fix is for the {@code @MeshA2A}
+         * dispatcher to auto-inject {@link io.mcpmesh.MeshJobSubmitter}
+         * for {@code task=true} dependencies (today it only injects
+         * {@link io.mcpmesh.types.McpMeshTool}). Tracked as a follow-up
+         * issue; once that lands this autowire-and-hand-construct dance
+         * goes away entirely.
+         */
+        @Autowired
+        @Lazy
+        private MeshRuntime meshRuntime;
+
+        /**
+         * Handle inbound A2A {@code tasks/send} (and {@code tasks/get},
+         * {@code tasks/cancel}, {@code tasks/sendSubscribe},
+         * {@code tasks/resubscribe} — same handler, the framework picks
+         * the right envelope shape based on the inbound method).
+         *
+         * <p>The A2A request {@code message} carries the user payload as
+         * a text part with JSON-encoded args. Real-world clients can use
+         * any parts shape; for this example we parse {@code parts[0].text}
+         * as JSON.
+         *
+         * <p>Returning the {@link JobProxy} switches the framework into
+         * long-running mode (see class Javadoc).
+         *
+         * @param message inbound A2A request message
+         * @return the parked job proxy (long-running mode trigger)
+         * @throws Exception on registry submission failure (becomes
+         *         state=failed)
+         */
+        @MeshA2A(
+            path = "/agents/report",
+            skillId = "generate-report",
+            skillName = "Generate Report",
+            description = "Generate a long-form report via A2A (task=True streaming)",
+            tags = {"reports", "long-running"}
+        )
+        public Object generateReport(Map<String, Object> message) throws Exception {
+            // Parse the user payload from the message's first text part.
+            // Tolerant: empty payload defaults to a single "overview" section.
+            String userId = "anon";
+            List<String> sections = List.of("overview");
+            Object partsObj = message != null ? message.get("parts") : null;
+            if (partsObj instanceof List<?> parts && !parts.isEmpty()
+                && parts.get(0) instanceof Map<?, ?> firstPart
+                && "text".equals(firstPart.get("type"))) {
+                Object textObj = firstPart.get("text");
+                if (textObj instanceof String text && !text.isEmpty()) {
+                    try {
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> args = JSON.readValue(text, Map.class);
+                        Object u = args.get("user_id");
+                        if (u instanceof String s && !s.isEmpty()) userId = s;
+                        Object s = args.get("sections");
+                        if (s instanceof List<?> list && !list.isEmpty()) {
+                            sections = list.stream().map(String::valueOf).toList();
+                        }
+                    } catch (Exception parseExc) {
+                        // Keep defaults on parse failure — A2A protocol does not
+                        // mandate any particular payload shape.
+                        log.debug("Failed to parse A2A message parts[0].text as JSON, using defaults: {}",
+                            parseExc.getMessage());
+                    }
+                }
+            }
+
+            // Construct a MeshJobSubmitter bound to the long-task-provider's
+            // generate_report capability. The framework's @MeshTool-side
+            // auto-wiring (JobsRuntimeManager.wireConsumers) does not run
+            // for @MeshA2A handlers; we wire by hand. Cheap to construct
+            // — no I/O until submit() fires.
+            String registryUrl = meshRuntime.getAgentSpec().getRegistryUrl();
+            String agentId = meshRuntime.getAgentSpec().getAgentId();
+            MeshJobSubmitter submitter = new MeshJobSubmitter("generate_report", agentId, registryUrl);
+
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("user_id", userId);
+            payload.put("sections", sections);
+            // submit() returns CompletableFuture<JobProxy>. We block here
+            // because the @MeshA2A dispatcher itself runs on a servlet
+            // thread that's already waiting for the handler return —
+            // returning the future would be misinterpreted as a sync result.
+            JobProxy proxy = submitter.submit(payload).get();
+            log.info("@MeshA2A generate-report: submitted job_id={} (will park in A2A task store)",
+                proxy.jobId());
+            return proxy;
+        }
+    }
+}

--- a/examples/java/producer-report-agent/src/main/java/com/example/reportproducer/ProducerReportAgentApplication.java
+++ b/examples/java/producer-report-agent/src/main/java/com/example/reportproducer/ProducerReportAgentApplication.java
@@ -17,6 +17,9 @@ import tools.jackson.databind.ObjectMapper;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * A2A producer example for LONG-RUNNING tasks (issue #932 Chunk 1C) —
@@ -220,7 +223,26 @@ public class ProducerReportAgentApplication {
             // because the @MeshA2A dispatcher itself runs on a servlet
             // thread that's already waiting for the handler return —
             // returning the future would be misinterpreted as a sync result.
-            JobProxy proxy = submitter.submit(payload).get();
+            //
+            // Bounded wait: submit() is a registry round-trip (and any
+            // capability claim handshake), NOT the long job itself. 30s
+            // covers normal-case latency with comfortable headroom; anything
+            // longer is a network / provider problem and should surface as a
+            // failed A2A task, not as an indefinite hang on the dispatcher.
+            JobProxy proxy;
+            try {
+                proxy = submitter.submit(payload).get(30, TimeUnit.SECONDS);
+            } catch (TimeoutException te) {
+                throw new RuntimeException(
+                    "submit() did not return a JobProxy within 30s — "
+                        + "registry / provider-side timeout", te);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("submit() interrupted", ie);
+            } catch (ExecutionException ee) {
+                Throwable cause = ee.getCause() != null ? ee.getCause() : ee;
+                throw new RuntimeException("submit() failed: " + cause.getMessage(), cause);
+            }
             log.info("@MeshA2A generate-report: submitted job_id={} (will park in A2A task store)",
                 proxy.jobId());
             return proxy;

--- a/examples/java/producer-report-agent/src/main/resources/application.yml
+++ b/examples/java/producer-report-agent/src/main/resources/application.yml
@@ -1,0 +1,26 @@
+# MCP Mesh A2A producer report agent (Java, long-running) — issue #932 Chunk 1C.
+#
+# Mirrors examples/a2a/report_a2a_agent.py. Override at runtime via:
+#   MCP_MESH_REGISTRY_URL - Registry URL
+#   MCP_MESH_HTTP_PORT    - Agent HTTP port (also where the agent card lives)
+#   MCP_MESH_AGENT_NAME   - Agent name (registers as agent_type=a2a once
+#                           the @MeshA2A surface is discovered at boot)
+
+spring:
+  application:
+    name: producer-report-agent
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9091}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:report-a2a-agent}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    io.mcpmesh: INFO
+    com.example.reportproducer: DEBUG

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -249,6 +249,7 @@ nav:
       - Scaffolding: a2a/scaffolding.md
       - Examples Gallery: a2a/examples.md
       - Architecture & Decisions: a2a/architecture.md
+      - Producer Spec (Conformance): a2a/surfaces-spec.md
 
   - API Reference:
       - MediaResult: api/media-result.md

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/AgentSpec.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/AgentSpec.java
@@ -62,8 +62,10 @@ public class AgentSpec {
      * JSONB column).
      *
      * <p>When {@code null} or empty, the field is omitted from the heartbeat
-     * envelope (Jackson's {@code @JsonInclude(NON_NULL)} on the class).
+     * envelope (per-field {@code @JsonInclude(NON_EMPTY)} overrides the
+     * class-level {@code NON_NULL} so accidental empty strings are dropped).
      */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private String surfaces;
 
     public AgentSpec() {

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/AgentSpec.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/AgentSpec.java
@@ -53,6 +53,19 @@ public class AgentSpec {
     @JsonProperty("heartbeat_interval")
     private long heartbeatInterval = 5;
 
+    /**
+     * A2A surfaces JSON (issue #903 / #932). Optional — populated only when
+     * {@code agentType="a2a"} and the SDK has at least one {@code @MeshA2A}
+     * surface registered. Stored as a JSON-encoded string to match the Rust
+     * core's {@code surfaces: Option<String>} field shape (the Rust side
+     * forwards it verbatim to the registry's {@code MeshAgentRegistration.surfaces}
+     * JSONB column).
+     *
+     * <p>When {@code null} or empty, the field is omitted from the heartbeat
+     * envelope (Jackson's {@code @JsonInclude(NON_NULL)} on the class).
+     */
+    private String surfaces;
+
     public AgentSpec() {
     }
 
@@ -123,6 +136,11 @@ public class AgentSpec {
         return this;
     }
 
+    public AgentSpec surfaces(String surfaces) {
+        this.surfaces = surfaces;
+        return this;
+    }
+
     // Standard getters
 
     public String getName() {
@@ -188,6 +206,10 @@ public class AgentSpec {
         return heartbeatInterval;
     }
 
+    public String getSurfaces() {
+        return surfaces;
+    }
+
     // Standard setters
 
     public void setName(String name) {
@@ -240,6 +262,10 @@ public class AgentSpec {
 
     public void setHeartbeatInterval(long heartbeatInterval) {
         this.heartbeatInterval = heartbeatInterval;
+    }
+
+    public void setSurfaces(String surfaces) {
+        this.surfaces = surfaces;
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshEvent.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshEvent.java
@@ -40,6 +40,16 @@ public class MeshEvent {
     private String reason;
     private String status;
 
+    /**
+     * Carried on {@link EventType#SURFACE_UPDATED} events: the A2A skill id
+     * the registry is stamping the public URL for. Combined with
+     * {@link #capability} (re-used as the path) this is the cache key in
+     * {@link io.mcpmesh.core.MeshEvent}'s consumer (the Spring starter's
+     * public-URL cache).
+     */
+    @JsonProperty("skill_id")
+    private String skillId;
+
     private List<LlmToolInfo> tools;
 
     @JsonProperty("provider_info")
@@ -89,6 +99,10 @@ public class MeshEvent {
 
     public String getStatus() {
         return status;
+    }
+
+    public String getSkillId() {
+        return skillId;
     }
 
     public List<LlmToolInfo> getTools() {
@@ -144,6 +158,20 @@ public class MeshEvent {
 
         @JsonProperty("registry_disconnected")
         REGISTRY_DISCONNECTED,
+
+        /**
+         * Registry stamped a public URL for a registered {@code @MeshA2A}
+         * surface (spec §2.4 / §8.2). Carried fields: {@code capability}
+         * (re-used as the {@code path}), {@code endpoint} (the public URL),
+         * and a {@code skill_id} field on the event payload.
+         *
+         * <p>The Rust core does not emit this variant today — it's reserved
+         * for the registry → Java consumer wiring that the A2A producer
+         * roadmap adds. Until then the cache stays empty and producers fall
+         * back to their local-form URL.
+         */
+        @JsonProperty("surface_updated")
+        SURFACE_UPDATED,
 
         @JsonProperty("shutdown")
         SHUTDOWN

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -264,10 +264,11 @@ public class MeshAutoConfiguration {
         registration.setFilter(new MeshA2AAuthFilter(registry));
         registration.addUrlPatterns("/*");
         registration.setName("meshA2AAuthFilter");
-        // Run BEFORE the tracing filter (which is at HIGHEST_PRECEDENCE);
-        // we still want rejected requests to skip tracing entirely. Using
-        // HIGHEST_PRECEDENCE + 5 keeps tracing first and auth second, so
-        // even rejected requests are traced for debuggability.
+        // Run AFTER the tracing filter (which is at HIGHEST_PRECEDENCE).
+        // Lower precedence = higher numeric order in Spring, so
+        // HIGHEST_PRECEDENCE + 5 places auth one step behind tracing —
+        // tracing first, auth second — and even rejected requests are
+        // still traced for debuggability.
         registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 5);
         return registration;
     }
@@ -393,10 +394,12 @@ public class MeshAutoConfiguration {
             McpHttpClient mcpHttpClient,
             McpMeshToolProxyFactory proxyFactory,
             ToolInvoker toolInvoker,
-            ApplicationContext applicationContext) {
+            ApplicationContext applicationContext,
+            MeshA2APublicUrlCache publicUrlCache) {
 
         return new MeshEventProcessor(runtime, injector, wrapperRegistry,
-            llmRegistry, mcpHttpClient, proxyFactory, toolInvoker, applicationContext);
+            llmRegistry, mcpHttpClient, proxyFactory, toolInvoker, applicationContext,
+            publicUrlCache);
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -5,6 +5,16 @@ import io.mcpmesh.core.MeshObjectMappers;
 import io.mcpmesh.MeshAgent;
 import io.mcpmesh.Selector;
 import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.spring.web.MeshA2AAuthFilter;
+import io.mcpmesh.spring.web.MeshA2ABeanPostProcessor;
+import io.mcpmesh.spring.web.MeshA2ACardBuilder;
+import io.mcpmesh.spring.web.MeshA2ADispatcher;
+import io.mcpmesh.spring.web.MeshA2ADispatcherController;
+import io.mcpmesh.spring.web.MeshA2APublicUrlCache;
+import io.mcpmesh.spring.web.MeshA2ARegistry;
+import io.mcpmesh.spring.web.MeshA2ASseDispatcher;
+import io.mcpmesh.spring.web.MeshA2ASseHeaderFilter;
+import io.mcpmesh.spring.web.MeshA2ATaskStore;
 import io.mcpmesh.spring.web.MeshRouteRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,6 +100,178 @@ public class MeshAutoConfiguration {
         return MeshObjectMappers.create();
     }
 
+    // ─────────────────────────────────────────────────────────────────
+    // Issue #932: @MeshA2A producer-side support (Chunk 1A — sync only).
+    //
+    // Adds five beans:
+    //   * MeshA2ARegistry          — collects @MeshA2A surfaces
+    //   * MeshA2ABeanPostProcessor — scans beans at boot for @MeshA2A
+    //   * MeshA2ATaskStore         — process-local A2A task store (300s eviction)
+    //   * MeshA2ACardBuilder       — renders /.well-known/agent.json
+    //   * MeshA2ADispatcher        — JSON-RPC entry point dispatcher
+    //   * MeshA2ADispatcherController — @RestController mounted at /**
+    //   * meshA2AAuthFilter        — bearer-auth gate (filter registration)
+    //
+    // The dispatcher + card builder + controller depend on a populated
+    // MeshA2ARegistry. The bean post-processor is declared as a static
+    // factory so it instantiates before user beans (same pattern as the
+    // route bean post-processor).
+    // ─────────────────────────────────────────────────────────────────
+
+    @Bean
+    @ConditionalOnMissingBean
+    public static MeshA2ARegistry meshA2ARegistry() {
+        return new MeshA2ARegistry();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public static MeshA2ABeanPostProcessor meshA2ABeanPostProcessor(MeshA2ARegistry registry) {
+        return new MeshA2ABeanPostProcessor(registry);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public MeshA2ATaskStore meshA2ATaskStore() {
+        return new MeshA2ATaskStore();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public MeshA2ACardBuilder meshA2ACardBuilder(
+            MeshToolRegistry toolRegistry, ObjectMapper objectMapper) {
+        return new MeshA2ACardBuilder(toolRegistry, objectMapper);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public MeshA2ADispatcher meshA2ADispatcher(
+            MeshA2ARegistry registry,
+            MeshA2ATaskStore taskStore,
+            ObjectMapper objectMapper,
+            ObjectProvider<MeshDependencyInjector> injectorProvider) {
+        return new MeshA2ADispatcher(registry, taskStore, objectMapper, injectorProvider);
+    }
+
+    /**
+     * Process-local cache of registry-stamped public URLs (spec §8.2). Populated
+     * by {@link MeshEventProcessor} when the Rust core surfaces a
+     * {@code surface_updated} event; read by
+     * {@link MeshA2ADispatcherController#buildRouterFunction()} at agent-card
+     * render time. Empty by default — controller falls back to the local
+     * host:port URL form.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public MeshA2APublicUrlCache meshA2APublicUrlCache() {
+        return new MeshA2APublicUrlCache();
+    }
+
+    /**
+     * Spring-MVC SSE adapter for the dispatcher's framework-agnostic
+     * stream-plan (spec §4.6 / §4.7 / §5). The adapter contains the only
+     * code that imports Spring MVC's functional SSE API; the dispatcher
+     * itself stays unit-testable without a servlet container.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public MeshA2ASseDispatcher meshA2ASseDispatcher(MeshA2ADispatcher dispatcher) {
+        return new MeshA2ASseDispatcher(dispatcher);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public MeshA2ADispatcherController meshA2ADispatcherController(
+            MeshA2ARegistry registry,
+            MeshA2ADispatcher dispatcher,
+            MeshA2ASseDispatcher sseDispatcher,
+            MeshA2ACardBuilder cardBuilder,
+            ObjectProvider<MeshProperties> propertiesProvider,
+            ObjectProvider<MeshA2APublicUrlCache> publicUrlCacheProvider) {
+        return new MeshA2ADispatcherController(
+            registry, dispatcher, sseDispatcher, cardBuilder,
+            propertiesProvider, publicUrlCacheProvider);
+    }
+
+    /**
+     * Functional router for every registered {@code @MeshA2A} surface.
+     * Spring MVC composes this {@link org.springframework.web.servlet.function.RouterFunction}
+     * with annotation-based {@code @RestController} mappings, so user
+     * controllers, static-resource serving, and error pages continue to
+     * work alongside the A2A producer routes.
+     *
+     * <p>The bean is built lazily from
+     * {@link MeshA2ADispatcherController#buildRouterFunction()} which
+     * iterates {@link MeshA2ARegistry} at bean-creation time. Because
+     * the controller depends on the registry and the registry is
+     * populated by {@link MeshA2ABeanPostProcessor} (which runs before
+     * this configuration's bean methods complete), the iteration sees
+     * the full surface set.
+     */
+    @Bean
+    @ConditionalOnMissingBean(name = "meshA2ARouterFunction")
+    public org.springframework.web.servlet.function.RouterFunction<
+            org.springframework.web.servlet.function.ServerResponse>
+            meshA2ARouterFunction(MeshA2ADispatcherController controller) {
+        // Force eager instantiation of all candidate beans so
+        // MeshA2ABeanPostProcessor populates MeshA2ARegistry before we
+        // build the router function. Without this, Spring's bean creation
+        // order would let the router-function be built BEFORE the user's
+        // @Component / @Service classes are instantiated, leaving the
+        // registry empty.
+        //
+        // The same eager-touch trick is used by buildAgentSpec() for the
+        // route-registry-based consumer-only mode detection.
+        applicationContext.getBeansWithAnnotation(
+            org.springframework.stereotype.Component.class);
+        applicationContext.getBeansWithAnnotation(
+            org.springframework.stereotype.Service.class);
+        applicationContext.getBeansWithAnnotation(
+            org.springframework.web.bind.annotation.RestController.class);
+        return controller.buildRouterFunction();
+    }
+
+    /**
+     * Bearer-auth filter (spec §6). Registered at HIGHEST_PRECEDENCE + 10
+     * so it runs BEFORE Spring's dispatcher servlet matches the request to
+     * the {@link MeshA2ADispatcherController} — rejection short-circuits
+     * the chain with HTTP 401 + JSON-RPC -32001 before the dispatcher sees
+     * the body. The filter is conditional only on the registry being
+     * present; it no-ops on every request that isn't a POST to a registered
+     * bearer-protected surface, so it's safe to register unconditionally.
+     */
+    /**
+     * Stamps SSE buffering hints ({@code Cache-Control: no-cache},
+     * {@code X-Accel-Buffering: no}, {@code Connection: keep-alive}) on
+     * every request that opts into {@code text/event-stream}. Registered at
+     * {@code HIGHEST_PRECEDENCE + 6}, just after the bearer-auth filter.
+     */
+    @Bean
+    @ConditionalOnMissingBean(name = "meshA2ASseHeaderFilter")
+    public FilterRegistrationBean<MeshA2ASseHeaderFilter> meshA2ASseHeaderFilter() {
+        FilterRegistrationBean<MeshA2ASseHeaderFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new MeshA2ASseHeaderFilter());
+        registration.addUrlPatterns("/*");
+        registration.setName("meshA2ASseHeaderFilter");
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 6);
+        return registration;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "meshA2AAuthFilter")
+    public FilterRegistrationBean<MeshA2AAuthFilter> meshA2AAuthFilter(MeshA2ARegistry registry) {
+        FilterRegistrationBean<MeshA2AAuthFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new MeshA2AAuthFilter(registry));
+        registration.addUrlPatterns("/*");
+        registration.setName("meshA2AAuthFilter");
+        // Run BEFORE the tracing filter (which is at HIGHEST_PRECEDENCE);
+        // we still want rejected requests to skip tracing entirely. Using
+        // HIGHEST_PRECEDENCE + 5 keeps tracing first and auth second, so
+        // even rejected requests are traced for debuggability.
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 5);
+        return registration;
+    }
+
     @Bean
     @ConditionalOnMissingBean
     public static MeshToolBeanPostProcessor meshToolBeanPostProcessor(
@@ -159,9 +341,11 @@ public class MeshAutoConfiguration {
             MeshLlmRegistry llmRegistry,
             MeshConfigResolver configResolver,
             ObjectMapper objectMapper,
-            ObjectProvider<MeshRouteRegistry> routeRegistryProvider) {
+            ObjectProvider<MeshRouteRegistry> routeRegistryProvider,
+            ObjectProvider<MeshA2ARegistry> a2aRegistryProvider) {
 
-        AgentSpec spec = buildAgentSpec(properties, toolRegistry, wrapperRegistry, llmRegistry, configResolver, objectMapper, routeRegistryProvider);
+        AgentSpec spec = buildAgentSpec(properties, toolRegistry, wrapperRegistry, llmRegistry,
+            configResolver, objectMapper, routeRegistryProvider, a2aRegistryProvider);
         log.info("Creating MeshRuntime for agent '{}' with {} tools",
             spec.getName(), spec.getTools().size());
 
@@ -215,10 +399,29 @@ public class MeshAutoConfiguration {
             llmRegistry, mcpHttpClient, proxyFactory, toolInvoker, applicationContext);
     }
 
+    /**
+     * Health endpoint controller — produces a CGLIB-proxied {@link MeshRuntime}
+     * via {@link org.springframework.context.annotation.Lazy @Lazy} so the
+     * runtime is NOT resolved at controller construction time.
+     *
+     * <p>Without {@code @Lazy} this factory transitively triggered a
+     * bean-creation cycle: {@link #meshA2ARouterFunction} and
+     * {@link MeshRuntime#buildAgentSpec}-style eager-touches both walk
+     * {@code @Component} beans (which match {@code MeshHealthController}
+     * via its {@code @Controller} stereotype). The two touches interleaved
+     * so that {@code meshHealthController} was constructed while
+     * {@code meshRuntime} was already in creation — at which point
+     * {@code getIfAvailable()} could not resolve and Spring rejected the
+     * cycle. Using {@code @Lazy} on the direct {@link MeshRuntime} parameter
+     * defers resolution to the first {@code /health} request: the
+     * controller is fully constructed without touching the real runtime,
+     * the cycle is broken, and the runtime is resolved transparently when
+     * a probe arrives.
+     */
     @Bean
     @ConditionalOnMissingBean
-    public MeshHealthController meshHealthController(ObjectProvider<MeshRuntime> runtimeProvider) {
-        MeshRuntime runtime = runtimeProvider.getIfAvailable();
+    public MeshHealthController meshHealthController(
+            @org.springframework.context.annotation.Lazy MeshRuntime runtime) {
         return new MeshHealthController(runtime);
     }
 
@@ -258,7 +461,8 @@ public class MeshAutoConfiguration {
             MeshLlmRegistry llmRegistry,
             MeshConfigResolver configResolver,
             ObjectMapper objectMapper,
-            ObjectProvider<MeshRouteRegistry> routeRegistryProvider) {
+            ObjectProvider<MeshRouteRegistry> routeRegistryProvider,
+            ObjectProvider<MeshA2ARegistry> a2aRegistryProvider) {
 
         // Find @MeshAgent annotation
         MeshAgent agentAnnotation = findMeshAgentAnnotation();
@@ -372,9 +576,83 @@ public class MeshAutoConfiguration {
         // Add @MeshRoute dependencies as a synthetic tool
         addRouteDependencies(allTools, routeRegistryProvider);
 
+        // Issue #932 Phase 1A: force user beans (containing @MeshA2A) to be
+        // created so MeshA2ABeanPostProcessor populates MeshA2ARegistry
+        // before we read it.
+        applicationContext.getBeansWithAnnotation(
+            org.springframework.stereotype.Component.class);
+        applicationContext.getBeansWithAnnotation(
+            org.springframework.stereotype.Service.class);
+
+        // Add @MeshA2A dependencies as a synthetic tool so the Rust core
+        // resolves them via the registry's dependency mechanism (same
+        // pattern as addRouteDependencies).
+        addA2ADependencies(allTools, a2aRegistryProvider);
+
         spec.setTools(allTools);
 
+        // Flip agent_type to "a2a" and emit a2a_surfaces[] (spec §2 / §8)
+        // when at least one @MeshA2A surface is registered. Tools coexist
+        // with surfaces — A2A producers may also expose @MeshTool
+        // capabilities.
+        applyA2ASurfaces(spec, a2aRegistryProvider, objectMapper);
+
         return spec;
+    }
+
+    /**
+     * Add {@code @MeshA2A} dependencies as a synthetic
+     * {@code __mesh_a2a_deps} tool. Mirrors {@link #addRouteDependencies}
+     * exactly — without this, the registry's dependency resolution
+     * mechanism never learns about the capabilities each surface needs,
+     * so the {@link MeshDependencyInjector}'s proxy stays stuck in the
+     * unavailable state.
+     */
+    private void addA2ADependencies(List<AgentSpec.ToolSpec> tools,
+                                    ObjectProvider<io.mcpmesh.spring.web.MeshA2ARegistry> a2aRegistryProvider) {
+        io.mcpmesh.spring.web.MeshA2ARegistry registry = a2aRegistryProvider.getIfAvailable();
+        if (registry == null || !registry.hasSurfaces()) {
+            return;
+        }
+        List<AgentSpec.DependencySpec> deps = registry.getUniqueDependencySpecs();
+        if (deps.isEmpty()) {
+            return;
+        }
+        AgentSpec.ToolSpec syntheticTool = new AgentSpec.ToolSpec();
+        syntheticTool.setFunctionName("__mesh_a2a_deps");
+        syntheticTool.setCapability("__mesh_a2a_deps");
+        syntheticTool.setDescription("Synthetic tool for @MeshA2A dependency resolution");
+        syntheticTool.setDependencies(deps);
+        tools.add(syntheticTool);
+        log.info("Added {} @MeshA2A dependencies to agent registration", deps.size());
+    }
+
+    /**
+     * Apply {@code agent_type="a2a"} + serialized {@code surfaces} JSON onto
+     * {@code spec} when at least one {@code @MeshA2A} surface is registered
+     * (spec §2 / §8). No-op when the A2A registry is unavailable or empty —
+     * the agent falls back to its existing {@code agent_type} (typically
+     * {@code mcp_agent}) and omits the surfaces field on the wire.
+     */
+    private void applyA2ASurfaces(
+            AgentSpec spec,
+            ObjectProvider<MeshA2ARegistry> a2aRegistryProvider,
+            ObjectMapper objectMapper) {
+        MeshA2ARegistry a2aRegistry = a2aRegistryProvider.getIfAvailable();
+        if (a2aRegistry == null || !a2aRegistry.hasSurfaces()) {
+            return;
+        }
+        List<Map<String, Object>> heartbeatSurfaces = a2aRegistry.buildHeartbeatSurfaces();
+        try {
+            String surfacesJson = objectMapper.writeValueAsString(heartbeatSurfaces);
+            spec.setSurfaces(surfacesJson);
+            spec.setAgentType("a2a");
+            log.info("@MeshA2A: {} surface(s) registered — agent_type=a2a, surfaces={}",
+                heartbeatSurfaces.size(), surfacesJson);
+        } catch (Exception e) {
+            log.warn("Failed to serialize @MeshA2A surfaces — leaving agent_type unchanged: {}",
+                e.getMessage());
+        }
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
@@ -570,12 +570,12 @@ public class MeshEventProcessor implements SmartLifecycle {
         String path = event.getCapability();
         String skillId = event.getSkillId();
         String publicUrl = event.getEndpoint();
-        if (path == null || path.isEmpty()) {
+        if (path == null || path.isBlank()) {
             log.debug("Surface update event missing path: {}", event);
             return;
         }
-        publicUrlCache.put(path, skillId, publicUrl);
+        publicUrlCache.put(path.trim(), skillId, publicUrl);
         log.info("Surface updated: path={} skill_id={} public_url={}",
-            path, skillId, publicUrl);
+            path.trim(), skillId, publicUrl);
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
@@ -2,6 +2,7 @@ package io.mcpmesh.spring;
 
 import io.mcpmesh.core.MeshEvent;
 import io.mcpmesh.spring.media.MediaStore;
+import io.mcpmesh.spring.web.MeshA2APublicUrlCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -150,6 +151,7 @@ public class MeshEventProcessor implements SmartLifecycle {
             case DEPENDENCY_CHANGED -> handleDependencyChanged(event);
             case LLM_TOOLS_UPDATED -> handleLlmToolsUpdated(event);
             case LLM_PROVIDER_AVAILABLE -> handleLlmProviderAvailable(event);
+            case SURFACE_UPDATED -> handleSurfaceUpdated(event);
             case SHUTDOWN -> handleShutdown(event);
             case REGISTRATION_FAILED -> handleRegistrationFailed(event);
             default -> log.debug("Unhandled event type: {}", event.getEventType());
@@ -543,5 +545,44 @@ public class MeshEventProcessor implements SmartLifecycle {
 
     private void handleRegistrationFailed(MeshEvent event) {
         log.error("Registration failed: {}", event.getError());
+    }
+
+    /**
+     * Cache a registry-stamped public URL for an {@code @MeshA2A} surface
+     * (spec §2.4 / §8.2). The event carries:
+     * <ul>
+     *   <li>{@code capability} → the surface path (e.g. {@code "/agents/date"})</li>
+     *   <li>{@code skill_id}  → the surface skill id</li>
+     *   <li>{@code endpoint}  → the externally-reachable public URL</li>
+     * </ul>
+     *
+     * <p>The cache bean is optional — looked up lazily from the
+     * application context so the {@link MeshEventProcessor} dependency
+     * graph doesn't force loading the cache (which lives in the
+     * {@code spring.web} package and is only relevant when the producer
+     * has registered at least one A2A surface).
+     *
+     * <p>The Rust core does not currently emit this event; the handler is
+     * wired so a future registry-side change lands without an SDK ship.
+     */
+    private void handleSurfaceUpdated(MeshEvent event) {
+        String path = event.getCapability();
+        String skillId = event.getSkillId();
+        String publicUrl = event.getEndpoint();
+        if (path == null || path.isEmpty()) {
+            log.debug("Surface update event missing path: {}", event);
+            return;
+        }
+        MeshA2APublicUrlCache cache;
+        try {
+            cache = applicationContext.getBean(MeshA2APublicUrlCache.class);
+        } catch (BeansException e) {
+            // No A2A surfaces registered in this process; nothing to cache.
+            log.debug("Surface update event received but no MeshA2APublicUrlCache bean; ignoring");
+            return;
+        }
+        cache.put(path, skillId, publicUrl);
+        log.info("Surface updated: path={} skill_id={} public_url={}",
+            path, skillId, publicUrl);
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
@@ -46,6 +46,7 @@ public class MeshEventProcessor implements SmartLifecycle {
     private final McpMeshToolProxyFactory proxyFactory;
     private final ToolInvoker toolInvoker;
     private final ApplicationContext applicationContext; // For MediaStore bean lookup
+    private final MeshA2APublicUrlCache publicUrlCache;
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final ExecutorService executor;
 
@@ -72,7 +73,8 @@ public class MeshEventProcessor implements SmartLifecycle {
             McpHttpClient mcpClient,
             McpMeshToolProxyFactory proxyFactory,
             ToolInvoker toolInvoker,
-            ApplicationContext applicationContext) {
+            ApplicationContext applicationContext,
+            MeshA2APublicUrlCache publicUrlCache) {
         this.runtime = runtime;
         this.injector = injector;
         this.wrapperRegistry = wrapperRegistry;
@@ -81,6 +83,7 @@ public class MeshEventProcessor implements SmartLifecycle {
         this.proxyFactory = proxyFactory;
         this.toolInvoker = toolInvoker;
         this.applicationContext = applicationContext;
+        this.publicUrlCache = publicUrlCache;
         this.executor = Executors.newSingleThreadExecutor(r -> {
             Thread t = new Thread(r, "mesh-event-processor");
             t.setDaemon(true);
@@ -556,11 +559,9 @@ public class MeshEventProcessor implements SmartLifecycle {
      *   <li>{@code endpoint}  → the externally-reachable public URL</li>
      * </ul>
      *
-     * <p>The cache bean is optional — looked up lazily from the
-     * application context so the {@link MeshEventProcessor} dependency
-     * graph doesn't force loading the cache (which lives in the
-     * {@code spring.web} package and is only relevant when the producer
-     * has registered at least one A2A surface).
+     * <p>The cache bean is registered unconditionally by
+     * {@code MeshAutoConfiguration} and constructor-injected here, so the
+     * handler can write to it directly without a defensive lookup.
      *
      * <p>The Rust core does not currently emit this event; the handler is
      * wired so a future registry-side change lands without an SDK ship.
@@ -573,15 +574,7 @@ public class MeshEventProcessor implements SmartLifecycle {
             log.debug("Surface update event missing path: {}", event);
             return;
         }
-        MeshA2APublicUrlCache cache;
-        try {
-            cache = applicationContext.getBean(MeshA2APublicUrlCache.class);
-        } catch (BeansException e) {
-            // No A2A surfaces registered in this process; nothing to cache.
-            log.debug("Surface update event received but no MeshA2APublicUrlCache bean; ignoring");
-            return;
-        }
-        cache.put(path, skillId, publicUrl);
+        publicUrlCache.put(path, skillId, publicUrl);
         log.info("Surface updated: path={} skill_id={} public_url={}",
             path, skillId, publicUrl);
     }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2A.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2A.java
@@ -9,9 +9,9 @@ import java.lang.annotation.Target;
 /**
  * Marks a method as an A2A (Agent-to-Agent) producer surface. The framework
  * mounts a JSON-RPC 2.0 entry point at {@code POST {path}} and an A2A v1.0
- * AgentCard at {@code GET {path}/.well-known/agent.json}, dispatching to the
- * annotated method whenever a client sends a {@code tasks/send} (Phase 1A
- * scope) or — once Chunk 1B lands — any other {@code tasks/*} verb.
+ * AgentCard at {@code GET {path}/.well-known/agent.json}, dispatching for
+ * the full {@code tasks/*} verb set ({@code tasks/send}, {@code tasks/get},
+ * {@code tasks/cancel}, {@code tasks/sendSubscribe}, {@code tasks/resubscribe}).
  *
  * <p>This annotation is the Spring equivalent of Python's {@code @mesh.a2a}
  * decorator + {@code mesh.a2a.mount(app, path=...)} call. It carries the

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2A.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2A.java
@@ -1,0 +1,204 @@
+package io.mcpmesh.spring.web;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as an A2A (Agent-to-Agent) producer surface. The framework
+ * mounts a JSON-RPC 2.0 entry point at {@code POST {path}} and an A2A v1.0
+ * AgentCard at {@code GET {path}/.well-known/agent.json}, dispatching to the
+ * annotated method whenever a client sends a {@code tasks/send} (Phase 1A
+ * scope) or — once Chunk 1B lands — any other {@code tasks/*} verb.
+ *
+ * <p>This annotation is the Spring equivalent of Python's {@code @mesh.a2a}
+ * decorator + {@code mesh.a2a.mount(app, path=...)} call. It carries the
+ * skill-level metadata that the framework projects onto:
+ * <ol>
+ *   <li>the heartbeat {@code a2a_surfaces[]} array (registry registration,
+ *       per spec §2 / §8);</li>
+ *   <li>the agent card returned from {@code .well-known/agent.json}
+ *       (per spec §3); and</li>
+ *   <li>the JSON-RPC dispatch table that handles {@code tasks/*} verbs at
+ *       {@code POST {path}} (per spec §4).</li>
+ * </ol>
+ *
+ * <p>The annotated method is invoked with the A2A {@code message} object
+ * already extracted from {@code params.message}. Return values are wrapped
+ * as a single text-part artifact on a {@code state=completed} Task envelope.
+ * Thrown exceptions become {@code state=failed} Tasks per the A2A v1.0 spec
+ * (handler exceptions are NEVER JSON-RPC errors — JSON-RPC errors are
+ * reserved for protocol-level issues).
+ *
+ * <h2>Example Usage</h2>
+ *
+ * <pre>{@code
+ * @Component
+ * public class DateAgent {
+ *
+ *     @MeshA2A(
+ *         path = "/agents/date",
+ *         skillId = "current-date",
+ *         skillName = "Current Date",
+ *         description = "Returns the current UTC date in ISO-8601 form",
+ *         tags = {"date", "v1"}
+ *     )
+ *     public Map<String, Object> currentDate(Map<String, Object> message) {
+ *         return Map.of("date", java.time.Instant.now().toString());
+ *     }
+ * }
+ * }</pre>
+ *
+ * <h3>With mesh dependency injection</h3>
+ *
+ * <p>{@link MeshDependency} entries declared on the annotation are resolved
+ * by the same {@link io.mcpmesh.spring.MeshDependencyInjector} that powers
+ * {@code @MeshRoute}. Inject the resolved {@link io.mcpmesh.types.McpMeshTool}
+ * via {@link MeshInject} on a method parameter:
+ *
+ * <pre>{@code
+ * @MeshA2A(
+ *     path = "/agents/report-generator",
+ *     skillId = "generate-report",
+ *     skillName = "Report Generator",
+ *     description = "Generates a long-form report from structured input",
+ *     dependencies = {
+ *         @MeshDependency(capability = "outline-tool"),
+ *         @MeshDependency(capability = "writer-tool", tags = "+premium")
+ *     }
+ * )
+ * public Map<String, Object> generateReport(
+ *         Map<String, Object> message,
+ *         @MeshInject("outline-tool") McpMeshTool outline,
+ *         @MeshInject("writer-tool") McpMeshTool writer) {
+ *     Map<String, Object> outlineResult = outline.call(message);
+ *     return writer.call(outlineResult);
+ * }
+ * }</pre>
+ *
+ * <h3>Bearer-token gate</h3>
+ *
+ * <p>Setting {@link #auth()} to {@code "bearer"} enables a header-presence
+ * gate on the {@code POST {path}} entry point. The agent card endpoint is
+ * always reachable without authentication so external clients can discover
+ * the scheme. Phase 1 only checks header presence; token-value validation
+ * (signature, issuer, audience) is Phase 2+ scope.
+ *
+ * <pre>{@code
+ * @MeshA2A(
+ *     path = "/agents/private",
+ *     skillId = "internal-report",
+ *     skillName = "Internal Report",
+ *     auth = "bearer"
+ * )
+ * public Map<String, Object> privateReport(Map<String, Object> message) { ... }
+ * }</pre>
+ *
+ * <h2>Registry registration</h2>
+ *
+ * <p>When this Spring Boot app heartbeats to the mesh registry, the
+ * presence of at least one {@code @MeshA2A} method flips {@code agent_type}
+ * to {@code "a2a"} and emits an {@code a2a_surfaces[]} array with one
+ * entry per surface. The registry stamps a public FQDN onto each surface
+ * (when {@code MCP_MESH_PUBLIC_URL_PREFIX} is configured) so external
+ * A2A clients can discover the agent via {@code GET /a2a/agents}.
+ *
+ * @see MeshDependency
+ * @see MeshInject
+ * @see MeshRoute
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MeshA2A {
+
+    /**
+     * URL path prefix for this A2A surface. Required.
+     *
+     * <p>The framework mounts the JSON-RPC entry point at {@code POST {path}}
+     * and the agent card at {@code GET {path}/.well-known/agent.json}. Must
+     * start with {@code /}. Example: {@code "/agents/report-generator"}.
+     *
+     * @return the path prefix
+     */
+    String path();
+
+    /**
+     * A2A skill identifier (kebab-case canonical). Required.
+     *
+     * <p>This is the {@code skill_id} surfaced on the registry's
+     * {@code a2a_surfaces[]} array and the {@code skills[0].id} field on
+     * the agent card. Example: {@code "generate-report"}.
+     *
+     * @return the skill id
+     */
+    String skillId();
+
+    /**
+     * Human-readable skill name surfaced on the agent card. Required.
+     *
+     * <p>Becomes the {@code skills[0].name} field on the agent card and the
+     * {@code name} field on the {@code a2a_surfaces[]} entry.
+     *
+     * @return the skill display name
+     */
+    String skillName();
+
+    /**
+     * Optional free-form skill description.
+     *
+     * <p>Surfaces on the agent card as {@code skills[0].description} and on
+     * the {@code a2a_surfaces[]} entry as {@code description}. Defaults to
+     * {@link #skillName()} on the card when blank.
+     *
+     * @return the skill description
+     */
+    String description() default "";
+
+    /**
+     * Optional tags for this skill. Surfaced verbatim on the agent card
+     * as {@code skills[0].tags} and on the {@code a2a_surfaces[]} entry
+     * as {@code tags}.
+     *
+     * @return the skill tags
+     */
+    String[] tags() default {};
+
+    /**
+     * Mesh dependencies to inject when the handler is invoked.
+     *
+     * <p>Each entry is resolved from the mesh registry by capability; the
+     * resolved {@link io.mcpmesh.types.McpMeshTool} proxy is made available
+     * to the handler via {@link MeshInject} parameter injection. Mirrors
+     * {@link MeshRoute#dependencies()}.
+     *
+     * @return the array of mesh dependencies
+     */
+    MeshDependency[] dependencies() default {};
+
+    /**
+     * Optional authentication scheme. Either {@code ""} (no gate, default)
+     * or {@code "bearer"} (Phase 1: header-presence check only).
+     *
+     * <p>Per spec §6, when set to {@code "bearer"} the producer:
+     * <ul>
+     *   <li>advertises {@code authentication.schemes = ["bearer"]} on the
+     *       agent card;</li>
+     *   <li>rejects any {@code POST {path}} request with a missing,
+     *       non-{@code Bearer}, or empty-token {@code Authorization} header
+     *       with HTTP 401 + JSON-RPC error code {@code -32001};</li>
+     *   <li>does NOT validate the token value (signature/issuer/audience
+     *       validation is Phase 2+).</li>
+     * </ul>
+     *
+     * <p>When unset (the default), the agent card advertises an empty
+     * {@code authentication.schemes} list (NOT {@code "none"} — A2A v1.0
+     * has no such scheme) and the entry point is reachable without
+     * authentication.
+     *
+     * @return {@code "bearer"} to enable the gate, {@code ""} otherwise
+     */
+    String auth() default "";
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2AAuthFilter.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2AAuthFilter.java
@@ -1,0 +1,160 @@
+package io.mcpmesh.spring.web;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Bearer-token authentication gate for {@code @MeshA2A} surfaces (spec §6).
+ *
+ * <p>Applies only to {@code POST {path}} where {@code path} matches a
+ * registered surface AND that surface declared {@code auth="bearer"}. The
+ * agent-card endpoint ({@code GET {path}/.well-known/agent.json}) is always
+ * reachable without auth (spec §6.2 + conformance checklist) so clients can
+ * discover the authentication scheme before authenticating.
+ *
+ * <h2>Phase 1 semantics</h2>
+ *
+ * <p>The filter checks the {@code Authorization} header for:
+ * <ol>
+ *   <li>presence (a missing header is rejected);</li>
+ *   <li>a {@code Bearer} scheme prefix (case-insensitive);</li>
+ *   <li>a non-empty token after the {@code Bearer } prefix
+ *       (whitespace-only counts as empty).</li>
+ * </ol>
+ *
+ * <p>The filter MUST NOT validate the token value — no signature check, no
+ * issuer/audience check, no expiry check. Value-level validation is Phase 2+
+ * (spec §6.2 + Appendix B item 4).
+ *
+ * <h2>Error shape</h2>
+ *
+ * <p>Rejections return HTTP 401 with a JSON-RPC envelope carrying
+ * {@code error.code = -32001} and {@code id = null} (the request body is
+ * never parsed at this stage). The {@code -32001} code sits in the
+ * implementation-defined {@code -32000} … {@code -32099} server-error range
+ * and matches the Python producer exactly for cross-runtime parity.
+ */
+public class MeshA2AAuthFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshA2AAuthFilter.class);
+
+    /** Implementation-defined server-error code for authentication failures. */
+    public static final int JSONRPC_AUTH_ERROR = -32001;
+
+    private static final String AUTH_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final MeshA2ARegistry registry;
+
+    public MeshA2AAuthFilter(MeshA2ARegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String path = normalizePath(request);
+        MeshA2ARegistry.SurfaceMetadata surface = registry.getByPath(path);
+        if (surface == null || !surface.bearerAuth()) {
+            // Either not an A2A surface or no bearer gate configured —
+            // the dispatcher (or other controllers) own this request.
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String authz = request.getHeader(AUTH_HEADER);
+        if (authz == null || authz.isEmpty()) {
+            writeAuthError(response,
+                "Authentication required: missing Authorization: Bearer <token> header");
+            return;
+        }
+        // Case-insensitive prefix check on "Bearer ".
+        if (authz.length() < BEARER_PREFIX.length()
+            || !authz.substring(0, BEARER_PREFIX.length()).equalsIgnoreCase(BEARER_PREFIX)) {
+            writeAuthError(response,
+                "Authentication required: missing Authorization: Bearer <token> header");
+            return;
+        }
+        String token = authz.substring(BEARER_PREFIX.length()).strip();
+        if (token.isEmpty()) {
+            writeAuthError(response,
+                "Authentication required: empty bearer token in Authorization header");
+            return;
+        }
+
+        // Phase 1: presence check only — DO NOT validate token value.
+        // Value validation (signature/issuer/audience) is Phase 2 scope.
+        chain.doFilter(request, response);
+    }
+
+    private void writeAuthError(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        // Hand-rolled JSON to avoid an ObjectMapper dependency on the
+        // filter path — the shape is fixed and small.
+        String escapedMessage = escapeJsonString(message);
+        String body = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":" + JSONRPC_AUTH_ERROR
+            + ",\"message\":\"" + escapedMessage + "\"},\"id\":null}";
+        response.getWriter().write(body);
+        response.getWriter().flush();
+    }
+
+    private static String normalizePath(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        if (uri == null || uri.isEmpty()) {
+            return "/";
+        }
+        String contextPath = request.getContextPath();
+        if (contextPath != null && !contextPath.isEmpty() && uri.startsWith(contextPath)) {
+            uri = uri.substring(contextPath.length());
+            if (uri.isEmpty()) {
+                uri = "/";
+            }
+        }
+        if (uri.length() > 1 && uri.endsWith("/")) {
+            uri = uri.substring(0, uri.length() - 1);
+        }
+        return uri;
+    }
+
+    private static String escapeJsonString(String s) {
+        if (s == null) return "";
+        StringBuilder sb = new StringBuilder(s.length() + 8);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\', '"' -> {
+                    sb.append('\\');
+                    sb.append(c);
+                }
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                case '\b' -> sb.append("\\b");
+                case '\f' -> sb.append("\\f");
+                default -> {
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ABeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ABeanPostProcessor.java
@@ -1,0 +1,86 @@
+package io.mcpmesh.spring.web;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Scans Spring beans for methods annotated with {@link MeshA2A} and registers
+ * them in {@link MeshA2ARegistry}.
+ *
+ * <p>Runs during application startup as a {@link BeanPostProcessor}. For every
+ * candidate bean it inspects declared methods; on each {@code @MeshA2A} hit it
+ * captures the annotation metadata + handler reference into a
+ * {@link MeshA2ARegistry.SurfaceMetadata} record. The dispatcher
+ * ({@link MeshA2ADispatcher}) and card builder ({@link MeshA2ACardBuilder})
+ * consult the registry at request time.
+ *
+ * <p>Unlike {@link MeshRouteBeanPostProcessor} this processor does not gate on
+ * {@code @RestController} / {@code @Controller} class-level annotations:
+ * {@code @MeshA2A} methods can live on any Spring bean (e.g. {@code @Component},
+ * {@code @Service}). The dispatch path is entirely framework-mounted, so the
+ * user's bean type is irrelevant.
+ */
+public class MeshA2ABeanPostProcessor implements BeanPostProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshA2ABeanPostProcessor.class);
+
+    private final MeshA2ARegistry registry;
+
+    public MeshA2ABeanPostProcessor(MeshA2ARegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        Class<?> targetClass = AopUtils.getTargetClass(bean);
+
+        for (Method method : targetClass.getDeclaredMethods()) {
+            MeshA2A annotation = AnnotationUtils.findAnnotation(method, MeshA2A.class);
+            if (annotation == null) {
+                continue;
+            }
+
+            String auth = annotation.auth() == null ? "" : annotation.auth();
+            if (!auth.isEmpty() && !"bearer".equals(auth)) {
+                throw new IllegalStateException(
+                    "@MeshA2A on " + targetClass.getName() + "#" + method.getName()
+                        + ": auth must be \"\" or \"bearer\" (got '" + auth + "'). "
+                        + "Spec §6 only defines the bearer scheme in Phase 1.");
+            }
+
+            List<MeshRouteRegistry.DependencySpec> deps = new ArrayList<>();
+            for (MeshDependency dep : annotation.dependencies()) {
+                deps.add(MeshRouteRegistry.DependencySpec.fromAnnotation(dep));
+            }
+
+            String handlerMethodId = targetClass.getName() + "." + method.getName();
+            MeshA2ARegistry.SurfaceMetadata metadata = new MeshA2ARegistry.SurfaceMetadata(
+                annotation.path(),
+                annotation.skillId(),
+                annotation.skillName(),
+                annotation.description(),
+                Arrays.asList(annotation.tags()),
+                deps,
+                auth,
+                handlerMethodId,
+                bean,
+                method
+            );
+
+            registry.register(metadata);
+            log.debug("@MeshA2A: {} → {} (auth='{}', deps={})",
+                metadata.path(), handlerMethodId, auth, deps.size());
+        }
+
+        return bean;
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ABeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ABeanPostProcessor.java
@@ -44,6 +44,14 @@ public class MeshA2ABeanPostProcessor implements BeanPostProcessor {
         Class<?> targetClass = AopUtils.getTargetClass(bean);
 
         for (Method method : targetClass.getDeclaredMethods()) {
+            // Skip compiler-generated bridge/synthetic methods. Generic erasure
+            // causes javac to emit a bridge method alongside the real handler,
+            // and AnnotationUtils#findAnnotation returns the same annotation
+            // on both — double-registering the surface (and tripping the
+            // duplicate-path guard in MeshA2ARegistry).
+            if (method.isBridge() || method.isSynthetic()) {
+                continue;
+            }
             MeshA2A annotation = AnnotationUtils.findAnnotation(method, MeshA2A.class);
             if (annotation == null) {
                 continue;

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ACardBuilder.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ACardBuilder.java
@@ -1,0 +1,198 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.spring.MeshToolRegistry;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds A2A v1.0 AgentCard JSON for {@code GET {path}/.well-known/agent.json}
+ * (spec §3).
+ *
+ * <p>One card is rendered per {@code @MeshA2A} surface — multi-skill grouping
+ * under a single card is v2 scope (spec Appendix B item 1). Auto-populates
+ * from:
+ *
+ * <ul>
+ *   <li>the surface's {@link MeshA2A} metadata directly (skill id, name,
+ *       description, tags);</li>
+ *   <li>the {@code @MeshTool} input-schema of the declared dependencies, when
+ *       one of them happens to be a local tool whose schema is in
+ *       {@link MeshToolRegistry} — surfaced under
+ *       {@code skills[0].metadata.input_schema} (optional in spec; useful
+ *       for downstream tooling like LangGraph).</li>
+ * </ul>
+ *
+ * <p>Mirrors Python's {@code _mcp_mesh.engine.a2a_card.build_agent_card}.
+ */
+public class MeshA2ACardBuilder {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshA2ACardBuilder.class);
+
+    /**
+     * A2A v1.0 default input modes. Materialised at card-render time (not at
+     * heartbeat-emit time per spec §2.1).
+     */
+    public static final List<String> DEFAULT_INPUT_MODES = List.of("application/json");
+
+    /**
+     * A2A v1.0 default output modes. Materialised at card-render time.
+     */
+    public static final List<String> DEFAULT_OUTPUT_MODES = List.of("application/json");
+
+    private final MeshToolRegistry toolRegistry;
+    private final ObjectMapper objectMapper;
+
+    public MeshA2ACardBuilder(MeshToolRegistry toolRegistry, ObjectMapper objectMapper) {
+        this.toolRegistry = toolRegistry;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Build the agent card JSON for {@code surface}.
+     *
+     * @param surface        the registered surface metadata
+     * @param agentName      the mesh agent display name (defaults to
+     *                       {@code "agent"} when blank; mirrors Python's
+     *                       fallback in {@code a2a.py:340-344})
+     * @param agentVersion   the agent version string ({@code "1.0.0"} by
+     *                       convention)
+     * @param agentDescription free-form agent description; falls back to
+     *                         {@code agentName} on the card (spec §3.2)
+     * @param publicUrl      the registry-stamped public FQDN for
+     *                       {@code POST {path}}, or {@code null} when the
+     *                       registry has not stamped one yet — the
+     *                       {@code url} field is OMITTED rather than emitted
+     *                       as an empty string (spec §3.2 + conformance
+     *                       checklist)
+     * @return a {@link LinkedHashMap} ready for JSON serialization with
+     *     deterministic key order
+     */
+    public Map<String, Object> build(
+            MeshA2ARegistry.SurfaceMetadata surface,
+            String agentName,
+            String agentVersion,
+            String agentDescription,
+            String publicUrl) {
+
+        String name = (agentName != null && !agentName.isBlank()) ? agentName : "agent";
+        String version = (agentVersion != null && !agentVersion.isBlank()) ? agentVersion : "1.0.0";
+        String description = (agentDescription != null && !agentDescription.isBlank())
+            ? agentDescription : name;
+
+        Map<String, Object> skill = new LinkedHashMap<>();
+        skill.put("id", surface.skillId());
+        skill.put("name", surface.skillName());
+        skill.put("description",
+            surface.description().isEmpty() ? surface.skillName() : surface.description());
+        skill.put("tags", new ArrayList<>(surface.tags()));
+        skill.put("inputModes", new ArrayList<>(DEFAULT_INPUT_MODES));
+        skill.put("outputModes", new ArrayList<>(DEFAULT_OUTPUT_MODES));
+
+        Map<String, Object> underlyingInputSchema = locateUnderlyingInputSchema(surface);
+        if (underlyingInputSchema != null) {
+            skill.put("metadata", Map.of("input_schema", underlyingInputSchema));
+        }
+
+        Map<String, Object> capabilities = new LinkedHashMap<>();
+        // Spec §3.2: capabilities.streaming MUST be true. Even in Chunk 1A
+        // (sync only) we advertise streaming=true so the wire shape matches
+        // Python — Chunk 1B will wire the real SSE handlers behind it.
+        capabilities.put("streaming", true);
+        capabilities.put("pushNotifications", false);
+        capabilities.put("stateTransitionHistory", false);
+
+        Map<String, Object> card = new LinkedHashMap<>();
+        card.put("name", name);
+        card.put("description", description);
+        card.put("version", version);
+        card.put("capabilities", capabilities);
+        card.put("defaultInputModes", new ArrayList<>(DEFAULT_INPUT_MODES));
+        card.put("defaultOutputModes", new ArrayList<>(DEFAULT_OUTPUT_MODES));
+        card.put("skills", List.of(skill));
+
+        if (publicUrl != null && !publicUrl.isBlank()) {
+            card.put("url", publicUrl);
+        }
+
+        // Spec §3.2 / §6.1: authentication.schemes is a list of scheme
+        // names. For bearer-token surfaces we emit ["bearer"]; otherwise an
+        // empty list (NOT "none" — A2A v1.0 has no "none" scheme).
+        Map<String, Object> authentication = new LinkedHashMap<>();
+        if (surface.bearerAuth()) {
+            authentication.put("schemes", List.of("bearer"));
+        } else {
+            authentication.put("schemes", List.of());
+        }
+        card.put("authentication", authentication);
+
+        return card;
+    }
+
+    /**
+     * Try to pull the local {@code @MeshTool} input schema for the first
+     * declared dependency that happens to be a tool registered on this
+     * process. Returns {@code null} when no dependency resolves to a local
+     * tool — cross-agent dependencies don't carry schema info on the
+     * decorator at registration time, so the card simply omits
+     * {@code skills[0].metadata.input_schema} in that case (spec §3.2:
+     * SHOULD-emit, not MUST-emit).
+     */
+    private Map<String, Object> locateUnderlyingInputSchema(MeshA2ARegistry.SurfaceMetadata surface) {
+        if (toolRegistry == null) {
+            return null;
+        }
+        for (MeshRouteRegistry.DependencySpec dep : surface.dependencies()) {
+            MeshToolRegistry.ToolMetadata tool = toolRegistry.getTool(dep.getCapability());
+            if (tool != null && tool.inputSchema() != null && !tool.inputSchema().isEmpty()) {
+                return new LinkedHashMap<>(tool.inputSchema());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Convenience: compute a local-fallback URL when no public FQDN is
+     * available yet. Format: {@code http://{host}:{port}{path}}. Mirrors
+     * Python's {@code _local_fallback_url} (mesh/a2a.py:236-247) — sufficient
+     * for local dev / CI before the first heartbeat round-trip.
+     */
+    public static String localFallbackUrl(String host, int port, String path) {
+        if (host == null || host.isBlank() || port <= 0) {
+            return null;
+        }
+        return "http://" + host + ":" + port + path;
+    }
+
+    /**
+     * Convert a card map to its canonical JSON string form. Provided as a
+     * helper for the dispatcher (which writes it to the HTTP response body)
+     * and for tests.
+     */
+    public String toJson(Map<String, Object> card) {
+        try {
+            return objectMapper.writeValueAsString(card);
+        } catch (Exception e) {
+            log.warn("Failed to serialize A2A agent card: {}", e.getMessage());
+            return "{}";
+        }
+    }
+
+    /**
+     * Helper for tests: parse a JSON string into a generic map. Kept out of
+     * the hot path; the dispatcher always serializes outgoing cards directly.
+     */
+    public Map<String, Object> parseCard(String json) {
+        try {
+            return objectMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse agent card JSON", e);
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ACardBuilder.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ACardBuilder.java
@@ -167,7 +167,15 @@ public class MeshA2ACardBuilder {
         if (host == null || host.isBlank() || port <= 0) {
             return null;
         }
-        return "http://" + host + ":" + port + path;
+        // IPv6 literals (e.g. "::1") must be wrapped in brackets when paired
+        // with a port — otherwise the result is an ambiguous, invalid URL like
+        // "http://::1:9090/...". Detect by colon-presence: an IPv6 literal
+        // contains at least one ":" and is NOT already bracketed.
+        String hostPart = host;
+        if (host.indexOf(':') >= 0 && host.charAt(0) != '[') {
+            hostPart = "[" + host + "]";
+        }
+        return "http://" + hostPart + ":" + port + path;
     }
 
     /**
@@ -179,8 +187,10 @@ public class MeshA2ACardBuilder {
         try {
             return objectMapper.writeValueAsString(card);
         } catch (Exception e) {
+            // Rethrow so the dispatcher returns a real 5xx — silently shipping
+            // "{}" hides serialization bugs and produces an A2A-invalid card.
             log.warn("Failed to serialize A2A agent card: {}", e.getMessage());
-            return "{}";
+            throw new RuntimeException("Failed to serialize A2A agent card", e);
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcher.java
@@ -346,6 +346,14 @@ public class MeshA2ADispatcher {
             return SseStreamPlan.error(jsonRpcError(null, JSONRPC_PARSE_ERROR,
                 "Parse error: request body is not valid JSON"), HttpStatus.BAD_REQUEST);
         }
+        // Mirror the dispatch() guard: Jackson 3's readTree(...) returns a
+        // MissingNode rather than throwing for whitespace-only bodies — treat
+        // that as a parse error too so we never fall through with a JsonNode
+        // that can't be inspected.
+        if (bodyNode == null || bodyNode.isMissingNode()) {
+            return SseStreamPlan.error(jsonRpcError(null, JSONRPC_PARSE_ERROR,
+                "Parse error: request body is not valid JSON"), HttpStatus.BAD_REQUEST);
+        }
         Object reqId = extractId(bodyNode);
         Map<String, Object> params = readParams(bodyNode.get("params"));
 
@@ -414,6 +422,10 @@ public class MeshA2ADispatcher {
         try {
             bodyNode = objectMapper.readTree(requestBody);
         } catch (Exception e) {
+            return SseStreamPlan.error(jsonRpcError(null, JSONRPC_PARSE_ERROR,
+                "Parse error: request body is not valid JSON"), HttpStatus.BAD_REQUEST);
+        }
+        if (bodyNode == null || bodyNode.isMissingNode()) {
             return SseStreamPlan.error(jsonRpcError(null, JSONRPC_PARSE_ERROR,
                 "Parse error: request body is not valid JSON"), HttpStatus.BAD_REQUEST);
         }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcher.java
@@ -859,6 +859,27 @@ public class MeshA2ADispatcher {
         return toJson(envelope);
     }
 
+    /**
+     * Peek at the {@code method} field of a JSON-RPC request body without
+     * committing to a full parse. Returns {@code null} when the body is
+     * empty, unparseable, or has no textual {@code method} field — callers
+     * fall through to the JSON-RPC dispatcher which produces the canonical
+     * parse-error response.
+     *
+     * <p>Reuses the dispatcher's injected {@link ObjectMapper} so the SSE
+     * controller does not have to construct a fresh mapper on every POST.
+     */
+    public String peekJsonRpcMethod(String body) {
+        if (body == null || body.isEmpty()) return null;
+        try {
+            tools.jackson.databind.JsonNode node = objectMapper.readTree(body);
+            tools.jackson.databind.JsonNode m = node.get("method");
+            return m != null && m.isTextual() ? m.asText() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     // ─────────────────────────────────────────────────────────────────
     // Task store interaction
     // ─────────────────────────────────────────────────────────────────

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcher.java
@@ -1,0 +1,1116 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.JobProxy;
+import io.mcpmesh.spring.MeshDependencyInjector;
+import io.mcpmesh.types.McpMeshTool;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * JSON-RPC 2.0 dispatcher for {@code @MeshA2A} producer surfaces (spec §4).
+ *
+ * <p>Chunk 1B coverage:
+ * <ul>
+ *   <li>{@code tasks/send} — sync handler return → {@code state=completed};
+ *       {@link JobProxy} return → {@code state=working} envelope with the
+ *       task parked in the {@link MeshA2ATaskStore} (spec §4.3 long-running
+ *       branch); handler exception → {@code state=failed} (spec §4.3).</li>
+ *   <li>{@code tasks/get} — looks up the cached terminal envelope OR pulls
+ *       live status from the parked {@link JobProxy} and translates the
+ *       mesh state to A2A via {@link MeshA2AStateTranslator} (spec §4.4 /
+ *       §7.2).</li>
+ *   <li>{@code tasks/cancel} — calls {@link JobProxy#cancel(String)} on the
+ *       parked task, then re-reads status; idempotent ack for already-terminal
+ *       tasks (spec §4.5).</li>
+ *   <li>{@code tasks/sendSubscribe} / {@code tasks/resubscribe} — exposed
+ *       indirectly through {@link #buildSendSubscribeStream} /
+ *       {@link #buildResubscribeStream} which return a framework-agnostic
+ *       sequence of {@link SseFrame}s. The SSE adapter
+ *       ({@link MeshA2ASseDispatcher}) maps each frame to a Spring
+ *       {@code text/event-stream} body. The dispatcher itself never imports
+ *       Spring SSE classes so it stays unit-testable with no servlet
+ *       container (spec §4.6 / §4.7 / §5).</li>
+ * </ul>
+ *
+ * <p>The dispatcher itself is path-agnostic — it consults
+ * {@link MeshA2ARegistry} for every request to locate the right handler. Path
+ * routing is handled by {@link MeshA2ADispatcherController}, which mounts the
+ * dispatcher at {@code POST /**} and delegates here after path-to-surface
+ * resolution.
+ */
+public class MeshA2ADispatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshA2ADispatcher.class);
+
+    /** JSON-RPC: Parse error (request body is not valid JSON). Spec §4.1. */
+    public static final int JSONRPC_PARSE_ERROR = -32700;
+    /** JSON-RPC: Invalid Request (well-formed JSON but not a valid JSON-RPC
+     *  request object — e.g. missing {@code method} field). Spec §4.1. */
+    public static final int JSONRPC_INVALID_REQUEST = -32600;
+    /** JSON-RPC: Method not found (unknown {@code tasks/*} verb). Spec §4.1. */
+    public static final int JSONRPC_METHOD_NOT_FOUND = -32601;
+    /** JSON-RPC: Invalid params (missing or unknown task id). Spec §4.4. */
+    public static final int JSONRPC_INVALID_PARAMS = -32602;
+
+    private final MeshA2ARegistry registry;
+    private final MeshA2ATaskStore taskStore;
+    private final ObjectMapper objectMapper;
+    private final ObjectProvider<MeshDependencyInjector> injectorProvider;
+
+    public MeshA2ADispatcher(
+            MeshA2ARegistry registry,
+            MeshA2ATaskStore taskStore,
+            ObjectMapper objectMapper,
+            ObjectProvider<MeshDependencyInjector> injectorProvider) {
+        this.registry = registry;
+        this.taskStore = taskStore;
+        this.objectMapper = objectMapper;
+        this.injectorProvider = injectorProvider;
+    }
+
+    /**
+     * Dispatch a POST request to the {@code @MeshA2A} surface at
+     * {@code path}.
+     *
+     * <p>Only handles JSON-RPC methods that respond with a single envelope
+     * ({@code tasks/send}, {@code tasks/get}, {@code tasks/cancel}). SSE
+     * methods are routed to the {@link MeshA2ASseDispatcher} adapter by the
+     * controller; the dispatcher exposes them through
+     * {@link #buildSendSubscribeStream} / {@link #buildResubscribeStream}.
+     *
+     * @param path        normalized request path (no trailing slash)
+     * @param requestBody raw request body bytes (UTF-8 JSON)
+     * @return a Spring {@link ResponseEntity} with the JSON-RPC response
+     */
+    public ResponseEntity<String> dispatch(String path, String requestBody) {
+        MeshA2ARegistry.SurfaceMetadata surface = registry.getByPath(path);
+        if (surface == null) {
+            // Should not happen if MeshA2ADispatcherController only routes
+            // registered paths here, but defensive 404 protects against
+            // mis-wiring during tests.
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(jsonRpcError(null, JSONRPC_METHOD_NOT_FOUND,
+                    "No @MeshA2A surface registered at path: " + path));
+        }
+
+        // Parse the JSON-RPC request body. Spec §4.1: malformed body → HTTP
+        // 400 + JSON-RPC error -32700.
+        if (requestBody == null || requestBody.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(jsonRpcError(null, JSONRPC_PARSE_ERROR,
+                    "Parse error: request body is empty"));
+        }
+        JsonNode bodyNode;
+        try {
+            bodyNode = objectMapper.readTree(requestBody);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(jsonRpcError(null, JSONRPC_PARSE_ERROR,
+                    "Parse error: request body is not valid JSON"));
+        }
+        // Jackson 3's readTree(...) returns a MissingNode rather than throwing
+        // for inputs like a stray whitespace-only body — treat that as a parse
+        // error too so we never fall through to the method-resolution branch
+        // with a JsonNode that can't be inspected.
+        if (bodyNode == null || bodyNode.isMissingNode()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(jsonRpcError(null, JSONRPC_PARSE_ERROR,
+                    "Parse error: request body did not contain a JSON value"));
+        }
+
+        Object reqId = extractId(bodyNode);
+        String method = bodyNode.has("method") && bodyNode.get("method").isTextual()
+            ? bodyNode.get("method").asText() : null;
+        // Spec §4.1: well-formed JSON missing the required `method` member is
+        // an Invalid Request (-32600), NOT Method not found (-32601). Without
+        // this guard the default branch below would emit a misleading
+        // "Method not implemented: 'null'" — the bug surfaced in issue #932
+        // when the body-read path silently dropped the parsed body.
+        if (method == null) {
+            return jsonRpcErrorResponse(reqId, JSONRPC_INVALID_REQUEST,
+                "Invalid Request: 'method' field is required and must be a string");
+        }
+        JsonNode paramsNode = bodyNode.get("params");
+        Map<String, Object> params = readParams(paramsNode);
+
+        return switch (method) {
+            case "tasks/send" -> handleTasksSend(surface, reqId, params);
+            case "tasks/get" -> handleTasksGet(reqId, params);
+            case "tasks/cancel" -> handleTasksCancel(reqId, params);
+            // SSE verbs are routed via the controller's SSE branch — if we
+            // see them here it means the controller fell through to the POST
+            // path without setting the SSE accept header. Surface a clear
+            // error rather than 500.
+            case "tasks/sendSubscribe", "tasks/resubscribe" ->
+                jsonRpcErrorResponse(reqId, JSONRPC_METHOD_NOT_FOUND,
+                    "Method '" + method + "' requires an SSE-capable client. "
+                        + "Set 'Accept: text/event-stream' or use a streaming HTTP client.");
+            default -> jsonRpcErrorResponse(reqId, JSONRPC_METHOD_NOT_FOUND,
+                "Method not implemented: '" + method + "'. "
+                    + "Supported A2A v1.0 methods: tasks/send, tasks/get, "
+                    + "tasks/cancel, tasks/sendSubscribe, tasks/resubscribe.");
+        };
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // tasks/send
+    // ─────────────────────────────────────────────────────────────────
+
+    private ResponseEntity<String> handleTasksSend(
+            MeshA2ARegistry.SurfaceMetadata surface, Object reqId, Map<String, Object> params) {
+        // Spec §4.2: extract (task_id, session_id, message).
+        String taskId = stringFromParams(params, "id");
+        if (taskId == null) {
+            taskId = UUID.randomUUID().toString();
+        }
+        String sessionId = stringFromParams(params, "sessionId");
+        if (sessionId == null) {
+            sessionId = taskId;
+        }
+        Map<String, Object> message = mapFromParams(params, "message");
+
+        // Spec §4.3: duplicate in-flight task_id → -32602 already in use.
+        // Terminal entries within the eviction window are also rejected
+        // (matches Python's `_A2A_TASK_STORE` check).
+        if (taskStore.contains(taskId)) {
+            return jsonRpcErrorResponse(reqId, JSONRPC_INVALID_PARAMS,
+                "A2A task id '" + taskId + "' is already in use");
+        }
+
+        Object handlerResult;
+        try {
+            handlerResult = invokeHandler(surface, message);
+        } catch (Throwable t) {
+            // Spec §4.3 "Response — handler raised": exceptions become
+            // state=failed Tasks, NOT JSON-RPC errors.
+            String errorText = t.getMessage() != null ? t.getMessage() : t.getClass().getSimpleName();
+            log.debug("@MeshA2A handler {} raised: {}", surface.handlerMethodId(), errorText, t);
+            Map<String, Object> envelope = buildFailedTask(taskId, sessionId, message, errorText);
+            cacheTerminal(taskId, sessionId, message, envelope, null);
+            return jsonRpcSuccessResponse(reqId, envelope);
+        }
+
+        // Spec §4.3 long-running branch: handler returned a JobProxy →
+        // park the task and respond with state=working immediately. The
+        // client polls tasks/get / tasks/sendSubscribe for progress and
+        // the terminal artifact.
+        if (handlerResult instanceof JobProxy proxy) {
+            Map<String, Object> envelope = buildWorkingTask(taskId, sessionId, message, null, null);
+            parkLongRunning(taskId, sessionId, message, proxy);
+            log.info("@MeshA2A tasks/send: long-running task parked (task_id={} job_id={} path={})",
+                taskId, proxy.jobId(), surface.path());
+            return jsonRpcSuccessResponse(reqId, envelope);
+        }
+
+        Map<String, Object> envelope = buildCompletedTask(taskId, sessionId, message, handlerResult);
+        cacheTerminal(taskId, sessionId, message, envelope, null);
+        return jsonRpcSuccessResponse(reqId, envelope);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // tasks/get
+    // ─────────────────────────────────────────────────────────────────
+
+    private ResponseEntity<String> handleTasksGet(Object reqId, Map<String, Object> params) {
+        String taskId = stringFromParams(params, "id");
+        if (taskId == null || taskId.isEmpty()) {
+            return jsonRpcErrorResponse(reqId, JSONRPC_INVALID_PARAMS,
+                "Invalid params: 'id' is required for tasks/get");
+        }
+        MeshA2ATaskStore.TaskRecord record = taskStore.get(taskId);
+        if (record == null) {
+            return jsonRpcErrorResponse(reqId, JSONRPC_INVALID_PARAMS,
+                "Unknown task id: " + taskId);
+        }
+        if (record.terminalEnvelope() != null) {
+            return jsonRpcSuccessResponse(reqId, record.terminalEnvelope());
+        }
+        // Non-terminal record: pull live status from the parked JobProxy.
+        // Per spec §4.4 "transient unreachability": if status() raises we
+        // return state=working with the error text in status.message rather
+        // than a JSON-RPC error — the registry's transient failure isn't
+        // authoritative evidence the job is dead.
+        Map<String, Object> envelope = buildTaskFromLiveStatus(taskId, record);
+        return jsonRpcSuccessResponse(reqId, envelope);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // tasks/cancel
+    // ─────────────────────────────────────────────────────────────────
+
+    private ResponseEntity<String> handleTasksCancel(Object reqId, Map<String, Object> params) {
+        String taskId = stringFromParams(params, "id");
+        if (taskId == null || taskId.isEmpty()) {
+            return jsonRpcErrorResponse(reqId, JSONRPC_INVALID_PARAMS,
+                "Invalid params: 'id' is required for tasks/cancel");
+        }
+        MeshA2ATaskStore.TaskRecord record = taskStore.get(taskId);
+        if (record == null) {
+            return jsonRpcErrorResponse(reqId, JSONRPC_INVALID_PARAMS,
+                "Unknown task id: " + taskId);
+        }
+
+        // Idempotent ack: already-terminal task → echo the cached envelope.
+        // Spec §4.5 "Idempotent; best-effort".
+        if (record.terminalEnvelope() != null) {
+            return jsonRpcSuccessResponse(reqId, record.terminalEnvelope());
+        }
+
+        String reason = stringFromParams(params, "reason");
+        JobProxy proxy = record.jobProxy();
+        if (proxy != null) {
+            try {
+                proxy.cancel(reason);
+            } catch (Exception e) {
+                // Spec §4.5: cancel exceptions are logged and swallowed —
+                // the underlying job may already be terminal.
+                log.info("A2A tasks/cancel: proxy.cancel() raised for task {} (may already be terminal): {}",
+                    taskId, e.getMessage());
+            }
+        }
+
+        // Re-read status post-cancel so the response reflects the latest
+        // state. If status() also fails we synthesize a state=canceled
+        // envelope (Python's a2a.py:817-826 fallback).
+        Map<String, Object> envelope = buildTaskFromLiveStatus(taskId, record);
+        // If the post-cancel state is terminal, mark the record so future
+        // tasks/get calls hit the cached envelope and don't re-poll a
+        // closed JobProxy.
+        Object statusObj = envelope.get("status");
+        if (statusObj instanceof Map<?, ?> statusMap) {
+            Object stateObj = statusMap.get("state");
+            if (stateObj instanceof String state && MeshA2AStateTranslator.isTerminal(state)) {
+                taskStore.markTerminal(taskId, envelope);
+            } else {
+                // Status didn't show terminal yet but cancel was requested —
+                // synthesize a canceled envelope so the client gets a clean
+                // terminal response. Matches Python's fallback in
+                // a2a.py:817-826 when post-cancel status() raises.
+                Map<String, Object> synth = buildCanceledTask(
+                    taskId,
+                    record.sessionId() != null ? record.sessionId() : taskId,
+                    record.requestMessage(),
+                    reason);
+                taskStore.markTerminal(taskId, synth);
+                envelope = synth;
+            }
+        }
+        return jsonRpcSuccessResponse(reqId, envelope);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // tasks/sendSubscribe + tasks/resubscribe (SSE)
+    // ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Build the SSE event stream for a {@code tasks/sendSubscribe} request.
+     * Returns an {@link SseStreamPlan} that the SSE adapter materialises
+     * into a Spring {@code text/event-stream} body.
+     *
+     * <p>This method invokes the user handler eagerly (before the stream
+     * opens) so handler exceptions become a single SSE failed frame, not
+     * an opaque HTTP error mid-stream (spec §4.6: "The producer invokes
+     * the user handler before the SSE stream opens").
+     */
+    public SseStreamPlan buildSendSubscribeStream(String path, String requestBody) {
+        MeshA2ARegistry.SurfaceMetadata surface = registry.getByPath(path);
+        if (surface == null) {
+            return SseStreamPlan.error(jsonRpcError(null, JSONRPC_METHOD_NOT_FOUND,
+                "No @MeshA2A surface registered at path: " + path), HttpStatus.NOT_FOUND);
+        }
+        JsonNode bodyNode;
+        try {
+            bodyNode = objectMapper.readTree(requestBody);
+        } catch (Exception e) {
+            return SseStreamPlan.error(jsonRpcError(null, JSONRPC_PARSE_ERROR,
+                "Parse error: request body is not valid JSON"), HttpStatus.BAD_REQUEST);
+        }
+        Object reqId = extractId(bodyNode);
+        Map<String, Object> params = readParams(bodyNode.get("params"));
+
+        String taskId = stringFromParams(params, "id");
+        if (taskId == null) {
+            taskId = UUID.randomUUID().toString();
+        }
+        String sessionId = stringFromParams(params, "sessionId");
+        if (sessionId == null) {
+            sessionId = taskId;
+        }
+        Map<String, Object> message = mapFromParams(params, "message");
+
+        if (taskStore.contains(taskId)) {
+            // Duplicate in-flight task_id — surface as a single SSE failed
+            // event so the SSE client sees a structured A2A failure rather
+            // than an opaque HTTP error (Python a2a.py:1143-1149).
+            return SseStreamPlan.singleFrame(buildStatusUpdateFrame(
+                reqId, taskId, MeshA2AStateTranslator.A2A_FAILED,
+                "A2A task id '" + taskId + "' is already in use", true, null));
+        }
+
+        Object handlerResult;
+        try {
+            handlerResult = invokeHandler(surface, message);
+        } catch (Throwable t) {
+            String errorText = t.getMessage() != null ? t.getMessage() : t.getClass().getSimpleName();
+            log.debug("@MeshA2A tasks/sendSubscribe handler {} raised: {}",
+                surface.handlerMethodId(), errorText, t);
+            // Even on failure, cache the terminal envelope so a subsequent
+            // tasks/get returns it consistently.
+            Map<String, Object> failed = buildFailedTask(taskId, sessionId, message, errorText);
+            cacheTerminal(taskId, sessionId, message, failed, null);
+            return SseStreamPlan.singleFrame(buildStatusUpdateFrame(
+                reqId, taskId, MeshA2AStateTranslator.A2A_FAILED, errorText, true, null));
+        }
+
+        if (handlerResult instanceof JobProxy proxy) {
+            parkLongRunning(taskId, sessionId, message, proxy);
+            log.info("@MeshA2A tasks/sendSubscribe: long-running stream started (task_id={} job_id={} path={})",
+                taskId, proxy.jobId(), surface.path());
+            return SseStreamPlan.longRunning(reqId, taskId, proxy);
+        }
+
+        // Sync handler over tasks/sendSubscribe: per spec §5.3, emit one
+        // artifact event then one final status event (state=completed).
+        Map<String, Object> artifactFrame = buildArtifactUpdateFrame(reqId, taskId, handlerResult);
+        Map<String, Object> terminalFrame = buildStatusUpdateFrame(
+            reqId, taskId, MeshA2AStateTranslator.A2A_COMPLETED, null, true, null);
+        // Cache the resulting envelope so a follow-up tasks/get returns
+        // the same payload deterministically (the SSE branch is otherwise
+        // ephemeral — no terminal envelope would be stored).
+        Map<String, Object> envelope = buildCompletedTask(taskId, sessionId, message, handlerResult);
+        cacheTerminal(taskId, sessionId, message, envelope, null);
+        return SseStreamPlan.syncCompleted(reqId, taskId, artifactFrame, terminalFrame);
+    }
+
+    /**
+     * Build the SSE event stream for a {@code tasks/resubscribe} request.
+     * Spec §4.7: looks up the parked task, emits an initial state=working
+     * event, then resumes polling from the registry's current view (no
+     * replay of past events).
+     */
+    public SseStreamPlan buildResubscribeStream(String requestBody) {
+        JsonNode bodyNode;
+        try {
+            bodyNode = objectMapper.readTree(requestBody);
+        } catch (Exception e) {
+            return SseStreamPlan.error(jsonRpcError(null, JSONRPC_PARSE_ERROR,
+                "Parse error: request body is not valid JSON"), HttpStatus.BAD_REQUEST);
+        }
+        Object reqId = extractId(bodyNode);
+        Map<String, Object> params = readParams(bodyNode.get("params"));
+
+        String taskId = stringFromParams(params, "id");
+        if (taskId == null || taskId.isEmpty()) {
+            // Spec §4.7 errors: return standard JSON-RPC, not SSE, because
+            // the response has not been promoted to text/event-stream yet.
+            return SseStreamPlan.error(jsonRpcError(reqId, JSONRPC_INVALID_PARAMS,
+                "Invalid params: 'id' is required for tasks/resubscribe"), HttpStatus.OK);
+        }
+        MeshA2ATaskStore.TaskRecord record = taskStore.get(taskId);
+        if (record == null) {
+            return SseStreamPlan.error(jsonRpcError(reqId, JSONRPC_INVALID_PARAMS,
+                "Unknown task id: " + taskId), HttpStatus.OK);
+        }
+        if (record.terminalEnvelope() != null) {
+            // Already terminal — emit ONE terminal status event and close.
+            // No replay per Python's a2a.py:1175-1178.
+            Map<String, Object> env = record.terminalEnvelope();
+            Object statusObj = env.get("status");
+            String state = MeshA2AStateTranslator.A2A_COMPLETED;
+            String msgText = null;
+            if (statusObj instanceof Map<?, ?> statusMap) {
+                Object st = statusMap.get("state");
+                if (st instanceof String s) state = s;
+                Object msg = statusMap.get("message");
+                if (msg instanceof Map<?, ?> msgMap) {
+                    Object parts = msgMap.get("parts");
+                    if (parts instanceof List<?> partsList && !partsList.isEmpty()
+                        && partsList.get(0) instanceof Map<?, ?> firstPart) {
+                        Object text = firstPart.get("text");
+                        if (text != null) msgText = text.toString();
+                    }
+                }
+            }
+            return SseStreamPlan.singleFrame(buildStatusUpdateFrame(
+                reqId, taskId, state, msgText, true, null));
+        }
+        JobProxy proxy = record.jobProxy();
+        if (proxy == null) {
+            // Non-terminal record without a JobProxy is an inconsistent
+            // state. Surface as a failed terminal event so the client
+            // doesn't hang.
+            log.warn("tasks/resubscribe: task {} has neither terminal envelope nor JobProxy; "
+                + "synthesizing failed terminal event", taskId);
+            return SseStreamPlan.singleFrame(buildStatusUpdateFrame(
+                reqId, taskId, MeshA2AStateTranslator.A2A_FAILED,
+                "Task state inconsistent: no live JobProxy and no terminal envelope", true, null));
+        }
+        return SseStreamPlan.longRunning(reqId, taskId, proxy);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Live-status poll (shared by tasks/get, tasks/cancel, SSE poll loop)
+    // ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Pull the latest status from a parked task's {@link JobProxy} and
+     * project it into an A2A v1.0 Task envelope. Handles the "transient
+     * unreachability" branch per spec §4.4 by returning {@code state=working}
+     * with the error text in {@code status.message} rather than throwing —
+     * matches Python's a2a.py:718-735 behavior.
+     */
+    private Map<String, Object> buildTaskFromLiveStatus(String taskId, MeshA2ATaskStore.TaskRecord record) {
+        String sessionId = record.sessionId() != null ? record.sessionId() : taskId;
+        JobProxy proxy = record.jobProxy();
+        if (proxy == null) {
+            return buildWorkingTask(taskId, sessionId, record.requestMessage(), null, null);
+        }
+        Map<String, Object> status;
+        try {
+            status = proxy.status();
+        } catch (Exception e) {
+            log.warn("A2A tasks/get: proxy.status() raised for task {}: {}", taskId, e.getMessage());
+            return buildWorkingTask(taskId, sessionId, record.requestMessage(),
+                "status unavailable: " + e.getMessage(), null);
+        }
+        if (status == null) {
+            status = new LinkedHashMap<>();
+        }
+        String meshState = MeshA2AStateTranslator.meshStatusOf(status);
+        String a2aState = MeshA2AStateTranslator.fromMesh(meshState);
+
+        // On completed, attempt proxy.await(timeoutSecs=1) to fetch the
+        // final artifact synchronously. Tight timeout per spec §4.4 so we
+        // don't block on a transiently-unreachable payload — fall back to
+        // no artifact in that case.
+        Object finalResult = null;
+        boolean hasFinalResult = false;
+        if (MeshA2AStateTranslator.A2A_COMPLETED.equals(a2aState)) {
+            try {
+                finalResult = proxy.await(1.0);
+                hasFinalResult = true;
+            } catch (Exception e) {
+                log.debug("A2A tasks/get: proxy.await() failed for completed task {}: {}",
+                    taskId, e.getMessage());
+            }
+        }
+
+        return buildTaskFromStatus(taskId, sessionId, record.requestMessage(),
+            a2aState, status, finalResult, hasFinalResult);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Handler invocation
+    // ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Reflectively invoke the user's {@code @MeshA2A} handler with:
+     * <ul>
+     *   <li>the A2A {@code message} at the first {@link Map} parameter slot,
+     *       OR at index 0 when none of the params is a {@code Map};</li>
+     *   <li>{@link McpMeshTool} proxies at any parameter annotated
+     *       {@link MeshInject} (or whose type is {@link McpMeshTool}),
+     *       resolved through {@link MeshDependencyInjector} — same DDDI
+     *       wiring used by {@code @MeshRoute} and {@code @A2AConsumer}.</li>
+     * </ul>
+     */
+    @SuppressWarnings("unchecked")
+    private Object invokeHandler(MeshA2ARegistry.SurfaceMetadata surface, Map<String, Object> message)
+            throws Throwable {
+        Method method = surface.method();
+        Parameter[] params = method.getParameters();
+        Object[] args = new Object[params.length];
+
+        boolean messageAssigned = false;
+        for (int i = 0; i < params.length; i++) {
+            Parameter p = params[i];
+            MeshInject inj = p.getAnnotation(MeshInject.class);
+            if (inj != null || McpMeshTool.class.isAssignableFrom(p.getType())) {
+                args[i] = resolveDependency(surface, p, inj);
+            } else if (Map.class.isAssignableFrom(p.getType()) && !messageAssigned) {
+                args[i] = message;
+                messageAssigned = true;
+            } else if (!messageAssigned && i == 0) {
+                // First non-DI parameter takes the message even if it's
+                // not a Map (e.g., user wants a custom POJO — out of scope
+                // for Chunk 1A, but we don't crash).
+                args[i] = message;
+                messageAssigned = true;
+            } else {
+                args[i] = null;
+            }
+        }
+
+        try {
+            if (!method.canAccess(surface.bean())) {
+                method.setAccessible(true);
+            }
+            return method.invoke(surface.bean(), args);
+        } catch (InvocationTargetException ite) {
+            throw ite.getCause() != null ? ite.getCause() : ite;
+        }
+    }
+
+    private McpMeshTool resolveDependency(
+            MeshA2ARegistry.SurfaceMetadata surface, Parameter param, MeshInject inj) {
+        MeshDependencyInjector injector = injectorProvider.getIfAvailable();
+        if (injector == null) {
+            log.warn("@MeshA2A {}: MeshDependencyInjector unavailable; injecting null McpMeshTool",
+                surface.handlerMethodId());
+            return null;
+        }
+        String requestedCapability = (inj != null && !inj.value().isEmpty())
+            ? inj.value() : param.getName();
+        // Match against the declared dependencies — the @MeshInject value
+        // (or parameter name) must align with one of @MeshA2A's
+        // @MeshDependency entries. We resolve through the injector so the
+        // proxy lifecycle matches the @MeshRoute path.
+        for (MeshRouteRegistry.DependencySpec dep : surface.dependencies()) {
+            if (dep.getCapability().equals(requestedCapability)
+                || requestedCapability.equals(dep.getParameterName())) {
+                return injector.getToolProxy(dep.getCapability());
+            }
+        }
+        log.debug("@MeshA2A {}: no @MeshDependency matches parameter '{}'",
+            surface.handlerMethodId(), requestedCapability);
+        return null;
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Task envelope builders (spec §4.3)
+    // ─────────────────────────────────────────────────────────────────
+
+    private Map<String, Object> buildCompletedTask(
+            String taskId, String sessionId, Map<String, Object> requestMessage, Object result) {
+        String text = stringifyResult(result);
+        Map<String, Object> status = new LinkedHashMap<>();
+        status.put("state", MeshA2AStateTranslator.A2A_COMPLETED);
+        status.put("timestamp", utcIso8601());
+
+        Map<String, Object> artifact = new LinkedHashMap<>();
+        artifact.put("name", "result");
+        // Appendix A: parts[0].type MUST be emitted as "text" for forward
+        // compatibility even though consumers ignore it.
+        artifact.put("parts", List.of(textPart(text)));
+        artifact.put("index", 0);
+
+        Map<String, Object> envelope = new LinkedHashMap<>();
+        envelope.put("id", taskId);
+        envelope.put("sessionId", sessionId);
+        envelope.put("status", status);
+        envelope.put("artifacts", List.of(artifact));
+        envelope.put("history", historyOf(requestMessage));
+        return envelope;
+    }
+
+    private Map<String, Object> buildFailedTask(
+            String taskId, String sessionId, Map<String, Object> requestMessage, String errorMsg) {
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("role", "agent");
+        message.put("parts", List.of(textPart(errorMsg)));
+
+        Map<String, Object> status = new LinkedHashMap<>();
+        status.put("state", MeshA2AStateTranslator.A2A_FAILED);
+        status.put("timestamp", utcIso8601());
+        status.put("message", message);
+
+        Map<String, Object> envelope = new LinkedHashMap<>();
+        envelope.put("id", taskId);
+        envelope.put("sessionId", sessionId);
+        envelope.put("status", status);
+        envelope.put("artifacts", List.of());
+        envelope.put("history", historyOf(requestMessage));
+        return envelope;
+    }
+
+    private Map<String, Object> buildCanceledTask(
+            String taskId, String sessionId, Map<String, Object> requestMessage, String reason) {
+        Map<String, Object> status = new LinkedHashMap<>();
+        status.put("state", MeshA2AStateTranslator.A2A_CANCELED);
+        status.put("timestamp", utcIso8601());
+        if (reason != null && !reason.isEmpty()) {
+            Map<String, Object> message = new LinkedHashMap<>();
+            message.put("role", "agent");
+            message.put("parts", List.of(textPart(reason)));
+            status.put("message", message);
+        }
+        Map<String, Object> envelope = new LinkedHashMap<>();
+        envelope.put("id", taskId);
+        envelope.put("sessionId", sessionId);
+        envelope.put("status", status);
+        envelope.put("artifacts", List.of());
+        envelope.put("history", historyOf(requestMessage));
+        return envelope;
+    }
+
+    /**
+     * Build a {@code state=working} task envelope (spec §4.3 long-running
+     * branch / spec §4.4 transient unreachability fallback).
+     */
+    Map<String, Object> buildWorkingTask(
+            String taskId, String sessionId, Map<String, Object> requestMessage,
+            String progressMessage, Object progress) {
+        Map<String, Object> status = new LinkedHashMap<>();
+        status.put("state", MeshA2AStateTranslator.A2A_WORKING);
+        status.put("timestamp", utcIso8601());
+        if (progressMessage != null && !progressMessage.isEmpty()) {
+            Map<String, Object> message = new LinkedHashMap<>();
+            message.put("role", "agent");
+            message.put("parts", List.of(textPart(progressMessage)));
+            status.put("message", message);
+        }
+
+        Map<String, Object> envelope = new LinkedHashMap<>();
+        envelope.put("id", taskId);
+        envelope.put("sessionId", sessionId);
+        envelope.put("status", status);
+        envelope.put("artifacts", List.of());
+        envelope.put("history", historyOf(requestMessage));
+        if (progress != null) {
+            envelope.put("metadata", Map.of("progress", progress));
+        }
+        return envelope;
+    }
+
+    /**
+     * Build a Task envelope from a {@code JobProxy.status()} result dict.
+     * Mirrors Python's {@code _build_task_from_status} (a2a.py:485-549) —
+     * folds {@code error} / {@code progress_message} into A2A
+     * {@code status.message}, materialises an artifact for completed
+     * tasks when the final result is available, and lifts
+     * {@code progress} to {@code metadata.progress}.
+     */
+    Map<String, Object> buildTaskFromStatus(
+            String taskId, String sessionId, Map<String, Object> requestMessage,
+            String a2aState, Map<String, Object> meshStatus,
+            Object finalResult, boolean hasFinalResult) {
+        Map<String, Object> status = new LinkedHashMap<>();
+        status.put("state", a2aState);
+        status.put("timestamp", utcIso8601());
+
+        Object msgText = null;
+        if (MeshA2AStateTranslator.A2A_FAILED.equals(a2aState)) {
+            msgText = meshStatus.get("error");
+            if (msgText == null) msgText = meshStatus.get("progress_message");
+        } else {
+            msgText = meshStatus.get("progress_message");
+        }
+        if (msgText != null && !msgText.toString().isEmpty()) {
+            Map<String, Object> message = new LinkedHashMap<>();
+            message.put("role", "agent");
+            message.put("parts", List.of(textPart(msgText.toString())));
+            status.put("message", message);
+        }
+
+        List<Map<String, Object>> artifacts = new ArrayList<>();
+        if (hasFinalResult && MeshA2AStateTranslator.A2A_COMPLETED.equals(a2aState)) {
+            Map<String, Object> artifact = new LinkedHashMap<>();
+            artifact.put("name", "result");
+            artifact.put("parts", List.of(textPart(stringifyResult(finalResult))));
+            artifact.put("index", 0);
+            artifacts.add(artifact);
+        }
+
+        Map<String, Object> envelope = new LinkedHashMap<>();
+        envelope.put("id", taskId);
+        envelope.put("sessionId", sessionId);
+        envelope.put("status", status);
+        envelope.put("artifacts", artifacts);
+        envelope.put("history", historyOf(requestMessage));
+        Object progress = meshStatus.get("progress");
+        if (progress != null) {
+            envelope.put("metadata", Map.of("progress", progress));
+        }
+        return envelope;
+    }
+
+    private Map<String, Object> textPart(String text) {
+        Map<String, Object> part = new LinkedHashMap<>();
+        part.put("type", "text");
+        part.put("text", text != null ? text : "");
+        return part;
+    }
+
+    private List<Map<String, Object>> historyOf(Map<String, Object> requestMessage) {
+        if (requestMessage == null || requestMessage.isEmpty()) {
+            return List.of();
+        }
+        List<Map<String, Object>> out = new ArrayList<>(1);
+        out.add(new LinkedHashMap<>(requestMessage));
+        return out;
+    }
+
+    /**
+     * Stringify a handler return value as the text body of the
+     * {@code result} artifact. {@link String} returns pass through verbatim;
+     * everything else is JSON-stringified via the bound {@link ObjectMapper}.
+     * Non-serializable returns fall back to {@link Object#toString()} so the
+     * artifact is always well-formed (mirrors Python's {@code default=str}
+     * coercion in {@code a2a.py:403}).
+     */
+    String stringifyResult(Object result) {
+        if (result == null) {
+            return "";
+        }
+        if (result instanceof String s) {
+            return s;
+        }
+        try {
+            return objectMapper.writeValueAsString(result);
+        } catch (Exception e) {
+            log.debug("Failed to JSON-serialize handler return ({}); falling back to toString()",
+                e.getMessage());
+            return result.toString();
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // SSE event builders (spec §5)
+    // ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Build a JSON-RPC envelope carrying an A2A v1.0
+     * {@code TaskStatusUpdateEvent} (spec §5.2). Used by the SSE adapter
+     * to serialize one frame.
+     *
+     * @param reqId       JSON-RPC request id to echo
+     * @param taskId      A2A task id
+     * @param a2aState    one of the four enumerated states
+     * @param messageText optional text for {@code status.message.parts[0].text}
+     * @param finalFlag   {@code true} only on the terminal frame — Appendix A
+     *                    requires a real boolean here
+     * @param progress    optional numeric progress; Appendix A requires a
+     *                    number (not stringified)
+     */
+    public Map<String, Object> buildStatusUpdateFrame(
+            Object reqId, String taskId, String a2aState, String messageText,
+            boolean finalFlag, Object progress) {
+        Map<String, Object> status = new LinkedHashMap<>();
+        status.put("state", a2aState);
+        status.put("timestamp", utcIso8601());
+        if (messageText != null && !messageText.isEmpty()) {
+            Map<String, Object> message = new LinkedHashMap<>();
+            message.put("role", "agent");
+            message.put("parts", List.of(textPart(messageText)));
+            status.put("message", message);
+        }
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("id", taskId);
+        result.put("status", status);
+        // Appendix A: real boolean, not a string.
+        result.put("final", finalFlag);
+        if (progress != null) {
+            result.put("metadata", Map.of("progress", progress));
+        }
+
+        Map<String, Object> envelope = new LinkedHashMap<>();
+        envelope.put("jsonrpc", "2.0");
+        envelope.put("id", reqId);
+        envelope.put("result", result);
+        return envelope;
+    }
+
+    /**
+     * Build a JSON-RPC envelope carrying an A2A v1.0
+     * {@code TaskArtifactUpdateEvent} (spec §5.2). The handler result is
+     * stringified per the {@code stringifyResult} contract.
+     */
+    public Map<String, Object> buildArtifactUpdateFrame(Object reqId, String taskId, Object value) {
+        Map<String, Object> artifact = new LinkedHashMap<>();
+        artifact.put("name", "result");
+        artifact.put("parts", List.of(textPart(stringifyResult(value))));
+        artifact.put("index", 0);
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("id", taskId);
+        result.put("artifact", artifact);
+
+        Map<String, Object> envelope = new LinkedHashMap<>();
+        envelope.put("jsonrpc", "2.0");
+        envelope.put("id", reqId);
+        envelope.put("result", result);
+        return envelope;
+    }
+
+    /** Serialize a JSON-RPC envelope as the {@code data:} payload of one SSE frame. */
+    public String toJsonString(Map<String, Object> envelope) {
+        return toJson(envelope);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Task store interaction
+    // ─────────────────────────────────────────────────────────────────
+
+    private void cacheTerminal(String taskId, String sessionId, Map<String, Object> requestMessage,
+                               Map<String, Object> envelope, JobProxy proxy) {
+        taskStore.put(taskId, new MeshA2ATaskStore.TaskRecord(
+            sessionId, requestMessage, envelope, System.currentTimeMillis(), proxy));
+    }
+
+    private void parkLongRunning(String taskId, String sessionId, Map<String, Object> requestMessage,
+                                 JobProxy proxy) {
+        // Non-terminal record: terminalEnvelope=null, terminalAt=null, jobProxy set.
+        taskStore.put(taskId, new MeshA2ATaskStore.TaskRecord(
+            sessionId, requestMessage, null, null, proxy));
+    }
+
+    /**
+     * Mark a parked task terminal with the supplied envelope. Used by the
+     * SSE long-running stream emitter to flip the record to "cached
+     * terminal" so subsequent tasks/get calls return the same envelope
+     * without re-polling the JobProxy.
+     */
+    public void markTaskTerminal(String taskId, Map<String, Object> terminalEnvelope) {
+        taskStore.markTerminal(taskId, terminalEnvelope);
+    }
+
+    /**
+     * Project the live status of a parked task into an A2A v1.0 Task
+     * envelope. Exposed for the SSE long-running stream emitter
+     * ({@link MeshA2ASseDispatcher}) so it can render terminal frames
+     * consistently with {@code tasks/get}.
+     */
+    public Map<String, Object> projectLiveStatus(String taskId) {
+        MeshA2ATaskStore.TaskRecord record = taskStore.get(taskId);
+        if (record == null) return null;
+        if (record.terminalEnvelope() != null) return record.terminalEnvelope();
+        return buildTaskFromLiveStatus(taskId, record);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // JSON-RPC helpers
+    // ─────────────────────────────────────────────────────────────────
+
+    private ResponseEntity<String> jsonRpcSuccessResponse(Object reqId, Object resultObj) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("jsonrpc", "2.0");
+        body.put("id", reqId);
+        body.put("result", resultObj);
+        return ResponseEntity.ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(toJson(body));
+    }
+
+    private ResponseEntity<String> jsonRpcErrorResponse(Object reqId, int code, String message) {
+        return ResponseEntity.ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(jsonRpcError(reqId, code, message));
+    }
+
+    private String jsonRpcError(Object reqId, int code, String message) {
+        Map<String, Object> error = new LinkedHashMap<>();
+        error.put("code", code);
+        error.put("message", message);
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("jsonrpc", "2.0");
+        body.put("error", error);
+        body.put("id", reqId);
+        return toJson(body);
+    }
+
+    private String toJson(Map<String, Object> body) {
+        try {
+            return objectMapper.writeValueAsString(body);
+        } catch (Exception e) {
+            // Truly unreachable for plain maps, but keep a defensive
+            // fallback so the dispatcher never returns an empty body.
+            return "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32603,\"message\":\"Internal serialization error\"},\"id\":null}";
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Body / params parsing
+    // ─────────────────────────────────────────────────────────────────
+
+    private Object extractId(JsonNode bodyNode) {
+        JsonNode idNode = bodyNode.get("id");
+        if (idNode == null || idNode.isNull()) {
+            return null;
+        }
+        if (idNode.isTextual()) return idNode.asText();
+        if (idNode.isInt()) return idNode.asInt();
+        if (idNode.isLong()) return idNode.asLong();
+        if (idNode.isFloatingPointNumber()) return idNode.asDouble();
+        if (idNode.isBoolean()) return idNode.asBoolean();
+        // Spec §4.1: "id" MAY be any JSON value. Convert anything else
+        // through the ObjectMapper.
+        try {
+            return objectMapper.convertValue(idNode, Object.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> readParams(JsonNode paramsNode) {
+        if (paramsNode == null || paramsNode.isNull() || !paramsNode.isObject()) {
+            return new LinkedHashMap<>();
+        }
+        try {
+            Object converted = objectMapper.convertValue(paramsNode,
+                new TypeReference<Map<String, Object>>() {});
+            return converted instanceof Map ? (Map<String, Object>) converted : new LinkedHashMap<>();
+        } catch (Exception e) {
+            return new LinkedHashMap<>();
+        }
+    }
+
+    private static String stringFromParams(Map<String, Object> params, String key) {
+        Object v = params.get(key);
+        if (v == null) return null;
+        if (v instanceof String s) return s.isEmpty() ? null : s;
+        return v.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> mapFromParams(Map<String, Object> params, String key) {
+        Object v = params.get(key);
+        if (v instanceof Map<?, ?> m) {
+            Map<String, Object> out = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> e : m.entrySet()) {
+                out.put(String.valueOf(e.getKey()), e.getValue());
+            }
+            return out;
+        }
+        return new LinkedHashMap<>();
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Time
+    // ─────────────────────────────────────────────────────────────────
+
+    /**
+     * UTC ISO-8601 with the {@code Z} suffix (NOT {@code +00:00}) per spec
+     * §5.2 / Appendix A. {@link Instant#toString()} already emits the
+     * right form ({@code 2026-05-11T12:34:56.789Z}).
+     */
+    private static String utcIso8601() {
+        return Instant.now().toString();
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Diagnostics for tests
+    // ─────────────────────────────────────────────────────────────────
+
+    /** Read-only view for tests. */
+    public MeshA2ATaskStore taskStore() {
+        return taskStore;
+    }
+
+    /** Read-only view for tests. */
+    public MeshA2ARegistry registry() {
+        return registry;
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // SSE stream-plan value classes (consumed by MeshA2ASseDispatcher)
+    // ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Framework-agnostic description of an SSE stream for a single
+     * {@code tasks/sendSubscribe} / {@code tasks/resubscribe} call. The
+     * SSE adapter ({@link MeshA2ASseDispatcher}) maps this into Spring's
+     * {@code ServerResponse.sse(...)} body.
+     *
+     * <p>Three shapes:
+     * <ul>
+     *   <li>{@link Kind#ERROR} — preflight error before SSE is even started
+     *       (parse error, unknown task id, missing path). Adapter emits a
+     *       JSON-RPC error response, NOT an SSE stream.</li>
+     *   <li>{@link Kind#SINGLE_FRAME} — one terminal SSE frame then close
+     *       (sync handler completed, handler raised, already-terminal
+     *       resubscribe).</li>
+     *   <li>{@link Kind#SYNC_COMPLETED} — one artifact frame + one final
+     *       status frame then close (sync handler called via
+     *       {@code tasks/sendSubscribe}).</li>
+     *   <li>{@link Kind#LONG_RUNNING} — initial working frame, then poll
+     *       loop with progress frames, keepalives, and a terminal frame.</li>
+     * </ul>
+     */
+    public static final class SseStreamPlan {
+        public enum Kind { ERROR, SINGLE_FRAME, SYNC_COMPLETED, LONG_RUNNING }
+
+        public final Kind kind;
+        public final String errorBody;
+        public final HttpStatus errorStatus;
+        public final Map<String, Object> firstFrame;
+        public final Map<String, Object> secondFrame;
+        public final Object reqId;
+        public final String taskId;
+        public final JobProxy proxy;
+
+        private SseStreamPlan(Kind kind, String errorBody, HttpStatus errorStatus,
+                              Map<String, Object> firstFrame, Map<String, Object> secondFrame,
+                              Object reqId, String taskId, JobProxy proxy) {
+            this.kind = kind;
+            this.errorBody = errorBody;
+            this.errorStatus = errorStatus;
+            this.firstFrame = firstFrame;
+            this.secondFrame = secondFrame;
+            this.reqId = reqId;
+            this.taskId = taskId;
+            this.proxy = proxy;
+        }
+
+        public static SseStreamPlan error(String body, HttpStatus status) {
+            return new SseStreamPlan(Kind.ERROR, body, status, null, null, null, null, null);
+        }
+
+        public static SseStreamPlan singleFrame(Map<String, Object> frame) {
+            return new SseStreamPlan(Kind.SINGLE_FRAME, null, null, frame, null, null, null, null);
+        }
+
+        /**
+         * Sync-completed plan: artifact frame first, then a final status
+         * frame with {@code state=completed, final=true}. Spec §5.3.
+         */
+        public static SseStreamPlan syncCompleted(
+                Object reqId, String taskId,
+                Map<String, Object> artifactFrame, Map<String, Object> terminalFrame) {
+            return new SseStreamPlan(Kind.SYNC_COMPLETED, null, null,
+                artifactFrame, terminalFrame, reqId, taskId, null);
+        }
+
+        public static SseStreamPlan longRunning(Object reqId, String taskId, JobProxy proxy) {
+            return new SseStreamPlan(Kind.LONG_RUNNING, null, null, null, null, reqId, taskId, proxy);
+        }
+    }
+
+    /**
+     * One SSE frame, with the payload already serialized. The adapter
+     * writes {@code data: <payload>\n\n} for data frames, or {@code <payload>\n\n}
+     * directly for keepalive comments (where the payload starts with
+     * {@code :} per SSE spec §5.1).
+     */
+    public record SseFrame(String payload, boolean isComment) {
+        public static SseFrame data(String json) {
+            return new SseFrame(json, false);
+        }
+
+        public static SseFrame keepalive() {
+            return new SseFrame(": keepalive", true);
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcherController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcherController.java
@@ -148,7 +148,7 @@ public class MeshA2ADispatcherController {
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(errorJson);
         }
-        String method = peekJsonRpcMethod(body);
+        String method = dispatcher.peekJsonRpcMethod(body);
         MeshA2ADispatcher.SseStreamPlan plan = switch (method == null ? "" : method) {
             case "tasks/sendSubscribe" -> dispatcher.buildSendSubscribeStream(surface.path(), body);
             case "tasks/resubscribe"   -> dispatcher.buildResubscribeStream(body);
@@ -220,25 +220,6 @@ public class MeshA2ADispatcherController {
         return "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":"
             + MeshA2ADispatcher.JSONRPC_PARSE_ERROR
             + ",\"message\":\"Parse error: failed to read request body\"},\"id\":null}";
-    }
-
-    /**
-     * Peek at the JSON-RPC body's {@code method} field without committing
-     * to the full parse — the dispatcher re-parses for full validation.
-     * Returns {@code null} on parse failure; the SSE branch then falls
-     * through to JSON-RPC dispatch, which produces the canonical parse
-     * error response.
-     */
-    private String peekJsonRpcMethod(String body) {
-        if (body == null || body.isEmpty()) return null;
-        try {
-            tools.jackson.databind.JsonNode node =
-                new tools.jackson.databind.ObjectMapper().readTree(body);
-            tools.jackson.databind.JsonNode m = node.get("method");
-            return m != null && m.isTextual() ? m.asText() : null;
-        } catch (Exception e) {
-            return null;
-        }
     }
 
     private ServerResponse handleGetCard(MeshA2ARegistry.SurfaceMetadata surface) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcherController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcherController.java
@@ -13,6 +13,7 @@ import org.springframework.web.servlet.function.ServerRequest;
 import org.springframework.web.servlet.function.ServerResponse;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
@@ -53,6 +54,27 @@ public class MeshA2ADispatcherController {
     private static final Logger log = LoggerFactory.getLogger(MeshA2ADispatcherController.class);
 
     private static final String AGENT_CARD_SUFFIX = "/.well-known/agent.json";
+
+    /**
+     * Hard cap on the size of an inbound JSON-RPC body read by {@link #readBody}.
+     * Matches Spring's typical {@code spring.servlet.multipart.max-request-size}
+     * default order of magnitude. A 1 MiB body is far larger than any realistic
+     * {@code tasks/*} envelope (the canonical {@code tasks/send} request is
+     * well under a kilobyte). Anything bigger is treated as a parse error —
+     * unbounded {@code readAllBytes()} would be an OOM vector.
+     */
+    static final long DEFAULT_MAX_BODY_BYTES = 1L * 1024 * 1024;
+
+    /**
+     * Static JSON-RPC parse-error envelope returned when {@link #readBody}
+     * fails (I/O error or oversized body). The body is fixed (no per-request
+     * id or message), so we hold it as a constant rather than re-rendering it
+     * through Jackson on every error.
+     */
+    private static final String PARSE_ERROR_BODY =
+        "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":"
+            + MeshA2ADispatcher.JSONRPC_PARSE_ERROR
+            + ",\"message\":\"Parse error: failed to read request body\"},\"id\":null}";
 
     private final MeshA2ARegistry registry;
     private final MeshA2ADispatcher dispatcher;
@@ -112,11 +134,10 @@ public class MeshA2ADispatcherController {
             // a JSON-RPC Parse error (-32700) with HTTP 400, not a generic 500.
             log.warn("@MeshA2A: failed to read request body for {}: {}",
                 surface.path(), e.getMessage());
-            String errorJson = parseErrorJson();
             return ServerResponse
                 .status(HttpStatus.BAD_REQUEST)
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(errorJson);
+                .body(PARSE_ERROR_BODY);
         }
         ResponseEntity<String> response = dispatcher.dispatch(surface.path(), body);
         return ServerResponse
@@ -142,11 +163,10 @@ public class MeshA2ADispatcherController {
             // get a JSON envelope back for the pre-stream parse failure.
             log.warn("@MeshA2A SSE: failed to read request body for {}: {}",
                 surface.path(), e.getMessage());
-            String errorJson = parseErrorJson();
             return ServerResponse
                 .status(HttpStatus.BAD_REQUEST)
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(errorJson);
+                .body(PARSE_ERROR_BODY);
         }
         String method = dispatcher.peekJsonRpcMethod(body);
         MeshA2ADispatcher.SseStreamPlan plan = switch (method == null ? "" : method) {
@@ -175,14 +195,40 @@ public class MeshA2ADispatcherController {
      * "Method not implemented: 'null'" errors for every well-formed
      * {@code tasks/send} request (issue #932).
      *
+     * <p>The read is bounded to {@link #DEFAULT_MAX_BODY_BYTES} so a malicious
+     * or buggy client cannot OOM the JVM by streaming a multi-gigabyte body.
+     * A Content-Length header that already exceeds the cap short-circuits the
+     * read; otherwise we count bytes as they arrive and abort the moment we
+     * cross the threshold.
+     *
      * <p>Wrapping in {@link BodyReadException} surfaces I/O failures to the
      * caller, which converts them into a proper {@code -32700 Parse error}
      * response per spec §4.1 instead of swallowing them.
      */
     private static String readBody(ServerRequest request) {
-        try {
-            byte[] bytes = request.servletRequest().getInputStream().readAllBytes();
-            return new String(bytes, StandardCharsets.UTF_8);
+        jakarta.servlet.http.HttpServletRequest servletRequest = request.servletRequest();
+        long declaredLength = servletRequest.getContentLengthLong();
+        if (declaredLength > DEFAULT_MAX_BODY_BYTES) {
+            throw new BodyReadException(
+                "Request body exceeds limit: declared Content-Length " + declaredLength
+                    + " > " + DEFAULT_MAX_BODY_BYTES + " bytes");
+        }
+        try (InputStream in = servletRequest.getInputStream()) {
+            java.io.ByteArrayOutputStream buf = new java.io.ByteArrayOutputStream(
+                declaredLength > 0 ? (int) Math.min(declaredLength, 8192) : 1024);
+            byte[] chunk = new byte[4096];
+            long total = 0;
+            int read;
+            while ((read = in.read(chunk)) != -1) {
+                total += read;
+                if (total > DEFAULT_MAX_BODY_BYTES) {
+                    throw new BodyReadException(
+                        "Request body exceeds limit: read " + total
+                            + " > " + DEFAULT_MAX_BODY_BYTES + " bytes");
+                }
+                buf.write(chunk, 0, read);
+            }
+            return buf.toString(StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new BodyReadException("Failed to read request body", e);
         }
@@ -202,24 +248,16 @@ public class MeshA2ADispatcherController {
             .body(response.getBody() == null ? "" : response.getBody());
     }
 
-    /** Unchecked wrapper for {@link IOException} during body read so the
-     *  router-handler signature (no checked exceptions) stays intact. */
+    /** Unchecked wrapper for I/O failures and oversize-body conditions during
+     *  body read so the router-handler signature (no checked exceptions) stays
+     *  intact. */
     static final class BodyReadException extends RuntimeException {
+        BodyReadException(String message) {
+            super(message);
+        }
         BodyReadException(String message, Throwable cause) {
             super(message, cause);
         }
-    }
-
-    /**
-     * Build a canonical JSON-RPC parse-error envelope for body-read failures.
-     * Hand-rolled (rather than going through the dispatcher's
-     * {@code ObjectMapper}) because the message is fixed and constructing a
-     * mapper on every error would be wasteful.
-     */
-    private static String parseErrorJson() {
-        return "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":"
-            + MeshA2ADispatcher.JSONRPC_PARSE_ERROR
-            + ",\"message\":\"Parse error: failed to read request body\"},\"id\":null}";
     }
 
     private ServerResponse handleGetCard(MeshA2ARegistry.SurfaceMetadata surface) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcherController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcherController.java
@@ -1,0 +1,276 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.spring.MeshProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.RouterFunctions;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * HTTP entry point for A2A producer surfaces (spec §3 + §4).
+ *
+ * <p>Exposes one {@link RouterFunction} per registered
+ * {@link MeshA2ARegistry.SurfaceMetadata}, composed into a single
+ * router-function bean by {@link #buildRouterFunction()}. The functional
+ * approach sits alongside annotation-based {@code @RestController} mappings
+ * in the same DispatcherServlet and only matches the exact paths owned by
+ * {@code @MeshA2A} — static resources, error pages, and user controllers
+ * are unaffected.
+ *
+ * <p>Each surface contributes three routes:
+ * <ul>
+ *   <li>{@code POST {path}} with {@code Accept: application/json}
+ *       (or no Accept header) — JSON-RPC entry point; delegates to
+ *       {@link MeshA2ADispatcher#dispatch(String, String)}. Handles
+ *       {@code tasks/send}, {@code tasks/get}, {@code tasks/cancel}.</li>
+ *   <li>{@code POST {path}} with {@code Accept: text/event-stream} — SSE
+ *       entry point for {@code tasks/sendSubscribe} and
+ *       {@code tasks/resubscribe}; delegates to
+ *       {@link MeshA2ASseDispatcher}.</li>
+ *   <li>{@code GET {path}/.well-known/agent.json} — agent card; rendered
+ *       by {@link MeshA2ACardBuilder#build}. Always reachable without
+ *       auth (spec §6.2).</li>
+ * </ul>
+ *
+ * <p>The SSE route is matched FIRST so a client setting
+ * {@code Accept: text/event-stream} doesn't fall through to the JSON-RPC
+ * branch. Curl-style clients that POST without an Accept header land on
+ * the JSON-RPC branch by default — which is what the {@code tasks/send}
+ * test fixtures expect.
+ */
+public class MeshA2ADispatcherController {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshA2ADispatcherController.class);
+
+    private static final String AGENT_CARD_SUFFIX = "/.well-known/agent.json";
+
+    private final MeshA2ARegistry registry;
+    private final MeshA2ADispatcher dispatcher;
+    private final MeshA2ASseDispatcher sseDispatcher;
+    private final MeshA2ACardBuilder cardBuilder;
+    private final ObjectProvider<MeshProperties> propertiesProvider;
+    private final ObjectProvider<MeshA2APublicUrlCache> publicUrlCacheProvider;
+
+    public MeshA2ADispatcherController(
+            MeshA2ARegistry registry,
+            MeshA2ADispatcher dispatcher,
+            MeshA2ASseDispatcher sseDispatcher,
+            MeshA2ACardBuilder cardBuilder,
+            ObjectProvider<MeshProperties> propertiesProvider,
+            ObjectProvider<MeshA2APublicUrlCache> publicUrlCacheProvider) {
+        this.registry = registry;
+        this.dispatcher = dispatcher;
+        this.sseDispatcher = sseDispatcher;
+        this.cardBuilder = cardBuilder;
+        this.propertiesProvider = propertiesProvider;
+        this.publicUrlCacheProvider = publicUrlCacheProvider;
+    }
+
+    /**
+     * Build the composed {@link RouterFunction} for every registered surface.
+     * Exposed as a Spring bean from {@code MeshAutoConfiguration} — see
+     * {@code meshA2ARouterFunction(...)} factory method.
+     */
+    public RouterFunction<ServerResponse> buildRouterFunction() {
+        RouterFunctions.Builder builder = RouterFunctions.route();
+        for (MeshA2ARegistry.SurfaceMetadata surface : registry.getAllSurfaces()) {
+            String path = surface.path();
+            String cardPath = path + AGENT_CARD_SUFFIX;
+            // SSE branch FIRST so Accept: text/event-stream wins the
+            // route over the plain JSON-RPC branch.
+            builder.POST(path,
+                accepts(MediaType.TEXT_EVENT_STREAM),
+                request -> handleSsePost(surface, request));
+            builder.POST(path, request -> handlePost(surface, request));
+            builder.GET(cardPath, request -> handleGetCard(surface));
+            log.info("@MeshA2A: mounted POST {} (json+sse) and GET {}", path, cardPath);
+        }
+        return builder.build();
+    }
+
+    private static org.springframework.web.servlet.function.RequestPredicate accepts(
+            MediaType mediaType) {
+        return org.springframework.web.servlet.function.RequestPredicates.accept(mediaType);
+    }
+
+    private ServerResponse handlePost(MeshA2ARegistry.SurfaceMetadata surface, ServerRequest request) {
+        String body;
+        try {
+            body = readBody(request);
+        } catch (BodyReadException e) {
+            // Spec §4.1: failure to read the body is reported to the client as
+            // a JSON-RPC Parse error (-32700) with HTTP 400, not a generic 500.
+            log.warn("@MeshA2A: failed to read request body for {}: {}",
+                surface.path(), e.getMessage());
+            String errorJson = parseErrorJson();
+            return ServerResponse
+                .status(HttpStatus.BAD_REQUEST)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(errorJson);
+        }
+        ResponseEntity<String> response = dispatcher.dispatch(surface.path(), body);
+        return ServerResponse
+            .status(response.getStatusCode())
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(response.getBody() == null ? "" : response.getBody());
+    }
+
+    /**
+     * SSE dispatch — peeks at the JSON-RPC method before promoting the
+     * connection to {@code text/event-stream}. For verbs that don't return
+     * SSE ({@code tasks/send}, {@code tasks/get}, {@code tasks/cancel}) the
+     * controller falls through to the JSON-RPC dispatcher even when the
+     * client set {@code Accept: text/event-stream} — matches Python's
+     * behavior where the framework dispatches by method, not by Accept.
+     */
+    private ServerResponse handleSsePost(MeshA2ARegistry.SurfaceMetadata surface, ServerRequest request) {
+        String body;
+        try {
+            body = readBody(request);
+        } catch (BodyReadException e) {
+            // Same parse-error path as the JSON-RPC branch — SSE clients still
+            // get a JSON envelope back for the pre-stream parse failure.
+            log.warn("@MeshA2A SSE: failed to read request body for {}: {}",
+                surface.path(), e.getMessage());
+            String errorJson = parseErrorJson();
+            return ServerResponse
+                .status(HttpStatus.BAD_REQUEST)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(errorJson);
+        }
+        String method = peekJsonRpcMethod(body);
+        MeshA2ADispatcher.SseStreamPlan plan = switch (method == null ? "" : method) {
+            case "tasks/sendSubscribe" -> dispatcher.buildSendSubscribeStream(surface.path(), body);
+            case "tasks/resubscribe"   -> dispatcher.buildResubscribeStream(body);
+            default -> null; // Fall through to JSON-RPC.
+        };
+        if (plan == null) {
+            // Fall through to the JSON-RPC branch — pass the already-read body
+            // so we don't try (and fail) to consume the input stream twice.
+            return handlePostWithBody(surface, body);
+        }
+        return sseDispatcher.render(plan);
+    }
+
+    /**
+     * Read the raw request body as a UTF-8 string directly from the servlet
+     * input stream.
+     *
+     * <p>We bypass {@link ServerRequest#body(Class)} because under Spring
+     * Boot 4 / Jackson 3, the framework does not register a
+     * {@code HttpMessageConverter<String>} that accepts
+     * {@code Content-Type: application/json} for the functional router path —
+     * the converter resolver throws and the body read silently fails. The
+     * earlier swallow-and-return-empty workaround masked this as
+     * "Method not implemented: 'null'" errors for every well-formed
+     * {@code tasks/send} request (issue #932).
+     *
+     * <p>Wrapping in {@link BodyReadException} surfaces I/O failures to the
+     * caller, which converts them into a proper {@code -32700 Parse error}
+     * response per spec §4.1 instead of swallowing them.
+     */
+    private static String readBody(ServerRequest request) {
+        try {
+            byte[] bytes = request.servletRequest().getInputStream().readAllBytes();
+            return new String(bytes, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new BodyReadException("Failed to read request body", e);
+        }
+    }
+
+    /**
+     * JSON-RPC dispatch with the body already in hand — used by the SSE
+     * branch when it has read the body to peek at the method and then needs
+     * to fall through to the sync dispatcher without re-reading the (already
+     * consumed) input stream.
+     */
+    private ServerResponse handlePostWithBody(MeshA2ARegistry.SurfaceMetadata surface, String body) {
+        ResponseEntity<String> response = dispatcher.dispatch(surface.path(), body);
+        return ServerResponse
+            .status(response.getStatusCode())
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(response.getBody() == null ? "" : response.getBody());
+    }
+
+    /** Unchecked wrapper for {@link IOException} during body read so the
+     *  router-handler signature (no checked exceptions) stays intact. */
+    static final class BodyReadException extends RuntimeException {
+        BodyReadException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    /**
+     * Build a canonical JSON-RPC parse-error envelope for body-read failures.
+     * Hand-rolled (rather than going through the dispatcher's
+     * {@code ObjectMapper}) because the message is fixed and constructing a
+     * mapper on every error would be wasteful.
+     */
+    private static String parseErrorJson() {
+        return "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":"
+            + MeshA2ADispatcher.JSONRPC_PARSE_ERROR
+            + ",\"message\":\"Parse error: failed to read request body\"},\"id\":null}";
+    }
+
+    /**
+     * Peek at the JSON-RPC body's {@code method} field without committing
+     * to the full parse — the dispatcher re-parses for full validation.
+     * Returns {@code null} on parse failure; the SSE branch then falls
+     * through to JSON-RPC dispatch, which produces the canonical parse
+     * error response.
+     */
+    private String peekJsonRpcMethod(String body) {
+        if (body == null || body.isEmpty()) return null;
+        try {
+            tools.jackson.databind.JsonNode node =
+                new tools.jackson.databind.ObjectMapper().readTree(body);
+            tools.jackson.databind.JsonNode m = node.get("method");
+            return m != null && m.isTextual() ? m.asText() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private ServerResponse handleGetCard(MeshA2ARegistry.SurfaceMetadata surface) {
+        MeshProperties properties = propertiesProvider.getIfAvailable();
+        String agentName = properties != null && properties.getAgent() != null
+            ? properties.getAgent().getName() : null;
+        String agentVersion = properties != null && properties.getAgent() != null
+            ? properties.getAgent().getVersion() : null;
+
+        // Public URL resolution priority (spec §3.2 / §8.2):
+        //   1. Registry-stamped public URL from the heartbeat-response cache.
+        //   2. Local fallback URL built from agent host:port.
+        //   3. Omit `url` entirely (never emit empty string).
+        String publicUrl = null;
+        MeshA2APublicUrlCache cache = publicUrlCacheProvider.getIfAvailable();
+        if (cache != null) {
+            publicUrl = cache.get(surface.path(), surface.skillId());
+        }
+        if (publicUrl == null || publicUrl.isEmpty()) {
+            String host = properties != null && properties.getAgent() != null
+                ? properties.getAgent().getHost() : null;
+            int port = properties != null && properties.getAgent() != null
+                ? properties.getAgent().getPort() : 0;
+            publicUrl = MeshA2ACardBuilder.localFallbackUrl(host, port, surface.path());
+        }
+
+        Map<String, Object> card = cardBuilder.build(
+            surface, agentName, agentVersion, null, publicUrl);
+
+        return ServerResponse
+            .ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(cardBuilder.toJson(card));
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2APublicUrlCache.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2APublicUrlCache.java
@@ -1,0 +1,93 @@
+package io.mcpmesh.spring.web;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Process-local cache of registry-stamped public URLs for each
+ * {@code @MeshA2A} surface (spec §8.2).
+ *
+ * <p>Populated by {@code MeshEventProcessor} when the registry sends a
+ * {@code surface_updated} event back as part of the heartbeat response. Read
+ * by {@link MeshA2ADispatcherController} at agent-card render time.
+ *
+ * <p>Mirrors the Python module-level {@code _PUBLIC_URL_CACHE} in
+ * {@code mesh/a2a.py:202-228}. Process-local — not persisted across
+ * restarts; the registry re-stamps on the next heartbeat.
+ *
+ * <p>When the cache has no entry for a given {@code (path, skillId)}, the
+ * controller falls back to building a local-form URL from the agent's
+ * configured host:port. Returning an externally-reachable FQDN matters once
+ * the producer is deployed behind a load balancer or ingress.
+ *
+ * <h2>Cross-runtime parity</h2>
+ *
+ * <p>The Rust core does not currently emit a {@code surface_updated} event to
+ * Java consumers — Java's {@link io.mcpmesh.core.MeshEvent} variants only
+ * cover dependency / LLM / lifecycle signals today (Phase 1 baseline). When
+ * the registry adds surface URL stamping events (issue follow-up), the
+ * {@code MeshEventProcessor} populates this cache via {@link #put}. Until
+ * then the cache stays empty and the controller's local-fallback URL form
+ * is used — which is the same fallback Python takes when the registry hasn't
+ * stamped a URL yet.
+ */
+public class MeshA2APublicUrlCache {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshA2APublicUrlCache.class);
+
+    private final Map<Key, String> cache = new ConcurrentHashMap<>();
+
+    /**
+     * Cache a registry-stamped public URL for one surface. Pass
+     * {@code null} or empty {@code publicUrl} to clear the cached entry —
+     * matches the Python helper's behaviour
+     * ({@code update_public_url_cache} drops the entry when the registry
+     * stops stamping it).
+     */
+    public void put(String path, String skillId, String publicUrl) {
+        Key key = new Key(path, skillId);
+        if (publicUrl == null || publicUrl.isEmpty()) {
+            String removed = cache.remove(key);
+            if (removed != null) {
+                log.debug("MeshA2A public URL cache: cleared entry for {} (skillId={})",
+                    path, skillId);
+            }
+            return;
+        }
+        cache.put(key, publicUrl);
+        log.debug("MeshA2A public URL cache: stored {} = {} (skillId={})",
+            path, publicUrl, skillId);
+    }
+
+    /**
+     * @return the cached public URL for {@code (path, skillId)}, or
+     *     {@code null} when no entry exists. Callers MUST fall back to the
+     *     local-form URL when this returns {@code null}.
+     */
+    public String get(String path, String skillId) {
+        return cache.get(new Key(path, skillId));
+    }
+
+    /** @return current cache size. For diagnostics. */
+    public int size() {
+        return cache.size();
+    }
+
+    /** Drop every cached entry. For tests and shutdown cleanup. */
+    public void clear() {
+        cache.clear();
+    }
+
+    private record Key(String path, String skillId) {
+        private Key {
+            // Defensive: empty skillId is acceptable (some heartbeat
+            // responses may omit it), but null path is a bug.
+            Objects.requireNonNull(path, "path");
+            skillId = skillId == null ? "" : skillId;
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2APublicUrlCache.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2APublicUrlCache.java
@@ -50,7 +50,7 @@ public class MeshA2APublicUrlCache {
      */
     public void put(String path, String skillId, String publicUrl) {
         Key key = new Key(path, skillId);
-        if (publicUrl == null || publicUrl.isEmpty()) {
+        if (publicUrl == null || publicUrl.isBlank()) {
             String removed = cache.remove(key);
             if (removed != null) {
                 log.debug("MeshA2A public URL cache: cleared entry for {} (skillId={})",

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ARegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ARegistry.java
@@ -1,0 +1,261 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.core.AgentSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Registry for {@code @MeshA2A} annotated methods discovered during bean
+ * post-processing.
+ *
+ * <p>The registry maps each producer path to the surface metadata captured
+ * from the annotation, plus a reference to the bean+method that handles
+ * {@code tasks/send}. Consulted by:
+ *
+ * <ul>
+ *   <li>{@link MeshA2ADispatcher} — to locate the handler for an incoming
+ *       JSON-RPC request at {@code POST {path}}.</li>
+ *   <li>{@link MeshA2ACardBuilder} — to render the {@code .well-known/agent.json}
+ *       card for {@code GET {path}/.well-known/agent.json}.</li>
+ *   <li>{@link MeshA2AAuthFilter} — to look up the {@code auth} setting for
+ *       a candidate path.</li>
+ *   <li>{@code MeshAutoConfiguration} — to enumerate all surfaces when
+ *       building the heartbeat {@code a2a_surfaces[]} array (spec §2 / §8).</li>
+ * </ul>
+ *
+ * <p>Mirrors the role of {@link MeshRouteRegistry} on the {@code @MeshRoute}
+ * side: built at bean-post-processing time, immutable from the user's
+ * perspective afterwards, queried during request dispatch.
+ */
+public class MeshA2ARegistry {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshA2ARegistry.class);
+
+    /**
+     * Surfaces indexed by the producer's {@code path} (e.g.,
+     * {@code "/agents/date"}). Insertion order is preserved to keep
+     * heartbeat envelope ordering stable across restarts.
+     */
+    private final Map<String, SurfaceMetadata> surfaces = new ConcurrentHashMap<>();
+
+    /**
+     * Insertion-ordered list mirror — {@link ConcurrentHashMap} doesn't
+     * preserve order, so we keep a parallel list for deterministic iteration
+     * when building the heartbeat envelope.
+     */
+    private final List<String> orderedPaths = Collections.synchronizedList(new ArrayList<>());
+
+    /**
+     * Register a {@code @MeshA2A} surface.
+     *
+     * @param metadata the captured surface metadata
+     */
+    public void register(SurfaceMetadata metadata) {
+        SurfaceMetadata previous = surfaces.putIfAbsent(metadata.path(), metadata);
+        if (previous != null) {
+            throw new IllegalStateException(
+                "@MeshA2A path collision: '" + metadata.path() + "' is already registered "
+                    + "by " + previous.handlerMethodId() + ". Each producer path must be unique.");
+        }
+        orderedPaths.add(metadata.path());
+        log.info("Registered @MeshA2A surface: path={} skillId={} dependencies={}",
+            metadata.path(), metadata.skillId(), metadata.dependencies().size());
+    }
+
+    /**
+     * Look up a surface by its path.
+     *
+     * @param path the {@code @MeshA2A.path()} value
+     * @return the metadata, or {@code null} when no surface owns that path
+     */
+    public SurfaceMetadata getByPath(String path) {
+        return surfaces.get(path);
+    }
+
+    /**
+     * @return read-only view of every registered surface in insertion order.
+     */
+    public List<SurfaceMetadata> getAllSurfaces() {
+        List<SurfaceMetadata> ordered = new ArrayList<>(orderedPaths.size());
+        synchronized (orderedPaths) {
+            for (String path : orderedPaths) {
+                SurfaceMetadata md = surfaces.get(path);
+                if (md != null) {
+                    ordered.add(md);
+                }
+            }
+        }
+        return Collections.unmodifiableList(ordered);
+    }
+
+    /**
+     * Read-only view of the path → metadata map. Provided for diagnostics.
+     */
+    public Collection<SurfaceMetadata> getMetadataCollection() {
+        return Collections.unmodifiableCollection(surfaces.values());
+    }
+
+    /**
+     * @return {@code true} when at least one {@code @MeshA2A} surface is
+     *     registered. Used by the heartbeat envelope builder to decide
+     *     whether to flip {@code agent_type} to {@code "a2a"}.
+     */
+    public boolean hasSurfaces() {
+        return !surfaces.isEmpty();
+    }
+
+    public int size() {
+        return surfaces.size();
+    }
+
+    /**
+     * Collect the unique dependency capabilities across every registered
+     * {@code @MeshA2A} surface and project them onto
+     * {@link AgentSpec.DependencySpec} entries for the registry's
+     * resolution mechanism. Deduplication is on capability name — first
+     * occurrence wins (tag/version refinements on later occurrences are
+     * dropped, matching the route-registry behaviour).
+     *
+     * <p>The returned specs are folded into a synthetic
+     * {@code __mesh_a2a_deps} tool on the heartbeat envelope (built by
+     * {@code MeshAutoConfiguration}) so the Rust core can drive
+     * {@code dependency_available} events for them — the same mechanism
+     * that powers {@code @MeshRoute} dependency wiring.
+     */
+    public List<AgentSpec.DependencySpec> getUniqueDependencySpecs() {
+        Set<String> seenCapabilities = new HashSet<>();
+        List<AgentSpec.DependencySpec> specs = new ArrayList<>();
+        for (SurfaceMetadata surface : getAllSurfaces()) {
+            for (MeshRouteRegistry.DependencySpec dep : surface.dependencies()) {
+                if (seenCapabilities.add(dep.getCapability())) {
+                    AgentSpec.DependencySpec agentDep = new AgentSpec.DependencySpec();
+                    agentDep.setCapability(dep.getCapability());
+                    if (dep.hasTags()) {
+                        agentDep.setTags(String.join(",", dep.getTags()));
+                    }
+                    if (dep.hasVersion()) {
+                        agentDep.setVersion(dep.getVersion());
+                    }
+                    specs.add(agentDep);
+                }
+            }
+        }
+        return specs;
+    }
+
+    /**
+     * Captured metadata for a single {@code @MeshA2A} method.
+     *
+     * <p>Constructed once at bean-post-processing time and immutable
+     * thereafter — the {@link MeshA2ADispatcher} reads
+     * {@link #bean()}/{@link #method()} via reflection on every request.
+     *
+     * @param path               the URL path prefix for this surface
+     * @param skillId            the A2A skill id (kebab-case)
+     * @param skillName          the human-readable skill name
+     * @param description        free-form skill description ({@code ""} when unset)
+     * @param tags               skill tags (empty list when unset)
+     * @param dependencies       declared mesh dependencies, in source order
+     * @param auth               {@code "bearer"} or {@code ""}
+     * @param handlerMethodId    {@code "ClassName.methodName"} identifier for
+     *                           logs and registry lookup
+     * @param bean               the Spring bean carrying the handler method
+     * @param method             the handler method itself
+     */
+    public record SurfaceMetadata(
+        String path,
+        String skillId,
+        String skillName,
+        String description,
+        List<String> tags,
+        List<MeshRouteRegistry.DependencySpec> dependencies,
+        String auth,
+        String handlerMethodId,
+        Object bean,
+        Method method
+    ) {
+        public SurfaceMetadata {
+            if (path == null || path.isEmpty()) {
+                throw new IllegalArgumentException("@MeshA2A.path() must be non-empty");
+            }
+            if (!path.startsWith("/")) {
+                throw new IllegalArgumentException(
+                    "@MeshA2A.path() must start with '/': got '" + path + "'");
+            }
+            if (skillId == null || skillId.isEmpty()) {
+                throw new IllegalArgumentException("@MeshA2A.skillId() must be non-empty");
+            }
+            if (skillName == null || skillName.isEmpty()) {
+                throw new IllegalArgumentException("@MeshA2A.skillName() must be non-empty");
+            }
+            // Normalize trailing slash so path collisions are unambiguous
+            // ("/agents/x/" and "/agents/x" must not co-exist).
+            if (path.length() > 1 && path.endsWith("/")) {
+                throw new IllegalArgumentException(
+                    "@MeshA2A.path() must not end with '/': got '" + path + "'");
+            }
+            tags = tags == null ? List.of() : List.copyOf(tags);
+            dependencies = dependencies == null ? List.of() : List.copyOf(dependencies);
+            description = description == null ? "" : description;
+            auth = auth == null ? "" : auth;
+        }
+
+        /** @return {@code true} when this surface declared {@code auth="bearer"}. */
+        public boolean bearerAuth() {
+            return "bearer".equals(auth);
+        }
+    }
+
+    /**
+     * Build the heartbeat {@code a2a_surfaces[]} array (spec §2.1).
+     *
+     * <p>Each registered surface produces one entry. Required fields
+     * ({@code path}, {@code skill_id}) are always emitted. Optional fields
+     * ({@code name}, {@code description}, {@code tags}) are emitted ONLY
+     * when set on the annotation, never as empty strings or empty arrays —
+     * spec §2.1 is explicit about this so the registry's OpenAPI defaults
+     * (e.g., {@code input_modes: ["application/json"]}) aren't overridden
+     * with empty values.
+     *
+     * @return list of plain-Map surfaces ready for JSON serialization
+     */
+    public List<Map<String, Object>> buildHeartbeatSurfaces() {
+        List<SurfaceMetadata> all = getAllSurfaces();
+        if (all.isEmpty()) {
+            return List.of();
+        }
+        List<Map<String, Object>> out = new ArrayList<>(all.size());
+        for (SurfaceMetadata md : all) {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("path", md.path());
+            entry.put("skill_id", md.skillId());
+            // skill_name is always present on @MeshA2A (required annotation
+            // field), so we always emit `name`. Python's
+            // collect_a2a_surfaces emits it only when set; on the Java
+            // annotation it's mandatory so absence is impossible.
+            entry.put("name", md.skillName());
+            if (md.description() != null && !md.description().isEmpty()) {
+                entry.put("description", md.description());
+            }
+            if (!md.tags().isEmpty()) {
+                entry.put("tags", new ArrayList<>(md.tags()));
+            }
+            // input_modes / output_modes default at card-render time, not at
+            // heartbeat-emit time. Java's @MeshA2A doesn't expose them yet
+            // (mirrors Python's decorator), so we omit them here.
+            out.add(entry);
+        }
+        return out;
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ASseDispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ASseDispatcher.java
@@ -61,6 +61,16 @@ public class MeshA2ASseDispatcher {
     public static final long KEEPALIVE_MILLIS = 15_000L;
     /** Maximum total stream duration as a defensive cap (1 hour). */
     public static final long MAX_STREAM_MILLIS = 60L * 60_000L;
+    /**
+     * Consecutive {@code proxy.status()} failures to tolerate during the SSE
+     * poll loop before giving up on the stream. Spec §4.4 conformance:
+     * transient unreachability is NOT authoritative evidence the job is dead,
+     * so we keep emitting {@code state=working} status frames and continue
+     * polling. Once this counter is reached we close the SSE stream without
+     * marking the task store record terminal — subsequent {@code tasks/get}
+     * resumes polling normally.
+     */
+    public static final int MAX_CONSECUTIVE_STATUS_FAILURES = 5;
 
     private final MeshA2ADispatcher dispatcher;
 
@@ -165,35 +175,59 @@ public class MeshA2ASseDispatcher {
         Object lastProgress = null;
         Object lastMessage = null;
         long lastEventTime = System.currentTimeMillis();
+        int consecutiveStatusFailures = 0;
 
         while (true) {
-            // Defensive cap so a stuck job can't pin a worker thread forever.
+            // Stream-level cap — preserves task state in the store so callers
+            // can resume via tasks/resubscribe or check status via tasks/get.
+            // The cap protects the worker thread from a stuck job; it is NOT
+            // a job-death signal, so we emit a non-terminal status frame and
+            // do NOT call markTaskTerminal (spec §4.4: producer-side resource
+            // limits must not poison the task store).
             if (System.currentTimeMillis() - started > MAX_STREAM_MILLIS) {
-                log.warn("SSE long-running stream for task {} exceeded {}ms cap; closing",
+                log.warn("SSE long-running stream for task {} exceeded {}ms cap; closing "
+                    + "(task state preserved — clients may resubscribe)",
                     taskId, MAX_STREAM_MILLIS);
                 writeFrame(builder, dispatcher.buildStatusUpdateFrame(
-                    reqId, taskId, MeshA2AStateTranslator.A2A_FAILED,
-                    "stream timeout: producer-side cap exceeded", true, null));
+                    reqId, taskId, MeshA2AStateTranslator.A2A_WORKING,
+                    "stream closed: producer-side cap exceeded "
+                        + "(task still running; reconnect via tasks/resubscribe)",
+                    true, null));
                 return;
             }
 
             Map<String, Object> status;
             try {
                 status = proxy.status();
+                consecutiveStatusFailures = 0;
             } catch (Exception e) {
-                log.warn("A2A SSE poll: proxy.status() raised for task {}: {}", taskId, e.getMessage());
-                writeFrame(builder, dispatcher.buildStatusUpdateFrame(
-                    reqId, taskId, MeshA2AStateTranslator.A2A_FAILED,
-                    "status unavailable: " + e.getMessage(), true, null));
-                // Mark the parked record terminal so subsequent tasks/get
-                // doesn't re-poll a broken proxy.
-                Map<String, Object> failedEnvelope = dispatcher.buildTaskFromStatus(
-                    taskId, taskId, null,
-                    MeshA2AStateTranslator.A2A_FAILED,
-                    Map.of("error", "status unavailable: " + e.getMessage()),
-                    null, false);
-                dispatcher.markTaskTerminal(taskId, failedEnvelope);
-                return;
+                consecutiveStatusFailures++;
+                log.warn("A2A SSE poll: proxy.status() raised for task {} (failure {}/{}): {}",
+                    taskId, consecutiveStatusFailures, MAX_CONSECUTIVE_STATUS_FAILURES, e.getMessage());
+                // Spec §4.4 conformance: transient unreachability is NOT
+                // authoritative evidence the job is dead. Emit a state=working
+                // status frame carrying the error in status.message and
+                // CONTINUE polling. Do NOT mark the task store terminal —
+                // subsequent tasks/get must keep re-polling the proxy.
+                if (!writeFrame(builder, dispatcher.buildStatusUpdateFrame(
+                        reqId, taskId, MeshA2AStateTranslator.A2A_WORKING,
+                        "status unavailable: " + e.getMessage(), false, null))) {
+                    return; // Client gone.
+                }
+                if (consecutiveStatusFailures >= MAX_CONSECUTIVE_STATUS_FAILURES) {
+                    log.warn("A2A SSE poll: giving up on task {} after {} consecutive status() "
+                        + "failures (task state preserved — clients may retry via tasks/get)",
+                        taskId, consecutiveStatusFailures);
+                    return;
+                }
+                try {
+                    Thread.sleep(POLL_INTERVAL_MILLIS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    log.debug("SSE long-running stream for task {} interrupted; exiting", taskId);
+                    return;
+                }
+                continue;
             }
             if (status == null) {
                 status = new LinkedHashMap<>();

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ASseDispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ASseDispatcher.java
@@ -188,11 +188,17 @@ public class MeshA2ASseDispatcher {
                 log.warn("SSE long-running stream for task {} exceeded {}ms cap; closing "
                     + "(task state preserved — clients may resubscribe)",
                     taskId, MAX_STREAM_MILLIS);
+                // final=false: the task is NOT terminal; we are only closing
+                // the SSE transport. A `final=true` here would tell A2A clients
+                // the task has reached a terminal state and they should not
+                // reconnect — but the worker is still running and the task
+                // store still holds non-terminal state. Clients should reopen
+                // via tasks/resubscribe.
                 writeFrame(builder, dispatcher.buildStatusUpdateFrame(
                     reqId, taskId, MeshA2AStateTranslator.A2A_WORKING,
                     "stream closed: producer-side cap exceeded "
                         + "(task still running; reconnect via tasks/resubscribe)",
-                    true, null));
+                    false, null));
                 return;
             }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ASseDispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ASseDispatcher.java
@@ -1,0 +1,334 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.JobProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.function.ServerResponse;
+import org.springframework.web.servlet.function.ServerResponse.SseBuilder;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Spring MVC SSE adapter for the framework-agnostic
+ * {@link MeshA2ADispatcher.SseStreamPlan} (spec §4.6 / §4.7 / §5).
+ *
+ * <p>The dispatcher produces a stream-plan (a value object describing one
+ * of four SSE shapes). This adapter materialises that plan as a Spring
+ * {@link ServerResponse#sse(java.util.function.Consumer)} body, emitting
+ * frames in the canonical {@code data: <json>\n\n} format plus
+ * {@code : keepalive\n\n} comment lines every {@link #KEEPALIVE_MILLIS}
+ * milliseconds of inactivity.
+ *
+ * <h2>Why a separate class?</h2>
+ *
+ * <p>Keeping the dispatcher Spring-SSE-free makes it unit-testable in plain
+ * JUnit without a servlet container. The adapter contains the only
+ * dependency on Spring MVC's functional SSE API. This separation mirrors
+ * the {@code MeshSseEventBuilder} → {@code MeshSseController} split on the
+ * {@code @MeshRoute} side.
+ *
+ * <h2>Threading</h2>
+ *
+ * <p>Spring's {@link SseBuilder} writes to the response synchronously on
+ * the calling thread; we block the request thread for the duration of the
+ * stream. This matches Python's {@code StreamingResponse} blocking
+ * behavior — Spring MVC dispatches each request on its own worker thread,
+ * so no extra async machinery is required. For long-running streams the
+ * adapter uses {@link Thread#sleep(long)} between polls; the call returns
+ * as soon as the underlying job reaches a terminal state OR the client
+ * disconnects (detected via {@link IOException} on write).
+ *
+ * <h2>Client-disconnect handling</h2>
+ *
+ * <p>Per spec §7.3 / §5.4: a client-side SSE disconnect MUST NOT cancel
+ * the underlying job — the client may rejoin via {@code tasks/resubscribe}.
+ * We swallow {@link IOException} from {@link SseBuilder#data} writes, log
+ * at DEBUG level, and exit the poll loop without calling
+ * {@link JobProxy#cancel}. The job continues running and the next
+ * {@code tasks/resubscribe} call re-attaches at the current registry view.
+ */
+public class MeshA2ASseDispatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshA2ASseDispatcher.class);
+
+    /** Poll cadence for the long-running stream (spec §4.6 sequence diagram: 1s). */
+    public static final long POLL_INTERVAL_MILLIS = 1000L;
+    /** Keepalive interval — SSE comment frame after this much inactivity (spec §5.1: 15s). */
+    public static final long KEEPALIVE_MILLIS = 15_000L;
+    /** Maximum total stream duration as a defensive cap (1 hour). */
+    public static final long MAX_STREAM_MILLIS = 60L * 60_000L;
+
+    private final MeshA2ADispatcher dispatcher;
+
+    public MeshA2ASseDispatcher(MeshA2ADispatcher dispatcher) {
+        this.dispatcher = dispatcher;
+    }
+
+    /**
+     * Materialise an SSE stream-plan as a Spring {@link ServerResponse}.
+     *
+     * <p>Headers per spec §4.6 / §5.1:
+     * <ul>
+     *   <li>{@code Content-Type: text/event-stream}</li>
+     *   <li>{@code Cache-Control: no-cache}</li>
+     *   <li>{@code X-Accel-Buffering: no}</li>
+     *   <li>{@code Connection: keep-alive}</li>
+     * </ul>
+     */
+    public ServerResponse render(MeshA2ADispatcher.SseStreamPlan plan) {
+        switch (plan.kind) {
+            case ERROR -> {
+                HttpStatus status = plan.errorStatus != null ? plan.errorStatus : HttpStatus.OK;
+                return ServerResponse
+                    .status(status)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(plan.errorBody == null ? "" : plan.errorBody);
+            }
+            case SINGLE_FRAME -> {
+                return sseResponse(builder -> {
+                    writeFrame(builder, plan.firstFrame);
+                });
+            }
+            case SYNC_COMPLETED -> {
+                return sseResponse(builder -> {
+                    writeFrame(builder, plan.firstFrame);
+                    writeFrame(builder, plan.secondFrame);
+                });
+            }
+            case LONG_RUNNING -> {
+                return sseResponse(builder -> {
+                    runLongRunningStream(builder, plan.reqId, plan.taskId, plan.proxy);
+                });
+            }
+            default -> throw new IllegalStateException("Unknown SSE plan kind: " + plan.kind);
+        }
+    }
+
+    private ServerResponse sseResponse(SseEmitter emitter) {
+        // Spec §4.6 / §5.1 mandates Content-Type: text/event-stream which
+        // {@code ServerResponse.sse(...)} sets automatically. The
+        // additional buffering hints (Cache-Control: no-cache,
+        // X-Accel-Buffering: no, Connection: keep-alive) are not
+        // expressible through the functional SSE builder once it's been
+        // promoted — Spring's BodyBuilder.headers(...) chain does not
+        // re-apply to an in-flight SSE body. The hints are added at the
+        // request level via {@link MeshA2ASseHeaderFilter} so they cover
+        // every SSE response uniformly.
+        return ServerResponse.sse(builder -> {
+            try {
+                emitter.emit(builder);
+            } catch (Exception e) {
+                log.debug("SSE stream terminated: {}", e.getMessage());
+            } finally {
+                try {
+                    builder.complete();
+                } catch (Exception ignored) {
+                    // Already closed — best-effort cleanup.
+                }
+            }
+        }, java.time.Duration.ofMillis(MAX_STREAM_MILLIS));
+    }
+
+    /**
+     * Run the long-running poll loop (spec §5.3 long-running case):
+     * <ol>
+     *   <li>Emit an initial {@code state=working, final=false} frame so
+     *       the client confirms subscription liveness.</li>
+     *   <li>Poll {@link JobProxy#status} every
+     *       {@link #POLL_INTERVAL_MILLIS} milliseconds.</li>
+     *   <li>Emit a {@code state=working} frame only when {@code progress}
+     *       or {@code progress_message} changed — suppress redundant
+     *       updates (Python a2a.py:1057-1070).</li>
+     *   <li>Emit a {@code : keepalive\n\n} SSE comment after
+     *       {@link #KEEPALIVE_MILLIS} ms of inactivity.</li>
+     *   <li>On terminal mesh state: attempt
+     *       {@link JobProxy#await(double)} with a 1-second timeout for
+     *       the completed branch, emit the artifact frame, emit the
+     *       terminal status frame ({@code final=true}), mark the task
+     *       store record terminal, return.</li>
+     * </ol>
+     */
+    private void runLongRunningStream(SseBuilder builder, Object reqId, String taskId, JobProxy proxy) {
+        long started = System.currentTimeMillis();
+
+        // 1. Initial state=working frame.
+        Map<String, Object> initial = dispatcher.buildStatusUpdateFrame(
+            reqId, taskId, MeshA2AStateTranslator.A2A_WORKING, null, false, null);
+        if (!writeFrame(builder, initial)) {
+            return; // Client gone.
+        }
+
+        Object lastProgress = null;
+        Object lastMessage = null;
+        long lastEventTime = System.currentTimeMillis();
+
+        while (true) {
+            // Defensive cap so a stuck job can't pin a worker thread forever.
+            if (System.currentTimeMillis() - started > MAX_STREAM_MILLIS) {
+                log.warn("SSE long-running stream for task {} exceeded {}ms cap; closing",
+                    taskId, MAX_STREAM_MILLIS);
+                writeFrame(builder, dispatcher.buildStatusUpdateFrame(
+                    reqId, taskId, MeshA2AStateTranslator.A2A_FAILED,
+                    "stream timeout: producer-side cap exceeded", true, null));
+                return;
+            }
+
+            Map<String, Object> status;
+            try {
+                status = proxy.status();
+            } catch (Exception e) {
+                log.warn("A2A SSE poll: proxy.status() raised for task {}: {}", taskId, e.getMessage());
+                writeFrame(builder, dispatcher.buildStatusUpdateFrame(
+                    reqId, taskId, MeshA2AStateTranslator.A2A_FAILED,
+                    "status unavailable: " + e.getMessage(), true, null));
+                // Mark the parked record terminal so subsequent tasks/get
+                // doesn't re-poll a broken proxy.
+                Map<String, Object> failedEnvelope = dispatcher.buildTaskFromStatus(
+                    taskId, taskId, null,
+                    MeshA2AStateTranslator.A2A_FAILED,
+                    Map.of("error", "status unavailable: " + e.getMessage()),
+                    null, false);
+                dispatcher.markTaskTerminal(taskId, failedEnvelope);
+                return;
+            }
+            if (status == null) {
+                status = new LinkedHashMap<>();
+            }
+            String meshState = MeshA2AStateTranslator.meshStatusOf(status);
+
+            if (MeshA2AStateTranslator.isMeshTerminal(meshState)) {
+                String a2aState = MeshA2AStateTranslator.fromMesh(meshState);
+                Object finalResult = null;
+                boolean hasFinalResult = false;
+
+                if (MeshA2AStateTranslator.A2A_COMPLETED.equals(a2aState)) {
+                    try {
+                        finalResult = proxy.await(1.0);
+                        hasFinalResult = true;
+                        // Emit artifact frame BEFORE the terminal status —
+                        // spec §5.3 ordering.
+                        if (!writeFrame(builder, dispatcher.buildArtifactUpdateFrame(
+                                reqId, taskId, finalResult))) {
+                            return;
+                        }
+                    } catch (Exception e) {
+                        log.debug("A2A SSE poll: proxy.await() raised on completed task {}: {}",
+                            taskId, e.getMessage());
+                    }
+                }
+
+                String finalMessage = null;
+                if (MeshA2AStateTranslator.A2A_FAILED.equals(a2aState)) {
+                    Object err = status.get("error");
+                    if (err == null) err = status.get("progress_message");
+                    if (err != null) finalMessage = err.toString();
+                } else if (MeshA2AStateTranslator.A2A_CANCELED.equals(a2aState)) {
+                    Object pm = status.get("progress_message");
+                    if (pm != null) finalMessage = pm.toString();
+                }
+
+                writeFrame(builder, dispatcher.buildStatusUpdateFrame(
+                    reqId, taskId, a2aState, finalMessage, true, null));
+
+                // Cache the terminal envelope so the task store reflects
+                // the same view tasks/get would return.
+                Map<String, Object> terminalEnvelope = dispatcher.buildTaskFromStatus(
+                    taskId, taskId, null, a2aState, status, finalResult, hasFinalResult);
+                dispatcher.markTaskTerminal(taskId, terminalEnvelope);
+                return;
+            }
+
+            Object progress = status.get("progress");
+            Object progressMessage = status.get("progress_message");
+            long now = System.currentTimeMillis();
+
+            boolean progressChanged = !java.util.Objects.equals(progress, lastProgress);
+            boolean messageChanged = !java.util.Objects.equals(progressMessage, lastMessage);
+
+            if (progressChanged || messageChanged) {
+                String msgText = progressMessage == null ? null : progressMessage.toString();
+                if (!writeFrame(builder, dispatcher.buildStatusUpdateFrame(
+                        reqId, taskId, MeshA2AStateTranslator.A2A_WORKING,
+                        msgText, false, progress))) {
+                    return;
+                }
+                lastProgress = progress;
+                lastMessage = progressMessage;
+                lastEventTime = now;
+            } else if (now - lastEventTime > KEEPALIVE_MILLIS) {
+                // Spec §5.1: SSE comment line, ignored by parsers but
+                // resets proxy idle timers.
+                if (!writeComment(builder, "keepalive")) {
+                    return;
+                }
+                lastEventTime = now;
+            }
+
+            try {
+                Thread.sleep(POLL_INTERVAL_MILLIS);
+            } catch (InterruptedException e) {
+                // Server shutdown — re-interrupt and exit cleanly.
+                Thread.currentThread().interrupt();
+                log.debug("SSE long-running stream for task {} interrupted; exiting", taskId);
+                return;
+            }
+        }
+    }
+
+    /**
+     * Write one JSON-RPC envelope as an SSE {@code data:} frame. Returns
+     * {@code false} when the client has disconnected; caller MUST exit the
+     * loop without calling {@code JobProxy.cancel()} per spec §7.3.
+     */
+    private boolean writeFrame(SseBuilder builder, Map<String, Object> envelope) {
+        if (envelope == null) {
+            return true;
+        }
+        try {
+            // Spring's data() method handles JSON serialization via the
+            // configured ObjectMapper — but we've already serialized the
+            // envelope shape ourselves to keep determinism with the
+            // Python frame builder. Pass the pre-serialized string.
+            String json = dispatcher.toJsonString(envelope);
+            builder.data(json);
+            return true;
+        } catch (IOException ioe) {
+            log.debug("SSE write failed (client disconnected?): {}", ioe.getMessage());
+            return false;
+        } catch (Exception e) {
+            log.warn("SSE write failed unexpectedly: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Write a raw SSE comment line ({@code : <text>\n\n}). Spec §5.1
+     * keepalive contract. Returns {@code false} on client disconnect.
+     *
+     * <p>{@code SseBuilder.comment(...)} only buffers the comment line; we
+     * must follow with {@link SseBuilder#send()} to flush the framing to
+     * the wire (Spring 6.1.4+ split the API this way).
+     */
+    private boolean writeComment(SseBuilder builder, String text) {
+        try {
+            builder.comment(text).send();
+            return true;
+        } catch (IOException ioe) {
+            log.debug("SSE keepalive write failed (client disconnected?): {}", ioe.getMessage());
+            return false;
+        } catch (Exception e) {
+            log.warn("SSE keepalive write failed unexpectedly: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /** Functional interface mirroring Spring's lambda parameter for clarity. */
+    @FunctionalInterface
+    private interface SseEmitter {
+        void emit(SseBuilder builder) throws Exception;
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ASseHeaderFilter.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ASseHeaderFilter.java
@@ -6,9 +6,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Adds the SSE-buffering hints that Spring's
@@ -47,13 +49,43 @@ public class MeshA2ASseHeaderFilter extends OncePerRequestFilter {
     protected void doFilterInternal(
             HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
-        String accept = request.getHeader("Accept");
-        if (accept != null && accept.contains("text/event-stream")) {
+        if (acceptsEventStream(request.getHeader("Accept"))) {
             response.setHeader("Cache-Control", "no-cache");
             response.setHeader("X-Accel-Buffering", "no");
             response.setHeader("Connection", "keep-alive");
             log.debug("SSE buffering hints stamped on {} {}", request.getMethod(), request.getRequestURI());
         }
         chain.doFilter(request, response);
+    }
+
+    /**
+     * Returns true when the {@code Accept} header asks for
+     * {@code text/event-stream}. Uses Spring's {@link MediaType#parseMediaTypes}
+     * so case ("TEXT/EVENT-STREAM"), parameter suffixes ("text/event-stream;
+     * charset=UTF-8"), and compound values ("application/json,
+     * text/event-stream;q=0.9") are all handled correctly — a raw
+     * {@code String.contains("text/event-stream")} check is brittle on all
+     * three counts.
+     */
+    static boolean acceptsEventStream(String acceptHeader) {
+        if (acceptHeader == null || acceptHeader.isBlank()) {
+            return false;
+        }
+        try {
+            List<MediaType> media = MediaType.parseMediaTypes(acceptHeader);
+            for (MediaType m : media) {
+                if (m.isCompatibleWith(MediaType.TEXT_EVENT_STREAM)) {
+                    return true;
+                }
+            }
+        } catch (org.springframework.http.InvalidMediaTypeException
+            | org.springframework.util.InvalidMimeTypeException e) {
+            // Malformed Accept header: fall back to a defensive substring
+            // check so we don't drop legitimate SSE clients on a header parse
+            // failure that's outside our control. Both Spring exception types
+            // are caught — different Spring versions raise different subclasses.
+            return acceptHeader.toLowerCase().contains("text/event-stream");
+        }
+        return false;
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ASseHeaderFilter.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ASseHeaderFilter.java
@@ -1,0 +1,59 @@
+package io.mcpmesh.spring.web;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Adds the SSE-buffering hints that Spring's
+ * {@code ServerResponse.sse(...)} helper does not set on its own (spec
+ * §4.6 / §5.1):
+ * <ul>
+ *   <li>{@code Cache-Control: no-cache} — stops intermediaries from
+ *       caching mid-flight events;</li>
+ *   <li>{@code X-Accel-Buffering: no} — defeats nginx response
+ *       buffering;</li>
+ *   <li>{@code Connection: keep-alive} — preserves the long-lived
+ *       connection.</li>
+ * </ul>
+ *
+ * <p>The filter peeks at the {@code Accept} header to decide whether to
+ * stamp the headers — only requests that ask for {@code text/event-stream}
+ * are affected. {@code POST {path}} requests for {@code tasks/send} (which
+ * default to {@code application/json}) are untouched, so curl-style sync
+ * clients see the regular JSON-RPC response shape.
+ *
+ * <p>Setting headers via a filter (rather than {@code ServerResponse}
+ * post-processing) is the canonical Spring-MVC pattern when the response
+ * body is delivered through an async/streaming mechanism — the body bypasses
+ * the regular {@code BodyBuilder} chain so header customisations applied
+ * after {@code sse()} return don't reach the wire.
+ *
+ * <p>Registered at {@code Ordered.HIGHEST_PRECEDENCE + 6} from
+ * {@code MeshAutoConfiguration} so it sits BETWEEN the bearer-auth gate
+ * (which rejects unauthenticated requests first) and the dispatcher.
+ */
+public class MeshA2ASseHeaderFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshA2ASseHeaderFilter.class);
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        String accept = request.getHeader("Accept");
+        if (accept != null && accept.contains("text/event-stream")) {
+            response.setHeader("Cache-Control", "no-cache");
+            response.setHeader("X-Accel-Buffering", "no");
+            response.setHeader("Connection", "keep-alive");
+            log.debug("SSE buffering hints stamped on {} {}", request.getMethod(), request.getRequestURI());
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2AStateTranslator.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2AStateTranslator.java
@@ -1,0 +1,108 @@
+package io.mcpmesh.spring.web;
+
+import java.util.Map;
+
+/**
+ * Mesh job lifecycle ↔ A2A v1.0 state translation (spec §7.2).
+ *
+ * <p>The mesh job substrate uses these internal statuses:
+ * <ul>
+ *   <li>{@code working}, {@code completed}, {@code failed}, {@code cancelled} (UK)</li>
+ * </ul>
+ * A2A v1.0 uses:
+ * <ul>
+ *   <li>{@code working}, {@code completed}, {@code failed}, {@code canceled} (US)</li>
+ * </ul>
+ *
+ * <p>The UK ↔ US spelling boundary is the most error-prone part of the
+ * translation (Appendix B item flagged in spec). Consumers accept both
+ * spellings; producers MUST emit the US form.
+ *
+ * <p>Unknown / unset mesh statuses fall back to {@code working} — preserves
+ * the invariant that we never emit an A2A state outside the spec's
+ * enumerated set, even when the registry reports a status we haven't mapped.
+ * Mirrors Python's {@code _map_mesh_state} (a2a.py:112-122).
+ */
+public final class MeshA2AStateTranslator {
+
+    /** A2A v1.0 state: long-running task in flight. */
+    public static final String A2A_WORKING = "working";
+    /** A2A v1.0 terminal state: task finished successfully. */
+    public static final String A2A_COMPLETED = "completed";
+    /** A2A v1.0 terminal state: handler raised or job failed. */
+    public static final String A2A_FAILED = "failed";
+    /** A2A v1.0 terminal state: task canceled (US spelling). */
+    public static final String A2A_CANCELED = "canceled";
+
+    private MeshA2AStateTranslator() {
+        // Utility class
+    }
+
+    /**
+     * Translate a mesh job status string to its A2A v1.0 equivalent.
+     *
+     * <p>Mapping table:
+     * <table border="1">
+     *   <tr><th>Mesh status</th><th>A2A state</th></tr>
+     *   <tr><td>{@code working}</td><td>{@code working}</td></tr>
+     *   <tr><td>{@code completed}</td><td>{@code completed}</td></tr>
+     *   <tr><td>{@code failed}</td><td>{@code failed}</td></tr>
+     *   <tr><td>{@code cancelled} (UK)</td><td>{@code canceled} (US)</td></tr>
+     *   <tr><td>anything else / null</td><td>{@code working} (fallback)</td></tr>
+     * </table>
+     *
+     * @param meshStatus the mesh-side status string (may be {@code null})
+     * @return one of the four A2A v1.0 enumerated states; never {@code null}
+     */
+    public static String fromMesh(String meshStatus) {
+        if (meshStatus == null || meshStatus.isEmpty()) {
+            return A2A_WORKING;
+        }
+        return switch (meshStatus) {
+            case "working" -> A2A_WORKING;
+            case "completed" -> A2A_COMPLETED;
+            case "failed" -> A2A_FAILED;
+            case "cancelled", "canceled" -> A2A_CANCELED;
+            default -> A2A_WORKING;
+        };
+    }
+
+    /**
+     * @return {@code true} when the A2A state is one of the three terminal
+     *     values ({@code completed} / {@code failed} / {@code canceled}).
+     */
+    public static boolean isTerminal(String a2aState) {
+        return A2A_COMPLETED.equals(a2aState)
+            || A2A_FAILED.equals(a2aState)
+            || A2A_CANCELED.equals(a2aState);
+    }
+
+    /**
+     * @return {@code true} when the mesh status string represents a terminal
+     *     state. Accepts both UK and US "canceled" spellings (the mesh
+     *     substrate emits {@code cancelled} but a normalizer upstream may
+     *     have already translated).
+     */
+    public static boolean isMeshTerminal(String meshStatus) {
+        if (meshStatus == null) {
+            return false;
+        }
+        return "completed".equals(meshStatus)
+            || "failed".equals(meshStatus)
+            || "cancelled".equals(meshStatus)
+            || "canceled".equals(meshStatus);
+    }
+
+    /**
+     * Extract the mesh-side status string from a {@code proxy.status()}
+     * payload. Returns {@code null} when the payload lacks a recognisable
+     * status field — callers default to {@code working} via {@link #fromMesh}.
+     */
+    public static String meshStatusOf(Map<String, Object> statusPayload) {
+        if (statusPayload == null) {
+            return null;
+        }
+        Object s = statusPayload.get("status");
+        return s == null ? null : s.toString();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ATaskStore.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ATaskStore.java
@@ -1,0 +1,186 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.JobProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Process-local in-memory A2A task store (spec §4.8).
+ *
+ * <p>Holds task records for {@code tasks/send}, {@code tasks/get},
+ * {@code tasks/cancel}, and the long-running paths. In Chunk 1A (sync only)
+ * the store is still populated on every successful sync {@code tasks/send}
+ * so {@code tasks/get} can return the cached terminal envelope until the
+ * 300-second eviction window elapses (spec Appendix B item 5 — match Python
+ * exactly for parity).
+ *
+ * <h2>Eviction</h2>
+ *
+ * <p>Entries are evicted {@value #TERMINAL_EVICTION_MILLIS} ms after the task
+ * first enters a terminal state ({@code completed} / {@code failed} /
+ * {@code canceled}). Eviction runs lazily on every store access — no
+ * background sweeper is required (spec Appendix B item 5).
+ *
+ * <h2>Cross-replica semantics</h2>
+ *
+ * <p>The store is process-local: a {@code tasks/get} against a replica that
+ * doesn't own the task returns "Unknown task id" per spec §4.4 / Appendix B
+ * item 3. Chunk 1B (long-running) inherits this constraint; Chunk 1C
+ * documents it.
+ */
+public class MeshA2ATaskStore {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshA2ATaskStore.class);
+
+    /**
+     * Grace window in milliseconds before a terminal-state task is evicted
+     * from the store. Matches Python's {@code _TERMINAL_GRACE_SECS = 300}
+     * exactly for cross-runtime parity (spec Appendix B item 5).
+     */
+    public static final long TERMINAL_EVICTION_MILLIS = 300_000L;
+
+    private final Map<String, TaskRecord> store = new ConcurrentHashMap<>();
+
+    /**
+     * Store the task record for {@code taskId}. Caller is responsible for
+     * having checked for duplicates via {@link #contains(String)} when
+     * uniqueness matters (spec §4.3 idempotency window).
+     */
+    public void put(String taskId, TaskRecord record) {
+        sweepExpired();
+        store.put(taskId, record);
+    }
+
+    /**
+     * Return the record for {@code taskId}, or {@code null} when missing or
+     * already evicted. Triggers a lazy sweep on each call.
+     */
+    public TaskRecord get(String taskId) {
+        sweepExpired();
+        return store.get(taskId);
+    }
+
+    /**
+     * @return {@code true} when the store currently holds a record for
+     *     {@code taskId} and that record has not been evicted by the lazy
+     *     sweep.
+     */
+    public boolean contains(String taskId) {
+        sweepExpired();
+        return store.containsKey(taskId);
+    }
+
+    /**
+     * @return current size (post-sweep). For diagnostics + tests.
+     */
+    public int size() {
+        sweepExpired();
+        return store.size();
+    }
+
+    /**
+     * Lazy sweep: evict any record whose terminal-state timestamp is older
+     * than {@link #TERMINAL_EVICTION_MILLIS}. Non-terminal records are
+     * never evicted (long-running paths in Chunk 1B keep them alive across
+     * arbitrary durations).
+     */
+    private void sweepExpired() {
+        long now = System.currentTimeMillis();
+        store.entrySet().removeIf(entry -> {
+            Long terminalAt = entry.getValue().terminalAt();
+            if (terminalAt == null) {
+                return false;
+            }
+            if (now - terminalAt > TERMINAL_EVICTION_MILLIS) {
+                log.debug("Evicting terminal A2A task {} ({}ms after terminal_at)",
+                    entry.getKey(), now - terminalAt);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    /**
+     * Atomically mark a previously parked non-terminal record as terminal by
+     * stamping {@link TaskRecord#terminalEnvelope()} + {@link TaskRecord#terminalAt()}.
+     * No-op when the record is absent or already terminal (idempotent — spec §4.5
+     * "Idempotent; best-effort"). Replaces the record so observers of subsequent
+     * {@link #get(String)} calls see the cached terminal envelope.
+     *
+     * @return the new terminal record, or {@code null} when the task is unknown
+     */
+    public TaskRecord markTerminal(String taskId, Map<String, Object> terminalEnvelope) {
+        TaskRecord existing = store.get(taskId);
+        if (existing == null) {
+            return null;
+        }
+        if (existing.terminalAt() != null) {
+            return existing;
+        }
+        TaskRecord updated = new TaskRecord(
+            existing.sessionId(),
+            existing.requestMessage(),
+            terminalEnvelope,
+            System.currentTimeMillis(),
+            existing.jobProxy()
+        );
+        store.put(taskId, updated);
+        return updated;
+    }
+
+    /**
+     * Cached A2A task envelope plus the metadata needed to keep it alive
+     * during the 300s idempotency window.
+     *
+     * @param sessionId        the A2A session id (defaults to taskId per spec §4.2)
+     * @param requestMessage   the originating request {@code message} object
+     *                         (echoed into {@code result.history[]}); {@code null}
+     *                         when the client omitted it
+     * @param terminalEnvelope the full Task envelope cached for {@code tasks/get}
+     *                         lookups; {@code null} for non-terminal records
+     *                         (long-running paths set this on terminal transition)
+     * @param terminalAt       monotonic timestamp (ms since epoch) when the
+     *                         task first entered a terminal state, or
+     *                         {@code null} when still in-flight
+     * @param jobProxy         live consumer-side handle to the underlying mesh
+     *                         job; {@code null} for sync (state=completed/failed)
+     *                         records that never had a backing JobProxy
+     */
+    public record TaskRecord(
+        String sessionId,
+        Map<String, Object> requestMessage,
+        Map<String, Object> terminalEnvelope,
+        Long terminalAt,
+        JobProxy jobProxy
+    ) {
+        public TaskRecord {
+            // Defensive copies: callers should not be able to mutate the
+            // stored envelope after handoff.
+            if (requestMessage != null) {
+                requestMessage = Collections.unmodifiableMap(new LinkedHashMap<>(requestMessage));
+            }
+            if (terminalEnvelope != null) {
+                terminalEnvelope = Collections.unmodifiableMap(new LinkedHashMap<>(terminalEnvelope));
+            }
+        }
+
+        /**
+         * Convenience overload for sync records (no backing JobProxy). Preserves
+         * the Chunk 1A constructor surface so existing call sites compile
+         * unchanged.
+         */
+        public TaskRecord(
+            String sessionId,
+            Map<String, Object> requestMessage,
+            Map<String, Object> terminalEnvelope,
+            Long terminalAt
+        ) {
+            this(sessionId, requestMessage, terminalEnvelope, terminalAt, null);
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ATaskStore.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ATaskStore.java
@@ -115,22 +115,23 @@ public class MeshA2ATaskStore {
      * @return the new terminal record, or {@code null} when the task is unknown
      */
     public TaskRecord markTerminal(String taskId, Map<String, Object> terminalEnvelope) {
-        TaskRecord existing = store.get(taskId);
-        if (existing == null) {
-            return null;
-        }
-        if (existing.terminalAt() != null) {
-            return existing;
-        }
-        TaskRecord updated = new TaskRecord(
-            existing.sessionId(),
-            existing.requestMessage(),
-            terminalEnvelope,
-            System.currentTimeMillis(),
-            existing.jobProxy()
-        );
-        store.put(taskId, updated);
-        return updated;
+        // Atomically flip to terminal so concurrent callers (e.g. SSE
+        // stream completion + tasks/cancel arriving simultaneously) cannot
+        // race past the null/terminal-at check and clobber each other's
+        // terminal envelope. First-write-wins is preserved: a record that
+        // already has terminalAt set is returned unchanged.
+        return store.computeIfPresent(taskId, (id, existing) -> {
+            if (existing.terminalAt() != null) {
+                return existing;
+            }
+            return new TaskRecord(
+                existing.sessionId(),
+                existing.requestMessage(),
+                terminalEnvelope,
+                System.currentTimeMillis(),
+                existing.jobProxy()
+            );
+        });
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/A2ATestFixtures.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/A2ATestFixtures.java
@@ -1,0 +1,150 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.spring.MeshDependencyInjector;
+import org.springframework.beans.factory.ObjectProvider;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared helpers for the A2A producer test suite. Centralises:
+ * <ul>
+ *   <li>a no-op {@link ObjectProvider} that resolves to {@code null}
+ *       (most tests don't exercise {@code @MeshInject} parameter resolution);</li>
+ *   <li>a canonical {@link ObjectMapper} matching the production
+ *       {@code tools.jackson} import path;</li>
+ *   <li>a {@link MeshA2ARegistry.SurfaceMetadata} builder bound to a real
+ *       Java method on an inner {@code TestHandlerBean} so the dispatcher's
+ *       reflective invocation has something to call.</li>
+ * </ul>
+ *
+ * <p>Test classes use {@link A2ATestFixtures} purely as a static helper —
+ * never extended or instantiated. Each test still owns its own per-test
+ * fixtures (BeforeEach) for isolation; this class only provides the
+ * common factories.
+ */
+final class A2ATestFixtures {
+
+    private A2ATestFixtures() {}
+
+    /** Real Jackson ObjectMapper matching the production
+     *  {@code tools.jackson} surface used by the dispatcher. */
+    static ObjectMapper objectMapper() {
+        return JsonMapper.builder().build();
+    }
+
+    /** Empty {@link ObjectProvider} that resolves to {@code null} on every
+     *  lookup — appropriate when the test doesn't exercise dependency
+     *  injection paths. */
+    static ObjectProvider<MeshDependencyInjector> emptyInjectorProvider() {
+        return new ObjectProvider<>() {
+            @Override
+            public MeshDependencyInjector getObject() { return null; }
+            @Override
+            public MeshDependencyInjector getObject(Object... args) { return null; }
+            @Override
+            public MeshDependencyInjector getIfAvailable() { return null; }
+            @Override
+            public MeshDependencyInjector getIfUnique() { return null; }
+        };
+    }
+
+    /**
+     * Build a {@link MeshA2ARegistry.SurfaceMetadata} that points at the
+     * named method on a fresh {@link TestHandlerBean}. The handler is
+     * implemented in plain Java so the dispatcher can reflectively invoke
+     * it without any Spring machinery.
+     */
+    static MeshA2ARegistry.SurfaceMetadata surfaceOf(String path, String skillId, String handlerMethod) {
+        TestHandlerBean bean = new TestHandlerBean();
+        Method method;
+        try {
+            method = TestHandlerBean.class.getDeclaredMethod(handlerMethod, Map.class);
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError("Test bean has no handler method: " + handlerMethod, e);
+        }
+        return new MeshA2ARegistry.SurfaceMetadata(
+            path,
+            skillId,
+            skillId, // skillName — required non-empty
+            "",      // description
+            List.of(),
+            List.of(),
+            "",      // auth
+            "TestHandlerBean." + handlerMethod,
+            bean,
+            method
+        );
+    }
+
+    /** Build a JSON-RPC request body string with the given method + params map. */
+    static String jsonRpcBody(Object id, String method, Map<String, Object> params) {
+        try {
+            return objectMapper().writeValueAsString(Map.of(
+                "jsonrpc", "2.0",
+                "id", id == null ? "" : id,
+                "method", method,
+                "params", params == null ? Map.of() : params
+            ));
+        } catch (Exception e) {
+            throw new AssertionError("Failed to serialize JSON-RPC body", e);
+        }
+    }
+
+    /**
+     * Test handler bean — all methods take a {@code Map} message and return
+     * something the dispatcher can serialize. Switch on the message {@code op}
+     * field to control behaviour for {@code tasks/send} tests:
+     * <ul>
+     *   <li>{@code "echo"} — returns the message verbatim;</li>
+     *   <li>{@code "string"} — returns a fixed string;</li>
+     *   <li>{@code "raise"} — throws RuntimeException with the message
+     *       {@code text} field as error text;</li>
+     *   <li>any other / missing op — returns "ok".</li>
+     * </ul>
+     */
+    public static class TestHandlerBean {
+
+        public Object syncHandler(Map<String, Object> message) {
+            Object op = message != null ? message.get("op") : null;
+            if ("raise".equals(op)) {
+                Object text = message.get("text");
+                throw new RuntimeException(text != null ? text.toString() : "boom");
+            }
+            if ("string".equals(op)) {
+                return "fixed string result";
+            }
+            if ("echo".equals(op)) {
+                return message;
+            }
+            return "ok";
+        }
+
+        /**
+         * Returns a {@link io.mcpmesh.JobProxy} when the test wants to
+         * exercise the long-running branch. The proxy is injected via a
+         * static slot set by the test before invocation.
+         */
+        public Object longRunningHandler(Map<String, Object> message) {
+            io.mcpmesh.JobProxy p = PROXY_SLOT.get();
+            if (p == null) {
+                throw new IllegalStateException(
+                    "Test setup error: PROXY_SLOT not populated before longRunningHandler invocation");
+            }
+            return p;
+        }
+
+        /** Sleep-free handler that always throws — for sendSubscribe
+         *  exception path tests. */
+        public Object alwaysRaises(Map<String, Object> message) {
+            throw new RuntimeException("handler exploded");
+        }
+
+        /** Static slot the test populates before invoking longRunningHandler.
+         *  Each test must clear it in @AfterEach for isolation. */
+        public static final ThreadLocal<io.mcpmesh.JobProxy> PROXY_SLOT = new ThreadLocal<>();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/A2ATestFixtures.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/A2ATestFixtures.java
@@ -6,6 +6,7 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -80,15 +81,22 @@ final class A2ATestFixtures {
         );
     }
 
-    /** Build a JSON-RPC request body string with the given method + params map. */
+    /** Build a JSON-RPC request body string with the given method + params map.
+     *
+     *  <p>Uses {@link HashMap} (not {@link Map#of}) so {@code null} is allowed
+     *  as the id value — the JSON-RPC 2.0 spec permits {@code "id": null} for
+     *  notifications, and the dispatcher's parse-error responses also emit
+     *  {@code id: null}. Coercing {@code null} to {@code ""} (the old
+     *  behaviour) lost the notification/null-id semantics the producer must
+     *  round-trip exactly. */
     static String jsonRpcBody(Object id, String method, Map<String, Object> params) {
         try {
-            return objectMapper().writeValueAsString(Map.of(
-                "jsonrpc", "2.0",
-                "id", id == null ? "" : id,
-                "method", method,
-                "params", params == null ? Map.of() : params
-            ));
+            Map<String, Object> body = new HashMap<>();
+            body.put("jsonrpc", "2.0");
+            body.put("id", id); // null is a legal JSON-RPC id; keep it.
+            body.put("method", method);
+            body.put("params", params == null ? Map.of() : params);
+            return objectMapper().writeValueAsString(body);
         } catch (Exception e) {
             throw new AssertionError("Failed to serialize JSON-RPC body", e);
         }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AContextLoadTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AContextLoadTest.java
@@ -1,0 +1,218 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.spring.MeshAutoConfiguration;
+import io.mcpmesh.spring.MeshRuntime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.function.RouterFunction;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the {@code meshA2ARouterFunction} bean-creation cycle
+ * (issue #932 Phase 1A/1B follow-up).
+ *
+ * <p>The original auto-configuration wired
+ * {@link io.mcpmesh.spring.MeshHealthController} via
+ * {@code ObjectProvider<MeshRuntime>}; the factory called
+ * {@code getIfAvailable()} at construction, which triggered
+ * {@link MeshRuntime} creation. Combined with the eager-touch
+ * ({@code applicationContext.getBeansWithAnnotation(Component.class)})
+ * performed by both {@code meshA2ARouterFunction} AND by
+ * {@code MeshRuntime#buildAgentSpec}, this produced a bean-creation cycle:
+ *
+ * <pre>
+ *   routerFunctionMapping
+ *     -> meshA2ARouterFunction
+ *       -> meshHealthController        (touched by eager getBeansWithAnnotation(@Component))
+ *         -> meshRuntime               (resolved via ObjectProvider.getIfAvailable)
+ *           -> meshHealthController    (re-touched by buildAgentSpec's eager scan; CYCLE)
+ * </pre>
+ *
+ * <p>Spring Boot 2.6+ rejects circular references by default; the application
+ * fails at context-refresh with a {@code BeanCurrentlyInCreationException}.
+ *
+ * <h2>The fix</h2>
+ *
+ * <p>The fix annotates the {@code MeshRuntime} parameter of
+ * {@code meshHealthController} with
+ * {@link org.springframework.context.annotation.Lazy @Lazy}. Spring then
+ * injects a CGLIB proxy that defers actual runtime resolution to the first
+ * method call (which happens at request time, not at construction time).
+ * The {@code meshHealthController -> meshRuntime} edge of the dependency
+ * graph is removed AT CONSTRUCTION, breaking the cycle structurally —
+ * regardless of which eager-touch runs first.
+ *
+ * <h2>How this test reproduces the cycle</h2>
+ *
+ * <p>The test wires the real {@link MeshAutoConfiguration} via
+ * {@link WebApplicationContextRunner}. To avoid hitting the native Rust
+ * core (which would otherwise try to register with a real registry during
+ * {@code MeshRuntime.start()}), the test config provides a no-op
+ * {@code MeshRuntime} subclass. Critically, the test factory <strong>also
+ * walks {@code @Component} beans during construction</strong>, mirroring
+ * the eager-touch that {@code buildAgentSpec()} performs in production.
+ * Without that mirror, the test factory would be too lightweight to
+ * surface the cycle.
+ *
+ * <p><strong>Pre-fix expectation:</strong> {@code meshHealthController}
+ * factory eagerly resolves {@code MeshRuntime} via
+ * {@code ObjectProvider.getIfAvailable()} — meanwhile the test's eager
+ * {@code @Component} scan re-enters {@code meshHealthController} → cycle.
+ *
+ * <p><strong>Post-fix expectation:</strong> {@code meshHealthController}
+ * receives a {@code @Lazy} runtime proxy — no eager resolution, no cycle.
+ * Context refreshes cleanly.
+ */
+@DisplayName("MeshA2A producer — context-load regression (no bean cycle)")
+class MeshA2AContextLoadTest {
+
+    /**
+     * Test fixture bean carrying a {@code @MeshA2A} surface so the producer
+     * autoconfig has at least one registered handler. Mirrors the shape of
+     * the producer-date-agent that originally surfaced the cycle.
+     */
+    @Component
+    public static class TestA2ABean {
+        @MeshA2A(path = "/agents/test", skillId = "test-skill", skillName = "Test Skill")
+        public Map<String, Object> handle(Map<String, Object> message) {
+            return Map.of("ok", true);
+        }
+    }
+
+    /**
+     * Test-only {@link MeshRuntime} subclass — overrides {@link #start()},
+     * {@link #stop()}, and {@link #isRunning()} so the Spring
+     * {@code SmartLifecycle} processor does not try to spin up the native
+     * Rust core during a unit test. All other methods inherit production
+     * behaviour.
+     */
+    static class NoOpMeshRuntime extends MeshRuntime {
+        private volatile boolean running;
+
+        NoOpMeshRuntime(AgentSpec spec) {
+            super(spec);
+        }
+
+        @Override
+        public void start() {
+            running = true;
+        }
+
+        @Override
+        public void stop() {
+            running = false;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return running;
+        }
+    }
+
+    /**
+     * Test config that provides a {@code MeshRuntime} stub satisfying the
+     * starter's {@code @ConditionalOnMissingBean} so the real factory (which
+     * loads the native lib) is skipped. The factory body intentionally walks
+     * {@code @Component} beans — the same eager-touch the production
+     * {@code buildAgentSpec()} performs — so the cycle structure being
+     * tested is preserved end-to-end.
+     */
+    @Configuration
+    static class TestConfig {
+
+        @Bean
+        public MeshRuntime meshRuntime(ApplicationContext applicationContext) {
+            // Mirror the eager-touch from MeshAutoConfiguration.buildAgentSpec().
+            // This is what re-enters MeshHealthController in the production
+            // cycle; keeping it here lets the regression test fail with the
+            // same BeanCurrentlyInCreationException pre-fix.
+            applicationContext.getBeansWithAnnotation(Component.class);
+            applicationContext.getBeansWithAnnotation(
+                org.springframework.stereotype.Service.class);
+
+            AgentSpec spec = new AgentSpec();
+            spec.setName("test-agent");
+            spec.setAgentId("test-agent-00000000");
+            return new NoOpMeshRuntime(spec);
+        }
+    }
+
+    private final WebApplicationContextRunner runner = new WebApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(MeshAutoConfiguration.class))
+        .withUserConfiguration(TestConfig.class, TestA2ABean.class);
+
+    @Test
+    @DisplayName("Context refreshes cleanly with @MeshA2A producer wiring (no bean cycle)")
+    void contextLoadsWithoutCircularReference() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).isNotNull();
+        });
+    }
+
+    @Test
+    @DisplayName("All A2A producer beans are wired and resolvable")
+    void allA2ABeansArePresent() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            // Core A2A producer beans.
+            assertThat(context).hasBean("meshA2ARegistry");
+            assertThat(context).hasBean("meshA2ADispatcher");
+            assertThat(context).hasBean("meshA2ASseDispatcher");
+            assertThat(context).hasBean("meshA2ADispatcherController");
+            assertThat(context).hasBean("meshA2ARouterFunction");
+            assertThat(context).hasBean("meshA2AAuthFilter");
+            // Health controller is part of the cycle path — assert it's
+            // present and resolvable post-fix.
+            assertThat(context).hasBean("meshHealthController");
+            // MeshA2A surface from TestA2ABean must have been registered by
+            // the bean post-processor, proving the eager-touch path still
+            // runs end-to-end post-fix.
+            MeshA2ARegistry registry = context.getBean(MeshA2ARegistry.class);
+            assertThat(registry.hasSurfaces())
+                .as("MeshA2ABeanPostProcessor must have populated the registry "
+                    + "with TestA2ABean.handle()")
+                .isTrue();
+        });
+    }
+
+    @Test
+    @DisplayName("Router function bean is the typed RouterFunction<ServerResponse>")
+    void routerFunctionIsTypedCorrectly() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            RouterFunction<?> router = context.getBean(
+                "meshA2ARouterFunction", RouterFunction.class);
+            assertThat(router).isNotNull();
+            // Sanity: the router was produced by buildRouterFunction(), so it
+            // composes (per surface) three sub-routes. We can't introspect
+            // the route table without spinning up MockMvc, but checking the
+            // bean is reachable confirms the factory ran without cycling.
+            assertThat(context.getBeansOfType(RouterFunction.class))
+                .as("Expected at least the meshA2ARouterFunction to be in the context")
+                .isNotEmpty();
+        });
+    }
+
+    @Test
+    @DisplayName("Context is autowireable post-refresh (no cycle, no startup failure)")
+    void contextIsAutowireable() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            // AssertableApplicationContext is itself an ApplicationContext —
+            // mirrors the spec's "Autowire ApplicationContext, assert non-null".
+            ApplicationContext ctx = context.getSourceApplicationContext();
+            assertThat(ctx).isNotNull();
+        });
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AControllerSliceTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AControllerSliceTest.java
@@ -1,0 +1,260 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.JobProxy;
+import io.mcpmesh.spring.MeshProperties;
+import jakarta.servlet.ServletContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.servlet.function.HandlerFunction;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * End-to-end producer pipeline test (spec §4 / §5).
+ *
+ * <p>Wires {@link MeshA2ADispatcherController#buildRouterFunction()}
+ * directly and drives it via Spring's {@link ServerRequest#create} factory.
+ * This is one level below MockMvc — we skip the DispatcherServlet because
+ * its standalone setup has Spring-version-dependent quirks around message
+ * converter wiring for functional routers, and the actual servlet
+ * round-trip isn't what this test asserts on. We're asserting that the
+ * <em>router + controller + dispatcher + state translator</em> pipeline
+ * produces wire-shape envelopes per spec §4.
+ *
+ * <p>End-to-end coverage:
+ * <ul>
+ *   <li>{@code tasks/send} sync handler → JSON-RPC envelope with
+ *       {@code state=completed} + artifact</li>
+ *   <li>{@code tasks/send} handler raises → state=failed envelope (NOT a
+ *       JSON-RPC error, per spec §4.3)</li>
+ *   <li>{@code tasks/cancel} on a parked long-running task → state=canceled</li>
+ *   <li>Unknown method → -32601</li>
+ *   <li>Malformed body → 400 + -32700</li>
+ *   <li>sessionId echoed back, non-string returns JSON-stringified</li>
+ * </ul>
+ */
+@DisplayName("MeshA2A producer — end-to-end router pipeline (spec §4 / §5)")
+class MeshA2AControllerSliceTest {
+
+    private static final List<org.springframework.http.converter.HttpMessageConverter<?>> CONVERTERS =
+        List.of(new StringHttpMessageConverter(StandardCharsets.UTF_8));
+
+    private MeshA2ARegistry registry;
+    private MeshA2ATaskStore taskStore;
+    private MeshA2ADispatcher dispatcher;
+    private RouterFunction<ServerResponse> routerFunction;
+    private ObjectMapper mapper;
+    private ServletContext servletContext;
+
+    @BeforeEach
+    void setUp() {
+        registry = new MeshA2ARegistry();
+        registry.register(A2ATestFixtures.surfaceOf("/svc/sync", "sync-skill", "syncHandler"));
+        registry.register(A2ATestFixtures.surfaceOf("/svc/long", "long-skill", "longRunningHandler"));
+        taskStore = new MeshA2ATaskStore();
+        mapper = A2ATestFixtures.objectMapper();
+        dispatcher = new MeshA2ADispatcher(
+            registry, taskStore, mapper, A2ATestFixtures.emptyInjectorProvider());
+        MeshA2ASseDispatcher sseDispatcher = new MeshA2ASseDispatcher(dispatcher);
+        MeshA2ACardBuilder cardBuilder = new MeshA2ACardBuilder(null, mapper);
+
+        MeshA2ADispatcherController controller = new MeshA2ADispatcherController(
+            registry, dispatcher, sseDispatcher, cardBuilder,
+            emptyProvider(MeshProperties.class),
+            emptyProvider(MeshA2APublicUrlCache.class));
+        routerFunction = controller.buildRouterFunction();
+        servletContext = new MockServletContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        A2ATestFixtures.TestHandlerBean.PROXY_SLOT.remove();
+    }
+
+    /** Wire a JSON-RPC request through the full router → dispatcher
+     *  pipeline. Returns the parsed JSON-RPC response envelope. */
+    private RouteResult dispatch(String path, String body) throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest(servletContext, "POST", path);
+        req.setContent(body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8));
+        req.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        req.addHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+
+        ServerRequest serverRequest = ServerRequest.create(req, CONVERTERS);
+        HandlerFunction<?> handler = routerFunction.route(serverRequest).orElseThrow(
+            () -> new AssertionError("No route matched: POST " + path));
+        ServerResponse response = (ServerResponse) handler.handle(serverRequest);
+        // Materialise the response onto our MockHttpServletResponse.
+        response.writeTo(req, resp, new ServerResponse.Context() {
+            @Override
+            public java.util.List<org.springframework.http.converter.HttpMessageConverter<?>> messageConverters() {
+                return CONVERTERS;
+            }
+        });
+        return new RouteResult(resp.getStatus(), resp.getContentAsString());
+    }
+
+    private record RouteResult(int status, String body) {}
+
+    /** Spec §4.3 sync: tasks/send returning a string → state=completed,
+     *  artifact carries the return as a text part. */
+    @Test
+    @DisplayName("tasks/send (sync return) → 200 with state=completed + artifact")
+    void tasksSend_syncReturn_completes() throws Exception {
+        String body = A2ATestFixtures.jsonRpcBody(1, "tasks/send",
+            Map.of("id", "t-sync",
+                "message", Map.of("role", "user",
+                    "parts", List.of(Map.of("type", "text", "text", "hello")))));
+
+        RouteResult res = dispatch("/svc/sync", body);
+
+        assertEquals(200, res.status, "Body: " + res.body);
+        JsonNode env = mapper.readTree(res.body);
+        assertEquals("2.0", env.get("jsonrpc").asText());
+        assertEquals(1, env.get("id").asInt(), "Body: " + res.body);
+        JsonNode result = env.get("result");
+        assertNotNull(result, "Expected success envelope, got: " + res.body);
+        assertEquals("t-sync", result.get("id").asText());
+        assertEquals("completed", result.get("status").get("state").asText());
+        assertEquals(1, result.get("artifacts").size());
+        // Spec Appendix A: parts[0].type MUST be 'text'.
+        assertEquals("text",
+            result.get("artifacts").get(0).get("parts").get(0).get("type").asText());
+        assertEquals("ok",
+            result.get("artifacts").get(0).get("parts").get(0).get("text").asText());
+    }
+
+    /** Spec §4.3: handler raises → state=failed envelope, NOT a JSON-RPC error. */
+    @Test
+    @DisplayName("tasks/send (handler raises) → state=failed envelope (NOT JSON-RPC error)")
+    void tasksSend_handlerRaises_returnsFailedTask() throws Exception {
+        String body = A2ATestFixtures.jsonRpcBody(2, "tasks/send",
+            Map.of("id", "t-raise",
+                "message", Map.of("op", "raise", "text", "topic required")));
+
+        RouteResult res = dispatch("/svc/sync", body);
+
+        assertEquals(200, res.status,
+            "Handler exceptions MUST surface as 200 + state=failed (spec §4.3), NOT HTTP 5xx");
+        JsonNode env = mapper.readTree(res.body);
+        assertFalse(env.has("error"),
+            "Spec §4.3: handler exception is a state=failed Task, not a JSON-RPC error. "
+                + "Body: " + res.body);
+        JsonNode result = env.get("result");
+        assertEquals("failed", result.get("status").get("state").asText());
+        assertEquals("topic required",
+            result.get("status").get("message").get("parts").get(0).get("text").asText(),
+            "Exception message must surface in status.message.parts[0].text");
+    }
+
+    /** Spec §4.5: tasks/cancel on a parked task. */
+    @Test
+    @DisplayName("tasks/cancel on parked long-running task → state=canceled")
+    void tasksCancel_parkedTask_returnsCanceled() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        when(proxy.jobId()).thenReturn("job-cancel");
+        when(proxy.status()).thenReturn(Map.of("status", "cancelled"));
+        A2ATestFixtures.TestHandlerBean.PROXY_SLOT.set(proxy);
+
+        // Park.
+        String sendBody = A2ATestFixtures.jsonRpcBody(1, "tasks/send",
+            Map.of("id", "t-cancel", "message", Map.of()));
+        RouteResult send = dispatch("/svc/long", sendBody);
+        JsonNode sendEnv = mapper.readTree(send.body);
+        assertEquals("working", sendEnv.get("result").get("status").get("state").asText(),
+            "Sanity: long-running send returns state=working");
+
+        // Cancel.
+        String cancelBody = A2ATestFixtures.jsonRpcBody(2, "tasks/cancel",
+            Map.of("id", "t-cancel", "reason", "user pressed stop"));
+        RouteResult cancel = dispatch("/svc/long", cancelBody);
+        assertEquals(200, cancel.status);
+        JsonNode env = mapper.readTree(cancel.body);
+        assertEquals("canceled", env.get("result").get("status").get("state").asText(),
+            "Spec §7.2: UK 'cancelled' from mesh substrate MUST surface as US 'canceled'");
+    }
+
+    /** Spec §4.1: unknown method → -32601 Method not implemented. */
+    @Test
+    @DisplayName("Unknown JSON-RPC method → -32601 'Method not implemented'")
+    void unknownMethod_returnsMethodNotFound() throws Exception {
+        String body = A2ATestFixtures.jsonRpcBody(99, "tasks/explode", Map.of());
+        RouteResult res = dispatch("/svc/sync", body);
+        JsonNode env = mapper.readTree(res.body);
+        assertEquals(MeshA2ADispatcher.JSONRPC_METHOD_NOT_FOUND,
+            env.get("error").get("code").asInt());
+        assertTrue(env.get("error").get("message").asText().contains("Method not implemented"));
+    }
+
+    /** Spec §4.1: malformed JSON body → HTTP 400 + -32700 Parse error. */
+    @Test
+    @DisplayName("Malformed body → 400 + -32700 Parse error")
+    void malformedBody_returns400ParseError() throws Exception {
+        RouteResult res = dispatch("/svc/sync", "not-json");
+        assertEquals(400, res.status,
+            "Spec §4.1: malformed body MUST return HTTP 400");
+        JsonNode env = mapper.readTree(res.body);
+        assertEquals(MeshA2ADispatcher.JSONRPC_PARSE_ERROR,
+            env.get("error").get("code").asInt());
+    }
+
+    /** Spec §4.3: sessionId echoed back when the client provides one. */
+    @Test
+    @DisplayName("sessionId echoed back from request to response (spec §4.3 / §4.2)")
+    void sessionIdEchoed() throws Exception {
+        String body = A2ATestFixtures.jsonRpcBody(1, "tasks/send",
+            Map.of("id", "t-x", "sessionId", "session-xyz",
+                "message", Map.of()));
+        RouteResult res = dispatch("/svc/sync", body);
+        JsonNode env = mapper.readTree(res.body);
+        assertEquals("session-xyz", env.get("result").get("sessionId").asText(),
+            "sessionId from request MUST be echoed back per spec §4.3");
+    }
+
+    /** Spec §4.3: non-string handler return is JSON-stringified into the
+     *  artifact text. */
+    @Test
+    @DisplayName("Non-string handler return is JSON-stringified into artifacts[0].parts[0].text")
+    void nonStringReturn_jsonStringifiedIntoArtifact() throws Exception {
+        Map<String, Object> message = Map.of("op", "echo", "k", "v");
+        String body = A2ATestFixtures.jsonRpcBody(1, "tasks/send",
+            Map.of("id", "t-echo", "message", message));
+        RouteResult res = dispatch("/svc/sync", body);
+        JsonNode env = mapper.readTree(res.body);
+        String text = env.get("result").get("artifacts").get(0)
+            .get("parts").get(0).get("text").asText();
+        JsonNode reparsed = mapper.readTree(text);
+        assertEquals("v", reparsed.get("k").asText(),
+            "Non-string returns MUST be JSON-stringified into the artifact text "
+                + "(spec §4.3 Implementation note)");
+    }
+
+    private static <T> ObjectProvider<T> emptyProvider(Class<T> ignored) {
+        return new ObjectProvider<>() {
+            @Override public T getObject() { return null; }
+            @Override public T getObject(Object... args) { return null; }
+            @Override public T getIfAvailable() { return null; }
+            @Override public T getIfUnique() { return null; }
+        };
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherCancelTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherCancelTest.java
@@ -1,0 +1,192 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.JobProxy;
+import io.mcpmesh.core.MeshException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link MeshA2ADispatcher#dispatch} on the {@code tasks/cancel}
+ * verb (spec §4.5).
+ *
+ * <p>Per spec §4.5: cancel is idempotent and best-effort. Underlying
+ * {@code JobProxy.cancel()} exceptions are swallowed (the job may already
+ * be terminal). Already-terminal tasks echo the cached envelope rather
+ * than re-poking the proxy.
+ *
+ * <p>Error cases (spec §4.5):
+ * <ul>
+ *   <li>Missing {@code params.id} → {@code -32602 Invalid params}.</li>
+ *   <li>Unknown {@code task_id} → {@code -32602 Unknown task id}.</li>
+ * </ul>
+ */
+@DisplayName("MeshA2ADispatcher.tasks/cancel (spec §4.5)")
+class MeshA2ADispatcherCancelTest {
+
+    private MeshA2ARegistry registry;
+    private MeshA2ATaskStore taskStore;
+    private MeshA2ADispatcher dispatcher;
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        registry = new MeshA2ARegistry();
+        registry.register(A2ATestFixtures.surfaceOf("/svc", "skill", "syncHandler"));
+        taskStore = new MeshA2ATaskStore();
+        mapper = A2ATestFixtures.objectMapper();
+        dispatcher = new MeshA2ADispatcher(
+            registry, taskStore, mapper, A2ATestFixtures.emptyInjectorProvider());
+    }
+
+    /** Spec §4.5: missing params.id → -32602 Invalid params. */
+    @Test
+    @DisplayName("Missing id → -32602 with message naming 'id'")
+    void missingId_returnsInvalidParams() throws Exception {
+        String body = A2ATestFixtures.jsonRpcBody(7, "tasks/cancel", Map.of());
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc", body);
+        assertEquals(200, resp.getStatusCode().value(),
+            "JSON-RPC errors return HTTP 200 with the error in the body");
+        JsonNode env = mapper.readTree(resp.getBody());
+        assertEquals(MeshA2ADispatcher.JSONRPC_INVALID_PARAMS,
+            env.get("error").get("code").asInt());
+        String msg = env.get("error").get("message").asText();
+        assertTrue(msg.contains("id"), "Error message must mention the missing 'id' field, got: " + msg);
+        assertEquals(7, env.get("id").asInt(), "Request id MUST be echoed in error responses");
+    }
+
+    /** Spec §4.5: unknown task_id → -32602 Unknown task id. */
+    @Test
+    @DisplayName("Unknown task id → -32602 'Unknown task id: ...'")
+    void unknownTaskId_returnsInvalidParams() throws Exception {
+        String body = A2ATestFixtures.jsonRpcBody(8, "tasks/cancel", Map.of("id", "no-such"));
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc", body);
+        JsonNode env = mapper.readTree(resp.getBody());
+        assertEquals(MeshA2ADispatcher.JSONRPC_INVALID_PARAMS,
+            env.get("error").get("code").asInt());
+        assertTrue(env.get("error").get("message").asText().contains("Unknown task id"),
+            "Error message must contain 'Unknown task id' per spec §4.5");
+    }
+
+    /** Spec §4.5: already-terminal task → echoes the cached terminal envelope
+     *  (idempotent ack, no proxy interaction). */
+    @Test
+    @DisplayName("Already-terminal task → echo cached envelope (idempotent ack)")
+    void terminalTask_echoesCachedEnvelope() throws Exception {
+        // Seed the store with a terminal record carrying a recognisable
+        // sentinel field so we can assert the response is the cached one.
+        Map<String, Object> cached = new LinkedHashMap<>();
+        cached.put("id", "t-done");
+        cached.put("sessionId", "t-done");
+        cached.put("status", Map.of("state", "completed"));
+        cached.put("artifacts", java.util.List.of());
+        cached.put("history", java.util.List.of());
+        cached.put("__cached_marker", "FROM_CACHE");
+
+        JobProxy proxy = mock(JobProxy.class);
+        taskStore.put("t-done", new MeshA2ATaskStore.TaskRecord(
+            "t-done", null, cached, System.currentTimeMillis(), proxy));
+
+        String body = A2ATestFixtures.jsonRpcBody(11, "tasks/cancel",
+            Map.of("id", "t-done", "reason", "user pressed stop"));
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc", body);
+        JsonNode env = mapper.readTree(resp.getBody());
+
+        // Cached envelope echoed verbatim (idempotent ack).
+        assertEquals("FROM_CACHE", env.get("result").get("__cached_marker").asText(),
+            "Already-terminal cancel must echo cached envelope (spec §4.5 idempotent)");
+        // Proxy must NOT have been called — idempotent ack short-circuits.
+        verify(proxy, never()).cancel(any());
+        verify(proxy, never()).status();
+    }
+
+    /** Spec §4.5: non-terminal task + JobProxy.cancel() succeeds → post-cancel
+     *  status reads as terminal and we return the canceled envelope. */
+    @Test
+    @DisplayName("Non-terminal task + cancel() succeeds → state=canceled returned")
+    void nonTerminal_cancelSucceeds_returnsCanceledEnvelope() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        // proxy.cancel() does NOT throw; proxy.status() reports cancelled (UK).
+        when(proxy.status()).thenReturn(Map.of("status", "cancelled"));
+
+        taskStore.put("t-alive", new MeshA2ATaskStore.TaskRecord(
+            "t-alive", null, null, null, proxy));
+
+        String body = A2ATestFixtures.jsonRpcBody(12, "tasks/cancel",
+            Map.of("id", "t-alive", "reason", "user pressed stop"));
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc", body);
+        JsonNode env = mapper.readTree(resp.getBody());
+
+        verify(proxy, times(1)).cancel("user pressed stop");
+        assertEquals("canceled", env.get("result").get("status").get("state").asText(),
+            "UK 'cancelled' from mesh substrate must surface as US 'canceled' on A2A wire");
+        // Record must now be terminal (markTerminal called by dispatcher).
+        MeshA2ATaskStore.TaskRecord post = taskStore.get("t-alive");
+        assertNotNull(post.terminalAt(),
+            "Successful cancel must flip the record to terminal so subsequent "
+                + "tasks/get is short-circuited from the cache");
+    }
+
+    /** Spec §4.5: cancel exceptions on the underlying job are logged and
+     *  SWALLOWED. The producer falls back to synthesizing a state=canceled
+     *  envelope so the A2A client sees a clean terminal response. */
+    @Test
+    @DisplayName("Non-terminal task + cancel() throws → exception swallowed, canceled envelope synthesized")
+    void nonTerminal_cancelThrows_swallowsAndSynthesizesCanceled() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        doThrow(new MeshException("registry unreachable"))
+            .when(proxy).cancel(any());
+        // Post-cancel status() ALSO fails — exercises the
+        // "transient unreachability" fallback path.
+        when(proxy.status()).thenThrow(new MeshException("registry still unreachable"));
+
+        taskStore.put("t-flaky", new MeshA2ATaskStore.TaskRecord(
+            "t-flaky", null, null, null, proxy));
+
+        String body = A2ATestFixtures.jsonRpcBody(13, "tasks/cancel",
+            Map.of("id", "t-flaky", "reason", "user pressed stop"));
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc", body);
+
+        // Did NOT propagate the proxy exception to the A2A caller.
+        assertEquals(200, resp.getStatusCode().value(),
+            "JobProxy.cancel() exceptions must NOT surface as HTTP errors — spec §4.5");
+        JsonNode env = mapper.readTree(resp.getBody());
+        assertEquals("canceled", env.get("result").get("status").get("state").asText(),
+            "Cancel exceptions must be swallowed and the response must synthesize "
+                + "a state=canceled terminal envelope (spec §4.5 fallback)");
+    }
+
+    /** Spec §4.5: cancel without a JobProxy slot (defensive — shouldn't
+     *  happen in practice but the dispatcher must not crash). The cancel
+     *  request still returns a terminal envelope. */
+    @Test
+    @DisplayName("Cancel on non-terminal record without JobProxy slot does not crash")
+    void noProxy_returnsCanceled() throws Exception {
+        // Non-terminal record with proxy=null — exotic but the dispatcher
+        // must remain robust.
+        taskStore.put("t-no-proxy", new MeshA2ATaskStore.TaskRecord(
+            "t-no-proxy", null, null, null, null));
+
+        String body = A2ATestFixtures.jsonRpcBody(14, "tasks/cancel",
+            Map.of("id", "t-no-proxy"));
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc", body);
+        JsonNode env = mapper.readTree(resp.getBody());
+
+        // No proxy → no cancel attempt; buildTaskFromLiveStatus returns
+        // a state=working envelope, which is non-terminal, so we synthesize
+        // a canceled envelope per the dispatcher fallback path.
+        String state = env.get("result").get("status").get("state").asText();
+        assertEquals("canceled", state,
+            "Missing JobProxy must still produce a clean canceled terminal");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherLongRunningSendTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherLongRunningSendTest.java
@@ -1,0 +1,188 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.JobProxy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link MeshA2ADispatcher#dispatch} on the {@code tasks/send}
+ * verb when the user handler returns a {@link JobProxy} — the long-running
+ * branch (spec §4.3).
+ *
+ * <p>Per spec §4.3 long-running branch:
+ * <ul>
+ *   <li>Response is a {@code Task} envelope with {@code status.state="working"}
+ *       and an empty {@code artifacts[]} array.</li>
+ *   <li>{@code sessionId} is echoed back (defaulting to the task_id when missing).</li>
+ *   <li>The task is parked in the {@link MeshA2ATaskStore} with a non-null
+ *       {@code jobProxy} slot — kept alive across {@code tasks/get} /
+ *       {@code tasks/cancel} / {@code tasks/resubscribe} calls.</li>
+ *   <li>{@code final} is NOT set on this envelope — {@code final} is only
+ *       emitted on SSE frames (spec §5.2).</li>
+ * </ul>
+ */
+@DisplayName("MeshA2ADispatcher.tasks/send long-running branch (spec §4.3)")
+class MeshA2ADispatcherLongRunningSendTest {
+
+    private MeshA2ARegistry registry;
+    private MeshA2ATaskStore taskStore;
+    private MeshA2ADispatcher dispatcher;
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        registry = new MeshA2ARegistry();
+        registry.register(A2ATestFixtures.surfaceOf("/svc", "skill", "longRunningHandler"));
+        taskStore = new MeshA2ATaskStore();
+        mapper = A2ATestFixtures.objectMapper();
+        dispatcher = new MeshA2ADispatcher(
+            registry, taskStore, mapper, A2ATestFixtures.emptyInjectorProvider());
+    }
+
+    @AfterEach
+    void tearDown() {
+        A2ATestFixtures.TestHandlerBean.PROXY_SLOT.remove();
+    }
+
+    /** Spec §4.3 long-running: handler returning JobProxy → state=working
+     *  envelope, empty artifacts, task parked. */
+    @Test
+    @DisplayName("Handler returns JobProxy → state=working envelope with empty artifacts")
+    void longRunningReturn_buildsWorkingEnvelope() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        when(proxy.jobId()).thenReturn("job-xyz");
+        A2ATestFixtures.TestHandlerBean.PROXY_SLOT.set(proxy);
+
+        String body = A2ATestFixtures.jsonRpcBody(42, "tasks/send",
+            Map.of("id", "t-long", "sessionId", "s-long", "message",
+                Map.of("role", "user", "parts",
+                    java.util.List.of(Map.of("type", "text", "text", "go")))));
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc", body);
+
+        assertEquals(200, resp.getStatusCode().value());
+        JsonNode env = mapper.readTree(resp.getBody());
+
+        // JSON-RPC envelope shape (spec §4.1).
+        assertEquals("2.0", env.get("jsonrpc").asText());
+        assertEquals(42, env.get("id").asInt(), "Request id echoed back (spec §4.1)");
+
+        JsonNode result = env.get("result");
+        assertEquals("t-long", result.get("id").asText());
+        assertEquals("s-long", result.get("sessionId").asText(),
+            "sessionId echoed back per spec §4.2");
+
+        // Spec §4.3 long-running: state=working, empty artifacts.
+        assertEquals("working", result.get("status").get("state").asText(),
+            "Long-running branch returns state=working immediately");
+        assertTrue(result.get("status").has("timestamp"),
+            "Status timestamp present (spec §5.2 timestamp REQUIRED)");
+        assertTrue(result.get("artifacts").isArray()
+                && result.get("artifacts").isEmpty(),
+            "artifacts MUST be empty array on long-running send (spec §4.3)");
+
+        // Spec §5.2: final is for SSE frames only — NOT present on the
+        // synchronous Task envelope.
+        assertFalse(result.has("final"),
+            "'final' field is for SSE frames only, MUST NOT appear on JSON-RPC envelope");
+    }
+
+    /** Spec §4.8: task parked in store with non-null jobProxy slot. */
+    @Test
+    @DisplayName("Long-running send parks task in store with jobProxy reference preserved")
+    void longRunningReturn_parksTaskWithProxySlot() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        when(proxy.jobId()).thenReturn("job-park");
+        A2ATestFixtures.TestHandlerBean.PROXY_SLOT.set(proxy);
+
+        String body = A2ATestFixtures.jsonRpcBody("req-1", "tasks/send",
+            Map.of("id", "t-parked", "message", Map.of()));
+        dispatcher.dispatch("/svc", body);
+
+        MeshA2ATaskStore.TaskRecord record = taskStore.get("t-parked");
+        assertNotNull(record, "Task must be parked in the store");
+        assertNull(record.terminalAt(),
+            "Long-running record is NOT terminal — terminalAt must be null");
+        assertNull(record.terminalEnvelope(),
+            "Long-running record has no terminal envelope yet");
+        assertSame(proxy, record.jobProxy(),
+            "JobProxy slot must hold the EXACT proxy returned by the handler "
+                + "(reference equality — needed for FFI handle stability)");
+    }
+
+    /** Spec §4.2: sessionId defaults to task_id when omitted. */
+    @Test
+    @DisplayName("sessionId defaults to task_id when omitted (spec §4.2)")
+    void sessionIdDefaultsToTaskId() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        when(proxy.jobId()).thenReturn("job-default");
+        A2ATestFixtures.TestHandlerBean.PROXY_SLOT.set(proxy);
+
+        String body = A2ATestFixtures.jsonRpcBody(1, "tasks/send",
+            Map.of("id", "t-no-session"));
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc", body);
+        JsonNode env = mapper.readTree(resp.getBody());
+
+        assertEquals("t-no-session", env.get("result").get("sessionId").asText(),
+            "sessionId defaults to task_id per spec §4.2");
+    }
+
+    /** Spec §4.3: duplicate task_id → -32602 already in use. */
+    @Test
+    @DisplayName("Duplicate task_id on long-running send → -32602 'already in use'")
+    void duplicateTaskId_returnsAlreadyInUse() throws Exception {
+        // Park a first task.
+        JobProxy proxy1 = mock(JobProxy.class);
+        when(proxy1.jobId()).thenReturn("job-1");
+        A2ATestFixtures.TestHandlerBean.PROXY_SLOT.set(proxy1);
+        dispatcher.dispatch("/svc",
+            A2ATestFixtures.jsonRpcBody(1, "tasks/send", Map.of("id", "t-dup")));
+
+        // Attempt to park a second task with the same id.
+        JobProxy proxy2 = mock(JobProxy.class);
+        A2ATestFixtures.TestHandlerBean.PROXY_SLOT.set(proxy2);
+        ResponseEntity<String> resp2 = dispatcher.dispatch("/svc",
+            A2ATestFixtures.jsonRpcBody(2, "tasks/send", Map.of("id", "t-dup")));
+
+        JsonNode env = mapper.readTree(resp2.getBody());
+        assertEquals(MeshA2ADispatcher.JSONRPC_INVALID_PARAMS,
+            env.get("error").get("code").asInt(),
+            "Duplicate task_id MUST surface as -32602 per spec §4.3");
+        assertTrue(env.get("error").get("message").asText().contains("already in use"),
+            "Error message must explicitly call out 'already in use'");
+    }
+
+    /** Spec §4.3: history echoes the originating request message. */
+    @Test
+    @DisplayName("history[] echoes the originating request message (spec §4.3 / Appendix B item 6)")
+    void historyEchoesRequestMessage() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        when(proxy.jobId()).thenReturn("job-hist");
+        A2ATestFixtures.TestHandlerBean.PROXY_SLOT.set(proxy);
+
+        Map<String, Object> message = Map.of(
+            "role", "user",
+            "parts", java.util.List.of(Map.of("type", "text", "text", "do the thing")));
+        String body = A2ATestFixtures.jsonRpcBody(1, "tasks/send",
+            Map.of("id", "t-hist", "message", message));
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc", body);
+        JsonNode env = mapper.readTree(resp.getBody());
+
+        JsonNode history = env.get("result").get("history");
+        assertTrue(history.isArray());
+        assertEquals(1, history.size(),
+            "v1 emits at most one entry in history[] (Appendix B item 6)");
+        assertEquals("user", history.get(0).get("role").asText());
+        assertEquals("do the thing", history.get(0).get("parts").get(0).get("text").asText());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherResubscribeTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherResubscribeTest.java
@@ -1,0 +1,172 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.JobProxy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link MeshA2ADispatcher#buildResubscribeStream} —
+ * the {@code tasks/resubscribe} entry point (spec §4.7).
+ *
+ * <p>Per spec §4.7:
+ * <ul>
+ *   <li>Missing {@code params.id} → {@code -32602} as a standard
+ *       JSON-RPC response (NOT SSE — the connection has not been
+ *       promoted to {@code text/event-stream} yet).</li>
+ *   <li>Unknown {@code task_id} → {@code -32602}.</li>
+ *   <li>Already-terminal task → ONE terminal status event + close
+ *       (no replay per spec §4.7 / Appendix B item documented in spec).</li>
+ *   <li>Active non-terminal task with {@code jobProxy} → switches to
+ *       {@code LONG_RUNNING} plan (initial state=working frame, poll loop).</li>
+ * </ul>
+ */
+@DisplayName("MeshA2ADispatcher.tasks/resubscribe (spec §4.7)")
+class MeshA2ADispatcherResubscribeTest {
+
+    private MeshA2ARegistry registry;
+    private MeshA2ATaskStore taskStore;
+    private MeshA2ADispatcher dispatcher;
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        registry = new MeshA2ARegistry();
+        registry.register(A2ATestFixtures.surfaceOf("/svc", "skill", "syncHandler"));
+        taskStore = new MeshA2ATaskStore();
+        mapper = A2ATestFixtures.objectMapper();
+        dispatcher = new MeshA2ADispatcher(
+            registry, taskStore, mapper, A2ATestFixtures.emptyInjectorProvider());
+    }
+
+    /** Spec §4.7: missing id → -32602 as a JSON-RPC response (NOT SSE). */
+    @Test
+    @DisplayName("Missing id → ERROR plan with JSON-RPC -32602 body (NOT SSE)")
+    void missingId_returnsErrorPlanNotSse() throws Exception {
+        String body = A2ATestFixtures.jsonRpcBody(1, "tasks/resubscribe", Map.of());
+        MeshA2ADispatcher.SseStreamPlan plan = dispatcher.buildResubscribeStream(body);
+
+        assertEquals(MeshA2ADispatcher.SseStreamPlan.Kind.ERROR, plan.kind,
+            "Spec §4.7: missing id MUST surface as a JSON-RPC error response, NOT SSE framing");
+        assertNotNull(plan.errorBody);
+        JsonNode env = mapper.readTree(plan.errorBody);
+        assertEquals(MeshA2ADispatcher.JSONRPC_INVALID_PARAMS,
+            env.get("error").get("code").asInt());
+        assertTrue(env.get("error").get("message").asText().contains("id"),
+            "Error message must reference the missing 'id' field");
+    }
+
+    /** Spec §4.7: unknown task_id → -32602. */
+    @Test
+    @DisplayName("Unknown task id → ERROR plan with -32602 'Unknown task id'")
+    void unknownTaskId_returnsErrorPlan() throws Exception {
+        String body = A2ATestFixtures.jsonRpcBody(2, "tasks/resubscribe",
+            Map.of("id", "no-such"));
+        MeshA2ADispatcher.SseStreamPlan plan = dispatcher.buildResubscribeStream(body);
+
+        assertEquals(MeshA2ADispatcher.SseStreamPlan.Kind.ERROR, plan.kind);
+        JsonNode env = mapper.readTree(plan.errorBody);
+        assertEquals(MeshA2ADispatcher.JSONRPC_INVALID_PARAMS,
+            env.get("error").get("code").asInt());
+        assertTrue(env.get("error").get("message").asText().contains("Unknown task id"));
+    }
+
+    /** Spec §4.7: already-terminal task → ONE status event + close (no replay). */
+    @Test
+    @DisplayName("Already-terminal task → SINGLE_FRAME plan with terminal status event")
+    void terminalTask_returnsSingleFrame() throws Exception {
+        Map<String, Object> envelope = Map.of(
+            "id", "t-done",
+            "sessionId", "t-done",
+            "status", Map.of(
+                "state", "completed",
+                "message", Map.of(
+                    "role", "agent",
+                    "parts", java.util.List.of(Map.of("type", "text", "text", "all done")))
+            ),
+            "artifacts", java.util.List.of(),
+            "history", java.util.List.of()
+        );
+        taskStore.put("t-done", new MeshA2ATaskStore.TaskRecord(
+            "t-done", null, envelope, System.currentTimeMillis(), null));
+
+        String body = A2ATestFixtures.jsonRpcBody(3, "tasks/resubscribe",
+            Map.of("id", "t-done"));
+        MeshA2ADispatcher.SseStreamPlan plan = dispatcher.buildResubscribeStream(body);
+
+        assertEquals(MeshA2ADispatcher.SseStreamPlan.Kind.SINGLE_FRAME, plan.kind,
+            "Already-terminal task on resubscribe → SINGLE_FRAME (one terminal event, then close)");
+        assertNotNull(plan.firstFrame);
+
+        // Frame is a JSON-RPC envelope carrying the terminal status update.
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result = (Map<String, Object>) plan.firstFrame.get("result");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> status = (Map<String, Object>) result.get("status");
+        assertEquals("completed", status.get("state"));
+        assertEquals(Boolean.TRUE, result.get("final"),
+            "Terminal resubscribe frame MUST set final=true so the consumer closes");
+    }
+
+    /** Spec §4.7: active non-terminal task with JobProxy → LONG_RUNNING plan. */
+    @Test
+    @DisplayName("Active non-terminal task → LONG_RUNNING plan with proxy slot preserved")
+    void activeTask_returnsLongRunningPlan() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        taskStore.put("t-live", new MeshA2ATaskStore.TaskRecord(
+            "t-live", null, null, null, proxy));
+
+        String body = A2ATestFixtures.jsonRpcBody(4, "tasks/resubscribe",
+            Map.of("id", "t-live"));
+        MeshA2ADispatcher.SseStreamPlan plan = dispatcher.buildResubscribeStream(body);
+
+        assertEquals(MeshA2ADispatcher.SseStreamPlan.Kind.LONG_RUNNING, plan.kind,
+            "Active non-terminal task on resubscribe → LONG_RUNNING (poll loop resumes)");
+        assertEquals("t-live", plan.taskId);
+        assertSame(proxy, plan.proxy,
+            "LONG_RUNNING plan must carry the same JobProxy handle from the store "
+                + "(reference identity required for FFI handle stability)");
+    }
+
+    /** Spec §4.7: non-terminal record without a JobProxy slot is an
+     *  inconsistent state — dispatcher synthesizes a single failed frame
+     *  rather than hanging. Defensive behaviour. */
+    @Test
+    @DisplayName("Non-terminal record without JobProxy → SINGLE_FRAME with state=failed (defensive)")
+    void inconsistentRecord_returnsFailedSingleFrame() throws Exception {
+        taskStore.put("t-inc", new MeshA2ATaskStore.TaskRecord(
+            "t-inc", null, null, null, null));
+
+        String body = A2ATestFixtures.jsonRpcBody(5, "tasks/resubscribe",
+            Map.of("id", "t-inc"));
+        MeshA2ADispatcher.SseStreamPlan plan = dispatcher.buildResubscribeStream(body);
+
+        assertEquals(MeshA2ADispatcher.SseStreamPlan.Kind.SINGLE_FRAME, plan.kind);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result = (Map<String, Object>) plan.firstFrame.get("result");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> status = (Map<String, Object>) result.get("status");
+        assertEquals("failed", status.get("state"),
+            "Inconsistent record (non-terminal w/o proxy) MUST surface as state=failed "
+                + "so the client doesn't hang waiting for a stream that won't make progress");
+        assertEquals(Boolean.TRUE, result.get("final"));
+    }
+
+    /** Spec §4.1: parse-error response on malformed body — JSON-RPC -32700. */
+    @Test
+    @DisplayName("Malformed request body → ERROR plan with -32700 Parse error")
+    void malformedBody_returnsParseError() throws Exception {
+        MeshA2ADispatcher.SseStreamPlan plan = dispatcher.buildResubscribeStream("not json");
+        assertEquals(MeshA2ADispatcher.SseStreamPlan.Kind.ERROR, plan.kind);
+        JsonNode env = mapper.readTree(plan.errorBody);
+        assertEquals(MeshA2ADispatcher.JSONRPC_PARSE_ERROR,
+            env.get("error").get("code").asInt());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherTasksGetLiveStatusTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherTasksGetLiveStatusTest.java
@@ -1,0 +1,230 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.JobProxy;
+import io.mcpmesh.core.MeshException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link MeshA2ADispatcher#dispatch} on the {@code tasks/get}
+ * verb when the task is parked with a live {@link JobProxy} (spec §4.4).
+ *
+ * <p>Per spec §4.4 the producer pulls the current mesh status from the
+ * parked proxy, translates the mesh status to an A2A state, and includes
+ * a result artifact ONLY when the state is {@code completed} AND the
+ * producer can synchronously fetch the final value via
+ * {@link JobProxy#await(double)}.
+ *
+ * <p>Transient status() failure (spec §4.4): MUST return a
+ * {@code state=working} envelope with the error text in {@code status.message}
+ * — NOT a JSON-RPC error. The registry's transient unreachability is not
+ * authoritative evidence the job is dead.
+ *
+ * <p>UK 'cancelled' → US 'canceled' (spec §7.2 / Appendix B) is asserted
+ * on the dispatcher boundary, not just on the translator unit.
+ */
+@DisplayName("MeshA2ADispatcher.tasks/get live-status pull (spec §4.4)")
+class MeshA2ADispatcherTasksGetLiveStatusTest {
+
+    private MeshA2ARegistry registry;
+    private MeshA2ATaskStore taskStore;
+    private MeshA2ADispatcher dispatcher;
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        registry = new MeshA2ARegistry();
+        registry.register(A2ATestFixtures.surfaceOf("/svc", "skill", "syncHandler"));
+        taskStore = new MeshA2ATaskStore();
+        mapper = A2ATestFixtures.objectMapper();
+        dispatcher = new MeshA2ADispatcher(
+            registry, taskStore, mapper, A2ATestFixtures.emptyInjectorProvider());
+    }
+
+    private JsonNode dispatchGet(String taskId) throws Exception {
+        String body = A2ATestFixtures.jsonRpcBody(1, "tasks/get", Map.of("id", taskId));
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc", body);
+        return mapper.readTree(resp.getBody());
+    }
+
+    /** Spec §4.4: parked task + status() reports working → A2A state=working,
+     *  no artifact, no proxy.await() call. */
+    @Test
+    @DisplayName("status=working → A2A state=working, no artifact, no await() call")
+    void working_returnsWorkingNoArtifact() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        when(proxy.status()).thenReturn(Map.of("status", "working", "progress", 0.25));
+        taskStore.put("t-w", new MeshA2ATaskStore.TaskRecord(
+            "t-w", null, null, null, proxy));
+
+        JsonNode env = dispatchGet("t-w");
+
+        JsonNode result = env.get("result");
+        assertEquals("working", result.get("status").get("state").asText());
+        assertTrue(result.get("artifacts").isArray() && result.get("artifacts").isEmpty(),
+            "No artifact must be emitted when state=working");
+        verify(proxy, never()).await(anyDouble());
+        // Spec §4.4: progress lifted to metadata.progress as a JSON number.
+        assertTrue(result.has("metadata"));
+        assertTrue(result.get("metadata").get("progress").isNumber(),
+            "progress MUST be a JSON number, never stringified (Appendix A)");
+    }
+
+    /** Spec §4.4: status=completed → A2A state=completed, await(1.0)
+     *  invoked, artifact populated from the await() return value. */
+    @Test
+    @DisplayName("status=completed → state=completed + artifact from await(1.0)")
+    void completed_invokesAwaitAndPopulatesArtifact() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        when(proxy.status()).thenReturn(Map.of("status", "completed"));
+        when(proxy.await(1.0)).thenReturn("the answer is 42");
+        taskStore.put("t-c", new MeshA2ATaskStore.TaskRecord(
+            "t-c", null, null, null, proxy));
+
+        JsonNode env = dispatchGet("t-c");
+
+        JsonNode result = env.get("result");
+        assertEquals("completed", result.get("status").get("state").asText());
+        verify(proxy, times(1)).await(1.0);
+        assertEquals(1, result.get("artifacts").size(),
+            "Single artifact emitted on completed task");
+        JsonNode artifact = result.get("artifacts").get(0);
+        assertEquals("result", artifact.get("name").asText(),
+            "Canonical single-artifact name is 'result' per spec §5.2");
+        assertEquals(0, artifact.get("index").asInt(),
+            "Single-artifact index is 0 per spec §5.2");
+        // Spec Appendix A: parts[0].type MUST be emitted as "text".
+        assertEquals("text", artifact.get("parts").get(0).get("type").asText(),
+            "parts[0].type MUST be 'text' for forward compatibility (Appendix A)");
+        assertEquals("the answer is 42", artifact.get("parts").get(0).get("text").asText());
+    }
+
+    /** Spec §4.4: status=failed → A2A state=failed, NO await() call
+     *  (don't block on a failed job's payload). */
+    @Test
+    @DisplayName("status=failed → state=failed, NO await() call")
+    void failed_skipsAwait() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        when(proxy.status()).thenReturn(Map.of(
+            "status", "failed",
+            "error", "tool returned non-zero"));
+        taskStore.put("t-f", new MeshA2ATaskStore.TaskRecord(
+            "t-f", null, null, null, proxy));
+
+        JsonNode env = dispatchGet("t-f");
+
+        JsonNode result = env.get("result");
+        assertEquals("failed", result.get("status").get("state").asText());
+        verify(proxy, never()).await(anyDouble());
+        // Spec §5.5: status.message carries the error text when available.
+        assertEquals("tool returned non-zero",
+            result.get("status").get("message").get("parts").get(0).get("text").asText());
+        assertTrue(result.get("artifacts").isArray() && result.get("artifacts").isEmpty(),
+            "No artifact must be emitted on failed jobs");
+    }
+
+    /** Spec §7.2 / Appendix B: mesh 'cancelled' (UK) → A2A 'canceled' (US). */
+    @Test
+    @DisplayName("status=cancelled (UK) → A2A state=canceled (US) — Appendix B")
+    void cancelled_translatedToUsSpelling() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        when(proxy.status()).thenReturn(Map.of("status", "cancelled"));
+        taskStore.put("t-x", new MeshA2ATaskStore.TaskRecord(
+            "t-x", null, null, null, proxy));
+
+        JsonNode env = dispatchGet("t-x");
+        assertEquals("canceled", env.get("result").get("status").get("state").asText(),
+            "Mesh UK 'cancelled' MUST surface as A2A US 'canceled' "
+                + "at the producer boundary (spec Appendix B)");
+        verify(proxy, never()).await(anyDouble());
+    }
+
+    /** Spec §4.4 transient unreachability: status() throws → A2A
+     *  state=working envelope with error text in status.message, NOT a
+     *  -32602 error. */
+    @Test
+    @DisplayName("status() throws → state=working + error in status.message (spec §4.4 transient)")
+    void transientStatusFailure_returnsWorkingWithMessage() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        when(proxy.status())
+            .thenThrow(new MeshException("registry connect timeout"));
+        taskStore.put("t-tx", new MeshA2ATaskStore.TaskRecord(
+            "t-tx", null, null, null, proxy));
+
+        String body = A2ATestFixtures.jsonRpcBody(99, "tasks/get",
+            Map.of("id", "t-tx"));
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc", body);
+        assertEquals(200, resp.getStatusCode().value(),
+            "Transient status() failure must NOT surface as HTTP error");
+        JsonNode env = mapper.readTree(resp.getBody());
+
+        // No JSON-RPC error code — this is a snapshot, not a protocol error.
+        assertFalse(env.has("error"),
+            "Transient status() failure MUST be a state=working snapshot, NOT a JSON-RPC error "
+                + "(spec §4.4: registry transient unreachability not authoritative)");
+
+        JsonNode result = env.get("result");
+        assertEquals("working", result.get("status").get("state").asText());
+        String msg = result.get("status").get("message").get("parts").get(0).get("text").asText();
+        assertTrue(msg.contains("registry connect timeout"),
+            "Error text must be present in status.message.parts[0].text — got: " + msg);
+    }
+
+    /** Spec §4.4: missing params.id → -32602. Sanity coverage on the
+     *  error branch shared with cancel/resubscribe. */
+    @Test
+    @DisplayName("Missing id → -32602")
+    void missingId_returnsInvalidParams() throws Exception {
+        String body = A2ATestFixtures.jsonRpcBody(1, "tasks/get", Map.of());
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc", body);
+        JsonNode env = mapper.readTree(resp.getBody());
+        assertEquals(MeshA2ADispatcher.JSONRPC_INVALID_PARAMS,
+            env.get("error").get("code").asInt());
+    }
+
+    /** Spec §4.4: unknown task_id → -32602. */
+    @Test
+    @DisplayName("Unknown task id → -32602 'Unknown task id: ...'")
+    void unknownTaskId_returnsInvalidParams() throws Exception {
+        String body = A2ATestFixtures.jsonRpcBody(1, "tasks/get",
+            Map.of("id", "no-such"));
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc", body);
+        JsonNode env = mapper.readTree(resp.getBody());
+        assertEquals(MeshA2ADispatcher.JSONRPC_INVALID_PARAMS,
+            env.get("error").get("code").asInt());
+        assertTrue(env.get("error").get("message").asText().contains("Unknown task id"));
+    }
+
+    /** Spec §4.4: cached terminal envelope is returned verbatim WITHOUT
+     *  re-polling the JobProxy — even if the proxy is still attached. */
+    @Test
+    @DisplayName("Cached terminal envelope short-circuits the proxy poll")
+    void cachedTerminalEnvelopeShortCircuitsPoll() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        Map<String, Object> cached = Map.of(
+            "id", "t-cached",
+            "sessionId", "t-cached",
+            "status", Map.of("state", "completed"),
+            "artifacts", java.util.List.of(),
+            "__cached", "yes"
+        );
+        taskStore.put("t-cached", new MeshA2ATaskStore.TaskRecord(
+            "t-cached", null, cached, System.currentTimeMillis(), proxy));
+
+        JsonNode env = dispatchGet("t-cached");
+        assertEquals("yes", env.get("result").get("__cached").asText(),
+            "Cached envelope must be returned verbatim");
+        verify(proxy, never()).status();
+        verify(proxy, never()).await(anyDouble());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AHttpDispatchTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AHttpDispatchTest.java
@@ -1,0 +1,301 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.spring.MeshRuntime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the {@code MeshA2ADispatcherController} body-read
+ * path over a real HTTP boundary (issue #932 follow-up).
+ *
+ * <p><strong>Background.</strong> The earlier slice test
+ * ({@link MeshA2AControllerSliceTest}) drives the
+ * {@link org.springframework.web.servlet.function.RouterFunction} directly via
+ * {@code ServerRequest.create} with an explicit
+ * {@link org.springframework.http.converter.StringHttpMessageConverter}. That
+ * lets the test feed bodies into the dispatcher pipeline without involving
+ * Spring Boot's actual message-converter resolution — which is precisely
+ * what hid the bug surfaced by the Java A2A producer smoke test.
+ *
+ * <p>Under Spring Boot 4 / Jackson 3 (Spring 7.0.x), calling
+ * {@code ServerRequest.body(String.class)} on a request with
+ * {@code Content-Type: application/json} throws because no
+ * {@code HttpMessageConverter<String>} is registered that accepts
+ * {@code application/json} on the functional router path. The old
+ * {@code readBody} swallowed the exception and returned an empty string,
+ * which then parsed as a missing JSON-RPC method — so every well-formed
+ * {@code tasks/send} produced a {@code -32601 Method not implemented:
+ * 'null'} error with {@code id=null}.
+ *
+ * <p>This test reproduces the production failure mode by booting a real
+ * Spring Boot context on a random port and POSTing via
+ * {@link TestRestTemplate} — the same converter resolution path the JVM
+ * actually walks in production. The slice test cannot exercise this path
+ * by construction.
+ *
+ * <p>The test covers the four canonical body-read outcomes per JSON-RPC
+ * spec §4.1:
+ * <ul>
+ *   <li>Valid {@code tasks/send} → {@code result.status.state}, not an error;</li>
+ *   <li>Valid {@code tasks/get} (unknown id) → {@code -32602 Invalid params};</li>
+ *   <li>Malformed JSON body → {@code -32700 Parse error};</li>
+ *   <li>Empty body → {@code -32700 Parse error};</li>
+ *   <li>Valid JSON missing {@code method} → {@code -32600 Invalid Request};</li>
+ *   <li>Unknown method → {@code -32601 Method not found} with the actual
+ *       method name (not {@code 'null'}).</li>
+ * </ul>
+ */
+@SpringBootTest(
+    classes = MeshA2AHttpDispatchTest.TestApp.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        // Keep the producer-agent metadata stable across the test JVM —
+        // the runtime is stubbed below, but heartbeat scrubbing still
+        // reads these from the environment.
+        "mcpmesh.agent.name=http-dispatch-test-agent",
+        "mcpmesh.agent.host=127.0.0.1",
+        "logging.level.io.mcpmesh=WARN"
+    }
+)
+@DisplayName("MeshA2A producer — real HTTP boundary regression (issue #932)")
+class MeshA2AHttpDispatchTest {
+
+    private static final ObjectMapper JSON = JsonMapper.builder().build();
+    private static final String PATH = "/agents/http-test";
+
+    @LocalServerPort
+    private int port;
+
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(5))
+        .build();
+
+    private URI url() {
+        return URI.create("http://127.0.0.1:" + port + PATH);
+    }
+
+    /**
+     * POST a raw body to the producer surface as
+     * {@code Content-Type: application/json}. We use the JDK
+     * {@link HttpClient} (rather than Spring's {@code TestRestTemplate},
+     * which was removed in Spring Boot 4) so the test layer adds zero
+     * message-converter machinery — the only converter resolution that
+     * happens is on the producer side, which is exactly what we want
+     * to exercise.
+     */
+    private HttpResponse<String> post(String body) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(url())
+            .timeout(Duration.ofSeconds(10))
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+        return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private JsonNode parse(String body) throws Exception {
+        return JSON.readTree(body == null ? "" : body);
+    }
+
+    /** Pre-fix: this returned -32601 with method='null'. Post-fix: it must
+     *  return a real Task envelope with state=completed. */
+    @Test
+    @DisplayName("POST tasks/send (valid JSON-RPC) → state=completed, not -32601")
+    void tasksSendOverHttp_returnsCompletedState() throws Exception {
+        String body = JSON.writeValueAsString(Map.of(
+            "jsonrpc", "2.0",
+            "id", 1,
+            "method", "tasks/send",
+            "params", Map.of(
+                "id", "t-http-1",
+                "message", Map.of("role", "user",
+                    "parts", List.of(Map.of("type", "text", "text", "hello"))))));
+
+        HttpResponse<String> resp = post(body);
+
+        assertThat(resp.statusCode())
+            .as("Body: %s", resp.body()).isEqualTo(200);
+        JsonNode env = parse(resp.body());
+        // Critical regression assertion: pre-fix this branch returned
+        // {"error":{"code":-32601,"message":"Method not implemented: 'null'"}}
+        // because readBody swallowed the converter exception.
+        assertThat(env.has("error"))
+            .as("Expected success envelope, got error: %s", resp.body())
+            .isFalse();
+        assertThat(env.get("id").asInt()).isEqualTo(1);
+        JsonNode result = env.get("result");
+        assertThat(result).isNotNull();
+        assertThat(result.get("id").asText()).isEqualTo("t-http-1");
+        assertThat(result.get("status").get("state").asText()).isEqualTo("completed");
+    }
+
+    /** Pre-fix: same -32601 method='null' bug. Post-fix: dispatcher reaches
+     *  handleTasksGet which returns -32602 for the unknown id. */
+    @Test
+    @DisplayName("POST tasks/get (unknown id) → -32602 Invalid params, not -32601")
+    void tasksGetOverHttp_unknownId_returnsInvalidParams() throws Exception {
+        String body = JSON.writeValueAsString(Map.of(
+            "jsonrpc", "2.0",
+            "id", 2,
+            "method", "tasks/get",
+            "params", Map.of("id", "does-not-exist")));
+
+        HttpResponse<String> resp = post(body);
+
+        JsonNode env = parse(resp.body());
+        assertThat(env.has("error"))
+            .as("Body: %s", resp.body()).isTrue();
+        assertThat(env.get("error").get("code").asInt())
+            .as("Pre-fix this was -32601 method='null'; post-fix it must be -32602 unknown id")
+            .isEqualTo(MeshA2ADispatcher.JSONRPC_INVALID_PARAMS);
+        assertThat(env.get("error").get("message").asText()).contains("Unknown task id");
+    }
+
+    /** Spec §4.1: malformed JSON → -32700 Parse error. Pre-fix the
+     *  request never reached the dispatcher's JSON parse (because
+     *  readBody dropped the body) so the same -32601 method='null'
+     *  appeared. Post-fix the raw body reaches the dispatcher and
+     *  Jackson's tree parse produces -32700 cleanly. */
+    @Test
+    @DisplayName("POST malformed JSON body → -32700 Parse error (not -32601)")
+    void malformedJsonOverHttp_returnsParseError() throws Exception {
+        HttpResponse<String> resp = post("not json");
+
+        assertThat(resp.statusCode()).isEqualTo(400);
+        JsonNode env = parse(resp.body());
+        assertThat(env.get("error").get("code").asInt())
+            .isEqualTo(MeshA2ADispatcher.JSONRPC_PARSE_ERROR);
+    }
+
+    /** Empty body must also produce a Parse error per spec §4.1. */
+    @Test
+    @DisplayName("POST empty body → -32700 Parse error")
+    void emptyBodyOverHttp_returnsParseError() throws Exception {
+        HttpResponse<String> resp = post("");
+
+        assertThat(resp.statusCode()).isEqualTo(400);
+        JsonNode env = parse(resp.body());
+        assertThat(env.get("error").get("code").asInt())
+            .isEqualTo(MeshA2ADispatcher.JSONRPC_PARSE_ERROR);
+    }
+
+    /** Spec §4.1: valid JSON missing required `method` → -32600
+     *  Invalid Request. Pre-fix the dispatcher's default switch case
+     *  emitted -32601 method='null' — wrong code, misleading message. */
+    @Test
+    @DisplayName("POST valid JSON missing 'method' → -32600 Invalid Request")
+    void missingMethodOverHttp_returnsInvalidRequest() throws Exception {
+        String body = JSON.writeValueAsString(Map.of(
+            "jsonrpc", "2.0",
+            "id", 3,
+            "params", Map.of()));
+
+        HttpResponse<String> resp = post(body);
+
+        JsonNode env = parse(resp.body());
+        assertThat(env.has("error"))
+            .as("Body: %s", resp.body()).isTrue();
+        assertThat(env.get("error").get("code").asInt())
+            .as("Spec §4.1: missing method is -32600 Invalid Request, not -32601 method='null'")
+            .isEqualTo(MeshA2ADispatcher.JSONRPC_INVALID_REQUEST);
+    }
+
+    /** Pre-fix: error message read "Method not implemented: 'null'" for
+     *  any unknown method (because the body never reached the parser).
+     *  Post-fix: the ACTUAL method name appears in the message. */
+    @Test
+    @DisplayName("POST unknown method → -32601 with real method name (not 'null')")
+    void unknownMethodOverHttp_carriesActualMethodName() throws Exception {
+        String body = JSON.writeValueAsString(Map.of(
+            "jsonrpc", "2.0",
+            "id", 4,
+            "method", "nonexistent/foo",
+            "params", Map.of()));
+
+        HttpResponse<String> resp = post(body);
+
+        JsonNode env = parse(resp.body());
+        assertThat(env.get("error").get("code").asInt())
+            .isEqualTo(MeshA2ADispatcher.JSONRPC_METHOD_NOT_FOUND);
+        String msg = env.get("error").get("message").asText();
+        assertThat(msg)
+            .as("Pre-fix this said \"Method not implemented: 'null'\"; "
+                + "post-fix it must carry the actual method name")
+            .contains("nonexistent/foo")
+            .doesNotContain("'null'");
+        assertThat(env.get("id").asInt())
+            .as("Pre-fix the id was null too because the body never reached the parser")
+            .isEqualTo(4);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Test fixtures
+    // ─────────────────────────────────────────────────────────────────
+
+    /** Spring Boot application stub — registers an A2A surface and pins
+     *  a no-op {@link MeshRuntime} so the JVM does not try to load the
+     *  native Rust core during the test.
+     *
+     *  <p>Relies on the starter's {@code AutoConfiguration.imports} file to
+     *  wire {@code MeshAutoConfiguration} via Spring Boot's auto-configuration
+     *  machinery. We do NOT {@code @Import} the auto-config explicitly because
+     *  that pathway registers it as a user-config and breaks
+     *  {@code @ConditionalOnMissingBean} ordering for the {@code meshRuntime}
+     *  bean override. */
+    @SpringBootApplication
+    static class TestApp {
+
+        @Component
+        public static class HttpTestSkill {
+            @MeshA2A(path = PATH, skillId = "http-test", skillName = "HTTP Test")
+            public Map<String, Object> handle(Map<String, Object> message) {
+                return Map.of("ok", true);
+            }
+        }
+
+        /**
+         * No-op {@link MeshRuntime} so the {@link org.springframework.context.SmartLifecycle}
+         * processor doesn't spin up the native core. Mirrors the pattern
+         * from {@link MeshA2AContextLoadTest} so the boot doesn't try to
+         * load the FFI dylib on the test classpath.
+         */
+        @Bean
+        public MeshRuntime meshRuntime(ApplicationContext applicationContext) {
+            // Mirror MeshAutoConfiguration.buildAgentSpec()'s eager scan so the
+            // bean-creation graph matches production.
+            applicationContext.getBeansWithAnnotation(Component.class);
+
+            AgentSpec spec = new AgentSpec();
+            spec.setName("http-dispatch-test-agent");
+            spec.setAgentId("http-dispatch-test-agent-00000000");
+
+            return new MeshRuntime(spec) {
+                private volatile boolean running;
+                @Override public void start() { running = true; }
+                @Override public void stop() { running = false; }
+                @Override public boolean isRunning() { return running; }
+            };
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AHttpDispatchTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AHttpDispatchTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
@@ -48,10 +49,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 'null'} error with {@code id=null}.
  *
  * <p>This test reproduces the production failure mode by booting a real
- * Spring Boot context on a random port and POSTing via
- * {@link TestRestTemplate} — the same converter resolution path the JVM
- * actually walks in production. The slice test cannot exercise this path
- * by construction.
+ * Spring Boot context on a random port and POSTing via the JDK
+ * {@link java.net.http.HttpClient} (Spring Boot 4 removed
+ * {@code TestRestTemplate}; we want zero test-side message-converter
+ * machinery so the only converter resolution that happens is on the producer
+ * side — exactly what we want to exercise). The slice test cannot exercise
+ * this path by construction.
  *
  * <p>The test covers the four canonical body-read outcomes per JSON-RPC
  * spec §4.1:
@@ -249,6 +252,31 @@ class MeshA2AHttpDispatchTest {
             .isEqualTo(4);
     }
 
+    /** Regression for the body-size cap (CodeRabbit A8). A request body larger
+     *  than {@link MeshA2ADispatcherController#DEFAULT_MAX_BODY_BYTES} (1 MiB)
+     *  MUST be rejected with HTTP 400 + JSON-RPC -32700 rather than draining
+     *  the entire stream into memory. */
+    @Test
+    @DisplayName("POST body > 1 MiB → 400 Parse error, NOT OOM")
+    void oversizedBody_returnsParseErrorNotOom() throws Exception {
+        // 1 MiB + 1 byte of arbitrary garbage. Doesn't need to be valid JSON —
+        // the size cap must trip before the parser sees a single byte.
+        int oversized = (int) MeshA2ADispatcherController.DEFAULT_MAX_BODY_BYTES + 1;
+        char[] padding = new char[oversized];
+        java.util.Arrays.fill(padding, 'x');
+        String body = new String(padding);
+
+        HttpResponse<String> resp = post(body);
+
+        assertThat(resp.statusCode())
+            .as("Oversized body MUST be rejected with 400 (got body=%s)", resp.body())
+            .isEqualTo(400);
+        JsonNode env = parse(resp.body());
+        assertThat(env.get("error").get("code").asInt())
+            .as("Oversize-body rejection MUST surface as JSON-RPC -32700 Parse error")
+            .isEqualTo(MeshA2ADispatcher.JSONRPC_PARSE_ERROR);
+    }
+
     // ─────────────────────────────────────────────────────────────────
     // Test fixtures
     // ─────────────────────────────────────────────────────────────────
@@ -283,8 +311,11 @@ class MeshA2AHttpDispatchTest {
         @Bean
         public MeshRuntime meshRuntime(ApplicationContext applicationContext) {
             // Mirror MeshAutoConfiguration.buildAgentSpec()'s eager scan so the
-            // bean-creation graph matches production.
+            // bean-creation graph matches production — production scans BOTH
+            // @Component and @Service, so the test must too if it wants to
+            // exercise the same cycle scenario.
             applicationContext.getBeansWithAnnotation(Component.class);
+            applicationContext.getBeansWithAnnotation(Service.class);
 
             AgentSpec spec = new AgentSpec();
             spec.setName("http-dispatch-test-agent");

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2APublicUrlCacheTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2APublicUrlCacheTest.java
@@ -1,0 +1,192 @@
+package io.mcpmesh.spring.web;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link MeshA2APublicUrlCache} (spec §2.4 / §8.2).
+ *
+ * <p>Public URL caching:
+ * <ul>
+ *   <li>Stores registry-stamped public URLs keyed by {@code (path, skill_id)};</li>
+ *   <li>Empty / blank / null {@code publicUrl} → REMOVES the cached entry,
+ *       so the controller falls back to the local-form URL (matches Python's
+ *       {@code update_public_url_cache} which drops the entry when the
+ *       registry stops stamping it);</li>
+ *   <li>Thread-safe — backed by {@link java.util.concurrent.ConcurrentHashMap}
+ *       so concurrent put/get from the heartbeat thread + request threads
+ *       never lose updates.</li>
+ * </ul>
+ */
+@DisplayName("MeshA2APublicUrlCache — registry public URL caching (spec §2.4 / §8.2)")
+class MeshA2APublicUrlCacheTest {
+
+    private MeshA2APublicUrlCache cache;
+
+    @BeforeEach
+    void setUp() {
+        cache = new MeshA2APublicUrlCache();
+    }
+
+    /** put/get round-trip — the canonical happy path. */
+    @Test
+    @DisplayName("put/get round-trip preserves the registry-stamped public URL")
+    void putGetRoundTrip() {
+        cache.put("/agents/report", "generate-report",
+            "https://agents.acme.com/agents/report");
+
+        assertEquals("https://agents.acme.com/agents/report",
+            cache.get("/agents/report", "generate-report"));
+    }
+
+    /** Distinct (path, skillId) pairs do NOT collide. */
+    @Test
+    @DisplayName("Distinct (path, skillId) keys do not collide")
+    void distinctKeysDoNotCollide() {
+        cache.put("/agents/x", "skill-a", "https://x/a");
+        cache.put("/agents/x", "skill-b", "https://x/b");
+        cache.put("/agents/y", "skill-a", "https://y/a");
+
+        assertEquals("https://x/a", cache.get("/agents/x", "skill-a"));
+        assertEquals("https://x/b", cache.get("/agents/x", "skill-b"));
+        assertEquals("https://y/a", cache.get("/agents/y", "skill-a"));
+        assertEquals(3, cache.size());
+    }
+
+    /** Missing key → null (caller falls back to local-form URL). */
+    @Test
+    @DisplayName("get() returns null for missing key (controller falls back to local URL)")
+    void missingKeyReturnsNull() {
+        assertNull(cache.get("/agents/missing", "skill"));
+        cache.put("/agents/x", "skill", "https://x");
+        assertNull(cache.get("/agents/x", "different-skill"),
+            "Same path but different skillId is a different key — must miss");
+    }
+
+    /** Empty publicUrl REMOVES any cached entry — matches Python helper
+     *  {@code update_public_url_cache} dropping the entry. */
+    @Test
+    @DisplayName("Empty publicUrl removes cached entry (Python parity)")
+    void emptyUrlRemovesEntry() {
+        cache.put("/agents/x", "skill", "https://x");
+        assertEquals(1, cache.size());
+
+        cache.put("/agents/x", "skill", "");
+        assertNull(cache.get("/agents/x", "skill"),
+            "Empty publicUrl MUST remove the cached entry — matches Python's "
+                + "update_public_url_cache behavior when registry stops stamping");
+        assertEquals(0, cache.size());
+    }
+
+    /** Null publicUrl also removes the entry. */
+    @Test
+    @DisplayName("Null publicUrl removes cached entry")
+    void nullUrlRemovesEntry() {
+        cache.put("/agents/x", "skill", "https://x");
+        cache.put("/agents/x", "skill", null);
+        assertNull(cache.get("/agents/x", "skill"));
+        assertEquals(0, cache.size());
+    }
+
+    /** Null/empty for a key that was never present is a no-op (does not crash). */
+    @Test
+    @DisplayName("Null/empty for absent key is a no-op")
+    void clearAbsentKeyIsNoOp() {
+        assertDoesNotThrow(() -> cache.put("/agents/none", "skill", ""));
+        assertDoesNotThrow(() -> cache.put("/agents/none", "skill", null));
+        assertEquals(0, cache.size());
+    }
+
+    /** clear() drops every entry. */
+    @Test
+    @DisplayName("clear() drops every entry")
+    void clearEmptiesCache() {
+        cache.put("/a", "s1", "https://a");
+        cache.put("/b", "s2", "https://b");
+        assertEquals(2, cache.size());
+
+        cache.clear();
+        assertEquals(0, cache.size());
+        assertNull(cache.get("/a", "s1"));
+        assertNull(cache.get("/b", "s2"));
+    }
+
+    /** Replace existing entry — last write wins. */
+    @Test
+    @DisplayName("Put on existing key replaces the URL (last write wins)")
+    void putReplacesExisting() {
+        cache.put("/agents/x", "skill", "https://old.example.com");
+        cache.put("/agents/x", "skill", "https://new.example.com");
+        assertEquals("https://new.example.com",
+            cache.get("/agents/x", "skill"));
+        assertEquals(1, cache.size());
+    }
+
+    /** Null skillId treated as empty string (defensive — some heartbeat
+     *  responses may omit it). */
+    @Test
+    @DisplayName("Null skillId treated as empty string for key purposes (defensive)")
+    void nullSkillIdNormalisedToEmpty() {
+        cache.put("/agents/x", null, "https://x");
+        assertEquals("https://x", cache.get("/agents/x", null));
+        assertEquals("https://x", cache.get("/agents/x", ""),
+            "Null and empty skillId must normalise to the same cache key");
+    }
+
+    /** Concurrent put/get safety — multiple threads must not lose updates
+     *  or observe torn state. ConcurrentHashMap-backed; this stress-tests
+     *  the contract. */
+    @Test
+    @DisplayName("Concurrent put + get from many threads does not lose updates")
+    void concurrentPutGetIsSafe() throws InterruptedException {
+        final int threads = 16;
+        final int opsPerThread = 200;
+        ExecutorService exec = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        AtomicInteger errors = new AtomicInteger(0);
+
+        for (int t = 0; t < threads; t++) {
+            final int threadId = t;
+            exec.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < opsPerThread; i++) {
+                        String path = "/agents/" + (i % 4);
+                        String skill = "skill-" + threadId;
+                        cache.put(path, skill, "https://t" + threadId + "/" + i);
+                        // Read back our own write — must see something non-null.
+                        String got = cache.get(path, skill);
+                        if (got == null) {
+                            errors.incrementAndGet();
+                        }
+                    }
+                } catch (Exception e) {
+                    errors.incrementAndGet();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+        start.countDown();
+        assertTrue(done.await(15, TimeUnit.SECONDS),
+            "Concurrent stress test must complete within 15s");
+        exec.shutdownNow();
+
+        assertEquals(0, errors.get(),
+            "Concurrent put/get must not lose own-thread writes (got " + errors.get() + " misses)");
+        // Final state: each (path, skill) pair has exactly one value.
+        // 4 paths × 16 threads = 64 distinct keys.
+        assertEquals(64, cache.size(),
+            "Final cache size must equal the number of distinct (path, skillId) keys");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ASseDispatcherStreamTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ASseDispatcherStreamTest.java
@@ -1,0 +1,401 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.JobProxy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.web.servlet.function.ServerResponse;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link MeshA2ASseDispatcher} stream emission (spec §5).
+ *
+ * <p>Each {@link MeshA2ADispatcher.SseStreamPlan} kind is fed into the
+ * dispatcher and the emitted frames are captured via a Mockito-mocked
+ * {@link ServerResponse.SseBuilder}. Frame payloads are parsed back into
+ * JSON via Jackson so we can assert on the SHAPE (real boolean
+ * {@code final}, real number {@code progress}, etc.) rather than on
+ * brittle string matches.
+ *
+ * <p>Test #7 (timing — exact poll cadence + keepalive interval) is
+ * deferred — see report; the dispatcher has no injectable clock and the
+ * keepalive interval is 15s, which is unsuitable for a unit test.
+ */
+@DisplayName("MeshA2ASseDispatcher — SSE stream emission (spec §5)")
+class MeshA2ASseDispatcherStreamTest {
+
+    private MeshA2ARegistry registry;
+    private MeshA2ATaskStore taskStore;
+    private MeshA2ADispatcher dispatcher;
+    private MeshA2ASseDispatcher sseDispatcher;
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        registry = new MeshA2ARegistry();
+        registry.register(A2ATestFixtures.surfaceOf("/svc", "skill", "syncHandler"));
+        taskStore = new MeshA2ATaskStore();
+        mapper = A2ATestFixtures.objectMapper();
+        dispatcher = new MeshA2ADispatcher(
+            registry, taskStore, mapper, A2ATestFixtures.emptyInjectorProvider());
+        sseDispatcher = new MeshA2ASseDispatcher(dispatcher);
+    }
+
+    /** Capture writes against a mocked {@link ServerResponse.SseBuilder}.
+     *  Each {@code builder.data(json)} call appends the raw JSON payload;
+     *  each {@code builder.comment(...).send()} call appends a comment marker. */
+    private static final class CapturingBuilder {
+        final List<String> dataFrames = new ArrayList<>();
+        final List<String> commentFrames = new ArrayList<>();
+        final ServerResponse.SseBuilder mockBuilder = mock(ServerResponse.SseBuilder.class);
+        // Disconnect flag to simulate client gone — when true, the next
+        // data() call throws IOException, which the dispatcher swallows
+        // and exits the loop cleanly.
+        boolean disconnected = false;
+
+        CapturingBuilder() {
+            try {
+                doAnswer((Answer<Void>) inv -> {
+                    if (disconnected) throw new IOException("client disconnected");
+                    dataFrames.add(inv.getArgument(0).toString());
+                    return null;
+                }).when(mockBuilder).data(any());
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+            // builder.comment(text).send() — return self from comment(...)
+            // so the chain works.
+            when(mockBuilder.comment(any())).thenAnswer(inv -> {
+                commentFrames.add(": " + inv.getArgument(0));
+                return mockBuilder;
+            });
+            try {
+                doNothing().when(mockBuilder).send();
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+        }
+
+        JsonNode parsed(int index, ObjectMapper m) {
+            try {
+                return m.readTree(dataFrames.get(index));
+            } catch (Exception e) {
+                throw new AssertionError("Frame " + index + " is not valid JSON", e);
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Plan kinds — exercise via direct frame-writing private methods
+    // ─────────────────────────────────────────────────────────────────
+
+    /** Spec §5.3 SINGLE_FRAME: one data frame then close. */
+    @Test
+    @DisplayName("SINGLE_FRAME plan emits exactly one data frame")
+    void singleFramePlan_emitsOneFrame() throws Exception {
+        Map<String, Object> frame = dispatcher.buildStatusUpdateFrame(
+            7, "t-1", MeshA2AStateTranslator.A2A_FAILED, "boom", true, null);
+        MeshA2ADispatcher.SseStreamPlan plan = MeshA2ADispatcher.SseStreamPlan.singleFrame(frame);
+        assertEquals(MeshA2ADispatcher.SseStreamPlan.Kind.SINGLE_FRAME, plan.kind);
+
+        CapturingBuilder cap = new CapturingBuilder();
+        invokeWriteFrame(cap.mockBuilder, plan.firstFrame);
+
+        assertEquals(1, cap.dataFrames.size(), "exactly one data frame for SINGLE_FRAME");
+        JsonNode env = cap.parsed(0, mapper);
+        assertEquals("2.0", env.get("jsonrpc").asText());
+        assertEquals(7, env.get("id").asInt());
+        JsonNode result = env.get("result");
+        assertEquals("t-1", result.get("id").asText());
+        assertEquals("failed", result.get("status").get("state").asText());
+        // Appendix A: 'final' MUST be a real boolean.
+        assertTrue(result.get("final").isBoolean(),
+            "'final' MUST be a real JSON boolean, not a stringified value (Appendix A)");
+        assertTrue(result.get("final").asBoolean());
+    }
+
+    /** Spec §5.3 SYNC_COMPLETED: artifact frame then terminal status frame. */
+    @Test
+    @DisplayName("SYNC_COMPLETED plan emits artifact frame then terminal status frame (final=true)")
+    void syncCompletedPlan_emitsArtifactThenTerminal() throws Exception {
+        Map<String, Object> artifactFrame = dispatcher.buildArtifactUpdateFrame(1, "t-sc", "the result");
+        Map<String, Object> terminalFrame = dispatcher.buildStatusUpdateFrame(
+            1, "t-sc", MeshA2AStateTranslator.A2A_COMPLETED, null, true, null);
+        MeshA2ADispatcher.SseStreamPlan plan =
+            MeshA2ADispatcher.SseStreamPlan.syncCompleted(1, "t-sc", artifactFrame, terminalFrame);
+        assertEquals(MeshA2ADispatcher.SseStreamPlan.Kind.SYNC_COMPLETED, plan.kind);
+
+        CapturingBuilder cap = new CapturingBuilder();
+        invokeWriteFrame(cap.mockBuilder, plan.firstFrame);
+        invokeWriteFrame(cap.mockBuilder, plan.secondFrame);
+
+        assertEquals(2, cap.dataFrames.size(),
+            "SYNC_COMPLETED emits artifact frame then terminal status frame");
+
+        JsonNode artifact = cap.parsed(0, mapper).get("result").get("artifact");
+        assertEquals("result", artifact.get("name").asText());
+        assertEquals(0, artifact.get("index").asInt(),
+            "Single artifact index is 0 per spec §5.2");
+        assertEquals("text", artifact.get("parts").get(0).get("type").asText(),
+            "parts[0].type MUST be 'text' (Appendix A)");
+        assertEquals("the result", artifact.get("parts").get(0).get("text").asText());
+
+        JsonNode terminal = cap.parsed(1, mapper).get("result");
+        assertEquals("completed", terminal.get("status").get("state").asText());
+        // Appendix A: real boolean.
+        assertTrue(terminal.get("final").isBoolean());
+        assertTrue(terminal.get("final").asBoolean(),
+            "Terminal frame MUST set final=true (spec §5.2)");
+    }
+
+    /** Spec §5.3 LONG_RUNNING: initial state=working frame on subscription. */
+    @Test
+    @DisplayName("LONG_RUNNING: initial frame is state=working with final=false (real boolean)")
+    void longRunning_initialFrameIsWorking() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        // Status reports terminal immediately so we exit after the initial frame.
+        when(proxy.status()).thenReturn(Map.of("status", "completed"));
+        when(proxy.await(1.0)).thenReturn("done");
+
+        CapturingBuilder cap = new CapturingBuilder();
+        invokeRunLongRunningStream(sseDispatcher, cap.mockBuilder, 1, "t-lr", proxy);
+
+        assertTrue(cap.dataFrames.size() >= 1, "at least the initial frame must be emitted");
+        JsonNode initial = cap.parsed(0, mapper).get("result");
+        assertEquals("working", initial.get("status").get("state").asText(),
+            "Initial LONG_RUNNING frame MUST be state=working (spec §5.3)");
+        // Appendix A: real boolean, not the string "false".
+        assertTrue(initial.get("final").isBoolean());
+        assertFalse(initial.get("final").asBoolean(),
+            "Initial frame MUST have final=false (spec §5.3)");
+    }
+
+    /** Spec §5.3 LONG_RUNNING completion: terminal arrives → artifact frame
+     *  then terminal status frame with final=true. */
+    @Test
+    @DisplayName("LONG_RUNNING: terminal=completed → artifact frame then final=true status frame")
+    void longRunning_terminalCompleted_emitsArtifactThenFinalTrue() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        when(proxy.status()).thenReturn(Map.of("status", "completed"));
+        when(proxy.await(1.0)).thenReturn("the answer");
+
+        CapturingBuilder cap = new CapturingBuilder();
+        invokeRunLongRunningStream(sseDispatcher, cap.mockBuilder, 99, "t-end", proxy);
+
+        // Expect at least: initial state=working (final=false), artifact, terminal (final=true).
+        assertTrue(cap.dataFrames.size() >= 3,
+            "Expected at least 3 frames (working/artifact/final); got " + cap.dataFrames.size());
+
+        // Last frame is the terminal status frame.
+        JsonNode terminal = cap.parsed(cap.dataFrames.size() - 1, mapper).get("result");
+        assertEquals("completed", terminal.get("status").get("state").asText());
+        assertTrue(terminal.get("final").isBoolean());
+        assertTrue(terminal.get("final").asBoolean(),
+            "Terminal frame on completion MUST set final=true (spec §5.3)");
+
+        // The frame before the terminal carries the artifact.
+        JsonNode beforeTerminal = cap.parsed(cap.dataFrames.size() - 2, mapper).get("result");
+        assertTrue(beforeTerminal.has("artifact"),
+            "Frame before terminal status MUST be the artifact event (spec §5.3 ordering)");
+        assertEquals("the answer",
+            beforeTerminal.get("artifact").get("parts").get(0).get("text").asText());
+    }
+
+    /** Spec §5.3 only-on-change emission: same status twice → only one
+     *  progress frame is emitted (suppress redundant). */
+    @Test
+    @DisplayName("Same progress/message twice → only one progress frame emitted")
+    void longRunning_suppressesRedundantProgressFrames() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        AtomicInteger calls = new AtomicInteger(0);
+        Map<String, Object> firstWorking = Map.of(
+            "status", "working", "progress", 0.5, "progress_message", "halfway");
+        Map<String, Object> sameWorking = Map.of(
+            "status", "working", "progress", 0.5, "progress_message", "halfway");
+        Map<String, Object> terminal = Map.of("status", "completed");
+        // 3 calls: same working twice, then completed.
+        when(proxy.status()).thenAnswer(inv -> switch (calls.getAndIncrement()) {
+            case 0 -> firstWorking;
+            case 1 -> sameWorking;
+            default -> terminal;
+        });
+        when(proxy.await(1.0)).thenReturn("done");
+
+        CapturingBuilder cap = new CapturingBuilder();
+        invokeRunLongRunningStream(sseDispatcher, cap.mockBuilder, 1, "t-rep", proxy);
+
+        // Count distinct "working+progress=0.5" frames in the data stream.
+        long progressFrames = cap.dataFrames.stream()
+            .filter(f -> f.contains("\"progress\":0.5"))
+            .count();
+        assertEquals(1, progressFrames,
+            "Identical progress on two consecutive polls MUST emit only ONE progress frame "
+                + "(spec §5.3 only-on-change suppression)");
+    }
+
+    /** Appendix A: progress MUST be a JSON number, not a string. */
+    @Test
+    @DisplayName("progress field is emitted as a JSON number (not a string) — Appendix A")
+    void longRunning_progressIsRealNumber() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        AtomicInteger calls = new AtomicInteger(0);
+        when(proxy.status()).thenAnswer(inv -> switch (calls.getAndIncrement()) {
+            case 0 -> Map.of("status", "working", "progress", 0.42, "progress_message", "draft 1");
+            default -> Map.of("status", "completed");
+        });
+        when(proxy.await(1.0)).thenReturn("done");
+
+        CapturingBuilder cap = new CapturingBuilder();
+        invokeRunLongRunningStream(sseDispatcher, cap.mockBuilder, 1, "t-num", proxy);
+
+        // Find the progress frame (state=working with metadata.progress).
+        JsonNode progressFrame = null;
+        for (int i = 0; i < cap.dataFrames.size(); i++) {
+            JsonNode env = cap.parsed(i, mapper);
+            JsonNode meta = env.get("result").get("metadata");
+            if (meta != null && meta.has("progress")) {
+                progressFrame = env;
+                break;
+            }
+        }
+        assertNotNull(progressFrame, "Expected a frame carrying metadata.progress");
+        JsonNode prog = progressFrame.get("result").get("metadata").get("progress");
+        assertTrue(prog.isNumber(),
+            "metadata.progress MUST be a real JSON number (Appendix A); got node type: " + prog.getNodeType());
+        assertEquals(0.42, prog.asDouble(), 0.0001);
+    }
+
+    /** Spec §5.3 LONG_RUNNING failed branch: terminal=failed → no
+     *  artifact, status frame with state=failed final=true. */
+    @Test
+    @DisplayName("LONG_RUNNING: terminal=failed → no artifact, final status frame state=failed")
+    void longRunning_terminalFailed_skipsArtifact() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        when(proxy.status()).thenReturn(Map.of(
+            "status", "failed", "error", "the tool exploded"));
+
+        CapturingBuilder cap = new CapturingBuilder();
+        invokeRunLongRunningStream(sseDispatcher, cap.mockBuilder, 1, "t-bad", proxy);
+
+        verify(proxy, never()).await(anyDouble());
+        // Last frame is the failed terminal frame.
+        JsonNode last = cap.parsed(cap.dataFrames.size() - 1, mapper).get("result");
+        assertEquals("failed", last.get("status").get("state").asText());
+        assertTrue(last.get("final").asBoolean());
+        // status.message present with the error text.
+        assertEquals("the tool exploded",
+            last.get("status").get("message").get("parts").get(0).get("text").asText());
+        // No artifact frame anywhere in the stream.
+        boolean hasArtifact = cap.dataFrames.stream().anyMatch(f -> f.contains("\"artifact\":"));
+        assertFalse(hasArtifact, "No artifact frame on failed terminal (spec §5.3)");
+    }
+
+    /** Spec §5.3 LONG_RUNNING cancellation: terminal=cancelled (UK) →
+     *  A2A state=canceled (US). */
+    @Test
+    @DisplayName("LONG_RUNNING: terminal=cancelled (UK) → final status frame state=canceled (US)")
+    void longRunning_terminalCancelled_emitsCanceled() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        when(proxy.status()).thenReturn(Map.of("status", "cancelled"));
+
+        CapturingBuilder cap = new CapturingBuilder();
+        invokeRunLongRunningStream(sseDispatcher, cap.mockBuilder, 1, "t-cx", proxy);
+
+        JsonNode last = cap.parsed(cap.dataFrames.size() - 1, mapper).get("result");
+        assertEquals("canceled", last.get("status").get("state").asText(),
+            "UK mesh 'cancelled' MUST surface as US A2A 'canceled' on the SSE wire");
+        assertTrue(last.get("final").asBoolean());
+    }
+
+    /** Spec §7.3 / §5.4: client disconnect (IOException on data write)
+     *  MUST NOT cancel the underlying job — the loop exits and proxy.cancel
+     *  is never called. */
+    @Test
+    @DisplayName("Client disconnect during stream → loop exits, JobProxy.cancel NOT called")
+    void clientDisconnect_doesNotCancelJob() throws Exception {
+        JobProxy proxy = mock(JobProxy.class);
+        AtomicInteger statusCalls = new AtomicInteger(0);
+        // First call returns working — gives the dispatcher something to
+        // try to emit. The client "disconnects" before the data() write
+        // succeeds.
+        when(proxy.status()).thenAnswer(inv -> {
+            statusCalls.incrementAndGet();
+            return Map.of("status", "working", "progress", 0.1, "progress_message", "starting");
+        });
+        CapturingBuilder cap = new CapturingBuilder();
+        cap.disconnected = true; // every data() call now throws.
+
+        invokeRunLongRunningStream(sseDispatcher, cap.mockBuilder, 1, "t-disco", proxy);
+
+        verify(proxy, never()).cancel(any()); // critical: do NOT cancel on disconnect.
+    }
+
+    /** ERROR plan — emits a JSON-RPC error body, NOT SSE framing.
+     *  Asserted via the public {@code render(plan)} which short-circuits
+     *  to {@code ServerResponse.status(...).body(...)} for ERROR kind. */
+    @Test
+    @DisplayName("ERROR plan → render() returns JSON-RPC error body, NOT SSE framing")
+    void errorPlan_returnsJsonRpcError() {
+        String errorBody = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32602,"
+            + "\"message\":\"Unknown task id: zzz\"},\"id\":1}";
+        MeshA2ADispatcher.SseStreamPlan plan = MeshA2ADispatcher.SseStreamPlan
+            .error(errorBody, org.springframework.http.HttpStatus.OK);
+        assertEquals(MeshA2ADispatcher.SseStreamPlan.Kind.ERROR, plan.kind);
+        // The render() path is mostly Spring plumbing — we assert on the
+        // plan shape itself, which the controller layer surfaces directly
+        // without SSE framing.
+        assertEquals(errorBody, plan.errorBody);
+        assertEquals(org.springframework.http.HttpStatus.OK, plan.errorStatus);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Reflection helpers — invoke the SSE dispatcher's private methods
+    // without standing up Spring's full SSE plumbing. Pattern mirrors
+    // MeshSseTest which also reaches into private fields via reflection.
+    // ─────────────────────────────────────────────────────────────────
+
+    private static void invokeRunLongRunningStream(
+            MeshA2ASseDispatcher sse, ServerResponse.SseBuilder builder,
+            Object reqId, String taskId, JobProxy proxy) throws Exception {
+        Method m = MeshA2ASseDispatcher.class.getDeclaredMethod(
+            "runLongRunningStream", ServerResponse.SseBuilder.class,
+            Object.class, String.class, JobProxy.class);
+        m.setAccessible(true);
+        m.invoke(sse, builder, reqId, taskId, proxy);
+    }
+
+    private static void invokeWriteFrame(
+            ServerResponse.SseBuilder builder, Map<String, Object> envelope) {
+        // For SINGLE_FRAME / SYNC_COMPLETED kinds we call the public
+        // dispatcher to serialize, then invoke builder.data() directly —
+        // that's exactly what writeFrame() does.
+        // Using the test's own dispatcher instance for serialization.
+        try {
+            MeshA2ASseDispatcher tmp = new MeshA2ASseDispatcher(
+                new MeshA2ADispatcher(
+                    new MeshA2ARegistry(), new MeshA2ATaskStore(),
+                    A2ATestFixtures.objectMapper(), A2ATestFixtures.emptyInjectorProvider()));
+            Method m = MeshA2ASseDispatcher.class.getDeclaredMethod(
+                "writeFrame", ServerResponse.SseBuilder.class, Map.class);
+            m.setAccessible(true);
+            m.invoke(tmp, builder, envelope);
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ASseDispatcherStreamTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ASseDispatcherStreamTest.java
@@ -345,6 +345,153 @@ class MeshA2ASseDispatcherStreamTest {
         verify(proxy, never()).cancel(any()); // critical: do NOT cancel on disconnect.
     }
 
+    /**
+     * Spec §4.4 conformance regression: transient {@code proxy.status()}
+     * failures during the SSE poll loop MUST NOT be treated as authoritative
+     * evidence the job is dead.
+     *
+     * <p>Before the fix, a single status() exception emitted a terminal
+     * {@code state=failed} frame AND called {@code dispatcher.markTaskTerminal},
+     * permanently poisoning the task store so subsequent {@code tasks/get}
+     * returned the cached failed envelope forever — even though the job
+     * may still have been running.
+     *
+     * <p>After the fix, transient failures surface as non-terminal
+     * {@code state=working} status frames carrying the error text in
+     * {@code status.message}, polling resumes when the proxy comes back, and
+     * {@code markTaskTerminal} is NEVER called for a transient failure.
+     */
+    @Test
+    @DisplayName("Transient proxy.status() failure → working frames, no terminal, polling resumes")
+    void longRunning_transientStatusFailure_doesNotPoisonTaskStore() throws Exception {
+        // Pre-park the task in the store with a non-terminal record so a
+        // hypothetical markTaskTerminal call would actually flip state we
+        // can observe (markTerminal is a no-op for unknown records).
+        String taskId = "t-transient";
+        taskStore.put(taskId, new MeshA2ATaskStore.TaskRecord(
+            taskId, null, null, null, null));
+
+        JobProxy proxy = mock(JobProxy.class);
+        AtomicInteger calls = new AtomicInteger(0);
+        // First 3 status() calls throw, 4th returns terminal completed so
+        // the loop exits cleanly without hitting the consecutive-failure cap.
+        when(proxy.status()).thenAnswer(inv -> {
+            int n = calls.getAndIncrement();
+            if (n < 3) {
+                throw new RuntimeException("transient registry blip #" + n);
+            }
+            return Map.of("status", "completed");
+        });
+        when(proxy.await(1.0)).thenReturn("eventual result");
+
+        CapturingBuilder cap = new CapturingBuilder();
+        invokeRunLongRunningStream(sseDispatcher, cap.mockBuilder, 1, taskId, proxy);
+
+        // Verify NO failed-terminal frame was emitted during the transient
+        // window. The only legitimate terminal frame in this test is the
+        // completed one at the end.
+        for (int i = 0; i < cap.dataFrames.size(); i++) {
+            JsonNode env = cap.parsed(i, mapper);
+            JsonNode result = env.get("result");
+            if (result == null) continue;
+            JsonNode statusNode = result.get("status");
+            JsonNode finalNode = result.get("final");
+            if (statusNode == null || finalNode == null) continue;
+            String state = statusNode.get("state").asText();
+            boolean isFinal = finalNode.asBoolean();
+            assertFalse(isFinal && "failed".equals(state),
+                "Transient status() failure MUST NOT emit a terminal state=failed frame; "
+                    + "frame[" + i + "]=" + cap.dataFrames.get(i));
+        }
+
+        // Verify at least one frame surfaced the transient error text inside
+        // a state=working (non-terminal) status.message — spec §4.4 contract.
+        boolean sawWorkingErrorFrame = false;
+        for (int i = 0; i < cap.dataFrames.size(); i++) {
+            JsonNode env = cap.parsed(i, mapper);
+            JsonNode result = env.get("result");
+            if (result == null) continue;
+            JsonNode statusNode = result.get("status");
+            if (statusNode == null) continue;
+            if (!"working".equals(statusNode.get("state").asText())) continue;
+            JsonNode message = statusNode.get("message");
+            if (message == null) continue;
+            String text = message.get("parts").get(0).get("text").asText();
+            if (text != null && text.contains("status unavailable")) {
+                sawWorkingErrorFrame = true;
+                assertTrue(env.get("result").get("final").isBoolean());
+                assertFalse(env.get("result").get("final").asBoolean(),
+                    "Transient-failure error frame MUST be non-terminal (final=false)");
+                break;
+            }
+        }
+        assertTrue(sawWorkingErrorFrame,
+            "Expected a state=working frame surfacing the transient error in status.message");
+
+        // Verify polling resumed and the proxy was queried at least 4 times
+        // (3 failures + 1 successful terminal). This proves the dispatcher
+        // did NOT bail after the first failure.
+        assertTrue(calls.get() >= 4,
+            "Polling MUST resume after transient failures; proxy.status() called "
+                + calls.get() + " time(s) — expected >= 4");
+
+        // Verify the task store record was NOT poisoned during the transient
+        // window. After the final completed status, the record should be
+        // marked terminal with the COMPLETED envelope, not a failed one.
+        MeshA2ATaskStore.TaskRecord finalRecord = taskStore.get(taskId);
+        assertNotNull(finalRecord, "Task record must still exist after the stream");
+        assertNotNull(finalRecord.terminalEnvelope(),
+            "Terminal envelope expected after the eventual completed status");
+        JsonNode finalEnv = mapper.valueToTree(finalRecord.terminalEnvelope());
+        assertEquals("completed", finalEnv.get("status").get("state").asText(),
+            "Stored terminal envelope MUST reflect the eventual completed state, "
+                + "NOT a poisoned failed envelope from the transient failure");
+    }
+
+    /**
+     * Defensive guard: when {@code proxy.status()} keeps failing past the
+     * {@link MeshA2ASseDispatcher#MAX_CONSECUTIVE_STATUS_FAILURES} threshold,
+     * the dispatcher gives up on the SSE stream but STILL does not poison
+     * the task store — clients can retry via {@code tasks/get}.
+     */
+    @Test
+    @DisplayName("Persistent proxy.status() failures → stream closes, task store NOT marked terminal")
+    void longRunning_persistentStatusFailure_preservesTaskStore() throws Exception {
+        String taskId = "t-persist";
+        taskStore.put(taskId, new MeshA2ATaskStore.TaskRecord(
+            taskId, null, null, null, null));
+
+        JobProxy proxy = mock(JobProxy.class);
+        when(proxy.status()).thenThrow(new RuntimeException("registry down"));
+
+        CapturingBuilder cap = new CapturingBuilder();
+        invokeRunLongRunningStream(sseDispatcher, cap.mockBuilder, 1, taskId, proxy);
+
+        // No failed-terminal frame should appear: even when we give up on
+        // the stream after MAX_CONSECUTIVE_STATUS_FAILURES, we do not claim
+        // the job is dead.
+        for (int i = 0; i < cap.dataFrames.size(); i++) {
+            JsonNode env = cap.parsed(i, mapper);
+            JsonNode result = env.get("result");
+            if (result == null) continue;
+            JsonNode finalNode = result.get("final");
+            JsonNode statusNode = result.get("status");
+            if (statusNode == null || finalNode == null) continue;
+            assertFalse(finalNode.asBoolean() && "failed".equals(statusNode.get("state").asText()),
+                "Persistent failure MUST NOT emit a terminal state=failed frame");
+        }
+
+        // Task store record MUST stay non-terminal so subsequent tasks/get
+        // can resume polling normally.
+        MeshA2ATaskStore.TaskRecord record = taskStore.get(taskId);
+        assertNotNull(record);
+        assertNull(record.terminalAt(),
+            "Persistent status() failures MUST NOT mark the task store terminal "
+                + "(spec §4.4: transient unreachability is not job death)");
+        assertNull(record.terminalEnvelope(),
+            "Persistent status() failures MUST leave terminalEnvelope null");
+    }
+
     /** ERROR plan — emits a JSON-RPC error body, NOT SSE framing.
      *  Asserted via the public {@code render(plan)} which short-circuits
      *  to {@code ServerResponse.status(...).body(...)} for ERROR kind. */

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ASseDispatcherTimingTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ASseDispatcherTimingTest.java
@@ -1,0 +1,67 @@
+package io.mcpmesh.spring.web;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Timing-related assertions for {@link MeshA2ASseDispatcher} (spec §4.6
+ * poll cadence, spec §5.1 keepalive interval).
+ *
+ * <h2>Status: constants-only assertions for now</h2>
+ *
+ * <p>The exact poll cadence (1s) and keepalive interval (15s) are encoded
+ * as {@code public static final long} constants on {@link MeshA2ASseDispatcher}.
+ * Asserting wall-clock <em>behavior</em> would require either:
+ * <ol>
+ *   <li>Standing up a real 15-second sleep — flaky and slow for a unit
+ *       test suite that targets sub-second runs;</li>
+ *   <li>Injecting a {@link java.time.Clock} or a sleep abstraction into
+ *       the dispatcher — a small but production-touching refactor.</li>
+ * </ol>
+ *
+ * <p>This chunk is "verify, don't modify" per task spec. We therefore
+ * assert that the constants match the canonical values from the spec
+ * here, and observe the qualitative behavior (only-on-change emission,
+ * disconnect-safe loop exit) in {@link MeshA2ASseDispatcherStreamTest}.
+ *
+ * <h3>Follow-up</h3>
+ *
+ * <p>If we want wall-clock timing assertions in CI, the smallest
+ * production change is to extract a package-private
+ * {@code Clock + Sleeper} pair on {@link MeshA2ASseDispatcher} that
+ * defaults to {@code Clock.systemUTC()} + {@code Thread::sleep}. Tests
+ * could then inject a fake clock + count-based sleeper. Tracked
+ * separately (Chunk 1C follow-up issue).
+ */
+@DisplayName("MeshA2ASseDispatcher — timing constants (spec §4.6 / §5.1)")
+class MeshA2ASseDispatcherTimingTest {
+
+    /** Spec §4.6 sequence diagram: producer polls JobProxy.status every 1s. */
+    @Test
+    @DisplayName("POLL_INTERVAL_MILLIS = 1000L (spec §4.6 sequence diagram)")
+    void pollCadenceConstant() {
+        assertEquals(1000L, MeshA2ASseDispatcher.POLL_INTERVAL_MILLIS,
+            "Spec §4.6 sequence diagram specifies a 1-second poll cadence — "
+                + "MUST match for cross-runtime parity with Python's _STATUS_POLL_SECS = 1");
+    }
+
+    /** Spec §5.1: SSE comment frames emitted every 15s of inactivity. */
+    @Test
+    @DisplayName("KEEPALIVE_MILLIS = 15_000L (spec §5.1)")
+    void keepaliveIntervalConstant() {
+        assertEquals(15_000L, MeshA2ASseDispatcher.KEEPALIVE_MILLIS,
+            "Spec §5.1 specifies 15s keepalive interval — MUST match for parity "
+                + "with Python's _SSE_KEEPALIVE_SECS = 15");
+    }
+
+    /** Defensive max-stream cap — production cuts streams off after 1h. */
+    @Test
+    @DisplayName("MAX_STREAM_MILLIS = 1 hour (defensive cap)")
+    void maxStreamCapConstant() {
+        assertEquals(60L * 60_000L, MeshA2ASseDispatcher.MAX_STREAM_MILLIS,
+            "Defensive 1-hour cap protects a worker thread from being pinned "
+                + "indefinitely by a stuck job");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ASseHeaderFilterTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ASseHeaderFilterTest.java
@@ -1,0 +1,163 @@
+package io.mcpmesh.spring.web;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link MeshA2ASseHeaderFilter} — the SSE buffering-hints
+ * filter (spec §4.6 / §5.1).
+ *
+ * <p>The filter looks at the request's {@code Accept} header. When the
+ * client asks for {@code text/event-stream}, the filter stamps the three
+ * SSE-friendly headers per spec §4.6 / §5.1:
+ * <ul>
+ *   <li>{@code Cache-Control: no-cache}</li>
+ *   <li>{@code X-Accel-Buffering: no}</li>
+ *   <li>{@code Connection: keep-alive}</li>
+ * </ul>
+ *
+ * <p>Non-SSE requests (e.g., {@code Accept: application/json} or no Accept
+ * header at all) MUST NOT have these headers stamped — curl-style sync
+ * clients see the regular JSON-RPC response.
+ *
+ * <p>Uses Spring's {@link MockHttpServletRequest} / {@link MockHttpServletResponse}
+ * — same idiom Spring Boot's own tests use for filter-level coverage.
+ */
+@DisplayName("MeshA2ASseHeaderFilter — SSE buffering hints (spec §4.6 / §5.1)")
+class MeshA2ASseHeaderFilterTest {
+
+    private MeshA2ASseHeaderFilter filter;
+    private FilterChain chain;
+    private AtomicInteger chainInvocations;
+
+    @BeforeEach
+    void setUp() {
+        filter = new MeshA2ASseHeaderFilter();
+        chainInvocations = new AtomicInteger(0);
+        chain = (req, resp) -> chainInvocations.incrementAndGet();
+    }
+
+    /** Spec §4.6 / §5.1: Accept: text/event-stream → three SSE headers stamped. */
+    @Test
+    @DisplayName("Accept: text/event-stream → stamps Cache-Control, X-Accel-Buffering, Connection")
+    void sseAccept_stampsAllThreeHeaders() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/agents/x");
+        req.addHeader("Accept", "text/event-stream");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+
+        invokeDoFilter(filter, req, resp, chain);
+
+        assertEquals("no-cache", resp.getHeader("Cache-Control"),
+            "Spec §4.6: SSE responses MUST set Cache-Control: no-cache");
+        assertEquals("no", resp.getHeader("X-Accel-Buffering"),
+            "Spec §4.6: X-Accel-Buffering: no defeats nginx response buffering");
+        assertEquals("keep-alive", resp.getHeader("Connection"),
+            "Spec §4.6: Connection: keep-alive preserves the long-lived stream");
+        assertEquals(1, chainInvocations.get(),
+            "Filter MUST always invoke the chain — not a short-circuit");
+    }
+
+    /** Spec §4.6: Accept: application/json → NO SSE headers stamped. */
+    @Test
+    @DisplayName("Accept: application/json → does NOT stamp SSE headers")
+    void jsonAccept_doesNotStampHeaders() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/agents/x");
+        req.addHeader("Accept", "application/json");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+
+        invokeDoFilter(filter, req, resp, chain);
+
+        assertNull(resp.getHeader("Cache-Control"));
+        assertNull(resp.getHeader("X-Accel-Buffering"));
+        assertNull(resp.getHeader("Connection"));
+        assertEquals(1, chainInvocations.get());
+    }
+
+    /** Spec §4.6: Missing Accept header → NO SSE headers (filter only
+     *  stamps when client explicitly opted into SSE). */
+    @Test
+    @DisplayName("Missing Accept header → does NOT stamp SSE headers")
+    void missingAccept_doesNotStampHeaders() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/agents/x");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+
+        invokeDoFilter(filter, req, resp, chain);
+
+        assertNull(resp.getHeader("Cache-Control"));
+        assertNull(resp.getHeader("X-Accel-Buffering"));
+        assertNull(resp.getHeader("Connection"));
+        assertEquals(1, chainInvocations.get());
+    }
+
+    /** Defensive: Accept header that CONTAINS text/event-stream (with
+     *  qualifier or multi-type list) still triggers stamping — the filter
+     *  uses {@code String.contains} semantics. */
+    @Test
+    @DisplayName("Accept header containing text/event-stream (with q-value) still stamps headers")
+    void sseAcceptWithQValue_stampsHeaders() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/agents/x");
+        req.addHeader("Accept", "text/event-stream;q=1.0, application/json;q=0.5");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+
+        invokeDoFilter(filter, req, resp, chain);
+
+        assertEquals("no-cache", resp.getHeader("Cache-Control"),
+            "Multi-type Accept that includes text/event-stream MUST trigger SSE header stamping");
+    }
+
+    /** Wrong media type — does NOT stamp. Guards against false positives. */
+    @Test
+    @DisplayName("Accept: text/plain → does NOT stamp SSE headers (only event-stream triggers)")
+    void plainTextAccept_doesNotStampHeaders() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/agents/x");
+        req.addHeader("Accept", "text/plain");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+
+        invokeDoFilter(filter, req, resp, chain);
+
+        assertNull(resp.getHeader("Cache-Control"),
+            "Only Accept containing 'text/event-stream' triggers the SSE-headers branch");
+    }
+
+    /** Filter always invokes the chain — never short-circuits, even when
+     *  it doesn't stamp headers. */
+    @Test
+    @DisplayName("Filter always invokes the chain, regardless of Accept value")
+    void chainAlwaysInvoked() throws Exception {
+        for (String accept : new String[]{
+                "text/event-stream", "application/json", "*/*", "weird-thing"}) {
+            chainInvocations.set(0);
+            MockHttpServletRequest req = new MockHttpServletRequest("POST", "/agents/x");
+            if (accept != null) req.addHeader("Accept", accept);
+            invokeDoFilter(filter, req, new MockHttpServletResponse(), chain);
+            assertEquals(1, chainInvocations.get(),
+                "Filter MUST invoke chain for Accept='" + accept + "'");
+        }
+    }
+
+    /** {@link MeshA2ASseHeaderFilter#doFilterInternal} is protected (inherited
+     *  from {@code OncePerRequestFilter}). Use reflection to invoke it directly
+     *  so we don't need to register the filter into a real chain. */
+    private static void invokeDoFilter(
+            MeshA2ASseHeaderFilter filter,
+            MockHttpServletRequest req,
+            MockHttpServletResponse resp,
+            FilterChain chain) throws Exception {
+        Method m = MeshA2ASseHeaderFilter.class.getDeclaredMethod(
+            "doFilterInternal",
+            jakarta.servlet.http.HttpServletRequest.class,
+            jakarta.servlet.http.HttpServletResponse.class,
+            FilterChain.class);
+        m.setAccessible(true);
+        m.invoke(filter, req, resp, chain);
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ASseHeaderFilterTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ASseHeaderFilterTest.java
@@ -144,6 +144,95 @@ class MeshA2ASseHeaderFilterTest {
         }
     }
 
+    /** Case-insensitive Accept value still triggers the SSE branch. The
+     *  HTTP spec says media types are case-insensitive; a raw
+     *  {@code String.contains("text/event-stream")} would miss
+     *  {@code TEXT/EVENT-STREAM}, but {@code MediaType.parseMediaTypes}
+     *  normalises case. */
+    @Test
+    @DisplayName("Accept: TEXT/EVENT-STREAM (uppercase) → stamps SSE headers")
+    void uppercaseAccept_stampsHeaders() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/agents/x");
+        req.addHeader("Accept", "TEXT/EVENT-STREAM");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+
+        invokeDoFilter(filter, req, resp, chain);
+
+        assertEquals("no-cache", resp.getHeader("Cache-Control"),
+            "Media types are case-insensitive per HTTP spec");
+        assertEquals(1, chainInvocations.get());
+    }
+
+    /** Accept with charset parameter → still stamps. The MediaType parser
+     *  knows {@code text/event-stream;charset=UTF-8} is compatible with
+     *  bare {@code text/event-stream}. */
+    @Test
+    @DisplayName("Accept: text/event-stream;charset=UTF-8 → stamps SSE headers")
+    void acceptWithCharsetParam_stampsHeaders() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/agents/x");
+        req.addHeader("Accept", "text/event-stream;charset=UTF-8");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+
+        invokeDoFilter(filter, req, resp, chain);
+
+        assertEquals("no-cache", resp.getHeader("Cache-Control"));
+    }
+
+    /** Compound Accept value listing JSON first then SSE → still stamps. The
+     *  order of media types in Accept does NOT affect compatibility; the
+     *  filter only checks "does any listed type accept SSE". */
+    @Test
+    @DisplayName("Accept: application/json, text/event-stream → stamps SSE headers")
+    void compoundAcceptWithJsonFirst_stampsHeaders() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/agents/x");
+        req.addHeader("Accept", "application/json, text/event-stream");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+
+        invokeDoFilter(filter, req, resp, chain);
+
+        assertEquals("no-cache", resp.getHeader("Cache-Control"),
+            "Compound Accept that includes SSE among its entries MUST trigger stamping");
+    }
+
+    /** Malformed Accept header → defensive substring fallback still works for
+     *  the common case. We never want a stray invalid header to drop a
+     *  legitimate SSE client. */
+    @Test
+    @DisplayName("Malformed Accept header containing 'text/event-stream' still stamps via fallback")
+    void malformedAcceptWithSubstring_stillStamps() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/agents/x");
+        // Intentionally malformed (unbalanced quote) — MediaType.parseMediaTypes
+        // throws InvalidMimeTypeException, we fall back to a lowercase substring
+        // check.
+        req.addHeader("Accept", "\"text/event-stream");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+
+        invokeDoFilter(filter, req, resp, chain);
+
+        assertEquals("no-cache", resp.getHeader("Cache-Control"),
+            "Malformed Accept should not drop legitimate SSE clients");
+    }
+
+    /** Direct unit tests of {@code acceptsEventStream} — pure helper, no
+     *  filter chain machinery. */
+    @Test
+    @DisplayName("acceptsEventStream() helper — case + compound + null + blank coverage")
+    void acceptsEventStreamHelperCoverage() {
+        assertTrue(MeshA2ASseHeaderFilter.acceptsEventStream("text/event-stream"));
+        assertTrue(MeshA2ASseHeaderFilter.acceptsEventStream("TEXT/EVENT-STREAM"));
+        assertTrue(MeshA2ASseHeaderFilter.acceptsEventStream(
+            "text/event-stream;charset=UTF-8"));
+        assertTrue(MeshA2ASseHeaderFilter.acceptsEventStream(
+            "application/json, text/event-stream"));
+        assertTrue(MeshA2ASseHeaderFilter.acceptsEventStream(
+            "text/event-stream;q=1.0, application/json;q=0.5"));
+        assertFalse(MeshA2ASseHeaderFilter.acceptsEventStream("application/json"));
+        assertFalse(MeshA2ASseHeaderFilter.acceptsEventStream("text/plain"));
+        assertFalse(MeshA2ASseHeaderFilter.acceptsEventStream(""));
+        assertFalse(MeshA2ASseHeaderFilter.acceptsEventStream("   "));
+        assertFalse(MeshA2ASseHeaderFilter.acceptsEventStream(null));
+    }
+
     /** {@link MeshA2ASseHeaderFilter#doFilterInternal} is protected (inherited
      *  from {@code OncePerRequestFilter}). Use reflection to invoke it directly
      *  so we don't need to register the filter into a real chain. */

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AStateTranslatorTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AStateTranslatorTest.java
@@ -1,0 +1,174 @@
+package io.mcpmesh.spring.web;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link MeshA2AStateTranslator} (spec §7.2).
+ *
+ * <p>This is the boundary between the mesh job substrate (UK-spelled
+ * {@code cancelled}) and A2A v1.0 (US-spelled {@code canceled}). The
+ * translator must:
+ * <ul>
+ *   <li>map every mesh status to one of the four enumerated A2A states;</li>
+ *   <li>translate {@code cancelled} → {@code canceled} (spec Appendix B item);</li>
+ *   <li>never return an A2A state outside the enumerated set, even on
+ *       unknown / null input (fall back to {@code working}).</li>
+ * </ul>
+ */
+@DisplayName("MeshA2AStateTranslator — mesh status ↔ A2A state mapping (spec §7.2)")
+class MeshA2AStateTranslatorTest {
+
+    /**
+     * Spec §7.2 mapping table — every mesh status must produce the
+     * enumerated A2A state, including the UK→US "cancelled" → "canceled"
+     * boundary explicitly called out in spec Appendix B.
+     */
+    @ParameterizedTest(name = "fromMesh(\"{0}\") = \"{1}\"")
+    @CsvSource({
+        "working,    working",
+        "completed,  completed",
+        "failed,     failed",
+        "cancelled,  canceled",   // UK→US boundary — spec Appendix B item
+        "canceled,   canceled"    // Already US-spelled (defensive identity)
+    })
+    void fromMesh_translatesAllKnownStatuses(String meshStatus, String expectedA2A) {
+        assertEquals(expectedA2A, MeshA2AStateTranslator.fromMesh(meshStatus),
+            "Mesh status '" + meshStatus + "' should map to A2A '" + expectedA2A + "'");
+    }
+
+    /** Spec §7.2: null input falls back to {@code working}. */
+    @Test
+    @DisplayName("fromMesh(null) falls back to 'working' (spec §7.2 default)")
+    void fromMesh_nullFallsBackToWorking() {
+        assertEquals("working", MeshA2AStateTranslator.fromMesh(null));
+    }
+
+    /** Spec §7.2: empty string treated as missing. */
+    @Test
+    @DisplayName("fromMesh(\"\") falls back to 'working' (spec §7.2 default)")
+    void fromMesh_emptyFallsBackToWorking() {
+        assertEquals("working", MeshA2AStateTranslator.fromMesh(""));
+    }
+
+    /** Spec §7.2: unknown mesh state falls back to working — never emit out-of-enum. */
+    @ParameterizedTest(name = "fromMesh(\"{0}\") falls back to 'working'")
+    @CsvSource({
+        "pending",       // Mesh state we haven't mapped to A2A
+        "running",       // Synonym for working in some runtimes — still fallback
+        "cancelling",    // Mid-cancellation transitional state
+        "unknown",
+        "BANANA",        // Total garbage
+        "WORKING"        // Wrong case — switch is case-sensitive
+    })
+    void fromMesh_unknownFallsBackToWorking(String unknownState) {
+        assertEquals("working", MeshA2AStateTranslator.fromMesh(unknownState),
+            "Unknown mesh status '" + unknownState + "' must fall back to 'working' "
+                + "to preserve the spec §7.2 invariant: emitted state ∈ "
+                + "{working, completed, failed, canceled}");
+    }
+
+    /** Constants must literally be the A2A v1.0 wire values. */
+    @Test
+    @DisplayName("A2A state constants match spec §7.1 exactly")
+    void constants_matchSpec() {
+        assertEquals("working", MeshA2AStateTranslator.A2A_WORKING);
+        assertEquals("completed", MeshA2AStateTranslator.A2A_COMPLETED);
+        assertEquals("failed", MeshA2AStateTranslator.A2A_FAILED);
+        // The whole point: US spelling (no second 'l').
+        assertEquals("canceled", MeshA2AStateTranslator.A2A_CANCELED);
+        assertNotEquals("cancelled", MeshA2AStateTranslator.A2A_CANCELED,
+            "A2A_CANCELED must be US-spelled 'canceled' (one 'l'), NOT UK 'cancelled'");
+    }
+
+    /** Spec §5.3: terminal states are the three end-of-task A2A states. */
+    @Test
+    @DisplayName("isTerminal returns true only for completed/failed/canceled")
+    void isTerminal_recognisesAllThreeTerminalStates() {
+        assertTrue(MeshA2AStateTranslator.isTerminal("completed"));
+        assertTrue(MeshA2AStateTranslator.isTerminal("failed"));
+        assertTrue(MeshA2AStateTranslator.isTerminal("canceled"));
+    }
+
+    /** isTerminal is strict: working and unknowns are NOT terminal. */
+    @Test
+    @DisplayName("isTerminal returns false for working / null / unknown / UK 'cancelled'")
+    void isTerminal_rejectsNonTerminalAndUkSpelling() {
+        assertFalse(MeshA2AStateTranslator.isTerminal("working"));
+        assertFalse(MeshA2AStateTranslator.isTerminal(null));
+        assertFalse(MeshA2AStateTranslator.isTerminal(""));
+        assertFalse(MeshA2AStateTranslator.isTerminal("submitted"));
+        // isTerminal operates on A2A states (US spelling); UK 'cancelled'
+        // is NOT a valid A2A state and must not be recognised here. The
+        // mesh-side check is via isMeshTerminal.
+        assertFalse(MeshA2AStateTranslator.isTerminal("cancelled"),
+            "isTerminal checks A2A states — UK 'cancelled' must NOT match");
+    }
+
+    /** isMeshTerminal accepts BOTH UK + US spellings because the mesh
+     *  substrate emits UK and the normalizer might already have translated. */
+    @Test
+    @DisplayName("isMeshTerminal accepts both UK ('cancelled') and US ('canceled')")
+    void isMeshTerminal_acceptsBothSpellings() {
+        assertTrue(MeshA2AStateTranslator.isMeshTerminal("completed"));
+        assertTrue(MeshA2AStateTranslator.isMeshTerminal("failed"));
+        assertTrue(MeshA2AStateTranslator.isMeshTerminal("cancelled"));  // UK
+        assertTrue(MeshA2AStateTranslator.isMeshTerminal("canceled"));   // US
+        assertFalse(MeshA2AStateTranslator.isMeshTerminal("working"));
+        assertFalse(MeshA2AStateTranslator.isMeshTerminal(null));
+        assertFalse(MeshA2AStateTranslator.isMeshTerminal("pending"));
+    }
+
+    /** meshStatusOf reads the 'status' key from a {@code JobProxy.status()} payload. */
+    @Test
+    @DisplayName("meshStatusOf extracts 'status' field from JobProxy status payload")
+    void meshStatusOf_extractsStatusField() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("status", "working");
+        payload.put("progress", 0.5);
+        assertEquals("working", MeshA2AStateTranslator.meshStatusOf(payload));
+    }
+
+    /** meshStatusOf returns null when the payload has no status key — caller
+     *  then defaults to A2A 'working' via fromMesh(null). */
+    @Test
+    @DisplayName("meshStatusOf returns null for null / empty / missing 'status' key")
+    void meshStatusOf_returnsNullWhenAbsent() {
+        assertNull(MeshA2AStateTranslator.meshStatusOf(null));
+        assertNull(MeshA2AStateTranslator.meshStatusOf(new HashMap<>()));
+        Map<String, Object> noStatus = new HashMap<>();
+        noStatus.put("progress", 0.5);
+        assertNull(MeshA2AStateTranslator.meshStatusOf(noStatus));
+    }
+
+    /** meshStatusOf coerces non-string status values via toString — defensive
+     *  against runtimes that emit an enum or symbol. */
+    @Test
+    @DisplayName("meshStatusOf coerces non-string status values via toString()")
+    void meshStatusOf_coercesNonString() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("status", 42); // Unexpected, but don't crash.
+        assertEquals("42", MeshA2AStateTranslator.meshStatusOf(payload));
+    }
+
+    /** End-to-end: meshStatusOf + fromMesh chained — the canonical
+     *  consumer flow inside the dispatcher. */
+    @Test
+    @DisplayName("Pipeline: meshStatusOf + fromMesh handles UK 'cancelled' end-to-end")
+    void pipeline_cancelledMeshStatusBecomesCanceledA2AState() {
+        Map<String, Object> meshPayload = new HashMap<>();
+        meshPayload.put("status", "cancelled");  // UK from mesh substrate
+        String meshState = MeshA2AStateTranslator.meshStatusOf(meshPayload);
+        String a2aState = MeshA2AStateTranslator.fromMesh(meshState);
+        assertEquals("canceled", a2aState,
+            "End-to-end pipeline must translate UK 'cancelled' to US 'canceled' "
+                + "at the producer boundary (spec Appendix B)");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ATaskStoreLongRunningTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ATaskStoreLongRunningTest.java
@@ -1,0 +1,227 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.JobProxy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link MeshA2ATaskStore} focused on the long-running
+ * (Chunk 1B) paths (spec §4.8 / Appendix B item 5).
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>{@link MeshA2ATaskStore#markTerminal} idempotency (spec §4.5
+ *       "Idempotent; best-effort").</li>
+ *   <li>{@link JobProxy} slot survives put/get cycles by reference.</li>
+ *   <li>Eviction sweep — terminal records evicted past
+ *       {@link MeshA2ATaskStore#TERMINAL_EVICTION_MILLIS}, non-terminal
+ *       records never evicted.</li>
+ *   <li>{@code TERMINAL_EVICTION_MILLIS} constant matches Python's
+ *       {@code _TERMINAL_GRACE_SECS = 300} (cross-runtime parity per spec
+ *       Appendix B item 5).</li>
+ * </ul>
+ */
+@DisplayName("MeshA2ATaskStore — long-running paths (spec §4.8)")
+class MeshA2ATaskStoreLongRunningTest {
+
+    private MeshA2ATaskStore store;
+
+    @BeforeEach
+    void setUp() {
+        store = new MeshA2ATaskStore();
+    }
+
+    /** Spec Appendix B item 5: Python's {@code _TERMINAL_GRACE_SECS = 300}.
+     *  Java MUST use the same window for cross-runtime parity. */
+    @Test
+    @DisplayName("TERMINAL_EVICTION_MILLIS = 300_000L (Python parity, Appendix B item 5)")
+    void evictionWindowMatchesPython() {
+        assertEquals(300_000L, MeshA2ATaskStore.TERMINAL_EVICTION_MILLIS,
+            "Eviction window must equal Python's _TERMINAL_GRACE_SECS (300s) "
+                + "for cross-runtime parity — spec Appendix B item 5");
+    }
+
+    /** Idempotent ack per spec §4.5: calling markTerminal twice with a
+     *  different envelope MUST NOT replace the cached envelope after the
+     *  first call. */
+    @Test
+    @DisplayName("markTerminal is idempotent — second call does NOT replace the cached envelope")
+    void markTerminal_idempotent() {
+        store.put("t-1", new MeshA2ATaskStore.TaskRecord(
+            "t-1", null, null, null, null));
+
+        Map<String, Object> firstEnvelope = new LinkedHashMap<>();
+        firstEnvelope.put("state", "completed");
+        firstEnvelope.put("token", "FIRST");
+
+        Map<String, Object> secondEnvelope = new LinkedHashMap<>();
+        secondEnvelope.put("state", "failed");
+        secondEnvelope.put("token", "SECOND");
+
+        MeshA2ATaskStore.TaskRecord r1 = store.markTerminal("t-1", firstEnvelope);
+        MeshA2ATaskStore.TaskRecord r2 = store.markTerminal("t-1", secondEnvelope);
+
+        assertNotNull(r1, "first markTerminal call must return the now-terminal record");
+        assertNotNull(r2, "second call still returns a record (the cached one)");
+        assertEquals("FIRST", r2.terminalEnvelope().get("token"),
+            "Second markTerminal call MUST be idempotent: cached envelope "
+                + "from the first call survives unchanged (spec §4.5)");
+        // The terminalAt timestamp also must not move on the second call —
+        // it stamps "when this task first entered terminal state".
+        assertEquals(r1.terminalAt(), r2.terminalAt(),
+            "terminalAt timestamp MUST be stamped on first transition only");
+    }
+
+    /** markTerminal returns null when the task id is unknown — caller
+     *  decides what to do (synthesize? log?). */
+    @Test
+    @DisplayName("markTerminal returns null for unknown task id")
+    void markTerminal_unknownTaskReturnsNull() {
+        Map<String, Object> envelope = new LinkedHashMap<>();
+        envelope.put("state", "completed");
+        assertNull(store.markTerminal("no-such-id", envelope));
+    }
+
+    /** JobProxy slot must survive put/get by reference equality — the
+     *  store does not clone or wrap the proxy handle, because the SSE
+     *  poll loop needs the original handle to make FFI calls on. */
+    @Test
+    @DisplayName("JobProxy slot survives put/get by reference equality")
+    void jobProxySlotSurvivesByReference() {
+        JobProxy proxy = mock(JobProxy.class);
+        store.put("t-proxy", new MeshA2ATaskStore.TaskRecord(
+            "t-proxy", null, null, null, proxy));
+
+        MeshA2ATaskStore.TaskRecord fetched = store.get("t-proxy");
+        assertNotNull(fetched);
+        // Reference equality (==) not Object.equals — the SSE adapter
+        // relies on the exact same FFI handle being preserved.
+        assertSame(proxy, fetched.jobProxy(),
+            "JobProxy slot MUST round-trip by reference — the SSE loop "
+                + "calls status()/await()/cancel() on the original handle");
+    }
+
+    /** Non-terminal records have terminalAt=null and MUST never be
+     *  evicted regardless of how old they are. Long-running tasks can
+     *  legitimately run for hours. */
+    @Test
+    @DisplayName("Eviction sweep does NOT evict non-terminal records, regardless of age")
+    void sweep_doesNotEvictNonTerminalRecords() throws Exception {
+        store.put("alive", new MeshA2ATaskStore.TaskRecord(
+            "alive", null, null, null, mock(JobProxy.class)));
+        store.put("terminal-old", new MeshA2ATaskStore.TaskRecord(
+            "terminal-old",
+            null,
+            Map.of("state", "completed"),
+            System.currentTimeMillis() - MeshA2ATaskStore.TERMINAL_EVICTION_MILLIS - 10_000L,
+            null));
+
+        // Mix of long-lived non-terminal + ancient terminal — sweep on
+        // next access should keep the alive one.
+        assertTrue(store.contains("alive"),
+            "Non-terminal record must survive eviction sweep");
+        assertFalse(store.contains("terminal-old"),
+            "Terminal record older than eviction window must be evicted");
+    }
+
+    /** Eviction sweep DOES evict terminal records past the 300s window. */
+    @Test
+    @DisplayName("Eviction sweep evicts terminal records older than 300s")
+    void sweep_evictsExpiredTerminalRecords() {
+        // 5 minutes + 1 second = past the window
+        long pastWindow = System.currentTimeMillis()
+            - MeshA2ATaskStore.TERMINAL_EVICTION_MILLIS - 1_000L;
+        store.put("dead", new MeshA2ATaskStore.TaskRecord(
+            "dead", null, Map.of("state", "completed"), pastWindow, null));
+
+        // Trigger sweep via any access.
+        assertNull(store.get("dead"),
+            "Expired terminal record must be evicted on next access");
+        assertEquals(0, store.size());
+    }
+
+    /** Eviction sweep KEEPS terminal records within the 300s window —
+     *  this is the idempotency grace for duplicate task ids (spec §4.3). */
+    @Test
+    @DisplayName("Eviction sweep keeps terminal records within the 300s window")
+    void sweep_keepsRecentTerminalRecords() {
+        // Just terminated — well inside the window.
+        long justNow = System.currentTimeMillis() - 100L;
+        store.put("recent", new MeshA2ATaskStore.TaskRecord(
+            "recent", null, Map.of("state", "completed"), justNow, null));
+
+        assertTrue(store.contains("recent"),
+            "Terminal record within eviction window MUST be retained — "
+                + "spec §4.3 idempotency grace for duplicate task ids");
+        assertEquals(1, store.size());
+    }
+
+    /** markTerminal stamps terminalAt to the current wall clock so the
+     *  300s window starts from the transition, not from put-time. */
+    @Test
+    @DisplayName("markTerminal stamps terminalAt to System.currentTimeMillis()")
+    void markTerminal_stampsTerminalAtToNow() {
+        store.put("t-stamp", new MeshA2ATaskStore.TaskRecord(
+            "t-stamp", null, null, null, null));
+
+        long before = System.currentTimeMillis();
+        MeshA2ATaskStore.TaskRecord terminal = store.markTerminal(
+            "t-stamp", Map.of("state", "completed"));
+        long after = System.currentTimeMillis();
+
+        assertNotNull(terminal);
+        assertNotNull(terminal.terminalAt());
+        assertTrue(terminal.terminalAt() >= before && terminal.terminalAt() <= after,
+            "terminalAt must be stamped to wall clock at transition time");
+    }
+
+    /** put() also triggers a sweep — proves the lazy-sweep contract is
+     *  honoured on every entry point (not just on get/contains). */
+    @Test
+    @DisplayName("put() triggers eviction sweep (lazy sweep on every access)")
+    void put_triggersEvictionSweep() throws Exception {
+        // Pre-populate with an already-expired terminal record via reflection
+        // so we observe the sweep on the next put().
+        long expired = System.currentTimeMillis()
+            - MeshA2ATaskStore.TERMINAL_EVICTION_MILLIS - 1_000L;
+        Field f = MeshA2ATaskStore.class.getDeclaredField("store");
+        f.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        ConcurrentHashMap<String, MeshA2ATaskStore.TaskRecord> raw =
+            (ConcurrentHashMap<String, MeshA2ATaskStore.TaskRecord>) f.get(store);
+        raw.put("zombie", new MeshA2ATaskStore.TaskRecord(
+            "zombie", null, Map.of("state", "completed"), expired, null));
+
+        // size() triggers sweep, so we need to bypass — direct map read
+        assertEquals(1, raw.size(), "Pre-condition: zombie record in raw map");
+        // Now put a new record; the lazy sweep inside put() should evict the zombie.
+        store.put("fresh", new MeshA2ATaskStore.TaskRecord(
+            "fresh", null, null, null, null));
+        assertNull(store.get("zombie"),
+            "put() must trigger eviction sweep — expired zombie record gone");
+        assertTrue(store.contains("fresh"));
+    }
+
+    /** Two-arg TaskRecord constructor exists for backward compatibility with
+     *  Chunk 1A sync-only call sites. Validates the convenience overload
+     *  produces a record with {@code jobProxy=null}. */
+    @Test
+    @DisplayName("Chunk 1A 4-arg TaskRecord constructor still produces a valid record (jobProxy=null)")
+    void taskRecordConvenienceCtorWorks() {
+        MeshA2ATaskStore.TaskRecord r = new MeshA2ATaskStore.TaskRecord(
+            "session-1", null, Map.of("k", "v"), 12345L);
+        assertNull(r.jobProxy(),
+            "Convenience constructor must set jobProxy=null for sync records");
+        assertEquals("session-1", r.sessionId());
+        assertEquals(12345L, r.terminalAt());
+    }
+}

--- a/tests/integration/suites/uc28_a2a_producer_java/artifacts/consumer-date-agent
+++ b/tests/integration/suites/uc28_a2a_producer_java/artifacts/consumer-date-agent
@@ -1,0 +1,1 @@
+../fixtures/consumer-date-agent

--- a/tests/integration/suites/uc28_a2a_producer_java/artifacts/long-task-provider
+++ b/tests/integration/suites/uc28_a2a_producer_java/artifacts/long-task-provider
@@ -1,0 +1,1 @@
+../fixtures/long-task-provider

--- a/tests/integration/suites/uc28_a2a_producer_java/artifacts/producer-date-agent-java
+++ b/tests/integration/suites/uc28_a2a_producer_java/artifacts/producer-date-agent-java
@@ -1,0 +1,1 @@
+../fixtures/producer-date-agent-java

--- a/tests/integration/suites/uc28_a2a_producer_java/artifacts/producer-date-auth-agent-java
+++ b/tests/integration/suites/uc28_a2a_producer_java/artifacts/producer-date-auth-agent-java
@@ -1,0 +1,1 @@
+../fixtures/producer-date-auth-agent-java

--- a/tests/integration/suites/uc28_a2a_producer_java/artifacts/producer-report-agent-java
+++ b/tests/integration/suites/uc28_a2a_producer_java/artifacts/producer-report-agent-java
@@ -1,0 +1,1 @@
+../fixtures/producer-report-agent-java

--- a/tests/integration/suites/uc28_a2a_producer_java/artifacts/system-agent
+++ b/tests/integration/suites/uc28_a2a_producer_java/artifacts/system-agent
@@ -1,0 +1,1 @@
+../fixtures/system-agent

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/consumer-date-agent/main.py
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/consumer-date-agent/main.py
@@ -1,0 +1,1 @@
+../../../../../../examples/a2a/consumer_date_agent.py

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/long-task-provider/main.py
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/long-task-provider/main.py
@@ -1,0 +1,1 @@
+../../../../../../examples/jobs/long-task-provider/main.py

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  uc28_a2a_producer_java fixture — Java A2A producer (issue #932 Chunk 1C).
+  Sync producer: @MeshA2A method exposes the get-date skill via the A2A
+  v1.0 protocol surface, depending on the existing date_service mesh
+  capability (provided by examples/simple/system_agent.py).
+
+  Mirrors examples/a2a/date_a2a_agent.py shape: same path
+  (/agents/date), same skill id (get-date), same artifact shape
+  ({"date": "<value>"} JSON-stringified into parts[0].text).
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>producer-date-agent-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>A2A Producer Date Agent (uc28 Java)</name>
+    <description>uc28 Java A2A producer fixture — exposes the get-date skill via @MeshA2A.</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.dateproducerjava.ProducerDateAgentApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/src/main/java/com/example/dateproducerjava/ProducerDateAgentApplication.java
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/src/main/java/com/example/dateproducerjava/ProducerDateAgentApplication.java
@@ -1,0 +1,67 @@
+package com.example.dateproducerjava;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.spring.web.MeshA2A;
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshInject;
+import io.mcpmesh.types.McpMeshTool;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * uc28_a2a_producer_java fixture (issue #932 Chunk 1C) — Java A2A
+ * producer mirroring date_a2a_agent.py. Same path, same skill id.
+ *
+ * <p>Listens on port 9090. Card at
+ * {@code GET /agents/date/.well-known/agent.json}; JSON-RPC entry at
+ * {@code POST /agents/date}. Depends on the {@code date_service} mesh
+ * capability (provided by examples/simple/system_agent.py on port 9100).
+ */
+@MeshAgent(
+    name = "date-a2a-agent",
+    version = "1.0.0",
+    description = "uc28 Java A2A producer fixture — exposes get-date via @MeshA2A.",
+    port = 9090
+)
+@SpringBootApplication
+public class ProducerDateAgentApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ProducerDateAgentApplication.class, args);
+    }
+
+    @Component
+    static class DateSkill {
+
+        @MeshA2A(
+            path = "/agents/date",
+            skillId = "get-date",
+            skillName = "Get Date",
+            description = "Get current date/time via A2A protocol",
+            tags = {"system", "date"},
+            dependencies = {
+                @MeshDependency(capability = "date_service")
+            }
+        )
+        public Map<String, Object> getDate(
+                Map<String, Object> message,
+                @MeshInject("date_service") McpMeshTool dateService) throws Exception {
+            Map<String, Object> payload = new LinkedHashMap<>();
+            if (dateService == null) {
+                // Defer-resolution: dependency not yet wired by mesh DI.
+                // Returning a sentinel keeps the example runnable solo.
+                payload.put("date", Instant.now().toString());
+                payload.put("note", "date_service not yet resolved");
+                return payload;
+            }
+            Object result = dateService.call(Map.of());
+            payload.put("date", result);
+            return payload;
+        }
+    }
+}

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/src/main/resources/application.yml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: producer-date-agent-java
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9090}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:date-a2a-agent}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    io.mcpmesh: INFO
+    com.example: DEBUG

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  uc28_a2a_producer_java fixture (bearer auth) — Java A2A producer
+  with @MeshA2A(auth="bearer") so the JSON-RPC entry rejects requests
+  without an Authorization: Bearer <token> header. The agent card
+  endpoint stays publicly reachable (spec §6.2 — clients need it for
+  scheme discovery).
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>producer-date-auth-agent-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>A2A Producer Date Auth Agent (uc28 Java)</name>
+    <description>uc28 Java A2A producer (bearer auth gate) — exposes get-date via @MeshA2A(auth="bearer").</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.dateauthproducer.ProducerDateAuthAgentApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/src/main/java/com/example/dateauthproducer/ProducerDateAuthAgentApplication.java
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/src/main/java/com/example/dateauthproducer/ProducerDateAuthAgentApplication.java
@@ -1,0 +1,49 @@
+package com.example.dateauthproducer;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.spring.web.MeshA2A;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * uc28_a2a_producer_java fixture (bearer auth) — Java A2A producer
+ * with {@code @MeshA2A(auth="bearer")} so the JSON-RPC entry rejects
+ * requests without an {@code Authorization: Bearer <token>} header.
+ * Listens on port 9092 to coexist with the non-auth fixtures.
+ *
+ * <p>The handler is dependency-free so the test doesn't need a
+ * sibling provider — solo agent + registry are enough.
+ */
+@MeshAgent(
+    name = "date-auth-agent",
+    version = "1.0.0",
+    description = "uc28 Java A2A producer fixture (bearer auth).",
+    port = 9092
+)
+@SpringBootApplication
+public class ProducerDateAuthAgentApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ProducerDateAuthAgentApplication.class, args);
+    }
+
+    @Component
+    static class AuthSkill {
+
+        @MeshA2A(
+            path = "/agents/date",
+            skillId = "get-date",
+            skillName = "Get Date (auth)",
+            description = "Get current date via bearer-protected A2A surface",
+            tags = {"system", "date", "auth"},
+            auth = "bearer"
+        )
+        public Map<String, Object> getDate(Map<String, Object> message) {
+            return Map.of("date", Instant.now().toString());
+        }
+    }
+}

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/src/main/resources/application.yml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: producer-date-auth-agent-java
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9092}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:date-auth-agent}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    io.mcpmesh: INFO
+    com.example: DEBUG

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  uc28_a2a_producer_java fixture (long-running) — Java A2A producer
+  exposing generate-report via @MeshA2A on top of the existing
+  generate_report task=true capability (examples/jobs/long-task-provider).
+
+  Handler submits work to the mesh job substrate via a hand-wired
+  MeshJobSubmitter (DDDI for @MeshA2A doesn't auto-inject MeshJob —
+  the @MeshTool path does, but the dispatcher here injects McpMeshTool
+  proxies only) and returns the resulting JobProxy to switch the
+  framework into long-running mode (parks the task in the A2A task
+  store, services tasks/get/cancel/sendSubscribe/resubscribe from it).
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>producer-report-agent-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>A2A Producer Report Agent (uc28 Java, long-running)</name>
+    <description>uc28 Java A2A producer fixture (long-running) — exposes generate-report via @MeshA2A on top of the mesh job substrate.</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.reportproducerjava.ProducerReportAgentApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/src/main/java/com/example/reportproducerjava/ProducerReportAgentApplication.java
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/src/main/java/com/example/reportproducerjava/ProducerReportAgentApplication.java
@@ -1,0 +1,96 @@
+package com.example.reportproducerjava;
+
+import io.mcpmesh.JobProxy;
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshJobSubmitter;
+import io.mcpmesh.spring.MeshRuntime;
+import io.mcpmesh.spring.web.MeshA2A;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * uc28_a2a_producer_java fixture (long-running) — Java A2A producer
+ * exposing the {@code generate-report} skill via {@code @MeshA2A} on
+ * top of the existing {@code generate_report} {@code task=true}
+ * capability served by the long-task-provider Python agent on port
+ * 9100. Returns a {@link JobProxy} to trigger the framework's
+ * long-running mode (parks the task in the A2A task store, services
+ * {@code tasks/get}, {@code tasks/cancel}, {@code tasks/sendSubscribe},
+ * {@code tasks/resubscribe} from it).
+ */
+@MeshAgent(
+    name = "report-a2a-agent",
+    version = "1.0.0",
+    description = "uc28 Java A2A producer fixture (long-running).",
+    port = 9091
+)
+@SpringBootApplication
+public class ProducerReportAgentApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(ProducerReportAgentApplication.class);
+
+    public static void main(String[] args) {
+        SpringApplication.run(ProducerReportAgentApplication.class, args);
+    }
+
+    @Component
+    static class ReportSkill {
+
+        private static final ObjectMapper JSON = new ObjectMapper();
+
+        @Autowired
+        private MeshRuntime meshRuntime;
+
+        @MeshA2A(
+            path = "/agents/report",
+            skillId = "generate-report",
+            skillName = "Generate Report",
+            description = "Generate a long-form report via A2A (task=True streaming)",
+            tags = {"reports", "long-running"}
+        )
+        public Object generateReport(Map<String, Object> message) throws Exception {
+            String userId = "anon";
+            List<String> sections = List.of("overview");
+            Object partsObj = message != null ? message.get("parts") : null;
+            if (partsObj instanceof List<?> parts && !parts.isEmpty()
+                && parts.get(0) instanceof Map<?, ?> firstPart
+                && "text".equals(firstPart.get("type"))) {
+                Object textObj = firstPart.get("text");
+                if (textObj instanceof String text && !text.isEmpty()) {
+                    try {
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> args = JSON.readValue(text, Map.class);
+                        Object u = args.get("user_id");
+                        if (u instanceof String s && !s.isEmpty()) userId = s;
+                        Object s = args.get("sections");
+                        if (s instanceof List<?> list && !list.isEmpty()) {
+                            sections = list.stream().map(String::valueOf).toList();
+                        }
+                    } catch (Exception parseExc) {
+                        log.debug("Failed to parse parts[0].text: {}", parseExc.getMessage());
+                    }
+                }
+            }
+
+            String registryUrl = meshRuntime.getAgentSpec().getRegistryUrl();
+            String agentId = meshRuntime.getAgentSpec().getAgentId();
+            MeshJobSubmitter submitter = new MeshJobSubmitter("generate_report", agentId, registryUrl);
+
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("user_id", userId);
+            payload.put("sections", sections);
+            JobProxy proxy = submitter.submit(payload).get();
+            log.info("@MeshA2A generate-report: parked job_id={}", proxy.jobId());
+            return proxy;
+        }
+    }
+}

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/src/main/java/com/example/reportproducerjava/ProducerReportAgentApplication.java
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/src/main/java/com/example/reportproducerjava/ProducerReportAgentApplication.java
@@ -16,6 +16,9 @@ import tools.jackson.databind.ObjectMapper;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * uc28_a2a_producer_java fixture (long-running) — Java A2A producer
@@ -88,7 +91,24 @@ public class ProducerReportAgentApplication {
             Map<String, Object> payload = new LinkedHashMap<>();
             payload.put("user_id", userId);
             payload.put("sections", sections);
-            JobProxy proxy = submitter.submit(payload).get();
+            // Bounded wait: submit() is a registry round-trip, NOT the long
+            // job itself. Anything beyond 30s is a registry/network problem
+            // and should surface as a failed A2A task, not as an indefinite
+            // hang on the dispatcher thread.
+            JobProxy proxy;
+            try {
+                proxy = submitter.submit(payload).get(30, TimeUnit.SECONDS);
+            } catch (TimeoutException te) {
+                throw new RuntimeException(
+                    "submit() did not return a JobProxy within 30s — "
+                        + "registry / provider-side timeout", te);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("submit() interrupted", ie);
+            } catch (ExecutionException ee) {
+                Throwable cause = ee.getCause() != null ? ee.getCause() : ee;
+                throw new RuntimeException("submit() failed: " + cause.getMessage(), cause);
+            }
             log.info("@MeshA2A generate-report: parked job_id={}", proxy.jobId());
             return proxy;
         }

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/src/main/resources/application.yml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: producer-report-agent-java
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9091}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:report-a2a-agent}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    io.mcpmesh: INFO
+    com.example: DEBUG

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/system-agent/main.py
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/system-agent/main.py
@@ -1,0 +1,1 @@
+../../../../../../examples/simple/system_agent.py

--- a/tests/integration/suites/uc28_a2a_producer_java/routines.yaml
+++ b/tests/integration/suites/uc28_a2a_producer_java/routines.yaml
@@ -1,0 +1,53 @@
+# UC-level routines for uc28_a2a_producer_java (issue #932 Chunk 1C).
+#
+# Exercises the producer side of @MeshA2A in the Java runtime. Test
+# cases cover the same matrix as uc24_a2a_python (Python producer) but
+# against a Java @MeshA2A surface:
+#
+#   tc01 — agent card (.well-known/agent.json) shape
+#   tc02 — tasks/send sync → state=completed (Python consumer driver)
+#   tc03 — tasks/send long-running → state=working (JobProxy parking)
+#   tc04 — tasks/sendSubscribe SSE wire framing (data: + final + progress)
+#   tc05 — tasks/cancel propagates to the JobProxy
+#   tc06 — bearer auth gate (200 with valid header, 401 + -32001 without)
+#
+# Reuses the fast-sweep + MCP_MESH_PUBLIC_URL_PREFIX registry-start
+# routine from uc24 so card public URL stamping is exercised.
+
+routines:
+  start_registry_a2a:
+    description: "Start the registry with fast-sweep timing AND MCP_MESH_PUBLIC_URL_PREFIX for A2A card stamping"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: |
+          MCP_MESH_PUBLIC_URL_PREFIX=https://test.example.com \
+          MCP_MESH_SWEEP_INTERVAL=10s \
+          MCP_MESH_RETENTION=10s \
+          MCP_MESH_HEALTH_CHECK_INTERVAL=5 \
+          DEFAULT_TIMEOUT_THRESHOLD=15 \
+            meshctl start --registry-only -d
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "registry ready after ${i}s"
+              tail -n 200 ~/.mcp-mesh/logs/registry.log \
+                | grep -qE '\[sweep\] using MCP_MESH_SWEEP_INTERVAL' \
+                || { echo "FAIL: MCP_MESH_SWEEP_INTERVAL override did not take effect"; exit 1; }
+              echo "[setup] confirmed sweep override active"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: registry did not become ready in 20s"
+          tail -50 ~/.mcp-mesh/logs/registry.log 2>/dev/null || true
+          exit 1
+        capture: registry_start
+        timeout: 30
+
+  stop_all:
+    description: "Stop all mesh processes started by this test"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: meshctl stop 2>/dev/null || true
+        ignore_errors: true

--- a/tests/integration/suites/uc28_a2a_producer_java/tc01_card_discovery/test.yaml
+++ b/tests/integration/suites/uc28_a2a_producer_java/tc01_card_discovery/test.yaml
@@ -1,0 +1,121 @@
+# tc01_card_discovery — Java A2A producer agent card endpoint smoke (issue #932 Chunk 1C).
+#
+# Verifies the Java @MeshA2A path mounts a valid /.well-known/agent.json
+# at the surface path AND that the card carries the A2A v1.0 required
+# fields: name, skills[*].id/name/description/tags, capabilities.streaming,
+# defaultInputModes/defaultOutputModes. Java port of uc24 tc01.
+#
+# Sync skill — capabilities.streaming is still advertised true because
+# the framework ALWAYS wires sendSubscribe + resubscribe on every
+# @MeshA2A surface (matches Python producer behavior; sync handlers
+# stream a single artifact + terminal event over SSE).
+
+name: "A2A Producer (Java): agent card discovery"
+description: "GET /agents/date/.well-known/agent.json on Java @MeshA2A returns valid A2A v1.0 card"
+tags:
+  - a2a
+  - java
+  - smoke
+  - issue-932
+  - producer
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/system-agent /workspace/
+      cp -rL /uc-artifacts/producer-date-agent-java /workspace/
+
+  - name: "Install system-agent deps"
+    handler: pip-install
+    path: /workspace/system-agent
+
+  - name: "Install producer-date-agent-java deps"
+    handler: maven-install
+    path: /workspace/producer-date-agent-java
+    timeout: 600
+
+  - routine: start_registry_a2a
+
+  - name: "Start system-agent (port 9100, provides date_service)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start system-agent/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for system-agent registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start producer-date-agent-java (port 9090)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start producer-date-agent-java --env MCP_MESH_HTTP_PORT=9090 -d
+
+  # Java cold-start ~30s for Spring Boot; the fast-sweep registry could
+  # mark the agent unhealthy if the first heartbeat is delayed past
+  # DEFAULT_TIMEOUT_THRESHOLD=15s. Poll until status==healthy AND
+  # agent_type=a2a (which only flips once MeshA2ABeanPostProcessor has
+  # populated the registry — confirms the producer surface registered).
+  - name: "Wait for Java producer to be healthy and agent_type=a2a"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        RESP=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null || echo "")
+        STATUS=$(echo "$RESP" | jq -r '.agents[] | select(.name=="date-a2a-agent") | .status' 2>/dev/null || echo "")
+        TYPE=$(echo "$RESP" | jq -r '.agents[] | select(.name=="date-a2a-agent") | .agent_type' 2>/dev/null || echo "")
+        if [ "$STATUS" = "healthy" ] && [ "$TYPE" = "a2a" ]; then
+          echo "Java producer healthy after ${i}x2s (agent_type=a2a)"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Java producer not healthy as agent_type=a2a within 120s (last status='$STATUS' type='$TYPE')"
+      meshctl logs producer-date-agent-java 2>&1 | tail -120 || true
+      exit 1
+    timeout: 150
+
+  - name: "Verify both agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Fetch agent card"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:9090/agents/date/.well-known/agent.json
+    capture: card_response
+    timeout: 15
+
+assertions:
+  - expr: "${captured.agent_list} contains 'system-agent'"
+    message: "system-agent should be registered"
+  - expr: "${captured.agent_list} contains 'date-a2a-agent'"
+    message: "Java producer should be registered as 'date-a2a-agent'"
+
+  # Card shape per A2A v1.0 (spec §3).
+  - expr: "${captured.card_response} contains '\"name\"'"
+    message: "card should carry a name field"
+  - expr: "${captured.card_response} contains '\"skills\"'"
+    message: "card should carry a skills array"
+  - expr: "${captured.card_response} contains '\"id\":\"get-date\"'"
+    message: "card should expose the get-date skill id"
+  - expr: "${captured.card_response} contains '\"name\":\"Get Date\"'"
+    message: "card should carry the skill display name 'Get Date'"
+  - expr: "${captured.card_response} contains '\"streaming\":true'"
+    message: "card should advertise streaming=true (sendSubscribe + resubscribe always wired)"
+  - expr: "${captured.card_response} contains '\"capabilities\"'"
+    message: "card should carry a capabilities block"
+  - expr: "${captured.card_response} contains '\"defaultInputModes\"'"
+    message: "card should carry defaultInputModes (A2A v1.0 required)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc28_a2a_producer_java/tc02_tasks_send_sync/test.yaml
+++ b/tests/integration/suites/uc28_a2a_producer_java/tc02_tasks_send_sync/test.yaml
@@ -74,7 +74,7 @@ test:
     handler: shell
     workdir: /workspace
     command: |
-      for i in $(seq 1 60); do
+      for i in $(seq 1 75); do
         RESP=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null || echo "")
         STATUS=$(echo "$RESP" | jq -r '.agents[] | select(.name=="date-a2a-agent") | .status' 2>/dev/null || echo "")
         TYPE=$(echo "$RESP" | jq -r '.agents[] | select(.name=="date-a2a-agent") | .agent_type' 2>/dev/null || echo "")
@@ -84,7 +84,7 @@ test:
         fi
         sleep 2
       done
-      echo "ERROR: Java producer not healthy within 120s (last status='$STATUS' type='$TYPE')"
+      echo "ERROR: Java producer not healthy within 150s (last status='$STATUS' type='$TYPE')"
       meshctl logs producer-date-agent-java 2>&1 | tail -120 || true
       exit 1
     timeout: 150

--- a/tests/integration/suites/uc28_a2a_producer_java/tc02_tasks_send_sync/test.yaml
+++ b/tests/integration/suites/uc28_a2a_producer_java/tc02_tasks_send_sync/test.yaml
@@ -1,0 +1,159 @@
+# tc02_tasks_send_sync — Python consumer ↔ Java producer sync round-trip (issue #932 Chunk 1C).
+#
+# Polyglot pairing: a known-good Python A2A consumer
+# (examples/a2a/consumer_date_agent.py) bridges the Java producer's
+# get-date skill onto the mesh as a regular current-date capability,
+# then meshctl call drives the consumer end-to-end. This exercises:
+#
+#   - Java @MeshA2A JSON-RPC dispatch (tasks/send → state=completed)
+#   - Artifact-text round-trip (handler dict → JSON-stringified into
+#     parts[0].text → consumer json.loads back to dict)
+#   - Java-side DDDI: producer's @MeshDependency(capability="date_service")
+#     resolves against the Python system-agent (cross-runtime DDDI
+#     inside an A2A handler).
+#
+# Same artifact-text contract as uc25 tc02 (Python ↔ Python) — the only
+# moving piece is which runtime owns the producer. tc02's success here
+# proves the Java producer is wire-compatible with the existing Python
+# consumer ecosystem.
+
+name: "A2A Producer (Java): tasks/send sync via Python consumer"
+description: "Python consumer drives Java @MeshA2A tasks/send → state=completed → artifact text round-trip"
+tags:
+  - a2a
+  - java
+  - polyglot
+  - smoke
+  - issue-932
+  - producer
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/system-agent /workspace/
+      cp -rL /uc-artifacts/producer-date-agent-java /workspace/
+      cp -rL /uc-artifacts/consumer-date-agent /workspace/
+
+  - name: "Install system-agent deps"
+    handler: pip-install
+    path: /workspace/system-agent
+
+  - name: "Install producer-date-agent-java deps"
+    handler: maven-install
+    path: /workspace/producer-date-agent-java
+    timeout: 600
+
+  - name: "Install consumer-date-agent deps"
+    handler: pip-install
+    path: /workspace/consumer-date-agent
+
+  - routine: start_registry_a2a
+
+  - name: "Start system-agent (port 9100, provides date_service)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start system-agent/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for system-agent registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start producer-date-agent-java (port 9090)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start producer-date-agent-java --env MCP_MESH_HTTP_PORT=9090 -d
+
+  - name: "Wait for Java producer to be healthy + a2a"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        RESP=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null || echo "")
+        STATUS=$(echo "$RESP" | jq -r '.agents[] | select(.name=="date-a2a-agent") | .status' 2>/dev/null || echo "")
+        TYPE=$(echo "$RESP" | jq -r '.agents[] | select(.name=="date-a2a-agent") | .agent_type' 2>/dev/null || echo "")
+        if [ "$STATUS" = "healthy" ] && [ "$TYPE" = "a2a" ]; then
+          echo "Java producer healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Java producer not healthy within 120s (last status='$STATUS' type='$TYPE')"
+      meshctl logs producer-date-agent-java 2>&1 | tail -120 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start consumer-date-agent (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start consumer-date-agent/main.py -d
+
+  - name: "Wait for consumer registration + DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Verify all 3 agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  - name: "Call the consumer's current-date tool (drives Java producer via A2A)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call current_date '{}' --raw
+    capture: tool_response
+    timeout: 30
+
+  # ALSO call the Java producer directly with raw JSON-RPC to assert the
+  # exact wire shape (state=completed, artifacts[0].name=result, etc.) per
+  # spec §4.3.
+  - name: "POST tasks/send directly to Java producer"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:9090/agents/date \
+        -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"t1","message":{"role":"user","parts":[{"type":"text","text":"now"}]}}}'
+    capture: direct_send_response
+    timeout: 15
+
+assertions:
+  - expr: "${captured.agent_list} contains 'system-agent'"
+    message: "system-agent should be registered"
+  - expr: "${captured.agent_list} contains 'date-a2a-agent'"
+    message: "Java producer should be registered"
+  - expr: "${captured.agent_list} contains 'date-consumer'"
+    message: "Python consumer should be registered"
+
+  # Direct JSON-RPC: verify the wire shape (spec §4.3).
+  - expr: "${captured.direct_send_response} contains '\"state\":\"completed\"'"
+    message: "sync handler should yield state=completed"
+  - expr: "${captured.direct_send_response} contains '\"id\":\"t1\"'"
+    message: "envelope should echo the submitted task id"
+  - expr: "${captured.direct_send_response} contains '\"sessionId\":\"t1\"'"
+    message: "sessionId should default to task id"
+  - expr: "${captured.direct_send_response} contains '\"artifacts\"'"
+    message: "envelope should carry artifacts array"
+  - expr: "${captured.direct_send_response} contains '\"name\":\"result\"'"
+    message: "artifact[0].name should be 'result'"
+  - expr: "${captured.direct_send_response} contains 'date'"
+    message: "artifact text should carry the JSON-stringified {date: ...} payload"
+
+  # End-to-end via Python consumer: the consumer parsed parts[0].text as
+  # JSON and returns the original {"date": ...} dict to meshctl.
+  - expr: "${captured.tool_response} not contains '\"isError\": true'"
+    message: "tool call should not return an MCP error envelope"
+  - expr: "${captured.tool_response} contains 'date'"
+    message: "tool response should carry the producer's date payload"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc28_a2a_producer_java/tc03_tasks_send_long_running/test.yaml
+++ b/tests/integration/suites/uc28_a2a_producer_java/tc03_tasks_send_long_running/test.yaml
@@ -1,0 +1,125 @@
+# tc03_tasks_send_long_running — Java A2A producer long-running (issue #932 Chunk 1C).
+#
+# The Java producer's handler obtains a MeshJobSubmitter (hand-wired in
+# the @MeshA2A path because the dispatcher only auto-injects McpMeshTool
+# proxies, not MeshJob — see fixture ProducerReportAgentApplication
+# Javadoc), submits a job to the Python long-task-provider's
+# generate_report (task=True) capability, and returns the resulting
+# JobProxy. The framework parks it in the A2A task store and responds
+# with state=working immediately.
+#
+# Java port of uc24 tc06.
+
+name: "A2A Producer (Java): tasks/send long-running returns state=working"
+description: "Java @MeshA2A handler returns JobProxy → framework parks task and responds with state=working"
+tags:
+  - a2a
+  - java
+  - smoke
+  - issue-932
+  - producer
+  - long-running
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/producer-report-agent-java /workspace/
+
+  - name: "Install long-task-provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install producer-report-agent-java deps"
+    handler: maven-install
+    path: /workspace/producer-report-agent-java
+    timeout: 600
+
+  - routine: start_registry_a2a
+
+  - name: "Start long-task-provider (port 9100, provides generate_report task=true)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py -d
+
+  - name: "Wait for provider registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start producer-report-agent-java (port 9091)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start producer-report-agent-java --env MCP_MESH_HTTP_PORT=9091 -d
+
+  - name: "Wait for Java producer to be healthy + a2a"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        RESP=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null || echo "")
+        STATUS=$(echo "$RESP" | jq -r '.agents[] | select(.name=="report-a2a-agent") | .status' 2>/dev/null || echo "")
+        TYPE=$(echo "$RESP" | jq -r '.agents[] | select(.name=="report-a2a-agent") | .agent_type' 2>/dev/null || echo "")
+        if [ "$STATUS" = "healthy" ] && [ "$TYPE" = "a2a" ]; then
+          echo "Java producer healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Java producer not healthy within 120s (last status='$STATUS' type='$TYPE')"
+      meshctl logs producer-report-agent-java 2>&1 | tail -120 || true
+      exit 1
+    timeout: 150
+
+  - name: "POST tasks/send to Java producer — submits long-running job"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:9091/agents/report \
+        -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"r1","message":{"role":"user","parts":[{"type":"text","text":"{\"user_id\": \"alice\", \"sections\": [\"intro\", \"body\", \"summary\"]}"}]}}}'
+    capture: task_response
+    timeout: 30
+
+  # Poll tasks/get to confirm the parked task is reachable.
+  - name: "Wait briefly so producer can poll the parked job once"
+    handler: wait
+    seconds: 3
+
+  - name: "POST tasks/get to confirm parked task is readable"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:9091/agents/report \
+        -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"id":"r1"}}'
+    capture: get_response
+    timeout: 30
+
+assertions:
+  # tasks/send returns state=working immediately per spec §4.3 long-running branch.
+  - expr: "${captured.task_response} contains '\"state\":\"working\"'"
+    message: "long-running submit should yield state=working"
+  - expr: "${captured.task_response} contains '\"id\":\"r1\"'"
+    message: "envelope should echo the submitted task id"
+  - expr: "${captured.task_response} contains '\"sessionId\":\"r1\"'"
+    message: "sessionId should default to task id"
+  - expr: "${captured.task_response} contains '\"artifacts\":[]'"
+    message: "no artifact on initial long-running submit"
+
+  # tasks/get on the parked task returns a live status (working OR completed
+  # depending on whether the underlying job has finished its 3 * 2s sections).
+  - expr: "${captured.get_response} contains '\"id\":\"r1\"'"
+    message: "tasks/get should echo the parked task id"
+  - expr: "${captured.get_response} contains '\"status\"'"
+    message: "tasks/get should carry a status block"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc28_a2a_producer_java/tc04_tasks_send_subscribe_sse/test.yaml
+++ b/tests/integration/suites/uc28_a2a_producer_java/tc04_tasks_send_subscribe_sse/test.yaml
@@ -1,0 +1,135 @@
+# tc04_tasks_send_subscribe_sse — Java A2A producer SSE wire framing (issue #932 Chunk 1C).
+#
+# tasks/sendSubscribe dispatches the same as tasks/send but the response
+# is an SSE stream of TaskStatusUpdateEvent + TaskArtifactUpdateEvent
+# JSON-RPC envelopes (spec §4.6 / §5). For a long-running JobProxy
+# return, the stream sequence is:
+#
+#   1. initial state=working event (final=false) — confirms subscription
+#   2. zero-or-more progress events (working, progress=N, final=false)
+#      — emitted only when progress / progress_message actually changed
+#   3. terminal artifact event (TaskArtifactUpdateEvent — carries result)
+#   4. terminal status event (state=completed, final=true) — closes stream
+#
+# We assert the SSE wire framing per Appendix A:
+#   - "data:" prefix on each event line
+#   - "final" boolean appears (true and false)
+#   - "progress" number appears at least once
+#   - terminal artifact event carries the producer payload
+#
+# Use a 2-section job (~4s + slight overhead) and -m 60 on curl to cap
+# consumption (Java cold-start + claim latency makes 60s a generous
+# upper bound; the stream closes on its own at final=true).
+
+name: "A2A Producer (Java): tasks/sendSubscribe SSE stream → working → progress → artifact → completed"
+description: "POST tasks/sendSubscribe to Java @MeshA2A producer opens an SSE stream that progresses to terminal completed"
+tags:
+  - a2a
+  - java
+  - smoke
+  - issue-932
+  - producer
+  - sse
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/producer-report-agent-java /workspace/
+
+  - name: "Install long-task-provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install producer-report-agent-java deps"
+    handler: maven-install
+    path: /workspace/producer-report-agent-java
+    timeout: 600
+
+  - routine: start_registry_a2a
+
+  - name: "Start long-task-provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start producer-report-agent-java (port 9091)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start producer-report-agent-java --env MCP_MESH_HTTP_PORT=9091 -d
+
+  - name: "Wait for Java producer healthy + a2a"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        RESP=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null || echo "")
+        STATUS=$(echo "$RESP" | jq -r '.agents[] | select(.name=="report-a2a-agent") | .status' 2>/dev/null || echo "")
+        TYPE=$(echo "$RESP" | jq -r '.agents[] | select(.name=="report-a2a-agent") | .agent_type' 2>/dev/null || echo "")
+        if [ "$STATUS" = "healthy" ] && [ "$TYPE" = "a2a" ]; then
+          echo "Java producer healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Java producer not healthy within 120s"
+      meshctl logs producer-report-agent-java 2>&1 | tail -120 || true
+      exit 1
+    timeout: 150
+
+  # -N disables curl buffering; -m 60 caps the consumption window.
+  # Accept: text/event-stream forces the SSE branch of the dispatcher
+  # controller (spec §4.6 — SSE is selected via the Accept header).
+  - name: "POST tasks/sendSubscribe and consume SSE stream"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -N -m 60 -s -X POST http://localhost:9091/agents/report \
+        -H 'Accept: text/event-stream' \
+        -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","id":99,"method":"tasks/sendSubscribe","params":{"id":"s1","message":{"role":"user","parts":[{"type":"text","text":"{\"user_id\": \"bob\", \"sections\": [\"a\", \"b\"]}"}]}}}'
+    capture: sse_stream
+    timeout: 90
+
+assertions:
+  # SSE wire framing per spec §5.1 + Appendix A.
+  - expr: "${captured.sse_stream} contains 'data:'"
+    message: "SSE stream must use 'data:' frame prefix (spec §5.1)"
+
+  # Status update event sequence (working → ... → completed).
+  - expr: "${captured.sse_stream} contains '\"state\":\"working\"'"
+    message: "SSE stream should emit a state=working event"
+  - expr: "${captured.sse_stream} contains '\"state\":\"completed\"'"
+    message: "SSE stream should emit a terminal state=completed status event"
+
+  # Final boolean per Appendix A — both false (non-terminal) and true
+  # (terminal) appear over the stream lifetime.
+  - expr: "${captured.sse_stream} contains '\"final\":false'"
+    message: "non-terminal events should carry final=false"
+  - expr: "${captured.sse_stream} contains '\"final\":true'"
+    message: "terminal status event should carry final=true"
+
+  # Progress number — the long-task-provider emits progress 1/2, 2/2.
+  - expr: "${captured.sse_stream} contains '\"progress\"'"
+    message: "SSE stream should emit at least one progress event (progress field)"
+
+  # Terminal artifact event (TaskArtifactUpdateEvent).
+  - expr: "${captured.sse_stream} contains '\"artifact\"'"
+    message: "SSE stream should emit a terminal artifact event"
+  - expr: "${captured.sse_stream} contains 'Generated content for'"
+    message: "artifact event should embed the generate_report marker text"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc28_a2a_producer_java/tc05_tasks_cancel_propagates/test.yaml
+++ b/tests/integration/suites/uc28_a2a_producer_java/tc05_tasks_cancel_propagates/test.yaml
@@ -1,0 +1,115 @@
+# tc05_tasks_cancel_propagates — Java A2A producer tasks/cancel (issue #932 Chunk 1C).
+#
+# Java port of uc24 tc09. Verifies tasks/cancel on a parked task
+# propagates JobProxy.cancel(reason) to the underlying mesh job AND
+# returns a Task envelope with state=canceled.
+#
+# A2A v1.0 spelling note: the protocol uses single-l "canceled" (the
+# US-English form Google chose). The Java MeshA2AStateTranslator
+# enforces this on the wire even when the mesh-side state is the
+# UK-spelled "cancelled".
+
+name: "A2A Producer (Java): tasks/cancel mid-flight returns state=canceled"
+description: "tasks/cancel on Java @MeshA2A long-running task → JobProxy.cancel propagates → state=canceled envelope"
+tags:
+  - a2a
+  - java
+  - smoke
+  - issue-932
+  - producer
+  - cancel
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/producer-report-agent-java /workspace/
+
+  - name: "Install long-task-provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install producer-report-agent-java deps"
+    handler: maven-install
+    path: /workspace/producer-report-agent-java
+    timeout: 600
+
+  - routine: start_registry_a2a
+
+  - name: "Start long-task-provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py -d
+
+  - name: "Wait for provider"
+    handler: wait
+    seconds: 12
+
+  - name: "Start producer-report-agent-java (port 9091)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start producer-report-agent-java --env MCP_MESH_HTTP_PORT=9091 -d
+
+  - name: "Wait for Java producer healthy + a2a"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        RESP=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null || echo "")
+        STATUS=$(echo "$RESP" | jq -r '.agents[] | select(.name=="report-a2a-agent") | .status' 2>/dev/null || echo "")
+        TYPE=$(echo "$RESP" | jq -r '.agents[] | select(.name=="report-a2a-agent") | .agent_type' 2>/dev/null || echo "")
+        if [ "$STATUS" = "healthy" ] && [ "$TYPE" = "a2a" ]; then
+          echo "Java producer healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Java producer not healthy within 120s"
+      meshctl logs producer-report-agent-java 2>&1 | tail -120 || true
+      exit 1
+    timeout: 150
+
+  # 4 sections * ~2s each = ~8s job runtime — plenty of cancel headroom.
+  - name: "POST tasks/send with id=cancel-mid (4 sections, ~8s job)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:9091/agents/report \
+        -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"cancel-mid","message":{"role":"user","parts":[{"type":"text","text":"{\"user_id\": \"alice\", \"sections\": [\"intro\", \"body\", \"summary\", \"appendix\"]}"}]}}}' \
+        > /dev/null
+
+  - name: "Let the job claim + start running"
+    handler: wait
+    seconds: 3
+
+  - name: "POST tasks/cancel for id=cancel-mid"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:9091/agents/report \
+        -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","id":2,"method":"tasks/cancel","params":{"id":"cancel-mid","reason":"manual cancel test"}}'
+    capture: cancel_response
+    timeout: 30
+
+assertions:
+  # Spec §4.5 + §7.2: the post-cancel envelope MUST carry state=canceled
+  # (US spelling, single 'l') even though the underlying mesh job uses
+  # the UK "cancelled" spelling internally — the Java state translator
+  # enforces this on the wire (mirrors a2a.py:817-826 fallback path).
+  - expr: "${captured.cancel_response} contains '\"state\":\"canceled\"'"
+    message: "tasks/cancel response should carry state=canceled (A2A spelling, single-l)"
+  - expr: "${captured.cancel_response} contains '\"id\":\"cancel-mid\"'"
+    message: "tasks/cancel response should echo the canceled task id"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc28_a2a_producer_java/tc05_tasks_cancel_propagates/test.yaml
+++ b/tests/integration/suites/uc28_a2a_producer_java/tc05_tasks_cancel_propagates/test.yaml
@@ -81,7 +81,7 @@ test:
     handler: shell
     workdir: /workspace
     command: |
-      curl -s -X POST http://localhost:9091/agents/report \
+      curl -fsS -X POST http://localhost:9091/agents/report \
         -H 'Content-Type: application/json' \
         -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"cancel-mid","message":{"role":"user","parts":[{"type":"text","text":"{\"user_id\": \"alice\", \"sections\": [\"intro\", \"body\", \"summary\", \"appendix\"]}"}]}}}' \
         > /dev/null
@@ -94,7 +94,7 @@ test:
     handler: shell
     workdir: /workspace
     command: |
-      curl -s -X POST http://localhost:9091/agents/report \
+      curl -fsS -X POST http://localhost:9091/agents/report \
         -H 'Content-Type: application/json' \
         -d '{"jsonrpc":"2.0","id":2,"method":"tasks/cancel","params":{"id":"cancel-mid","reason":"manual cancel test"}}'
     capture: cancel_response

--- a/tests/integration/suites/uc28_a2a_producer_java/tc06_auth_gate_bearer/test.yaml
+++ b/tests/integration/suites/uc28_a2a_producer_java/tc06_auth_gate_bearer/test.yaml
@@ -1,0 +1,126 @@
+# tc06_auth_gate_bearer — Java A2A producer bearer auth gate (issue #932 Chunk 1C).
+#
+# Verifies the @MeshA2A(auth="bearer") gate per spec §6:
+#
+#   - GET {path}/.well-known/agent.json: always reachable without auth
+#     (card discovery is unauthenticated by design — clients need it
+#     to discover the scheme). Card MUST advertise the bearer scheme.
+#   - POST {path} without Authorization header: HTTP 401 + JSON-RPC
+#     error -32001 ("Authentication required").
+#   - POST {path} with Authorization: Bearer <token>: 200 + valid
+#     Task envelope. Phase 1 only checks header presence, NOT value.
+
+name: "A2A Producer (Java): bearer auth gate (200 with header, 401 -32001 without)"
+description: "@MeshA2A(auth=\"bearer\") rejects missing Authorization headers with -32001; accepts any present Bearer token"
+tags:
+  - a2a
+  - java
+  - smoke
+  - issue-932
+  - producer
+  - auth
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/producer-date-auth-agent-java /workspace/
+
+  - name: "Install producer-date-auth-agent-java deps"
+    handler: maven-install
+    path: /workspace/producer-date-auth-agent-java
+    timeout: 600
+
+  - routine: start_registry_a2a
+
+  - name: "Start producer-date-auth-agent-java (port 9092)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start producer-date-auth-agent-java --env MCP_MESH_HTTP_PORT=9092 -d
+
+  - name: "Wait for Java producer healthy + a2a"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        RESP=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null || echo "")
+        STATUS=$(echo "$RESP" | jq -r '.agents[] | select(.name=="date-auth-agent") | .status' 2>/dev/null || echo "")
+        TYPE=$(echo "$RESP" | jq -r '.agents[] | select(.name=="date-auth-agent") | .agent_type' 2>/dev/null || echo "")
+        if [ "$STATUS" = "healthy" ] && [ "$TYPE" = "a2a" ]; then
+          echo "Java auth producer healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Java auth producer not healthy within 120s"
+      meshctl logs producer-date-auth-agent-java 2>&1 | tail -120 || true
+      exit 1
+    timeout: 150
+
+  # 1) Card is reachable WITHOUT auth (spec §6.2 — clients need it for
+  #    scheme discovery) and advertises authentication.schemes=["bearer"].
+  - name: "Fetch agent card (no auth header)"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:9092/agents/date/.well-known/agent.json
+    capture: card_response
+    timeout: 15
+
+  # 2) POST WITHOUT Authorization header → 401 + JSON-RPC -32001.
+  - name: "POST tasks/send WITHOUT Authorization header"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -o /tmp/no_auth_body.json -w "HTTP_STATUS=%{http_code}" \
+        -X POST http://localhost:9092/agents/date \
+        -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","id":1,"method":"tasks/send","params":{"id":"t1","message":{"role":"user","parts":[{"type":"text","text":"now"}]}}}'
+      echo ""
+      cat /tmp/no_auth_body.json
+    capture: no_auth_response
+    timeout: 15
+
+  # 3) POST WITH Authorization: Bearer <token> → 200 + valid envelope.
+  - name: "POST tasks/send WITH Authorization: Bearer header"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -o /tmp/with_auth_body.json -w "HTTP_STATUS=%{http_code}" \
+        -X POST http://localhost:9092/agents/date \
+        -H 'Authorization: Bearer abc123testtoken' \
+        -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","id":2,"method":"tasks/send","params":{"id":"t2","message":{"role":"user","parts":[{"type":"text","text":"now"}]}}}'
+      echo ""
+      cat /tmp/with_auth_body.json
+    capture: with_auth_response
+    timeout: 15
+
+assertions:
+  # Card discovery — scheme advertised, no auth needed.
+  - expr: "${captured.card_response} contains '\"name\"'"
+    message: "card endpoint should return JSON (always reachable, even on auth-protected surfaces)"
+  - expr: "${captured.card_response} contains 'bearer'"
+    message: "card should advertise the bearer authentication scheme"
+
+  # No-auth: 401 + -32001 (spec §6.3).
+  - expr: "${captured.no_auth_response} contains 'HTTP_STATUS=401'"
+    message: "POST without Authorization should return HTTP 401"
+  - expr: "${captured.no_auth_response} contains '-32001'"
+    message: "401 body should carry JSON-RPC error code -32001"
+
+  # With-auth: 200 + state=completed (Phase 1 doesn't validate token value).
+  - expr: "${captured.with_auth_response} contains 'HTTP_STATUS=200'"
+    message: "POST with Authorization: Bearer should return HTTP 200"
+  - expr: "${captured.with_auth_response} contains '\"state\":\"completed\"'"
+    message: "POST with Authorization: Bearer should reach the handler and return state=completed"
+  - expr: "${captured.with_auth_response} contains '\"id\":\"t2\"'"
+    message: "envelope should echo the submitted task id"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

Closes the Java half of the A2A producer arc — sibling to `@MeshRoute`, NOT a mesh-agent feature. Exposes a user-owned Spring Boot app as an A2A v1.0 producer via `@MeshA2A` annotation. Mirrors Python's `mesh.a2a.mount()` as the reference implementation.

### Architecture
```
mesh.tool         →  inside a mesh agent
@MeshRoute        →  inside a user-owned Spring Boot app, DDDI of mesh tools
@MeshA2A          →  inside a user-owned Spring Boot app, A2A envelope + DDDI  ← THIS PR
```

### Scope (~3000 LOC SDK + ~2400 LOC tests)

- **Phase 0**: `docs/a2a/surfaces-spec.md` — 1156-line cross-runtime conformance spec grounded in Python source. Unblocks #933 (TypeScript producer).
- **Phase 1A-1B**: 12 SDK classes in `io.mcpmesh.spring.web` (`@MeshA2A` annotation, dispatcher, SSE adapter, card builder, auth filter, state translator, task store, public URL cache, header filter, bean post-processor). JobProxy long-running parity with Python. Cancel propagation, 15s SSE keepalive, mesh→A2A state translation (UK→US "canceled" spelling). `RouterFunction` over `@RequestMapping("/**")` to avoid intercepting unrelated routes.
- **Phase 1C**: 98 new unit tests (270 → 282 total), 2 Java example agents (sync + long-running JobProxy), uc28 polyglot integration suite (6 tcs).

## Review Notes

### Bugs caught by local smoke test (both fixed in this PR)

**Smoke testing caught 2 SDK bugs that 270 unit tests missed:**

1. **`readBody` silently swallowed body-parse failures** under Spring Boot 4 + Jackson 3 → every sync request returned `-32601 method='null'` regardless of body. Card endpoint (GET) was the only working surface. Fixed by reading raw bytes via `request.servletRequest().getInputStream()` + proper `-32700`/`-32600`/`-32601` error semantics. New `MeshA2AHttpDispatchTest` drives real HTTP via JDK HttpClient on `@SpringBootTest(RANDOM_PORT)`, closing the gap the slice test had to bypass due to Spring 7.0.6 converter quirks.

2. **Spring circular bean dependency** introduced by `meshA2ARouterFunction` → `meshHealthController` → `meshRuntime` → `meshHealthController`. Fixed with `@Lazy MeshRuntime` injection (CGLIB proxy defers resolution to request time, structurally breaks cycle). New `MeshA2AContextLoadTest @SpringBootTest` reproduces the cycle via a NoOpMeshRuntime stub mirroring `buildAgentSpec`'s eager `@Component` walk — verified to fail without the fix.

Both fixes have dedicated regression tests in commit `813b888a`.

### Pre-merge review (review-agent)

Review found 1 BLOCKER + 8 WARNINGs + 7 INFOs. All applied except 3 deferred to follow-up:

**BLOCKER (fixed in commit `e9edce0a`)** — SSE transient `proxy.status()` failures permanently poisoned the task store (called `markTaskTerminal`). Spec §4.4 says transient unreachability is not authoritative evidence the job is dead; the `tasks/get` path was already correct on this. Aligned SSE path with JSON path semantics. 2 regression tests added (transient-then-recover; persistent failure with defensive 5-failure cap that preserves store).

**5 WARNINGs applied (commit `e9edce0a`)**:
- W1: Doc comment said auth filter ran BEFORE tracing but the order says AFTER — rewritten
- W3: MAX_STREAM 1h cap made consistent with BLOCKER fix (stream-level timeout, not job-death signal — preserves task store for `tasks/get` to resume)
- W4: `MeshA2ATaskStore.markTerminal` was non-atomic on `ConcurrentHashMap` — replaced get/check/put with `computeIfPresent` for atomic first-write-wins
- W5: SSE controller constructed `new ObjectMapper()` per request — moved to dispatcher's injected mapper
- W8: Dead `BeansException` catch in `MeshEventProcessor` — replaced with direct cache injection

**3 WARNINGs deferred to follow-up issues**:
- W2: Broader user-`@Component` → `MeshRuntime` cycle pattern (only framework's own controller is mitigated; user code workarounds with `@Lazy` are doc'd in example)
- W6: Non-atomic `register` in `MeshA2ARegistry` (refactor-fragility)
- W7: Boot-time `@MeshInject` parameter type validation

**7 INFOs skipped** per project convention (spec doc Java-planning labels, defensive `progress` coercion, unreachable null branch, path-parameter handling in auth filter, SSE worker-thread blocking deployment concern, `readParams` lenient empty map).

### Follow-up issues to file post-merge

- `MeshA2ASseDispatcher` injectable `Clock` + `Sleeper` for proper timing tests (1C-unit reduced timing test to constants-only)
- `@MeshA2A` should auto-inject `MeshJobSubmitter` for `task=true` deps the way `@MeshTool` does (example's `@Lazy` workaround would go away)
- Rust core `libmcp_mesh_core.dylib` feature-flag pollution under default features (pyo3 symbols cause Java JNA load failures) — build hygiene
- 6 BeanPostProcessorChecker warnings (non-fatal; pre-existing pattern)
- Registry-side emission of `SURFACE_UPDATED` event (Java consumer side is wired and waiting)
- W2/W6/W7 (deferred review findings above)

## Test plan

- [x] 282/282 Java unit tests pass (`mvn -pl mcp-mesh-spring-boot-starter test -am`)
- [x] mkdocs build clean (only pre-existing `python/llm/index.md` warnings)
- [x] Both example agents boot in ~1s with no cycle
- [x] 13/13 end-to-end smoke-test cases pass against live producers:
  - [x] Card endpoint, sync `tasks/send`, `tasks/get` caching
  - [x] JSON-RPC error codes (`-32700`/`-32600`/`-32601`/`-32602`) with correct method-name preservation
  - [x] Long-running JobProxy parking via `state=working`
  - [x] SSE wire framing (`data: ...\n\n`, `: keepalive\n\n`)
  - [x] Cancel propagation via `tasks/cancel` → `state=canceled` (US spelling)
  - [x] Live-status polling via `tasks/get` on parked task
- [x] SSE Appendix A conformance verified on the wire:
  - [x] `final` field type via `jq` → only `boolean` (never string)
  - [x] State values → only `working`/`canceled` (never UK `cancelled`)
  - [x] Keepalive frames emitted past 15s
- [ ] uc28 polyglot integration suite — written + tsuite-discoverable (6 tcs); execution requires beelink5 image rebuild (out of band)

Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Java Agent-to-Agent (A2A) producer support via `@MeshA2A` annotation for exposing skills
  * Added long-running task support for Java A2A producers with job tracking and polling
  * Added bearer token authentication gates for A2A surface endpoints
  * Added Server-Sent Events (SSE) streaming support for task subscriptions

* **Documentation**
  * Added comprehensive A2A conformance specification document
  * Expanded producer documentation with Java examples and implementation details

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/934)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->