### PR TITLE
docs(registry): fix endpoint table — drop /capabilities, add /schemas

### DIFF
--- a/src/core/cli/man/content/registry.md
+++ b/src/core/cli/man/content/registry.md
@@ -70,14 +70,16 @@ export MCP_MESH_DEBUG_MODE=false
 
 ## API Endpoints
 
-| Endpoint        | Method    | Description            |
-| --------------- | --------- | ---------------------- |
-| `/health`       | GET       | Registry health check  |
-| `/agents`       | GET       | List registered agents |
-| `/agents/{id}`  | GET       | Get agent details      |
-| `/capabilities` | GET       | List all capabilities  |
-| `/register`     | POST      | Register/update agent  |
-| `/heartbeat`    | HEAD/POST | Agent heartbeat        |
+| Endpoint       | Method    | Description                                |
+| -------------- | --------- | ------------------------------------------ |
+| `/health`      | GET       | Registry health check                      |
+| `/agents`      | GET       | List registered agents (capabilities embedded per agent) |
+| `/agents/{id}` | GET       | Get agent details                          |
+| `/schemas`     | GET       | List canonical schemas (issue #547)        |
+| `/register`    | POST      | Register/update agent                      |
+| `/heartbeat`   | HEAD/POST | Agent heartbeat                            |
+
+> Capability data is surfaced per-agent inside `/agents` responses; there is no dedicated `/capabilities` endpoint.
 
 ## Dependency Resolution
 


### PR DESCRIPTION
## Summary

The `meshctl man registry` API endpoint table had a documented endpoint that doesn't exist (`GET /capabilities` → 404) and was missing one that does (`GET /schemas`, issue #547 schema registry).

## Verification

```bash
$ curl -sk http://localhost:8000/capabilities       → HTTP 404
$ curl -sk http://localhost:8000/api/capabilities   → HTTP 404
$ curl -sk http://localhost:8000/v1/capabilities    → HTTP 404
$ curl -sk http://localhost:8000/schemas            → HTTP 200
```

Verified against `mcpmesh/registry:2.0.0-beta.3`.

## Changes

- Drop the bogus `/capabilities` row
- Add `/schemas` row with #547 reference
- Annotate the `/agents` row to note capabilities are embedded
- Short callout below the table pointing readers to `/agents` for capability data, so anyone looking for `/capabilities` knows where it actually lives

## Stats

1 file changed, +10 / −8.

Closes #997

🤖 Generated with [Claude Code](https://claude.com/claude-code)