### PR TITLE
docs(a2a): sweep stale Producer-Python references after multi-runtime arc

### DIFF
--- a/docs/a2a/authentication.md
+++ b/docs/a2a/authentication.md
@@ -99,7 +99,7 @@ If the card declares no authentication scheme, no auth block is generated. See [
 
 ## Producer-side bearer
 
-On the producer side, `mesh.a2a.mount(...)` accepts `auth="bearer"` (a literal string, not an `A2ABearer` instance). This advertises the bearer scheme on the published agent card and gates the JSON-RPC entry route — incoming requests must carry an `Authorization: Bearer ...` header to pass the gate. Phase 1 does NOT validate the token value itself: the producer-side `auth=` parameter takes only the string `"bearer"` (or `None` for no auth), and downstream verification of the token is left to the user (e.g., a FastAPI dependency, a sidecar, or the broader auth stack). The full token-resolution model — `token` literal vs `token_env` — lives on the **consumer** side via `mesh.A2ABearer`. Card auth schemes are auto-published in `/.well-known/agent.json` so external scaffolders (mesh's own or third-party A2A tooling) can detect bearer requirements automatically. Token-value validation on the producer side is deferred to a future phase. See [Producer (Python)](producer.md).
+On the producer side, all three runtimes accept the literal string `"bearer"` — Python `mesh.a2a.mount(..., auth="bearer")`, Java `@MeshA2A(auth = "bearer")`, TypeScript `mesh.a2a.mount(app, { auth: "bearer", ... })`. This advertises the bearer scheme on the published agent card and gates the JSON-RPC entry route — incoming requests must carry an `Authorization: Bearer ...` header to pass the gate. Phase 1 does NOT validate the token value itself: the producer-side `auth` parameter takes only the string `"bearer"` (or unset for no auth), and downstream verification of the token is left to the user (e.g., a FastAPI dependency, a Spring Security filter, an Express middleware, a sidecar, or the broader auth stack). The full token-resolution model — `token` literal vs `token_env` — lives on the **consumer** side via `mesh.A2ABearer` / `@A2AConsumer(authBearerEnv = ...)` / `a2aConfig.auth`. Card auth schemes are auto-published in `/.well-known/agent.json` so external scaffolders (mesh's own or third-party A2A tooling) can detect bearer requirements automatically. Token-value validation on the producer side is deferred to a future phase. See [Producer](producer.md).
 
 ## Phase 1 scope and deferred work
 
@@ -114,5 +114,5 @@ For non-bearer schemes today the workaround is to handle the auth headers in you
 
 ## See also
 
-- [Producer (Python)](producer.md) — producer-side bearer enforcement
+- [Producer](producer.md) — producer-side bearer enforcement
 - [Scaffolding](scaffolding.md) — card-driven auth wiring

--- a/docs/a2a/consumer-quickstart.md
+++ b/docs/a2a/consumer-quickstart.md
@@ -5,7 +5,7 @@ Bridge an external A2A `get-date` skill into the mesh as a `current-date` capabi
 ## Prereqs
 
 - A registry — `meshctl start --registry-only`
-- An external A2A producer reachable at `http://localhost:9090/agents/date` exposing a `get-date` skill (the canonical example is `examples/a2a/date_a2a_agent.py` — see the [Producer (Python)](producer.md) page).
+- An external A2A producer reachable at `http://localhost:9090/agents/date` exposing a `get-date` skill (the canonical example is `examples/a2a/date_a2a_agent.py` — see the [Producer](producer.md) page).
 
 ## The bridge
 

--- a/docs/a2a/examples.md
+++ b/docs/a2a/examples.md
@@ -2,12 +2,26 @@
 
 Every A2A-related example in the repo, grouped by runtime, with the scenario each one demonstrates.
 
-## Producer (Python)
+## Producer — Python
 
 | Example                                  | Scenario                                                |
 | ---------------------------------------- | ------------------------------------------------------- |
 | `examples/a2a/date_a2a_agent.py`         | Sync handler — bridges the `date_service` mesh capability via A2A `tasks/send` |
 | `examples/a2a/report_a2a_agent.py`       | Long-running + SSE handler — bridges `generate_report` (`task=True`) via A2A `tasks/send` / `tasks/get` / `tasks/cancel` / `tasks/sendSubscribe` / `tasks/resubscribe` |
+
+## Producer — TypeScript
+
+| Example                                                  | Scenario                                       |
+| -------------------------------------------------------- | ---------------------------------------------- |
+| `examples/typescript/producer-date-agent/`               | Sync `mesh.a2a.mount(app, ...)` Express producer — bridges `date_service` via A2A `tasks/send` |
+| `examples/typescript/producer-report-agent/`             | Long-running `mesh.a2a.mount` returning a `JobProxy` — bridges `generate_report` (`task=true`) via A2A `tasks/send` / `tasks/get` / `tasks/cancel` / `tasks/sendSubscribe` / `tasks/resubscribe` |
+
+## Producer — Java
+
+| Example                                                  | Scenario                                       |
+| -------------------------------------------------------- | ---------------------------------------------- |
+| `examples/java/producer-date-agent/`                     | Sync `@MeshA2A` Spring Boot producer — bridges `date_service` via A2A `tasks/send` |
+| `examples/java/producer-report-agent/`                   | Long-running `@MeshA2A` returning a `JobProxy` — bridges `generate_report` (`task = true`) via A2A `tasks/send` / `tasks/get` / `tasks/cancel` / `tasks/sendSubscribe` / `tasks/resubscribe` |
 
 ## Consumer — Python
 
@@ -78,7 +92,7 @@ Or chain it from a downstream caller (a separate mesh agent depending on `curren
 ## See also
 
 - [Overview](overview.md)
-- [Producer (Python)](producer.md)
+- [Producer](producer.md)
 - [Consumer Quick Start](consumer-quickstart.md)
 - [Failover & Federation](failover.md)
 - [Long-Running & SSE](long-running.md)

--- a/docs/a2a/long-running.md
+++ b/docs/a2a/long-running.md
@@ -2,7 +2,7 @@
 
 External A2A skills that take longer than a sync `tools/call` window need to be bridged into the mesh as `MeshJob`-shaped capabilities. This page covers the consumer-side bridging primitives — `A2AJob.bridge(JobController)` for polling and `A2AStream.bridge(JobController)` for SSE — plus cancel propagation and SSE constraints.
 
-The producer side (Python `mesh.a2a.mount` returning a `JobProxy`) is covered in [Producer (Python)](producer.md).
+The producer side — Python's `mesh.a2a.mount`, Java's `@MeshA2A`, or TypeScript's `mesh.a2a.mount` returning a `JobProxy` — is covered in [Producer](producer.md).
 
 ## The bridge model
 

--- a/docs/a2a/overview.md
+++ b/docs/a2a/overview.md
@@ -6,7 +6,7 @@ MCP Mesh implements the [A2A v1.0 protocol](https://a2a-protocol.org/latest/spec
 
 The A2A v1.0 spec defines an HTTP + JSON-RPC envelope for cross-vendor agent calls. It deliberately stops at the protocol — capability discovery is per-card, there is no resolver, no failover, no DDDI. MCP Mesh adds those layers around A2A:
 
-- **Producer** (Python, Java, TypeScript — all three runtimes; TS shipped via [#933](https://github.com/dhyanraj/mcp-mesh/issues/933)): the producer entry builds the agent card automatically from declared metadata and attaches both `/.well-known/agent.json` and the JSON-RPC entrypoint to a user-owned hosting framework — `mesh.a2a.mount(app, ...)` on FastAPI in Python, `@MeshA2A` on a Spring Boot bean in Java, `mesh.a2a.mount(app, ...)` on Express in TypeScript. Sync, long-running (`task=True`/`task=true`), and SSE handlers are all supported.
+- **Producer** (Python, Java, TypeScript — all three runtimes): the producer entry builds the agent card automatically from declared metadata and attaches both `/.well-known/agent.json` and the JSON-RPC entrypoint to a user-owned hosting framework — `mesh.a2a.mount(app, ...)` on FastAPI in Python, `@MeshA2A` on a Spring Boot bean in Java, `mesh.a2a.mount(app, ...)` on Express in TypeScript. Sync, long-running (`task=True`/`task=true`), and SSE handlers are all supported.
 - **Consumer** (Python, Java, TypeScript): a mesh capability whose body issues outbound `tasks/send` / `tasks/sendSubscribe` against a foreign A2A backend. The bridge re-publishes the upstream skill as a normal mesh capability — downstream callers do not need to know they are talking to A2A.
 
 ## The strategic value-add

--- a/docs/a2a/producer.md
+++ b/docs/a2a/producer.md
@@ -3,7 +3,7 @@
 Expose mesh tools to external A2A clients via the A2A v1.0 protocol surface.
 
 !!! info "Producer support is complete across all three runtimes"
-    Producer support ships in **Python**, **Java**, and **TypeScript** (issue [#933](https://github.com/dhyanraj/mcp-mesh/issues/933)) — all three runtimes have full A2A support on both the producer and consumer sides.
+    Producer support ships in **Python**, **Java**, and **TypeScript** — all three runtimes have full A2A support on both the producer and consumer sides.
 
 ## Decoration and mounting
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -241,7 +241,7 @@ nav:
 
   - A2A:
       - Overview: a2a/overview.md
-      - Producer (Python): a2a/producer.md
+      - Producer: a2a/producer.md
       - Consumer Quick Start: a2a/consumer-quickstart.md
       - Failover & Federation: a2a/failover.md
       - Long-Running & SSE: a2a/long-running.md


### PR DESCRIPTION
## Summary

Small doc cleanup PR. After #934 (Java A2A producer) and #935 (TypeScript A2A producer) merged, `producer.md` itself got the 3-way Python|Java|TypeScript treatment, but several other docs that link to / cross-reference it never got swept. This sweeps them all.

## Files updated

- `mkdocs.yml` — nav entry: "Producer (Python)" → "Producer"
- `docs/a2a/examples.md` — split "Producer (Python)" section into 3 per-runtime sections (mirroring the existing consumer pattern). 4 new example entries: `producer-date-agent` + `producer-report-agent` × Java + TypeScript.
- `docs/a2a/authentication.md` — generalized producer-side bearer paragraph to call out all three runtimes. Verified identical semantics in `MeshA2AAuthFilter.java`, `auth-filter.ts`, and Python mount entry — all three do presence-only check, auto-publish the scheme, reject non-`"bearer"` values at registration.
- `docs/a2a/consumer-quickstart.md` — "(Python)" qualifier dropped from cross-reference link
- `docs/a2a/long-running.md` — generalized producer reference (line 5); rest of file verified clean (already has full 3-way tabbed examples)
- `docs/a2a/overview.md` — dropped stale "TS shipped via #933" parenthetical (#933 was the tracking issue; TS actually shipped via #935)
- `docs/a2a/producer.md` — same stale "(issue #933)" reference dropped from info box

## What's NOT changed (still accurate)

- `docs/concepts/streaming.md:182` "Producers are Python-only" — refers to **streaming** producers (#854 Phase B), not A2A producers
- `docs/comparison.md:172` "Python only" — refers to other frameworks in a comparison table
- OAuth/mTLS "future work" notes — still accurate
- Path qualifiers like "(Python)" next to specific source files — correct usage

## Test plan

- [x] `mkdocs build` clean (only pre-existing `python/llm/index.md` relative-link INFOs)
- [x] No code changes — markdown + mkdocs.yml only
- [x] Re-grep after edits confirms no remaining stale references

Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified A2A producer-side bearer semantics and authentication flow across Python, Java, and TypeScript runtimes.
  * Expanded producer examples gallery with dedicated TypeScript section and reorganized runtime-specific guides.
  * Updated references throughout to remove Python-specific language and reflect multi-runtime support for producers.
  * Enhanced clarity on producer setup, entry mounting, and handler support across all supported runtimes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/940)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->