### PR TITLE
MeshJob: Stream subscription — subscribe_events (Python)

### DIFF
--- a/src/runtime/core/src/jobs.rs
+++ b/src/runtime/core/src/jobs.rs
@@ -720,6 +720,55 @@ impl JobProxy {
         }
     }
 
+    /// Fetch a batch of events with `seq > after`, optionally filtered by
+    /// `types`.
+    ///
+    /// This is the low-level building block for the language SDKs'
+    /// ``subscribe_events`` async-iterator semantics — callers manage
+    /// their own cursor across calls. See [`JobController::recv_event`]
+    /// for the alternative single-event-with-internal-cursor shape used
+    /// inside running ``task=True`` jobs.
+    ///
+    /// `wait`: long-poll budget (`None` = single immediate read; `Some(d)`
+    /// = long-poll up to `d`, capped at 60s by the registry). An empty
+    /// result means "no events arrived within the wait window" — the
+    /// caller continues with the same cursor.
+    ///
+    /// Unlike [`JobController::recv_event`] this method:
+    ///
+    /// * Does NOT advance any internal cursor — `after` is supplied by
+    ///   the caller and the returned events leave it to the caller to
+    ///   track the next watermark.
+    /// * Is NOT serialised under a mutex — multiple subscribers against
+    ///   the same proxy run independently, observing the same events.
+    /// * Returns ALL matching events from the single registry round
+    ///   trip (up to 100), not just the head — this is a batch primitive,
+    ///   not a single-event primitive.
+    /// * Returns the registry-supplied `next_after` watermark alongside
+    ///   the events — callers should feed it back as `after` on the next
+    ///   call so empty pages caused by server-side filters still advance
+    ///   the cursor.
+    pub async fn list_events(
+        &self,
+        after: i64,
+        types: Option<Vec<String>>,
+        wait: Option<Duration>,
+    ) -> Result<(Vec<JobEvent>, i64), JobError> {
+        // Server-side limit (matches OpenAPI `limit` maximum).
+        const FETCH_LIMIT: usize = 100;
+        let resp = self
+            .backend
+            .list_job_events(
+                &self.job_id,
+                after,
+                types.as_deref(),
+                wait.unwrap_or_default(),
+                FETCH_LIMIT,
+            )
+            .await?;
+        Ok((resp.events, resp.next_after))
+    }
+
     /// Poll until the job reaches a terminal state, returns its `result`
     /// payload, or surfaces an error. Convenience wrapper around
     /// [`Self::wait_with_config`] that uses [`WaitConfig::default`] for
@@ -2518,5 +2567,149 @@ mod tests {
 
         // Drain A.
         let _ = a_handle.await.unwrap();
+    }
+
+    // ---- JobProxy::list_events ---------------------------------------------
+    //
+    // `list_events` is the low-level batch primitive that the language
+    // SDKs build their `subscribe_events` async-iterator semantics on top
+    // of. Unlike `JobController::recv_event` it has NO per-call mutex (no
+    // shared cursor), advances NO internal state, and returns the full
+    // batch up to limit. Tests below pin those three differences.
+
+    #[tokio::test]
+    async fn list_events_returns_all_matching_events_in_one_call() {
+        // Three events on the job; `list_events(after=0)` returns all three
+        // in ascending-seq order (the batch shape `subscribe_events` relies on).
+        let backend = MockBackend::new();
+        backend.push_event("j-list-1", "tick", serde_json::json!({"n": 1}));
+        backend.push_event("j-list-1", "tick", serde_json::json!({"n": 2}));
+        backend.push_event("j-list-1", "tick", serde_json::json!({"n": 3}));
+
+        let proxy = JobProxy::new("j-list-1", backend.clone() as Arc<dyn TaskBackend>);
+        let (events, next_after) = proxy.list_events(0, None, None).await.unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].seq, 1);
+        assert_eq!(events[1].seq, 2);
+        assert_eq!(events[2].seq, 3);
+        assert_eq!(next_after, 3);
+    }
+
+    #[tokio::test]
+    async fn list_events_honors_after_cursor() {
+        // `after=1` skips seq=1; the caller-managed cursor pattern that
+        // `subscribe_events` uses to avoid re-yielding observed events.
+        let backend = MockBackend::new();
+        backend.push_event("j-list-2", "tick", serde_json::json!({"n": 1}));
+        backend.push_event("j-list-2", "tick", serde_json::json!({"n": 2}));
+        backend.push_event("j-list-2", "tick", serde_json::json!({"n": 3}));
+
+        let proxy = JobProxy::new("j-list-2", backend.clone() as Arc<dyn TaskBackend>);
+        let (events, next_after) = proxy.list_events(1, None, None).await.unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].seq, 2);
+        assert_eq!(events[1].seq, 3);
+        assert_eq!(next_after, 3);
+    }
+
+    #[tokio::test]
+    async fn list_events_filters_by_types() {
+        // `types=["target"]` filters out unrelated event types — same
+        // filter contract the registry's `types=` query param honours.
+        let backend = MockBackend::new();
+        backend.push_event("j-list-3", "ignore", serde_json::json!({"n": 1}));
+        backend.push_event("j-list-3", "target", serde_json::json!({"n": 2}));
+        backend.push_event("j-list-3", "ignore", serde_json::json!({"n": 3}));
+        backend.push_event("j-list-3", "target", serde_json::json!({"n": 4}));
+
+        let proxy = JobProxy::new("j-list-3", backend.clone() as Arc<dyn TaskBackend>);
+        let (events, _next_after) = proxy
+            .list_events(0, Some(vec!["target".into()]), None)
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].seq, 2);
+        assert_eq!(events[1].seq, 4);
+    }
+
+    #[tokio::test]
+    async fn list_events_returns_empty_when_no_events() {
+        // No events on the job → empty batch (NOT NotFound). The caller's
+        // `subscribe_events` loop interprets this as "no events arrived
+        // within the wait window".
+        let backend = MockBackend::new();
+        let proxy = JobProxy::new("j-list-empty", backend.clone() as Arc<dyn TaskBackend>);
+        let (events, _next_after) = proxy.list_events(0, None, None).await.unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_events_propagates_not_found_error() {
+        // Registry-side NotFound (job reaped from registry) surfaces as
+        // `JobError::Backend(NotFound(_))` — the SDK translates it to a
+        // typed `JobNotFoundError` so `subscribe_events` callers can
+        // terminate cleanly when the job is gone.
+        let backend = MockBackend::new();
+        backend.set_events_list_not_found(true);
+        let proxy = JobProxy::new("j-list-404", backend.clone() as Arc<dyn TaskBackend>);
+        let err = proxy.list_events(0, None, None).await.unwrap_err();
+        assert!(
+            matches!(err, JobError::Backend(BackendError::NotFound(_))),
+            "expected Backend(NotFound), got {:?}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn list_events_does_not_share_cursor_with_recv_event() {
+        // Two independent observer cursors per proxy call: a `JobController`
+        // recv_event consumes seq=1; a parallel `list_events(after=0)` MUST
+        // still see seq=1 (subscribe_events observes events without
+        // affecting the producer's recv_event cursor).
+        let backend = MockBackend::new();
+        backend.jobs.lock().unwrap().insert(
+            "j-mixed".to_string(),
+            Job {
+                id: "j-mixed".to_string(),
+                capability: "cap".into(),
+                owner_instance_id: Some("inst-1".into()),
+                status: JobStatus::Working,
+                progress: None,
+                progress_message: None,
+                result: None,
+                error: None,
+                submitted_payload: serde_json::json!({}),
+                attempt_count: 0,
+                max_retries: 1,
+                max_duration: None,
+                total_deadline: None,
+                lease_expires_at: None,
+                last_heartbeat_at: None,
+                submitted_at: 0,
+                submitted_by: "client-1".into(),
+            },
+        );
+        backend.push_event("j-mixed", "tick", serde_json::json!({"n": 1}));
+
+        let ctrl = JobController::new(
+            "j-mixed".to_string(),
+            "inst-1".to_string(),
+            backend.clone() as Arc<dyn TaskBackend>,
+            new_coalescing_queue(),
+        );
+        let observed_by_recv = ctrl
+            .recv_event(None, Some(Duration::from_secs(1)))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(observed_by_recv.seq, 1);
+
+        // Observer-side: still sees seq=1 because `list_events` is
+        // stateless wrt the producer's recv_event cursor.
+        let proxy = JobProxy::new("j-mixed", backend.clone() as Arc<dyn TaskBackend>);
+        let (observer_batch, _next_after) =
+            proxy.list_events(0, None, None).await.unwrap();
+        assert_eq!(observer_batch.len(), 1);
+        assert_eq!(observer_batch[0].seq, 1);
     }
 }

--- a/src/runtime/core/src/jobs_py.rs
+++ b/src/runtime/core/src/jobs_py.rs
@@ -502,6 +502,50 @@ impl PyJobProxy {
         })
     }
 
+    /// Fetch a single batch of events from this job's event log with
+    /// ``seq > after``, optionally filtered by ``types``. The Python SDK's
+    /// ``mesh.jobs.subscribe_events`` async iterator is built on top of
+    /// this primitive — callers manage their own cursor between calls.
+    ///
+    /// ``timeout_secs``: long-poll budget. ``None`` ≡ single immediate
+    /// read; ``Some(secs)`` long-polls up to that many seconds (capped
+    /// at 60s by the registry). An empty result means "no events arrived
+    /// within the wait window" — the caller continues with the same
+    /// cursor.
+    ///
+    /// Returns a ``(events, next_after)`` tuple: ``events`` is the list
+    /// of event dicts (same shape as ``recv_event``'s single-event dict);
+    /// ``next_after`` is the registry-supplied watermark that the caller
+    /// should feed back as ``after`` on the next call so empty pages
+    /// caused by server-side ``types`` filtering still advance the cursor.
+    ///
+    /// Signature: ``list_events(after: int = 0, types: Optional[List[str]] = None, timeout_secs: Optional[float] = None) -> Tuple[List[dict], int]``
+    #[pyo3(signature = (after=0, types=None, timeout_secs=None))]
+    fn list_events<'py>(
+        &self,
+        py: Python<'py>,
+        after: i64,
+        types: Option<Vec<String>>,
+        timeout_secs: Option<f64>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
+        let wait = parse_timeout_secs(timeout_secs)?;
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let (events, next_after) = inner
+                .list_events(after, types, wait)
+                .await
+                .map_err(job_error_to_py)?;
+            Python::with_gil(|py| {
+                let list = PyList::empty(py);
+                for ev in events {
+                    list.append(job_event_to_pydict(py, ev)?)?;
+                }
+                let tuple = (list, next_after).into_pyobject(py)?;
+                Ok::<Py<PyAny>, PyErr>(tuple.into_any().unbind())
+            })
+        })
+    }
+
     fn __repr__(&self) -> String {
         format!("JobProxy(job_id={:?})", self.inner.job_id())
     }

--- a/src/runtime/python/mesh/jobs.py
+++ b/src/runtime/python/mesh/jobs.py
@@ -10,6 +10,14 @@ The primary surfaces are:
   their request payload (e.g. a "submit_user_input" tool exposed by an
   orchestrator agent).
 
+* :func:`subscribe_events` — observer-side async iterator over events
+  posted to a running job. Useful for UI gateways that want to mirror
+  events as they arrive, or any agent that wants to forward events to
+  a downstream system in real time. Each call manages its own cursor,
+  so multiple subscribers can observe the same job's events
+  independently without disturbing the producer's ``recv_event``
+  consumption.
+
 * :class:`JobNotFoundError` / :class:`JobTerminalError` — typed
   ``RuntimeError`` subclasses translated from the Rust core's
   :enum:`JobError` variants. Because pyo3 surfaces all
@@ -18,10 +26,10 @@ The primary surfaces are:
   on the Python side via stable error-message substrings.
 
 The :class:`mcp_mesh_core.JobController` / :class:`mcp_mesh_core.JobProxy`
-methods (``recv_event`` / ``send_event``) are exposed directly on the
-pyo3-bound classes — application code calls them via the
-``MeshJob``-typed parameter the framework injects. This module just
-adds the helper + error classes around that surface.
+methods (``recv_event`` / ``send_event`` / ``list_events``) are exposed
+directly on the pyo3-bound classes — application code calls them via
+the ``MeshJob``-typed parameter the framework injects. This module
+just adds the helpers + error classes around that surface.
 """
 
 from __future__ import annotations
@@ -29,12 +37,13 @@ from __future__ import annotations
 import asyncio
 import os
 from collections import OrderedDict
-from typing import Any, Optional
+from typing import Any, AsyncIterator, Optional
 
 __all__ = [
     "JobNotFoundError",
     "JobTerminalError",
     "post_event",
+    "subscribe_events",
 ]
 
 
@@ -272,3 +281,96 @@ async def post_event(
         if translated is exc:
             raise
         raise translated from exc
+
+
+# ---------------------------------------------------------------------------
+# subscribe_events convenience helper (observer-side iterator)
+# ---------------------------------------------------------------------------
+
+
+async def subscribe_events(
+    job_id: str,
+    types: Optional[list[str]] = None,
+    after: int = 0,
+    long_poll_secs: Optional[float] = 30.0,
+) -> AsyncIterator[dict]:
+    """Subscribe to events posted to a running job by ID.
+
+    Long-lived async iterator. Each call manages its own cursor — multiple
+    subscribers can observe the same job's events independently without
+    affecting the producer's ``recv_event`` consumption (the producer's
+    cursor is per-controller, this observer's cursor is per-call).
+
+    The iterator runs indefinitely until the caller breaks out of the
+    ``async for`` loop or the underlying registry returns
+    :class:`JobNotFoundError`. There is no automatic terminal-state
+    detection — use a synthetic event type (e.g. ``{"type": "ended"}``)
+    posted by your application to signal iteration end.
+
+    Args:
+        job_id: Target job's server-assigned id.
+        types: Optional filter; only events whose ``type`` matches one
+            of these is yielded. ``None`` ≡ all types.
+        after: Initial cursor (default ``0`` ≡ from the beginning of the
+            event log). Pass a higher value to skip historical events.
+        long_poll_secs: Long-poll wait budget per registry call.
+            Default ``30s``. Capped at ``60s`` by the registry.
+            Pass ``None`` to skip the long-poll entirely (single
+            immediate read; rarely needed — tight-poll callers should
+            pass ``0.0`` instead).
+
+    Yields:
+        Event dicts: ``{seq, type, payload, trace_context, posted_by,
+        created_at, job_id}``.
+
+    Raises:
+        JobNotFoundError: If the job has been reaped from the registry
+            (404 on the ``GET /jobs/{id}/events`` endpoint).
+        RuntimeError: For transport errors (registry unreachable, 5xx
+            after retries, malformed payload, etc.) — the underlying
+            error message is preserved.
+
+    Example:
+        Mirror events from a running job into a downstream system::
+
+            async def mirror_events(job_id: str) -> None:
+                async for event in mesh.jobs.subscribe_events(
+                    job_id, types=["progress", "result"]
+                ):
+                    await downstream.publish(event)
+                    if event["type"] == "result":
+                        break  # caller-defined termination
+    """
+    registry_url = _resolve_registry_url()
+    proxy = await _get_or_create_proxy(registry_url, job_id)
+    cursor = after
+    while True:
+        try:
+            events, next_after = await proxy.list_events(
+                cursor, types, long_poll_secs
+            )
+        except RuntimeError as exc:
+            translated = _translate_job_error(exc)
+            if translated is exc:
+                raise
+            raise translated from exc
+        for event in events:
+            seq = event.get("seq")
+            # `type(...) is not int` (rather than `isinstance(..., int)`)
+            # rejects booleans: `type(True) is bool`, but
+            # `isinstance(True, int)` is True. The registry contract is
+            # integer seqs; a bool here would be a wire-level malformed
+            # payload.
+            if type(seq) is not int:
+                raise RuntimeError(
+                    f"subscribe_events: registry returned event without integer 'seq': {event!r}"
+                )
+            cursor = max(cursor, seq)
+            # list_events returns ascending-seq; cursor advance before
+            # yield ensures correctness across consumer cancellation.
+            yield event
+        # Empty pages (or pages filtered by `types` server-side) still
+        # advance the cursor via the registry-supplied watermark, so
+        # subsequent polls don't re-scan the same filtered range.
+        if next_after > cursor:
+            cursor = next_after

--- a/src/runtime/python/tests/unit/test_meshjob_events.py
+++ b/src/runtime/python/tests/unit/test_meshjob_events.py
@@ -329,11 +329,18 @@ class TestPublicExports:
         sub = mesh.jobs
         assert sub.__name__ == "mesh.jobs"
         assert callable(sub.post_event)
+        assert callable(sub.subscribe_events)
 
     def test_direct_jobs_import(self):
-        from mesh.jobs import post_event, JobNotFoundError, JobTerminalError
+        from mesh.jobs import (
+            JobNotFoundError,
+            JobTerminalError,
+            post_event,
+            subscribe_events,
+        )
 
         assert callable(post_event)
+        assert callable(subscribe_events)
         assert issubclass(JobNotFoundError, RuntimeError)
         assert issubclass(JobTerminalError, RuntimeError)
 
@@ -343,6 +350,324 @@ class TestPublicExports:
         # Lazy __getattr__ path.
         assert mesh.JobNotFoundError is not None
         assert mesh.JobTerminalError is not None
+
+
+# ===========================================================================
+# mesh.jobs.subscribe_events — observer-side async iterator
+# ===========================================================================
+
+
+class TestSubscribeEvents:
+    """``mesh.jobs.subscribe_events`` builds a long-lived async iterator
+    on top of the pyo3 ``JobProxy.list_events`` batch primitive. The
+    iterator manages its own cursor (no shared state with the producer's
+    ``recv_event``) and yields events strictly in ascending-seq order
+    until the caller breaks out of the loop."""
+
+    @pytest.mark.asyncio
+    async def test_subscribe_events_yields_events_until_break(
+        self, monkeypatch
+    ):
+        """A subscriber yields every event the fake ``list_events`` returns
+        across multiple batches, in order, until the caller breaks."""
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        # Two batches: first returns 2 events, second returns 1, then
+        # any further call returns []. The subscriber should yield 3
+        # events total, in seq order.
+        batches: list[list[dict[str, Any]]] = [
+            [
+                {"job_id": "j1", "seq": 1, "type": "work", "payload": {"n": 1}},
+                {"job_id": "j1", "seq": 2, "type": "work", "payload": {"n": 2}},
+            ],
+            [
+                {"job_id": "j1", "seq": 3, "type": "work", "payload": {"n": 3}},
+            ],
+        ]
+
+        class _FakeProxy:
+            def __init__(self, _job_id: str, _registry_url: str) -> None:
+                self._cursor = 0
+
+            async def list_events(
+                self, after: int, _types: Any, _wait: float
+            ) -> tuple[list[dict[str, Any]], int]:
+                if batches:
+                    batch = batches.pop(0)
+                    return batch, batch[-1]["seq"]
+                return [], after
+
+        observed: list[dict[str, Any]] = []
+        with mock.patch("mcp_mesh_core.JobProxy", _FakeProxy, create=True):
+            async for event in mesh_jobs.subscribe_events(
+                "j1", long_poll_secs=0.0
+            ):
+                observed.append(event)
+                if len(observed) == 3:
+                    break
+
+        seqs = [e["seq"] for e in observed]
+        assert seqs == [1, 2, 3], (
+            f"subscriber must yield events in ascending-seq order, got {seqs}"
+        )
+        assert observed[0]["payload"] == {"n": 1}
+        assert observed[2]["payload"] == {"n": 3}
+
+    @pytest.mark.asyncio
+    async def test_subscribe_events_advances_cursor_between_calls(
+        self, monkeypatch
+    ):
+        """The cursor passed to the SECOND ``list_events`` call must be
+        the seq of the last yielded event — proves the iterator advances
+        its watermark internally between batches."""
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        cursors_seen: list[int] = []
+        batches: list[list[dict[str, Any]]] = [
+            [
+                {"job_id": "j1", "seq": 1, "type": "x", "payload": None},
+                {"job_id": "j1", "seq": 5, "type": "x", "payload": None},
+            ],
+            [
+                {"job_id": "j1", "seq": 9, "type": "x", "payload": None},
+            ],
+        ]
+
+        class _FakeProxy:
+            def __init__(self, _job_id: str, _registry_url: str) -> None:
+                pass
+
+            async def list_events(
+                self, after: int, _types: Any, _wait: float
+            ) -> tuple[list[dict[str, Any]], int]:
+                cursors_seen.append(after)
+                if batches:
+                    batch = batches.pop(0)
+                    return batch, batch[-1]["seq"]
+                return [], after
+
+        observed: list[int] = []
+        with mock.patch("mcp_mesh_core.JobProxy", _FakeProxy, create=True):
+            async for event in mesh_jobs.subscribe_events(
+                "j1", long_poll_secs=0.0
+            ):
+                observed.append(event["seq"])
+                if len(observed) == 3:
+                    break
+
+        # First call uses the initial cursor (default 0). Second call
+        # must use the max seq from the first batch (5). Third would be
+        # 9 if we kept going, but we break first — at minimum the second
+        # call's cursor proves the advance.
+        assert cursors_seen[0] == 0, (
+            f"first list_events must use the initial after=0; got {cursors_seen[0]}"
+        )
+        assert cursors_seen[1] == 5, (
+            f"second list_events must use the seq of the last yielded event "
+            f"(5), got {cursors_seen[1]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_subscribe_events_filter_by_types(self, monkeypatch):
+        """The ``types`` arg passes through to ``list_events`` so the
+        registry-side filter trims the batch BEFORE the iterator
+        observes it."""
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        types_seen: list[Any] = []
+
+        class _FakeProxy:
+            def __init__(self, _job_id: str, _registry_url: str) -> None:
+                pass
+
+            async def list_events(
+                self, _after: int, types: Any, _wait: float
+            ) -> tuple[list[dict[str, Any]], int]:
+                types_seen.append(types)
+                return [
+                    {"job_id": "j1", "seq": 1, "type": "user_input", "payload": None}
+                ], 1
+
+        with mock.patch("mcp_mesh_core.JobProxy", _FakeProxy, create=True):
+            async for _ in mesh_jobs.subscribe_events(
+                "j1", types=["user_input"], long_poll_secs=0.0
+            ):
+                break
+
+        assert types_seen[0] == ["user_input"], (
+            f"types filter must pass through to list_events verbatim; "
+            f"got {types_seen[0]!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_subscribe_events_propagates_job_not_found(
+        self, monkeypatch
+    ):
+        """When ``list_events`` raises a JobNotFound-shaped RuntimeError
+        (registry reaped the job row), the iterator must surface it as
+        the typed :class:`JobNotFoundError` so callers can ``except``
+        cleanly without inspecting strings."""
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        class _FakeProxy:
+            def __init__(self, _job_id: str, _registry_url: str) -> None:
+                pass
+
+            async def list_events(self, *_args: Any, **_kw: Any) -> list[Any]:
+                raise RuntimeError("backend error: job not found: gone")
+
+        with mock.patch("mcp_mesh_core.JobProxy", _FakeProxy, create=True):
+            with pytest.raises(mesh_jobs.JobNotFoundError):
+                async for _ in mesh_jobs.subscribe_events(
+                    "missing", long_poll_secs=0.0
+                ):
+                    pass  # pragma: no cover - iterator raises on first call
+
+    @pytest.mark.asyncio
+    async def test_mesh_jobs_subscribe_events_uses_cached_proxy(
+        self, monkeypatch
+    ):
+        """``subscribe_events`` reuses the same module-level
+        ``(registry_url, job_id)`` proxy cache as ``post_event``. Two
+        sequential subscriptions to the same job must construct ONE
+        underlying ``JobProxy`` instance (the cache is shared across
+        helpers)."""
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        construct_count = 0
+
+        class _CountingFake:
+            def __init__(self, _job_id: str, _registry_url: str) -> None:
+                nonlocal construct_count
+                construct_count += 1
+
+            async def list_events(
+                self, _after: int, _types: Any, _wait: float
+            ) -> tuple[list[dict[str, Any]], int]:
+                return [
+                    {"job_id": "j-cached", "seq": 1, "type": "t", "payload": None}
+                ], 1
+
+        with mock.patch("mcp_mesh_core.JobProxy", _CountingFake, create=True):
+            async for _ in mesh_jobs.subscribe_events(
+                "j-cached", long_poll_secs=0.0
+            ):
+                break
+            async for _ in mesh_jobs.subscribe_events(
+                "j-cached", long_poll_secs=0.0
+            ):
+                break
+
+        # Two iterations, ONE proxy construction — the cache hit on the
+        # second call must reuse the proxy from the first call (same
+        # `(registry_url, job_id)` key as `post_event`).
+        assert construct_count == 1, (
+            f"expected the JobProxy cache to be shared across helpers "
+            f"(post_event + subscribe_events); got {construct_count} "
+            f"constructions for the same job_id"
+        )
+
+    @pytest.mark.asyncio
+    async def test_subscribe_events_forwards_none_long_poll_secs(
+        self, monkeypatch
+    ):
+        """``long_poll_secs=None`` MUST pass through verbatim to the pyo3
+        binding so the Rust side treats it as "single immediate read"
+        (no ``wait`` query param sent). Pre-fix the signature typed this
+        as ``float`` and hid the ``None`` path entirely."""
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        wait_args: list[Any] = []
+
+        class _FakeProxy:
+            def __init__(self, _job_id: str, _registry_url: str) -> None:
+                pass
+
+            async def list_events(
+                self, _after: int, _types: Any, wait: Any
+            ) -> tuple[list[dict[str, Any]], int]:
+                wait_args.append(wait)
+                return [
+                    {"job_id": "j1", "seq": 1, "type": "x", "payload": None}
+                ], 1
+
+        with mock.patch("mcp_mesh_core.JobProxy", _FakeProxy, create=True):
+            async for _ in mesh_jobs.subscribe_events(
+                "j1", long_poll_secs=None
+            ):
+                break
+
+        assert wait_args[0] is None, (
+            f"long_poll_secs=None must forward as None to proxy.list_events "
+            f"(single immediate read); got {wait_args[0]!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_subscribe_events_raises_on_missing_seq(self, monkeypatch):
+        """An event missing the integer ``seq`` key surfaces as a
+        ``RuntimeError`` BEFORE the event is yielded — so callers don't
+        observe a half-yielded malformed payload, and the error message
+        names the offending field."""
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        class _FakeProxy:
+            def __init__(self, _job_id: str, _registry_url: str) -> None:
+                pass
+
+            async def list_events(
+                self, _after: int, _types: Any, _wait: Any
+            ) -> tuple[list[dict[str, Any]], int]:
+                return [{"type": "work", "payload": {}}], 0  # no 'seq' key
+
+        with mock.patch("mcp_mesh_core.JobProxy", _FakeProxy, create=True):
+            with pytest.raises(RuntimeError) as exc:
+                async for _ in mesh_jobs.subscribe_events(
+                    "j1", long_poll_secs=0.0
+                ):
+                    pass  # pragma: no cover - iterator raises on first event
+        assert "seq" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_subscribe_events_rejects_bool_seq(self, monkeypatch):
+        """A bool ``seq`` value (``True``/``False``) must be rejected:
+        ``isinstance(True, int)`` is True in Python, but the registry
+        contract is integer seqs — a bool here is a malformed wire payload.
+        The guard uses ``type(seq) is not int`` so booleans fail BEFORE
+        the event is yielded."""
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        class _FakeProxy:
+            def __init__(self, _job_id: str, _registry_url: str) -> None:
+                pass
+
+            async def list_events(
+                self, _after: int, _types: Any, _wait: Any
+            ) -> tuple[list[dict[str, Any]], int]:
+                return [{"seq": True, "type": "work", "payload": {}}], 1
+
+        with mock.patch("mcp_mesh_core.JobProxy", _FakeProxy, create=True):
+            with pytest.raises(RuntimeError) as exc:
+                async for _ in mesh_jobs.subscribe_events(
+                    "j1", long_poll_secs=0.0
+                ):
+                    pass  # pragma: no cover - iterator raises on first event
+        assert "seq" in str(exc.value)
 
 
 # ===========================================================================

--- a/tests/integration/suites/uc21_meshjob/fixtures/long-task-consumer/main.py
+++ b/tests/integration/suites/uc21_meshjob/fixtures/long-task-consumer/main.py
@@ -405,6 +405,114 @@ async def commission_cancel_via_event(
     }
 
 
+@app.tool()
+@mesh.tool(
+    capability="commission_subscribe_observer",
+    dependencies=["run_until_done"],
+    description="Submit run_until_done, concurrently post 'work' events and subscribe — verifies observer pattern.",
+)
+async def commission_subscribe_observer(
+    run_until_done: MeshJob = None,
+) -> dict:
+    """Tc27 driver: producer consumes 'work' events; observer subscribes
+    independently. Both sides must observe all 3 posted events; the
+    producer's recv_event cursor is independent of the observer's.
+
+    Sequence:
+      1. Submit run_until_done.
+      2. Concurrently:
+         a) Background task fires 3 'work' events (the 3rd carries
+            ``{"final": true}`` to terminate the producer).
+         b) Background task subscribes via mesh.jobs.subscribe_events
+            and collects every 'work' event until it sees the final one.
+      3. Wait for both tasks + the producer to complete.
+      4. Return a structured report so the integration assertions can
+         pin all three observers (producer, subscriber, posters) agree
+         on the event count and ordering.
+    """
+    if run_until_done is None:
+        return {"error": "run_until_done submitter not injected"}
+    proxy = await run_until_done.submit(ctx={}, max_duration=60)
+    job_id = proxy.job_id
+
+    # Give the producer a moment to claim + park on recv_event before we
+    # post anything. Without this the first 'work' event could land
+    # before the producer's claim worker has pulled the row off the
+    # queue — the event would still be observable (the cursor is
+    # per-controller), but the test would not exercise the long-poll
+    # wake path.
+    await asyncio.sleep(2.0)
+
+    observed_events: list[dict] = []
+
+    async def _subscriber() -> None:
+        """Observe events via subscribe_events until the final one arrives."""
+        async for event in mesh.jobs.subscribe_events(
+            job_id, types=["work"], long_poll_secs=5.0
+        ):
+            observed_events.append(
+                {"seq": event["seq"], "payload": event["payload"]}
+            )
+            payload = event.get("payload") or {}
+            if isinstance(payload, dict) and payload.get("final"):
+                return
+
+    async def _poster() -> list[int]:
+        """Fire 3 work events spaced ~500ms apart — last one terminates."""
+        seqs: list[int] = []
+        for i, payload in enumerate(
+            [
+                {"item": 1},
+                {"item": 2},
+                {"item": 3, "final": True},
+            ]
+        ):
+            await asyncio.sleep(0.5)
+            receipt = await mesh.jobs.post_event(
+                job_id=job_id,
+                event_type="work",
+                payload=payload,
+            )
+            seqs.append(receipt["seq"])
+        return seqs
+
+    # Run subscriber + poster concurrently. The subscriber races the
+    # producer for events but each has its own cursor, so both observe
+    # the same set.
+    sub_task = asyncio.create_task(_subscriber())
+    posted_seqs = await _poster()
+
+    # Bound the subscriber wait so a stuck observer doesn't hang the
+    # whole test — 15s is well above the producer's expected runtime
+    # (3 events * 500ms post-spacing + handler overhead).
+    try:
+        await asyncio.wait_for(sub_task, timeout=15.0)
+        subscriber_status = "ok"
+    except asyncio.TimeoutError:
+        sub_task.cancel()
+        # Drain the cancelled task so asyncio doesn't emit "Task was
+        # destroyed but it is pending" warnings. The `Exception` arm
+        # handles surfaces from the subscriber's error path — we've
+        # already decided the subscriber didn't keep up, so the failure
+        # mode of the drain is uninteresting.
+        try:
+            await sub_task
+        except (asyncio.CancelledError, Exception):
+            pass
+        subscriber_status = "timeout"
+
+    job_result = await proxy.wait(timeout_secs=30)
+
+    return {
+        "job_id": job_id,
+        "posted_seqs": posted_seqs,
+        "subscriber_status": subscriber_status,
+        "observed_count": len(observed_events),
+        "observed_events": observed_events,
+        "job_result": job_result,
+    }
+
+
 import os  # noqa: E402  (kept here for clarity that env-port is the only env hook)
 
 

--- a/tests/integration/suites/uc21_meshjob/fixtures/long-task-provider/main.py
+++ b/tests/integration/suites/uc21_meshjob/fixtures/long-task-provider/main.py
@@ -388,6 +388,50 @@ async def run_with_filter(
 
 @app.tool()
 @mesh.tool(
+    capability="run_until_done",
+    task=True,
+    description="Loop on recv_event for 'work' events, exit on payload {'final': true} — paired with subscribe_events observer.",
+)
+async def run_until_done(
+    ctx: dict | None = None,
+    job: MeshJob = None,
+) -> dict[str, Any]:
+    """Producer side of tc27_subscribe_events_streams_observer_pattern.
+
+    Consumes ``work`` events in a loop. A caller-defined termination event
+    — a ``work`` event whose payload contains ``{"final": true}`` — is
+    the signal to exit gracefully and return the count of events
+    processed. The subscribe_events observer on the consumer side
+    watches the SAME event stream independently.
+    """
+    if job is None:
+        return {"status": "no_job_ctx"}
+    events_processed: list[dict[str, Any]] = []
+    # Bounded loop — safety net so a missing termination event doesn't
+    # hang the job indefinitely. Per-call long timeout matches the
+    # consumer's posting cadence (the consumer fires ~3 events within
+    # a few seconds, so 10s/iteration is plenty).
+    for _ in range(20):
+        event = await job.recv_event(types=["work"], timeout_secs=10.0)
+        if event is None:
+            return {"status": "timeout", "processed": events_processed}
+        events_processed.append(
+            {"seq": event["seq"], "payload": event["payload"]}
+        )
+        payload = event.get("payload") or {}
+        if isinstance(payload, dict) and payload.get("final"):
+            payload_result = {
+                "status": "done",
+                "processed_count": len(events_processed),
+                "events": events_processed,
+            }
+            await job.complete(payload_result)
+            return payload_result
+    return {"status": "loop_exhausted", "processed": events_processed}
+
+
+@app.tool()
+@mesh.tool(
     capability="run_until_cancel",
     task=True,
     description="Loop on recv_event for 'work'/'cancelled' types until cancelled-event arrives.",

--- a/tests/integration/suites/uc21_meshjob/tc27_subscribe_events_streams_observer_pattern/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc27_subscribe_events_streams_observer_pattern/test.yaml
@@ -1,0 +1,135 @@
+# tc27_subscribe_events_streams_observer_pattern — JobProxy.subscribe_events
+# observer pattern (issue #1032).
+#
+# Verifies the consumer-side observer iterator built on the Phase D
+# `mesh.jobs.subscribe_events` async generator. Unlike `recv_event`
+# (single per-controller cursor that advances on consumption),
+# `subscribe_events` is an OBSERVER — it has a per-call cursor, so
+# multiple subscribers can watch the same job's events without
+# disturbing the producer's consumption.
+#
+# Sequence (driven by ``commission_subscribe_observer``):
+#   1. Submit ``run_until_done`` (producer that consumes 'work' events
+#      until one carries ``{"final": true}``).
+#   2. Spawn a subscriber via ``mesh.jobs.subscribe_events(job_id,
+#      types=["work"])`` in a background asyncio task. It collects every
+#      'work' event into a list, breaks when it sees ``{"final": true}``.
+#   3. Concurrently post 3 'work' events with ``mesh.jobs.post_event``,
+#      the 3rd carrying ``{"final": true}``.
+#   4. Wait for both the subscriber task and ``proxy.wait()`` to
+#      complete.
+#
+# Asserts:
+#   - producer's job result has ``status=done`` + ``processed_count=3``
+#     (proves the recv_event side consumed all 3 in order)
+#   - subscriber observed all 3 events
+#     (proves subscribe_events runs independently of the producer's cursor)
+#   - subscriber_status == "ok" (no observer timeout)
+#   - posted seqs are [1, 2, 3] (first events on a fresh job)
+#
+# This is the headline regression for the Phase D
+# ``JobProxy.subscribe_events`` async iterator surface — unit tests
+# cover the helper itself but they bind to a fake JobProxy, so this is
+# the first time we exercise the iterator against a real registry +
+# Rust core.
+
+name: "MeshJob: subscribe_events streams events to an observer running alongside the producer"
+description: "Producer recv_event + observer subscribe_events run independently against the same event stream"
+tags:
+  - meshjob
+  - python
+  - issue-1032
+  - events
+  - subscribe
+timeout: 90
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for provider registration"
+    handler: wait
+    seconds: 12
+
+  - name: "Start consumer (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for consumer + DI resolution"
+    handler: wait
+    seconds: 18
+
+  - name: "Call commission_subscribe_observer — submit, post 3 events, observe via subscribe_events"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_subscribe_observer '{}'
+    capture: commission_response
+    timeout: 60
+
+assertions:
+  # MCP envelope check: must not be an error response.
+  - expr: "${captured.commission_response} not contains '\"isError\": true'"
+    message: "commission_subscribe_observer should NOT return an MCP error envelope"
+
+  # Subscriber finished cleanly (no observer timeout).
+  - expr: "${captured.commission_response} contains '\"subscriber_status\": \"ok\"'"
+    message: "subscriber task must complete cleanly (observed the final event before timeout)"
+  - expr: "${captured.commission_response} not contains '\"subscriber_status\": \"timeout\"'"
+    message: "subscriber must NOT have timed out — the final event should have arrived in time"
+
+  # Observer-side event count: subscribe_events yields all 3 'work' events.
+  - expr: "${captured.commission_response} contains '\"observed_count\": 3'"
+    message: "subscribe_events must yield all 3 'work' events the consumer posted (observer cursor is independent of producer's)"
+
+  # Producer-side processing: recv_event also consumed all 3 events.
+  - expr: "${captured.commission_response} contains '\"processed_count\": 3'"
+    message: "producer must have processed all 3 'work' events via recv_event (independent cursor from subscriber)"
+  - expr: "${captured.commission_response} contains '\"status\": \"done\"'"
+    message: "producer must report status=done after observing the final event"
+
+  # Posted seqs prove the events landed in order on a fresh job.
+  # We assert each seq is present near a posted_seqs reference; we don't
+  # match the array literal exactly because meshctl call's structuredContent
+  # pretty-printer may insert whitespace between elements while the embedded
+  # MCP `text` field uses compact JSON. Asserting on individual seqs is
+  # encoder-spacing tolerant.
+  - expr: "${captured.commission_response} contains 'posted_seqs'"
+    message: "commission response must include posted_seqs key from the post_event return values"
+  - expr: "${captured.commission_response} contains '\"seq\": 1'"
+    message: "first posted event must have seq=1"
+  - expr: "${captured.commission_response} contains '\"seq\": 2'"
+    message: "second posted event must have seq=2"
+  - expr: "${captured.commission_response} contains '\"seq\": 3'"
+    message: "third posted event must have seq=3"
+
+  # Payload round-trip: the final event's marker reaches both observers.
+  - expr: "${captured.commission_response} contains '\"final\": true'"
+    message: "the final event's payload marker must round-trip through both recv_event and subscribe_events"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

- Adds **Stream[T] subscription mode** for MeshJob (Python vertical of #1032 follow-up): `mesh.jobs.subscribe_events(job_id, types=, after=, long_poll_secs=) -> AsyncIterator[dict]`.
- Counterpart to the point-to-point `recv_event`/`send_event` surface (#1041). Subscription is non-destructive — multiple subscribers can observe the same job's event log independently, each with its own per-call cursor.
- Three layers: Rust core `JobProxy::list_events` (thin pass-through to `backend.list_job_events`), pyo3 binding `PyJobProxy.list_events` with `parse_timeout_secs` guard, Python SDK `mesh.jobs.subscribe_events` async generator.
- Integration test tc27 extends existing fixtures with `run_until_done` (producer) and `commission_subscribe_observer` (consumer) tools — same job is observed by both `recv_event` (consumer) and `subscribe_events` (third-party observer), proving cursor independence.

## Review Notes

Independent review caught 1 blocker + 2 substantive warnings (all addressed in the amended commit):

1. **Public `long_poll_secs` surface**: now `Optional[float] = 30.0` (was `float = 30.0`). `None` reaches the binding's "single immediate read" path; previously unreachable from Python. Unit test added.
2. **Cursor advance + `seq` validation**: cursor now advances **before** yield, and `event["seq"]` is type-validated with a clear `RuntimeError` instead of a half-yielded `KeyError`. Unit test added.
3. **YAML assertion robustness**: replaced the whitespace-sensitive `"posted_seqs":[1,2,3]` substring with structured per-seq checks tolerant to encoder spacing changes.

Other review WARNINGs (`async def`+`yield` annotation footgun in docstring, subscriber-vs-poster scheduling race in the fixture) and the 5 INFOs are deferred — none affect correctness.

Closes #1046

Sibling verticals (TS, Java) of this same subscription mode will follow as separate PRs to keep the diffs reviewable, mirroring the #1041 → #1043 → #1045 cadence.

## Test plan

- [x] Python unit tests pass (`test_meshjob_events.py`: 27 tests, +5 new in this PR — 2 from fixes, 3 from initial implementation)
- [x] Rust unit tests pass (`jobs.rs`: +6 new for `JobProxy::list_events`)
- [x] uc21_meshjob integration suite: 21/21 pass (20 baseline + 1 new tc27 in 193.8s)
- [x] `parse_timeout_secs` guard reused from #1041 (NaN/Inf/negative reject; `try_from_secs_f64` overflow)
- [x] LRU `JobProxy` cache reused from #1041 (no duplicate cache)
- [x] Server-side `types` filter forwarded all the way to `backend.list_job_events` (no client-side post-filter)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job event listing: Query events with optional type filtering and long-polling support for efficient batch retrieval without affecting internal state
  * Job event subscription: Subscribe to event streams with automatic cursor management, enabling asynchronous observation of job activity across multiple batches
  
* **Tests**
  * Integration tests validating concurrent event publishing and concurrent subscription via observer pattern

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->