### PR TITLE
feat(mesh.llm): retry synthetic-tool call on schema validation failure (#961)

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -549,6 +549,21 @@ export LITELLM_URL=http://localhost:4000
 export LITELLM_TIMEOUT_MS=300000
 ```
 
+### LLM Provider Behavior (Python)
+
+```bash
+# Cap on synthetic-tool corrective retries when Claude returns malformed
+# tool_use.input against the structured-output schema (issue #961).
+# Default: 1. Set to 0 to disable. Values must be int >= 0; invalid input
+# logs a WARN and falls back to the default. Anthropic native path only
+# in v1; OpenAI / Gemini follow in a future release.
+# Background: PR #960 added a defensive single-key envelope unwrap in
+# ResponseParser; this env var controls the broader provider-side
+# shape-agnostic retry loop that mirrors the LiteLLM HINT->response_format
+# fallback.
+export MCP_MESH_LLM_SYNTHETIC_RETRY_MAX=1
+```
+
 ## CLI & Development
 
 ```bash

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -557,10 +557,12 @@ export LITELLM_TIMEOUT_MS=300000
 # Default: 1. Set to 0 to disable. Values must be int >= 0; invalid input
 # logs a WARN and falls back to the default. Anthropic native path only
 # in v1; OpenAI / Gemini follow in a future release.
-# Background: PR #960 added a defensive single-key envelope unwrap in
-# ResponseParser; this env var controls the broader provider-side
-# shape-agnostic retry loop that mirrors the LiteLLM HINT->response_format
-# fallback.
+# Scope: applies ONLY to the buffered (non-streaming) provider agentic
+# loop. Streaming calls do not invoke this retry — streaming support is
+# pending. The env var currently controls the Anthropic buffered retry
+# loop tied to ResponseParser's defensive single-key envelope unwrap
+# (PR #960); the broader provider-side shape-agnostic retry loop here
+# mirrors the LiteLLM HINT->response_format fallback.
 export MCP_MESH_LLM_SYNTHETIC_RETRY_MAX=1
 ```
 

--- a/docs/mesh-decorators.md
+++ b/docs/mesh-decorators.md
@@ -1179,6 +1179,19 @@ chat(
 )
 ```
 
+#### Structured-Output Schema Retry (Anthropic native path)
+
+When using `output_type=SomePydanticModel` with a Claude provider on the
+native SDK path, the provider performs JSON-schema validation on the
+structured-output tool call before returning. If validation fails (e.g., the
+model wraps fields in an envelope like `{"parameter": {...}}`), the provider
+retries the call once with a corrective prompt that includes the schema and
+validation error. This restores parity with the legacy LiteLLM
+HINT→`response_format` fallback. Configure with
+`MCP_MESH_LLM_SYNTHETIC_RETRY_MAX` (default `1`, set to `0` to disable).
+Currently active on Anthropic path only; OpenAI / Gemini support follows in
+a future release.
+
 ### Enhanced Schemas for LLM Chains
 
 When orchestrator LLMs call specialist LLMs, Field descriptions are automatically extracted into tool schemas:

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -8,9 +8,12 @@ mesh decorators to simplify common patterns like zero-code LLM providers.
 import asyncio
 import json
 import logging
+import os
 import re
 from collections.abc import AsyncIterator
 from typing import Any
+
+import jsonschema  # type: ignore
 
 from _mcp_mesh.engine.provider_handlers import ProviderHandlerRegistry
 from _mcp_mesh.shared.logging_config import format_log_value
@@ -295,15 +298,18 @@ def _build_assistant_tool_call_dict_from_merged(tc: dict[str, Any]) -> dict[str,
 def _extract_synthetic_format_arguments(
     message: Any,
     synthetic_tool_name: str,
-) -> str | None:
-    """Return the synthetic tool's JSON arguments string if present, else None.
+) -> tuple[str | None, str | None]:
+    """Return the synthetic tool's ``(args_json_str, tool_call_id)`` pair.
 
     Walks ``message.tool_calls`` (litellm/_MockMessage shape) looking for a
     call to the synthetic tool. Returns the raw ``function.arguments`` string
-    (already JSON per the SDK contract). When the model called real tools
-    AND the synthetic in the same turn, the synthetic still wins — the model
-    signaled "I'm done", and surfacing real-tool execution would defeat the
-    point. Tolerant of malformed JSON: caller validates downstream.
+    (already JSON per the SDK contract) plus the ``tool_call_id`` that
+    callers need for the corrective-retry tool_use round-trip (issue #961).
+    When the model called real tools AND the synthetic in the same turn,
+    the synthetic still wins — the model signaled "I'm done", and surfacing
+    real-tool execution would defeat the point. Tolerant of malformed JSON:
+    caller validates downstream. Returns ``(None, None)`` when the synthetic
+    tool was not called.
     """
     tool_calls = getattr(message, "tool_calls", None) or []
     for tc in tool_calls:
@@ -312,10 +318,14 @@ def _extract_synthetic_format_arguments(
             continue
         if getattr(fn, "name", None) == synthetic_tool_name:
             args = getattr(fn, "arguments", None)
+            tc_id = getattr(tc, "id", None)
             if args is None:
-                return "{}"
-            return args if isinstance(args, str) else json.dumps(args)
-    return None
+                return "{}", tc_id
+            return (
+                args if isinstance(args, str) else json.dumps(args),
+                tc_id,
+            )
+    return None, None
 
 
 async def _maybe_run_hint_fallback(
@@ -441,8 +451,6 @@ def _read_synthetic_retry_max(loop_logger: logging.Logger | None) -> int:
     single WARN per call so that misconfiguration surfaces in logs without
     masking the retry feature entirely.
     """
-    import os
-
     raw = os.environ.get("MCP_MESH_LLM_SYNTHETIC_RETRY_MAX")
     if raw is None or raw == "":
         return _DEFAULT_SYNTHETIC_RETRY_MAX
@@ -470,7 +478,7 @@ def _read_synthetic_retry_max(loop_logger: logging.Logger | None) -> int:
 
 
 def _serialize_assistant_message_for_retry(
-    message: Any, synthetic_tool_name: str
+    message: Any,
 ) -> dict[str, Any]:
     """Serialize the bad-attempt assistant turn into the dict shape that the
     LLM client accepts as a prior assistant turn.
@@ -552,15 +560,6 @@ async def _maybe_retry_synthetic_on_validation_failure(
         return synthetic_args, None
 
     try:
-        import jsonschema  # type: ignore
-    except ImportError:
-        effective_logger.warning(
-            "[provider:retry] jsonschema not importable; skipping synthetic-tool "
-            "validation retry (install jsonschema>=4)"
-        )
-        return synthetic_args, None
-
-    try:
         parsed_args = json.loads(synthetic_args) if synthetic_args else {}
     except (TypeError, ValueError) as e:
         # Malformed JSON is not what this retry is for — ResponseParser handles
@@ -577,12 +576,19 @@ async def _maybe_retry_synthetic_on_validation_failure(
         return synthetic_args, None
     except jsonschema.ValidationError as ve:
         first_error_msg = str(ve)
-    except Exception as e:  # noqa: BLE001 - guard against jsonschema oddities
+    except jsonschema.exceptions.SchemaError as schema_err:
+        # Provider-side schema authoring bug; loud WARN, no retry (won't help).
         effective_logger.warning(
-            "[provider:retry] unexpected error during synthetic-tool schema "
-            "validation (%s: %s); skipping retry",
-            type(e).__name__,
-            e,
+            "[provider:retry] synthetic tool schema is malformed (SchemaError: %s) — "
+            "skipping retry; this indicates a provider/decorator misconfiguration",
+            schema_err,
+        )
+        return synthetic_args, None
+    except Exception as exc:  # noqa: BLE001 - guard against jsonschema oddities
+        # jsonschema oddity (corrupt args, decode failure, etc.) — log and skip retry.
+        effective_logger.warning(
+            "[provider:retry] unexpected error during schema validation pre-check: %s — skipping retry",
+            exc,
         )
         return synthetic_args, None
 
@@ -611,6 +617,10 @@ async def _maybe_retry_synthetic_on_validation_failure(
             f"directly as the tool arguments."
         ),
     }
+    # Invariant: current_messages ends in a USER turn at this point — the
+    # loop only invokes this helper after the LLM's first response, which
+    # was the assistant turn we're appending below. Anthropic rejects
+    # assistant→assistant adjacency.
     new_messages = list(current_messages) + [
         assistant_message_dict,
         tool_result_dict,
@@ -626,6 +636,8 @@ async def _maybe_retry_synthetic_on_validation_failure(
         # risking another tool-call detour. OpenAI-shape tool_choice is what
         # ``_inject_synthetic_format_tool`` and the rest of the loop use; the
         # vendor-native adapters translate as needed.
+        # Use OpenAI shape; anthropic_native._convert_tool_choice
+        # (anthropic_native.py:800-807) translates to {"type": "tool", "name": ...}.
         "tool_choice": {
             "type": "function",
             "function": {"name": synthetic_tool_name},
@@ -643,25 +655,39 @@ async def _maybe_retry_synthetic_on_validation_failure(
 
     # Mirror the dispatch logic of the outer loop: prefer native handler when
     # available, otherwise fall back to LiteLLM via asyncio.to_thread.
-    if native_handler is not None and native_handler.has_native():
-        native_args = {
-            k: v
-            for k, v in retry_args.items()
-            if k not in ("model", "api_key", "base_url")
-        }
-        retry_response = await native_handler.complete(
-            native_args,
-            model=effective_model,
-            api_key=retry_args.get("api_key"),
-            base_url=retry_args.get("base_url"),
+    # The retry call itself can fail (rate limits, timeouts, anthropic outages,
+    # transient network errors). When it does, fall back to the original (bad)
+    # args so ResponseParser's defensive envelope-unwrap (PR #960) still gets
+    # a chance to salvage — the documented "ResponseParser is the final salvage
+    # gate" design must hold across transient retry failures.
+    try:
+        if native_handler is not None and native_handler.has_native():
+            native_args = {
+                k: v
+                for k, v in retry_args.items()
+                if k not in ("model", "api_key", "base_url")
+            }
+            retry_response = await native_handler.complete(
+                native_args,
+                model=effective_model,
+                api_key=retry_args.get("api_key"),
+                base_url=retry_args.get("base_url"),
+            )
+        else:
+            retry_response = await asyncio.to_thread(
+                litellm_module.completion, **retry_args
+            )
+    except Exception as retry_exc:  # noqa: BLE001 - any retry failure falls back
+        effective_logger.warning(
+            "[provider:retry] retry call raised %s: %s; falling back to "
+            "original (attempt 1) args for downstream salvage",
+            type(retry_exc).__name__,
+            retry_exc,
         )
-    else:
-        retry_response = await asyncio.to_thread(
-            litellm_module.completion, **retry_args
-        )
+        return synthetic_args, None
 
     retry_message = retry_response.choices[0].message
-    retry_args_str = _extract_synthetic_format_arguments(
+    retry_args_str, _retry_tc_id = _extract_synthetic_format_arguments(
         retry_message, synthetic_tool_name
     )
     if retry_args_str is None:
@@ -699,10 +725,6 @@ async def _maybe_retry_synthetic_on_validation_failure(
             "prompt_tokens": getattr(ru, "prompt_tokens", 0) or 0,
             "completion_tokens": getattr(ru, "completion_tokens", 0) or 0,
         }
-        retry_usage_dict["total_tokens"] = (
-            retry_usage_dict["prompt_tokens"]
-            + retry_usage_dict["completion_tokens"]
-        )
 
     return retry_args_str, retry_usage_dict
 
@@ -1140,7 +1162,7 @@ async def _provider_agentic_loop(
         # synthetic call signals "I'm done", and executing additional tools
         # would mean another iteration that the model already opted out of.
         if synthetic_tool_name and hasattr(message, "tool_calls") and message.tool_calls:
-            synthetic_args = _extract_synthetic_format_arguments(
+            synthetic_args, bad_tc_id = _extract_synthetic_format_arguments(
                 message, synthetic_tool_name
             )
             if synthetic_args is not None:
@@ -1163,17 +1185,12 @@ async def _provider_agentic_loop(
                 # TODO(#961): enable retry for openai/gemini after per-vendor
                 # verification of the corrective-prompt round-trip.
                 retry_usage: dict | None = None
+                # ``bad_tc_id`` is the synthetic tool_call's id recovered
+                # alongside ``synthetic_args`` above — it's the bad
+                # ``tool_use_id`` that the corrective ``role:tool`` message
+                # must reference for the Anthropic tool_use/tool_result
+                # correlation contract.
                 if vendor == "anthropic" and synthetic_tool is not None:
-                    # Locate the synthetic tool_call to recover its id (the
-                    # bad ``tool_use_id`` that the corrective ``role:tool``
-                    # message must reference).
-                    bad_tc_id: str | None = None
-                    for _tc in message.tool_calls:
-                        _fn = getattr(_tc, "function", None)
-                        if _fn is not None and getattr(_fn, "name", None) == synthetic_tool_name:
-                            bad_tc_id = getattr(_tc, "id", None)
-                            break
-
                     if bad_tc_id is not None:
                         # Rebuild a fresh template from the current iteration's
                         # completion_args (excluding messages/tools/tool_choice
@@ -1197,7 +1214,7 @@ async def _provider_agentic_loop(
                                 synthetic_tool_name=synthetic_tool_name,
                                 bad_tool_use_id=bad_tc_id,
                                 assistant_message_dict=_serialize_assistant_message_for_retry(
-                                    message, synthetic_tool_name
+                                    message
                                 ),
                                 current_messages=current_messages,
                                 tools=tools,
@@ -2225,7 +2242,7 @@ def llm_provider(
                 # try to "execute" a synthetic tool that has no MCP endpoint.
                 synthetic_args: str | None = None
                 if synthetic_tool_name:
-                    synthetic_args = _extract_synthetic_format_arguments(
+                    synthetic_args, _ = _extract_synthetic_format_arguments(
                         message, synthetic_tool_name
                     )
 

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -428,6 +428,285 @@ async def _maybe_run_hint_fallback(
     return (fb_content if fb_content else "", fb_message, fallback_response)
 
 
+# Default cap on synthetic-tool corrective retries (issue #961). Set to 0 to
+# disable; values > 1 are accepted but discouraged because the corrective
+# prompt is bounded — additional iterations rarely buy more than the first.
+_DEFAULT_SYNTHETIC_RETRY_MAX = 1
+
+
+def _read_synthetic_retry_max(loop_logger: logging.Logger | None) -> int:
+    """Parse ``MCP_MESH_LLM_SYNTHETIC_RETRY_MAX`` once with safe defaults.
+
+    Negative or non-integer values fall back to the default (1) and emit a
+    single WARN per call so that misconfiguration surfaces in logs without
+    masking the retry feature entirely.
+    """
+    import os
+
+    raw = os.environ.get("MCP_MESH_LLM_SYNTHETIC_RETRY_MAX")
+    if raw is None or raw == "":
+        return _DEFAULT_SYNTHETIC_RETRY_MAX
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        if loop_logger:
+            loop_logger.warning(
+                "Invalid MCP_MESH_LLM_SYNTHETIC_RETRY_MAX=%r (expected int >= 0); "
+                "falling back to default %d",
+                raw,
+                _DEFAULT_SYNTHETIC_RETRY_MAX,
+            )
+        return _DEFAULT_SYNTHETIC_RETRY_MAX
+    if value < 0:
+        if loop_logger:
+            loop_logger.warning(
+                "Invalid MCP_MESH_LLM_SYNTHETIC_RETRY_MAX=%d (must be >= 0); "
+                "falling back to default %d",
+                value,
+                _DEFAULT_SYNTHETIC_RETRY_MAX,
+            )
+        return _DEFAULT_SYNTHETIC_RETRY_MAX
+    return value
+
+
+def _serialize_assistant_message_for_retry(
+    message: Any, synthetic_tool_name: str
+) -> dict[str, Any]:
+    """Serialize the bad-attempt assistant turn into the dict shape that the
+    LLM client accepts as a prior assistant turn.
+
+    Mirrors the conversation-dict shape built when real tool calls iterate
+    (see :func:`_build_assistant_tool_call_dict` and the assistant_msg
+    construction in ``_provider_agentic_loop``). Used by the synthetic-tool
+    corrective-retry path (issue #961) to thread the failed ``tool_use``
+    back to the model so its next turn can reference the same tool_use_id
+    via a ``role:tool`` message.
+    """
+    tool_calls = getattr(message, "tool_calls", None) or []
+    return {
+        "role": getattr(message, "role", "assistant"),
+        "content": getattr(message, "content", "") or "",
+        "tool_calls": [_build_assistant_tool_call_dict(tc) for tc in tool_calls],
+    }
+
+
+async def _maybe_retry_synthetic_on_validation_failure(
+    *,
+    synthetic_args: str,
+    synthetic_tool: dict,
+    synthetic_tool_name: str,
+    bad_tool_use_id: str,
+    assistant_message_dict: dict,
+    current_messages: list[dict],
+    tools: list[dict],
+    completion_args_template: dict,
+    native_handler,
+    litellm_module,
+    effective_model: str,
+    vendor: str | None,
+    loop_logger: logging.Logger | None,
+) -> tuple[str, dict | None]:
+    """Validate synthetic-tool args against the schema; retry once on failure.
+
+    Issue #961 — adds a shape-agnostic, schema-driven corrective retry to the
+    native-path provider agentic loop. The native synthetic-tool path is
+    single-shot: when Claude returns malformed ``tool_use.input`` (for
+    example, the well-known ``{"parameter": {<real fields>}}`` envelope
+    hallucination), Pydantic validation downstream fails with no recovery.
+    This helper runs a provider-side ``jsonschema`` pre-filter on the
+    synthetic-tool arguments and, on failure, asks the model to try again
+    with the schema and the validation error inlined into the prompt.
+    Mirrors the LiteLLM HINT->``response_format`` fallback pattern in
+    :func:`_maybe_run_hint_fallback`.
+
+    Returns ``(final_args_str, usage_to_fold_or_None)``. If validation
+    passes or the retry feature is disabled (``MCP_MESH_LLM_SYNTHETIC_RETRY_MAX=0``),
+    returns the input ``synthetic_args`` unchanged with ``usage=None``. On
+    retry, returns the second attempt's args (whether validated or not —
+    :class:`_mcp_mesh.engine.response_parser.ResponseParser` is the final
+    gate; validation failure on attempt 2 falls through with a WARN so the
+    consumer-side parser can apply its own envelope-unwrap heuristic before
+    Pydantic raises) plus the retry call's usage dict so callers can fold
+    it into their cumulative ``_mesh_usage`` block.
+
+    Tracing: TODO(#961) — when the OpenTelemetry tracer is wired into this
+    module the retry call should be wrapped in a span with attributes
+    ``mesh.llm.synthetic_retry=true``, ``mesh.llm.vendor``,
+    ``mesh.llm.model``, ``mesh.llm.validation_error``. Until then the same
+    information is captured at WARN level.
+    """
+    # Fall back to the module logger when no caller-supplied logger is
+    # threaded through — the buffered loop's ``loop_logger`` parameter is
+    # ``None`` by default, but observability still needs the WARN trail
+    # because the consumer-facing failure mode (Pydantic validation error)
+    # is downstream of this helper.
+    effective_logger = loop_logger if loop_logger is not None else logger
+
+    retry_max = _read_synthetic_retry_max(effective_logger)
+    if retry_max <= 0:
+        return synthetic_args, None
+
+    schema = (synthetic_tool or {}).get("function", {}).get("parameters")
+    if not schema:
+        # No schema to validate against — nothing to retry for.
+        return synthetic_args, None
+
+    try:
+        import jsonschema  # type: ignore
+    except ImportError:
+        effective_logger.warning(
+            "[provider:retry] jsonschema not importable; skipping synthetic-tool "
+            "validation retry (install jsonschema>=4)"
+        )
+        return synthetic_args, None
+
+    try:
+        parsed_args = json.loads(synthetic_args) if synthetic_args else {}
+    except (TypeError, ValueError) as e:
+        # Malformed JSON is not what this retry is for — ResponseParser handles
+        # the salvage path. Don't mask weird bugs; just log and bail.
+        effective_logger.warning(
+            "[provider:retry] synthetic args not JSON-parseable (%s); skipping "
+            "validation retry",
+            e,
+        )
+        return synthetic_args, None
+
+    try:
+        jsonschema.validate(instance=parsed_args, schema=schema)
+        return synthetic_args, None
+    except jsonschema.ValidationError as ve:
+        first_error_msg = str(ve)
+    except Exception as e:  # noqa: BLE001 - guard against jsonschema oddities
+        effective_logger.warning(
+            "[provider:retry] unexpected error during synthetic-tool schema "
+            "validation (%s: %s); skipping retry",
+            type(e).__name__,
+            e,
+        )
+        return synthetic_args, None
+
+    # Build the corrective conversation: prior turn (with the bad tool_use)
+    # + a tool result acknowledging the failure + a user message that inlines
+    # the schema and the validation error.
+    tool_result_dict = {
+        "role": "tool",
+        "tool_call_id": bad_tool_use_id,
+        "content": json.dumps(
+            {"error": "schema validation failed", "is_error": True}
+        ),
+    }
+    corrective_user_dict = {
+        "role": "user",
+        "content": (
+            f"Your previous response to {synthetic_tool_name} failed schema validation:\n"
+            f"<error>{first_error_msg[:2000]}</error>\n"
+            f"\n"
+            f"The required schema is:\n"
+            f"<schema>{json.dumps(schema, indent=2)}</schema>\n"
+            f"\n"
+            f"Call {synthetic_tool_name} again with arguments that exactly match the "
+            f"schema. Do NOT wrap the fields in an envelope (e.g., "
+            f'{{"parameter": {{...}}}} or {{"input": {{...}}}}). Pass the fields '
+            f"directly as the tool arguments."
+        ),
+    }
+    new_messages = list(current_messages) + [
+        assistant_message_dict,
+        tool_result_dict,
+        corrective_user_dict,
+    ]
+
+    retry_args = {
+        **completion_args_template,
+        "messages": new_messages,
+        "tools": tools,
+        # Force the synthetic on retry — the model already chose it once, and
+        # we want a deterministic single-call corrective turn rather than
+        # risking another tool-call detour. OpenAI-shape tool_choice is what
+        # ``_inject_synthetic_format_tool`` and the rest of the loop use; the
+        # vendor-native adapters translate as needed.
+        "tool_choice": {
+            "type": "function",
+            "function": {"name": synthetic_tool_name},
+        },
+    }
+
+    effective_logger.warning(
+        "[provider:retry] synthetic-tool schema validation failed (attempt 1) "
+        "for vendor=%s model=%s tool=%s: %s; retrying once",
+        vendor,
+        effective_model,
+        synthetic_tool_name,
+        first_error_msg[:500],
+    )
+
+    # Mirror the dispatch logic of the outer loop: prefer native handler when
+    # available, otherwise fall back to LiteLLM via asyncio.to_thread.
+    if native_handler is not None and native_handler.has_native():
+        native_args = {
+            k: v
+            for k, v in retry_args.items()
+            if k not in ("model", "api_key", "base_url")
+        }
+        retry_response = await native_handler.complete(
+            native_args,
+            model=effective_model,
+            api_key=retry_args.get("api_key"),
+            base_url=retry_args.get("base_url"),
+        )
+    else:
+        retry_response = await asyncio.to_thread(
+            litellm_module.completion, **retry_args
+        )
+
+    retry_message = retry_response.choices[0].message
+    retry_args_str = _extract_synthetic_format_arguments(
+        retry_message, synthetic_tool_name
+    )
+    if retry_args_str is None:
+        effective_logger.warning(
+            "[provider:retry] retry response did not call synthetic tool '%s' — "
+            "falling back to original (bad) args; ResponseParser will attempt "
+            "envelope-unwrap salvage",
+            synthetic_tool_name,
+        )
+        return synthetic_args, None
+
+    # Log attempt 2's validation outcome too — useful when both attempts fail.
+    try:
+        retry_parsed = json.loads(retry_args_str) if retry_args_str else {}
+        jsonschema.validate(instance=retry_parsed, schema=schema)
+    except jsonschema.ValidationError as ve2:
+        effective_logger.warning(
+            "[provider:retry] synthetic-tool schema validation still failed "
+            "(attempt 2) for vendor=%s model=%s tool=%s: %s; returning "
+            "second-attempt args anyway (ResponseParser is the final gate)",
+            vendor,
+            effective_model,
+            synthetic_tool_name,
+            str(ve2)[:500],
+        )
+    except Exception:  # noqa: BLE001
+        # Non-validation errors on attempt 2 are ignored here — the args are
+        # returned regardless and ResponseParser will surface any real failure.
+        pass
+
+    retry_usage_dict: dict | None = None
+    if hasattr(retry_response, "usage") and retry_response.usage:
+        ru = retry_response.usage
+        retry_usage_dict = {
+            "prompt_tokens": getattr(ru, "prompt_tokens", 0) or 0,
+            "completion_tokens": getattr(ru, "completion_tokens", 0) or 0,
+        }
+        retry_usage_dict["total_tokens"] = (
+            retry_usage_dict["prompt_tokens"]
+            + retry_usage_dict["completion_tokens"]
+        )
+
+    return retry_args_str, retry_usage_dict
+
+
 def _extract_text_from_message_content(content: Any) -> str:
     """Normalize a LiteLLM message ``content`` field to a plain string.
 
@@ -874,6 +1153,63 @@ async def _provider_agentic_loop(
                         iteration,
                         max_iterations,
                     )
+
+                # Schema-validation retry for the synthetic tool (issue #961).
+                # Gated to anthropic for v1 — the bad-tool_use_id round-trip
+                # follows Anthropic's tool_use/tool_result correlation contract;
+                # OpenAI/Gemini equivalents need per-vendor verification before
+                # opt-in. See the helper docstring for the corrective-prompt
+                # rationale.
+                # TODO(#961): enable retry for openai/gemini after per-vendor
+                # verification of the corrective-prompt round-trip.
+                retry_usage: dict | None = None
+                if vendor == "anthropic" and synthetic_tool is not None:
+                    # Locate the synthetic tool_call to recover its id (the
+                    # bad ``tool_use_id`` that the corrective ``role:tool``
+                    # message must reference).
+                    bad_tc_id: str | None = None
+                    for _tc in message.tool_calls:
+                        _fn = getattr(_tc, "function", None)
+                        if _fn is not None and getattr(_fn, "name", None) == synthetic_tool_name:
+                            bad_tc_id = getattr(_tc, "id", None)
+                            break
+
+                    if bad_tc_id is not None:
+                        # Rebuild a fresh template from the current iteration's
+                        # completion_args (excluding messages/tools/tool_choice
+                        # which the helper sets explicitly, and stream flags
+                        # that don't apply on the buffered retry path).
+                        retry_template = {
+                            k: v
+                            for k, v in completion_args.items()
+                            if k not in (
+                                "messages",
+                                "tools",
+                                "tool_choice",
+                                "stream",
+                                "stream_options",
+                            )
+                        }
+                        synthetic_args, retry_usage = (
+                            await _maybe_retry_synthetic_on_validation_failure(
+                                synthetic_args=synthetic_args,
+                                synthetic_tool=synthetic_tool,
+                                synthetic_tool_name=synthetic_tool_name,
+                                bad_tool_use_id=bad_tc_id,
+                                assistant_message_dict=_serialize_assistant_message_for_retry(
+                                    message, synthetic_tool_name
+                                ),
+                                current_messages=current_messages,
+                                tools=tools,
+                                completion_args_template=retry_template,
+                                native_handler=_native_handler,
+                                litellm_module=litellm,
+                                effective_model=effective_model,
+                                vendor=vendor,
+                                loop_logger=loop_logger,
+                            )
+                        )
+
                 message_dict: dict[str, Any] = {
                     "role": getattr(message, "role", "assistant"),
                     "content": synthetic_args,
@@ -885,6 +1221,24 @@ async def _provider_agentic_loop(
                         "completion_tokens": getattr(usage, "completion_tokens", 0) or 0,
                         "model": effective_model,
                     }
+                # Fold retry usage into the cumulative block so observability
+                # captures the corrective call's tokens.
+                if retry_usage:
+                    if "_mesh_usage" not in message_dict:
+                        message_dict["_mesh_usage"] = {
+                            "prompt_tokens": 0,
+                            "completion_tokens": 0,
+                            "model": effective_model,
+                        }
+                    bucket = message_dict["_mesh_usage"]
+                    bucket["prompt_tokens"] = (
+                        bucket.get("prompt_tokens", 0)
+                        + retry_usage.get("prompt_tokens", 0)
+                    )
+                    bucket["completion_tokens"] = (
+                        bucket.get("completion_tokens", 0)
+                        + retry_usage.get("completion_tokens", 0)
+                    )
                 return message_dict
 
         if hasattr(message, "tool_calls") and message.tool_calls:
@@ -1102,6 +1456,14 @@ async def _provider_agentic_loop_stream(
         iterations followed by a final iteration that returns empty
         content).
     """
+    # TODO(#961): synthetic-tool validation retry is not implemented for the
+    # streaming path. The buffered loop performs a one-shot corrective retry
+    # via :func:`_maybe_retry_synthetic_on_validation_failure` when Claude
+    # returns malformed ``tool_use.input`` against the synthetic tool schema;
+    # the streaming path needs an equivalent path that handles mid-stream
+    # tool_use accumulation, abandons the in-flight stream cleanly, and
+    # re-issues the corrective call without breaking partial-text yields.
+    # Tracking issue: https://github.com/dhyanraj/mcp-mesh/issues/961.
     import litellm
 
     # Imported here to avoid a circular import: ``_mcp_mesh.engine`` imports

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -479,6 +479,7 @@ def _read_synthetic_retry_max(loop_logger: logging.Logger | None) -> int:
 
 def _serialize_assistant_message_for_retry(
     message: Any,
+    bad_tool_use_id: str | None = None,
 ) -> dict[str, Any]:
     """Serialize the bad-attempt assistant turn into the dict shape that the
     LLM client accepts as a prior assistant turn.
@@ -489,12 +490,26 @@ def _serialize_assistant_message_for_retry(
     corrective-retry path (issue #961) to thread the failed ``tool_use``
     back to the model so its next turn can reference the same tool_use_id
     via a ``role:tool`` message.
+
+    When ``bad_tool_use_id`` is supplied, the ``tool_calls`` list is filtered
+    to the single entry whose ``id`` matches. This preserves Anthropic's 1:1
+    ``tool_use``/``tool_result`` correlation invariant: the corrective retry
+    only emits one ``tool_result`` (for ``bad_tool_use_id``), so any other
+    parallel ``tool_use`` blocks from the same assistant turn would be
+    orphaned and rejected by the API. Per
+    :func:`_extract_synthetic_format_arguments`, the model may return real
+    tool calls AND the synthetic in the same turn; this filter ensures the
+    retry payload is protocol-conformant in that case.
     """
-    tool_calls = getattr(message, "tool_calls", None) or []
+    raw_tool_calls = getattr(message, "tool_calls", None) or []
+    if bad_tool_use_id:
+        raw_tool_calls = [
+            tc for tc in raw_tool_calls if getattr(tc, "id", None) == bad_tool_use_id
+        ]
     return {
         "role": getattr(message, "role", "assistant"),
         "content": getattr(message, "content", "") or "",
-        "tool_calls": [_build_assistant_tool_call_dict(tc) for tc in tool_calls],
+        "tool_calls": [_build_assistant_tool_call_dict(tc) for tc in raw_tool_calls],
     }
 
 
@@ -1214,7 +1229,7 @@ async def _provider_agentic_loop(
                                 synthetic_tool_name=synthetic_tool_name,
                                 bad_tool_use_id=bad_tc_id,
                                 assistant_message_dict=_serialize_assistant_message_for_retry(
-                                    message
+                                    message, bad_tool_use_id=bad_tc_id
                                 ),
                                 current_messages=current_messages,
                                 tools=tools,

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -79,7 +79,8 @@ dependencies = [
     "redis>=4.0.0,<7.0.0",
     "cachetools>=5.3.0",
     "watchfiles>=1.0.0",
-    "orjson>=3.10.0"
+    "orjson>=3.10.0",
+    "jsonschema>=4"
 ]
 
 [project.optional-dependencies]
@@ -92,8 +93,7 @@ dev = [
     "mypy>=1.16.0",
     "pre-commit>=4.0.0",
     "isort>=6.0.0",
-    "bandit[toml]>=1.7.0",
-    "jsonschema>=4.0.0"
+    "bandit[toml]>=1.7.0"
 ]
 docs = [
     "mkdocs>=1.5.0",

--- a/src/runtime/python/tests/unit/test_provider_agentic_loop_synthetic_format.py
+++ b/src/runtime/python/tests/unit/test_provider_agentic_loop_synthetic_format.py
@@ -383,9 +383,12 @@ class TestBufferedLoopSyntheticRecognition:
         """
         from mesh.helpers import _provider_agentic_loop
 
+        # Schema-valid args so issue #961's synthetic-tool validation retry
+        # does NOT fire — this test asserts on the FIRST/only call's
+        # ``tool_choice``, not the corrective-retry call's forced choice.
         msg = _message(
             content=None,
-            tool_calls=[_tool_call("t", SYNTHETIC_TOOL_NAME, "{}")],
+            tool_calls=[_tool_call("t", SYNTHETIC_TOOL_NAME, '{"answer":"hi"}')],
         )
 
         with patch("asyncio.to_thread", new=AsyncMock(return_value=_response(msg))) as mock_call:
@@ -419,9 +422,13 @@ class TestBufferedLoopSyntheticRecognition:
         """
         from mesh.helpers import _provider_agentic_loop
 
+        # Schema-valid args so issue #961's synthetic-tool validation retry
+        # does NOT fire — this test asserts the FIRST-call forced-synthetic
+        # ``tool_choice`` set by ``_inject_synthetic_format_tool``, which is
+        # already the same shape the retry would force.
         msg = _message(
             content=None,
-            tool_calls=[_tool_call("t", SYNTHETIC_TOOL_NAME, "{}")],
+            tool_calls=[_tool_call("t", SYNTHETIC_TOOL_NAME, '{"answer":"hi"}')],
         )
 
         with patch("asyncio.to_thread", new=AsyncMock(return_value=_response(msg))) as mock_call:

--- a/src/runtime/python/tests/unit/test_provider_agentic_loop_synthetic_retry.py
+++ b/src/runtime/python/tests/unit/test_provider_agentic_loop_synthetic_retry.py
@@ -670,3 +670,77 @@ class TestProviderAgenticLoopSyntheticRetry:
         assert any(
             "did not call synthetic tool" in m for m in warn_msgs
         ), f"Expected missing-synthetic-tool WARN; got: {warn_msgs}"
+
+
+# ---------------------------------------------------------------------------
+# _serialize_assistant_message_for_retry — Anthropic 1:1 invariant
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeAssistantMessageForRetry:
+    """Pin down the ``bad_tool_use_id`` filter that preserves Anthropic's
+    1:1 ``tool_use``/``tool_result`` correlation invariant on the
+    corrective-retry payload (issue #961). Per
+    ``_extract_synthetic_format_arguments``'s docstring, the model may emit
+    real tool calls AND the synthetic in the same turn — the retry only
+    sends one ``tool_result`` (for the bad synthetic call_id), so any
+    parallel real ``tool_use`` blocks must be filtered out of the prior
+    assistant turn or Anthropic rejects the request.
+    """
+
+    def test_serialize_filters_tool_calls_to_bad_id_when_message_has_multiple(self):
+        """Assistant turn carries 2 tool_calls (a real one and the synthetic);
+        only the entry whose id matches ``bad_tool_use_id`` is retained.
+        """
+        from mesh.helpers import _serialize_assistant_message_for_retry
+
+        msg = _message(
+            content=None,
+            tool_calls=[
+                _tool_call("toolu_real", "real_tool", '{"x": 1}'),
+                _tool_call("toolu_bad", SYNTHETIC_TOOL_NAME, '{"parameter": {}}'),
+            ],
+        )
+
+        out = _serialize_assistant_message_for_retry(msg, bad_tool_use_id="toolu_bad")
+
+        assert out["role"] == "assistant"
+        assert len(out["tool_calls"]) == 1
+        assert out["tool_calls"][0]["id"] == "toolu_bad"
+        assert out["tool_calls"][0]["function"]["name"] == SYNTHETIC_TOOL_NAME
+
+    def test_serialize_passes_through_all_tool_calls_when_no_bad_id(self):
+        """Backward-compat: no ``bad_tool_use_id`` → all tool_calls survive."""
+        from mesh.helpers import _serialize_assistant_message_for_retry
+
+        msg = _message(
+            content=None,
+            tool_calls=[
+                _tool_call("toolu_a", "a", "{}"),
+                _tool_call("toolu_b", "b", "{}"),
+            ],
+        )
+
+        out = _serialize_assistant_message_for_retry(msg)
+
+        assert len(out["tool_calls"]) == 2
+        assert {tc["id"] for tc in out["tool_calls"]} == {"toolu_a", "toolu_b"}
+
+    def test_serialize_with_bad_id_not_in_tool_calls_yields_empty_list(self):
+        """Defensive: if the supplied ``bad_tool_use_id`` doesn't match any
+        tool_call (shouldn't happen in practice — the id was extracted from
+        the same message), the filter yields an empty list rather than
+        falling back silently to all calls.
+        """
+        from mesh.helpers import _serialize_assistant_message_for_retry
+
+        msg = _message(
+            content=None,
+            tool_calls=[_tool_call("toolu_real", "real_tool", "{}")],
+        )
+
+        out = _serialize_assistant_message_for_retry(
+            msg, bad_tool_use_id="toolu_missing"
+        )
+
+        assert out["tool_calls"] == []

--- a/src/runtime/python/tests/unit/test_provider_agentic_loop_synthetic_retry.py
+++ b/src/runtime/python/tests/unit/test_provider_agentic_loop_synthetic_retry.py
@@ -1,0 +1,411 @@
+"""Unit tests for synthetic-tool corrective-retry in the provider agentic loop.
+
+Issue #961 — when Claude returns malformed ``tool_use.input`` against the
+``__mesh_format_response`` schema (the canonical example: the
+``{"parameter": {<real fields>}}`` envelope hallucination), the buffered
+provider agentic loop performs a single shape-agnostic, schema-driven
+corrective retry that mirrors the LiteLLM HINT->``response_format``
+fallback in :func:`mesh.helpers._maybe_run_hint_fallback`.
+
+These tests pin down the loop-side behavior. The PR #960 consumer-side
+single-key envelope unwrap is covered separately by
+``test_response_parser_unwrap.py``; this file is provider-side only.
+
+Mock pattern follows ``test_provider_agentic_loop_synthetic_format.py``
+(the local ``_func`` / ``_tool_call`` / ``_message`` / ``_response``
+factories are duplicated rather than imported because the source file
+keeps them module-private).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _force_litellm_path(monkeypatch):
+    """Force the LiteLLM dispatch path for every test in this module.
+
+    The synthetic-tool retry logic is identical on both native and LiteLLM
+    paths (the dispatch fork is just where the request is sent). Pinning
+    the LiteLLM path lets us mock ``asyncio.to_thread`` directly without
+    needing to stand up a fake native handler.
+    """
+    monkeypatch.setenv("MCP_MESH_NATIVE_LLM", "0")
+
+
+# ---------------------------------------------------------------------------
+# Test fakes (mirrored from test_provider_agentic_loop_synthetic_format.py).
+# ---------------------------------------------------------------------------
+
+
+def _func(name: str, arguments: str) -> MagicMock:
+    fn = MagicMock()
+    fn.name = name
+    fn.arguments = arguments
+    return fn
+
+
+def _tool_call(id: str, name: str, arguments: str) -> MagicMock:
+    tc = MagicMock()
+    tc.id = id
+    tc.type = "function"
+    tc.function = _func(name, arguments)
+    return tc
+
+
+def _message(content: str | None, tool_calls: list | None = None) -> MagicMock:
+    m = MagicMock()
+    m.content = content
+    m.role = "assistant"
+    m.tool_calls = tool_calls
+    return m
+
+
+def _response(
+    message: MagicMock,
+    prompt_tokens: int = 5,
+    completion_tokens: int = 3,
+) -> MagicMock:
+    resp = MagicMock()
+    choice = MagicMock()
+    choice.message = message
+    resp.choices = [choice]
+    usage = MagicMock()
+    usage.prompt_tokens = prompt_tokens
+    usage.completion_tokens = completion_tokens
+    resp.usage = usage
+    resp.model = "claude-sonnet-4-5"
+    return resp
+
+
+SYNTHETIC_TOOL_NAME = "__mesh_format_response"
+
+
+def _synthetic_tool() -> dict:
+    """Synthetic tool with a single-required-field schema.
+
+    The single ``answer`` required field is enough to exercise both the
+    pass and fail branches of ``jsonschema.validate``.
+    """
+    return {
+        "type": "function",
+        "function": {
+            "name": SYNTHETIC_TOOL_NAME,
+            "description": "synthetic format tool",
+            "parameters": {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+                "required": ["answer"],
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Buffered loop: synthetic-tool validation retry
+# ---------------------------------------------------------------------------
+
+
+class TestProviderAgenticLoopSyntheticRetry:
+    """Cover the issue #961 corrective-retry path on the buffered provider
+    agentic loop. All tests here gate on ``vendor=="anthropic"`` because the
+    v1 retry is anthropic-only (see the TODO at the wiring site in
+    ``_provider_agentic_loop``).
+    """
+
+    @pytest.mark.asyncio
+    async def test_retry_fires_on_envelope_shape_and_returns_corrected_args(self):
+        """First response wraps the real fields in the well-known
+        ``{"parameter": {...}}`` envelope (the exact hallucination shape that
+        motivated #961). Schema validation fails, the loop fires the
+        corrective retry, the second response returns clean schema-conformant
+        args, and that's what the loop surfaces as ``content``.
+        """
+        from mesh.helpers import _provider_agentic_loop
+
+        bad_args = json.dumps({"parameter": {"answer": "42"}})  # envelope
+        good_args = json.dumps({"answer": "42"})  # schema-conformant
+
+        bad_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("toolu_bad", SYNTHETIC_TOOL_NAME, bad_args)],
+        )
+        good_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("toolu_good", SYNTHETIC_TOOL_NAME, good_args)],
+        )
+
+        with patch(
+            "asyncio.to_thread",
+            new=AsyncMock(side_effect=[_response(bad_msg), _response(good_msg)]),
+        ) as mock_call:
+            result = await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-5",
+                messages=[{"role": "user", "content": "What's the answer?"}],
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_synthetic_format_tool_name": SYNTHETIC_TOOL_NAME,
+                    "_mesh_synthetic_format_tool": _synthetic_tool(),
+                },
+                litellm_kwargs={"api_key": "sk-test"},
+                max_iterations=5,
+                vendor="anthropic",
+            )
+
+        # Two LLM calls: original + one corrective retry.
+        assert mock_call.await_count == 2
+        # Final content is the GOOD args, not the envelope-wrapped one.
+        assert result["content"] == good_args
+        assert json.loads(result["content"]) == {"answer": "42"}
+
+    @pytest.mark.asyncio
+    async def test_retry_disabled_when_env_var_zero(self, monkeypatch):
+        """``MCP_MESH_LLM_SYNTHETIC_RETRY_MAX=0`` disables the feature
+        entirely. The bad args propagate unchanged for the consumer-side
+        Pydantic / ResponseParser to handle.
+        """
+        from mesh.helpers import _provider_agentic_loop
+
+        monkeypatch.setenv("MCP_MESH_LLM_SYNTHETIC_RETRY_MAX", "0")
+
+        bad_args = json.dumps({"parameter": {"answer": "42"}})
+        bad_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("toolu_bad", SYNTHETIC_TOOL_NAME, bad_args)],
+        )
+
+        with patch(
+            "asyncio.to_thread", new=AsyncMock(return_value=_response(bad_msg))
+        ) as mock_call:
+            result = await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-5",
+                messages=[{"role": "user", "content": "Q?"}],
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_synthetic_format_tool_name": SYNTHETIC_TOOL_NAME,
+                    "_mesh_synthetic_format_tool": _synthetic_tool(),
+                },
+                litellm_kwargs={},
+                max_iterations=5,
+                vendor="anthropic",
+            )
+
+        assert mock_call.await_count == 1
+        # Bad args propagate unchanged when the retry is disabled.
+        assert result["content"] == bad_args
+
+    @pytest.mark.asyncio
+    async def test_no_retry_when_first_response_validates(self):
+        """Happy path: the first response is schema-conformant, so no retry
+        fires and only ONE LLM call is made.
+        """
+        from mesh.helpers import _provider_agentic_loop
+
+        good_args = json.dumps({"answer": "hello"})
+        good_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("toolu_ok", SYNTHETIC_TOOL_NAME, good_args)],
+        )
+
+        with patch(
+            "asyncio.to_thread", new=AsyncMock(return_value=_response(good_msg))
+        ) as mock_call:
+            result = await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-5",
+                messages=[{"role": "user", "content": "Q?"}],
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_synthetic_format_tool_name": SYNTHETIC_TOOL_NAME,
+                    "_mesh_synthetic_format_tool": _synthetic_tool(),
+                },
+                litellm_kwargs={},
+                vendor="anthropic",
+            )
+
+        assert mock_call.await_count == 1
+        assert result["content"] == good_args
+
+    @pytest.mark.asyncio
+    async def test_retry_also_invalid_returns_second_args_unchanged(self, caplog):
+        """When BOTH the original and the corrective-retry call return
+        schema-invalid args, the loop returns the second-attempt args
+        anyway (the consumer-side ResponseParser is the final salvage gate)
+        and emits a WARN for each attempt for observability.
+        """
+        from mesh.helpers import _provider_agentic_loop
+
+        bad1 = json.dumps({"parameter": {"answer": "x"}})
+        bad2 = json.dumps({"input": {"answer": "y"}})
+        msg1 = _message(
+            content=None,
+            tool_calls=[_tool_call("t1", SYNTHETIC_TOOL_NAME, bad1)],
+        )
+        msg2 = _message(
+            content=None,
+            tool_calls=[_tool_call("t2", SYNTHETIC_TOOL_NAME, bad2)],
+        )
+
+        with patch(
+            "asyncio.to_thread",
+            new=AsyncMock(side_effect=[_response(msg1), _response(msg2)]),
+        ) as mock_call, caplog.at_level("WARNING", logger="mesh.helpers"):
+            result = await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-5",
+                messages=[{"role": "user", "content": "Q?"}],
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_synthetic_format_tool_name": SYNTHETIC_TOOL_NAME,
+                    "_mesh_synthetic_format_tool": _synthetic_tool(),
+                },
+                litellm_kwargs={},
+                vendor="anthropic",
+            )
+
+        assert mock_call.await_count == 2
+        # Returned content is the second-attempt args.
+        assert result["content"] == bad2
+
+        warn_msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        # Exactly one WARN per attempt — attempt 1 (initial failure) +
+        # attempt 2 (still-failed) — both routed through the retry helper.
+        assert any("attempt 1" in m for m in warn_msgs), (
+            f"Expected attempt-1 WARN; got: {warn_msgs}"
+        )
+        assert any("attempt 2" in m for m in warn_msgs), (
+            f"Expected attempt-2 WARN; got: {warn_msgs}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_retry_preserves_model_messages_tools_and_forces_synthetic_tool_choice(self):
+        """The corrective retry call must preserve model + api_key + the
+        augmented tools list, append exactly three new messages (assistant
+        bad-turn + tool result + corrective user), and force ``tool_choice``
+        to the synthetic tool.
+        """
+        from mesh.helpers import _provider_agentic_loop
+
+        bad_args = json.dumps({"parameter": {"answer": "x"}})
+        good_args = json.dumps({"answer": "x"})
+        bad_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("toolu_bad", SYNTHETIC_TOOL_NAME, bad_args)],
+        )
+        good_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("toolu_good", SYNTHETIC_TOOL_NAME, good_args)],
+        )
+
+        original_messages = [{"role": "user", "content": "Q?"}]
+
+        with patch(
+            "asyncio.to_thread",
+            new=AsyncMock(side_effect=[_response(bad_msg), _response(good_msg)]),
+        ) as mock_call:
+            await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-5",
+                messages=original_messages,
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_synthetic_format_tool_name": SYNTHETIC_TOOL_NAME,
+                    "_mesh_synthetic_format_tool": _synthetic_tool(),
+                },
+                litellm_kwargs={"api_key": "sk-test"},
+                max_iterations=5,
+                vendor="anthropic",
+            )
+
+        assert mock_call.await_count == 2
+        first_kwargs = mock_call.await_args_list[0].kwargs
+        retry_kwargs = mock_call.await_args_list[1].kwargs
+
+        # Model + api_key preserved across the retry call.
+        assert retry_kwargs["model"] == first_kwargs["model"]
+        assert retry_kwargs.get("api_key") == first_kwargs.get("api_key")
+
+        # Tools list preserved (synthetic already augmented in the first call,
+        # and we want the same augmented list on the retry).
+        assert retry_kwargs["tools"] == first_kwargs["tools"]
+        retry_tool_names = [t["function"]["name"] for t in retry_kwargs["tools"]]
+        assert SYNTHETIC_TOOL_NAME in retry_tool_names
+
+        # Messages: original (1) + assistant-bad-turn (1) + tool-result (1)
+        # + corrective-user (1) = 4 messages on the retry call.
+        assert len(retry_kwargs["messages"]) == len(first_kwargs["messages"]) + 3
+        last_three = retry_kwargs["messages"][-3:]
+        assert last_three[0]["role"] == "assistant"
+        assert last_three[1]["role"] == "tool"
+        assert last_three[1]["tool_call_id"] == "toolu_bad"
+        assert last_three[2]["role"] == "user"
+        # Corrective prompt mentions the tool name and the explicit
+        # "do NOT wrap" instruction.
+        corrective_text = last_three[2]["content"]
+        assert SYNTHETIC_TOOL_NAME in corrective_text
+        assert "envelope" in corrective_text
+        assert "schema validation" in corrective_text
+
+        # tool_choice forced to the synthetic tool on retry.
+        assert retry_kwargs["tool_choice"] == {
+            "type": "function",
+            "function": {"name": SYNTHETIC_TOOL_NAME},
+        }
+
+        # Internal mesh flags MUST NOT leak into the retry call (same
+        # invariant as the non-retry path).
+        assert "_mesh_synthetic_format_tool" not in retry_kwargs
+        assert "_mesh_synthetic_format_tool_name" not in retry_kwargs
+
+    @pytest.mark.asyncio
+    async def test_retry_usage_tokens_summed_across_both_calls(self):
+        """When BOTH calls report usage, the returned ``_mesh_usage`` block
+        sums prompt_tokens and completion_tokens across the original + retry
+        calls (so observability captures the corrective call's tokens).
+        """
+        from mesh.helpers import _provider_agentic_loop
+
+        bad_args = json.dumps({"parameter": {"answer": "x"}})
+        good_args = json.dumps({"answer": "x"})
+        bad_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("toolu_bad", SYNTHETIC_TOOL_NAME, bad_args)],
+        )
+        good_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("toolu_good", SYNTHETIC_TOOL_NAME, good_args)],
+        )
+        # Distinct token counts so the sum is unambiguous.
+        bad_resp = _response(bad_msg, prompt_tokens=10, completion_tokens=4)
+        good_resp = _response(good_msg, prompt_tokens=20, completion_tokens=8)
+
+        with patch(
+            "asyncio.to_thread",
+            new=AsyncMock(side_effect=[bad_resp, good_resp]),
+        ):
+            result = await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-5",
+                messages=[{"role": "user", "content": "Q?"}],
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_synthetic_format_tool_name": SYNTHETIC_TOOL_NAME,
+                    "_mesh_synthetic_format_tool": _synthetic_tool(),
+                },
+                litellm_kwargs={},
+                vendor="anthropic",
+            )
+
+        usage = result["_mesh_usage"]
+        # 10 (original prompt) + 20 (retry prompt) = 30
+        assert usage["prompt_tokens"] == 30
+        # 4 (original completion) + 8 (retry completion) = 12
+        assert usage["completion_tokens"] == 12
+        assert usage["model"] == "anthropic/claude-sonnet-4-5"

--- a/src/runtime/python/tests/unit/test_provider_agentic_loop_synthetic_retry.py
+++ b/src/runtime/python/tests/unit/test_provider_agentic_loop_synthetic_retry.py
@@ -409,3 +409,264 @@ class TestProviderAgenticLoopSyntheticRetry:
         # 4 (original completion) + 8 (retry completion) = 12
         assert usage["completion_tokens"] == 12
         assert usage["model"] == "anthropic/claude-sonnet-4-5"
+
+    @pytest.mark.asyncio
+    async def test_retry_short_circuits_for_non_anthropic_vendor(self):
+        """v1 vendor gate: when ``vendor != "anthropic"`` the retry helper is
+        not invoked even if validation would have failed. Original (bad) args
+        propagate unchanged for the consumer-side ResponseParser to handle.
+        Verifies the wiring-site vendor gate so future per-vendor opt-in can
+        be added without accidentally regressing the v1 scope.
+        """
+        from mesh.helpers import _provider_agentic_loop
+
+        bad_args = json.dumps({"parameter": {"answer": "x"}})
+        bad_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("toolu_bad", SYNTHETIC_TOOL_NAME, bad_args)],
+        )
+
+        with patch(
+            "asyncio.to_thread", new=AsyncMock(return_value=_response(bad_msg))
+        ) as mock_call:
+            result = await _provider_agentic_loop(
+                effective_model="openai/gpt-4o",
+                messages=[{"role": "user", "content": "Q?"}],
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_synthetic_format_tool_name": SYNTHETIC_TOOL_NAME,
+                    "_mesh_synthetic_format_tool": _synthetic_tool(),
+                },
+                litellm_kwargs={},
+                vendor="openai",
+            )
+
+        # Exactly one LLM call — the retry helper is gated out for openai.
+        assert mock_call.await_count == 1
+        # Bad args propagate unchanged.
+        assert result["content"] == bad_args
+
+    @pytest.mark.asyncio
+    async def test_retry_invalid_env_var_falls_back_to_default(self, monkeypatch, caplog):
+        """When ``MCP_MESH_LLM_SYNTHETIC_RETRY_MAX`` is non-integer (e.g.,
+        ``"abc"``), the helper logs a WARN and falls back to the default
+        (1) — the retry STILL fires.
+        """
+        from mesh.helpers import _provider_agentic_loop
+
+        monkeypatch.setenv("MCP_MESH_LLM_SYNTHETIC_RETRY_MAX", "abc")
+
+        bad_args = json.dumps({"parameter": {"answer": "x"}})
+        good_args = json.dumps({"answer": "x"})
+        bad_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("t1", SYNTHETIC_TOOL_NAME, bad_args)],
+        )
+        good_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("t2", SYNTHETIC_TOOL_NAME, good_args)],
+        )
+
+        with patch(
+            "asyncio.to_thread",
+            new=AsyncMock(side_effect=[_response(bad_msg), _response(good_msg)]),
+        ) as mock_call, caplog.at_level("WARNING", logger="mesh.helpers"):
+            result = await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-5",
+                messages=[{"role": "user", "content": "Q?"}],
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_synthetic_format_tool_name": SYNTHETIC_TOOL_NAME,
+                    "_mesh_synthetic_format_tool": _synthetic_tool(),
+                },
+                litellm_kwargs={},
+                vendor="anthropic",
+            )
+
+        # Retry STILL fires under the default — two LLM calls.
+        assert mock_call.await_count == 2
+        assert result["content"] == good_args
+        warn_msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any(
+            "MCP_MESH_LLM_SYNTHETIC_RETRY_MAX" in m and "abc" in m for m in warn_msgs
+        ), f"Expected invalid-env-var WARN; got: {warn_msgs}"
+
+    @pytest.mark.asyncio
+    async def test_retry_negative_env_var_falls_back_to_default(self, monkeypatch, caplog):
+        """``MCP_MESH_LLM_SYNTHETIC_RETRY_MAX="-1"`` is rejected the same way:
+        WARN logged, retry still fires under the default (1).
+        """
+        from mesh.helpers import _provider_agentic_loop
+
+        monkeypatch.setenv("MCP_MESH_LLM_SYNTHETIC_RETRY_MAX", "-1")
+
+        bad_args = json.dumps({"parameter": {"answer": "x"}})
+        good_args = json.dumps({"answer": "x"})
+        bad_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("t1", SYNTHETIC_TOOL_NAME, bad_args)],
+        )
+        good_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("t2", SYNTHETIC_TOOL_NAME, good_args)],
+        )
+
+        with patch(
+            "asyncio.to_thread",
+            new=AsyncMock(side_effect=[_response(bad_msg), _response(good_msg)]),
+        ) as mock_call, caplog.at_level("WARNING", logger="mesh.helpers"):
+            result = await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-5",
+                messages=[{"role": "user", "content": "Q?"}],
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_synthetic_format_tool_name": SYNTHETIC_TOOL_NAME,
+                    "_mesh_synthetic_format_tool": _synthetic_tool(),
+                },
+                litellm_kwargs={},
+                vendor="anthropic",
+            )
+
+        assert mock_call.await_count == 2
+        assert result["content"] == good_args
+        warn_msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any(
+            "MCP_MESH_LLM_SYNTHETIC_RETRY_MAX" in m and "-1" in m for m in warn_msgs
+        ), f"Expected negative-env-var WARN; got: {warn_msgs}"
+
+    @pytest.mark.asyncio
+    async def test_retry_missing_schema_skips_retry(self):
+        """When the synthetic tool has no ``parameters`` schema (None or {}),
+        the retry helper has nothing to validate against — it bails early
+        with no retry, returning the original args unchanged.
+        """
+        from mesh.helpers import _provider_agentic_loop
+
+        synthetic_tool_no_schema = {
+            "type": "function",
+            "function": {
+                "name": SYNTHETIC_TOOL_NAME,
+                "description": "synthetic format tool (no schema)",
+                "parameters": None,
+            },
+        }
+
+        bad_args = json.dumps({"parameter": {"answer": "x"}})
+        bad_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("toolu_bad", SYNTHETIC_TOOL_NAME, bad_args)],
+        )
+
+        with patch(
+            "asyncio.to_thread", new=AsyncMock(return_value=_response(bad_msg))
+        ) as mock_call:
+            result = await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-5",
+                messages=[{"role": "user", "content": "Q?"}],
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_synthetic_format_tool_name": SYNTHETIC_TOOL_NAME,
+                    "_mesh_synthetic_format_tool": synthetic_tool_no_schema,
+                },
+                litellm_kwargs={},
+                vendor="anthropic",
+            )
+
+        # No retry — single call only.
+        assert mock_call.await_count == 1
+        assert result["content"] == bad_args
+
+    @pytest.mark.asyncio
+    async def test_retry_dispatch_raises_returns_original_args(self, caplog):
+        """When the corrective-retry dispatch raises (rate limit, timeout,
+        anthropic outage, network error), the helper catches, logs WARN,
+        and returns the original (bad) args so the consumer-side
+        ResponseParser still has a chance to salvage. Validates the W1 fix.
+        """
+        from mesh.helpers import _provider_agentic_loop
+
+        bad_args = json.dumps({"parameter": {"answer": "x"}})
+        bad_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("toolu_bad", SYNTHETIC_TOOL_NAME, bad_args)],
+        )
+
+        # First call returns bad args; second call raises (transient failure).
+        with patch(
+            "asyncio.to_thread",
+            new=AsyncMock(
+                side_effect=[
+                    _response(bad_msg),
+                    RuntimeError("network error"),
+                ]
+            ),
+        ) as mock_call, caplog.at_level("WARNING", logger="mesh.helpers"):
+            result = await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-5",
+                messages=[{"role": "user", "content": "Q?"}],
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_synthetic_format_tool_name": SYNTHETIC_TOOL_NAME,
+                    "_mesh_synthetic_format_tool": _synthetic_tool(),
+                },
+                litellm_kwargs={},
+                vendor="anthropic",
+            )
+
+        # Two calls were attempted (original + retry).
+        assert mock_call.await_count == 2
+        # Original (bad) args returned for downstream salvage.
+        assert result["content"] == bad_args
+        # WARN about the retry exception was logged.
+        warn_msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any(
+            "retry call raised" in m and "RuntimeError" in m and "network error" in m
+            for m in warn_msgs
+        ), f"Expected retry-exception WARN; got: {warn_msgs}"
+
+    @pytest.mark.asyncio
+    async def test_retry_response_has_no_synthetic_tool_call_returns_original(self, caplog):
+        """When the corrective-retry response doesn't include a call to the
+        synthetic tool (model returned plain text or called a different tool),
+        the helper logs WARN and returns the original args so ResponseParser
+        can attempt envelope-unwrap salvage.
+        """
+        from mesh.helpers import _provider_agentic_loop
+
+        bad_args = json.dumps({"parameter": {"answer": "x"}})
+        bad_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("toolu_bad", SYNTHETIC_TOOL_NAME, bad_args)],
+        )
+        # Second response has plain text content, no tool_calls.
+        retry_msg = _message(content="I don't understand the request.", tool_calls=None)
+
+        with patch(
+            "asyncio.to_thread",
+            new=AsyncMock(side_effect=[_response(bad_msg), _response(retry_msg)]),
+        ) as mock_call, caplog.at_level("WARNING", logger="mesh.helpers"):
+            result = await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-5",
+                messages=[{"role": "user", "content": "Q?"}],
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_synthetic_format_tool_name": SYNTHETIC_TOOL_NAME,
+                    "_mesh_synthetic_format_tool": _synthetic_tool(),
+                },
+                litellm_kwargs={},
+                vendor="anthropic",
+            )
+
+        assert mock_call.await_count == 2
+        # Original (bad) args returned.
+        assert result["content"] == bad_args
+        warn_msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any(
+            "did not call synthetic tool" in m for m in warn_msgs
+        ), f"Expected missing-synthetic-tool WARN; got: {warn_msgs}"


### PR DESCRIPTION
## Summary

Restores LiteLLM-parity retry on synthetic-tool validation failure for the native Anthropic path. PR #862 lost the LiteLLM HINT→`response_format` fallback when migrating to the native SDK; PR #960 added a defensive single-key envelope unwrap for known shapes; this PR adds the **shape-agnostic retry** that re-prompts the LLM with the schema and validation error so it can self-correct.

## Architecture

- **Hook**: provider-side, inside `_provider_agentic_loop` at the synthetic-tool extraction site (mirrors `_maybe_run_hint_fallback` pattern). Lives where LLM client + conversation state + tool list all exist; `ResponseParser` is the wrong layer (consumer-side, no LLM client).
- **Validator**: `jsonschema` (provider-side pre-filter; Pydantic remains consumer-side source of truth). Promoted from transitive dep to explicit runtime dep in `pyproject.toml`.
- **Retry mechanics**: max 1 retry (configurable), corrective prompt with schema + truncated error + explicit "do NOT wrap in `parameter`/`input` envelopes" instruction, force `tool_choice` to the synthetic tool on retry, sum usage tokens across both calls.
- **On retry-also-fails**: return second attempt's args; PR #960's defensive unwrap + consumer-side `ResponseParser` handle the final outcome (preserves today's failure mode).
- **Anthropic protocol correctness**: corrective conversation appends `assistant(tool_use) → tool_result(is_error=true) → user(corrective)` to satisfy the tool_use/tool_result correlation contract.

## Configurability

`MCP_MESH_LLM_SYNTHETIC_RETRY_MAX` env var (default `1`, set to `0` to disable, invalid values fall back to default with WARN).

## Scope

- **Anthropic only for v1**. OpenAI/Gemini use the same loop but are explicitly gated out (`vendor == "anthropic"` check) with TODO referencing #961 for staged rollout.
- **Streaming path** (`_provider_agentic_loop_stream`) explicitly skipped with TODO — separate follow-up.

## Review Notes

Initial implementation reviewed; 4 warnings + 7 INFOs raised by review-agent. **All addressed in commit `5d2c50de`**:

- W1 (high-value): retry network call now wrapped in try/except — transient failures fall back to original args so ResponseParser's salvage path still runs
- W2: dropped dead `total_tokens` field from retry usage
- W3: added 6 edge-case tests (vendor short-circuit, env var parsing, missing schema, retry-raises, retry-no-synthetic-tool-call)
- W4: split `jsonschema.SchemaError` from generic exceptions — provider misconfig now produces loud WARN
- INFO 1-7: dead param removal, top-level imports, dead-import cleanup, protocol invariant comment, translation-pointer comment, tuple-return refactor on `_extract_synthetic_format_arguments` (eliminates duplicate walk)

INFO 6 explicitly skipped per scope decision.

## Tracing

Log-only with TODO. Tracer integration in `helpers.py` would require importing OpenTelemetry directly and managing spans around the retry call — non-trivial and tangential. WARN logs carry `vendor`, `model`, `tool_name`, and validation error (truncated to 500 chars). TODO in helper docstring tracks span upgrade.

Closes #961

## Test plan

- [x] 12 retry-suite tests pass (6 happy-path + 6 edge cases from W3)
- [x] 13 format-suite tests pass (no regressions; 2 minor mock-arg tweaks for retry-not-firing intent preservation)
- [x] 4 unwrap-suite tests pass (PR #960 carry-forward)
- [x] Full SDK unit suite: 903 passed, 0 failed
- [x] `pyproject.toml` lists `jsonschema>=4` as runtime dep
- [x] Streaming path has TODO referencing #961
- [x] Vendor gate is `vendor == "anthropic"` with TODO for openai/gemini
- [ ] Integration: `tests/integration/suites/uc20_tutorial/tc07_day07_committee` passes 10/10 consecutive runs (manual smoke pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic corrective retry for malformed synthetic tool outputs (Anthropic path), improving resilience when structured-output validation fails.
  * Retry behavior configurable via MCP_MESH_LLM_SYNTHETIC_RETRY_MAX (0 to disable).

* **Documentation**
  * Added docs describing provider retry behavior, defaults and validation semantics.

* **Tests**
  * Added unit tests covering retry scenarios, configuration parsing, and retry token accounting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/962)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->