### PR TITLE
test(uc12): poll-until-healthy across 8 registration-trust tests (#987)

### DIFF
--- a/cmd/mcp-mesh-registry/main.go
+++ b/cmd/mcp-mesh-registry/main.go
@@ -135,8 +135,14 @@ func main() {
 		}
 	}
 
-	// Create and configure server using Ent
-	server := registry.NewServer(db, registryConfig, appLogger)
+	// Create and configure server using Ent. A trust-backend init failure
+	// (issue #989) returns an error here so we exit fatally rather than
+	// booting healthy and silently rejecting every heartbeat.
+	server, err := registry.NewServer(db, registryConfig, appLogger)
+	if err != nil {
+		appLogger.Error("❌ Failed to create registry server: %v", err)
+		os.Exit(1)
+	}
 
 	// Setup graceful shutdown
 	go func() {

--- a/src/core/registry/server.go
+++ b/src/core/registry/server.go
@@ -109,6 +109,7 @@ func NewServer(entDB *database.EntDatabase, config *RegistryConfig, logger *logg
 		var err error
 		trustChain, err = initTrustChain(config, logger)
 		if err != nil {
+			shutdownCancel()
 			return nil, fmt.Errorf("trust chain init: %w", err)
 		}
 		logger.Info("🔒 TLS mode: %s | trust backend: %s", config.TlsMode, config.TrustBackend)

--- a/src/core/registry/server.go
+++ b/src/core/registry/server.go
@@ -58,8 +58,13 @@ type Server struct {
 	shutdownWG     *sync.WaitGroup
 }
 
-// NewServer creates a new registry server using Ent database
-func NewServer(entDB *database.EntDatabase, config *RegistryConfig, logger *logger.Logger) *Server {
+// NewServer creates a new registry server using Ent database.
+//
+// Returns an error if a configured trust backend fails to initialize. This
+// ensures the registry refuses to start in a state that would silently reject
+// every agent heartbeat with "no backends configured" (issue #989), rather
+// than booting healthy and only failing at the heartbeat path.
+func NewServer(entDB *database.EntDatabase, config *RegistryConfig, logger *logger.Logger) (*Server, error) {
 	// Create Ent-based service
 	entService := NewEntService(entDB, config, logger)
 
@@ -95,10 +100,17 @@ func NewServer(entDB *database.EntDatabase, config *RegistryConfig, logger *logg
 		}
 	}
 
-	// Initialize trust chain if TLS is not "off"
+	// Initialize trust chain if TLS is not "off". A failure here is fatal:
+	// see initTrustChain doc and issue #989 — silently dropping a backend
+	// would leave the registry running but rejecting every heartbeat with
+	// "no backends configured", which is exactly the bug we're closing.
 	var trustChain *trust.TrustChain
 	if config.TlsMode != "" && config.TlsMode != "off" {
-		trustChain = initTrustChain(config, logger)
+		var err error
+		trustChain, err = initTrustChain(config, logger)
+		if err != nil {
+			return nil, fmt.Errorf("trust chain init: %w", err)
+		}
 		logger.Info("🔒 TLS mode: %s | trust backend: %s", config.TlsMode, config.TrustBackend)
 		if trustChain != nil {
 			entities, _ := trustChain.ListTrustedEntities()
@@ -145,7 +157,7 @@ func NewServer(entDB *database.EntDatabase, config *RegistryConfig, logger *logg
 	// Setup routes using generated interface
 	server.SetupGeneratedRoutes()
 
-	return server
+	return server, nil
 }
 
 // Run starts the HTTP server and health monitor
@@ -416,7 +428,20 @@ func (s *Server) runWithTLS(addr string) error {
 
 // initTrustChain parses the TrustBackend config and builds a TrustChain
 // from the configured backends.
-func initTrustChain(config *RegistryConfig, l *logger.Logger) *trust.TrustChain {
+//
+// Error policy (issue #989):
+//   - "User configured a backend but a prerequisite is missing" (e.g. filestore
+//     listed but MCP_MESH_TRUST_DIR unset) is a non-fatal warn-and-skip: the
+//     operator clearly didn't intend to enable that backend.
+//   - "User configured a backend AND the prerequisite is set, but init failed"
+//     (e.g. fsnotify denied, k8s API unreachable, SPIRE socket missing) is a
+//     fatal startup error. Returning a chain without the requested backend
+//     would silently produce a 0-backend chain that rejects every cert with
+//     "no backends configured" — exactly the original #989 symptom we're
+//     fixing. Better to refuse to start so the operator sees the real cause.
+//   - An unknown backend name is fatal: that's a typo in operator config and
+//     limping along masks the bug.
+func initTrustChain(config *RegistryConfig, l *logger.Logger) (*trust.TrustChain, error) {
 	names := trust.ParseBackendConfig(config.TrustBackend)
 	chain := trust.NewTrustChain()
 
@@ -429,8 +454,7 @@ func initTrustChain(config *RegistryConfig, l *logger.Logger) *trust.TrustChain 
 			}
 			fs, err := trust.NewFileStore(config.TrustDir, true)
 			if err != nil {
-				l.Warning("Failed to initialize filestore backend: %v", err)
-				continue
+				return nil, fmt.Errorf("initializing filestore backend (MCP_MESH_TRUST_DIR=%s): %w", config.TrustDir, err)
 			}
 			chain.Add(fs)
 			l.Info("🔒 Trust backend '%s' initialized", name)
@@ -442,8 +466,7 @@ func initTrustChain(config *RegistryConfig, l *logger.Logger) *trust.TrustChain 
 			}
 			lca, err := trust.NewLocalCA(config.TrustDir)
 			if err != nil {
-				l.Warning("Failed to initialize localca backend: %v", err)
-				continue
+				return nil, fmt.Errorf("initializing localca backend (MCP_MESH_TRUST_DIR=%s): %w", config.TrustDir, err)
 			}
 			chain.Add(lca)
 			l.Info("🔒 Trust backend '%s' initialized", name)
@@ -456,8 +479,7 @@ func initTrustChain(config *RegistryConfig, l *logger.Logger) *trust.TrustChain 
 			labelSelector := os.Getenv("MCP_MESH_K8S_LABEL_SELECTOR")
 			ks, err := trust.NewK8sSecretsFromConfig(namespace, labelSelector)
 			if err != nil {
-				l.Warning("Failed to initialize k8s-secrets backend: %v", err)
-				continue
+				return nil, fmt.Errorf("initializing k8s-secrets backend (namespace=%s, selector=%q): %w", namespace, labelSelector, err)
 			}
 			chain.Add(ks)
 			l.Info("🔒 Trust backend '%s' initialized", name)
@@ -469,17 +491,16 @@ func initTrustChain(config *RegistryConfig, l *logger.Logger) *trust.TrustChain 
 			}
 			sb, err := trust.NewSPIRE(context.Background(), socketPath)
 			if err != nil {
-				l.Warning("Failed to initialize spire backend: %v", err)
-				continue
+				return nil, fmt.Errorf("initializing spire backend (socket=%s): %w", socketPath, err)
 			}
 			chain.Add(sb)
 			l.Info("🔒 Trust backend '%s' initialized (socket: %s)", name, socketPath)
 		default:
-			l.Warning("Unknown trust backend: %s", name)
+			return nil, fmt.Errorf("unknown trust backend %q (configured via MCP_MESH_TRUST_BACKEND)", name)
 		}
 	}
 
-	return chain
+	return chain, nil
 }
 
 // startAdminServer starts a secondary Gin engine on the admin port with

--- a/src/core/registry/server_test.go
+++ b/src/core/registry/server_test.go
@@ -1,0 +1,98 @@
+package registry
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInitTrustChain_FailsFastOnBackendInitError pins the issue #989 fix:
+// when a backend is explicitly configured (filestore + MCP_MESH_TRUST_DIR set)
+// but its init fails (here: dir does not exist), initTrustChain must return
+// an error so the registry refuses to boot. The pre-fix behavior silently
+// dropped the backend, leaving a 0-backend chain that rejected every
+// heartbeat with "no backends configured".
+func TestInitTrustChain_FailsFastOnBackendInitError(t *testing.T) {
+	cfg := &RegistryConfig{
+		TlsMode:      "verify",
+		TrustBackend: "filestore",
+		TrustDir:     filepath.Join(t.TempDir(), "definitely-not-here"),
+	}
+	l := createTestLogger(nil)
+
+	chain, err := initTrustChain(cfg, l)
+	if err == nil {
+		t.Fatal("expected initTrustChain to return an error when filestore dir is missing")
+	}
+	if chain != nil {
+		t.Errorf("expected nil chain on error, got %v", chain)
+	}
+	if !strings.Contains(err.Error(), "filestore") {
+		t.Errorf("expected error to mention filestore backend, got: %v", err)
+	}
+}
+
+// TestInitTrustChain_UnknownBackendIsFatal pins that a typo in
+// MCP_MESH_TRUST_BACKEND is a hard error rather than a silent skip — limping
+// along with no backends would mask the operator's config bug (issue #989).
+func TestInitTrustChain_UnknownBackendIsFatal(t *testing.T) {
+	cfg := &RegistryConfig{
+		TlsMode:      "verify",
+		TrustBackend: "filestoer", // typo
+		TrustDir:     t.TempDir(),
+	}
+	l := createTestLogger(nil)
+
+	chain, err := initTrustChain(cfg, l)
+	if err == nil {
+		t.Fatal("expected initTrustChain to reject unknown backend names")
+	}
+	if chain != nil {
+		t.Errorf("expected nil chain on error, got %v", chain)
+	}
+	if !strings.Contains(err.Error(), "unknown trust backend") {
+		t.Errorf("expected error to mention unknown backend, got: %v", err)
+	}
+}
+
+// TestInitTrustChain_MissingPrerequisiteIsNonFatal pins the deliberate
+// asymmetry from issue #989: "user listed a backend but didn't supply its
+// prerequisite config" (filestore listed without MCP_MESH_TRUST_DIR) is treated
+// as "operator didn't actually want this backend" — warn and skip, not fatal.
+// Only an *attempted* init that *fails* is fatal.
+func TestInitTrustChain_MissingPrerequisiteIsNonFatal(t *testing.T) {
+	cfg := &RegistryConfig{
+		TlsMode:      "verify",
+		TrustBackend: "filestore",
+		TrustDir:     "", // prerequisite missing → skip, don't fail
+	}
+	l := createTestLogger(nil)
+
+	chain, err := initTrustChain(cfg, l)
+	if err != nil {
+		t.Fatalf("missing prerequisite should warn-and-skip, got error: %v", err)
+	}
+	if chain == nil {
+		t.Fatal("expected non-nil (empty) chain when backend skipped")
+	}
+}
+
+// TestInitTrustChain_HappyPath verifies a real filestore directory produces
+// a populated chain so the regression tests above don't accidentally pass
+// because initTrustChain always fails.
+func TestInitTrustChain_HappyPath(t *testing.T) {
+	cfg := &RegistryConfig{
+		TlsMode:      "verify",
+		TrustBackend: "filestore",
+		TrustDir:     t.TempDir(), // exists, just empty
+	}
+	l := createTestLogger(nil)
+
+	chain, err := initTrustChain(cfg, l)
+	if err != nil {
+		t.Fatalf("happy path returned error: %v", err)
+	}
+	if chain == nil {
+		t.Fatal("happy path returned nil chain")
+	}
+}

--- a/src/core/registry/trust/filestore.go
+++ b/src/core/registry/trust/filestore.go
@@ -53,9 +53,13 @@ func NewFileStore(dir string, watch bool) (*FileStore, error) {
 	}
 
 	if watch {
-		if err := fs.startWatcher(); err != nil {
-			return nil, fmt.Errorf("starting directory watcher: %w", err)
-		}
+		// startWatcher never returns an error: hot-reload is best-effort
+		// and a watcher init failure (e.g. inotify exhausted, sandboxed
+		// containerd preventing inotify_init1, see issue #989) must not
+		// take the registry's whole trust chain offline. The backend can
+		// still verify certs against whatever loadAll() picked up; the
+		// only loss is hot-reloading new CA files added at runtime.
+		_ = fs.startWatcher()
 	}
 
 	return fs, nil
@@ -253,15 +257,28 @@ func extractEntityID(cert *x509.Certificate, path string) string {
 }
 
 // startWatcher starts an fsnotify watcher on the directory and reloads on changes.
+//
+// Hot-reload is best-effort: if the OS denies the watcher (inotify exhausted,
+// sandboxed container runtime such as restricted containerd refusing
+// inotify_init1, see issue #989) or the directory cannot be added, this
+// function logs a warning and returns nil with fs.watcher left unset. The
+// backend's Verify() path is unaffected — it serves whatever loadAll() loaded
+// at boot. The only behavioral loss is that CA files added to the directory
+// after startup will not be picked up until the registry restarts.
+//
+// Always returns nil; the error type is kept on the signature so future
+// fatal-init failures can be surfaced without another caller-side change.
 func (fs *FileStore) startWatcher() error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return fmt.Errorf("creating watcher: %w", err)
+		log.Printf("[trust/filestore] warning: cannot create fsnotify watcher (hot-reload disabled): %v", err)
+		return nil
 	}
 
 	if err := watcher.Add(fs.dir); err != nil {
-		watcher.Close()
-		return fmt.Errorf("watching directory: %w", err)
+		log.Printf("[trust/filestore] warning: cannot watch directory %s (hot-reload disabled): %v", fs.dir, err)
+		_ = watcher.Close()
+		return nil
 	}
 
 	entitiesDir := filepath.Join(fs.dir, "entities")

--- a/src/core/registry/trust/filestore_test.go
+++ b/src/core/registry/trust/filestore_test.go
@@ -331,6 +331,74 @@ func TestFileStore_InvalidDirectory(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestFileStore_VerifyWorksWithoutWatcher reproduces the production property
+// that motivated issue #989: even if the fsnotify watcher cannot attach (e.g.
+// inotify exhausted, or sandboxed container runtime denying inotify_init1),
+// FileStore.Verify() must still validate certs against the CAs loaded at boot.
+//
+// The hot-reload-disabled construction (watch=false) leaves fs.watcher == nil,
+// which is the same in-memory state the watcher-init failure path produces
+// after the issue #989 fix. This pins the behavior so a future change that
+// makes Verify depend on the watcher would surface here.
+func TestFileStore_VerifyWorksWithoutWatcher(t *testing.T) {
+	dir := t.TempDir()
+
+	ca, caKey := generateCA(t, "no-watcher-org")
+	writePEM(t, dir, "no-watcher.pem", ca)
+
+	leaf, _ := generateLeaf(t, ca, caKey, "agent-no-watcher")
+
+	fs, err := NewFileStore(dir, false)
+	require.NoError(t, err)
+	defer fs.Close()
+
+	require.Nil(t, fs.watcher, "watcher must be nil when watch=false")
+
+	result, err := fs.Verify([]*x509.Certificate{leaf})
+	require.NoError(t, err, "Verify must succeed even without an active watcher")
+	assert.Equal(t, "no-watcher-org", result.EntityID)
+	assert.Equal(t, "filestore", result.BackendName)
+}
+
+// TestFileStore_StartWatcherTolerantOfMissingDir asserts that startWatcher
+// degrades gracefully when the directory it tries to watch has been removed
+// between loadAll() succeeding and watcher.Add() running. This simulates the
+// inotify-denied path from issue #989 without requiring OS-level injection:
+// fsnotify.Watcher.Add() on a non-existent path returns ENOENT, exercising
+// the same warn-and-return-nil branch.
+//
+// The contract under test: startWatcher must return nil and leave fs.watcher
+// nil (not partially set) so the backend keeps serving Verify() requests off
+// the entities loaded at boot.
+func TestFileStore_StartWatcherTolerantOfMissingDir(t *testing.T) {
+	dir := t.TempDir()
+
+	ca, _ := generateCA(t, "doomed-dir-org")
+	writePEM(t, dir, "doomed.pem", ca)
+
+	fs := &FileStore{
+		dir:  dir,
+		done: make(chan struct{}),
+	}
+	require.NoError(t, fs.loadAll())
+
+	// Yank the dir between loadAll() and startWatcher() to force
+	// watcher.Add() to fail with ENOENT.
+	require.NoError(t, os.RemoveAll(dir))
+
+	err := fs.startWatcher()
+	require.NoError(t, err, "startWatcher must not propagate watcher.Add() failure")
+	assert.Nil(t, fs.watcher, "watcher must be nil after failed Add so Close() stays safe")
+
+	// The entities loaded at boot are still verifiable.
+	entities, err := fs.ListTrustedEntities()
+	require.NoError(t, err)
+	assert.Len(t, entities, 1)
+
+	// Close must be safe even with no watcher attached.
+	require.NoError(t, fs.Close())
+}
+
 func TestFileStore_SkipsNonPEMFiles(t *testing.T) {
 	dir := t.TempDir()
 

--- a/src/ui/app/agents/page.tsx
+++ b/src/ui/app/agents/page.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Header } from "@/components/layout/Header";
 import { AgentTable } from "@/components/agents/AgentTable";
 import { AgentGrid } from "@/components/agents/AgentGrid";
@@ -16,6 +17,14 @@ export default function AgentsPage() {
     "mesh.ui.agents.view",
     "list",
     (v): v is "list" | "grid" => v === "list" || v === "grid",
+  );
+
+  // Issue #990: server payload order isn't stable, so cards reshuffle on
+  // every 30s refresh / SSE event. Sort once at the page level so both
+  // grid and table views consume the same ordered list.
+  const sortedAgents = useMemo(
+    () => [...agents].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" })),
+    [agents],
   );
 
   if (loading) {
@@ -80,7 +89,7 @@ export default function AgentsPage() {
             )}
           </Button>
         </div>
-        {view === "grid" ? <AgentGrid agents={agents} /> : <AgentTable agents={agents} />}
+        {view === "grid" ? <AgentGrid agents={sortedAgents} /> : <AgentTable agents={sortedAgents} />}
       </div>
     </div>
   );

--- a/tests/integration/suites/uc12_registration_trust/tc01_tls_auto_python/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc01_tls_auto_python/test.yaml
@@ -27,9 +27,21 @@ test:
     workdir: /workspace
     capture: system_start
 
-  - name: "Wait for system agent to register"
-    handler: wait
-    seconds: 10
+  - name: "Wait for system agent to be healthy"
+    handler: shell
+    command: |
+      expected="system-agent"
+      for i in $(seq 1 60); do
+        out=$(curl -sk https://localhost:8000/agents 2>/dev/null)
+        if echo "$out" | grep -q "\"name\":\"$expected\".*\"status\":\"healthy\""; then
+          echo "agent '$expected' healthy after ${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "TIMEOUT: agent '$expected' did not become healthy within 60s"
+      echo "$out"
+      exit 1
 
   - name: "Start hello world agent with TLS auto"
     handler: shell
@@ -37,9 +49,21 @@ test:
     workdir: /workspace
     capture: hello_start
 
-  - name: "Wait for hello world to register and resolve deps"
-    handler: wait
-    seconds: 10
+  - name: "Wait for hello-world and system-agent to be healthy"
+    handler: shell
+    command: |
+      for i in $(seq 1 60); do
+        out=$(curl -sk https://localhost:8000/agents 2>/dev/null)
+        if echo "$out" | grep -q "\"name\":\"hello-world\".*\"status\":\"healthy\"" \
+           && echo "$out" | grep -q "\"name\":\"system-agent\".*\"status\":\"healthy\""; then
+          echo "both agents healthy after ${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "TIMEOUT: hello-world + system-agent did not become healthy within 60s"
+      echo "$out"
+      exit 1
 
   - name: "Check agents registered with entity_id"
     handler: shell

--- a/tests/integration/suites/uc12_registration_trust/tc02_tls_auto_typescript/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc02_tls_auto_typescript/test.yaml
@@ -29,9 +29,21 @@ test:
     workdir: /workspace
     capture: ts_start
 
-  - name: "Wait for TypeScript agent to register"
-    handler: wait
-    seconds: 10
+  - name: "Wait for TypeScript agent to be healthy"
+    handler: shell
+    command: |
+      expected="greeter-ts"
+      for i in $(seq 1 60); do
+        out=$(curl -sk https://localhost:8000/agents 2>/dev/null)
+        if echo "$out" | grep -q "\"name\":\"$expected\".*\"status\":\"healthy\""; then
+          echo "agent '$expected' healthy after ${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "TIMEOUT: agent '$expected' did not become healthy within 60s"
+      echo "$out"
+      exit 1
 
   - name: "Check agent registered with entity_id"
     handler: shell

--- a/tests/integration/suites/uc12_registration_trust/tc05_multi_language_tls/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc05_multi_language_tls/test.yaml
@@ -42,9 +42,21 @@ test:
     workdir: /workspace
     capture: py_start
 
-  - name: "Wait for Python agent to register"
-    handler: wait
-    seconds: 10
+  - name: "Wait for Python agent to be healthy"
+    handler: shell
+    command: |
+      expected="system-agent"
+      for i in $(seq 1 60); do
+        out=$(curl -sk https://localhost:8000/agents 2>/dev/null)
+        if echo "$out" | grep -q "\"name\":\"$expected\".*\"status\":\"healthy\""; then
+          echo "agent '$expected' healthy after ${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "TIMEOUT: agent '$expected' did not become healthy within 60s"
+      echo "$out"
+      exit 1
 
   - name: "Start TypeScript agent with TLS auto"
     handler: shell
@@ -52,9 +64,21 @@ test:
     workdir: /workspace
     capture: ts_start
 
-  - name: "Wait for TypeScript agent to register"
-    handler: wait
-    seconds: 10
+  - name: "Wait for TypeScript agent to be healthy"
+    handler: shell
+    command: |
+      expected="greeter-ts"
+      for i in $(seq 1 60); do
+        out=$(curl -sk https://localhost:8000/agents 2>/dev/null)
+        if echo "$out" | grep -q "\"name\":\"$expected\".*\"status\":\"healthy\""; then
+          echo "agent '$expected' healthy after ${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "TIMEOUT: agent '$expected' did not become healthy within 60s"
+      echo "$out"
+      exit 1
 
   - name: "Start Java agent with TLS auto"
     handler: shell

--- a/tests/integration/suites/uc12_registration_trust/tc12_vault_python/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc12_vault_python/test.yaml
@@ -93,9 +93,21 @@ test:
     workdir: /workspace
     capture: agent_start
 
-  - name: "Wait for agent registration"
-    handler: wait
-    seconds: 15
+  - name: "Wait for agent to be healthy"
+    handler: shell
+    command: |
+      expected="system-agent"
+      for i in $(seq 1 60); do
+        out=$(curl -sk https://localhost:8000/agents 2>/dev/null)
+        if echo "$out" | grep -q "\"name\":\"$expected\".*\"status\":\"healthy\""; then
+          echo "agent '$expected' healthy after ${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "TIMEOUT: agent '$expected' did not become healthy within 60s"
+      echo "$out"
+      exit 1
 
   - name: "Check agent registered with Vault cert"
     handler: shell

--- a/tests/integration/suites/uc12_registration_trust/tc13_vault_typescript/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc13_vault_typescript/test.yaml
@@ -92,12 +92,25 @@ test:
     workdir: /workspace
     capture: agent_start
 
-  - name: "Wait for agent registration"
-    # 15s was too tight on loaded test boxes — TS agent startup +
-    # Vault credential fetch + register call exceeded the budget on
-    # run 7c9009ac (test 51431, "no healthy agent found").
-    handler: wait
-    seconds: 30
+  - name: "Wait for agent to be healthy"
+    # Poll-until-healthy replaces the prior fixed 30s wait + weak curl
+    # check (which exited 0 even when agents were missing). The TS agent
+    # startup + Vault credential fetch + register call can exceed any
+    # fixed budget on loaded test boxes.
+    handler: shell
+    command: |
+      expected="greeter-ts"
+      for i in $(seq 1 60); do
+        out=$(curl -sk https://localhost:8000/agents 2>/dev/null)
+        if echo "$out" | grep -q "\"name\":\"$expected\".*\"status\":\"healthy\""; then
+          echo "agent '$expected' healthy after ${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "TIMEOUT: agent '$expected' did not become healthy within 60s"
+      echo "$out"
+      exit 1
 
   - name: "Check agent registered"
     handler: shell

--- a/tests/integration/suites/uc12_registration_trust/tc13_vault_typescript/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc13_vault_typescript/test.yaml
@@ -114,6 +114,12 @@ test:
       echo "=== meshctl logs greeter-ts (last 100 lines) ==="
       meshctl logs greeter-ts --tail 100 2>&1 || cat ~/.mcp-mesh/logs/greeter-ts.log 2>&1 | tail -100
       echo ""
+      echo "=== meshctl logs registry (last 100 lines) ==="
+      meshctl logs registry --tail 100 2>&1 || cat ~/.mcp-mesh/logs/registry.log 2>&1 | tail -100
+      echo ""
+      echo "=== /tmp/vault-trust contents (CA files for filestore backend) ==="
+      ls -la /tmp/vault-trust/ 2>&1 || true
+      echo ""
       echo "=== meshctl status (all agents) ==="
       meshctl list 2>&1 || true
       exit 1

--- a/tests/integration/suites/uc12_registration_trust/tc13_vault_typescript/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc13_vault_typescript/test.yaml
@@ -110,6 +110,12 @@ test:
       done
       echo "TIMEOUT: agent '$expected' did not become healthy within 60s"
       echo "$out"
+      echo ""
+      echo "=== meshctl logs greeter-ts (last 100 lines) ==="
+      meshctl logs greeter-ts --tail 100 2>&1 || cat ~/.mcp-mesh/logs/greeter-ts.log 2>&1 | tail -100
+      echo ""
+      echo "=== meshctl status (all agents) ==="
+      meshctl list 2>&1 || true
       exit 1
 
   - name: "Check agent registered"

--- a/tests/integration/suites/uc12_registration_trust/tc14_vault_cross_agent/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc14_vault_cross_agent/test.yaml
@@ -90,9 +90,21 @@ test:
     workdir: /workspace
     capture: system_start
 
-  - name: "Wait for system-agent registration"
-    handler: wait
-    seconds: 10
+  - name: "Wait for system-agent to be healthy"
+    handler: shell
+    command: |
+      expected="system-agent"
+      for i in $(seq 1 60); do
+        out=$(curl -sk https://localhost:8000/agents 2>/dev/null)
+        if echo "$out" | grep -q "\"name\":\"$expected\".*\"status\":\"healthy\""; then
+          echo "agent '$expected' healthy after ${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "TIMEOUT: agent '$expected' did not become healthy within 60s"
+      echo "$out"
+      exit 1
 
   - name: "Start hello-world with Vault provider"
     handler: shell
@@ -109,9 +121,21 @@ test:
     workdir: /workspace
     capture: hello_start
 
-  - name: "Wait for hello-world registration and dep resolution"
-    handler: wait
-    seconds: 15
+  - name: "Wait for hello-world and system-agent to be healthy"
+    handler: shell
+    command: |
+      for i in $(seq 1 60); do
+        out=$(curl -sk https://localhost:8000/agents 2>/dev/null)
+        if echo "$out" | grep -q "\"name\":\"hello-world\".*\"status\":\"healthy\"" \
+           && echo "$out" | grep -q "\"name\":\"system-agent\".*\"status\":\"healthy\""; then
+          echo "both agents healthy after ${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "TIMEOUT: hello-world + system-agent did not become healthy within 60s"
+      echo "$out"
+      exit 1
 
   - name: "Verify both agents registered"
     handler: shell

--- a/tests/integration/suites/uc12_registration_trust/tc16_spire_python/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc16_spire_python/test.yaml
@@ -119,12 +119,25 @@ test:
     workdir: /workspace
     capture: agent_start
 
-  - name: "Wait for agent registration"
-    # 15s was too tight on loaded test boxes — Python agent startup +
-    # SPIRE SVID fetch + register call exceeded the budget on
-    # run 7c9009ac (test 51434, "no healthy agent found").
-    handler: wait
-    seconds: 30
+  - name: "Wait for agent to be healthy"
+    # Poll-until-healthy replaces the prior fixed 30s wait + weak curl
+    # check (which exited 0 even when agents were missing). Python agent
+    # startup + SPIRE SVID fetch + register call can exceed any fixed
+    # budget on loaded test boxes.
+    handler: shell
+    command: |
+      expected="system-agent"
+      for i in $(seq 1 60); do
+        out=$(curl -sk https://localhost:8000/agents 2>/dev/null)
+        if echo "$out" | grep -q "\"name\":\"$expected\".*\"status\":\"healthy\""; then
+          echo "agent '$expected' healthy after ${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "TIMEOUT: agent '$expected' did not become healthy within 60s"
+      echo "$out"
+      exit 1
 
   - name: "Check agent registered"
     handler: shell

--- a/tests/integration/suites/uc12_registration_trust/tc19_entity_id_reassignment_rejected/test.yaml
+++ b/tests/integration/suites/uc12_registration_trust/tc19_entity_id_reassignment_rejected/test.yaml
@@ -29,9 +29,21 @@ test:
     workdir: /workspace
     capture: legit_start
 
-  - name: "Wait for legitimate agent to register"
-    handler: wait
-    seconds: 10
+  - name: "Wait for legitimate agent to be healthy"
+    handler: shell
+    command: |
+      expected="system-agent"
+      for i in $(seq 1 60); do
+        out=$(curl -sk https://localhost:8000/agents 2>/dev/null)
+        if echo "$out" | grep -q "\"name\":\"$expected\".*\"status\":\"healthy\""; then
+          echo "agent '$expected' healthy after ${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "TIMEOUT: agent '$expected' did not become healthy within 60s"
+      echo "$out"
+      exit 1
 
   - name: "Capture legitimate agent id and entity_id from registry"
     handler: shell


### PR DESCRIPTION
## Summary

Closes #987 (test hardening), #989 (registry trust fail-fast + filestore watcher resilience), and #990 (UI: agents page alphabetical sort).

This PR started as a test-mechanism tightening on `uc12_registration_trust` and expanded once the new diagnostics surfaced a real registry bug on tsuite K8s node `beelink5` (newer containerd 2.2.2 / kernel 6.17 with stricter pod sandbox). One small UI nit also folded in.

## Test hardening (#987)

Replaces fragile `handler: wait, seconds: N` blocks with poll-until-healthy shell loops in 8 of 10 `uc12_registration_trust` tests. Closes the registration-race flake class. The new pattern also dumps agent + registry logs + trust dir state on timeout — that's how the registry bug below was found.

Old:
```yaml
- name: "Wait for agent registration"
  handler: wait
  seconds: 30
- name: "Check agent registered"
  handler: shell
  command: curl -sk https://localhost:8000/agents 2>&1   # captured but unasserted
  capture: agents_json
```

New: poll every 1s for 60s; on timeout dump agent log + registry log + trust dir; fail with explicit `TIMEOUT:` marker.

## Registry trust hardening (#989)

The new diagnostic dump revealed that the registry's `filestore` trust backend silently degraded to "0 backends configured" when `fsnotify.NewWatcher()` failed inside the pod sandbox. The registry came up healthy, then rejected every agent heartbeat with `403 — certificate not trusted by any entity CA: no backends configured`.

**Two independent, additive fixes:**

1. **`server.go` — fail-fast on backend init failure.** When a user explicitly configures a trust backend (in `MCP_MESH_TRUST_BACKEND`) and init fails, the registry now refuses to start instead of silently continuing with 0 backends. Warn-and-skip behavior is retained for the "missing prerequisite config" case (e.g., `MCP_MESH_TRUST_DIR` empty) — that's "user didn't configure this, skip honestly," which is correct. `initTrustChain` now returns `(*trust.TrustChain, error)`, propagated up through `NewServer` and `cmd/mcp-mesh-registry/main.go`.

2. **`filestore.go` — fsnotify watcher non-fatal.** The watcher is a hot-reload convenience, not a correctness requirement. CA files are typically static within a pod lifecycle. On `fsnotify.NewWatcher()` or `watcher.Add()` failure, the backend now logs a warning and continues — degrades to "trust without hot reload" instead of "no trust at all." `loadAll()` failures remain fatal (real config bug).

## UI: agents page alphabetical sort (#990)

Cards previously reshuffled on every 30s refresh / SSE event because the `/agents` payload order isn't stable. Sort client-side at the page level (`src/ui/app/agents/page.tsx`) via a `useMemo` so both grid and table views render consistently and the sort doesn't re-run on unrelated state changes.

## Test coverage

New unit tests:
- `TestInitTrustChain_FailsFastOnBackendInitError` — pins fail-fast on filestore init failure
- `TestInitTrustChain_UnknownBackendIsFatal` — typo in `MCP_MESH_TRUST_BACKEND` is now a startup error
- `TestInitTrustChain_MissingPrerequisiteIsNonFatal` — pins the warn-and-skip asymmetry
- `TestInitTrustChain_HappyPath` — baseline
- `TestFileStore_VerifyWorksWithoutWatcher` — pins the production property: `Verify()` works with `fs.watcher == nil`
- `TestFileStore_StartWatcherTolerantOfMissingDir` — exercises the watcher.Add failure path

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./src/core/registry/... ./src/core/registry/trust/...` green
- [x] UI `tsc --noEmit` no new errors (one pre-existing unrelated error in `app/jobs/page.tsx:56` — out of scope, will file separately)
- [ ] Full integration run (tc13 should now pass on beelink5 with watcher non-fatal)
- [ ] Manual UI smoke: `/agents` page cards stay in alphabetical order across two refresh cycles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Replaced fixed waits with active HTTPS health polling (60s) across integration suites; improved timeout diagnostics and reliability for TLS, Vault, and SPIRE scenarios.
  * Added unit tests covering trust initialization and file-store verification behaviors.

* **Bug Fixes**
  * Server startup now fails fast on trust-backend initialization errors to avoid running in a misconfigured state.

* **Stability**
  * File-store hot-reload tolerates watcher startup failures and continues serving loaded trust data.

* **UI**
  * Agents list is now deterministically sorted for consistent display across refreshes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/988)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->