### PR TITLE
docs(quickstart): fix meshctl call syntax + scaffold example block

### DIFF
--- a/src/core/cli/man/content/quickstart.md
+++ b/src/core/cli/man/content/quickstart.md
@@ -66,7 +66,7 @@ class GreeterAgent:
     pass
 ```
 
-The scaffolded `hello()` tool is a working stub that returns `"Not implemented"`. You can run it as-is and call it to verify the mesh end-to-end, then edit `greeter/main.py` to give the tool real behavior (e.g., return `f"Hello, {name}!"` and add a `name: str` parameter).
+The scaffolded `hello()` tool is a working stub that returns `"Not implemented"`. You can run it as-is and call it to verify the mesh end-to-end, then edit `greeter/main.py` to give the tool real behavior (e.g., change the return value or add parameters as needed).
 
 ## 3. Run the Agent
 

--- a/src/core/cli/man/content/quickstart.md
+++ b/src/core/cli/man/content/quickstart.md
@@ -33,26 +33,40 @@ meshctl scaffold --name greeter --agent-type tool
 This creates `greeter/main.py`:
 
 ```python
+#!/usr/bin/env python3
+"""greeter - MCP Mesh Agent."""
+
 import mesh
+from fastmcp import FastMCP
 
-app = mesh.get_app()
+app = FastMCP("Greeter Service")
 
-@app.tool()        # Register with FastMCP protocol
-@mesh.tool(        # Register with mesh for discovery + dependency injection
-    capability="greeting",
-    description="Greet a user by name",
+
+@app.tool()
+@mesh.tool(
+    capability="hello",
+    description="A tool",
+    tags=["tools"],
 )
-def greet(name: str) -> str:
-    return f"Hello, {name}!"
+async def hello() -> str:
+    """A tool."""
+    # TODO: Implement tool logic
+    return "Not implemented"
+
 
 @mesh.agent(
     name="greeter",
     version="1.0.0",
+    description="MCP Mesh agent for greeter",
     http_port=8080,
+    enable_http=True,
+    auto_run=True,
 )
 class GreeterAgent:
     pass
 ```
+
+The scaffolded `hello()` tool is a working stub that returns `"Not implemented"`. You can run it as-is and call it to verify the mesh end-to-end, then edit `greeter/main.py` to give the tool real behavior (e.g., return `f"Hello, {name}!"` and add a `name: str` parameter).
 
 ## 3. Run the Agent
 
@@ -65,8 +79,8 @@ meshctl start greeter/main.py --debug
 
 ```bash
 # Terminal 3: Call the agent
-meshctl call greeter greeting --params '{"name": "World"}'
-# Output: Hello, World!
+meshctl call greeter:hello '{}'
+# Output: Not implemented
 
 # Or list running agents
 meshctl list
@@ -80,32 +94,42 @@ Create a second agent that depends on the greeter:
 meshctl scaffold --name assistant --agent-type tool
 ```
 
-Edit `assistant/main.py`:
+Edit `assistant/main.py` to add a `dependencies=` clause on the tool and accept the injected proxy as a keyword parameter:
 
 ```python
+#!/usr/bin/env python3
+"""assistant - MCP Mesh Agent demonstrating dependency injection."""
+
 import mesh
+from fastmcp import FastMCP
 
-app = mesh.get_app()
+app = FastMCP("Assistant Service")
 
-@app.tool()        # Register with FastMCP protocol
-@mesh.tool(        # Register with mesh for discovery + dependency injection
+
+@app.tool()
+@mesh.tool(
     capability="smart_greeting",
-    description="Enhanced greeting with time",
-    dependencies=["greeting"],  # Depend on greeter
+    description="Enhanced greeting that calls the greeter",
+    tags=["tools"],
+    dependencies=["hello"],   # depend on greeter's "hello" capability
 )
 async def smart_greet(
     name: str,
-    greeting_svc: mesh.McpMeshTool = None,  # Injected!
+    hello: mesh.McpMeshTool = None,    # injected by mesh
 ) -> str:
-    if greeting_svc:
-        base_greeting = await greeting_svc(name=name)
-        return f"{base_greeting} Welcome to MCP Mesh!"
-    return f"Hello, {name}! (greeter unavailable)"
+    if hello is None:
+        return f"Hello, {name}! (greeter unavailable)"
+    base = await hello()                # call the greeter
+    return f"{base} Welcome to MCP Mesh, {name}!"
+
 
 @mesh.agent(
     name="assistant",
     version="1.0.0",
+    description="MCP Mesh agent for assistant",
     http_port=9001,
+    enable_http=True,
+    auto_run=True,
 )
 class AssistantAgent:
     pass
@@ -116,8 +140,8 @@ class AssistantAgent:
 meshctl start assistant/main.py --debug
 
 # Call the smart greeting
-meshctl call assistant smart_greeting --params '{"name": "Developer"}'
-# Output: Hello, Developer! Welcome to MCP Mesh!
+meshctl call assistant:smart_greet '{"name":"Developer"}'
+# Output: Not implemented Welcome to MCP Mesh, Developer!
 ```
 
 ## Next Steps


### PR DESCRIPTION
## Summary

Fixes the two MAJOR bugs in `meshctl man quickstart` surfaced by the meshctl audit:

1. **`meshctl call` syntax** — doc used `meshctl call X Y --params '{...}'`, but `--params` is not a real flag and tool address requires the `agent:tool` colon form with positional JSON. Now matches the (correct) form already used in `meshctl man tutorial` Day 1.

2. **Scaffold example mismatch** — doc's `greeter/main.py` snippet bore no resemblance to what `meshctl scaffold basic --name greeter` actually emits. New snippet matches scaffold output exactly: FastMCP-direct, async `hello()` stub with `capability="hello"`, default fields including `enable_http=True` and `auto_run=True`.

Also updated the assistant DI example to reflect the same "edit-from-scaffold" workflow and fixed its call invocation.

## What changed

- Section 2: `greeter/main.py` snippet now matches scaffold output; added explanatory line that the `hello()` stub returns `"Not implemented"` and is runnable as-is before user edits it for real behavior.
- Section 4: `meshctl call greeter:hello '{}'` (was `meshctl call greeter greeting --params '...'`).
- Section 5: `assistant/main.py` snippet rewritten to demonstrate DI via the scaffold's "uncomment and adapt" pattern; assistant now depends on `hello` (not `greeting`).
- Section 5 call: `meshctl call assistant:smart_greet '{"name":"Developer"}'` (was `meshctl call assistant smart_greeting --params '...'`).

## What's deliberately NOT changed (strict scope)

- The `meshctl scaffold --name X --agent-type tool` lines (sections 2 + 5) — reserved for #994 (broader scaffold doc rewrite across 7 pages, per `.claude/CLAUDE.md` no-deprecated-in-docs convention).
- `pip install mcp-mesh` (section 1) — pulls v1.4.1 today; covered by the quickstart DEFERRED gap (v2 stable will fix when 2.0 graduates to PyPI `latest`).

## Test plan

- [x] `grep -E "(get_app\(\)|--params)" src/core/cli/man/content/quickstart.md` → 0 matches (old broken symbols gone)
- [x] `grep -E "(FastMCP|capability=\"hello\"|meshctl call greeter:hello)" ...` → all new symbols present
- [x] Pre-commit hooks pass
- [ ] Manual smoke test: `make build && ./bin/meshctl man quickstart --raw` shows new content (reviewer-side verification — man pages embed at build time)

## Notes

- Reviewer may see grep matches for the substring `greeting` inside the legitimate new `capability="smart_greeting"` symbol — not a remnant of the old `capability="greeting"`.

Closes #998

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Refreshed quickstart guide with updated patterns for agent and tool definitions
* Updated example CLI commands and expected output to reflect current syntax
* Expanded examples demonstrating how agents can depend on and use other agents' tools

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1001)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->