### PR TITLE
java: MeshJob event injection parity — recvEvent/sendEvent/postEvent

### DIFF
--- a/src/runtime/core/include/mcp_mesh_core.h
+++ b/src/runtime/core/include/mcp_mesh_core.h
@@ -761,6 +761,46 @@ int32_t mesh_job_controller_is_terminal(const struct JobControllerHandle *handle
 // `-1` on error.
 int32_t mesh_job_controller_is_cancelled(const struct JobControllerHandle *handle);
 
+// Wait for the next event posted to this job's event channel.
+//
+// Mirrors [`JobController::recv_event`]. Returns the event as a JSON
+// string written to `*out_event_json`, or a null pointer when the
+// timeout elapses without a matching event. Cursor is per-controller-
+// instance (shared across `clone`s); a fresh controller for the same
+// `job_id` replays from seq=0.
+//
+// # Arguments
+// - `types_json`: optional UTF-8 NUL-terminated JSON string encoding an
+//   array of event-type tags. `NULL` (or a JSON `null`) means "receive
+//   all types". Invalid JSON or non-array shape returns -1 with the
+//   last-error slot populated.
+// - `timeout_secs`: f64 timeout in seconds. The C ABI cannot pass
+//   `Option<f64>`, so the convention is: pass a negative value (e.g.
+//   `-1.0`) to express "no timeout" (mirrors `Optional<Duration>::empty()`
+//   on the Java side). NaN / ±Infinity reject with -1. Finite-but-
+//   overflowing values (e.g. `f64::MAX`) reject with -1 via
+//   [`Duration::try_from_secs_f64`] — see `parse_ffi_timeout_secs`.
+// - `out_event_json`: receives `*mut c_char` JSON string of the event
+//   on arrival, or a NULL pointer on clean timeout (in which case the
+//   return code is still 0). Caller frees via `mesh_free_string` when
+//   the pointer is non-null.
+//
+// # Returns
+// - `0` on success (event delivered OR clean timeout — caller checks
+//   if `*out_event_json` is null to distinguish)
+// - `-1` on invalid args (null handle, malformed types_json, invalid
+//   timeout)
+// - `-2` on JobNotFound (registry doesn't know the job — typically
+//   "404 Not Found" from `GET /jobs/{id}/events`). Distinct from the
+//   generic -3 so the Java SDK can map to a typed
+//   `JobNotFoundException`.
+// - `-3` on other backend errors (5xx after retries, network failure,
+//   etc.). See `mesh_last_error` for details.
+int32_t mesh_job_controller_recv_event(struct JobControllerHandle *handle,
+                                       const char *types_json,
+                                       double timeout_secs,
+                                       char **out_event_json);
+
 // Read the job ID this controller is bound to. Caller frees the returned
 // string via `mesh_free_string`.
 int32_t mesh_job_controller_job_id(const struct JobControllerHandle *handle, char **out_job_id);
@@ -829,6 +869,40 @@ int32_t mesh_job_proxy_wait(struct JobProxyHandle *handle,
 // Request cancellation. The registry forwards the signal to the owner
 // replica when alive. `reason` may be NULL.
 int32_t mesh_job_proxy_cancel(struct JobProxyHandle *handle, const char *reason);
+
+// Post an event into this job's event channel.
+//
+// Mirrors [`JobProxy::send_event`]. The running handler (inside a
+// `task=true` job) will see the event on its next `recv_event` call —
+// or wake immediately if it's currently long-polling.
+//
+// # Arguments
+// - `event_type`: UTF-8 NUL-terminated event-type tag (e.g. `"signal"`,
+//   `"user_input"`).
+// - `payload_json`: optional UTF-8 NUL-terminated JSON string encoding
+//   the event payload. May be `NULL` to send an empty payload (the
+//   Rust core treats null/missing as an empty JSON object — matching
+//   the Python/TS `payload=None` shape).
+// - `out_receipt_json`: receives `*mut c_char` JSON string of the
+//   receipt (`{job_id, seq, created_at}`). Caller frees via
+//   `mesh_free_string`.
+//
+// # Returns
+// - `0` on success
+// - `-1` on invalid args (null handle, malformed payload_json)
+// - `-2` on JobNotFound (registry doesn't know the job — 404 from
+//   `POST /jobs/{id}/events`). Mapped by the Java SDK to
+//   `JobNotFoundException`.
+// - `-3` on JobTerminal (job already completed/failed/cancelled — 409
+//   from the registry, surfaced as [`JobError::JobTerminal`]). Mapped
+//   by the Java SDK to `JobTerminalException`. Distinct from -2 so
+//   callers can branch on terminal-state vs. unknown-job.
+// - `-4` on other backend errors (transport failure, 5xx after
+//   retries, etc.). See `mesh_last_error` for details.
+int32_t mesh_job_proxy_send_event(struct JobProxyHandle *handle,
+                                  const char *event_type,
+                                  const char *payload_json,
+                                  char **out_receipt_json);
 
 // Free a [`JobProxyHandle`] returned by [`mesh_submit_job`] /
 // [`mesh_job_proxy_new`].

--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -153,6 +153,13 @@ fn job_status_to_str(s: JobStatus) -> &'static str {
     }
 }
 
+// Stricter timeout-policy than mesh_job_proxy_wait's predicate (which
+// silently aliases NaN/Inf to "no timeout" for back-compat). New FFI
+// surfaces should adopt this form: surface callers' invalid inputs as
+// errors rather than aliasing — matches the napi/pyo3 `parse_timeout_secs`
+// helpers in jobs_napi.rs / jobs_py.rs. The two policies coexist
+// intentionally; do not unify without coordinating a deprecation cycle
+// for mesh_job_proxy_wait.
 /// Parse an FFI-supplied `timeout_secs` f64 into an `Option<Duration>`,
 /// using the negative-sentinel convention to bridge `Option<Duration>` over
 /// the C ABI (which cannot pass `null` doubles).

--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -50,7 +50,9 @@ use crate::jobs::{
     new_coalescing_queue, run_as_job, spawn_batching_tick, submit_job, BatchingConfig,
     BatchingHandle, JobController, JobError, JobProxy, SubmitJobArgs,
 };
-use crate::task_backend::{Job, JobStatus, RegistryHttpBackend, TaskBackend};
+use crate::task_backend::{
+    Job, JobEvent, JobEventReceipt, JobStatus, RegistryHttpBackend, TaskBackend,
+};
 
 // =============================================================================
 // Process-wide blocking runtime
@@ -149,6 +151,64 @@ fn job_status_to_str(s: JobStatus) -> &'static str {
         JobStatus::Failed => "failed",
         JobStatus::Cancelled => "cancelled",
     }
+}
+
+/// Parse an FFI-supplied `timeout_secs` f64 into an `Option<Duration>`,
+/// using the negative-sentinel convention to bridge `Option<Duration>` over
+/// the C ABI (which cannot pass `null` doubles).
+///
+/// Policy (matches `parse_timeout_secs` in `jobs_napi.rs` / `jobs_py.rs`):
+/// - `secs < 0.0` → `Ok(None)` (no timeout — Java passes `-1.0` to express
+///   `Optional<Duration>::empty()`)
+/// - `secs.is_nan() || secs.is_infinite()` → `Err(...)` — these are likely
+///   bugs in the caller; surfacing a clean error beats silent "no timeout"
+/// - finite `>= 0` but overflows `Duration::from_secs_f64` (e.g. `f64::MAX`)
+///   → `Err(...)` via `try_from_secs_f64` (the panicking constructor
+///   `from_secs_f64` would have aborted the host process)
+/// - finite `>= 0` and convertible → `Ok(Some(Duration::...))`
+fn parse_ffi_timeout_secs(secs: f64) -> Result<Option<Duration>, String> {
+    if secs.is_nan() {
+        return Err(format!("timeout_secs must be a finite number, got NaN"));
+    }
+    if secs.is_infinite() {
+        return Err(format!(
+            "timeout_secs must be a finite number, got {}",
+            secs
+        ));
+    }
+    if secs < 0.0 {
+        return Ok(None);
+    }
+    Duration::try_from_secs_f64(secs)
+        .map(Some)
+        .map_err(|e| format!("timeout_secs out of range: {} (got {})", e, secs))
+}
+
+/// Convert a [`JobEvent`] to a JSON string matching the wire shape that
+/// the Python (`job_event_to_pydict`) and TS (`job_event_to_json`) bindings
+/// expose. Java callers parse this with Jackson on their side.
+fn job_event_to_json_string(ev: JobEvent) -> String {
+    serde_json::json!({
+        "job_id": ev.job_id,
+        "seq": ev.seq,
+        "type": ev.event_type,
+        "payload": ev.payload.unwrap_or(serde_json::Value::Null),
+        "trace_context": ev.trace_context.unwrap_or(serde_json::Value::Null),
+        "posted_by": ev.posted_by,
+        "created_at": ev.created_at,
+    })
+    .to_string()
+}
+
+/// Convert a [`JobEventReceipt`] to a JSON string matching the wire shape
+/// Python/TS bindings expose.
+fn job_event_receipt_to_json_string(receipt: JobEventReceipt) -> String {
+    serde_json::json!({
+        "job_id": receipt.job_id,
+        "seq": receipt.seq,
+        "created_at": receipt.created_at,
+    })
+    .to_string()
 }
 
 /// Serialize a [`Job`] row to JSON matching the wire shape Python/TS bindings
@@ -454,6 +514,128 @@ pub unsafe extern "C" fn mesh_job_controller_is_cancelled(
     }
 }
 
+/// Wait for the next event posted to this job's event channel.
+///
+/// Mirrors [`JobController::recv_event`]. Returns the event as a JSON
+/// string written to `*out_event_json`, or a null pointer when the
+/// timeout elapses without a matching event. Cursor is per-controller-
+/// instance (shared across `clone`s); a fresh controller for the same
+/// `job_id` replays from seq=0.
+///
+/// # Arguments
+/// - `types_json`: optional UTF-8 NUL-terminated JSON string encoding an
+///   array of event-type tags. `NULL` (or a JSON `null`) means "receive
+///   all types". Invalid JSON or non-array shape returns -1 with the
+///   last-error slot populated.
+/// - `timeout_secs`: f64 timeout in seconds. The C ABI cannot pass
+///   `Option<f64>`, so the convention is: pass a negative value (e.g.
+///   `-1.0`) to express "no timeout" (mirrors `Optional<Duration>::empty()`
+///   on the Java side). NaN / ±Infinity reject with -1. Finite-but-
+///   overflowing values (e.g. `f64::MAX`) reject with -1 via
+///   [`Duration::try_from_secs_f64`] — see `parse_ffi_timeout_secs`.
+/// - `out_event_json`: receives `*mut c_char` JSON string of the event
+///   on arrival, or a NULL pointer on clean timeout (in which case the
+///   return code is still 0). Caller frees via `mesh_free_string` when
+///   the pointer is non-null.
+///
+/// # Returns
+/// - `0` on success (event delivered OR clean timeout — caller checks
+///   if `*out_event_json` is null to distinguish)
+/// - `-1` on invalid args (null handle, malformed types_json, invalid
+///   timeout)
+/// - `-2` on JobNotFound (registry doesn't know the job — typically
+///   "404 Not Found" from `GET /jobs/{id}/events`). Distinct from the
+///   generic -3 so the Java SDK can map to a typed
+///   `JobNotFoundException`.
+/// - `-3` on other backend errors (5xx after retries, network failure,
+///   etc.). See `mesh_last_error` for details.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_controller_recv_event(
+    handle: *mut JobControllerHandle,
+    types_json: *const c_char,
+    timeout_secs: f64,
+    out_event_json: *mut *mut c_char,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    if out_event_json.is_null() {
+        set_last_error("out_event_json is null");
+        return -1;
+    }
+    // Default to empty so the success-path null-write is unambiguous
+    // (callers can treat a null out-pointer as "timeout elapsed").
+    *out_event_json = ptr::null_mut();
+    let handle = &*handle;
+
+    // Parse optional types filter — NULL → None (receive all); JSON array
+    // → Some(Vec<String>); anything else rejects.
+    let types_opt: Option<Vec<String>> = match opt_cstr(types_json, "types_json") {
+        Ok(None) => None,
+        Ok(Some(s)) => match serde_json::from_str::<serde_json::Value>(s) {
+            Ok(serde_json::Value::Null) => None,
+            Ok(serde_json::Value::Array(arr)) => {
+                let mut out = Vec::with_capacity(arr.len());
+                for v in arr {
+                    match v {
+                        serde_json::Value::String(s) => out.push(s),
+                        other => {
+                            set_last_error(format!(
+                                "types_json must be an array of strings, got element: {}",
+                                other
+                            ));
+                            return -1;
+                        }
+                    }
+                }
+                Some(out)
+            }
+            Ok(other) => {
+                set_last_error(format!(
+                    "types_json must be a JSON array or null, got: {}",
+                    other
+                ));
+                return -1;
+            }
+            Err(e) => {
+                set_last_error(format!("invalid types_json: {}", e));
+                return -1;
+            }
+        },
+        Err(()) => return -1,
+    };
+
+    let timeout = match parse_ffi_timeout_secs(timeout_secs) {
+        Ok(t) => t,
+        Err(msg) => {
+            set_last_error(msg);
+            return -1;
+        }
+    };
+
+    let inner = handle.inner.clone();
+    let result = jobs_runtime().block_on(async move { inner.recv_event(types_opt, timeout).await });
+    match result {
+        Ok(None) => {
+            // Clean timeout — leave out-pointer as null and return 0.
+            // Caller distinguishes "event arrived" from "timeout" by
+            // checking the out-pointer.
+            0
+        }
+        Ok(Some(ev)) => write_out_string(out_event_json, job_event_to_json_string(ev)),
+        Err(JobError::Backend(crate::task_backend::BackendError::NotFound(msg))) => {
+            set_last_error(format!("job not found: {}", msg));
+            -2
+        }
+        Err(e) => {
+            set_last_error(e.to_string());
+            -3
+        }
+    }
+}
+
 /// Read the job ID this controller is bound to. Caller frees the returned
 /// string via `mesh_free_string`.
 #[no_mangle]
@@ -716,6 +898,91 @@ pub unsafe extern "C" fn mesh_job_proxy_cancel(
     jobs_runtime().block_on(async move { inner.cancel(reason).await })
         .map(|_| 0)
         .unwrap_or_else(jobs_set_err)
+}
+
+/// Post an event into this job's event channel.
+///
+/// Mirrors [`JobProxy::send_event`]. The running handler (inside a
+/// `task=true` job) will see the event on its next `recv_event` call —
+/// or wake immediately if it's currently long-polling.
+///
+/// # Arguments
+/// - `event_type`: UTF-8 NUL-terminated event-type tag (e.g. `"signal"`,
+///   `"user_input"`).
+/// - `payload_json`: optional UTF-8 NUL-terminated JSON string encoding
+///   the event payload. May be `NULL` to send an empty payload (the
+///   Rust core treats null/missing as an empty JSON object — matching
+///   the Python/TS `payload=None` shape).
+/// - `out_receipt_json`: receives `*mut c_char` JSON string of the
+///   receipt (`{job_id, seq, created_at}`). Caller frees via
+///   `mesh_free_string`.
+///
+/// # Returns
+/// - `0` on success
+/// - `-1` on invalid args (null handle, malformed payload_json)
+/// - `-2` on JobNotFound (registry doesn't know the job — 404 from
+///   `POST /jobs/{id}/events`). Mapped by the Java SDK to
+///   `JobNotFoundException`.
+/// - `-3` on JobTerminal (job already completed/failed/cancelled — 409
+///   from the registry, surfaced as [`JobError::JobTerminal`]). Mapped
+///   by the Java SDK to `JobTerminalException`. Distinct from -2 so
+///   callers can branch on terminal-state vs. unknown-job.
+/// - `-4` on other backend errors (transport failure, 5xx after
+///   retries, etc.). See `mesh_last_error` for details.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_proxy_send_event(
+    handle: *mut JobProxyHandle,
+    event_type: *const c_char,
+    payload_json: *const c_char,
+    out_receipt_json: *mut *mut c_char,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    if out_receipt_json.is_null() {
+        set_last_error("out_receipt_json is null");
+        return -1;
+    }
+    let handle = &*handle;
+
+    let event_type = match req_cstr(event_type, "event_type") {
+        Ok(s) => s.to_string(),
+        Err(()) => return -1,
+    };
+
+    // NULL payload → empty object (matches Python's `payload=None` →
+    // `{}` normalization in `mesh.jobs.post_event`).
+    let payload: serde_json::Value = match opt_cstr(payload_json, "payload_json") {
+        Ok(None) => serde_json::Value::Object(serde_json::Map::new()),
+        Ok(Some(s)) => match serde_json::from_str(s) {
+            Ok(v) => v,
+            Err(e) => {
+                set_last_error(format!("invalid payload_json: {}", e));
+                return -1;
+            }
+        },
+        Err(()) => return -1,
+    };
+
+    let inner = handle.inner.clone();
+    let result = jobs_runtime().block_on(async move { inner.send_event(event_type, payload).await });
+    match result {
+        Ok(receipt) => write_out_string(out_receipt_json, job_event_receipt_to_json_string(receipt)),
+        Err(JobError::JobTerminal(msg)) => {
+            set_last_error(format!("job is terminal: {}", msg));
+            -3
+        }
+        Err(JobError::Backend(crate::task_backend::BackendError::NotFound(msg))) => {
+            set_last_error(format!("job not found: {}", msg));
+            -2
+        }
+        Err(e) => {
+            set_last_error(e.to_string());
+            -4
+        }
+    }
 }
 
 /// Free a [`JobProxyHandle`] returned by [`mesh_submit_job`] /
@@ -1197,6 +1464,75 @@ mod tests {
         // last-error slot should carry the diagnostic.
         let err = take_last_error();
         assert!(err.is_some(), "expected last_error to be populated");
+    }
+
+    /// `parse_ffi_timeout_secs` mirrors `parse_timeout_secs` in napi /
+    /// pyo3 bindings — same NaN/Inf/overflow rejection. The Java/FFI
+    /// twist is the negative-sentinel "no timeout" convention since C
+    /// ABI cannot pass a nullable double.
+    #[test]
+    fn parse_ffi_timeout_secs_negative_means_no_timeout() {
+        assert_eq!(parse_ffi_timeout_secs(-1.0).unwrap(), None);
+        assert_eq!(parse_ffi_timeout_secs(-0.5).unwrap(), None);
+        assert_eq!(parse_ffi_timeout_secs(f64::MIN).unwrap(), None);
+    }
+
+    #[test]
+    fn parse_ffi_timeout_secs_accepts_zero_and_positive() {
+        assert_eq!(
+            parse_ffi_timeout_secs(0.0).unwrap(),
+            Some(Duration::from_secs(0))
+        );
+        assert_eq!(
+            parse_ffi_timeout_secs(1.5).unwrap(),
+            Some(Duration::from_secs_f64(1.5))
+        );
+    }
+
+    #[test]
+    fn parse_ffi_timeout_secs_rejects_nan_and_infinity() {
+        assert!(parse_ffi_timeout_secs(f64::NAN).is_err());
+        assert!(parse_ffi_timeout_secs(f64::INFINITY).is_err());
+        assert!(parse_ffi_timeout_secs(f64::NEG_INFINITY).is_err());
+    }
+
+    #[test]
+    fn parse_ffi_timeout_secs_rejects_overflow() {
+        let err = parse_ffi_timeout_secs(f64::MAX).expect_err("overflow must reject");
+        assert!(err.contains("out of range"), "got: {err}");
+    }
+
+    /// `mesh_job_controller_recv_event` must reject null handle / null
+    /// out-ptr cleanly via the last-error slot rather than crashing.
+    #[test]
+    fn recv_event_rejects_null_handle() {
+        let mut out: *mut c_char = ptr::null_mut();
+        let rc = unsafe {
+            mesh_job_controller_recv_event(
+                ptr::null_mut(),
+                ptr::null(),
+                -1.0,
+                &mut out as *mut _,
+            )
+        };
+        assert_eq!(rc, -1);
+    }
+
+    /// `mesh_job_proxy_send_event` must reject null handle / null
+    /// out-ptr cleanly via the last-error slot rather than crashing.
+    #[test]
+    fn send_event_rejects_null_handle() {
+        let mut out: *mut c_char = ptr::null_mut();
+        let event_type = CString::new("signal").unwrap();
+        let rc = unsafe {
+            mesh_job_proxy_send_event(
+                ptr::null_mut(),
+                event_type.as_ptr(),
+                ptr::null(),
+                &mut out as *mut _,
+            )
+        };
+        assert_eq!(rc, -1);
     }
 
     /// `mesh_job_proxy_wait` with an overflowing finite timeout must

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
@@ -556,6 +556,38 @@ public interface MeshCore {
     int mesh_job_controller_is_cancelled(Pointer handle);
 
     /**
+     * Wait for the next event posted to this job's event channel
+     * (mirror of {@code JobController::recv_event} in the Rust core,
+     * issue #1032). Returns the event as a JSON string written to
+     * outEventJson; on a clean timeout writes a null pointer and
+     * returns 0.
+     *
+     * <p>The C ABI cannot pass a nullable double, so {@code timeoutSecs}
+     * uses a negative-sentinel convention: pass a negative value (e.g.
+     * {@code -1.0}) to express "no timeout" (mirrors Java's
+     * {@code Optional<Duration>::empty()} on the wrapper). NaN /
+     * Infinity / finite overflow (e.g. {@code Double.MAX_VALUE}) all
+     * reject with -1.
+     *
+     * @param handle         Controller handle
+     * @param typesJson      Optional JSON array of event-type strings to
+     *                       filter on (e.g. {@code ["signal","cancel"]});
+     *                       null or a JSON {@code null} means "all types"
+     * @param timeoutSecs    Wall-clock timeout in seconds; negative means
+     *                       "no timeout" (block until event arrives or
+     *                       cancellation fires)
+     * @param outEventJson   Out-param: receives the event JSON string
+     *                       (caller frees via mesh_free_string), or
+     *                       NULL on clean timeout
+     * @return 0 on success (event delivered OR clean timeout — distinguish
+     *         via whether {@code outEventJson} carries a non-null pointer),
+     *         -1 on invalid args, -2 on JobNotFound, -3 on other backend
+     *         errors (see {@link #mesh_last_error})
+     */
+    int mesh_job_controller_recv_event(
+        Pointer handle, String typesJson, double timeoutSecs, PointerByReference outEventJson);
+
+    /**
      * Read the job ID this controller is bound to.
      *
      * @param handle    Controller handle
@@ -635,6 +667,33 @@ public interface MeshCore {
      * @return 0 on success, -1 on error
      */
     int mesh_job_proxy_cancel(Pointer handle, String reason);
+
+    /**
+     * Post an event into this job's event channel (mirror of
+     * {@code JobProxy::send_event} in the Rust core, issue #1032).
+     * The running handler (inside a {@code task=true} job) will see
+     * the event on its next {@code recvEvent} call — or wake immediately
+     * if it's currently long-polling.
+     *
+     * @param handle           Proxy handle
+     * @param eventType        Event-type tag (e.g. {@code "signal"},
+     *                         {@code "user_input"}) — required, non-null
+     * @param payloadJson      Optional JSON-encoded payload (object,
+     *                         array, or scalar); null is treated as an
+     *                         empty JSON object {@code {}} matching the
+     *                         Python {@code payload=None} normalization
+     * @param outReceiptJson   Out-param: receives the receipt JSON
+     *                         string {@code {job_id, seq, created_at}}
+     *                         (caller frees via mesh_free_string)
+     * @return 0 on success, -1 on invalid args, -2 on JobNotFound,
+     *         -3 on JobTerminal (job already in a terminal state),
+     *         -4 on other backend errors (see {@link #mesh_last_error}).
+     *         Distinct error codes let the Java SDK map -2 and -3 to
+     *         typed {@code JobNotFoundException} /
+     *         {@code JobTerminalException}.
+     */
+    int mesh_job_proxy_send_event(
+        Pointer handle, String eventType, String payloadJson, PointerByReference outReceiptJson);
 
     /**
      * Free a JobProxy handle returned by mesh_submit_job / mesh_job_proxy_new.

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
@@ -328,6 +328,12 @@ public final class JobController implements MeshJob, AutoCloseable {
             timeoutSecs = secs < 0.0 ? -1.0 : secs;
         }
 
+        // Lock held for the full long-poll duration. Mirrors JobProxy.await()'s
+        // trade-off: concurrent isCancelled() / updateProgress() / complete()
+        // calls on the same JobController will block while recvEvent is parked.
+        // The fence is required for use-after-free safety across the FFI
+        // boundary (handle pointer must not be freed mid-call). See PR #891
+        // for the original rationale on the wait/await side.
         Pointer p;
         synchronized (lock) {
             ensureOpen();

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
@@ -9,6 +9,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tools.jackson.databind.ObjectMapper;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -256,6 +259,109 @@ public final class JobController implements MeshJob, AutoCloseable {
                 throw new MeshException("mesh_job_controller_is_cancelled failed: " + lastError(core));
             }
             return rc == 1;
+        }
+    }
+
+    /**
+     * Wait for the next event posted to this job's event channel
+     * (mirror of {@code JobController::recv_event} in the Rust core,
+     * issue #1032). Returns the event payload as a {@code Map<String,
+     * Object>} on arrival, or {@code null} on a clean timeout.
+     *
+     * <p>The cursor is per-controller-instance (shared across handle
+     * copies); a fresh controller for the same {@code jobId} replays
+     * from seq=0.
+     *
+     * <p>Mirrors:
+     * <ul>
+     *   <li>Python {@code job.recv_event(types=..., timeout_secs=...)}</li>
+     *   <li>TypeScript {@code job.recvEvent(types, timeoutSecs)}</li>
+     * </ul>
+     *
+     * @param types   Optional list of event-type tags to filter on
+     *                (e.g. {@code List.of("signal","cancel")}); {@code null}
+     *                or empty means "receive all types".
+     * @param timeout Optional max wait. {@code null} means block until
+     *                an event arrives or the enclosing cancel token
+     *                fires (internally bridged to FFI's negative-
+     *                sentinel "no timeout" convention since the C ABI
+     *                cannot pass {@code null} doubles). Negative
+     *                durations behave like {@code null}.
+     * @return Event map with fields {@code job_id, seq, type, payload,
+     *         trace_context, posted_by, created_at}; or {@code null} if
+     *         the timeout elapsed without a matching event.
+     * @throws JobNotFoundException if the job has been deleted from the
+     *                              registry (or never existed)
+     * @throws MeshException        for transport errors after retry
+     *                              exhaustion, or invalid arguments
+     *                              (NaN/Infinity timeout, etc.)
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> recvEvent(List<String> types, Duration timeout) {
+        // Serialize the types filter OUTSIDE the lock — Jackson is
+        // thread-safe and the list is typically short, but keeping
+        // user-data work off the FFI critical section matches the
+        // pattern used by complete()/wait().
+        String typesJson;
+        if (types == null || types.isEmpty()) {
+            // null on the Java side → null pointer on the FFI side →
+            // "receive all types" in the Rust core. Don't serialize an
+            // empty list — the wire shape uses null/missing as the
+            // "all types" sentinel (matches Python's
+            // recv_event(types=None) and TS's recvEvent(undefined, ...)).
+            typesJson = null;
+        } else {
+            try {
+                typesJson = MAPPER.writeValueAsString(types);
+            } catch (Exception e) {
+                throw new MeshException("Failed to serialize types filter", e);
+            }
+        }
+        // Bridge Optional<Duration> to the FFI's negative-sentinel
+        // convention. Treat null AND negative as "no timeout" so the
+        // boundary matches Python/TS Optional<float>/Optional<number>.
+        double timeoutSecs;
+        if (timeout == null) {
+            timeoutSecs = -1.0;
+        } else {
+            double secs = timeout.toNanos() / 1_000_000_000.0;
+            timeoutSecs = secs < 0.0 ? -1.0 : secs;
+        }
+
+        Pointer p;
+        synchronized (lock) {
+            ensureOpen();
+            PointerByReference out = new PointerByReference();
+            int rc = core.mesh_job_controller_recv_event(handle, typesJson, timeoutSecs, out);
+            String err = rc == 0 ? null : lastError(core);
+            switch (rc) {
+                case 0:
+                    // Success — out may carry the event JSON or NULL on
+                    // clean timeout.
+                    p = out.getValue();
+                    break;
+                case -2:
+                    throw new JobNotFoundException(
+                        "mesh_job_controller_recv_event: job not found: " + err);
+                case -1:
+                default:
+                    // -1 = invalid args; -3 = backend error; any other
+                    // value is treated as a generic backend failure.
+                    throw new MeshException(
+                        "mesh_job_controller_recv_event failed (rc=" + rc + "): " + err);
+            }
+        }
+        if (p == null) {
+            // Clean timeout — caller distinguishes by the null return.
+            return null;
+        }
+        try {
+            String json = p.getString(0);
+            return (Map<String, Object>) MAPPER.readValue(json, Map.class);
+        } catch (Exception e) {
+            throw new MeshException("Failed to parse recv_event JSON", e);
+        } finally {
+            core.mesh_free_string(p);
         }
     }
 

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobNotFoundException.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobNotFoundException.java
@@ -1,0 +1,31 @@
+package io.mcpmesh;
+
+import io.mcpmesh.core.MeshException;
+
+/**
+ * The targeted job does not exist (or has been swept) in the registry.
+ *
+ * <p>Translated from the Rust core's {@code JobError::Other(BackendError::NotFound)}
+ * error path (HTTP 404 from {@code GET}/{@code POST /jobs/{id}/events}).
+ *
+ * <p>Mirrors:
+ * <ul>
+ *   <li>Python {@code mesh.jobs.JobNotFoundError}</li>
+ *   <li>TypeScript {@code JobNotFoundError}</li>
+ * </ul>
+ *
+ * <p>Extends {@link MeshException} so existing {@code catch (MeshException ...)}
+ * handlers continue to catch this; callers that want to branch on
+ * job-not-found vs. transport failure should catch this subclass
+ * specifically.
+ */
+public final class JobNotFoundException extends MeshException {
+
+    public JobNotFoundException(String message) {
+        super(message);
+    }
+
+    public JobNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobNotFoundException.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobNotFoundException.java
@@ -5,7 +5,7 @@ import io.mcpmesh.core.MeshException;
 /**
  * The targeted job does not exist (or has been swept) in the registry.
  *
- * <p>Translated from the Rust core's {@code JobError::Other(BackendError::NotFound)}
+ * <p>Translated from the Rust core's {@code JobError::Backend(BackendError::NotFound)}
  * error path (HTTP 404 from {@code GET}/{@code POST /jobs/{id}/events}).
  *
  * <p>Mirrors:

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobProxy.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobProxy.java
@@ -200,6 +200,90 @@ public final class JobProxy implements MeshJob, AutoCloseable {
         }
     }
 
+    /**
+     * Post an event into this job's event channel (mirror of
+     * {@code JobProxy::send_event} in the Rust core, issue #1032).
+     * The running handler (inside a {@code task=true} job) will see
+     * the event on its next {@code recvEvent} call — or wake immediately
+     * if it's currently long-polling.
+     *
+     * <p>Mirrors:
+     * <ul>
+     *   <li>Python {@code proxy.send_event(event_type, payload)}</li>
+     *   <li>TypeScript {@code proxy.sendEvent(eventType, payload)}</li>
+     * </ul>
+     *
+     * @param eventType Event-type tag (required, non-null)
+     * @param payload   Optional payload Map; {@code null} normalises to
+     *                  an empty JSON object {@code {}} matching the
+     *                  Python {@code payload=None} contract
+     * @return Receipt map with {@code job_id, seq, created_at} so
+     *         callers can stitch a follow-up {@code recvEvent} via
+     *         {@code seq}.
+     * @throws JobNotFoundException if the registry doesn't know the
+     *                              job (404 from {@code POST /jobs/{id}/events})
+     * @throws JobTerminalException if the job has already reached a
+     *                              terminal state — no more events
+     *                              accepted (409 from the registry)
+     * @throws MeshException        for transport errors, serialization
+     *                              failures, or other backend issues
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> sendEvent(String eventType, Map<String, Object> payload) {
+        if (eventType == null || eventType.isEmpty()) {
+            throw new IllegalArgumentException("eventType is required");
+        }
+        // Serialize OUTSIDE the lock — keep FFI critical section short.
+        String payloadJson;
+        if (payload == null) {
+            // null → null pointer at the FFI boundary → Rust treats as
+            // {} (matches Python's `payload=None` → empty-dict
+            // normalisation in `mesh.jobs.post_event`).
+            payloadJson = null;
+        } else {
+            try {
+                payloadJson = MAPPER.writeValueAsString(payload);
+            } catch (Exception e) {
+                throw new MeshException("Failed to serialize event payload", e);
+            }
+        }
+
+        Pointer p;
+        synchronized (lock) {
+            ensureOpen();
+            PointerByReference out = new PointerByReference();
+            int rc = core.mesh_job_proxy_send_event(handle, eventType, payloadJson, out);
+            String err = rc == 0 ? null : lastError(core);
+            switch (rc) {
+                case 0:
+                    p = out.getValue();
+                    break;
+                case -2:
+                    throw new JobNotFoundException(
+                        "mesh_job_proxy_send_event: job not found: " + err);
+                case -3:
+                    throw new JobTerminalException(
+                        "mesh_job_proxy_send_event: job is terminal: " + err);
+                case -1:
+                case -4:
+                default:
+                    throw new MeshException(
+                        "mesh_job_proxy_send_event failed (rc=" + rc + "): " + err);
+            }
+        }
+        if (p == null) {
+            throw new MeshException("mesh_job_proxy_send_event returned null receipt");
+        }
+        try {
+            String json = p.getString(0);
+            return (Map<String, Object>) MAPPER.readValue(json, Map.class);
+        } catch (Exception e) {
+            throw new MeshException("Failed to parse send_event receipt JSON", e);
+        } finally {
+            core.mesh_free_string(p);
+        }
+    }
+
     /** Free the underlying native handle. Idempotent. */
     @Override
     public void close() {

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobTerminalException.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobTerminalException.java
@@ -1,0 +1,33 @@
+package io.mcpmesh;
+
+import io.mcpmesh.core.MeshException;
+
+/**
+ * The targeted job is in a terminal state (completed / failed /
+ * cancelled) and no longer accepts events.
+ *
+ * <p>Translated from the Rust {@code JobError::JobTerminal} variant —
+ * {@code POST /jobs/{id}/events} returns HTTP 409 once the row is
+ * terminal, and the Rust layer maps that to {@code JobTerminal}.
+ *
+ * <p>Mirrors:
+ * <ul>
+ *   <li>Python {@code mesh.jobs.JobTerminalError}</li>
+ *   <li>TypeScript {@code JobTerminalError}</li>
+ * </ul>
+ *
+ * <p>Extends {@link MeshException} so existing {@code catch (MeshException ...)}
+ * handlers continue to catch this; callers that want to branch on
+ * terminal-state vs. unknown-job vs. transport failure should catch
+ * this subclass specifically.
+ */
+public final class JobTerminalException extends MeshException {
+
+    public JobTerminalException(String message) {
+        super(message);
+    }
+
+    public JobTerminalException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJobs.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJobs.java
@@ -1,0 +1,226 @@
+package io.mcpmesh;
+
+import io.mcpmesh.core.MeshException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Convenience helpers for the MeshJob event-injection primitive
+ * (issue #1032). Static-only utility class — mirror of:
+ * <ul>
+ *   <li>Python {@code mesh.jobs} module ({@code mesh.jobs.post_event})</li>
+ *   <li>TypeScript {@code mesh.jobs} namespace ({@code mesh.jobs.postEvent})</li>
+ * </ul>
+ *
+ * <p>The primary surface is {@link #postEvent(String, String, Map)} —
+ * a fire-and-forget helper that lets tool bodies post events to running
+ * jobs without holding a {@link JobProxy} reference. Constructs (or
+ * looks up from the process-wide LRU cache) a proxy bound to the
+ * current agent's registry URL and forwards the call.
+ *
+ * <p>The {@link JobController#recvEvent(java.util.List, java.time.Duration)}
+ * and {@link JobProxy#sendEvent(String, Map)} methods are the lower-level
+ * primitives; this class is the small layer on top that takes care of
+ * registry URL discovery + proxy caching.
+ */
+public final class MeshJobs {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshJobs.class);
+
+    /**
+     * Default cap for the process-wide {@code JobProxy} LRU cache.
+     * Matches the Python/TS defaults exactly so cross-runtime tests
+     * exercise identical eviction behavior. Override via the
+     * {@code MCP_MESH_JOBPROXY_CACHE_MAX} environment variable.
+     */
+    private static final int PROXY_CACHE_DEFAULT_MAX = 256;
+
+    /**
+     * Process-wide LRU cache of {@link JobProxy} instances keyed by
+     * {@code (registryUrl, jobId)}.
+     *
+     * <p>{@code postEvent} would otherwise construct a fresh proxy on
+     * every call. Each proxy wraps a Rust {@code reqwest::Client} with
+     * its own connection pool, so a steady-state sender firing
+     * {@code postEvent} in a hot loop would force a fresh TCP/TLS
+     * handshake against the registry on every call. Cache by
+     * {@code (registryUrl, jobId)} for the process lifetime.
+     *
+     * <p>If a job is cancelled and re-submitted with the same id (rare
+     * in practice), the cached proxy would just see a
+     * {@link JobTerminalException} on its next sendEvent call — the
+     * correct surface — and the caller can retry.
+     *
+     * <p><b>Implementation</b>: {@link LinkedHashMap} with
+     * {@code accessOrder=true} for O(1) LRU semantics. Wrapped in
+     * {@code synchronized} blocks because {@code LinkedHashMap} is NOT
+     * thread-safe (even read access mutates the recency order under
+     * access-order mode). The cache is a process resource — the
+     * synchronisation overhead is negligible compared to the
+     * eliminated FFI handshake cost.
+     */
+    private static final Object cacheLock = new Object();
+    private static final LinkedHashMap<CacheKey, JobProxy> proxyCache =
+        new LinkedHashMap<CacheKey, JobProxy>(16, 0.75f, /*accessOrder=*/true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<CacheKey, JobProxy> eldest) {
+                // Bound the cache so a long-lived sender posting events
+                // to many distinct jobs can't grow it without limit.
+                // Closing the evicted proxy frees the underlying FFI
+                // handle's reqwest::Client connection pool — without
+                // close(), the native handle would leak until GC ran
+                // (and GC of off-heap-backed objects is unpredictable).
+                int max = proxyCacheMax();
+                if (size() > max) {
+                    try {
+                        eldest.getValue().close();
+                    } catch (RuntimeException e) {
+                        log.warn("Failed to close evicted JobProxy for {}: {}",
+                            eldest.getKey(), e.getMessage());
+                    }
+                    return true;
+                }
+                return false;
+            }
+        };
+
+    private MeshJobs() {
+        // Utility class — no instances.
+    }
+
+    /**
+     * Post an event to a running job by ID. Convenience helper for tool
+     * bodies that hold a {@code jobId} (e.g. from a request body, a
+     * token lookup, or a stashed reference) but do NOT have a
+     * {@link JobProxy} reference in scope.
+     *
+     * <p>The registry URL is discovered from the
+     * {@code MCP_MESH_REGISTRY_URL} environment variable — the
+     * configuration pipeline writes this on agent startup, matching
+     * the convention used by every other job-substrate code path.
+     *
+     * <p>Cached proxies: this method caches one {@link JobProxy}
+     * instance per {@code (registryUrl, jobId)} pair for the process
+     * lifetime, eliminating the per-call FFI handshake cost. Override
+     * the cap via {@code MCP_MESH_JOBPROXY_CACHE_MAX}.
+     *
+     * @param jobId     Target job's server-assigned ID
+     * @param eventType Event-type tag (e.g. {@code "user_input"},
+     *                  {@code "extend_deadline"})
+     * @param payload   Optional payload; {@code null} normalises to
+     *                  an empty JSON object {@code {}}
+     * @return Receipt map with {@code job_id, seq, created_at}
+     * @throws JobNotFoundException if the registry doesn't know the job
+     * @throws JobTerminalException if the job is already terminal
+     * @throws MeshException        for transport errors or missing
+     *                              {@code MCP_MESH_REGISTRY_URL}
+     */
+    public static Map<String, Object> postEvent(
+            String jobId, String eventType, Map<String, Object> payload) {
+        if (jobId == null || jobId.isEmpty()) {
+            throw new IllegalArgumentException("jobId is required");
+        }
+        if (eventType == null || eventType.isEmpty()) {
+            throw new IllegalArgumentException("eventType is required");
+        }
+        String registryUrl = resolveRegistryUrl();
+        JobProxy proxy = getOrCreateProxy(registryUrl, jobId);
+        return proxy.sendEvent(eventType, payload);
+    }
+
+    /**
+     * Discover the registry base URL the running agent is bound to.
+     * Mirrors the {@code MCP_MESH_REGISTRY_URL} convention used by
+     * Python's {@code _resolve_registry_url} and TypeScript's
+     * {@code resolveRegistryUrl}.
+     */
+    static String resolveRegistryUrl() {
+        String url = System.getenv("MCP_MESH_REGISTRY_URL");
+        if (url == null || url.isEmpty()) {
+            throw new MeshException(
+                "MeshJobs.postEvent: MCP_MESH_REGISTRY_URL is not set; "
+                    + "cannot resolve registry base URL. Ensure the calling "
+                    + "process is running inside a mesh agent.");
+        }
+        return url;
+    }
+
+    /**
+     * Resolve the LRU cache cap from {@code MCP_MESH_JOBPROXY_CACHE_MAX}
+     * (env override; falls back to {@link #PROXY_CACHE_DEFAULT_MAX}).
+     * Invalid / non-positive values fall back to the default so a
+     * typo'd env doesn't silently disable the cache.
+     */
+    static int proxyCacheMax() {
+        String raw = System.getenv("MCP_MESH_JOBPROXY_CACHE_MAX");
+        if (raw == null || raw.isEmpty()) {
+            return PROXY_CACHE_DEFAULT_MAX;
+        }
+        try {
+            int value = Integer.parseInt(raw);
+            return value > 0 ? value : PROXY_CACHE_DEFAULT_MAX;
+        } catch (NumberFormatException e) {
+            return PROXY_CACHE_DEFAULT_MAX;
+        }
+    }
+
+    /**
+     * Return a process-cached {@link JobProxy} for the given
+     * {@code (registryUrl, jobId)} pair, constructing one on first
+     * miss. Hit bumps the entry to the most-recent end (LRU); misses
+     * on a full cache evict the least-recent entry via
+     * {@code removeEldestEntry}.
+     *
+     * <p>Package-private for tests.
+     */
+    static JobProxy getOrCreateProxy(String registryUrl, String jobId) {
+        CacheKey key = new CacheKey(registryUrl, jobId);
+        synchronized (cacheLock) {
+            JobProxy cached = proxyCache.get(key);
+            if (cached != null) {
+                return cached;
+            }
+            JobProxy proxy = JobProxy.open(jobId, registryUrl);
+            // put() will trigger removeEldestEntry if we're over cap.
+            proxyCache.put(key, proxy);
+            return proxy;
+        }
+    }
+
+    /**
+     * Drop all cached proxies. Test-only — closes each evicted proxy
+     * so a subsequent test starts from a clean cache state.
+     */
+    static void clearProxyCacheForTest() {
+        synchronized (cacheLock) {
+            for (JobProxy p : proxyCache.values()) {
+                try {
+                    p.close();
+                } catch (RuntimeException ignored) {
+                    // Test cleanup — swallow.
+                }
+            }
+            proxyCache.clear();
+        }
+    }
+
+    /**
+     * Current cache size — test-only.
+     */
+    static int cacheSizeForTest() {
+        synchronized (cacheLock) {
+            return proxyCache.size();
+        }
+    }
+
+    /**
+     * Composite cache key. {@code record} keeps {@code equals}/
+     * {@code hashCode} implementations honest and is non-null-safe by
+     * construction — both fields are validated in
+     * {@link #postEvent(String, String, Map)} before this is constructed.
+     */
+    record CacheKey(String registryUrl, String jobId) {}
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/JobEventApiTest.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/JobEventApiTest.java
@@ -1,0 +1,102 @@
+package io.mcpmesh;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Surface-shape tests for {@link JobController#recvEvent(List, Duration)}
+ * and {@link JobProxy#sendEvent(String, Map)} (issue #1032). These tests
+ * cover the public API signatures and arg-validation paths that DON'T
+ * require a live FFI handle.
+ *
+ * <p>The full FFI round-trip (recv_event → backend HTTP, send_event →
+ * backend HTTP, JobNotFound/JobTerminal classification) is exercised in
+ * the integration suite (uc23_meshjob_java/tc24–tc26) which spins up a
+ * real registry and two real Java agents.
+ *
+ * <p>This file complements {@link MeshJobsTest} which covers the
+ * static helper + cache layer.
+ */
+class JobEventApiTest {
+
+    /**
+     * {@link JobController#recvEvent} must be a public instance method
+     * accepting {@code (List<String>, Duration)} and returning
+     * {@code Map<String, Object>}. Pinning the contract here means a
+     * future refactor that accidentally changes the signature breaks
+     * compilation rather than silently diverging from Python/TS.
+     */
+    @Test
+    void jobController_recvEvent_hasExpectedSignature() throws NoSuchMethodException {
+        Method m = JobController.class.getMethod("recvEvent", List.class, Duration.class);
+        assertEquals(Map.class, m.getReturnType());
+        assertTrue(java.lang.reflect.Modifier.isPublic(m.getModifiers()));
+        // Throws clause should be empty (we throw RuntimeException
+        // subclasses), so the method declares no checked exceptions.
+        assertEquals(0, m.getExceptionTypes().length,
+            "recvEvent must not declare checked exceptions");
+    }
+
+    /**
+     * {@link JobProxy#sendEvent} must be public, accept
+     * {@code (String, Map)}, and return {@code Map<String, Object>}.
+     */
+    @Test
+    void jobProxy_sendEvent_hasExpectedSignature() throws NoSuchMethodException {
+        Method m = JobProxy.class.getMethod("sendEvent", String.class, Map.class);
+        assertEquals(Map.class, m.getReturnType());
+        assertTrue(java.lang.reflect.Modifier.isPublic(m.getModifiers()));
+        assertEquals(0, m.getExceptionTypes().length,
+            "sendEvent must not declare checked exceptions");
+    }
+
+    /**
+     * {@link MeshJobs#postEvent} must be public + static, accept
+     * {@code (String, String, Map)}, and return {@code Map<String, Object>}.
+     */
+    @Test
+    void meshJobs_postEvent_hasExpectedSignature() throws NoSuchMethodException {
+        Method m = MeshJobs.class.getMethod("postEvent", String.class, String.class, Map.class);
+        assertEquals(Map.class, m.getReturnType());
+        assertTrue(java.lang.reflect.Modifier.isPublic(m.getModifiers()));
+        assertTrue(java.lang.reflect.Modifier.isStatic(m.getModifiers()),
+            "postEvent must be a static helper");
+        assertEquals(0, m.getExceptionTypes().length);
+    }
+
+    /**
+     * Typed exception inheritance: both must extend MeshException so
+     * existing {@code catch (MeshException ...)} handlers keep working
+     * (mirrors Python's {@code RuntimeError} subclassing pattern).
+     */
+    @Test
+    void jobNotFoundException_isMeshException() {
+        JobNotFoundException e = new JobNotFoundException("missing");
+        assertTrue(e instanceof io.mcpmesh.core.MeshException);
+    }
+
+    @Test
+    void jobTerminalException_isMeshException() {
+        JobTerminalException e = new JobTerminalException("done");
+        assertTrue(e instanceof io.mcpmesh.core.MeshException);
+    }
+
+    /**
+     * Cause-chaining works on both typed exceptions (matches the
+     * {@code MeshException(String, Throwable)} ctor pattern).
+     */
+    @Test
+    void typedExceptions_supportCauseChaining() {
+        Throwable cause = new RuntimeException("root");
+        JobNotFoundException nf = new JobNotFoundException("wrap", cause);
+        assertSame(cause, nf.getCause());
+        JobTerminalException term = new JobTerminalException("wrap", cause);
+        assertSame(cause, term.getCause());
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/MeshJobsTest.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/MeshJobsTest.java
@@ -230,6 +230,64 @@ class MeshJobsTest {
     }
 
     /**
+     * Direct eviction-path coverage: populate the cache past the default
+     * cap of 256 and verify that {@code removeEldestEntry} fires —
+     * (a) cache size stays bounded at the cap,
+     * (b) the evicted {@link JobProxy} has {@code close()} called (its
+     *     {@code toString()} reports {@code closed=true}), and
+     * (c) re-fetching the evicted key constructs a NEW proxy instance.
+     *
+     * <p>The companion {@link #getOrCreateProxy_cacheGrowsUpToCap()}
+     * exercises only the pre-eviction growth path; this test exercises
+     * the resource-cleanup guarantee (the {@code JobProxy.close()} call
+     * inside {@code removeEldestEntry}) that the growth-only test
+     * cannot reach.
+     *
+     * <p>Mirrors the Python {@code test_meshjob_events.py} and TypeScript
+     * {@code jobs.spec.ts} LRU-eviction tests. Those runtimes can mutate
+     * their env at test time (pytest's {@code monkeypatch.setenv} /
+     * mutating {@code process.env}); the JVM's env table is effectively
+     * read-only without {@code --add-opens java.base/java.lang}, so we
+     * exercise the eviction path at the default cap (256) instead of
+     * lowering it to 2. The eviction logic is identical at any cap —
+     * what matters is that {@code removeEldestEntry} fires and that
+     * {@code JobProxy.close()} is invoked on the evicted entry. 257
+     * lightweight FFI proxy allocations stay well under 1 second.
+     */
+    @Test
+    void getOrCreateProxy_evictsLruAndClosesProxyAtCap() {
+        int cap = MeshJobs.proxyCacheMax();
+        // Insert the LRU sentinel first — this entry will be the
+        // least-recently-used after we populate the cache to the cap.
+        JobProxy lru = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "job-lru");
+        assertFalse(lru.toString().contains("closed=true"),
+            "freshly constructed proxy must not be closed");
+        // Fill the cache to its cap; each new insert pushes job-lru
+        // further from the most-recent end.
+        for (int i = 0; i < cap - 1; i++) {
+            MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "filler-" + i);
+        }
+        assertEquals(cap, MeshJobs.cacheSizeForTest(),
+            "cache should be exactly at cap before the eviction-triggering put");
+        // One more insert — this is the put that overflows and triggers
+        // removeEldestEntry, which closes the LRU and drops it from the map.
+        JobProxy overflow = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "overflow");
+        assertEquals(cap, MeshJobs.cacheSizeForTest(),
+            "cache must stay bounded at cap after overflow");
+        // The eldest (job-lru) must have been close()d by removeEldestEntry.
+        assertTrue(lru.toString().contains("closed=true"),
+            "evicted JobProxy must have close() called by removeEldestEntry; "
+                + "toString reported: " + lru.toString());
+        // overflow itself is still open — only the eldest is evicted.
+        assertFalse(overflow.toString().contains("closed=true"));
+        // Re-fetching the evicted key constructs a NEW proxy instance —
+        // the original was dropped from the cache.
+        JobProxy refetch = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "job-lru");
+        assertNotSame(lru, refetch,
+            "re-fetching the evicted key must construct a new proxy instance");
+    }
+
+    /**
      * Smoke check: postEvent's argument validation runs BEFORE the
      * registry URL resolution. A caller passing an invalid jobId must
      * see the IllegalArgumentException regardless of MCP_MESH_REGISTRY_URL.

--- a/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/MeshJobsTest.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/MeshJobsTest.java
@@ -1,0 +1,247 @@
+package io.mcpmesh;
+
+import io.mcpmesh.core.MeshException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link MeshJobs} — the static {@code postEvent} helper +
+ * the LRU proxy cache. Mirrors the Python {@code jobs_test.py} and
+ * TypeScript {@code jobs.spec.ts} coverage:
+ *
+ * <ul>
+ *   <li>{@code MCP_MESH_REGISTRY_URL} unset → clean error (no NPE)</li>
+ *   <li>arg validation (null/empty jobId, null/empty eventType)</li>
+ *   <li>cache hit returns the same proxy instance for repeated calls</li>
+ *   <li>cache miss on a different jobId allocates a new instance</li>
+ *   <li>LRU eviction when the cache exceeds {@code MCP_MESH_JOBPROXY_CACHE_MAX}</li>
+ * </ul>
+ *
+ * <p>The full FFI send-event round-trip (recv_event / send_event /
+ * JobNotFound / JobTerminal exceptions) is exercised in the integration
+ * suite (uc23_meshjob_java/tc24–tc26) because it needs a live registry.
+ * Mocking the FFI layer here would require subclassing the JNR-FFI
+ * binding — not a pattern this codebase uses; integration tests are
+ * the canonical cover.
+ *
+ * <p>The cache tests reach the {@code getOrCreateProxy} entry point
+ * which DOES construct a {@link JobProxy} via {@code JobProxy.open}.
+ * That construction is harmless without a live registry — the proxy
+ * holds a registry URL string but doesn't make any HTTP calls until
+ * {@code sendEvent} is invoked. We close each constructed proxy after
+ * the test to drop the underlying FFI handle.
+ */
+class MeshJobsTest {
+
+    private static final String FAKE_REGISTRY = "http://localhost:0/no-such";
+
+    @BeforeEach
+    void clearCache() {
+        MeshJobs.clearProxyCacheForTest();
+    }
+
+    @AfterEach
+    void clearCacheAfter() {
+        MeshJobs.clearProxyCacheForTest();
+    }
+
+    @Test
+    void postEvent_rejectsNullJobId() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.postEvent(null, "signal", null));
+        assertTrue(e.getMessage().toLowerCase().contains("jobid"),
+            "error should mention jobId; got: " + e.getMessage());
+    }
+
+    @Test
+    void postEvent_rejectsEmptyJobId() {
+        assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.postEvent("", "signal", null));
+    }
+
+    @Test
+    void postEvent_rejectsNullEventType() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.postEvent("j-1", null, null));
+        assertTrue(e.getMessage().toLowerCase().contains("eventtype"),
+            "error should mention eventType; got: " + e.getMessage());
+    }
+
+    @Test
+    void postEvent_rejectsEmptyEventType() {
+        assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.postEvent("j-1", "", null));
+    }
+
+    /**
+     * {@code MCP_MESH_REGISTRY_URL} unset must surface a clean
+     * MeshException with a useful message. Mirrors the Python
+     * {@code _resolve_registry_url} and TS {@code resolveRegistryUrl}
+     * error path.
+     *
+     * <p>Note: we can't easily unset the env var on the live process
+     * here, so we drive {@code resolveRegistryUrl()} directly. The env
+     * is preserved on entry/exit; if it's already unset, this exercises
+     * the actual unset path; if set, we skip with a clean message.
+     */
+    @Test
+    void resolveRegistryUrl_failsCleanlyWhenEnvUnset() {
+        String existing = System.getenv("MCP_MESH_REGISTRY_URL");
+        if (existing != null && !existing.isEmpty()) {
+            // CI / dev shell already exports the env — can't directly
+            // assert the unset path. We DO assert that resolveRegistryUrl
+            // returns the same value (sanity check) so the test stays
+            // useful in both shells.
+            assertEquals(existing, MeshJobs.resolveRegistryUrl());
+            return;
+        }
+        MeshException e = assertThrows(MeshException.class,
+            MeshJobs::resolveRegistryUrl);
+        assertTrue(e.getMessage().contains("MCP_MESH_REGISTRY_URL"),
+            "error should reference the env var name; got: " + e.getMessage());
+    }
+
+    /**
+     * Cache hit: a second {@code getOrCreateProxy} call for the same
+     * key MUST return the same {@link JobProxy} instance — proves the
+     * LRU lookup short-circuits before reconstructing the proxy. This
+     * is the cache's reason for existence.
+     */
+    @Test
+    void getOrCreateProxy_returnsSameInstanceForRepeatedKey() {
+        JobProxy first = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "job-A");
+        JobProxy second = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "job-A");
+        assertSame(first, second,
+            "second call with the same key must return the cached instance");
+        assertEquals(1, MeshJobs.cacheSizeForTest(),
+            "cache should hold exactly one entry");
+    }
+
+    /**
+     * Cache miss on a distinct jobId allocates a new proxy. The cache
+     * MUST then carry both entries.
+     */
+    @Test
+    void getOrCreateProxy_distinctJobIdsAreCachedIndependently() {
+        JobProxy a = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "job-A");
+        JobProxy b = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "job-B");
+        assertNotSame(a, b, "distinct jobIds must yield distinct proxies");
+        assertEquals(2, MeshJobs.cacheSizeForTest());
+    }
+
+    /**
+     * Cache miss on a distinct registryUrl ALSO allocates a new proxy
+     * (the cache is keyed on the pair, not just jobId). This matters
+     * for multi-registry setups (e.g. agent rebinding mid-process).
+     */
+    @Test
+    void getOrCreateProxy_distinctRegistryUrlsAreCachedIndependently() {
+        JobProxy a = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "job-A");
+        JobProxy b = MeshJobs.getOrCreateProxy("http://example.org/registry", "job-A");
+        assertNotSame(a, b);
+        assertEquals(2, MeshJobs.cacheSizeForTest());
+    }
+
+    /**
+     * LRU eviction: when the cache exceeds {@code MCP_MESH_JOBPROXY_CACHE_MAX},
+     * the least-recently-used entry MUST be dropped. This test sets the
+     * cap to 2 via a system-level env-var trick: we can't mutate the
+     * process env table portably across JDKs, so we exercise the cap
+     * indirectly by feeding the default cap of 256 a smaller number of
+     * entries and confirming size monotonically grows up to the cap.
+     *
+     * <p>A direct eviction test would need to either set the env at
+     * launch (via Surefire's {@code <environmentVariables>}) or
+     * reflect into {@link System#getenv()} (fragile). We instead test
+     * the eviction policy via {@code proxyCacheMax()} env parsing +
+     * size-grows behaviour — the eviction logic itself is the
+     * {@link java.util.LinkedHashMap} default which is well-tested in
+     * the JDK.
+     */
+    @Test
+    void getOrCreateProxy_cacheGrowsUpToCap() {
+        for (int i = 0; i < 5; i++) {
+            MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "job-" + i);
+        }
+        assertEquals(5, MeshJobs.cacheSizeForTest(),
+            "default cap is 256 — 5 entries must all fit");
+    }
+
+    /**
+     * {@code proxyCacheMax} fallback when env is unset or invalid —
+     * confirms a typo'd / missing env doesn't silently disable the cache.
+     */
+    @Test
+    void proxyCacheMax_fallsBackOnUnsetOrInvalidEnv() {
+        // We can't portably mutate the env table here; we rely on the
+        // CI shell NOT exporting MCP_MESH_JOBPROXY_CACHE_MAX in the
+        // test environment (matches the Python / TS test setup).
+        // If the env IS set, this test just confirms the helper returns
+        // SOMETHING positive.
+        int cap = MeshJobs.proxyCacheMax();
+        assertTrue(cap > 0, "cache cap must always be positive; got " + cap);
+        // The default is 256; if the env override is unset, we should
+        // see the default. (If a CI env override is in play we skip the
+        // strict-equality check.)
+        String env = System.getenv("MCP_MESH_JOBPROXY_CACHE_MAX");
+        if (env == null || env.isEmpty()) {
+            assertEquals(256, cap, "default cap should be 256 when env unset");
+        }
+    }
+
+    /**
+     * The {@code MeshJobs} class is intended as a static-only utility —
+     * its constructor must be private so callers can't instantiate it.
+     * (Defence-in-depth; lints would catch this, but the test pins the
+     * contract.)
+     */
+    @Test
+    void meshJobs_isUtilityClass() {
+        java.lang.reflect.Constructor<?>[] ctors = MeshJobs.class.getDeclaredConstructors();
+        assertEquals(1, ctors.length, "exactly one ctor expected");
+        assertTrue(java.lang.reflect.Modifier.isPrivate(ctors[0].getModifiers()),
+            "ctor must be private");
+    }
+
+    /**
+     * Type-tag and instance-of checks for the typed exception hierarchy —
+     * verifies {@link JobNotFoundException} and {@link JobTerminalException}
+     * both extend {@link MeshException}, so existing
+     * {@code catch (MeshException ...)} handlers continue to catch them.
+     */
+    @Test
+    void typedExceptions_extendMeshException() {
+        JobNotFoundException nf = new JobNotFoundException("missing");
+        JobTerminalException term = new JobTerminalException("done");
+        assertTrue(nf instanceof MeshException);
+        assertTrue(term instanceof MeshException);
+        assertEquals("missing", nf.getMessage());
+        assertEquals("done", term.getMessage());
+
+        // Cause chaining works through both.
+        RuntimeException cause = new RuntimeException("root");
+        JobNotFoundException withCause = new JobNotFoundException("wrap", cause);
+        assertSame(cause, withCause.getCause());
+    }
+
+    /**
+     * Smoke check: postEvent's argument validation runs BEFORE the
+     * registry URL resolution. A caller passing an invalid jobId must
+     * see the IllegalArgumentException regardless of MCP_MESH_REGISTRY_URL.
+     */
+    @Test
+    void postEvent_argValidationRunsBeforeEnvResolution() {
+        // Even with the env set or unset, the IllegalArgumentException
+        // wins because the null check is the first thing postEvent does.
+        Map<String, Object> payload = Map.of("k", "v");
+        assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.postEvent(null, "signal", payload));
+        assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.postEvent("j", null, payload));
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/MeshJobsTest.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/MeshJobsTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Unit tests for {@link MeshJobs} — the static {@code postEvent} helper +
@@ -257,6 +258,9 @@ class MeshJobsTest {
     @Test
     void getOrCreateProxy_evictsLruAndClosesProxyAtCap() {
         int cap = MeshJobs.proxyCacheMax();
+        assumeTrue(cap <= 1024,
+            "Skipping eviction test: cache cap " + cap + " exceeds bound (1024). "
+                + "Unset MCP_MESH_JOBPROXY_CACHE_MAX or set it <= 1024 to run.");
         // Insert the LRU sentinel first — this entry will be the
         // least-recently-used after we populate the cache to the cap.
         JobProxy lru = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "job-lru");

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
@@ -484,8 +484,18 @@ public class LongTaskConsumerApplication {
             // observe the synthetic 'cancelled' event and return its
             // dict via the normal task return path. We CANNOT use
             // proxy.await() because wait() raises on cancelled terminal.
-            Thread.sleep(3000);
+            // Poll for terminal status with deadline (was fixed 3s sleep);
+            // gives headroom on slow cancels and exits fast on quick ones.
+            long deadline = System.currentTimeMillis() + 8_000L;
             Map<String, Object> status = proxy.status();
+            while (System.currentTimeMillis() < deadline) {
+                String s = status != null ? (String) status.get("status") : null;
+                if (s != null && (s.equals("completed") || s.equals("failed") || s.equals("cancelled"))) {
+                    break;
+                }
+                Thread.sleep(300);
+                status = proxy.status();
+            }
             Map<String, Object> response = new LinkedHashMap<>();
             response.put("job_id", jobId);
             response.put("work_seq", workReceipt.get("seq"));

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
@@ -4,6 +4,7 @@ import io.mcpmesh.JobProxy;
 import io.mcpmesh.MeshAgent;
 import io.mcpmesh.MeshJob;
 import io.mcpmesh.MeshJobSubmitter;
+import io.mcpmesh.MeshJobs;
 import io.mcpmesh.MeshTool;
 import io.mcpmesh.Param;
 import io.mcpmesh.Selector;
@@ -366,6 +367,130 @@ public class LongTaskConsumerApplication {
         try (JobProxy proxy = submitter.submit(opts).get()) {
             Map<String, Object> response = new LinkedHashMap<>();
             response.put("job_id", proxy.jobId());
+            return response;
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Event-injection submitters (tc24 / tc25 / tc26 — issue #1032)
+    // -------------------------------------------------------------------
+    //
+    // Each capability submits one of the new task=true producers and
+    // drives MeshJobs.postEvent from inside the consumer's tool body
+    // to exercise the producer's recvEvent long-poll. The static helper
+    // MeshJobs.postEvent discovers the registry URL from
+    // MCP_MESH_REGISTRY_URL (set by the agent startup pipeline) and
+    // POSTs /jobs/{id}/events.
+    // -------------------------------------------------------------------
+
+    @MeshTool(
+        capability = "commission_event",
+        description = "Submit run_with_event, sleep so producer parks on recvEvent, then post one event.",
+        dependencies = @Selector(capability = "run_with_event")
+    )
+    public Map<String, Object> commissionEvent(MeshJob runWithEvent) throws Exception {
+        if (!(runWithEvent instanceof MeshJobSubmitter submitter)) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "run_with_event submitter not injected");
+            return err;
+        }
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            new LinkedHashMap<>(), null, 60, null, null);
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            String jobId = proxy.jobId();
+            // Brief wait so producer reaches recvEvent before we post.
+            // Without this, the post may land before the producer's
+            // claim worker has even pulled the job off the queue.
+            Thread.sleep(2000);
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("hello", "world");
+            payload.put("n", 42);
+            Map<String, Object> receipt = MeshJobs.postEvent(jobId, "signal", payload);
+            Object result = proxy.await(30.0);
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("job_id", jobId);
+            response.put("post_seq", receipt.get("seq"));
+            response.put("job_result", result);
+            return response;
+        }
+    }
+
+    @MeshTool(
+        capability = "commission_event_filter",
+        description = "Submit run_with_filter, post 2 ignored events, then the matching one.",
+        dependencies = @Selector(capability = "run_with_filter")
+    )
+    public Map<String, Object> commissionEventFilter(MeshJob runWithFilter) throws Exception {
+        if (!(runWithFilter instanceof MeshJobSubmitter submitter)) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "run_with_filter submitter not injected");
+            return err;
+        }
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            new LinkedHashMap<>(), null, 60, null, null);
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            String jobId = proxy.jobId();
+            Thread.sleep(2000);
+            // Post 2 unrelated events — producer must NOT wake on these.
+            Map<String, Object> p1 = new LinkedHashMap<>();
+            p1.put("n", 1);
+            Map<String, Object> r1 = MeshJobs.postEvent(jobId, "ignore_a", p1);
+            Map<String, Object> p2 = new LinkedHashMap<>();
+            p2.put("n", 2);
+            Map<String, Object> r2 = MeshJobs.postEvent(jobId, "ignore_b", p2);
+            // Brief gap so a buggy filter (one that DID wake on ignore_a)
+            // has time to drive the producer to completion; if the producer
+            // is already done by now, the matching post will get
+            // JobTerminalException.
+            Thread.sleep(1000);
+            Map<String, Object> p3 = new LinkedHashMap<>();
+            p3.put("got_it", true);
+            Map<String, Object> r3 = MeshJobs.postEvent(jobId, "target", p3);
+            Object result = proxy.await(30.0);
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("job_id", jobId);
+            response.put("ignore_seqs", List.of(r1.get("seq"), r2.get("seq")));
+            response.put("target_seq", r3.get("seq"));
+            response.put("result", result);
+            return response;
+        }
+    }
+
+    @MeshTool(
+        capability = "commission_cancel_via_event",
+        description = "Submit run_until_cancel, post 'work', then cancel — synthetic 'cancelled' event must arrive.",
+        dependencies = @Selector(capability = "run_until_cancel")
+    )
+    public Map<String, Object> commissionCancelViaEvent(MeshJob runUntilCancel) throws Exception {
+        if (!(runUntilCancel instanceof MeshJobSubmitter submitter)) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "run_until_cancel submitter not injected");
+            return err;
+        }
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            new LinkedHashMap<>(), null, 60, null, null);
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            String jobId = proxy.jobId();
+            Thread.sleep(2000);
+            Map<String, Object> workPayload = new LinkedHashMap<>();
+            workPayload.put("item", 1);
+            Map<String, Object> workReceipt = MeshJobs.postEvent(jobId, "work", workPayload);
+            // Give producer a moment to consume the 'work' event before
+            // firing cancel — makes the events strictly ordered in
+            // events_seen (work first, cancelled second).
+            Thread.sleep(1000);
+            proxy.cancel("external_stop_requested");
+            // The job is now cancelled — producer's recvEvent loop will
+            // observe the synthetic 'cancelled' event and return its
+            // dict via the normal task return path. We CANNOT use
+            // proxy.await() because wait() raises on cancelled terminal.
+            Thread.sleep(3000);
+            Map<String, Object> status = proxy.status();
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("job_id", jobId);
+            response.put("work_seq", workReceipt.get("seq"));
+            response.put("terminal_status", status.get("status"));
+            response.put("terminal_error", status.get("error"));
             return response;
         }
     }

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
@@ -493,6 +493,136 @@ public class LongTaskProviderApplication {
         return client.send(req, HttpResponse.BodyHandlers.ofString());
     }
 
+    // -------------------------------------------------------------------
+    // Event-injection scenarios (tc24/tc25/tc26 — recvEvent primitive,
+    // issue #1032). Mirrors Python uc21 / TS uc22 fixtures field-for-field:
+    //   - run_with_event   — happy path: wait for one 'signal' event
+    //   - run_with_filter  — type-filter correctness
+    //   - run_until_cancel — synthetic 'cancelled' event observation
+    // All three use task=true and call job.recvEvent(...) on the injected
+    // JobController. The producer's recvEvent timeout uses Duration to
+    // bridge cleanly through the SDK's Optional<Duration> API.
+    // -------------------------------------------------------------------
+
+    @MeshTool(
+        capability = "run_with_event",
+        task = true,
+        description = "Wait for one 'signal' event and return its payload — happy path for recvEvent."
+    )
+    public Map<String, Object> runWithEvent(MeshJob job) {
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller == null) {
+            Map<String, Object> noJob = new LinkedHashMap<>();
+            noJob.put("status", "no_job_ctx");
+            return noJob;
+        }
+        controller.updateProgress(0.1, "parked on recvEvent");
+        Map<String, Object> event = controller.recvEvent(
+            List.of("signal"), Duration.ofSeconds(10));
+        if (event == null) {
+            Map<String, Object> timeout = new LinkedHashMap<>();
+            timeout.put("status", "timeout");
+            timeout.put("received", false);
+            return timeout;
+        }
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("status", "got_event");
+        payload.put("received", true);
+        payload.put("type", event.get("type"));
+        payload.put("payload", event.get("payload"));
+        payload.put("seq", event.get("seq"));
+        controller.complete(payload);
+        return payload;
+    }
+
+    @MeshTool(
+        capability = "run_with_filter",
+        task = true,
+        description = "Wait for a 'target' event and ignore other types — exercises recvEvent filter."
+    )
+    public Map<String, Object> runWithFilter(MeshJob job) {
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller == null) {
+            Map<String, Object> noJob = new LinkedHashMap<>();
+            noJob.put("status", "no_job_ctx");
+            return noJob;
+        }
+        controller.updateProgress(0.1, "parked with type filter");
+        // Long timeout so the consumer has slack to post 2 ignored
+        // events before the matching one. A broken filter would wake
+        // on the FIRST event (ignore_a) and the test would catch it.
+        Map<String, Object> event = controller.recvEvent(
+            List.of("target"), Duration.ofSeconds(15));
+        if (event == null) {
+            Map<String, Object> timeout = new LinkedHashMap<>();
+            timeout.put("timeout", true);
+            return timeout;
+        }
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("type", event.get("type"));
+        payload.put("payload", event.get("payload"));
+        payload.put("seq", event.get("seq"));
+        controller.complete(payload);
+        return payload;
+    }
+
+    @MeshTool(
+        capability = "run_until_cancel",
+        task = true,
+        description = "Loop on recvEvent for 'work'/'cancelled' types until cancelled-event arrives."
+    )
+    public Map<String, Object> runUntilCancel(MeshJob job) {
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller == null) {
+            Map<String, Object> noJob = new LinkedHashMap<>();
+            noJob.put("status", "no_job_ctx");
+            return noJob;
+        }
+        List<Map<String, Object>> eventsSeen = new ArrayList<>();
+        // Loop with per-iteration long timeout. A correct flow exits
+        // via the "cancelled" branch within ~3s of the consumer firing
+        // cancel. Bounded loop count is a safety net against runaway
+        // iterations if the cancel event never lands.
+        for (int i = 0; i < 20; i++) {
+            Map<String, Object> event = controller.recvEvent(
+                List.of("work", "cancelled"), Duration.ofSeconds(15));
+            if (event == null) {
+                // Surface the partial state so the test can distinguish
+                // "no event ever arrived" from "wrong event type observed".
+                Map<String, Object> timeoutResult = new LinkedHashMap<>();
+                timeoutResult.put("status", "timeout");
+                timeoutResult.put("events_seen", eventsSeen);
+                return timeoutResult;
+            }
+            Map<String, Object> seen = new LinkedHashMap<>();
+            seen.put("type", event.get("type"));
+            seen.put("payload", event.get("payload"));
+            eventsSeen.add(seen);
+            if ("cancelled".equals(event.get("type"))) {
+                // Don't call complete()/fail() — the registry row is
+                // already cancelled (synthetic event posted by CancelJob
+                // AFTER the row transition). The runtime's auto-complete
+                // is a no-op once terminal is recorded.
+                //
+                // Log a marker line so the test driver can assert the
+                // producer observed the synthetic cancel event WITHOUT
+                // relying on proxy.wait() (raises on cancelled terminal).
+                System.out.println(
+                    "[run_until_cancel] cancelled_gracefully events_seen="
+                        + eventsSeen);
+                System.out.flush();
+                Map<String, Object> result = new LinkedHashMap<>();
+                result.put("status", "cancelled_gracefully");
+                result.put("events_seen", eventsSeen);
+                return result;
+            }
+        }
+        Map<String, Object> exhausted = new LinkedHashMap<>();
+        exhausted.put("status", "loop_exhausted");
+        exhausted.put("events_seen", eventsSeen);
+        return exhausted;
+    }
+
     /**
      * Find the {@code endpoint} field for the named agent in a
      * registry {@code GET /agents} response body. Returns {@code null}

--- a/tests/integration/suites/uc23_meshjob_java/tc24_event_injection_happy_path_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc24_event_injection_happy_path_java/test.yaml
@@ -1,0 +1,128 @@
+# tc24_event_injection_happy_path_java — Java port of uc21/tc24 +
+# uc22/tc24_ts (recvEvent / postEvent happy path; issue #1032).
+#
+# Verifies the basic event-injection round trip end-to-end through a
+# real registry and two real Java agents:
+#
+#   1. Producer task=true tool `runWithEvent` parks on
+#      `controller.recvEvent(List.of("signal"), Duration.ofSeconds(10))`.
+#   2. Consumer's `commissionEvent` submits the job, sleeps ~2s so the
+#      producer reaches the long-poll, then calls the SDK helper
+#      `MeshJobs.postEvent(jobId, "signal", Map.of("hello","world","n",42))`.
+#   3. The registry persists the event, the producer's long-poll wakes,
+#      `recvEvent` returns the event Map, the handler returns it via
+#      `controller.complete(...)`.
+#   4. Consumer awaits `proxy.await(...)` and surfaces the structured payload.
+#
+# Asserts:
+#   - the producer returned `status=got_event` (not `timeout`)
+#   - the payload echoes `{hello: "world", n: 42}` exactly
+#   - the receipt's seq is 1 (first event posted into this job)
+#
+# This is the headline regression for the new Java `MeshJobs.postEvent`
+# helper in a real-agent context — the unit tests cover the helper
+# itself but they don't load the FFI library, so this is the first time
+# we exercise the helper from inside a running tool body.
+
+name: "MeshJob Java: postEvent helper wakes a producer parked on recvEvent"
+description: "Java producer recvEvent → Java consumer postEvent → handler completes with event payload"
+tags:
+  - meshjob
+  - java
+  - issue-1032
+  - events
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9120)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for Java provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done
+      echo "ERROR: provider not healthy"
+      meshctl logs long-task-provider-java 2>&1 | tail -50 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start consumer (port 9121)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
+      done
+      echo "ERROR: consumer not ready"
+      meshctl logs long-task-consumer-java 2>&1 | tail -50 || true
+      exit 1
+    timeout: 150
+
+  - name: "Call commission_event — submit, post one event, wait for result"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_event '{}'
+    capture: commission_response
+    timeout: 60
+
+assertions:
+  # Java's Jackson serializer emits compact JSON without spaces, and the
+  # meshctl envelope JSON-escapes the inner text — match the escaped form
+  # used by the Java tc01 baseline test (and tc24/tc26 TS).
+  - expr: "${captured.commission_response} not contains '\"isError\":true'"
+    message: "commission_event should NOT return an MCP error envelope"
+  # Producer reached recvEvent AND woke on the posted signal.
+  - expr: "${captured.commission_response} contains '\\\"status\\\":\\\"got_event\\\"'"
+    message: "producer must report status=got_event (proves recvEvent woke on the post)"
+  - expr: "${captured.commission_response} not contains '\\\"status\\\":\\\"timeout\\\"'"
+    message: "producer must NOT have timed out — the post should have woken it"
+  # Payload echo: full event payload must round-trip through the registry.
+  - expr: "${captured.commission_response} contains '\\\"hello\\\":\\\"world\\\"'"
+    message: "payload string field must round-trip through recvEvent"
+  - expr: "${captured.commission_response} contains '\\\"n\\\":42'"
+    message: "payload numeric field must round-trip through recvEvent"
+  - expr: "${captured.commission_response} contains '\\\"type\\\":\\\"signal\\\"'"
+    message: "event type must be surfaced on the producer side"
+  # Receipt seq: this was the first event posted into the job.
+  - expr: "${captured.commission_response} contains '\\\"post_seq\\\":1'"
+    message: "first postEvent into a fresh job must return seq=1"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc25_event_type_filter_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc25_event_type_filter_java/test.yaml
@@ -1,0 +1,123 @@
+# tc25_event_type_filter_java — Java port of uc21/tc25 + uc22/tc25_ts
+# (recvEvent types filter; issue #1032).
+#
+# Producer `runWithFilter` calls `controller.recvEvent(List.of("target"),
+# Duration.ofSeconds(15))` and must IGNORE events whose `type` is not in
+# that list. Consumer posts three events in sequence:
+#
+#   1. `ignore_a` — wrong type, must be skipped
+#   2. `ignore_b` — wrong type, must be skipped
+#   3. `target`   — matching type, producer wakes here
+#
+# Asserts:
+#   - the producer returned the THIRD event (seq=3), not the first or second
+#   - payload echoes `{got_it: true}`
+#   - producer did NOT time out
+#
+# This proves the type-filter is applied during the long-poll: a broken
+# filter would wake on seq=1 (`ignore_a`), return `{n: 1}` instead of
+# `{got_it: true}`, and complete the job with the wrong payload.
+
+name: "MeshJob Java: recvEvent type filter skips unrelated events and wakes on matching type"
+description: "Post 2 ignored events + 1 matching; producer must see only the matching one (seq=3)"
+tags:
+  - meshjob
+  - java
+  - issue-1032
+  - events
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9120)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for Java provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done
+      echo "ERROR: provider not healthy"
+      meshctl logs long-task-provider-java 2>&1 | tail -50 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start consumer (port 9121)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
+      done
+      echo "ERROR: consumer not ready"
+      meshctl logs long-task-consumer-java 2>&1 | tail -50 || true
+      exit 1
+    timeout: 150
+
+  - name: "Call commission_event_filter — post 3 events, expect producer to wake only on 'target'"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_event_filter '{}'
+    capture: commission_response
+    timeout: 60
+
+assertions:
+  - expr: "${captured.commission_response} not contains '\"isError\":true'"
+    message: "commission_event_filter should NOT return an MCP error envelope"
+  # Producer must not have timed out.
+  - expr: "${captured.commission_response} not contains '\\\"timeout\\\":true'"
+    message: "producer must NOT have timed out — the 'target' event should have woken it"
+  # The matching event was the 3rd posted into the job; the producer
+  # must surface its seq, type and payload — NOT the ignored events'.
+  - expr: "${captured.commission_response} contains '\\\"type\\\":\\\"target\\\"'"
+    message: "producer must wake on the 'target' event type"
+  - expr: "${captured.commission_response} contains '\\\"got_it\\\":true'"
+    message: "payload of the matching event must round-trip to the producer"
+  # Belt-and-suspenders: ensure the producer's result is NOT one of the
+  # ignored events. A broken filter would wake on the first post and
+  # complete with payload={"n":1} type="ignore_a".
+  - expr: "${captured.commission_response} not contains '\\\"type\\\":\\\"ignore_a\\\"'"
+    message: "producer must NOT have woken on the 'ignore_a' event (filter broken)"
+  - expr: "${captured.commission_response} not contains '\\\"type\\\":\\\"ignore_b\\\"'"
+    message: "producer must NOT have woken on the 'ignore_b' event (filter broken)"
+  # Sequence number: the matching event was the 3rd post into this job.
+  - expr: "${captured.commission_response} contains '\\\"target_seq\\\":3'"
+    message: "the matching event must have been the 3rd post (seq=3)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc26_cancel_posts_synthetic_event_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc26_cancel_posts_synthetic_event_java/test.yaml
@@ -1,0 +1,182 @@
+# tc26_cancel_posts_synthetic_event_java — Java port of uc21/tc26 +
+# uc22/tc26_ts (CancelJob posts a synthetic `{type: "cancelled"}` event
+# the parked recvEvent observes; issue #1032).
+#
+# Producer `runUntilCancel` loops calling `controller.recvEvent(
+# List.of("work","cancelled"), Duration.ofSeconds(15))`. Consumer:
+#
+#   1. submits the job
+#   2. posts a 'work' event with payload `{item: 1}`
+#   3. sleeps so producer consumes it
+#   4. calls `proxy.cancel("external_stop_requested")`
+#
+# Inside the registry's CancelJob handler the row transitions to
+# status=cancelled AND the handler then posts a synthetic
+# `{type: "cancelled", payload: {reason: "external_stop_requested"}}`
+# event with `allowTerminal=true`. The producer's long-poll wakes on
+# that synthetic event and returns `{status: "cancelled_gracefully",
+# events_seen: [<work>, <cancelled>]}` — the test asserts the marker
+# line in the producer log.
+#
+# Asserts:
+#   - the registry row is in status=cancelled (per existing semantics)
+#   - the producer logged the cancelled_gracefully marker (proves the
+#     synthetic event was both posted by the registry AND observed by
+#     the parked recvEvent call)
+#   - the producer's events_seen list contains BOTH the 'work' event
+#     and the 'cancelled' event (in that order)
+#
+# Note on Java's cancel limitation (#889): Java's sync JNR-FFI bindings
+# cannot bind the per-job cancel registry. The producer's recvEvent
+# CAN still observe the synthetic `cancelled` event via the long-poll
+# (it's a normal event flow through the events log), but the runtime's
+# CancelledError-style abort path that Python/TS have does NOT fire.
+# This test exercises the substrate-side correctness: the cancel posts
+# the synthetic event AND the producer's long-poll on the events log
+# wakes on it — both verified independently.
+
+name: "MeshJob Java: cancel posts a synthetic 'cancelled' event the parked recvEvent observes"
+description: "Consumer cancels mid-flight; producer's recvEvent must wake on the synthetic 'cancelled' event"
+tags:
+  - meshjob
+  - java
+  - issue-1032
+  - events
+  - cancel
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9120)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for Java provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done
+      echo "ERROR: provider not healthy"
+      meshctl logs long-task-provider-java 2>&1 | tail -50 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start consumer (port 9121)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
+      done
+      echo "ERROR: consumer not ready"
+      meshctl logs long-task-consumer-java 2>&1 | tail -50 || true
+      exit 1
+    timeout: 150
+
+  - name: "Call commission_cancel_via_event — submit, post work, cancel"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_cancel_via_event '{}'
+    capture: commission_response
+    timeout: 60
+
+  # Allow a moment for the producer's stdout to flush after the cancel
+  # event arrives. The producer's marker line is printed inside the
+  # recvEvent loop and the runtime captures stdout to the agent's log.
+  - name: "Wait for producer log to flush"
+    handler: wait
+    seconds: 3
+
+  - name: "Read producer log for the cancelled_gracefully marker"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl logs long-task-provider-java 2>&1 | tail -200 | grep "\[run_until_cancel\] cancelled_gracefully" || true
+    capture: producer_log
+
+  # Independent verification: even if the producer didn't observe the
+  # synthetic 'cancelled' event in its recvEvent branch (e.g., because
+  # the cancel-token race fired on the task body first), the registry
+  # MUST have persisted it. Hit the events endpoint directly to confirm
+  # the event-row exists. This separates "registry side broken" from
+  # "SDK cancel-token races recvEvent" — matches the Python tc26 /
+  # TS tc26_ts pattern.
+  - name: "Read registry events log for the synthetic cancelled event"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # Java's meshctl envelope wraps the result inside content[0].text
+      # as a JSON string — unwrap that first, then read .job_id from
+      # the inner JSON. Same pattern as TS tc26_ts.
+      JOB_ID=$(echo '${captured.commission_response}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}/events" | jq '.events | map({seq, type, payload})'
+    capture: registry_events
+
+assertions:
+  - expr: "${captured.commission_response} not contains '\"isError\":true'"
+    message: "commission_cancel_via_event should NOT return an MCP error envelope"
+  # Registry's terminal status — per the existing cancel semantics.
+  - expr: "${captured.commission_response} contains '\\\"terminal_status\\\":\\\"cancelled\\\"'"
+    message: "registry row must show status=cancelled after proxy.cancel"
+  - expr: "${captured.commission_response} contains '\\\"work_seq\\\":1'"
+    message: "the 'work' event must have been the first posted (seq=1)"
+  # Synthetic-event observability: the producer logs the marker ONLY
+  # when its recvEvent branch sees type=='cancelled'.
+  - expr: "${captured.producer_log} contains '[run_until_cancel] cancelled_gracefully'"
+    message: "producer must log the cancelled_gracefully marker — proves recvEvent observed the synthetic 'cancelled' event"
+  # The events_seen list (rendered as a Java Map toString in the log
+  # line) must include BOTH the 'work' event the consumer posted AND
+  # the 'cancelled' synthetic event the registry stamped in CancelJob.
+  # Java's LinkedHashMap.toString uses `=` and `type=work` form.
+  - expr: "${captured.producer_log} contains 'type=work'"
+    message: "events_seen must include the 'work' event the consumer posted"
+  - expr: "${captured.producer_log} contains 'type=cancelled'"
+    message: "events_seen must include the synthetic 'cancelled' event from CancelJob"
+  - expr: "${captured.producer_log} contains 'external_stop_requested'"
+    message: "the cancel reason must propagate through the synthetic event payload"
+  # Registry-side check (independent of producer observability): the
+  # synthetic cancel event MUST have been posted to the events log.
+  - expr: "${captured.registry_events} contains '\"type\": \"work\"'"
+    message: "registry events log must contain the 'work' event"
+  - expr: "${captured.registry_events} contains '\"type\": \"cancelled\"'"
+    message: "registry events log must contain the synthetic 'cancelled' event posted by CancelJob"
+  - expr: "${captured.registry_events} contains 'external_stop_requested'"
+    message: "the cancel reason must appear in the synthetic event's payload"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

Closes #1044. Java vertical for the consumer-pushed event-injection primitive shipped Python-first in #1041 and TypeScript in #1043. **Completes the cross-runtime fan-out for issue #1032.**

Follows the original MeshJob shipping cadence: Python (#861/#878) → TypeScript (#885) → Java (#891). This PR is the Java step.

## What's in the PR

### FFI bindings (`src/runtime/core/src/jobs_ffi.rs`)
- `mesh_job_controller_recv_event(handle, types_json, timeout_secs, out_event_json)` → `i32` (0 ok, -1 invalid, -2 NotFound, -3 backend)
- `mesh_job_proxy_send_event(handle, event_type, payload_json, out_receipt_json)` → `i32` (0 ok, -1 invalid, -2 NotFound, -3 **Terminal**, -4 backend) — distinct codes for `JobNotFound` vs `JobTerminal` so the Java SDK can map to distinct typed exceptions
- `parse_ffi_timeout_secs` helper: rejects NaN/Inf, uses `Duration::try_from_secs_f64` for overflow safety, negative-sentinel `< 0` convention for "no timeout" (since C ABI can't pass `Option<f64>`)
- +6 Rust FFI tests (jobs_ffi: 16 → 22)

### Java SDK (`src/runtime/java/mcp-mesh-sdk/`)
- `JobController.recvEvent(List<String> types, Duration timeout)` → `Map<String, Object>` or null
- `JobProxy.sendEvent(String eventType, Map<String, Object> payload)` → receipt Map
- New `MeshJobs.postEvent(jobId, eventType, payload)` static helper with LRU-bounded `JobProxy` cache (default 256, env override `MCP_MESH_JOBPROXY_CACHE_MAX`)
  - Uses `LinkedHashMap(accessOrder=true)` with explicit `synchronized` blocks — access-order mode mutates internal state on `get()` so thread-safety requires external sync
  - `removeEldestEntry` closes evicted proxies so FFI handles release promptly
- `JobNotFoundException` + `JobTerminalException` typed exceptions extending the existing `MeshException` (which extends `RuntimeException` — unchecked, matches Python's `RuntimeError`-subclassing)
- mcp-mesh-core `MeshCore` JNR-FFI interface gets 2 new method declarations

### Tests
- **Rust FFI**: +6 unit tests
- **Java unit**: +20 tests (`MeshJobsTest` 14, `JobEventApiTest` 6); sdk module 42 → 62; full Java module 124 → 125
- **Integration suite `uc23_meshjob_java`**: 3 new test cases mirroring Python tc24/25/26 and TS tc24/25/26_ts:
  - `tc24_event_injection_happy_path_java` — payload round-trip
  - `tc25_event_type_filter_java` — registry-side WHERE filter
  - `tc26_cancel_posts_synthetic_event_java` — cancel-grace verified in Java path
  - Reuses existing `long-task-provider-java` / `long-task-consumer-java` fixtures (extended with 3 new tools each)
  - Baseline 23 + new 3 = **26/26 pass**

### API parity matrix completed (3 runtimes)

| API | Java | TypeScript | Python |
|---|---|---|---|
| Producer wait for event | `job.recvEvent(types, duration)` | `job.recvEvent(types, timeoutSecs)` | `job.recv_event(types, timeout_secs)` |
| Consumer post to specific proxy | `proxy.sendEvent(type, payload)` | `proxy.sendEvent(type, payload)` | `proxy.send_event(type, payload)` |
| Convenience helper | `MeshJobs.postEvent(...)` | `mesh.jobs.postEvent(...)` | `mesh.jobs.post_event(...)` |
| Typed errors | `JobNotFoundException` / `JobTerminalException` | `JobNotFoundError` / `JobTerminalError` | `JobNotFoundError` / `JobTerminalError` |
| Proxy cache cap | `MCP_MESH_JOBPROXY_CACHE_MAX` (256) | same | same |
| Cancel synthetic event grace | Server-side `MCP_MESH_CANCEL_EVENT_GRACE_MS` (200ms default, 10s cap) | same | same |

## Review Notes

Independent review returned **0 BLOCKERs, 0 WARNINGs, 4 INFOs.** All 4 addressed in commit `99da6a504`:

- **I1**: `JobNotFoundException` javadoc had `JobError::Other(BackendError::NotFound)` — actual variant is `JobError::Backend(BackendError::NotFound)`. Typo fixed.
- **I2**: Added a 7-line policy comment above `parse_ffi_timeout_secs` documenting why two timeout policies coexist (strict for new surfaces; permissive for back-compat on `mesh_job_proxy_wait`).
- **I3**: Added a parallel 6-line lock-rationale comment on `JobController.recvEvent`'s synchronized block, modeled on `JobProxy.await()`'s existing doc — explains the use-after-free fence (concurrent `close()` must not free the FFI handle mid-poll).
- **I4**: Added direct LRU eviction test `getOrCreateProxy_evictsLruAndClosesProxyAtCap` exercising the `removeEldestEntry → JobProxy.close() → mesh_job_proxy_free` path with the default cap (256 + 1 overflow). 257 FFI allocations in 24ms — acceptable cost for a regression guard on the resource-cleanup guarantee.

## What's still open for #1032 epic

After this PR merges:
- ✅ Python (#1041)
- ✅ TypeScript (#1043)
- ✅ Java (#1044, this PR)
- ⏳ `Stream[T]` subscription mode (the paired feature originally cited in #1032 — depends on reading #645's current Stream[T] producer model)

## Test plan

- [ ] CI green across Rust, Java, integration suite
- [ ] Manual: cross-runtime sanity (Python `mesh.jobs.post_event(jobId, ...)` reaches Java `await job.recvEvent(["..."], ...)` — and vice versa)
- [ ] Manual: a Java producer with `await job.recvEvent(["cancelled"])` exits gracefully when consumer (any runtime) calls `proxy.cancel("reason")` (200ms grace observed)

Closes #1044

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

## New Features
- Added job event communication: send events via `sendEvent()` and receive events via `recvEvent()` with optional timeout support
- Event type filtering to selectively consume specific event types while ignoring others
- New `MeshJobs` utility class for posting events without maintaining proxy instances
- New typed exceptions for better error handling: `JobNotFoundException` and `JobTerminalException`

## Tests
- Added integration tests validating event injection, type filtering, and event-based cancellation workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1045?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->