### PR TITLE
runtime+docs: TS/Java modelParams escape-hatch for vendor-specific kwargs

### DIFF
--- a/docs/reference/kwargs.md
+++ b/docs/reference/kwargs.md
@@ -121,6 +121,22 @@ const result = await agent.run("Help me draft a release note", {
 });
 ```
 
+For vendor-specific kwargs the typed surface doesn't expose (e.g. Gemini
+`thinking_config`, Anthropic `output_config`, OpenAI `reasoning_effort`), use
+the `modelParams` escape hatch on `LlmCallOptions`. The dict is merged into the
+wire `model_params` **before** typed fields, so typed options (`maxOutputTokens`,
+`temperature`, ...) win on collision and remain authoritative:
+
+```typescript
+const reply = await llm.call(prompt, {
+  maxOutputTokens: 4096,
+  temperature: 0.3,
+  modelParams: {
+    thinking_config: { thinking_budget: 0 }, // escape hatch for vendor-specific kwargs
+  },
+});
+```
+
 Source: [`src/runtime/typescript/src/llm-agent.ts`](https://github.com/dhyansraj/mcp-mesh/blob/main/src/runtime/typescript/src/llm-agent.ts).
 
 ### Java
@@ -152,6 +168,23 @@ public String summarize(@Param("text") String text, MeshLlmAgent llm) {
         .generate()
         .text();
 }
+```
+
+For vendor-specific kwargs the typed builder doesn't expose (e.g. Gemini
+`thinking_config`, Anthropic `output_config`, OpenAI `reasoning_effort`), use
+the `.modelParams(...)` escape hatch on the builder. The map is merged into the
+wire `model_params` **before** typed setters, so typed setters (`maxTokens`,
+`temperature`, ...) win on collision and remain authoritative:
+
+```java
+String response = llm.request()
+    .user(prompt)
+    .maxTokens(4096)
+    .temperature(0.3)
+    .modelParams(Map.of(
+        "thinking_config", Map.of("thinking_budget", 0)
+    ))
+    .generate();
 ```
 
 Source: [`MeshLlmAgentProxy.java`](https://github.com/dhyansraj/mcp-mesh/blob/main/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java).

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/types/MeshLlmAgent.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/types/MeshLlmAgent.java
@@ -318,6 +318,38 @@ public interface MeshLlmAgent {
          */
         GenerateBuilder stop(String... sequences);
 
+        /**
+         * Set additional model parameters that aren't covered by the typed
+         * builder methods.
+         *
+         * <p>Escape-hatch for vendor-specific kwargs (e.g., Gemini
+         * {@code thinking_config}, Anthropic {@code output_config}, OpenAI
+         * {@code reasoning_effort}). Merged into the wire {@code model_params}
+         * dict BEFORE typed fields, so typed setters ({@link #maxTokens},
+         * {@link #temperature}, etc.) win on collision and the typed surface
+         * stays authoritative.
+         *
+         * <p>Example:
+         * <pre>{@code
+         * String response = llm.request()
+         *     .user("Tell me a story")
+         *     .maxTokens(4096)
+         *     .modelParams(Map.of(
+         *         "thinking_config", Map.of("thinking_budget", 0)
+         *     ))
+         *     .generate();
+         * }</pre>
+         *
+         * <p>Successive calls REPLACE prior values (not merged). Pass
+         * {@code null} or empty map to clear/reset.
+         *
+         * @param params Map of model parameter names to values (any JSON-
+         *               serializable value: primitives, lists, nested maps).
+         *               Pass {@code null} or empty map to clear/reset.
+         * @return This builder for chaining
+         */
+        GenerateBuilder modelParams(Map<String, Object> params);
+
         // --- Media ---
 
         /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -378,6 +378,12 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
         private List<String> stopSequences = null;
         private int maxIterations = defaultMaxIterations;
 
+        // Issue #1019: escape-hatch for vendor-specific model_params kwargs
+        // (e.g., thinking_config, output_config, reasoning_effort) not exposed
+        // by the typed builder. Merged into the wire model_params BEFORE typed
+        // setters so typed values win on collision.
+        private Map<String, Object> userModelParams = null;
+
         // Response type for auto-generating JSON schema instructions
         private Class<?> responseType = null;
 
@@ -465,6 +471,12 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
         @Override
         public GenerateBuilder stop(String... sequences) {
             this.stopSequences = Arrays.asList(sequences);
+            return this;
+        }
+
+        @Override
+        public GenerateBuilder modelParams(Map<String, Object> params) {
+            this.userModelParams = params;
             return this;
         }
 
@@ -591,8 +603,29 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
 
                 // Build model_params (LLM provider configuration)
                 Map<String, Object> modelParams = new LinkedHashMap<>();
-                modelParams.put("max_tokens", maxTokens != null ? maxTokens : defaultMaxTokens);
-                modelParams.put("temperature", temperature != null ? temperature : defaultTemperature);
+                // Issue #1019: escape-hatch merge — callers can pass vendor-
+                // specific kwargs (e.g., thinking_config, output_config) via
+                // .modelParams(...). Merged FIRST so typed setters below take
+                // precedence on collision (keeps the typed surface authoritative).
+                if (userModelParams != null && !userModelParams.isEmpty()) {
+                    modelParams.putAll(userModelParams);
+                }
+                // Typed setters win on collision with modelParams (escape-hatch).
+                // Annotation defaults apply only when neither typed setter nor
+                // modelParams provided the key. Matches TS guard semantics
+                // (`if (options?.maxOutputTokens) ...`) so callers can set
+                // max_tokens / temperature purely via .modelParams(...) without
+                // the annotation defaults clobbering their values.
+                if (maxTokens != null) {
+                    modelParams.put("max_tokens", maxTokens);
+                } else if (!modelParams.containsKey("max_tokens")) {
+                    modelParams.put("max_tokens", defaultMaxTokens);
+                }
+                if (temperature != null) {
+                    modelParams.put("temperature", temperature);
+                } else if (!modelParams.containsKey("temperature")) {
+                    modelParams.put("temperature", defaultTemperature);
+                }
                 if (topP != null) {
                     modelParams.put("top_p", topP);
                 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyModelParamsTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyModelParamsTest.java
@@ -1,0 +1,327 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.core.MeshObjectMappers;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the {@code modelParams} escape-hatch on the buffered
+ * {@code generate()} path — issue #1019.
+ *
+ * <p>The Java SDK exposes a typed builder surface ({@code maxTokens},
+ * {@code temperature}, {@code topP}, {@code stop}) whose values map to wire
+ * {@code model_params} keys. For vendor-specific kwargs that the typed surface
+ * doesn't expose (e.g., Gemini {@code thinking_config}, Anthropic
+ * {@code output_config}, OpenAI {@code reasoning_effort}) callers can pass an
+ * arbitrary {@code Map<String, Object>} via {@code .modelParams(...)}. The map
+ * is merged into the wire {@code model_params} BEFORE typed setters so typed
+ * values win on collision and the typed surface stays authoritative.
+ *
+ * <p>Mirrors {@code MeshLlmAgentProxyStreamTest}'s wiring: a real
+ * {@link McpHttpClient} pointed at a {@link MockWebServer} that returns the
+ * MCP tools/call shape the LLM provider produces. We inspect the captured
+ * request body to assert the {@code model_params} merge semantics.
+ */
+@DisplayName("MeshLlmAgentProxy.generate() — modelParams escape hatch (issue #1019)")
+class MeshLlmAgentProxyModelParamsTest {
+
+    private MockWebServer server;
+    private McpHttpClient client;
+    private ObjectMapper mapper;
+    private MeshLlmAgentProxy proxy;
+
+    @BeforeAll
+    static void initTlsConfig() throws Exception {
+        // Pre-seed MeshTlsConfig.cached so tests don't hit native FFI
+        Constructor<MeshTlsConfig> ctor = MeshTlsConfig.class.getDeclaredConstructor(
+            boolean.class, String.class, String.class, String.class, String.class);
+        ctor.setAccessible(true);
+        MeshTlsConfig disabled = ctor.newInstance(false, "off", null, null, null);
+
+        Field cachedField = MeshTlsConfig.class.getDeclaredField("cached");
+        cachedField.setAccessible(true);
+        cachedField.set(null, disabled);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        mapper = MeshObjectMappers.create();
+        client = new McpHttpClient(mapper);
+
+        proxy = new MeshLlmAgentProxy("test.modelparams");
+        // Configure with maxIterations=1 so generate() returns after a single LLM call.
+        // Defaults: maxTokens=4096, temperature=0.7, parallelToolCalls=false.
+        proxy.configure(client, null, null, null, "", "ctx", 1, false);
+        proxy.updateProvider(
+            server.url("/").toString().replaceAll("/$", ""),
+            "process_chat",
+            "mesh-delegated"
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (client != null) client.close();
+        server.shutdown();
+    }
+
+    // -------------------------------------------------------------------------
+    // Mock helpers — return the MCP tools/call shape the LLM provider produces.
+    // The inner `content[0].text` is a JSON-encoded mesh-provider response:
+    //     { role, content, tool_calls?, _mesh_usage? }
+    // -------------------------------------------------------------------------
+
+    private MockResponse stubLlmResponse(String reply) {
+        long id = System.currentTimeMillis();
+        Map<String, Object> innerPayload = Map.of(
+            "role", "assistant",
+            "content", reply
+        );
+        String innerJson;
+        try {
+            innerJson = mapper.writeValueAsString(innerPayload);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        Map<String, Object> envelope = Map.of(
+            "jsonrpc", "2.0",
+            "id", id,
+            "result", Map.of(
+                "content", java.util.List.of(
+                    Map.of("type", "text", "text", innerJson)
+                )
+            )
+        );
+        String body;
+        try {
+            body = mapper.writeValueAsString(envelope);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return new MockResponse()
+            .setBody(body)
+            .setHeader("Content-Type", "application/json");
+    }
+
+    /** Read the captured outbound request body and pull out the model_params node. */
+    private JsonNode readModelParams(RecordedRequest request) throws Exception {
+        String body = request.getBody().readUtf8();
+        JsonNode root = mapper.readTree(body);
+        JsonNode args = root.get("params").get("arguments");
+        JsonNode req = args.get("request");
+        JsonNode modelParams = req.get("model_params");
+        assertNotNull(modelParams, "request.model_params must be present");
+        return modelParams;
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("modelParams keys flow into the wire request's model_params")
+    void modelParamsKeysFlowThrough() throws Exception {
+        server.enqueue(stubLlmResponse("ok"));
+
+        String result = proxy.request()
+            .user("hi")
+            .modelParams(Map.of(
+                "thinking_config", Map.of("thinking_budget", 0),
+                "reasoning_effort", "high"
+            ))
+            .generate();
+
+        assertEquals("ok", result);
+
+        RecordedRequest req = server.takeRequest();
+        JsonNode modelParams = readModelParams(req);
+
+        JsonNode thinking = modelParams.get("thinking_config");
+        assertNotNull(thinking, "thinking_config must be present in model_params");
+        assertEquals(0, thinking.get("thinking_budget").asInt());
+        assertEquals("high", modelParams.get("reasoning_effort").asText());
+
+        // Typed defaults still emitted
+        assertTrue(modelParams.has("max_tokens"));
+        assertTrue(modelParams.has("temperature"));
+    }
+
+    @Test
+    @DisplayName("typed setter (.temperature) wins over modelParams on collision")
+    void typedSetterWinsOnCollision() throws Exception {
+        server.enqueue(stubLlmResponse("ok"));
+
+        // Builder typed-temperature is 0.5; .modelParams supplies 0.9 for the
+        // same key. The merge order in executeAgenticLoop must put the user
+        // modelParams FIRST so the typed .put("temperature", ...) overwrites.
+        Map<String, Object> userModelParams = new LinkedHashMap<>();
+        userModelParams.put("temperature", 0.9);
+        userModelParams.put("max_tokens", 999);                       // typed maxTokens overrides
+        userModelParams.put("thinking_config", Map.of("thinking_budget", 0));
+
+        proxy.request()
+            .user("hi")
+            .temperature(0.5)
+            .maxTokens(200)
+            .modelParams(userModelParams)
+            .generate();
+
+        RecordedRequest req = server.takeRequest();
+        JsonNode modelParams = readModelParams(req);
+
+        assertEquals(0.5, modelParams.get("temperature").asDouble(), 1e-9,
+            "typed .temperature(0.5) must win over modelParams temperature=0.9");
+        assertEquals(200, modelParams.get("max_tokens").asInt(),
+            "typed .maxTokens(200) must win over modelParams max_tokens=999");
+        // Vendor-specific key (no typed equivalent) flows through untouched
+        assertEquals(0, modelParams.get("thinking_config").get("thinking_budget").asInt());
+    }
+
+    @Test
+    @DisplayName("vendor-specific keys flow through untouched (no key translation)")
+    void vendorSpecificKeysUntouched() throws Exception {
+        server.enqueue(stubLlmResponse("ok"));
+
+        Map<String, Object> outputConfig = Map.of(
+            "format", Map.of(
+                "type", "json_schema",
+                "schema", Map.of("type", "object")
+            )
+        );
+
+        proxy.request()
+            .user("hi")
+            .modelParams(Map.of(
+                "output_config", outputConfig,
+                "extra_headers", Map.of("x-vendor-flag", "1")
+            ))
+            .generate();
+
+        RecordedRequest req = server.takeRequest();
+        JsonNode modelParams = readModelParams(req);
+
+        JsonNode oc = modelParams.get("output_config");
+        assertNotNull(oc, "output_config must be present");
+        assertEquals("json_schema", oc.get("format").get("type").asText());
+        assertEquals("object", oc.get("format").get("schema").get("type").asText());
+
+        JsonNode headers = modelParams.get("extra_headers");
+        assertNotNull(headers);
+        assertEquals("1", headers.get("x-vendor-flag").asText());
+    }
+
+    @Test
+    @DisplayName("modelParams can set max_tokens when no typed .maxTokens() setter is used")
+    void modelParamsCanSetMaxTokensWhenNoTypedSetter() throws Exception {
+        // Regression: previously the unconditional `modelParams.put("max_tokens", defaults)`
+        // clobbered any value the caller passed via .modelParams(Map.of("max_tokens", 999)).
+        // TS path guards with `if (options?.maxOutputTokens) ...`; Java must match.
+        server.enqueue(stubLlmResponse("ok"));
+
+        proxy.request()
+            .user("hi")
+            // NO .maxTokens() typed setter — only the escape-hatch.
+            .modelParams(Map.of("max_tokens", 999))
+            .generate();
+
+        RecordedRequest req = server.takeRequest();
+        JsonNode modelParams = readModelParams(req);
+
+        assertEquals(999, modelParams.get("max_tokens").asInt(),
+            "modelParams.max_tokens=999 must reach the wire when no typed .maxTokens() is set;"
+            + " annotation default (4096) must NOT clobber it");
+    }
+
+    @Test
+    @DisplayName("modelParams can set temperature when no typed .temperature() setter is used")
+    void modelParamsCanSetTemperatureWhenNoTypedSetter() throws Exception {
+        // Same regression shape as the max_tokens test above, for temperature.
+        server.enqueue(stubLlmResponse("ok"));
+
+        proxy.request()
+            .user("hi")
+            // NO .temperature() typed setter — only the escape-hatch.
+            .modelParams(Map.of("temperature", 0.123))
+            .generate();
+
+        RecordedRequest req = server.takeRequest();
+        JsonNode modelParams = readModelParams(req);
+
+        assertEquals(0.123, modelParams.get("temperature").asDouble(), 1e-9,
+            "modelParams.temperature=0.123 must reach the wire when no typed .temperature() is set;"
+            + " annotation default (0.7) must NOT clobber it");
+    }
+
+    @Test
+    @DisplayName("successive .modelParams(...) calls REPLACE prior values (last-call-wins)")
+    void modelParamsSuccessiveCallsReplace() throws Exception {
+        server.enqueue(stubLlmResponse("ok"));
+
+        Map<String, Object> m1 = Map.of(
+            "thinking_config", Map.of("thinking_budget", 0),
+            "reasoning_effort", "high"
+        );
+        Map<String, Object> m2 = Map.of(
+            "reasoning_effort", "low"
+        );
+
+        proxy.request()
+            .user("hi")
+            .modelParams(m1)
+            .modelParams(m2)
+            .generate();
+
+        RecordedRequest req = server.takeRequest();
+        JsonNode modelParams = readModelParams(req);
+
+        // m2's keys present
+        assertEquals("low", modelParams.get("reasoning_effort").asText(),
+            "second .modelParams() call must overwrite reasoning_effort to 'low'");
+        // m1-only keys absent (REPLACE semantics, not merge)
+        assertFalse(modelParams.has("thinking_config"),
+            "thinking_config from the FIRST .modelParams() call must be absent —"
+            + " successive calls REPLACE, do not merge");
+    }
+
+    @Test
+    @DisplayName("null/empty modelParams → behavior unchanged from before this change")
+    void nullOrEmptyModelParamsIsNoOp() throws Exception {
+        server.enqueue(stubLlmResponse("ok"));
+        server.enqueue(stubLlmResponse("ok"));
+        server.enqueue(stubLlmResponse("ok"));
+
+        // Baseline: no .modelParams() call at all
+        proxy.request().user("hi").generate();
+        JsonNode baseline = readModelParams(server.takeRequest());
+
+        // null map → must not throw, must produce identical wire shape
+        proxy.request().user("hi").modelParams(null).generate();
+        JsonNode nullCase = readModelParams(server.takeRequest());
+
+        // empty map → must not throw, must produce identical wire shape
+        proxy.request().user("hi").modelParams(Map.of()).generate();
+        JsonNode emptyCase = readModelParams(server.takeRequest());
+
+        assertEquals(baseline.toString(), nullCase.toString(),
+            "null modelParams must produce the same model_params as no call");
+        assertEquals(baseline.toString(), emptyCase.toString(),
+            "empty modelParams must produce the same model_params as no call");
+    }
+}

--- a/src/runtime/typescript/src/__tests__/llm-agent-model-params.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-agent-model-params.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for the `modelParams` escape-hatch — issue #1019.
+ *
+ * The TS SDK exposes a typed option surface (`maxOutputTokens`, `temperature`,
+ * `topP`, `stop`) that maps to wire `model_params` keys. For vendor-specific
+ * kwargs that the typed surface doesn't expose (e.g., Gemini `thinking_config`,
+ * Anthropic `output_config`, OpenAI `reasoning_effort`) callers can pass an
+ * arbitrary dict via `options.modelParams`. The dict is merged into the wire
+ * `model_params` BEFORE typed fields, so typed options always win on collision
+ * (keeping the typed surface authoritative).
+ *
+ * Covers both the buffered (`complete()`) and the streaming (`streamComplete()`)
+ * paths since both build `model_params` independently.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@mcpmesh/core", () => ({
+  generateTraceId: () => "trace-mock",
+  generateSpanId: () => "span-mock",
+  injectTraceContext: (argsJson: string) => argsJson,
+  publishSpan: vi.fn(async () => false),
+  parseSseResponse: (s: string) => s,
+  parseSseResponseToObject: (s: string) => JSON.parse(s),
+}));
+
+vi.mock("../http-pool.js", () => ({
+  getDispatcher: () => undefined,
+}));
+
+import { MeshDelegatedProvider } from "../llm-agent.js";
+import type { LlmMessage } from "../types.js";
+
+function makeSseStream(blocks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < blocks.length) {
+        controller.enqueue(encoder.encode(blocks[i]));
+        i += 1;
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function sseEvent(payload: object): string {
+  return `event: message\ndata: ${JSON.stringify(payload)}\n\n`;
+}
+
+function makeMockResponse(blocks: string[]): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    body: makeSseStream(blocks),
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "text/event-stream" : null,
+    },
+  } as unknown as Response;
+}
+
+const ENDPOINT = "http://provider.local:9001";
+const FN_BUFFERED = "process_chat";
+const FN_STREAM = "process_chat_stream";
+
+// ----------------------------------------------------------------------------
+// complete() — buffered path
+// ----------------------------------------------------------------------------
+
+describe("MeshDelegatedProvider.complete() — modelParams escape hatch", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function mockJsonResponse(body: object): Response {
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "content-type" ? "application/json" : null,
+      },
+      text: async () => JSON.stringify(body),
+      json: async () => body,
+    } as unknown as Response;
+  }
+
+  function mcpToolResponse(payload: object) {
+    return {
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        content: [{ type: "text", text: JSON.stringify(payload) }],
+      },
+    };
+  }
+
+  // complete() expects the MCP content[0].text payload to be the
+  // mesh-provider shape: { role, content, tool_calls?, _mesh_usage? }
+  const STUB_COMPLETION = { role: "assistant", content: "ok" };
+
+  it("merges modelParams keys into the wire request's model_params", async () => {
+    let capturedBody: string | undefined;
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      capturedBody = init.body as string;
+      return mockJsonResponse(mcpToolResponse(STUB_COMPLETION));
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = new MeshDelegatedProvider(ENDPOINT, FN_BUFFERED, false);
+    const messages: LlmMessage[] = [{ role: "user", content: "hi" }];
+
+    await provider.complete("anthropic/claude-sonnet-4-5", messages, undefined, {
+      maxOutputTokens: 256,
+      modelParams: {
+        thinking_config: { thinking_budget: 0 },
+        reasoning_effort: "high",
+      },
+    });
+
+    const body = JSON.parse(capturedBody!);
+    const request = body.params.arguments.request as Record<string, unknown>;
+    const modelParams = request.model_params as Record<string, unknown>;
+    expect(modelParams.thinking_config).toEqual({ thinking_budget: 0 });
+    expect(modelParams.reasoning_effort).toBe("high");
+    // Typed fields still flow through
+    expect(modelParams.max_tokens).toBe(256);
+    expect(modelParams.model).toBe("anthropic/claude-sonnet-4-5");
+  });
+
+  it("typed options win over modelParams on collision", async () => {
+    let capturedBody: string | undefined;
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      capturedBody = init.body as string;
+      return mockJsonResponse(mcpToolResponse(STUB_COMPLETION));
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = new MeshDelegatedProvider(ENDPOINT, FN_BUFFERED, false);
+    const messages: LlmMessage[] = [{ role: "user", content: "hi" }];
+
+    await provider.complete("anthropic/claude-sonnet-4-5", messages, undefined, {
+      temperature: 0.5,
+      maxOutputTokens: 200,
+      modelParams: {
+        temperature: 0.9, // caller tried to set via escape hatch — typed wins
+        max_tokens: 999,  // caller used the wire-name; typed maxOutputTokens wins
+        thinking_config: { thinking_budget: 0 },
+      },
+    });
+
+    const body = JSON.parse(capturedBody!);
+    const modelParams = body.params.arguments.request.model_params as Record<string, unknown>;
+    expect(modelParams.temperature).toBe(0.5);
+    expect(modelParams.max_tokens).toBe(200);
+    // Untouched vendor-specific keys flow through
+    expect(modelParams.thinking_config).toEqual({ thinking_budget: 0 });
+  });
+
+  it("vendor-specific keys flow through untouched (no key translation)", async () => {
+    let capturedBody: string | undefined;
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      capturedBody = init.body as string;
+      return mockJsonResponse(mcpToolResponse(STUB_COMPLETION));
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = new MeshDelegatedProvider(ENDPOINT, FN_BUFFERED, false);
+    const messages: LlmMessage[] = [{ role: "user", content: "hi" }];
+
+    await provider.complete("anthropic/claude-sonnet-4-5", messages, undefined, {
+      modelParams: {
+        output_config: { format: { type: "json_schema", schema: { type: "object" } } },
+        extra_headers: { "x-vendor-flag": "1" },
+      },
+    });
+
+    const body = JSON.parse(capturedBody!);
+    const modelParams = body.params.arguments.request.model_params as Record<string, unknown>;
+    expect(modelParams.output_config).toEqual({
+      format: { type: "json_schema", schema: { type: "object" } },
+    });
+    expect(modelParams.extra_headers).toEqual({ "x-vendor-flag": "1" });
+  });
+
+  it("absent modelParams → behavior unchanged (no model_params keys leak)", async () => {
+    let capturedBody: string | undefined;
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      capturedBody = init.body as string;
+      return mockJsonResponse(mcpToolResponse(STUB_COMPLETION));
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = new MeshDelegatedProvider(ENDPOINT, FN_BUFFERED, false);
+    const messages: LlmMessage[] = [{ role: "user", content: "hi" }];
+
+    // No options at all; model="default" so no model_params should be emitted.
+    await provider.complete("default", messages);
+
+    const body = JSON.parse(capturedBody!);
+    const request = body.params.arguments.request as Record<string, unknown>;
+    expect(request.model_params).toBeUndefined();
+  });
+});
+
+// ----------------------------------------------------------------------------
+// streamComplete() — streaming path
+// ----------------------------------------------------------------------------
+
+describe("MeshDelegatedProvider.streamComplete() — modelParams escape hatch", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  async function drain(gen: AsyncGenerator<string, void, void>): Promise<string[]> {
+    const out: string[] = [];
+    for await (const c of gen) out.push(c);
+    return out;
+  }
+
+  it("merges modelParams into the streaming request and lets typed options win", async () => {
+    let capturedBody: string | undefined;
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      capturedBody = init.body as string;
+      const body = JSON.parse(capturedBody);
+      const reqId = body.id as string;
+      return makeMockResponse([
+        sseEvent({ jsonrpc: "2.0", id: reqId, result: { content: [{ type: "text", text: "" }] } }),
+      ]);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = new MeshDelegatedProvider(ENDPOINT, FN_STREAM, false);
+    const messages: LlmMessage[] = [{ role: "user", content: "hi" }];
+
+    await drain(provider.streamComplete("anthropic/claude-sonnet-4-5", messages, undefined, {
+      temperature: 0.4,
+      modelParams: {
+        temperature: 0.9, // typed wins
+        thinking_config: { thinking_budget: 0 }, // flows through
+      },
+    }));
+
+    const body = JSON.parse(capturedBody!);
+    const modelParams = body.params.arguments.request.model_params as Record<string, unknown>;
+    expect(modelParams.temperature).toBe(0.4);
+    expect(modelParams.thinking_config).toEqual({ thinking_budget: 0 });
+    expect(modelParams.model).toBe("anthropic/claude-sonnet-4-5");
+  });
+});

--- a/src/runtime/typescript/src/llm-agent.ts
+++ b/src/runtime/typescript/src/llm-agent.ts
@@ -136,6 +136,9 @@ export interface LlmProvider {
       stop?: string[];
       // Issue #459: Output schema for provider to apply vendor-specific handling
       outputSchema?: { schema: Record<string, unknown>; name: string };
+      // Issue #1019: escape-hatch for vendor-specific kwargs not exposed by the
+      // typed option surface (e.g., thinking_config, output_config, reasoning_effort).
+      modelParams?: Record<string, unknown>;
     }
   ): Promise<LlmCompletionResponse>;
 }
@@ -165,10 +168,19 @@ export class MeshDelegatedProvider implements LlmProvider {
       stop?: string[];
       // Issue #459: Output schema for provider to apply vendor-specific handling
       outputSchema?: { schema: Record<string, unknown>; name: string };
+      // Issue #1019: escape-hatch for vendor-specific kwargs not exposed by the
+      // typed option surface (e.g., thinking_config, output_config, reasoning_effort).
+      modelParams?: Record<string, unknown>;
     }
   ): Promise<LlmCompletionResponse> {
     // Build MeshLlmRequest structure (matches Python claude_provider schema)
     const modelParams: Record<string, unknown> = {};
+    // Escape-hatch merge: callers can pass vendor-specific kwargs
+    // (e.g., thinking_config, output_config) via options.modelParams.
+    // Merged FIRST so typed fields below take precedence on collision.
+    if (options?.modelParams) {
+      Object.assign(modelParams, options.modelParams);
+    }
     // Only pass model if it's a real model name (not "default")
     if (model && model !== "default") {
       modelParams.model = model;
@@ -400,10 +412,19 @@ export class MeshDelegatedProvider implements LlmProvider {
       topP?: number;
       stop?: string[];
       outputSchema?: { schema: Record<string, unknown>; name: string };
+      // Issue #1019: escape-hatch for vendor-specific kwargs not exposed by the
+      // typed option surface (e.g., thinking_config, output_config, reasoning_effort).
+      modelParams?: Record<string, unknown>;
     }
   ): AsyncGenerator<string, void, void> {
     // Build MeshLlmRequest body — same shape as complete()
     const modelParams: Record<string, unknown> = {};
+    // Escape-hatch merge: callers can pass vendor-specific kwargs
+    // (e.g., thinking_config, output_config) via options.modelParams.
+    // Merged FIRST so typed fields below take precedence on collision.
+    if (options?.modelParams) {
+      Object.assign(modelParams, options.modelParams);
+    }
     if (model && model !== "default") {
       modelParams.model = model;
     }
@@ -633,7 +654,15 @@ export class MeshLlmAgent<T = string> {
         model,
         messages,
         toolDefs.length > 0 ? toolDefs : undefined,
-        { maxOutputTokens: maxTokens, temperature, topP: this.config.topP, stop: this.config.stop, outputSchema }
+        {
+          maxOutputTokens: maxTokens,
+          temperature,
+          topP: this.config.topP,
+          stop: this.config.stop,
+          outputSchema,
+          // Issue #1019: forward caller-supplied escape-hatch kwargs
+          modelParams: context.options?.modelParams,
+        }
       );
 
       // Track tokens
@@ -876,7 +905,15 @@ export class MeshLlmAgent<T = string> {
       model,
       messages,
       toolDefs.length > 0 ? toolDefs : undefined,
-      { maxOutputTokens: maxTokens, temperature, topP: this.config.topP, stop: this.config.stop, outputSchema },
+      {
+        maxOutputTokens: maxTokens,
+        temperature,
+        topP: this.config.topP,
+        stop: this.config.stop,
+        outputSchema,
+        // Issue #1019: forward caller-supplied escape-hatch kwargs
+        modelParams: context.options?.modelParams,
+      },
     );
   }
 

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -1002,6 +1002,18 @@ export interface LlmCallOptions {
    * with text + image_url blocks (OpenAI-compatible format).
    */
   media?: Array<string | { data: Buffer; mimeType: string }>;
+  /**
+   * Escape-hatch for vendor-specific kwargs that aren't covered by the
+   * typed option surface (e.g., Gemini `thinking_config`, Anthropic
+   * `output_config`, OpenAI `reasoning_effort`). Merged into the wire
+   * `model_params` dict BEFORE typed fields, so typed options
+   * (`maxOutputTokens`, `temperature`, etc.) win on collision and the
+   * typed surface stays authoritative. For arbitrary kwargs the typed
+   * surface doesn't expose, this field is the only way to set them.
+   *
+   * Example: ``modelParams: { thinking_config: { thinking_budget: 0 } }``
+   */
+  modelParams?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Brings TypeScript and Java SDKs to parity with Python on vendor-specific LLM kwargs (Gemini `thinking_config`, Anthropic `output_config`, OpenAI `reasoning_effort`). Python already supports these via raw `@mesh.llm(model_params={...})` passthrough; this PR adds an equivalent escape-hatch surface to the TS and Java SDKs.

### TypeScript

- `LlmCallOptions` gains `modelParams?: Record<string, unknown>` field
- `llm-agent.ts` `complete()` and `streamComplete()` merge `modelParams` BEFORE typed fields so typed options (`maxOutputTokens`, `temperature`, etc.) win on collision

```typescript
const reply = await llm.call(prompt, {
  maxOutputTokens: 4096,
  temperature: 0.3,
  modelParams: {
    thinking_config: { thinking_budget: 0 },  // escape hatch
  },
});
```

### Java

- `MeshLlmAgent.GenerateBuilder.modelParams(Map<String, Object>)` added to the SDK interface
- `MeshLlmAgentProxy.GenerateBuilderImpl` stores the user map and merges before typed setters
- Annotation defaults (`defaultMaxTokens`, `defaultTemperature`) now apply only when neither the typed setter nor `modelParams` provided the key — matches TS semantics, prevents the escape-hatch from being silently overwritten for those two fields

```java
String response = llm.request()
    .user(prompt)
    .maxTokens(4096)
    .temperature(0.3)
    .modelParams(Map.of(
        "thinking_config", Map.of("thinking_budget", 0)
    ))
    .generate();
```

### Merge semantics

`modelParams` is written first, typed options overwrite on collision. The escape-hatch is purely additive for vendor-specific kwargs the typed surface doesn't expose. Successive `.modelParams(...)` calls REPLACE prior values (documented in Javadoc).

## Review Notes

Internal review verdict: **0 BLOCKER, 2 WARNING (both fixed), 3 INFO (skipped as nits)**. Verdict: ship.

WARNINGs addressed before push:
- Java annotation defaults were unconditionally overwriting `max_tokens` / `temperature` from `modelParams` when no typed setter was called. Fixed: defaults now apply only when neither typed setter nor `modelParams` provided the key. Added `modelParamsCanSetMaxTokensWhenNoTypedSetter` + `modelParamsCanSetTemperatureWhenNoTypedSetter` to cover the gap.
- `modelParams(Map)` Javadoc tightened to make replace semantics explicit. Added `modelParamsSuccessiveCallsReplace` test asserting last-call-wins.

INFOs deferred as pre-existing patterns or minor nits.

## Known Gap

Java streaming surface (`MeshLlmAgent.stream(List<Message>)`) doesn't use the builder pattern, so `modelParams` can't be set on streaming Java calls. Tracked as [#1023](https://github.com/dhyansraj/mcp-mesh/issues/1023) — separate follow-up. Buffered path covers the dominant case.

Closes #1019

## Test plan

- [ ] TypeScript: `cd src/runtime/typescript && npm test` → expect **734 passed** (+5 from this PR in `__tests__/llm-agent-model-params.test.ts`)
- [ ] Java SDK: `cd src/runtime/java/mcp-mesh-sdk && mvn -B -q test` → clean
- [ ] Java spring-boot-starter: `cd src/runtime/java/mcp-mesh-spring-boot-starter && mvn -B -q test` → expect **316 passed** (+7 from this PR)
- [ ] Python sanity: `cd src/runtime/python && pytest _mcp_mesh/ tests/unit/ -q` → **1471 passed, 2 skipped** (no Python touched; sanity only)
- [ ] Cross-runtime spot-check: Python consumer with `model_params={"thinking_config": {...}}`, TS consumer with `modelParams: {thinking_config: {...}}`, Java consumer with `.modelParams(Map.of("thinking_config", ...))` — all should reach a Gemini provider's wire request with the same `model_params.thinking_config` shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)