### PR TITLE
fix(registry): derive agent trace activity from recent ring buffer

### DIFF
--- a/src/core/registry/tracing/accumulator.go
+++ b/src/core/registry/tracing/accumulator.go
@@ -57,9 +57,6 @@ type TraceAccumulator struct {
 	// Per-edge stats keyed by "source -> target"
 	edgeStats map[string]*edgeAccum
 
-	// Per-agent activity count (spans seen per agent)
-	agentActivity map[string]int
-
 	// Total number of finalized traces (never resets)
 	totalFinalized int
 
@@ -110,15 +107,14 @@ func NewTraceAccumulator(ringSize int, logger *log.Logger) *TraceAccumulator {
 		ringSize = 200
 	}
 	return &TraceAccumulator{
-		recentTraces:  make([]RecentTraceSummary, ringSize),
-		ringSize:      ringSize,
-		activeTraces:  make(map[string]*activeTrace),
-		edgeStats:     make(map[string]*edgeAccum),
-		agentActivity: make(map[string]int),
-		liveClients:   make(map[chan *LiveTraceEvent]struct{}),
-		dirtyTraces:   make(map[string]bool),
-		logger:        logger,
-		cancel:        make(chan struct{}),
+		recentTraces: make([]RecentTraceSummary, ringSize),
+		ringSize:     ringSize,
+		activeTraces: make(map[string]*activeTrace),
+		edgeStats:    make(map[string]*edgeAccum),
+		liveClients:  make(map[chan *LiveTraceEvent]struct{}),
+		dirtyTraces:  make(map[string]bool),
+		logger:       logger,
+		cancel:       make(chan struct{}),
 	}
 }
 
@@ -127,12 +123,10 @@ func (ta *TraceAccumulator) ProcessTraceEvent(event *TraceEvent) error {
 	ta.mu.Lock()
 	defer ta.mu.Unlock()
 
-	// 1. Update agent activity count
-	if event.AgentName != "" {
-		ta.agentActivity[event.AgentName]++
-	}
+	// Note: agent activity counts are derived from the recent-traces ring buffer
+	// in GetAgentActivity(); they are no longer incremented per span event.
 
-	// 2. Add to active trace (create if first span for this trace)
+	// Add to active trace (create if first span for this trace)
 	at, exists := ta.activeTraces[event.TraceID]
 	if !exists {
 		at = &activeTrace{
@@ -163,7 +157,7 @@ func (ta *TraceAccumulator) ProcessTraceEvent(event *TraceEvent) error {
 		at.RootOp = event.Operation
 	}
 
-	// 3. Publish live events based on trace state
+	// Publish live events based on trace state
 	if !exists {
 		// New trace — publish trace_started
 		ta.publishLive(&LiveTraceEvent{
@@ -172,7 +166,7 @@ func (ta *TraceAccumulator) ProcessTraceEvent(event *TraceEvent) error {
 		})
 	}
 
-	// 4. On root span completion (span_end with no parent), mark for deferred finalization.
+	// On root span completion (span_end with no parent), mark for deferred finalization.
 	// Don't finalize immediately — wait a short grace period for remaining in-flight
 	// spans from other processes to arrive via Redis consumer.
 	if event.DurationMS != nil && event.ParentSpan == nil {
@@ -454,13 +448,25 @@ func (ta *TraceAccumulator) GetTotalErrors() int {
 	return ta.totalErrors
 }
 
-// GetAgentActivity returns a copy of the agent activity map.
+// GetAgentActivity returns the per-agent count of finalized traces currently in
+// the recent-traces ring buffer that involve each agent. By construction this
+// matches what /trace/recent would return when filtered by an agent: the badge
+// count never exceeds the number of recent traces visible to the user.
+//
+// The map is computed on read by walking the ring buffer (size O(ringSize)
+// with small per-trace agent lists, so the cost is negligible at the ring
+// sizes we care about).
 func (ta *TraceAccumulator) GetAgentActivity() map[string]int {
 	ta.mu.RLock()
 	defer ta.mu.RUnlock()
-	result := make(map[string]int, len(ta.agentActivity))
-	for k, v := range ta.agentActivity {
-		result[k] = v
+	result := make(map[string]int)
+	for i := 0; i < ta.ringCount; i++ {
+		idx := (ta.ringHead - 1 - i + ta.ringSize) % ta.ringSize
+		for _, agent := range ta.recentTraces[idx].Agents {
+			if agent != "" {
+				result[agent]++
+			}
+		}
 	}
 	return result
 }

--- a/src/core/registry/tracing/accumulator_test.go
+++ b/src/core/registry/tracing/accumulator_test.go
@@ -1,0 +1,243 @@
+package tracing
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"testing"
+	"time"
+)
+
+// newTestAccumulator returns an accumulator with a quiet logger and the given
+// ring size. Background goroutines are NOT started — tests drive finalization
+// directly to keep them deterministic and fast.
+func newTestAccumulator(t *testing.T, ringSize int) *TraceAccumulator {
+	t.Helper()
+	logger := log.New(io.Discard, "", 0)
+	return NewTraceAccumulator(ringSize, logger)
+}
+
+// makeStartEvent builds a span_start event for the given trace/span/agent.
+// Pass parent="" for a root span.
+func makeStartEvent(traceID, spanID, parent, agent string) *TraceEvent {
+	var parentPtr *string
+	if parent != "" {
+		p := parent
+		parentPtr = &p
+	}
+	return &TraceEvent{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		ParentSpan: parentPtr,
+		AgentName:  agent,
+		Operation:  "test_op",
+		EventType:  "span_start",
+		Timestamp:  float64(time.Now().UnixNano()) / 1e9,
+		Runtime:    "go",
+	}
+}
+
+// makeEndEvent builds a span_end event. For root span, pass parent="".
+func makeEndEvent(traceID, spanID, parent, agent string, durationMs int64, success bool) *TraceEvent {
+	var parentPtr *string
+	if parent != "" {
+		p := parent
+		parentPtr = &p
+	}
+	d := durationMs
+	s := success
+	return &TraceEvent{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		ParentSpan: parentPtr,
+		AgentName:  agent,
+		Operation:  "test_op",
+		EventType:  "span_end",
+		Timestamp:  float64(time.Now().UnixNano()) / 1e9,
+		DurationMS: &d,
+		Success:    &s,
+		Runtime:    "go",
+	}
+}
+
+// finalizeNow forces any active traces with a seen root span to finalize
+// immediately, regardless of the grace period. It mutates RootSeen to be far
+// enough in the past then calls the package's finalizeReadyTraces helper.
+func finalizeNow(ta *TraceAccumulator) {
+	ta.mu.Lock()
+	past := time.Now().Add(-2 * traceGracePeriod)
+	for _, at := range ta.activeTraces {
+		if at.RootSeen != nil {
+			at.RootSeen = &past
+		}
+	}
+	ta.mu.Unlock()
+	ta.finalizeReadyTraces()
+}
+
+// pushTrace simulates a single-span trace from a single agent that finalizes
+// immediately.
+func pushTrace(ta *TraceAccumulator, traceID, agent string) {
+	_ = ta.ProcessTraceEvent(makeStartEvent(traceID, traceID+"-s", "", agent))
+	_ = ta.ProcessTraceEvent(makeEndEvent(traceID, traceID+"-s", "", agent, 5, true))
+	finalizeNow(ta)
+}
+
+// pushTraceMulti simulates a trace with one root span on rootAgent and one
+// child span on childAgent — both agents end up in the trace's Agents list.
+func pushTraceMulti(ta *TraceAccumulator, traceID, rootAgent, childAgent string) {
+	rootID := traceID + "-r"
+	childID := traceID + "-c"
+	_ = ta.ProcessTraceEvent(makeStartEvent(traceID, rootID, "", rootAgent))
+	_ = ta.ProcessTraceEvent(makeStartEvent(traceID, childID, rootID, childAgent))
+	_ = ta.ProcessTraceEvent(makeEndEvent(traceID, childID, rootID, childAgent, 2, true))
+	_ = ta.ProcessTraceEvent(makeEndEvent(traceID, rootID, "", rootAgent, 5, true))
+	finalizeNow(ta)
+}
+
+// TestAgentActivity_NoIncrementOnSpanEvent verifies that span events alone do
+// not bump the activity counter — only finalized traces in the ring buffer do.
+func TestAgentActivity_NoIncrementOnSpanEvent(t *testing.T) {
+	ta := newTestAccumulator(t, 20)
+
+	// Send several span_start events without any root_end → no finalization.
+	_ = ta.ProcessTraceEvent(makeStartEvent("t1", "s1", "", "agent-a"))
+	_ = ta.ProcessTraceEvent(makeStartEvent("t1", "s2", "s1", "agent-b"))
+	_ = ta.ProcessTraceEvent(makeStartEvent("t2", "s3", "", "agent-a"))
+
+	got := ta.GetAgentActivity()
+	if len(got) != 0 {
+		t.Fatalf("expected empty activity before finalization, got %v", got)
+	}
+}
+
+// TestAgentActivity_IncrementsOnFinalize verifies that once a trace is
+// finalized into the ring buffer, every agent in it gains +1 in the count.
+func TestAgentActivity_IncrementsOnFinalize(t *testing.T) {
+	ta := newTestAccumulator(t, 20)
+
+	pushTraceMulti(ta, "t1", "agent-a", "agent-b")
+
+	got := ta.GetAgentActivity()
+	if got["agent-a"] != 1 {
+		t.Errorf("agent-a: expected 1, got %d (full map: %v)", got["agent-a"], got)
+	}
+	if got["agent-b"] != 1 {
+		t.Errorf("agent-b: expected 1, got %d (full map: %v)", got["agent-b"], got)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 agents, got %d (%v)", len(got), got)
+	}
+}
+
+// TestAgentActivity_MatchesRecentTraces verifies that for each agent, the
+// activity count exactly equals the number of recent traces containing that
+// agent — the property that makes the badge match the detail tab by
+// construction.
+func TestAgentActivity_MatchesRecentTraces(t *testing.T) {
+	ta := newTestAccumulator(t, 20)
+
+	pushTrace(ta, "t1", "agent-a")
+	pushTraceMulti(ta, "t2", "agent-a", "agent-b")
+	pushTrace(ta, "t3", "agent-c")
+	pushTraceMulti(ta, "t4", "agent-b", "agent-a")
+
+	activity := ta.GetAgentActivity()
+	recent := ta.GetRecentTraces(0)
+
+	// Recompute expected counts from /trace/recent equivalent.
+	expected := make(map[string]int)
+	for _, s := range recent {
+		for _, a := range s.Agents {
+			expected[a]++
+		}
+	}
+
+	for agent, want := range expected {
+		if got := activity[agent]; got != want {
+			t.Errorf("agent %s: activity=%d, expected (from recent)=%d", agent, got, want)
+		}
+	}
+	for agent := range activity {
+		if _, ok := expected[agent]; !ok {
+			t.Errorf("agent %s present in activity but not in recent", agent)
+		}
+	}
+}
+
+// TestAgentActivity_DecrementsOnRingEviction verifies that when the ring
+// buffer rolls over and an old trace is evicted, agents that only appeared in
+// the evicted trace lose their count, and agents that still appear in newer
+// traces retain a count equal to the number of remaining traces they're in.
+func TestAgentActivity_DecrementsOnRingEviction(t *testing.T) {
+	const ringSize = 3
+	ta := newTestAccumulator(t, ringSize)
+
+	// Fill the ring with traces: t1=agent-x, t2=agent-y, t3=agent-y
+	pushTrace(ta, "t1", "agent-x")
+	pushTrace(ta, "t2", "agent-y")
+	pushTrace(ta, "t3", "agent-y")
+
+	got := ta.GetAgentActivity()
+	if got["agent-x"] != 1 {
+		t.Fatalf("setup: agent-x expected 1, got %d", got["agent-x"])
+	}
+	if got["agent-y"] != 2 {
+		t.Fatalf("setup: agent-y expected 2, got %d", got["agent-y"])
+	}
+
+	// Push a 4th trace from agent-y → evicts t1 (the only agent-x trace).
+	pushTrace(ta, "t4", "agent-y")
+
+	got = ta.GetAgentActivity()
+	if _, ok := got["agent-x"]; ok {
+		t.Errorf("agent-x should have been evicted, but still in map: %v", got)
+	}
+	if got["agent-y"] != 3 {
+		t.Errorf("agent-y expected 3 after eviction, got %d", got["agent-y"])
+	}
+}
+
+// TestAgentActivity_BadgeNeverExceedsRingSize verifies the headline invariant:
+// an agent's activity count cannot exceed the ring buffer size, no matter how
+// many traces are processed.
+func TestAgentActivity_BadgeNeverExceedsRingSize(t *testing.T) {
+	const ringSize = 5
+	ta := newTestAccumulator(t, ringSize)
+
+	for i := 0; i < 50; i++ {
+		pushTrace(ta, fmt.Sprintf("trace-%d", i), "spammy-agent")
+	}
+
+	got := ta.GetAgentActivity()
+	if got["spammy-agent"] > ringSize {
+		t.Errorf("agent count %d exceeded ring size %d", got["spammy-agent"], ringSize)
+	}
+	if got["spammy-agent"] != ringSize {
+		t.Errorf("expected exactly %d (ring full of this agent), got %d", ringSize, got["spammy-agent"])
+	}
+
+	// And it must equal the number of recent traces containing that agent.
+	recent := ta.GetRecentTraces(0)
+	count := 0
+	for _, s := range recent {
+		for _, a := range s.Agents {
+			if a == "spammy-agent" {
+				count++
+				break
+			}
+		}
+	}
+	if got["spammy-agent"] != count {
+		t.Errorf("activity count %d != recent-trace count %d", got["spammy-agent"], count)
+	}
+}
+
+// TestAgentActivity_EmptyOnFreshAccumulator verifies the initial state.
+func TestAgentActivity_EmptyOnFreshAccumulator(t *testing.T) {
+	ta := newTestAccumulator(t, 20)
+	got := ta.GetAgentActivity()
+	if len(got) != 0 {
+		t.Errorf("fresh accumulator should have empty activity, got %v", got)
+	}
+}

--- a/src/core/registry/tracing/manager.go
+++ b/src/core/registry/tracing/manager.go
@@ -748,7 +748,11 @@ func (tm *TracingManager) GetTotalErrors() int {
 	return 0
 }
 
-// GetAgentActivity returns per-agent span counts from the accumulator.
+// GetAgentActivity returns the per-agent count of finalized traces currently in
+// the accumulator's recent-traces ring buffer that involve each agent. This
+// matches the set of traces returned by /trace/recent when filtered by agent,
+// so the dashboard "activity" badge can never exceed the number of recent
+// traces a user can actually drill into.
 func (tm *TracingManager) GetAgentActivity() map[string]int {
 	if tm.accumulator != nil {
 		return tm.accumulator.GetAgentActivity()


### PR DESCRIPTION
## Summary

Closes #981.

Makes the agent trace-activity counter agree with `/trace/recent` by construction. PR #983 shipped a frontend copy fix for #974 that explained the gap ("Trace activity recorded, but no completed traces in recent window") — this PR removes the gap entirely.

## What changed

`agentActivity map[string]int` is no longer maintained as accumulated state on every span event. Instead, `GetAgentActivity()` derives the count on read by walking the recent-traces ring buffer once and tallying each summary's `Agents` slice.

By construction:
- For every agent, count = number of `/trace/recent` entries containing that agent
- Badge and detail tab can **never** disagree
- Counts bump only when a trace finalizes and lands in the ring
- Ring rollover correctly drops counts for agents that only appeared in the evicted trace
- Badge count is bounded by ring buffer size

## Trade-off (per locked design path B)

Lost: real-time in-flight signal. Long-running async spans (MeshJob workloads) no longer bump the counter until the trace finalizes. Acceptable per the issue body's analysis — the previous "live spans count" was misleading because the badge promised something the detail tab couldn't deliver.

## Test plan

Build / test status (all green):
- [x] `go test ./src/core/registry/tracing/...` — 6 new tests pass
- [x] `go test ./...` — full Go suite green; `mcp-mesh/src/core/ui` (consumer of `GetAgentActivity()` via SSE poller) still passes
- [x] `go build ./...` clean

New tests in `accumulator_test.go`:
- `TestAgentActivity_NoIncrementOnSpanEvent` — regression guard for the removed behavior
- `TestAgentActivity_IncrementsOnFinalize`
- `TestAgentActivity_MatchesRecentTraces` — **the headline invariant**
- `TestAgentActivity_DecrementsOnRingEviction`
- `TestAgentActivity_BadgeNeverExceedsRingSize` — 50 traces from one agent into a ring-of-5 → count = exactly 5
- `TestAgentActivity_EmptyOnFreshAccumulator`

## Out of scope (intentionally untouched)

- SSE `trace_activity` event publisher in `trace_poller.go` — unchanged. It still re-emits whenever counts change, which now happens on finalize/eviction instead of every span event. Emissions are slightly less frequent and more meaningful.
- `/trace/recent` API shape, ring buffer size, retention — unchanged.
- Frontend — untouched. The #974 copy fix from PR #983 remains in place; with this PR, the underlying numbers no longer need that workaround. The copy ("Trace activity recorded, but no completed traces in recent window") will only fire if the ring buffer somehow stores a trace whose agents list excludes a counted-elsewhere agent — should be impossible under the new derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)