### PR TITLE
meshctl stop: group-aware liveness probe — kill orphan descendants

### DIFF
--- a/src/core/cli/lifecycle/enumerate.go
+++ b/src/core/cli/lifecycle/enumerate.go
@@ -60,6 +60,11 @@ func ListAgents() ([]AgentEntry, error) {
 		if err != nil || pid == 0 {
 			continue
 		}
+		// Alive here intentionally stays single-PID: ListAgents results feed
+		// cosmetic surfaces (e.g., suggestAgentNames fuzzy match). The
+		// actionable liveness predicate that drives stop / start-validation
+		// lives in LookupAgent / LookupService and is group-aware via
+		// groupAliveFn.
 		entry := AgentEntry{Name: base, PID: pid, Alive: processAliveFn(pid)}
 		// Best-effort group lookup; missing .group means the agent was written
 		// by some non-current code path (or via WriteService) — treat as no

--- a/src/core/cli/lifecycle/enumerate.go
+++ b/src/core/cli/lifecycle/enumerate.go
@@ -99,7 +99,7 @@ func IsAgentRunning(name string) (bool, int, error) {
 	if pid == 0 {
 		return false, 0, nil
 	}
-	if !IsAliveOrGroupAlive(pid) {
+	if !groupAliveFn(pid) {
 		return false, pid, nil
 	}
 	return true, pid, nil
@@ -107,6 +107,11 @@ func IsAgentRunning(name string) (bool, int, error) {
 
 // LookupAgent returns the on-disk record for a single agent, or (nil, nil)
 // if the agent has no PID file.
+//
+// Alive uses group-aware liveness so callers see the consistent
+// orphan-descendants story across start (single-instance), stop (kill
+// path), and status display. Single-PID liveness is available via
+// IsAlive() for callers that need the narrower predicate.
 func LookupAgent(name string) (*AgentEntry, error) {
 	pid, err := readPIDFromFile(PIDFile(name))
 	if err != nil {
@@ -115,7 +120,7 @@ func LookupAgent(name string) (*AgentEntry, error) {
 	if pid == 0 {
 		return nil, nil
 	}
-	entry := &AgentEntry{Name: name, PID: pid, Alive: processAliveFn(pid)}
+	entry := &AgentEntry{Name: name, PID: pid, Alive: groupAliveFn(pid)}
 	g, gErr := LookupGroup(name)
 	if gErr == nil {
 		entry.Group = g
@@ -134,6 +139,11 @@ type ServicePIDInfo struct {
 
 // LookupService returns the PID record for a service, or (nil, nil) if no
 // PID file is present.
+//
+// Alive uses group-aware liveness so callers see the consistent
+// orphan-descendants story across start (single-instance), stop (kill
+// path), and status display. Single-PID liveness is available via
+// IsAlive() for callers that need the narrower predicate.
 func LookupService(service string) (*ServicePIDInfo, error) {
 	if !isServiceName(service) {
 		return nil, nil
@@ -145,7 +155,7 @@ func LookupService(service string) (*ServicePIDInfo, error) {
 	if pid == 0 {
 		return nil, nil
 	}
-	return &ServicePIDInfo{Name: service, PID: pid, Alive: processAliveFn(pid)}, nil
+	return &ServicePIDInfo{Name: service, PID: pid, Alive: groupAliveFn(pid)}, nil
 }
 
 // isServiceName reports whether base is a known service PID filename.

--- a/src/core/cli/lifecycle/enumerate.go
+++ b/src/core/cli/lifecycle/enumerate.go
@@ -78,14 +78,19 @@ func ListAgents() ([]AgentEntry, error) {
 
 // IsAgentRunning reports whether an agent with the given name has a live
 // process recorded on disk. Returns (true, pid, nil) when the .pid file
-// exists AND the kernel still has an entry for that PID. Returns
-// (false, 0, nil) when no .pid file is present, the file is empty, or the
-// recorded PID is dead. Errors are only returned for unexpected I/O failures
-// reading the .pid file (e.g., permission denied) — "no such file" is not an
-// error.
+// exists AND either the kernel still has an entry for that PID or its
+// process group has surviving descendants. Returns (false, 0, nil) when no
+// .pid file is present or the file is empty; (false, pid, nil) when the
+// recorded PID is dead AND its process group is empty. Errors are only
+// returned for unexpected I/O failures reading the .pid file.
 //
 // Used by `meshctl start` to refuse same-name re-starts before a duplicate
 // process can clobber the on-disk PID/group bookkeeping.
+//
+// Group-aware (issue #1033): orphan descendants of a crashed parent count as
+// "running" so the user is told to clean up rather than getting a confusing
+// port-bind failure on re-start. Callers that need to distinguish parent-alive
+// from orphan-only can pair this with IsAlive(pid) on the returned PID.
 func IsAgentRunning(name string) (bool, int, error) {
 	pid, err := readPIDFromFile(PIDFile(name))
 	if err != nil {
@@ -94,7 +99,7 @@ func IsAgentRunning(name string) (bool, int, error) {
 	if pid == 0 {
 		return false, 0, nil
 	}
-	if !processAliveFn(pid) {
+	if !IsAliveOrGroupAlive(pid) {
 		return false, pid, nil
 	}
 	return true, pid, nil

--- a/src/core/cli/lifecycle/enumerate_test.go
+++ b/src/core/cli/lifecycle/enumerate_test.go
@@ -1,0 +1,106 @@
+package lifecycle
+
+import (
+	"testing"
+)
+
+// TestIsAgentRunning_LiveParent: parent PID alive AND group alive → running.
+func TestIsAgentRunning_LiveParent(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	const pid = 11111
+	useStubAlive(t, map[int]bool{pid: true})
+	useStubGroupAlive(t, map[int]bool{pid: true})
+
+	g := NewGroupID()
+	if err := WriteAgent("live", pid, g); err != nil {
+		t.Fatalf("WriteAgent: %v", err)
+	}
+
+	running, gotPID, err := IsAgentRunning("live")
+	if err != nil {
+		t.Fatalf("IsAgentRunning: %v", err)
+	}
+	if !running {
+		t.Error("expected running=true for live parent")
+	}
+	if gotPID != pid {
+		t.Errorf("pid = %d, want %d", gotPID, pid)
+	}
+}
+
+// TestIsAgentRunning_OrphanDescendants: parent dead, group has orphan
+// descendants → running (issue #1033). Uses groupAliveFn via the test seam to
+// confirm the call path routes through it (W1).
+func TestIsAgentRunning_OrphanDescendants(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	const pid = 22222
+	useStubAlive(t, map[int]bool{}) // parent dead
+	useStubGroupAlive(t, map[int]bool{pid: true})
+
+	g := NewGroupID()
+	if err := WriteAgent("orphan", pid, g); err != nil {
+		t.Fatalf("WriteAgent: %v", err)
+	}
+
+	running, gotPID, err := IsAgentRunning("orphan")
+	if err != nil {
+		t.Fatalf("IsAgentRunning: %v", err)
+	}
+	if !running {
+		t.Error("expected running=true when parent dead but group alive")
+	}
+	if gotPID != pid {
+		t.Errorf("pid = %d, want %d", gotPID, pid)
+	}
+}
+
+// TestIsAgentRunning_AllDead: both single-PID and group probes return dead →
+// not running, PID returned so callers can clean stale state.
+func TestIsAgentRunning_AllDead(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	const pid = 33333
+	useStubAlive(t, map[int]bool{})
+	useStubGroupAlive(t, map[int]bool{})
+
+	g := NewGroupID()
+	if err := WriteAgent("gone", pid, g); err != nil {
+		t.Fatalf("WriteAgent: %v", err)
+	}
+
+	running, gotPID, err := IsAgentRunning("gone")
+	if err != nil {
+		t.Fatalf("IsAgentRunning: %v", err)
+	}
+	if running {
+		t.Error("expected running=false when both probes return dead")
+	}
+	if gotPID != pid {
+		t.Errorf("pid = %d, want %d (caller needs PID for cleanup)", gotPID, pid)
+	}
+}
+
+// TestIsAgentRunning_MissingPIDFile: no .pid file → not running, pid=0.
+func TestIsAgentRunning_MissingPIDFile(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	useStubAlive(t, map[int]bool{})
+	useStubGroupAlive(t, map[int]bool{})
+
+	running, gotPID, err := IsAgentRunning("nonexistent")
+	if err != nil {
+		t.Fatalf("IsAgentRunning: %v", err)
+	}
+	if running {
+		t.Error("expected running=false when no PID file")
+	}
+	if gotPID != 0 {
+		t.Errorf("pid = %d, want 0", gotPID)
+	}
+}

--- a/src/core/cli/lifecycle/gc.go
+++ b/src/core/cli/lifecycle/gc.go
@@ -74,10 +74,23 @@ func Sweep() (Report, error) {
 		// process is dead we sweep the file the same as any agent PID file, so
 		// stale service state from a crash doesn't haunt the user. Live
 		// services are left alone; stop is the only path that signals them.
+		//
+		// Group-aware liveness (issue #1033): we use groupAliveFn here so that
+		// when the recorded parent crashed mid-startup but its uvicorn worker
+		// (or other descendant in the same pgid) survives, we KEEP the .pid
+		// file. The user-facing `meshctl stop` path then has bookkeeping to
+		// act on and can reap the orphan group, rather than Sweep silently
+		// pruning the .pid and leaving the orphan invisible.
+		//
+		// MUST stay in sync with the deps-walk site below — if this site keeps
+		// the .pid but the deps walk prunes the agent from refcounts, the
+		// shared registry/UI service can be killed while the orphan is still
+		// using it. Wrapper markers (above) and watcher markers (above) stay
+		// on single-PID processAliveFn — see comments at those sites.
 		path := pidsDirJoin(name)
 		pid, _ := readPIDFromFile(path)
-		if pid > 0 && processAliveFn(pid) {
-			continue // alive — leave alone
+		if pid > 0 && groupAliveFn(pid) {
+			continue // alive (parent or group descendant) — leave alone
 		}
 		// Reaching here means pid==0 OR pid is dead — the cleanup branch is
 		// unconditional. (Previously this re-tested processAliveFn, which was
@@ -134,7 +147,15 @@ func Sweep() (Report, error) {
 					}
 					pidPath := PIDFile(a)
 					pid, _ := readPIDFromFile(pidPath)
-					if pid > 0 && processAliveFn(pid) {
+					// Group-aware liveness (issue #1033): mirror the agent .pid
+					// sweep above. If the parent crashed but the process group
+					// has orphan descendants, the agent is still using the
+					// shared service (registry/UI). Pruning the deps entry
+					// here while the .pid sweep above keeps the .pid would
+					// underreport refcount and let stop kill a service that
+					// the orphan is still talking to. The two sites MUST move
+					// together.
+					if pid > 0 && groupAliveFn(pid) {
 						alive = append(alive, a)
 					} else {
 						r.StaleDepsEntries++

--- a/src/core/cli/lifecycle/gc.go
+++ b/src/core/cli/lifecycle/gc.go
@@ -92,10 +92,10 @@ func Sweep() (Report, error) {
 		if pid > 0 && groupAliveFn(pid) {
 			continue // alive (parent or group descendant) — leave alone
 		}
-		// Reaching here means pid==0 OR pid is dead — the cleanup branch is
-		// unconditional. (Previously this re-tested processAliveFn, which was
-		// always true given the continue above, and called the syscall twice
-		// for every dead PID.)
+		// Reaching here means pid==0 OR pid is dead OR the group is dead — the
+		// cleanup branch is unconditional. (Previously this re-tested
+		// processAliveFn, which was always true given the continue above, and
+		// called the syscall twice for every dead PID.)
 		if os.Remove(path) == nil {
 			r.DeadAgentPIDsCleaned++
 		}

--- a/src/core/cli/lifecycle/gc_test.go
+++ b/src/core/cli/lifecycle/gc_test.go
@@ -11,6 +11,7 @@ func TestSweepDropsDeadAgentPID(t *testing.T) {
 	defer WithRoot(tmp)()
 
 	useStubAlive(t, map[int]bool{}) // nothing is alive
+	useStubGroupAlive(t, map[int]bool{})
 	g := NewGroupID()
 	_ = WriteAgent("dead-agent", 12345, g)
 
@@ -31,6 +32,7 @@ func TestSweepKeepsLiveAgentPID(t *testing.T) {
 	defer WithRoot(tmp)()
 
 	useStubAlive(t, map[int]bool{777: true}) // 777 is alive
+	useStubGroupAlive(t, map[int]bool{777: true})
 	g := NewGroupID()
 	_ = WriteAgent("alive-agent", 777, g)
 
@@ -50,6 +52,7 @@ func TestSweepRemovesOrphanGroupFile(t *testing.T) {
 	defer WithRoot(tmp)()
 
 	useStubAlive(t, map[int]bool{})
+	useStubGroupAlive(t, map[int]bool{})
 	if err := os.MkdirAll(PIDsDir(), 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -75,6 +78,7 @@ func TestSweepDropsDeadDepsEntries(t *testing.T) {
 	defer WithRoot(tmp)()
 
 	useStubAlive(t, map[int]bool{777: true}) // alive-agent's pid
+	useStubGroupAlive(t, map[int]bool{777: true})
 	g := NewGroupID()
 	_ = WriteAgent("alive-agent", 777, g)
 	_ = WriteAgent("dead-agent", 12345, g) // 12345 not in alive map
@@ -106,6 +110,7 @@ func TestSweepRemovesEmptyDepsFile(t *testing.T) {
 	defer WithRoot(tmp)()
 
 	useStubAlive(t, map[int]bool{}) // nothing alive
+	useStubGroupAlive(t, map[int]bool{})
 	g := NewGroupID()
 	_ = WriteAgent("dead", 12345, g)
 	_ = RegisterDep(ServiceRegistry, g, []string{"dead"})
@@ -128,6 +133,7 @@ func TestSweepDoesNotKillProcesses(t *testing.T) {
 
 	// All PIDs alive — Sweep must not touch them.
 	useStubAlive(t, map[int]bool{777: true, 888: true, 999: true})
+	useStubGroupAlive(t, map[int]bool{777: true, 888: true, 999: true})
 	g := NewGroupID()
 	_ = WriteAgent("a", 777, g)
 	_ = WriteService("registry", 888)
@@ -151,6 +157,7 @@ func TestSweepRemovesStaleWrapperPID(t *testing.T) {
 	defer WithRoot(tmp)()
 
 	useStubAlive(t, map[int]bool{}) // nothing alive
+	useStubGroupAlive(t, map[int]bool{})
 	g := NewGroupID()
 	_ = WriteWrapperPID(g, 12345)
 
@@ -182,5 +189,147 @@ func TestSweepCleansTmpDepsLeftover(t *testing.T) {
 	}
 	if _, err := os.Stat(leftover); !os.IsNotExist(err) {
 		t.Errorf("leftover .tmp should be removed")
+	}
+}
+
+// TestSweep_AgentPID_KeepsWhenGroupAlive guards the #1033 fix: the agent .pid
+// sweep MUST keep the file when the parent PID is dead but the process group
+// has surviving descendants (orphans), so `meshctl stop` can still find the
+// bookkeeping and reap them.
+func TestSweep_AgentPID_KeepsWhenGroupAlive(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	// Parent dead, group alive — the orphan case.
+	useStubAlive(t, map[int]bool{})
+	useStubGroupAlive(t, map[int]bool{55555: true})
+	g := NewGroupID()
+	_ = WriteAgent("orphan-agent", 55555, g)
+
+	r, err := Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if r.DeadAgentPIDsCleaned != 0 {
+		t.Errorf("DeadAgentPIDsCleaned should be 0 when group is alive; got %+v", r)
+	}
+	if _, err := os.Stat(PIDFile("orphan-agent")); err != nil {
+		t.Errorf("pid file must be preserved when group is alive: %v", err)
+	}
+	if _, err := os.Stat(GroupFile("orphan-agent")); err != nil {
+		t.Errorf("group file must be preserved when group is alive: %v", err)
+	}
+}
+
+// TestSweep_AgentPID_RemovesWhenGroupDead preserves the original behavior when
+// both parent AND group are dead — the .pid file is cleaned.
+func TestSweep_AgentPID_RemovesWhenGroupDead(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	useStubAlive(t, map[int]bool{})
+	useStubGroupAlive(t, map[int]bool{})
+	g := NewGroupID()
+	_ = WriteAgent("gone", 12345, g)
+
+	r, err := Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if r.DeadAgentPIDsCleaned == 0 {
+		t.Errorf("expected DeadAgentPIDsCleaned > 0, got %+v", r)
+	}
+	if _, err := os.Stat(PIDFile("gone")); !os.IsNotExist(err) {
+		t.Errorf("pid file should be removed when both parent and group dead")
+	}
+}
+
+// TestSweep_DepsWalk_KeepsEntryWhenGroupAlive guards refcount-sync with the
+// agent .pid sweep above: if the .pid is kept (group alive), the deps entry
+// must also be kept so registry/UI refcount doesn't underreport.
+func TestSweep_DepsWalk_KeepsEntryWhenGroupAlive(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	// Parent dead, group alive for orphan-agent; nothing in alive map for
+	// processAliveFn so the deps walk would (in the OLD behavior) prune it.
+	useStubAlive(t, map[int]bool{})
+	useStubGroupAlive(t, map[int]bool{66666: true})
+	g := NewGroupID()
+	_ = WriteAgent("orphan-agent", 66666, g)
+	if err := RegisterDep(ServiceRegistry, g, []string{"orphan-agent"}); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if r.StaleDepsEntries != 0 {
+		t.Errorf("StaleDepsEntries should be 0 when group is alive; got %+v", r)
+	}
+	got, _ := AgentsInGroup(ServiceRegistry, g)
+	if len(got) != 1 || got[0] != "orphan-agent" {
+		t.Errorf("deps after sweep = %v, want [orphan-agent]", got)
+	}
+}
+
+// TestSweep_WrapperMarker_RemovesWhenSinglePIDDead is a REGRESSION GUARD:
+// wrapper markers MUST remain on single-PID processAliveFn semantics. If they
+// switched to group-aware, the wrapper's own forked child (which is in the
+// same pgid) would keep the marker file alive forever — wrappers exit when
+// the agent backgrounds, but the agent stays in the same pgid.
+func TestSweep_WrapperMarker_RemovesWhenSinglePIDDead(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	const wrapperPID = 77777
+	// Wrapper PID is dead. Group probe would say "alive" (forked agent still
+	// in group), but Sweep MUST use the single-PID probe here.
+	useStubAlive(t, map[int]bool{})
+	useStubGroupAlive(t, map[int]bool{wrapperPID: true})
+
+	g := NewGroupID()
+	if err := WriteWrapperPID(g, wrapperPID); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if r.StaleWrapperPIDs == 0 {
+		t.Errorf("wrapper marker should be cleaned when single-PID is dead even if group has descendants; got %+v", r)
+	}
+	if _, err := os.Stat(WrapperPIDFile(g)); !os.IsNotExist(err) {
+		t.Errorf("wrapper marker should be removed")
+	}
+}
+
+// TestSweep_WatcherMarker_RemovesWhenSinglePIDDead is the corresponding
+// regression guard for watcher markers. Watchers live in the controlling
+// meshctl process; their semantics REQUIRE single-PID — switching to group
+// would cause the watcher .pid to linger forever.
+func TestSweep_WatcherMarker_RemovesWhenSinglePIDDead(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	const watcherPID = 88888
+	useStubAlive(t, map[int]bool{})
+	useStubGroupAlive(t, map[int]bool{watcherPID: true})
+
+	if err := WriteWatcher("watched-agent", watcherPID); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if r.StaleWatcherPIDs == 0 {
+		t.Errorf("watcher marker should be cleaned when single-PID is dead even if group reports alive; got %+v", r)
+	}
+	if _, err := os.Stat(WatcherPIDFile("watched-agent")); !os.IsNotExist(err) {
+		t.Errorf("watcher marker should be removed")
 	}
 }

--- a/src/core/cli/lifecycle/kill.go
+++ b/src/core/cli/lifecycle/kill.go
@@ -1,6 +1,7 @@
 package lifecycle
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -33,6 +34,39 @@ func IsAlive(pid int) bool {
 	}
 	return proc.Signal(syscall.Signal(0)) == nil
 }
+
+// IsAliveOrGroupAlive reports whether the given PID is alive OR any process
+// in PID's process group is alive. Used when the "is there cleanup to do"
+// decision should include orphan descendants of a dead parent.
+//
+// Tries kill(-pid, 0) first (group probe): success means at least one process
+// in the group whose pgid equals pid still exists. ESRCH falls through to
+// the single-PID IsAlive check, which catches processes that were not spawned
+// with Setpgid (PID != PGID, so the group probe doesn't apply).
+//
+// Returns true conservatively on EPERM: cannot probe doesn't mean dead.
+//
+// NOTE: descendants that escaped the process group via setsid() or
+// multiprocessing(daemon=False) are NOT visible to this probe and will not
+// be reaped by the cleanup path. Documented limitation; see #1033.
+func IsAliveOrGroupAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	// Group probe: kill(-pid, 0) returns nil iff at least one process is
+	// in the process group whose pgid equals pid. Permission errors are
+	// treated as "still there" — we cannot prove death.
+	if err := syscall.Kill(-pid, syscall.Signal(0)); err == nil {
+		return true
+	} else if errors.Is(err, syscall.EPERM) {
+		return true
+	}
+	// Fall through to the canonical single-PID check.
+	return IsAlive(pid)
+}
+
+// groupAliveFn is overridable for tests; production uses IsAliveOrGroupAlive.
+var groupAliveFn = IsAliveOrGroupAlive
 
 // readPIDFromFile reads and parses a PID file. Returns (0, nil) if missing.
 func readPIDFromFile(path string) (int, error) {
@@ -87,6 +121,38 @@ func pollUntilDead(pid int, timeout time.Duration) bool {
 	return false
 }
 
+// pollUntilGroupDead is the group-aware variant of pollUntilDead. It polls
+// groupAliveFn (kill(-pid, 0) + single-PID fallback) at 50ms ticks until either
+// the entire process group is empty or the deadline passes. Returns true iff
+// the group is confirmed empty.
+//
+// Used by the KillVerifyAndCleanup branch where the parent PID is already
+// dead but descendants survive in the same pgid (issue #1033). pollUntilDead
+// would return true immediately in that scenario because the parent is gone —
+// we need to wait on the orphans instead.
+//
+// Same zombie semantics as pollUntilDead: a zombie counts as dead so an
+// init-reaped orphan isn't a false negative. Probe errors stay inconclusive.
+func pollUntilGroupDead(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !groupAliveFn(pid) {
+			return true
+		}
+		if z, err := isZombieFn(pid); err == nil && z {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !groupAliveFn(pid) {
+		return true
+	}
+	if z, err := isZombieFn(pid); err == nil && z {
+		return true
+	}
+	return false
+}
+
 // signalGroupOrPID sends sig first to the process group (negative PID) and
 // falls back to a single-process signal if that errors (process wasn't started
 // with Setpgid). Returns the LAST error seen — caller should still verify
@@ -129,10 +195,33 @@ func KillVerifyAndCleanup(name string, timeout time.Duration) (killed bool, err 
 	}
 
 	if !processAliveFn(pid) {
-		// Process already dead — clean up bookkeeping and report no kill.
-		_ = os.Remove(pidPath)
+		// Parent PID is dead. Check whether descendants survive in the same
+		// process group — that's the #1033 case (crash mid-startup, uvicorn
+		// worker or similar lingers).
+		if !groupAliveFn(pid) {
+			// Parent dead AND group empty — pure stale bookkeeping. Clean up.
+			_ = os.Remove(pidPath)
+			_ = os.Remove(groupPath)
+			return false, nil
+		}
+		// Parent dead but group has surviving descendants — proceed to kill
+		// the group as if normal stop. signalGroupOrPID's negative-PID send
+		// catches everyone in the group. The "parent" SIGTERM to a dead PID
+		// is a no-op (ESRCH); signalGroupOrPID does -pid first.
+		// Poll on group death, not parent death, since the parent is already
+		// gone and pollUntilDead would return true immediately.
+		_ = signalGroupOrPID(pid, syscall.SIGTERM)
+		if !pollUntilGroupDead(pid, timeout) {
+			_ = signalGroupOrPID(pid, syscall.SIGKILL)
+			if !pollUntilGroupDead(pid, 3*time.Second) {
+				return false, fmt.Errorf("lifecycle: process group %d (%s) still alive after SIGKILL", pid, name)
+			}
+		}
+		if err := os.Remove(pidPath); err != nil && !os.IsNotExist(err) {
+			return true, fmt.Errorf("lifecycle: process group killed but failed to remove %s: %w", pidPath, err)
+		}
 		_ = os.Remove(groupPath)
-		return false, nil
+		return true, nil
 	}
 
 	// Graceful: SIGTERM + poll.

--- a/src/core/cli/lifecycle/kill.go
+++ b/src/core/cli/lifecycle/kill.go
@@ -41,16 +41,24 @@ func IsAlive(pid int) bool {
 //
 // Tries kill(-pid, 0) first (group probe): success means at least one process
 // in the group whose pgid equals pid still exists. ESRCH falls through to
-// the single-PID IsAlive check, which catches processes that were not spawned
-// with Setpgid (PID != PGID, so the group probe doesn't apply).
+// the single-PID check, which catches processes that were not spawned with
+// Setpgid (PID != PGID, so the group probe doesn't apply).
 //
-// Returns true conservatively on EPERM: cannot probe doesn't mean dead.
+// Returns true conservatively on EPERM at either probe site: "cannot probe"
+// is not the same as "dead". The single-PID fallback inlines the syscall +
+// EPERM handling rather than calling IsAlive — IsAlive collapses EPERM to
+// false (its callers depend on that narrower predicate), but the group-aware
+// contract here promises EPERM-as-alive on both probes.
 //
 // NOTE: descendants that escaped the process group via setsid() or
 // multiprocessing(daemon=False) are NOT visible to this probe and will not
 // be reaped by the cleanup path. Documented limitation; see #1033.
 func IsAliveOrGroupAlive(pid int) bool {
-	if pid <= 0 {
+	if pid <= 1 {
+		// pid <= 0: invalid. pid == 1: kill(-1, ...) is POSIX broadcast —
+		// treating a PID file containing 1 as "alive" via the group probe
+		// would let the orphan-group branch in KillVerifyAndCleanup issue
+		// a broadcast SIGKILL. Refuse to probe.
 		return false
 	}
 	// Group probe: kill(-pid, 0) returns nil iff at least one process is
@@ -61,8 +69,19 @@ func IsAliveOrGroupAlive(pid int) bool {
 	} else if errors.Is(err, syscall.EPERM) {
 		return true
 	}
-	// Fall through to the canonical single-PID check.
-	return IsAlive(pid)
+	// Single-PID fallback — alive if signal-0 succeeds, OR errors with EPERM.
+	// Inlined (rather than delegating to IsAlive) so EPERM-as-alive symmetry
+	// with the group probe above is preserved.
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	if err := proc.Signal(syscall.Signal(0)); err == nil {
+		return true
+	} else if errors.Is(err, syscall.EPERM) {
+		return true
+	}
+	return false
 }
 
 // groupAliveFn is overridable for tests; production uses IsAliveOrGroupAlive.
@@ -131,8 +150,10 @@ func pollUntilDead(pid int, timeout time.Duration) bool {
 // would return true immediately in that scenario because the parent is gone —
 // we need to wait on the orphans instead.
 //
-// Same zombie semantics as pollUntilDead: a zombie counts as dead so an
-// init-reaped orphan isn't a false negative. Probe errors stay inconclusive.
+// Same zombie semantics as pollUntilDead: a zombie at the (originally
+// tracked) PID counts as dead so an init-reaped orphan isn't a false
+// negative. The PID-reuse race window is microseconds and matches
+// pollUntilDead's pre-existing exposure. Probe errors stay inconclusive.
 func pollUntilGroupDead(pid int, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -158,6 +179,12 @@ func pollUntilGroupDead(pid int, timeout time.Duration) bool {
 // with Setpgid). Returns the LAST error seen — caller should still verify
 // death rather than trust the error code.
 func signalGroupOrPID(pid int, sig syscall.Signal) error {
+	if pid <= 1 {
+		// Defensive: a corrupted PID file containing 1 (or 0/negative) must
+		// never trigger kill(-1, ...), which is a POSIX broadcast to every
+		// process the caller can signal. Refuse rather than translate.
+		return fmt.Errorf("lifecycle: refusing to signal pid %d (would broadcast)", pid)
+	}
 	if err := syscall.Kill(-pid, sig); err == nil {
 		return nil
 	}

--- a/src/core/cli/lifecycle/kill_test.go
+++ b/src/core/cli/lifecycle/kill_test.go
@@ -399,6 +399,59 @@ func TestKillVerifyFailureLeavesFile(t *testing.T) {
 	}
 }
 
+// TestIsAliveOrGroupAlive_RefusesPID1 guards against accidental broadcast
+// signals: a corrupted .pid file containing 1 must never be reported as
+// "alive" via the group probe, since kill(-1, ...) is POSIX broadcast to
+// every process the caller can signal — the orphan-group branch in
+// KillVerifyAndCleanup would then issue a session-wide SIGKILL.
+func TestIsAliveOrGroupAlive_RefusesPID1(t *testing.T) {
+	// PID 1 (init) is always alive on POSIX. The function must still return
+	// false because the group probe at -1 is too dangerous to issue.
+	if IsAliveOrGroupAlive(1) {
+		t.Error("IsAliveOrGroupAlive(1) must return false — kill(-1,...) would broadcast")
+	}
+}
+
+// TestSignalGroupOrPID_RefusesPID1 verifies the same guard at the signal-send
+// site: even if a pid==1 leaked past the probe layer somehow (caller bug,
+// future code path, etc.), signalGroupOrPID itself refuses rather than
+// translating to kill(-1, ...).
+//
+// Verification strategy: spawn a benign sleep, attempt signalGroupOrPID(1, ...)
+// for SIGTERM, and confirm (a) an error is returned and (b) the sleep is
+// still alive — proving no broadcast was issued.
+func TestSignalGroupOrPID_RefusesPID1(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn sleep: %v", err)
+	}
+	go func() { _ = cmd.Wait() }()
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	sleepPID := cmd.Process.Pid
+
+	err := signalGroupOrPID(1, syscall.SIGTERM)
+	if err == nil {
+		t.Fatal("signalGroupOrPID(1, SIGTERM) must return an error — would broadcast")
+	}
+
+	// Give any (incorrectly issued) signal a moment to land before we probe.
+	time.Sleep(50 * time.Millisecond)
+
+	if !IsAlive(sleepPID) {
+		t.Errorf("benign sleep PID %d is dead — signalGroupOrPID(1, ...) appears to have broadcast", sleepPID)
+	}
+
+	// Also verify pid==0 and pid<0 are refused symmetrically.
+	if err := signalGroupOrPID(0, syscall.SIGTERM); err == nil {
+		t.Error("signalGroupOrPID(0, SIGTERM) must return an error")
+	}
+	if err := signalGroupOrPID(-5, syscall.SIGTERM); err == nil {
+		t.Error("signalGroupOrPID(-5, SIGTERM) must return an error")
+	}
+}
+
 // TestPollUntilDeadIgnoresZombieProbeError guards the invariant that a
 // transient ps failure (EAGAIN under load, RLIMIT_NPROC, etc.) must NEVER
 // be interpreted as "process is dead". Pre-fix, isZombie returned bool only

--- a/src/core/cli/lifecycle/kill_test.go
+++ b/src/core/cli/lifecycle/kill_test.go
@@ -46,6 +46,48 @@ func useStubAlive(t *testing.T, alive map[int]bool) {
 	})
 }
 
+// stubGroupAlivePIDs mirrors stubAlivePIDs but for the group-aware probe.
+// Tests can drive parent-alive vs group-alive independently to exercise the
+// #1033 orphan-descendants branch in KillVerifyAndCleanup.
+var stubGroupAlivePIDs = struct {
+	sync.Mutex
+	pids map[int]bool
+	use  bool
+}{pids: make(map[int]bool)}
+
+func useStubGroupAlive(t *testing.T, alive map[int]bool) {
+	t.Helper()
+	stubGroupAlivePIDs.Lock()
+	prev := groupAliveFn
+	stubGroupAlivePIDs.pids = alive
+	stubGroupAlivePIDs.use = true
+	groupAliveFn = func(pid int) bool {
+		stubGroupAlivePIDs.Lock()
+		defer stubGroupAlivePIDs.Unlock()
+		return stubGroupAlivePIDs.pids[pid]
+	}
+	stubGroupAlivePIDs.Unlock()
+	t.Cleanup(func() {
+		stubGroupAlivePIDs.Lock()
+		groupAliveFn = prev
+		stubGroupAlivePIDs.use = false
+		stubGroupAlivePIDs.pids = make(map[int]bool)
+		stubGroupAlivePIDs.Unlock()
+	})
+}
+
+// setGroupAlive updates the stub map for an in-flight test (e.g., to flip
+// the group from "still alive" to "dead" after SIGTERM is sent).
+func setGroupAlive(pid int, alive bool) {
+	stubGroupAlivePIDs.Lock()
+	defer stubGroupAlivePIDs.Unlock()
+	if alive {
+		stubGroupAlivePIDs.pids[pid] = true
+	} else {
+		delete(stubGroupAlivePIDs.pids, pid)
+	}
+}
+
 func TestKillVerifyMissingPIDFile(t *testing.T) {
 	tmp := t.TempDir()
 	defer WithRoot(tmp)()
@@ -66,6 +108,9 @@ func TestKillVerifyDeadPIDCleansFile(t *testing.T) {
 	// Write a PID file pointing at a dead PID. Use the stub so we don't depend
 	// on the OS reporting a real PID as dead.
 	useStubAlive(t, map[int]bool{}) // empty map = nothing alive
+	// Group must also be empty so we hit the "pure stale bookkeeping" branch
+	// rather than the #1033 orphan-group path.
+	useStubGroupAlive(t, map[int]bool{})
 
 	g := NewGroupID()
 	_ = WriteAgent("zombie", 12345, g)
@@ -82,6 +127,180 @@ func TestKillVerifyDeadPIDCleansFile(t *testing.T) {
 	}
 	if _, err := os.Stat(GroupFile("zombie")); !os.IsNotExist(err) {
 		t.Errorf("expected group file removed: %v", err)
+	}
+}
+
+// TestKillVerifyAndCleanup_ParentDeadGroupDead_CleansFilesOnly verifies the
+// pure stale-bookkeeping branch: both single-PID and group probes return dead,
+// so no signal is sent and the PID/group files are cleaned.
+func TestKillVerifyAndCleanup_ParentDeadGroupDead_CleansFilesOnly(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	useStubAlive(t, map[int]bool{})
+	useStubGroupAlive(t, map[int]bool{})
+
+	g := NewGroupID()
+	_ = WriteAgent("stale", 22222, g)
+
+	killed, err := KillVerifyAndCleanup("stale", 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if killed {
+		t.Error("killed should be false when parent and group are both dead")
+	}
+	if _, err := os.Stat(PIDFile("stale")); !os.IsNotExist(err) {
+		t.Errorf("pid file should be removed")
+	}
+	if _, err := os.Stat(GroupFile("stale")); !os.IsNotExist(err) {
+		t.Errorf("group file should be removed")
+	}
+}
+
+// TestKillVerifyAndCleanup_ParentDeadGroupAlive_SignalsGroup verifies the
+// #1033 orphan-descendants branch: parent is dead but group has surviving
+// processes. We expect SIGTERM to the group, then cleanup once the group dies.
+func TestKillVerifyAndCleanup_ParentDeadGroupAlive_SignalsGroup(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	const pid = 33333
+	useStubAlive(t, map[int]bool{}) // parent already dead
+	useStubGroupAlive(t, map[int]bool{pid: true})
+
+	// Flip the group to "dead" after a short delay so pollUntilGroupDead
+	// observes the transition rather than timing out.
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		setGroupAlive(pid, false)
+	}()
+
+	g := NewGroupID()
+	_ = WriteAgent("orphan", pid, g)
+
+	killed, err := KillVerifyAndCleanup("orphan", 2*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !killed {
+		t.Error("killed should be true when orphan group was reaped")
+	}
+	if _, err := os.Stat(PIDFile("orphan")); !os.IsNotExist(err) {
+		t.Errorf("pid file should be removed after group reap")
+	}
+	if _, err := os.Stat(GroupFile("orphan")); !os.IsNotExist(err) {
+		t.Errorf("group file should be removed after group reap")
+	}
+}
+
+// TestKillVerifyAndCleanup_ParentDeadGroupRefusesToDie verifies that when the
+// orphan group survives SIGTERM and SIGKILL the function errors and does NOT
+// remove the PID file — the user must be able to retry.
+func TestKillVerifyAndCleanup_ParentDeadGroupRefusesToDie(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	const pid = 44444
+	useStubAlive(t, map[int]bool{}) // parent dead
+	// Group stays alive throughout — no goroutine flips it.
+	useStubGroupAlive(t, map[int]bool{pid: true})
+
+	g := NewGroupID()
+	_ = WriteAgent("undead-group", pid, g)
+
+	_, err := KillVerifyAndCleanup("undead-group", 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error when group can't be killed")
+	}
+	if _, statErr := os.Stat(PIDFile("undead-group")); statErr != nil {
+		t.Errorf("PID file should be preserved on verify failure: %v", statErr)
+	}
+}
+
+// TestPollUntilGroupDead_TreatsZombieAsDead guards the zombie-as-dead invariant
+// in the group-aware poll loop — init-reaped orphans must not be a false
+// negative.
+func TestPollUntilGroupDead_TreatsZombieAsDead(t *testing.T) {
+	prevGroup, prevZombie := groupAliveFn, isZombieFn
+	groupAliveFn = func(pid int) bool { return true } // never empty
+	isZombieFn = func(pid int) (bool, error) { return true, nil }
+	t.Cleanup(func() {
+		groupAliveFn = prevGroup
+		isZombieFn = prevZombie
+	})
+
+	if !pollUntilGroupDead(12345, 100*time.Millisecond) {
+		t.Error("pollUntilGroupDead must treat zombie as dead even when group probe stays alive")
+	}
+}
+
+// TestIsAliveOrGroupAlive_RealFork spawns a child with Setpgid, kills the
+// parent (leaving the child as an orphan in the same pgid), and verifies the
+// group probe correctly differentiates the orphan-alive case from group-dead.
+//
+// Darwin-friendly: relies only on POSIX kill(2) semantics that match Linux.
+func TestIsAliveOrGroupAlive_RealFork(t *testing.T) {
+	// Spawn the parent and the child via a single bash so the child inherits
+	// the parent's pgid. We use a shell that backgrounds a sleep, then the
+	// shell itself dies — the orphan sleep stays in the original pgid.
+	parent := exec.Command("bash", "-c", "sleep 10 & sleep 10")
+	parent.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := parent.Start(); err != nil {
+		t.Fatalf("spawn parent: %v", err)
+	}
+	parentPID := parent.Process.Pid
+	t.Cleanup(func() {
+		_ = syscall.Kill(-parentPID, syscall.SIGKILL)
+		_ = parent.Wait()
+	})
+
+	// Give the shell time to fork its background sleep into the pgid.
+	time.Sleep(150 * time.Millisecond)
+
+	// Kill ONLY the parent (the bash shell). The background sleep stays alive
+	// in the same pgid as an orphan.
+	if err := parent.Process.Signal(syscall.SIGKILL); err != nil {
+		t.Fatalf("signal parent: %v", err)
+	}
+	go func() { _ = parent.Wait() }()
+
+	// Wait for the parent to be reaped from the process table.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !IsAlive(parentPID) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if IsAlive(parentPID) {
+		t.Fatal("parent did not die")
+	}
+
+	// Parent is dead. Group still has the orphan sleep — group probe should
+	// return true.
+	if !IsAliveOrGroupAlive(parentPID) {
+		t.Errorf("IsAliveOrGroupAlive(%d): expected true (orphan in group), got false", parentPID)
+	}
+	if IsAlive(parentPID) {
+		t.Errorf("IsAlive(%d): expected false (parent dead), got true", parentPID)
+	}
+
+	// Kill the whole group.
+	if err := syscall.Kill(-parentPID, syscall.SIGKILL); err != nil {
+		t.Fatalf("kill group: %v", err)
+	}
+
+	// Wait for the group to drain.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !IsAliveOrGroupAlive(parentPID) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if IsAliveOrGroupAlive(parentPID) {
+		t.Errorf("IsAliveOrGroupAlive(%d): expected false after group SIGKILL", parentPID)
 	}
 }
 

--- a/src/core/cli/lifecycle/kill_test.go
+++ b/src/core/cli/lifecycle/kill_test.go
@@ -251,8 +251,9 @@ func TestIsAliveOrGroupAlive_RealFork(t *testing.T) {
 	}
 	parentPID := parent.Process.Pid
 	t.Cleanup(func() {
+		// Kill the orphan group descendants. Parent was already reaped
+		// inline above (exec.Cmd.Wait may only be called once).
 		_ = syscall.Kill(-parentPID, syscall.SIGKILL)
-		_ = parent.Wait()
 	})
 
 	// Give the shell time to fork its background sleep into the pgid.
@@ -263,18 +264,15 @@ func TestIsAliveOrGroupAlive_RealFork(t *testing.T) {
 	if err := parent.Process.Signal(syscall.SIGKILL); err != nil {
 		t.Fatalf("signal parent: %v", err)
 	}
-	go func() { _ = parent.Wait() }()
+	// Reap the parent inline. Wait() blocks until the kernel finishes
+	// teardown so the PID is no longer in the process table when we check
+	// IsAlive below. Single Wait() — t.Cleanup must NOT call Wait() again
+	// since exec.Cmd.Wait() is callable exactly once (race detector flags
+	// concurrent or repeated calls).
+	_ = parent.Wait()
 
-	// Wait for the parent to be reaped from the process table.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if !IsAlive(parentPID) {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
 	if IsAlive(parentPID) {
-		t.Fatal("parent did not die")
+		t.Fatal("parent did not die after SIGKILL + Wait")
 	}
 
 	// Parent is dead. Group still has the orphan sleep — group probe should
@@ -292,7 +290,7 @@ func TestIsAliveOrGroupAlive_RealFork(t *testing.T) {
 	}
 
 	// Wait for the group to drain.
-	deadline = time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if !IsAliveOrGroupAlive(parentPID) {
 			break

--- a/src/core/cli/start_validation.go
+++ b/src/core/cli/start_validation.go
@@ -62,11 +62,25 @@ func validateAgentsNotRunning(agentPaths []string) error {
 			}
 		}
 		if running {
+			// Distinguish parent-alive (normal "already running") from
+			// orphan-descendants (parent crashed, group still has live
+			// processes — issue #1033). Better message for the orphan case
+			// so the user knows what to expect on `meshctl stop`.
+			if lifecycle.IsAlive(pid) {
+				return &PrerequisiteError{
+					Check:   "Agent already running",
+					Message: fmt.Sprintf("agent '%s' is already running (PID %d). Stop it first with 'meshctl stop %s'.", name, pid, name),
+					Remediation: fmt.Sprintf(`To fix this issue:
+  1. Stop the running agent: meshctl stop %s
+  2. Or list all running agents: meshctl list
+  3. Then start it again`, name),
+				}
+			}
 			return &PrerequisiteError{
 				Check:   "Agent already running",
-				Message: fmt.Sprintf("agent '%s' is already running (PID %d). Stop it first with 'meshctl stop %s'.", name, pid, name),
+				Message: fmt.Sprintf("agent '%s' has orphan descendants (tracked PID %d is dead but its process group is still alive). Run 'meshctl stop %s' to clean up before starting a new instance.", name, pid, name),
 				Remediation: fmt.Sprintf(`To fix this issue:
-  1. Stop the running agent: meshctl stop %s
+  1. Stop the orphan process group: meshctl stop %s
   2. Or list all running agents: meshctl list
   3. Then start it again`, name),
 			}

--- a/src/core/cli/stop.go
+++ b/src/core/cli/stop.go
@@ -282,7 +282,15 @@ func killWatcherForAgent(agent string, timeout time.Duration, quiet bool) {
 // watcher meshctl processes). Returns true on confirmed death (including
 // zombie state — see lifecycle.KillVerifyAndCleanup commentary).
 func killProcessByPID(pid int, timeout time.Duration) bool {
-	if pid <= 0 || !lifecycle.IsAlive(pid) {
+	if pid <= 1 || !lifecycle.IsAlive(pid) {
+		// pid <= 0: invalid. pid == 1: kill(-1, ...) is POSIX broadcast to
+		// every process the user can signal — refuse rather than translate a
+		// corrupted/tampered <agent>.watcher.pid into a session-wide kill.
+		// Symmetric with the lifecycle.IsAliveOrGroupAlive / signalGroupOrPID
+		// guards on the agent-PID path.
+		if pid == 1 {
+			fmt.Fprintf(os.Stderr, "warning: refusing to signal PID 1 (corrupt watcher.pid?) — kill(-1, ...) would broadcast\n")
+		}
 		return true
 	}
 	// SIGTERM the process group first (the watcher meshctl was started with

--- a/src/core/cli/stop_test.go
+++ b/src/core/cli/stop_test.go
@@ -2,7 +2,10 @@ package cli
 
 import (
 	"os"
+	"os/exec"
+	"syscall"
 	"testing"
+	"time"
 
 	"mcp-mesh/src/core/cli/lifecycle"
 )
@@ -64,6 +67,36 @@ func TestSuggestAgentNamesCapped(t *testing.T) {
 	want := []string{"alpha-agent", "beta-agent", "delta-agent"}
 	if !equalStringSlices(got, want) {
 		t.Errorf("suggestAgentNames(\"agent\") = %v, want %v (sorted and capped)", got, want)
+	}
+}
+
+// TestKillProcessByPID_RefusesPID1 guards the symmetric pid==1 hole on the
+// <agent>.watcher.pid path: killProcessByPID(1, ...) must never reach
+// syscall.Kill(-1, ...), which is POSIX broadcast to every process the user
+// can signal. Strategy mirrors TestSignalGroupOrPID_RefusesPID1: spawn a
+// benign sleep we own, invoke killProcessByPID(1, ...), then confirm the
+// sleep is still alive — proving no broadcast was issued.
+func TestKillProcessByPID_RefusesPID1(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn sleep: %v", err)
+	}
+	go func() { _ = cmd.Wait() }()
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	sleepPID := cmd.Process.Pid
+
+	// Must not panic, must return true (treated as no-op success).
+	if !killProcessByPID(1, 100*time.Millisecond) {
+		t.Error("killProcessByPID(1, ...) returned false — expected no-op true")
+	}
+
+	// Give any (incorrectly issued) broadcast signal a moment to land.
+	time.Sleep(50 * time.Millisecond)
+
+	if !lifecycle.IsAlive(sleepPID) {
+		t.Errorf("benign sleep PID %d is dead — killProcessByPID(1, ...) appears to have broadcast", sleepPID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #1033: when an agent's tracked parent crashes but descendants survive in the same process group (uvicorn workers, asyncio child reactors), `meshctl stop <agent>` falsely reports "agent is not running" while pgrep still finds the orphans. Subsequent restarts fail with port-bind conflicts.

Approach: introduce a group-aware liveness probe (`IsAliveOrGroupAlive` — POSIX `kill(-pid, 0)` with `IsAlive` fallback) and apply it at exactly three sites in the lifecycle layer. Carefully scoped to avoid regressing the load-bearing invariants established by prior PRs (#827, #844, #770, #749).

### Where the new probe is used vs. where it isn't

| Site | Probe | Reason |
|---|---|---|
| `gc.go:79` (agent .pid sweep) | `groupAliveFn` | Keeps .pid file when group survives |
| `gc.go:137` (deps refcount walk) | `groupAliveFn` | Moves in lockstep with sweep to keep refcounts in sync |
| `kill.go:131` (`KillVerifyAndCleanup` pre-check) | new three-branch decision | Parent alive → existing dance; parent dead + group empty → cleanup; parent dead + group alive → SIGTERM-to-group + `pollUntilGroupDead` + SIGKILL escalation |
| `enumerate.go:102` (`IsAgentRunning`) | `groupAliveFn` | Single-instance check now sees orphan descendants |
| `enumerate.go:123/158` (`LookupAgent.Alive`, `LookupService.Alive`) | `groupAliveFn` | Stop prelude message matches the actionable start-validation message |
| `gc.go:48` (wrapper marker) | `processAliveFn` (single-PID) | Wrapper marker's purpose is to clean up after marker-owner died — group-awareness would keep it forever |
| `gc.go:61` (watcher marker) | `processAliveFn` (single-PID) | Same reasoning as wrapper marker |
| `kill.go:73/81` (`pollUntilDead` main path) | unchanged | Watch-mode reload uses this path; `pollUntilGroupDead` is a separate variant only in the orphan-group branch |
| `enumerate.go:63` (`ListAgents.Alive`) | `processAliveFn` (single-PID) | Intentionally asymmetric — only feeds `suggestAgentNames` fuzzy match (cosmetic); documented inline |

### Defensive guards

- **`pid <= 1` guard** in `IsAliveOrGroupAlive`, `signalGroupOrPID`, AND `killProcessByPID`. `kill(-1, sig)` is POSIX broadcast to every process the user can signal — a corrupted PID file containing `1` (agent.pid OR watcher.pid) could otherwise let the orphan-group branch issue a session-wide SIGKILL.
- **EPERM-as-alive symmetry** in both the group probe and the single-PID fallback of `IsAliveOrGroupAlive`. The docstring promises "cannot probe doesn't mean dead" — applied consistently end-to-end so PID-reuse to a foreign-owned process surfaces a stop error rather than silently abandoning bookkeeping.

### Documented limitation

Descendants that called `os.setsid()` or escaped the process group (multiprocessing(daemon=False), some uvicorn --reload configs) are invisible to `kill(-pid, 0)` and still require manual `pgrep | kill`. Documented in `IsAliveOrGroupAlive`'s docstring.

## Review Notes

Two full review passes (both 0 BLOCKERs). The cleanup commits address everything surfaced:
- Commit 2 (`1fc9ba1bb`): pid<=1 guards, EPERM symmetry, `groupAliveFn` test seam at `IsAgentRunning`, group-aware `Alive` on `LookupAgent`/`LookupService`, comment polish
- Commit 3 (`de5ebb0ee`): symmetric pid<=1 guard on `killProcessByPID` (watcher.pid path), comment on `ListAgents.Alive` asymmetry

Reviewer explicitly confirmed all preserved invariants:
- Wrapper/watcher marker cleanup still fires on single-PID death (`TestSweep_WrapperMarker_RemovesWhenSinglePIDDead` is the regression guard)
- `pollUntilDead` main path untouched
- `IsAlive` (canonical single-PID) untouched
- Test seam consistency at all 6 production `groupAliveFn` call sites

## Tests

`mcp-mesh/src/core/cli/lifecycle`: 53 tests pass (42 baseline + 11 new) including `TestIsAliveOrGroupAlive_RealFork` which spawns bash + 2 sleeps with Setpgid, SIGKILLs the parent, and verifies the group probe end-to-end on darwin (the runner platform).

`mcp-mesh/src/core/cli`: 73 tests pass (72 baseline + 1 new `TestKillProcessByPID_RefusesPID1`).

Closes #1033

## Test plan

- [ ] CI green on linux + darwin
- [ ] Manual: agent crashes mid-startup with uvicorn worker forked → `meshctl stop` reaps both (was leaking orphan)
- [ ] Manual: clean agent crash with no descendants → `meshctl stop` still fast-path-cleans (no regression)
- [ ] Manual: setsid-escapee descendant → `meshctl stop` reports honest "still alive after SIGKILL" error rather than silent leak (documented limitation)
- [ ] Manual: meshctl restart with watch-mode → no slowdown (pollUntilDead main path unchanged)
- [ ] Manual: stop with stale wrapper.pid containing `1` → stderr warning + no broadcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent liveness now considers surviving descendant processes, not just parent process status.

* **Bug Fixes**
  * Improved handling of orphaned agent processes with surviving descendants.
  * Added safety checks to prevent dangerous broadcast signaling.
  * Enhanced error messages distinguishing running agents from orphaned processes.

* **Tests**
  * Added comprehensive test coverage for group-aware liveness and orphan process scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1035?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->