### PR TITLE
docs(homepage): fix Helm OCI install path

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -394,7 +394,7 @@ A `kubectl`-style command-line tool that follows you from first agent to product
 === "Helm Charts"
 
     ```bash
-    helm install mcp-mesh oci://ghcr.io/dhyansraj/mcp-mesh/charts/mcp-mesh
+    helm install mcp-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core
     ```
 
     Kubernetes deployment with the umbrella chart.


### PR DESCRIPTION
## Summary

`docs/index.md:397` (Installation tab → Helm Charts) shows a non-existent OCI path:

```bash
helm install mcp-mesh oci://ghcr.io/dhyansraj/mcp-mesh/charts/mcp-mesh
```

The `/charts/mcp-mesh` segment doesn't exist on GHCR. Discovered while verifying the v2.0.0-beta.1 publish — `helm pull` against this path returns 403.

## Actual path

Helm charts are published per-component under `ghcr.io/dhyansraj/mcp-mesh/<chart-name>`. The **umbrella chart** is `mcp-mesh-core`. Correct command:

```bash
helm install mcp-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core
```

Other docs already use the correct path:
- `docs/dashboard.md:20`
- `docs/04-kubernetes-basics.md` (multiple sites)

Only the homepage installation tab had the stale form — likely a copy-paste artifact from an earlier OCI layout.

## Test plan

- [x] `mkdocs build` clean
- [x] `helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core --version 2.0.0-beta.1` succeeds against the live registry

## Release implications

None — docs-only fix. Doesn't require its own release/publish cycle. Will land on `main` and be served via the next `mkdocs gh-deploy` (or whatever your docs publish cadence is).

Closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated Helm Charts installation instructions to reference the OCI registry for deploying `mcp-mesh-core`.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/954)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->