### PR TITLE
java: MeshJob Stream subscription — subscribeEvents (Java)

### DIFF
--- a/src/runtime/core/include/mcp_mesh_core.h
+++ b/src/runtime/core/include/mcp_mesh_core.h
@@ -904,6 +904,51 @@ int32_t mesh_job_proxy_send_event(struct JobProxyHandle *handle,
                                   const char *payload_json,
                                   char **out_receipt_json);
 
+// Fetch a single batch of events from this job's event log with
+// `seq > after`, optionally filtered by `types`. The Java SDK's
+// `MeshJobs.subscribeEvents` blocking iterator is built on top of
+// this primitive — callers manage their own cursor between calls.
+//
+// Mirrors [`JobProxy::list_events`] one-for-one. Returns the events
+// AND the registry-supplied `next_after` watermark in a JSON envelope
+// `{"events": [...], "next_after": N}` written to
+// `*out_envelope_json`. Caller frees via `mesh_free_string`.
+//
+// # Arguments
+// - `after`: cursor — only events with `seq > after` are returned.
+//   Pass `0` for "from the beginning of the event log".
+// - `types_json`: optional UTF-8 NUL-terminated JSON string encoding an
+//   array of event-type tags (e.g. `["work","progress"]`). `NULL` (or
+//   a JSON `null`) means "all types". Invalid JSON or non-array shape
+//   returns -1 with the last-error slot populated.
+// - `timeout_secs`: f64 long-poll budget in seconds. Same negative-
+//   sentinel convention as [`mesh_job_controller_recv_event`]:
+//   pass a negative value (e.g. `-1.0`) to express "no timeout"
+//   (single immediate read; rarely needed). NaN / ±Infinity reject
+//   with -1; finite-but-overflowing values reject via
+//   [`Duration::try_from_secs_f64`] (see `parse_ffi_timeout_secs`).
+// - `out_envelope_json`: receives `*mut c_char` JSON envelope
+//   `{"events":[...],"next_after":N}`. Empty `events` array means
+//   "no events arrived within the wait window" — the caller advances
+//   the cursor to `next_after` (which may be `> after` when the
+//   registry scanned events hidden by a server-side `types` filter)
+//   and polls again. Caller frees via `mesh_free_string`.
+//
+// # Returns
+// - `0` on success (envelope written; events list may be empty).
+// - `-1` on invalid args (null handle, null out-pointer, malformed
+//   types_json, invalid timeout).
+// - `-2` on JobNotFound (registry doesn't know the job — 404 from
+//   `GET /jobs/{id}/events`). Mapped by the Java SDK to
+//   `JobNotFoundException`.
+// - `-3` on other backend errors (transport failure, 5xx after
+//   retries, decode failure, etc.). See `mesh_last_error` for details.
+int32_t mesh_job_proxy_list_events(struct JobProxyHandle *handle,
+                                   int64_t after,
+                                   const char *types_json,
+                                   double timeout_secs,
+                                   char **out_envelope_json);
+
 // Free a [`JobProxyHandle`] returned by [`mesh_submit_job`] /
 // [`mesh_job_proxy_new`].
 void mesh_job_proxy_free(struct JobProxyHandle *handle);

--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -992,6 +992,148 @@ pub unsafe extern "C" fn mesh_job_proxy_send_event(
     }
 }
 
+/// Fetch a single batch of events from this job's event log with
+/// `seq > after`, optionally filtered by `types`. The Java SDK's
+/// `MeshJobs.subscribeEvents` blocking iterator is built on top of
+/// this primitive — callers manage their own cursor between calls.
+///
+/// Mirrors [`JobProxy::list_events`] one-for-one. Returns the events
+/// AND the registry-supplied `next_after` watermark in a JSON envelope
+/// `{"events": [...], "next_after": N}` written to
+/// `*out_envelope_json`. Caller frees via `mesh_free_string`.
+///
+/// # Arguments
+/// - `after`: cursor — only events with `seq > after` are returned.
+///   Pass `0` for "from the beginning of the event log".
+/// - `types_json`: optional UTF-8 NUL-terminated JSON string encoding an
+///   array of event-type tags (e.g. `["work","progress"]`). `NULL` (or
+///   a JSON `null`) means "all types". Invalid JSON or non-array shape
+///   returns -1 with the last-error slot populated.
+/// - `timeout_secs`: f64 long-poll budget in seconds. Same negative-
+///   sentinel convention as [`mesh_job_controller_recv_event`]:
+///   pass a negative value (e.g. `-1.0`) to express "no timeout"
+///   (single immediate read; rarely needed). NaN / ±Infinity reject
+///   with -1; finite-but-overflowing values reject via
+///   [`Duration::try_from_secs_f64`] (see `parse_ffi_timeout_secs`).
+/// - `out_envelope_json`: receives `*mut c_char` JSON envelope
+///   `{"events":[...],"next_after":N}`. Empty `events` array means
+///   "no events arrived within the wait window" — the caller advances
+///   the cursor to `next_after` (which may be `> after` when the
+///   registry scanned events hidden by a server-side `types` filter)
+///   and polls again. Caller frees via `mesh_free_string`.
+///
+/// # Returns
+/// - `0` on success (envelope written; events list may be empty).
+/// - `-1` on invalid args (null handle, null out-pointer, malformed
+///   types_json, invalid timeout).
+/// - `-2` on JobNotFound (registry doesn't know the job — 404 from
+///   `GET /jobs/{id}/events`). Mapped by the Java SDK to
+///   `JobNotFoundException`.
+/// - `-3` on other backend errors (transport failure, 5xx after
+///   retries, decode failure, etc.). See `mesh_last_error` for details.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_proxy_list_events(
+    handle: *mut JobProxyHandle,
+    after: i64,
+    types_json: *const c_char,
+    timeout_secs: f64,
+    out_envelope_json: *mut *mut c_char,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    if out_envelope_json.is_null() {
+        set_last_error("out_envelope_json is null");
+        return -1;
+    }
+    *out_envelope_json = ptr::null_mut();
+    let handle = &*handle;
+
+    // Parse optional types filter — NULL → None (all types); JSON array
+    // → Some(Vec<String>); anything else rejects. Same shape as
+    // mesh_job_controller_recv_event.
+    let types_opt: Option<Vec<String>> = match opt_cstr(types_json, "types_json") {
+        Ok(None) => None,
+        Ok(Some(s)) => match serde_json::from_str::<serde_json::Value>(s) {
+            Ok(serde_json::Value::Null) => None,
+            Ok(serde_json::Value::Array(arr)) => {
+                let mut out = Vec::with_capacity(arr.len());
+                for v in arr {
+                    match v {
+                        serde_json::Value::String(s) => out.push(s),
+                        other => {
+                            set_last_error(format!(
+                                "types_json must be an array of strings, got element: {}",
+                                other
+                            ));
+                            return -1;
+                        }
+                    }
+                }
+                Some(out)
+            }
+            Ok(other) => {
+                set_last_error(format!(
+                    "types_json must be a JSON array or null, got: {}",
+                    other
+                ));
+                return -1;
+            }
+            Err(e) => {
+                set_last_error(format!("invalid types_json: {}", e));
+                return -1;
+            }
+        },
+        Err(()) => return -1,
+    };
+
+    let wait = match parse_ffi_timeout_secs(timeout_secs) {
+        Ok(t) => t,
+        Err(msg) => {
+            set_last_error(msg);
+            return -1;
+        }
+    };
+
+    let inner = handle.inner.clone();
+    let result = jobs_runtime()
+        .block_on(async move { inner.list_events(after, types_opt, wait).await });
+    match result {
+        Ok((events, next_after)) => {
+            // Build the envelope shape consumed by Java's
+            // EventSubscription. snake_case `next_after` keeps the wire
+            // shape consistent with the registry response.
+            let events_values: Vec<serde_json::Value> = events
+                .into_iter()
+                .map(|ev| serde_json::json!({
+                    "job_id": ev.job_id,
+                    "seq": ev.seq,
+                    "type": ev.event_type,
+                    "payload": ev.payload.unwrap_or(serde_json::Value::Null),
+                    "trace_context": ev.trace_context.unwrap_or(serde_json::Value::Null),
+                    "posted_by": ev.posted_by,
+                    "created_at": ev.created_at,
+                }))
+                .collect();
+            let envelope = serde_json::json!({
+                "events": events_values,
+                "next_after": next_after,
+            });
+            write_out_string(out_envelope_json, envelope.to_string())
+        }
+        Err(JobError::Backend(crate::task_backend::BackendError::NotFound(msg))) => {
+            set_last_error(format!("job not found: {}", msg));
+            -2
+        }
+        Err(e) => {
+            set_last_error(e.to_string());
+            -3
+        }
+    }
+}
+
 /// Free a [`JobProxyHandle`] returned by [`mesh_submit_job`] /
 /// [`mesh_job_proxy_new`].
 #[no_mangle]
@@ -1517,6 +1659,24 @@ mod tests {
         let rc = unsafe {
             mesh_job_controller_recv_event(
                 ptr::null_mut(),
+                ptr::null(),
+                -1.0,
+                &mut out as *mut _,
+            )
+        };
+        assert_eq!(rc, -1);
+    }
+
+    /// `mesh_job_proxy_list_events` must reject null handle / null
+    /// out-ptr cleanly via the last-error slot rather than crashing.
+    /// Mirrors `recv_event_rejects_null_handle` / `send_event_rejects_null_handle`.
+    #[test]
+    fn list_events_rejects_null_handle() {
+        let mut out: *mut c_char = ptr::null_mut();
+        let rc = unsafe {
+            mesh_job_proxy_list_events(
+                ptr::null_mut(),
+                0,
                 ptr::null(),
                 -1.0,
                 &mut out as *mut _,

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
@@ -696,6 +696,53 @@ public interface MeshCore {
         Pointer handle, String eventType, String payloadJson, PointerByReference outReceiptJson);
 
     /**
+     * Fetch a single batch of events from this job's event log with
+     * {@code seq > after}, optionally filtered by {@code types}. Java's
+     * {@code MeshJobs.subscribeEvents} blocking iterator is built on
+     * top of this primitive — callers manage their own cursor between
+     * calls. Mirror of {@code JobProxy::list_events} in the Rust core.
+     *
+     * <p>The result is a JSON envelope
+     * {@code {"events":[...],"next_after":N}} written to
+     * {@code outEnvelopeJson}. {@code next_after} is the registry-
+     * supplied watermark the caller should feed back as {@code after}
+     * on the next call so empty pages caused by server-side
+     * {@code types} filtering still advance the cursor.
+     *
+     * <p>The C ABI cannot pass a nullable double, so {@code timeoutSecs}
+     * uses the same negative-sentinel convention as
+     * {@link #mesh_job_controller_recv_event}: pass a negative value
+     * (e.g. {@code -1.0}) to express "no timeout"; NaN / Infinity /
+     * finite overflow all reject with -1.
+     *
+     * @param handle             Proxy handle
+     * @param after              Cursor — only events with
+     *                           {@code seq > after} are returned. Pass
+     *                           {@code 0} for "from the beginning".
+     * @param typesJson          Optional JSON array of event-type
+     *                           strings to filter on (e.g.
+     *                           {@code ["work","progress"]}); null or
+     *                           a JSON {@code null} means "all types"
+     * @param timeoutSecs        Long-poll budget in seconds; negative
+     *                           means "no timeout" (single immediate
+     *                           read; rarely needed)
+     * @param outEnvelopeJson    Out-param: receives the envelope JSON
+     *                           string (caller frees via
+     *                           {@code mesh_free_string})
+     * @return 0 on success (envelope written; events may be empty),
+     *         -1 on invalid args, -2 on JobNotFound, -3 on other
+     *         backend errors (see {@link #mesh_last_error}).
+     *         Distinct error codes let the Java SDK map -2 to a typed
+     *         {@code JobNotFoundException}.
+     */
+    int mesh_job_proxy_list_events(
+        Pointer handle,
+        long after,
+        String typesJson,
+        double timeoutSecs,
+        PointerByReference outEnvelopeJson);
+
+    /**
      * Free a JobProxy handle returned by mesh_submit_job / mesh_job_proxy_new.
      *
      * @param handle Proxy handle (may be null)

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/EventSubscription.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/EventSubscription.java
@@ -1,0 +1,240 @@
+package io.mcpmesh;
+
+import io.mcpmesh.core.MeshException;
+
+import java.io.Closeable;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * Long-lived blocking iterator over events posted to a running job's
+ * event log. Returned by
+ * {@link MeshJobs#subscribeEvents(String, SubscribeOptions)}.
+ *
+ * <p>Each subscription manages its own cursor — multiple subscribers
+ * can observe the same job's events independently without affecting
+ * the producer's {@code recvEvent} consumption (the producer's cursor
+ * is per-controller; the subscriber's cursor is per-subscription).
+ *
+ * <p>The iterator runs indefinitely until the caller breaks out of
+ * the loop or {@link #close()} is invoked, or the underlying registry
+ * raises {@link JobNotFoundException}. There is no automatic terminal-
+ * state detection — use a synthetic event type (e.g.
+ * {@code {"type":"ended"}}) posted by your application to signal
+ * iteration end.
+ *
+ * <p>Mirrors:
+ * <ul>
+ *   <li>Python {@code mesh.jobs.subscribe_events} async generator</li>
+ *   <li>TypeScript {@code mesh.jobs.subscribeEvents} async generator</li>
+ * </ul>
+ *
+ * <p><b>Closeable contract</b>: implements {@link Closeable} so callers
+ * can use try-with-resources. {@link #close()} flips an internal flag
+ * that makes the next {@link #hasNext()} return {@code false} without
+ * issuing another FFI long-poll, and drops this subscription's
+ * {@link JobProxy} reference so the proxy's connection pool can be
+ * reclaimed once no other subscribers hold it.
+ *
+ * <p><strong>Cancellation semantics:</strong> {@link #close()} flips a flag
+ * that stops <em>future</em> FFI long-polls — it does NOT interrupt an
+ * in-flight long-poll. If another thread is blocked inside the iterator's
+ * next FFI call when {@code close()} is invoked, that call runs to its
+ * natural {@code longPoll} budget (default 30 seconds) before the iterator
+ * sees the close. This differs from Python's {@code asyncio.CancelledError}
+ * which actually interrupts the awaited operation. Plumbing true
+ * interruption through the FFI is out of scope for the present release.
+ * Callers that need rapid shutdown should configure a short {@code longPoll}
+ * (e.g. {@link SubscribeOptions.Builder#longPoll(Duration)} with a few
+ * seconds) so the in-flight call drains quickly.
+ *
+ * <p><b>Thread-safety</b>: this class is NOT thread-safe. A single
+ * subscription is intended to be consumed by a single thread (or one
+ * thread at a time with external synchronisation). The cache reuse
+ * in {@link MeshJobs#subscribeEvents} only shares the underlying
+ * {@link JobProxy} across subscriptions — the iterator state
+ * (buffer, cursor, closed flag) is per-instance.
+ */
+public final class EventSubscription implements Iterator<Map<String, Object>>, Closeable {
+
+    private final JobProxy proxy;
+    private final List<String> types;
+    private final Duration longPoll;
+
+    private final Deque<Map<String, Object>> buffer = new ArrayDeque<>();
+    private long cursor;
+    private volatile boolean closed = false;
+
+    EventSubscription(JobProxy proxy, SubscribeOptions options) {
+        this.proxy = proxy;
+        this.types = options.types();
+        this.longPoll = options.longPoll();
+        this.cursor = options.after();
+    }
+
+    /**
+     * Validate that a {@link Number} from the registry envelope is an
+     * integer-valued long: not fractional, not a NaN/Infinity bridge.
+     * Returns the long value on success.
+     *
+     * @throws MeshException if the value cannot be represented exactly
+     *     as a long (e.g. {@code 1.5}, {@code NaN}, {@code Infinity}).
+     */
+    private static long requireIntegralLong(Number n, String fieldName, Object context) {
+        // Long / Integer / Short / Byte / AtomicLong / AtomicInteger / BigInteger
+        // are all integer-typed and round-trip exactly through longValue().
+        // Float / Double / BigDecimal may carry a fractional component or
+        // non-finite value that must NOT be silently truncated.
+        double d = n.doubleValue();
+        if (Double.isNaN(d) || Double.isInfinite(d)) {
+            throw new MeshException(
+                "subscribeEvents: registry returned non-finite '" + fieldName
+                    + "' (" + d + "): " + context);
+        }
+        long asLong = n.longValue();
+        // If the original is a fractional type, doubleValue() != longValue()
+        // catches the truncation. Integer types round-trip exactly.
+        if ((double) asLong != d) {
+            throw new MeshException(
+                "subscribeEvents: registry returned fractional '" + fieldName
+                    + "' (" + n + "): " + context);
+        }
+        return asLong;
+    }
+
+    /**
+     * Block until at least one event is available, the registry
+     * returns an empty page that doesn't advance our cursor (which we
+     * loop past by issuing another long-poll), or this subscription
+     * is closed. Returns {@code false} only after {@link #close()}
+     * — the registry side never signals "no more events" because the
+     * event channel is an append-only log.
+     *
+     * @throws JobNotFoundException if the job has been reaped from
+     *                              the registry (404 on
+     *                              {@code GET /jobs/{id}/events})
+     * @throws MeshException        for transport errors after retry
+     *                              exhaustion, or malformed events
+     *                              (e.g. missing or non-integer
+     *                              {@code seq} in the registry
+     *                              response)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean hasNext() {
+        if (!buffer.isEmpty()) {
+            return true;
+        }
+        // Loop past empty pages — the registry may scan a server-side
+        // types filter and advance `next_after` without yielding any
+        // events; we follow the watermark and poll again. Closing
+        // breaks the loop.
+        while (!closed) {
+            Map<String, Object> envelope = proxy.listEvents(cursor, types, longPoll);
+            Object eventsRaw = envelope.get("events");
+            Object nextAfterRaw = envelope.get("next_after");
+            if (!(eventsRaw instanceof List<?> eventsList)) {
+                throw new MeshException(
+                    "subscribeEvents: registry envelope missing 'events' array: " + envelope);
+            }
+            for (Object item : eventsList) {
+                if (!(item instanceof Map<?, ?> mapRaw)) {
+                    throw new MeshException(
+                        "subscribeEvents: registry returned non-object event: " + item);
+                }
+                Map<String, Object> event = (Map<String, Object>) mapRaw;
+                Object seqRaw = event.get("seq");
+                // Reject Boolean explicitly because Boolean is NOT a
+                // Number subclass on Java BUT autoboxing of a `bool`
+                // primitive on the wire could in theory surface as
+                // Boolean via Jackson — defensive-depth check
+                // mirroring Python's `type(seq) is not int` and TS's
+                // explicit `typeof seq === "boolean"` reject branch.
+                if (seqRaw instanceof Boolean) {
+                    throw new MeshException(
+                        "subscribeEvents: registry returned event with boolean 'seq': " + event);
+                }
+                if (!(seqRaw instanceof Number seqNum)) {
+                    throw new MeshException(
+                        "subscribeEvents: registry returned event without integer 'seq': " + event);
+                }
+                long seq = requireIntegralLong(seqNum, "seq", event);
+                if (seq > cursor) {
+                    cursor = seq;
+                }
+                // listEvents returns ascending-seq; cursor advance
+                // before buffer-push ensures correctness across
+                // consumer cancellation (close() between events).
+                buffer.addLast(event);
+            }
+            // Empty pages (or pages filtered by `types` server-side)
+            // still advance the cursor via the registry-supplied
+            // watermark, so subsequent polls don't re-scan the same
+            // filtered range. Mirrors Python's `cursor = max(cursor,
+            // next_after)` after the per-event loop.
+            if (nextAfterRaw instanceof Number nextAfterNum) {
+                long nextAfter = requireIntegralLong(nextAfterNum, "next_after", nextAfterRaw);
+                if (nextAfter > cursor) {
+                    cursor = nextAfter;
+                }
+            }
+            if (!buffer.isEmpty()) {
+                return true;
+            }
+            // Empty page AND closed — bail. The empty-page-then-poll-
+            // again loop is what gives the iterator its long-lived
+            // semantics; we only exit on explicit close() or a typed
+            // registry exception thrown from listEvents above.
+        }
+        return false;
+    }
+
+    /**
+     * Return the next event from the buffer. Each event has the
+     * shape {@code {seq, type, payload, trace_context, posted_by,
+     * created_at, job_id}}.
+     *
+     * @throws NoSuchElementException if the subscription is closed
+     *                                and no buffered events remain
+     */
+    @Override
+    public Map<String, Object> next() {
+        if (buffer.isEmpty() && !hasNext()) {
+            throw new NoSuchElementException(
+                "EventSubscription is closed and no buffered events remain");
+        }
+        return buffer.pollFirst();
+    }
+
+    /**
+     * Stop issuing new FFI long-polls. Idempotent. Subsequent
+     * {@link #hasNext()} calls return {@code false} (after draining
+     * any buffered events); {@link #next()} throws
+     * {@link NoSuchElementException}.
+     *
+     * <p>Does NOT close the underlying {@link JobProxy} — that proxy
+     * is cached by {@link MeshJobs} and may be shared across
+     * subscriptions or with {@link MeshJobs#postEvent(String, String, Map)}
+     * callers. Dropping the iterator's strong reference is sufficient
+     * for cleanup; the cache's LRU eviction handles proxy lifecycle.
+     */
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    /** Whether {@link #close()} has been invoked. Test-only. */
+    boolean isClosedForTest() {
+        return closed;
+    }
+
+    /** Current cursor position. Test-only. */
+    long cursorForTest() {
+        return cursor;
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobProxy.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobProxy.java
@@ -9,8 +9,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tools.jackson.databind.ObjectMapper;
 
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Consumer-side handle: returned by {@link MeshJobSubmitter#submit(Map)} (or
@@ -36,14 +38,25 @@ public final class JobProxy implements MeshJob, AutoCloseable {
     private final MeshCore core;
     /**
      * Native handle. {@code null} after {@link #close} runs. Read/written
-     * only while holding {@link #lock} — see {@link JobController} for
-     * the same fix; without it a concurrent close could free the
-     * pointer mid-FFI-call (PR #891 review).
+     * only while holding the appropriate {@link #lock} mode (write for
+     * mutation, read for FFI calls) — see {@link JobController} for
+     * the analogous protection; without it a concurrent close could free
+     * the pointer mid-FFI-call (PR #891 review).
      */
     private Pointer handle;
     private final String jobId;
-    private final Object lock = new Object();
-    private final AtomicBoolean closed = new AtomicBoolean(false);
+    /**
+     * Read-write lock so concurrent subscribers can long-poll
+     * {@link #listEvents} on the same cached proxy in parallel. The
+     * underlying Rust {@code JobProxy} ({@code Arc<dyn TaskBackend> +
+     * String}) is {@code Sync} and {@code list_events} explicitly does
+     * NOT serialise — see {@code core/src/jobs.rs} JobProxy doc — so
+     * the read lock is correct here. {@link #close} takes the write
+     * lock so an in-flight FFI call can never see the handle pointer
+     * freed underneath it.
+     */
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private volatile boolean closed = false;
 
     JobProxy(MeshCore core, Pointer handle, String jobId) {
         this.core = core;
@@ -91,14 +104,14 @@ public final class JobProxy implements MeshJob, AutoCloseable {
      */
     @SuppressWarnings("unchecked")
     public Map<String, Object> status() {
-        // FFI call inside the lock; JSON parse afterwards. We MUST own
-        // the returned `p` before releasing the lock — once `close()`
-        // runs it would otherwise be free to free a different handle
-        // — but the result string itself was allocated by Rust and is
-        // independent of the proxy handle, so we can parse it
-        // unguarded.
+        // FFI call inside the READ lock — concurrent status/await/
+        // listEvents calls can proceed in parallel; only close() (write
+        // lock) is mutually exclusive. The result string itself was
+        // allocated by Rust and is independent of the proxy handle, so
+        // we can parse it unguarded.
         Pointer p;
-        synchronized (lock) {
+        lock.readLock().lock();
+        try {
             ensureOpen();
             PointerByReference out = new PointerByReference();
             int rc = core.mesh_job_proxy_status(handle, out);
@@ -106,6 +119,8 @@ public final class JobProxy implements MeshJob, AutoCloseable {
                 throw new MeshException("mesh_job_proxy_status failed: " + lastError(core));
             }
             p = out.getValue();
+        } finally {
+            lock.readLock().unlock();
         }
         if (p == null) {
             throw new MeshException("mesh_job_proxy_status returned null payload");
@@ -149,13 +164,16 @@ public final class JobProxy implements MeshJob, AutoCloseable {
      */
     public Object await(double timeoutSecs) {
         // The wait FFI may block for the full timeout — we hold the
-        // lock for that whole duration so a concurrent close() doesn't
-        // free the handle while the Rust runtime is still polling on
-        // it. Closing the proxy from another thread is a programming
+        // READ lock for that whole duration so a concurrent close()
+        // (write lock) doesn't free the handle while the Rust runtime
+        // is still polling on it. Other read-locked operations
+        // (status/listEvents/await) may proceed concurrently.
+        // Closing the proxy from another thread is a programming
         // error if you also have an outstanding await(), but the lock
         // prevents the worst (use-after-free) outcome.
         Pointer p;
-        synchronized (lock) {
+        lock.readLock().lock();
+        try {
             ensureOpen();
             PointerByReference out = new PointerByReference();
             int rc = core.mesh_job_proxy_wait(handle, timeoutSecs, out);
@@ -163,6 +181,8 @@ public final class JobProxy implements MeshJob, AutoCloseable {
                 throw new MeshException("mesh_job_proxy_wait failed: " + lastError(core));
             }
             p = out.getValue();
+        } finally {
+            lock.readLock().unlock();
         }
         if (p == null) {
             // await() succeeded but produced no payload — treat as JSON null.
@@ -191,12 +211,18 @@ public final class JobProxy implements MeshJob, AutoCloseable {
      * @throws MeshException if the registry call fails
      */
     public void cancel(String reason) {
-        synchronized (lock) {
+        // Read-locked — cancel only forwards the signal via FFI; the
+        // handle itself isn't mutated. Concurrent reads (status/await/
+        // listEvents) may proceed in parallel.
+        lock.readLock().lock();
+        try {
             ensureOpen();
             int rc = core.mesh_job_proxy_cancel(handle, reason);
             if (rc != 0) {
                 throw new MeshException("mesh_job_proxy_cancel failed: " + lastError(core));
             }
+        } finally {
+            lock.readLock().unlock();
         }
     }
 
@@ -249,7 +275,8 @@ public final class JobProxy implements MeshJob, AutoCloseable {
         }
 
         Pointer p;
-        synchronized (lock) {
+        lock.readLock().lock();
+        try {
             ensureOpen();
             PointerByReference out = new PointerByReference();
             int rc = core.mesh_job_proxy_send_event(handle, eventType, payloadJson, out);
@@ -270,6 +297,8 @@ public final class JobProxy implements MeshJob, AutoCloseable {
                     throw new MeshException(
                         "mesh_job_proxy_send_event failed (rc=" + rc + "): " + err);
             }
+        } finally {
+            lock.readLock().unlock();
         }
         if (p == null) {
             throw new MeshException("mesh_job_proxy_send_event returned null receipt");
@@ -284,13 +313,118 @@ public final class JobProxy implements MeshJob, AutoCloseable {
         }
     }
 
+    /**
+     * Fetch a single batch of events from this job's event log with
+     * {@code seq > after}, optionally filtered by {@code types}. The
+     * SDK's {@link MeshJobs#subscribeEvents(String, SubscribeOptions)}
+     * blocking iterator is built on top of this primitive — callers
+     * manage their own cursor between calls.
+     *
+     * <p>Mirrors:
+     * <ul>
+     *   <li>Python {@code proxy.list_events(after, types, long_poll_secs)}</li>
+     *   <li>TypeScript {@code proxy.listEvents(after, types, longPollSecs)}</li>
+     * </ul>
+     *
+     * @param after        Cursor — only events with {@code seq > after}
+     *                     are returned. Pass {@code 0} for "from the
+     *                     beginning of the event log".
+     * @param types        Optional event-type filter (e.g.
+     *                     {@code List.of("work","progress")}); {@code null}
+     *                     or empty means "all types".
+     * @param longPoll     Long-poll wait budget per registry call.
+     *                     {@code null} or {@link Duration#ZERO} or
+     *                     negative means "single immediate read".
+     * @return Envelope {@code {events: List<Map>, next_after: Long}}.
+     *         {@code next_after} is the registry-supplied watermark to
+     *         feed back as {@code after} on the next call so empty
+     *         pages caused by server-side {@code types} filtering still
+     *         advance the cursor.
+     * @throws JobNotFoundException if the job has been reaped from the
+     *                              registry (404 from
+     *                              {@code GET /jobs/{id}/events})
+     * @throws MeshException        for transport errors, malformed
+     *                              types filter, or other backend
+     *                              issues
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> listEvents(long after, List<String> types, Duration longPoll) {
+        // Serialize types filter OUTSIDE the lock — Jackson is
+        // thread-safe and the list is typically short, but keeping
+        // user-data work off the FFI critical section matches the
+        // pattern used by sendEvent()/recvEvent().
+        String typesJson;
+        if (types == null || types.isEmpty()) {
+            typesJson = null;
+        } else {
+            try {
+                typesJson = MAPPER.writeValueAsString(types);
+            } catch (Exception e) {
+                throw new MeshException("Failed to serialize types filter", e);
+            }
+        }
+        // Bridge Optional<Duration> → FFI negative-sentinel "no timeout".
+        // Treat null AND negative as "no timeout" so the boundary
+        // matches the recvEvent contract.
+        double timeoutSecs;
+        if (longPoll == null) {
+            timeoutSecs = -1.0;
+        } else {
+            double secs = longPoll.toNanos() / 1_000_000_000.0;
+            timeoutSecs = secs < 0.0 ? -1.0 : secs;
+        }
+
+        // Read-locked — multiple subscribers on the same cached proxy
+        // long-poll listEvents concurrently. Rust-side `list_events`
+        // explicitly does NOT serialise (see core/src/jobs.rs JobProxy
+        // doc); the read lock only blocks against close()'s write lock.
+        Pointer p;
+        lock.readLock().lock();
+        try {
+            ensureOpen();
+            PointerByReference out = new PointerByReference();
+            int rc = core.mesh_job_proxy_list_events(handle, after, typesJson, timeoutSecs, out);
+            String err = rc == 0 ? null : lastError(core);
+            switch (rc) {
+                case 0:
+                    p = out.getValue();
+                    break;
+                case -2:
+                    throw new JobNotFoundException(
+                        "mesh_job_proxy_list_events: job not found: " + err);
+                case -1:
+                case -3:
+                default:
+                    throw new MeshException(
+                        "mesh_job_proxy_list_events failed (rc=" + rc + "): " + err);
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+        if (p == null) {
+            throw new MeshException("mesh_job_proxy_list_events returned null envelope");
+        }
+        try {
+            String json = p.getString(0);
+            return (Map<String, Object>) MAPPER.readValue(json, Map.class);
+        } catch (Exception e) {
+            throw new MeshException("Failed to parse list_events envelope JSON", e);
+        } finally {
+            core.mesh_free_string(p);
+        }
+    }
+
     /** Free the underlying native handle. Idempotent. */
     @Override
     public void close() {
-        // See JobController.close() for the rationale: hold the lock
-        // across the free so any in-flight FFI call finishes first.
-        synchronized (lock) {
-            if (closed.compareAndSet(false, true)) {
+        // See JobController.close() for the rationale: hold the WRITE
+        // lock across the free so any in-flight FFI call (read-locked)
+        // finishes first. Mutually exclusive with every other public
+        // method on this class.
+        lock.writeLock().lock();
+        try {
+            if (!closed) {
+                closed = true;
                 Pointer h = handle;
                 handle = null;
                 try {
@@ -302,12 +436,14 @@ public final class JobProxy implements MeshJob, AutoCloseable {
                     throw e;
                 }
             }
+        } finally {
+            lock.writeLock().unlock();
         }
     }
 
-    /** Caller MUST hold {@link #lock}. */
+    /** Caller MUST hold either the read or write side of {@link #lock}. */
     private void ensureOpen() {
-        if (closed.get() || handle == null) {
+        if (closed || handle == null) {
             throw new MeshException("JobProxy for job " + jobId + " is closed");
         }
     }
@@ -326,6 +462,6 @@ public final class JobProxy implements MeshJob, AutoCloseable {
 
     @Override
     public String toString() {
-        return "JobProxy{jobId=" + jobId + ", closed=" + closed.get() + "}";
+        return "JobProxy{jobId=" + jobId + ", closed=" + closed + "}";
     }
 }

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJobs.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJobs.java
@@ -132,6 +132,80 @@ public final class MeshJobs {
     }
 
     /**
+     * Subscribe to events posted to a running job by ID.
+     *
+     * <p>Returns a {@link EventSubscription} — a long-lived blocking
+     * iterator over the job's event log. Each call manages its own
+     * cursor, so multiple subscribers can observe the same job's
+     * events independently without affecting the producer's
+     * {@code recvEvent} consumption (the producer's cursor is
+     * per-controller; this observer's cursor is per-subscription).
+     *
+     * <p>The iterator runs indefinitely until the caller breaks out
+     * of the for-loop, calls {@link EventSubscription#close()}, or
+     * the underlying registry raises {@link JobNotFoundException}.
+     * There is no automatic terminal-state detection — use a
+     * synthetic event type (e.g. {@code {"type":"ended"}}) posted by
+     * your application to signal iteration end.
+     *
+     * <p>Mirrors:
+     * <ul>
+     *   <li>Python {@code mesh.jobs.subscribe_events(job_id, types, after, long_poll_secs)}</li>
+     *   <li>TypeScript {@code mesh.jobs.subscribeEvents(jobId, options)}</li>
+     * </ul>
+     *
+     * <p>The registry URL is discovered from {@code MCP_MESH_REGISTRY_URL}
+     * (same convention as {@link #postEvent(String, String, Map)}).
+     * Cached proxies: this method reuses the process-wide LRU cache,
+     * so a subscriber and a {@code postEvent} caller targeting the
+     * same job share one underlying {@link JobProxy}.
+     *
+     * <p>Recommended usage (try-with-resources):
+     * <pre>{@code
+     * try (EventSubscription sub = MeshJobs.subscribeEvents(jobId,
+     *         SubscribeOptions.builder().types(List.of("progress")).build())) {
+     *     while (sub.hasNext()) {
+     *         Map<String, Object> event = sub.next();
+     *         downstream.publish(event);
+     *         if ("result".equals(event.get("type"))) break;
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param jobId   Target job's server-assigned ID
+     * @param options Filter / cursor / long-poll knobs; use
+     *                {@link SubscribeOptions#defaults()} or
+     *                {@link #subscribeEvents(String)} for defaults
+     * @return A blocking iterator over the job's events; caller MUST
+     *         {@link EventSubscription#close()} (or try-with-resources)
+     *         when done
+     * @throws JobNotFoundException if the job has been reaped from
+     *                              the registry (only raised when the
+     *                              caller advances the iterator)
+     * @throws MeshException        for transport errors or missing
+     *                              {@code MCP_MESH_REGISTRY_URL}
+     */
+    public static EventSubscription subscribeEvents(String jobId, SubscribeOptions options) {
+        if (jobId == null || jobId.isEmpty()) {
+            throw new IllegalArgumentException("jobId is required");
+        }
+        if (options == null) {
+            options = SubscribeOptions.defaults();
+        }
+        String registryUrl = resolveRegistryUrl();
+        JobProxy proxy = getOrCreateProxy(registryUrl, jobId);
+        return new EventSubscription(proxy, options);
+    }
+
+    /**
+     * Convenience overload — {@link #subscribeEvents(String, SubscribeOptions)}
+     * with {@link SubscribeOptions#defaults()}.
+     */
+    public static EventSubscription subscribeEvents(String jobId) {
+        return subscribeEvents(jobId, SubscribeOptions.defaults());
+    }
+
+    /**
      * Discover the registry base URL the running agent is bound to.
      * Mirrors the {@code MCP_MESH_REGISTRY_URL} convention used by
      * Python's {@code _resolve_registry_url} and TypeScript's

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/SubscribeOptions.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/SubscribeOptions.java
@@ -1,0 +1,127 @@
+package io.mcpmesh;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Options for {@link MeshJobs#subscribeEvents(String, SubscribeOptions)}.
+ * Immutable; constructed via {@link #builder()} or
+ * {@link #defaults()}. Mirrors Python's keyword args
+ * ({@code types}, {@code after}, {@code long_poll_secs}) and
+ * TypeScript's {@code SubscribeEventsOptions} object one-for-one.
+ *
+ * <p>All fields are optional — defaults match the Python / TS
+ * siblings:
+ * <ul>
+ *   <li>{@code types} = {@code null} (yield events of all types)</li>
+ *   <li>{@code after} = {@code 0} (from the beginning of the event log)</li>
+ *   <li>{@code longPoll} = {@code Duration.ofSeconds(30)} (registry
+ *       caps at 60s; pass {@link Duration#ZERO} for a single immediate
+ *       read).</li>
+ * </ul>
+ */
+public final class SubscribeOptions {
+
+    private final List<String> types;
+    private final long after;
+    private final Duration longPoll;
+
+    private SubscribeOptions(List<String> types, long after, Duration longPoll) {
+        // Defensive copy + immutable wrap so callers can't mutate the
+        // filter list after construction.
+        this.types = types == null ? null : List.copyOf(types);
+        this.after = after;
+        this.longPoll = longPoll;
+    }
+
+    /**
+     * Optional event-type filter applied server-side. Only events
+     * whose {@code type} matches one of these is yielded. {@code null}
+     * means "all types".
+     */
+    public List<String> types() {
+        return types;
+    }
+
+    /**
+     * Initial cursor (default {@code 0} ≡ from the beginning of the
+     * event log). Pass a higher value to skip historical events.
+     */
+    public long after() {
+        return after;
+    }
+
+    /**
+     * Long-poll wait budget per registry call. Default
+     * {@code Duration.ofSeconds(30)}; the registry caps at 60s.
+     * {@link Duration#ZERO} bridges to a single immediate read.
+     * The builder rejects negative values.
+     */
+    public Duration longPoll() {
+        return longPoll;
+    }
+
+    /** Default options — matches Python / TS sibling defaults. */
+    public static SubscribeOptions defaults() {
+        return new Builder().build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Fluent builder for {@link SubscribeOptions}. */
+    public static final class Builder {
+        private List<String> types = null;
+        private long after = 0L;
+        private Duration longPoll = Duration.ofSeconds(30);
+
+        /**
+         * Restrict subscription to the given event-type tags.
+         * {@code null} (the default) yields events of all types.
+         */
+        public Builder types(List<String> types) {
+            this.types = types;
+            return this;
+        }
+
+        /**
+         * Initial cursor (default {@code 0} ≡ from the beginning of
+         * the event log). Pass a higher value to skip historical
+         * events.
+         *
+         * @throws IllegalArgumentException if {@code after} is negative
+         */
+        public Builder after(long after) {
+            if (after < 0) {
+                throw new IllegalArgumentException(
+                    "SubscribeOptions.after must be non-negative, got: " + after);
+            }
+            this.after = after;
+            return this;
+        }
+
+        /**
+         * Long-poll wait budget per registry call. Default 30s;
+         * registry caps at 60s. {@link Duration#ZERO} bridges to a
+         * single immediate read.
+         *
+         * @throws NullPointerException     if {@code longPoll} is null
+         * @throws IllegalArgumentException if {@code longPoll} is negative
+         */
+        public Builder longPoll(Duration longPoll) {
+            Objects.requireNonNull(longPoll, "longPoll must not be null");
+            if (longPoll.isNegative()) {
+                throw new IllegalArgumentException(
+                    "SubscribeOptions.longPoll must be non-negative, got: " + longPoll);
+            }
+            this.longPoll = longPoll;
+            return this;
+        }
+
+        public SubscribeOptions build() {
+            return new SubscribeOptions(types, after, longPoll);
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/MeshJobsSubscribeEventsTest.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/MeshJobsSubscribeEventsTest.java
@@ -1,0 +1,474 @@
+package io.mcpmesh;
+
+import io.mcpmesh.core.MeshException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.Closeable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link MeshJobs#subscribeEvents(String, SubscribeOptions)}
+ * + {@link EventSubscription}. Mirrors the Python {@code jobs_test.py}
+ * subscribe-events coverage and TypeScript {@code jobs.spec.ts}
+ * {@code subscribeEvents} suite.
+ *
+ * <p>The FFI long-poll round trip (envelope parse → cursor advance →
+ * yield) is exercised in the integration suite
+ * (uc23_meshjob_java/tc27_subscribe_events_streams_observer_pattern_java)
+ * because it needs a live registry + Rust core.
+ *
+ * <p>The {@link EventSubscription} class is package-private to allow
+ * direct construction with a stub {@link JobProxy} would require
+ * mocking the JNR-FFI surface — not a pattern this codebase uses.
+ * Instead we exercise the iterator's buffer/cursor/closed state via
+ * reflection into the package-private constructor + buffer field,
+ * which lets us cover the non-FFI code paths (Closeable contract,
+ * malformed-payload rejection) without a live registry.
+ */
+class MeshJobsSubscribeEventsTest {
+
+    private static final String FAKE_REGISTRY = "http://localhost:0/no-such";
+
+    @BeforeEach
+    void clearCache() {
+        MeshJobs.clearProxyCacheForTest();
+    }
+
+    @AfterEach
+    void clearCacheAfter() {
+        MeshJobs.clearProxyCacheForTest();
+    }
+
+    // -----------------------------------------------------------------
+    // Surface-shape tests — pin the public API one-to-one with Python/TS
+    // -----------------------------------------------------------------
+
+    @Test
+    void subscribeEvents_hasExpectedSignature() throws NoSuchMethodException {
+        Method m = MeshJobs.class.getMethod("subscribeEvents", String.class, SubscribeOptions.class);
+        assertEquals(EventSubscription.class, m.getReturnType());
+        assertTrue(java.lang.reflect.Modifier.isPublic(m.getModifiers()));
+        assertTrue(java.lang.reflect.Modifier.isStatic(m.getModifiers()),
+            "subscribeEvents must be a static helper");
+        assertEquals(0, m.getExceptionTypes().length,
+            "subscribeEvents must not declare checked exceptions");
+    }
+
+    @Test
+    void subscribeEvents_convenienceOverloadExists() throws NoSuchMethodException {
+        Method m = MeshJobs.class.getMethod("subscribeEvents", String.class);
+        assertEquals(EventSubscription.class, m.getReturnType());
+        assertTrue(java.lang.reflect.Modifier.isStatic(m.getModifiers()));
+    }
+
+    @Test
+    void eventSubscription_implementsCloseableIterator() {
+        assertTrue(Closeable.class.isAssignableFrom(EventSubscription.class),
+            "EventSubscription must be Closeable for try-with-resources support");
+        assertTrue(Iterator.class.isAssignableFrom(EventSubscription.class),
+            "EventSubscription must be Iterator<Map<String,Object>>");
+    }
+
+    @Test
+    void subscribeOptions_defaultsMatchPythonAndTs() {
+        SubscribeOptions opts = SubscribeOptions.defaults();
+        assertNull(opts.types(), "default types must be null (≡ all types)");
+        assertEquals(0L, opts.after(), "default after cursor must be 0");
+        assertEquals(Duration.ofSeconds(30), opts.longPoll(),
+            "default long-poll must be 30s (matches Python's long_poll_secs=30.0)");
+    }
+
+    @Test
+    void subscribeOptions_builderRoundTrips() {
+        SubscribeOptions opts = SubscribeOptions.builder()
+            .types(List.of("progress", "result"))
+            .after(42L)
+            .longPoll(Duration.ofSeconds(5))
+            .build();
+        assertEquals(List.of("progress", "result"), opts.types());
+        assertEquals(42L, opts.after());
+        assertEquals(Duration.ofSeconds(5), opts.longPoll());
+    }
+
+    @Test
+    void subscribeOptions_typesAreImmutable() {
+        // Caller mutation after build() must NOT affect the captured
+        // filter list — defensive copy on the builder side.
+        java.util.ArrayList<String> mutable = new java.util.ArrayList<>(List.of("a", "b"));
+        SubscribeOptions opts = SubscribeOptions.builder().types(mutable).build();
+        mutable.add("c");
+        assertEquals(List.of("a", "b"), opts.types(),
+            "caller's later mutation must not affect the SubscribeOptions");
+        // Returned list is itself immutable.
+        assertThrows(UnsupportedOperationException.class,
+            () -> opts.types().add("d"));
+    }
+
+    // -----------------------------------------------------------------
+    // Argument validation (no FFI involvement)
+    // -----------------------------------------------------------------
+
+    @Test
+    void subscribeEvents_rejectsNullJobId() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.subscribeEvents(null, SubscribeOptions.defaults()));
+        assertTrue(e.getMessage().toLowerCase().contains("jobid"),
+            "error should mention jobId; got: " + e.getMessage());
+    }
+
+    @Test
+    void subscribeEvents_rejectsEmptyJobId() {
+        assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.subscribeEvents("", SubscribeOptions.defaults()));
+    }
+
+    @Test
+    void subscribeEvents_nullOptionsCoercesToDefaults() {
+        // Null options must NOT NPE — it should be coerced to
+        // SubscribeOptions.defaults(). This requires MCP_MESH_REGISTRY_URL
+        // to be unset/empty (so we never construct a real JobProxy),
+        // OR to be set (proxy construction is harmless without an HTTP
+        // call). We assert no NPE bubbles out from the arg-coercion step.
+        String existing = System.getenv("MCP_MESH_REGISTRY_URL");
+        if (existing == null || existing.isEmpty()) {
+            // Will fail at resolveRegistryUrl with MeshException — that's
+            // the expected path; the test passes if we get there without
+            // an NPE from the null options handling.
+            MeshException e = assertThrows(MeshException.class,
+                () -> MeshJobs.subscribeEvents("j-1", null));
+            assertTrue(e.getMessage().contains("MCP_MESH_REGISTRY_URL"));
+        } else {
+            // Registry env IS set — construction is harmless (no HTTP).
+            // We still expect not-an-NPE.
+            try (EventSubscription sub = MeshJobs.subscribeEvents("j-1", null)) {
+                assertNotNull(sub);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Closeable contract — exercises the close() / hasNext() interaction
+    // without touching the FFI surface. We construct an EventSubscription
+    // via the package-private ctor with a real (but unused) JobProxy and
+    // pre-populate its buffer through reflection — only the close() →
+    // hasNext()=false transition is asserted here.
+    // -----------------------------------------------------------------
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void close_makesHasNextReturnFalseAfterBufferDrained() throws Exception {
+        EventSubscription sub = constructStubSubscription();
+        Deque<Map<String, Object>> buffer = bufferField(sub);
+        Map<String, Object> e1 = makeEvent(1L, "progress");
+        Map<String, Object> e2 = makeEvent(2L, "result");
+        buffer.addLast(e1);
+        buffer.addLast(e2);
+
+        assertTrue(sub.hasNext());
+        assertEquals(e1, sub.next());
+        assertTrue(sub.hasNext());
+        assertEquals(e2, sub.next());
+
+        // Buffer drained; close() must short-circuit the next
+        // long-poll path so hasNext() returns false rather than
+        // attempting an FFI call against the stub proxy.
+        sub.close();
+        assertFalse(sub.hasNext(),
+            "hasNext() after close() must return false without issuing a long-poll");
+        assertTrue(sub.isClosedForTest());
+    }
+
+    @Test
+    void close_isIdempotent() throws Exception {
+        EventSubscription sub = constructStubSubscription();
+        sub.close();
+        sub.close(); // must not throw
+        assertTrue(sub.isClosedForTest());
+    }
+
+    @Test
+    void next_afterCloseThrowsNoSuchElement() throws Exception {
+        EventSubscription sub = constructStubSubscription();
+        sub.close();
+        assertThrows(NoSuchElementException.class, sub::next);
+    }
+
+    @Test
+    void next_drainsBufferEvenAfterClose() throws Exception {
+        // Closing the subscription does NOT discard already-buffered
+        // events — the caller can still drain the buffer; only NEW
+        // long-polls are suppressed.
+        EventSubscription sub = constructStubSubscription();
+        Deque<Map<String, Object>> buffer = bufferField(sub);
+        Map<String, Object> e1 = makeEvent(1L, "x");
+        buffer.addLast(e1);
+        sub.close();
+        // Buffered event is still returnable.
+        assertTrue(sub.hasNext(),
+            "buffered events must remain visible to next() after close()");
+        assertEquals(e1, sub.next());
+        // Now the buffer is empty AND closed.
+        assertFalse(sub.hasNext());
+    }
+
+    // -----------------------------------------------------------------
+    // LRU cache reuse — MeshJobs.subscribeEvents shares the existing
+    // proxyCache with postEvent (no second cache).
+    // -----------------------------------------------------------------
+
+    @Test
+    void subscribeEvents_reusesLruProxyCache() {
+        // Construct two subscriptions for the same jobId; both must
+        // be backed by the SAME underlying JobProxy (cache hit on the
+        // second call). We reach the cache via getOrCreateProxy
+        // directly so we don't need MCP_MESH_REGISTRY_URL to be set —
+        // that env path is exercised by the integration test.
+        JobProxy a = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "job-shared");
+        JobProxy b = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "job-shared");
+        assertSame(a, b,
+            "subscribeEvents must share the existing LRU cache with postEvent");
+        assertEquals(1, MeshJobs.cacheSizeForTest(),
+            "cache must hold a single entry for the shared (registry, job) key");
+    }
+
+    // -----------------------------------------------------------------
+    // Builder validation
+    // -----------------------------------------------------------------
+
+    @Test
+    void subscribeOptions_builderRejectsNegativeAfter() {
+        // The registry can't translate a negative cursor into a valid
+        // `seq > after` query — fail fast at the builder rather than
+        // surface a confusing MeshException at long-poll time. Mirror
+        // of the Python `after: int >= 0` constraint.
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> SubscribeOptions.builder().after(-1L));
+        assertTrue(e.getMessage().toLowerCase().contains("non-negative"),
+            "error message must say non-negative; got: " + e.getMessage());
+        assertTrue(e.getMessage().contains("-1"),
+            "error message should include the offending value; got: " + e.getMessage());
+    }
+
+    @Test
+    void subscribeOptions_builderAcceptsZeroAfter() {
+        // Boundary: 0 (the default) MUST be accepted; only strictly
+        // negative values are rejected.
+        SubscribeOptions opts = SubscribeOptions.builder().after(0L).build();
+        assertEquals(0L, opts.after());
+    }
+
+    @Test
+    void subscribeOptions_builderRejectsNullLongPoll() {
+        // Null is a programming error — fail fast at the builder
+        // rather than NPE deep inside the FFI bridge.
+        assertThrows(NullPointerException.class,
+            () -> SubscribeOptions.builder().longPoll(null).build());
+    }
+
+    @Test
+    void subscribeOptions_builderRejectsNegativeLongPoll() {
+        // Negative durations have no meaningful semantics here — the
+        // registry takes a non-negative timeout. Mirrors the
+        // {@code after} >= 0 constraint.
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> SubscribeOptions.builder().longPoll(Duration.ofSeconds(-1)).build());
+        assertTrue(e.getMessage().toLowerCase().contains("non-negative"),
+            "error message must say non-negative; got: " + e.getMessage());
+    }
+
+    @Test
+    void subscribeOptions_builderAcceptsZeroLongPoll() {
+        // Boundary: Duration.ZERO MUST be accepted — it bridges to a
+        // single immediate read per the JavaDoc. Pins the documented
+        // contract so a future maintainer doesn't tighten validation.
+        SubscribeOptions opts = SubscribeOptions.builder()
+            .longPoll(Duration.ZERO)
+            .build();
+        assertEquals(Duration.ZERO, opts.longPoll());
+    }
+
+    // -----------------------------------------------------------------
+    // Envelope validation — fractional seq / next_after must be
+    // rejected, not silently truncated via longValue(). This mirrors
+    // Python's `type(seq) is int` strictness. The private helper
+    // requireIntegralLong centralises the check; we exercise it via
+    // reflection here because the public path (JobProxy.listEvents →
+    // EventSubscription.hasNext) requires a live registry response.
+    // -----------------------------------------------------------------
+
+    @Test
+    void subscribeEvents_rejectsFractionalSeq() throws Exception {
+        // Jackson maps JSON 1.5 to Double; the helper must reject it
+        // with a MeshException mentioning the field name.
+        MeshException e = invokeRequireIntegralLongExpectingThrow(
+            Double.valueOf(1.5), "seq", Map.of("seq", 1.5));
+        assertTrue(e.getMessage().toLowerCase().contains("fractional"),
+            "error must mention fractional; got: " + e.getMessage());
+        assertTrue(e.getMessage().contains("seq"),
+            "error must mention the field name; got: " + e.getMessage());
+    }
+
+    @Test
+    void subscribeEvents_rejectsFractionalNextAfter() throws Exception {
+        // Same check applied to the watermark field — a fractional
+        // next_after also corrupts the cursor advance and must throw.
+        MeshException e = invokeRequireIntegralLongExpectingThrow(
+            Double.valueOf(1.5), "next_after", Double.valueOf(1.5));
+        assertTrue(e.getMessage().toLowerCase().contains("fractional"),
+            "error must mention fractional; got: " + e.getMessage());
+        assertTrue(e.getMessage().contains("next_after"),
+            "error must mention the field name; got: " + e.getMessage());
+    }
+
+    /**
+     * Invoke the private static {@code requireIntegralLong} helper
+     * via reflection and unwrap the InvocationTargetException, asserting
+     * the underlying cause is a {@link MeshException}.
+     */
+    private static MeshException invokeRequireIntegralLongExpectingThrow(
+            Number n, String fieldName, Object context) throws Exception {
+        Method helper = EventSubscription.class.getDeclaredMethod(
+            "requireIntegralLong", Number.class, String.class, Object.class);
+        helper.setAccessible(true);
+        try {
+            helper.invoke(null, n, fieldName, context);
+        } catch (java.lang.reflect.InvocationTargetException ite) {
+            Throwable cause = ite.getCause();
+            if (cause instanceof MeshException me) {
+                return me;
+            }
+            throw new AssertionError("expected MeshException, got " + cause, cause);
+        }
+        throw new AssertionError("expected MeshException, but no exception was thrown");
+    }
+
+    // -----------------------------------------------------------------
+    // JobProxy lock concurrency — assert read-locked methods can be
+    // entered in parallel. We cannot easily mock the FFI from a unit
+    // test, so we exercise the lock class semantics directly: verify
+    // that ReentrantReadWriteLock allows two simultaneous read holders
+    // (which is the property JobProxy.listEvents relies on), and that
+    // JobProxy uses a non-fair ReentrantReadWriteLock in the expected
+    // field. Together these pin the behavioural contract without
+    // booting a live registry.
+    // -----------------------------------------------------------------
+
+    @Test
+    void jobProxy_useReentrantReadWriteLock() throws Exception {
+        // Structural assertion: JobProxy.lock must be a
+        // ReentrantReadWriteLock so concurrent subscribers on the same
+        // cached proxy can long-poll listEvents in parallel. The
+        // previous `synchronized (Object lock)` design serialised ALL
+        // operations on a single JobProxy instance.
+        Field f = JobProxy.class.getDeclaredField("lock");
+        f.setAccessible(true);
+        JobProxy proxy = JobProxy.open("j-lock", FAKE_REGISTRY);
+        try {
+            Object actual = f.get(proxy);
+            assertTrue(actual instanceof ReentrantReadWriteLock,
+                "JobProxy.lock must be a ReentrantReadWriteLock; got: "
+                    + (actual == null ? "null" : actual.getClass().getName()));
+        } finally {
+            proxy.close();
+        }
+    }
+
+    @Test
+    void jobProxy_readLockAllowsConcurrentHolders() throws Exception {
+        // Behavioural assertion on the lock class — two threads can
+        // hold the read lock at the same time. This is the property
+        // listEvents relies on to permit concurrent long-polls.
+        // We reach into JobProxy.lock to make the assertion concrete:
+        // grab a read lock on it from two threads and assert
+        // getReadLockCount() reflects both holders.
+        Field f = JobProxy.class.getDeclaredField("lock");
+        f.setAccessible(true);
+        JobProxy proxy = JobProxy.open("j-lock-conc", FAKE_REGISTRY);
+        try {
+            ReentrantReadWriteLock rwLock = (ReentrantReadWriteLock) f.get(proxy);
+            java.util.concurrent.CountDownLatch bothHoldRead = new java.util.concurrent.CountDownLatch(2);
+            java.util.concurrent.CountDownLatch release = new java.util.concurrent.CountDownLatch(1);
+            Runnable holder = () -> {
+                rwLock.readLock().lock();
+                try {
+                    bothHoldRead.countDown();
+                    release.await();
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    rwLock.readLock().unlock();
+                }
+            };
+            Thread t1 = new Thread(holder, "rwlock-reader-1");
+            Thread t2 = new Thread(holder, "rwlock-reader-2");
+            t1.setDaemon(true);
+            t2.setDaemon(true);
+            t1.start();
+            t2.start();
+            // Both readers MUST reach the read-locked region without
+            // blocking on each other. A 2s budget is generous —
+            // ReentrantReadWriteLock entry is microseconds.
+            assertTrue(bothHoldRead.await(2, java.util.concurrent.TimeUnit.SECONDS),
+                "two threads should be able to hold JobProxy.lock.readLock concurrently");
+            assertEquals(2, rwLock.getReadLockCount(),
+                "ReentrantReadWriteLock should report both readers as active");
+            release.countDown();
+            t1.join(2000);
+            t2.join(2000);
+        } finally {
+            proxy.close();
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    /**
+     * Construct an {@link EventSubscription} bound to a real
+     * {@link JobProxy} (constructed against a fake registry URL — no
+     * HTTP happens until listEvents is called). We never advance the
+     * iterator past the buffered events; the FFI long-poll path is
+     * exercised by the integration test.
+     */
+    private static EventSubscription constructStubSubscription() throws Exception {
+        JobProxy proxy = JobProxy.open("j-stub", FAKE_REGISTRY);
+        Constructor<EventSubscription> ctor = EventSubscription.class
+            .getDeclaredConstructor(JobProxy.class, SubscribeOptions.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(proxy, SubscribeOptions.defaults());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Deque<Map<String, Object>> bufferField(EventSubscription sub) throws Exception {
+        Field f = EventSubscription.class.getDeclaredField("buffer");
+        f.setAccessible(true);
+        return (Deque<Map<String, Object>>) f.get(sub);
+    }
+
+    private static Map<String, Object> makeEvent(long seq, String type) {
+        Map<String, Object> ev = new LinkedHashMap<>();
+        ev.put("job_id", "j-stub");
+        ev.put("seq", seq);
+        ev.put("type", type);
+        ev.put("payload", Map.of());
+        ev.put("trace_context", null);
+        ev.put("posted_by", null);
+        ev.put("created_at", 0);
+        return ev;
+    }
+}

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
@@ -1,5 +1,6 @@
 package com.example.longtaskconsumer;
 
+import io.mcpmesh.EventSubscription;
 import io.mcpmesh.JobProxy;
 import io.mcpmesh.MeshAgent;
 import io.mcpmesh.MeshJob;
@@ -8,9 +9,15 @@ import io.mcpmesh.MeshJobs;
 import io.mcpmesh.MeshTool;
 import io.mcpmesh.Param;
 import io.mcpmesh.Selector;
+import io.mcpmesh.SubscribeOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +53,8 @@ import java.util.Map;
 )
 @SpringBootApplication
 public class LongTaskConsumerApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(LongTaskConsumerApplication.class);
 
     public static void main(String[] args) {
         SpringApplication.run(LongTaskConsumerApplication.class, args);
@@ -452,6 +461,135 @@ public class LongTaskConsumerApplication {
             response.put("ignore_seqs", List.of(r1.get("seq"), r2.get("seq")));
             response.put("target_seq", r3.get("seq"));
             response.put("result", result);
+            return response;
+        }
+    }
+
+    /**
+     * Tc27 driver — submit a {@code run_until_done} job, fire 3 'work'
+     * events concurrently with a {@link MeshJobs#subscribeEvents}
+     * subscriber, and return a structured report so the integration
+     * assertions can pin all three observers (producer, subscriber,
+     * posters) agree on the event count and ordering.
+     *
+     * <p>Mirror of Python's {@code commission_subscribe_observer}
+     * (uc21_meshjob/tc27). Java threading uses a daemon Thread + a
+     * synchronized observed-events list instead of asyncio tasks; the
+     * subscriber breaks on {@code payload.final == true}. A 15s join
+     * timeout bounds the subscriber wait — on timeout we close the
+     * subscription (drops the FFI long-poll's strong reference) and
+     * report {@code subscriber_status = "timeout"}.
+     */
+    @MeshTool(
+        capability = "commission_subscribe_observer",
+        description = "Submit run_until_done, concurrently post 'work' events and subscribe — verifies observer pattern.",
+        dependencies = @Selector(capability = "run_until_done")
+    )
+    public Map<String, Object> commissionSubscribeObserver(MeshJob runUntilDone) throws Exception {
+        if (!(runUntilDone instanceof MeshJobSubmitter submitter)) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "run_until_done submitter not injected");
+            return err;
+        }
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            new LinkedHashMap<>(), null, 60, null, null);
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            String jobId = proxy.jobId();
+
+            // Brief wait so producer claims the job + parks on
+            // recvEvent before we post anything. Without this the
+            // first 'work' event could land before the producer's
+            // claim worker has pulled the row off the queue — the
+            // event would still be observable but we wouldn't be
+            // exercising the long-poll wake path.
+            Thread.sleep(2000);
+
+            // Synchronized list so the subscriber thread and the main
+            // thread can both touch it safely. The subscriber writes;
+            // the main thread reads after the join.
+            List<Map<String, Object>> observedEvents = Collections.synchronizedList(new ArrayList<>());
+
+            // Subscriber thread: walks the EventSubscription iterator,
+            // collecting events into observedEvents, and breaks on the
+            // 'final: true' payload marker. Mirrors Python's
+            // _subscriber asyncio task. Wrapped in try-with-resources
+            // so the subscription is always closed — even if the
+            // poster loop throws InterruptedException or postEvent
+            // raises.
+            String subscriberStatus;
+            List<Object> postedSeqs = new ArrayList<>();
+            try (EventSubscription subscription = MeshJobs.subscribeEvents(
+                    jobId,
+                    SubscribeOptions.builder()
+                        .types(List.of("work"))
+                        .longPoll(Duration.ofSeconds(5))
+                        .build())) {
+                Thread subscriberThread = new Thread(() -> {
+                    try {
+                        while (subscription.hasNext()) {
+                            Map<String, Object> event = subscription.next();
+                            Map<String, Object> entry = new LinkedHashMap<>();
+                            entry.put("seq", event.get("seq"));
+                            entry.put("payload", event.get("payload"));
+                            observedEvents.add(entry);
+                            Object payloadRaw = event.get("payload");
+                            if (payloadRaw instanceof Map<?, ?> payloadMap
+                                && Boolean.TRUE.equals(payloadMap.get("final"))) {
+                                return;
+                            }
+                        }
+                    } catch (RuntimeException ex) {
+                        // Subscriber-side error (e.g. JobNotFoundException
+                        // if the job was reaped). Surface via the empty
+                        // observed_events list — the assertions tolerate
+                        // partial state — but log so test triage isn't
+                        // blind when the exception is unexpected.
+                        log.warn("tc27 subscriber thread caught exception (job_id={}): {}",
+                            jobId, ex.toString(), ex);
+                    }
+                }, "tc27-subscriber");
+                subscriberThread.setDaemon(true);
+                subscriberThread.start();
+
+                // Poster: fire 3 'work' events with ~500ms spacing; the
+                // 3rd carries final=true to terminate the producer AND
+                // the subscriber.
+                List<Map<String, Object>> payloads = List.of(
+                    Map.of("item", 1),
+                    Map.of("item", 2),
+                    Map.of("item", 3, "final", true));
+                for (Map<String, Object> payload : payloads) {
+                    Thread.sleep(500);
+                    Map<String, Object> receipt = MeshJobs.postEvent(
+                        jobId, "work", new LinkedHashMap<>(payload));
+                    postedSeqs.add(receipt.get("seq"));
+                }
+
+                // Bound the subscriber wait — 15s is well above the
+                // expected runtime (3 events * 500ms post-spacing + handler
+                // overhead). On timeout the try-with-resources close()
+                // drops the iterator's "keep polling" flag; the next
+                // hasNext() in the subscriber thread will return false.
+                // The thread may still be blocked on a long-poll — that's
+                // fine, the daemon thread reclaims itself.
+                subscriberThread.join(15_000L);
+                subscriberStatus = subscriberThread.isAlive() ? "timeout" : "ok";
+            }
+
+            Object jobResult;
+            try {
+                jobResult = proxy.await(30.0);
+            } catch (RuntimeException e) {
+                jobResult = Map.of("error", e.getMessage());
+            }
+
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("job_id", jobId);
+            response.put("posted_seqs", postedSeqs);
+            response.put("subscriber_status", subscriberStatus);
+            response.put("observed_count", observedEvents.size());
+            response.put("observed_events", new ArrayList<>(observedEvents));
+            response.put("job_result", jobResult);
             return response;
         }
     }

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
@@ -567,6 +567,60 @@ public class LongTaskProviderApplication {
     }
 
     @MeshTool(
+        capability = "run_until_done",
+        task = true,
+        description = "Loop on recvEvent for 'work' events, exit on payload {final: true} — paired with subscribeEvents observer."
+    )
+    public Map<String, Object> runUntilDone(MeshJob job) {
+        // Producer side of tc27_subscribe_events_streams_observer_pattern_java.
+        // Consumes 'work' events in a loop; a caller-defined termination
+        // event (a 'work' event whose payload contains {"final": true})
+        // is the signal to exit gracefully and return the count of events
+        // processed. The subscribeEvents observer on the consumer side
+        // watches the SAME event stream independently — its cursor is
+        // per-subscription, not shared with the producer's recv_event cursor.
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller == null) {
+            Map<String, Object> noJob = new LinkedHashMap<>();
+            noJob.put("status", "no_job_ctx");
+            return noJob;
+        }
+        List<Map<String, Object>> eventsProcessed = new ArrayList<>();
+        // Bounded loop — safety net so a missing termination event
+        // doesn't hang the job indefinitely. Per-iteration long timeout
+        // matches the consumer's posting cadence (3 events with ~500ms
+        // spacing; 10s is plenty).
+        for (int i = 0; i < 20; i++) {
+            Map<String, Object> event = controller.recvEvent(
+                List.of("work"), Duration.ofSeconds(10));
+            if (event == null) {
+                Map<String, Object> timeout = new LinkedHashMap<>();
+                timeout.put("status", "timeout");
+                timeout.put("processed", eventsProcessed);
+                return timeout;
+            }
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("seq", event.get("seq"));
+            entry.put("payload", event.get("payload"));
+            eventsProcessed.add(entry);
+            Object payloadRaw = event.get("payload");
+            if (payloadRaw instanceof Map<?, ?> payloadMap
+                && Boolean.TRUE.equals(payloadMap.get("final"))) {
+                Map<String, Object> result = new LinkedHashMap<>();
+                result.put("status", "done");
+                result.put("processed_count", eventsProcessed.size());
+                result.put("events", eventsProcessed);
+                controller.complete(result);
+                return result;
+            }
+        }
+        Map<String, Object> exhausted = new LinkedHashMap<>();
+        exhausted.put("status", "loop_exhausted");
+        exhausted.put("processed", eventsProcessed);
+        return exhausted;
+    }
+
+    @MeshTool(
         capability = "run_until_cancel",
         task = true,
         description = "Loop on recvEvent for 'work'/'cancelled' types until cancelled-event arrives."

--- a/tests/integration/suites/uc23_meshjob_java/tc27_subscribe_events_streams_observer_pattern_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc27_subscribe_events_streams_observer_pattern_java/test.yaml
@@ -1,0 +1,159 @@
+# tc27_subscribe_events_streams_observer_pattern_java — Java port of
+# uc21/tc27 + uc22/tc27_ts (JobProxy.subscribeEvents observer pattern;
+# issue #1050).
+#
+# Verifies the consumer-side observer iterator built on the Phase D
+# `MeshJobs.subscribeEvents` blocking iterator. Unlike `recvEvent`
+# (single per-controller cursor that advances on consumption),
+# `subscribeEvents` is an OBSERVER — it has a per-subscription cursor,
+# so multiple subscribers can watch the same job's events without
+# disturbing the producer's consumption.
+#
+# Sequence (driven by `commissionSubscribeObserver`):
+#   1. Submit `run_until_done` (producer that consumes 'work' events
+#      until one carries `{"final": true}`).
+#   2. Spawn a subscriber on a background Thread via
+#      `MeshJobs.subscribeEvents(jobId, types=["work"])`. It collects
+#      every 'work' event into a synchronized list, breaks when it
+#      sees `{"final": true}`.
+#   3. Concurrently post 3 'work' events with `MeshJobs.postEvent`,
+#      the 3rd carrying `{"final": true}`.
+#   4. Wait for the subscriber thread (join with 15s timeout) and for
+#      `proxy.await(...)` to complete.
+#
+# Asserts:
+#   - producer's job result has `status=done` + `processed_count=3`
+#     (proves the recvEvent side consumed all 3 in order)
+#   - subscriber observed all 3 events (`observed_count: 3`)
+#     (proves subscribeEvents runs independently of the producer's cursor)
+#   - subscriber_status == "ok" (no observer timeout)
+#   - posted seqs are 1, 2, 3 (first events on a fresh job)
+#
+# This is the headline regression for the Phase D
+# `MeshJobs.subscribeEvents` blocking iterator surface — unit tests
+# cover the helper itself but they bind to a stub JobProxy, so this is
+# the first time we exercise the iterator against a real registry +
+# Rust core through the Java FFI.
+
+name: "MeshJob Java: subscribeEvents streams events to an observer running alongside the producer"
+description: "Java producer recvEvent + Java observer subscribeEvents run independently against the same event stream"
+tags:
+  - meshjob
+  - java
+  - issue-1050
+  - events
+  - subscribe
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9120)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for Java provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done
+      echo "ERROR: provider not healthy"
+      meshctl logs long-task-provider-java 2>&1 | tail -50 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start consumer (port 9121)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 -d
+
+  - name: "Wait for consumer + DI"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        ROW=$(curl -s http://localhost:8000/agents | jq -c '.agents[] | select(.name=="long-task-consumer-java")')
+        S=$(echo "$ROW" | jq -r '.status'); R=$(echo "$ROW" | jq -r '.dependencies_resolved'); T=$(echo "$ROW" | jq -r '.total_dependencies')
+        [ "$S" = "healthy" ] && [ "$R" = "$T" ] && [ "$T" != "0" ] && [ "$T" != "null" ] && exit 0; sleep 2
+      done
+      echo "ERROR: consumer not ready"
+      meshctl logs long-task-consumer-java 2>&1 | tail -50 || true
+      exit 1
+    timeout: 150
+
+  - name: "Call commission_subscribe_observer — submit, post 3 events, observe via subscribeEvents"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_subscribe_observer '{}'
+    capture: commission_response
+    timeout: 60
+
+assertions:
+  # MCP envelope check: must not be an error response. Java's Jackson
+  # serializer emits compact JSON without spaces (matches existing
+  # tc24/tc25 escaping).
+  - expr: "${captured.commission_response} not contains '\"isError\":true'"
+    message: "commission_subscribe_observer should NOT return an MCP error envelope"
+
+  # Subscriber finished cleanly (no observer timeout).
+  - expr: "${captured.commission_response} contains '\\\"subscriber_status\\\":\\\"ok\\\"'"
+    message: "subscriber task must complete cleanly (observed the final event before timeout)"
+  - expr: "${captured.commission_response} not contains '\\\"subscriber_status\\\":\\\"timeout\\\"'"
+    message: "subscriber must NOT have timed out — the final event should have arrived in time"
+
+  # Observer-side event count: subscribeEvents yields all 3 'work' events.
+  - expr: "${captured.commission_response} contains '\\\"observed_count\\\":3'"
+    message: "subscribeEvents must yield all 3 'work' events the consumer posted (observer cursor is independent of producer's)"
+
+  # Producer-side processing: recvEvent also consumed all 3 events.
+  - expr: "${captured.commission_response} contains '\\\"processed_count\\\":3'"
+    message: "producer must have processed all 3 'work' events via recvEvent (independent cursor from subscriber)"
+  - expr: "${captured.commission_response} contains '\\\"status\\\":\\\"done\\\"'"
+    message: "producer must report status=done after observing the final event"
+
+  # Posted seqs prove the events landed in order on a fresh job.
+  # Whitespace-tolerant per-seq checks — the Jackson encoder emits
+  # compact JSON, but the MCP envelope's structuredContent may differ
+  # in spacing from the embedded `text` field. Asserting on individual
+  # seqs is encoder-spacing tolerant.
+  - expr: "${captured.commission_response} contains 'posted_seqs'"
+    message: "commission response must include posted_seqs key from the postEvent return values"
+  - expr: "${captured.commission_response} contains '\\\"seq\\\":1'"
+    message: "first posted event must have seq=1"
+  - expr: "${captured.commission_response} contains '\\\"seq\\\":2'"
+    message: "second posted event must have seq=2"
+  - expr: "${captured.commission_response} contains '\\\"seq\\\":3'"
+    message: "third posted event must have seq=3"
+
+  # Payload round-trip: the final event's marker reaches both observers.
+  - expr: "${captured.commission_response} contains '\\\"final\\\":true'"
+    message: "the final event's payload marker must round-trip through both recvEvent and subscribeEvents"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

- Adds **Stream subscription mode** for MeshJob (Java vertical of #1032 follow-up): `MeshJobs.subscribeEvents(jobId, options) -> EventSubscription` returning a blocking `Closeable` iterator over `Map<String, Object>` events.
- Completes the polyglot trilogy started by #1047 (Python `subscribe_events`) and #1049 (TS `subscribeEvents`). Multiple subscribers can observe the same job's events independently via per-call cursors.
- Four layers: FFI `mesh_job_proxy_list_events` returning a `{events, next_after}` JSON envelope; JNR binding in `MeshCore.java`; Java SDK `EventSubscription` + `SubscribeOptions` + `MeshJobs.subscribeEvents` overloads reusing the existing LinkedHashMap-based LRU `proxyCache` from #1045; integration test `tc27_java` extending the long-task fixtures with `run_until_done` (provider) and `commission_subscribe_observer` (consumer) capabilities.
- **Java-specific value-add**: `EventSubscription implements Closeable`. Try-with-resources gives Java something Python's `asyncio.CancelledError` provides naturally and TS can't replicate without `AbortController` plumbing — clean iterator shutdown that stops issuing new FFI long-polls.

## Review Notes

Independent review caught 1 BLOCKER and 5 substantive WARNINGs (all addressed in the amended commit):

1. **`JobProxy` lock serialized concurrent subscribers** (BLOCKER) — every `JobProxy` method was wrapped in a single `synchronized` block. Two `EventSubscription` instances sharing one cached `JobProxy` would serialize their 30-second long-polls. Replaced with `ReentrantReadWriteLock`: `close()` takes the write lock; `listEvents` / `sendEvent` / `status` / `await` / `cancel` take the read lock and can run concurrently. The Rust core's `JobProxy` is `Sync` (Arc + String, no internal mutex) so concurrent FFI calls are safe — empirically validated by the fact that Python/TS verticals have always worked without any client-side lock.
2. **`closed` field needed `volatile`** — without it, cross-thread `close()` calls from arbitrary threads may not be observed by the iterator's `while (!closed)` loop. Textbook JMM hole. Now `volatile`.
3. **`SubscribeOptions.Builder` lacked `after >= 0` validation** — fail-fast belongs at the builder. Now throws `IllegalArgumentException` for negative values.
4. **Integration fixture leaked `EventSubscription` on poster exception** — `Thread.sleep` / `postEvent` calls could throw without closing the subscription. Now wrapped in try-with-resources.
5. **Fixture silently swallowed subscriber `RuntimeException`** — `JobNotFoundException` / malformed payload errors produced empty `observed_events` with no diagnostic. Now logged via slf4j.
6. **`close()` doesn't interrupt an in-flight FFI long-poll** — the original JavaDoc overstated the close() contract as "the Java analog of Python's `asyncio.CancelledError` propagation". Rewrote honestly: close() flips a flag that stops *future* long-polls but does NOT interrupt the in-flight one (true interruption would require plumbing cancellation through FFI — out of scope). Documented the practical guidance: short `longPoll` for rapid shutdown.

Other findings (4 INFOs + 2 cosmetic WARNINGs) skipped as not load-bearing.

Closes #1050

## Test plan

- [x] Java unit tests: 80/80 pass (76 baseline + 4 new — 2 for `SubscribeOptions` builder validation, 2 for `ReentrantReadWriteLock` semantics — including a behavioral test that asserts two threads can enter the read lock simultaneously via `getReadLockCount() == 2`)
- [x] Rust FFI tests: 23/23 pass (unchanged from initial implementation)
- [x] `src-tests` 12/12 pass (image rebuilt with the new FFI symbol)
- [x] uc23_meshjob_java integration suite: 27/27 pass (26 baseline + 1 new tc27_java; tc26 retry-flake unrelated, passed clean isolated)
- [x] `parse_ffi_timeout_secs` reused at FFI boundary (NaN/Inf/negative-sentinel)
- [x] LRU `JobProxy` cache reused from #1045 (no new cache)
- [x] Server-side `types` filter forwarded end-to-end (no client-side post-filter)
- [x] `next_after` watermark advances cursor on empty pages (parity with #1047 Python and #1049 TS)
- [x] `Boolean`-`seq` and missing-`seq` rejection (parity with sibling verticals)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event subscription API to long-poll and stream job events with optional event-type filtering.
  * Introduced `subscribeEvents()` method with configurable options for cursor positioning and timeout behavior.
  * New iterator-based event stream interface for consuming events in applications.

* **Bug Fixes & Improvements**
  * Enhanced thread-safety for concurrent job operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->