### PR TITLE
java: parallel_tool_calls precedence + streamGenerate ThreadLocal clear

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -480,72 +480,83 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
 
         @Override
         public Flow.Publisher<String> streamGenerate() {
-            ProviderEndpoint provider = providerRef.get();
-            if (provider == null || !provider.isAvailable()) {
-                throw new IllegalStateException(
-                    "MeshLlmAgent.streamGenerate(): LLM provider not available for " + functionId
-                        + ". Ensure the @MeshLlm providerSelector resolves a streaming @mesh.llm_provider "
-                        + "(must include the 'ai.mcpmesh.stream' tag)."
-                );
-            }
-            if (mcpClient == null) {
-                throw new IllegalStateException(
-                    "MeshLlmAgent.streamGenerate(): MCP client not configured for LLM agent " + functionId);
-            }
-
-            // Build llmMessages mirroring executeAgenticLoop:
-            // 1. Prepend rendered system prompt template if no explicit system message.
-            // Use LinkedHashMap instead of Map.of() because Message.content() can be null
-            // for tool/assistant messages that only carry tool_calls (Map.of throws NPE on null).
-            List<Map<String, Object>> llmMessages = new ArrayList<>();
-            boolean hasExplicitSystem = messages.stream()
-                .anyMatch(m -> "system".equals(m.role()));
-            if (!hasExplicitSystem) {
-                String renderedSystemPrompt = renderSystemPrompt();
-                if (!renderedSystemPrompt.isBlank()) {
-                    Map<String, Object> systemEntry = new LinkedHashMap<>(2);
-                    systemEntry.put("role", "system");
-                    systemEntry.put("content", renderedSystemPrompt);
-                    llmMessages.add(systemEntry);
+            try {
+                ProviderEndpoint provider = providerRef.get();
+                if (provider == null || !provider.isAvailable()) {
+                    throw new IllegalStateException(
+                        "MeshLlmAgent.streamGenerate(): LLM provider not available for " + functionId
+                            + ". Ensure the @MeshLlm providerSelector resolves a streaming @mesh.llm_provider "
+                            + "(must include the 'ai.mcpmesh.stream' tag)."
+                    );
                 }
+                if (mcpClient == null) {
+                    throw new IllegalStateException(
+                        "MeshLlmAgent.streamGenerate(): MCP client not configured for LLM agent " + functionId);
+                }
+
+                // Build llmMessages mirroring executeAgenticLoop:
+                // 1. Prepend rendered system prompt template if no explicit system message.
+                // Use LinkedHashMap instead of Map.of() because Message.content() can be null
+                // for tool/assistant messages that only carry tool_calls (Map.of throws NPE on null).
+                List<Map<String, Object>> llmMessages = new ArrayList<>();
+                boolean hasExplicitSystem = messages.stream()
+                    .anyMatch(m -> "system".equals(m.role()));
+                if (!hasExplicitSystem) {
+                    String renderedSystemPrompt = renderSystemPrompt();
+                    if (!renderedSystemPrompt.isBlank()) {
+                        Map<String, Object> systemEntry = new LinkedHashMap<>(2);
+                        systemEntry.put("role", "system");
+                        systemEntry.put("content", renderedSystemPrompt);
+                        llmMessages.add(systemEntry);
+                    }
+                }
+
+                // 2. Convert builder messages to LLM format
+                for (Message msg : messages) {
+                    Map<String, Object> entry = new LinkedHashMap<>(2);
+                    entry.put("role", msg.role());
+                    entry.put("content", msg.content());
+                    llmMessages.add(entry);
+                }
+
+                // 2.5. Resolve media URIs and attach to last user message
+                if (!mediaUris.isEmpty()) {
+                    attachMediaToLastUserMessage(llmMessages, provider);
+                }
+
+                // 3. Build merged model_params (same guard semantics as executeAgenticLoop:
+                // userModelParams merged FIRST, typed setters take precedence on collision,
+                // annotation defaults apply only when neither source supplied the key).
+                Map<String, Object> modelParams = buildMergedModelParams();
+
+                // 4. Tool definitions (provider executes them server-side in its loop)
+                List<Map<String, Object>> toolDefs = buildToolDefinitions();
+
+                // 5. Build request wrapper
+                Map<String, Object> request = new LinkedHashMap<>();
+                request.put("messages", llmMessages);
+                if (!toolDefs.isEmpty()) {
+                    request.put("tools", toolDefs);
+                }
+                request.put("model_params", modelParams);
+
+                Map<String, Object> params = Map.of("request", request);
+
+                log.debug("streamGenerate(mesh): routing to {}/{} (messages={}, tools={})",
+                    provider.endpoint(), provider.functionName(),
+                    llmMessages.size(), toolDefs.size());
+
+                return mcpClient.streamTool(provider.endpoint(), provider.functionName(), params, null);
+            } finally {
+                // Clear the ThreadLocal invocationContext on return so it does not
+                // leak across pooled-thread reuse (Spring/Tomcat). The ThreadLocal
+                // is only read synchronously during Publisher construction
+                // (renderSystemPrompt above); subscriber callbacks run on the
+                // streaming I/O thread, so clearing here on the originating
+                // thread is the correct place. Mirrors the buffered generate()
+                // path which already wraps in try/finally.
+                clearInvocationContext();
             }
-
-            // 2. Convert builder messages to LLM format
-            for (Message msg : messages) {
-                Map<String, Object> entry = new LinkedHashMap<>(2);
-                entry.put("role", msg.role());
-                entry.put("content", msg.content());
-                llmMessages.add(entry);
-            }
-
-            // 2.5. Resolve media URIs and attach to last user message
-            if (!mediaUris.isEmpty()) {
-                attachMediaToLastUserMessage(llmMessages, provider);
-            }
-
-            // 3. Build merged model_params (same guard semantics as executeAgenticLoop:
-            // userModelParams merged FIRST, typed setters take precedence on collision,
-            // annotation defaults apply only when neither source supplied the key).
-            Map<String, Object> modelParams = buildMergedModelParams();
-
-            // 4. Tool definitions (provider executes them server-side in its loop)
-            List<Map<String, Object>> toolDefs = buildToolDefinitions();
-
-            // 5. Build request wrapper
-            Map<String, Object> request = new LinkedHashMap<>();
-            request.put("messages", llmMessages);
-            if (!toolDefs.isEmpty()) {
-                request.put("tools", toolDefs);
-            }
-            request.put("model_params", modelParams);
-
-            Map<String, Object> params = Map.of("request", request);
-
-            log.debug("streamGenerate(mesh): routing to {}/{} (messages={}, tools={})",
-                provider.endpoint(), provider.functionName(),
-                llmMessages.size(), toolDefs.size());
-
-            return mcpClient.streamTool(provider.endpoint(), provider.functionName(), params, null);
         }
 
         // --- Internal ---
@@ -560,8 +571,14 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
          *   <li>Typed setters ({@link #maxTokens}, {@link #temperature}, etc.)
          *       win on collision with {@code modelParams}.</li>
          *   <li>Annotation defaults ({@code defaultMaxTokens},
-         *       {@code defaultTemperature}) apply only when neither typed
-         *       setter nor {@code modelParams} supplied the key.</li>
+         *       {@code defaultTemperature}, {@code parallel_tool_calls})
+         *       apply only when {@code modelParams} did not supply the key.
+         *       For {@code parallel_tool_calls} specifically: the annotation
+         *       value is written only when {@code parallelToolCalls=true} AND
+         *       {@code modelParams} did not already provide the key, so a
+         *       caller can explicitly disable parallel-tool-calls for a single
+         *       call via {@code .modelParams(Map.of("parallel_tool_calls", false))}
+         *       even when the annotation enabled it.</li>
          * </ol>
          *
          * <p>Note: {@code output_schema} (structured-output) is not added here
@@ -589,7 +606,7 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
             if (stopSequences != null && !stopSequences.isEmpty()) {
                 modelParams.put("stop", stopSequences);
             }
-            if (parallelToolCalls) {
+            if (parallelToolCalls && !modelParams.containsKey("parallel_tool_calls")) {
                 modelParams.put("parallel_tool_calls", true);
             }
             return modelParams;

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyModelParamsTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyModelParamsTest.java
@@ -329,6 +329,48 @@ class MeshLlmAgentProxyModelParamsTest {
     }
 
     @Test
+    @DisplayName("parallelToolCalls annotation honors user modelParams override (issue #1026)")
+    void parallelToolCallsHonorsUserModelParamsOverride() throws Exception {
+        // Issue #1026: previously `if (parallelToolCalls) modelParams.put("parallel_tool_calls", true)`
+        // sat AFTER userModelParams.putAll() with NO containsKey guard. If the
+        // annotation enabled parallel-tool-calls but the caller passed `false`
+        // via .modelParams() to disable for one call, the annotation value
+        // silently clobbered the user's `false`. Now follows the same
+        // containsKey-guard pattern as max_tokens / temperature.
+
+        // Case A: annotation parallelToolCalls=true, user overrides to false.
+        proxy.configure(client, null, null, null, "", "ctx", 1, true);
+        server.enqueue(stubLlmResponse("ok"));
+        proxy.request()
+            .user("hi")
+            .modelParams(Map.of("parallel_tool_calls", false))
+            .generate();
+        JsonNode modelParamsA = readModelParams(server.takeRequest());
+        assertEquals(false, modelParamsA.get("parallel_tool_calls").asBoolean(),
+            "user-supplied parallel_tool_calls=false in modelParams must survive over annotation=true");
+
+        // Case B: annotation parallelToolCalls=true, no user override → annotation wins.
+        server.enqueue(stubLlmResponse("ok"));
+        proxy.request()
+            .user("hi")
+            .generate();
+        JsonNode modelParamsB = readModelParams(server.takeRequest());
+        assertEquals(true, modelParamsB.get("parallel_tool_calls").asBoolean(),
+            "annotation parallelToolCalls=true must reach the wire when caller passes no override (regression guard)");
+
+        // Case C: annotation parallelToolCalls=false, user passes true → user value wins.
+        proxy.configure(client, null, null, null, "", "ctx", 1, false);
+        server.enqueue(stubLlmResponse("ok"));
+        proxy.request()
+            .user("hi")
+            .modelParams(Map.of("parallel_tool_calls", true))
+            .generate();
+        JsonNode modelParamsC = readModelParams(server.takeRequest());
+        assertEquals(true, modelParamsC.get("parallel_tool_calls").asBoolean(),
+            "user-supplied parallel_tool_calls=true in modelParams must reach the wire when annotation is false");
+    }
+
+    @Test
     @DisplayName("null/empty modelParams → behavior unchanged from before this change")
     void nullOrEmptyModelParamsIsNoOp() throws Exception {
         server.enqueue(stubLlmResponse("ok"));

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyStreamGenerateTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyStreamGenerateTest.java
@@ -215,6 +215,41 @@ class MeshLlmAgentProxyStreamGenerateTest {
     }
 
     @Test
+    @DisplayName("streamGenerate clears ThreadLocal invocationContext on return (issue #1026)")
+    @SuppressWarnings("unchecked")
+    void streamGenerateClearsInvocationContextOnReturn() throws Exception {
+        // Issue #1026: buffered generate() wraps in try/finally{clearInvocationContext()},
+        // but streamGenerate() did not — leaking the per-invocation ThreadLocal
+        // context onto the originating thread. In Spring/Tomcat pooled-thread
+        // environments the next request reusing the thread can observe the
+        // stale context until MeshToolWrapper re-populates it. Fix wraps the
+        // streamGenerate body in try/finally so the ThreadLocal is cleared
+        // synchronously after Publisher construction.
+        enqueueCapturingDispatcher();
+
+        // Seed the ThreadLocal as MeshToolWrapper.setInvocationContext() would.
+        proxy.setInvocationContext(Map.of("user_name", "alice"));
+
+        // Sanity: the ThreadLocal is populated BEFORE the call.
+        Field ctxField = MeshLlmAgentProxy.class.getDeclaredField("invocationContext");
+        ctxField.setAccessible(true);
+        ThreadLocal<Map<String, Object>> tl = (ThreadLocal<Map<String, Object>>) ctxField.get(proxy);
+        assertNotNull(tl.get(), "ThreadLocal must be seeded before streamGenerate()");
+        assertEquals("alice", tl.get().get("user_name"));
+
+        Flow.Publisher<String> pub = proxy.request().user("hi").streamGenerate();
+        assertNotNull(pub, "streamGenerate() must return a non-null Publisher");
+
+        // IMMEDIATELY after return (no subscriber yet) the ThreadLocal must be cleared.
+        assertNull(tl.get(),
+            "streamGenerate() must clear the ThreadLocal invocationContext on return "
+            + "to prevent leak across pooled-thread reuse (issue #1026)");
+
+        // Drain the publisher so the mock server doesn't hang.
+        collect(pub);
+    }
+
+    @Test
     @DisplayName("legacy stream(messages) shortcut delegates to builder — same wire shape as streamGenerate")
     void streamLegacyShortFormDelegatesToBuilder() throws Exception {
         // Path A: legacy stream(messages)


### PR DESCRIPTION
## Summary

Two surgical fixes in `MeshLlmAgentProxy` surfaced by review of #1027. Both predate the streamGenerate consolidation; the shared `buildMergedModelParams()` made them easier to spot.

### 1. \`parallel_tool_calls\` precedence guard

`buildMergedModelParams()` wrote `parallel_tool_calls=true` from the annotation field AFTER both the user's `userModelParams.putAll()` and the typed-setter overrides — so `.modelParams(Map.of("parallel_tool_calls", false))` was silently ignored. Now matches the `containsKey` guard pattern already used for `max_tokens` / `temperature`:

```java
if (parallelToolCalls && !modelParams.containsKey("parallel_tool_calls")) {
    modelParams.put("parallel_tool_calls", true);
}
```

Wire behavior:
| Annotation | User modelParams | Wire |
|---|---|---|
| true  | absent | true (unchanged) |
| true  | false  | **false** (was true; now honors user) |
| true  | true   | true (unchanged) |
| false | true   | true (unchanged) |
| false | absent | omitted (unchanged) |

### 2. `streamGenerate()` clears ThreadLocal on return

`MeshToolWrapper.setInvocationContext()` seeds a `ThreadLocal<Map>` before invoking the user method. The buffered `generate()` always cleared it in `finally`; `streamGenerate()` did not, so the value survived on the calling thread after the cold Publisher was returned — observable by the next request reusing the same Tomcat/Spring pooled thread.

Fix: wrap the `streamGenerate()` body in `try { ... } finally { clearInvocationContext(); }`. The ThreadLocal is read synchronously during `renderSystemPrompt()` inside the try; subscriber drain happens on the streaming I/O thread which never reads it. Restores symmetry with `generate()`.

## Tests

- `parallelToolCallsHonorsUserModelParamsOverride` — three sub-cases verifying annotation+user combinations land the right wire value.
- `streamGenerateClearsInvocationContextOnReturn` — seeds the ThreadLocal, calls `streamGenerate()`, asserts the ThreadLocal is null on return (before any subscriber attaches). **Verified to FAIL against the pre-fix code** (`expected: <null> but was: <{user_name=alice}>`), passes with the fix.

**Test counts:**
- `mcp-mesh-spring-boot-starter`: **323 passed** (321 baseline + 2 new)
- `mcp-mesh-sdk`: 42 passed (unchanged)
- Python: 1471 passed, 2 skipped (no Python touched)

## Review Notes

Independent review returned 0 BLOCKERs, 0 WARNINGs, 2 INFOs (minor test-coverage suggestion + pre-existing `setInvocationContext` docstring gap — both out of scope).

Closes #1026

## Test plan

- [ ] CI green
- [ ] `.modelParams("parallel_tool_calls", false)` honored on the wire when annotation has `parallelToolCalls=true`
- [ ] `streamGenerate()` returns with ThreadLocal cleared (verified via existing test)
- [ ] Exception path: a throw inside `streamGenerate()` body still triggers the finally clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved potential thread context leakage in streaming operations by ensuring context is properly cleared when operations complete.
  * Fixed model parameter precedence to correctly honor explicitly-supplied parallel tool calls configuration over defaults.

* **Tests**
  * Added regression tests verifying thread context cleanup and ensuring user-provided parameter overrides are preserved across different configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1028?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->