### PR TITLE
java: streamGenerate() builder + @MeshLlm defaults wiring

### DIFF
--- a/docs/reference/kwargs.md
+++ b/docs/reference/kwargs.md
@@ -165,8 +165,7 @@ public String summarize(@Param("text") String text, MeshLlmAgent llm) {
         .temperature(0.5)
         .topP(0.95)
         .stop("END")
-        .generate()
-        .text();
+        .generate();
 }
 ```
 
@@ -186,6 +185,27 @@ String response = llm.request()
     ))
     .generate();
 ```
+
+The same builder surface — including `.modelParams(...)` — is available on the
+streaming path via `.streamGenerate()`. The merge semantics (escape hatch
+first, typed setters win, annotation defaults only when unset) are shared with
+the buffered `.generate()` path:
+
+```java
+Flow.Publisher<String> chunks = llm.request()
+    .system("You are helpful")
+    .user(prompt)
+    .maxTokens(4096)
+    .temperature(0.7)
+    .modelParams(Map.of(
+        "thinking_config", Map.of("thinking_budget", 0)
+    ))
+    .streamGenerate();
+```
+
+Streaming requires the consumer to opt in via the `ai.mcpmesh.stream` tag on
+`@MeshLlm(providerSelector = ...)` — see
+[Java LLM Integration](../java/llm/index.md).
 
 Source: [`MeshLlmAgentProxy.java`](https://github.com/dhyansraj/mcp-mesh/blob/main/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java).
 

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/types/MeshLlmAgent.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/types/MeshLlmAgent.java
@@ -452,6 +452,26 @@ public interface MeshLlmAgent {
         <T> CompletableFuture<T> generateAsync(Class<T> responseType);
 
         /**
+         * Execute the generation and stream the text response chunk-by-chunk.
+         *
+         * <p>Requires a streaming-tagged mesh provider (see
+         * {@link MeshLlmAgent#stream(List)} for the tag-opt-in convention).
+         * Honors all builder state: messages,
+         * {@link #maxTokens(int)}, {@link #temperature(double)}, {@link #topP(double)},
+         * {@link #stop(String...)}, {@link #modelParams(Map)}, etc.
+         *
+         * <p>Annotation defaults apply only when neither typed setter nor
+         * {@code modelParams} provided the key, matching the buffered
+         * {@link #generate()} merge semantics.
+         *
+         * @return A {@link Flow.Publisher} that emits text chunks as the
+         *         provider produces them. The final accumulated result is NOT
+         *         emitted (consumers iterate to assemble it themselves).
+         * @throws UnsupportedOperationException for direct (non-mesh) providers
+         */
+        Flow.Publisher<String> streamGenerate();
+
+        /**
          * Get metadata from the last generation call.
          *
          * <p>Returns null if generate() hasn't been called yet.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
@@ -323,8 +323,10 @@ public class MeshEventProcessor implements SmartLifecycle {
             String contextParam = config != null ? config.contextParam() : "ctx";
             int maxIterations = config != null ? config.maxIterations() : 1;
             boolean parallelToolCalls = config != null && config.parallelToolCalls();
+            int maxTokens = config != null ? config.maxTokens() : 4096;
+            double temperature = config != null ? config.temperature() : 0.7;
 
-            proxy.configure(mcpClient, proxyFactory, toolInvoker, injector, systemPrompt, contextParam, maxIterations, parallelToolCalls);
+            proxy.configure(mcpClient, proxyFactory, toolInvoker, injector, systemPrompt, contextParam, maxIterations, parallelToolCalls, maxTokens, temperature);
 
             // Wire MediaStore for multimodal support
             wireMediaStore(proxy);
@@ -500,8 +502,10 @@ public class MeshEventProcessor implements SmartLifecycle {
             String contextParam = config != null ? config.contextParam() : "ctx";
             int maxIterations = config != null ? config.maxIterations() : 1;
             boolean parallelToolCalls = config != null && config.parallelToolCalls();
+            int maxTokens = config != null ? config.maxTokens() : 4096;
+            double temperature = config != null ? config.temperature() : 0.7;
 
-            proxy.configure(mcpClient, proxyFactory, toolInvoker, injector, systemPrompt, contextParam, maxIterations, parallelToolCalls);
+            proxy.configure(mcpClient, proxyFactory, toolInvoker, injector, systemPrompt, contextParam, maxIterations, parallelToolCalls, maxTokens, temperature);
 
             // Wire MediaStore for multimodal support
             wireMediaStore(proxy);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -136,6 +136,24 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
     }
 
     /**
+     * Configure the proxy with dependencies, parallel tool calls option, and
+     * {@code @MeshLlm} annotation defaults for {@code maxTokens} / {@code temperature}.
+     *
+     * <p>Wires the annotation values through to the wire {@code model_params} so a
+     * user writing {@code @MeshLlm(maxTokens=2000, temperature=0.3)} actually sees
+     * those values on the wire instead of the hardcoded 4096 / 0.7 defaults.
+     */
+    public void configure(McpHttpClient mcpClient, McpMeshToolProxyFactory proxyFactory,
+                          ToolInvoker toolInvoker, MeshDependencyInjector dependencyInjector,
+                          String systemPrompt, String contextParamName, int maxIterations,
+                          boolean parallelToolCalls, int maxTokens, double temperature) {
+        configure(mcpClient, proxyFactory, toolInvoker, dependencyInjector, systemPrompt, contextParamName, maxIterations, parallelToolCalls);
+        this.defaultMaxTokens = maxTokens;
+        this.defaultTemperature = temperature;
+        log.info("@MeshLlm defaults for {}: maxTokens={}, temperature={}", functionId, maxTokens, temperature);
+    }
+
+    /**
      * Set the MediaStore for resolving media URIs in multimodal requests.
      *
      * @param mediaStore The MediaStore bean (may be null if not configured)
@@ -242,19 +260,11 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
     /**
      * Stream chunks from the resolved mesh-delegated streaming provider.
      *
-     * <p>Builds the same {@code {request: <MeshLlmRequest>}} body shape that
-     * the buffered {@link MeshLlmAgentProxy.GenerateBuilderImpl#executeAgenticLoop}
-     * produces, then routes the call through {@link McpHttpClient#streamTool}
-     * (Stage 2). The provider's {@code functionName} resolved here is already
-     * the streaming variant — the registry resolver picked it because the
-     * consumer opted into the {@code ai.mcpmesh.stream} tag (see
-     * {@link MeshLlmAgent#stream(List)}).
-     *
-     * <p>Note: this proxy applies <em>no</em> agentic loop to the streaming
-     * call. Tools, system prompt rendering, and template context are still
-     * forwarded so the provider can run its own loop server-side. Tool
-     * results emitted by the provider are surfaced via the same chunk stream
-     * (provider-decided format) — Stage 3 is consumer-side only.
+     * <p>Delegates to the builder path
+     * ({@code request().messages(messages).streamGenerate()}) so the
+     * model_params merge, system-prompt rendering, tool definitions, and
+     * transport routing are consolidated into a single code path shared with
+     * {@link GenerateBuilder#streamGenerate()}.
      *
      * @param messages Conversation messages to send
      * @return A {@link Flow.Publisher} of text chunks
@@ -262,102 +272,7 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
      */
     @Override
     public Flow.Publisher<String> stream(List<Message> messages) {
-        ProviderEndpoint provider = providerRef.get();
-        if (provider == null || !provider.isAvailable()) {
-            throw new IllegalStateException(
-                "MeshLlmAgent.stream(): LLM provider not available for " + functionId
-                    + ". Ensure the @MeshLlm providerSelector resolves a streaming @mesh.llm_provider "
-                    + "(must include the 'ai.mcpmesh.stream' tag)."
-            );
-        }
-        if (mcpClient == null) {
-            throw new IllegalStateException(
-                "MeshLlmAgent.stream(): MCP client not configured for LLM agent " + functionId);
-        }
-
-        // Build the LLM messages list — same shape the buffered
-        // executeAgenticLoop produces, including the rendered system prompt
-        // when the caller didn't supply one. Diverging from generate() here
-        // would mean the same agent renders different prompts depending on
-        // which method the caller picks (silent behavioral drift).
-        // Use a LinkedHashMap rather than Map.of: Map.of throws NPE on null
-        // values, but Message.content() can legitimately be null for tool /
-        // assistant messages that only carry tool_calls. Spec says cold-
-        // publisher errors should reach the subscriber via onError, not
-        // throw synchronously from stream().
-        List<Message> safeMessages = (messages != null) ? messages : List.<Message>of();
-        List<Map<String, Object>> llmMessages = new ArrayList<>();
-
-        // Prepend the rendered system prompt template if no explicit system
-        // message is present (matches executeAgenticLoop in generate()).
-        // The renderSystemPrompt() helper lives on the inner GenerateBuilder;
-        // for streaming we inline the equivalent logic against the agent-
-        // level systemPromptTemplate. Per-call FreeMarker variables aren't
-        // exposed on the streaming surface (no builder context), so we
-        // render with an empty context — string-literal templates and
-        // templates that don't depend on per-call vars work; per-call
-        // variable refs render to empty values, matching the no-builder
-        // contract.
-        boolean hasExplicitSystem = safeMessages.stream()
-            .anyMatch(m -> "system".equals(m.role()));
-        if (!hasExplicitSystem
-            && systemPromptTemplate != null
-            && !systemPromptTemplate.isBlank()) {
-            String renderedSystemPrompt = systemPromptTemplate;
-            try {
-                if (templateRenderer != null && templateRenderer.isTemplate(systemPromptTemplate)) {
-                    renderedSystemPrompt = templateRenderer.render(
-                        systemPromptTemplate, java.util.Collections.emptyMap());
-                }
-            } catch (RuntimeException renderErr) {
-                // Match generate()'s leniency: if template rendering fails,
-                // fall back to the raw template string rather than throwing
-                // synchronously from a cold publisher.
-                log.warn("System prompt template render failed for {}, using raw: {}",
-                    functionId, renderErr.getMessage());
-            }
-            if (!renderedSystemPrompt.isBlank()) {
-                Map<String, Object> systemEntry = new LinkedHashMap<>(2);
-                systemEntry.put("role", "system");
-                systemEntry.put("content", renderedSystemPrompt);
-                llmMessages.add(systemEntry);
-            }
-        }
-
-        for (Message msg : safeMessages) {
-            Map<String, Object> entry = new LinkedHashMap<>(2);
-            entry.put("role", msg.role());
-            entry.put("content", msg.content());
-            llmMessages.add(entry);
-        }
-
-        // Build model_params (vendor-agnostic; provider handler maps to its API)
-        Map<String, Object> modelParams = new LinkedHashMap<>();
-        modelParams.put("max_tokens", defaultMaxTokens);
-        modelParams.put("temperature", defaultTemperature);
-        if (parallelToolCalls) {
-            modelParams.put("parallel_tool_calls", true);
-        }
-
-        // Tool definitions (provider executes them server-side in its loop)
-        List<Map<String, Object>> toolDefs = buildToolDefinitions();
-
-        Map<String, Object> request = new LinkedHashMap<>();
-        request.put("messages", llmMessages);
-        if (!toolDefs.isEmpty()) {
-            request.put("tools", toolDefs);
-        }
-        request.put("model_params", modelParams);
-
-        Map<String, Object> params = Map.of("request", request);
-
-        log.debug("stream(mesh): routing to {}/{} (messages={}, tools={})",
-            provider.endpoint(), provider.functionName(),
-            llmMessages.size(), toolDefs.size());
-
-        // Delegate to McpHttpClient.streamTool — handles SSE parsing,
-        // notifications/progress correlation, trace context, etc.
-        return mcpClient.streamTool(provider.endpoint(), provider.functionName(), params, null);
+        return request().messages(messages).streamGenerate();
     }
 
     // =========================================================================
@@ -563,7 +478,122 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
             return lastMeta;
         }
 
+        @Override
+        public Flow.Publisher<String> streamGenerate() {
+            ProviderEndpoint provider = providerRef.get();
+            if (provider == null || !provider.isAvailable()) {
+                throw new IllegalStateException(
+                    "MeshLlmAgent.streamGenerate(): LLM provider not available for " + functionId
+                        + ". Ensure the @MeshLlm providerSelector resolves a streaming @mesh.llm_provider "
+                        + "(must include the 'ai.mcpmesh.stream' tag)."
+                );
+            }
+            if (mcpClient == null) {
+                throw new IllegalStateException(
+                    "MeshLlmAgent.streamGenerate(): MCP client not configured for LLM agent " + functionId);
+            }
+
+            // Build llmMessages mirroring executeAgenticLoop:
+            // 1. Prepend rendered system prompt template if no explicit system message.
+            // Use LinkedHashMap instead of Map.of() because Message.content() can be null
+            // for tool/assistant messages that only carry tool_calls (Map.of throws NPE on null).
+            List<Map<String, Object>> llmMessages = new ArrayList<>();
+            boolean hasExplicitSystem = messages.stream()
+                .anyMatch(m -> "system".equals(m.role()));
+            if (!hasExplicitSystem) {
+                String renderedSystemPrompt = renderSystemPrompt();
+                if (!renderedSystemPrompt.isBlank()) {
+                    Map<String, Object> systemEntry = new LinkedHashMap<>(2);
+                    systemEntry.put("role", "system");
+                    systemEntry.put("content", renderedSystemPrompt);
+                    llmMessages.add(systemEntry);
+                }
+            }
+
+            // 2. Convert builder messages to LLM format
+            for (Message msg : messages) {
+                Map<String, Object> entry = new LinkedHashMap<>(2);
+                entry.put("role", msg.role());
+                entry.put("content", msg.content());
+                llmMessages.add(entry);
+            }
+
+            // 2.5. Resolve media URIs and attach to last user message
+            if (!mediaUris.isEmpty()) {
+                attachMediaToLastUserMessage(llmMessages, provider);
+            }
+
+            // 3. Build merged model_params (same guard semantics as executeAgenticLoop:
+            // userModelParams merged FIRST, typed setters take precedence on collision,
+            // annotation defaults apply only when neither source supplied the key).
+            Map<String, Object> modelParams = buildMergedModelParams();
+
+            // 4. Tool definitions (provider executes them server-side in its loop)
+            List<Map<String, Object>> toolDefs = buildToolDefinitions();
+
+            // 5. Build request wrapper
+            Map<String, Object> request = new LinkedHashMap<>();
+            request.put("messages", llmMessages);
+            if (!toolDefs.isEmpty()) {
+                request.put("tools", toolDefs);
+            }
+            request.put("model_params", modelParams);
+
+            Map<String, Object> params = Map.of("request", request);
+
+            log.debug("streamGenerate(mesh): routing to {}/{} (messages={}, tools={})",
+                provider.endpoint(), provider.functionName(),
+                llmMessages.size(), toolDefs.size());
+
+            return mcpClient.streamTool(provider.endpoint(), provider.functionName(), params, null);
+        }
+
         // --- Internal ---
+
+        /**
+         * Build the wire {@code model_params} map applying the same merge
+         * semantics used by both the buffered {@link #executeAgenticLoop} and
+         * the streaming {@link #streamGenerate} paths:
+         * <ol>
+         *   <li>{@code userModelParams} (escape-hatch) is merged FIRST so
+         *       typed setters can override on collision.</li>
+         *   <li>Typed setters ({@link #maxTokens}, {@link #temperature}, etc.)
+         *       win on collision with {@code modelParams}.</li>
+         *   <li>Annotation defaults ({@code defaultMaxTokens},
+         *       {@code defaultTemperature}) apply only when neither typed
+         *       setter nor {@code modelParams} supplied the key.</li>
+         * </ol>
+         *
+         * <p>Note: {@code output_schema} (structured-output) is not added here
+         * because it's specific to the buffered {@code generate(Class)} path —
+         * streaming does not currently parse structured output.
+         */
+        private Map<String, Object> buildMergedModelParams() {
+            Map<String, Object> modelParams = new LinkedHashMap<>();
+            if (userModelParams != null && !userModelParams.isEmpty()) {
+                modelParams.putAll(userModelParams);
+            }
+            if (maxTokens != null) {
+                modelParams.put("max_tokens", maxTokens);
+            } else if (!modelParams.containsKey("max_tokens")) {
+                modelParams.put("max_tokens", defaultMaxTokens);
+            }
+            if (temperature != null) {
+                modelParams.put("temperature", temperature);
+            } else if (!modelParams.containsKey("temperature")) {
+                modelParams.put("temperature", defaultTemperature);
+            }
+            if (topP != null) {
+                modelParams.put("top_p", topP);
+            }
+            if (stopSequences != null && !stopSequences.isEmpty()) {
+                modelParams.put("stop", stopSequences);
+            }
+            if (parallelToolCalls) {
+                modelParams.put("parallel_tool_calls", true);
+            }
+            return modelParams;
+        }
 
         private String executeAgenticLoop(ProviderEndpoint provider) {
             // Build the messages list for the LLM
@@ -601,38 +631,12 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                 iteration++;
                 log.debug("Agentic loop iteration {}/{}", iteration, maxIterations);
 
-                // Build model_params (LLM provider configuration)
-                Map<String, Object> modelParams = new LinkedHashMap<>();
-                // Issue #1019: escape-hatch merge — callers can pass vendor-
-                // specific kwargs (e.g., thinking_config, output_config) via
-                // .modelParams(...). Merged FIRST so typed setters below take
-                // precedence on collision (keeps the typed surface authoritative).
-                if (userModelParams != null && !userModelParams.isEmpty()) {
-                    modelParams.putAll(userModelParams);
-                }
-                // Typed setters win on collision with modelParams (escape-hatch).
-                // Annotation defaults apply only when neither typed setter nor
-                // modelParams provided the key. Matches TS guard semantics
-                // (`if (options?.maxOutputTokens) ...`) so callers can set
-                // max_tokens / temperature purely via .modelParams(...) without
-                // the annotation defaults clobbering their values.
-                if (maxTokens != null) {
-                    modelParams.put("max_tokens", maxTokens);
-                } else if (!modelParams.containsKey("max_tokens")) {
-                    modelParams.put("max_tokens", defaultMaxTokens);
-                }
-                if (temperature != null) {
-                    modelParams.put("temperature", temperature);
-                } else if (!modelParams.containsKey("temperature")) {
-                    modelParams.put("temperature", defaultTemperature);
-                }
-                if (topP != null) {
-                    modelParams.put("top_p", topP);
-                }
-                if (stopSequences != null && !stopSequences.isEmpty()) {
-                    modelParams.put("stop", stopSequences);
-                }
-                // Pass output_schema for structured output (provider handles vendor-specific conversion)
+                // Build model_params via the shared merge helper. Shared with
+                // streamGenerate() so both paths apply identical escape-hatch
+                // / typed-setter / annotation-default precedence (issue #1019).
+                Map<String, Object> modelParams = buildMergedModelParams();
+                // Pass output_schema for structured output (provider handles vendor-specific conversion).
+                // Buffered-path only — streaming does not currently parse structured output.
                 if (responseType != null && responseType != String.class) {
                     Map<String, Object> outputSchema = buildJsonSchema(responseType);
                     if (outputSchema != null) {
@@ -640,12 +644,6 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                         modelParams.put("output_type_name", responseType.getSimpleName());
                         log.debug("Added output_schema for structured output: {}", responseType.getSimpleName());
                     }
-                }
-                // Issue #713: Include parallel_tool_calls for provider-side parallel execution.
-                // Provider handlers strip this from LLM API params (e.g., Claude doesn't accept it),
-                // but the provider's agentic loop needs it to decide parallel vs sequential execution.
-                if (parallelToolCalls) {
-                    modelParams.put("parallel_tool_calls", true);
                 }
 
                 // Build request wrapper (matches Python/TypeScript SDK format)

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyModelParamsTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyModelParamsTest.java
@@ -301,6 +301,34 @@ class MeshLlmAgentProxyModelParamsTest {
     }
 
     @Test
+    @DisplayName("@MeshLlm(maxTokens, temperature) annotation defaults flow through to wire model_params")
+    void annotationDefaultsFromMeshLlmFlowToWire() throws Exception {
+        // Regression: MeshLlmAgentProxy previously hardcoded defaultMaxTokens=4096
+        // and defaultTemperature=0.7. The @MeshLlm(maxTokens=…, temperature=…)
+        // annotation values carried by MeshLlmRegistry.LlmConfig were never wired
+        // through MeshEventProcessor → proxy.configure(...). Now the 10-arg
+        // configure overload accepts them and writes them onto the proxy so a
+        // user-supplied annotation value reaches the wire.
+        server.enqueue(stubLlmResponse("ok"));
+
+        // Re-configure proxy via the 10-arg overload simulating @MeshLlm(maxTokens=2000, temperature=0.3).
+        proxy.configure(client, null, null, null, "", "ctx", 1, false, 2000, 0.3);
+
+        proxy.request()
+            .user("hi")
+            // NO typed .maxTokens()/.temperature() and NO .modelParams() — defaults must surface.
+            .generate();
+
+        RecordedRequest req = server.takeRequest();
+        JsonNode modelParams = readModelParams(req);
+
+        assertEquals(2000, modelParams.get("max_tokens").asInt(),
+            "@MeshLlm(maxTokens=2000) must reach the wire — not the hardcoded 4096 default");
+        assertEquals(0.3, modelParams.get("temperature").asDouble(), 1e-9,
+            "@MeshLlm(temperature=0.3) must reach the wire — not the hardcoded 0.7 default");
+    }
+
+    @Test
     @DisplayName("null/empty modelParams → behavior unchanged from before this change")
     void nullOrEmptyModelParamsIsNoOp() throws Exception {
         server.enqueue(stubLlmResponse("ok"));

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyStreamGenerateTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyStreamGenerateTest.java
@@ -1,0 +1,253 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.core.MeshObjectMappers;
+import io.mcpmesh.types.MeshLlmAgent;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link MeshLlmAgent.GenerateBuilder#streamGenerate()} — issue #1023.
+ *
+ * <p>The builder's {@code streamGenerate()} is a terminal method that mirrors
+ * the buffered {@code generate()} path's model_params merge semantics
+ * (issue #1019 / PR #1024) while routing the call through the streaming
+ * {@code process_chat_stream} MCP transport. This file asserts:
+ * <ul>
+ *   <li>{@code modelParams} keys (e.g., {@code thinking_config}) flow into the
+ *       wire request's {@code model_params}</li>
+ *   <li>Typed setters ({@code .temperature}) win over {@code modelParams}
+ *       on collision</li>
+ *   <li>Annotation defaults DON'T clobber values supplied solely via
+ *       {@code .modelParams(Map.of("max_tokens", ...))}</li>
+ *   <li>The legacy {@code stream(List)} shortcut delegates to the builder so
+ *       its wire shape matches {@code request().messages(...).streamGenerate()}</li>
+ * </ul>
+ *
+ * <p>Mirrors {@link MeshLlmAgentProxyStreamTest}'s {@link MockWebServer} wiring.
+ */
+@DisplayName("GenerateBuilder.streamGenerate() — issue #1023")
+class MeshLlmAgentProxyStreamGenerateTest {
+
+    private MockWebServer server;
+    private McpHttpClient client;
+    private ObjectMapper mapper;
+    private MeshLlmAgentProxy proxy;
+
+    @BeforeAll
+    static void initTlsConfig() throws Exception {
+        Constructor<MeshTlsConfig> ctor = MeshTlsConfig.class.getDeclaredConstructor(
+            boolean.class, String.class, String.class, String.class, String.class);
+        ctor.setAccessible(true);
+        MeshTlsConfig disabled = ctor.newInstance(false, "off", null, null, null);
+
+        Field cachedField = MeshTlsConfig.class.getDeclaredField("cached");
+        cachedField.setAccessible(true);
+        cachedField.set(null, disabled);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        mapper = MeshObjectMappers.create();
+        client = new McpHttpClient(mapper);
+
+        proxy = new MeshLlmAgentProxy("test.streamGenerate");
+        // Defaults: maxTokens=4096, temperature=0.7, parallelToolCalls=false.
+        proxy.configure(client, null, null, null, "", "ctx", 1, false);
+        proxy.updateProvider(
+            server.url("/").toString().replaceAll("/$", ""),
+            "process_chat_stream",
+            "mesh-delegated"
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (client != null) client.close();
+        server.shutdown();
+    }
+
+    // -------------------------------------------------------------------------
+    // SSE helpers — same shape as MeshLlmAgentProxyStreamTest.
+    // -------------------------------------------------------------------------
+
+    private String sseEvent(String json) {
+        return "event: message\ndata: " + json + "\n\n";
+    }
+
+    private String finalEmptyResultEvent(long requestId) {
+        return sseEvent("{\"jsonrpc\":\"2.0\",\"id\":" + requestId + ",\"result\":{}}");
+    }
+
+    /**
+     * Dispatcher that captures the outbound request body and returns an SSE
+     * stream with only a final-result event (no progress chunks needed —
+     * we're only inspecting the request, not the response chunks).
+     */
+    private String[] enqueueCapturingDispatcher() {
+        final String[] bodyHolder = new String[1];
+        server.setDispatcher(new okhttp3.mockwebserver.Dispatcher() {
+            @Override
+            public MockResponse dispatch(RecordedRequest request) {
+                bodyHolder[0] = request.getBody().readUtf8();
+                try {
+                    long id = mapper.readTree(bodyHolder[0]).get("id").asLong();
+                    return new MockResponse()
+                        .setBody(finalEmptyResultEvent(id))
+                        .setHeader("Content-Type", "text/event-stream");
+                } catch (Exception e) {
+                    return new MockResponse().setResponseCode(500);
+                }
+            }
+        });
+        return bodyHolder;
+    }
+
+    /** Collect Flow.Publisher chunks blocking, throwing on onError. */
+    private static List<String> collect(Flow.Publisher<String> publisher) throws Exception {
+        ConcurrentLinkedQueue<String> chunks = new ConcurrentLinkedQueue<>();
+        CompletableFuture<Throwable> done = new CompletableFuture<>();
+        publisher.subscribe(new Flow.Subscriber<>() {
+            @Override public void onSubscribe(Flow.Subscription s) { s.request(Long.MAX_VALUE); }
+            @Override public void onNext(String item) { chunks.add(item); }
+            @Override public void onError(Throwable t) { done.complete(t); }
+            @Override public void onComplete() { done.complete(null); }
+        });
+        Throwable err = done.get(10, TimeUnit.SECONDS);
+        if (err != null) {
+            if (err instanceof RuntimeException re) throw re;
+            throw new RuntimeException(err);
+        }
+        return new ArrayList<>(chunks);
+    }
+
+    /** Read the captured outbound body and pull out the model_params node. */
+    private JsonNode readModelParams(String body) throws Exception {
+        JsonNode root = mapper.readTree(body);
+        JsonNode args = root.get("params").get("arguments");
+        JsonNode req = args.get("request");
+        JsonNode modelParams = req.get("model_params");
+        assertNotNull(modelParams, "request.model_params must be present");
+        return modelParams;
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("streamGenerate merges modelParams into wire request")
+    void streamGenerateMergesModelParamsIntoWire() throws Exception {
+        String[] bodyHolder = enqueueCapturingDispatcher();
+
+        Flow.Publisher<String> pub = proxy.request()
+            .user("hi")
+            .modelParams(Map.of(
+                "thinking_config", Map.of("thinking_budget", 0)
+            ))
+            .streamGenerate();
+        collect(pub);
+
+        JsonNode modelParams = readModelParams(bodyHolder[0]);
+        JsonNode thinking = modelParams.get("thinking_config");
+        assertNotNull(thinking, "thinking_config must be present in wire model_params");
+        assertEquals(0, thinking.get("thinking_budget").asInt());
+
+        // Annotation defaults still present
+        assertTrue(modelParams.has("max_tokens"));
+        assertTrue(modelParams.has("temperature"));
+    }
+
+    @Test
+    @DisplayName("streamGenerate: typed setter (.temperature) wins on collision with modelParams")
+    void streamGenerateTypedSetterWinsOnCollision() throws Exception {
+        String[] bodyHolder = enqueueCapturingDispatcher();
+
+        Flow.Publisher<String> pub = proxy.request()
+            .user("hi")
+            .temperature(0.5)
+            .modelParams(Map.of("temperature", 0.9))
+            .streamGenerate();
+        collect(pub);
+
+        JsonNode modelParams = readModelParams(bodyHolder[0]);
+        assertEquals(0.5, modelParams.get("temperature").asDouble(), 1e-9,
+            "typed .temperature(0.5) must win over modelParams temperature=0.9");
+    }
+
+    @Test
+    @DisplayName("streamGenerate: annotation default does NOT clobber modelParams when no typed setter is used")
+    void streamGenerateAnnotationDefaultOnlyAppliesWhenUnset() throws Exception {
+        String[] bodyHolder = enqueueCapturingDispatcher();
+
+        Flow.Publisher<String> pub = proxy.request()
+            .user("hi")
+            // NO .maxTokens() typed setter — escape-hatch only.
+            .modelParams(Map.of("max_tokens", 999))
+            .streamGenerate();
+        collect(pub);
+
+        JsonNode modelParams = readModelParams(bodyHolder[0]);
+        assertEquals(999, modelParams.get("max_tokens").asInt(),
+            "modelParams.max_tokens=999 must reach the wire when no typed .maxTokens() is set;"
+            + " annotation default (4096) must NOT clobber it");
+    }
+
+    @Test
+    @DisplayName("legacy stream(messages) shortcut delegates to builder — same wire shape as streamGenerate")
+    void streamLegacyShortFormDelegatesToBuilder() throws Exception {
+        // Path A: legacy stream(messages)
+        String[] legacyBody = enqueueCapturingDispatcher();
+        collect(proxy.stream(List.of(MeshLlmAgent.Message.user("hello"))));
+        String legacyWire = legacyBody[0];
+        assertNotNull(legacyWire, "legacy stream() must have hit the mock server");
+
+        // Path B: builder request().messages(...).streamGenerate()
+        String[] builderBody = enqueueCapturingDispatcher();
+        collect(proxy.request()
+            .messages(List.of(MeshLlmAgent.Message.user("hello")))
+            .streamGenerate());
+        String builderWire = builderBody[0];
+        assertNotNull(builderWire, "builder streamGenerate() must have hit the mock server");
+
+        // Compare the inner `request` payloads — they should be identical
+        // structurally (the only thing that differs between calls is the
+        // JSON-RPC id and progressToken, both of which are outside `arguments.request`).
+        JsonNode legacyReq = mapper.readTree(legacyWire)
+            .get("params").get("arguments").get("request");
+        JsonNode builderReq = mapper.readTree(builderWire)
+            .get("params").get("arguments").get("request");
+
+        assertEquals(legacyReq.get("messages").toString(), builderReq.get("messages").toString(),
+            "legacy stream() and builder streamGenerate() must produce identical messages");
+        assertEquals(legacyReq.get("model_params").toString(), builderReq.get("model_params").toString(),
+            "legacy stream() and builder streamGenerate() must produce identical model_params");
+
+        // Full-shape contract: the entire `request` payload must be byte-for-byte
+        // structurally identical between the two paths. Per-key assertions above
+        // remain for nicer diagnostic-on-failure messages.
+        assertEquals(legacyReq, builderReq,
+            "Legacy stream(messages) must produce identical wire shape to request().messages(messages).streamGenerate()");
+    }
+}


### PR DESCRIPTION
## Summary

- **#1023 — Java streaming builder**: Add `Flow.Publisher<String> streamGenerate()` terminal to `GenerateBuilder` so the streaming path gains the full builder surface (messages, typed options, `modelParams` escape-hatch). Refactor `stream(List<Message>)` to delegate via `request().messages(messages).streamGenerate()`, consolidating the model_params merge logic into a single `buildMergedModelParams()` helper shared with the buffered `executeAgenticLoop` path. Net −20 LOC in the proxy after dedup.

- **#1025 — Annotation defaults wiring**: `@MeshLlm(maxTokens, temperature)` values were carried into `MeshLlmRegistry.LlmConfig` but never reached the proxy — `MeshEventProcessor.configure(...)` calls didn't pass them, so the hardcoded `defaultMaxTokens=4096` / `defaultTemperature=0.7` silently overrode every caller's annotation. Add a 10-arg `configure(...)` overload, wire `config.maxTokens()` / `config.temperature()` at both `MeshEventProcessor` call sites. Fix affects both buffered and streaming paths.

## API

```java
Flow.Publisher<String> chunks = llm.request()
    .system("You are helpful")
    .user(prompt)
    .maxTokens(4096)
    .temperature(0.7)
    .modelParams(Map.of("thinking_config", Map.of("thinking_budget", 0)))
    .streamGenerate();
```

Back-compat: existing `stream(List<Message>)` / `stream(String)` shortcuts remain functional and delegate to the builder, so any external caller continues to compile and produces an identical wire shape.

## Tests

- `mcp-mesh-spring-boot-starter`: **321 passed** (320 baseline + 1 annotation-defaults test, plus 4 new in `MeshLlmAgentProxyStreamGenerateTest`)
- `mcp-mesh-sdk`: 42 passed (unchanged)
- Python: 1471 passed, 2 skipped (no Python touched)

## Review Notes

Independent review found 2 WARNINGs both pre-existing in `HEAD~1` and unchanged by this PR — tracked separately in #1026 (parallel_tool_calls precedence + streaming ThreadLocal leak).

Closes #1023
Closes #1025

## Test plan

- [ ] CI green on all matrix
- [ ] Spring-boot-starter Java tests pass: 321
- [ ] Legacy `stream(messages)` path still emits identical wire shape (covered by `streamLegacyShortFormDelegatesToBuilder`)
- [ ] `@MeshLlm(maxTokens=N, temperature=T)` flows to wire `model_params` (covered by `annotationDefaultsFromMeshLlmFlowToWire`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added streaming text generation capability for LLM agents, enabling real-time response handling via `Flow.Publisher<String>`.
  * Support for configurable max tokens and temperature parameters with proper precedence merging.

* **Documentation**
  * Updated examples demonstrating streaming generation usage and model parameter configuration.

* **Tests**
  * Added comprehensive test coverage for streaming generation and parameter merging behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1027?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->