### PR TITLE
runtime: native LLM adapter polish + Gemini 2.5 Flash migration

### DIFF
--- a/docs/01-getting-started/06-llm-integration.md
+++ b/docs/01-getting-started/06-llm-integration.md
@@ -157,7 +157,7 @@ Provide detailed analysis appropriate for {{ user_level }}-level users.
 
 > **Vertex AI (Gemini via IAM)**: For production deployments using Google
 > Cloud IAM instead of API keys, run a Gemini provider with
-> `model="vertex_ai/gemini-2.0-flash"` and install the `[vertex]` extra.
+> `model="vertex_ai/gemini-2.5-flash"` and install the `[vertex]` extra.
 > Consumers don't change. The TypeScript and Java runtimes have equivalent
 > support — see the [Python](../python/llm/index.md),
 > [TypeScript](../typescript/llm/index.md), and [Java](../java/llm/index.md)

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -421,7 +421,7 @@ Run a `@mesh.llm_provider` agent with the `vertex_ai/*` model string:
 @mesh.llm_provider(
     capability="llm",
     tags=["llm", "gemini", "vertex"],
-    model="vertex_ai/gemini-2.0-flash",
+    model="vertex_ai/gemini-2.5-flash",
 )
 def gemini_provider(): pass
 ```
@@ -454,7 +454,7 @@ LiteLLM auth resolution order:
 
 ```typescript
 agent.addLlmProvider({
-  model: "vertex_ai/gemini-2.0-flash",
+  model: "vertex_ai/gemini-2.5-flash",
   capability: "llm",
   tags: ["gemini", "vertex"],
 });
@@ -477,7 +477,7 @@ when present:
 @MeshLlmProvider(
     capability = "llm",
     tags = {"llm", "gemini", "vertex"},
-    model = "vertex_ai/gemini-2.0-flash"
+    model = "vertex_ai/gemini-2.5-flash"
 )
 @SpringBootApplication
 public class GeminiProviderApplication { … }
@@ -512,9 +512,9 @@ that changes between AI Studio and Vertex AI. Consumer agents keep the same
 
 |                | AI Studio                                  | Vertex AI                                                          |
 | -------------- | ------------------------------------------ | ------------------------------------------------------------------ |
-| Python provider | `model="gemini/gemini-2.0-flash"`          | `model="vertex_ai/gemini-2.0-flash"`                               |
-| TypeScript provider | `model: "gemini/gemini-2.0-flash"`     | `model: "vertex_ai/gemini-2.0-flash"`                              |
-| Java provider   | `model = "gemini/gemini-2.0-flash"`        | `model = "vertex_ai/gemini-2.0-flash"`                             |
+| Python provider | `model="gemini/gemini-2.5-flash"`          | `model="vertex_ai/gemini-2.5-flash"`                               |
+| TypeScript provider | `model: "gemini/gemini-2.5-flash"`     | `model: "vertex_ai/gemini-2.5-flash"`                              |
+| Java provider   | `model = "gemini/gemini-2.5-flash"`        | `model = "vertex_ai/gemini-2.5-flash"`                             |
 | Auth env       | `GOOGLE_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY` / `GOOGLE_AI_GEMINI_API_KEY` | `GOOGLE_APPLICATION_CREDENTIALS` (ADC)        |
 
 #### Provisioned Throughput

--- a/docs/java/llm/index.md
+++ b/docs/java/llm/index.md
@@ -245,8 +245,8 @@ Uses LiteLLM model format in `@MeshLlmProvider`:
 | ----------------------- | ------------------------------ |
 | Anthropic               | `anthropic/claude-sonnet-4-5`  |
 | OpenAI                  | `openai/gpt-4o`                |
-| Google AI Studio        | `gemini/gemini-2.0-flash`      |
-| Google Vertex AI (IAM)  | `vertex_ai/gemini-2.0-flash`   |
+| Google AI Studio        | `gemini/gemini-2.5-flash`      |
+| Google Vertex AI (IAM)  | `vertex_ai/gemini-2.5-flash`   |
 | Mistral                 | `mistral/mistral-large-latest` |
 
 ## Vertex AI (Gemini via IAM)
@@ -260,8 +260,8 @@ provider value, dependency, and auth config change.
 
 | Use case                                              | Pick                                                                                  |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| Quickstart / dev / lowest setup                       | AI Studio provider (`model = "gemini/gemini-2.0-flash"`, `GOOGLE_AI_GEMINI_API_KEY`)  |
-| Production with IAM auth, GCP audit logs, VPC-SC      | Vertex AI provider (`model = "vertex_ai/gemini-2.0-flash"`, ADC)                      |
+| Quickstart / dev / lowest setup                       | AI Studio provider (`model = "gemini/gemini-2.5-flash"`, `GOOGLE_AI_GEMINI_API_KEY`)  |
+| Production with IAM auth, GCP audit logs, VPC-SC      | Vertex AI provider (`model = "vertex_ai/gemini-2.5-flash"`, ADC)                      |
 | Need Provisioned Throughput (no capacity 429s)        | Vertex AI provider                                                                    |
 | Multi-tenant org-controlled billing                   | Vertex AI provider                                                                    |
 
@@ -292,7 +292,7 @@ provider value, dependency, and auth config change.
              location:   ${SPRING_AI_VERTEX_AI_GEMINI_LOCATION:us-central1}
              chat:
                options:
-                 model: gemini-2.0-flash
+                 model: gemini-2.5-flash
    ```
 
 3. Configure GCP Application Default Credentials:
@@ -310,7 +310,7 @@ provider value, dependency, and auth config change.
    @MeshLlmProvider(
        capability = "llm",
        tags = {"llm", "gemini", "vertex"},
-       model = "vertex_ai/gemini-2.0-flash"
+       model = "vertex_ai/gemini-2.5-flash"
    )
    @SpringBootApplication
    public class GeminiProviderApplication {
@@ -332,9 +332,9 @@ string and swapping the Spring AI starter dependency:
 
 ```java
 // Provider — before:
-@MeshLlmProvider(model = "gemini/gemini-2.0-flash", capability = "llm", tags = {"llm","gemini"})
+@MeshLlmProvider(model = "gemini/gemini-2.5-flash", capability = "llm", tags = {"llm","gemini"})
 // Provider — after:
-@MeshLlmProvider(model = "vertex_ai/gemini-2.0-flash", capability = "llm", tags = {"llm","gemini","vertex"})
+@MeshLlmProvider(model = "vertex_ai/gemini-2.5-flash", capability = "llm", tags = {"llm","gemini","vertex"})
 ```
 
 Swap the dependency in `pom.xml`

--- a/docs/python/llm/index.md
+++ b/docs/python/llm/index.md
@@ -157,8 +157,8 @@ anthropic/claude-opus-4
 openai/gpt-4o
 openai/gpt-4-turbo
 openai/gpt-3.5-turbo
-gemini/gemini-2.0-flash          # Google AI Studio (API key)
-vertex_ai/gemini-2.0-flash       # Google Vertex AI (IAM)
+gemini/gemini-2.5-flash          # Google AI Studio (API key)
+vertex_ai/gemini-2.5-flash       # Google Vertex AI (IAM)
 ```
 
 ## Vertex AI (Gemini via IAM)
@@ -226,7 +226,7 @@ auth env vars (each follows its own ecosystem's naming convention).
    @mesh.llm_provider(
        capability="llm",
        tags=["gemini", "vertex"],
-       model="vertex_ai/gemini-2.0-flash",
+       model="vertex_ai/gemini-2.5-flash",
    )
    def my_provider(): pass
    ```
@@ -241,7 +241,7 @@ To migrate an existing agent from AI Studio to Vertex AI:
 
 ```python
 # Change one line in the decorator:
-model="vertex_ai/gemini-2.0-flash"   # was: "gemini/gemini-2.0-flash"
+model="vertex_ai/gemini-2.5-flash"   # was: "gemini/gemini-2.5-flash"
 ```
 
 ```bash

--- a/docs/typescript/llm/index.md
+++ b/docs/typescript/llm/index.md
@@ -222,8 +222,8 @@ Uses LiteLLM model format:
 | ----------------------- | ------------------------------ |
 | Anthropic               | `anthropic/claude-sonnet-4-5`  |
 | OpenAI                  | `openai/gpt-4o`                |
-| Google AI Studio        | `gemini/gemini-2.0-flash`      |
-| Google Vertex AI (IAM)  | `vertex_ai/gemini-2.0-flash`   |
+| Google AI Studio        | `gemini/gemini-2.5-flash`      |
+| Google Vertex AI (IAM)  | `vertex_ai/gemini-2.5-flash`   |
 | Mistral                 | `mistral/mistral-large-latest` |
 | Ollama                  | `ollama/llama3`                |
 
@@ -272,7 +272,7 @@ needed.
 
    ```typescript
    agent.addLlmProvider({
-     model: "vertex_ai/gemini-2.0-flash",
+     model: "vertex_ai/gemini-2.5-flash",
      capability: "llm",
      tags: ["llm", "gemini", "vertex"],
    });
@@ -288,9 +288,9 @@ Migrate from AI Studio to Vertex AI by changing the model prefix and env vars:
 
 ```typescript
 // before:
-model: "gemini/gemini-2.0-flash";
+model: "gemini/gemini-2.5-flash";
 // after:
-model: "vertex_ai/gemini-2.0-flash";
+model: "vertex_ai/gemini-2.5-flash";
 ```
 
 ```bash

--- a/examples/parallel-tools/direct-consumer-gemini-py/main.py
+++ b/examples/parallel-tools/direct-consumer-gemini-py/main.py
@@ -36,7 +36,7 @@ class StockAnalysis(BaseModel):
 @app.tool()
 @mesh.llm(
     filter=[{"tags": ["financial", "slow-tool"]}],
-    provider="gemini/gemini-2.0-flash",
+    provider="gemini/gemini-2.5-flash",
     max_iterations=5,
     parallel_tool_calls=True,
     system_prompt="file://prompts/system.jinja2",

--- a/examples/python/multimedia/llm_provider_gemini.py
+++ b/examples/python/multimedia/llm_provider_gemini.py
@@ -17,7 +17,7 @@ app = FastMCP("Media LLM Provider Gemini")
 
 
 @mesh.llm_provider(
-    model="gemini/gemini-2.0-flash",
+    model="gemini/gemini-2.5-flash",
     capability="llm",
     tags=["gemini", "flash", "media"],
     version="1.0.0",

--- a/examples/python/vertex-ai-agent/README.md
+++ b/examples/python/vertex-ai-agent/README.md
@@ -6,7 +6,7 @@ the model prefix and auth env vars change.
 
 ## What it shows
 
-- `model="vertex_ai/gemini-2.0-flash"` on `@mesh.llm_provider`
+- `model="vertex_ai/gemini-2.5-flash"` on `@mesh.llm_provider`
 - A Pydantic structured-output return type (`CapitalInfo`)
 - Mesh's HINT-mode prompt shaping is applied automatically (same as for
   `gemini/*`), so structured output works alongside tool use without
@@ -61,7 +61,7 @@ You should see a structured response like:
 To run the same agent against Google AI Studio instead, change two things:
 
 ```python
-model="gemini/gemini-2.0-flash"   # was: vertex_ai/gemini-2.0-flash
+model="gemini/gemini-2.5-flash"   # was: vertex_ai/gemini-2.5-flash
 ```
 
 ```bash

--- a/examples/python/vertex-ai-agent/main.py
+++ b/examples/python/vertex-ai-agent/main.py
@@ -27,7 +27,7 @@ class CapitalInfo(BaseModel):
 
 
 @mesh.llm_provider(
-    model="vertex_ai/gemini-2.0-flash",
+    model="vertex_ai/gemini-2.5-flash",
     capability="llm",
     tags=["gemini", "vertex"],
     version="1.0.0",

--- a/examples/typescript/vertex-ai-agent/README.md
+++ b/examples/typescript/vertex-ai-agent/README.md
@@ -6,7 +6,7 @@ path — only the model prefix and auth env vars change.
 
 ## What it shows
 
-- `model="vertex_ai/gemini-2.0-flash"` on `agent.addLlmProvider`
+- `model="vertex_ai/gemini-2.5-flash"` on `agent.addLlmProvider`
 - A Zod structured-output schema (`CapitalInfo`)
 - Mesh's HINT-mode prompt shaping is applied automatically (same as for
   `gemini/*`), so structured output works alongside tool use without
@@ -61,7 +61,7 @@ You should see a structured response like:
 To run the same agent against Google AI Studio instead, change two things:
 
 ```typescript
-model: "gemini/gemini-2.0-flash"   // was: "vertex_ai/gemini-2.0-flash"
+model: "gemini/gemini-2.5-flash"   // was: "vertex_ai/gemini-2.5-flash"
 ```
 
 ```bash

--- a/examples/typescript/vertex-ai-agent/src/index.ts
+++ b/examples/typescript/vertex-ai-agent/src/index.ts
@@ -32,7 +32,7 @@ const agent = mesh(server, {
 // Zero-code Vertex AI provider — selected via the vertex_ai/* model prefix.
 agent.addLlmProvider({
   name: "vertex_chat",
-  model: "vertex_ai/gemini-2.0-flash",
+  model: "vertex_ai/gemini-2.5-flash",
   capability: "llm",
   tags: ["llm", "gemini", "vertex", "provider"],
   version: "1.0.0",

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -134,7 +134,7 @@ transport and env var names differ.
 @mesh.llm_provider(
     capability="llm",
     tags=["gemini", "vertex"],
-    model="vertex_ai/gemini-2.0-flash",  # vs "gemini/gemini-2.0-flash" for AI Studio
+    model="vertex_ai/gemini-2.5-flash",  # vs "gemini/gemini-2.5-flash" for AI Studio
 )
 def my_provider(): pass
 ```
@@ -155,7 +155,7 @@ pip install 'mcp-mesh[vertex]'
 
 ```typescript
 agent.addLlmProvider({
-  model: "vertex_ai/gemini-2.0-flash",
+  model: "vertex_ai/gemini-2.5-flash",
   capability: "llm",
   tags: ["gemini", "vertex"],
 });

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -166,8 +166,8 @@ anthropic/claude-opus-4
 openai/gpt-4o
 openai/gpt-4-turbo
 openai/gpt-3.5-turbo
-gemini/gemini-2.0-flash          # Google AI Studio (API key)
-vertex_ai/gemini-2.0-flash       # Google Vertex AI (IAM)
+gemini/gemini-2.5-flash          # Google AI Studio (API key)
+vertex_ai/gemini-2.5-flash       # Google Vertex AI (IAM)
 ```
 
 ## Gemini Backend Selection
@@ -176,8 +176,8 @@ Mesh routes Gemini calls via the model prefix:
 
 | Backend                    | Model prefix                 | Auth                                            |
 | -------------------------- | ---------------------------- | ----------------------------------------------- |
-| Google AI Studio (API key) | `gemini/gemini-2.0-flash`    | `GOOGLE_API_KEY` env                            |
-| Google Vertex AI (IAM)     | `vertex_ai/gemini-2.0-flash` | ADC + `VERTEXAI_PROJECT` + `VERTEXAI_LOCATION`  |
+| Google AI Studio (API key) | `gemini/gemini-2.5-flash`    | `GOOGLE_API_KEY` env                            |
+| Google Vertex AI (IAM)     | `vertex_ai/gemini-2.5-flash` | ADC + `VERTEXAI_PROJECT` + `VERTEXAI_LOCATION`  |
 
 Same `GeminiHandler` runs for both — identical HINT-mode prompt shaping for
 structured output with tools. Switch backends by changing only the model

--- a/src/core/cli/man/content/llm_java.md
+++ b/src/core/cli/man/content/llm_java.md
@@ -283,8 +283,8 @@ Uses LiteLLM model format in `@MeshLlmProvider`:
 | ----------------------- | ------------------------------ |
 | Anthropic               | `anthropic/claude-sonnet-4-5`  |
 | OpenAI                  | `openai/gpt-4o`                |
-| Google AI Studio        | `gemini/gemini-2.0-flash`      |
-| Google Vertex AI (IAM)  | `vertex_ai/gemini-2.0-flash`   |
+| Google AI Studio        | `gemini/gemini-2.5-flash`      |
+| Google Vertex AI (IAM)  | `vertex_ai/gemini-2.5-flash`   |
 | Mistral                 | `mistral/mistral-large-latest` |
 
 ## Vertex AI (Gemini via IAM)
@@ -330,7 +330,7 @@ provider's `model` string, dependency, and auth config change.
              location:   ${SPRING_AI_VERTEX_AI_GEMINI_LOCATION:us-central1}
              chat:
                options:
-                 model: gemini-2.0-flash
+                 model: gemini-2.5-flash
    ```
 
 3. Configure GCP Application Default Credentials:
@@ -346,7 +346,7 @@ provider's `model` string, dependency, and auth config change.
    ```java
    @MeshAgent(name = "gemini-vertex-provider", port = 9111)
    @MeshLlmProvider(
-       model = "vertex_ai/gemini-2.0-flash",
+       model = "vertex_ai/gemini-2.5-flash",
        capability = "llm",
        tags = {"llm", "gemini", "vertex"}
    )
@@ -374,9 +374,9 @@ Migrate from AI Studio to Vertex AI by updating only the provider agent:
 
 ```java
 // before:
-@MeshLlmProvider(model = "gemini/gemini-2.0-flash", …)
+@MeshLlmProvider(model = "gemini/gemini-2.5-flash", …)
 // after:
-@MeshLlmProvider(model = "vertex_ai/gemini-2.0-flash", …)
+@MeshLlmProvider(model = "vertex_ai/gemini-2.5-flash", …)
 ```
 
 Swap the dependency in `pom.xml`

--- a/src/core/cli/man/content/llm_typescript.md
+++ b/src/core/cli/man/content/llm_typescript.md
@@ -232,8 +232,8 @@ Uses LiteLLM model format:
 | ----------------------- | ------------------------------ |
 | Anthropic               | `anthropic/claude-sonnet-4-5`  |
 | OpenAI                  | `openai/gpt-4o`                |
-| Google AI Studio        | `gemini/gemini-2.0-flash`      |
-| Google Vertex AI (IAM)  | `vertex_ai/gemini-2.0-flash`   |
+| Google AI Studio        | `gemini/gemini-2.5-flash`      |
+| Google Vertex AI (IAM)  | `vertex_ai/gemini-2.5-flash`   |
 | Mistral                 | `mistral/mistral-large-latest` |
 | Ollama                  | `ollama/llama3`                |
 
@@ -282,7 +282,7 @@ needed.
 
    ```typescript
    agent.addLlmProvider({
-     model: "vertex_ai/gemini-2.0-flash",
+     model: "vertex_ai/gemini-2.5-flash",
      capability: "llm",
      tags: ["llm", "gemini", "vertex"],
    });
@@ -298,9 +298,9 @@ Migrate from AI Studio to Vertex AI by changing the model prefix and env vars:
 
 ```typescript
 // before:
-model: "gemini/gemini-2.0-flash"
+model: "gemini/gemini-2.5-flash"
 // after:
-model: "vertex_ai/gemini-2.0-flash"
+model: "vertex_ai/gemini-2.5-flash"
 ```
 
 ```bash

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/_native_client_helpers.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/_native_client_helpers.py
@@ -16,6 +16,49 @@ import logging
 from typing import Any
 
 
+def warn_unsupported_kwarg_once(
+    dedupe_set: set[str],
+    *,
+    kwarg: str,
+    adapter_label: str,
+    sdk_call_label: str,
+    logger: logging.Logger,
+) -> None:
+    """Log a WARNing for a dropped kwarg, deduplicating per-process via the
+    caller-supplied set.
+
+    Each adapter owns its own ``dedupe_set`` so dedupe is per-vendor — a
+    LiteLLM-only kwarg dropped on the Anthropic path won't suppress the
+    WARN if it later shows up on the OpenAI path (different translation
+    surface, different signal).
+
+    ``adapter_label`` is the human-readable vendor name ("Anthropic",
+    "OpenAI", "Gemini"); ``sdk_call_label`` is the qualified SDK method
+    referenced in the message body so reviewers can grep from the log line
+    back to the dropping site.
+    """
+    if kwarg in dedupe_set:
+        return
+    dedupe_set.add(kwarg)
+    logger.warning(
+        "Native %s adapter dropping unsupported kwarg: '%s' "
+        "(LiteLLM-only — not forwarded to %s)",
+        adapter_label,
+        kwarg,
+        sdk_call_label,
+    )
+
+
+def reset_unsupported_kwargs_dedupe(dedupe_set: set[str]) -> None:
+    """Clear the caller-supplied dedupe set so a re-run sees a fresh state.
+
+    Test hook — NOT for production use. The adapters expose thin module-
+    level wrappers (``_reset_unsupported_kwargs_dedupe``) that call this
+    with their own module-level dedupe set.
+    """
+    dedupe_set.clear()
+
+
 def resolve_request_timeout(
     request_params: dict[str, Any],
     *,

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
@@ -44,7 +44,11 @@ from .._structured_output_helpers import (
     is_synthetic_tool_in_list,
     schema_to_synthetic_tool,
 )
-from ._native_client_helpers import resolve_request_timeout
+from ._native_client_helpers import (
+    reset_unsupported_kwargs_dedupe,
+    resolve_request_timeout,
+    warn_unsupported_kwarg_once,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -748,41 +752,45 @@ _ANTHROPIC_PASSTHROUGH_KWARGS = frozenset(
 # Older models (Haiku, Sonnet 3.x / 4.0, Opus 3.x) reject the field, so we
 # fall through to the existing synthetic-tool injection path for those.
 # LiteLLM uses a substring allow-list at transformation.py:822-830; we mirror
-# it plus the Sonnet 4.6 / Opus 4.5 / 4.7 releases. Both dash and dot version
-# forms are accepted (callers pass both in the wild); substring (not prefix)
-# match so Bedrock model ids (``anthropic.claude-sonnet-4-6-20260301-v1:0``)
-# and date-pinned variants are covered.
-_NATIVE_OUTPUT_FORMAT_MODEL_SUBSTRINGS = frozenset(
-    {
-        "sonnet-4-5",
-        "sonnet-4.5",
-        "sonnet-4-6",
-        "sonnet-4.6",
-        "opus-4-1",
-        "opus-4.1",
-        "opus-4-5",
-        "opus-4.5",
-        "opus-4-7",
-        "opus-4.7",
-    }
+# it plus the Sonnet 4.6 / Opus 4.5 / 4.7 releases.
+#
+# Patterns (not raw substrings) so the trailing minor-version digit is
+# boundary-anchored: ``opus-4-1`` must NOT match a hypothetical future
+# ``opus-4-10``. Each pattern accepts both dash and dot separators (callers
+# pass both forms in the wild) and uses a negative-lookahead to forbid an
+# additional digit immediately after the minor version. Bedrock model ids
+# (``anthropic.claude-sonnet-4-6-20260301-v1:0``) and date-pinned variants
+# still match because the patterns use ``re.search`` (not anchored to start)
+# and tolerate ``-`` / ``.`` / end-of-string after the version.
+_NATIVE_OUTPUT_FORMAT_MODEL_PATTERNS = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"(?<!\d)sonnet-4[-.]5(?!\d)",
+        r"(?<!\d)sonnet-4[-.]6(?!\d)",
+        r"(?<!\d)opus-4[-.]1(?!\d)",
+        r"(?<!\d)opus-4[-.]5(?!\d)",
+        r"(?<!\d)opus-4[-.]7(?!\d)",
+    )
 )
 
 
 def _supports_native_output_format(model: str | None) -> bool:
     """True when ``model`` accepts the native ``output_config.format`` field.
 
-    Substring match (not prefix) because model ids are date-pinned
-    (``claude-sonnet-4-6-20260301``) and Bedrock prefixes the SDK id with
-    ``anthropic.``. Both dash (``-``) and dot (``.``) versions are accepted
-    because callers pass both forms in the wild.
+    Substring-style match via ``re.search`` (not prefix-anchored) because
+    model ids are date-pinned (``claude-sonnet-4-6-20260301``) and Bedrock
+    prefixes the SDK id with ``anthropic.``. Both dash (``-``) and dot
+    (``.``) versions are accepted because callers pass both forms in the
+    wild. The trailing-digit guard (``(?!\\d)``) prevents a future
+    ``opus-4-10`` from being silently accepted on the ``opus-4-1`` pattern.
 
-    Haiku and pre-4.5 Sonnet / pre-4.1 Opus models are intentionally NOT in
-    this set — they route through the existing synthetic-tool path.
+    Haiku and pre-4.5 Sonnet / pre-4.1 Opus models are intentionally NOT
+    matched by any pattern — they route through the existing synthetic-tool
+    path.
     """
     if not model:
         return False
-    model_lower = model.lower()
-    return any(s in model_lower for s in _NATIVE_OUTPUT_FORMAT_MODEL_SUBSTRINGS)
+    return any(p.search(model) for p in _NATIVE_OUTPUT_FORMAT_MODEL_PATTERNS)
 
 
 # ``_filter_anthropic_output_schema`` (which strips ``maxItems`` / ``minItems``
@@ -1340,26 +1348,29 @@ def is_fallback_logged() -> bool:
 # providers receiving the same litellm-only kwarg every request would
 # otherwise flood the log with identical messages (unbounded growth).
 #
-# Test reset hook is the module-level _reset_unsupported_kwargs_dedupe()
-# function below — DRY-up candidate (mirror functions live in
-# openai_native + gemini_native) when a 4th adapter shows up.
+# The dedupe set is per-vendor: a LiteLLM-only kwarg dropped on the
+# Anthropic path won't suppress the WARN if it later shows up on the
+# OpenAI path. The actual WARN-emit + dedupe machinery lives in
+# ``_native_client_helpers.warn_unsupported_kwarg_once``; this module
+# owns only the per-vendor state.
 _logged_unsupported_kwargs: set[str] = set()
 
 
 def _warn_unsupported_kwarg_once(key: str) -> None:
     """WARN once per unique unsupported kwarg name.
 
-    Used by ``_build_create_kwargs`` to surface litellm-only knobs the
-    adapter is silently dropping (parallel_tool_calls, stream_options, etc.)
-    without logging on every single request.
+    Thin wrapper over the shared helper so call sites stay terse
+    (single-arg) and the per-vendor dedupe state stays local to this
+    module. Used by ``_build_create_kwargs`` to surface litellm-only
+    knobs the adapter is silently dropping (parallel_tool_calls,
+    stream_options, etc.) without logging on every single request.
     """
-    if key in _logged_unsupported_kwargs:
-        return
-    _logged_unsupported_kwargs.add(key)
-    logger.warning(
-        "Native Anthropic adapter dropping unsupported kwarg: '%s' "
-        "(LiteLLM-only — not forwarded to anthropic.messages.create)",
-        key,
+    warn_unsupported_kwarg_once(
+        _logged_unsupported_kwargs,
+        kwarg=key,
+        adapter_label="Anthropic",
+        sdk_call_label="anthropic.messages.create",
+        logger=logger,
     )
 
 
@@ -1367,4 +1378,4 @@ def _reset_unsupported_kwargs_dedupe() -> None:
     """For tests — drop the WARN-once dedupe set so each test sees a fresh
     WARN trail. NOT for production use.
     """
-    _logged_unsupported_kwargs.clear()
+    reset_unsupported_kwargs_dedupe(_logged_unsupported_kwargs)

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
@@ -57,7 +57,11 @@ from typing import Any
 
 import httpx
 
-from ._native_client_helpers import resolve_request_timeout
+from ._native_client_helpers import (
+    reset_unsupported_kwargs_dedupe,
+    resolve_request_timeout,
+    warn_unsupported_kwarg_once,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1783,26 +1787,29 @@ def is_fallback_logged() -> bool:
 # otherwise flood the log with identical messages (unbounded growth
 # pre-fix).
 #
-# Test reset hook is the module-level _reset_unsupported_kwargs_dedupe()
-# function below — DRY-up candidate (mirror functions live in
-# anthropic_native + openai_native) when a 4th adapter shows up.
+# The dedupe set is per-vendor: a LiteLLM-only kwarg dropped on the
+# Gemini path won't suppress the WARN if it later shows up on the
+# Anthropic / OpenAI path. The actual WARN-emit + dedupe machinery lives
+# in ``_native_client_helpers.warn_unsupported_kwarg_once``; this module
+# owns only the per-vendor state.
 _logged_unsupported_kwargs: set[str] = set()
 
 
 def _warn_unsupported_kwarg_once(key: str) -> None:
     """WARN once per unique unsupported kwarg name.
 
-    Used by ``_build_create_kwargs`` to surface litellm-only knobs the
-    adapter is silently dropping (or new fields the google-genai SDK
-    doesn't accept yet) without logging on every single request.
+    Thin wrapper over the shared helper so call sites stay terse
+    (single-arg) and the per-vendor dedupe state stays local to this
+    module. Used by ``_build_create_kwargs`` to surface litellm-only
+    knobs the adapter is silently dropping (or new fields the google-genai
+    SDK doesn't accept yet) without logging on every single request.
     """
-    if key in _logged_unsupported_kwargs:
-        return
-    _logged_unsupported_kwargs.add(key)
-    logger.warning(
-        "Native Gemini adapter dropping unsupported kwarg: '%s' "
-        "(LiteLLM-only — not forwarded to google.genai.Client.aio.models.generate_content)",
-        key,
+    warn_unsupported_kwarg_once(
+        _logged_unsupported_kwargs,
+        kwarg=key,
+        adapter_label="Gemini",
+        sdk_call_label="google.genai.Client.aio.models.generate_content",
+        logger=logger,
     )
 
 
@@ -1810,4 +1817,4 @@ def _reset_unsupported_kwargs_dedupe() -> None:
     """For tests — drop the WARN-once dedupe set so each test sees a fresh
     WARN trail. NOT for production use.
     """
-    _logged_unsupported_kwargs.clear()
+    reset_unsupported_kwargs_dedupe(_logged_unsupported_kwargs)

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
@@ -414,8 +414,8 @@ def supports_model(model: str) -> bool:
 def _strip_prefix(model: str) -> str:
     """Return the bare Gemini model id for the SDK call.
 
-    ``gemini/gemini-2.0-flash`` → ``gemini-2.0-flash``
-    ``vertex_ai/gemini-2.0-flash`` → ``gemini-2.0-flash``
+    ``gemini/gemini-2.5-flash`` → ``gemini-2.5-flash``
+    ``vertex_ai/gemini-2.5-flash`` → ``gemini-2.5-flash``
     """
     if model.startswith(_GEMINI_PREFIX):
         return model[len(_GEMINI_PREFIX):]

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -40,7 +40,11 @@ from typing import Any
 
 import httpx
 
-from ._native_client_helpers import resolve_request_timeout
+from ._native_client_helpers import (
+    reset_unsupported_kwargs_dedupe,
+    resolve_request_timeout,
+    warn_unsupported_kwarg_once,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -832,26 +836,29 @@ def is_fallback_logged() -> bool:
 # otherwise flood the log with identical messages (unbounded growth
 # pre-fix).
 #
-# Test reset hook is the module-level _reset_unsupported_kwargs_dedupe()
-# function below — DRY-up candidate (mirror functions live in
-# anthropic_native + gemini_native) when a 4th adapter shows up.
+# The dedupe set is per-vendor: a LiteLLM-only kwarg dropped on the
+# OpenAI path won't suppress the WARN if it later shows up on the
+# Anthropic path. The actual WARN-emit + dedupe machinery lives in
+# ``_native_client_helpers.warn_unsupported_kwarg_once``; this module
+# owns only the per-vendor state.
 _logged_unsupported_kwargs: set[str] = set()
 
 
 def _warn_unsupported_kwarg_once(key: str) -> None:
     """WARN once per unique unsupported kwarg name.
 
-    Used by ``_build_create_kwargs`` to surface litellm-only knobs the
-    adapter is silently dropping (or new fields the OpenAI SDK doesn't
-    accept yet) without logging on every single request.
+    Thin wrapper over the shared helper so call sites stay terse
+    (single-arg) and the per-vendor dedupe state stays local to this
+    module. Used by ``_build_create_kwargs`` to surface litellm-only
+    knobs the adapter is silently dropping (or new fields the OpenAI SDK
+    doesn't accept yet) without logging on every single request.
     """
-    if key in _logged_unsupported_kwargs:
-        return
-    _logged_unsupported_kwargs.add(key)
-    logger.warning(
-        "Native OpenAI adapter dropping unsupported kwarg: '%s' "
-        "(LiteLLM-only — not forwarded to openai.chat.completions.create)",
-        key,
+    warn_unsupported_kwarg_once(
+        _logged_unsupported_kwargs,
+        kwarg=key,
+        adapter_label="OpenAI",
+        sdk_call_label="openai.chat.completions.create",
+        logger=logger,
     )
 
 
@@ -859,4 +866,4 @@ def _reset_unsupported_kwargs_dedupe() -> None:
     """For tests — drop the WARN-once dedupe set so each test sees a fresh
     WARN trail. NOT for production use.
     """
-    _logged_unsupported_kwargs.clear()
+    reset_unsupported_kwargs_dedupe(_logged_unsupported_kwargs)

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native_output_format.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native_output_format.py
@@ -117,7 +117,7 @@ class TestSupportsNativeOutputFormat:
             "ANTHROPIC/CLAUDE-SONNET-4-6",
             # Dot separator with trailing suffix.
             "anthropic/claude-sonnet-4.6.preview",
-            # Underscore separator after version (anthropic.claude-sonnet-4-6_test).
+            # Underscore separator after version (anthropic/claude-sonnet-4-6_internal).
             "anthropic/claude-sonnet-4-6_internal",
         ],
     )

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native_output_format.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native_output_format.py
@@ -115,6 +115,10 @@ class TestSupportsNativeOutputFormat:
             "databricks/anthropic.claude-sonnet-4-6",
             # Case-insensitive (defensive).
             "ANTHROPIC/CLAUDE-SONNET-4-6",
+            # Dot separator with trailing suffix.
+            "anthropic/claude-sonnet-4.6.preview",
+            # Underscore separator after version (anthropic.claude-sonnet-4-6_test).
+            "anthropic/claude-sonnet-4-6_internal",
         ],
     )
     def test_allow_list_positive(self, model):
@@ -139,6 +143,38 @@ class TestSupportsNativeOutputFormat:
         ],
     )
     def test_allow_list_negative(self, model):
+        assert anthropic_native._supports_native_output_format(model) is False
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            # Trailing-digit overmatch guard: hypothetical future versions
+            # whose minor digit follows the current allow-listed one with
+            # NO separator. The pre-regex substring allow-list would have
+            # silently accepted these because "opus-4-1" is a substring of
+            # "opus-4-10". The negative lookahead must reject them.
+            "anthropic/claude-opus-4-10",
+            "anthropic/claude-opus-4-11",
+            "anthropic/claude-opus-4-15",
+            "anthropic/claude-sonnet-4-50",
+            "anthropic/claude-sonnet-4-60",
+            "anthropic/claude-sonnet-4-55",
+            # Dot-form overmatch — same problem, dot separator.
+            "anthropic/claude-opus-4.10",
+            "anthropic/claude-sonnet-4.55",
+            # Date-pinned variants of the hypothetical future minor (must
+            # also be rejected — the date doesn't rescue the unknown
+            # output_config support).
+            "anthropic/claude-opus-4-10-20270101",
+            "bedrock/anthropic.claude-opus-4-10-20270101-v1:0",
+        ],
+    )
+    def test_allow_list_overmatch_rejected(self, model):
+        """Regression guard: regex boundary must reject future minor
+        versions whose digit suffix extends a current allow-listed
+        version (opus-4-1 → opus-4-10) — output_config support for those
+        is unknown until explicitly added to the allow-list.
+        """
         assert anthropic_native._supports_native_output_format(model) is False
 
     def test_none_input(self):

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
@@ -101,10 +101,10 @@ class TestSupportsModel:
     @pytest.mark.parametrize(
         "model",
         [
-            "gemini/gemini-2.0-flash",
+            "gemini/gemini-2.5-flash",
             "gemini/gemini-1.5-pro",
             "gemini/gemini-3-pro-preview",
-            "vertex_ai/gemini-2.0-flash",
+            "vertex_ai/gemini-2.5-flash",
             "vertex_ai/gemini-1.5-pro",
         ],
     )
@@ -118,7 +118,7 @@ class TestSupportsModel:
             "openai/gpt-4o",
             "bedrock/anthropic.claude-3-5-sonnet",
             "azure/gpt-4o",
-            "gemini-2.0-flash",  # bare, no prefix
+            "gemini-2.5-flash",  # bare, no prefix
             "",
         ],
     )
@@ -137,11 +137,11 @@ class TestStripPrefix:
     @pytest.mark.parametrize(
         ("model", "expected"),
         [
-            ("gemini/gemini-2.0-flash", "gemini-2.0-flash"),
+            ("gemini/gemini-2.5-flash", "gemini-2.5-flash"),
             ("gemini/gemini-1.5-pro", "gemini-1.5-pro"),
-            ("vertex_ai/gemini-2.0-flash", "gemini-2.0-flash"),
+            ("vertex_ai/gemini-2.5-flash", "gemini-2.5-flash"),
             ("vertex_ai/gemini-3-pro-preview", "gemini-3-pro-preview"),
-            ("gemini-2.0-flash", "gemini-2.0-flash"),  # bare passthrough
+            ("gemini-2.5-flash", "gemini-2.5-flash"),  # bare passthrough
         ],
     )
     def test_strip_prefix(self, model, expected):
@@ -165,7 +165,7 @@ class TestBuildClient:
     def test_ai_studio_with_explicit_api_key(self, monkeypatch):
         cls_mock = MagicMock(return_value=MagicMock())
         monkeypatch.setattr("google.genai.Client", cls_mock)
-        gemini_native._build_client("gemini/gemini-2.0-flash", "GAK-test", None)
+        gemini_native._build_client("gemini/gemini-2.5-flash", "GAK-test", None)
         kwargs = cls_mock.call_args.kwargs
         assert kwargs["api_key"] == "GAK-test"
         # AI Studio backend must NOT pass vertexai/project/location.
@@ -176,14 +176,14 @@ class TestBuildClient:
         monkeypatch.setenv("GOOGLE_API_KEY", "GAK-from-env")
         cls_mock = MagicMock(return_value=MagicMock())
         monkeypatch.setattr("google.genai.Client", cls_mock)
-        gemini_native._build_client("gemini/gemini-2.0-flash", None, None)
+        gemini_native._build_client("gemini/gemini-2.5-flash", None, None)
         # api_key flows from env into the resolved kwarg.
         kwargs = cls_mock.call_args.kwargs
         assert kwargs["api_key"] == "GAK-from-env"
 
     def test_ai_studio_raises_when_no_api_key(self, monkeypatch):
         with pytest.raises(ValueError) as exc_info:
-            gemini_native._build_client("gemini/gemini-2.0-flash", None, None)
+            gemini_native._build_client("gemini/gemini-2.5-flash", None, None)
         msg = str(exc_info.value)
         assert "GOOGLE_API_KEY" in msg
         assert "MCP_MESH_NATIVE_LLM=0" in msg
@@ -192,7 +192,7 @@ class TestBuildClient:
         monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
         cls_mock = MagicMock(return_value=MagicMock())
         monkeypatch.setattr("google.genai.Client", cls_mock)
-        gemini_native._build_client("vertex_ai/gemini-2.0-flash", None, None)
+        gemini_native._build_client("vertex_ai/gemini-2.5-flash", None, None)
         kwargs = cls_mock.call_args.kwargs
         assert kwargs["vertexai"] is True
         assert kwargs["project"] == "my-gcp-project"
@@ -204,7 +204,7 @@ class TestBuildClient:
         monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "europe-west4")
         cls_mock = MagicMock(return_value=MagicMock())
         monkeypatch.setattr("google.genai.Client", cls_mock)
-        gemini_native._build_client("vertex_ai/gemini-2.0-flash", None, None)
+        gemini_native._build_client("vertex_ai/gemini-2.5-flash", None, None)
         kwargs = cls_mock.call_args.kwargs
         assert kwargs["location"] == "europe-west4"
 
@@ -217,7 +217,7 @@ class TestBuildClient:
             gemini_native, "_derive_vertex_project_from_adc", lambda: None
         )
         with pytest.raises(ValueError) as exc_info:
-            gemini_native._build_client("vertex_ai/gemini-2.0-flash", None, None)
+            gemini_native._build_client("vertex_ai/gemini-2.5-flash", None, None)
         msg = str(exc_info.value)
         assert "GOOGLE_CLOUD_PROJECT" in msg
         assert "MCP_MESH_NATIVE_LLM=0" in msg
@@ -233,7 +233,7 @@ class TestBuildClient:
         )
         cls_mock = MagicMock(return_value=MagicMock())
         monkeypatch.setattr("google.genai.Client", cls_mock)
-        gemini_native._build_client("vertex_ai/gemini-2.0-flash", None, None)
+        gemini_native._build_client("vertex_ai/gemini-2.5-flash", None, None)
         kwargs = cls_mock.call_args.kwargs
         assert kwargs["project"] == "adc-derived-project"
         assert kwargs["vertexai"] is True
@@ -253,7 +253,7 @@ class TestBuildClient:
         )
         cls_mock = MagicMock(return_value=MagicMock())
         monkeypatch.setattr("google.genai.Client", cls_mock)
-        gemini_native._build_client("vertex_ai/gemini-2.0-flash", None, None)
+        gemini_native._build_client("vertex_ai/gemini-2.5-flash", None, None)
         assert cls_mock.call_args.kwargs["project"] == "explicit-env-project"
 
     def test_derive_vertex_project_calls_google_auth_default(
@@ -310,7 +310,7 @@ class TestBuildClient:
         gemini_native._logged_unsupported_kwargs.clear()
         with caplog.at_level("WARNING", logger=gemini_native.logger.name):
             gemini_native._build_client(
-                "vertex_ai/gemini-2.0-flash", "GAK-ignored", None
+                "vertex_ai/gemini-2.5-flash", "GAK-ignored", None
             )
         # api_key MUST NOT be forwarded on the Vertex backend.
         kwargs = cls_mock.call_args.kwargs
@@ -329,7 +329,7 @@ class TestBuildClient:
         monkeypatch.setattr("google.genai.Client", cls_mock)
 
         gemini_native._build_client(
-            "gemini/gemini-2.0-flash",
+            "gemini/gemini-2.5-flash",
             "GAK-test",
             "https://custom-proxy.example.com",
         )
@@ -929,9 +929,9 @@ class TestBuildCreateKwargs:
                 "temperature": 0.3,
                 "max_tokens": 512,
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
-        assert out["model"] == "gemini-2.0-flash"
+        assert out["model"] == "gemini-2.5-flash"
         # System message NOT in contents.
         assert all(
             m.get("role") != "system" for m in out["contents"]
@@ -957,7 +957,7 @@ class TestBuildCreateKwargs:
                     {"role": "user", "content": "Hi"},
                 ]
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         assert out["config"]["system_instruction"] == "Be brief."
         # Contents has only the user message.
@@ -971,7 +971,7 @@ class TestBuildCreateKwargs:
                 "messages": [{"role": "user", "content": "Hi"}],
                 "max_tokens": None,
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         # Don't forward None to the SDK (Gemini rejects it).
         assert "max_output_tokens" not in out["config"]
@@ -982,7 +982,7 @@ class TestBuildCreateKwargs:
                 "messages": [{"role": "user", "content": "Hi"}],
                 "max_completion_tokens": 200,
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         assert out["config"]["max_output_tokens"] == 200
 
@@ -996,7 +996,7 @@ class TestBuildCreateKwargs:
                 "stop": ["END"],
                 "seed": 42,
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         cfg = out["config"]
         assert cfg["temperature"] == 0.5
@@ -1018,7 +1018,7 @@ class TestBuildCreateKwargs:
                     },
                 },
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         assert out["config"]["response_mime_type"] == "application/json"
         assert out["config"]["response_schema"] == {"type": "object"}
@@ -1044,7 +1044,7 @@ class TestBuildCreateKwargs:
                     },
                 },
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         rs = out["config"]["response_schema"]
         assert "additionalProperties" not in rs
@@ -1073,7 +1073,7 @@ class TestBuildCreateKwargs:
                     },
                 },
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         rs = out["config"]["response_schema"]
         # Both casings dropped (only camelCase whitelist members survive).
@@ -1104,7 +1104,7 @@ class TestBuildCreateKwargs:
                     },
                 },
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         rs = out["config"]["response_schema"]
         assert "title" not in rs
@@ -1123,7 +1123,7 @@ class TestBuildCreateKwargs:
                 "_mesh_hint_mode": True,
                 "_mesh_hint_schema": {"type": "object"},
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         # No WARN logged for the _mesh_ keys.
         assert all(
@@ -1151,7 +1151,7 @@ class TestUnsupportedKwargWarn:
                     "messages": [{"role": "user", "content": "Hi"}],
                     "some_litellm_only_knob": 30,
                 },
-                model="gemini/gemini-2.0-flash",
+                model="gemini/gemini-2.5-flash",
             )
         warn_msgs = [
             r.getMessage() for r in caplog.records if r.levelname == "WARNING"
@@ -1199,7 +1199,7 @@ class TestUnsupportedKwargWarn:
                     "messages": [{"role": "user", "content": "Hi"}],
                     "candidate_count": 3,
                 },
-                model="gemini/gemini-2.0-flash",
+                model="gemini/gemini-2.5-flash",
             )
         # Not forwarded into the SDK config.
         assert "candidate_count" not in out["config"]
@@ -1225,7 +1225,7 @@ def _make_gemini_response(
     prompt_tokens: int = 12,
     completion_tokens: int = 7,
     finish_reason: str = "STOP",
-    model_version: str | None = "gemini-2.0-flash",
+    model_version: str | None = "gemini-2.5-flash",
 ):
     """Build a fake genai.GenerateContentResponse-like object."""
     parts = []
@@ -1258,14 +1258,14 @@ def _make_gemini_response(
 class TestAdaptResponse:
     def test_text_only_response(self):
         raw = _make_gemini_response(text="Hello world", finish_reason="STOP")
-        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         assert out.choices[0].message.content == "Hello world"
         assert out.choices[0].message.role == "assistant"
         assert out.choices[0].message.tool_calls is None
         assert out.choices[0].finish_reason == "stop"
         assert out.usage.prompt_tokens == 12
         assert out.usage.completion_tokens == 7
-        assert out.model == "gemini-2.0-flash"
+        assert out.model == "gemini-2.5-flash"
 
     def test_function_call_response_synthesizes_ids(self):
         raw = _make_gemini_response(
@@ -1275,7 +1275,7 @@ class TestAdaptResponse:
             ],
             finish_reason="STOP",
         )
-        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         tcs = out.choices[0].message.tool_calls
         assert len(tcs) == 2
         # Synthesized ids are sequential gemini_call_<index>.
@@ -1292,7 +1292,7 @@ class TestAdaptResponse:
             text="Calling weather...",
             function_calls=[{"name": "get_weather", "args": {"city": "NYC"}}],
         )
-        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         assert out.choices[0].message.content == "Calling weather..."
         assert len(out.choices[0].message.tool_calls) == 1
 
@@ -1302,7 +1302,7 @@ class TestAdaptResponse:
             prompt_tokens=100,
             completion_tokens=50,
         )
-        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         # promptTokenCount → prompt_tokens; candidatesTokenCount → completion_tokens.
         assert out.usage.prompt_tokens == 100
         assert out.usage.completion_tokens == 50
@@ -1319,9 +1319,9 @@ class TestAdaptResponse:
                 )
             ],
             usage_metadata=None,
-            model_version="gemini-2.0-flash",
+            model_version="gemini-2.5-flash",
         )
-        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         assert out.usage is None
         assert out.choices[0].message.content == "hi"
 
@@ -1334,7 +1334,7 @@ class TestAdaptResponse:
             text="garbled tool call",
             finish_reason="MALFORMED_FUNCTION_CALL",
         )
-        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         assert out.choices[0].finish_reason == "tool_calls"
 
 
@@ -1373,10 +1373,10 @@ class TestComplete:
         )
         await gemini_native.complete(
             {"messages": [{"role": "user", "content": "Hi"}]},
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         kwargs = generate_mock.call_args.kwargs
-        assert kwargs["model"] == "gemini-2.0-flash"
+        assert kwargs["model"] == "gemini-2.5-flash"
 
     @pytest.mark.asyncio
     async def test_complete_returns_adapted_response(self, monkeypatch):
@@ -1386,7 +1386,7 @@ class TestComplete:
         _patched_genai_client(api_resp, monkeypatch=monkeypatch)
         out = await gemini_native.complete(
             {"messages": [{"role": "user", "content": "Hi"}]},
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         assert out.choices[0].message.content == "Hello!"
         assert out.usage.prompt_tokens == 10
@@ -1482,7 +1482,7 @@ class TestCompleteStream:
     @pytest.mark.asyncio
     async def test_text_stream_yields_litellm_chunks(self, monkeypatch):
         chunks_in = [
-            _make_stream_chunk(text="Hello ", model_version="gemini-2.0-flash"),
+            _make_stream_chunk(text="Hello ", model_version="gemini-2.5-flash"),
             _make_stream_chunk(text="world"),
             _make_stream_chunk(
                 finish_reason="STOP",
@@ -1493,7 +1493,7 @@ class TestCompleteStream:
 
         stream = gemini_native.complete_stream(
             {"messages": [{"role": "user", "content": "Hi"}]},
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         chunks = []
         async for c in stream:
@@ -1523,7 +1523,7 @@ class TestCompleteStream:
                     "name": "get_weather",
                     "args": {"city": "NYC"},
                 },
-                model_version="gemini-2.0-flash",
+                model_version="gemini-2.5-flash",
             ),
             _make_stream_chunk(
                 finish_reason="STOP",
@@ -1534,7 +1534,7 @@ class TestCompleteStream:
 
         stream = gemini_native.complete_stream(
             {"messages": [{"role": "user", "content": "weather?"}]},
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         chunks = []
         async for c in stream:
@@ -1559,14 +1559,14 @@ class TestCompleteStream:
         finally block has nothing to fall back on (counters are 0) and
         must NOT emit a misleading 0-token usage chunk."""
         chunks_in = [
-            _make_stream_chunk(text="Hello", model_version="gemini-2.0-flash"),
+            _make_stream_chunk(text="Hello", model_version="gemini-2.5-flash"),
             _make_stream_chunk(finish_reason="STOP"),
         ]
         _patched_streaming_genai(chunks_in, monkeypatch=monkeypatch)
 
         stream = gemini_native.complete_stream(
             {"messages": [{"role": "user", "content": "Hi"}]},
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         chunks = []
         async for c in stream:
@@ -1600,7 +1600,7 @@ class TestCompleteStream:
             _make_stream_chunk(
                 text="partial",
                 usage={"prompt_tokens": 5, "completion_tokens": 1},
-                model_version="gemini-2.0-flash",
+                model_version="gemini-2.5-flash",
             ),
             "RAISE",
         ]
@@ -1615,7 +1615,7 @@ class TestCompleteStream:
 
         stream = gemini_native.complete_stream(
             {"messages": [{"role": "user", "content": "Hi"}]},
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         chunks = []
         raised = None
@@ -1648,7 +1648,7 @@ class TestCompleteStream:
                     "name": "get_weather",
                     "args": {"city": "NYC"},
                 },
-                model_version="gemini-2.0-flash",
+                model_version="gemini-2.5-flash",
             ),
             _make_stream_chunk(
                 finish_reason="STOP",
@@ -1659,7 +1659,7 @@ class TestCompleteStream:
 
         stream = gemini_native.complete_stream(
             {"messages": [{"role": "user", "content": "weather?"}]},
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         chunks = []
         async for c in stream:
@@ -1701,8 +1701,8 @@ class TestSharedHttpxClient:
         # Run inside an async context so _get_shared_httpx_client() picks
         # up the running loop and caches against it.
         async def _do_two_builds():
-            gemini_native._build_client("gemini/gemini-2.0-flash", "GAK-A", None)
-            gemini_native._build_client("gemini/gemini-2.0-flash", "GAK-B", None)
+            gemini_native._build_client("gemini/gemini-2.5-flash", "GAK-A", None)
+            gemini_native._build_client("gemini/gemini-2.5-flash", "GAK-B", None)
 
         await _do_two_builds()
 
@@ -1770,7 +1770,7 @@ class TestSharedHttpxClient:
         async def _one_call():
             await gemini_native.complete(
                 {"messages": [{"role": "user", "content": "hi"}]},
-                model="gemini/gemini-2.0-flash",
+                model="gemini/gemini-2.5-flash",
             )
 
         loop_a = asyncio.new_event_loop()
@@ -1812,8 +1812,8 @@ class TestSharedHttpxClient:
         monkeypatch.setenv("GOOGLE_API_KEY", "GAK-test")
         cls_mock = MagicMock(return_value=MagicMock())
         monkeypatch.setattr("google.genai.Client", cls_mock)
-        gemini_native._build_client("gemini/gemini-2.0-flash", "GAK-A", None)
-        gemini_native._build_client("gemini/gemini-2.0-flash", "GAK-B", None)
+        gemini_native._build_client("gemini/gemini-2.5-flash", "GAK-A", None)
+        gemini_native._build_client("gemini/gemini-2.5-flash", "GAK-B", None)
         assert cls_mock.call_count == 2
         # Second call has the rotated key.
         second_kwargs = cls_mock.call_args_list[1].kwargs
@@ -1896,7 +1896,7 @@ class TestThoughtSignatureExtraction:
                 ({"name": "get_weather", "args": {"city": "NYC"}}, sig_bytes),
             ],
         )
-        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         tcs = out.choices[0].message.tool_calls
         assert len(tcs) == 1
         # Signature stashed on the _ToolCall as raw bytes (not yet encoded).
@@ -1909,7 +1909,7 @@ class TestThoughtSignatureExtraction:
         raw = _make_gemini_response(
             function_calls=[{"name": "get_weather", "args": {"city": "NYC"}}],
         )
-        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         tcs = out.choices[0].message.tool_calls
         assert len(tcs) == 1
         assert tcs[0]._thought_signature is None
@@ -1923,7 +1923,7 @@ class TestThoughtSignatureExtraction:
                 ({"name": "get_weather", "args": {}}, None),
             ],
         )
-        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         assert out.choices[0].message.tool_calls[0]._thought_signature is None
 
     def test_empty_bytes_signature_treated_as_absent(self):
@@ -1935,7 +1935,7 @@ class TestThoughtSignatureExtraction:
                 ({"name": "get_weather", "args": {}}, b""),
             ],
         )
-        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         assert out.choices[0].message.tool_calls[0]._thought_signature is None
 
     def test_multiple_function_calls_each_carry_own_signature(self):
@@ -1951,7 +1951,7 @@ class TestThoughtSignatureExtraction:
                 ({"name": "call_B", "args": {}}, sig_b),
             ],
         )
-        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         tcs = out.choices[0].message.tool_calls
         assert len(tcs) == 2
         assert tcs[0]._thought_signature == sig_a
@@ -1986,7 +1986,7 @@ class TestThoughtSignatureStreamingExtraction:
             model_version="gemini-2.0-flash-thinking",
         )
         adapted = gemini_native._adapt_stream_chunk(
-            chunk, model="gemini-2.0-flash", tool_call_index_state=[0]
+            chunk, model="gemini-2.5-flash", tool_call_index_state=[0]
         )
         deltas = adapted.choices[0].delta.tool_calls
         assert deltas is not None and len(deltas) == 1
@@ -2002,7 +2002,7 @@ class TestThoughtSignatureStreamingExtraction:
             function_call={"name": "get_weather", "args": {}},
         )
         adapted = gemini_native._adapt_stream_chunk(
-            chunk, model="gemini-2.0-flash", tool_call_index_state=[0]
+            chunk, model="gemini-2.5-flash", tool_call_index_state=[0]
         )
         deltas = adapted.choices[0].delta.tool_calls
         assert deltas is not None and len(deltas) == 1
@@ -2124,7 +2124,7 @@ class TestThoughtSignatureRoundTrip:
                 ({"name": "get_weather", "args": {"city": "NYC"}}, original_sig),
             ],
         )
-        adapted = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        adapted = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         tc = adapted.choices[0].message.tool_calls[0]
 
         # 2. Simulate helpers.py serializer (mesh.helpers

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native_contract.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native_contract.py
@@ -51,7 +51,7 @@ def _make_gemini_response(
     finish_reason: str = "STOP",
     finish_message: str | None = None,
     safety_ratings: list | None = None,
-    model_version: str | None = "gemini-2.0-flash",
+    model_version: str | None = "gemini-2.5-flash",
     prompt_tokens: int = 5,
     completion_tokens: int = 3,
     prompt_block_reason: str | None = None,
@@ -138,7 +138,7 @@ class TestTimeoutTranslation:
                 "messages": [{"role": "user", "content": "Hi"}],
                 "request_timeout": 42,
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         http_opts = out["config"].get("http_options")
         assert http_opts is not None, "expected HttpOptions on config"
@@ -151,7 +151,7 @@ class TestTimeoutTranslation:
                 "messages": [{"role": "user", "content": "Hi"}],
                 "timeout": 30,
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         http_opts = out["config"].get("http_options")
         assert http_opts is not None
@@ -165,7 +165,7 @@ class TestTimeoutTranslation:
                 "timeout": 10,
                 "request_timeout": 99,
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         assert out["config"]["http_options"].timeout == 10_000
 
@@ -175,7 +175,7 @@ class TestTimeoutTranslation:
                 "messages": [{"role": "user", "content": "Hi"}],
                 "timeout": 42.7,
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         # 42.7 seconds → 42700 ms (int-coerced).
         assert out["config"]["http_options"].timeout == 42_700
@@ -187,7 +187,7 @@ class TestTimeoutTranslation:
                     "messages": [{"role": "user", "content": "Hi"}],
                     "timeout": "not-an-int",
                 },
-                model="gemini/gemini-2.0-flash",
+                model="gemini/gemini-2.5-flash",
             )
         # No HttpOptions attached when timeout can't be coerced.
         assert "http_options" not in out["config"]
@@ -207,7 +207,7 @@ class TestTimeoutTranslation:
                     "messages": [{"role": "user", "content": "Hi"}],
                     "timeout": float("inf"),
                 },
-                model="gemini/gemini-2.0-flash",
+                model="gemini/gemini-2.5-flash",
             )
         # No HttpOptions attached when timeout can't be coerced.
         assert "http_options" not in out["config"]
@@ -229,7 +229,7 @@ class TestTimeoutTranslation:
                 "messages": [{"role": "user", "content": "Hi"}],
                 "timeout": 300,
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         assert out["config"]["http_options"].timeout == 300_000
 
@@ -239,7 +239,7 @@ class TestTimeoutTranslation:
                 "messages": [{"role": "user", "content": "Hi"}],
                 "request_timeout": 90,
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         assert out["config"]["http_options"].timeout == 90_000
 
@@ -249,7 +249,7 @@ class TestTimeoutTranslation:
                 "messages": [{"role": "user", "content": "Hi"}],
                 "timeout": 0.5,
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         assert out["config"]["http_options"].timeout == 500
 
@@ -260,7 +260,7 @@ class TestTimeoutTranslation:
                     "messages": [{"role": "user", "content": "Hi"}],
                     "request_timeout": 90,
                 },
-                model="gemini/gemini-2.0-flash",
+                model="gemini/gemini-2.5-flash",
             )
         warns = [
             r.getMessage()
@@ -284,7 +284,7 @@ class TestExtraEscapeHatches:
                 "messages": [{"role": "user", "content": "Hi"}],
                 "extra_headers": {"X-Test": "1"},
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         http_opts = out["config"]["http_options"]
         assert http_opts.headers == {"X-Test": "1"}
@@ -295,7 +295,7 @@ class TestExtraEscapeHatches:
                 "messages": [{"role": "user", "content": "Hi"}],
                 "extra_headers": {"X-Num": 42},
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         assert out["config"]["http_options"].headers == {"X-Num": "42"}
 
@@ -305,7 +305,7 @@ class TestExtraEscapeHatches:
                 "messages": [{"role": "user", "content": "Hi"}],
                 "extra_headers": {},
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         assert "http_options" not in out["config"]
 
@@ -315,7 +315,7 @@ class TestExtraEscapeHatches:
                 "messages": [{"role": "user", "content": "Hi"}],
                 "extra_body": {"foo": "bar"},
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         assert out["config"]["http_options"].extra_body == {"foo": "bar"}
 
@@ -326,7 +326,7 @@ class TestExtraEscapeHatches:
                     "messages": [{"role": "user", "content": "Hi"}],
                     "extra_query": {"q": "1"},
                 },
-                model="gemini/gemini-2.0-flash",
+                model="gemini/gemini-2.5-flash",
             )
         warns = [
             r.getMessage()
@@ -347,7 +347,7 @@ class TestExtraEscapeHatches:
                 "extra_headers": {"X-A": "1"},
                 "extra_body": {"b": 2},
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         http_opts = out["config"]["http_options"]
         # mesh's timeout convention is seconds; HttpOptions.timeout is ms.
@@ -372,7 +372,7 @@ class TestBareResponseSchema:
                     "additionalProperties": False,
                 },
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         rs = out["config"].get("response_schema")
         assert rs is not None
@@ -403,7 +403,7 @@ class TestBareResponseSchema:
                     "properties": {"from_direct": {"type": "string"}},
                 },
             },
-            model="gemini/gemini-2.0-flash",
+            model="gemini/gemini-2.5-flash",
         )
         rs = out["config"]["response_schema"]
         # The response_format path's schema wins.
@@ -417,7 +417,7 @@ class TestBareResponseSchema:
                     "messages": [{"role": "user", "content": "Hi"}],
                     "response_schema": {"type": "object"},
                 },
-                model="gemini/gemini-2.0-flash",
+                model="gemini/gemini-2.5-flash",
             )
         warns = [
             r.getMessage()
@@ -444,14 +444,14 @@ class TestSafetyBlockDetection:
             text=None,
             finish_reason=finish_reason,
             finish_message="blocked by policy",
-            model_version="gemini-2.0-flash",
+            model_version="gemini-2.5-flash",
         )
         with pytest.raises(LLMRefusedError) as exc_info:
-            gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+            gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         err = exc_info.value
         assert err.vendor == "gemini"
         assert err.category == finish_reason
-        assert err.model == "gemini-2.0-flash"
+        assert err.model == "gemini-2.5-flash"
 
     def test_adapt_response_uses_finish_message_when_present(self):
         raw = _make_gemini_response(
@@ -460,7 +460,7 @@ class TestSafetyBlockDetection:
             finish_message="No can do",
         )
         with pytest.raises(LLMRefusedError) as exc_info:
-            gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+            gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         assert exc_info.value.refusal_text == "No can do"
 
     def test_adapt_response_synthesizes_message_from_blocking_ratings(self):
@@ -476,7 +476,7 @@ class TestSafetyBlockDetection:
             safety_ratings=[rating],
         )
         with pytest.raises(LLMRefusedError) as exc_info:
-            gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+            gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         assert "HARM_CATEGORY_DANGEROUS" in exc_info.value.refusal_text
         assert "safety filter" in exc_info.value.refusal_text
 
@@ -500,7 +500,7 @@ class TestSafetyBlockDetection:
         )
         # Must NOT raise TypeError; raises LLMRefusedError via SAFETY path.
         with pytest.raises(LLMRefusedError) as exc_info:
-            gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+            gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         # Non-blocking rating → falls through to "blocked by Gemini policy"
         # synthesis (the "blocked by safety filter (...)" branch requires
         # at least one blocking rating).
@@ -514,7 +514,7 @@ class TestSafetyBlockDetection:
             safety_ratings=[],
         )
         with pytest.raises(LLMRefusedError) as exc_info:
-            gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+            gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         assert "blocked by Gemini policy" in exc_info.value.refusal_text
         assert "SAFETY" in exc_info.value.refusal_text
 
@@ -527,14 +527,14 @@ class TestSafetyBlockDetection:
             finish_message="partial",
         )
         with pytest.raises(LLMRefusedError):
-            gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+            gemini_native._adapt_response(raw, model="gemini-2.5-flash")
 
     def test_adapt_response_normal_finish_reason_unchanged(self):
         raw = _make_gemini_response(
             text="hello",
             finish_reason="STOP",
         )
-        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         assert out.choices[0].message.content == "hello"
         assert out.choices[0].finish_reason == "stop"
 
@@ -546,7 +546,7 @@ class TestSafetyBlockDetection:
             model_version="gemini-3-pro-preview",
         )
         with pytest.raises(LLMRefusedError) as exc_info:
-            gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+            gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         # Resolved model from raw.model_version wins.
         assert exc_info.value.model == "gemini-3-pro-preview"
 
@@ -564,7 +564,7 @@ class TestSafetyBlockDetection:
         with pytest.raises(LLMRefusedError) as exc_info:
             await gemini_native.complete(
                 {"messages": [{"role": "user", "content": "Hi"}]},
-                model="gemini/gemini-2.0-flash",
+                model="gemini/gemini-2.5-flash",
             )
         assert exc_info.value.vendor == "gemini"
         assert exc_info.value.category == "SAFETY"
@@ -594,11 +594,11 @@ class TestPromptLevelSafetyBlockDetection:
             prompt_block_reason_message=None,
         )
         with pytest.raises(LLMRefusedError) as exc_info:
-            gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+            gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         err = exc_info.value
         assert err.vendor == "gemini"
         assert err.category == "PROMPT_BLOCK"
-        assert err.model == "gemini-2.0-flash"
+        assert err.model == "gemini-2.5-flash"
         # Synthesized refusal text carries the reason enum name.
         assert block_reason in err.refusal_text
 
@@ -610,7 +610,7 @@ class TestPromptLevelSafetyBlockDetection:
             prompt_block_reason_message="Prompt contained disallowed content.",
         )
         with pytest.raises(LLMRefusedError) as exc_info:
-            gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+            gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         assert (
             exc_info.value.refusal_text
             == "Prompt contained disallowed content."
@@ -630,7 +630,7 @@ class TestPromptLevelSafetyBlockDetection:
             prompt_block_reason_message="prompt-level block message",
         )
         with pytest.raises(LLMRefusedError) as exc_info:
-            gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+            gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         err = exc_info.value
         assert err.category == "PROMPT_BLOCK"
         assert err.refusal_text == "prompt-level block message"
@@ -643,7 +643,7 @@ class TestPromptLevelSafetyBlockDetection:
             finish_reason="STOP",
             prompt_block_reason="BLOCKED_REASON_UNSPECIFIED",
         )
-        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         assert out.choices[0].message.content == "hello"
         assert out.choices[0].finish_reason == "stop"
 
@@ -652,7 +652,7 @@ class TestPromptLevelSafetyBlockDetection:
         raw = _make_gemini_response(text="hello", finish_reason="STOP")
         # _make_gemini_response leaves prompt_feedback=None by default.
         assert raw.prompt_feedback is None
-        out = gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         assert out.choices[0].message.content == "hello"
         assert out.choices[0].finish_reason == "stop"
 
@@ -664,7 +664,7 @@ class TestPromptLevelSafetyBlockDetection:
             model_version="gemini-3-pro-preview",
         )
         with pytest.raises(LLMRefusedError) as exc_info:
-            gemini_native._adapt_response(raw, model="gemini-2.0-flash")
+            gemini_native._adapt_response(raw, model="gemini-2.5-flash")
         # Resolved model from raw.model_version wins.
         assert exc_info.value.model == "gemini-3-pro-preview"
 
@@ -683,7 +683,7 @@ class TestPromptLevelSafetyBlockDetection:
         with pytest.raises(LLMRefusedError) as exc_info:
             await gemini_native.complete(
                 {"messages": [{"role": "user", "content": "Hi"}]},
-                model="gemini/gemini-2.0-flash",
+                model="gemini/gemini-2.5-flash",
             )
         assert exc_info.value.vendor == "gemini"
         assert exc_info.value.category == "PROMPT_BLOCK"
@@ -715,7 +715,7 @@ class TestLLMRefusedErrorBackwardsCompat:
         err = LLMRefusedError(
             "blocked",
             vendor="gemini",
-            model="gemini-2.0-flash",
+            model="gemini-2.5-flash",
             category="SAFETY",
         )
         assert err.category == "SAFETY"
@@ -775,7 +775,7 @@ class TestLiveSafetyBlockIntegration:
         try:
             response = await gemini_native.complete(
                 request_params,
-                model="gemini/gemini-2.0-flash",
+                model="gemini/gemini-2.5-flash",
             )
         except LLMRefusedError as exc:
             assert exc.vendor == "gemini"

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
@@ -128,7 +128,7 @@ class GeminiHandler(BaseProviderHandler):
     Supported Models (via LiteLLM):
     - gemini/gemini-3-flash-preview (reasoning support)
     - gemini/gemini-3-pro-preview (advanced reasoning)
-    - gemini/gemini-2.0-flash (fast, efficient)
+    - gemini/gemini-2.5-flash (fast, efficient)
     - gemini/gemini-2.0-flash-lite (fastest, most efficient)
     - gemini/gemini-1.5-pro (high capability)
     - gemini/gemini-1.5-flash (balanced)

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_gemini_handler_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_gemini_handler_native.py
@@ -175,7 +175,7 @@ class TestComplete:
         ) as mock_complete:
             result = await handler.complete(
                 {"messages": [{"role": "user", "content": "Hi"}]},
-                model="gemini/gemini-2.0-flash",
+                model="gemini/gemini-2.5-flash",
                 api_key="GAK-test",
                 base_url=None,
             )
@@ -183,7 +183,7 @@ class TestComplete:
         assert result is sentinel
         mock_complete.assert_awaited_once()
         kwargs = mock_complete.await_args.kwargs
-        assert kwargs["model"] == "gemini/gemini-2.0-flash"
+        assert kwargs["model"] == "gemini/gemini-2.5-flash"
         assert kwargs["api_key"] == "GAK-test"
 
     @pytest.mark.asyncio
@@ -200,7 +200,7 @@ class TestComplete:
         ) as mock_stream:
             stream = await handler.complete_stream(
                 {"messages": [{"role": "user", "content": "Hi"}]},
-                model="gemini/gemini-2.0-flash",
+                model="gemini/gemini-2.5-flash",
                 api_key="GAK-test",
             )
             chunks = [c async for c in stream]
@@ -208,7 +208,7 @@ class TestComplete:
         assert chunks == ["chunk1", "chunk2"]
         mock_stream.assert_called_once()
         kwargs = mock_stream.call_args.kwargs
-        assert kwargs["model"] == "gemini/gemini-2.0-flash"
+        assert kwargs["model"] == "gemini/gemini-2.5-flash"
         assert kwargs["api_key"] == "GAK-test"
 
     @pytest.mark.asyncio
@@ -224,11 +224,11 @@ class TestComplete:
         ) as mock_complete:
             result = await handler.complete(
                 {"messages": [{"role": "user", "content": "Hi"}]},
-                model="vertex_ai/gemini-2.0-flash",
+                model="vertex_ai/gemini-2.5-flash",
             )
         assert result is sentinel
         assert mock_complete.await_args.kwargs["model"] == (
-            "vertex_ai/gemini-2.0-flash"
+            "vertex_ai/gemini-2.5-flash"
         )
 
 

--- a/src/runtime/python/tests/unit/test_phase_c_streaming_routing.py
+++ b/src/runtime/python/tests/unit/test_phase_c_streaming_routing.py
@@ -32,6 +32,8 @@ helpers.py wiring + fallback semantics.
 
 from __future__ import annotations
 
+import ast
+import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -319,6 +321,64 @@ class TestMaybeRunSyntheticFallbackRetry:
 # ---------------------------------------------------------------------------
 
 
+def _find_function_defs(
+    node: ast.AST, name: str
+) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Walk ``node`` recursively and return EVERY FunctionDef /
+    AsyncFunctionDef whose ``name`` matches.
+
+    Returns a list (not a first-match scalar) because ``mesh.helpers``
+    intentionally defines ``process_chat`` twice — once as a sync legacy
+    factory and once as an async provider-managed factory. A regression
+    that diverges only the second closure (e.g., drops ``streaming=False``
+    on its ``_prepare_provider_request`` call) must still fail the audit;
+    a first-match-only helper would silently pass.
+    """
+    return [
+        child
+        for child in ast.walk(node)
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and child.name == name
+    ]
+
+
+def _iter_calls(node: ast.AST):
+    """Yield every ``ast.Call`` inside ``node`` (descends into nested defs)."""
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            yield child
+
+
+def _call_target_name(call: ast.Call) -> str | None:
+    """Return the bare callee name for a ``Call`` whose target is either a
+    simple ``Name`` (``foo(...)``) or a single-level ``Attribute``
+    (``obj.foo(...)``). Returns ``None`` for deeper chains.
+    """
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _keyword_constant(call: ast.Call, name: str):
+    """Return the constant value of keyword ``name`` on ``call`` if present
+    and a ``Constant``; ``Ellipsis`` (sentinel) if absent; ``MISSING`` if
+    present but not constant.
+    """
+    for kw in call.keywords:
+        if kw.arg == name:
+            if isinstance(kw.value, ast.Constant):
+                return kw.value.value
+            return _NON_CONSTANT
+    return _NOT_PRESENT
+
+
+_NON_CONSTANT = object()
+_NOT_PRESENT = object()
+
+
 class TestStreamingNoToolsPathSyntheticBugRemoved:
     """The legacy ``process_chat_stream`` no-tools path used to set up
     ``buffer_for_synthetic`` when synthetic flags were present, drain the
@@ -331,47 +391,82 @@ class TestStreamingNoToolsPathSyntheticBugRemoved:
     sentinels should never reach this path. The strip is kept defensively;
     the buffer-for-synthetic logic is removed. These tests confirm the
     streaming-side code no longer references the removed names.
+
+    AST-based (not substring): a refactor that renamed
+    ``_pop_mesh_synthetic_format_flags`` would fail SPECIFICALLY because the
+    renamed call doesn't appear in ``process_chat_stream``'s call sites, not
+    because the literal substring no longer matches. Same goes for any
+    whitespace / line-break / argument-spread change to the call.
     """
 
+    @staticmethod
+    def _helpers_module_ast() -> ast.Module:
+        import mesh.helpers as helpers_module
+
+        return ast.parse(inspect.getsource(helpers_module))
+
     def test_helpers_module_streaming_branch_does_not_buffer_for_synthetic(self):
-        """Source-level check: the legacy streaming path must no longer
-        contain the ``buffer_for_synthetic`` bug branch. This is a
-        belt-and-suspenders assertion against accidental reintroduction.
+        """The removed branch was identified by a local ``buffer_for_synthetic``
+        flag. Walk the streaming closure's AST and confirm no ``Name`` or
+        ``arg`` carries that identifier. Catches reintroduction regardless
+        of whitespace / line-wrap.
+
+        Iterates over EVERY ``process_chat_stream`` definition — today
+        there's one, but if a second factory ever defines another, a
+        regression in the new closure must still fail this audit.
         """
-        import inspect
-
-        import mesh.helpers as helpers_module
-
-        source = inspect.getsource(helpers_module)
-        # The flag name was specific to the removed branch — its presence
-        # would mean someone reintroduced the buffer-then-fallback path.
-        assert "buffer_for_synthetic" not in source, (
-            "process_chat_stream no-tools path must not buffer for "
-            "synthetic-tool emission — Phase C routes streaming to HINT "
-            "mode in ClaudeHandler instead"
+        tree = self._helpers_module_ast()
+        streams = _find_function_defs(tree, "process_chat_stream")
+        assert streams, (
+            "process_chat_stream closure not found inside mesh.helpers — "
+            "this test (and the streaming wiring it guards) is out of date"
         )
 
-    def test_helpers_module_still_strips_synthetic_flags_defensively(self):
-        """Even though the synthetic-format flags should never reach the
-        streaming path, the strip via ``_pop_mesh_synthetic_format_flags``
-        must remain — defense-in-depth against misconfiguration where a
+        for idx, process_chat_stream in enumerate(streams):
+            offending: list[str] = []
+            for child in ast.walk(process_chat_stream):
+                if isinstance(child, ast.Name) and child.id == "buffer_for_synthetic":
+                    offending.append(f"Name@line {child.lineno}")
+                elif isinstance(child, ast.arg) and child.arg == "buffer_for_synthetic":
+                    offending.append(f"arg@line {child.lineno}")
+
+            assert not offending, (
+                f"process_chat_stream #{idx} (defined at line "
+                f"{process_chat_stream.lineno}) must not reference "
+                "`buffer_for_synthetic` (removed Phase C bug branch). "
+                "Found: " + ", ".join(offending)
+            )
+
+    def test_streaming_no_tools_path_calls_pop_synthetic_format_flags(self):
+        """``process_chat_stream`` must call ``_pop_mesh_synthetic_format_flags``
+        at least once — defense-in-depth against misconfiguration where a
         custom handler stamps the sentinels on a streaming request.
+
+        AST check: a refactor that renamed the function (e.g. to
+        ``_pop_synthetic_flags``) would break this test because the renamed
+        ``Call.func.id`` no longer matches, NOT because a substring stopped
+        appearing.
+
+        Iterates over every ``process_chat_stream`` definition so a future
+        second factory cannot silently skip the defense-in-depth strip.
         """
-        import inspect
+        tree = self._helpers_module_ast()
+        streams = _find_function_defs(tree, "process_chat_stream")
+        assert streams, "process_chat_stream closure not found"
 
-        import mesh.helpers as helpers_module
-
-        source = inspect.getsource(helpers_module)
-        # Anchor on the exact call expression in the streaming no-tools path.
-        # A bare-symbol search would pass even if every call site were removed,
-        # because `_pop_mesh_synthetic_format_flags` is DEFINED in this module.
-        # The arg name `completion_args` pins us to the streaming/agentic-loop
-        # call sites (the strip-on-streaming defense-in-depth lives there).
-        assert "_pop_mesh_synthetic_format_flags(completion_args)" in source, (
-            "process_chat_stream no-tools path must still strip the "
-            "synthetic-format sentinels defensively — Phase C routes "
-            "streaming to HINT mode, but the strip remains as defense-in-depth"
-        )
+        for idx, process_chat_stream in enumerate(streams):
+            target_calls = [
+                call
+                for call in _iter_calls(process_chat_stream)
+                if _call_target_name(call) == "_pop_mesh_synthetic_format_flags"
+            ]
+            assert target_calls, (
+                f"process_chat_stream #{idx} (defined at line "
+                f"{process_chat_stream.lineno}) must call "
+                "_pop_mesh_synthetic_format_flags (defense-in-depth strip "
+                "of the synthetic-format sentinels). If you renamed the "
+                "function, update this AST check too."
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -383,30 +478,139 @@ class TestStreamingNoToolsPathSyntheticBugRemoved:
 class TestPrepareProviderRequestStreamingFlag:
     """``_prepare_provider_request`` is a local closure inside the
     ``llm_provider`` decorator factory, so we can't import and call it
-    directly. Source-level inspection is the pragmatic guard: the two call
-    sites must pass ``streaming=True`` (process_chat_stream) and
-    ``streaming=False`` (process_chat), and the handler call must forward
-    the flag.
+    directly. AST inspection covers the contract: the two outer call sites
+    must pass ``streaming=True`` (process_chat_stream) and ``streaming=False``
+    (process_chat); the inner handler call must forward ``streaming=streaming``.
+
+    AST (not substring) so a refactor that renamed ``_prepare_provider_request``
+    or ``apply_structured_output`` would fail the test SPECIFICALLY because
+    the renamed call site isn't found, not because the literal string no
+    longer appears.
     """
 
-    def test_streaming_flag_is_plumbed_through_to_handler(self):
-        import inspect
-
+    @staticmethod
+    def _helpers_module_ast() -> ast.Module:
         import mesh.helpers as helpers_module
 
-        source = inspect.getsource(helpers_module)
-        # The buffered path passes streaming=False explicitly (or omits to
-        # default). The streaming path MUST pass streaming=True.
-        assert "_prepare_provider_request(request, streaming=True)" in source, (
-            "process_chat_stream must call _prepare_provider_request with "
-            "streaming=True so ClaudeHandler routes to HINT mode"
-        )
-        assert "_prepare_provider_request(request, streaming=False)" in source, (
-            "process_chat must call _prepare_provider_request with "
-            "streaming=False to preserve buffered synthetic-tool behavior"
-        )
-        # And the apply_structured_output call must forward streaming.
-        assert "streaming=streaming" in source, (
-            "_prepare_provider_request must forward its streaming kwarg to "
-            "handler.apply_structured_output"
-        )
+        return ast.parse(inspect.getsource(helpers_module))
+
+    def _streaming_kw_in_call_to(
+        self, parent: ast.AST, callee_name: str
+    ) -> list[object]:
+        """Walk ``parent`` for every ``Call`` to ``callee_name`` and return
+        the ``streaming`` keyword value (constant) of each.
+        """
+        return [
+            _keyword_constant(call, "streaming")
+            for call in _iter_calls(parent)
+            if _call_target_name(call) == callee_name
+        ]
+
+    def test_process_chat_calls_prepare_with_streaming_false(self):
+        """``mesh.helpers`` defines ``process_chat`` in BOTH the legacy and
+        provider-managed factories. Iterate over every occurrence so a
+        regression in either closure (e.g., dropping the explicit
+        ``streaming=False``) fails the audit.
+        """
+        tree = self._helpers_module_ast()
+        process_chats = _find_function_defs(tree, "process_chat")
+        assert process_chats, "process_chat closure not found"
+
+        for idx, process_chat in enumerate(process_chats):
+            streaming_kws = self._streaming_kw_in_call_to(
+                process_chat, "_prepare_provider_request"
+            )
+            # process_chat may call _prepare_provider_request at least once;
+            # every such call must pass streaming=False explicitly (no
+            # implicit default — explicit is the design contract).
+            assert streaming_kws, (
+                f"process_chat #{idx} (defined at line {process_chat.lineno}) "
+                "must call _prepare_provider_request (none found)"
+            )
+            assert all(v is False for v in streaming_kws), (
+                f"process_chat #{idx} (defined at line {process_chat.lineno}) "
+                "must pass streaming=False to _prepare_provider_request "
+                f"(observed: {streaming_kws}) to preserve buffered "
+                "synthetic-tool behavior"
+            )
+
+    def test_process_chat_stream_calls_prepare_with_streaming_true(self):
+        """Iterates over every ``process_chat_stream`` definition — today
+        there's only one, but the helper returns ALL matches so a future
+        second factory cannot silently skip the ``streaming=True`` contract.
+        """
+        tree = self._helpers_module_ast()
+        streams = _find_function_defs(tree, "process_chat_stream")
+        assert streams, "process_chat_stream closure not found"
+
+        for idx, process_chat_stream in enumerate(streams):
+            streaming_kws = self._streaming_kw_in_call_to(
+                process_chat_stream, "_prepare_provider_request"
+            )
+            assert streaming_kws, (
+                f"process_chat_stream #{idx} (defined at line "
+                f"{process_chat_stream.lineno}) must call "
+                "_prepare_provider_request (none found)"
+            )
+            assert all(v is True for v in streaming_kws), (
+                f"process_chat_stream #{idx} (defined at line "
+                f"{process_chat_stream.lineno}) must pass streaming=True "
+                f"to _prepare_provider_request (observed: {streaming_kws}) "
+                "so ClaudeHandler routes to HINT mode"
+            )
+
+    def test_prepare_provider_request_forwards_streaming_to_handler(self):
+        """Inside ``_prepare_provider_request``, the call to
+        ``handler.apply_structured_output`` must forward ``streaming=streaming``
+        (pass-through of the outer parameter, not a literal True/False).
+
+        Iterates over every ``_prepare_provider_request`` definition so any
+        future second copy must also forward the parameter.
+        """
+        tree = self._helpers_module_ast()
+        prepares = _find_function_defs(tree, "_prepare_provider_request")
+        assert prepares, "_prepare_provider_request closure not found"
+
+        for idx, prepare in enumerate(prepares):
+            # First, the function must declare a ``streaming`` parameter —
+            # that's the source of the value we forward.
+            all_args = (
+                prepare.args.args
+                + prepare.args.kwonlyargs
+                + ([prepare.args.vararg] if prepare.args.vararg else [])
+            )
+            param_names = [a.arg for a in all_args if a is not None]
+            assert "streaming" in param_names, (
+                f"_prepare_provider_request #{idx} (defined at line "
+                f"{prepare.lineno}) must declare a `streaming` parameter "
+                f"(found: {param_names})"
+            )
+
+            # Find every call to apply_structured_output inside the closure
+            # and verify each forwards streaming=<the parameter>.
+            forwarding_calls = []
+            for call in _iter_calls(prepare):
+                if _call_target_name(call) != "apply_structured_output":
+                    continue
+                for kw in call.keywords:
+                    if kw.arg == "streaming":
+                        # The forwarded value should be a Name node
+                        # referencing the closure's `streaming` parameter —
+                        # NOT a constant.
+                        is_forward = (
+                            isinstance(kw.value, ast.Name)
+                            and kw.value.id == "streaming"
+                        )
+                        forwarding_calls.append((call.lineno, is_forward))
+
+            assert forwarding_calls, (
+                f"_prepare_provider_request #{idx} (defined at line "
+                f"{prepare.lineno}) must call handler.apply_structured_output "
+                "with a streaming= kwarg"
+            )
+            assert all(is_forward for _, is_forward in forwarding_calls), (
+                f"_prepare_provider_request #{idx} (defined at line "
+                f"{prepare.lineno}) must forward its own `streaming` "
+                "parameter (Name node) to apply_structured_output, not a "
+                f"literal — observed: {forwarding_calls}"
+            )

--- a/src/runtime/python/tests/unit/test_phase_c_streaming_routing.py
+++ b/src/runtime/python/tests/unit/test_phase_c_streaming_routing.py
@@ -364,8 +364,12 @@ def _call_target_name(call: ast.Call) -> str | None:
 
 def _keyword_constant(call: ast.Call, name: str):
     """Return the constant value of keyword ``name`` on ``call`` if present
-    and a ``Constant``; ``Ellipsis`` (sentinel) if absent; ``MISSING`` if
-    present but not constant.
+    and an ``ast.Constant``.
+
+    Returns ``_NOT_PRESENT`` (sentinel) if the keyword is absent.
+    Returns ``_NON_CONSTANT`` (sentinel) if the keyword is present but
+    its value is not an ``ast.Constant`` (e.g. a Name reference like
+    ``streaming=streaming`` rather than a literal ``streaming=True``).
     """
     for kw in call.keywords:
         if kw.arg == name:

--- a/src/runtime/typescript/src/llm-agent.ts
+++ b/src/runtime/typescript/src/llm-agent.ts
@@ -9,7 +9,7 @@
  * - Metadata tracking (tokens, latency, tool calls)
  *
  * Configuration Hierarchy (ENV > Config):
- * - MESH_LLM_MODEL: Override model (e.g., "gpt-4o", "gemini-2.0-flash")
+ * - MESH_LLM_MODEL: Override model (e.g., "gpt-4o", "gemini-2.5-flash")
  * - MESH_LLM_MAX_ITERATIONS: Override max agentic loop iterations
  *
  * @example

--- a/src/runtime/typescript/src/provider-handlers/gemini-handler.ts
+++ b/src/runtime/typescript/src/provider-handlers/gemini-handler.ts
@@ -55,7 +55,7 @@ const debug = createDebug("gemini-handler");
  * Supported Models (via Vercel AI SDK):
  * - gemini-3-flash-preview (reasoning support)
  * - gemini-3-pro-preview (advanced reasoning)
- * - gemini-2.0-flash (fast, efficient)
+ * - gemini-2.5-flash (fast, efficient)
  * - gemini-2.0-flash-lite (fastest, most efficient)
  * - gemini-1.5-pro (high capability)
  * - gemini-1.5-flash (balanced)

--- a/tests/integration/suites/uc04_llm_integration/tc35_vertex_provider_ts/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc35_vertex_provider_ts/test.yaml
@@ -149,7 +149,7 @@ assertions:
     message: "Response should contain Paris as the capital"
   # Routing — confirm we actually went through the Vertex path, not AI Studio.
   # The TS Vercel AI SDK emits a startup line like:
-  #   AI SDK Warning (google.vertex.chat / gemini-2.0-flash): ...
+  #   AI SDK Warning (google.vertex.chat / gemini-2.5-flash): ...
   # which is the smoking gun for @ai-sdk/google-vertex (vs @ai-sdk/google AI Studio)..
   # The TS provider is registered as "vertex_chat" and the runtime selects
   # GeminiHandler for vendor "vertex_ai".


### PR DESCRIPTION
## Summary

Four cleanup items — three deferred from PR #1014's review plus a pre-emptive migration for the Gemini 2.0 Flash deprecation (June 1, 2026).

### 1. DRY the dedupe pattern across native adapters

Each of `anthropic_native`, `openai_native`, `gemini_native` had its own copy of "log unsupported kwarg WARN once per process". Shared into `_native_client_helpers.warn_unsupported_kwarg_once(dedupe_set, ...)` taking the adapter's set as input. Each adapter keeps its module-level set (per-vendor dedupe state preserved); behavior is identical.

### 2. Anthropic `output_config` allow-list — anchored regex

Substring set "opus-4-1" would silently accept hypothetical future "opus-4-10". Replaced with compiled regex patterns using boundary guards `(?<!\d)` leading + `(?!\d)` trailing. +10 parametrized tests covering the overmatch boundary.

### 3. Replace `inspect.getsource()` substring assertions with AST walks

Two test files used `inspect.getsource()` + substring checks on closure-trapped functions. Brittle to whitespace/refactor. Replaced with AST traversal asserting on `Call.func.id` / `Call.keywords`. `_find_function_defs` returns a list of all matches; tests iterate per-occurrence — a regression in a same-named sibling factory now fails specifically rather than slipping through.

### 4. Gemini 2.0 Flash → 2.5 Flash migration

Gemini 2.0 Flash sunsets June 1, 2026 per Google's pricing page. 2.5 Flash is the canonical successor. 23 files updated across docs, examples, tests, and source-code docstrings. Used perl negative-lookahead substitution to preserve `gemini-2.0-flash-lite` and `gemini-2.0-flash-thinking` variants (different models, retain their identity). No behavioral defaults touched — all 4 source-code references were docstrings / JSDoc examples / "Supported Models" lists.

## Review Notes

Internal review verdict on items 1–3: **merge with minor polish**. 0 BLOCKERs, 1 WARNING (fixed), 3 INFOs (1 fixed, 2 deferred as nits).

Addressed before push:
- `_find_function_def` → `_find_function_defs` (plural; returns list of all matches; tests iterate per-occurrence)
- Regex prefix lookbehind: `(?<!\d)` added to all 5 patterns (defends against hypothetical `sonnet-40-5` overmatch)

Migration verification:
- `grep -rn 'gemini-2\.0-flash[^-]'` returns 0 hits
- Variants preserved: 2 `-lite` references, 2 `-thinking` references intact
- Test pass count unchanged (mocked test layer opaque to model strings)

Closes #1015

## Test plan

- [ ] Unit suite: `cd src/runtime/python && pytest _mcp_mesh/ tests/unit/ -q` → expect **1462 passed, 2 skipped**
- [ ] Overmatch regression check: `pytest -k test_allow_list_overmatch_rejected -v` (10 parametrized cases pass)
- [ ] AST-test rename safety: temporarily rename `_pop_mesh_synthetic_format_flags` → `_pop_renamed_test` in `helpers.py`; the test should fail specifically on the missing AST node (then revert)
- [ ] Dedupe helper smoke: trigger an unsupported kwarg on each adapter; confirm WARN fires once per kwarg per adapter
- [ ] Migration: `grep -rn 'gemini-2\.0-flash[^-]' src/ docs/ examples/ tests/` returns 0 hits
- [ ] Variants preserved: `grep -rn 'gemini-2\.0-flash-lite\|gemini-2\.0-flash-thinking'` still returns matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)