### PR TITLE
fix(registry): unhealthy agents must re-register via POST (#955)

### DIFF
--- a/src/core/registry/ent_handlers.go
+++ b/src/core/registry/ent_handlers.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"mcp-mesh/src/core/ent/agent"
 	"mcp-mesh/src/core/registry/generated"
 )
 
@@ -564,8 +565,20 @@ func (h *EntBusinessLogicHandlers) FastHeartbeatCheck(c *gin.Context, agentId st
 		return
 	}
 
-	// Update agent timestamp to indicate recent activity (prevents health monitor eviction)
-	// This also handles recovery from unhealthy status if needed
+	// Issue #955: an agent marked unhealthy by startup cleanup or the
+	// health monitor must re-register via POST /heartbeat before it can
+	// transition back to healthy. Allowing a bare HEAD ping to revive it
+	// bypasses metadata refresh and lets orphans from a prior session
+	// (with stale endpoint / capabilities) silently re-claim a healthy
+	// row forever. The SDK clients (Rust core / Python) already map 410
+	// to AGENT_UNKNOWN → requires_full_heartbeat() → POST re-register.
+	if agentEntity.Status == agent.StatusUnhealthy {
+		c.Status(http.StatusGone) // 410 — please re-register via POST
+		return
+	}
+
+	// Update agent timestamp to indicate recent activity (prevents health monitor eviction).
+	// Unhealthy→Healthy transitions are NOT handled here — see the 410 short-circuit above (#955).
 	err = h.entService.UpdateAgentHeartbeatTimestamp(c.Request.Context(), agentId)
 	if err != nil {
 		// Service error - back off and retry

--- a/src/core/registry/ent_service.go
+++ b/src/core/registry/ent_service.go
@@ -2206,7 +2206,13 @@ func (s *EntService) markAgentStaleAttempt(ctx context.Context, staleAgent *ent.
 	return nil
 }
 
-// UpdateAgentHeartbeatTimestamp updates only the agent's timestamp for HEAD heartbeat requests
+// UpdateAgentHeartbeatTimestamp updates only the agent's timestamp for HEAD heartbeat requests.
+//
+// Unhealthy→Healthy transitions belong exclusively in RegisterAgent / UpdateHeartbeat
+// (POST paths) where full metadata is reconciled. The HEAD heartbeat handler
+// (FastHeartbeatCheck) short-circuits to 410 Gone for unhealthy agents, so this
+// function only ever sees agents that are already healthy (or about-to-be-unknown,
+// which is treated idempotently below). See #955.
 func (s *EntService) UpdateAgentHeartbeatTimestamp(ctx context.Context, agentID string) error {
 	now := time.Now().UTC()
 
@@ -2220,18 +2226,9 @@ func (s *EntService) UpdateAgentHeartbeatTimestamp(ctx context.Context, agentID 
 		return fmt.Errorf("failed to query agent: %w", err)
 	}
 
-	// Update timestamp and reset to healthy if agent was previously unhealthy
-	// If agent can send HEAD requests, it's clearly responsive and should be marked healthy
-	updateBuilder := existingAgent.Update().SetUpdatedAt(now)
-
-	if existingAgent.Status == agent.StatusUnhealthy {
-		s.logger.Info("Agent %s recovered: marking healthy (was %v)", agentID, existingAgent.Status)
-		updateBuilder = updateBuilder.SetStatus(agent.StatusHealthy)
-
-		// Recovery event will be created automatically by status change hook
-	}
-
-	_, err = updateBuilder.Save(ctx)
+	// Bump the last-heartbeat timestamp. Status is intentionally NOT modified here
+	// (#955): the caller has already verified the agent is healthy.
+	_, err = existingAgent.Update().SetUpdatedAt(now).Save(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to update agent heartbeat timestamp: %w", err)
 	}

--- a/src/core/registry/heartbeat_unhealthy_test.go
+++ b/src/core/registry/heartbeat_unhealthy_test.go
@@ -1,0 +1,175 @@
+package registry
+
+// Regression coverage for #955: a registry restart leaves stdio agents (or any
+// previously-registered agent the registry can't reach) as orphans. Startup
+// cleanup correctly marks them unhealthy, but commit 032a9128 added an
+// auto-recovery branch to UpdateAgentHeartbeatTimestamp that silently flipped
+// any agent sending a HEAD heartbeat back to healthy and bumped updated_at.
+// Net effect: the sweep job never got a window to evict the row, and orphans
+// persisted forever as "healthy".
+//
+// The fix has two parts:
+//
+//  1. FastHeartbeatCheck (HEAD /heartbeat/{id}) now short-circuits to 410 Gone
+//     for any unhealthy agent. The SDK clients map 410 → AGENT_UNKNOWN →
+//     requires_full_heartbeat() and re-register via POST.
+//  2. UpdateAgentHeartbeatTimestamp no longer touches status — it only bumps
+//     updated_at for the (necessarily healthy) agent.
+//
+// Together: an unhealthy row stays unhealthy until a POST heartbeat arrives
+// with full metadata, at which point RegisterAgent/UpdateHeartbeat handle the
+// transition with the up-to-date endpoint / capability set.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"mcp-mesh/src/core/ent/agent"
+	"mcp-mesh/src/core/registry/generated"
+)
+
+// TestFastHeartbeatCheck_UnhealthyAgentRequiresReregistration is the primary
+// regression test for #955: a HEAD heartbeat to an unhealthy agent must
+// return 410 Gone and must NOT mutate the row (no status flip, no
+// updated_at bump). A subsequent POST /heartbeat with the full registration
+// payload must then transition the agent back to healthy.
+func TestFastHeartbeatCheck_UnhealthyAgentRequiresReregistration(t *testing.T) {
+	client, service, cleanup := newAuditTestEnv(t)
+	defer cleanup()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handlers := NewEntBusinessLogicHandlers(service)
+	generated.RegisterHandlers(router, handlers)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	ctx := context.Background()
+	agentID := "orphan-agent-1"
+	// Seed an agent that was marked unhealthy an hour ago — e.g. by
+	// CleanupStaleAgentsOnStartup after a registry restart. updated_at is
+	// deliberately stale so the assertion below can prove the HEAD call
+	// did NOT touch it.
+	staleTime := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Microsecond)
+	_, err := client.Agent.Create().
+		SetID(agentID).
+		SetName(agentID).
+		SetAgentType(agent.AgentTypeMcpAgent).
+		SetStatus(agent.StatusUnhealthy).
+		SetUpdatedAt(staleTime).
+		Save(ctx)
+	require.NoError(t, err, "seed unhealthy agent")
+	// Re-write defensively in case the schema defaulted updated_at.
+	_, err = client.Agent.UpdateOneID(agentID).SetUpdatedAt(staleTime).Save(ctx)
+	require.NoError(t, err, "force stale updated_at")
+
+	// Phase 1: HEAD heartbeat from the orphan must be rejected with 410 Gone.
+	req, err := http.NewRequest("HEAD", srv.URL+"/heartbeat/"+agentID, nil)
+	require.NoError(t, err)
+	resp, err := (&http.Client{}).Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusGone, resp.StatusCode,
+		"unhealthy agent must receive 410 Gone on HEAD heartbeat (#955)")
+
+	// Phase 2: the row must NOT have been auto-recovered or touched.
+	got, err := client.Agent.Get(ctx, agentID)
+	require.NoError(t, err)
+	assert.Equal(t, agent.StatusUnhealthy, got.Status,
+		"HEAD heartbeat must NOT auto-promote unhealthy → healthy (#955)")
+	assert.True(t, got.UpdatedAt.Equal(staleTime),
+		"HEAD heartbeat must NOT bump updated_at on an unhealthy agent (#955); "+
+			"got=%s want=%s",
+		got.UpdatedAt.UTC().Format(time.RFC3339Nano),
+		staleTime.Format(time.RFC3339Nano))
+
+	// Phase 3: a POST /heartbeat with a full registration payload (the path
+	// the SDK takes on 410) must transition the agent back to healthy and
+	// bump updated_at. This is the architecture: unhealthy → healthy is a
+	// POST-only operation that reconciles metadata.
+	hb := &HeartbeatRequest{
+		AgentID: agentID,
+		Status:  "healthy",
+		Metadata: map[string]interface{}{
+			"agent_id":  agentID,
+			"name":      agentID,
+			"version":   "1.0.0",
+			"namespace": "default",
+			"endpoint":  "http://127.0.0.1:9999",
+			"tools": []interface{}{
+				map[string]interface{}{
+					"function_name": "do_thing",
+					"capability":    "thing",
+					"version":       "1.0.0",
+				},
+			},
+		},
+	}
+	hbResp, err := service.UpdateHeartbeat(hb)
+	require.NoError(t, err, "POST heartbeat after 410 must succeed")
+	require.NotNil(t, hbResp)
+
+	// Re-query: agent must now be healthy and updated_at recent.
+	got, err = client.Agent.Get(ctx, agentID)
+	require.NoError(t, err)
+	assert.Equal(t, agent.StatusHealthy, got.Status,
+		"POST /heartbeat must transition unhealthy → healthy when full metadata is provided")
+	assert.True(t, got.UpdatedAt.After(staleTime),
+		"POST /heartbeat must bump updated_at; got=%s, stale=%s",
+		got.UpdatedAt.UTC().Format(time.RFC3339Nano),
+		staleTime.Format(time.RFC3339Nano))
+}
+
+// TestFastHeartbeatCheck_HealthyAgentBumpsTimestamp is the positive-case
+// counterpart: a HEAD heartbeat to a healthy agent must return 200 OK and
+// bump updated_at. This is the steady-state heartbeat path and must not
+// regress under the #955 fix.
+func TestFastHeartbeatCheck_HealthyAgentBumpsTimestamp(t *testing.T) {
+	client, service, cleanup := newAuditTestEnv(t)
+	defer cleanup()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handlers := NewEntBusinessLogicHandlers(service)
+	generated.RegisterHandlers(router, handlers)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	ctx := context.Background()
+	agentID := "healthy-agent-1"
+	// Seed a healthy agent with an old updated_at so the bump is observable.
+	oldUpdatedAt := time.Now().UTC().Add(-5 * time.Minute).Truncate(time.Microsecond)
+	_, err := client.Agent.Create().
+		SetID(agentID).
+		SetName(agentID).
+		SetAgentType(agent.AgentTypeMcpAgent).
+		SetStatus(agent.StatusHealthy).
+		SetUpdatedAt(oldUpdatedAt).
+		Save(ctx)
+	require.NoError(t, err, "seed healthy agent")
+	_, err = client.Agent.UpdateOneID(agentID).SetUpdatedAt(oldUpdatedAt).Save(ctx)
+	require.NoError(t, err, "force old updated_at")
+
+	req, err := http.NewRequest("HEAD", srv.URL+"/heartbeat/"+agentID, nil)
+	require.NoError(t, err)
+	resp, err := (&http.Client{}).Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"healthy agent must receive 200 OK on HEAD heartbeat")
+
+	got, err := client.Agent.Get(ctx, agentID)
+	require.NoError(t, err)
+	assert.Equal(t, agent.StatusHealthy, got.Status, "status must remain healthy")
+	assert.True(t, got.UpdatedAt.After(oldUpdatedAt),
+		"HEAD heartbeat must bump updated_at for healthy agents; got=%s old=%s",
+		got.UpdatedAt.UTC().Format(time.RFC3339Nano),
+		oldUpdatedAt.Format(time.RFC3339Nano))
+}


### PR DESCRIPTION
## Summary

Closes #955. v1.4.1 → 2.0.0-beta.1 regression introduced by commit `032a9128` ("Complete heartbeat and health monitoring system overhaul") that silently auto-promotes unhealthy agents back to healthy on bare HEAD heartbeat.

## What was broken

`UpdateAgentHeartbeatTimestamp` (called from HEAD `/heartbeat/<id>`) had this branch (added post-v1.4.1):

```go
if existingAgent.Status == agent.StatusUnhealthy {
    s.logger.Info("Agent %s recovered: marking healthy (was %v)", agentID, ...)
    updateBuilder = updateBuilder.SetStatus(agent.StatusHealthy)
}
```

Net effect:
1. Registry restarts → `CleanupStaleAgentsOnStartup` correctly marks orphan unhealthy
2. 5s later, orphan's HEAD heartbeat arrives → auto-recovery promotes back to healthy + bumps `updated_at`
3. Sweep job (only purges agents already in Unhealthy/Unknown) never gets a window
4. Orphan persists forever with stale metadata (capabilities, http_port, endpoint scheme)

The `agent-3185355b` orphan that surfaced in v2.0.0-beta.1 smoke (#955) was exactly this — the user's stray Python process kept HEAD-pinging, registry kept silently reviving it.

Verified by git-archeology that the auto-recovery branch is NOT in v1.4.1.

## Fix

Two surgical registry-side changes — no client SDK changes needed:

1. **`src/core/registry/ent_handlers.go`** — `FastHeartbeatCheck` short-circuits with `410 Gone` when stored status is Unhealthy, before any call to `UpdateAgentHeartbeatTimestamp`. Forces the client to re-POST via the full `UpdateHeartbeat` path (which carries fresh metadata).

2. **`src/core/registry/ent_service.go`** — removed the auto-recovery branch entirely. `UpdateAgentHeartbeatTimestamp` now only bumps `updated_at` for already-healthy agents. Unhealthy→Healthy transitions live exclusively in `RegisterAgent` / `UpdateHeartbeat` (POST paths) where metadata is reconciled.

The "agent had a network blip" recovery case still works — just routes through full re-POST instead of bare HEAD revive.

## Client compatibility — no changes needed

All 4 runtime SDKs already handle 410 correctly:

| SDK | Mapping |
|-----|---------|
| Rust core | `registry.rs:127` → `AgentUnknown` → `requires_full_heartbeat()` |
| Python | `fast_heartbeat_status.py:52` → `AGENT_UNKNOWN` (covered by `test_17_fast_heartbeat_status.py::test_from_http_code_410_gone`) |
| TypeScript + Java | Delegate to Rust core via FFI (`mcp-mesh-native`) |

## Regression test

`heartbeat_unhealthy_test.go` (new, 175 LOC, 2 tests):

- **`TestFastHeartbeatCheck_UnhealthyAgentRequiresReregistration`** — seeds Unhealthy agent with stale `updated_at`. HEAD → 410, row unchanged. POST `UpdateHeartbeat` with full metadata → transitions to Healthy with bumped `updated_at`.
- **`TestFastHeartbeatCheck_HealthyAgentBumpsTimestamp`** — positive-case companion. HEAD against healthy agent returns 200 + bumps `updated_at`.

**Red-then-green verified**: reverted both fix sites → test fails (status promoted to Healthy, 200 instead of 410). Re-applied → green.

## Test plan

- [x] `make build` clean (registry + meshctl + meshui)
- [x] `go test -count=1 ./src/core/registry/...` — **207/207** pass (was 205; +2 regression). Existing `TestCleanupStaleAgentsOnStartupPreservesUpdatedAt` still passes.
- [x] **Smoke test** against the production registry binary with two real stale agents (from a prior session, 8+ hours old):
  - Startup cleanup correctly marked both unhealthy ✅
  - SDK's first HEAD heartbeat returned 410 Gone ✅
  - 7s later, SDK re-registered via POST → back to healthy ✅
  - Steady-state HEAD heartbeats then returned 200 ✅
  - Orphan with no live process stayed unhealthy → sweep-eligible ✅
  - End-to-end flow matches the intended lifecycle ✅

## Notable side observation

The pre-existing `TestHandlers` mock in `ent_handlers_test.go:246-250` already had a "return 410 if agent is unhealthy" branch — added at some prior point, but the production handler never matched. The unit-test scaffolding had silently diverged from implementation. This fix brings production back into line with the (already correct) test mock.

## Out of scope (separate tracking)

- 13 UX quirks + 4 doc gaps from v2.0.0-beta.1 smoke (#956)
- `http_port=0` registration mechanism — verified NOT a regression. The orphan's `http_port=NULL` was a downstream consequence of stale rows never refreshing via POST; the primary fix resolves naturally because re-registration carries the resolved port.

Closes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Unhealthy agents can no longer be revived through heartbeat pings; they now require explicit re-registration to ensure proper metadata refresh and topology updates.

* **Tests**
  * Added regression tests for heartbeat handling of unhealthy agents.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/959)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->