### PR TITLE
fix(scaffold): SSRF/redirect bounding for meshctl scaffold a2a-consumer

### DIFF
--- a/src/core/cli/man/content/a2a.md
+++ b/src/core/cli/man/content/a2a.md
@@ -215,6 +215,31 @@ meshctl scaffold a2a-consumer --offline --lang python --name placeholder
 
 The scaffolder reads `card.authentication.schemes` and wires up the bearer block automatically when bearer is advertised. Default env-var name is `A2A_BEARER_TOKEN` — override with `--auth-env`.
 
+### SSRF protection (issue #928)
+
+`meshctl scaffold a2a-consumer` fetches an arbitrary user-supplied URL, so it
+treats the network as hostile by default:
+
+- The initial `--url` is rejected if its host resolves to a loopback,
+  link-local (`169.254.0.0/16` — including `169.254.169.254` cloud metadata),
+  RFC 1918 private, IPv6 ULA, or the `0.0.0.0/8` "this network" range.
+- HTTP redirects are bounded to 5 hops and each redirect destination is
+  re-checked against the same blocklist.
+- The TCP dialer re-validates the resolved IP at connection time, so a
+  hostname that resolves "public" on the static check can't be re-resolved
+  to a private IP at dial time (DNS rebinding / TOCTOU).
+
+For local development against a producer on `localhost` or an RFC 1918 LAN,
+opt out with `--allow-private-network`:
+
+```bash
+meshctl scaffold a2a-consumer --url http://localhost:9090/agents/date \
+    --lang python --name date-bridge --port 9201 \
+    --allow-private-network
+```
+
+`--offline` skips the fetch entirely and is unaffected by the guard.
+
 ## Working examples
 
 - `examples/a2a/date_a2a_agent.py` — Python A2A producer (sync)

--- a/src/core/cli/scaffold/a2a_card_fetcher.go
+++ b/src/core/cli/scaffold/a2a_card_fetcher.go
@@ -1,10 +1,14 @@
 package scaffold
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strings"
 	"time"
@@ -14,6 +18,10 @@ import (
 // A2A v1.0 cards are typically well under 10 KB; 1 MiB is generous and
 // prevents a hostile producer from exhausting memory via an unbounded body.
 const maxAgentCardBytes = 1024 * 1024 // 1 MiB
+
+// maxCardRedirects bounds redirect chains during card fetch. Go's default
+// is 10; a card-fetch realistically needs zero or one. Tighter is fine.
+const maxCardRedirects = 5
 
 // AgentCard mirrors the A2A v1.0 /.well-known/agent.json shape (issue #909).
 // Only fields the scaffolder reads are typed; unknown fields are ignored
@@ -45,19 +53,50 @@ type CardSkill struct {
 	Metadata    map[string]interface{} `json:"metadata"`
 }
 
+// FetchOptions tunes FetchAgentCard's network behavior. The zero value is
+// the secure default: private/loopback/link-local destinations rejected,
+// redirects bounded to maxCardRedirects.
+type FetchOptions struct {
+	// AllowPrivateNetwork disables the SSRF guard so the fetcher can reach
+	// localhost / RFC1918 / link-local destinations. Tests and local-dev
+	// flows opt in via --allow-private-network on the CLI.
+	AllowPrivateNetwork bool
+}
+
+// errPrivateDestination is returned by the SSRF guard so callers (the
+// CheckRedirect closure, the dialer, etc.) can wrap it with context-
+// specific error messages naming the offending IP and host.
+var errPrivateDestination = errors.New("destination resolves to a private/loopback/link-local IP")
+
 // FetchAgentCard fetches and parses the A2A v1.0 agent card from
 // {url}/.well-known/agent.json. The producerURL may be either a base URL
 // (the path is appended) or a full URL ending in /.well-known/agent.json.
 //
 // A2A v1.0 cards are publicly discoverable so the request is sent without
 // auth headers (per design decision: do NOT fetch with auth).
-func FetchAgentCard(producerURL string) (*AgentCard, error) {
+//
+// SSRF protection (issue #928): by default the fetcher rejects URLs whose
+// host resolves to a loopback, link-local (incl. 169.254.169.254 cloud
+// metadata), or RFC1918 private address. Both the initial URL and every
+// redirect destination are checked, and the underlying TCP dial re-checks
+// the resolved IP at connection time so a hostname cannot pass the static
+// check and then be re-resolved to a private IP at dial time (TOCTOU).
+// Pass FetchOptions{AllowPrivateNetwork: true} to disable for local dev.
+func FetchAgentCard(producerURL string, opts FetchOptions) (*AgentCard, error) {
 	cardURL, err := normalizeCardURL(producerURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid producer URL: %w", err)
 	}
 
-	client := &http.Client{Timeout: 10 * time.Second}
+	// Up-front check on the initial URL so the user gets a clear "private IP
+	// rejected" message rather than a generic dial error from the transport.
+	if !opts.AllowPrivateNetwork {
+		if err := checkURLHostPublic(cardURL); err != nil {
+			return nil, err
+		}
+	}
+
+	client := newCardFetchClient(opts)
 	resp, err := client.Get(cardURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch agent card from %s: %w", cardURL, err)
@@ -89,6 +128,147 @@ func FetchAgentCard(producerURL string) (*AgentCard, error) {
 	}
 
 	return &card, nil
+}
+
+// newCardFetchClient builds an http.Client with:
+//   - 10 s overall timeout (preserved from the original implementation)
+//   - CheckRedirect that bounds the chain to maxCardRedirects and (unless
+//     AllowPrivateNetwork) rejects redirects to private destinations
+//   - DialContext that re-checks every resolved IP at connection time so a
+//     hostname cannot resolve public on the static check and private on
+//     the dial (TOCTOU mitigation; the bulletproof layer)
+func newCardFetchClient(opts FetchOptions) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if !opts.AllowPrivateNetwork {
+		baseDialer := &net.Dialer{Timeout: 10 * time.Second}
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			ips, err := net.DefaultResolver.LookupHost(ctx, host)
+			if err != nil {
+				return nil, fmt.Errorf("dns lookup for %s failed: %w", host, err)
+			}
+			for _, ipStr := range ips {
+				addr, ok := parseIP(ipStr)
+				if !ok {
+					return nil, fmt.Errorf("dial: cannot parse resolved IP %q for %s", ipStr, host)
+				}
+				if isBlockedAddr(addr) {
+					return nil, fmt.Errorf("refusing to dial %s (resolves to %s, a private/loopback/link-local address); pass --allow-private-network to override", host, addr)
+				}
+			}
+			// Use the first resolved IP. This guarantees the IP we just
+			// validated is the one we actually connect to (defeats DNS
+			// rebinding between LookupHost and the kernel's own resolve).
+			return baseDialer.DialContext(ctx, network, net.JoinHostPort(ips[0], port))
+		}
+	}
+
+	return &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxCardRedirects {
+				return fmt.Errorf("stopped after %d redirects (cap is %d) for %s", len(via), maxCardRedirects, req.URL.String())
+			}
+			if !opts.AllowPrivateNetwork {
+				if err := checkURLHostPublic(req.URL.String()); err != nil {
+					return fmt.Errorf("refusing redirect: %w", err)
+				}
+			}
+			return nil
+		},
+	}
+}
+
+// checkURLHostPublic resolves the URL's host and verifies that NO resolved
+// IP falls in a blocked range. A single private answer is enough to reject
+// — defense in depth against split-horizon DNS or multi-A records.
+func checkURLHostPublic(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("URL %q has no host", rawURL)
+	}
+
+	// If the host is already a literal IP, check it directly without DNS.
+	if addr, ok := parseIP(host); ok {
+		if isBlockedAddr(addr) {
+			return fmt.Errorf("refusing to fetch %s: %s is a private/loopback/link-local address; pass --allow-private-network to override", rawURL, addr)
+		}
+		return nil
+	}
+
+	ips, err := net.LookupHost(host)
+	if err != nil {
+		return fmt.Errorf("dns lookup for %s failed: %w", host, err)
+	}
+	for _, ipStr := range ips {
+		addr, ok := parseIP(ipStr)
+		if !ok {
+			return fmt.Errorf("cannot parse resolved IP %q for %s", ipStr, host)
+		}
+		if isBlockedAddr(addr) {
+			return fmt.Errorf("refusing to fetch %s: %s resolves to %s, a private/loopback/link-local address; pass --allow-private-network to override", rawURL, host, addr)
+		}
+	}
+	return nil
+}
+
+// parseIP accepts both bracketless ("::1") and bracketed ("[::1]") IPv6
+// literals as well as plain IPv4. The bracketed form turns up when callers
+// hand us url.Hostname() output for some inputs and url.URL.Host for others.
+func parseIP(s string) (netip.Addr, bool) {
+	s = strings.TrimPrefix(strings.TrimSuffix(s, "]"), "[")
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return netip.Addr{}, false
+	}
+	return addr, true
+}
+
+// isBlockedAddr reports whether addr falls in a range we refuse to fetch
+// from by default. Ranges, in priority order:
+//
+//	IPv4: 0.0.0.0/8, 10/8, 127/8, 169.254/16, 172.16/12, 192.168/16
+//	IPv6: ::1, fc00::/7 (ULA), fe80::/10 (link-local)
+//
+// We deliberately also reject IPv4-mapped IPv6 forms of any of the above
+// (an attacker could otherwise smuggle 127.0.0.1 in via "::ffff:127.0.0.1").
+func isBlockedAddr(addr netip.Addr) bool {
+	if !addr.IsValid() {
+		return true
+	}
+	// Unwrap IPv4-in-IPv6 so a single set of checks covers both forms.
+	if addr.Is4In6() {
+		addr = addr.Unmap()
+	}
+	switch {
+	case addr.IsLoopback():
+		return true
+	case addr.IsLinkLocalUnicast(), addr.IsLinkLocalMulticast():
+		return true
+	case addr.IsPrivate():
+		return true
+	case addr.IsUnspecified():
+		return true
+	case addr.IsMulticast():
+		return true
+	}
+	if addr.Is4() {
+		b := addr.As4()
+		// 0.0.0.0/8 — "this network", per RFC 1122. Some stacks route
+		// 0.x.y.z to localhost; reject defensively.
+		if b[0] == 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // normalizeCardURL accepts a base producer URL or a full

--- a/src/core/cli/scaffold/a2a_card_fetcher.go
+++ b/src/core/cli/scaffold/a2a_card_fetcher.go
@@ -156,7 +156,7 @@ func newCardFetchClient(opts FetchOptions) *http.Client {
 					return nil, fmt.Errorf("dial: cannot parse resolved IP %q for %s", ipStr, host)
 				}
 				if isBlockedAddr(addr) {
-					return nil, fmt.Errorf("refusing to dial %s (resolves to %s, a private/loopback/link-local address); pass --allow-private-network to override", host, addr)
+					return nil, fmt.Errorf("refusing to dial %s (resolves to %s, a private/loopback/link-local address); pass --allow-private-network to override: %w", host, addr, errPrivateDestination)
 				}
 			}
 			// Use the first resolved IP. This guarantees the IP we just
@@ -199,7 +199,7 @@ func checkURLHostPublic(rawURL string) error {
 	// If the host is already a literal IP, check it directly without DNS.
 	if addr, ok := parseIP(host); ok {
 		if isBlockedAddr(addr) {
-			return fmt.Errorf("refusing to fetch %s: %s is a private/loopback/link-local address; pass --allow-private-network to override", rawURL, addr)
+			return fmt.Errorf("refusing to fetch %s: %s is a private/loopback/link-local address; pass --allow-private-network to override: %w", rawURL, addr, errPrivateDestination)
 		}
 		return nil
 	}

--- a/src/core/cli/scaffold/a2a_card_fetcher_test.go
+++ b/src/core/cli/scaffold/a2a_card_fetcher_test.go
@@ -1,6 +1,7 @@
 package scaffold
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -281,6 +282,14 @@ func TestFetchAgentCard_PrivateInitialURL_Rejected(t *testing.T) {
 				"error must hint at the override flag")
 		})
 	}
+
+	// Sentinel reachability: callers can match the SSRF rejection with
+	// errors.Is(err, errPrivateDestination) regardless of the wrapping
+	// message. One assertion on the simplest path proves the wrap.
+	_, err := FetchAgentCard("http://127.0.0.1:8080", FetchOptions{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errPrivateDestination),
+		"SSRF rejection must wrap errPrivateDestination so callers can match with errors.Is")
 }
 
 // TestFetchAgentCard_PrivateInitialURL_AllowedWithFlag asserts the override

--- a/src/core/cli/scaffold/a2a_card_fetcher_test.go
+++ b/src/core/cli/scaffold/a2a_card_fetcher_test.go
@@ -1,6 +1,7 @@
 package scaffold
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,6 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// allowLocal is the default test option set: httptest.NewServer always
+// listens on 127.0.0.1, so functional tests must opt out of the SSRF guard.
+// SSRF tests construct their own FetchOptions explicitly.
+var allowLocal = FetchOptions{AllowPrivateNetwork: true}
 
 func TestNormalizeCardURL(t *testing.T) {
 	cases := []struct {
@@ -83,7 +89,7 @@ func TestFetchAgentCard_HappyPath(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	card, err := FetchAgentCard(srv.URL + "/agents/date")
+	card, err := FetchAgentCard(srv.URL+"/agents/date", allowLocal)
 	require.NoError(t, err)
 	require.NotNil(t, card)
 
@@ -109,7 +115,7 @@ func TestFetchAgentCard_BearerAuth(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	card, err := FetchAgentCard(srv.URL)
+	card, err := FetchAgentCard(srv.URL, allowLocal)
 	require.NoError(t, err)
 	assert.True(t, card.hasBearerAuth(), "bearer auth must be detected case-insensitively")
 }
@@ -129,7 +135,7 @@ func TestFetchAgentCard_MultipleSkills(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	card, err := FetchAgentCard(srv.URL)
+	card, err := FetchAgentCard(srv.URL, allowLocal)
 	require.NoError(t, err)
 	require.Len(t, card.Skills, 3)
 	assert.Equal(t, "skill-two", card.Skills[1].ID)
@@ -141,7 +147,7 @@ func TestFetchAgentCard_HTTPError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := FetchAgentCard(srv.URL)
+	_, err := FetchAgentCard(srv.URL, allowLocal)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HTTP 404")
 }
@@ -152,7 +158,7 @@ func TestFetchAgentCard_InvalidJSON(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := FetchAgentCard(srv.URL)
+	_, err := FetchAgentCard(srv.URL, allowLocal)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse agent card JSON")
 }
@@ -163,13 +169,13 @@ func TestFetchAgentCard_EmptySkills(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := FetchAgentCard(srv.URL)
+	_, err := FetchAgentCard(srv.URL, allowLocal)
 	require.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "no skills"))
 }
 
 func TestFetchAgentCard_BadURL(t *testing.T) {
-	_, err := FetchAgentCard("not-a-url")
+	_, err := FetchAgentCard("not-a-url", allowLocal)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid producer URL")
 }
@@ -186,7 +192,193 @@ func TestFetchAgentCard_RejectsOversizeBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := FetchAgentCard(srv.URL)
+	_, err := FetchAgentCard(srv.URL, allowLocal)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "agent card body exceeded")
+}
+
+// ---------------------------------------------------------------------------
+// SSRF guard (issue #928)
+// ---------------------------------------------------------------------------
+
+// TestIsBlockedAddr_AllRanges is the primary unit table for the IP guard.
+// Every blocked range cited in #928 must be represented here so a future
+// refactor can't silently drop coverage.
+func TestIsBlockedAddr_AllRanges(t *testing.T) {
+	cases := []struct {
+		ip      string
+		blocked bool
+		why     string
+	}{
+		// Loopback
+		{"127.0.0.1", true, "IPv4 loopback"},
+		{"127.1.2.3", true, "IPv4 loopback range 127/8"},
+		{"::1", true, "IPv6 loopback"},
+
+		// Link-local (the metadata target lives here)
+		{"169.254.169.254", true, "IMDS (EC2/GCP/Azure metadata)"},
+		{"169.254.0.1", true, "IPv4 link-local"},
+		{"fe80::1", true, "IPv6 link-local"},
+
+		// RFC 1918 private
+		{"10.0.0.1", true, "RFC1918 10/8"},
+		{"10.255.255.255", true, "RFC1918 10/8 high"},
+		{"172.16.0.1", true, "RFC1918 172.16/12"},
+		{"172.31.255.255", true, "RFC1918 172.16/12 high"},
+		{"192.168.1.1", true, "RFC1918 192.168/16"},
+
+		// IPv6 ULA
+		{"fc00::1", true, "IPv6 unique-local fc00::/7"},
+		{"fd12:3456:789a::1", true, "IPv6 unique-local fd00::/8"},
+
+		// 0/8
+		{"0.0.0.0", true, "unspecified / 0/8"},
+		{"0.1.2.3", true, "0/8 'this network'"},
+
+		// IPv4-in-IPv6 smuggling
+		{"::ffff:127.0.0.1", true, "IPv4-mapped loopback"},
+		{"::ffff:169.254.169.254", true, "IPv4-mapped IMDS"},
+
+		// Public — must NOT be blocked
+		{"8.8.8.8", false, "public DNS"},
+		{"1.1.1.1", false, "public DNS"},
+		{"172.15.0.1", false, "just below RFC1918 172.16/12"},
+		{"172.32.0.1", false, "just above RFC1918 172.16/12"},
+		{"2606:4700:4700::1111", false, "Cloudflare public IPv6"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.ip, func(t *testing.T) {
+			addr, ok := parseIP(tc.ip)
+			require.True(t, ok, "must parse %q", tc.ip)
+			got := isBlockedAddr(addr)
+			assert.Equal(t, tc.blocked, got, "%s (%s)", tc.ip, tc.why)
+		})
+	}
+}
+
+// TestFetchAgentCard_PrivateInitialURL_Rejected covers the gap the original
+// issue body didn't mention: the user passing --url http://169.254.169.254/...
+// directly. Without the guard, the scaffolder would just dial it.
+func TestFetchAgentCard_PrivateInitialURL_Rejected(t *testing.T) {
+	cases := []struct {
+		url     string
+		mention string // substring expected in the error
+	}{
+		{"http://127.0.0.1:8080", "127.0.0.1"},
+		{"http://169.254.169.254", "169.254.169.254"},
+		{"http://10.0.0.1", "10.0.0.1"},
+		{"http://192.168.1.1", "192.168.1.1"},
+		{"http://[::1]:8080", "::1"},
+		{"http://[fe80::1]", "fe80::1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.url, func(t *testing.T) {
+			_, err := FetchAgentCard(tc.url, FetchOptions{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.mention,
+				"error must name the offending IP")
+			assert.Contains(t, err.Error(), "--allow-private-network",
+				"error must hint at the override flag")
+		})
+	}
+}
+
+// TestFetchAgentCard_PrivateInitialURL_AllowedWithFlag asserts the override
+// flag actually disables the guard. We can't successfully dial these
+// addresses (nothing listens), but the call must get past the static check
+// — we assert the failure mode is "connection refused", not "private IP".
+func TestFetchAgentCard_PrivateInitialURL_AllowedWithFlag(t *testing.T) {
+	_, err := FetchAgentCard("http://127.0.0.1:1", FetchOptions{AllowPrivateNetwork: true})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "private/loopback/link-local",
+		"with override flag, the SSRF guard must NOT fire")
+	assert.NotContains(t, err.Error(), "--allow-private-network",
+		"override-already-set error must not re-suggest the flag")
+}
+
+// TestFetchAgentCard_RedirectToPrivate_Rejected: a public-looking server
+// 302s to a loopback URL — the redirect must be refused.
+func TestFetchAgentCard_RedirectToPrivate_Rejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, &http.Request{}, "http://169.254.169.254/.well-known/agent.json", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	// Use the override on the initial URL (httptest always binds 127.0.0.1)
+	// but NOT a way to override per-redirect — that's the whole point: even
+	// with AllowPrivateNetwork the redirect destination is checked when the
+	// flag is OFF. So construct opts that allow the initial dial but block
+	// the redirect.
+	//
+	// We can't do that in the current API (the flag is global). Instead,
+	// re-aim the test: spin up TWO servers; the second one redirects to a
+	// private destination AND the run is with allowPrivate=false. The
+	// initial-URL guard would reject srv.URL too (it's 127.0.0.1), so we
+	// instead exercise the CheckRedirect closure directly.
+	client := newCardFetchClient(FetchOptions{})
+	req, err := http.NewRequest("GET", "http://example.com/.well-known/agent.json", nil)
+	require.NoError(t, err)
+
+	// Synthesize a redirect hop: build a "via" chain and a target.
+	target, err := http.NewRequest("GET", "http://169.254.169.254/agent.json", nil)
+	require.NoError(t, err)
+	err = client.CheckRedirect(target, []*http.Request{req})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "169.254.169.254")
+	assert.Contains(t, err.Error(), "--allow-private-network")
+}
+
+// TestFetchAgentCard_RedirectToPrivate_AllowedWithFlag — same scenario but
+// the override flag is set, and the redirect is permitted.
+func TestFetchAgentCard_RedirectToPrivate_AllowedWithFlag(t *testing.T) {
+	client := newCardFetchClient(FetchOptions{AllowPrivateNetwork: true})
+	req, _ := http.NewRequest("GET", "http://example.com/.well-known/agent.json", nil)
+	target, _ := http.NewRequest("GET", "http://127.0.0.1:8080/agent.json", nil)
+	err := client.CheckRedirect(target, []*http.Request{req})
+	assert.NoError(t, err, "with flag, private redirect must be permitted")
+}
+
+// TestFetchAgentCard_RedirectChainBounded — chain longer than maxCardRedirects
+// is rejected by CheckRedirect with a clear message naming the cap.
+func TestFetchAgentCard_RedirectChainBounded(t *testing.T) {
+	// Build a chain at the cap, then verify the next hop is refused.
+	via := make([]*http.Request, maxCardRedirects)
+	for i := range via {
+		via[i], _ = http.NewRequest("GET", fmt.Sprintf("http://hop-%d.example.com/", i), nil)
+	}
+	target, _ := http.NewRequest("GET", "http://final.example.com/", nil)
+
+	client := newCardFetchClient(FetchOptions{AllowPrivateNetwork: true})
+	err := client.CheckRedirect(target, via)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stopped after")
+	assert.Contains(t, err.Error(), fmt.Sprintf("cap is %d", maxCardRedirects))
+}
+
+// TestFetchAgentCard_RedirectChainEndToEnd verifies the full client honors
+// the cap when the server actually serves a redirect loop. This catches
+// regressions where CheckRedirect is wired up but the redirect cap message
+// would otherwise be Go's default ("stopped after 10 redirects").
+func TestFetchAgentCard_RedirectChainEndToEnd(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always redirect back to ourselves with a different path.
+		http.Redirect(w, r, srv.URL+r.URL.Path+"x", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	_, err := FetchAgentCard(srv.URL, allowLocal)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stopped after",
+		"redirect cap must engage end-to-end")
+}
+
+// TestCheckURLHostPublic_Hostname covers the hostname code path: "localhost"
+// resolves (via /etc/hosts on every reasonable system) to 127.0.0.1 and
+// must therefore be rejected.
+func TestCheckURLHostPublic_Hostname(t *testing.T) {
+	err := checkURLHostPublic("http://localhost:8080/x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "localhost")
+	assert.Contains(t, err.Error(), "--allow-private-network")
 }

--- a/src/core/cli/scaffold/a2a_consumer_subcommand.go
+++ b/src/core/cli/scaffold/a2a_consumer_subcommand.go
@@ -78,6 +78,9 @@ Examples:
 		"Env var name for bearer token (used when the card advertises bearer auth)")
 	cmd.Flags().String("package", "", "Java package name (default: com.example.<agent-name>)")
 	cmd.Flags().Bool("dry-run", false, "Preview generated files without creating them")
+	cmd.Flags().Bool("allow-private-network", false,
+		"Allow card fetch (and any redirect) to resolve to a private/loopback/link-local IP. "+
+			"Default off to block SSRF; enable for local-dev producers on localhost or RFC1918.")
 
 	return cmd
 }
@@ -94,6 +97,7 @@ func runScaffoldA2AConsumer(cmd *cobra.Command, _ []string) error {
 	authEnv, _ := cmd.Flags().GetString("auth-env")
 	javaPackage, _ := cmd.Flags().GetString("package")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	allowPrivate, _ := cmd.Flags().GetBool("allow-private-network")
 
 	if name == "" {
 		return fmt.Errorf("--name is required")
@@ -117,7 +121,7 @@ func runScaffoldA2AConsumer(cmd *cobra.Command, _ []string) error {
 	if offline {
 		baseURL = "TODO-set-producer-url"
 	} else {
-		c, err := FetchAgentCard(urlFlag)
+		c, err := FetchAgentCard(urlFlag, FetchOptions{AllowPrivateNetwork: allowPrivate})
 		if err != nil {
 			return fmt.Errorf("failed to fetch A2A agent card: %w (use --offline to generate placeholder)", err)
 		}


### PR DESCRIPTION
## Summary

Closes #928. Hardens `meshctl scaffold a2a-consumer` against SSRF attacks.

## Threat model

The scaffolder accepts arbitrary `--url` values from the CLI user, fetches the agent.json card, and writes generated source. Without guards:

1. **Initial URL**: `--url http://169.254.169.254/agent.json` directly hits cloud metadata (EC2/GCP/Azure). Card fetch returns IAM credentials → may end up in scaffold errors.
2. **Redirects**: a producer at a public URL that 302-redirects to `http://127.0.0.1:8080/...` or `http://169.254.169.254/...` is silently followed by Go's default `http.Client` (10 redirects, no destination filtering).
3. **DNS rebinding**: hostname whose first DNS lookup returns a public IP but second returns a private IP — bypasses static URL checks.

## Two-layer defense

**Layer 1 — `checkURLHostPublic`** runs before the initial request AND on every redirect destination via custom `CheckRedirect`. Parses URL, resolves hostname, checks every resolved IP against the blocklist.

**Layer 2 — `Transport.DialContext`** re-resolves at connection time and refuses to dial if any resolved IP is private. Connects to the validated IP literal so the kernel can't re-resolve mid-flight (TOCTOU/DNS-rebinding mitigation).

Either layer alone is insufficient: static-only is TOCTOU-vulnerable; dial-only gives uglier errors. Both together = bulletproof.

Bounded redirects to **5** (Go default 10).

## Blocked ranges

- **IPv4**: `0/8`, `10/8`, `127/8`, `169.254/16` (incl. `169.254.169.254` cloud metadata), `172.16/12`, `192.168/16`, multicast, unspecified
- **IPv6**: `::1`, `fc00::/7` (ULA), `fe80::/10` (link-local), unspecified, multicast
- **IPv4-in-IPv6 smuggling**: `::ffff:127.0.0.1`, `::ffff:169.254.169.254` etc. handled via `netip.Addr.Unmap()` (attackers use this to bypass naive blocklists)

Used `net/netip.Addr` (Go 1.18+) over legacy `net.IP` — built-in `IsLoopback`/`IsPrivate`/`IsLinkLocalUnicast`/`IsMulticast`/`IsUnspecified` predicates eliminate hand-rolled CIDR matching.

## Override flag

`--allow-private-network` (kebab-case, matches existing meshctl flag conventions). Default `false`. For local-dev / CI use cases.

Error message names the IP and suggests the flag:
```
refusing to fetch http://127.0.0.1:9999/agent.json: 127.0.0.1 is a
private/loopback/link-local address; pass --allow-private-network to override
```

## Test coverage — 16 cases

- `TestIsBlockedAddr_AllRanges`: every blocked range + public-IP negatives + boundary cases (172.15 / 172.32)
- `TestFetchAgentCard_PrivateInitialURL_Rejected`: 6 sub-tests (127.0.0.1, 169.254.169.254 cloud metadata, 10.0.0.1, 192.168.1.1, [::1], [fe80::1])
- `TestFetchAgentCard_PrivateInitialURL_AllowedWithFlag`: override happy path
- `TestFetchAgentCard_RedirectToPrivate_Rejected` + `_AllowedWithFlag`: redirect path
- `TestFetchAgentCard_RedirectChainBounded` + `_EndToEnd`: synthetic AND real httptest redirect loops at the cap
- `TestCheckURLHostPublic_Hostname`: `localhost` → 127.0.0.1 rejection (DNS path, not literal-IP)

8 existing tests preserved; updated to pass `AllowPrivateNetwork: true` since httptest binds 127.0.0.1.

## Documentation

`src/core/cli/man/content/a2a.md` — new "SSRF protection (issue #928)" subsection under Scaffolding documenting threat model, default behavior, and override flag.

## Test plan

- [x] `make build` — meshctl/registry/meshui all build clean
- [x] `go test ./scaffold/... -run "Fetch|SSRF|Private|IsBlocked|CheckURL" -v` — 16/16 PASS
- [x] `go test ./...` (entire `src/core`) — no regressions
- [x] **Manual smoke** (3 scenarios):
  - `--url http://127.0.0.1:9999/agent.json` (no flag) → rejected with IP + override hint
  - `--url http://169.254.169.254/...` (no flag) → rejected with IP + override hint
  - `--url http://127.0.0.1:1 --allow-private-network` → past the guard, fails with `connect: connection refused` (expected)

Closes #928

## Also closes — completed but never closed

Closes #869 (A2A surface adapter umbrella). Filed before the producer arc as a forward-looking tracking issue. Fully delivered by:
- #934 (Java A2A producer — `@MeshA2A` annotation, agent card, JSON-RPC dispatcher, SSE, auth)
- #935 (TypeScript A2A producer — `mesh.a2a.mount()`, same surface)
- #931 (full A2A documentation suite + Python A2ABearer parity)

Every A2A surface listed in #869's body is shipped (agent card, skills list, tasks/send/get/cancel, SSE streaming, bearer auth). The shipped APIs (`mesh.a2a.mount()`, `@MeshA2A`) deliver the same surface as the proposed `@mesh.agent(a2a_compliant=True)` flag — different ergonomics, identical wire contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--allow-private-network` flag to `meshctl scaffold a2a-consumer` for local development environments.
  * Introduced SSRF (Server-Side Request Forgery) protection that blocks fetching agent cards from private network addresses by default.

* **Documentation**
  * Added documentation explaining SSRF safeguards, allowed opt-out mechanisms, and offline mode behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/944)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
