### PR TITLE
docs: cover MeshJob event injection + stream subscription (v2.2.0)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,38 @@
 # MCP Mesh Release Notes
 
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v2.1.0...HEAD)
+
+## v2.2.0 (UNRELEASED)
+
+The MeshJob substrate gains a second-direction primitive: a per-job, ordered, append-only event log every running job carries, with cross-runtime parity across Python, TypeScript, and Java. Closes the sub-iteration gap left by the v2.0 progress-only surface — handlers can now drain events inline instead of polling state agents at iteration boundaries — and adds an observer iterator so multiple subscribers can mirror the same job's events independently without disturbing the producer's drain.
+
+### 📬 MeshJob event injection (#1041, #1043, #1045)
+
+Point-to-point: caller writes, handler drains. Same wire shape across all three runtimes; differences are limited to native idiom (async generator vs blocking `Closeable`, exception class hierarchy).
+
+- **Static helpers for fire-and-forget posting**: `mesh.jobs.post_event(job_id, event_type, payload)` (Python), `mesh.jobs.postEvent(jobId, eventType, payload)` (TypeScript), `MeshJobs.postEvent(jobId, eventType, payload)` (Java). Each helper resolves `MCP_MESH_REGISTRY_URL` and constructs (or reuses, via the new LRU) a `JobProxy` — MCP tool bodies that hold a `job_id` no longer need a controller reference in scope to push an event into a running job.
+- **In-handler drain**: producer-side `await controller.recv_event(types=[...], timeout_secs=N)` (Python) / `await controller.recvEvent([...], N)` (TypeScript) / `controller.recvEvent(List.of(...), Duration.ofSeconds(N))` (Java). Long-poll backed; returns one event dict (or `None` / null on timeout). Cursor is per-controller-instance.
+- **Per-proxy send**: `proxy.send_event` / `proxy.sendEvent` is the fire-and-forget on a `JobProxy` already in scope. Same wire shape as `post_event`; use whichever surface you have.
+- **Typed errors**: `JobNotFoundError` / `JobTerminalError` (Python, both subclass `RuntimeError`), `JobNotFoundError` / `JobTerminalError` (TypeScript, both extend `Error`), `JobNotFoundException` / `JobTerminalException` (Java, both extend `MeshException`). All translated from the Rust core's `JobError` variants via stable message substrings emitted by the pyo3 / napi wrappers.
+- **LRU `JobProxy` cache** (256 entries by default, override via `MCP_MESH_JOBPROXY_CACHE_MAX`): the SDK caches `JobProxy` instances keyed by `(registry_url, job_id)` so steady-state senders don't pay a TCP/TLS handshake on every call. Eviction closes the native handle.
+- **Synthetic cancel event with grace window**: when a consumer calls `proxy.cancel(reason)`, the registry writes `{"type": "cancelled", "payload": {"reason": "..."}}` into the job's event log before forwarding the cancel signal to the owner replica. A handler parked on `recv_event(types=["cancelled", ...])` observes the event and can return cleanly instead of being interrupted by `CancelledError`. The registry waits `MCP_MESH_CANCEL_EVENT_GRACE_MS` (default 200ms, capped at 10s) before issuing the cancel-forward so the synthetic event lands first.
+
+### 👁️ MeshJob stream subscription (#1047, #1049, #1051)
+
+Observer counterpart to `recv_event`: non-destructive, per-call cursor, multi-subscriber.
+
+- **Async-iterator surface**: `async for event in mesh.jobs.subscribe_events(job_id, types=[...], after=0, long_poll_secs=30.0)` (Python async generator), `for await (const event of mesh.jobs.subscribeEvents(jobId, { types, after, longPollSecs }))` (TypeScript async generator), `try (EventSubscription sub = MeshJobs.subscribeEvents(jobId, SubscribeOptions.builder()...build())) { while (sub.hasNext()) { ... } }` (Java blocking `Closeable` iterator with try-with-resources).
+- **Per-call cursor, registry-supplied watermark**: each subscription manages its own cursor — multiple subscribers can mirror the same job's events independently without affecting the producer's `recv_event` consumption. The `next_after` watermark advances even on empty pages, so a server-side `types` filter doesn't force the client to re-scan filtered ranges.
+- **No automatic terminal detection**: the iterator runs until the caller breaks out of the loop or the registry raises `JobNotFoundError` / `JobNotFoundException` (job reaped). Applications signal end via a sentinel event type (e.g. `{"type": "ended"}`). This is intentional — the registry's event log is append-only, and "the job is terminal" is not the same condition as "the subscriber wants to stop."
+- **Shared LRU**: `subscribe_events` and `post_event` reuse the same `JobProxy` cache, so a subscriber and a poster targeting the same job share one underlying connection pool.
+
+### 📚 Documentation
+
+- New "Event injection" and "Stream subscription" sections in `docs/concepts/jobs.md` with cross-runtime tabbed code examples and the synthetic-cancel-event flow.
+- `docs/concepts/stateful-agents.md` — replaces the v2.0 "Coming soon" pointer to issue #1032 with a brief paragraph linking to the new sections and noting the feature is now shipped.
+- `docs/environment-variables.md` + `meshctl man environment` — adds the `MCP_MESH_JOBPROXY_CACHE_MAX` and `MCP_MESH_CANCEL_EVENT_GRACE_MS` entries under a new "MeshJob event channel" section.
+- `meshctl man jobs` (Python / `--typescript` / `--java` variants) — adds the same two sections to each per-runtime man page.
+
 [Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v2.0.1...v2.1.0)
 
 ## v2.1.0 (2026-05-17)

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -54,7 +54,7 @@ to understand the mechanism behind it.
     ***
 
     How data flows once agents are wired — streaming responses, long-running
-    jobs, and the audit trail that records every call.
+    jobs with event injection, and the audit trail that records every call.
 
     - [Streaming](streaming.md)
     - [Long-Running Jobs](jobs.md)

--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -511,6 +511,359 @@ and [`MESHJOB_DDDI_CONTRACT.md`](https://github.com/dhyansraj/mcp-mesh/blob/main
   Java peer claiming the same capability — declare the whitelist
   separately on each runtime that hosts the capability.
 
+## Event injection
+
+`update_progress` is producer-to-consumer one-way reporting. **Event
+injection** opens the other direction (and the side channel between
+two consumers): a per-job, ordered, append-only event log the registry
+hosts, that anyone holding the `job_id` can write into and that the
+running handler can drain from inline.
+
+The shape is symmetric to a tiny pub/sub bus scoped to one job. Three
+surfaces:
+
+- **Inside the `task=True` handler** — drain events posted to this job
+  via the injected `MeshJob` controller. Long-poll backed; returns one
+  event dict (or `None` on timeout).
+- **Outside the handler, holding a `job_id`** — fire one event into the
+  job's log via a static helper. The SDK constructs (and caches) a
+  transient `JobProxy` from `MCP_MESH_REGISTRY_URL`; no controller
+  reference needed.
+- **From a consumer that already holds a `JobProxy`** — `proxy.send_event`
+  is the per-proxy fire-and-forget. Same wire shape as `post_event`;
+  use whichever surface you have in scope.
+
+```mermaid
+sequenceDiagram
+    participant C as Caller (any agent w/ job_id)
+    participant R as Registry (event log)
+    participant H as Handler (task=True)
+
+    C->>R: POST /jobs/{id}/events  (type, payload)
+    R-->>C: 201 (seq, created_at)
+    Note over R: Append-only log<br/>(per-job seq)
+    H->>R: GET /jobs/{id}/events?after=N  (long-poll)
+    R-->>H: event dict (or empty after timeout)
+    Note over H: Cursor advances<br/>per-controller
+```
+
+### Receiving events inside a handler
+
+The producer-side recv loop. Filter by `types` to drop noise, set a
+`timeout_secs` so the loop can wake periodically to check other state.
+
+<!-- markdownlint-disable MD046 -->
+=== "Python"
+
+    ```python
+    @app.tool()
+    @mesh.tool(capability="run_workflow", task=True)
+    async def run_workflow(tenant_id: str, job: MeshJob = None) -> dict:
+        while True:
+            event = await job.recv_event(
+                types=["user_input", "cancelled"],
+                timeout_secs=10.0,
+            )
+            if event is None:
+                continue  # timeout: tick housekeeping, then re-park
+            if event["type"] == "cancelled":
+                return {"status": "cancelled", "reason": event["payload"].get("reason")}
+            # ...handle user_input...
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    agent.addTool({
+      name: "run_workflow",
+      capability: "run_workflow",
+      task: true,
+      meshJobParamIndex: 1,
+      parameters: z.object({ tenant_id: z.string() }),
+      execute: async ({ tenant_id }, job: MeshJob | null = null) => {
+        if (!job) throw new Error("job slot is not bound");
+        while (true) {
+          const event = await job.recvEvent(["user_input", "cancelled"], 10);
+          if (event === null) continue;
+          if (event.type === "cancelled") {
+            const payload = event.payload as Record<string, unknown> | null;
+            const reason = typeof payload?.reason === "string" ? payload.reason : "";
+            return { status: "cancelled", reason };
+          }
+          // ...handle user_input...
+        }
+      },
+    });
+    ```
+
+=== "Java"
+
+    ```java
+    @MeshTool(capability = "run_workflow", task = true)
+    public Map<String, Object> runWorkflow(
+        @Param("tenant_id") String tenantId,
+        MeshJob job) throws Exception {
+      JobController controller = (JobController) job;
+      while (true) {
+        Map<String, Object> event = controller.recvEvent(
+            List.of("user_input", "cancelled"),
+            Duration.ofSeconds(10));
+        if (event == null) continue;
+        if ("cancelled".equals(event.get("type"))) {
+          Map<?, ?> payload = (Map<?, ?>) event.get("payload");
+          String reason = payload == null ? "" : Objects.toString(payload.get("reason"), "");
+          return Map.of("status", "cancelled", "reason", reason);
+        }
+        // ...handle user_input...
+      }
+    }
+    ```
+<!-- markdownlint-enable MD046 -->
+
+The handler's `recv_event` cursor is per-`JobController` instance — a
+fresh controller for the same `job_id` replays from `seq=0`. The
+running handler always sees events in monotonic seq order.
+
+### Posting events from outside the handler
+
+`mesh.jobs.post_event` is the canonical fire-and-forget. It resolves the
+registry from `MCP_MESH_REGISTRY_URL`, reuses a process-cached
+`JobProxy` from the LRU keyed by `(registry_url, job_id)` (configurable
+via [`MCP_MESH_JOBPROXY_CACHE_MAX`](../environment-variables.md#meshjob-event-channel)),
+and forwards the call. Use it from any MCP tool that receives a
+`job_id` in its request payload (a "submit_user_input" pattern):
+
+<!-- markdownlint-disable MD046 -->
+=== "Python"
+
+    ```python
+    import mesh
+
+    @app.tool()
+    @mesh.tool(capability="submit_user_input")
+    async def submit_user_input(job_id: str, text: str) -> dict:
+        receipt = await mesh.jobs.post_event(
+            job_id, "user_input", {"text": text},
+        )
+        return {"seq": receipt["seq"]}
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    agent.addTool({
+      name: "submit_user_input",
+      capability: "submit_user_input",
+      parameters: z.object({ jobId: z.string(), text: z.string() }),
+      execute: async ({ jobId, text }) => {
+        const receipt = await mesh.jobs.postEvent(
+          jobId, "user_input", { text },
+        );
+        return { seq: receipt.seq };
+      },
+    });
+    ```
+
+=== "Java"
+
+    ```java
+    @MeshTool(capability = "submit_user_input")
+    public Map<String, Object> submitUserInput(
+        @Param("job_id") String jobId,
+        @Param("text") String text) {
+      Map<String, Object> receipt = MeshJobs.postEvent(
+          jobId, "user_input", Map.of("text", text));
+      return Map.of("seq", receipt.get("seq"));
+    }
+    ```
+<!-- markdownlint-enable MD046 -->
+
+If the calling code already holds a `JobProxy` (e.g. the consumer that
+called `submitter.submit(...)`), the same wire surface is on the proxy
+directly: `proxy.send_event(event_type, payload)` (Python) /
+`proxy.sendEvent(eventType, payload)` (TS/Java). Skip the helper +
+cache lookup when you already have a proxy in scope.
+
+### Typed errors
+
+Both `post_event` and `send_event` raise typed errors for the two
+classes of failure the registry surfaces explicitly. Catch the
+specific class if you care about distinguishing them; both still
+descend from the runtime's generic exception type for back-compat
+with broad handlers.
+
+| Runtime    | Job not found in registry  | Job in terminal state         |
+| ---------- | -------------------------- | ----------------------------- |
+| Python     | `mesh.JobNotFoundError`    | `mesh.JobTerminalError`       |
+| TypeScript | `JobNotFoundError`         | `JobTerminalError`            |
+| Java       | `JobNotFoundException`     | `JobTerminalException`        |
+
+Python's classes subclass `RuntimeError`; TypeScript's classes
+subclass `Error`; Java's classes subclass `MeshException`.
+`JobNotFoundError` covers the "sweep reaped it" / "id typo" case;
+`JobTerminalError` covers "the job already completed / failed /
+cancelled — no more events accepted."
+
+### Synthetic cancel event
+
+When a consumer calls `proxy.cancel(reason)`, the registry writes a
+synthetic event into the log before forwarding the cancel signal to
+the owner replica:
+
+```
+{"type": "cancelled", "payload": {"reason": "..."}}
+```
+
+A handler parked on `recv_event(types=["cancelled", ...])` observes
+the event and can return cleanly instead of being interrupted by a
+`CancelledError`-style exception at the next `await` point. The
+registry waits a small grace window (default 200ms, configurable via
+[`MCP_MESH_CANCEL_EVENT_GRACE_MS`](../environment-variables.md#meshjob-event-channel))
+before issuing the cancel-forward, closing the race where the
+synthetic event would otherwise be in flight when the cancel token
+fires. The grace is capped at 10s — long enough for any reasonable
+`recv_event` long-poll to wake, short enough that cancel calls don't
+visibly stall.
+
+Use this pattern when you want graceful shutdown semantics inside the
+handler body instead of exception unwinding. The traditional
+`CancelledError` path is still available — handlers that don't
+subscribe to events continue to see the same behavior as before.
+
+## Stream subscription
+
+`recv_event` is **consumed** — once the handler reads an event at
+`seq=N`, that controller's cursor advances past `N` and won't see it
+again. **Stream subscription** is the **observer** counterpart: a
+non-destructive iterator any caller can open against a job's event
+log, each with its own cursor. Multiple subscribers can mirror the
+same job's events without disturbing the producer's drain.
+
+```mermaid
+sequenceDiagram
+    participant H as Handler (producer)
+    participant R as Registry (event log)
+    participant S1 as Subscriber 1
+    participant S2 as Subscriber 2
+
+    H->>R: recv_event  (cursor advances)
+    S1->>R: list_events(after=0)
+    R-->>S1: events 1..N + next_after
+    S2->>R: list_events(after=12)
+    R-->>S2: events 13..N + next_after
+    Note over R: Each subscriber's<br/>cursor is per-call<br/>(not shared with handler)
+```
+
+### When to use it
+
+- **Fan-out**: ship the same event stream to a downstream queue, a UI
+  websocket, and a metrics sink — three subscribers, three cursors,
+  zero coordination.
+- **Third-party observer**: a sidecar that mirrors events without
+  being the running handler.
+- **Reconnect-from-cursor**: persist `next_after` between subscriber
+  sessions to resume from where the last session left off (the
+  registry's log is append-only; the cursor is durable as long as
+  the registry hasn't reaped the job).
+
+For the in-handler drain — where each event is processed once — use
+`recv_event` instead. Subscription is for cases where the act of
+observing must not consume.
+
+### Per-call cursor and watermark
+
+Each call manages its own cursor. `after=0` (the default) starts from
+the beginning of the log; pass a higher value to skip historical
+events. The registry returns an ascending batch of events plus a
+`next_after` watermark — the watermark advances even on empty pages
+(useful when a server-side `types` filter scans past events that
+don't match), so subsequent polls don't re-scan the same filtered
+range.
+
+There is **no automatic terminal-state detection**. The subscription
+keeps polling until the caller breaks out of the loop or the
+registry raises `JobNotFoundError` (job swept). Applications that
+want a clean end signal post a sentinel event (e.g.
+`{"type": "ended"}`) and break when the subscriber observes it.
+
+### Cross-runtime examples
+
+The three runtimes use the idiomatic iterator shape for each language:
+Python and TypeScript expose async generators; Java exposes a blocking
+`Closeable` iterator (try-with-resources is the canonical pattern).
+
+<!-- markdownlint-disable MD046 -->
+=== "Python"
+
+    ```python
+    import mesh
+
+    async def mirror_progress(job_id: str) -> None:
+        async for event in mesh.jobs.subscribe_events(
+            job_id,
+            types=["progress", "ended"],
+            after=0,
+            long_poll_secs=30.0,
+        ):
+            await downstream.publish(event)
+            if event["type"] == "ended":
+                break
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { mesh } from "@mcpmesh/sdk";
+
+    async function mirrorProgress(jobId: string): Promise<void> {
+      for await (const event of mesh.jobs.subscribeEvents(jobId, {
+        types: ["progress", "ended"],
+        after: 0,
+        longPollSecs: 30,
+      })) {
+        await downstream.publish(event);
+        if (event.type === "ended") break;
+      }
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    void mirrorProgress(String jobId) {
+      SubscribeOptions opts = SubscribeOptions.builder()
+          .types(List.of("progress", "ended"))
+          .after(0L)
+          .longPoll(Duration.ofSeconds(30))
+          .build();
+      try (EventSubscription sub = MeshJobs.subscribeEvents(jobId, opts)) {
+        while (sub.hasNext()) {
+          Map<String, Object> event = sub.next();
+          downstream.publish(event);
+          if ("ended".equals(event.get("type"))) break;
+        }
+      }
+    }
+    ```
+<!-- markdownlint-enable MD046 -->
+
+A note on the Java shape: `EventSubscription` is **blocking** — `hasNext()`
+parks inside the long-poll until an event arrives or the subscription
+is closed. Use try-with-resources so `close()` flips the iterator's
+"don't issue another long-poll" flag deterministically. Callers that
+need fast shutdown should configure a shorter `longPoll` budget so an
+in-flight FFI long-poll drains quickly when `close()` is invoked from
+another thread (the close flag only stops *future* long-polls, not the
+in-flight one). Python's `async for` and TS's `for await` integrate
+with the runtime's cooperative cancellation natively.
+
+The underlying `JobProxy` is reused across `post_event` /
+`subscribe_events` calls targeting the same `(registry_url, job_id)`
+via the shared process-wide LRU cache — one TCP/TLS pool serves both
+surfaces. Cache cap and grace window knobs live with the other
+MeshJob event-channel variables in
+[Environment Variables](../environment-variables.md#meshjob-event-channel).
+
 ## See Also
 
 - [Streaming](streaming.md) — token-by-token progress for the request-
@@ -519,6 +872,12 @@ and [`MESHJOB_DDDI_CONTRACT.md`](https://github.com/dhyansraj/mcp-mesh/blob/main
   `X-Mesh-Timeout` propagation through the audit pipeline
 - [DDDI](dddi.md) — Distributed Dynamic Dependency Injection overview;
   explains how `MeshJob` slots are resolved
+- [Stateful Agents](stateful-agents.md) — the broader decomposition
+  pattern for agents that hold state across multiple tool calls;
+  event injection is the sub-iteration primitive that pattern leans
+  on for external signals
+- [Environment Variables](../environment-variables.md#meshjob-event-channel)
+  — `MCP_MESH_JOBPROXY_CACHE_MAX`, `MCP_MESH_CANCEL_EVENT_GRACE_MS`
 - [`MESHJOB_DESIGN.org`](https://github.com/dhyansraj/mcp-mesh/blob/main/MESHJOB_DESIGN.org)
   — full design doc with state machine, lifecycle, and SQL schema
 - [`MESHJOB_DDDI_CONTRACT.md`](https://github.com/dhyansraj/mcp-mesh/blob/main/MESHJOB_DDDI_CONTRACT.md)

--- a/docs/concepts/stateful-agents.md
+++ b/docs/concepts/stateful-agents.md
@@ -393,16 +393,32 @@ streaming LLM call that runs for two minutes, the user clicking "extend
 my deadline" lands in `pending_inputs` and sits there until the next
 boundary — which may be after the event was useful.
 
-### Coming soon: mesh-managed event channel
+### Sub-iteration events: mesh-managed event channel (shipped in v2.2)
 
-A mesh-managed bidirectional event channel between consumer and running
-job is on the roadmap as **issue #1032**. The shape is symmetric to
-streaming today: `JobProxy.send_event(payload)` from any consumer that
-holds the `job_id`, `await job.recv_event()` inside the job body —
-mesh handles delivery, trace propagation, and survival across reroute.
-That closes the sub-iteration gap. Until it lands, the inbox pattern
-above covers the iteration-boundary case, which is most of what
-production workflows need.
+The sub-iteration gap above closes with **MeshJob event injection** —
+a per-job, ordered, append-only event log every running job carries.
+Anyone holding the `job_id` posts into the log; the running handler
+drains it inline. Producer-side `proxy.send_event(payload)` (or
+`mesh.jobs.post_event(job_id, ...)` from a caller that doesn't already
+have a proxy), consumer-side `await job.recv_event(types=[...],
+timeout_secs=...)` inside the handler body. Cross-runtime parity
+(Python / TypeScript / Java).
+
+For long-lived observers that want to mirror events without consuming
+them, the **stream subscription** counterpart opens a non-destructive
+iterator with per-call cursor — multiple subscribers can mirror the
+same job's events independently. See
+[Event injection](jobs.md#event-injection) and
+[Stream subscription](jobs.md#stream-subscription) on the Jobs page
+for the canonical surface, cross-runtime examples, and the synthetic
+cancel-event pattern that gives handlers a graceful shutdown path.
+
+The inbox-via-state-agent pattern above still has its place — it's the
+right tool when the workflow naturally syncs at iteration boundaries
+and the state agent's storage is also where you want the inbox to
+live. Reach for the event channel when sub-iteration latency matters:
+a handler parked on a long `recv_event` wakes the moment the event is
+posted, not on the next boundary.
 
 ## Cancel and graceful shutdown
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -301,6 +301,47 @@ export MCP_MESH_PROXY_TIMEOUT=120
 export MCP_MESH_CALL_TIMEOUT=600
 ```
 
+## MeshJob event channel
+
+Tunables for the [MeshJob event injection + stream subscription
+surface](concepts/jobs.md#event-injection). Both variables are
+optional with sensible defaults — most deployments never need to
+override them.
+
+```bash
+# Max JobProxy instances held in the SDK's process-wide LRU cache
+# (default: 256). Used by the SDK helpers mesh.jobs.post_event /
+# mesh.jobs.subscribe_events (Python), mesh.jobs.postEvent /
+# mesh.jobs.subscribeEvents (TypeScript), and MeshJobs.postEvent /
+# MeshJobs.subscribeEvents (Java). Each JobProxy wraps a Rust
+# reqwest::Client connection pool, so caching keyed by
+# (registry_url, job_id) eliminates a TCP/TLS handshake on every
+# call. When the cache fills, the least-recently-used entry is
+# evicted (its native handle is closed). Invalid / non-positive
+# values fall back to the default — a typo'd env doesn't silently
+# disable the cache. Increase if you have many concurrent active
+# jobs from the same SDK process.
+export MCP_MESH_JOBPROXY_CACHE_MAX=256
+
+# How long the registry's CancelJob handler waits (in milliseconds)
+# after writing a synthetic "cancelled" event into a job's event log
+# before HTTP-forwarding the cancel to the owner replica (default:
+# 200, capped at 10000). Closes a race window where a producer
+# parked on recv_event(["cancelled", ...]) could otherwise see
+# CancelledError before observing the synthetic event. Set to 0 to
+# disable the grace and revert to pre-v2.2 immediate cancel-forward
+# behavior. Values above the cap are clamped with a logged warning
+# rather than rejected, so a bad env var can't take down
+# cancellation entirely.
+export MCP_MESH_CANCEL_EVENT_GRACE_MS=200
+```
+
+The SDK-side cache cap is read by the runtime that owns the
+`post_event` / `subscribe_events` call (Python / TypeScript / Java
+agents that act as producers of events). The cancel-event grace is
+read by the **registry** binary at startup and applies to every job
+running against that registry.
+
 ## Tracing & Observability
 
 ### Distributed Tracing

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -399,6 +399,34 @@ export MCP_MESH_PROXY_TIMEOUT=60
 export MCP_MESH_CALL_TIMEOUT=300
 ```
 
+## MeshJob event channel
+
+Tunables for the MeshJob event injection + stream subscription surface
+(see `meshctl man jobs`). Both variables are optional with sensible
+defaults — most deployments never need to override them.
+
+```bash
+# Max JobProxy instances held in the SDK's process-wide LRU cache
+# (default: 256). Used by mesh.jobs.post_event / mesh.jobs.subscribe_events
+# (Python), mesh.jobs.postEvent / mesh.jobs.subscribeEvents (TS), and
+# MeshJobs.postEvent / MeshJobs.subscribeEvents (Java). Each cached
+# JobProxy wraps a reqwest::Client connection pool — caching keyed by
+# (registry_url, job_id) eliminates a TCP/TLS handshake on every call.
+# Eviction closes the native handle. Invalid / non-positive values
+# fall back to the default. Increase if you have many concurrent
+# active jobs from the same SDK process.
+export MCP_MESH_JOBPROXY_CACHE_MAX=256
+
+# Registry-side: how long CancelJob waits (in ms) after writing the
+# synthetic "cancelled" event into the job's event log before HTTP-
+# forwarding the cancel to the owner replica (default: 200, capped at
+# 10000). Closes a race where a producer parked on recv_event(
+# ["cancelled", ...]) could otherwise see CancelledError before
+# observing the synthetic event. 0 disables the grace and reverts to
+# pre-v2.2 immediate cancel-forward behavior.
+export MCP_MESH_CANCEL_EVENT_GRACE_MS=200
+```
+
 ## Registry Configuration
 
 ```bash

--- a/src/core/cli/man/content/jobs.md
+++ b/src/core/cli/man/content/jobs.md
@@ -217,6 +217,99 @@ app). On the producer side, the in-process cancel token fires:
 The registry treats cancel as terminal (idempotent — already-terminal
 jobs return ok without re-firing).
 
+## Event injection
+
+Per-job append-only event log every running job carries. Anyone with
+the `job_id` writes; the running handler drains.
+
+**Inside a `task=True` handler — receive events:**
+
+```python
+event = await job.recv_event(
+    types=["user_input", "cancelled"],
+    timeout_secs=10.0,
+)
+# event is dict with {seq, type, payload, ...}, or None on timeout.
+if event is None:
+    pass  # nothing arrived within timeout
+elif event["type"] == "cancelled":
+    return {"status": "cancelled", "reason": event["payload"].get("reason")}
+```
+
+**Outside the handler, with a `job_id` in scope — fire an event:**
+
+```python
+import mesh
+
+@app.tool()
+@mesh.tool(capability="submit_user_input")
+async def submit_user_input(job_id: str, text: str) -> dict:
+    receipt = await mesh.jobs.post_event(
+        job_id, "user_input", {"text": text},
+    )
+    return {"seq": receipt["seq"]}
+```
+
+`mesh.jobs.post_event` is the canonical fire-and-forget. It resolves
+the registry from `MCP_MESH_REGISTRY_URL` and reuses a process-cached
+`JobProxy` from a bounded LRU keyed by `(registry_url, job_id)`
+(default cap 256; tune via `MCP_MESH_JOBPROXY_CACHE_MAX`). If the
+calling code already holds a `JobProxy`, use `proxy.send_event(
+event_type, payload)` directly — same wire shape, skip the helper.
+
+**Typed errors** (both subclass `RuntimeError` for back-compat):
+
+- `mesh.JobNotFoundError` — job swept or id typo
+- `mesh.JobTerminalError` — job already terminal, no more events accepted
+
+**Synthetic cancel event**. When a consumer calls `proxy.cancel(
+reason)`, the registry writes a synthetic
+`{"type": "cancelled", "payload": {"reason": "..."}}` event into the
+log before forwarding the cancel signal. A handler parked on
+`recv_event(types=["cancelled", ...])` observes it and can return
+cleanly instead of being interrupted by `CancelledError`. The
+registry waits a small grace window before issuing the cancel-forward
+(default 200ms, tunable via `MCP_MESH_CANCEL_EVENT_GRACE_MS`, capped
+at 10s) so the synthetic event lands before the cancel token fires.
+
+## Stream subscription
+
+Non-destructive observer iterator. Multiple subscribers can mirror
+the same job's events independently — each call has its own cursor,
+none of them disturb the producer's `recv_event` drain.
+
+```python
+import mesh
+
+async def mirror(job_id: str) -> None:
+    async for event in mesh.jobs.subscribe_events(
+        job_id,
+        types=["progress", "ended"],
+        after=0,
+        long_poll_secs=30.0,
+    ):
+        await downstream.publish(event)
+        if event["type"] == "ended":
+            break
+```
+
+**Use it for**: fan-out to a downstream queue / UI websocket /
+metrics sink; third-party observer that mirrors events without
+being the running handler; reconnect-from-cursor (persist
+`next_after` between sessions). For the in-handler drain — where each
+event is processed once — use `recv_event` instead.
+
+**Semantics:**
+
+- `after=0` starts from the beginning of the log; pass a higher
+  value to skip historical events.
+- Server-side `types` filter; the `next_after` watermark advances
+  even on empty pages so filtered re-scans are O(1).
+- No automatic terminal-state detection. The iterator runs until the
+  caller breaks out of the loop or the registry raises
+  `JobNotFoundError`. Applications signal end via a sentinel event
+  type (e.g. `{"type": "ended"}`).
+
 ## Timeout propagation
 
 Jobs use the `X-Mesh-Timeout` header (#656) to carry a per-attempt

--- a/src/core/cli/man/content/jobs_java.md
+++ b/src/core/cli/man/content/jobs_java.md
@@ -305,14 +305,135 @@ The registry forwards the cancel to the owner replica via
 `POST /jobs/{id}/cancel` (auto-registered on every agent's HTTP
 server). On the producer side, the cancel token fires:
 
-- Thread interrupt is signaled at the next `Thread.sleep` /
-  `Object.wait` / blocking I/O — the handler should propagate
-  `InterruptedException` rather than swallow it.
+- Handlers cannot rely on `Thread#sleep` being interrupted — Java's
+  `Thread.interrupt()` cannot be signaled by the Tokio cancel token
+  firing on the registry side. Long-running task handlers MUST poll
+  `controller.isCancelled()` between work units (the cooperative
+  model), OR park on `controller.recvEvent(List.of("cancelled", ...),
+  ...)` to observe the synthetic cancel event (see [Event
+  injection](#event-injection) below).
 - Outbound `McpMeshTool` proxy calls abort their underlying HTTP
   request (cancel propagates through `X-Mesh-Job-Id` header binding).
 
 The registry treats cancel as terminal (idempotent — already-terminal
 jobs return ok without re-firing).
+
+## Event injection
+
+Per-job append-only event log every running job carries. Anyone with
+the `jobId` writes; the running handler drains.
+
+**Inside a `task = true` handler — receive events:**
+
+```java
+@MeshTool(capability = "run_workflow", task = true)
+public Map<String, Object> runWorkflow(
+    @Param("tenant_id") String tenantId,
+    MeshJob job) throws Exception {
+  JobController controller = (JobController) job;
+  while (true) {
+    Map<String, Object> event = controller.recvEvent(
+        List.of("user_input", "cancelled"),
+        Duration.ofSeconds(10));
+    if (event == null) continue;       // clean timeout
+    if ("cancelled".equals(event.get("type"))) {
+      return Map.of("status", "cancelled");
+    }
+    // ...handle user_input...
+  }
+}
+```
+
+**Outside the handler, with a `jobId` in scope — fire an event:**
+
+```java
+import io.mcpmesh.MeshJobs;
+
+@MeshTool(capability = "submit_user_input")
+public Map<String, Object> submitUserInput(
+    @Param("job_id") String jobId,
+    @Param("text") String text) {
+  Map<String, Object> receipt = MeshJobs.postEvent(
+      jobId, "user_input", Map.of("text", text));
+  return Map.of("seq", receipt.get("seq"));
+}
+```
+
+`MeshJobs.postEvent` is the canonical fire-and-forget. It resolves
+the registry from `MCP_MESH_REGISTRY_URL` and reuses a process-wide
+LRU cache keyed by `(registryUrl, jobId)` (default cap 256; tune via
+`MCP_MESH_JOBPROXY_CACHE_MAX`). If the calling code already holds a
+`JobProxy`, use `proxy.sendEvent(eventType, payload)` directly.
+
+**Typed exceptions** (both extend `MeshException`):
+
+- `JobNotFoundException` — job swept or id typo
+- `JobTerminalException` — job already terminal, no more events accepted
+
+**Synthetic cancel event**. When a consumer calls `proxy.cancel(
+reason)`, the registry writes a synthetic event into the log before
+HTTP-forwarding the cancel signal. A handler parked on `recvEvent(
+List.of("cancelled", ...), ...)` observes the synthetic event and can
+return cleanly. This is the recommended pattern for cancel-aware Java
+handlers — `Thread#sleep` cannot be interrupted by the registry's
+cancel token firing, so handlers that sleep between work units must
+poll `controller.isCancelled()` between intervals; `recvEvent` on the
+synthetic `"cancelled"` event type sidesteps the polling requirement
+by tying cancel observation to the event channel. The registry waits
+a small grace window before issuing the cancel-forward (default
+200ms, tunable via `MCP_MESH_CANCEL_EVENT_GRACE_MS`, capped at 10s).
+
+## Stream subscription
+
+Non-destructive observer iterator. Multiple subscribers can mirror
+the same job's events independently — each subscription has its own
+cursor, none disturb the producer's `recvEvent` drain.
+
+```java
+import io.mcpmesh.EventSubscription;
+import io.mcpmesh.MeshJobs;
+import io.mcpmesh.SubscribeOptions;
+
+void mirror(String jobId) {
+  SubscribeOptions opts = SubscribeOptions.builder()
+      .types(List.of("progress", "ended"))
+      .after(0L)
+      .longPoll(Duration.ofSeconds(30))
+      .build();
+  try (EventSubscription sub = MeshJobs.subscribeEvents(jobId, opts)) {
+    while (sub.hasNext()) {
+      Map<String, Object> event = sub.next();
+      downstream.publish(event);
+      if ("ended".equals(event.get("type"))) break;
+    }
+  }
+}
+```
+
+**`EventSubscription` is `Closeable` and blocking.** `hasNext()`
+parks inside the long-poll until an event arrives or the iterator is
+closed. Use try-with-resources so `close()` flips the "don't issue
+another long-poll" flag deterministically when control leaves the
+block. `close()` does **not** interrupt an in-flight FFI long-poll —
+if you need fast shutdown, configure a shorter `longPoll` budget so
+the in-flight call drains quickly.
+
+**Use it for**: fan-out to a downstream queue / UI websocket /
+metrics sink; third-party observer that mirrors events without being
+the running handler; reconnect-from-cursor (persist `next_after`
+between sessions). For the in-handler drain — where each event is
+processed once — use `recvEvent` instead.
+
+**Semantics:**
+
+- `after(0)` (the default) starts from the beginning of the log; pass
+  a higher value to skip historical events.
+- Server-side `types` filter; the `next_after` watermark advances
+  even on empty pages so filtered re-scans are O(1).
+- No automatic terminal-state detection. The iterator runs until the
+  caller breaks out of the loop, calls `close()`, or the registry
+  raises `JobNotFoundException`. Applications signal end via a
+  sentinel event type (e.g. `{"type": "ended"}`).
 
 ## Timeout propagation
 

--- a/src/core/cli/man/content/jobs_typescript.md
+++ b/src/core/cli/man/content/jobs_typescript.md
@@ -251,6 +251,103 @@ server). On the producer side, the cancel token fires:
 The registry treats cancel as terminal (idempotent — already-terminal
 jobs return ok without re-firing).
 
+## Event injection
+
+Per-job append-only event log every running job carries. Anyone with
+the `jobId` writes; the running handler drains.
+
+**Inside a `task: true` handler — receive events:**
+
+```typescript
+if (!job) throw new Error("job slot is not bound");
+const event = await job.recvEvent(["user_input", "cancelled"], 10);
+// event is { seq, type, payload, ... } | null
+if (event === null) {
+  // nothing arrived within timeout
+} else if (event.type === "cancelled") {
+  const payload = event.payload as Record<string, unknown> | null;
+  const reason = typeof payload?.reason === "string" ? payload.reason : "";
+  return { status: "cancelled", reason };
+}
+```
+
+**Outside the handler, with a `jobId` in scope — fire an event:**
+
+```typescript
+import { mesh } from "@mcpmesh/sdk";
+
+agent.addTool({
+  name: "submit_user_input",
+  capability: "submit_user_input",
+  parameters: z.object({ jobId: z.string(), text: z.string() }),
+  execute: async ({ jobId, text }) => {
+    const receipt = await mesh.jobs.postEvent(
+      jobId, "user_input", { text },
+    );
+    return { seq: receipt.seq };
+  },
+});
+```
+
+`mesh.jobs.postEvent` is the canonical fire-and-forget. It resolves
+the registry from `MCP_MESH_REGISTRY_URL` and reuses a process-cached
+`JobProxy` from a bounded LRU keyed by `(registryUrl, jobId)` (default
+cap 256; tune via `MCP_MESH_JOBPROXY_CACHE_MAX`). If the calling code
+already holds a `JobProxy`, use `proxy.sendEvent(eventType, payload)`
+directly — same wire shape, skip the helper.
+
+**Typed errors** (both extend `Error`):
+
+- `JobNotFoundError` — job swept or id typo
+- `JobTerminalError` — job already terminal, no more events accepted
+
+**Synthetic cancel event**. When a consumer calls `proxy.cancel(
+reason)`, the registry writes a synthetic
+`{ type: "cancelled", payload: { reason: "..." } }` event into the log
+before forwarding the cancel signal. A handler parked on `recvEvent(
+["cancelled", ...])` observes it and can return cleanly instead of
+relying on the `AbortSignal`. The registry waits a small grace window
+before issuing the cancel-forward (default 200ms, tunable via
+`MCP_MESH_CANCEL_EVENT_GRACE_MS`, capped at 10s).
+
+## Stream subscription
+
+Non-destructive observer iterator. Multiple subscribers can mirror
+the same job's events independently — each call has its own cursor,
+none of them disturb the producer's `recvEvent` drain.
+
+```typescript
+import { mesh } from "@mcpmesh/sdk";
+
+async function mirror(jobId: string): Promise<void> {
+  for await (const event of mesh.jobs.subscribeEvents(jobId, {
+    types: ["progress", "ended"],
+    after: 0,
+    longPollSecs: 30,
+  })) {
+    await downstream.publish(event);
+    if (event.type === "ended") break;
+  }
+}
+```
+
+**Use it for**: fan-out to a downstream queue / UI websocket /
+metrics sink; third-party observer that mirrors events without
+being the running handler; reconnect-from-cursor (persist
+`next_after` between sessions). For the in-handler drain — where each
+event is processed once — use `recvEvent` instead.
+
+**Semantics:**
+
+- `after = 0` (the default) starts from the beginning of the log; pass
+  a higher value to skip historical events.
+- Server-side `types` filter; the `nextAfter` watermark advances even
+  on empty pages so filtered re-scans are O(1).
+- No automatic terminal-state detection. The iterator runs until the
+  caller breaks out of the `for await` loop or the registry raises
+  `JobNotFoundError`. Applications signal end via a sentinel event
+  type (e.g. `{ type: "ended" }`).
+
 ## Timeout propagation
 
 Jobs use the `X-Mesh-Timeout` header (#656) to carry a per-attempt


### PR DESCRIPTION
## Summary

Documentation-only PR covering the six commits shipped since v2.1.0 (MeshJob event-injection trilogy: #1041 / #1043 / #1045 for `recv_event` / `send_event` / `post_event`; #1047 / #1049 / #1051 for `subscribe_events`).

- `docs/concepts/jobs.md` — adds two new sections after the existing v2.0 baseline material: **Event injection** (producer/consumer model + recv loop + post pattern + type filtering + synthetic cancel event with grace window + typed errors) and **Stream subscription** (per-call cursor + `next_after` watermark + no-automatic-terminal-detection + multiple-concurrent-subscribers semantics). Both sections carry cross-runtime Python/TS/Java tabbed examples respecting the three distinct iterator shapes (Python async generator, TS async generator, Java blocking `Closeable` iterator).
- `docs/concepts/stateful-agents.md` — replaces the stale "Coming soon: mesh-managed event channel" block (which referenced #1032 as roadmap) with an accurate cross-link to the new sections.
- `docs/concepts/index.md` — grid card teaser mentions event injection.
- `docs/environment-variables.md` — documents `MCP_MESH_JOBPROXY_CACHE_MAX` (default 256) and `MCP_MESH_CANCEL_EVENT_GRACE_MS` (default 200, capped 10000).
- `src/core/cli/man/content/` — same env-var content mirrored to `environment.md`; new **Event injection** + **Stream subscription** sections added to `jobs.md`, `jobs_typescript.md`, `jobs_java.md` (each variant carries idiomatic native-runtime code).
- `RELEASE_NOTES.md` — `## v2.2.0 (UNRELEASED)` stub at the top, grouping the six commits by feature rather than PR number, mirroring the v2.1.0 entry's voice and structure.

`meshctl man` content is **hand-maintained markdown**, not generated from `docs/` — both surfaces were updated to keep them in sync.

## Review Notes

Independent review caught 3 substantive WARNINGs (all addressed) and surfaced one pre-existing adjacent inaccuracy (also folded in):

1. **Java `Map.of` foot-gun** — the cancel-event handling example used `Map.of("reason", payloadMap.get("reason"))`, which NPEs if the synthetic cancel event has no `reason` field (the API allows null reasons). Replaced with a null-tolerant pattern using `Objects.toString(payload.get("reason"), "")`.
2. **Misstated Java cancel mechanism** — `jobs_java.md` claimed handlers observe cancel via `InterruptedException`. Per `JobController.java:239-249`, Java's `Thread#sleep` cannot be interrupted by the Tokio cancel token firing — handlers must poll `isCancelled()` between work units OR park on `recvEvent(["cancelled", ...])`. Rewrote the section accurately.
3. **TS double-bang + `as any` cast** — the canonical TS doc example used `job!.recvEvent!(...)` and `(event.payload as any)?.reason`. Replaced with idiomatic early-return narrowing + `Record<string, unknown>` payload typing so the example doesn't teach non-idiomatic TS.
4. **Adjacent pre-existing inaccuracy** — `jobs_java.md:308-310` (outside the diff) carried the same wrong `Thread.sleep` interrupt claim in the Cancellation section. Folded a one-paragraph fix in since the same surface area was already being edited.

All API signatures, env-var defaults (256, 200ms, 10000ms cap), tab indentation, sequence-diagram syntax, anchor links, and framing verified accurate against source files.

Closes #1052

A follow-up PR (tracked separately) will add a runnable example agent under `examples/` demonstrating the same APIs.

## Test plan

- [x] `mkdocs build` clean (no new errors/warnings introduced; pre-existing orphan-page warnings unrelated)
- [x] `mkdocs serve` renders new sections cleanly (grid cards, tabbed code, mermaid `sequenceDiagram` blocks)
- [x] `meshctl man environment --raw | grep -E 'MCP_MESH_(JOBPROXY|CANCEL_EVENT)'` matches both env vars
- [x] `meshctl man jobs [--typescript|--java] --raw` matches new Event injection + Stream subscription sections per runtime
- [x] `meshctl man jobs --java --raw | grep InterruptedException` returns only an unrelated `throws` clause in a code sample — the wrong cancel-mechanism claim is gone
- [x] `meshctl man jobs --typescript --raw | grep -E '!\.|\bas any\b'` zero matches — non-idiomatic TS scrubbed
- [x] `go build ./...` clean (man content compiles via `//go:embed`)
- [x] No-deprecated-in-docs rule observed; public-artifact framing observed (no naming of downstream consumers, no behavioral framing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MeshJob event injection: post and receive job events across all supported runtimes with typed error handling and configurable cancel-event grace window.
  * MeshJob stream subscription: non-destructive event observation with independent per-call cursors and watermark filtering.

* **Documentation**
  * Added comprehensive event injection and stream subscription guidance across Python, TypeScript, and Java documentation.
  * Documented new environment variables for event channel tuning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->