### PR TITLE
feat(a2a): auto-inject MeshJobSubmitter + Java user-@Component cycle fix

### DIFF
--- a/docs/a2a/producer.md
+++ b/docs/a2a/producer.md
@@ -240,6 +240,14 @@ When the underlying work is long-running (`task=True` in the dependency graph), 
                 // declared @MeshDependency or, when none is declared, to the
                 // skillId with '-' replaced by '_' (so "generate-report"
                 // resolves to the generate_report task capability).
+                if (jobSubmitter == null) {
+                    // MeshRuntime hasn't finished initialising yet — surface
+                    // a clear retryable error rather than NPE on .submit().
+                    throw new IllegalStateException(
+                        "MeshJobSubmitter injection unavailable — runtime "
+                            + "not yet started. This is a transient startup "
+                            + "condition; retry the request.");
+                }
                 Map<String, Object> payload = new LinkedHashMap<>();
                 payload.put("user_id", "alice");
                 payload.put("sections", java.util.List.of("intro", "body"));

--- a/docs/a2a/producer.md
+++ b/docs/a2a/producer.md
@@ -205,9 +205,7 @@ When the underlying work is long-running (`task=True` in the dependency graph), 
     import io.mcpmesh.JobProxy;
     import io.mcpmesh.MeshAgent;
     import io.mcpmesh.MeshJobSubmitter;
-    import io.mcpmesh.spring.MeshRuntime;
     import io.mcpmesh.spring.web.MeshA2A;
-    import org.springframework.beans.factory.annotation.Autowired;
     import org.springframework.boot.SpringApplication;
     import org.springframework.boot.autoconfigure.SpringBootApplication;
     import org.springframework.stereotype.Component;
@@ -227,9 +225,6 @@ When the underlying work is long-running (`task=True` in the dependency graph), 
         @Component
         static class ReportSkill {
 
-            @Autowired
-            private MeshRuntime meshRuntime;
-
             @MeshA2A(
                 path = "/agents/report",
                 skillId = "generate-report",
@@ -237,15 +232,14 @@ When the underlying work is long-running (`task=True` in the dependency graph), 
                 description = "Generate a long-form report via A2A (task=True streaming)",
                 tags = {"reports", "long-running"}
             )
-            public Object generateReport(Map<String, Object> message) throws Exception {
-                // @MeshA2A injects McpMeshTool proxies at parameter slots but does
-                // not (today) auto-wire MeshJobSubmitter — construct it inline from
-                // the autowired MeshRuntime. Cheap to construct, stateless after.
-                String registryUrl = meshRuntime.getAgentSpec().getRegistryUrl();
-                String agentId = meshRuntime.getAgentSpec().getAgentId();
-                MeshJobSubmitter submitter =
-                    new MeshJobSubmitter("generate_report", agentId, registryUrl);
-
+            public Object generateReport(
+                    Map<String, Object> message,
+                    MeshJobSubmitter jobSubmitter) throws Exception {
+                // Issue #936: the framework auto-injects a MeshJobSubmitter
+                // bound to the task capability — defaults to the first
+                // declared @MeshDependency or, when none is declared, to the
+                // skillId with '-' replaced by '_' (so "generate-report"
+                // resolves to the generate_report task capability).
                 Map<String, Object> payload = new LinkedHashMap<>();
                 payload.put("user_id", "alice");
                 payload.put("sections", java.util.List.of("intro", "body"));
@@ -253,7 +247,7 @@ When the underlying work is long-running (`task=True` in the dependency graph), 
                 // long job itself. 30s is comfortable headroom; anything
                 // longer is a registry/provider problem and should surface
                 // as a failed A2A task rather than an indefinite hang.
-                JobProxy proxy = submitter.submit(payload).get(30, TimeUnit.SECONDS);
+                JobProxy proxy = jobSubmitter.submit(payload).get(30, TimeUnit.SECONDS);
                 return proxy; // long-running mode trigger
             }
         }
@@ -264,7 +258,7 @@ When the underlying work is long-running (`task=True` in the dependency graph), 
 
     ```typescript
     import express from "express";
-    import { getApiRuntime, mesh, MeshJobSubmitter } from "@mcpmesh/sdk";
+    import { mesh } from "@mcpmesh/sdk";
 
     process.env.MCP_MESH_HTTP_PORT = process.env.MCP_MESH_HTTP_PORT ?? "9091";
     process.env.MCP_MESH_AGENT_NAME = process.env.MCP_MESH_AGENT_NAME ?? "report-a2a-agent";
@@ -281,27 +275,20 @@ When the underlying work is long-running (`task=True` in the dependency graph), 
         description: "Generate a long-form report via A2A (task=True streaming)",
         tags: ["reports", "long-running"],
       },
-      async (_deps, payload) => {
-        // mesh.a2a.mount injects McpMeshTool proxies into A2A handlers but
-        // does NOT (today) auto-wire MeshJobSubmitter for task=true deps —
-        // construct it inline from the api-runtime singleton + the registry
-        // URL the SDK already resolved. Cheap, stateless after construction.
-        const agentId = getApiRuntime().getServiceId();
-        if (!agentId) {
-          // Runtime not yet fully initialised — serviceId is empty until
-          // the api-runtime singleton finishes start(). Surface a clear
-          // error rather than constructing a submitter with a blank agentId.
-          throw new Error("api-runtime not ready: serviceId is empty");
+      async (_deps, payload, jobSubmitter) => {
+        // Issue #936: the framework auto-injects a MeshJobSubmitter as the
+        // third positional handler arg. The capability defaults to the
+        // first declared dependency or, when none is declared, to the
+        // skillId with '-' replaced by '_' (so "generate-report" resolves
+        // to the generate_report task capability).
+        if (!jobSubmitter) {
+          // api-runtime not yet started — submitter is unavailable until
+          // the very first heartbeat. Surface a clear error so the client
+          // knows to retry rather than hang.
+          throw new Error("MeshJobSubmitter not yet available — retry shortly.");
         }
-        const registryUrl =
-          process.env.MCP_MESH_REGISTRY_URL ?? "http://localhost:8000";
-        const submitter = new MeshJobSubmitter(
-          "generate_report",
-          agentId,
-          registryUrl,
-        );
 
-        const proxy = await submitter.submit({
+        const proxy = await jobSubmitter.submit({
           user_id: "alice",
           sections: ["intro", "body"],
         });

--- a/examples/java/producer-report-agent/src/main/java/com/example/reportproducer/ProducerReportAgentApplication.java
+++ b/examples/java/producer-report-agent/src/main/java/com/example/reportproducer/ProducerReportAgentApplication.java
@@ -3,14 +3,11 @@ package com.example.reportproducer;
 import io.mcpmesh.JobProxy;
 import io.mcpmesh.MeshAgent;
 import io.mcpmesh.MeshJobSubmitter;
-import io.mcpmesh.spring.MeshRuntime;
 import io.mcpmesh.spring.web.MeshA2A;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.ObjectMapper;
 
@@ -47,16 +44,14 @@ import java.util.concurrent.TimeoutException;
  *
  * <h2>MeshJobSubmitter wiring</h2>
  *
- * <p>{@code @MeshA2A} handlers receive {@link io.mcpmesh.types.McpMeshTool}
- * proxies at parameter slots but the framework does not (today) inject
- * a {@link MeshJobSubmitter} via the {@code dependencies} array — that
- * auto-wiring is reserved for {@code @MeshTool}-decorated consumers.
- * For long-running producers we construct the submitter manually from
- * the autowired {@link MeshRuntime}: it carries both the registry URL
- * and the local agent id (the {@code submitted_by} identity recorded
- * on every new job row). The submitter is cheap to construct (no I/O
- * until {@link MeshJobSubmitter#submit(java.util.Map)} fires) and
- * stateless after construction.
+ * <p>Issue #936: the dispatcher auto-injects {@link MeshJobSubmitter}
+ * at any handler parameter typed {@code MeshJobSubmitter}. The capability
+ * defaults to the first declared {@code @MeshDependency} on the surface,
+ * or — when none is declared, as in this example — to the {@code skillId}
+ * with {@code '-'} replaced by {@code '_'} (so {@code "generate-report"}
+ * resolves to the {@code generate_report} task capability). The submitter
+ * is stateless and reused across requests; user code never has to autowire
+ * {@code MeshRuntime} or know about agent identity / registry URL.
  *
  * <h2>Stack</h2>
  *
@@ -121,38 +116,6 @@ public class ProducerReportAgentApplication {
         private static final ObjectMapper JSON = new ObjectMapper();
 
         /**
-         * Reference to the MeshRuntime — we read the registry URL and
-         * the local agent id from {@link MeshRuntime#getAgentSpec()} at
-         * request time. Autowiring (rather than constructor injection)
-         * keeps the component decoupled from runtime construction order
-         * (the runtime bean is created late, after auto-config).
-         *
-         * <p><strong>Why {@code @Lazy}.</strong> The user-level workaround
-         * of injecting {@link MeshRuntime} into a {@code @Component} to
-         * construct a {@code MeshJobSubmitter} by hand creates a bean-
-         * creation cycle in Spring 6+: {@code MeshRuntime#buildAgentSpec}
-         * eagerly walks {@code @Component} beans → finds this
-         * {@code ReportSkill} (currently in creation) → cycle. The
-         * {@code @Lazy} annotation tells Spring to inject a CGLIB proxy
-         * that defers actual runtime resolution to first method call (at
-         * request time, not at construction time), so the
-         * {@code ReportSkill -> MeshRuntime} edge of the dependency graph
-         * is broken structurally — regardless of which side is constructed
-         * first. Same fix pattern as {@code MeshHealthController} in
-         * {@code MeshAutoConfiguration}.
-         *
-         * <p>The cleaner long-term fix is for the {@code @MeshA2A}
-         * dispatcher to auto-inject {@link io.mcpmesh.MeshJobSubmitter}
-         * for {@code task=true} dependencies (today it only injects
-         * {@link io.mcpmesh.types.McpMeshTool}). Tracked as a follow-up
-         * issue; once that lands this autowire-and-hand-construct dance
-         * goes away entirely.
-         */
-        @Autowired
-        @Lazy
-        private MeshRuntime meshRuntime;
-
-        /**
          * Handle inbound A2A {@code tasks/send} (and {@code tasks/get},
          * {@code tasks/cancel}, {@code tasks/sendSubscribe},
          * {@code tasks/resubscribe} — same handler, the framework picks
@@ -167,6 +130,9 @@ public class ProducerReportAgentApplication {
          * long-running mode (see class Javadoc).
          *
          * @param message inbound A2A request message
+         * @param jobSubmitter framework-injected submitter bound to the
+         *                     {@code generate_report} capability (derived
+         *                     from {@code skillId} per issue #936)
          * @return the parked job proxy (long-running mode trigger)
          * @throws Exception on registry submission failure (becomes
          *         state=failed)
@@ -178,7 +144,9 @@ public class ProducerReportAgentApplication {
             description = "Generate a long-form report via A2A (task=True streaming)",
             tags = {"reports", "long-running"}
         )
-        public Object generateReport(Map<String, Object> message) throws Exception {
+        public Object generateReport(
+                Map<String, Object> message,
+                MeshJobSubmitter jobSubmitter) throws Exception {
             // Parse the user payload from the message's first text part.
             // Tolerant: empty payload defaults to a single "overview" section.
             String userId = "anon";
@@ -207,14 +175,13 @@ public class ProducerReportAgentApplication {
                 }
             }
 
-            // Construct a MeshJobSubmitter bound to the long-task-provider's
-            // generate_report capability. The framework's @MeshTool-side
-            // auto-wiring (JobsRuntimeManager.wireConsumers) does not run
-            // for @MeshA2A handlers; we wire by hand. Cheap to construct
-            // — no I/O until submit() fires.
-            String registryUrl = meshRuntime.getAgentSpec().getRegistryUrl();
-            String agentId = meshRuntime.getAgentSpec().getAgentId();
-            MeshJobSubmitter submitter = new MeshJobSubmitter("generate_report", agentId, registryUrl);
+            if (jobSubmitter == null) {
+                // The framework injects the submitter; null only happens
+                // when MeshRuntime hasn't finished initialising (transient).
+                throw new IllegalStateException(
+                    "MeshJobSubmitter not yet available — mesh runtime is still initialising. "
+                        + "Retry tasks/send shortly.");
+            }
 
             Map<String, Object> payload = new LinkedHashMap<>();
             payload.put("user_id", userId);
@@ -231,7 +198,7 @@ public class ProducerReportAgentApplication {
             // failed A2A task, not as an indefinite hang on the dispatcher.
             JobProxy proxy;
             try {
-                proxy = submitter.submit(payload).get(30, TimeUnit.SECONDS);
+                proxy = jobSubmitter.submit(payload).get(30, TimeUnit.SECONDS);
             } catch (TimeoutException te) {
                 throw new RuntimeException(
                     "submit() did not return a JobProxy within 30s — "

--- a/examples/typescript/producer-report-agent/index.ts
+++ b/examples/typescript/producer-report-agent/index.ts
@@ -21,20 +21,16 @@
  * wait}`. When it's a plain object/string, the surface treats the task
  * as sync (`state=completed` inline).
  *
- * `MeshJobSubmitter` wiring
- * =========================
+ * `MeshJobSubmitter` wiring (issue #936)
+ * ======================================
  *
- * The Java analog autowires `MeshRuntime` to read `registryUrl` and
- * `agentId` for hand-constructing a `MeshJobSubmitter` inside the
- * `@MeshA2A` handler (a framework gap — `@MeshA2A` injects
- * `McpMeshTool` proxies but NOT `MeshJobSubmitter` for `task=true`
- * deps).
- *
- * The TS equivalent is `getApiRuntime().getServiceId()` for the agent
- * id + `process.env.MCP_MESH_REGISTRY_URL` for the registry URL (the
- * same env var the SDK's `resolveConfig("registry_url", ...)` reads).
- * Cheap to construct (no I/O until `.submit(...)` fires) and stateless
- * after construction.
+ * The framework auto-injects a `MeshJobSubmitter` as the third positional
+ * argument of the handler. The submitter is bound to the producer's task
+ * capability — derived from the first declared dependency or, when none
+ * are declared, from the `skillId` with `-` replaced by `_` (so
+ * `"generate-report"` resolves to the `generate_report` task capability).
+ * No more hand-construction from `getApiRuntime().getServiceId()` and
+ * `MCP_MESH_REGISTRY_URL` — the framework owns this plumbing now.
  *
  * Stack
  * =====
@@ -93,7 +89,7 @@ process.env.MCP_MESH_AGENT_NAME =
   process.env.MCP_MESH_AGENT_NAME ?? "report-a2a-agent";
 
 import express from "express";
-import { getApiRuntime, mesh, MeshJobSubmitter } from "@mcpmesh/sdk";
+import { mesh } from "@mcpmesh/sdk";
 
 const app = express();
 app.use(express.json());
@@ -107,7 +103,7 @@ mesh.a2a.mount(
     description: "Generate a long-form report via A2A (task=True streaming)",
     tags: ["reports", "long-running"],
   },
-  async (_deps, payload) => {
+  async (_deps, payload, jobSubmitter) => {
     // The A2A request message carries the user payload as a text part
     // with JSON-encoded args. Real-world clients can use any parts
     // shape; for this example we parse parts[0].text as JSON.
@@ -132,32 +128,19 @@ mesh.a2a.mount(
       }
     }
 
-    // Construct a MeshJobSubmitter bound to the long-task-provider's
-    // generate_report capability. `@MeshA2A`-style auto-wiring of
-    // `MeshJobSubmitter` for `task=true` deps inside A2A handlers is
-    // not implemented today — the dispatcher only injects
-    // `McpMeshTool` proxies. We wire by hand from the api-runtime
-    // singleton (same pattern Java's example uses with autowired
-    // MeshRuntime).
-    //
-    // Cheap to construct — no I/O until submit() fires; stateless
-    // after construction.
-    const agentId = getApiRuntime().getServiceId();
-    if (!agentId) {
+    if (!jobSubmitter) {
+      // The framework injects a MeshJobSubmitter bound to the
+      // generate_report capability (derived from skillId per issue
+      // #936). Null only when the api-runtime hasn't finished
+      // initialising; surface a clear error so the client knows to
+      // retry rather than hang.
       throw new Error(
-        "api-runtime not yet started — cannot resolve agentId. " +
-        "Wait for the first heartbeat before calling tasks/send.",
+        "MeshJobSubmitter not yet available — mesh runtime is still " +
+          "initialising. Retry tasks/send shortly."
       );
     }
-    const registryUrl =
-      process.env.MCP_MESH_REGISTRY_URL ?? "http://localhost:8000";
-    const submitter = new MeshJobSubmitter(
-      "generate_report",
-      agentId,
-      registryUrl,
-    );
 
-    const proxy = await submitter.submit({
+    const proxy = await jobSubmitter.submit({
       user_id: userId,
       sections,
     });

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshA2ALazyRouterFunction.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshA2ALazyRouterFunction.java
@@ -1,0 +1,90 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.spring.web.MeshA2ADispatcherController;
+import org.springframework.web.servlet.function.HandlerFunction;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.RouterFunctions;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import java.util.Optional;
+
+/**
+ * Lazy wrapper around {@link MeshA2ADispatcherController#buildRouterFunction()}.
+ *
+ * <p>Returned by {@code MeshAutoConfiguration.meshA2ARouterFunction(...)} as the
+ * registered {@link RouterFunction} bean. The inner router is materialised on the
+ * first invocation of either {@link #route(ServerRequest)} or
+ * {@link #accept(RouterFunctions.Visitor)}, OR explicitly via
+ * {@link #materialise()} (called from a {@code SmartInitializingSingleton}).
+ *
+ * <h2>Why lazy</h2>
+ *
+ * <p>An earlier revision built the inner router synchronously inside the
+ * {@code meshA2ARouterFunction} factory, after forcing creation of every
+ * {@code @Component}/{@code @Service} bean so {@link io.mcpmesh.spring.web.MeshA2ABeanPostProcessor}
+ * had a chance to populate {@link io.mcpmesh.spring.web.MeshA2ARegistry}. That
+ * forced walk re-entered any user {@code @Component} that autowired
+ * {@link MeshRuntime}, triggering a Spring bean-creation cycle (issue #937).
+ *
+ * <p>Deferring the {@code buildRouterFunction()} call to first-access
+ * (either {@code accept(...)} from {@code RouterFunctionMapping.afterPropertiesSet()}
+ * or {@code route(...)} from the first matching HTTP request) removes the
+ * factory from the cycle path. By the time first-access occurs, every
+ * candidate bean has been post-processed by Spring's bean-creation pipeline
+ * and the registry is fully populated — the registry-driven route table
+ * is built once and cached.
+ *
+ * <h2>Concurrency</h2>
+ *
+ * <p>The build is single-shot and guarded by the monitor on {@code this}.
+ * Concurrent first-access from multiple HTTP threads is harmless: only one
+ * thread executes {@code buildRouterFunction()}, the rest re-read the
+ * cached reference. {@link #materialise()} runs synchronously on the
+ * Spring bootstrap thread, so contention in practice is negligible.
+ */
+final class MeshA2ALazyRouterFunction implements RouterFunction<ServerResponse> {
+
+    private final MeshA2ADispatcherController controller;
+    private volatile RouterFunction<ServerResponse> delegate;
+
+    MeshA2ALazyRouterFunction(MeshA2ADispatcherController controller) {
+        this.controller = controller;
+    }
+
+    /**
+     * Build the inner router if it hasn't been built yet. Idempotent —
+     * subsequent calls are no-ops. Invoked by the post-singleton
+     * {@code SmartInitializingSingleton} initializer in
+     * {@code MeshAutoConfiguration} to guarantee the router is ready
+     * before the first request can arrive.
+     */
+    void materialise() {
+        ensureDelegate();
+    }
+
+    private RouterFunction<ServerResponse> ensureDelegate() {
+        RouterFunction<ServerResponse> local = this.delegate;
+        if (local != null) {
+            return local;
+        }
+        synchronized (this) {
+            local = this.delegate;
+            if (local == null) {
+                local = controller.buildRouterFunction();
+                this.delegate = local;
+            }
+            return local;
+        }
+    }
+
+    @Override
+    public Optional<HandlerFunction<ServerResponse>> route(ServerRequest request) {
+        return ensureDelegate().route(request);
+    }
+
+    @Override
+    public void accept(RouterFunctions.Visitor visitor) {
+        ensureDelegate().accept(visitor);
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -19,6 +19,7 @@ import io.mcpmesh.spring.web.MeshRouteRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -30,6 +31,9 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.RouterFunctions;
+import org.springframework.web.servlet.function.ServerResponse;
 
 import io.mcpmesh.spring.tracing.TracingFilter;
 
@@ -149,8 +153,17 @@ public class MeshAutoConfiguration {
             MeshA2ARegistry registry,
             MeshA2ATaskStore taskStore,
             ObjectMapper objectMapper,
-            ObjectProvider<MeshDependencyInjector> injectorProvider) {
-        return new MeshA2ADispatcher(registry, taskStore, objectMapper, injectorProvider);
+            ObjectProvider<MeshDependencyInjector> injectorProvider,
+            ObjectProvider<MeshRuntime> runtimeProvider) {
+        // Issue #936: thread the MeshRuntime ObjectProvider through so the
+        // dispatcher can auto-inject MeshJobSubmitter parameters on
+        // @MeshA2A handlers (long-running producers). The provider is
+        // resolved lazily at the first request that actually declares a
+        // MeshJobSubmitter parameter — the dispatcher never resolves it at
+        // construction time, which keeps it off the bean-creation cycle
+        // that #937 fixed.
+        return new MeshA2ADispatcher(
+            registry, taskStore, objectMapper, injectorProvider, runtimeProvider);
     }
 
     /**
@@ -200,35 +213,66 @@ public class MeshAutoConfiguration {
      * controllers, static-resource serving, and error pages continue to
      * work alongside the A2A producer routes.
      *
-     * <p>The bean is built lazily from
-     * {@link MeshA2ADispatcherController#buildRouterFunction()} which
-     * iterates {@link MeshA2ARegistry} at bean-creation time. Because
-     * the controller depends on the registry and the registry is
-     * populated by {@link MeshA2ABeanPostProcessor} (which runs before
-     * this configuration's bean methods complete), the iteration sees
-     * the full surface set.
+     * <h2>Why this returns a lazy wrapper</h2>
+     *
+     * <p>An earlier revision walked {@code @Component}/{@code @Service}
+     * beans eagerly in this factory to force {@link MeshA2ABeanPostProcessor}
+     * to populate {@link MeshA2ARegistry} before the router was built. That
+     * eager walk caused a bean-creation cycle (issue #937): any user
+     * {@code @Component} that autowires {@link MeshRuntime} would re-enter
+     * {@code MeshRuntime}'s factory mid-creation and Spring 2.6+ rejects
+     * the cycle with {@code BeanCurrentlyInCreationException}.
+     *
+     * <p>This factory now returns a {@link MeshA2ALazyRouterFunction}: the
+     * router-function bean materialises immediately so {@code RouterFunctionMapping}
+     * can detect it as a bean, but {@link MeshA2ADispatcherController#buildRouterFunction()}
+     * is not invoked until either Spring asks for a route match
+     * (per-request {@code route(...)} call) or visits the route tree
+     * (e.g. {@code accept(ChangePathPatternParserVisitor)} from
+     * {@code RouterFunctionMapping.afterPropertiesSet()}). At those
+     * moments the {@link MeshA2ARegistry} is fully populated because
+     * {@link MeshA2ABeanPostProcessor} runs as part of each candidate
+     * bean's lifecycle — the eager walk is no longer required.
+     *
+     * <p>To guarantee the inner router exists before the first request,
+     * we additionally register a {@link SmartInitializingSingleton} below
+     * that proactively materialises it after all singletons have been
+     * created (and well before {@link MeshRuntime} starts).
      */
     @Bean
     @ConditionalOnMissingBean(name = "meshA2ARouterFunction")
-    public org.springframework.web.servlet.function.RouterFunction<
-            org.springframework.web.servlet.function.ServerResponse>
-            meshA2ARouterFunction(MeshA2ADispatcherController controller) {
-        // Force eager instantiation of all candidate beans so
-        // MeshA2ABeanPostProcessor populates MeshA2ARegistry before we
-        // build the router function. Without this, Spring's bean creation
-        // order would let the router-function be built BEFORE the user's
-        // @Component / @Service classes are instantiated, leaving the
-        // registry empty.
-        //
-        // The same eager-touch trick is used by buildAgentSpec() for the
-        // route-registry-based consumer-only mode detection.
-        applicationContext.getBeansWithAnnotation(
-            org.springframework.stereotype.Component.class);
-        applicationContext.getBeansWithAnnotation(
-            org.springframework.stereotype.Service.class);
-        applicationContext.getBeansWithAnnotation(
-            org.springframework.web.bind.annotation.RestController.class);
-        return controller.buildRouterFunction();
+    public RouterFunction<ServerResponse> meshA2ARouterFunction(
+            MeshA2ADispatcherController controller) {
+        return new MeshA2ALazyRouterFunction(controller);
+    }
+
+    /**
+     * Materialises the lazy {@link MeshA2ALazyRouterFunction} once Spring
+     * has finished creating all singletons. Running here (instead of
+     * inside the {@code meshA2ARouterFunction} factory) keeps the bean
+     * factory off the user-{@code @Component} bean-creation path that
+     * triggered issue #937, while ensuring the registry-driven route
+     * table is built before the first HTTP request can reach the
+     * dispatcher.
+     *
+     * <p>This runs as a {@link SmartInitializingSingleton} — Spring
+     * guarantees it fires AFTER every singleton has been instantiated
+     * (so every {@code @MeshA2A}-bearing {@code @Component} has been
+     * post-processed into the registry) and BEFORE any
+     * {@link org.springframework.context.SmartLifecycle#start()} call
+     * (so {@link MeshRuntime}'s heartbeat loop sees a fully-built
+     * surface set — see {@link #meshA2ASpecFinalizer} which mutates the
+     * agent spec in the same phase).
+     */
+    @Bean
+    @ConditionalOnMissingBean(name = "meshA2ARouterFunctionInitializer")
+    public SmartInitializingSingleton meshA2ARouterFunctionInitializer(
+            RouterFunction<ServerResponse> meshA2ARouterFunction) {
+        return () -> {
+            if (meshA2ARouterFunction instanceof MeshA2ALazyRouterFunction lazy) {
+                lazy.materialise();
+            }
+        };
     }
 
     /**
@@ -338,19 +382,61 @@ public class MeshAutoConfiguration {
     public MeshRuntime meshRuntime(
             MeshProperties properties,
             MeshToolRegistry toolRegistry,
-            MeshToolWrapperRegistry wrapperRegistry,
             MeshLlmRegistry llmRegistry,
             MeshConfigResolver configResolver,
+            ObjectMapper objectMapper) {
+
+        // Build the bare agent spec — identity, ports, registry URL.
+        // Tools, route/A2A dependencies, and surfaces are folded in by
+        // meshAgentSpecFinalizer below, AFTER Spring has finished creating
+        // every singleton. Walking @Component beans from this factory
+        // (the old behaviour) triggered a bean-creation cycle for any user
+        // @Component that autowired MeshRuntime — see issue #937.
+        AgentSpec spec = buildBaseAgentSpec(properties, toolRegistry, llmRegistry,
+            configResolver);
+        log.info("Creating MeshRuntime for agent '{}' (tools/surfaces populated post-init)",
+            spec.getName());
+
+        return new MeshRuntime(spec, objectMapper);
+    }
+
+    /**
+     * Fold tools, route/A2A dependencies, LLM provider tools, and A2A
+     * surfaces into the agent spec AFTER every singleton has been
+     * instantiated. Runs as a {@link SmartInitializingSingleton} which
+     * Spring guarantees fires:
+     *
+     * <ul>
+     *   <li>AFTER every {@code @Component}/{@code @Service}/{@code @RestController}
+     *       singleton (so {@link MeshA2ABeanPostProcessor},
+     *       {@link MeshToolBeanPostProcessor}, and
+     *       {@link io.mcpmesh.spring.web.MeshRouteBeanPostProcessor} have
+     *       seen every candidate bean and populated their registries).</li>
+     *   <li>BEFORE any {@link org.springframework.context.SmartLifecycle#start()}
+     *       call — including {@link MeshRuntime#start()} — so the spec
+     *       handed to the native core's heartbeat loop reflects the full
+     *       tool/surface set on the very first heartbeat envelope.</li>
+     * </ul>
+     *
+     * <p>This deliberately replaces the previous eager
+     * {@code applicationContext.getBeansWithAnnotation(...)} calls inside
+     * the {@code meshRuntime} factory; those calls re-entered user
+     * {@code @Component} beans that autowired {@code MeshRuntime}, which
+     * Spring 2.6+ rejects as {@code BeanCurrentlyInCreationException}
+     * (issue #937).
+     */
+    @Bean
+    @ConditionalOnMissingBean(name = "meshAgentSpecFinalizer")
+    public SmartInitializingSingleton meshAgentSpecFinalizer(
+            MeshRuntime runtime,
+            MeshToolRegistry toolRegistry,
+            MeshToolWrapperRegistry wrapperRegistry,
+            MeshLlmRegistry llmRegistry,
             ObjectMapper objectMapper,
             ObjectProvider<MeshRouteRegistry> routeRegistryProvider,
             ObjectProvider<MeshA2ARegistry> a2aRegistryProvider) {
-
-        AgentSpec spec = buildAgentSpec(properties, toolRegistry, wrapperRegistry, llmRegistry,
-            configResolver, objectMapper, routeRegistryProvider, a2aRegistryProvider);
-        log.info("Creating MeshRuntime for agent '{}' with {} tools",
-            spec.getName(), spec.getTools().size());
-
-        return new MeshRuntime(spec, objectMapper);
+        return () -> finalizeAgentSpec(runtime.getAgentSpec(), toolRegistry, wrapperRegistry,
+            llmRegistry, objectMapper, routeRegistryProvider, a2aRegistryProvider);
     }
 
     @Bean
@@ -457,15 +543,25 @@ public class MeshAutoConfiguration {
             a2aConsumerBeanPostProcessor);
     }
 
-    private AgentSpec buildAgentSpec(
+    /**
+     * Build the bare {@link AgentSpec} — identity, ports, host, namespace,
+     * heartbeat interval, registry URL. Does NOT walk {@code @Component}
+     * beans or read the tool/route/A2A registries; that work is done by
+     * {@link #finalizeAgentSpec} after every singleton has been
+     * instantiated.
+     *
+     * <p>Splitting the spec build into a "metadata-only" phase here and a
+     * "tools and surfaces" phase post-singleton-init is the structural
+     * fix for issue #937 — the old factory walked
+     * {@code @Component}/{@code @Service} beans synchronously, which
+     * re-entered any user component that autowired {@link MeshRuntime}
+     * and triggered Spring's circular-reference guard.
+     */
+    private AgentSpec buildBaseAgentSpec(
             MeshProperties properties,
             MeshToolRegistry toolRegistry,
-            MeshToolWrapperRegistry wrapperRegistry,
             MeshLlmRegistry llmRegistry,
-            MeshConfigResolver configResolver,
-            ObjectMapper objectMapper,
-            ObjectProvider<MeshRouteRegistry> routeRegistryProvider,
-            ObjectProvider<MeshA2ARegistry> a2aRegistryProvider) {
+            MeshConfigResolver configResolver) {
 
         // Find @MeshAgent annotation
         MeshAgent agentAnnotation = findMeshAgentAnnotation();
@@ -479,18 +575,17 @@ public class MeshAutoConfiguration {
         String name = configResolver.resolve("agent_name", paramName);
 
         if (name == null || name.isBlank()) {
-            // No agent name configured — check if this is consumer-only mode.
-            // Force RestController beans to be created first so MeshRouteBeanPostProcessor
-            // populates MeshRouteRegistry before we check it.
-            applicationContext.getBeansWithAnnotation(
-                org.springframework.web.bind.annotation.RestController.class);
-            MeshRouteRegistry routeRegistry = routeRegistryProvider.getIfAvailable();
-            if (routeRegistry != null && routeRegistry.hasRoutes()) {
-                log.info("No @MeshAgent found, but @MeshRoute dependencies detected — starting in consumer-only mode");
-                return buildConsumerAgentSpec(properties, configResolver, routeRegistryProvider);
-            }
-            throw new IllegalStateException(
-                "Agent name is required. Set MCP_MESH_AGENT_NAME, mesh.agent.name, or @MeshAgent(name=...)");
+            // No agent name configured — fall back to consumer-only mode.
+            // We can't yet check MeshRouteRegistry (it's populated by a
+            // BeanPostProcessor as @RestController beans are created); we
+            // build a consumer-only spec optimistically and the post-init
+            // finalizer will populate route deps. If neither @MeshAgent
+            // nor any @MeshRoute is present, the finalizer would have
+            // nothing to add — in that case the agent has no reason to
+            // start. To preserve the previous fail-fast behaviour we
+            // re-check inside the finalizer (see finalizeAgentSpec).
+            log.info("No agent name configured — provisional consumer-only spec; will validate after singletons init");
+            return buildConsumerAgentSpec(properties, configResolver);
         }
 
         // Append UUID suffix like Python/TypeScript SDKs: {name}-{8char_uuid}.
@@ -537,35 +632,58 @@ public class MeshAutoConfiguration {
         String propertiesRegistryUrl = properties.getRegistry().getUrl();
         spec.setRegistryUrl(configResolver.resolve("registry_url", propertiesRegistryUrl));
 
-        // Phase B MeshJob substrate: register the three helper tools as
-        // synthetic specs BEFORE getToolSpecs() is read into the
-        // heartbeat catalog. Without this the registry never learns the
-        // helpers exist (they were registered too late in JobsRuntimeManager).
-        // Also registers the wrapper-side handlers so MCP tools/call
-        // requests for the helper names dispatch correctly. Skips
-        // gracefully when no registry URL is configured.
-        String resolvedRegistryUrl = configResolver.resolve("registry_url",
-            properties.getRegistry().getUrl());
-        try {
-            JobsHelperToolsRegistrar.register(toolRegistry, wrapperRegistry, resolvedRegistryUrl);
-        } catch (Exception e) {
-            log.warn("Failed to register MeshJob helper tools at startup", e);
-        }
-
         // Issue #916 Phase 1: inject the surrounding @MeshAgent name as
-        // a tag on every @A2AConsumer-annotated tool BEFORE
-        // toolRegistry.getToolSpecs() snapshots the catalog. Mirrors
-        // Python's _resolve_pending_consumer_self_tags substitution —
-        // makes a bridged capability distinguishable from sibling
-        // consumers in the registry, so downstream dependencies can
-        // pin a specific bridge by tag and untagged dependencies still
-        // auto-fail-over when one bridge dies.
+        // a tag on every @A2AConsumer-annotated tool. This only mutates
+        // ToolSpec metadata captured by the @A2AConsumer post-processor
+        // at bean-creation time — no bean walking, no cycle risk.
         try {
             toolRegistry.injectConsumerNameTags(name);
         } catch (Exception e) {
             log.warn("Failed to inject @A2AConsumer auto-tags for agent '{}': {}",
                 name, e.getMessage());
         }
+
+        // Start with an empty tools list; finalizeAgentSpec populates it
+        // post-singleton-init. We initialise to an empty list (not null)
+        // so any callers reading getTools() between now and the finalizer
+        // get a stable, non-null reference.
+        spec.setTools(new ArrayList<>());
+        return spec;
+    }
+
+    /**
+     * Second-phase agent-spec build: fold tools, route/A2A dependencies,
+     * LLM provider tools, MeshJob helper tools, and A2A surfaces into the
+     * spec built by {@link #buildBaseAgentSpec}. Called from
+     * {@link #meshAgentSpecFinalizer} as a {@link SmartInitializingSingleton}
+     * — runs AFTER every bean has been post-processed (so every registry
+     * is fully populated) and BEFORE {@link MeshRuntime#start()} fires.
+     */
+    private void finalizeAgentSpec(
+            AgentSpec spec,
+            MeshToolRegistry toolRegistry,
+            MeshToolWrapperRegistry wrapperRegistry,
+            MeshLlmRegistry llmRegistry,
+            ObjectMapper objectMapper,
+            ObjectProvider<MeshRouteRegistry> routeRegistryProvider,
+            ObjectProvider<MeshA2ARegistry> a2aRegistryProvider) {
+
+        // Phase B MeshJob substrate: register the three helper tools as
+        // synthetic specs BEFORE getToolSpecs() is read into the
+        // heartbeat catalog. Skips gracefully when no registry URL is
+        // configured.
+        try {
+            JobsHelperToolsRegistrar.register(toolRegistry, wrapperRegistry, spec.getRegistryUrl());
+        } catch (Exception e) {
+            log.warn("Failed to register MeshJob helper tools at startup", e);
+        }
+
+        // Consumer-only fallback validation: if buildBaseAgentSpec
+        // produced a consumer-only spec (agent_type="api") because no
+        // agent name was configured, surface a clear error when the user
+        // also has no @MeshRoute dependencies — otherwise the agent has
+        // no reason to start.
+        boolean consumerOnly = "api".equals(spec.getAgentType());
 
         // Add tools from registry (dependencies are embedded in tool specs)
         List<AgentSpec.ToolSpec> allTools = new ArrayList<>(toolRegistry.getToolSpecs());
@@ -579,18 +697,24 @@ public class MeshAutoConfiguration {
         // Add @MeshRoute dependencies as a synthetic tool
         addRouteDependencies(allTools, routeRegistryProvider);
 
-        // Issue #932 Phase 1A: force user beans (containing @MeshA2A) to be
-        // created so MeshA2ABeanPostProcessor populates MeshA2ARegistry
-        // before we read it.
-        applicationContext.getBeansWithAnnotation(
-            org.springframework.stereotype.Component.class);
-        applicationContext.getBeansWithAnnotation(
-            org.springframework.stereotype.Service.class);
-
         // Add @MeshA2A dependencies as a synthetic tool so the Rust core
         // resolves them via the registry's dependency mechanism (same
-        // pattern as addRouteDependencies).
+        // pattern as addRouteDependencies). No eager bean-walk needed —
+        // MeshA2ABeanPostProcessor populated the registry as each
+        // @Component was created during the singleton init phase.
         addA2ADependencies(allTools, a2aRegistryProvider);
+
+        if (consumerOnly) {
+            MeshRouteRegistry routeRegistry = routeRegistryProvider.getIfAvailable();
+            boolean hasRoutes = routeRegistry != null && routeRegistry.hasRoutes();
+            if (!hasRoutes) {
+                throw new IllegalStateException(
+                    "Agent name is required. Set MCP_MESH_AGENT_NAME, mesh.agent.name, "
+                        + "or @MeshAgent(name=...)");
+            }
+            log.info("Consumer-only mode confirmed: {} @MeshRoute dependency tool(s) registered",
+                allTools.size());
+        }
 
         spec.setTools(allTools);
 
@@ -600,7 +724,8 @@ public class MeshAutoConfiguration {
         // capabilities.
         applyA2ASurfaces(spec, a2aRegistryProvider, objectMapper);
 
-        return spec;
+        log.info("Agent spec finalized for '{}' with {} tool(s)",
+            spec.getName(), spec.getTools().size());
     }
 
     /**
@@ -672,8 +797,7 @@ public class MeshAutoConfiguration {
      */
     private AgentSpec buildConsumerAgentSpec(
             MeshProperties properties,
-            MeshConfigResolver configResolver,
-            ObjectProvider<MeshRouteRegistry> routeRegistryProvider) {
+            MeshConfigResolver configResolver) {
 
         AgentSpec spec = new AgentSpec();
 
@@ -718,13 +842,11 @@ public class MeshAutoConfiguration {
         String propertiesRegistryUrl = properties.getRegistry().getUrl();
         spec.setRegistryUrl(configResolver.resolve("registry_url", propertiesRegistryUrl));
 
-        // No tools or LLM agents — only route dependencies
-        List<AgentSpec.ToolSpec> tools = new ArrayList<>();
-        addRouteDependencies(tools, routeRegistryProvider);
-        spec.setTools(tools);
+        // Tools populated by finalizeAgentSpec (post-singleton-init).
+        spec.setTools(new ArrayList<>());
 
-        log.info("Consumer-only AgentSpec: name='{}', agentType='api', dependencies={}",
-            spec.getName(), tools.size());
+        log.info("Consumer-only AgentSpec (base): name='{}', agentType='api' "
+            + "(route deps populated post-init)", spec.getName());
 
         return spec;
     }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -267,6 +268,7 @@ public class MeshAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(name = "meshA2ARouterFunctionInitializer")
     public SmartInitializingSingleton meshA2ARouterFunctionInitializer(
+            @Qualifier("meshA2ARouterFunction")
             RouterFunction<ServerResponse> meshA2ARouterFunction) {
         return () -> {
             if (meshA2ARouterFunction instanceof MeshA2ALazyRouterFunction lazy) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcher.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -79,45 +80,33 @@ public class MeshA2ADispatcher {
     private final ObjectProvider<MeshRuntime> runtimeProvider;
 
     /**
-     * Per-surface cache of {@link MeshJobSubmitter} instances. Issue #936:
-     * {@code @MeshA2A} handlers may declare a {@link MeshJobSubmitter}
+     * Per-surface cache of REAL {@link MeshJobSubmitter} instances. Issue
+     * #936: {@code @MeshA2A} handlers may declare a {@link MeshJobSubmitter}
      * parameter that the framework auto-injects at call time. Submitters
      * are stateless after construction (capability + agent id + registry
      * URL), so one cached instance per surface is correct — we look up
      * by {@code handlerMethodId} since the same surface can be re-resolved
      * across requests but always points at the same skill.
+     *
+     * <p>This map ONLY contains successfully constructed submitters; the
+     * sibling {@link #unbuildableSurfaces} set tracks surfaces we have
+     * determined can never produce a submitter. Splitting the two states
+     * into separate collections (rather than using a sentinel value)
+     * eliminates the risk of accidentally exposing a fake submitter
+     * identity through any future getter / debug API and keeps class-load
+     * independent of {@link MeshJobSubmitter}'s constructor health.
      */
     private final Map<String, MeshJobSubmitter> jobSubmitterCache = new ConcurrentHashMap<>();
 
     /**
-     * Sentinel marker used by {@link #jobSubmitterCache} to memoize a
-     * "no submitter buildable" outcome (e.g. {@link MeshRuntime} not
-     * yet available, or no capability can be resolved). We can't store
-     * {@code null} in a {@link ConcurrentHashMap} so a sentinel instance
-     * lets us treat "definitively unbuildable" as a distinct cached
-     * outcome from "not yet attempted".
+     * Set of surface handler IDs we have determined can NEVER produce a
+     * usable {@link MeshJobSubmitter} — either because no capability can
+     * be derived or because the dispatcher was constructed without a
+     * runtime provider. This is the "permanent unbuildable" memo; transient
+     * conditions (runtime not yet available, agent id empty, constructor
+     * threw) are NOT recorded here so they can be retried on the next call.
      */
-    private static final MeshJobSubmitter UNBUILDABLE_SUBMITTER = makeUnbuildableSentinel();
-
-    /**
-     * Construct an unbuildable sentinel using legal placeholder arguments
-     * — the constructor refuses null/empty so we pass throwaway strings
-     * the cache will never expose to user code.
-     */
-    private static MeshJobSubmitter makeUnbuildableSentinel() {
-        // The constructor validates non-empty args but doesn't touch the
-        // FFI runtime until submit() is called; safe to instantiate here
-        // purely as a unique reference value.
-        try {
-            return new MeshJobSubmitter("__sentinel__", "__sentinel__", "__sentinel__");
-        } catch (Throwable t) {
-            // If even the sentinel can't be built (e.g. core load fails
-            // in test JVMs without the native lib), fall back to a proxy
-            // that's distinguishable by identity — but every test JVM
-            // does load the native lib so this path is defensive.
-            throw new IllegalStateException("Failed to build MeshJobSubmitter sentinel", t);
-        }
-    }
+    private final Set<String> unbuildableSurfaces = ConcurrentHashMap.newKeySet();
 
     public MeshA2ADispatcher(
             MeshA2ARegistry registry,
@@ -682,24 +671,41 @@ public class MeshA2ADispatcher {
      * </ol>
      */
     private MeshJobSubmitter resolveJobSubmitter(MeshA2ARegistry.SurfaceMetadata surface) {
-        MeshJobSubmitter cached = jobSubmitterCache.get(surface.handlerMethodId());
+        String surfaceId = surface.handlerMethodId();
+        // Permanent-unbuildable check first: surfaces marked here will
+        // NEVER produce a submitter (no capability, or no runtime provider
+        // wired) so short-circuit without touching the runtime provider.
+        if (unbuildableSurfaces.contains(surfaceId)) {
+            return null;
+        }
+        MeshJobSubmitter cached = jobSubmitterCache.get(surfaceId);
         if (cached != null) {
-            return cached == UNBUILDABLE_SUBMITTER ? null : cached;
+            return cached;
         }
         if (runtimeProvider == null) {
             log.warn("@MeshA2A {} declares MeshJobSubmitter parameter but the dispatcher was "
                 + "constructed without a MeshRuntime provider — injecting null. Use the "
                 + "five-arg MeshA2ADispatcher constructor (the Spring autoconfiguration wires "
-                + "this automatically).", surface.handlerMethodId());
-            jobSubmitterCache.put(surface.handlerMethodId(), UNBUILDABLE_SUBMITTER);
+                + "this automatically).", surfaceId);
+            unbuildableSurfaces.add(surfaceId);
             return null;
         }
-        MeshRuntime runtime = runtimeProvider.getIfAvailable();
+        MeshRuntime runtime;
+        try {
+            runtime = runtimeProvider.getIfAvailable();
+        } catch (Exception e) {
+            // Treat provider faults (Spring bean init exceptions) as
+            // transient — the bean may be available on a later request
+            // once Spring finishes its init pass.
+            log.warn("@MeshA2A {}: MeshRuntime provider raised on getIfAvailable() — injecting null: {}",
+                surfaceId, e.getMessage());
+            return null;
+        }
         if (runtime == null || runtime.getAgentSpec() == null) {
             log.warn("@MeshA2A {} declares MeshJobSubmitter parameter but MeshRuntime is not "
                 + "yet available — injecting null. This usually means tasks/send fired before "
                 + "the runtime finished initialising; retrying the request shortly should succeed.",
-                surface.handlerMethodId());
+                surfaceId);
             // Don't memoize this — the runtime may become available later.
             return null;
         }
@@ -708,7 +714,7 @@ public class MeshA2ADispatcher {
         if (agentId == null || agentId.isEmpty() || registryUrl == null || registryUrl.isEmpty()) {
             log.warn("@MeshA2A {} declares MeshJobSubmitter parameter but agent id / registry URL "
                 + "is not configured (agentId='{}' registryUrl='{}') — injecting null.",
-                surface.handlerMethodId(), agentId, registryUrl);
+                surfaceId, agentId, registryUrl);
             // Don't memoize — config may be filled in later if the runtime
             // is mid-finalize.
             return null;
@@ -717,19 +723,19 @@ public class MeshA2ADispatcher {
         if (capability == null || capability.isEmpty()) {
             log.warn("@MeshA2A {} declares MeshJobSubmitter parameter but no capability can be "
                 + "derived (no @MeshDependency declared and skillId is empty) — injecting null.",
-                surface.handlerMethodId());
-            jobSubmitterCache.put(surface.handlerMethodId(), UNBUILDABLE_SUBMITTER);
+                surfaceId);
+            unbuildableSurfaces.add(surfaceId);
             return null;
         }
         try {
             MeshJobSubmitter submitter = new MeshJobSubmitter(capability, agentId, registryUrl);
-            jobSubmitterCache.put(surface.handlerMethodId(), submitter);
+            jobSubmitterCache.put(surfaceId, submitter);
             log.info("@MeshA2A {}: auto-injected MeshJobSubmitter (capability={}, agentId={})",
-                surface.handlerMethodId(), capability, agentId);
+                surfaceId, capability, agentId);
             return submitter;
         } catch (Exception e) {
             log.warn("@MeshA2A {}: failed to construct MeshJobSubmitter: {}",
-                surface.handlerMethodId(), e.getMessage());
+                surfaceId, e.getMessage());
             // Don't memoize a transient construction failure — the FFI
             // runtime may be in a recoverable state.
             return null;

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcher.java
@@ -1,7 +1,9 @@
 package io.mcpmesh.spring.web;
 
 import io.mcpmesh.JobProxy;
+import io.mcpmesh.MeshJobSubmitter;
 import io.mcpmesh.spring.MeshDependencyInjector;
+import io.mcpmesh.spring.MeshRuntime;
 import io.mcpmesh.types.McpMeshTool;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -22,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * JSON-RPC 2.0 dispatcher for {@code @MeshA2A} producer surfaces (spec §4).
@@ -73,16 +76,76 @@ public class MeshA2ADispatcher {
     private final MeshA2ATaskStore taskStore;
     private final ObjectMapper objectMapper;
     private final ObjectProvider<MeshDependencyInjector> injectorProvider;
+    private final ObjectProvider<MeshRuntime> runtimeProvider;
+
+    /**
+     * Per-surface cache of {@link MeshJobSubmitter} instances. Issue #936:
+     * {@code @MeshA2A} handlers may declare a {@link MeshJobSubmitter}
+     * parameter that the framework auto-injects at call time. Submitters
+     * are stateless after construction (capability + agent id + registry
+     * URL), so one cached instance per surface is correct — we look up
+     * by {@code handlerMethodId} since the same surface can be re-resolved
+     * across requests but always points at the same skill.
+     */
+    private final Map<String, MeshJobSubmitter> jobSubmitterCache = new ConcurrentHashMap<>();
+
+    /**
+     * Sentinel marker used by {@link #jobSubmitterCache} to memoize a
+     * "no submitter buildable" outcome (e.g. {@link MeshRuntime} not
+     * yet available, or no capability can be resolved). We can't store
+     * {@code null} in a {@link ConcurrentHashMap} so a sentinel instance
+     * lets us treat "definitively unbuildable" as a distinct cached
+     * outcome from "not yet attempted".
+     */
+    private static final MeshJobSubmitter UNBUILDABLE_SUBMITTER = makeUnbuildableSentinel();
+
+    /**
+     * Construct an unbuildable sentinel using legal placeholder arguments
+     * — the constructor refuses null/empty so we pass throwaway strings
+     * the cache will never expose to user code.
+     */
+    private static MeshJobSubmitter makeUnbuildableSentinel() {
+        // The constructor validates non-empty args but doesn't touch the
+        // FFI runtime until submit() is called; safe to instantiate here
+        // purely as a unique reference value.
+        try {
+            return new MeshJobSubmitter("__sentinel__", "__sentinel__", "__sentinel__");
+        } catch (Throwable t) {
+            // If even the sentinel can't be built (e.g. core load fails
+            // in test JVMs without the native lib), fall back to a proxy
+            // that's distinguishable by identity — but every test JVM
+            // does load the native lib so this path is defensive.
+            throw new IllegalStateException("Failed to build MeshJobSubmitter sentinel", t);
+        }
+    }
 
     public MeshA2ADispatcher(
             MeshA2ARegistry registry,
             MeshA2ATaskStore taskStore,
             ObjectMapper objectMapper,
             ObjectProvider<MeshDependencyInjector> injectorProvider) {
+        this(registry, taskStore, objectMapper, injectorProvider, null);
+    }
+
+    /**
+     * Full constructor — accepts an {@link MeshRuntime} provider so the
+     * dispatcher can auto-inject {@link MeshJobSubmitter} parameters
+     * on {@code @MeshA2A} handlers (issue #936). Pass {@code null} for
+     * the runtime provider in tests that don't exercise the submitter
+     * injection path; the dispatcher then falls back to leaving any
+     * {@code MeshJobSubmitter} parameter slot as {@code null}.
+     */
+    public MeshA2ADispatcher(
+            MeshA2ARegistry registry,
+            MeshA2ATaskStore taskStore,
+            ObjectMapper objectMapper,
+            ObjectProvider<MeshDependencyInjector> injectorProvider,
+            ObjectProvider<MeshRuntime> runtimeProvider) {
         this.registry = registry;
         this.taskStore = taskStore;
         this.objectMapper = objectMapper;
         this.injectorProvider = injectorProvider;
+        this.runtimeProvider = runtimeProvider;
     }
 
     /**
@@ -544,7 +607,17 @@ public class MeshA2ADispatcher {
      *   <li>{@link McpMeshTool} proxies at any parameter annotated
      *       {@link MeshInject} (or whose type is {@link McpMeshTool}),
      *       resolved through {@link MeshDependencyInjector} — same DDDI
-     *       wiring used by {@code @MeshRoute} and {@code @A2AConsumer}.</li>
+     *       wiring used by {@code @MeshRoute} and {@code @A2AConsumer};</li>
+     *   <li>a {@link MeshJobSubmitter} at any parameter typed
+     *       {@code MeshJobSubmitter} (issue #936) — auto-constructed by the
+     *       framework with the surface's task capability + the local agent
+     *       id + registry URL, so long-running producers no longer need to
+     *       autowire {@link MeshRuntime} and hand-construct the submitter.
+     *       The capability defaults to the first declared
+     *       {@code @MeshDependency} entry; when no deps are declared we
+     *       derive it from {@code skillId} by replacing {@code '-'} with
+     *       {@code '_'} (the canonical skill-id-to-capability mapping —
+     *       matches the existing examples' usage).</li>
      * </ul>
      */
     @SuppressWarnings("unchecked")
@@ -560,6 +633,11 @@ public class MeshA2ADispatcher {
             MeshInject inj = p.getAnnotation(MeshInject.class);
             if (inj != null || McpMeshTool.class.isAssignableFrom(p.getType())) {
                 args[i] = resolveDependency(surface, p, inj);
+            } else if (MeshJobSubmitter.class.isAssignableFrom(p.getType())) {
+                // Issue #936: framework-injected MeshJobSubmitter for
+                // long-running producers. Cache per surface — the submitter
+                // is stateless after construction.
+                args[i] = resolveJobSubmitter(surface);
             } else if (Map.class.isAssignableFrom(p.getType()) && !messageAssigned) {
                 args[i] = message;
                 messageAssigned = true;
@@ -582,6 +660,100 @@ public class MeshA2ADispatcher {
         } catch (InvocationTargetException ite) {
             throw ite.getCause() != null ? ite.getCause() : ite;
         }
+    }
+
+    /**
+     * Resolve (and cache) a {@link MeshJobSubmitter} bound to the given
+     * surface (issue #936). Returns {@code null} if the runtime isn't
+     * available or no capability can be derived — callers that hit this
+     * fallback will surface a clear error from the user's handler when
+     * they invoke {@link MeshJobSubmitter#submit(Map)} on a null reference,
+     * which is the same failure mode as forgetting to autowire today.
+     *
+     * <p>Capability resolution order:
+     * <ol>
+     *   <li>The first declared {@code @MeshDependency} capability on the
+     *       surface — matches what the existing user-side workaround
+     *       hand-constructs against today.</li>
+     *   <li>{@code skillId} with {@code '-'} replaced by {@code '_'} —
+     *       e.g. {@code "generate-report"} becomes {@code "generate_report"},
+     *       the canonical kebab-to-snake convention. Matches the
+     *       producer-report-agent example's hardcoded capability.</li>
+     * </ol>
+     */
+    private MeshJobSubmitter resolveJobSubmitter(MeshA2ARegistry.SurfaceMetadata surface) {
+        MeshJobSubmitter cached = jobSubmitterCache.get(surface.handlerMethodId());
+        if (cached != null) {
+            return cached == UNBUILDABLE_SUBMITTER ? null : cached;
+        }
+        if (runtimeProvider == null) {
+            log.warn("@MeshA2A {} declares MeshJobSubmitter parameter but the dispatcher was "
+                + "constructed without a MeshRuntime provider — injecting null. Use the "
+                + "five-arg MeshA2ADispatcher constructor (the Spring autoconfiguration wires "
+                + "this automatically).", surface.handlerMethodId());
+            jobSubmitterCache.put(surface.handlerMethodId(), UNBUILDABLE_SUBMITTER);
+            return null;
+        }
+        MeshRuntime runtime = runtimeProvider.getIfAvailable();
+        if (runtime == null || runtime.getAgentSpec() == null) {
+            log.warn("@MeshA2A {} declares MeshJobSubmitter parameter but MeshRuntime is not "
+                + "yet available — injecting null. This usually means tasks/send fired before "
+                + "the runtime finished initialising; retrying the request shortly should succeed.",
+                surface.handlerMethodId());
+            // Don't memoize this — the runtime may become available later.
+            return null;
+        }
+        String agentId = runtime.getAgentSpec().getAgentId();
+        String registryUrl = runtime.getAgentSpec().getRegistryUrl();
+        if (agentId == null || agentId.isEmpty() || registryUrl == null || registryUrl.isEmpty()) {
+            log.warn("@MeshA2A {} declares MeshJobSubmitter parameter but agent id / registry URL "
+                + "is not configured (agentId='{}' registryUrl='{}') — injecting null.",
+                surface.handlerMethodId(), agentId, registryUrl);
+            // Don't memoize — config may be filled in later if the runtime
+            // is mid-finalize.
+            return null;
+        }
+        String capability = pickSubmitterCapability(surface);
+        if (capability == null || capability.isEmpty()) {
+            log.warn("@MeshA2A {} declares MeshJobSubmitter parameter but no capability can be "
+                + "derived (no @MeshDependency declared and skillId is empty) — injecting null.",
+                surface.handlerMethodId());
+            jobSubmitterCache.put(surface.handlerMethodId(), UNBUILDABLE_SUBMITTER);
+            return null;
+        }
+        try {
+            MeshJobSubmitter submitter = new MeshJobSubmitter(capability, agentId, registryUrl);
+            jobSubmitterCache.put(surface.handlerMethodId(), submitter);
+            log.info("@MeshA2A {}: auto-injected MeshJobSubmitter (capability={}, agentId={})",
+                surface.handlerMethodId(), capability, agentId);
+            return submitter;
+        } catch (Exception e) {
+            log.warn("@MeshA2A {}: failed to construct MeshJobSubmitter: {}",
+                surface.handlerMethodId(), e.getMessage());
+            // Don't memoize a transient construction failure — the FFI
+            // runtime may be in a recoverable state.
+            return null;
+        }
+    }
+
+    /**
+     * Pick the capability the auto-injected {@link MeshJobSubmitter}
+     * should target for the given surface. See {@link #resolveJobSubmitter}
+     * for the resolution order rationale.
+     */
+    private static String pickSubmitterCapability(MeshA2ARegistry.SurfaceMetadata surface) {
+        List<MeshRouteRegistry.DependencySpec> deps = surface.dependencies();
+        if (deps != null && !deps.isEmpty()) {
+            String cap = deps.get(0).getCapability();
+            if (cap != null && !cap.isEmpty()) {
+                return cap;
+            }
+        }
+        String skillId = surface.skillId();
+        if (skillId == null || skillId.isEmpty()) {
+            return null;
+        }
+        return skillId.replace('-', '_');
     }
 
     private McpMeshTool resolveDependency(

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherJobSubmitterInjectionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherJobSubmitterInjectionTest.java
@@ -239,7 +239,7 @@ class MeshA2ADispatcherJobSubmitterInjectionTest {
     }
 
     @Test
-    @DisplayName("Three-arg dispatcher constructor: handler with submitter param gets null (back-compat)")
+    @DisplayName("Four-arg dispatcher constructor: handler with submitter param gets null (back-compat)")
     void legacyConstructor_doesNotCrashOnMeshJobSubmitterParam() throws Exception {
         registry.register(surfaceFor("/svc", "generate-report", List.of()));
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherJobSubmitterInjectionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherJobSubmitterInjectionTest.java
@@ -1,0 +1,273 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.MeshJobSubmitter;
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.spring.MeshRuntime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.ResponseEntity;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link MeshA2ADispatcher}'s framework auto-injection of
+ * {@link MeshJobSubmitter} parameter slots on {@code @MeshA2A} handlers
+ * (issue #936).
+ *
+ * <p>Mirrors what TS coverage of the same feature asserts on
+ * {@code mesh.a2a.mount(...)}:
+ *
+ * <ul>
+ *   <li>A handler declaring a {@code MeshJobSubmitter} parameter gets a
+ *       non-null instance at call time (no more {@code @Lazy MeshRuntime}
+ *       autowire dance in user code).</li>
+ *   <li>The submitter's {@code capability} defaults to the first declared
+ *       {@code @MeshDependency} entry when present.</li>
+ *   <li>Otherwise the capability defaults to {@code skillId} with
+ *       {@code '-'} replaced by {@code '_'} — the canonical
+ *       kebab-to-snake mapping that matches the existing
+ *       producer-report-agent example (skill {@code "generate-report"} →
+ *       capability {@code "generate_report"}).</li>
+ *   <li>{@code submittedBy} equals the {@link MeshRuntime}'s agent id.</li>
+ *   <li>{@code registryUrl} is sourced from the agent spec.</li>
+ *   <li>The dispatcher caches one submitter per surface (calls do not
+ *       reconstruct a fresh instance for every request).</li>
+ *   <li>When the {@link MeshRuntime} provider is null OR returns null
+ *       (transient startup), the parameter is filled with {@code null}
+ *       rather than crashing the dispatch.</li>
+ * </ul>
+ */
+@DisplayName("MeshA2ADispatcher: framework MeshJobSubmitter injection (issue #936)")
+class MeshA2ADispatcherJobSubmitterInjectionTest {
+
+    private MeshA2ARegistry registry;
+    private MeshA2ATaskStore taskStore;
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        registry = new MeshA2ARegistry();
+        taskStore = new MeshA2ATaskStore();
+        mapper = A2ATestFixtures.objectMapper();
+        SubmitterCapturingBean.LAST_SUBMITTER.set(null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SubmitterCapturingBean.LAST_SUBMITTER.set(null);
+    }
+
+    @Test
+    @DisplayName("Handler with MeshJobSubmitter param: framework injects non-null bound to skill-derived capability")
+    void injectsMeshJobSubmitterFromSkillIdFallback() throws Exception {
+        registry.register(surfaceFor("/svc", "generate-report", List.of()));
+
+        MeshRuntime runtime = mockRuntime("report-a2a-agent-abcd1234", "http://localhost:8000");
+        MeshA2ADispatcher dispatcher = new MeshA2ADispatcher(
+            registry, taskStore, mapper,
+            A2ATestFixtures.emptyInjectorProvider(),
+            singletonProvider(runtime));
+
+        String body = A2ATestFixtures.jsonRpcBody(1, "tasks/send",
+            Map.of("id", "t1", "message", Map.of()));
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc", body);
+
+        assertEquals(200, resp.getStatusCode().value());
+        MeshJobSubmitter submitter = SubmitterCapturingBean.LAST_SUBMITTER.get();
+        assertNotNull(submitter, "Framework must inject a non-null MeshJobSubmitter");
+        // Skill-id fallback: "generate-report" -> "generate_report".
+        assertEquals("generate_report", submitter.capability(),
+            "Default capability must be skillId with '-' replaced by '_'");
+        assertEquals("report-a2a-agent-abcd1234", submitter.submittedBy(),
+            "submittedBy must equal the runtime's agentId");
+    }
+
+    @Test
+    @DisplayName("Handler with declared @MeshDependency: submitter capability matches first dep")
+    void firstDeclaredDependencyWinsOverSkillIdFallback() throws Exception {
+        registry.register(surfaceFor("/svc", "generate-report",
+            List.of(stubDep("custom_task_cap"))));
+
+        MeshRuntime runtime = mockRuntime("report-a2a-agent-xyz", "http://localhost:8000");
+        MeshA2ADispatcher dispatcher = new MeshA2ADispatcher(
+            registry, taskStore, mapper,
+            A2ATestFixtures.emptyInjectorProvider(),
+            singletonProvider(runtime));
+
+        String body = A2ATestFixtures.jsonRpcBody(1, "tasks/send",
+            Map.of("id", "t1", "message", Map.of()));
+        dispatcher.dispatch("/svc", body);
+
+        MeshJobSubmitter submitter = SubmitterCapturingBean.LAST_SUBMITTER.get();
+        assertNotNull(submitter);
+        assertEquals("custom_task_cap", submitter.capability(),
+            "Declared @MeshDependency capability must override the skillId fallback");
+    }
+
+    @Test
+    @DisplayName("Submitter is cached per surface — repeat calls reuse the same instance")
+    void submitterIsCachedPerSurface() throws Exception {
+        registry.register(surfaceFor("/svc", "generate-report", List.of()));
+
+        MeshRuntime runtime = mockRuntime("agent-1", "http://localhost:8000");
+        MeshA2ADispatcher dispatcher = new MeshA2ADispatcher(
+            registry, taskStore, mapper,
+            A2ATestFixtures.emptyInjectorProvider(),
+            singletonProvider(runtime));
+
+        dispatcher.dispatch("/svc", A2ATestFixtures.jsonRpcBody(1, "tasks/send",
+            Map.of("id", "t1", "message", Map.of())));
+        MeshJobSubmitter first = SubmitterCapturingBean.LAST_SUBMITTER.get();
+
+        dispatcher.dispatch("/svc", A2ATestFixtures.jsonRpcBody(2, "tasks/send",
+            Map.of("id", "t2", "message", Map.of())));
+        MeshJobSubmitter second = SubmitterCapturingBean.LAST_SUBMITTER.get();
+
+        assertNotNull(first);
+        assertSame(first, second,
+            "MeshJobSubmitter must be cached per surface (one instance reused across requests)");
+    }
+
+    @Test
+    @DisplayName("MeshRuntime unavailable: param injected as null, dispatch still succeeds")
+    void runtimeUnavailable_fallsBackToNull() throws Exception {
+        registry.register(surfaceFor("/svc", "generate-report", List.of()));
+
+        // Provider that always returns null — simulates the runtime not
+        // yet being available (e.g. mid-startup).
+        ObjectProvider<MeshRuntime> nullProvider = new ObjectProvider<>() {
+            @Override public MeshRuntime getObject() { return null; }
+            @Override public MeshRuntime getObject(Object... args) { return null; }
+            @Override public MeshRuntime getIfAvailable() { return null; }
+            @Override public MeshRuntime getIfUnique() { return null; }
+        };
+        MeshA2ADispatcher dispatcher = new MeshA2ADispatcher(
+            registry, taskStore, mapper,
+            A2ATestFixtures.emptyInjectorProvider(),
+            nullProvider);
+
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc",
+            A2ATestFixtures.jsonRpcBody(1, "tasks/send",
+                Map.of("id", "t1", "message", Map.of())));
+
+        assertEquals(200, resp.getStatusCode().value());
+        // The handler stashes null on the slot — it must not crash; user
+        // code surfaces the missing-submitter case as a failed Task.
+        // SubmitterCapturingBean#handler treats a null submitter as a
+        // controlled error → state=failed.
+        JsonNode env = mapper.readTree(resp.getBody());
+        String state = env.get("result").get("status").get("state").asText();
+        assertEquals("failed", state,
+            "Handler observing null submitter must surface state=failed (not 500)");
+    }
+
+    @Test
+    @DisplayName("Three-arg dispatcher constructor: handler with submitter param gets null (back-compat)")
+    void legacyConstructor_doesNotCrashOnMeshJobSubmitterParam() throws Exception {
+        registry.register(surfaceFor("/svc", "generate-report", List.of()));
+
+        // Use the legacy four-arg constructor (no MeshRuntime provider).
+        MeshA2ADispatcher dispatcher = new MeshA2ADispatcher(
+            registry, taskStore, mapper,
+            A2ATestFixtures.emptyInjectorProvider());
+
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc",
+            A2ATestFixtures.jsonRpcBody(1, "tasks/send",
+                Map.of("id", "t1", "message", Map.of())));
+
+        assertEquals(200, resp.getStatusCode().value(),
+            "Legacy constructor must not crash on MeshJobSubmitter params");
+        JsonNode env = mapper.readTree(resp.getBody());
+        // Handler gets null submitter and surfaces failed — same fallback
+        // as the runtime-unavailable case.
+        assertEquals("failed", env.get("result").get("status").get("state").asText());
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Fixtures
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * Build a surface metadata that points at
+     * {@link SubmitterCapturingBean#handler(Map, MeshJobSubmitter)}.
+     */
+    private static MeshA2ARegistry.SurfaceMetadata surfaceFor(
+            String path,
+            String skillId,
+            List<MeshRouteRegistry.DependencySpec> deps) {
+        SubmitterCapturingBean bean = new SubmitterCapturingBean();
+        Method method;
+        try {
+            method = SubmitterCapturingBean.class.getDeclaredMethod(
+                "handler", Map.class, MeshJobSubmitter.class);
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+        return new MeshA2ARegistry.SurfaceMetadata(
+            path,
+            skillId,
+            skillId,
+            "",
+            List.of(),
+            deps,
+            "",
+            "SubmitterCapturingBean.handler[" + skillId + "]",
+            bean,
+            method
+        );
+    }
+
+    private static MeshRuntime mockRuntime(String agentId, String registryUrl) {
+        MeshRuntime runtime = mock(MeshRuntime.class);
+        AgentSpec spec = new AgentSpec();
+        spec.setAgentId(agentId);
+        spec.setRegistryUrl(registryUrl);
+        when(runtime.getAgentSpec()).thenReturn(spec);
+        return runtime;
+    }
+
+    private static ObjectProvider<MeshRuntime> singletonProvider(MeshRuntime runtime) {
+        return new ObjectProvider<>() {
+            @Override public MeshRuntime getObject() { return runtime; }
+            @Override public MeshRuntime getObject(Object... args) { return runtime; }
+            @Override public MeshRuntime getIfAvailable() { return runtime; }
+            @Override public MeshRuntime getIfUnique() { return runtime; }
+        };
+    }
+
+    private static MeshRouteRegistry.DependencySpec stubDep(String capability) {
+        return new MeshRouteRegistry.DependencySpec(
+            capability, new String[0], "", capability);
+    }
+
+    /**
+     * Test handler bean that captures the injected {@link MeshJobSubmitter}
+     * for inspection. Returns "ok" on success, throws when the submitter
+     * is null so the dispatcher emits state=failed (a structured signal
+     * the test can assert on without resorting to log scraping).
+     */
+    public static class SubmitterCapturingBean {
+
+        static final AtomicReference<MeshJobSubmitter> LAST_SUBMITTER = new AtomicReference<>();
+
+        public Object handler(Map<String, Object> message, MeshJobSubmitter submitter) {
+            LAST_SUBMITTER.set(submitter);
+            if (submitter == null) {
+                throw new IllegalStateException("submitter was null");
+            }
+            return "ok";
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherJobSubmitterInjectionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherJobSubmitterInjectionTest.java
@@ -174,6 +174,71 @@ class MeshA2ADispatcherJobSubmitterInjectionTest {
     }
 
     @Test
+    @DisplayName("Class load + dispatch resilient when runtimeProvider.getIfAvailable() throws")
+    void dispatcherClassLoadIsIndependentOfRuntimeProviderHealth() throws Exception {
+        // Regression for the BLOCKER review finding: the dispatcher used to
+        // construct a static sentinel MeshJobSubmitter at class load via
+        // an unguarded constructor call. If MeshJobSubmitter ever started
+        // doing real work in its constructor (FFI load, registry registration,
+        // etc.), class load would cascade-fail with ExceptionInInitializerError
+        // and brick the entire A2A starter — even for surfaces that don't use
+        // MeshJobSubmitter at all.
+        //
+        // The two-collection refactor eliminates that risk: we no longer
+        // construct a sentinel statically. This test asserts the contract
+        // structurally by wiring a runtime provider whose getIfAvailable()
+        // raises — equivalent in effect to "MeshJobSubmitter ctor would
+        // explode" without our test needing to depend on the ctor's health.
+        // The dispatcher must:
+        //   (a) construct without throwing,
+        //   (b) handle the explosion from getIfAvailable() gracefully,
+        //   (c) inject null into the MeshJobSubmitter slot,
+        //   (d) NOT memoize this transient failure (next call retries).
+        registry.register(surfaceFor("/svc", "generate-report", List.of()));
+
+        AtomicReference<Integer> providerCalls = new AtomicReference<>(0);
+        ObjectProvider<MeshRuntime> faultyProvider = new ObjectProvider<>() {
+            @Override public MeshRuntime getObject() { throw new IllegalStateException("bean init failed"); }
+            @Override public MeshRuntime getObject(Object... args) { throw new IllegalStateException("bean init failed"); }
+            @Override public MeshRuntime getIfAvailable() {
+                providerCalls.updateAndGet(v -> v + 1);
+                throw new IllegalStateException("simulated bean-init failure");
+            }
+            @Override public MeshRuntime getIfUnique() { throw new IllegalStateException("bean init failed"); }
+        };
+
+        // (a) Dispatcher constructs cleanly even though the provider would
+        // throw if asked.
+        MeshA2ADispatcher dispatcher = new MeshA2ADispatcher(
+            registry, taskStore, mapper,
+            A2ATestFixtures.emptyInjectorProvider(),
+            faultyProvider);
+        assertNotNull(dispatcher);
+
+        // (b) + (c) First call falls through to null injection without
+        // crashing the dispatch. The handler bean treats null submitter as
+        // a controlled error → state=failed.
+        ResponseEntity<String> resp = dispatcher.dispatch("/svc",
+            A2ATestFixtures.jsonRpcBody(1, "tasks/send",
+                Map.of("id", "t1", "message", Map.of())));
+        assertEquals(200, resp.getStatusCode().value(),
+            "Dispatcher must not surface provider faults as HTTP errors");
+        JsonNode env = mapper.readTree(resp.getBody());
+        assertEquals("failed", env.get("result").get("status").get("state").asText());
+        assertEquals(1, providerCalls.get(),
+            "Provider must have been consulted exactly once on the first call");
+
+        // (d) Second call also invokes the provider — the provider fault is
+        // treated as transient, NOT memoized as permanent-unbuildable.
+        ResponseEntity<String> resp2 = dispatcher.dispatch("/svc",
+            A2ATestFixtures.jsonRpcBody(2, "tasks/send",
+                Map.of("id", "t2", "message", Map.of())));
+        assertEquals(200, resp2.getStatusCode().value());
+        assertEquals(2, providerCalls.get(),
+            "Transient provider fault must NOT be cached — provider must be retried on the next call");
+    }
+
+    @Test
     @DisplayName("Three-arg dispatcher constructor: handler with submitter param gets null (back-compat)")
     void legacyConstructor_doesNotCrashOnMeshJobSubmitterParam() throws Exception {
         registry.register(surfaceFor("/svc", "generate-report", List.of()));

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AUserComponentCycleTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AUserComponentCycleTest.java
@@ -1,0 +1,274 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.spring.MeshAutoConfiguration;
+import io.mcpmesh.spring.MeshRuntime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #937 — broader user-{@code @Component} →
+ * {@link MeshRuntime} bean-creation cycle.
+ *
+ * <p>PR #934 mitigated ONE specific cycle path
+ * ({@code meshHealthController} → {@code meshRuntime}) by injecting the
+ * runtime via {@link org.springframework.context.annotation.Lazy @Lazy}.
+ * The cycle pattern, however, is generic: ANY user {@code @Component} or
+ * {@code @Service} bean that autowires {@link MeshRuntime} would hit the
+ * same {@code BeanCurrentlyInCreationException} because the
+ * {@code meshA2ARouterFunction} and {@code meshRuntime} factories walked
+ * {@code @Component}/{@code @Service} beans eagerly during construction —
+ * re-entering the very user beans that needed the runtime.
+ *
+ * <h2>What this test asserts</h2>
+ *
+ * <p>A plain user {@code @Component} (and a sibling {@code @Service})
+ * autowire {@link MeshRuntime} <strong>without {@code @Lazy}</strong>.
+ * Loading the context proves the structural fix — if the eager bean walk
+ * remained anywhere on the construction path, refresh would fail with
+ * {@code BeanCurrentlyInCreationException} and the assertions below
+ * would never execute.
+ *
+ * <h2>Pre-fix vs. post-fix</h2>
+ *
+ * <ul>
+ *   <li><strong>Pre-fix</strong> ({@code MeshAutoConfiguration} walking
+ *       {@code getBeansWithAnnotation(@Component.class)} inside the
+ *       {@code meshRuntime} factory): refresh fails with
+ *       {@code BeanCurrentlyInCreationException}.</li>
+ *   <li><strong>Post-fix</strong> (eager walks replaced by a
+ *       {@code SmartInitializingSingleton} that runs AFTER all singletons
+ *       and BEFORE {@code SmartLifecycle.start()}): refresh completes,
+ *       the runtime is injected into the user beans, and the spec is
+ *       fully populated by the time the heartbeat loop starts.</li>
+ * </ul>
+ *
+ * <h2>Test-mode caveats</h2>
+ *
+ * <p>The native Rust core is not exercised here; the test config
+ * provides a no-op {@link MeshRuntime} subclass identical in shape to
+ * the one used by {@link MeshA2AContextLoadTest}, so the
+ * {@code SmartLifecycle} processor does not attempt to bind to a
+ * registry during the unit test.
+ */
+@DisplayName("MeshRuntime — broader user-@Component cycle regression (#937)")
+class MeshA2AUserComponentCycleTest {
+
+    /**
+     * Plain {@code @Component} autowiring {@link MeshRuntime} <strong>without
+     * {@code @Lazy}</strong>. This is the exact failure shape reported in
+     * issue #937 — the user-facing reproduction case.
+     */
+    @Component
+    public static class UserComponentWithRuntime {
+        private final MeshRuntime runtime;
+
+        @Autowired
+        public UserComponentWithRuntime(MeshRuntime runtime) {
+            this.runtime = runtime;
+        }
+
+        public String agentName() {
+            return runtime.getAgentSpec().getName();
+        }
+    }
+
+    /**
+     * {@code @Service} variant — different stereotype, same cycle pattern.
+     * Ensures the fix isn't accidentally specific to one stereotype.
+     */
+    @Service
+    public static class UserServiceWithRuntime {
+        @Autowired
+        private MeshRuntime runtime;
+
+        public String agentId() {
+            return runtime.getAgentSpec().getAgentId();
+        }
+    }
+
+    /**
+     * Component that ALSO carries a {@code @MeshA2A} surface AND autowires
+     * {@code MeshRuntime}. Covers the precise shape that bit
+     * {@code producer-report-agent} during local smoke testing: a real
+     * A2A handler bean that needs the runtime for downstream work.
+     */
+    @Component
+    public static class UserA2ABeanWithRuntime {
+        private final MeshRuntime runtime;
+
+        @Autowired
+        public UserA2ABeanWithRuntime(MeshRuntime runtime) {
+            this.runtime = runtime;
+        }
+
+        @MeshA2A(path = "/agents/cycle-test", skillId = "cycle-test",
+                 skillName = "Cycle Test Skill")
+        public Map<String, Object> handle(Map<String, Object> message) {
+            return Map.of("agent", runtime.getAgentSpec().getName());
+        }
+    }
+
+    static class NoOpMeshRuntime extends MeshRuntime {
+        private volatile boolean running;
+
+        NoOpMeshRuntime(AgentSpec spec) {
+            super(spec);
+        }
+
+        @Override
+        public void start() {
+            running = true;
+        }
+
+        @Override
+        public void stop() {
+            running = false;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return running;
+        }
+    }
+
+    /**
+     * Carries a {@link MeshAgent} class-level annotation so the
+     * production {@link MeshAutoConfiguration#meshRuntime} factory
+     * resolves a valid agent name. WITHOUT this, the production
+     * factory would fall through to the consumer-only branch and the
+     * post-singleton finalizer would reject the spec (no
+     * {@code @MeshRoute} dependencies present). Crucially, this
+     * approach lets the test exercise the REAL production
+     * {@code meshRuntime} factory — which is the only call site that
+     * surfaced issue #937's cycle pre-fix. A {@code @Bean}-based stub
+     * (the approach used by {@link MeshA2AContextLoadTest}) would
+     * bypass the production factory via {@code @ConditionalOnMissingBean}
+     * and the regression coverage would be lost.
+     */
+    @MeshAgent(name = "cycle-test-agent")
+    @Configuration
+    static class TestConfig {
+
+        /**
+         * Intercepts the production {@link MeshRuntime} bean right
+         * after construction (BEFORE Spring fires its
+         * {@code SmartLifecycle.start()}) and swaps in a
+         * {@link NoOpMeshRuntime} carrying the same spec. This
+         * preserves the bean-creation cycle path under test (the
+         * production factory still ran, with whatever bean walks
+         * {@code MeshAutoConfiguration} performed) while preventing
+         * the native Rust core from being loaded during the unit
+         * test's lifecycle phase.
+         *
+         * <p>Replacing the bean instance via
+         * {@code postProcessAfterInitialization} is safe here because
+         * no other bean has captured a reference to the production
+         * {@code MeshRuntime} yet — Spring's
+         * {@code AbstractAutowireCapableBeanFactory} calls
+         * post-processors before exposing the bean to dependents.
+         * Beans that later autowire {@code MeshRuntime} (user
+         * {@code @Component}s, {@code ToolInvoker}, the post-singleton
+         * finalizer) will all receive the {@code NoOpMeshRuntime}.
+         */
+        @Bean
+        static BeanPostProcessor meshRuntimeNoOpAdapter() {
+            return new BeanPostProcessor() {
+                @Override
+                public Object postProcessAfterInitialization(Object bean, String beanName)
+                        throws BeansException {
+                    if (bean instanceof MeshRuntime runtime
+                            && !(bean instanceof NoOpMeshRuntime)) {
+                        return new NoOpMeshRuntime(runtime.getAgentSpec());
+                    }
+                    return bean;
+                }
+            };
+        }
+    }
+
+    private final WebApplicationContextRunner runner = new WebApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(MeshAutoConfiguration.class))
+        .withUserConfiguration(TestConfig.class,
+            UserComponentWithRuntime.class,
+            UserServiceWithRuntime.class,
+            UserA2ABeanWithRuntime.class);
+
+    @Test
+    @DisplayName("User @Component autowires MeshRuntime without @Lazy — context loads")
+    void userComponentAutowiresMeshRuntimeWithoutLazy_boots() {
+        runner.run(context -> {
+            // Refresh completing is the primary assertion — pre-fix this
+            // would have failed with BeanCurrentlyInCreationException
+            // from the production buildAgentSpec()'s eager @Component
+            // walk re-entering UserComponentWithRuntime mid-creation.
+            assertThat(context).hasNotFailed();
+
+            // Defence-in-depth: confirm the user component actually got
+            // its runtime injection and can read the spec.
+            UserComponentWithRuntime userComponent =
+                context.getBean(UserComponentWithRuntime.class);
+            assertThat(userComponent.agentName()).isEqualTo("cycle-test-agent");
+
+            // The agent ID is name + 8-char UUID suffix (production
+            // buildBaseAgentSpec ran end-to-end). Just sanity-check the
+            // prefix — full equality would be flaky across runs.
+            UserServiceWithRuntime userService =
+                context.getBean(UserServiceWithRuntime.class);
+            assertThat(userService.agentId()).startsWith("cycle-test-agent-");
+        });
+    }
+
+    @Test
+    @DisplayName("User @Component with @MeshA2A surface also autowires MeshRuntime without @Lazy")
+    void userA2ABeanWithRuntimeAutowireSurface_boots() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            // The producer-report-agent shape: an A2A handler that
+            // needs MeshRuntime for downstream work.
+            UserA2ABeanWithRuntime a2aBean = context.getBean(UserA2ABeanWithRuntime.class);
+            assertThat(a2aBean).isNotNull();
+
+            // The surface must have made it into the registry — proves
+            // MeshA2ABeanPostProcessor ran on the user bean even though
+            // the eager-walk was removed from the factories.
+            MeshA2ARegistry registry = context.getBean(MeshA2ARegistry.class);
+            assertThat(registry.hasSurfaces())
+                .as("MeshA2ABeanPostProcessor must register the surface "
+                    + "from UserA2ABeanWithRuntime")
+                .isTrue();
+            assertThat(registry.getByPath("/agents/cycle-test"))
+                .as("The surface registered by UserA2ABeanWithRuntime "
+                    + "must be queryable by path")
+                .isNotNull();
+        });
+    }
+
+    @Test
+    @DisplayName("Router function is materialised by the SmartInitializingSingleton after refresh")
+    void routerFunctionMaterialisedPostInit() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            // The lazy router function bean is present and resolvable —
+            // the post-singleton initializer drove buildRouterFunction()
+            // exactly once, populating it with the (then fully-populated)
+            // registry.
+            assertThat(context).hasBean("meshA2ARouterFunction");
+            assertThat(context).hasBean("meshA2ARouterFunctionInitializer");
+        });
+    }
+}

--- a/src/runtime/typescript/src/__tests__/a2a/producer/dispatcher.spec.ts
+++ b/src/runtime/typescript/src/__tests__/a2a/producer/dispatcher.spec.ts
@@ -880,3 +880,131 @@ describe("dispatcher: JSON-RPC error semantics (spec §4.1)", () => {
     expect(body.id).toBeNull();
   });
 });
+
+// ────────────────────────────────────────────────────────────────────────
+// jobSubmitter injection (issue #936)
+// ────────────────────────────────────────────────────────────────────────
+
+describe("dispatcher: handler jobSubmitter arg (issue #936)", () => {
+  let store: A2ATaskStore;
+  beforeEach(() => {
+    RouteRegistry.reset();
+    store = new A2ATaskStore();
+  });
+
+  /**
+   * The framework auto-injects a MeshJobSubmitter on the third positional
+   * arg so long-running handlers don't have to hand-construct one from
+   * getApiRuntime().getServiceId() + MCP_MESH_REGISTRY_URL. Mirrors Java's
+   * MeshA2ADispatcher behavior.
+   */
+  it("passes provided submitter through to the handler as the third arg", async () => {
+    let captured3rdArg: unknown = "<not-called>";
+    const handler: A2AHandler = async (_deps, _payload, jobSubmitter) => {
+      captured3rdArg = jobSubmitter;
+      return "ok";
+    };
+    const baseDeps = makeDeps(handler, store);
+    const fakeSubmitter = { __fake: "submitter" } as never;
+    const deps: DispatcherDeps = {
+      ...baseDeps,
+      jobSubmitterProvider: () => fakeSubmitter,
+    };
+
+    await dispatch(deps, {
+      jsonrpc: "2.0",
+      method: "tasks/send",
+      params: { id: "t-with-submitter" },
+    });
+
+    expect(captured3rdArg).toBe(fakeSubmitter);
+  });
+
+  /**
+   * Without a `jobSubmitterProvider` (e.g. test fixtures, advanced
+   * wiring) the dispatcher passes `null` — handler can check and
+   * surface a clear error rather than blow up.
+   */
+  it("passes null when no jobSubmitterProvider is configured", async () => {
+    let captured3rdArg: unknown = "<not-called>";
+    const handler: A2AHandler = async (_deps, _payload, jobSubmitter) => {
+      captured3rdArg = jobSubmitter;
+      return "ok";
+    };
+    const deps = makeDeps(handler, store);
+
+    await dispatch(deps, {
+      jsonrpc: "2.0",
+      method: "tasks/send",
+      params: { id: "t-no-provider" },
+    });
+
+    expect(captured3rdArg).toBeNull();
+  });
+
+  /**
+   * The provider is called per-request — the dispatcher does NOT memoize
+   * inside itself. (Caching is the provider's responsibility — `mount.ts`
+   * memoizes after the first successful construction.) This matters for
+   * the early-startup case where the provider returns null on the first
+   * call but a real instance on the second.
+   */
+  it("calls the provider on every dispatch (no internal memoization)", async () => {
+    const handler: A2AHandler = async () => "ok";
+    const baseDeps = makeDeps(handler, store);
+
+    const providerCalls: number[] = [];
+    let callIndex = 0;
+    const deps: DispatcherDeps = {
+      ...baseDeps,
+      jobSubmitterProvider: () => {
+        callIndex += 1;
+        providerCalls.push(callIndex);
+        return null;
+      },
+    };
+
+    await dispatch(deps, {
+      jsonrpc: "2.0",
+      method: "tasks/send",
+      params: { id: "t-call-1" },
+    });
+    await dispatch(deps, {
+      jsonrpc: "2.0",
+      method: "tasks/send",
+      params: { id: "t-call-2" },
+    });
+
+    expect(providerCalls).toEqual([1, 2]);
+  });
+
+  /**
+   * The handler's third arg must be passed on the SSE
+   * (`tasks/sendSubscribe`) path too — not just JSON-RPC. Java's
+   * dispatcher exercises both call sites; the TS equivalent must
+   * match.
+   */
+  it("threads jobSubmitter through to tasks/sendSubscribe handler", async () => {
+    let captured3rdArg: unknown = "<not-called>";
+    const fakeProxyResult = fakeProxy({ jobId: "job-stream" });
+    const handler: A2AHandler = async (_deps, _payload, jobSubmitter) => {
+      captured3rdArg = jobSubmitter;
+      return fakeProxyResult;
+    };
+    const baseDeps = makeDeps(handler, store);
+    const fakeSubmitter = { __fake: "submitter" } as never;
+    const deps: DispatcherDeps = {
+      ...baseDeps,
+      jobSubmitterProvider: () => fakeSubmitter,
+    };
+
+    // Call buildSendSubscribeStream directly — the dispatcher's
+    // tasks/sendSubscribe entry point.
+    const { buildSendSubscribeStream } = await import(
+      "../../../a2a/producer/dispatcher.js"
+    );
+    await buildSendSubscribeStream("req-1", { id: "t-sse-1" }, deps);
+
+    expect(captured3rdArg).toBe(fakeSubmitter);
+  });
+});

--- a/src/runtime/typescript/src/__tests__/a2a/producer/dispatcher.spec.ts
+++ b/src/runtime/typescript/src/__tests__/a2a/producer/dispatcher.spec.ts
@@ -28,6 +28,7 @@ import {
   JSONRPC_INVALID_PARAMS,
 } from "../../../a2a/producer/dispatcher.js";
 import type { A2ASurfaceMetadata } from "../../../a2a/producer/registry.js";
+import type { MeshJobSubmitter } from "../../../mesh-job-submitter.js";
 
 // ────────────────────────────────────────────────────────────────────────
 // Test fixtures
@@ -905,7 +906,7 @@ describe("dispatcher: handler jobSubmitter arg (issue #936)", () => {
       return "ok";
     };
     const baseDeps = makeDeps(handler, store);
-    const fakeSubmitter = { __fake: "submitter" } as never;
+    const fakeSubmitter = { __fake: "submitter" } as unknown as MeshJobSubmitter;
     const deps: DispatcherDeps = {
       ...baseDeps,
       jobSubmitterProvider: () => fakeSubmitter,
@@ -992,7 +993,7 @@ describe("dispatcher: handler jobSubmitter arg (issue #936)", () => {
       return fakeProxyResult;
     };
     const baseDeps = makeDeps(handler, store);
-    const fakeSubmitter = { __fake: "submitter" } as never;
+    const fakeSubmitter = { __fake: "submitter" } as unknown as MeshJobSubmitter;
     const deps: DispatcherDeps = {
       ...baseDeps,
       jobSubmitterProvider: () => fakeSubmitter,

--- a/src/runtime/typescript/src/a2a/producer/dispatcher.ts
+++ b/src/runtime/typescript/src/a2a/producer/dispatcher.ts
@@ -40,6 +40,7 @@ import { JobProxy } from "@mcpmesh/core";
 
 import type { McpMeshTool } from "../../types.js";
 import { RouteRegistry } from "../../route.js";
+import { MeshJobSubmitter } from "../../mesh-job-submitter.js";
 import type { A2ASurfaceMetadata } from "./registry.js";
 import { A2ATaskStore, type TaskRecord } from "./task-store.js";
 import {
@@ -70,9 +71,22 @@ export const JSONRPC_INVALID_PARAMS = -32602;
 export type A2ADependencies = Record<string, McpMeshTool | null>;
 
 /**
- * Handler signature for `mesh.a2a.mount(...)`. Receives resolved
- * dependencies first (so destructuring is ergonomic) and the raw A2A
- * `tasks/send` `params` object second.
+ * Handler signature for `mesh.a2a.mount(...)`. Receives:
+ *
+ * 1. Resolved dependencies (`deps`) — keyed by capability name, same shape
+ *    as `mesh.route()`'s `deps` parameter. Destructure to access individual
+ *    `McpMeshTool` proxies.
+ * 2. The raw A2A `tasks/send` `payload` (the `message` object the client
+ *    sent).
+ * 3. A framework-managed {@link MeshJobSubmitter} (`jobSubmitter`) — issue
+ *    #936. Bound to the producer's task capability so long-running handlers
+ *    can `await jobSubmitter.submit(payload)` without hand-constructing the
+ *    submitter from `getApiRuntime().getServiceId()` and the registry URL.
+ *    The capability defaults to the first declared `dependencies[]` entry
+ *    on the mount config; when no deps are declared, falls back to the
+ *    `skillId` with `-` replaced by `_` (the canonical kebab-to-snake
+ *    convention — so a `"generate-report"` skill submits to the
+ *    `generate_report` task capability without further configuration).
  *
  * Return value: any JSON-serializable value or a `JobProxy`.
  * - JSON-serializable value → framework wraps it into the A2A v1.0 `Task`
@@ -88,7 +102,8 @@ export type A2ADependencies = Record<string, McpMeshTool | null>;
  */
 export type A2AHandler<D extends A2ADependencies = A2ADependencies> = (
   deps: D,
-  payload: Record<string, unknown>
+  payload: Record<string, unknown>,
+  jobSubmitter: MeshJobSubmitter | null
 ) => unknown | Promise<unknown>;
 
 /**
@@ -106,6 +121,17 @@ export interface DispatcherDeps {
   readonly taskStore: A2ATaskStore;
   /** Shared `RouteRegistry` for dependency resolution (DDDI). */
   readonly routeRegistry: RouteRegistry;
+  /**
+   * Lazy provider for the {@link MeshJobSubmitter} auto-injected on the
+   * third handler arg (issue #936). Called on every dispatch so the
+   * provider can return `null` until the api-runtime has finished
+   * initialising; the dispatcher caches the resolved value internally
+   * after the first non-null return.
+   *
+   * Optional for back-compat with existing callers; when omitted the
+   * handler receives `null` on the third arg.
+   */
+  readonly jobSubmitterProvider?: () => MeshJobSubmitter | null;
 }
 
 /**
@@ -121,7 +147,7 @@ export interface DispatcherDeps {
  * `next()` and execution falls through here.
  */
 export function buildDispatcherMiddleware(deps: DispatcherDeps): RequestHandler {
-  const { surface, handler, taskStore, routeRegistry } = deps;
+  const { surface, handler, taskStore, routeRegistry, jobSubmitterProvider } = deps;
 
   return async function a2aDispatcher(
     req: Request,
@@ -170,6 +196,7 @@ export function buildDispatcherMiddleware(deps: DispatcherDeps): RequestHandler 
           handler,
           taskStore,
           routeRegistry,
+          jobSubmitterProvider,
         });
         return;
 
@@ -256,9 +283,13 @@ async function handleTasksSend(
     }
   }
 
+  const jobSubmitter = deps.jobSubmitterProvider
+    ? deps.jobSubmitterProvider()
+    : null;
+
   let handlerResult: unknown;
   try {
-    handlerResult = await deps.handler(resolvedDeps, message);
+    handlerResult = await deps.handler(resolvedDeps, message, jobSubmitter);
   } catch (err) {
     // Spec §4.3 "Response — handler raised": exceptions become
     // state=failed Tasks, NOT JSON-RPC errors. Upgrade the placeholder
@@ -473,9 +504,13 @@ export async function buildSendSubscribeStream(
     }
   }
 
+  const jobSubmitter = deps.jobSubmitterProvider
+    ? deps.jobSubmitterProvider()
+    : null;
+
   let handlerResult: unknown;
   try {
-    handlerResult = await deps.handler(resolvedDeps, message);
+    handlerResult = await deps.handler(resolvedDeps, message, jobSubmitter);
   } catch (err) {
     const errorText = errorTextOf(err);
     // Cache the failed envelope so a subsequent tasks/get returns it

--- a/src/runtime/typescript/src/a2a/producer/mount.ts
+++ b/src/runtime/typescript/src/a2a/producer/mount.ts
@@ -38,6 +38,7 @@ import type { AgentConfig } from "../../types.js";
 import { RouteRegistry } from "../../route.js";
 import { normalizeDependency } from "../../proxy.js";
 import { getApiRuntime } from "../../api-runtime.js";
+import { MeshJobSubmitter } from "../../mesh-job-submitter.js";
 
 import {
   A2AProducerRegistry,
@@ -264,6 +265,19 @@ export function mount<D extends A2ADependencies = A2ADependencies>(
   // ── Register in A2AProducerRegistry ──────────────────────────────────
   A2AProducerRegistry.getInstance().register(surface);
 
+  // ── Build a lazy MeshJobSubmitter provider (issue #936) ──────────────
+  // The submitter is bound to the producer's task capability + the
+  // api-runtime singleton's service id + the resolved registry URL.
+  // Lazy because the api-runtime's `serviceId` is `""` until its first
+  // tick, so we can't construct the submitter at mount time — instead
+  // we resolve on first request that actually uses it, then memoize.
+  const submitterCapability = pickSubmitterCapability(surface);
+  const jobSubmitterProvider = buildJobSubmitterProvider(
+    submitterCapability,
+    surface.path,
+    surface.skillId
+  );
+
   // ── Wire dispatch route ──────────────────────────────────────────────
   // Per spec §4.6 / §4.7, `tasks/sendSubscribe` and `tasks/resubscribe`
   // emit a `text/event-stream` body while the other three verbs emit a
@@ -276,6 +290,7 @@ export function mount<D extends A2ADependencies = A2ADependencies>(
     handler: handler as A2AHandler,
     taskStore: SHARED_TASK_STORE,
     routeRegistry,
+    jobSubmitterProvider,
   };
   const sseDispatcher = buildSseDispatcherMiddleware(dispatcherDeps);
   const jsonDispatcher = buildDispatcherMiddleware(dispatcherDeps);
@@ -360,6 +375,120 @@ export function __buildCardRenderContextForTests(
     agentDescription: undefined,
     publicUrl: undefined,
     ...overrides,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// MeshJobSubmitter auto-injection helpers (issue #936)
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Pick the capability the framework-injected {@link MeshJobSubmitter}
+ * should target for the given surface. Resolution order matches Java's
+ * {@code MeshA2ADispatcher.pickSubmitterCapability}:
+ *
+ * 1. The first declared dependency capability on the mount config — matches
+ *    what user code typically hand-constructs the submitter against today.
+ * 2. The `skillId` with `-` replaced by `_` (kebab-to-snake). Matches the
+ *    existing producer-report-agent example: skill `"generate-report"`
+ *    becomes capability `"generate_report"`.
+ *
+ * Returns `null` only when neither source yields a non-empty capability —
+ * the dispatcher then injects `null` into the handler's `jobSubmitter`
+ * arg and the user code must surface a clear error (mirrors Java's
+ * fallback).
+ */
+function pickSubmitterCapability(surface: A2ASurfaceMetadata): string | null {
+  if (surface.dependencies && surface.dependencies.length > 0) {
+    const first = surface.dependencies[0]?.capability;
+    if (typeof first === "string" && first.length > 0) {
+      return first;
+    }
+  }
+  if (surface.skillId && surface.skillId.length > 0) {
+    return surface.skillId.replace(/-/g, "_");
+  }
+  return null;
+}
+
+/**
+ * Build a `() => MeshJobSubmitter | null` provider for the dispatcher.
+ * Memoizes the first successful construction; before that point (when
+ * `getApiRuntime().getServiceId()` is still empty) it logs once and
+ * returns `null` so the dispatcher can pass `null` through to the
+ * handler. The handler observes the null and surfaces a clear error —
+ * the same fallback path Java uses when MeshRuntime isn't yet
+ * available.
+ *
+ * The registry URL is resolved on first call (env-var lookup is cheap
+ * but we still avoid doing it per-request once we have a submitter).
+ */
+function buildJobSubmitterProvider(
+  capability: string | null,
+  path: string,
+  skillId: string
+): () => MeshJobSubmitter | null {
+  let cached: MeshJobSubmitter | null = null;
+  let warnedUnresolvable = false;
+
+  if (!capability) {
+    return () => {
+      if (!warnedUnresolvable) {
+        warnedUnresolvable = true;
+        console.warn(
+          `mesh.a2a.mount(${path}): MeshJobSubmitter cannot be built — ` +
+            `no capability resolvable from dependencies[] or skillId='${skillId}'. ` +
+            `Handler's jobSubmitter arg will be null.`
+        );
+      }
+      return null;
+    };
+  }
+
+  return () => {
+    if (cached) return cached;
+    let agentId: string | undefined;
+    try {
+      // getServiceId() may be missing in test fixtures that mock the
+      // api-runtime singleton with a partial object; treat that as
+      // "runtime not started yet" rather than a hard failure so the
+      // dispatcher's user-facing fallback (handler observes null
+      // jobSubmitter and surfaces a clear error) still fires.
+      const runtime = getApiRuntime() as { getServiceId?: () => string };
+      agentId = typeof runtime.getServiceId === "function"
+        ? runtime.getServiceId()
+        : undefined;
+    } catch {
+      agentId = undefined;
+    }
+    if (!agentId) {
+      // api-runtime not yet started — handler observes null. Common on
+      // the very first tasks/send if the client races the agent's
+      // scheduled start; subsequent requests succeed.
+      return null;
+    }
+    // Match the original example's resolution path so users see the
+    // same behavior. process.env.MCP_MESH_REGISTRY_URL is the env var
+    // the SDK's resolveConfig("registry_url", ...) reads.
+    const registryUrl =
+      process.env.MCP_MESH_REGISTRY_URL ?? "http://localhost:8000";
+    try {
+      cached = new MeshJobSubmitter(capability, agentId, registryUrl);
+      return cached;
+    } catch (err) {
+      const msg = (err as Error)?.message ?? String(err);
+      // Don't memoize transient construction failures — try again on
+      // the next request. The submitter constructor itself is currently
+      // trivial (no I/O until submit() fires) so failures here are rare.
+      if (!warnedUnresolvable) {
+        warnedUnresolvable = true;
+        console.warn(
+          `mesh.a2a.mount(${path}): failed to construct MeshJobSubmitter ` +
+            `(capability='${capability}'): ${msg}`
+        );
+      }
+      return null;
+    }
   };
 }
 

--- a/src/runtime/typescript/src/a2a/producer/mount.ts
+++ b/src/runtime/typescript/src/a2a/producer/mount.ts
@@ -446,7 +446,7 @@ function buildJobSubmitterProvider(
   }
 
   return () => {
-    if (cached) return cached;
+    if (cached !== null) return cached;
     let agentId: string | undefined;
     try {
       // getServiceId() may be missing in test fixtures that mock the

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/src/main/java/com/example/reportproducerjava/ProducerReportAgentApplication.java
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/src/main/java/com/example/reportproducerjava/ProducerReportAgentApplication.java
@@ -3,11 +3,9 @@ package com.example.reportproducerjava;
 import io.mcpmesh.JobProxy;
 import io.mcpmesh.MeshAgent;
 import io.mcpmesh.MeshJobSubmitter;
-import io.mcpmesh.spring.MeshRuntime;
 import io.mcpmesh.spring.web.MeshA2A;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.stereotype.Component;
@@ -29,6 +27,12 @@ import java.util.concurrent.TimeoutException;
  * long-running mode (parks the task in the A2A task store, services
  * {@code tasks/get}, {@code tasks/cancel}, {@code tasks/sendSubscribe},
  * {@code tasks/resubscribe} from it).
+ *
+ * <p>Issue #936: the {@link MeshJobSubmitter} is auto-injected by the
+ * dispatcher — capability defaults to the {@code skillId} with
+ * {@code '-'} replaced by {@code '_'} (so {@code "generate-report"}
+ * resolves to {@code generate_report}). No more {@code @Lazy MeshRuntime}
+ * workaround.
  */
 @MeshAgent(
     name = "report-a2a-agent",
@@ -50,9 +54,6 @@ public class ProducerReportAgentApplication {
 
         private static final ObjectMapper JSON = new ObjectMapper();
 
-        @Autowired
-        private MeshRuntime meshRuntime;
-
         @MeshA2A(
             path = "/agents/report",
             skillId = "generate-report",
@@ -60,7 +61,9 @@ public class ProducerReportAgentApplication {
             description = "Generate a long-form report via A2A (task=True streaming)",
             tags = {"reports", "long-running"}
         )
-        public Object generateReport(Map<String, Object> message) throws Exception {
+        public Object generateReport(
+                Map<String, Object> message,
+                MeshJobSubmitter jobSubmitter) throws Exception {
             String userId = "anon";
             List<String> sections = List.of("overview");
             Object partsObj = message != null ? message.get("parts") : null;
@@ -84,9 +87,11 @@ public class ProducerReportAgentApplication {
                 }
             }
 
-            String registryUrl = meshRuntime.getAgentSpec().getRegistryUrl();
-            String agentId = meshRuntime.getAgentSpec().getAgentId();
-            MeshJobSubmitter submitter = new MeshJobSubmitter("generate_report", agentId, registryUrl);
+            if (jobSubmitter == null) {
+                throw new IllegalStateException(
+                    "MeshJobSubmitter not yet available — mesh runtime is still initialising. "
+                        + "Retry tasks/send shortly.");
+            }
 
             Map<String, Object> payload = new LinkedHashMap<>();
             payload.put("user_id", userId);
@@ -97,7 +102,7 @@ public class ProducerReportAgentApplication {
             // hang on the dispatcher thread.
             JobProxy proxy;
             try {
-                proxy = submitter.submit(payload).get(30, TimeUnit.SECONDS);
+                proxy = jobSubmitter.submit(payload).get(30, TimeUnit.SECONDS);
             } catch (TimeoutException te) {
                 throw new RuntimeException(
                     "submit() did not return a JobProxy within 30s — "

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-report-agent-ts/src/index.ts
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-report-agent-ts/src/index.ts
@@ -7,10 +7,10 @@
  * task store, services tasks/get, tasks/cancel, tasks/sendSubscribe,
  * tasks/resubscribe from it).
  *
- * MeshJobSubmitter is hand-constructed from the api-runtime singleton
- * + MCP_MESH_REGISTRY_URL because the @MeshA2A-style dispatcher only
- * auto-injects McpMeshTool proxies, not MeshJobSubmitter — same
- * framework gap noted in the Java fixture's Javadoc.
+ * Issue #936: the MeshJobSubmitter is auto-injected as the third
+ * positional handler arg — capability derives from skillId
+ * ("generate-report" → "generate_report"). No more hand-construction
+ * from getApiRuntime().getServiceId() + MCP_MESH_REGISTRY_URL.
  */
 const HTTP_PORT = parseInt(
   (process.env.MCP_MESH_HTTP_PORT = process.env.MCP_MESH_HTTP_PORT ?? "9091"),
@@ -20,7 +20,7 @@ process.env.MCP_MESH_AGENT_NAME =
   process.env.MCP_MESH_AGENT_NAME ?? "report-a2a-agent";
 
 import express from "express";
-import { getApiRuntime, mesh, MeshJobSubmitter } from "@mcpmesh/sdk";
+import { mesh } from "@mcpmesh/sdk";
 
 const app = express();
 app.use(express.json());
@@ -34,7 +34,7 @@ mesh.a2a.mount(
     description: "Generate a long-form report via A2A (task=True streaming)",
     tags: ["reports", "long-running"],
   },
-  async (_deps, payload) => {
+  async (_deps, payload, jobSubmitter) => {
     let userId = "anon";
     let sections: string[] = ["overview"];
     const parts =
@@ -56,22 +56,14 @@ mesh.a2a.mount(
       }
     }
 
-    const agentId = getApiRuntime().getServiceId();
-    if (!agentId) {
+    if (!jobSubmitter) {
       throw new Error(
-        "api-runtime not yet started — agentId unknown. " +
-        "Wait for the first heartbeat before calling tasks/send.",
+        "MeshJobSubmitter not yet available — mesh runtime is still " +
+          "initialising. Retry tasks/send shortly.",
       );
     }
-    const registryUrl =
-      process.env.MCP_MESH_REGISTRY_URL ?? "http://localhost:8000";
-    const submitter = new MeshJobSubmitter(
-      "generate_report",
-      agentId,
-      registryUrl,
-    );
 
-    const proxy = await submitter.submit({
+    const proxy = await jobSubmitter.submit({
       user_id: userId,
       sections,
     });


### PR DESCRIPTION
## Summary

Two-issue bundle that ships together because the example cleanup from #936 obviates the `@Lazy MeshRuntime` workaround that triggers #937 in practice — but #937 is a real bug for any user `@Component` autowiring `MeshRuntime`.

### #937 — Java A2A producer: user-`@Component` → `MeshRuntime` cycle fix

Two factories in `MeshAutoConfiguration` eagerly walked `@Component`/`@Service` beans during construction. ANY user `@Component` autowiring `MeshRuntime` triggered `BeanCurrentlyInCreationException`.

**Fix** (Option 1 from issue): defer to `SmartInitializingSingleton` (post-singleton-init phase). Split `buildAgentSpec` → `buildBaseAgentSpec` (synchronous, no walks) + `finalizeAgentSpec` (post-init, reads registries). New `MeshA2ALazyRouterFunction` wrapper defers `controller.buildRouterFunction()` to materialization time.

Heartbeat ordering preserved — Spring lifecycle guarantees `SmartInitializingSingleton.afterSingletonsInstantiated()` runs BEFORE `SmartLifecycle.start()` (verified by review-agent against Spring's `AbstractApplicationContext.finishRefresh()` source).

3 regression tests in `MeshA2AUserComponentCycleTest` cover `@Component` / `@Service` / `@Component`+`@MeshA2A` shapes autowiring `MeshRuntime` without `@Lazy`. All FAIL pre-fix with the exact `BeanCurrentlyInCreationException` from the issue.

### #936 — Auto-inject `MeshJobSubmitter` (cross-runtime)

`@MeshA2A` (Java) / `mesh.a2a.mount(...)` (TS) injected `McpMeshTool` proxies but NOT `MeshJobSubmitter` — the primitive long-running producers need to return `JobProxy`. `@MeshTool` handlers inside mesh agents got this via `JobsRuntimeManager.wireConsumers`; producer-side missed it.

**Java**: `MeshA2ADispatcher#invokeHandler` detects `MeshJobSubmitter`-typed parameters, injects from a per-surface cache. Capability resolution: first declared `@MeshDependency` → fallback to `skillId.replace('-', '_')`. New 5-arg dispatcher ctor accepting `ObjectProvider<MeshRuntime>`; legacy 4-arg preserved for back-compat.

**TypeScript**: Handler signature now `(deps, payload, jobSubmitter)`. Lazy memoized provider in `mount.ts`. Provider returns null when api-runtime hasn't started yet — handler observes the absence and can surface a clear error rather than racing.

**Cross-runtime parity**: Python uses keyword-DDDI; type-driven introspection isn't viable in Java/TS, so:
- Java: parameter-type detection (`MeshJobSubmitter`-typed param)
- TS: positional 3rd arg

User-visible ergonomics — "declare it and it's there" — match across all 3 runtimes.

**Examples cleaned up**:
- `examples/java/producer-report-agent` — `@Lazy MeshRuntime` GONE
- `examples/typescript/producer-report-agent` — hand-construction + `getApiRuntime().getServiceId()` GONE
- Same cleanup in uc28/uc29 integration fixtures
- `docs/a2a/producer.md` long-running tabs rewritten to clean idiom

5 new Java tests + 4 new TS tests cover capability resolution, caching, runtime-unavailable fallback, legacy ctor back-compat.

## Review Notes

Pre-merge review-agent found **1 BLOCKER, 6 WARNINGs, 6 INFOs**. Per user direction: applied BLOCKER + 2 small WARNINGs (commit `d62b849b`).

**BLOCKER fixed**: `UNBUILDABLE_SUBMITTER` sentinel was a `static final MeshJobSubmitter` constructed at class load. Risks: (1) class-load cascade if `MeshJobSubmitter` ctor ever acquired resources, (2) sentinel reference leakage via static field. Replaced with `Set<String> unbuildableSurfaces` + `Map<String, MeshJobSubmitter> jobSubmitterCache` — structurally explicit permanent-vs-transient null states. Eliminates the placeholder instance entirely.

**Incidental bug caught during BLOCKER fix**: original code didn't wrap `runtimeProvider.getIfAvailable()` in try/catch; a Spring bean-init exception propagating through would have NPE'd on the next line. New structure has explicit guard.

**New regression test** verifies dispatcher class-load is independent of MeshJobSubmitter ctor health AND that transient provider faults are NOT memoized as permanent-unbuildable (2 dispatches both consult the provider).

**W6 applied** — TS `if (cached)` truthy check → explicit `!== null`
**W7 applied** — TS test `as never` → `as unknown as MeshJobSubmitter` for type-safety

**Skipped WARNINGs** (with reasons):
- W2 param-walk ordering edge case — comment-clarity nit
- W3 fail-fast UX regression — acceptable trade-off for cycle elimination
- W4 cross-test contamination — mitigated by existing `@BeforeEach`
- W5 memoization asymmetry — addressed implicitly by the BLOCKER refactor

**6 INFOs skipped** per project convention.

## Test plan

- [x] Java unit tests: 296 → **297 pass** (1 new BLOCKER regression)
- [x] TypeScript unit tests: 710/710 pass
- [x] `npm run typecheck:all` clean (Express 4 + 5)
- [x] `npm run build` clean
- [x] `mvn install` clean
- [x] **9/9 end-to-end smoke tests pass** against live agents:
  - Both producer-report-agents boot cleanly with no `BeanCurrentlyInCreationException`
  - `tasks/send` long-running → `state=working` (auto-injected `MeshJobSubmitter` works on the wire)
  - SSE wire framing correct: `final` is real boolean, state US `"canceled"`
  - `tasks/cancel` propagates correctly with SSE final frame
  - Source confirmed: `@Lazy MeshRuntime` / hand-construction patterns GONE from both examples
- [x] producer-date-agent (Java, sync, no MeshJobSubmitter) boots cleanly — confirms #937 fix is intact at runtime
- [ ] uc28/uc29 polyglot integration suites need beelink5 image rebuild to execute (out of band)

Closes #936
Closes #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * A2A producer handlers now support framework auto-injection of `MeshJobSubmitter`, simplifying long-running task submission without manual construction.

* **Documentation**
  * Updated A2A producer examples and documentation for Java and TypeScript to reflect the new auto-injection behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/941)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->