### PR TITLE
docs: homepage + README + comparison cleanup (A2A coverage, positioning reframe, failover accuracy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,28 +239,6 @@ forecast = await weather(destination, dates)
 
 ---
 
-## MCP Mesh vs Other AI Agent Frameworks
-
-| Feature                                      | Other Frameworks  | MCP Mesh                      |
-| -------------------------------------------- | ----------------- | ----------------------------- |
-| **Zero-config Dependency Injection**         | ❌                | ✅                            |
-| **Dynamic Agent Discovery & Hot Join/Leave** | ❌                | ✅                            |
-| **Cross-language Support**                   | ❌                | ✅ Python + Java + TypeScript |
-| **Same Code: Local → Docker → K8s**          | ❌ Rewrite needed | ✅                            |
-| **Developer CLI (scaffold, trace, status)**  | ❌                | ✅ `meshctl`                  |
-| **Kubernetes-native (Helm)**                 | ❌ DIY            | ✅                            |
-| **Distributed Tracing (OpenTelemetry)**      | ❌ DIY            | ✅ Grafana/Tempo              |
-| **Auto-failover & Graceful Degradation**     | ❌                | ✅                            |
-| **LLM as Dependency (Discovery + Failover)** | ❌                | ✅                            |
-| **Zero-config Testing (Topology Mocking)**   | ❌                | ✅                            |
-| **Standard Protocol**                        | ❌ Custom         | ✅ MCP                        |
-| **Framework Lock-in**                        | High (classes)    | Low (decorators)              |
-| **Lines of Code per Agent**                  | ~50+              | ~10                           |
-
-**[See full comparison →](https://mcp-mesh.ai/comparison/)**
-
----
-
 ## Contributing
 
 We welcome contributions from the community! MCP Mesh is designed to be a collaborative effort to advance the state of distributed MCP applications.

--- a/docs/a2a/architecture.md
+++ b/docs/a2a/architecture.md
@@ -24,7 +24,7 @@ Source: `src/runtime/python/mesh/_a2a_consumer.py` (`A2AJob.bridge`, `A2AStream.
 
 Capability+tag failover applies differently depending on call shape:
 
-- **Sync consumers.** Every `tools/call` is a fresh resolution. A dead consumer is detoured cleanly on the next call. Caller experience: transparent rewire to a peer consumer in seconds (see [Failover & Federation](failover.md)).
+- **Sync consumers.** Each `tools/call` re-resolves the target consumer against the caller's local registry view (kept fresh by background heartbeats; the registry is not in the request path). When a consumer dies, orphan-reset on the registry side drops it from the view at the next heartbeat refresh, and subsequent calls transparently rewire to a peer consumer in seconds. The A2A wire call itself stays peer-to-peer — caller → consumer → external A2A producer URL (see [Failover & Federation](failover.md)).
 
 - **Long-running consumers (`task=True`).** The job is **pinned** to the consumer that submitted it. The state lives on the external A2A backend; the consumer holds the open polling / SSE channel as the only mesh-side handle on it. Killing the consumer mid-job:
     - Surfaces to the caller as a job-lost terminal: the registry's orphan-reset sweep moves the job to a failed/lost terminal state once the consumer's lease expires, and the caller's `proxy.wait()` returns that terminal (no in-process resume).

--- a/docs/a2a/failover.md
+++ b/docs/a2a/failover.md
@@ -116,8 +116,8 @@ Once orphan-reset fires (consumer B dead), any new resolution that previously pi
 
 Capability+tag failover applies at **dispatch time**:
 
-- **Sync calls** (`tools/call`): every call is a fresh resolution, so a dead consumer is detoured cleanly on the next call.
-- **Long-running jobs** (`task=True`): the job is pinned to the consumer that submitted it — the job state lives on the external A2A backend and the consumer holds the open polling / SSE channel. Killing the consumer mid-job surfaces as `JobLost` to the caller; retrying the submission routes to a peer consumer (which submits a fresh A2A task — there is no portable "resume" semantic on A2A v1.0).
+- **Sync calls** (`tools/call`): consumer selection happens per-call against the caller's local registry view, which is kept fresh by background heartbeats (~5s) — the registry is NOT in the request path. When a consumer dies and orphan-reset fires on the registry side, the next heartbeat refresh drops it from the local view, and subsequent calls transparently route to a peer consumer. The A2A wire call itself goes peer-to-peer (caller → consumer → external A2A producer URL); the registry never sees the in-flight traffic.
+- **Long-running jobs** (`task=True`): the job is pinned to the consumer that submitted it because the A2A task state lives on the external A2A producer and only that consumer holds the open polling / SSE channel. Killing the consumer mid-job surfaces as `JobLost` to the caller. Retrying the submission goes through mesh resolution again (same local-view lookup) and routes to a peer consumer, which submits a fresh A2A task — A2A v1.0 has no portable "resume" semantic across consumer instances.
 
 See [Long-Running & SSE](long-running.md) for the bridging primitives and [Architecture & Decisions](architecture.md) for the pinning rationale.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,169 +1,146 @@
-# Feature Comparison
+# What MCP Mesh Does
 
-> **MCP Mesh vs Agent Frameworks and Cloud Platforms**
+> A capability catalog organized by lifecycle phase: develop, build, test, run, observe, secure, deploy.
 
-How does MCP Mesh compare to agent frameworks (LangChain, AutoGen, CrewAI) and managed cloud agent services (AWS Bedrock, Google Vertex AI, Azure AI)? This comparison covers development, deployment, security, observability, and enterprise features.
+This page enumerates what mesh ships with, out of the box. For a side-by-side comparison against managed cloud agent platforms (AWS Bedrock, Vertex AI, Azure AI) where the managed-vs-self-hosted trade-off matters, jump to [Cloud Agent Platforms](#vs-cloud-agent-platforms) below.
 
 ---
 
 ## Develop
 
-| Feature          | LangChain | AutoGen | CrewAI | MCP Mesh                              |
-| ---------------- | --------- | ------- | ------ | ------------------------------------- |
-| Scaffold agents  | :x:       | :x:     | :x:    | :white_check_mark: `meshctl scaffold` |
-| Local dev server | :x:       | :x:     | :x:    | :white_check_mark: `meshctl start`    |
-| List agents      | :x:       | :x:     | :x:    | :white_check_mark: `meshctl list`     |
-| Status check     | :x:       | :x:     | :x:    | :white_check_mark: `meshctl status`   |
-| Built-in docs    | :x:       | :x:     | :x:    | :white_check_mark: `meshctl man`      |
-| Hot reload       | :x:       | :x:     | :x:    | :white_check_mark:                    |
-| Local tracing    | :x:       | :x:     | :x:    | :white_check_mark: `meshctl trace`    |
+- **Scaffold agents** — `meshctl scaffold` creates new agents per runtime (Python / Java / TypeScript) with idiomatic project layouts
+- **Local dev server** — `meshctl start` brings up the registry plus your agents in one command — no Docker required
+- **List agents** — `meshctl list` shows live mesh topology including capabilities and tags
+- **Status check** — `meshctl status` gives instant health view across the mesh
+- **Built-in docs** — `meshctl man` covers every feature offline; works as a primer for AI coding assistants
+- **Hot reload** — code changes pick up without restart
+- **Local tracing** — `meshctl trace <id>` walks the full call tree across languages and agents
 
 ---
 
 ## Build
 
-| Feature                                           | LangChain        | AutoGen          | CrewAI           | MCP Mesh                                      |
-| ------------------------------------------------- | ---------------- | ---------------- | ---------------- | --------------------------------------------- |
-| Zero-config Dependency Injection                  | :x:              | :x:              | :x:              | :white_check_mark:                            |
-| Distributed Dynamic DI ([DDDI](concepts/dddi.md)) | :x:              | :x:              | :x:              | :white_check_mark:                            |
-| Capability-based discovery                        | :x:              | :x:              | :x:              | :white_check_mark:                            |
-| Tag-based filtering                               | :x:              | :x:              | :x:              | :white_check_mark:                            |
-| Cross-language support                            | :x:              | :x:              | :x:              | :white_check_mark: Python + Java + TypeScript |
-| Same code local/Docker/K8s                        | :x:              | :x:              | :x:              | :white_check_mark:                            |
-| Monolith mode (single process)                    | :x:              | :x:              | :x:              | :white_check_mark:                            |
-| Distributed mode                                  | :warning: DIY    | :warning: DIY    | :warning: DIY    | :white_check_mark: Auto                       |
-| Structured output                                 | :warning: Manual | :warning: Manual | :warning: Manual | :white_check_mark: Native (Pydantic/Zod)      |
+- **Zero-config dependency injection** — declare capabilities + dependencies on the function; mesh handles wiring
+- **Distributed Dynamic DI ([DDDI](concepts/dddi.md))** — dependencies resolved at runtime across processes, machines, and clouds
+- **Capability-based discovery** — agents declare capabilities, not URLs; resolution is by intent
+- **Tag-based filtering** — `+claude`, `+gpt`, `+v2`, and arbitrary tags refine selection at runtime
+- **Cross-language support** — Python, Java, and TypeScript agents call each other natively via shared Rust FFI core
+- **Multi-protocol bridging** — MCP, A2A v1.0, and REST — consume external A2A producers or expose mesh tools to A2A / REST clients without rewriting business logic
+- **Same code local / Docker / Kubernetes** — environment differences live in config, not code
+- **Monolith mode** — run all agents in one process for fast local iteration
+- **Distributed mode** — scale to many processes with the same code
+- **Structured output** — Pydantic (Python), Zod (TypeScript), Java records — native typed returns from LLMs
 
 ---
 
 ## Test
 
-| Feature                    | LangChain     | AutoGen       | CrewAI        | MCP Mesh                          |
-| -------------------------- | ------------- | ------------- | ------------- | --------------------------------- |
-| Zero-config mocking        | :x:           | :x:           | :x:           | :white_check_mark: Topology-based |
-| Mock by presence           | :x:           | :x:           | :x:           | :white_check_mark:                |
-| No code change for tests   | :x:           | :x:           | :x:           | :white_check_mark:                |
-| No config change for tests | :x:           | :x:           | :x:           | :white_check_mark:                |
-| Integration test support   | :warning: DIY | :warning: DIY | :warning: DIY | :white_check_mark: Native         |
+- **Zero-config mocking** — start the topology you want to test; mesh resolves what's running
+- **Mock by presence** — bring up a stub agent that declares the dependency capability; consumers find it
+- **No code change for tests** — production code IS the test code
+- **No config change for tests** — test environment differences live in agent-start choices, not config files
+- **Integration test support** — tsuite framework ships with mesh for end-to-end suites
 
 ---
 
 ## Multi-LLM
 
-| Feature                 | LangChain          | AutoGen            | CrewAI             | MCP Mesh                    |
-| ----------------------- | ------------------ | ------------------ | ------------------ | --------------------------- |
-| Multi-LLM support       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:          |
-| Dynamic LLM discovery   | :x:                | :x:                | :x:                | :white_check_mark:          |
-| LLM auto-failover       | :x:                | :x:                | :x:                | :white_check_mark:          |
-| Dynamic tool calls      | :warning: Manual   | :warning: Manual   | :warning: Manual   | :white_check_mark: Native   |
-| LLM provider hot-swap   | :x:                | :x:                | :x:                | :white_check_mark:          |
-| Zero-code LLM providers | :x:                | :x:                | :x:                | :white_check_mark: Scaffold |
+- **Multi-LLM support** — Claude, GPT, Gemini, plus any provider supported by LiteLLM / Vercel AI SDK / Spring AI
+- **Dynamic LLM discovery** — LLM agents are mesh agents; discovered the same way as any tool
+- **LLM auto-failover** — provider goes down, mesh rewires to a peer (e.g., `+claude` falls back to `+gpt` when tagged)
+- **Dynamic tool calls** — LLM picks a tool, mesh dispatches to the right agent — no agentic loop to write
+- **LLM provider hot-swap** — change the active provider without restart
+- **Zero-code LLM providers** — `meshctl scaffold llm-provider` creates a new provider in seconds
 
 ---
 
 ## Agents
 
-| Feature                   | LangChain        | AutoGen            | CrewAI             | MCP Mesh                               |
-| ------------------------- | ---------------- | ------------------ | ------------------ | -------------------------------------- |
-| Agent-to-agent calls      | :warning: Manual | :white_check_mark: | :white_check_mark: | :white_check_mark:                     |
-| Dynamic agent discovery   | :x:              | :x:                | :x:                | :white_check_mark:                     |
-| Agent hot join            | :x:              | :x:                | :x:                | :white_check_mark:                     |
-| Agent hot leave           | :x:              | :x:                | :x:                | :white_check_mark:                     |
-| Agent health checks       | :x:              | :x:                | :x:                | :white_check_mark:                     |
-| N-way agent communication | :x:              | :x:                | :x:                | :white_check_mark: `filter_mode="all"` |
+- **Agent-to-agent calls** — native, typed, with auto-retry and trace propagation
+- **Dynamic agent discovery** — new agents register and become callable without consumer-side changes
+- **Agent hot join** — new agent starts mid-flight, becomes discoverable on next heartbeat tick
+- **Agent hot leave** — graceful shutdown drains in-flight work; orphan-reset handles unclean kills
+- **Agent health checks** — registry tracks per-agent health and drops unhealthy peers from resolution
+- **N-way agent communication** — `filter_mode="all"` calls every consumer of a capability and aggregates results
 
 ---
 
 ## Deploy
 
-| Feature              | LangChain     | AutoGen       | CrewAI        | MCP Mesh                        |
-| -------------------- | ------------- | ------------- | ------------- | ------------------------------- |
-| Docker images        | :warning: DIY | :warning: DIY | :warning: DIY | :white_check_mark: Built-in     |
-| Helm charts          | :x:           | :x:           | :x:           | :white_check_mark:              |
-| Kubernetes-native    | :x:           | :x:           | :x:           | :white_check_mark:              |
-| Auto-scaling         | :x:           | :x:           | :x:           | :white_check_mark: K8s native   |
-| Service discovery    | :warning: DIY | :warning: DIY | :warning: DIY | :white_check_mark: Native       |
-| Zero-downtime deploy | :x:           | :x:           | :x:           | :white_check_mark:              |
-| Environment parity   | :x:           | :x:           | :x:           | :white_check_mark: Local = Prod |
+- **Docker images** — official runtimes published per release
+- **Helm charts** — umbrella + per-agent charts on OCI registry
+- **Kubernetes-native** — declarative deployment with HPA, health probes, and service discovery
+- **Auto-scaling** — Kubernetes-native horizontal pod autoscaling
+- **Service discovery** — built into the registry; no external coordination needed
+- **Zero-downtime deploy** — rolling updates with heartbeat-driven cutover
+- **Environment parity** — same code runs locally, in Docker, and in Kubernetes
 
 ---
 
 ## Observe
 
-| Feature                | LangChain     | AutoGen       | CrewAI        | MCP Mesh                         |
-| ---------------------- | ------------- | ------------- | ------------- | -------------------------------- |
-| Distributed tracing    | :x:           | :x:           | :x:           | :white_check_mark:               |
-| Cross-language tracing | :x:           | :x:           | :x:           | :white_check_mark:               |
-| Local tracing          | :x:           | :x:           | :x:           | :white_check_mark: CLI           |
-| Production tracing     | :x:           | :x:           | :x:           | :white_check_mark: Grafana/Tempo |
-| OpenTelemetry support  | :warning: DIY | :warning: DIY | :warning: DIY | :white_check_mark: Native        |
-| Trace propagation      | :x:           | :x:           | :x:           | :white_check_mark: Auto          |
-| Span visualization     | :x:           | :x:           | :x:           | :white_check_mark: Grafana       |
+- **Distributed tracing** — every cross-agent call carries a trace context
+- **Cross-language tracing** — Python → Java → TypeScript spans land in the same trace tree
+- **Local tracing** — `meshctl trace <id>` renders the call tree in the terminal
+- **Production tracing** — Grafana + Tempo deployment included in the Helm umbrella chart
+- **OpenTelemetry support** — native, no glue code
+- **Trace propagation** — automatic across mesh calls, no manual context wiring
+- **Span visualization** — Grafana dashboards ship with the platform
 
 ---
 
 ## Resilience
 
-| Feature              | LangChain     | AutoGen       | CrewAI        | MCP Mesh                  |
-| -------------------- | ------------- | ------------- | ------------- | ------------------------- |
-| Auto-failover        | :x:           | :x:           | :x:           | :white_check_mark:        |
-| Graceful degradation | :x:           | :x:           | :x:           | :white_check_mark:        |
-| Circuit breaker      | :x:           | :x:           | :x:           | :white_check_mark:        |
-| Retry logic          | :warning: DIY | :warning: DIY | :warning: DIY | :white_check_mark: Native |
-| Dead agent removal   | :x:           | :x:           | :x:           | :white_check_mark: Auto   |
+- **Auto-failover** — capability+tag mechanism rewires consumers transparently when an agent dies
+- **Graceful degradation** — partial mesh failures don't cascade; degraded calls return useful errors
+- **Circuit breaker** — repeated failures from a downstream agent trip the circuit; recovery is automatic
+- **Retry logic** — built into the resolver with configurable policy
+- **Dead agent removal** — orphan-reset sweep drops agents whose heartbeats stop
 
 ---
 
 ## Security
 
-| Feature                     | LangChain | AutoGen | CrewAI | MCP Mesh                                       |
-| --------------------------- | --------- | ------- | ------ | ---------------------------------------------- |
-| Registration trust          | :x:       | :x:     | :x:    | :white_check_mark: X.509 identity verification |
-| Agent-to-agent mTLS         | :x:       | :x:     | :x:    | :white_check_mark: Every call authenticated    |
-| Fine-grained authorization  | :x:       | :x:     | :x:    | :white_check_mark: Header propagation          |
-| Zero-config TLS (dev)       | :x:       | :x:     | :x:    | :white_check_mark: `--tls-auto`                |
-| Vault integration           | :x:       | :x:     | :x:    | :white_check_mark: PKI provider                |
-| SPIRE / workload identity   | :x:       | :x:     | :x:    | :white_check_mark: X.509-SVID                  |
-| Cert rotation via heartbeat | :x:       | :x:     | :x:    | :white_check_mark: Auto                        |
+- **Registration trust** — X.509 identity verification at agent registration
+- **Agent-to-agent mTLS** — every call authenticated; optional auto-rotation
+- **Fine-grained authorization** — header propagation lets agents enforce caller-context rules
+- **Zero-config TLS (dev)** — `--tls-auto` mints self-signed certs for local dev
+- **Vault integration** — HashiCorp Vault as a PKI provider
+- **SPIRE / workload identity** — X.509-SVID rotation via heartbeat
+- **Cert rotation via heartbeat** — automatic, no restarts
 
 ---
 
 ## Architecture
 
-| Feature                       | LangChain     | AutoGen       | CrewAI        | MCP Mesh                      |
-| ----------------------------- | ------------- | ------------- | ------------- | ----------------------------- |
-| Monolith → Distributed        | :x: Rewrite   | :x: Rewrite   | :x: Rewrite   | :white_check_mark: Same code  |
-| Central orchestrator required | :warning: Yes | :warning: Yes | :warning: Yes | :white_check_mark: Not needed |
-| Topology-based wiring         | :x:           | :x:           | :x:           | :white_check_mark:            |
-| Standard protocol             | :x: Custom    | :x: Custom    | :x: Custom    | :white_check_mark: MCP        |
+- **Monolith → distributed without rewrite** — same decorators, same code, different topology
+- **No central orchestrator required** — peer-to-peer mesh, registry is for discovery only
+- **Topology-based wiring** — what's running IS what's connected
+- **Standard protocol** — MCP (Anthropic's open protocol), not custom RPC
 
 ---
 
-## Developer Experience
+## Developer experience
 
-| Feature                 | LangChain             | AutoGen               | CrewAI                | MCP Mesh                            |
-| ----------------------- | --------------------- | --------------------- | --------------------- | ----------------------------------- |
-| Lines of code for agent | ~50+                  | ~50+                  | ~50+                  | **~10**                             |
-| Framework lock-in       | :x: High              | :x: High              | :x: High              | :white_check_mark: Low (decorators) |
-| Learning curve          | Steep                 | Steep                 | Medium                | **Low**                             |
-| Pure Python/Java/TS     | :x: Framework classes | :x: Framework classes | :x: Framework classes | :white_check_mark: Just decorators  |
+- **Lines of code per agent** — ~10 lines for a typical agent
+- **Low framework lock-in** — your code stays regular Python / Java / TypeScript with two mesh decorators
+- **Low learning curve** — if you know FastAPI / Spring / Express, you know mesh
+- **No framework classes** — `@mesh.tool`, `@mesh.agent`, `@mesh.llm` — plain decorators on plain functions
 
 ---
 
 ## Enterprise
 
-| Feature                  | LangChain    | AutoGen      | CrewAI       | MCP Mesh                                 |
-| ------------------------ | ------------ | ------------ | ------------ | ---------------------------------------- |
-| Mature                   | :warning:    | :warning:    | :warning:    | :white_check_mark:                       |
-| Enterprise observability | :x:          | :x:          | :x:          | :white_check_mark:                       |
-| Team development         | :x: Blocking | :x: Blocking | :x: Blocking | :white_check_mark: Non-blocking          |
-| Multi-team support       | :x:          | :x:          | :x:          | :white_check_mark: Capability boundaries |
+- **Mature** — actively developed, production-ready
+- **Enterprise observability** — Grafana + Tempo + Prometheus stack ships with the platform
+- **Non-blocking team development** — capability boundaries let teams build agents independently
+- **Multi-team support** — capability namespaces + tags let teams ship without coordination
 
 ---
 
 ## vs Cloud Agent Platforms
 
-How MCP Mesh compares to managed cloud agent services — AWS Bedrock Agents, Google Vertex AI Agent Builder, and Azure AI Agent Service.
+How MCP Mesh compares to managed cloud agent services — AWS Bedrock Agents, Google Vertex AI Agent Builder, and Azure AI Agent Service. This is a genuine trade-off (managed vs self-hosted, vendor-tied vs portable) rather than a feature gap, so a side-by-side comparison is useful here.
 
 | Feature                            | Bedrock Agents              | Vertex AI Agent Builder     | Azure AI Agent Service      | MCP Mesh                                        |
 | ---------------------------------- | --------------------------- | --------------------------- | --------------------------- | ----------------------------------------------- |
@@ -190,11 +167,12 @@ Cloud platforms give you a managed environment — but lock you into one vendor'
 
 MCP Mesh is designed for **production AI systems** where you need:
 
-- **Zero infrastructure code** - Just decorators, no boilerplate
-- **Dynamic discovery** - Agents find each other automatically
-- **Enterprise operations** - Tracing, failover, and scaling built-in
-- **Standard protocol** - MCP, not proprietary formats
-- **Low lock-in** - Your code stays clean Python/Java/TypeScript
+- **Zero infrastructure code** — just decorators, no boilerplate
+- **Dynamic discovery** — agents find each other automatically
+- **Multi-protocol** — MCP, A2A, and REST agents in one framework
+- **Multi-language** — Python, Java, TypeScript agents calling each other natively
+- **Enterprise operations** — tracing, failover, and scaling built-in
+- **Low lock-in** — your code stays clean Python / Java / TypeScript
 
 [Get Started](python/getting-started/index.md){ .md-button .md-button--primary }
 [View Architecture](concepts/architecture.md){ .md-button }

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,31 @@ MCP Mesh is a complete platform for **building and deploying AI agents to produc
 
 ---
 
-## :rocket: Quick Start
+## :zap: Getting Started
+
+Start with the CLI — fastest way to explore mesh, scaffold agents, and read documentation offline.
+
+`meshctl` is a fully-featured command-line tool that follows you from your first agent through production and beyond: scaffolding, local dev, registry inspection, tracing, observability, deployment, and operations are all one command away. [Explore the full CLI reference →](cli/index.md)
+
+```bash
+# Install the CLI
+npm install -g @mcpmesh/cli
+
+# Explore commands
+meshctl --help
+
+# Built-in documentation
+meshctl man
+```
+
+!!! tip "Turn your AI coding assistant into a mesh expert"
+    Working with Claude Code, Cursor, Copilot, or any other AI coding assistant? Ask it to run `meshctl man` and read through the topics it surfaces. The built-in man pages cover every feature in depth — within a few minutes your assistant will be fluent in mesh, ready to scaffold agents, debug DDDI wiring, and answer architecture questions without you having to copy-paste docs into the chat.
+
+---
+
+## :rocket: Quick Overview
+
+Build multi-agent systems that are production-ready from day one. Mesh handles the operational surface — scaling, security, observability, and seamless routing across protocols (MCP, A2A, REST), languages (Python, Java, TypeScript), and LLM providers — so the code you write stays focused on business logic, in whatever language fits.
 
 === "Python"
 
@@ -226,12 +250,24 @@ Graceful failure handling, auto-reconnection, RBAC support, and real-time monito
 Write agents in Python, TypeScript, or Java — they discover and call each other natively across the mesh via a shared Rust FFI core.
 </div>
 <div class="feature-card" markdown>
+### :material-swap-horizontal: Multi-Protocol Bridging
+Native support for MCP, Google's A2A v1.0, and REST. Consume external A2A producers as mesh capabilities, or expose mesh agents as A2A producers for non-mesh callers — same code, same `@mesh.tool` shape.
+</div>
+<div class="feature-card" markdown>
 ### :brain: Multi-Provider LLM Support
 First-class support for Claude, GPT, and Gemini with agentic tool execution, structured output, and auto-resolution. Any provider supported by LiteLLM, Vercel AI SDK, or Spring AI works out of the box.
 </div>
 <div class="feature-card" markdown>
 ### :camera: Multimodal Support
 Pass images, PDFs, and files between agents and LLMs. Claude, OpenAI, and Gemini each require different API structures for media — the mesh abstracts that away.
+</div>
+<div class="feature-card" markdown>
+### :material-progress-clock: Long-Running with MeshJob
+Mark a tool `task=True` and mesh handles the rest — job persistence, status polling, cancellation, SSE streaming, and retries on transient failure. No queue infrastructure to provision; the registry IS the job substrate.
+</div>
+<div class="feature-card" markdown>
+### :material-console-line: meshctl CLI
+A `kubectl`-style command-line tool that follows you from first agent to production — scaffold new agents, inspect the registry, view traces, call tools directly, and manage agent lifecycle. Same commands work against local dev, Docker, and Kubernetes.
 </div>
 </div>
 
@@ -245,6 +281,7 @@ Pass images, PDFs, and files between agents and LLMs. Claude, OpenAI, and Gemini
 
     - **Zero Boilerplate**: Simple decorators/functions replace hundreds of lines of networking code
     - **Python, Java & TypeScript**: Write MCP servers as simple functions in your preferred language — no manual client/server setup
+    - **Multi-Protocol**: Build MCP, A2A, and REST agents with the same framework. Bridge between protocols — consume external A2A producers, or expose mesh tools to A2A clients — without rewriting business logic
     - **Web Framework Integration**: Inject MCP agents directly into FastAPI (Python), Spring Boot (Java), or Express (TypeScript) APIs seamlessly
     - **LLM as Dependencies**: Inject LLMs just like MCP agents — dynamic prompts with Jinja2 (Python), FreeMarker (Java), or Handlebars (TypeScript)
     - **Seamless Development Flow**: Code locally, test with Docker Compose, deploy to Kubernetes — same code, zero changes
@@ -291,32 +328,6 @@ Pass images, PDFs, and files between agents and LLMs. Claude, OpenAI, and Gemini
     - **Future-Proof Architecture**: Add new AI capabilities without disrupting existing systems
 
     Turn your AI strategy from "promising experiments" to "competitive advantage in production."
-
----
-
-## :chart_with_upwards_trend: MCP vs MCP Mesh
-
-| Challenge                | Traditional MCP                  | MCP Mesh                       |
-| ------------------------ | -------------------------------- | ------------------------------ |
-| **Connect 5 servers**    | 200+ lines of networking code    | 2 decorators                   |
-| **Handle failures**      | Manual error handling everywhere | Automatic graceful degradation |
-| **Scale to production**  | Custom Kubernetes setup          | `helm install mcp-mesh`        |
-| **Monitor system**       | Build custom dashboards          | Built-in observability stack   |
-| **Add new capabilities** | Restart and reconfigure clients  | Auto-discovery, zero downtime  |
-
----
-
-## :vs: MCP Mesh vs Other Frameworks
-
-| Framework     | K8s Native              | Independent Scaling               | Service Discovery           | Best For              |
-| ------------- | ----------------------- | --------------------------------- | --------------------------- | --------------------- |
-| **MCP Mesh**  | :white_check_mark: Helm | :white_check_mark: Per-agent pods | :white_check_mark: Built-in | Production deployment |
-| LangGraph     | :x: Manual              | :x: Same process                  | :x: DIY                     | Complex workflows     |
-| CrewAI        | :x: Manual              | :x: Limited                       | :x: None                    | Rapid prototyping     |
-| AutoGen       | :x: Manual              | :x: Manual                        | :x: DIY                     | Enterprise/Azure      |
-| OpenAI Agents | :x: Manual              | :x: Manual                        | :x: None                    | OpenAI-centric        |
-
-[:material-arrow-right: Full comparison with code examples](00-why-mcp-mesh/index.md){ .md-button }
 
 ---
 
@@ -411,6 +422,7 @@ Pass images, PDFs, and files between agents and LLMs. Claude, OpenAI, and Gemini
 ## :pray: Acknowledgments
 
 - **[Anthropic](https://anthropic.com)** for creating the MCP protocol
+- **[Google](https://a2a-protocol.org/)** for the A2A protocol
 - **[FastMCP](https://github.com/jlowin/fastmcp)** for excellent MCP server foundations
 - **[Kubernetes](https://kubernetes.io)** community for the infrastructure platform
 - All **contributors** who help make MCP Mesh better

--- a/docs/python/llm/index.md
+++ b/docs/python/llm/index.md
@@ -1,9 +1,9 @@
 <div class="runtime-crossref">
   <span class="runtime-crossref-icon">☕</span>
-  <span>Looking for Java? See <a href="../../java/llm/index/">Java LLM Integration</a></span>
+  <span>Looking for Java? See <a href="../../java/llm/">Java LLM Integration</a></span>
   <span> | </span>
   <span class="runtime-crossref-icon">📘</span>
-  <span>Looking for TypeScript? See <a href="../../typescript/llm/index/">TypeScript LLM Integration</a></span>
+  <span>Looking for TypeScript? See <a href="../../typescript/llm/">TypeScript LLM Integration</a></span>
 </div>
 
 # LLM Integration
@@ -168,8 +168,8 @@ alternative to AI Studio. Same handler, same HINT-mode prompt shaping for
 structured output with tools — only the model prefix and auth env vars change.
 
 The TypeScript and Java runtimes have equivalent support — see
-[TypeScript LLM Integration](../../typescript/llm/index/) and
-[Java LLM Integration](../../java/llm/index/) for the runtime-specific
+[TypeScript LLM Integration](../../typescript/llm/index.md) and
+[Java LLM Integration](../../java/llm/index.md) for the runtime-specific
 auth env vars (each follows its own ecosystem's naming convention).
 
 ### When to use Vertex AI vs AI Studio


### PR DESCRIPTION
## Summary

Eight related docs items addressed in one PR — homepage and README cleanup, comparison-page reframe, A2A docs accuracy fix, and broken link cleanup.

## Per-file changes

### `docs/index.md` (homepage)

- **New "Getting Started" section** above Quick Start — `meshctl` CLI install block + AI-coding-assistant primer tip (mirrors README's section)
- **Renamed `Quick Start` → `Quick Overview`** (dedicated per-runtime Quick Start pages exist in nav; homepage section is just a sketch)
- **Added value-prop paragraph** to Quick Overview: production-ready from day one, mesh handles operational surface across protocols / languages / LLM providers
- **3 new Key Features cards**: Multi-Protocol Bridging (MCP+A2A+REST), Long-Running with MeshJob, meshctl CLI
- **Added A2A bullet** to "For Developers" persona tab
- **Removed two stale tables**:
  - `MCP vs MCP Mesh` (category mismatch — comparing a protocol to a framework)
  - `MCP Mesh vs Other Frameworks` (per-framework checkboxes vs LangGraph/CrewAI/AutoGen — goes stale weekly, duplicates content we removed from comparison.md)
- **Acknowledgments**: added Google for A2A protocol (alongside Anthropic for MCP)

### `docs/comparison.md`

Full reframe: `MCP Mesh vs Agent Frameworks` → `What MCP Mesh Does` capability catalog organized by lifecycle phase (12 sections). Each section's mesh capability + sub-description preserved from the previous tables; per-framework checkbox columns dropped. Added missing multi-protocol bullet in Build section. **Kept `vs Cloud Agent Platforms` section** (legitimate trade-off discussion).

Rationale: per-framework checkboxes go stale fast (LangChain ships features weekly; can't track every release), read combatively, and don't help readers understand what mesh actually does.

### `README.md`

Removed `MCP Mesh vs Other AI Agent Frameworks` section (13-row checkbox table) for the same reasons as the homepage cleanup. README flow now goes Key Features → Contributing.

### `docs/a2a/failover.md` + `docs/a2a/architecture.md`

Both files said *"every `tools/call` is a fresh resolution"* — misleading wording that read like the registry is in the call path on every call. Actually:
- Mesh calls are peer-to-peer; registry is **NOT** in the request path
- Consumer agents have a local registry view, kept fresh by background heartbeats (~5s)
- "Fresh resolution per call" = per-call local-view lookup, NOT a network roundtrip
- When a consumer dies and orphan-reset fires, next heartbeat refresh drops it from view; calls route around transparently
- A2A wire call goes consumer → external A2A producer URL directly — registry never sees in-flight traffic

Both sites rewritten to spell this out accurately.

### `docs/python/llm/index.md`

Fixed 4 broken relative links that were emitting INFO warnings on every `mkdocs build`:
- HTML `<a href>` sites: `../../java/llm/index/` → `../../java/llm/` (rendered URL form)
- Markdown link sites: `../../typescript/llm/index/` → `.../index.md` (idiomatic markdown form)

## Test plan

- [x] `mkdocs build` clean (only pre-existing git-revision-date warning for unstaged docs dir, disappears once committed)
- [x] All cross-references verified
- [x] Visual review at `http://localhost:<port>/` — homepage, comparison page, README render correctly
- [x] No code changes — docs only

## Diff stat

```
 README.md                |  22 ------
 docs/a2a/architecture.md |   2 +-
 docs/a2a/failover.md     |   4 +-
 docs/comparison.md       | 188 +++++++++++++++++++++--------------------------
 docs/index.md            |  66 ++++++++++-------
 docs/python/llm/index.md |   8 +-
 6 files changed, 129 insertions(+), 161 deletions(-)
```

Net 32 lines removed — the docs got tighter while gaining more accurate A2A coverage.

Closes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Reorganized comparison documentation from table-based to narrative format for improved readability
* Added "Getting Started" section featuring CLI tool installation and usage
* Expanded feature overview with multi-protocol bridging capabilities and long-running job support
* Clarified failover and synchronization semantics in architecture documentation
* Fixed cross-reference links in language-specific integration guides

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/951)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->