### PR TITLE
docs+test: SSE gateway shapes — body parsing inside async-gen deadlocks

### DIFF
--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -164,6 +164,8 @@ Both patterns are valid — pick the one that matches the error model. If only m
 
 A subtler failure mode: declaring `request: Request` and awaiting `request.json()` (or `await request.body()`, etc.) **inside** an `async def ... yield` handler hangs the connection. Starlette parses the request body lazily and only after the response generator has begun emitting — but the generator is suspended on `await request.json()`, which is itself waiting for the body. Neither side progresses.
 
+This is the same underlying ASGI commit-timing constraint discussed in [Pre-stream errors](#pre-stream-errors) above: anything that needs to run *before* the response stream commits — `HTTPException`, body validation, header inspection — must run in the outer coroutine, before returning the async generator.
+
 ```python
 # Hangs — body parsing inside an async-gen wrapped in StreamingResponse.
 @app.post("/api/chat")

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -160,6 +160,47 @@ Pre-flight checks in `chat_endpoint` fire BEFORE `StreamingResponse` is built, s
 
 Both patterns are valid — pick the one that matches the error model. If only mid-stream errors matter, the simpler `async def ... yield` form is fine; if pre-flight failures must be visible to non-SSE clients via HTTP status, use the coroutine-returns-generator pattern.
 
+### Don't parse `request.json()` inside an async-generator body
+
+A subtler failure mode: declaring `request: Request` and awaiting `request.json()` (or `await request.body()`, etc.) **inside** an `async def ... yield` handler hangs the connection. Starlette parses the request body lazily and only after the response generator has begun emitting — but the generator is suspended on `await request.json()`, which is itself waiting for the body. Neither side progresses.
+
+```python
+# Hangs — body parsing inside an async-gen wrapped in StreamingResponse.
+@app.post("/api/chat")
+@mesh.route(dependencies=["chat"])
+async def chat_endpoint(
+    request: Request,
+    chat: McpMeshTool = None,
+) -> mesh.Stream[str]:
+    body = await request.json()   # deadlocks
+    async for chunk in chat.stream(prompt=body["prompt"]):
+        yield chunk
+```
+
+Two safe shapes:
+
+1. **Pydantic body model (preferred).** FastAPI parses the body before your handler runs, so `body` is a plain dataclass by the time you yield. This is what the `Example` section above uses (`body: ChatRequest`).
+2. **Coroutine-returns-generator.** If you need the raw `Request`, parse the body in the outer coroutine (where awaits are safe), then `return` an inner async-gen helper:
+
+   ```python
+   @app.post("/api/chat")
+   @mesh.route(dependencies=["chat"])
+   async def chat_endpoint(
+       request: Request,
+       chat: McpMeshTool = None,
+   ) -> mesh.Stream[str]:
+       if chat is None:
+           raise HTTPException(status_code=503, detail="chat unavailable")
+       body = await request.json()   # OK — outer coroutine, no StreamingResponse yet
+       return _stream_chat(body, chat)
+
+   async def _stream_chat(body, chat):
+       async for chunk in chat.stream(prompt=body["prompt"]):
+           yield chunk
+   ```
+
+The same shape unblocks pre-stream `HTTPException` (see preceding section), so the two-function pattern is the right default whenever a handler needs `Request` introspection.
+
 ## Provider-side streaming resolution
 
 `MeshLlmAgent.stream()` always routes through a mesh-registered `@mesh.llm_provider` agent. The provider runs the agentic loop and the consumer iterates chunks via the auto-generated `process_chat_stream` tool. The resolver picks the right provider tool variant based on the consumer's return type:

--- a/src/runtime/python/tests/unit/_route_sse_gateway_handlers.py
+++ b/src/runtime/python/tests/unit/_route_sse_gateway_handlers.py
@@ -1,0 +1,54 @@
+"""Module-scope @mesh.route handlers for issue #1037 regression tests.
+
+These handlers live in a SEPARATE module (no ``from __future__ import
+annotations``) so ``inspect.signature`` returns real type objects, not the
+PEP 563 string forms. Production agent code is almost always written this
+way, so this faithfully mirrors what a real user gateway module produces.
+
+The companion test file (test_route_sse_wrapping.py) uses
+``from __future__ import annotations`` and cannot host these handlers
+itself — under PEP 563 ``Request``/``McpMeshTool`` annotations stay as
+strings and FastAPI cannot recognize ``Request`` as the Starlette injection.
+"""
+
+from fastapi import HTTPException
+from starlette.requests import Request
+
+import mesh
+from mesh.types import McpMeshTool
+
+
+async def chat_single_fn(
+    request: Request, dep: McpMeshTool = None
+) -> mesh.Stream[str]:
+    """Single-function user-natural shape under test (issue #1037).
+
+    Combines: async-gen body, ``Stream[str]`` return, ``Request`` parameter,
+    ``await request.json()`` inside the body, dep consumed via ``async for``,
+    and the missing-dep early-yield branch.
+    """
+    if dep is None:
+        yield "no dep"
+        return
+    body = await request.json()
+    async for chunk in dep.stream(text=body["text"]):
+        yield chunk
+
+
+async def _stream_helper(dep, body):
+    async for chunk in dep.stream(text=body["text"]):
+        yield chunk
+
+
+async def chat_two_fn_outer(
+    request: Request, dep: McpMeshTool = None
+):
+    """Canonical two-function shape: validate + parse up-front in a plain
+    coroutine, then RETURN an async-iter helper that does the actual
+    streaming. The outer coroutine can ``raise HTTPException`` cleanly
+    because the response has not been committed yet.
+    """
+    if dep is None:
+        raise HTTPException(status_code=503, detail="dep unavailable")
+    body = await request.json()
+    return _stream_helper(dep, body)

--- a/src/runtime/python/tests/unit/test_route_sse_wrapping.py
+++ b/src/runtime/python/tests/unit/test_route_sse_wrapping.py
@@ -36,6 +36,15 @@ from _mcp_mesh.pipeline.api_startup.route_integration import (
     _resolve_user_function,
 )
 
+# Production-shaped @mesh.route handlers for issue #1037 regression tests.
+# Defined in a sibling module that does NOT use `from __future__ import
+# annotations`, so FastAPI sees real type objects (not PEP 563 strings) on
+# parameters like `request: Request` and `dep: McpMeshTool`.
+from tests.unit._route_sse_gateway_handlers import (  # noqa: E402
+    chat_single_fn as _gw_chat_single_fn,
+    chat_two_fn_outer as _gw_chat_two_fn_outer,
+)
+
 
 # ---------------------------------------------------------------------------
 # _resolve_user_function
@@ -456,3 +465,236 @@ class TestSseEndpointEndToEnd:
             "data: beta\n\n"
             "data: [DONE]\n\n"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #1037: production-natural @mesh.route SSE shape
+# ---------------------------------------------------------------------------
+
+
+class FakeStreamingDep:
+    """Stand-in for an injected McpMeshTool whose remote tool streams chunks."""
+
+    def __init__(self, chunks):
+        self.chunks = chunks
+        self.last_kwargs = None
+
+    async def stream(self, **kwargs):
+        self.last_kwargs = kwargs
+        for c in self.chunks:
+            yield c
+
+
+class TestSseGatewayShape:
+    """Regression coverage for issue #1037.
+
+    Probes the single-function, user-natural gateway shape combining:
+      * async-gen handler (`yield` in body)
+      * `mesh.Stream[str]` return annotation
+      * `request: Request` parameter (FastAPI request injection)
+      * `await request.json()` as the first async operation INSIDE the gen body
+      * mesh-DI'd McpMeshTool consumed via `async for chunk in dep.stream(...)`
+      * early-error branch with `yield "..."; return` when dep is missing
+
+    Findings (May 2026):
+
+    * The `_build_sse_endpoint` machinery handles the user-natural shape
+      correctly when driven directly with an async-iter response (see
+      ``test_async_gen_with_request_body_inside_works_at_wrapper_level``).
+    * Routing the same shape through TestClient (and, by extension, any real
+      ASGI server) **deadlocks** because Starlette parses the request body
+      lazily: the StreamingResponse iterator must yield its first chunk
+      before the request body is available, but the iterator is itself
+      ``await``-ing ``request.json()``. This is the production bug that
+      issue #1037 reproduces.
+    * The early-error branch (``yield "..."; return`` BEFORE
+      ``await request.json()``) does work end-to-end — it never touches the
+      request body, so the deadlock never forms. It surfaces as HTTP 200
+      with an SSE body, NOT as an HTTP-level error.
+    * The canonical two-function shape (parse + validate up-front in a
+      coroutine handler, ``return`` an async-gen helper) works cleanly
+      end-to-end, including HTTP 503 on the missing-dep path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_async_gen_with_request_body_inside_works_at_wrapper_level(self):
+        """The mesh SSE wrapper itself handles the user-natural shape fine.
+
+        The bug (issue #1037) is NOT in ``_build_sse_endpoint`` — when driven
+        with an awaitable Request stand-in, all the chunks flow correctly,
+        ``dep.stream(**kwargs)`` is called with the right kwargs, and the
+        ``[DONE]`` terminator is emitted. The deadlock surfaces only when the
+        Request is a real Starlette request being parsed by an ASGI server
+        (see the next test for that production-path failure).
+        """
+        fake_dep = FakeStreamingDep(["alpha", "beta", "gamma"])
+        wrapper = MagicMock()
+        wrapper._mesh_original_func = _gw_chat_single_fn
+        wrapper._mesh_positions = [1]
+        wrapper._mesh_dependencies = ["dep-cap-name"]
+        wrapper._mesh_injected_deps = [fake_dep]
+        wrapper._mesh_route_metadata = {}
+
+        sse_endpoint = _build_sse_endpoint(wrapper, _gw_chat_single_fn)
+
+        class _FakeReq:
+            async def json(self):
+                return {"text": "hello"}
+
+        response = await sse_endpoint(request=_FakeReq())
+        body = await _drain(response)
+        assert body == (
+            "data: alpha\n\n"
+            "data: beta\n\n"
+            "data: gamma\n\n"
+            "data: [DONE]\n\n"
+        )
+        assert fake_dep.last_kwargs == {"text": "hello"}
+
+    def test_async_gen_with_request_body_deadlocks_over_http(self):
+        """**Regression guard for issue #1037.**
+
+        ``await request.json()`` placed INSIDE an async-gen body that's
+        wrapped in a StreamingResponse deadlocks under a real ASGI driver
+        (TestClient here, but the same applies to uvicorn). Starlette only
+        starts feeding the response generator after the request body has
+        been fully delivered — but the generator is suspended on
+        ``await request.json()``, which is itself waiting for the body.
+        Neither side can progress.
+
+        This test runs the call in a background thread and asserts the
+        thread does NOT finish within a generous timeout — i.e. the
+        deadlock IS reproducible. The day this test fails (i.e. the call
+        returns), the upstream framework deadlock has been fixed and the
+        single-function shape can be promoted to first-class.
+        """
+        import threading
+
+        fake_dep = FakeStreamingDep(["alpha", "beta", "gamma"])
+        wrapper = MagicMock()
+        wrapper._mesh_original_func = _gw_chat_single_fn
+        wrapper._mesh_positions = [1]
+        wrapper._mesh_dependencies = ["dep-cap-name"]
+        wrapper._mesh_injected_deps = [fake_dep]
+        wrapper._mesh_route_metadata = {}
+
+        sse_endpoint = _build_sse_endpoint(wrapper, _gw_chat_single_fn)
+        app = FastAPI()
+        app.post("/api/chat")(sse_endpoint)
+
+        result: dict = {}
+
+        def _call():
+            try:
+                client = TestClient(app)
+                r = client.post("/api/chat", json={"text": "hello"})
+                result["status"] = r.status_code
+                result["body"] = r.text
+            except Exception as e:
+                result["error"] = repr(e)
+
+        t = threading.Thread(target=_call, daemon=True)
+        t.start()
+        t.join(timeout=2.0)
+        assert t.is_alive(), (
+            "Expected the single-function gateway shape to deadlock over HTTP "
+            f"(issue #1037), but the call returned: result={result!r}. "
+            "If this test now passes-as-non-deadlock, the upstream Starlette/"
+            "FastAPI body-parsing flow has been fixed and docs should be "
+            "updated to promote the single-function shape."
+        )
+
+    def test_early_error_yield_before_request_body_works_over_http(self):
+        """The missing-dep branch (`yield "..."; return` BEFORE
+        ``await request.json()``) does NOT touch the request body, so the
+        deadlock never forms. It surfaces as HTTP 200 with an SSE body —
+        NOT HTTP 503. That's the contract trade-off users need to understand
+        when they pick the single-function shape.
+        """
+        wrapper = MagicMock()
+        wrapper._mesh_original_func = _gw_chat_single_fn
+        wrapper._mesh_positions = [1]
+        wrapper._mesh_dependencies = ["dep-cap-name"]
+        wrapper._mesh_injected_deps = [None]
+        wrapper._mesh_route_metadata = {}
+
+        sse_endpoint = _build_sse_endpoint(wrapper, _gw_chat_single_fn)
+        app = FastAPI()
+        app.post("/api/chat")(sse_endpoint)
+
+        client = TestClient(app)
+        with client.stream("POST", "/api/chat", json={}) as response:
+            status = response.status_code
+            ct = response.headers.get("content-type", "")
+            body = response.read().decode("utf-8")
+
+        # Status is 200 with SSE framing — NOT 503. Once the SSE wrapper
+        # returns a StreamingResponse, response headers flush before the
+        # user gen runs, so HTTP-level errors are unreachable from inside
+        # the gen body.
+        assert status == 200
+        assert ct.startswith("text/event-stream")
+        assert body == "data: no dep\n\ndata: [DONE]\n\n"
+
+    def test_canonical_two_function_shape_streams_and_503s_correctly(self):
+        """The canonical fix for issue #1037: a coroutine handler that
+        validates + parses the body up-front and ``return``s an async-gen
+        helper. The helper does the streaming; the outer coroutine can
+        ``raise HTTPException`` cleanly because the response status hasn't
+        been committed yet.
+
+        Happy path: stream all chunks + [DONE].
+        Error path: clean HTTP 503, no SSE framing.
+        """
+        fake_dep = FakeStreamingDep(["alpha", "beta", "gamma"])
+
+        # Outer coroutine (NOT an async-gen) defined at module scope so
+        # annotations resolve under `from __future__ import annotations`.
+        outer = _gw_chat_two_fn_outer
+
+        # Happy path
+        wrapper_ok = MagicMock()
+        wrapper_ok._mesh_original_func = outer
+        wrapper_ok._mesh_positions = [1]
+        wrapper_ok._mesh_dependencies = ["dep-cap-name"]
+        wrapper_ok._mesh_injected_deps = [fake_dep]
+        wrapper_ok._mesh_route_metadata = {}
+
+        sse_endpoint_ok = _build_sse_endpoint(wrapper_ok, outer)
+        app_ok = FastAPI()
+        app_ok.post("/api/chat")(sse_endpoint_ok)
+
+        client_ok = TestClient(app_ok)
+        with client_ok.stream(
+            "POST", "/api/chat", json={"text": "hello"}
+        ) as response:
+            assert response.status_code == 200
+            assert response.headers.get("content-type", "").startswith(
+                "text/event-stream"
+            )
+            body = response.read().decode("utf-8")
+        assert body == (
+            "data: alpha\n\n"
+            "data: beta\n\n"
+            "data: gamma\n\n"
+            "data: [DONE]\n\n"
+        )
+
+        # Error path — dep is None: outer raises HTTPException up-front,
+        # before any StreamingResponse is constructed, so FastAPI returns
+        # a clean HTTP 503.
+        wrapper_err = MagicMock()
+        wrapper_err._mesh_original_func = outer
+        wrapper_err._mesh_positions = [1]
+        wrapper_err._mesh_dependencies = ["dep-cap-name"]
+        wrapper_err._mesh_injected_deps = [None]
+        wrapper_err._mesh_route_metadata = {}
+
+        sse_endpoint_err = _build_sse_endpoint(wrapper_err, outer)
+        app_err = FastAPI()
+        app_err.post("/api/chat")(sse_endpoint_err)
+
+        client_err = TestClient(app_err)
+        r = client_err.post("/api/chat", json={})
+        assert r.status_code == 503
+        assert "dep unavailable" in r.text

--- a/src/runtime/python/tests/unit/test_route_sse_wrapping.py
+++ b/src/runtime/python/tests/unit/test_route_sse_wrapping.py
@@ -40,7 +40,7 @@ from _mcp_mesh.pipeline.api_startup.route_integration import (
 # Defined in a sibling module that does NOT use `from __future__ import
 # annotations`, so FastAPI sees real type objects (not PEP 563 strings) on
 # parameters like `request: Request` and `dep: McpMeshTool`.
-from tests.unit._route_sse_gateway_handlers import (  # noqa: E402
+from ._route_sse_gateway_handlers import (
     chat_single_fn as _gw_chat_single_fn,
     chat_two_fn_outer as _gw_chat_two_fn_outer,
 )
@@ -551,6 +551,7 @@ class TestSseGatewayShape:
         )
         assert fake_dep.last_kwargs == {"text": "hello"}
 
+    @pytest.mark.filterwarnings("ignore::ResourceWarning")
     def test_async_gen_with_request_body_deadlocks_over_http(self):
         """**Regression guard for issue #1037.**
 
@@ -586,16 +587,16 @@ class TestSseGatewayShape:
 
         def _call():
             try:
-                client = TestClient(app)
-                r = client.post("/api/chat", json={"text": "hello"})
-                result["status"] = r.status_code
-                result["body"] = r.text
+                with TestClient(app) as client:
+                    r = client.post("/api/chat", json={"text": "hello"})
+                    result["status"] = r.status_code
+                    result["body"] = r.text
             except Exception as e:
                 result["error"] = repr(e)
 
         t = threading.Thread(target=_call, daemon=True)
         t.start()
-        t.join(timeout=2.0)
+        t.join(timeout=8.0)
         assert t.is_alive(), (
             "Expected the single-function gateway shape to deadlock over HTTP "
             f"(issue #1037), but the call returned: result={result!r}. "


### PR DESCRIPTION
## Summary

Closes #1037. Investigation of the structural test gap surfaced a production bug that turned out **not to be in mesh**: any FastAPI route that returns an async-generator-as-StreamingResponse AND awaits `request.json()` inside the gen body deadlocks at the Starlette level. Reproduced with a plain FastAPI handler (no mesh in the loop) — patching the mesh SSE wrapper would not help.

The fix is teach-the-user: add tests that surface the deadlock and document the anti-pattern + two safe shapes.

## What's in the PR

### Tests (`src/runtime/python/tests/unit/test_route_sse_wrapping.py`, +242 LOC)

New `TestSseGatewayShape` class with 4 tests (22 baseline → 26 total):

1. **`test_async_gen_with_request_body_inside_works_at_wrapper_level`** — confirms `_build_sse_endpoint` itself handles the user-natural shape correctly when driven with an awaitable Request stand-in. The mesh wrapper is innocent.
2. **`test_async_gen_with_request_body_deadlocks_over_http`** — regression guard for the actual #1037 bug. Runs TestClient in a background thread, asserts it does NOT return within 8s, capturing the Starlette-level deadlock. Marked `@pytest.mark.filterwarnings("ignore::ResourceWarning")` since the deadlocked thread can't run `with`-block cleanup.
3. **`test_early_error_yield_before_request_body_works_over_http`** — confirms the secondary contract issue: `yield "msg"; return` for missing-dep cases emits HTTP 200 + in-band SSE error frame, NOT HTTP 503. Browser clients can't distinguish "service unavailable" from "service working" without parsing the SSE body.
4. **`test_canonical_two_function_shape_streams_and_503s_correctly`** — confirms the recommended fix (HTTPException upfront in a coroutine that returns an async-gen helper) streams correctly AND returns proper HTTP 503.

Supporting module `_route_sse_gateway_handlers.py` (+54 LOC) holds handler fixtures at module scope so FastAPI's `Request` annotation detection works (the test file uses `from __future__ import annotations` which stringifies type annotations and blocks the detection for locally-defined handlers).

### Docs (`docs/concepts/streaming.md`, +41 LOC)

New section "Don't parse `request.json()` inside an async-generator body" under "Pre-stream errors." Shows the deadlock anti-pattern and the two safe shapes:
- **Preferred:** Pydantic body model (FastAPI parses upfront)
- **When raw Request needed:** coroutine that parses body, then returns an async-gen helper

Cross-links to "Pre-stream errors" since both sections solve the same underlying ASGI commit-timing constraint.

## Review Notes

Commit `33d31e122` addresses the review findings cleanly:
- W1: `with TestClient(app) as client:` + `filterwarnings("ignore::ResourceWarning")` decorator
- W2: relative import `from ._route_sse_gateway_handlers import ...` (was a fragile `tests.<...>` absolute path that worked only with rootdir auto-prepend)
- W3: deadlock-probe timeout bumped 2.0s → 8.0s to survive heavily-contended CI runners
- I3: cross-link added in streaming.md between the two related sections

0 BLOCKERs across both review passes.

## Why this matters

Today users writing the natural-looking single-function shape get silent failure (SSE headers + 0 bytes body for the curl `--max-time` window) with no diagnostic. The two canonical working examples already use the two-function pattern, but nothing in the test suite or docs explained the constraint — until now.

Closes #1037

## Test plan

- [ ] CI green on linux + darwin
- [ ] `pytest src/runtime/python/tests/unit/test_route_sse_wrapping.py -v` shows 26 passed
- [ ] Manual: a downstream gateway following the new "Pre-stream errors" + "Don't parse request.json() inside an async-generator body" guidance streams correctly via curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced new guidance on streaming response implementation, outlining safe request handling patterns and solutions to prevent deadlock issues when parsing request data in streaming contexts.

* **Tests**
  * Added regression tests for streaming response functionality, covering both successful streaming scenarios and error handling cases for Server-Sent Events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->