### PR TITLE
[HOTFIX] fix(a2a-java): empty @MeshA2A registry crashes Spring Boot startup

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcherController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcherController.java
@@ -15,7 +15,9 @@ import org.springframework.web.servlet.function.ServerResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * HTTP entry point for A2A producer surfaces (spec §3 + §4).
@@ -54,6 +56,29 @@ public class MeshA2ADispatcherController {
     private static final Logger log = LoggerFactory.getLogger(MeshA2ADispatcherController.class);
 
     private static final String AGENT_CARD_SUFFIX = "/.well-known/agent.json";
+
+    /**
+     * Empty-registry router: a {@link RouterFunction} that matches no
+     * requests, returned when no {@code @MeshA2A} surfaces are registered.
+     *
+     * <p>{@code RouterFunctions.Builder.build()} throws
+     * {@code IllegalStateException: No routes registered. Register a route
+     * with GET(), POST(), etc.} when called with zero accumulated routes,
+     * which crashed the agent process at context refresh before it could
+     * register with the mesh registry.
+     *
+     * <p>Most Java agents do NOT declare {@code @MeshA2A} surfaces (basic
+     * {@code @MeshTool} agents, registry/lifecycle tests, consumer-only
+     * apps), so the empty-registry case is the common case. Returning a
+     * never-matching {@code RouterFunction} bypasses the builder entirely
+     * — Spring's {@code RouterFunctionMapping} accepts the bean without
+     * complaint, and no fake/internal path appears in the route table.
+     * If anything ever does try to dispatch through it, {@code route()}
+     * returns {@code Optional.empty()} and the request falls through to
+     * the next handler in the chain.
+     */
+    static final RouterFunction<ServerResponse> EMPTY_REGISTRY_ROUTER =
+        request -> Optional.empty();
 
     /**
      * Hard cap on the size of an inbound JSON-RPC body read by {@link #readBody}.
@@ -104,8 +129,21 @@ public class MeshA2ADispatcherController {
      * {@code meshA2ARouterFunction(...)} factory method.
      */
     public RouterFunction<ServerResponse> buildRouterFunction() {
+        List<MeshA2ARegistry.SurfaceMetadata> allSurfaces = registry.getAllSurfaces();
+        if (allSurfaces.isEmpty()) {
+            // Empty-registry guard: RouterFunctions.Builder.build() rejects an
+            // empty route list (IllegalStateException: "No routes registered"),
+            // crashing every Java agent that has no @MeshA2A surfaces — basic
+            // @MeshTool agents, consumer-only apps, registry/lifecycle tests.
+            // Return a never-matching RouterFunction directly so the bean
+            // exists for Spring's RouterFunctionMapping to collect, but no
+            // fake path lands in the route table. See EMPTY_REGISTRY_ROUTER
+            // javadoc for rationale.
+            log.debug("@MeshA2A: no surfaces registered — installing never-matching router");
+            return EMPTY_REGISTRY_ROUTER;
+        }
         RouterFunctions.Builder builder = RouterFunctions.route();
-        for (MeshA2ARegistry.SurfaceMetadata surface : registry.getAllSurfaces()) {
+        for (MeshA2ARegistry.SurfaceMetadata surface : allSurfaces) {
             String path = surface.path();
             String cardPath = path + AGENT_CARD_SUFFIX;
             // SSE branch FIRST so Accept: text/event-stream wins the

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AEmptyRegistryRouterTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AEmptyRegistryRouterTest.java
@@ -1,0 +1,216 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.spring.MeshAutoConfiguration;
+import io.mcpmesh.spring.MeshProperties;
+import io.mcpmesh.spring.MeshRuntime;
+import jakarta.servlet.ServletContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.servlet.function.HandlerFunction;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for the empty-{@code @MeshA2A}-registry crash
+ * (hotfix follow-up to #934 + #941).
+ *
+ * <p>{@link MeshA2ADispatcherController#buildRouterFunction()} previously
+ * called {@code RouterFunctions.Builder.build()} on a builder that received
+ * zero routes whenever no {@code @MeshA2A} surfaces were registered.
+ * {@code Builder.build()} throws:
+ *
+ * <pre>
+ *   IllegalStateException: No routes registered.
+ *   Register a route with GET(), POST(), etc.
+ * </pre>
+ *
+ * <p>which crashed the agent process at context refresh BEFORE it could
+ * register with the mesh registry. The crash hit ~100 integration tests
+ * because most Java agents (basic {@code @MeshTool} agents, consumer-only
+ * apps, lifecycle/registry tests) do NOT declare {@code @MeshA2A} surfaces
+ * — the producer wiring is always installed but the registry is empty
+ * until a user opts in.
+ *
+ * <h2>The fix</h2>
+ *
+ * <p>When the registry is empty, {@code buildRouterFunction()} returns a
+ * never-matching {@link RouterFunction} directly (bypassing the builder
+ * entirely). Spring's {@code RouterFunctionMapping} accepts the bean
+ * without complaint and no fake/internal path lands in the route table; if
+ * any request ever reaches it, {@code route()} returns
+ * {@link Optional#empty()} and the request falls through to the next
+ * handler.
+ *
+ * <h2>Coverage</h2>
+ *
+ * <ol>
+ *   <li>Unit: {@code buildRouterFunction()} on an empty registry does NOT
+ *       throw and returns a non-null router.</li>
+ *   <li>Unit: the returned router never matches any probe request
+ *       (route() returns Optional.empty() in every case).</li>
+ *   <li>Context: a Spring application context with NO {@code @MeshA2A}
+ *       beans refreshes cleanly (no {@code IllegalStateException: No
+ *       routes registered}) and exposes the {@code meshA2ARouterFunction}
+ *       bean.</li>
+ * </ol>
+ */
+@DisplayName("MeshA2A producer — empty-registry router (hotfix regression)")
+class MeshA2AEmptyRegistryRouterTest {
+
+    private static final List<HttpMessageConverter<?>> CONVERTERS =
+        List.of(new StringHttpMessageConverter(StandardCharsets.UTF_8));
+
+    @Test
+    @DisplayName("Empty registry → router exists but matches no requests "
+        + "(bypasses RouterFunctions.Builder.build() empty-list rejection)")
+    void buildRouterFunction_emptyRegistry_returnsNeverMatchingRouter() throws Exception {
+        MeshA2ARegistry emptyRegistry = new MeshA2ARegistry();
+        assertTrue(emptyRegistry.getAllSurfaces().isEmpty(),
+            "Pre-condition: registry must be empty for this regression case");
+
+        MeshA2ADispatcherController controller = new MeshA2ADispatcherController(
+            emptyRegistry,
+            new MeshA2ADispatcher(emptyRegistry, new MeshA2ATaskStore(),
+                A2ATestFixtures.objectMapper(),
+                A2ATestFixtures.emptyInjectorProvider()),
+            new MeshA2ASseDispatcher(new MeshA2ADispatcher(emptyRegistry,
+                new MeshA2ATaskStore(), A2ATestFixtures.objectMapper(),
+                A2ATestFixtures.emptyInjectorProvider())),
+            new MeshA2ACardBuilder(null, A2ATestFixtures.objectMapper()),
+            emptyProvider(MeshProperties.class),
+            emptyProvider(MeshA2APublicUrlCache.class));
+
+        RouterFunction<ServerResponse> router = controller.buildRouterFunction();
+        assertNotNull(router, "buildRouterFunction() must never return null");
+
+        // The empty-registry router must match NO request — there's no fake
+        // path in the route table. Probe a few representative paths to prove
+        // that route() returns Optional.empty() in every case. The bean
+        // exists only so Spring's RouterFunctionMapping can collect it; it
+        // never serves real traffic.
+        ServletContext servletContext = new MockServletContext();
+        for (String path : new String[]{
+                "/", "/anything", "/agents/foo", "/agents/foo/.well-known/agent.json"}) {
+            MockHttpServletRequest req = new MockHttpServletRequest(
+                servletContext, "GET", path);
+            req.addHeader(HttpHeaders.ACCEPT, MediaType.ALL_VALUE);
+            ServerRequest serverRequest = ServerRequest.create(req, CONVERTERS);
+            Optional<HandlerFunction<ServerResponse>> match = router.route(serverRequest);
+            assertTrue(match.isEmpty(),
+                "Empty-registry router must NOT match any request (probed "
+                    + path + ") — it returns Optional.empty() so requests fall "
+                    + "through to other handlers in the chain");
+        }
+    }
+
+    /**
+     * Context-level guard: boots a real {@link MeshAutoConfiguration} with
+     * NO user beans declaring {@code @MeshA2A}. Pre-fix this fails at
+     * context refresh with {@code IllegalStateException: No routes
+     * registered}; post-fix the context loads cleanly and the router bean
+     * is present (carrying the never-matching empty-registry router).
+     *
+     * <p>Uses a {@link WebApplicationContextRunner} rather than a full
+     * {@code @SpringBootTest} so the regression target — the empty-builder
+     * rejection by {@code RouterFunctions.Builder.build()} during the
+     * {@link RouterFunction} bean's materialisation — is exercised at
+     * context refresh without spinning up Tomcat or the native Rust core.
+     */
+    @Test
+    @DisplayName("Context with NO @MeshA2A beans loads cleanly "
+        + "(no IllegalStateException: No routes registered)")
+    void contextLoads_withoutAnyMeshA2ABeans() {
+        new WebApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(MeshAutoConfiguration.class))
+            .withUserConfiguration(NoA2ABeansTestConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                assertThat(context).hasBean("meshA2ARegistry");
+                MeshA2ARegistry registry = context.getBean(MeshA2ARegistry.class);
+                assertThat(registry.hasSurfaces())
+                    .as("Pre-condition for this regression: no @MeshA2A "
+                        + "surfaces should have been registered")
+                    .isFalse();
+                // The router bean must still exist (it's what would have
+                // crashed RouterFunctionMapping pre-fix); post-fix it is
+                // a never-matching RouterFunction.
+                assertThat(context).hasBean("meshA2ARouterFunction");
+                RouterFunction<?> router = context.getBean(
+                    "meshA2ARouterFunction", RouterFunction.class);
+                assertThat(router).isNotNull();
+            });
+    }
+
+    /**
+     * Test config providing a no-op {@link MeshRuntime} so the auto-config
+     * doesn't try to load the native Rust core during a unit test. NOTE:
+     * this config deliberately registers NO {@code @MeshA2A} beans — that's
+     * the regression scenario.
+     */
+    @Configuration
+    static class NoA2ABeansTestConfig {
+
+        @Bean
+        public MeshRuntime meshRuntime() {
+            AgentSpec spec = new AgentSpec();
+            spec.setName("no-a2a-test-agent");
+            spec.setAgentId("no-a2a-test-agent-00000000");
+            return new NoOpMeshRuntime(spec);
+        }
+    }
+
+    /** Test-only {@link MeshRuntime} that overrides the SmartLifecycle hooks
+     *  so the native core never starts. */
+    static class NoOpMeshRuntime extends MeshRuntime {
+        private volatile boolean running;
+
+        NoOpMeshRuntime(AgentSpec spec) {
+            super(spec);
+        }
+
+        @Override
+        public void start() {
+            running = true;
+        }
+
+        @Override
+        public void stop() {
+            running = false;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return running;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> ObjectProvider<T> emptyProvider(Class<T> type) {
+        ObjectProvider<T> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(null);
+        return provider;
+    }
+}


### PR DESCRIPTION
## Summary

Hotfix for #946. PR #934 + #941 broke every Java agent that does NOT use `@MeshA2A` annotations — ~100 Java integration tests failing on main since 2026-05-11.

## The bug

`MeshA2ADispatcherController.buildRouterFunction()` calls `RouterFunctions.route().build()` with zero routes when `MeshA2ARegistry.getAllSurfaces()` is empty. `Builder.build()` rejects empty lists:

```
IllegalStateException: No routes registered. Register a route with GET(), POST(), etc.
```

Java agent process exits code 1 during boot, BEFORE registering with the registry. Tests wait for registration → timeout → fail.

Diagnosis credit: tsuite Claude.

## Fix — Option C (clean)

When `MeshA2ARegistry` is empty, return a never-matching `RouterFunction` implemented inline:

```java
static final RouterFunction<ServerResponse> EMPTY_REGISTRY_ROUTER =
    request -> Optional.empty();

if (allSurfaces.isEmpty()) {
    return EMPTY_REGISTRY_ROUTER;
}
```

By bypassing `RouterFunctions.Builder` entirely, we sidestep the at-least-one-route check. Spring's `RouterFunctionMapping` accepts the never-matching bean without complaint — confirmed by 299/299 test suite + new regression test.

### Options considered + rejected

- **Option A** (sentinel route `/__mesh_a2a_internal_noop__`): workaround. Adds a fake endpoint, pollutes the route table with a path users would see and wonder about.
- **Option B** (`@Conditional` on bean registration): chicken-and-egg — `@Conditional` evaluates BEFORE the post-processor populates the registry.
- **Option D** (refactor to `@RestController`): right long-term but ~200 LOC change, wrong scope for hotfix.

## Regression test

`MeshA2AEmptyRegistryRouterTest` covers two scenarios:
- `contextLoads_withoutAnyMeshA2ABeans` — boots a Spring context with NO `@MeshA2A` beans, verifies no `IllegalStateException` and that `meshA2ARouterFunction` bean exists
- `buildRouterFunction_emptyRegistry_returnsNeverMatchingRouter` — probes 4 paths against the returned router, asserts `Optional.empty()` for each

Verified to FAIL pre-fix, PASS post-fix.

## Why this slipped through

Smoke testing for #934/#941 only covered `producer-date-agent` and `producer-report-agent` — both have `@MeshA2A` annotations. The failure mode only fires for agents WITHOUT `@MeshA2A`.

**Lesson**: smoke tests should always include negative coverage — at least one agent that does NOT use the feature being shipped, not just positive happy-path agents. Will apply this going forward.

## Test plan

- [x] `mvn -pl mcp-mesh-spring-boot-starter test -am`: **299/299 PASS** (was 297 + 2 new regression tests)
- [x] Empty-registry boot scenario covered by regression test
- [ ] tsuite Java integration suites should resume green once this lands and the image rebuilds

Closes #946
Related: #934 #941

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a critical crash that occurred when initializing the service mesh with an empty registry or no configured services. The dispatcher now gracefully handles this state, allowing applications to start and operate normally even when no services are registered.

* **Tests**
  * Added regression tests for empty registry scenarios to prevent future regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/947)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->