### PR TITLE
fix(media): fail-fast S3 startup validation + docs accuracy (4 of 5 items from #846)

### DIFF
--- a/src/core/cli/man/content/media.md
+++ b/src/core/cli/man/content/media.md
@@ -24,15 +24,22 @@ export MCP_MESH_MEDIA_STORAGE_PREFIX=media/
 
 ## Environment Variables
 
-| Variable                          | Default               | Description                |
-| --------------------------------- | --------------------- | -------------------------- |
-| `MCP_MESH_MEDIA_STORAGE`          | `local`               | Backend: `local` or `s3`   |
-| `MCP_MESH_MEDIA_STORAGE_PATH`     | `/tmp/mcp-mesh-media` | Local filesystem base path |
-| `MCP_MESH_MEDIA_STORAGE_BUCKET`   | `mcp-mesh-media`      | S3 bucket name             |
-| `MCP_MESH_MEDIA_STORAGE_ENDPOINT` | (none)                | S3-compatible endpoint URL |
-| `MCP_MESH_MEDIA_STORAGE_PREFIX`   | `media/`              | Key/directory prefix       |
-| `AWS_ACCESS_KEY_ID`               | _(none)_              | S3 access key (or IAM)     |
-| `AWS_SECRET_ACCESS_KEY`           | _(none)_              | S3 secret key (or IAM)     |
+| Variable                          | Default               | Description                                            |
+| --------------------------------- | --------------------- | ------------------------------------------------------ |
+| `MCP_MESH_MEDIA_STORAGE`          | `local`               | Backend: `local` or `s3`                               |
+| `MCP_MESH_MEDIA_STORAGE_PATH`     | `/tmp/mcp-mesh-media` | Local filesystem base path                             |
+| `MCP_MESH_MEDIA_STORAGE_BUCKET`   | _(required for s3)_   | S3 bucket name (must be set when backend is `s3`)      |
+| `MCP_MESH_MEDIA_STORAGE_ENDPOINT` | (none)                | S3-compatible endpoint URL                             |
+| `MCP_MESH_MEDIA_STORAGE_PREFIX`   | `media/`              | Key/directory prefix                                   |
+| `MCP_MESH_MEDIA_STORAGE_VALIDATE` | `false`               | When `true`, run a head_bucket probe at startup        |
+| `AWS_ACCESS_KEY_ID`               | _(none)_              | S3 access key (or IAM)                                 |
+| `AWS_SECRET_ACCESS_KEY`           | _(none)_              | S3 secret key (or IAM)                                 |
+
+When `MCP_MESH_MEDIA_STORAGE=s3` is set, the agent fails fast at startup if
+`boto3` is missing or `MCP_MESH_MEDIA_STORAGE_BUCKET` is unset. Set
+`MCP_MESH_MEDIA_STORAGE_VALIDATE=true` to additionally probe credentials and
+bucket reachability before the agent starts serving traffic (off by default
+so CI/local-dev environments without real AWS creds keep working).
 
 ## Uploading Media
 

--- a/src/core/cli/man/content/multimodal.md
+++ b/src/core/cli/man/content/multimodal.md
@@ -10,6 +10,10 @@ return await llm("Describe this image", media=["file:///tmp/photo.png"])
 return await llm("What is this?", media=[(png_bytes, "image/png")])
 ```
 
+`media=` is a kwarg on `MeshLlmAgent.__call__()`. Items are resolved on the
+**consumer side** into provider-native content blocks before the request is
+serialized — they do not appear on the `MeshLlmRequest` wire schema.
+
 ### Media Item Types
 
 | Type        | Format              | Example                                              |
@@ -43,9 +47,23 @@ async def analyze(
 
 ## Resource Link Resolution
 
-LLM providers auto-resolve `resource_link` URIs — the provider fetches media bytes and converts them to the vendor's native format. No manual fetching needed.
+LLM providers auto-resolve `resource_link` URIs returned from agentic tool calls — the provider fetches media bytes and converts them to the vendor's native format. No manual fetching needed.
 
-Only the **producer** (write) and **provider** (read) need MediaStore access. See `meshctl man media` for setup.
+### Who needs MediaStore access?
+
+The two media flows have different access requirements:
+
+| Flow                                       | Resolved by | Needs MediaStore access |
+| ------------------------------------------ | ----------- | ----------------------- |
+| `media=[uri]` kwarg on `MeshLlmAgent`      | Consumer    | Producer + **consumer** |
+| `resource_link` returned from a tool call  | Provider    | Producer + **provider** |
+
+If your consumer passes `media=["s3://..."]`, the consumer process needs S3
+credentials and `boto3` installed. If you only return `resource_link` from
+agentic tools and let the LLM provider fetch them, only the provider needs
+MediaStore access.
+
+See `meshctl man media` for storage setup.
 
 ## Multi-Agent Media Chain
 

--- a/src/runtime/python/_mcp_mesh/media/media_store.py
+++ b/src/runtime/python/_mcp_mesh/media/media_store.py
@@ -104,14 +104,31 @@ class LocalMediaStore(MediaStore):
 
 
 class S3MediaStore(MediaStore):
-    """S3-compatible media store (requires boto3 at runtime)."""
+    """S3-compatible media store (requires boto3 at runtime).
+
+    Construction is fail-fast: boto3 is imported eagerly, ``MCP_MESH_MEDIA_STORAGE_BUCKET``
+    must be set explicitly (no silent default), and — when
+    ``MCP_MESH_MEDIA_STORAGE_VALIDATE=true`` — an inexpensive ``head_bucket`` probe
+    runs to confirm credentials and bucket reachability before the agent starts
+    serving traffic. The probe is opt-in to keep CI/local-dev workflows that
+    set ``MCP_MESH_MEDIA_STORAGE=s3`` without real AWS creds working.
+    """
 
     def __init__(self) -> None:
-        self._bucket: str = get_config_value(
+        # Bucket must be configured explicitly — silently defaulting to
+        # "mcp-mesh-media" would let typos produce confusing 404s at first use.
+        bucket = get_config_value(
             "MCP_MESH_MEDIA_STORAGE_BUCKET",
-            default="mcp-mesh-media",
+            default=None,
             rule=ValidationRule.STRING_RULE,
         )
+        if not bucket:
+            raise ValueError(
+                "MCP_MESH_MEDIA_STORAGE=s3 requires MCP_MESH_MEDIA_STORAGE_BUCKET to be set. "
+                "Set the bucket name in your environment, e.g. "
+                "MCP_MESH_MEDIA_STORAGE_BUCKET=my-media-bucket."
+            )
+        self._bucket: str = bucket
         endpoint: str | None = get_config_value(
             "MCP_MESH_MEDIA_STORAGE_ENDPOINT",
             default=None,
@@ -127,7 +144,7 @@ class S3MediaStore(MediaStore):
             import boto3  # type: ignore[import-untyped]
         except ImportError as exc:
             raise ImportError(
-                "boto3 is required for S3 media storage. "
+                "boto3 is required for S3 media storage (MCP_MESH_MEDIA_STORAGE=s3). "
                 "Install it with: pip install boto3"
             ) from exc
 
@@ -135,6 +152,38 @@ class S3MediaStore(MediaStore):
         if endpoint:
             kwargs["endpoint_url"] = endpoint
         self._client = boto3.client("s3", **kwargs)
+
+        # Optional eager probe — confirms creds + bucket reachability at startup
+        # rather than at first media call. Off by default so dev/CI environments
+        # that set MCP_MESH_MEDIA_STORAGE=s3 without live creds aren't broken.
+        validate = get_config_value(
+            "MCP_MESH_MEDIA_STORAGE_VALIDATE",
+            default="false",
+            rule=ValidationRule.STRING_RULE,
+        )
+        if str(validate).lower() in ("true", "1", "yes", "on"):
+            self._probe_bucket()
+
+    def _probe_bucket(self) -> None:
+        """Cheap reachability check — head_bucket only needs object-level perms."""
+        from botocore.exceptions import ClientError, NoCredentialsError
+
+        try:
+            self._client.head_bucket(Bucket=self._bucket)
+        except NoCredentialsError as exc:
+            raise RuntimeError(
+                "S3 media store probe failed: AWS credentials not found. "
+                "Set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY (or use an IAM role). "
+                "Set MCP_MESH_MEDIA_STORAGE_VALIDATE=false to defer this check."
+            ) from exc
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "Unknown")
+            raise RuntimeError(
+                f"S3 media store probe failed for bucket '{self._bucket}' "
+                f"(error code: {code}). Verify MCP_MESH_MEDIA_STORAGE_BUCKET, "
+                "MCP_MESH_MEDIA_STORAGE_ENDPOINT, and AWS credentials. "
+                "Set MCP_MESH_MEDIA_STORAGE_VALIDATE=false to defer this check."
+            ) from exc
 
     def _key(self, filename: str) -> str:
         return f"{self._prefix}{filename}"

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/__init__.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/__init__.py
@@ -14,6 +14,7 @@ from .heartbeat_preparation import HeartbeatPreparationStep
 from .jobs_cancel_route import JobsCancelRouteStep
 from .jobs_claim_workers import JobsClaimWorkersStep
 from .jobs_helper_tools import JobsHelperToolsStep
+from .media_store_validation import MediaStoreValidationStep
 from .startup_orchestrator import (MeshOrchestrator,
                                    clear_debounce_coordinator,
                                    get_debounce_coordinator,
@@ -30,6 +31,7 @@ __all__ = [
     "JobsCancelRouteStep",
     "JobsClaimWorkersStep",
     "JobsHelperToolsStep",
+    "MediaStoreValidationStep",
     "MeshOrchestrator",
     "StartupPipeline",
     "clear_debounce_coordinator",

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/media_store_validation.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/media_store_validation.py
@@ -1,0 +1,58 @@
+"""Eager media store initialization for fail-fast startup.
+
+When ``MCP_MESH_MEDIA_STORAGE=s3`` is set explicitly, instantiating the store
+here (rather than at first LLM call) surfaces three classes of misconfiguration
+at agent boot:
+
+- ``boto3`` missing -> ``ImportError`` with install hint
+- ``MCP_MESH_MEDIA_STORAGE_BUCKET`` unset -> ``ValueError`` naming the env var
+- (opt-in) AWS creds / bucket unreachable -> ``RuntimeError`` from head_bucket probe
+
+For ``local`` (the default), construction is essentially free, so we always run
+this step — it costs nothing and keeps the contract uniform.
+"""
+
+import os
+from typing import Any
+
+from ..shared import PipelineResult, PipelineStatus, PipelineStep
+
+
+class MediaStoreValidationStep(PipelineStep):
+    """Eagerly initialize the media store so config errors surface at startup."""
+
+    def __init__(self):
+        super().__init__(
+            name="media-store-validation",
+            required=False,
+            description="Eagerly initialize media store to fail-fast on misconfiguration",
+        )
+
+    async def execute(self, context: dict[str, Any]) -> PipelineResult:
+        result = PipelineResult(message="Media store validation completed")
+
+        # Local import keeps pipeline import-time cheap (and avoids pulling
+        # the media subsystem during pure-decorator unit tests).
+        from ...media.media_store import get_media_store
+
+        try:
+            store = get_media_store()
+            result.add_context("media_store_type", type(store).__name__)
+            backend = os.getenv("MCP_MESH_MEDIA_STORAGE", "local")
+            result.message = (
+                f"Media store initialized: {type(store).__name__} (backend='{backend}')"
+            )
+            self.logger.info(
+                "Media store initialized: %s (backend='%s')",
+                type(store).__name__,
+                backend,
+            )
+        except (ImportError, ValueError, RuntimeError) as e:
+            result.status = PipelineStatus.FAILED
+            result.message = f"Media store initialization failed: {e}"
+            result.add_error(str(e))
+            self.logger.error(
+                "Media store initialization failed: %s", e
+            )
+
+        return result

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_pipeline.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_pipeline.py
@@ -13,7 +13,7 @@ from . import (ConfigurationStep, DecoratorCollectionStep,
                FastAPIServerSetupStep, FastMCPServerDiscoveryStep,
                HeartbeatLoopStep, HeartbeatPreparationStep,
                JobsCancelRouteStep, JobsClaimWorkersStep,
-               JobsHelperToolsStep)
+               JobsHelperToolsStep, MediaStoreValidationStep)
 from .server_discovery import ServerDiscoveryStep
 
 logger = logging.getLogger(__name__)
@@ -46,6 +46,11 @@ class StartupPipeline(MeshPipeline):
         steps = [
             DecoratorCollectionStep(),
             ConfigurationStep(),
+            # Eagerly initialize the media store so MCP_MESH_MEDIA_STORAGE=s3
+            # misconfiguration (missing boto3, missing bucket, bad creds when
+            # validation is enabled) fails at startup instead of at first LLM
+            # call. Issue #846 (#1, #2).
+            MediaStoreValidationStep(),
             FastMCPServerDiscoveryStep(),  # Discover user's FastMCP instances (MOVED UP for Phase 2)
             # Phase 1 MeshJob: register helper tools on the FastMCP server
             # BEFORE FastAPIServerSetup mounts it (so they appear in /tools/list).

--- a/src/runtime/python/mesh/types.py
+++ b/src/runtime/python/mesh/types.py
@@ -617,6 +617,13 @@ class MeshLlmRequest:
         context: Optional arbitrary context data for debugging/tracing
         request_id: Optional request ID for tracking
         caller_agent: Optional agent name that initiated the request
+
+    Note:
+        ``media=`` is *not* a field on this dataclass. It is a kwarg on
+        ``MeshLlmAgent.__call__()`` (e.g. ``await llm("describe", media=["s3://..."])``)
+        that the consumer pre-resolves into provider-native content blocks
+        before constructing the request — the resolved blocks land inside
+        ``messages[*].content``. See ``meshctl man multimodal`` for details.
     """
 
     messages: list[dict[str, Any]]  # Changed from Dict[str, str] to allow tool_calls

--- a/tests/unit/test_media_store.py
+++ b/tests/unit/test_media_store.py
@@ -2,7 +2,7 @@
 
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -118,3 +118,153 @@ class TestGetMediaStore:
             store1 = get_media_store()
             store2 = get_media_store()
             assert store1 is store2
+
+
+class TestS3MediaStoreFailFast:
+    """Issue #846: S3MediaStore must fail-fast on misconfiguration at startup
+    (not at first LLM call).
+
+    The constructor is the validation surface — when MCP_MESH_MEDIA_STORAGE=s3
+    is set explicitly, missing boto3, missing bucket, or (opt-in) bad creds
+    must raise immediately rather than silently producing a broken store.
+    """
+
+    def setup_method(self):
+        media_store_mod._instance = None
+
+    def teardown_method(self):
+        media_store_mod._instance = None
+
+    def _config(self, **overrides):
+        """Build a config_value side_effect with sensible s3 defaults."""
+        base = {
+            "MCP_MESH_MEDIA_STORAGE": "s3",
+            "MCP_MESH_MEDIA_STORAGE_BUCKET": "test-bucket",
+            "MCP_MESH_MEDIA_STORAGE_ENDPOINT": None,
+            "MCP_MESH_MEDIA_STORAGE_PREFIX": "media/",
+            "MCP_MESH_MEDIA_STORAGE_VALIDATE": "false",
+        }
+        base.update(overrides)
+        return lambda env_var, default=None, rule=None: base.get(env_var, default)
+
+    def test_missing_bucket_raises_value_error(self):
+        """Issue #846 #1: bucket must be explicit — no silent default."""
+        with patch(
+            "_mcp_mesh.media.media_store.get_config_value",
+            side_effect=self._config(MCP_MESH_MEDIA_STORAGE_BUCKET=None),
+        ):
+            with pytest.raises(ValueError, match="MCP_MESH_MEDIA_STORAGE_BUCKET"):
+                get_media_store()
+
+    def test_missing_boto3_raises_at_construction(self):
+        """Issue #846 #2: boto3 ImportError must surface at startup, not lazily."""
+        # Simulate boto3 not being importable.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "boto3":
+                raise ImportError("No module named 'boto3'")
+            return real_import(name, *args, **kwargs)
+
+        with patch(
+            "_mcp_mesh.media.media_store.get_config_value",
+            side_effect=self._config(),
+        ), patch.object(builtins, "__import__", side_effect=fake_import):
+            with pytest.raises(ImportError, match="boto3 is required"):
+                get_media_store()
+
+    def test_valid_config_with_mocked_boto3_succeeds(self):
+        """Working path: boto3 present, bucket set, validate off -> store ready."""
+        fake_boto3 = MagicMock()
+        fake_client = MagicMock()
+        fake_boto3.client.return_value = fake_client
+
+        with patch(
+            "_mcp_mesh.media.media_store.get_config_value",
+            side_effect=self._config(),
+        ), patch.dict(sys.modules, {"boto3": fake_boto3}):
+            store = get_media_store()
+            assert type(store).__name__ == "S3MediaStore"
+            # head_bucket must NOT have been called (validate=false default)
+            fake_client.head_bucket.assert_not_called()
+
+    def test_validate_enabled_calls_head_bucket(self):
+        """Opt-in probe: head_bucket runs when MCP_MESH_MEDIA_STORAGE_VALIDATE=true."""
+        fake_boto3 = MagicMock()
+        fake_client = MagicMock()
+        fake_boto3.client.return_value = fake_client
+        botocore_pkg, botoexc = self._fake_botocore_exceptions()
+
+        with patch(
+            "_mcp_mesh.media.media_store.get_config_value",
+            side_effect=self._config(MCP_MESH_MEDIA_STORAGE_VALIDATE="true"),
+        ), patch.dict(
+            sys.modules,
+            {"boto3": fake_boto3, "botocore": botocore_pkg, "botocore.exceptions": botoexc},
+        ):
+            store = get_media_store()
+            assert type(store).__name__ == "S3MediaStore"
+            fake_client.head_bucket.assert_called_once_with(Bucket="test-bucket")
+
+    def _fake_botocore_exceptions(self):
+        """Build a fake botocore.exceptions module shim with the two error types
+        the probe handler imports. Lets these tests run without botocore installed."""
+        import types
+
+        mod = types.ModuleType("botocore.exceptions")
+
+        class NoCredentialsError(Exception):
+            def __init__(self):
+                super().__init__("Unable to locate credentials")
+
+        class ClientError(Exception):
+            def __init__(self, error_response, operation_name):
+                super().__init__(str(error_response))
+                self.response = error_response
+                self.operation_name = operation_name
+
+        mod.NoCredentialsError = NoCredentialsError
+        mod.ClientError = ClientError
+        parent = types.ModuleType("botocore")
+        parent.exceptions = mod
+        return parent, mod
+
+    def test_validate_no_credentials_raises_runtime_error(self):
+        """Probe surfaces NoCredentialsError as a clear RuntimeError naming the env vars."""
+        fake_boto3 = MagicMock()
+        fake_client = MagicMock()
+        fake_boto3.client.return_value = fake_client
+        botocore_pkg, botoexc = self._fake_botocore_exceptions()
+        fake_client.head_bucket.side_effect = botoexc.NoCredentialsError()
+
+        with patch(
+            "_mcp_mesh.media.media_store.get_config_value",
+            side_effect=self._config(MCP_MESH_MEDIA_STORAGE_VALIDATE="true"),
+        ), patch.dict(
+            sys.modules,
+            {"boto3": fake_boto3, "botocore": botocore_pkg, "botocore.exceptions": botoexc},
+        ):
+            with pytest.raises(RuntimeError, match="AWS credentials not found"):
+                get_media_store()
+
+    def test_validate_client_error_raises_runtime_error_with_code(self):
+        """Probe surfaces a ClientError (e.g. NoSuchBucket) with the error code."""
+        fake_boto3 = MagicMock()
+        fake_client = MagicMock()
+        fake_boto3.client.return_value = fake_client
+        botocore_pkg, botoexc = self._fake_botocore_exceptions()
+        fake_client.head_bucket.side_effect = botoexc.ClientError(
+            {"Error": {"Code": "NoSuchBucket", "Message": "nope"}}, "HeadBucket"
+        )
+
+        with patch(
+            "_mcp_mesh.media.media_store.get_config_value",
+            side_effect=self._config(MCP_MESH_MEDIA_STORAGE_VALIDATE="true"),
+        ), patch.dict(
+            sys.modules,
+            {"boto3": fake_boto3, "botocore": botocore_pkg, "botocore.exceptions": botoexc},
+        ):
+            with pytest.raises(RuntimeError, match="NoSuchBucket"):
+                get_media_store()


### PR DESCRIPTION
## Summary

Closes 4 of 5 items in #846 (media handling). Item #4 (structured failure-mode response) deferred — needs API design pass; will file follow-up if observability gap becomes urgent.

## Verify-first findings

The issue's specific claim — `MCP_MESH_MEDIA_STORAGE=s3` with missing config → silently initializes `LocalMediaStore` — does NOT match current code. `get_media_store()` constructs `S3MediaStore` directly when `backend == "s3"`, no fallback path.

The actual silent-failure shapes:
- Missing `_BUCKET` → silently used default `"mcp-mesh-media"` → 404s on first `put_object`
- Missing creds → no construction-time check; `NoCredentialsError` at first S3 op
- `boto3` missing → `ImportError` at first `get_media_store()` call (lazy from `MeshLlmAgent.__call__`), NOT at agent startup

The fix shape (fail-fast at startup) is identical regardless of which specific failure mode bites.

## #1 + #2 — fail-fast S3 startup validation

**New pipeline step**: `MediaStoreValidationStep` at `src/runtime/python/_mcp_mesh/pipeline/mcp_startup/media_store_validation.py`. Wired between `ConfigurationStep` and `FastMCPServerDiscoveryStep` so any of {missing boto3, missing bucket, opt-in probe failure} surface at agent boot rather than at first LLM media call.

**Tightened `S3MediaStore.__init__`**:
- `_BUCKET` now REQUIRED (was: silently defaulted to `"mcp-mesh-media"`). Missing → `ValueError` at construction with message naming the env var.
- `boto3` import was already eager at `S3MediaStore.__init__` (correct); the bug was `get_media_store()` lazy invocation. Eager startup call fixes the timing.

**Opt-in AWS creds probe**: `MCP_MESH_MEDIA_STORAGE_VALIDATE=true` (default `false`). Uses `head_bucket(self._bucket)` — cheapest probe that confirms creds + bucket reachability. Default false because many CI/dev envs set `MCP_MESH_MEDIA_STORAGE=s3` for parity without real creds — making the probe mandatory would break those.

## #3 — Docs/source drift on MediaStore access

`multimodal.md:48` claimed *"Only the producer (write) and provider (read) need MediaStore access"* — true for the `resource_link` flow but NOT for `media=[uri]` direct flow where `_resolve_media_inputs` runs consumer-side.

Replaced with a per-flow access table:
- `media=[uri]` direct flow → consumer + provider need access
- `resource_link` agentic-tool flow → provider only

TS/Java multimodal variants didn't have the misclaim — only `multimodal.md` updated.

## #5 — `MeshLlmRequest` no `media` hint

`MeshLlmRequest` has no `media` field, and adding one would be misleading because the `media=` kwarg is pre-resolved into `messages[*].content` blocks before constructing the request.

Picked **Option A** (lighter): added a `Note:` block to `MeshLlmRequest` docstring pointing readers at `MeshLlmAgent.__call__` + `meshctl man multimodal`. Plus discoverability paragraph in `multimodal.md`.

## Test plan

- [x] **14/14 media-store tests pass** (8 baseline + 6 new in `TestS3MediaStoreFailFast`):
  - Missing bucket → `ValueError` at construction
  - boto3 missing → `ImportError` at startup with install hint
  - Validate=true + `head_bucket` succeeds → no error
  - Validate=true + `NoCredentialsError` → re-raised with helpful message
  - Validate=true + bucket 404 → re-raised with bucket name
  - Validate=false → no probe (default behavior preserved)
- [x] `mkdocs build` clean (only pre-existing `python/llm/index.md` warnings)
- [x] **Smoke**: `MCP_MESH_MEDIA_STORAGE=s3` + boto3 missing → `ImportError` at startup (not deferred to first LLM call) ✓

## Pre-existing test failures noted (NOT caused by this PR)

13 failing tests in `tests/unit/test_llm_media_input.py` at baseline — all `AttributeError: 'MeshLlmAgent' object has no attribute '_provider_handler'`. Tests construct `MeshLlmAgent` without going through `__init__` properly. Worth a separate follow-up issue to fix the test fixture.

## Out of scope

- **Item #4**: structured `media_resolution_failures` response field — needs API design pass on `MeshLlmRequest` response shape; would change a public surface. Deferred.
- **Architecture note** (consumer-side vs provider-side resolution N-misconfig surface area) — design discussion, not an implementation fix.

Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)