### PR TITLE
docs: stateful agents trilogy + reference landing page

### DIFF
--- a/docs/concepts/in-process-state.md
+++ b/docs/concepts/in-process-state.md
@@ -159,7 +159,7 @@ pattern imposes that mesh otherwise handles for you.
 
 A `@mesh.tool` function's DI parameters (`McpMeshTool`, `MeshLlmAgent`,
 `MeshJob`) are injected by a wrapper mesh installs at module load time.
-The wrapper is what subsitutes the proxy for the parameter — the raw
+The wrapper is what substitutes the proxy for the parameter — the raw
 function underneath has `None` defaults that never get filled in unless
 you call the wrapper.
 

--- a/docs/concepts/in-process-state.md
+++ b/docs/concepts/in-process-state.md
@@ -1,0 +1,307 @@
+# In-Process State (Escape Hatch)
+
+> When MeshJob can't fit your shape: in-process state with documented
+> caveats.
+
+The two patterns covered in [Stateful Agents](stateful-agents.md) cover
+the overwhelming majority of stateful workloads in mesh:
+
+- **Externalized state via a state agent + MeshJob orchestrator** —
+  durable, horizontally scalable, restart-tolerant.
+- **Single-worker mode** ([`MCP_MESH_TOOL_WORKERS=1`](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources))
+  — collapse to one worker loop, share a loop-bound resource at module
+  level, give up parallel execution.
+
+This page is for the **narrow class** of agents where neither of those
+fits — typically because the state cannot tolerate the ~10ms HTTP
+round-trip per mutation, or because the stateful resource genuinely
+cannot cross processes, or because the work is not request-driven at
+all. The pattern documented here works, but it imposes constraints
+mesh otherwise hides from you. The default answer should still be
+MeshJob.
+
+## Gate: should you actually be here?
+
+Before reaching for the in-process runtime pattern, can you answer **no** to all of these?
+
+1. **Is your work driven by tool calls (request-driven)?** → if yes, try `MCP_MESH_TOOL_WORKERS=1` (see [single-worker mode](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources)).
+2. **Can your state mutations tolerate ~10ms HTTP round-trip overhead per mutation?** → if yes, use MeshJob with a state agent (see [stateful agents](stateful-agents.md)).
+3. **Is your stateful resource portable across processes (DB pool, Redis connection, message-broker client)?** → if yes, you don't need in-process binding.
+
+Only if all three are **no** is the in-process runtime pattern likely the right answer.
+
+If you answered "yes" to any of them, close this page and go back to
+the linked alternative. The pattern below is more code, more failure
+modes, and more discipline than either of those — only worth it when
+the constraints actually demand it.
+
+## What the narrow cases look like
+
+The shapes that genuinely need in-process state:
+
+- **Real-time aggregators with sub-10ms state-mutation latency
+  budgets.** Market-data tick consolidators that update a moving
+  window on every tick. Sensor stream processors that fuse 1kHz inputs
+  into a single observable. Anything where adding an HTTP hop to the
+  state agent dominates the work being done.
+- **Long-lived loop-bound resources that can't cross processes.** A
+  GPU context bound to a CUDA stream. A WebSocket connection to a
+  hardware controller. An LLM KV-cache that's expensive enough to
+  rebuild that you genuinely want it to outlive a single tool call.
+  Anything where the resource's lifetime is "the lifetime of the
+  process" and serializing it to another process is either impossible
+  or prohibitively expensive.
+- **True background work that runs constantly between tool calls.**
+  Driver loops that poll an upstream every N milliseconds regardless
+  of whether a user is asking. Reconciliation loops that watch a
+  feed. The work is not request-driven — it's a daemon embedded in
+  the agent.
+
+If your workload doesn't look like one of those, you're in the wrong
+place.
+
+## The pattern: dedicated engine thread + bridge
+
+The shape is consistent across all three of those cases:
+
+- The agent spawns a **dedicated background thread** at startup.
+- That thread owns its own `asyncio.new_event_loop()` and runs
+  `loop.run_forever()` for the lifetime of the process.
+- All long-lived state — asyncpg pools, asyncio queues, the GPU
+  context, background tasks — lives on that engine loop.
+- `@mesh.tool` handlers run on mesh's worker loops (a different
+  thread). They bridge into the engine loop with
+  `asyncio.run_coroutine_threadsafe(coro, engine_loop)`, get a
+  `concurrent.futures.Future` back, and wrap it with
+  `asyncio.wrap_future(...)` so the handler can `await` the result
+  on its own worker loop.
+
+A minimal skeleton:
+
+=== "Python"
+
+    ```python
+    import asyncio
+    import threading
+    from typing import Any
+
+    import mesh
+    from fastmcp import FastMCP
+
+    app = FastMCP("In-Process Engine Agent")
+
+
+    class Engine:
+        """Owns a dedicated thread + its own asyncio loop."""
+
+        def __init__(self) -> None:
+            self.loop: asyncio.AbstractEventLoop | None = None
+            self._thread: threading.Thread | None = None
+            self._ready = threading.Event()
+            self._state: dict[str, Any] = {}  # the in-process state
+
+        def start(self) -> None:
+            def runner() -> None:
+                self.loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(self.loop)
+                # Schedule any always-on background tasks here.
+                self.loop.create_task(self._driver_loop())
+                self._ready.set()
+                self.loop.run_forever()
+
+            self._thread = threading.Thread(
+                target=runner, name="engine-loop", daemon=True,
+            )
+            self._thread.start()
+            self._ready.wait()  # block until loop is up
+
+        async def stop(self) -> None:
+            assert self.loop is not None
+            self.loop.call_soon_threadsafe(self.loop.stop)
+            # Optionally join the thread with a timeout in lifespan finally.
+
+        async def _driver_loop(self) -> None:
+            """Always-on background work runs HERE, not in a tool."""
+            while True:
+                # ... poll upstream / update state / etc ...
+                await asyncio.sleep(0.01)
+
+        def dispatch(self, coro):
+            """Call this from a worker-loop tool handler."""
+            assert self.loop is not None
+            fut = asyncio.run_coroutine_threadsafe(coro, self.loop)
+            return asyncio.wrap_future(fut)
+
+
+    engine = Engine()
+    engine.start()
+
+
+    @app.tool()
+    @mesh.tool(capability="get_aggregate")
+    async def get_aggregate(key: str) -> dict:
+        # Worker-loop side: bridge into engine loop, await the result.
+        async def on_engine() -> dict:
+            return dict(engine._state.get(key, {}))
+        return await engine.dispatch(on_engine())
+
+
+    @mesh.agent(name="engine-agent", http_port=9210, auto_run=True)
+    class EngineAgent: pass
+    ```
+
+That's the substrate. Everything below is the cookbook of gotchas this
+pattern imposes that mesh otherwise handles for you.
+
+## The cookbook
+
+### Boundary-crossing DI
+
+A `@mesh.tool` function's DI parameters (`McpMeshTool`, `MeshLlmAgent`,
+`MeshJob`) are injected by a wrapper mesh installs at module load time.
+The wrapper is what subsitutes the proxy for the parameter — the raw
+function underneath has `None` defaults that never get filled in unless
+you call the wrapper.
+
+That matters here because your engine code may want to call other
+`@mesh.tool` functions from the engine loop. Two pitfalls:
+
+- **The raw function vs. the wrapper.** If you write
+  `from some_module import some_tool` and then `await some_tool(...)`
+  on the engine loop, you're calling the wrapper — DI works fine.
+  Don't reach into the function's `__wrapped__` attribute trying to
+  "skip the wrapper"; you'll silently lose injection.
+- **`__main__` vs. import-name dual-import.** If `main.py` is started
+  as `python main.py`, Python loads it as the module `__main__`. If
+  any other code in the process then does `from main import some_tool`,
+  Python loads it again as the module `main` — two separate module
+  instances, each with its own copy of the wrapped function. The mesh
+  decorator installed the proxy on the `__main__` instance; the code
+  that imported `main.some_tool` is calling the `main` instance, which
+  has no proxy. Resolution silently fails to `None`. This is a real
+  footgun severe enough that the runtime now detects it explicitly —
+  see issue #1031 for the detection mechanism.
+
+  **Recommendation:** lay your agent out as a package and start it as
+  `python -m pkg.main` (or via the scaffold's entrypoint). Sibling
+  imports then all resolve to the same module instance and DI works
+  uniformly.
+
+### Restart recovery is your problem
+
+In-process state is lost on every restart. Mesh's MeshJob substrate
+handles this for orchestrator agents (orphan reroute + state-agent
+snapshot); the engine pattern bypasses that substrate by design.
+
+The discipline:
+
+- Every state mutation that must survive restart goes to durable
+  storage **before** acknowledging the change to the caller.
+- On agent startup, the engine reads the durable store and
+  reconstructs in-memory state before serving any tool calls (or
+  serves degraded responses until reconstruction completes).
+- This is app-side code mesh cannot enforce. If you skip it, restarts
+  silently lose state.
+
+### Long-poll tool timeouts
+
+If a consumer calls a tool on this agent that long-polls on engine
+state (e.g., "wait until the aggregator has at least N samples"), the
+consumer's mesh proxy enforces a default timeout (~30s). Calls that
+exceed it abort.
+
+To allow longer polls, the **consumer** declares it explicitly:
+
+=== "Python"
+
+    ```python
+    @mesh.tool(
+        capability="my_tool",
+        dependencies=["wait_for_threshold"],
+        dependency_kwargs={
+            "wait_for_threshold": {"timeout": 300},  # 5 minutes
+        },
+    )
+    async def my_tool(wait_for_threshold: mesh.McpMeshTool = None):
+        return await wait_for_threshold(min_samples=1000)
+    ```
+
+The kwarg lives on the caller side because it's the caller's HTTP
+proxy that's enforcing the timeout. The engine agent has no way to
+override it from its own side.
+
+### Horizontal scaling is broken
+
+This is the central trade-off and it deserves a callout.
+
+State pins the agent to a single replica. If you deploy two replicas
+of this agent, tool calls from any given consumer will round-robin
+across them — and each replica has its own independent in-memory
+state. Reads against the wrong replica silently return stale or empty
+data; writes silently land in the wrong bucket.
+
+Mitigations are all imperfect:
+
+- Run with `replicas: 1` and accept the loss of redundancy.
+- Use session-affinity routing (`session_required: True` in
+  `dependency_kwargs`) to pin a consumer to a replica for the
+  duration of a logical session. This shifts the problem rather
+  than solving it: cross-session reads still hit the wrong replica.
+- Externalize the state to a state agent — at which point you're
+  back to the [MeshJob pattern](stateful-agents.md) and don't need
+  this page.
+
+If horizontal scaling matters and the state genuinely can't be
+externalized, you have an architectural problem mesh can't paper over
+for you.
+
+### Graceful shutdown
+
+SIGTERM (pod eviction, deployment rollout, `Ctrl-C` in dev) needs to
+reach the engine thread cleanly. The runtime's lifespan exit phase
+fires on SIGTERM (fix shipped in #1029 — the exit phase is now honored
+rather than skipped), so wire the engine's `stop()` into the lifespan:
+
+=== "Python"
+
+    ```python
+    from contextlib import asynccontextmanager
+    from fastapi import FastAPI
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        # Engine was started at module load; nothing to do here on entry.
+        try:
+            yield
+        finally:
+            await engine.stop()
+
+    app = FastAPI(lifespan=lifespan)
+    ```
+
+The `finally` block runs on both clean shutdown and SIGTERM. Persist
+final state from the engine into durable storage there if you haven't
+been persisting incrementally; the engine thread will be torn down
+immediately after.
+
+## Closing
+
+This pattern is an escape hatch, not a recommendation. If you're
+reading it because you hit a cross-loop Future error or a "where do I
+put my asyncpg pool" question, the answer is almost always
+[single-worker mode](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources)
+or the [MeshJob state-agent decomposition](stateful-agents.md) — not
+this page. Use MeshJob unless you can answer the three gate questions
+with "no, no, and no."
+
+## See Also
+
+- [Stateful Agents](stateful-agents.md) — the canonical MeshJob +
+  state-agent decomposition that covers the common case
+- [Single-Worker Mode](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources)
+  — when you have one shared loop-bound resource and request-driven
+  tools
+- [Long-Running Jobs](jobs.md) — MeshJob substrate: lifecycle,
+  retries, cancel, orphan reroute
+- `meshctl man dependency-injection` — DDDI, worker-loop topology,
+  and dependency proxy configuration

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,0 +1,82 @@
+---
+title: Concepts
+description: Architecture, runtime model, and design rationale behind MCP Mesh
+---
+
+# Concepts
+
+The Concepts section explains *why* MCP Mesh works the way it does — the
+structural primitives, the runtime model, and the design tradeoffs behind
+features like DDDI, tag matching, and the registry. It is reference-shaped: you
+look up a concept when you need to understand a behavior, not when you need to
+remember a function signature.
+
+Use it alongside the other sections:
+
+- [**Tutorial**](../tutorial/index.md) walks you through building a real
+  multi-agent application from scratch.
+- [**Reference**](../reference/index.md) covers exact API signatures, CLI
+  flags, and environment variables you look up while writing code.
+- The **Python SDK**, **Java SDK**, and **TypeScript SDK** sections in the top
+  nav are the language-specific deep references.
+
+Concepts is what you reach for when something works (or doesn't) and you want
+to understand the mechanism behind it.
+
+## Sections
+
+<div class="grid cards" markdown>
+
+-   :material-sitemap:{ .lg .middle } **Architecture core**
+
+    ***
+
+    The framework's structural primitives — how agents, the registry, and
+    dependency injection compose into a mesh.
+
+    - [Architecture & Design](architecture.md)
+    - [DDDI: Distributed Dynamic Dependency Injection](dddi.md)
+    - [Registry](registry.md)
+
+-   :material-lan-connect:{ .lg .middle } **Discovery & matching**
+
+    ***
+
+    How the mesh wires agents together at runtime — heartbeats, capability
+    resolution, and the matching rules that pick a provider.
+
+    - [Health & Discovery](health-discovery.md)
+    - [Tag Matching](tag-matching.md)
+    - [Schema Matching](schema-matching.md)
+
+-   :material-transit-connection-variant:{ .lg .middle } **Runtime surfaces**
+
+    ***
+
+    How data flows once agents are wired — streaming responses, long-running
+    jobs, and the audit trail that records every call.
+
+    - [Streaming](streaming.md)
+    - [Long-Running Jobs](jobs.md)
+    - [Audit Trail](audit.md)
+
+-   :material-database-cog:{ .lg .middle } **Stateful patterns**
+
+    ***
+
+    Agents that hold state across calls — the session model and the in-process
+    escape hatch for code that can't be made stateless.
+
+    - [Stateful Agents](stateful-agents.md)
+    - [In-Process State (Escape Hatch)](in-process-state.md)
+
+</div>
+
+## See also
+
+- [Tutorial](../tutorial/index.md) — guided build of a multi-agent application.
+- [Reference](../reference/index.md) — API signatures, CLI flags, env vars.
+- [Python SDK](../python/index.md) — decorators, dependency injection, LLM
+  integration, FastAPI wiring.
+- [Java SDK](../java/index.md) — Spring Boot annotations and integration.
+- [TypeScript SDK](../typescript/index.md) — mesh functions and Express wiring.

--- a/docs/concepts/stateful-agents.md
+++ b/docs/concepts/stateful-agents.md
@@ -1,0 +1,488 @@
+# Stateful Agents
+
+> Building agents that hold per-tenant state across multiple tool calls —
+> without reinventing the runtime.
+
+A single `@mesh.tool` call is stateless from the mesh's perspective: a
+request arrives, a handler runs on a worker loop, a response goes out.
+That's the right shape for most tools. But some agents are not a
+function — they're a **session**: a debate that runs over many turns, a
+multi-stage workflow with checkpoints, an aggregator that accumulates
+inputs across calls. State has to survive between calls, survive a
+replica restart, and (for long-running work) keep advancing even when no
+client is actively waiting.
+
+This page walks through the mesh-idiomatic decomposition for that
+class of agent: a **state agent** that owns durable storage, an
+**orchestrator agent** that runs the long-lived unit of work, and a
+**client surface** (browser via `mesh.route`, MCP via Claude Code /
+Cursor) that talks to both. The pattern is small, but it pulls in
+several primitives — MeshJob, DDDI, the worker-pool topology — so the
+"why" matters as much as the "how."
+
+## The problem
+
+"Stateful" in mesh has a specific meaning:
+
+- **Multiple tool calls touch shared state.** A debate agent has turns:
+  turn N reads the transcript through turn N-1, appends, and writes
+  back. A multi-tenant aggregator has one logical bucket per tenant
+  that tool calls from many clients land into.
+- **State outlives a single MCP request-response.** The client closes
+  the connection, comes back five minutes later, picks up where they
+  left off.
+- **State survives replica restart.** Pods get evicted, deployments
+  roll, OOMKills happen. The in-flight unit of work has to resume on a
+  peer (or on the same pod after restart) without rewinding to zero.
+- **Background work runs between user-driven calls.** A driver loop
+  polls an upstream every 10 seconds; a workflow stage waits on an
+  external signal; a timer fires at a deadline. None of this is gated
+  on a user tool call landing.
+
+The temptation when you the author hit this for the first time is to
+cache state in process memory at the module level. The shape feels
+natural — it's how FastAPI services without mesh usually look:
+
+```python
+# DON'T DO THIS in a multi-worker mesh agent.
+import asyncpg
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Bad State Agent")
+_pool: asyncpg.Pool | None = None  # module-level cache
+
+async def _get_pool() -> asyncpg.Pool:
+    global _pool
+    if _pool is None:
+        _pool = await asyncpg.create_pool("postgres://...")
+    return _pool
+
+@app.tool()
+@mesh.tool(capability="read_state")
+async def read_state(tenant_id: str) -> dict:
+    pool = await _get_pool()
+    async with pool.acquire() as conn:
+        return await conn.fetchrow("SELECT * FROM state WHERE tenant=$1", tenant_id)
+```
+
+The first `read_state` call lands on worker loop A, lazily builds the
+pool on loop A, returns. The second `read_state` call round-robins to
+worker loop B. The pool's internal Futures were created on loop A; when
+loop B tries to await them, asyncio throws:
+
+```
+RuntimeError: Task <Task pending name='Task-N'> got Future <Future pending>
+attached to a different loop
+```
+
+Why does this happen? The Python runtime dispatches `async def`
+`@mesh.tool` functions across a small pool of worker loops — default
+`min(8, max(2, cpu_count()))`, always ≥ 2. The pool keeps `/health`,
+`/livez`, registry heartbeats, and other concurrent tool calls
+responsive even when one tool blocks. The trade-off: module-level
+loop-bound resources (asyncpg pools, `redis.asyncio.Redis`,
+`motor.motor_asyncio.AsyncIOMotorClient`, `aiohttp.ClientSession`) bind
+to whatever loop created them and fail on every subsequent call that
+lands on a different worker. The full topology is documented in
+[`meshctl man dependency-injection`](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources).
+
+There are two clean answers to this problem in mesh. The simple one is
+to collapse to a single worker loop with `MCP_MESH_TOOL_WORKERS=1`
+(covered in [single-worker mode](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources)).
+The structural one — the one that survives replica restart, scales
+horizontally, and composes with the rest of the mesh — is the
+three-agent decomposition that follows.
+
+## The mesh-idiomatic decomposition
+
+Three agents. One owns durable state. One owns the long-running unit
+of work. One (or more) is the user-facing surface. Each is independently
+deployable, independently scalable, and binds to the rest of the mesh
+via plain DDDI.
+
+### State agent — stateless CRUD over durable storage
+
+The state agent exposes `@mesh.tool` functions that read and write a
+Postgres (or Redis) database. It does no business logic. It does no
+long-running work. From mesh's perspective it's an ordinary CRUD
+agent — every tool call is short, idempotent where possible, and
+returns. The pool lives inside the agent process and (because the agent
+is shaped for a single shared resource) runs with
+`MCP_MESH_TOOL_WORKERS=1` so it can cache the pool at module level
+without the cross-loop footgun.
+
+Schema:
+
+- An **event log** table — append-only record of every state mutation.
+  Cheap to scan, replayable for audit / debugging.
+- A **state snapshot** table — current state per logical key (tenant,
+  session, workflow id). Read-optimized; reconstructed from the event
+  log if it gets out of sync.
+- A **pending_inputs** table — inbox for events that target a
+  running workflow (covered in
+  [Handling external events](#handling-external-events-during-a-run) below).
+
+=== "Python"
+
+    ```python
+    import os
+    import asyncpg
+    import mesh
+    from fastmcp import FastMCP
+
+    app = FastMCP("State Agent")
+    _pool: asyncpg.Pool | None = None  # safe: MCP_MESH_TOOL_WORKERS=1
+
+    async def _pool_handle() -> asyncpg.Pool:
+        global _pool
+        if _pool is None:
+            _pool = await asyncpg.create_pool(os.environ["DATABASE_URL"])
+        return _pool
+
+    @app.tool()
+    @mesh.tool(capability="read_state")
+    async def read_state(tenant_id: str) -> dict:
+        pool = await _pool_handle()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT state FROM tenant_state WHERE tenant_id=$1",
+                tenant_id,
+            )
+            return dict(row["state"]) if row else {}
+
+    @app.tool()
+    @mesh.tool(capability="append_event")
+    async def append_event(tenant_id: str, event_type: str, payload: dict) -> dict:
+        pool = await _pool_handle()
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    "INSERT INTO event_log (tenant_id, event_type, payload) "
+                    "VALUES ($1, $2, $3)",
+                    tenant_id, event_type, payload,
+                )
+                await conn.execute(
+                    "INSERT INTO tenant_state (tenant_id, state) "
+                    "VALUES ($1, $2) "
+                    "ON CONFLICT (tenant_id) DO UPDATE "
+                    "SET state = tenant_state.state || EXCLUDED.state",
+                    tenant_id, payload,
+                )
+        return {"ok": True}
+
+    @mesh.agent(name="state-agent", http_port=9200, auto_run=True)
+    class StateAgent: pass
+    ```
+
+Deployment env:
+
+```yaml
+env:
+  MCP_MESH_TOOL_WORKERS: "1"      # collapse to one worker loop
+  DATABASE_URL: "postgres://..."
+```
+
+This agent scales horizontally if you front it with Postgres-side
+locking on the rows that need serialization — but for most state-agent
+shapes the bottleneck is the database, not the agent.
+
+### Orchestrator agent — `@mesh.tool(task=True)` MeshJob bodies
+
+The orchestrator hosts the long-running unit of work. Each unit is one
+`@mesh.tool(capability=..., task=True)` body. Inside the body:
+
+- Call into the state agent for every mutation (no in-process state).
+- Drive an LLM via `mesh.MeshLlmAgent`.
+- Emit progress with `await job.update_progress(fraction, message)`.
+- Persist after every meaningful step. If the pod dies, the next claim
+  cycle reroutes the job (orphan reroute is mesh-managed — see
+  [`jobs.md`](jobs.md)) and the new owner reads the latest snapshot
+  from the state agent to know where to resume.
+
+=== "Python"
+
+    ```python
+    import mesh
+    from fastmcp import FastMCP
+    from mesh import MeshJob
+
+    app = FastMCP("Orchestrator")
+
+    @app.tool()
+    @mesh.tool(
+        capability="run_workflow",
+        task=True,
+        dependencies=["read_state", "append_event"],
+    )
+    async def run_workflow(
+        tenant_id: str,
+        plan: list[str],
+        job: MeshJob = None,
+        read_state: mesh.McpMeshTool = None,
+        append_event: mesh.McpMeshTool = None,
+        llm: mesh.MeshLlmAgent = None,
+    ) -> dict:
+        if job is not None:
+            await job.update_progress(0.0, "loading state")
+
+        state = await read_state(tenant_id=tenant_id)
+        completed = set(state.get("completed_stages", []))
+
+        total = max(len(plan), 1)
+        for i, stage in enumerate(plan):
+            if stage in completed:
+                continue  # resumed run skips finished stages
+
+            # Real work for this stage.
+            answer = await llm(f"Execute stage {stage} for tenant {tenant_id}")
+
+            # Persist BEFORE acknowledging progress — on crash the state
+            # agent is source of truth.
+            await append_event(
+                tenant_id=tenant_id,
+                event_type="stage_completed",
+                payload={"stage": stage, "result": answer,
+                         "completed_stages": list(completed | {stage})},
+            )
+            completed.add(stage)
+
+            if job is not None:
+                await job.update_progress((i + 1) / total, f"{stage} done")
+
+        result = {"tenant_id": tenant_id, "completed": list(completed)}
+        if job is not None:
+            await job.complete(result)
+        return result
+
+    @mesh.agent(name="orchestrator", http_port=9201, auto_run=True)
+    class Orchestrator: pass
+    ```
+
+This body runs on mesh's default worker pool (no `WORKERS=1` here — the
+agent is stateless from a resource-binding standpoint; all loop-bound
+resources live across the boundary in the state agent's process).
+
+### Client surface — `mesh.route` for web, MCP for tools
+
+Both the browser and an MCP-aware tool (Claude Code, Cursor) hit the
+same backend capabilities. A FastAPI route translates HTTP into a
+MeshJob submit + wait:
+
+=== "Python"
+
+    ```python
+    import mesh
+    from fastapi import FastAPI
+    from mesh import MeshJob
+    from pydantic import BaseModel
+
+    app = FastAPI()
+
+    class StartRequest(BaseModel):
+        tenant_id: str
+        plan: list[str]
+
+    @app.post("/api/workflows")
+    @mesh.route(dependencies=["run_workflow"])
+    async def start_workflow(
+        body: StartRequest,
+        run_workflow: MeshJob = None,
+    ) -> dict:
+        proxy = await run_workflow.submit(
+            tenant_id=body.tenant_id, plan=body.plan, max_duration=3600,
+        )
+        return {"job_id": proxy.job_id}
+    ```
+
+The browser polls `__mesh_job_status` (or subscribes via SSE — see
+[`streaming.md`](streaming.md) for the progress-notification path) for
+updates. An MCP client calls `commission_workflow` directly through the
+mesh as a normal tool that returns the `job_id`.
+
+## Why this shape
+
+Each piece of the decomposition pays for itself:
+
+- **In-memory state is a cache; Postgres is authoritative.** When the
+  orchestrator pod dies mid-stage, the next claim cycle hands the job
+  to a peer. The peer reads the state-agent snapshot, sees which stages
+  completed, and resumes. Lost in-flight CPU is bounded by the time
+  between the last `append_event` and the crash — typically seconds.
+- **MeshJob owns the long-running task lifecycle.** Orphan reroute on
+  replica death, cancel propagation, progress streaming, per-attempt
+  deadlines, retry-on-transient — all of that is the substrate's job,
+  not yours. You write the body. See [`jobs.md`](jobs.md) for the
+  full lifecycle.
+- **Tool calls are stateless from mesh's perspective.** The orchestrator
+  scales horizontally without coordination; the state agent scales
+  horizontally with Postgres as the coordination point; the route agent
+  scales horizontally trivially.
+- **Loop-bound resources stay inside one process.** The asyncpg pool
+  lives in the state agent (which runs `WORKERS=1`). No cross-loop
+  sharing. No cross-process sharing. The pool is invisible to the
+  orchestrator and to the route agent.
+
+## Handling external events during a run
+
+A common real-world wrinkle: while the workflow is running, the user
+wants to interact with it — submit input mid-stage, change a parameter,
+extend a deadline. The workflow body is sitting on an `await` inside an
+LLM call or a state-agent write. It needs a channel to receive these
+mid-flight signals.
+
+### Today's pattern: inbox-via-state-agent
+
+The state agent grows a `pending_inputs` table. The route agent writes
+to it. The orchestrator polls it at iteration boundaries:
+
+=== "Python"
+
+    ```python
+    # State agent — inbox writer (called by the route agent on user input)
+    @app.tool()
+    @mesh.tool(capability="enqueue_input")
+    async def enqueue_input(tenant_id: str, input_type: str, payload: dict) -> dict:
+        pool = await _pool_handle()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO pending_inputs (tenant_id, input_type, payload, claimed) "
+                "VALUES ($1, $2, $3, FALSE)",
+                tenant_id, input_type, payload,
+            )
+        return {"ok": True}
+
+    # State agent — inbox reader (called by the orchestrator each iteration)
+    @app.tool()
+    @mesh.tool(capability="claim_inputs")
+    async def claim_inputs(tenant_id: str) -> list[dict]:
+        pool = await _pool_handle()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "UPDATE pending_inputs SET claimed=TRUE "
+                "WHERE tenant_id=$1 AND NOT claimed RETURNING input_type, payload",
+                tenant_id,
+            )
+            return [{"input_type": r["input_type"], "payload": r["payload"]} for r in rows]
+    ```
+
+The orchestrator polls inside the loop:
+
+=== "Python"
+
+    ```python
+    for i, stage in enumerate(plan):
+        # Drain inbox at the iteration boundary
+        inputs = await claim_inputs(tenant_id=tenant_id)
+        for inp in inputs:
+            # Apply mid-flight input — e.g., update parameters, abort stage
+            ...
+
+        # ... run the stage as before ...
+    ```
+
+The latency cost is one HTTP round-trip per poll. Against the cost of
+the LLM call or the work itself, that's noise.
+
+### Limitations of polling
+
+Polling works when the workflow naturally cycles through iteration
+boundaries. It does **not** work for sub-iteration events: if your body
+is parked on a long `asyncio.sleep_until(deadline)` or inside a single
+streaming LLM call that runs for two minutes, the user clicking "extend
+my deadline" lands in `pending_inputs` and sits there until the next
+boundary — which may be after the event was useful.
+
+### Coming soon: mesh-managed event channel
+
+A mesh-managed bidirectional event channel between consumer and running
+job is on the roadmap as **issue #1032**. The shape is symmetric to
+streaming today: `JobProxy.send_event(payload)` from any consumer that
+holds the `job_id`, `await job.recv_event()` inside the job body —
+mesh handles delivery, trace propagation, and survival across reroute.
+That closes the sub-iteration gap. Until it lands, the inbox pattern
+above covers the iteration-boundary case, which is most of what
+production workflows need.
+
+## Cancel and graceful shutdown
+
+A long-running job needs a clean termination story. There are two cases:
+
+- **Consumer cancels** via `JobProxy.cancel(reason)`. The owner replica
+  receives the cancel signal and (today) raises `CancelledError` into
+  the running handler. Once #1032 lands, handlers that subscribe to
+  events will see a synthetic `{"type":"cancelled","reason":...}`
+  event instead, which they can handle inline rather than via
+  exception. Either way: persist final state to the state agent in a
+  `finally` block before the handler exits.
+- **Replica shutdown** (SIGTERM during pod eviction / deployment
+  rollout). The runtime's lifespan exit phase fires (fix shipped in
+  #1029 — the exit phase is now honored on SIGTERM rather than skipped),
+  any registered cleanup runs, and the registry sees the agent
+  disappear. In-flight jobs become orphans and reroute to a peer
+  within ~5 seconds.
+
+The contract for the handler body:
+
+=== "Python"
+
+    ```python
+    @app.tool()
+    @mesh.tool(capability="run_workflow", task=True, ...)
+    async def run_workflow(...):
+        try:
+            ...  # main loop
+        except asyncio.CancelledError:
+            # Persist what we've done so far so the next attempt can resume.
+            await append_event(
+                tenant_id=tenant_id, event_type="cancelled",
+                payload={"completed_stages": list(completed)},
+            )
+            raise
+        finally:
+            # Anything that must run regardless of outcome — flush
+            # metrics, close per-tenant resources, etc.
+            ...
+    ```
+
+## What NOT to do
+
+A handful of anti-patterns this decomposition exists to prevent:
+
+- **Dedicated background-thread engine with `loop.run_forever()`.** The
+  pattern looks like: spawn a thread at agent startup, give it its own
+  `asyncio.new_event_loop()`, run an engine on that loop, and bridge
+  `@mesh.tool` handlers into it via `asyncio.run_coroutine_threadsafe`.
+  This re-invents MeshJob — orphan reroute, cancel propagation,
+  per-attempt deadlines — in application code, and breaks horizontal
+  scaling because state pins the agent to one replica. It also drags
+  in hand-rolled cross-thread plumbing (`sys.modules['__main__']`
+  lookups for DI-wired functions, `dependency_kwargs.timeout` knobs
+  for long-poll). There IS a narrow class of agents where this
+  pattern is the right answer (GPU contexts, real-time aggregators
+  with sub-10ms latency budgets) — see
+  [In-Process State](in-process-state.md) — but it should never be
+  the default reach.
+- **Module-level state without `MCP_MESH_TOOL_WORKERS=1`.** Don't
+  cache asyncpg pools, redis clients, or any other loop-bound resource
+  at module level on default workers. It will work the first call.
+  It will fail the second. The fix is either single-worker mode
+  ([details](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources))
+  or moving the resource into a dedicated state agent (the pattern
+  above).
+- **Putting orchestration state on the orchestrator process.** The
+  orchestrator's job body should be a pure transformer: read state in,
+  drive work, write state out. The moment it caches anything across
+  tool calls, restart recovery breaks.
+
+## See Also
+
+- [Long-Running Jobs](jobs.md) — MeshJob substrate: lifecycle, retries,
+  cancel, orphan reroute, `task=true` opt-in
+- [Streaming](streaming.md) — progress notifications and chunked text
+  responses; pairs with MeshJob for live updates
+- [In-Process State (Escape Hatch)](in-process-state.md) — when even
+  MeshJob can't fit your shape, with documented caveats
+- [Single-Worker Mode](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources)
+  — the `MCP_MESH_TOOL_WORKERS=1` flag and when to use it
+- `meshctl man dependency-injection` — DDDI and worker-loop topology

--- a/docs/concepts/stateful-agents.md
+++ b/docs/concepts/stateful-agents.md
@@ -15,8 +15,8 @@ client is actively waiting.
 This page walks through the mesh-idiomatic decomposition for that
 class of agent: a **state agent** that owns durable storage, an
 **orchestrator agent** that runs the long-lived unit of work, and a
-**client surface** (browser via `mesh.route`, MCP via Claude Code /
-Cursor) that talks to both. The pattern is small, but it pulls in
+**client surface** (browser via `mesh.route`, MCP-aware clients via the
+MCP transport) that talks to both. The pattern is small, but it pulls in
 several primitives — MeshJob, DDDI, the worker-pool topology — so the
 "why" matters as much as the "how."
 
@@ -39,8 +39,8 @@ several primitives — MeshJob, DDDI, the worker-pool topology — so the
   external signal; a timer fires at a deadline. None of this is gated
   on a user tool call landing.
 
-The temptation when you the author hit this for the first time is to
-cache state in process memory at the module level. The shape feels
+The temptation when you hit this for the first time is to cache state
+in process memory at the module level. The shape feels
 natural — it's how FastAPI services without mesh usually look:
 
 ```python
@@ -85,7 +85,7 @@ loop-bound resources (asyncpg pools, `redis.asyncio.Redis`,
 `motor.motor_asyncio.AsyncIOMotorClient`, `aiohttp.ClientSession`) bind
 to whatever loop created them and fail on every subsequent call that
 lands on a different worker. The full topology is documented in
-[`meshctl man dependency-injection`](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources).
+[the dependency-injection reference](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources).
 
 There are two clean answers to this problem in mesh. The simple one is
 to collapse to a single worker loop with `MCP_MESH_TOOL_WORKERS=1`
@@ -197,7 +197,7 @@ The orchestrator hosts the long-running unit of work. Each unit is one
 - Emit progress with `await job.update_progress(fraction, message)`.
 - Persist after every meaningful step. If the pod dies, the next claim
   cycle reroutes the job (orphan reroute is mesh-managed — see
-  [`jobs.md`](jobs.md)) and the new owner reads the latest snapshot
+  [Long-Running Jobs](jobs.md)) and the new owner reads the latest snapshot
   from the state agent to know where to resume.
 
 === "Python"
@@ -265,7 +265,7 @@ resources live across the boundary in the state agent's process).
 
 ### Client surface — `mesh.route` for web, MCP for tools
 
-Both the browser and an MCP-aware tool (Claude Code, Cursor) hit the
+Both the browser and MCP-aware clients (over the MCP transport) hit the
 same backend capabilities. A FastAPI route translates HTTP into a
 MeshJob submit + wait:
 
@@ -296,8 +296,8 @@ MeshJob submit + wait:
     ```
 
 The browser polls `__mesh_job_status` (or subscribes via SSE — see
-[`streaming.md`](streaming.md) for the progress-notification path) for
-updates. An MCP client calls `commission_workflow` directly through the
+[Streaming](streaming.md) for the progress-notification path) for
+updates. An MCP client calls `run_workflow` directly through the
 mesh as a normal tool that returns the `job_id`.
 
 ## Why this shape
@@ -312,8 +312,8 @@ Each piece of the decomposition pays for itself:
 - **MeshJob owns the long-running task lifecycle.** Orphan reroute on
   replica death, cancel propagation, progress streaming, per-attempt
   deadlines, retry-on-transient — all of that is the substrate's job,
-  not yours. You write the body. See [`jobs.md`](jobs.md) for the
-  full lifecycle.
+  not yours. You write the body. See [Long-Running Jobs](jobs.md) for
+  the full lifecycle.
 - **Tool calls are stateless from mesh's perspective.** The orchestrator
   scales horizontally without coordination; the state agent scales
   horizontally with Postgres as the coordination point; the route agent
@@ -478,7 +478,7 @@ A handful of anti-patterns this decomposition exists to prevent:
 ## See Also
 
 - [Long-Running Jobs](jobs.md) — MeshJob substrate: lifecycle, retries,
-  cancel, orphan reroute, `task=true` opt-in
+  cancel, orphan reroute, `task=True` opt-in
 - [Streaming](streaming.md) — progress notifications and chunked text
   responses; pairs with MeshJob for live updates
 - [In-Process State (Escape Hatch)](in-process-state.md) — when even

--- a/docs/python/dependency-injection.md
+++ b/docs/python/dependency-injection.md
@@ -182,9 +182,123 @@ When topology changes (agents join/leave), the mesh:
 
 No code changes needed - happens transparently.
 
+## Single-worker mode for shared loop-bound resources
+
+Some Python async libraries hand back objects that are bound to the
+specific asyncio loop they were created on — `asyncpg.Pool`,
+`redis.asyncio.Redis`, `motor.motor_asyncio.AsyncIOMotorClient`,
+`aiohttp.ClientSession`, and many others. The library caches internal
+`Future` objects against the creating loop; awaiting any of them from a
+different loop throws:
+
+```
+RuntimeError: Task <...> got Future <...> attached to a different loop
+```
+
+The mesh Python runtime dispatches `async def` `@mesh.tool` functions
+across a small pool of worker loops (default `min(8, max(2, cpu_count()))`,
+always ≥ 2). The pool keeps `/health`, `/livez`, registry heartbeats,
+and other concurrent tool calls responsive even when one tool blocks the
+loop. The full topology is documented in `meshctl man dependency-injection`.
+
+The interaction: if you cache a pool at module level on default workers,
+the lazy initializer runs on whichever worker loop happened to receive
+the first call. Subsequent calls round-robin to a different worker, the
+pool's internal Futures fail the cross-loop check, and every call after
+the first raises.
+
+### The flag: `MCP_MESH_TOOL_WORKERS=1`
+
+Pin the agent to a single worker loop. The pool gets created on that
+loop, every subsequent tool call lands on that same loop, no cross-loop
+sharing happens. Module-level resource caching works the way you'd
+expect from a non-mesh FastAPI agent.
+
+### Trade-offs
+
+| Property | Default (N≥2) | `WORKERS=1` |
+|---|---|---|
+| Health/livez endpoint stays responsive when a tool blocks | ✓ | ✓ |
+| Module-level loop-bound resource shared across tools | ✗ | ✓ |
+| Parallel execution when a tool does blocking sync work | ✓ | ✗ (serialized) |
+| Async cooperative concurrency within a tool body | ✓ | ✓ |
+
+The `/health` and `/livez` endpoints run on their own thread regardless
+of `WORKERS`, so infra signals stay responsive in both modes. The
+asymmetry is in parallel execution of tool bodies that block the loop:
+on default workers, two blocking tools run concurrently on two
+workers; on `WORKERS=1`, the second waits for the first.
+
+### When to use it
+
+Good fit:
+
+- **Single-tenant CRUD agents** with one shared asyncpg pool or one
+  shared Redis client.
+- **State agents** in the [stateful-agents pattern](../concepts/stateful-agents.md) —
+  pure read/write tools over durable storage, no long-running work in
+  the agent itself.
+- Any agent where the shared resource cost (creating per-tool pools)
+  outweighs the parallel-execution gain.
+
+Bad fit:
+
+- **Agents that do blocking sync work** (sync DB drivers, CPU-bound
+  computation) and need true parallelism. Keep default workers and use
+  `await asyncio.to_thread(blocking_fn, ...)` inside the handler — that
+  offloads to the runtime's thread pool without freezing the worker
+  loop.
+- **CPU-bound workloads** that need to use multiple cores in parallel.
+  `WORKERS=1` serializes; default workers parallelize only across
+  loops, not across CPU cores (use process-level parallelism for that).
+- **Agents that hold genuinely long-lived state in process memory**
+  beyond a connection pool. See
+  [In-Process State (Escape Hatch)](../concepts/in-process-state.md)
+  for the narrower cases where `WORKERS=1` isn't enough.
+
+### How to set it
+
+Docker compose:
+
+```yaml
+services:
+  state-agent:
+    environment:
+      MCP_MESH_TOOL_WORKERS: "1"
+```
+
+Helm values:
+
+```yaml
+env:
+  MCP_MESH_TOOL_WORKERS: "1"
+```
+
+Kubernetes deployment spec:
+
+```yaml
+spec:
+  containers:
+    - name: state-agent
+      env:
+        - name: MCP_MESH_TOOL_WORKERS
+          value: "1"
+```
+
+For the bigger-picture decomposition (state agent + MeshJob orchestrator
++ client surface) that motivates this flag, see
+[Stateful Agents](../concepts/stateful-agents.md). For the narrower
+cases where even single-worker isn't enough (sub-10ms latency budgets,
+unportable loop-bound resources, true background daemons), see
+[In-Process State](../concepts/in-process-state.md).
+
 ## See Also
 
 - `meshctl man capabilities` - Declaring capabilities
 - `meshctl man tags` - Tag-based selection
 - `meshctl man health` - Health monitoring
 - `meshctl man proxies` - Proxy details
+- [Stateful Agents](../concepts/stateful-agents.md) - State agents +
+  MeshJob orchestrators
+- [In-Process State](../concepts/in-process-state.md) - Escape hatch
+  for narrow cases

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -26,45 +26,45 @@ need the exact spelling.
 
 <div class="grid cards" markdown>
 
-- :material-api:{ .lg .middle } **API**
+-   :material-api:{ .lg .middle } **API**
 
-  ***
+    ***
 
-  Symbol references for the multimodal media surfaces — return types, parameter
-  annotations, upload helpers, and storage configuration.
+    Symbol references for the multimodal media surfaces — return types, parameter
+    annotations, upload helpers, and storage configuration.
 
-  - [MediaResult](../api/media-result.md)
-  - [MediaParam](../api/media-param.md)
-  - [save_upload](../api/save-upload.md)
-  - [MediaStore](../api/media-store.md)
+    - [MediaResult](../api/media-result.md)
+    - [MediaParam](../api/media-param.md)
+    - [save_upload](../api/save-upload.md)
+    - [MediaStore](../api/media-store.md)
 
-- :material-console:{ .lg .middle } **CLI**
+-   :material-console:{ .lg .middle } **CLI**
 
-  ***
+    ***
 
-  `meshctl` command reference — every subcommand, flag, and environment
-  variable that the CLI honors, generated from the embedded man pages.
+    `meshctl` command reference — every subcommand, flag, and environment
+    variable that the CLI honors, generated from the embedded man pages.
 
-  [:octicons-arrow-right-24: meshctl Overview](../cli/index.md)
+    [:octicons-arrow-right-24: meshctl Overview](../cli/index.md)
 
-- :material-cog:{ .lg .middle } **Environment Variables**
+-   :material-cog:{ .lg .middle } **Environment Variables**
 
-  ***
+    ***
 
-  Exhaustive list of runtime environment variables read by the registry,
-  agents, and SDKs — TLS, observability, retries, transport, and more.
+    Exhaustive list of runtime environment variables read by the registry,
+    agents, and SDKs — TLS, observability, retries, transport, and more.
 
-  [:octicons-arrow-right-24: Environment Variables](../environment-variables.md)
+    [:octicons-arrow-right-24: Environment Variables](../environment-variables.md)
 
-- :material-tune:{ .lg .middle } **Kwargs**
+-   :material-tune:{ .lg .middle } **Kwargs**
 
-  ***
+    ***
 
-  Vendor-specific `model_params` cheatsheet for `@mesh.llm` consumers —
-  `thinking_config` (Gemini), `output_config` (Anthropic), `reasoning_effort`
-  (OpenAI), and the cross-vendor common kwargs.
+    Vendor-specific `model_params` cheatsheet for `@mesh.llm` consumers —
+    `thinking_config` (Gemini), `output_config` (Anthropic), `reasoning_effort`
+    (OpenAI), and the cross-vendor common kwargs.
 
-  [:octicons-arrow-right-24: LLM Kwargs](kwargs.md)
+    [:octicons-arrow-right-24: LLM Kwargs](kwargs.md)
 
 </div>
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -28,43 +28,43 @@ need the exact spelling.
 
 - :material-api:{ .lg .middle } **API**
 
-    ***
+  ***
 
-    Symbol references for the multimodal media surfaces — return types, parameter
-    annotations, upload helpers, and storage configuration.
+  Symbol references for the multimodal media surfaces — return types, parameter
+  annotations, upload helpers, and storage configuration.
 
-    [:octicons-arrow-right-24: MediaResult](../api/media-result.md)
-    [:octicons-arrow-right-24: MediaParam](../api/media-param.md)
-    [:octicons-arrow-right-24: save_upload](../api/save-upload.md)
-    [:octicons-arrow-right-24: MediaStore](../api/media-store.md)
+  - [MediaResult](../api/media-result.md)
+  - [MediaParam](../api/media-param.md)
+  - [save_upload](../api/save-upload.md)
+  - [MediaStore](../api/media-store.md)
 
 - :material-console:{ .lg .middle } **CLI**
 
-    ***
+  ***
 
-    `meshctl` command reference — every subcommand, flag, and environment
-    variable that the CLI honors, generated from the embedded man pages.
+  `meshctl` command reference — every subcommand, flag, and environment
+  variable that the CLI honors, generated from the embedded man pages.
 
-    [:octicons-arrow-right-24: meshctl Overview](../cli/index.md)
+  [:octicons-arrow-right-24: meshctl Overview](../cli/index.md)
 
 - :material-cog:{ .lg .middle } **Environment Variables**
 
-    ***
+  ***
 
-    Exhaustive list of runtime environment variables read by the registry,
-    agents, and SDKs — TLS, observability, retries, transport, and more.
+  Exhaustive list of runtime environment variables read by the registry,
+  agents, and SDKs — TLS, observability, retries, transport, and more.
 
-    [:octicons-arrow-right-24: Environment Variables](../environment-variables.md)
+  [:octicons-arrow-right-24: Environment Variables](../environment-variables.md)
 
 - :material-tune:{ .lg .middle } **Kwargs**
 
-    ***
+  ***
 
-    Vendor-specific `model_params` cheatsheet for `@mesh.llm` consumers —
-    `thinking_config` (Gemini), `output_config` (Anthropic), `reasoning_effort`
-    (OpenAI), and the cross-vendor common kwargs.
+  Vendor-specific `model_params` cheatsheet for `@mesh.llm` consumers —
+  `thinking_config` (Gemini), `output_config` (Anthropic), `reasoning_effort`
+  (OpenAI), and the cross-vendor common kwargs.
 
-    [:octicons-arrow-right-24: LLM Kwargs](kwargs.md)
+  [:octicons-arrow-right-24: LLM Kwargs](kwargs.md)
 
 </div>
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,78 @@
+---
+title: Reference
+description: API signatures, CLI flags, env vars, and model-parameter cheatsheets you look up while writing code
+---
+
+# Reference
+
+The Reference section covers the surfaces you look up *while writing code* —
+exact API signatures, CLI flags, environment-variable names, and vendor-specific
+model-parameter cheatsheets. It is deliberately compact and lookup-shaped.
+
+Use it alongside the other sections:
+
+- [**Concepts**](../concepts/architecture.md) explains the architecture and the
+  design rationale behind features like DDDI, tag matching, and the registry.
+- [**Tutorial**](../tutorial/index.md) walks you through building a real
+  multi-agent application from scratch.
+- The **Python SDK**, **Java SDK**, and **TypeScript SDK** sections in the top
+  nav are the language-specific deep references — decorators, annotations,
+  per-language idioms.
+
+Reference is what you reach for *after* you know the shape of the thing and just
+need the exact spelling.
+
+## Sections
+
+<div class="grid cards" markdown>
+
+- :material-api:{ .lg .middle } **API**
+
+    ***
+
+    Symbol references for the multimodal media surfaces — return types, parameter
+    annotations, upload helpers, and storage configuration.
+
+    [:octicons-arrow-right-24: MediaResult](../api/media-result.md)
+    [:octicons-arrow-right-24: MediaParam](../api/media-param.md)
+    [:octicons-arrow-right-24: save_upload](../api/save-upload.md)
+    [:octicons-arrow-right-24: MediaStore](../api/media-store.md)
+
+- :material-console:{ .lg .middle } **CLI**
+
+    ***
+
+    `meshctl` command reference — every subcommand, flag, and environment
+    variable that the CLI honors, generated from the embedded man pages.
+
+    [:octicons-arrow-right-24: meshctl Overview](../cli/index.md)
+
+- :material-cog:{ .lg .middle } **Environment Variables**
+
+    ***
+
+    Exhaustive list of runtime environment variables read by the registry,
+    agents, and SDKs — TLS, observability, retries, transport, and more.
+
+    [:octicons-arrow-right-24: Environment Variables](../environment-variables.md)
+
+- :material-tune:{ .lg .middle } **Kwargs**
+
+    ***
+
+    Vendor-specific `model_params` cheatsheet for `@mesh.llm` consumers —
+    `thinking_config` (Gemini), `output_config` (Anthropic), `reasoning_effort`
+    (OpenAI), and the cross-vendor common kwargs.
+
+    [:octicons-arrow-right-24: LLM Kwargs](kwargs.md)
+
+</div>
+
+## See also
+
+- [Python SDK](../python/index.md) — decorators, dependency injection, LLM
+  integration, FastAPI wiring.
+- [Java SDK](../java/index.md) — Spring Boot annotations and integration.
+- [TypeScript SDK](../typescript/index.md) — mesh functions and Express wiring.
+- [Concepts](../concepts/architecture.md) — architecture and design rationale.
+- [Tutorial](../tutorial/index.md) — guided build of a multi-agent application.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -220,6 +220,7 @@ nav:
 
   # Shared sections (language-agnostic)
   - Concepts:
+      - concepts/index.md
       - Architecture & Design: concepts/architecture.md
       - "DDDI: Distributed Dynamic Dependency Injection": concepts/dddi.md
       - Registry: concepts/registry.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,7 +102,7 @@ markdown_extensions:
   - md_in_html
   - toc:
       permalink: true
-      toc_depth: 2
+      toc_depth: 3
 
   # Python Markdown Extensions
   - pymdownx.arithmatex:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -229,6 +229,8 @@ nav:
       - Audit Trail: concepts/audit.md
       - Streaming: concepts/streaming.md
       - Long-Running Jobs: concepts/jobs.md
+      - Stateful Agents: concepts/stateful-agents.md
+      - In-Process State (Escape Hatch): concepts/in-process-state.md
 
   - Multimodal:
       - Getting Started: multimodal/getting-started.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,7 +102,7 @@ markdown_extensions:
   - md_in_html
   - toc:
       permalink: true
-      toc_depth: 3
+      toc_depth: 2
 
   # Python Markdown Extensions
   - pymdownx.arithmatex:
@@ -254,6 +254,7 @@ nav:
       - Producer Spec (Conformance): a2a/surfaces-spec.md
 
   - Reference:
+      - reference/index.md
       - API:
           - MediaResult: api/media-result.md
           - MediaParam: api/media-param.md

--- a/src/core/cli/man/content/dependency-injection.md
+++ b/src/core/cli/man/content/dependency-injection.md
@@ -35,6 +35,26 @@ health → capability_match → tags → version → schema → tiebreaker
 
 Every decision the registry makes is recorded as a `dependency_resolved` (or `dependency_unresolved`) event. Use `meshctl audit <agent>` to read them back — see `meshctl man audit`.
 
+## Loop topology
+
+The Python runtime dispatches `async def` `@mesh.tool` functions across a pool of worker threads, each owning its own asyncio loop. Default pool size is `min(8, max(2, cpu_count()))` — always ≥ 2.
+
+**Why a pool, not one loop.** A tool that blocks the asyncio loop (sync `time.sleep`, sync DB driver, CPU-bound work) shouldn't freeze `/health`, `/livez`, registry heartbeats, or other concurrent tool calls. Isolating tool dispatch onto a pool of worker loops keeps infra endpoints responsive even when a handler is misbehaving.
+
+**The implication.** Module-level loop-bound resources bind to whatever loop created them and fail when reused from a different loop. The canonical examples are `asyncpg.Pool`, `redis.asyncio.Redis`, `motor.motor_asyncio.AsyncIOMotorClient`, and `aiohttp.ClientSession` — all of them cache internal `Future` objects against the creating loop. On default workers, the first call lazily creates the resource on worker A; the second call lands on worker B and throws:
+
+```
+RuntimeError: Task <...> got Future <...> attached to a different loop
+```
+
+This is a real footgun for the natural FastAPI-shaped pattern of "cache a pool at module level." Two clean answers, depending on what you need:
+
+- **One shared loop-bound resource, CRUD-shape tools.** Set `MCP_MESH_TOOL_WORKERS=1` to collapse to a single worker loop. Module-level resource caching works as expected. Trade-off: lose parallel execution of blocking work (async still interleaves cooperatively within a single loop). Full trade-off table in `meshctl man dependency-injection` (Python doc) under "Single-worker mode for shared loop-bound resources".
+
+- **Long-running stateful work.** Use MeshJob (`@mesh.tool(task=True)`) with state externalized to a separate state agent. The orchestrator stays stateless; the state agent owns the durable storage. See `meshctl man jobs` for the MeshJob primitive and the Stateful Agents concept doc for the full decomposition.
+
+For the narrow case where neither answer fits (sub-10ms state-mutation latency budgets, unportable loop-bound resources like GPU contexts, true background daemons running between tool calls), see the In-Process State escape hatch in the concepts docs. The default answer should still be MeshJob.
+
 ## Declaring Dependencies
 
 ### Simple Dependencies
@@ -203,3 +223,6 @@ No code changes needed - happens transparently.
 - `meshctl man audit` - Inspecting resolution decisions
 - `meshctl man health` - Health monitoring
 - `meshctl man proxies` - Proxy details
+- `meshctl man jobs` - MeshJob primitive for long-running stateful work
+- Stateful Agents concept doc - State agent + MeshJob orchestrator decomposition
+- In-Process State concept doc - Escape hatch for the narrow cases neither MeshJob nor `WORKERS=1` cover


### PR DESCRIPTION
## Summary

Closes #1030 with a three-tier documentation trilogy for building stateful mesh agents, plus a Reference section landing page for nav discoverability.

### Trilogy (the core deliverable)

| Tier | File | Purpose |
|---|---|---|
| **1 — headline** | `docs/concepts/stateful-agents.md` (NEW, 488 LOC) | Canonical decomposition: stateless state-agent + orchestrator agent using `@mesh.tool(task=True)` MeshJob + thin client surface. Cites #1029 (SIGTERM lifespan), #1031 (dual-import detection), #1032 (forthcoming recv_event/send_event). |
| **2 — compact** | section added to `docs/python/dependency-injection.md` (+111 LOC) | `MCP_MESH_TOOL_WORKERS=1` for module-level loop-bound resources (asyncpg pool, etc.) — trade-off table, when-to-use, deployment snippets. Anchored as `#single-worker-mode-for-shared-loop-bound-resources`. |
| **3 — escape hatch** | `docs/concepts/in-process-state.md` (NEW, 307 LOC) | When MeshJob and `WORKERS=1` both don't fit. Three-question gate up front (<10ms latency / >10ms HTTP tolerance / portable resource). Engine-thread cookbook with caveats. |
| **CLI man** | `src/core/cli/man/content/dependency-injection.md` (+23 LOC) | New "Loop topology" section between Resolution Pipeline and Declaring Dependencies. |

### Reference landing page

`docs/reference/index.md` (NEW, 78 LOC) mirrors `docs/tutorial/index.md` pattern. Wired via `navigation.indexes`, so clicking "Reference" in the top tabs now lands on a clean overview (API / CLI / Environment Variables / Kwargs as grid cards) instead of routing to a leaf page.

### mkdocs nav

Two new entries in Concepts:
```yaml
- Stateful Agents: concepts/stateful-agents.md
- In-Process State (Escape Hatch): concepts/in-process-state.md
```

Plus `reference/index.md` wired as Reference section index.

## Review Notes

Two review passes; zero BLOCKERs remain.

Round 1 (commit `8f389980e` addresses all):
- BLOCKER: reverted a globally-scoped `toc_depth: 3 → 2` change (would have hidden H3 entries from concepts/architecture, dddi, a2a/surfaces-spec, and others site-wide; the landing page alone solves the Reference UX)
- 4 WARNINGs: scrubbed product names ("Claude Code"/"Cursor"), fixed `commission_workflow` capability name typo, fixed garbled sentence, fixed "subsitutes" typo
- 4 INFOs: reworked grid-card API entry (one card with bulleted link list, 2-space indent matching `security/index.md`), aligned body-prose link text with See Also human-readable titles, fixed `task=true` → `task=True`

## Public-artifact framing

No naming of downstream consumers anywhere in the docs. All examples are structural (state agents, orchestrators, market-data ticks, GPU contexts).

Closes #1030

## Test plan

- [ ] CI green
- [ ] Local `mkdocs serve` verifies the Reference tab lands on the new index page
- [ ] Local preview verifies the Concepts section now has the two new entries between Long-Running Jobs and the next section
- [ ] Local preview verifies the integrated TOC behavior on existing pages (concepts/architecture.md, concepts/dddi.md) is unchanged (toc_depth reverted to 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for building stateful agents with persistence and state management patterns.
  * Added escape-hatch documentation for in-process state handling in narrow use cases.
  * Enhanced dependency injection documentation with single-worker mode guidance for loop-bound resources.
  * Added Reference section landing page for quick API and configuration lookup.
  * Updated navigation structure for improved documentation discoverability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1036?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->