### PR TITLE
docs: fix send_event/post_event signatures in stateful-agents.md

### DIFF
--- a/docs/concepts/stateful-agents.md
+++ b/docs/concepts/stateful-agents.md
@@ -398,11 +398,11 @@ boundary — which may be after the event was useful.
 The sub-iteration gap above closes with **MeshJob event injection** —
 a per-job, ordered, append-only event log every running job carries.
 Anyone holding the `job_id` posts into the log; the running handler
-drains it inline. Producer-side `proxy.send_event(payload)` (or
-`mesh.jobs.post_event(job_id, ...)` from a caller that doesn't already
-have a proxy), consumer-side `await job.recv_event(types=[...],
-timeout_secs=...)` inside the handler body. Cross-runtime parity
-(Python / TypeScript / Java).
+drains it inline. Producer-side `proxy.send_event(event_type, payload)`
+(or `mesh.jobs.post_event(job_id, event_type, payload)` from a caller
+that doesn't already have a proxy), consumer-side
+`await job.recv_event(types=[...], timeout_secs=...)` inside the
+handler body. Cross-runtime parity (Python / TypeScript / Java).
 
 For long-lived observers that want to mirror events without consuming
 them, the **stream subscription** counterpart opens a non-destructive


### PR DESCRIPTION
## Summary

Fixes wrong API signatures introduced in #1053 at `docs/concepts/stateful-agents.md:401-405`:

- `proxy.send_event(payload)` → `proxy.send_event(event_type, payload)`
- `mesh.jobs.post_event(job_id, ...)` → `mesh.jobs.post_event(job_id, event_type, payload)`

Verified against authoritative source signatures:

- `src/runtime/core/src/jobs_py.rs:487` — `send_event(event_type: str, payload: Any) -> dict`
- `src/runtime/python/mesh/jobs.py:226-229` — `post_event(job_id: str, event_type: str, payload: Optional[dict] = None) -> dict`

A reader copying the prior example as-is would get `TypeError: send_event() missing 1 required positional argument`.

The canonical surface in `docs/concepts/jobs.md` and the meshctl man pages already use the correct signatures — this PR fixes a one-paragraph drift in the stateful-agents.md cross-link.

Closes #1055

## Test plan

- [x] `grep -n "send_event\|post_event" docs/concepts/stateful-agents.md` shows both signatures with full positional args
- [x] `mkdocs build` clean (no new warnings)
