### PR TITLE
[HOTFIX] fix(java): synthetic tools (__mesh_job_*, llm_*) registered too late after #941

### DIFF
--- a/src/core/cli/call.go
+++ b/src/core/cli/call.go
@@ -35,8 +35,9 @@ type MCPResponse struct {
 
 // MCPError represents an MCP JSON-RPC error
 type MCPError struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
 }
 
 // MCPCallResult holds the result and trace information from an MCP call
@@ -681,6 +682,9 @@ func callMCPToolWithHost(client *http.Client, endpoint, hostHeader, toolName str
 	}
 
 	if mcpResp.Error != nil {
+		if mcpResp.Error.Data != nil {
+			return nil, fmt.Errorf("MCP error %d: %s (data: %v)", mcpResp.Error.Code, mcpResp.Error.Message, mcpResp.Error.Data)
+		}
 		return nil, fmt.Errorf("MCP error %d: %s", mcpResp.Error.Code, mcpResp.Error.Message)
 	}
 
@@ -792,6 +796,9 @@ func callMCPTool(client *http.Client, endpoint, toolName string, args map[string
 	}
 
 	if mcpResp.Error != nil {
+		if mcpResp.Error.Data != nil {
+			return nil, fmt.Errorf("MCP error %d: %s (data: %v)", mcpResp.Error.Code, mcpResp.Error.Message, mcpResp.Error.Data)
+		}
 		return nil, fmt.Errorf("MCP error %d: %s", mcpResp.Error.Code, mcpResp.Error.Message)
 	}
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
@@ -117,9 +117,11 @@ public final class JobsRuntimeManager implements SmartLifecycle {
         //    true status from the registry's dependency events).
         wireConsumers(instanceId, registryUrl);
 
-        // Helper tools are registered earlier (in MeshAutoConfiguration's
-        // buildAgentSpec) so the synthetic ToolSpecs make it into the
-        // heartbeat catalog. Don't double-register here.
+        // Helper tools are registered eagerly in MeshAutoConfiguration#meshRuntime
+        // (synchronous bean-construction phase) so the synthetic handlers are
+        // visible to mcpStatelessServer when it snapshots its tool list, and the
+        // synthetic ToolSpecs make it into the heartbeat catalog via toolRegistry.
+        // Don't double-register here.
     }
 
     private void wireProducers(String instanceId, String registryUrl) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -384,6 +384,7 @@ public class MeshAutoConfiguration {
     public MeshRuntime meshRuntime(
             MeshProperties properties,
             MeshToolRegistry toolRegistry,
+            MeshToolWrapperRegistry wrapperRegistry,
             MeshLlmRegistry llmRegistry,
             MeshConfigResolver configResolver,
             ObjectMapper objectMapper) {
@@ -396,6 +397,22 @@ public class MeshAutoConfiguration {
         // @Component that autowired MeshRuntime — see issue #937.
         AgentSpec spec = buildBaseAgentSpec(properties, toolRegistry, llmRegistry,
             configResolver);
+
+        // Register MeshJob helper tools (__mesh_job_status / __mesh_job_result /
+        // __mesh_job_cancel) and LLM provider tool handlers EAGERLY into the
+        // wrapper registry. mcpStatelessServer (see MeshMcpServerConfiguration)
+        // snapshots tool handlers at bean-construction time — anything registered
+        // later (in a SmartInitializingSingleton) won't be visible to the MCP SDK
+        // and every call would hit the upstream "Unknown tool" sentinel. Neither
+        // call walks @Component beans, so the bean-cycle that #937 fixed is
+        // preserved by keeping the bean-walking work in finalizeAgentSpec().
+        try {
+            JobsHelperToolsRegistrar.register(toolRegistry, wrapperRegistry, spec.getRegistryUrl());
+        } catch (Exception e) {
+            log.warn("Failed to register MeshJob helper tools at startup", e);
+        }
+        registerLlmProviderHandlers(wrapperRegistry);
+
         log.info("Creating MeshRuntime for agent '{}' (tools/surfaces populated post-init)",
             spec.getName());
 
@@ -432,12 +449,11 @@ public class MeshAutoConfiguration {
     public SmartInitializingSingleton meshAgentSpecFinalizer(
             MeshRuntime runtime,
             MeshToolRegistry toolRegistry,
-            MeshToolWrapperRegistry wrapperRegistry,
             MeshLlmRegistry llmRegistry,
             ObjectMapper objectMapper,
             ObjectProvider<MeshRouteRegistry> routeRegistryProvider,
             ObjectProvider<MeshA2ARegistry> a2aRegistryProvider) {
-        return () -> finalizeAgentSpec(runtime.getAgentSpec(), toolRegistry, wrapperRegistry,
+        return () -> finalizeAgentSpec(runtime.getAgentSpec(), toolRegistry,
             llmRegistry, objectMapper, routeRegistryProvider, a2aRegistryProvider);
     }
 
@@ -664,21 +680,18 @@ public class MeshAutoConfiguration {
     private void finalizeAgentSpec(
             AgentSpec spec,
             MeshToolRegistry toolRegistry,
-            MeshToolWrapperRegistry wrapperRegistry,
             MeshLlmRegistry llmRegistry,
             ObjectMapper objectMapper,
             ObjectProvider<MeshRouteRegistry> routeRegistryProvider,
             ObjectProvider<MeshA2ARegistry> a2aRegistryProvider) {
 
-        // Phase B MeshJob substrate: register the three helper tools as
-        // synthetic specs BEFORE getToolSpecs() is read into the
-        // heartbeat catalog. Skips gracefully when no registry URL is
-        // configured.
-        try {
-            JobsHelperToolsRegistrar.register(toolRegistry, wrapperRegistry, spec.getRegistryUrl());
-        } catch (Exception e) {
-            log.warn("Failed to register MeshJob helper tools at startup", e);
-        }
+        // Helper tools (MeshJob substrate) and LLM provider handlers are
+        // registered eagerly in meshRuntime() — see the comment there. By
+        // the time we reach this finalizer the synthetic helper tool specs
+        // are already in toolRegistry and the LLM provider handlers are
+        // already in wrapperRegistry. We still need to fold the LLM
+        // provider tool SPECS into the heartbeat catalog here (they live
+        // in the spring-ai processor, not in toolRegistry).
 
         // Consumer-only fallback validation: if buildBaseAgentSpec
         // produced a consumer-only spec (agent_type="api") because no
@@ -693,8 +706,9 @@ public class MeshAutoConfiguration {
         // Enrich tools with @MeshLlm provider info for mesh delegation
         enrichToolsWithLlmProvider(allTools, toolRegistry, llmRegistry, objectMapper);
 
-        // Add LLM provider tools if mcp-mesh-spring-ai is on classpath
-        addLlmProviderTools(allTools, wrapperRegistry);
+        // Add LLM provider tool specs to the heartbeat (handlers were
+        // already registered eagerly in meshRuntime()).
+        addLlmProviderToolSpecs(allTools);
 
         // Add @MeshRoute dependencies as a synthetic tool
         addRouteDependencies(allTools, routeRegistryProvider);
@@ -999,60 +1013,78 @@ public class MeshAutoConfiguration {
     }
 
     /**
-     * Add LLM provider tool specs and register handlers if spring-ai module is available.
+     * Register LLM provider tool handlers with the wrapper registry if the
+     * spring-ai module is available. Called eagerly from {@link #meshRuntime}
+     * so the handlers are visible when {@code mcpStatelessServer} snapshots
+     * its tool list at bean-construction time.
      *
-     * <p>This method uses reflection to avoid hard dependency on mcp-mesh-spring-ai.
-     * If the module is present and has registered providers:
-     * <ol>
-     *   <li>Tool specs are added to agent registration (for heartbeat)</li>
-     *   <li>Tool wrappers are registered with wrapper registry (for MCP calls)</li>
-     * </ol>
+     * <p>Uses reflection to avoid a hard dependency on mcp-mesh-spring-ai.
      *
-     * @param tools           List to add LLM provider tools to
      * @param wrapperRegistry Registry to add LLM provider handlers to
      */
     @SuppressWarnings("unchecked")
-    private void addLlmProviderTools(List<AgentSpec.ToolSpec> tools, MeshToolWrapperRegistry wrapperRegistry) {
+    private void registerLlmProviderHandlers(MeshToolWrapperRegistry wrapperRegistry) {
         try {
-            // Check if MeshLlmProviderProcessor class exists (spring-ai module)
             Class<?> processorClass = Class.forName("io.mcpmesh.ai.MeshLlmProviderProcessor");
-
-            // Try to get the bean from application context
             Object processor = applicationContext.getBean(processorClass);
 
-            // Check if it has providers
             java.lang.reflect.Method hasProvidersMethod = processorClass.getMethod("hasProviders");
             Boolean hasProviders = (Boolean) hasProvidersMethod.invoke(processor);
-
-            if (Boolean.TRUE.equals(hasProviders)) {
-                // Get tool specs from the processor (for heartbeat)
-                java.lang.reflect.Method getToolSpecsMethod = processorClass.getMethod("getToolSpecs");
-                List<AgentSpec.ToolSpec> llmTools = (List<AgentSpec.ToolSpec>) getToolSpecsMethod.invoke(processor);
-                tools.addAll(llmTools);
-
-                // Get tool wrappers from the processor (for MCP calls)
-                java.lang.reflect.Method createToolWrappersMethod = processorClass.getMethod("createToolWrappers");
-                List<?> wrappers = (List<?>) createToolWrappersMethod.invoke(processor);
-
-                // Register each wrapper with the registry
-                for (Object wrapper : wrappers) {
-                    // Cast to McpToolHandler (LlmProviderToolWrapper implements it)
-                    if (wrapper instanceof McpToolHandler handler) {
-                        wrapperRegistry.registerHandler(handler);
-                    }
-                }
-
-                log.info("Added {} LLM provider tool(s) to agent registration and MCP server",
-                    llmTools.size());
+            if (!Boolean.TRUE.equals(hasProviders)) {
+                return;
             }
+
+            java.lang.reflect.Method createToolWrappersMethod = processorClass.getMethod("createToolWrappers");
+            List<?> wrappers = (List<?>) createToolWrappersMethod.invoke(processor);
+            int count = 0;
+            for (Object wrapper : wrappers) {
+                if (wrapper instanceof McpToolHandler handler) {
+                    wrapperRegistry.registerHandler(handler);
+                    count++;
+                }
+            }
+            log.info("Registered {} LLM provider tool handler(s) with MCP server", count);
         } catch (ClassNotFoundException e) {
             // mcp-mesh-spring-ai not on classpath - this is fine
             log.debug("MeshLlmProviderProcessor not found - LLM provider support not enabled");
         } catch (org.springframework.beans.factory.NoSuchBeanDefinitionException e) {
-            // Processor class exists but no bean registered
             log.debug("MeshLlmProviderProcessor not registered as bean");
         } catch (Exception e) {
-            log.warn("Failed to check for LLM provider tools: {}", e.getMessage());
+            log.warn("Failed to register LLM provider handlers: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Append LLM provider tool specs to the heartbeat catalog if the
+     * spring-ai module is available. Called from {@link #finalizeAgentSpec}
+     * after every singleton is initialised. Pairs with
+     * {@link #registerLlmProviderHandlers} which performs the eager
+     * MCP-handler registration earlier in the lifecycle.
+     *
+     * @param tools List to add LLM provider tool specs to
+     */
+    @SuppressWarnings("unchecked")
+    private void addLlmProviderToolSpecs(List<AgentSpec.ToolSpec> tools) {
+        try {
+            Class<?> processorClass = Class.forName("io.mcpmesh.ai.MeshLlmProviderProcessor");
+            Object processor = applicationContext.getBean(processorClass);
+
+            java.lang.reflect.Method hasProvidersMethod = processorClass.getMethod("hasProviders");
+            Boolean hasProviders = (Boolean) hasProvidersMethod.invoke(processor);
+            if (!Boolean.TRUE.equals(hasProviders)) {
+                return;
+            }
+
+            java.lang.reflect.Method getToolSpecsMethod = processorClass.getMethod("getToolSpecs");
+            List<AgentSpec.ToolSpec> llmTools = (List<AgentSpec.ToolSpec>) getToolSpecsMethod.invoke(processor);
+            tools.addAll(llmTools);
+            log.info("Added {} LLM provider tool spec(s) to agent registration", llmTools.size());
+        } catch (ClassNotFoundException e) {
+            log.debug("MeshLlmProviderProcessor not found - LLM provider support not enabled");
+        } catch (org.springframework.beans.factory.NoSuchBeanDefinitionException e) {
+            log.debug("MeshLlmProviderProcessor not registered as bean");
+        } catch (Exception e) {
+            log.warn("Failed to collect LLM provider tool specs: {}", e.getMessage());
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcherController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcherController.java
@@ -15,7 +15,9 @@ import org.springframework.web.servlet.function.ServerResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * HTTP entry point for A2A producer surfaces (spec §3 + §4).
@@ -54,6 +56,29 @@ public class MeshA2ADispatcherController {
     private static final Logger log = LoggerFactory.getLogger(MeshA2ADispatcherController.class);
 
     private static final String AGENT_CARD_SUFFIX = "/.well-known/agent.json";
+
+    /**
+     * Empty-registry router: a {@link RouterFunction} that matches no
+     * requests, returned when no {@code @MeshA2A} surfaces are registered.
+     *
+     * <p>{@code RouterFunctions.Builder.build()} throws
+     * {@code IllegalStateException: No routes registered. Register a route
+     * with GET(), POST(), etc.} when called with zero accumulated routes,
+     * which crashed the agent process at context refresh before it could
+     * register with the mesh registry.
+     *
+     * <p>Most Java agents do NOT declare {@code @MeshA2A} surfaces (basic
+     * {@code @MeshTool} agents, registry/lifecycle tests, consumer-only
+     * apps), so the empty-registry case is the common case. Returning a
+     * never-matching {@code RouterFunction} bypasses the builder entirely
+     * — Spring's {@code RouterFunctionMapping} accepts the bean without
+     * complaint, and no fake/internal path appears in the route table.
+     * If anything ever does try to dispatch through it, {@code route()}
+     * returns {@code Optional.empty()} and the request falls through to
+     * the next handler in the chain.
+     */
+    static final RouterFunction<ServerResponse> EMPTY_REGISTRY_ROUTER =
+        request -> Optional.empty();
 
     /**
      * Hard cap on the size of an inbound JSON-RPC body read by {@link #readBody}.
@@ -104,8 +129,21 @@ public class MeshA2ADispatcherController {
      * {@code meshA2ARouterFunction(...)} factory method.
      */
     public RouterFunction<ServerResponse> buildRouterFunction() {
+        List<MeshA2ARegistry.SurfaceMetadata> allSurfaces = registry.getAllSurfaces();
+        if (allSurfaces.isEmpty()) {
+            // Empty-registry guard: RouterFunctions.Builder.build() rejects an
+            // empty route list (IllegalStateException: "No routes registered"),
+            // crashing every Java agent that has no @MeshA2A surfaces — basic
+            // @MeshTool agents, consumer-only apps, registry/lifecycle tests.
+            // Return a never-matching RouterFunction directly so the bean
+            // exists for Spring's RouterFunctionMapping to collect, but no
+            // fake path lands in the route table. See EMPTY_REGISTRY_ROUTER
+            // javadoc for rationale.
+            log.debug("@MeshA2A: no surfaces registered — installing never-matching router");
+            return EMPTY_REGISTRY_ROUTER;
+        }
         RouterFunctions.Builder builder = RouterFunctions.route();
-        for (MeshA2ARegistry.SurfaceMetadata surface : registry.getAllSurfaces()) {
+        for (MeshA2ARegistry.SurfaceMetadata surface : allSurfaces) {
             String path = surface.path();
             String cardPath = path + AGENT_CARD_SUFFIX;
             // SSE branch FIRST so Accept: text/event-stream wins the

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHelperToolsEagerRegistrationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHelperToolsEagerRegistrationTest.java
@@ -1,0 +1,233 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.core.AgentSpec;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the MeshJob helper-tool registration timing bug.
+ *
+ * <p><b>Background.</b> PR #941 (issue #937 follow-up) moved the
+ * {@link JobsHelperToolsRegistrar#register} call out of the synchronous
+ * {@code meshRuntime} factory and into a {@link
+ * org.springframework.beans.factory.SmartInitializingSingleton}
+ * ({@code meshAgentSpecFinalizer}) so the {@code applicationContext.getBeansWithAnnotation(...)}
+ * walks would not re-enter user {@code @Component} beans during
+ * {@code MeshRuntime} creation.
+ *
+ * <p><b>Side-effect bug.</b> {@code MeshMcpServerConfiguration#mcpStatelessServer}
+ * snapshots the {@link MeshToolWrapperRegistry}'s handlers at bean-construction
+ * time (it iterates {@code wrapperRegistry.getAllHandlers()} once and
+ * registers each into the MCP SDK's stateless server). Because the
+ * {@code mcpStatelessServer} bean is constructed BEFORE any
+ * {@code SmartInitializingSingleton} fires, the helper handlers
+ * ({@code __mesh_job_status}, {@code __mesh_job_result},
+ * {@code __mesh_job_cancel}) — registered from {@code finalizeAgentSpec} —
+ * never made it into the snapshot. Every meshctl call to a helper tool
+ * therefore failed with the upstream MCP SDK's hardcoded
+ * {@code Unknown tool: invalid_tool_name} sentinel.
+ *
+ * <h2>What this test asserts</h2>
+ *
+ * <p>The test boots the real {@link MeshAutoConfiguration} (so the production
+ * {@code meshRuntime} factory runs unmodified) and uses a
+ * {@link BeanPostProcessor} to neutralise {@link MeshRuntime#start()} —
+ * preventing the native Rust core from being loaded — without intercepting
+ * the factory itself. A "snapshot bean" (constructed during the same
+ * singleton phase as {@code mcpStatelessServer}) records the wrapperRegistry's
+ * handler-capability set at its own construction time.
+ *
+ * <ul>
+ *   <li><b>Pre-fix</b> (helpers registered from finalizeAgentSpec only):
+ *       the snapshot does NOT contain the three helper capabilities — they
+ *       are registered later, after every singleton has been instantiated.</li>
+ *   <li><b>Post-fix</b> (helpers registered eagerly from the
+ *       {@code meshRuntime} factory): the snapshot contains all three
+ *       helper capabilities — they are visible to anything that snapshots
+ *       wrapperRegistry during the construction phase, including the real
+ *       {@code mcpStatelessServer}.</li>
+ * </ul>
+ *
+ * <p>This is a structural test of the registration timing — not the MCP
+ * SDK integration itself — so it stays independent of the SDK's snapshot
+ * implementation while still surfacing the regression that broke 32 Java
+ * integration tests.
+ */
+@DisplayName("MeshJob helper tools — eager wrapper-registry registration (regression for PR #941)")
+class MeshHelperToolsEagerRegistrationTest {
+
+    /**
+     * Snapshot bean that records the wrapperRegistry's handler-capability
+     * set at its own construction time.
+     *
+     * <p>To accurately mirror {@code mcpStatelessServer}'s production
+     * lifecycle, this bean depends on BOTH {@link MeshToolWrapperRegistry}
+     * (the snapshot source) AND {@link MeshRuntime} (a no-op declaring
+     * dependency). The {@code MeshRuntime} edge guarantees that this
+     * snapshot bean is constructed AFTER the {@code meshRuntime} factory
+     * has run — which is the same window where {@code mcpStatelessServer}
+     * snapshots in production (the {@code MeshAutoConfiguration} class
+     * is processed before {@code MeshMcpServerConfiguration} per the
+     * {@code AutoConfiguration.imports} ordering).
+     *
+     * <p>The bean is constructed BEFORE any
+     * {@link org.springframework.beans.factory.SmartInitializingSingleton}
+     * fires — that's the singleton-instantiation-phase invariant Spring
+     * guarantees, and it's the same invariant the production
+     * {@code mcpStatelessServer} relies on.
+     */
+    static class WrapperRegistrySnapshot {
+        final Set<String> capabilitiesAtConstruction;
+
+        WrapperRegistrySnapshot(MeshToolWrapperRegistry wrapperRegistry, MeshRuntime runtime) {
+            // Snapshot at construction — the production mcpStatelessServer
+            // takes its tool list at the same moment. The unused `runtime`
+            // parameter declares an ordering edge so this bean is constructed
+            // after the meshRuntime factory has run (whose body performs the
+            // eager helper-tool registration this test validates).
+            this.capabilitiesAtConstruction = Set.copyOf(
+                wrapperRegistry.getHandlersByCapability().keySet());
+        }
+    }
+
+    /**
+     * Replaces the real {@link MeshRuntime} bean with a no-op subclass
+     * AFTER the production {@code meshRuntime} factory has run — so all
+     * the eager registration logic in the factory body executes against
+     * the real {@link MeshToolRegistry} / {@link MeshToolWrapperRegistry}
+     * beans, but {@link MeshRuntime#start} never loads the native FFI.
+     *
+     * <p>Using a {@link BeanPostProcessor} here (rather than a stub
+     * {@code @Bean MeshRuntime} that satisfies {@code @ConditionalOnMissingBean})
+     * is critical for the test's value: a stub would replace the
+     * production factory and silently mask a regression where someone
+     * removes the eager registration call.
+     */
+    static class MeshRuntimeNeutralizer implements BeanPostProcessor {
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+            if (bean instanceof MeshRuntime real && !(bean instanceof NoOpRuntime)) {
+                // Replace with a NoOp subclass that shares the same agent
+                // spec — so spec mutations made by the SmartInitializingSingleton
+                // (e.g. agent_type=a2a, tool list) still land on the same
+                // object the rest of the context has a reference to.
+                return new NoOpRuntime(real.getAgentSpec());
+            }
+            return bean;
+        }
+    }
+
+    /**
+     * No-op runtime stub so the {@code SmartLifecycle} container doesn't
+     * try to spin up the native Rust core in a unit test.
+     */
+    static class NoOpRuntime extends MeshRuntime {
+        private volatile boolean running;
+
+        NoOpRuntime(AgentSpec spec) {
+            super(spec);
+        }
+
+        @Override
+        public void start() {
+            running = true;
+        }
+
+        @Override
+        public void stop() {
+            running = false;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return running;
+        }
+    }
+
+    @Configuration
+    static class TestConfig {
+
+        @Bean
+        public WrapperRegistrySnapshot wrapperRegistrySnapshot(
+                MeshToolWrapperRegistry wrapperRegistry,
+                MeshRuntime runtime) {
+            return new WrapperRegistrySnapshot(wrapperRegistry, runtime);
+        }
+
+        @Bean
+        public MeshRuntimeNeutralizer meshRuntimeNeutralizer() {
+            return new MeshRuntimeNeutralizer();
+        }
+    }
+
+    private final WebApplicationContextRunner runner = new WebApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(MeshAutoConfiguration.class))
+        .withUserConfiguration(TestConfig.class)
+        // Required: finalizeAgentSpec rejects an empty agent name (consumer-only
+        // mode without any @MeshRoute deps). We don't care about the value —
+        // only that the spec is well-formed enough for the context to refresh.
+        .withPropertyValues("mesh.agent.name=test-helper-eager-registration");
+
+    @Test
+    @DisplayName("Helper handlers are visible to wrapperRegistry consumers " +
+        "constructed before SmartInitializingSingleton fires")
+    void helperHandlersAreEagerlyRegistered() {
+        AtomicReference<Set<String>> snapshotRef = new AtomicReference<>();
+
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            WrapperRegistrySnapshot snapshot = context.getBean(WrapperRegistrySnapshot.class);
+            snapshotRef.set(snapshot.capabilitiesAtConstruction);
+
+            // The snapshot was taken at WrapperRegistrySnapshot construction —
+            // i.e. during the singleton-instantiation phase, BEFORE any
+            // SmartInitializingSingleton (including meshAgentSpecFinalizer)
+            // fires. The three helper-tool handlers must already be registered
+            // at that moment so mcpStatelessServer's identical snapshot
+            // includes them.
+            assertThat(snapshot.capabilitiesAtConstruction)
+                .as("Helper handler __mesh_job_status must be registered "
+                    + "BEFORE SmartInitializingSingleton fires (otherwise "
+                    + "mcpStatelessServer's snapshot won't include it)")
+                .contains(JobsHelperToolHandler.TOOL_NAME_STATUS);
+            assertThat(snapshot.capabilitiesAtConstruction)
+                .as("Helper handler __mesh_job_result must be registered "
+                    + "BEFORE SmartInitializingSingleton fires")
+                .contains(JobsHelperToolHandler.TOOL_NAME_RESULT);
+            assertThat(snapshot.capabilitiesAtConstruction)
+                .as("Helper handler __mesh_job_cancel must be registered "
+                    + "BEFORE SmartInitializingSingleton fires")
+                .contains(JobsHelperToolHandler.TOOL_NAME_CANCEL);
+        });
+    }
+
+    @Test
+    @DisplayName("Helper synthetic tool specs are present in toolRegistry post-context-init")
+    void helperToolSpecsAreInToolRegistry() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            MeshToolRegistry toolRegistry = context.getBean(MeshToolRegistry.class);
+
+            // The three synthetic ToolSpecs must be present in the heartbeat
+            // catalog so the registry knows the agent advertises them.
+            assertThat(toolRegistry.getToolSpecs())
+                .as("toolRegistry must contain three synthetic helper specs")
+                .extracting(AgentSpec.ToolSpec::getCapability)
+                .contains(
+                    JobsHelperToolHandler.TOOL_NAME_STATUS,
+                    JobsHelperToolHandler.TOOL_NAME_RESULT,
+                    JobsHelperToolHandler.TOOL_NAME_CANCEL);
+        });
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AEmptyRegistryRouterTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2AEmptyRegistryRouterTest.java
@@ -1,0 +1,216 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.spring.MeshAutoConfiguration;
+import io.mcpmesh.spring.MeshProperties;
+import io.mcpmesh.spring.MeshRuntime;
+import jakarta.servlet.ServletContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.servlet.function.HandlerFunction;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for the empty-{@code @MeshA2A}-registry crash
+ * (hotfix follow-up to #934 + #941).
+ *
+ * <p>{@link MeshA2ADispatcherController#buildRouterFunction()} previously
+ * called {@code RouterFunctions.Builder.build()} on a builder that received
+ * zero routes whenever no {@code @MeshA2A} surfaces were registered.
+ * {@code Builder.build()} throws:
+ *
+ * <pre>
+ *   IllegalStateException: No routes registered.
+ *   Register a route with GET(), POST(), etc.
+ * </pre>
+ *
+ * <p>which crashed the agent process at context refresh BEFORE it could
+ * register with the mesh registry. The crash hit ~100 integration tests
+ * because most Java agents (basic {@code @MeshTool} agents, consumer-only
+ * apps, lifecycle/registry tests) do NOT declare {@code @MeshA2A} surfaces
+ * — the producer wiring is always installed but the registry is empty
+ * until a user opts in.
+ *
+ * <h2>The fix</h2>
+ *
+ * <p>When the registry is empty, {@code buildRouterFunction()} returns a
+ * never-matching {@link RouterFunction} directly (bypassing the builder
+ * entirely). Spring's {@code RouterFunctionMapping} accepts the bean
+ * without complaint and no fake/internal path lands in the route table; if
+ * any request ever reaches it, {@code route()} returns
+ * {@link Optional#empty()} and the request falls through to the next
+ * handler.
+ *
+ * <h2>Coverage</h2>
+ *
+ * <ol>
+ *   <li>Unit: {@code buildRouterFunction()} on an empty registry does NOT
+ *       throw and returns a non-null router.</li>
+ *   <li>Unit: the returned router never matches any probe request
+ *       (route() returns Optional.empty() in every case).</li>
+ *   <li>Context: a Spring application context with NO {@code @MeshA2A}
+ *       beans refreshes cleanly (no {@code IllegalStateException: No
+ *       routes registered}) and exposes the {@code meshA2ARouterFunction}
+ *       bean.</li>
+ * </ol>
+ */
+@DisplayName("MeshA2A producer — empty-registry router (hotfix regression)")
+class MeshA2AEmptyRegistryRouterTest {
+
+    private static final List<HttpMessageConverter<?>> CONVERTERS =
+        List.of(new StringHttpMessageConverter(StandardCharsets.UTF_8));
+
+    @Test
+    @DisplayName("Empty registry → router exists but matches no requests "
+        + "(bypasses RouterFunctions.Builder.build() empty-list rejection)")
+    void buildRouterFunction_emptyRegistry_returnsNeverMatchingRouter() throws Exception {
+        MeshA2ARegistry emptyRegistry = new MeshA2ARegistry();
+        assertTrue(emptyRegistry.getAllSurfaces().isEmpty(),
+            "Pre-condition: registry must be empty for this regression case");
+
+        MeshA2ADispatcherController controller = new MeshA2ADispatcherController(
+            emptyRegistry,
+            new MeshA2ADispatcher(emptyRegistry, new MeshA2ATaskStore(),
+                A2ATestFixtures.objectMapper(),
+                A2ATestFixtures.emptyInjectorProvider()),
+            new MeshA2ASseDispatcher(new MeshA2ADispatcher(emptyRegistry,
+                new MeshA2ATaskStore(), A2ATestFixtures.objectMapper(),
+                A2ATestFixtures.emptyInjectorProvider())),
+            new MeshA2ACardBuilder(null, A2ATestFixtures.objectMapper()),
+            emptyProvider(MeshProperties.class),
+            emptyProvider(MeshA2APublicUrlCache.class));
+
+        RouterFunction<ServerResponse> router = controller.buildRouterFunction();
+        assertNotNull(router, "buildRouterFunction() must never return null");
+
+        // The empty-registry router must match NO request — there's no fake
+        // path in the route table. Probe a few representative paths to prove
+        // that route() returns Optional.empty() in every case. The bean
+        // exists only so Spring's RouterFunctionMapping can collect it; it
+        // never serves real traffic.
+        ServletContext servletContext = new MockServletContext();
+        for (String path : new String[]{
+                "/", "/anything", "/agents/foo", "/agents/foo/.well-known/agent.json"}) {
+            MockHttpServletRequest req = new MockHttpServletRequest(
+                servletContext, "GET", path);
+            req.addHeader(HttpHeaders.ACCEPT, MediaType.ALL_VALUE);
+            ServerRequest serverRequest = ServerRequest.create(req, CONVERTERS);
+            Optional<HandlerFunction<ServerResponse>> match = router.route(serverRequest);
+            assertTrue(match.isEmpty(),
+                "Empty-registry router must NOT match any request (probed "
+                    + path + ") — it returns Optional.empty() so requests fall "
+                    + "through to other handlers in the chain");
+        }
+    }
+
+    /**
+     * Context-level guard: boots a real {@link MeshAutoConfiguration} with
+     * NO user beans declaring {@code @MeshA2A}. Pre-fix this fails at
+     * context refresh with {@code IllegalStateException: No routes
+     * registered}; post-fix the context loads cleanly and the router bean
+     * is present (carrying the never-matching empty-registry router).
+     *
+     * <p>Uses a {@link WebApplicationContextRunner} rather than a full
+     * {@code @SpringBootTest} so the regression target — the empty-builder
+     * rejection by {@code RouterFunctions.Builder.build()} during the
+     * {@link RouterFunction} bean's materialisation — is exercised at
+     * context refresh without spinning up Tomcat or the native Rust core.
+     */
+    @Test
+    @DisplayName("Context with NO @MeshA2A beans loads cleanly "
+        + "(no IllegalStateException: No routes registered)")
+    void contextLoads_withoutAnyMeshA2ABeans() {
+        new WebApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(MeshAutoConfiguration.class))
+            .withUserConfiguration(NoA2ABeansTestConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                assertThat(context).hasBean("meshA2ARegistry");
+                MeshA2ARegistry registry = context.getBean(MeshA2ARegistry.class);
+                assertThat(registry.hasSurfaces())
+                    .as("Pre-condition for this regression: no @MeshA2A "
+                        + "surfaces should have been registered")
+                    .isFalse();
+                // The router bean must still exist (it's what would have
+                // crashed RouterFunctionMapping pre-fix); post-fix it is
+                // a never-matching RouterFunction.
+                assertThat(context).hasBean("meshA2ARouterFunction");
+                RouterFunction<?> router = context.getBean(
+                    "meshA2ARouterFunction", RouterFunction.class);
+                assertThat(router).isNotNull();
+            });
+    }
+
+    /**
+     * Test config providing a no-op {@link MeshRuntime} so the auto-config
+     * doesn't try to load the native Rust core during a unit test. NOTE:
+     * this config deliberately registers NO {@code @MeshA2A} beans — that's
+     * the regression scenario.
+     */
+    @Configuration
+    static class NoA2ABeansTestConfig {
+
+        @Bean
+        public MeshRuntime meshRuntime() {
+            AgentSpec spec = new AgentSpec();
+            spec.setName("no-a2a-test-agent");
+            spec.setAgentId("no-a2a-test-agent-00000000");
+            return new NoOpMeshRuntime(spec);
+        }
+    }
+
+    /** Test-only {@link MeshRuntime} that overrides the SmartLifecycle hooks
+     *  so the native core never starts. */
+    static class NoOpMeshRuntime extends MeshRuntime {
+        private volatile boolean running;
+
+        NoOpMeshRuntime(AgentSpec spec) {
+            super(spec);
+        }
+
+        @Override
+        public void start() {
+            running = true;
+        }
+
+        @Override
+        public void stop() {
+            running = false;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return running;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> ObjectProvider<T> emptyProvider(Class<T> type) {
+        ObjectProvider<T> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(null);
+        return provider;
+    }
+}

--- a/tests/integration/suites/uc23_meshjob_java/tc23_retry_on_raise_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc23_retry_on_raise_java/test.yaml
@@ -132,7 +132,7 @@ test:
     handler: shell
     workdir: /workspace
     command: |
-      JOB_ID=$(echo '${captured.commission_response}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      JOB_ID=$(echo '${captured.commission_response}' | jq -r '.content[0].text | fromjson | .job_id')
       echo "JOB_ID=${JOB_ID}"
       curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,attempt_count,error}'
     capture: final_status


### PR DESCRIPTION
## Summary

Hotfix for #948. After #947 brought Java integration test failures down from 150+ to 32, the remaining 32 are consistently failing with `MCP error -32602: Unknown tool: invalid_tool_name`. Real cause: synthetic helper tools and LLM provider tools register AFTER the MCP server has snapshotted its tool list.

**Affected**: uc04 tc12/tc13 (Claude/OpenAI Java providers calling `llm_generate`) + all uc23 meshjob_java tcs that call `__mesh_job_status` / `__mesh_job_result` / `__mesh_job_cancel`.

Diagnosis credit: tsuite Claude (failure pattern) + debug-agent (root-cause trace through Spring lifecycle + decompiled upstream MCP SDK source).

## Root cause

PR #941's bean-cycle fix split `buildAgentSpec` → `buildBaseAgentSpec` (synchronous) + `finalizeAgentSpec` (`SmartInitializingSingleton`). It moved BOTH `JobsHelperToolsRegistrar.register()` and `addLlmProviderTools()` into the SmartInitializingSingleton phase.

But `mcpStatelessServer` (in `MeshMcpServerConfiguration.java:85-112`) snapshots tool handlers from `wrapperRegistry` at bean-CONSTRUCTION time — strictly BEFORE the SmartInitializingSingleton phase fires. Sequence:

1. `meshRuntime` factory runs
2. `mcpStatelessServer` factory runs → snapshots `wrapperRegistry` (only `@MeshTool` user beans, NO synthetic helpers)
3. `SmartInitializingSingleton.afterSingletonsInstantiated()` → adds `__mesh_job_*` + `llm_generate` handlers (TOO LATE)
4. `MeshRuntime.start()` → heartbeats spec advertising the helper tools
5. `meshctl call __mesh_job_status` → registry routes to Java agent → MCP server doesn't have it → returns the upstream SDK's hardcoded sentinel `Unknown tool: invalid_tool_name` (the real tool name lives in the `data` field, which meshctl drops)

## Fix 1 — Restore synchronous helper-tool registration

Move `JobsHelperToolsRegistrar.register()` back to the synchronous `meshRuntime` factory. Split `addLlmProviderTools` into two methods:
- `registerLlmProviderHandlers(wrapperRegistry)` — eager (synchronous, called from `meshRuntime`)
- `addLlmProviderToolSpecs(tools)` — lazy (stays in `finalizeAgentSpec`)

**Why safe** (verified by debug-agent): neither moved call walks `@Component` beans. The bean cycle in #937 was caused by `getBeansWithAnnotation(@Component.class)` in OTHER paths in the same file — those stay in `finalizeAgentSpec`. #937's fix is preserved.

Stale comment in `JobsRuntimeManager.java:120-124` updated (was true pre-#941, false post-#941, true again after this fix).

**New regression test** `MeshHelperToolsEagerRegistrationTest`:
- `helperHandlersAreEagerlyRegistered` — snapshots `wrapperRegistry` at the moment a depends-on-`meshRuntime` bean is created (mirrors `mcpStatelessServer`'s lifecycle); asserts `__mesh_job_status` / `__mesh_job_result` / `__mesh_job_cancel` are present
- `helperToolSpecsAreInToolRegistry` — asserts synthetic `ToolSpec`s are in the heartbeat catalog

Verified to FAIL pre-fix (empty wrapperRegistry/toolRegistry snapshots), PASS post-fix.

## Fix 2 — uc23 tc23 jq filter (pre-existing test bug from #899)

Java tc23 was copy-pasted from Python tc23 in #899 (`f0c1eaa6`) but uses `jq -r '.. | objects | select(has("job_id"))'` — only works on Python's `structuredContent` output. Java's MCP server explicitly emits `structuredContent=null`; payload lives only inside `content[0].text` as a JSON-stringified blob.

Replaced with `.content[0].text | fromjson | .job_id` — the structurally-correct pattern other Java tcs (e.g., tc05) already use. Python tc23 unchanged.

Latent until Pattern A unmasked it.

## Fix 3 (bonus) — meshctl surfaces MCP error data field

`src/core/cli/call.go`: added `Data interface{}` to `MCPError` struct; both error-format sites now append `(data: %v)` when present. Backward-compat: errors without `data` produce identical output.

This would have made the `invalid_tool_name` mystery a 5-minute fix instead of a tour through Spring lifecycle internals + decompiled upstream MCP SDK source. Worth-it.

## Test plan

- [x] `mvn -pl mcp-mesh-spring-boot-starter test -am`: **301/301 PASS** (was 299 + 2 new regression)
- [x] `mvn install -DskipTests` clean
- [x] `make build` clean (meshctl + registry + meshui)
- [x] `go test ./src/core/cli/...` clean
- [x] **Smoke**: `producer-report-agent` boots; `meshctl call __mesh_job_status` returns "job not found" (real response, NOT `invalid_tool_name`)
- [x] **Fix 3 manual**: error WITH data shows `(data: Tool not found: __mesh_job_status)`; error WITHOUT data unchanged

## Follow-up tracked separately

`mcpStatelessServer`'s snapshot-once pattern is the same "captured-once" footgun #941 fixed for `meshA2ARouterFunction` (lazy router via `SmartInitializingSingleton.materialise()`). Mirroring that pattern for the MCP server is the cleanest long-term hardening so future late-registered tools don't repeat this. Will file as separate hardening issue once dust settles.

Closes #948
Related: #934, #941, #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses now surface additional error payloads when present.
  * Routing no longer fails when no A2A surfaces are registered; startup is stable with empty registries.
  * Test YAML step reliably extracts job IDs from commission responses.

* **Refactor**
  * LLM provider integration split into two phases to separate handler registration from tool-spec collection; helper-tool registration remains eager.

* **Tests**
  * Added regression tests covering helper-tool eager registration and empty-registry routing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/949)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->