### PR TITLE
docs: correct heartbeat env var + decorator parameter labels (3 docs)

### DIFF
--- a/src/core/cli/man/content/decorators.md
+++ b/src/core/cli/man/content/decorators.md
@@ -35,13 +35,15 @@ Configures the agent server settings. Applied to a class.
     name="my-service",           # Required: unique agent identifier
     version="1.0.0",             # Semantic version
     description="Service desc",  # Human-readable description
-    http_port=8080,              # HTTP server port (0 = auto-assign)
     http_host="localhost",       # Host announced to registry
+    http_port=8080,              # HTTP server port (0 = auto-assign)
+    enable_http=True,            # Bind HTTP server (default True)
     namespace="default",         # Namespace for isolation
-    auto_run=True,               # Start automatically (no main() needed)
-    auto_run_interval=10,        # Heartbeat interval in seconds
+    heartbeat_interval=5,        # Heartbeat cadence in seconds (env: MCP_MESH_HEALTH_INTERVAL)
     health_check=health_fn,      # Optional health check function
-    health_check_ttl=30,         # Health check cache TTL
+    health_check_ttl=15,         # Health check cache TTL (seconds)
+    auto_run=True,               # Start automatically (no main() needed)
+    auto_run_interval=10,        # Auto-run loop interval (env: MCP_MESH_AUTO_RUN_INTERVAL)
 )
 class MyAgent:
     pass

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -32,10 +32,10 @@ export MCP_MESH_HTTP_HOST=my-service  # Announced hostname
 
 # Auto-run behavior
 export MCP_MESH_AUTO_RUN=true
-export MCP_MESH_AUTO_RUN_INTERVAL=30  # Heartbeat interval (seconds)
+export MCP_MESH_AUTO_RUN_INTERVAL=10  # Auto-run loop interval (seconds, default 10)
 
-# Health monitoring
-export MCP_MESH_HEALTH_INTERVAL=30
+# Heartbeat cadence — overrides @mesh.agent(heartbeat_interval=...)
+export MCP_MESH_HEALTH_INTERVAL=5     # Heartbeat interval to registry (seconds, default 5)
 
 # Global toggle
 export MCP_MESH_ENABLED=true

--- a/src/core/cli/man/content/health.md
+++ b/src/core/cli/man/content/health.md
@@ -45,11 +45,11 @@ Background process that:
 ### Agent Settings
 
 ```bash
-# Heartbeat interval (seconds)
-export MCP_MESH_AUTO_RUN_INTERVAL=30
+# Heartbeat cadence to registry (overrides @mesh.agent heartbeat_interval, default 5)
+export MCP_MESH_HEALTH_INTERVAL=5
 
-# Health check interval (seconds)
-export MCP_MESH_HEALTH_INTERVAL=30
+# Auto-run loop interval (overrides @mesh.agent auto_run_interval, default 10)
+export MCP_MESH_AUTO_RUN_INTERVAL=10
 ```
 
 ### Registry Settings


### PR DESCRIPTION
## Summary

Three `meshctl man` content docs mislabeled the heartbeat-cadence knob, conflating `auto_run_interval` (auto-run/event-loop interval) with the actual heartbeat parameter (`heartbeat_interval`).

Source-of-truth verified in `src/runtime/python/mesh/decorators.py` and `_mcp_mesh/engine/decorator_registry.py`:

- `MCP_MESH_HEALTH_INTERVAL` → overrides `heartbeat_interval` (default **5**)
- `MCP_MESH_AUTO_RUN_INTERVAL` → overrides `auto_run_interval` (default **10**)

## Fixes

### `decorators.md` — `@mesh.agent` example
- Added missing `enable_http=True` (default — scaffolded code uses it; doc didn't list it)
- Added missing `heartbeat_interval=5` with env-var hint (`MCP_MESH_HEALTH_INTERVAL`)
- Corrected `health_check_ttl` default `30` → `15`
- Reworded `auto_run_interval=10` comment so it no longer claims "Heartbeat interval"
- Reordered fields slightly for cleaner visual grouping (HTTP cluster / heartbeat-health cluster)

### `environment.md`
- `MCP_MESH_AUTO_RUN_INTERVAL` comment corrected; default `30` → `10`
- Section heading `## Health monitoring` → `## Heartbeat cadence` with cross-reference to the decorator parameter
- `MCP_MESH_HEALTH_INTERVAL` comment now correctly says "Heartbeat interval to registry"; default `30` → `5`
- Profile examples (Development / Production) intentionally kept as-is — they're override examples

### `health.md`
- Agent Settings block reordered (heartbeat first — that's what users tuning heartbeat reach for)
- Both env var comments corrected
- Defaults fixed (5 and 10)

## Stats

3 files changed, +13 / −11.

## Verification

```
$ go build -o /tmp/meshctl-test ./cmd/meshctl
$ /tmp/meshctl-test man decorators --raw | grep -E "enable_http|heartbeat_interval"
    enable_http=True,            # Bind HTTP server (default True)
    heartbeat_interval=5,        # Heartbeat cadence in seconds (env: MCP_MESH_HEALTH_INTERVAL)

$ /tmp/meshctl-test man environment --raw | grep -B1 "MCP_MESH_HEALTH_INTERVAL"
# Heartbeat cadence — overrides @mesh.agent(heartbeat_interval=...)
export MCP_MESH_HEALTH_INTERVAL=5     # Heartbeat interval to registry (seconds, default 5)

$ /tmp/meshctl-test man health --raw | grep -B1 "MCP_MESH_HEALTH_INTERVAL"
# Heartbeat cadence to registry (overrides @mesh.agent heartbeat_interval, default 5)
export MCP_MESH_HEALTH_INTERVAL=5
```

Closes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent configuration documentation with new options and parameter organization.
  * Adjusted default values for health monitoring and auto-run intervals in both configuration and environment variables.
  * Clarified environment variable documentation for health interval and heartbeat cadence settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1006)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->