### PR TITLE
scaffold: rewrite docs to subcommand form + reintroduce 'api' subcommand

### DIFF
--- a/src/core/cli/man/content/api.md
+++ b/src/core/cli/man/content/api.md
@@ -2,6 +2,8 @@
 
 > Add mesh capabilities to your FastAPI routes with @mesh.route
 
+> Use `meshctl scaffold api --name X --lang python|typescript|java` to generate a runnable starter that already wires `@mesh.route` (or the language equivalent).
+
 ## Why Use This
 
 - You have a FastAPI app (or are building one) and want your routes to call mesh agent capabilities (LLMs, data services, etc.)

--- a/src/core/cli/man/content/cli.md
+++ b/src/core/cli/man/content/cli.md
@@ -198,21 +198,21 @@ Generates new agents from templates. Three input modes: interactive wizard, CLI 
 meshctl scaffold
 
 # CLI flags - basic tool agent
-meshctl scaffold --name my-agent --agent-type tool
+meshctl scaffold basic --name my-agent
 
 # Other languages
-meshctl scaffold --name my-agent --agent-type tool --lang typescript
-meshctl scaffold --name my-agent --agent-type tool --lang java
+meshctl scaffold basic --name my-agent --lang typescript
+meshctl scaffold basic --name my-agent --lang java
 
 # LLM-powered agent + zero-code provider
-meshctl scaffold --name analyzer --agent-type llm-agent --llm-selector claude
-meshctl scaffold --name claude-provider --agent-type llm-provider --model anthropic/claude-sonnet-4-5
+meshctl scaffold llm --name analyzer --vendor claude
+meshctl scaffold llm-provider --name claude-provider --vendor claude
 
 # Generate docker-compose.yml + observability stack
 meshctl scaffold --compose --observability
 
 # Preview only
-meshctl scaffold --name my-agent --agent-type tool --dry-run
+meshctl scaffold basic --name my-agent --dry-run
 ```
 
 ### `meshctl config`

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -25,7 +25,7 @@ Create a virtual environment in your project root. `meshctl start` automatically
 
 ```bash
 # Create project and virtual environment
-meshctl scaffold --name my-agent --agent-type tool
+meshctl scaffold basic --name my-agent
 cd my-agent
 
 # Create .venv (meshctl looks for this first)
@@ -90,7 +90,7 @@ See `meshctl start --help` and `meshctl stop --help` for options.
 
 ```bash
 # Create agent with Dockerfile
-meshctl scaffold --name my-agent --agent-type tool
+meshctl scaffold basic --name my-agent
 
 # Files created:
 # my-agent/
@@ -252,7 +252,7 @@ resources:
 
 ```bash
 # 1. Scaffold your agent (creates Dockerfile + helm-values.yaml)
-meshctl scaffold --name my-agent --agent-type tool
+meshctl scaffold basic --name my-agent
 
 # 2. Build and push Docker image (works on all platforms)
 cd my-agent

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -19,7 +19,7 @@ MCP Mesh supports multiple deployment patterns for TypeScript agents. Use `meshc
 
 ```bash
 # Create project
-meshctl scaffold --name my-agent --agent-type tool --lang typescript
+meshctl scaffold basic --name my-agent --lang typescript
 cd my-agent
 
 # Install dependencies
@@ -188,7 +188,7 @@ resources:
 
 ```bash
 # 1. Scaffold TypeScript agent
-meshctl scaffold --name my-agent --agent-type tool --lang typescript
+meshctl scaffold basic --name my-agent --lang typescript
 
 # 2. Build and push Docker image
 cd my-agent

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -416,10 +416,10 @@ return await llm("Standalone query", context={}, context_mode="replace")
 
 ```bash
 # Generate LLM agent
-meshctl scaffold --name my-agent --agent-type llm-agent --llm-selector claude
+meshctl scaffold llm --name my-agent --vendor claude
 
 # Generate LLM provider
-meshctl scaffold --name claude-provider --agent-type llm-provider --model anthropic/claude-sonnet-4-5
+meshctl scaffold llm-provider --name claude-provider --vendor claude
 ```
 
 ## See Also

--- a/src/core/cli/man/content/prerequisites.md
+++ b/src/core/cli/man/content/prerequisites.md
@@ -66,8 +66,8 @@ pip install mcp-mesh
 deactivate                   # Can deactivate after pip install
 
 # 2. Scaffold agents - meshctl auto-detects .venv (no activation needed)
-meshctl scaffold --name hello --agent-type basic
-meshctl scaffold --name assistant --agent-type llm-agent
+meshctl scaffold basic --name hello
+meshctl scaffold llm --name assistant
 
 # 3. Run agent - meshctl uses .venv/bin/python automatically
 meshctl start hello/main.py --debug

--- a/src/core/cli/man/content/prerequisites_java.md
+++ b/src/core/cli/man/content/prerequisites_java.md
@@ -74,7 +74,7 @@ meshctl --version
 
 ```bash
 # 1. Scaffold a Java agent
-meshctl scaffold --name hello --agent-type basic --lang java
+meshctl scaffold basic --name hello --lang java
 
 # 2. Run with meshctl (detects pom.xml, supports --debug/--watch)
 meshctl start hello/ --debug

--- a/src/core/cli/man/content/prerequisites_typescript.md
+++ b/src/core/cli/man/content/prerequisites_typescript.md
@@ -51,7 +51,7 @@ meshctl --version
 
 ```bash
 # 1. Scaffold TypeScript agent
-meshctl scaffold --name hello --agent-type basic --lang typescript
+meshctl scaffold basic --name hello --lang typescript
 
 # 2. Install dependencies
 cd hello

--- a/src/core/cli/man/content/quickstart.md
+++ b/src/core/cli/man/content/quickstart.md
@@ -27,7 +27,7 @@ meshctl start --registry-only --debug
 
 ```bash
 # Terminal 2: Scaffold a basic agent
-meshctl scaffold --name greeter --agent-type tool
+meshctl scaffold basic --name greeter
 ```
 
 This creates `greeter/main.py`:
@@ -91,7 +91,7 @@ meshctl list
 Create a second agent that depends on the greeter:
 
 ```bash
-meshctl scaffold --name assistant --agent-type tool
+meshctl scaffold basic --name assistant
 ```
 
 Edit `assistant/main.py` to add a `dependencies=` clause on the tool and accept the injected proxy as a keyword parameter:

--- a/src/core/cli/man/content/quickstart_typescript.md
+++ b/src/core/cli/man/content/quickstart_typescript.md
@@ -23,7 +23,7 @@ meshctl start --registry-only --debug
 
 ```bash
 # Terminal 2: Scaffold a TypeScript agent
-meshctl scaffold --name greeter --agent-type tool --lang typescript
+meshctl scaffold basic --name greeter --lang typescript
 ```
 
 This creates `greeter/src/index.ts`:
@@ -75,7 +75,7 @@ meshctl list
 Create a second agent that depends on the greeter:
 
 ```bash
-meshctl scaffold --name assistant --agent-type tool --lang typescript --port 9001
+meshctl scaffold basic --name assistant --lang typescript --port 9001
 ```
 
 Edit `assistant/src/index.ts`:

--- a/src/core/cli/man/content/scaffold.md
+++ b/src/core/cli/man/content/scaffold.md
@@ -14,12 +14,13 @@ Scaffold supports **Python**, **TypeScript**, and **Java** agents. Use `--lang t
 
 ## Agent Types
 
-| Subcommand     | Decorator            | Description                               |
-| -------------- | -------------------- | ----------------------------------------- |
-| `basic`        | `@mesh.tool`         | Basic capability agent                    |
-| `llm`          | `@mesh.llm`          | LLM-powered agent that consumes providers |
-| `llm-provider` | `@mesh.llm_provider` | Zero-code LLM provider                    |
-| `a2a-consumer` | (A2A bridge)         | Bridge external A2A producer skills       |
+| Subcommand     | Decorator                               | Description                                  |
+| -------------- | --------------------------------------- | -------------------------------------------- |
+| `basic`        | `@mesh.tool`                            | Basic capability agent                       |
+| `llm`          | `@mesh.llm`                             | LLM-powered agent that consumes providers    |
+| `llm-provider` | `@mesh.llm_provider`                    | Zero-code LLM provider                       |
+| `a2a-consumer` | (A2A bridge)                            | Bridge external A2A producer skills          |
+| `api`          | (`@mesh.route` / Express / Spring Boot) | HTTP API gateway consuming mesh capabilities |
 
 ## Quick Examples
 
@@ -38,6 +39,15 @@ meshctl scaffold llm --name analyzer --vendor claude
 
 # LLM provider exposing OpenAI
 meshctl scaffold llm-provider --name gpt-provider --vendor openai
+
+# Python FastAPI gateway with @mesh.route
+meshctl scaffold api --name gateway --lang python
+
+# TypeScript Express gateway
+meshctl scaffold api --name gateway --lang typescript
+
+# Java Spring Boot gateway
+meshctl scaffold api --name gateway --lang java
 
 # Preview without creating files
 meshctl scaffold basic --name my-agent --dry-run

--- a/src/core/cli/man/content/scaffold.md
+++ b/src/core/cli/man/content/scaffold.md
@@ -19,6 +19,7 @@ Scaffold supports **Python**, **TypeScript**, and **Java** agents. Use `--lang t
 | `basic`        | `@mesh.tool`         | Basic capability agent                    |
 | `llm`          | `@mesh.llm`          | LLM-powered agent that consumes providers |
 | `llm-provider` | `@mesh.llm_provider` | Zero-code LLM provider                    |
+| `a2a-consumer` | (A2A bridge)         | Bridge external A2A producer skills       |
 
 ## Quick Examples
 
@@ -58,23 +59,60 @@ meshctl scaffold --compose --observability
 meshctl scaffold --compose --project-name my-project
 ```
 
+### Generate observability stack alone
+
+If you only want the observability infra (Redis + Tempo + Grafana) without bundling it into your main `docker-compose.yml`, use the standalone `--observability` mode:
+
+```bash
+meshctl scaffold --observability
+```
+
+This emits a separate `docker-compose.observability.yml` file. Start it with:
+
+```bash
+docker compose -f docker-compose.observability.yml up -d
+```
+
+Combine with `--compose --observability` if you want a single merged file instead.
+
 ## Key Flags
 
-| Flag               | Description                                           |
-| ------------------ | ----------------------------------------------------- |
-| `--name`           | Agent name (required for non-interactive)             |
-| `--lang`           | Language: `python` (default), `typescript`, or `java` |
-| `--dry-run`        | Preview generated code                                |
-| `--no-interactive` | Disable prompts (for scripting)                       |
-| `--output`         | Output directory (default: `.`)                       |
-| `--port`           | HTTP port (default: 8080)                             |
-| `--model`          | LiteLLM model for llm-provider                        |
-| `--llm-selector`   | LLM provider for llm-agent: `claude`, `openai`        |
-| `--filter`         | Tool filter for llm-agent (capability selector JSON)  |
-| `--compose`        | Generate docker-compose.yml                           |
-| `--observability`  | Add Redis/Tempo/Grafana to compose                    |
+Common flags (apply to all subcommands):
 
-The `--filter` flag uses capability selector syntax. See `meshctl man capabilities` for details.
+| Flag               | Description                                            |
+| ------------------ | ------------------------------------------------------ |
+| `--name`           | Agent name (required for non-interactive)              |
+| `--lang`           | Language: `python` (default), `typescript`, or `java`  |
+| `--output`         | Output directory (default: `.`)                        |
+| `--port`           | HTTP port (default: 8080)                              |
+| `--description`    | Agent description                                      |
+| `--package`        | Java package name (default `com.example.<agent-name>`) |
+| `--dry-run`        | Preview generated code                                 |
+| `--no-interactive` | Disable prompts (for scripting)                        |
+
+LLM agent flags (`llm` and `llm-provider` subcommands):
+
+| Flag                | Description                                                                          |
+| ------------------- | ------------------------------------------------------------------------------------ |
+| `--vendor`          | Provider tag: `claude` (default), `openai`, `gemini`, `litellm-fallback`             |
+| `--model`           | Override LiteLLM model string (default derived from `--vendor`)                      |
+| `--response-format` | LLM response format: `text` (default), `json` (`llm` subcommand)                     |
+| `--max-iterations`  | Max agentic loop iterations (default 1) (`llm` subcommand)                           |
+| `--system-prompt`   | System prompt (inline or `file://path` for Jinja2 template) (`llm` subcommand)       |
+| `--context-param`   | Context parameter name (default `ctx`)                                               |
+| `--tags`            | Tags for discovery (comma-separated)                                                 |
+| `--filter`          | Tool filter for `llm` agents (capability selector JSON)                              |
+| `--filter-mode`     | Filter mode: `all` (default), `best_match`, `*` (wildcard) — companion to `--filter` |
+
+Docker compose flags (top-level scaffold, no subcommand):
+
+| Flag              | Description                                           |
+| ----------------- | ----------------------------------------------------- |
+| `--compose`       | Generate docker-compose.yml                           |
+| `--observability` | Add Redis/Tempo/Grafana (compose or standalone)       |
+| `--project-name`  | Docker compose project name (default: directory name) |
+
+The `--filter` flag uses capability selector syntax. See `meshctl man capabilities` for details. Pair it with `--filter-mode` to control how multiple filter clauses combine.
 
 ```bash
 # Filter tools by capability
@@ -82,7 +120,35 @@ meshctl scaffold llm --name analyzer --filter '[{"capability": "calculator"}]'
 
 # Filter tools by tags
 meshctl scaffold llm --name analyzer --filter '[{"tags": ["tools"]}]'
+
+# Best-match mode (pick the single best-scoring provider)
+meshctl scaffold llm --name analyzer --filter '[{"tags": ["math"]}]' --filter-mode best_match
 ```
+
+## A2A Consumer Scaffold
+
+Bridge an external A2A v1.0 producer's skills into the mesh as ordinary capabilities. Fetches the producer's `/.well-known/agent.json` at scaffold time; each skill in the card becomes a mesh capability in the generated agent.
+
+```bash
+# Python consumer bridging an external A2A producer
+meshctl scaffold a2a-consumer --url http://localhost:9090/agents/date \
+  --lang python --name date-bridge --port 9201
+
+# TypeScript variant
+meshctl scaffold a2a-consumer --url https://weather.com/agents/forecast \
+  --lang typescript --name weather-bridge
+
+# Java variant
+meshctl scaffold a2a-consumer --url https://weather.com/agents/forecast \
+  --lang java --name weather-bridge
+
+# Offline placeholder (no fetch — user fills in URL, skill, auth later)
+meshctl scaffold a2a-consumer --offline --lang python --name placeholder
+```
+
+If the producer's card declares bearer authentication, the generated code wires up an env-var-based bearer token placeholder (default `A2A_BEARER_TOKEN`).
+
+See `meshctl man a2a` for the full A2A protocol bridge guide.
 
 ## Hybrid Development Workflow
 

--- a/src/core/cli/man/content/scaffold.md
+++ b/src/core/cli/man/content/scaffold.md
@@ -6,43 +6,43 @@ Scaffold supports **Python**, **TypeScript**, and **Java** agents. Use `--lang t
 
 ## Input Modes
 
-| Mode        | Usage                                                | Best For         |
-| ----------- | ---------------------------------------------------- | ---------------- |
-| Interactive | `meshctl scaffold`                                   | First-time users |
-| CLI flags   | `meshctl scaffold --name my-agent --agent-type tool` | Scripting        |
-| Config file | `meshctl scaffold --config scaffold.yaml`            | Complex agents   |
+| Mode        | Usage                                       | Best For         |
+| ----------- | ------------------------------------------- | ---------------- |
+| Interactive | `meshctl scaffold`                          | First-time users |
+| CLI flags   | `meshctl scaffold basic --name my-agent`    | Scripting        |
+| Config file | `meshctl scaffold --config scaffold.yaml`   | Complex agents   |
 
 ## Agent Types
 
-| Type           | Decorator            | Description                               |
+| Subcommand     | Decorator            | Description                               |
 | -------------- | -------------------- | ----------------------------------------- |
-| `tool`         | `@mesh.tool`         | Basic capability agent                    |
-| `llm-agent`    | `@mesh.llm`          | LLM-powered agent that consumes providers |
+| `basic`        | `@mesh.tool`         | Basic capability agent                    |
+| `llm`          | `@mesh.llm`          | LLM-powered agent that consumes providers |
 | `llm-provider` | `@mesh.llm_provider` | Zero-code LLM provider                    |
 
 ## Quick Examples
 
 ```bash
 # Basic tool agent (Python - default)
-meshctl scaffold --name my-agent --agent-type tool
+meshctl scaffold basic --name my-agent
 
 # Basic tool agent (TypeScript)
-meshctl scaffold --name my-agent --agent-type tool --lang typescript
+meshctl scaffold basic --name my-agent --lang typescript
 
 # Basic tool agent (Java/Spring Boot)
-meshctl scaffold --name my-agent --agent-type tool --lang java
+meshctl scaffold basic --name my-agent --lang java
 
 # LLM agent using Claude
-meshctl scaffold --name analyzer --agent-type llm-agent --llm-selector claude
+meshctl scaffold llm --name analyzer --vendor claude
 
-# LLM provider exposing GPT-4
-meshctl scaffold --name gpt-provider --agent-type llm-provider --model openai/gpt-4
+# LLM provider exposing OpenAI
+meshctl scaffold llm-provider --name gpt-provider --vendor openai
 
 # Preview without creating files
-meshctl scaffold --name my-agent --agent-type tool --dry-run
+meshctl scaffold basic --name my-agent --dry-run
 
 # Non-interactive mode (for CI/scripts)
-meshctl scaffold --name my-agent --agent-type tool --no-interactive
+meshctl scaffold basic --name my-agent --no-interactive
 ```
 
 ## Docker Compose Generation
@@ -63,7 +63,6 @@ meshctl scaffold --compose --project-name my-project
 | Flag               | Description                                           |
 | ------------------ | ----------------------------------------------------- |
 | `--name`           | Agent name (required for non-interactive)             |
-| `--agent-type`     | `tool`, `llm-agent`, or `llm-provider`                |
 | `--lang`           | Language: `python` (default), `typescript`, or `java` |
 | `--dry-run`        | Preview generated code                                |
 | `--no-interactive` | Disable prompts (for scripting)                       |
@@ -79,10 +78,10 @@ The `--filter` flag uses capability selector syntax. See `meshctl man capabiliti
 
 ```bash
 # Filter tools by capability
-meshctl scaffold --name analyzer --agent-type llm-agent --filter '[{"capability": "calculator"}]'
+meshctl scaffold llm --name analyzer --filter '[{"capability": "calculator"}]'
 
 # Filter tools by tags
-meshctl scaffold --name analyzer --agent-type llm-agent --filter '[{"tags": ["tools"]}]'
+meshctl scaffold llm --name analyzer --filter '[{"tags": ["tools"]}]'
 ```
 
 ## Hybrid Development Workflow

--- a/src/core/cli/man/content/tutorial.md
+++ b/src/core/cli/man/content/tutorial.md
@@ -208,11 +208,11 @@ flight data. That's the complete Day 1 mesh.
 ## Step 1: Scaffold the agent
 
 `meshctl scaffold` generates a ready-to-run agent from a built-in template. For
-a basic Python tool agent, the flags you need are `--name`, `--agent-type tool`,
-and `--lang python` (which is the default, so you can omit it).
+a basic Python tool agent, you use the `basic` subcommand with `--name` and
+optionally `--lang python` (which is the default, so you can omit it).
 
 ```shell
-$ meshctl scaffold --name flight-agent --agent-type tool --port 9101
+$ meshctl scaffold basic --name flight-agent --port 9101
 
 Created agent 'flight-agent' in flight-agent/
 
@@ -483,10 +483,10 @@ outdoor activities. The other three -- `hotel-agent`, `weather-agent`, and
 You know `meshctl scaffold` from Day 1. Scaffold four new agents:
 
 ```shell
-$ meshctl scaffold --name hotel-agent --agent-type tool --port 9102
-$ meshctl scaffold --name weather-agent --agent-type tool --port 9103
-$ meshctl scaffold --name poi-agent --agent-type tool --port 9104
-$ meshctl scaffold --name user-prefs-agent --agent-type tool --port 9105
+$ meshctl scaffold basic --name hotel-agent --port 9102
+$ meshctl scaffold basic --name weather-agent --port 9103
+$ meshctl scaffold basic --name poi-agent --port 9104
+$ meshctl scaffold basic --name user-prefs-agent --port 9105
 ```
 
 Each command creates the same set of files you saw on Day 1: `main.py`,
@@ -722,7 +722,7 @@ handles the LiteLLM integration, request parsing, and response formatting.
 ### Scaffold the provider
 
 ```shell
-$ meshctl scaffold --name claude-provider --agent-type llm-provider --model anthropic/claude-sonnet-4-5 --port 9106
+$ meshctl scaffold llm-provider --name claude-provider --vendor claude --port 9106
 ```
 
 [Note: See the tutorial source files in examples/tutorial/trip-planner/day-03/ for full code listings]
@@ -759,7 +759,7 @@ model at call time.
 ### The planner code
 
 ```shell
-$ meshctl scaffold --name planner-agent --agent-type llm-agent --port 9107
+$ meshctl scaffold llm --name planner-agent --port 9107
 ```
 
 Three things to note:
@@ -873,7 +873,7 @@ Today has six parts:
 > `OPENAI_API_KEY` set in your environment.
 
 ```shell
-$ meshctl scaffold --name openai-provider --agent-type llm-provider --model openai/gpt-4o-mini --port 9108
+$ meshctl scaffold llm-provider --name openai-provider --vendor openai --port 9108
 ```
 
 [Note: See the tutorial source files in examples/tutorial/trip-planner/day-04/ for full code listings]
@@ -1059,7 +1059,7 @@ Today has four parts:
 ### Scaffold the gateway
 
 ```shell
-$ meshctl scaffold --name gateway --agent-type api --lang python --port 8080
+$ meshctl scaffold basic --name gateway --lang python --port 8080
 ```
 
 [Note: See the tutorial source files in examples/tutorial/trip-planner/day-05/ for full code listings]
@@ -1203,7 +1203,7 @@ primitive for state -- you write an agent that wraps a data store, and other
 agents call it like any other tool.
 
 ```shell
-$ meshctl scaffold --name chat-history-agent --agent-type tool --port 9109
+$ meshctl scaffold basic --name chat-history-agent --port 9109
 ```
 
 [Note: See the tutorial source files in examples/tutorial/trip-planner/day-06/ for full code listings]
@@ -1360,7 +1360,7 @@ to produce JSON matching the schema and validates the response automatically.
 ### Budget analyst
 
 ```shell
-$ meshctl scaffold --name budget-analyst --agent-type llm-agent --port 9110
+$ meshctl scaffold llm --name budget-analyst --port 9110
 ```
 
 [Note: See the tutorial source files in examples/tutorial/trip-planner/day-07/ for full code listings]
@@ -1372,7 +1372,7 @@ JSON.
 ### Adventure advisor
 
 ```shell
-$ meshctl scaffold --name adventure-advisor --agent-type llm-agent --port 9111
+$ meshctl scaffold llm --name adventure-advisor --port 9111
 ```
 
 Returns `AdventureAdvice` with `unique_experiences`, `local_gems`, and
@@ -1381,7 +1381,7 @@ Returns `AdventureAdvice` with `unique_experiences`, `local_gems`, and
 ### Logistics planner
 
 ```shell
-$ meshctl scaffold --name logistics-planner --agent-type llm-agent --port 9112
+$ meshctl scaffold llm --name logistics-planner --port 9112
 ```
 
 Returns `LogisticsPlan` with `daily_schedule`, `transit_tips`, and

--- a/src/core/cli/man/content/tutorial.md
+++ b/src/core/cli/man/content/tutorial.md
@@ -1059,7 +1059,7 @@ Today has four parts:
 ### Scaffold the gateway
 
 ```shell
-$ meshctl scaffold basic --name gateway --lang python --port 8080
+$ meshctl scaffold api --name gateway --lang python --port 8080
 ```
 
 [Note: See the tutorial source files in examples/tutorial/trip-planner/day-05/ for full code listings]

--- a/src/core/cli/scaffold.go
+++ b/src/core/cli/scaffold.go
@@ -23,6 +23,7 @@ Subcommands (per agent type):
   llm           Consumer agent that uses an LLM via mesh delegation
   llm-provider  @mesh.llm_provider agent for a specific vendor
   a2a-consumer  Bridge an external A2A producer onto the mesh
+  api           HTTP gateway (FastAPI / Express / Spring Boot) that consumes mesh capabilities
 
 Run 'meshctl scaffold <subcommand> --help' for per-subcommand flags.
 
@@ -141,6 +142,12 @@ Infrastructure:
 	// agent skeleton with one mesh capability per skill in the card.
 	scaffold.AttachA2AConsumerSubcommand(cmd)
 
+	// Attach `api` subcommand (#1005). Generates an HTTP gateway agent
+	// (FastAPI / Express / Spring Boot) that consumes mesh capabilities
+	// via @mesh.route or the language-equivalent middleware. Restores
+	// the capability dropped in #958 alongside the --agent-type removal.
+	scaffold.AttachAPISubcommand(cmd)
+
 	return cmd
 }
 
@@ -223,14 +230,16 @@ var agentTypeToSubcommand = map[string]string{
 // subcommand's full Execute path (so its own flag parsing + RunE fire
 // exactly as if the user had typed `meshctl scaffold <sub>` directly).
 func routeDeprecatedAgentType(cmd *cobra.Command, agentType string, _ []string) error {
-	// `api` was removed from the supported set in PR #958. There is no
-	// drop-in replacement subcommand — HTTP gateway scaffolding is now
-	// covered by deployment docs, not a scaffold template.
+	// The legacy `--agent-type api` form is intentionally not shimmed
+	// even though `meshctl scaffold api` was reintroduced in #1005.
+	// The whole `--agent-type` flag is being retired holistically; we
+	// don't want to encourage continued use of it for any value, so the
+	// `api` form errors out and points the user at the subcommand UX.
 	if agentType == "api" {
 		cmd.SilenceUsage = true
 		return fmt.Errorf(
-			"the 'api' agent type was removed; HTTP gateways are now built differently. " +
-				"See `meshctl man deployment`")
+			"the '--agent-type api' form was removed; use 'meshctl scaffold api' instead " +
+				"(see 'meshctl scaffold api --help')")
 	}
 
 	subName, ok := agentTypeToSubcommand[agentType]

--- a/src/core/cli/scaffold/api_subcommand.go
+++ b/src/core/cli/scaffold/api_subcommand.go
@@ -1,0 +1,128 @@
+package scaffold
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// newScaffoldAPICommand builds `meshctl scaffold api`.
+//
+// It scaffolds a non-mesh HTTP API server (FastAPI / Express / Spring
+// Boot) that consumes mesh capabilities via dependency injection:
+//   - Python: @mesh.route on FastAPI handlers
+//   - TypeScript: Express middleware that wires McpMeshTool proxies
+//   - Java: Spring Boot starter that injects mesh capabilities
+//
+// Different from the `basic` subcommand, which produces a mesh-native
+// MCP agent. This subcommand produces an HTTP gateway/API server whose
+// routes call into the mesh.
+//
+// The --agent-type api form was removed in PR #958 during the
+// subcommand migration; this subcommand restores the capability via the
+// canonical subcommand UX (issue #1005).
+func newScaffoldAPICommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "api",
+		Short: "Generate an HTTP gateway agent (FastAPI / Express / Spring Boot) that consumes mesh capabilities",
+		Long: `Generate a non-mesh HTTP API server that consumes mesh capabilities via
+dependency injection.
+
+Unlike 'meshctl scaffold basic' (which generates a mesh-native MCP
+agent), this subcommand emits an HTTP gateway whose routes resolve
+mesh capabilities at request time:
+
+  - Python:     FastAPI app with @mesh.route handlers
+  - TypeScript: Express app with mesh middleware
+  - Java:       Spring Boot app with mesh starter
+
+The generated app registers as a consumer (Type: API) on the mesh
+control plane; it does not implement the MCP protocol itself.
+
+Examples:
+  # Python FastAPI gateway with @mesh.route
+  meshctl scaffold api --name gateway --lang python
+
+  # TypeScript Express gateway
+  meshctl scaffold api --name gateway --lang typescript
+
+  # Java Spring Boot gateway
+  meshctl scaffold api --name gateway --lang java
+
+  # Preview without writing files
+  meshctl scaffold api --name gateway --dry-run`,
+		RunE: runScaffoldAPI,
+	}
+
+	cmd.Flags().StringP("name", "n", "",
+		"Agent name (required)")
+	cmd.Flags().StringP("lang", "l", "python",
+		fmt.Sprintf("Language runtime: %v", supportedLanguages))
+	cmd.Flags().StringP("output", "o", ".", "Output directory")
+	cmd.Flags().IntP("port", "p", 8080, "HTTP port for the API gateway")
+	cmd.Flags().String("description", "", "Agent description")
+	cmd.Flags().String("package", "",
+		"Java package name (default: com.example.<agent-name>)")
+	cmd.Flags().StringSlice("tags", nil, "Tags for discovery (comma-separated)")
+	cmd.Flags().Bool("dry-run", false, "Preview generated files without creating them")
+	// --no-interactive is registered for v1.4.1 script compatibility.
+	// TODO: wire to actual prompt-suppression once interactive prompts are added.
+	cmd.Flags().Bool("no-interactive", false, "Disable interactive prompts (for scripting)")
+
+	return cmd
+}
+
+// runScaffoldAPI executes the `api` subcommand.
+func runScaffoldAPI(cmd *cobra.Command, _ []string) error {
+	name, _ := cmd.Flags().GetString("name")
+	lang, _ := cmd.Flags().GetString("lang")
+	output, _ := cmd.Flags().GetString("output")
+	port, _ := cmd.Flags().GetInt("port")
+	description, _ := cmd.Flags().GetString("description")
+	javaPackage, _ := cmd.Flags().GetString("package")
+	tags, _ := cmd.Flags().GetStringSlice("tags")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+	if name == "" {
+		return fmt.Errorf("--name is required")
+	}
+
+	language := NormalizeLanguage(lang)
+	if !IsValidLanguage(language) {
+		return fmt.Errorf("unsupported language: %s (supported: %v)", lang, supportedLanguages)
+	}
+
+	// Auto-increment port if --port wasn't explicitly set (issue #957 fix 2).
+	port = AutoAssignScaffoldPort(cmd, port, output, name)
+
+	ctx := &ScaffoldContext{
+		Name:        name,
+		Description: description,
+		Language:    language,
+		OutputDir:   output,
+		Port:        port,
+		AgentType:   "api",
+		Template:    "api",
+		Tags:        tags,
+		JavaPackage: javaPackage,
+		Cmd:         cmd,
+		DryRun:      dryRun,
+	}
+
+	provider := NewStaticProvider()
+	if err := provider.Validate(ctx); err != nil {
+		return err
+	}
+	return provider.Execute(ctx)
+}
+
+// AttachAPISubcommand registers `meshctl scaffold api` onto the
+// scaffold root command. Called from cli.NewScaffoldCommand.
+//
+// Reintroduced in #1005 after the --agent-type api form was removed in
+// #958 without a subcommand replacement. The 3 template trees
+// (python/api, typescript/api, java/api) were left orphaned in the
+// repo; this hooks them back up via the canonical subcommand UX.
+func AttachAPISubcommand(parent *cobra.Command) {
+	parent.AddCommand(newScaffoldAPICommand())
+}

--- a/src/core/cli/scaffold/api_subcommand_test.go
+++ b/src/core/cli/scaffold/api_subcommand_test.go
@@ -1,0 +1,155 @@
+package scaffold
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewScaffoldAPICommand_BasicShape verifies the subcommand is
+// registered with the expected Use string and metadata.
+func TestNewScaffoldAPICommand_BasicShape(t *testing.T) {
+	cmd := newScaffoldAPICommand()
+	assert.Equal(t, "api", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+	assert.NotNil(t, cmd.RunE)
+}
+
+// TestNewScaffoldAPICommand_Flags verifies the full flag surface
+// matches the basic subcommand plus --tags. These are the flags
+// scripts and tests in tsuite expect to be present.
+func TestNewScaffoldAPICommand_Flags(t *testing.T) {
+	cmd := newScaffoldAPICommand()
+	for _, name := range []string{
+		"name", "lang", "output", "port", "description",
+		"package", "tags", "dry-run", "no-interactive",
+	} {
+		assert.NotNil(t, cmd.Flags().Lookup(name),
+			"--%s must be registered", name)
+	}
+}
+
+// TestNewScaffoldAPICommand_NoInteractiveFlag verifies the
+// --no-interactive flag is present so 1.4.1-era scripts that pass it
+// don't fail with "unknown flag".
+func TestNewScaffoldAPICommand_NoInteractiveFlag(t *testing.T) {
+	cmd := newScaffoldAPICommand()
+	assert.NotNil(t, cmd.Flags().Lookup("no-interactive"))
+}
+
+// TestNewScaffoldAPICommand_DefaultLanguage confirms python is the
+// default runtime, matching basic and the other scaffold subcommands.
+func TestNewScaffoldAPICommand_DefaultLanguage(t *testing.T) {
+	cmd := newScaffoldAPICommand()
+	lang, err := cmd.Flags().GetString("lang")
+	require.NoError(t, err)
+	assert.Equal(t, "python", lang)
+}
+
+// TestNewScaffoldAPICommand_DefaultPort confirms the default port
+// matches basic (8080), so port-collision auto-increment behaves
+// identically across subcommands.
+func TestNewScaffoldAPICommand_DefaultPort(t *testing.T) {
+	cmd := newScaffoldAPICommand()
+	port, err := cmd.Flags().GetInt("port")
+	require.NoError(t, err)
+	assert.Equal(t, 8080, port)
+}
+
+// TestRunScaffoldAPI_RequiresName verifies the --name flag is
+// required. Mirrors basic's contract.
+func TestRunScaffoldAPI_RequiresName(t *testing.T) {
+	cmd := newScaffoldAPICommand()
+	cmd.SetOut(bytes.NewBufferString(""))
+	cmd.SetErr(bytes.NewBufferString(""))
+	cmd.SetArgs([]string{"--no-interactive"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--name is required")
+}
+
+// TestRunScaffoldAPI_RejectsInvalidLanguage verifies unsupported
+// languages produce a clear error before the template lookup runs.
+func TestRunScaffoldAPI_RejectsInvalidLanguage(t *testing.T) {
+	cmd := newScaffoldAPICommand()
+	cmd.SetOut(bytes.NewBufferString(""))
+	cmd.SetErr(bytes.NewBufferString(""))
+	cmd.SetArgs([]string{
+		"--name", "gw",
+		"--lang", "cobol",
+		"--no-interactive",
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported language")
+}
+
+// TestRunScaffoldAPI_DryRunPython exercises the dry-run path with
+// filesystem-backed templates (the embedded FS is only set when the
+// binary is built; unit tests rely on the cmd/meshctl/templates dir
+// fallback wired into the static provider).
+func TestRunScaffoldAPI_DryRunPython(t *testing.T) {
+	out, err := runAPISubcommandDryRun(t, "python", "gw-py")
+	require.NoError(t, err, "dry-run should succeed for python; got stderr/log output:\n%s", out)
+	assertAPIDryRunMentions(t, out, "main.py")
+	assertAPIDryRunMentions(t, out, "@mesh.route")
+}
+
+// TestRunScaffoldAPI_DryRunTypeScript exercises the dry-run path for
+// the TypeScript Express template.
+func TestRunScaffoldAPI_DryRunTypeScript(t *testing.T) {
+	out, err := runAPISubcommandDryRun(t, "typescript", "gw-ts")
+	require.NoError(t, err, "dry-run should succeed for typescript; got:\n%s", out)
+	assertAPIDryRunMentions(t, out, "package.json")
+}
+
+// TestRunScaffoldAPI_DryRunJava exercises the dry-run path for the
+// Java Spring Boot template.
+func TestRunScaffoldAPI_DryRunJava(t *testing.T) {
+	out, err := runAPISubcommandDryRun(t, "java", "gw-java")
+	require.NoError(t, err, "dry-run should succeed for java; got:\n%s", out)
+	assertAPIDryRunMentions(t, out, "pom.xml")
+}
+
+// runAPISubcommandDryRun wires the api subcommand to a captured
+// buffer and points the static provider at the in-repo template tree
+// via MESHCTL_TEMPLATE_DIR. Returns the captured stdout and execution
+// error.
+func runAPISubcommandDryRun(t *testing.T, lang, name string) (string, error) {
+	t.Helper()
+
+	// Point at in-repo cmd/meshctl/templates so the filesystem fallback
+	// resolves when embedded templates aren't compiled in.
+	t.Setenv("MESHCTL_TEMPLATE_DIR",
+		getProjectRoot()+"/cmd/meshctl/templates")
+
+	cmd := newScaffoldAPICommand()
+	out := bytes.NewBufferString("")
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{
+		"--name", name,
+		"--lang", lang,
+		"--no-interactive",
+		"--dry-run",
+	})
+
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// assertAPIDryRunMentions checks that the captured dry-run output
+// includes the expected substring (a generated filename or template
+// fragment), giving an actionable error message on failure.
+func assertAPIDryRunMentions(t *testing.T, out, want string) {
+	t.Helper()
+	if !strings.Contains(out, want) {
+		t.Errorf("dry-run output should mention %q; got:\n%s", want, out)
+	}
+}

--- a/src/core/cli/scaffold_test.go
+++ b/src/core/cli/scaffold_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,6 +46,26 @@ func TestScaffoldCommand_HasStaticFlags(t *testing.T) {
 	assert.NotNil(t, cmd.Flags().Lookup("template"))
 	assert.NotNil(t, cmd.Flags().Lookup("template-dir"))
 	assert.NotNil(t, cmd.Flags().Lookup("config"))
+}
+
+// TestScaffoldCommand_HasAPISubcommand verifies the `api` subcommand
+// is wired alongside basic, llm, llm-provider, a2a-consumer (issue
+// #1005). Reintroduced after the --agent-type api removal in #958
+// orphaned the python/typescript/java/api template trees.
+func TestScaffoldCommand_HasAPISubcommand(t *testing.T) {
+	cmd := NewScaffoldCommand()
+
+	sub, _, err := cmd.Find([]string{"api"})
+	require.NoError(t, err)
+	require.NotNil(t, sub)
+	assert.Equal(t, "api", sub.Name(),
+		"`meshctl scaffold api` must be registered as a subcommand")
+
+	// Same flag surface as basic + tags.
+	for _, name := range []string{"name", "lang", "output", "port", "description", "package", "tags", "dry-run", "no-interactive"} {
+		assert.NotNil(t, sub.Flags().Lookup(name),
+			"`scaffold api` must register --%s", name)
+	}
 }
 
 // TestScaffoldCommand_HasKeepListFlags asserts the flags that back the
@@ -206,8 +225,11 @@ func TestScaffoldCommand_AgentTypeLLMAgentRoutesToLLM(t *testing.T) {
 		"expected llm-agent to map to 'scaffold llm', got stderr:\n%s", stderr)
 }
 
-// TestScaffoldCommand_AgentTypeAPIErrors verifies the removed `api`
-// value produces a clear error referencing the deployment man page.
+// TestScaffoldCommand_AgentTypeAPIErrors verifies the legacy
+// `--agent-type api` form errors with a pointer to the new
+// `meshctl scaffold api` subcommand. The subcommand was reintroduced
+// in #1005 but the legacy --agent-type flag is being retired
+// holistically, so api is intentionally not shimmed.
 func TestScaffoldCommand_AgentTypeAPIErrors(t *testing.T) {
 	cmd := NewScaffoldCommand()
 	cmd.SetOut(bytes.NewBufferString(""))
@@ -221,12 +243,10 @@ func TestScaffoldCommand_AgentTypeAPIErrors(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	msg := err.Error()
-	assert.Contains(t, msg, "'api' agent type was removed",
+	assert.Contains(t, msg, "'--agent-type api' form was removed",
 		"expected explicit removal message, got: %s", msg)
-	assert.True(t,
-		strings.Contains(msg, "meshctl man deployment") ||
-			strings.Contains(msg, "man deployment"),
-		"expected pointer to deployment docs, got: %s", msg)
+	assert.Contains(t, msg, "meshctl scaffold api",
+		"expected pointer to the new subcommand, got: %s", msg)
 }
 
 // TestScaffoldCommand_AgentTypeUnknownErrors verifies that an unknown


### PR DESCRIPTION
## Summary

Three commits closing **two** issues:

- **#994** — rewrite all 47 deprecated `meshctl scaffold --name X --agent-type Y` examples across 11 `meshctl man` content files to the canonical subcommand form
- **#1005** — reintroduce `meshctl scaffold api` as the 5th subcommand (regression from PR #958 — templates existed orphaned in repo, command path was severed)

Per the project doc convention (`.claude/CLAUDE.md`): no "deprecated → use X" callouts in user-facing docs — runtime warnings carry the deprecation for existing users.

## #994 — Doc rewrite (commits ba573cdd8 + 03567c880)

### Per-file occurrence count (BEFORE → AFTER)

| File | Before | After |
|---|---|---|
| `tutorial.md` | 14 | 0 |
| `scaffold.md` | 11 | 0 |
| `cli.md` | 6 | 0 |
| `deployment.md` | 3 | 0 |
| `deployment_typescript.md` | 2 | 0 |
| `quickstart.md` | 2 | 0 |
| `quickstart_typescript.md` | 2 | 0 |
| `prerequisites.md` | 2 | 0 |
| `llm.md` | 2 | 0 |
| `prerequisites_typescript.md` | 1 | 0 |
| `prerequisites_java.md` | 1 | 0 |

`grep -l "agent-type" src/core/cli/man/content/*.md` returns no matches.

### Notable doc fixes

- **`prerequisites.md` had a fully broken example**: `meshctl scaffold --name hello --agent-type basic` — `basic` was never a valid `--agent-type` value. Now `meshctl scaffold basic --name hello`.
- **`scaffold.md` additive content**: new A2A Consumer section, restructured Key Flags into 3 grouped tables (Common / LLM agent / Docker compose), `--filter-mode` companion to `--filter`, standalone `--observability` mode (`docker-compose.observability.yml`).

## #1005 — `scaffold api` subcommand (commit b2b6e4692)

### Background

PR #756 introduced `--agent-type api` for HTTP gateway scaffolding. PR #958 removed it during the subcommand migration **but did not add a replacement subcommand**. The 3 template trees were orphaned:

- `cmd/meshctl/templates/python/api/` (FastAPI + `@mesh.route`)
- `cmd/meshctl/templates/typescript/api/` (Express)
- `cmd/meshctl/templates/java/api/` (Spring Boot)

Runtime support intact (`@mesh.route` works, `meshctl man api` documents it, Spring Boot starter shipped). Just no command surface to scaffold a starter.

### What's new

- **`scaffold api` subcommand** — 5th sibling of `basic` / `llm` / `llm-provider` / `a2a-consumer`. Mirrors the basic-subcommand pattern; wires the existing template dirs.
- **`api_subcommand.go`** (128 lines) + **`api_subcommand_test.go`** (155 lines, 10 tests covering all 3 langs)
- **Doc updates**: `man scaffold` adds `api` row to Agent Types table + 3 examples; `man api` adds cross-reference one-liner; `man tutorial` Day 5 swaps the `scaffold basic` workaround (introduced in this PR's first commit) for the proper `scaffold api`
- **Legacy `--agent-type api` error**: updated message points users at the new subcommand instead of deployment docs

### Verification

```
$ go build ./...
$ go test ./src/core/cli/... ./src/core/cli/scaffold/...   → all pass
$ /tmp/meshctl-test scaffold --help | grep "api  "          → present
$ /tmp/meshctl-test scaffold api --name gw-py --lang python --no-interactive --dry-run    → emits FastAPI files
$ /tmp/meshctl-test scaffold api --name gw-ts --lang typescript --no-interactive --dry-run → emits Express files
$ /tmp/meshctl-test scaffold api --name gw-java --lang java --no-interactive --dry-run    → emits Spring Boot files
$ /tmp/meshctl-test man scaffold --raw | grep "scaffold api"     → 3 example lines
$ /tmp/meshctl-test man api --raw | grep "scaffold api"          → cross-reference present
$ /tmp/meshctl-test man tutorial --raw --day 5 | grep "scaffold api" → Day 5 updated
```

## Commits

- `ba573cdd8` — `docs(scaffold): rewrite scaffold examples to subcommand form (#994)`
- `03567c880` — `docs(scaffold): add a2a-consumer + --filter-mode + missing flags (#994)`
- `b2b6e4692` — `feat(scaffold): reintroduce api subcommand for HTTP gateway agents (#1005)`

Closes #994
Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)