### PR TITLE
docs(decorators): add a2a decorator family to decorators reference (3 langs)

### DIFF
--- a/src/core/cli/man/content/decorators.md
+++ b/src/core/cli/man/content/decorators.md
@@ -13,15 +13,18 @@ MCP Mesh provides decorators (Python), annotations (Java), and function wrappers
 | `@mesh.llm`          | Enable LLM-powered tools        |
 | `@mesh.llm_provider` | Create LLM provider (zero-code) |
 | `@mesh.route`        | FastAPI route with mesh DI      |
+| `@mesh.a2a`          | Expose mesh tools as A2A v1.0 skills (producer, Python only) |
+| `@mesh.a2a_consumer` | Bridge an external A2A skill into the mesh as a capability   |
 
 ## Decorator Order (Critical!)
 
 When using multiple decorators, order matters:
 
 ```python
-@app.tool()           # 1. FastMCP protocol handler (outermost)
-@mesh.llm(...)        # 2. LLM integration (if using)
-@mesh.tool(...)       # 3. Mesh capability registration (innermost)
+@app.tool()                  # 1. FastMCP protocol handler (outermost)
+@mesh.llm(...)               # 2. LLM integration (if using)
+@mesh.a2a_consumer(...)      # 2. OR A2A bridge (mutually exclusive with @mesh.llm)
+@mesh.tool(...)              # 3. Mesh capability registration (innermost)
 def my_function():
     pass
 ```
@@ -194,6 +197,80 @@ async def chat_endpoint(
 **Note**: `@mesh.route` is for FastAPI backends that _consume_ mesh capabilities. Use `@mesh.tool` for MCP agents that _provide_ capabilities.
 
 See `meshctl man fastapi` for complete FastAPI integration guide.
+
+## @mesh.a2a (Producer — Python only)
+
+Expose mesh tools as A2A v1.0 skills via the `mesh.a2a.mount(...)` style. The user owns the FastAPI app AND the uvicorn lifecycle — no `@mesh.agent` decorator. The mount auto-generates the `/.well-known/agent.json` card and the JSON-RPC entry route.
+
+```python
+import mesh
+from fastapi import FastAPI
+from mesh.types import McpMeshTool
+
+app = FastAPI(title="Date A2A Agent")
+
+
+@mesh.a2a.mount(
+    app,
+    path="/agents/date",
+    dependencies=["date_service"],
+    skill_id="get-date",
+    skill_name="Get Date",
+)
+async def date_a2a(payload: dict, date_service: McpMeshTool = None):
+    if date_service is None:
+        return {"error": "date_service not yet resolved"}
+    return {"date": await date_service()}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=9090)
+```
+
+The mount attaches both:
+- `GET  /agents/date/.well-known/agent.json` — auto-generated card
+- `POST /agents/date` — JSON-RPC entry for `tasks/*` methods
+
+**Note**: A single Python process may NOT host both `@mesh.tool` capabilities and a `mesh.a2a.mount(...)` surface — the framework rejects mixed-mode at boot. Split into two agents (one provider, one A2A surface that depends on it).
+
+Java and TypeScript producer support is future work.
+
+See `meshctl man a2a` for the full producer + bearer auth + skill-card guide.
+
+## @mesh.a2a_consumer
+
+Bridge an external A2A v1.0 skill into the mesh as an ordinary mesh capability. Downstream callers consume it with no awareness of A2A.
+
+```python
+import json
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Date Consumer Bridge")
+
+
+@app.tool()
+@mesh.a2a_consumer(
+    capability="current-date",
+    a2a_url="http://localhost:9090/agents/date",
+    a2a_skill_id="get-date",
+)
+async def current_date(_a2a: mesh.A2AClient = None) -> dict:
+    response = await _a2a.send(
+        message={"role": "user", "parts": [{"type": "text", "text": "now"}]},
+    )
+    return json.loads(response.artifact_text)
+
+
+@mesh.agent(name="date-consumer", http_port=9201)
+class DateConsumer:
+    pass
+```
+
+The injected `_a2a: mesh.A2AClient` parameter exposes `.send(...)`. Bearer auth (`A2A_BEARER_TOKEN` env var by default) is wired automatically when the upstream card declares it.
+
+See `meshctl man a2a` for cross-language consumer parity (Python/TypeScript/Java) and offline-card scaffolding via `meshctl scaffold a2a-consumer`.
 
 ## Environment Variable Overrides
 

--- a/src/core/cli/man/content/decorators_java.md
+++ b/src/core/cli/man/content/decorators_java.md
@@ -15,6 +15,7 @@ MCP Mesh provides annotations that transform regular Spring Boot methods into me
 | `@MeshLlm`         | Enable LLM-powered tools                  |
 | `@MeshLlmProvider` | Create zero-code LLM provider             |
 | `@MeshRoute`       | REST endpoint with mesh DI                |
+| `@A2AConsumer`     | Bridge an external A2A skill as a mesh capability |
 
 ## @MeshAgent
 
@@ -326,6 +327,39 @@ public ResponseEntity<ChatResponse> chat(
     return ResponseEntity.ok(new ChatResponse(result));
 }
 ```
+
+## @A2AConsumer
+
+Bridge an external A2A v1.0 skill into the mesh as a regular mesh capability. The framework injects an `A2AClient` parameter slot into a `@MeshTool`-annotated method.
+
+```java
+@MeshAgent(name = "date-consumer", port = 9201)
+@SpringBootApplication
+public class DateConsumerAgentApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DateConsumerAgentApplication.class, args);
+    }
+
+    @MeshTool(capability = "current-date")
+    @A2AConsumer(
+        url = "http://localhost:9090/agents/date",
+        skillId = "get-date"
+    )
+    public Map<String, Object> currentDate(A2AClient a2a) throws Exception {
+        A2AResponse r = a2a.send(Map.of(
+            "role", "user",
+            "parts", List.of(Map.of("type", "text", "text", "now"))
+        ));
+        return new ObjectMapper().readValue(r.artifactText(), Map.class);
+    }
+}
+```
+
+Bearer auth is wired via `@A2AConsumer(authBearerEnv = "UPSTREAM_TOKEN")` when the upstream card requires it.
+
+A2A producer support in Java is future work — only consumer is available today.
+
+See `meshctl man a2a` for the full A2A protocol bridge guide.
 
 ## Environment Variable Overrides
 

--- a/src/core/cli/man/content/decorators_typescript.md
+++ b/src/core/cli/man/content/decorators_typescript.md
@@ -13,6 +13,7 @@ MCP Mesh provides core functions that transform regular TypeScript functions int
 | `mesh.llm()`       | Enable LLM-powered tools           |
 | `mesh.llmProvider()` | Create LLM provider (zero-code)  |
 | `mesh.route()`     | Express route with mesh DI         |
+| `addTool({ a2aConfig })` | Bridge an external A2A skill as a mesh capability |
 
 ## mesh() Function
 
@@ -218,6 +219,42 @@ app.listen(3000);
 **Note**: `mesh.route()` is for Express backends that _consume_ mesh capabilities. Use `agent.addTool()` for MCP agents that _provide_ capabilities.
 
 See `meshctl man express` for complete Express integration guide.
+
+## A2A Consumer (`a2aConfig` on `addTool`)
+
+Bridge an external A2A v1.0 skill into the mesh as a regular mesh capability. The framework injects an `A2AClient` into the tool's execute callback.
+
+```typescript
+import { FastMCP, mesh, type A2AClient } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const server = new FastMCP({ name: "Date Consumer Bridge", version: "1.0.0" });
+const agent = mesh(server, { name: "date-consumer-ts", httpPort: 9201 });
+
+agent.addTool({
+  name: "current_date",
+  capability: "current-date",
+  parameters: z.object({}),
+  a2aConfig: {
+    url: "http://localhost:9090/agents/date",
+    skillId: "get-date",
+  },
+  execute: async (_args, ..._injected) => {
+    const a2a = _injected[0] as A2AClient;
+    const r = await a2a.send({
+      role: "user",
+      parts: [{ type: "text", text: "now" }],
+    });
+    return r.artifactText ? JSON.parse(r.artifactText) : "";
+  },
+});
+```
+
+Bearer auth is wired via `a2aConfig.auth = { tokenEnv: "UPSTREAM_TOKEN" }` when the upstream card requires it.
+
+A2A producer support in TypeScript is future work — only consumer is available today.
+
+See `meshctl man a2a` for the full A2A protocol bridge guide.
 
 ## Environment Variable Overrides
 


### PR DESCRIPTION
## Summary

The decorators reference page listed 5 mesh decorators but completely omitted the a2a family. The a2a surface IS comprehensively documented in `meshctl man a2a`, but a user reading `meshctl man decorators` for "what decorators exist?" got an incomplete picture.

## Changes

Adds to all 3 language variants:

| File | Added |
|---|---|
| `decorators.md` (Python) | `@mesh.a2a` (producer, mount-style) + `@mesh.a2a_consumer` |
| `decorators_typescript.md` | `addTool({ a2aConfig })` consumer-side |
| `decorators_java.md` | `@A2AConsumer` annotation consumer-side |

Each variant got:
- A new row in the decorator-summary table at the top
- A dedicated section with a canonical example (sourced from `meshctl man a2a`)
- Cross-reference back to `meshctl man a2a` for full bridge semantics

Python `decorators.md` also got the Decorator Order block updated to show `@mesh.a2a_consumer` as mutually exclusive with `@mesh.llm`.

## Producer is Python-only

A2A producer support in TypeScript and Java is future work — flagged honestly in each language's section ("A2A producer support in TypeScript is future work — only consumer is available today"). Not a doc gap; an honest platform constraint.

## Stats

3 files changed, +151 / −3.

## Verification

```
$ go build -o /tmp/meshctl-test ./cmd/meshctl
$ /tmp/meshctl-test man decorators --raw | grep -E "@mesh.a2a|@mesh.a2a_consumer"   → 7 hits
$ /tmp/meshctl-test man decorators --typescript --raw | grep -E "a2aConfig|A2AClient"  → 6 hits
$ /tmp/meshctl-test man decorators --java --raw | grep -E "@A2AConsumer|A2AClient"     → 5 hits
$ /tmp/meshctl-test man a2a --raw | head -5    → unchanged sanity ✓
```

Closes #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)