### PR TITLE
v2.2.1: cross-loop affinity fix — lifespan + tools on single user loop

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,37 @@
 # MCP Mesh Release Notes
 
-[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v2.2.0...HEAD)
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v2.2.1...HEAD)
+
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v2.2.0...v2.2.1)
+
+## v2.2.1 (2026-05-20)
+
+Cross-loop affinity fix for v2.2 adopters using FastAPI lifespan patterns. Apps that create loop-bound resources (`asyncpg.Pool`, `redis.asyncio.Redis`, `aiohttp.ClientSession`) in `lifespan` startup and use them from tool bodies hit "Future attached to a different loop" errors in v2.2.0 — the documented `MCP_MESH_TOOL_WORKERS=1` "escape hatch" did not actually solve it. v2.2.1 fixes the topology so standard FastAPI patterns work as expected.
+
+### 🪢 Loop topology fix (#1061)
+
+- **Lifespan, tools, and lifespan exit now share one user loop.** Previously, `lifespan` ran on uvicorn's main loop and tools dispatched to N worker loops with their own asyncio runtimes — any loop-bound resource created in `lifespan` failed when reused from a tool body. The SDK now hijacks the composed lifespan and dispatches it to the user loop via `asyncio.run_coroutine_threadsafe` + `asyncio.wrap_future`, mirroring the pattern already used internally for cross-loop httpx-client close in `unified_mcp_proxy.close_connection_pools`.
+- **`/health` / `/ready` / `/livez` remain on the framework loop**, never blocked by user-tool execution. K8s probe responsiveness during long tool calls is preserved (verified by integration test: `/health` responded in 0.958ms during a 10-second `await asyncio.sleep(10)` tool).
+- **Contextvar propagation across the loop boundary** (mesh trace IDs, propagated headers) honored in the lifespan body via the same `contextvars.copy_context()` + `loop.create_task(..., context=ctx)` pattern used for tool dispatch.
+- **Exception forwarding through `__aexit__`** preserves `exc_type` / `exc_val` / `exc_tb` per PEP 343, so user lifespan `finally` / except blocks see the original error if uvicorn raises during the yield.
+- **Single wrap site** (`wrap_lifespan_for_user_loop()` in `lifespan_factory.py`) replaces the previous duplicate-wrap-site shape — future lifespan-related changes have one place to edit.
+
+### ⚙️ Default worker pool size: 1 (was `min(8, max(2, cpu_count()))`)
+
+- **Default tool dispatch now runs on a single-user loop.** Async-correct tool bodies (LLM calls, `asyncio.gather` fan-out, async DB drivers) see no throughput regression — `asyncio.gather` over 3 outbound mesh calls completes in 2.04 seconds at N=1, identical to N=8 (integration-test measured).
+- **Apps with sync-blocking calls in tool bodies** (`time.sleep`, `requests.get`, CPU-bound work) that relied on `cpu_count()` worker pool absorbing concurrent load **must either**:
+    - Refactor the blocking call to `await asyncio.to_thread(blocking_call)` (recommended — Python idiom; user loop stays free).
+    - Or set `MCP_MESH_TOOL_WORKERS=N` (N>1) in the agent's environment to restore N worker loops. The loop-affinity caveat applies — resources created in `lifespan` startup bind to worker-0 only.
+- **Apps that set `MCP_MESH_TOOL_WORKERS=1` as the documented escape hatch in v2.0/v2.1** are source-compatible in v2.2.1 — no code edits are required. The setting was previously insufficient for FastAPI `lifespan` + loop-bound resource patterns: it collapsed worker loops but did not unify the lifespan loop with the tool loop, so cross-loop errors still surfaced. v2.2.1 fixes the underlying lifespan-loop topology, so those same apps now function correctly without any changes — the previous escape hatch becomes a no-op duplication of the new default.
+
+### 📚 Documentation
+
+- `docs/concepts/stateful-agents.md`, `docs/python/dependency-injection.md`, `meshctl man dependency-injection` rewritten with a "Loop topology" section reflecting the new default and the FastAPI standard pattern that just works.
+- `docs/environment-variables.md` updated for the new `MCP_MESH_TOOL_WORKERS` default.
+
+### 🧪 Tests
+
+`uc02_agent_lifecycle` gains 10 new test files (`tc12`–`tc19`, with `tc18` split into three concurrency variants `tc18a`/`tc18b`/`tc18c`) covering 8 logical scenarios that pin the loop-affinity contract — the FastAPI lifespan pattern, parallel `asyncio.gather` fan-out, lazy pool reuse, sync-blocking serialization vs opt-in N>1 recovery, exception-propagation through hijack, and `/health` responsiveness during a 10-second tool.
 
 [Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v2.1.0...v2.2.0)
 

--- a/docs/concepts/in-process-state.md
+++ b/docs/concepts/in-process-state.md
@@ -8,9 +8,10 @@ the overwhelming majority of stateful workloads in mesh:
 
 - **Externalized state via a state agent + MeshJob orchestrator** —
   durable, horizontally scalable, restart-tolerant.
-- **Single-worker mode** ([`MCP_MESH_TOOL_WORKERS=1`](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources))
-  — collapse to one worker loop, share a loop-bound resource at module
-  level, give up parallel execution.
+- **FastAPI `lifespan` for a loop-bound resource** (see
+  [Loop topology](../python/dependency-injection.md#loop-topology-v221))
+  — create the pool / client in `lifespan` startup; the default single
+  user loop hosts both `lifespan` and every tool body.
 
 This page is for the **narrow class** of agents where neither of those
 fits — typically because the state cannot tolerate the ~10ms HTTP
@@ -24,7 +25,7 @@ MeshJob.
 
 Before reaching for the in-process runtime pattern, can you answer **no** to all of these?
 
-1. **Is your work driven by tool calls (request-driven)?** → if yes, try `MCP_MESH_TOOL_WORKERS=1` (see [single-worker mode](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources)).
+1. **Is your work driven by tool calls (request-driven)?** → if yes, put your loop-bound resource in FastAPI `lifespan` startup (see [Loop topology](../python/dependency-injection.md#loop-topology-v221)).
 2. **Can your state mutations tolerate ~10ms HTTP round-trip overhead per mutation?** → if yes, use MeshJob with a state agent (see [stateful agents](stateful-agents.md)).
 3. **Is your stateful resource portable across processes (DB pool, Redis connection, message-broker client)?** → if yes, you don't need in-process binding.
 
@@ -287,9 +288,9 @@ immediately after.
 ## Closing
 
 This pattern is an escape hatch, not a recommendation. If you're
-reading it because you hit a cross-loop Future error or a "where do I
-put my asyncpg pool" question, the answer is almost always
-[single-worker mode](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources)
+reading it because of a "where do I put my asyncpg pool" question, the
+answer is almost always the standard FastAPI `lifespan` pattern (see
+[Loop topology](../python/dependency-injection.md#loop-topology-v221))
 or the [MeshJob state-agent decomposition](stateful-agents.md) — not
 this page. Use MeshJob unless you can answer the three gate questions
 with "no, no, and no."
@@ -298,9 +299,9 @@ with "no, no, and no."
 
 - [Stateful Agents](stateful-agents.md) — the canonical MeshJob +
   state-agent decomposition that covers the common case
-- [Single-Worker Mode](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources)
-  — when you have one shared loop-bound resource and request-driven
-  tools
+- [Loop Topology](../python/dependency-injection.md#loop-topology-v221)
+  — two-loop model, default `MCP_MESH_TOOL_WORKERS=1`, FastAPI
+  `lifespan` for loop-bound resources
 - [Long-Running Jobs](jobs.md) — MeshJob substrate: lifecycle,
   retries, cancel, orphan reroute
 - `meshctl man dependency-injection` — DDDI, worker-loop topology,

--- a/docs/concepts/stateful-agents.md
+++ b/docs/concepts/stateful-agents.md
@@ -39,58 +39,40 @@ several primitives — MeshJob, DDDI, the worker-pool topology — so the
   external signal; a timer fires at a deadline. None of this is gated
   on a user tool call landing.
 
-The temptation when you hit this for the first time is to cache state
-in process memory at the module level. The shape feels
-natural — it's how FastAPI services without mesh usually look:
+### Loop topology (v2.2.1+)
+
+mcp-mesh runs your agent across two event loops:
+
+- **Framework loop** (uvicorn main): serves `/health`, `/ready`, `/livez`, and routes MCP protocol traffic. Always responsive.
+- **User loop** (single, dedicated): runs your FastAPI `lifespan` startup, all `@mesh.tool` and `@app.tool` bodies, and `lifespan` exit. One loop for everything you write.
+
+The two-loop split means a long-running tool body (LLM call, slow registry hop, multi-minute MeshJob) holds the user loop, but never the framework loop — your K8s liveness/readiness probes stay responsive.
+
+**What this fixes**: standard FastAPI patterns for loop-bound resources work as expected. `asyncpg.Pool`, `redis.asyncio.Redis`, and `aiohttp.ClientSession` are all loop-affine — they bind to the asyncio loop that created them and fail if reused from a different one. Because v2.2.1 runs your lifespan AND your tools on the same user loop, the standard FastAPI idiom just works:
 
 ```python
-# DON'T DO THIS in a multi-worker mesh agent.
-import asyncpg
-import mesh
-from fastmcp import FastMCP
+@asynccontextmanager
+async def lifespan(app):
+    app.state.pool = await asyncpg.create_pool(...)
+    yield
+    await app.state.pool.close()
 
-app = FastMCP("Bad State Agent")
-_pool: asyncpg.Pool | None = None  # module-level cache
-
-async def _get_pool() -> asyncpg.Pool:
-    global _pool
-    if _pool is None:
-        _pool = await asyncpg.create_pool("postgres://...")
-    return _pool
+app = FastMCP("my-agent", lifespan=lifespan)
 
 @app.tool()
-@mesh.tool(capability="read_state")
-async def read_state(tenant_id: str) -> dict:
-    pool = await _get_pool()
-    async with pool.acquire() as conn:
-        return await conn.fetchrow("SELECT * FROM state WHERE tenant=$1", tenant_id)
+@mesh.tool(capability="query")
+async def query() -> dict:
+    async with app.state.pool.acquire() as conn:
+        return await conn.fetchrow("SELECT ...")
 ```
 
-The first `read_state` call lands on worker loop A, lazily builds the
-pool on loop A, returns. The second `read_state` call round-robins to
-worker loop B. The pool's internal Futures were created on loop A; when
-loop B tries to await them, asyncio throws:
+No per-loop dict workarounds, no `WORKERS=1` ceremony, no surprises. The pool is created on the user loop in `lifespan` startup; tools use it on the same user loop; `lifespan` exit closes it on the same loop.
 
-```
-RuntimeError: Task <Task pending name='Task-N'> got Future <Future pending>
-attached to a different loop
-```
+**Opt-in N>1 worker pool**: if a tool body does sync blocking work (e.g. `time.sleep`, a sync HTTP client, CPU-bound number crunching) and you need concurrent calls to absorb it instead of serializing on one loop, set `MCP_MESH_TOOL_WORKERS=N` (N>1). You get N worker loops, dispatched round-robin. Loop-bound resources created in `lifespan` still bind to one loop (worker-0); tools dispatched to worker-1..N-1 cannot access them. The supported pattern for that case is the per-loop dict cache (see `src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py` for the SDK's own internal use of this pattern for httpx clients).
 
-Why does this happen? The Python runtime dispatches `async def`
-`@mesh.tool` functions across a small pool of worker loops — default
-`min(8, max(2, cpu_count()))`, always ≥ 2. The pool keeps `/health`,
-`/livez`, registry heartbeats, and other concurrent tool calls
-responsive even when one tool blocks. The trade-off: module-level
-loop-bound resources (asyncpg pools, `redis.asyncio.Redis`,
-`motor.motor_asyncio.AsyncIOMotorClient`, `aiohttp.ClientSession`) bind
-to whatever loop created them and fail on every subsequent call that
-lands on a different worker. The full topology is documented in
-[the dependency-injection reference](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources).
+**Better escape for sync-blocking**: refactor the blocking call to `await asyncio.to_thread(blocking_call)`. The blocking call runs on Python's default thread pool; the user loop stays free; you don't need N>1 workers.
 
-There are two clean answers to this problem in mesh. The simple one is
-to collapse to a single worker loop with `MCP_MESH_TOOL_WORKERS=1`
-(covered in [single-worker mode](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources)).
-The structural one — the one that survives replica restart, scales
+The structural answer — the one that survives replica restart, scales
 horizontally, and composes with the rest of the mesh — is the
 three-agent decomposition that follows.
 
@@ -107,10 +89,10 @@ The state agent exposes `@mesh.tool` functions that read and write a
 Postgres (or Redis) database. It does no business logic. It does no
 long-running work. From mesh's perspective it's an ordinary CRUD
 agent — every tool call is short, idempotent where possible, and
-returns. The pool lives inside the agent process and (because the agent
-is shaped for a single shared resource) runs with
-`MCP_MESH_TOOL_WORKERS=1` so it can cache the pool at module level
-without the cross-loop footgun.
+returns. The pool lives inside the agent process — created in
+`lifespan` startup, attached to `app.state`, and closed in `lifespan`
+exit. Since v2.2.1, `lifespan` and all tool bodies share the single
+user loop, so the standard FastAPI pattern is the supported pattern.
 
 Schema:
 
@@ -127,24 +109,23 @@ Schema:
 
     ```python
     import os
+    from contextlib import asynccontextmanager
     import asyncpg
     import mesh
     from fastmcp import FastMCP
 
-    app = FastMCP("State Agent")
-    _pool: asyncpg.Pool | None = None  # safe: MCP_MESH_TOOL_WORKERS=1
+    @asynccontextmanager
+    async def lifespan(app):
+        app.state.pool = await asyncpg.create_pool(os.environ["DATABASE_URL"])
+        yield
+        await app.state.pool.close()
 
-    async def _pool_handle() -> asyncpg.Pool:
-        global _pool
-        if _pool is None:
-            _pool = await asyncpg.create_pool(os.environ["DATABASE_URL"])
-        return _pool
+    app = FastMCP("State Agent", lifespan=lifespan)
 
     @app.tool()
     @mesh.tool(capability="read_state")
     async def read_state(tenant_id: str) -> dict:
-        pool = await _pool_handle()
-        async with pool.acquire() as conn:
+        async with app.state.pool.acquire() as conn:
             row = await conn.fetchrow(
                 "SELECT state FROM tenant_state WHERE tenant_id=$1",
                 tenant_id,
@@ -154,8 +135,7 @@ Schema:
     @app.tool()
     @mesh.tool(capability="append_event")
     async def append_event(tenant_id: str, event_type: str, payload: dict) -> dict:
-        pool = await _pool_handle()
-        async with pool.acquire() as conn:
+        async with app.state.pool.acquire() as conn:
             async with conn.transaction():
                 await conn.execute(
                     "INSERT INTO event_log (tenant_id, event_type, payload) "
@@ -179,7 +159,6 @@ Deployment env:
 
 ```yaml
 env:
-  MCP_MESH_TOOL_WORKERS: "1"      # collapse to one worker loop
   DATABASE_URL: "postgres://..."
 ```
 
@@ -259,9 +238,11 @@ The orchestrator hosts the long-running unit of work. Each unit is one
     class Orchestrator: pass
     ```
 
-This body runs on mesh's default worker pool (no `WORKERS=1` here — the
-agent is stateless from a resource-binding standpoint; all loop-bound
-resources live across the boundary in the state agent's process).
+The orchestrator is stateless from a resource-binding standpoint — all
+loop-bound resources live across the boundary in the state agent's
+process. Whether the orchestrator runs at the default single-user loop
+or opts into `MCP_MESH_TOOL_WORKERS=N` for sync-blocking parallelism
+is independent of this decomposition.
 
 ### Client surface — `mesh.route` for web, MCP for tools
 
@@ -319,9 +300,11 @@ Each piece of the decomposition pays for itself:
   horizontally with Postgres as the coordination point; the route agent
   scales horizontally trivially.
 - **Loop-bound resources stay inside one process.** The asyncpg pool
-  lives in the state agent (which runs `WORKERS=1`). No cross-loop
-  sharing. No cross-process sharing. The pool is invisible to the
-  orchestrator and to the route agent.
+  lives in the state agent — created in `lifespan` startup on the user
+  loop, used by every tool body on the same user loop, closed in
+  `lifespan` exit on the same loop. No cross-loop sharing. No
+  cross-process sharing. The pool is invisible to the orchestrator and
+  to the route agent.
 
 ## Handling external events during a run
 
@@ -479,13 +462,16 @@ A handful of anti-patterns this decomposition exists to prevent:
   with sub-10ms latency budgets) — see
   [In-Process State](in-process-state.md) — but it should never be
   the default reach.
-- **Module-level state without `MCP_MESH_TOOL_WORKERS=1`.** Don't
-  cache asyncpg pools, redis clients, or any other loop-bound resource
-  at module level on default workers. It will work the first call.
-  It will fail the second. The fix is either single-worker mode
-  ([details](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources))
-  or moving the resource into a dedicated state agent (the pattern
-  above).
+- **Loop-bound resource cached at module level when `MCP_MESH_TOOL_WORKERS>1`.**
+  At the default `WORKERS=1`, module-level caching of an asyncpg pool /
+  redis client works, but it's brittle — anyone setting `WORKERS=N` to
+  absorb sync-blocking work will see "Future attached to a different
+  loop" on the second worker. The supported shape is to create the
+  resource in FastAPI `lifespan` startup (binds to the single-user
+  loop, used by all tools on the same loop) — see
+  [Loop topology](#loop-topology-v221) above. If you also need N>1
+  workers for sync-blocking parallelism, use a per-loop dict cache
+  (each worker lazily builds its own resource on first access).
 - **Putting orchestration state on the orchestrator process.** The
   orchestrator's job body should be a pure transformer: read state in,
   drive work, write state out. The moment it caches anything across
@@ -499,6 +485,6 @@ A handful of anti-patterns this decomposition exists to prevent:
   responses; pairs with MeshJob for live updates
 - [In-Process State (Escape Hatch)](in-process-state.md) — when even
   MeshJob can't fit your shape, with documented caveats
-- [Single-Worker Mode](../python/dependency-injection.md#single-worker-mode-for-shared-loop-bound-resources)
-  — the `MCP_MESH_TOOL_WORKERS=1` flag and when to use it
-- `meshctl man dependency-injection` — DDDI and worker-loop topology
+- [Loop Topology](../python/dependency-injection.md#loop-topology-v221)
+  — two-loop model, default `MCP_MESH_TOOL_WORKERS=1`, when to opt into N>1
+- `meshctl man dependency-injection` — DDDI and loop topology

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -65,6 +65,25 @@ export MCP_MESH_HEARTBEAT_INTERVAL=5
 export MCP_MESH_SESSION_TTL=3600
 ```
 
+### Tool Dispatch (Python)
+
+```bash
+# Number of worker loops for @mesh.tool / @app.tool body dispatch
+# Default: 1 (since v2.2.1; previously min(8, max(2, cpu_count())))
+#
+# At 1 (default): FastAPI lifespan startup, all tool bodies, and lifespan
+# exit share one user loop. Loop-bound resources (asyncpg.Pool, redis.asyncio,
+# aiohttp.ClientSession) created in lifespan startup work in every tool body.
+# /health, /ready, /livez stay responsive on a separate framework loop.
+#
+# At N>1: N worker loops dispatched round-robin. Use this when tool bodies
+# do sync blocking work (time.sleep, sync HTTP client, CPU-bound) and need
+# concurrent calls absorbed across loops. Caveat: resources created in
+# lifespan bind to worker-0 only; use a per-loop dict cache for cross-worker
+# access. Prefer `await asyncio.to_thread(blocking_call)` when feasible.
+export MCP_MESH_TOOL_WORKERS=1
+```
+
 ### HTTP Server Settings
 
 ```bash

--- a/docs/python/dependency-injection.md
+++ b/docs/python/dependency-injection.md
@@ -182,79 +182,79 @@ When topology changes (agents join/leave), the mesh:
 
 No code changes needed - happens transparently.
 
-## Single-worker mode for shared loop-bound resources
+## Loop topology (v2.2.1+)
 
-Some Python async libraries hand back objects that are bound to the
-specific asyncio loop they were created on — `asyncpg.Pool`,
-`redis.asyncio.Redis`, `motor.motor_asyncio.AsyncIOMotorClient`,
-`aiohttp.ClientSession`, and many others. The library caches internal
-`Future` objects against the creating loop; awaiting any of them from a
-different loop throws:
+mcp-mesh runs your agent across two event loops:
 
+- **Framework loop** (uvicorn main): serves `/health`, `/ready`,
+  `/livez`, and routes MCP protocol traffic. Always responsive.
+- **User loop** (single, dedicated): runs your FastAPI `lifespan`
+  startup, all `@mesh.tool` and `@app.tool` bodies, and `lifespan`
+  exit. One loop for everything you write.
+
+A long-running tool body holds the user loop, but never the framework
+loop — K8s liveness/readiness probes stay responsive.
+
+### Default `MCP_MESH_TOOL_WORKERS=1`
+
+Since v2.2.1, default tool dispatch runs on a single-user loop (was
+`min(8, max(2, cpu_count()))`). The standard FastAPI pattern for
+loop-bound resources works as expected — `lifespan` startup creates the
+resource on the user loop; every tool body uses it on the same loop;
+`lifespan` exit closes it on the same loop.
+
+```python
+from contextlib import asynccontextmanager
+import asyncpg
+import mesh
+from fastmcp import FastMCP
+
+@asynccontextmanager
+async def lifespan(app):
+    app.state.pool = await asyncpg.create_pool(...)
+    yield
+    await app.state.pool.close()
+
+app = FastMCP("my-agent", lifespan=lifespan)
+
+@app.tool()
+@mesh.tool(capability="query")
+async def query() -> dict:
+    async with app.state.pool.acquire() as conn:
+        return await conn.fetchrow("SELECT ...")
 ```
-RuntimeError: Task <...> got Future <...> attached to a different loop
-```
 
-The mesh Python runtime dispatches `async def` `@mesh.tool` functions
-across a small pool of worker loops (default `min(8, max(2, cpu_count()))`,
-always ≥ 2). The pool keeps `/health`, `/livez`, registry heartbeats,
-and other concurrent tool calls responsive even when one tool blocks the
-loop. The full topology is documented in `meshctl man dependency-injection`.
+No per-loop dict workarounds, no `WORKERS=1` ceremony. Loop-affine
+libraries (`asyncpg.Pool`, `redis.asyncio.Redis`, `aiohttp.ClientSession`)
+just work.
 
-The interaction: if you cache a pool at module level on default workers,
-the lazy initializer runs on whichever worker loop happened to receive
-the first call. Subsequent calls round-robin to a different worker, the
-pool's internal Futures fail the cross-loop check, and every call after
-the first raises.
+### Opt-in `MCP_MESH_TOOL_WORKERS=N` (N>1)
 
-### The flag: `MCP_MESH_TOOL_WORKERS=1`
+If a tool body does sync blocking work (`time.sleep`, `requests.get`,
+CPU-bound number crunching) and you need concurrent calls to absorb it
+rather than serializing on one loop, set `MCP_MESH_TOOL_WORKERS=N`.
+You get N worker loops, dispatched round-robin.
 
-Pin the agent to a single worker loop. The pool gets created on that
-loop, every subsequent tool call lands on that same loop, no cross-loop
-sharing happens. Module-level resource caching works the way you'd
-expect from a non-mesh FastAPI agent.
+Loop-affinity caveat: resources created in `lifespan` bind to worker-0
+only. Tools dispatched to worker-1..N-1 cannot share them. For
+cross-worker access, use a per-loop dict cache — each worker lazily
+builds its own resource on first access. See
+`src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py` for the SDK's
+own internal use of this pattern for httpx clients.
+
+**Better escape for sync-blocking**: prefer
+`await asyncio.to_thread(blocking_call)` over N>1. The blocking call
+runs on Python's default thread pool; the user loop stays free; no
+cross-worker resource problem.
 
 ### Trade-offs
 
-| Property | Default (N≥2) | `WORKERS=1` |
+| Concern | N=1 (default) | `MCP_MESH_TOOL_WORKERS=N` (N>1) |
 |---|---|---|
-| Health/livez endpoint stays responsive when a tool blocks | ✓ | ✓ |
-| Module-level loop-bound resource shared across tools | ✗ | ✓ |
-| Parallel execution when a tool does blocking sync work | ✓ | ✗ (serialized) |
-| Async cooperative concurrency within a tool body | ✓ | ✓ |
-
-The `/health` and `/livez` endpoints run on their own thread regardless
-of `WORKERS`, so infra signals stay responsive in both modes. The
-asymmetry is in parallel execution of tool bodies that block the loop:
-on default workers, two blocking tools run concurrently on two
-workers; on `WORKERS=1`, the second waits for the first.
-
-### When to use it
-
-Good fit:
-
-- **Single-tenant CRUD agents** with one shared asyncpg pool or one
-  shared Redis client.
-- **State agents** in the [stateful-agents pattern](../concepts/stateful-agents.md) —
-  pure read/write tools over durable storage, no long-running work in
-  the agent itself.
-- Any agent where the shared resource cost (creating per-tool pools)
-  outweighs the parallel-execution gain.
-
-Bad fit:
-
-- **Agents that do blocking sync work** (sync DB drivers, CPU-bound
-  computation) and need true parallelism. Keep default workers and use
-  `await asyncio.to_thread(blocking_fn, ...)` inside the handler — that
-  offloads to the runtime's thread pool without freezing the worker
-  loop.
-- **CPU-bound workloads** that need to use multiple cores in parallel.
-  `WORKERS=1` serializes; default workers parallelize only across
-  loops, not across CPU cores (use process-level parallelism for that).
-- **Agents that hold genuinely long-lived state in process memory**
-  beyond a connection pool. See
-  [In-Process State (Escape Hatch)](../concepts/in-process-state.md)
-  for the narrower cases where `WORKERS=1` isn't enough.
+| FastAPI `lifespan` + loop-bound resource (asyncpg, redis, aiohttp) | Works | Resource bound to worker-0 only — use per-loop dict for cross-worker access |
+| Parallel `asyncio.gather` fan-out within one tool body | Full parallelism via async I/O | Same |
+| Sync blocking in tool body (`time.sleep`, `requests.get`) | Serializes — use `asyncio.to_thread` instead | Absorbed across N worker loops |
+| `/health`, `/ready` during long tool calls | Always responsive (framework loop separate) | Same |
 
 ### How to set it
 
@@ -262,16 +262,16 @@ Docker compose:
 
 ```yaml
 services:
-  state-agent:
+  my-agent:
     environment:
-      MCP_MESH_TOOL_WORKERS: "1"
+      MCP_MESH_TOOL_WORKERS: "4"
 ```
 
 Helm values:
 
 ```yaml
 env:
-  MCP_MESH_TOOL_WORKERS: "1"
+  MCP_MESH_TOOL_WORKERS: "4"
 ```
 
 Kubernetes deployment spec:
@@ -279,18 +279,17 @@ Kubernetes deployment spec:
 ```yaml
 spec:
   containers:
-    - name: state-agent
+    - name: my-agent
       env:
         - name: MCP_MESH_TOOL_WORKERS
-          value: "1"
+          value: "4"
 ```
 
 For the bigger-picture decomposition (state agent + MeshJob orchestrator
-+ client surface) that motivates this flag, see
-[Stateful Agents](../concepts/stateful-agents.md). For the narrower
-cases where even single-worker isn't enough (sub-10ms latency budgets,
-unportable loop-bound resources, true background daemons), see
-[In-Process State](../concepts/in-process-state.md).
++ client surface), see [Stateful Agents](../concepts/stateful-agents.md).
+For the narrow cases where neither default nor N>1 fits (sub-10ms
+latency budgets, unportable loop-bound resources, true background
+daemons), see [In-Process State](../concepts/in-process-state.md).
 
 ## See Also
 

--- a/src/core/cli/man/content/dependency-injection.md
+++ b/src/core/cli/man/content/dependency-injection.md
@@ -35,25 +35,36 @@ health → capability_match → tags → version → schema → tiebreaker
 
 Every decision the registry makes is recorded as a `dependency_resolved` (or `dependency_unresolved`) event. Use `meshctl audit <agent>` to read them back — see `meshctl man audit`.
 
-## Loop topology
+## Loop topology (v2.2.1+)
 
-The Python runtime dispatches `async def` `@mesh.tool` functions across a pool of worker threads, each owning its own asyncio loop. Default pool size is `min(8, max(2, cpu_count()))` — always ≥ 2.
+mcp-mesh runs your agent across two event loops:
 
-**Why a pool, not one loop.** A tool that blocks the asyncio loop (sync `time.sleep`, sync DB driver, CPU-bound work) shouldn't freeze `/health`, `/livez`, registry heartbeats, or other concurrent tool calls. Isolating tool dispatch onto a pool of worker loops keeps infra endpoints responsive even when a handler is misbehaving.
+- **Framework loop** (uvicorn main): serves `/health`, `/ready`, `/livez`, and routes MCP protocol traffic. Always responsive.
+- **User loop** (single, dedicated): runs FastAPI `lifespan` startup, all `@mesh.tool` and `@app.tool` bodies, and `lifespan` exit.
 
-**The implication.** Module-level loop-bound resources bind to whatever loop created them and fail when reused from a different loop. The canonical examples are `asyncpg.Pool`, `redis.asyncio.Redis`, `motor.motor_asyncio.AsyncIOMotorClient`, and `aiohttp.ClientSession` — all of them cache internal `Future` objects against the creating loop. On default workers, the first call lazily creates the resource on worker A; the second call lands on worker B and throws:
+A long-running tool body holds the user loop, but never the framework loop — K8s probes stay responsive during long tool calls.
 
+**Default `MCP_MESH_TOOL_WORKERS=1`** (since v2.2.1; previously `min(8, max(2, cpu_count()))`). Loop-affine resources (`asyncpg.Pool`, `redis.asyncio.Redis`, `motor.motor_asyncio.AsyncIOMotorClient`, `aiohttp.ClientSession`) created in FastAPI `lifespan` startup bind to the single-user loop and are reused by every tool body on the same loop — the standard FastAPI pattern just works:
+
+```python
+from contextlib import asynccontextmanager
+import asyncpg
+from fastmcp import FastMCP
+
+@asynccontextmanager
+async def lifespan(app):
+    app.state.pool = await asyncpg.create_pool(...)
+    yield
+    await app.state.pool.close()
+
+app = FastMCP("my-agent", lifespan=lifespan)
 ```
-RuntimeError: Task <...> got Future <...> attached to a different loop
-```
 
-This is a real footgun for the natural FastAPI-shaped pattern of "cache a pool at module level." Two clean answers, depending on what you need:
+**Opt-in `MCP_MESH_TOOL_WORKERS=N` (N>1)** for tool bodies that do sync blocking work and need concurrent calls to absorb it. Loop-affinity caveat: resources created in `lifespan` bind to worker-0 only. For cross-worker access, use a per-loop dict cache (each worker lazily builds its own resource on first access). Better escape: `await asyncio.to_thread(blocking_call)` keeps the user loop free without N>1 workers.
 
-- **One shared loop-bound resource, CRUD-shape tools.** Set `MCP_MESH_TOOL_WORKERS=1` to collapse to a single worker loop. Module-level resource caching works as expected. Trade-off: lose parallel execution of blocking work (async still interleaves cooperatively within a single loop). Full trade-off table in `meshctl man dependency-injection` (Python doc) under "Single-worker mode for shared loop-bound resources".
+For long-running stateful work, use MeshJob (`@mesh.tool(task=True)`) with state externalized to a separate state agent — see `meshctl man jobs` and the Stateful Agents concept doc.
 
-- **Long-running stateful work.** Use MeshJob (`@mesh.tool(task=True)`) with state externalized to a separate state agent. The orchestrator stays stateless; the state agent owns the durable storage. See `meshctl man jobs` for the MeshJob primitive and the Stateful Agents concept doc for the full decomposition.
-
-For the narrow case where neither answer fits (sub-10ms state-mutation latency budgets, unportable loop-bound resources like GPU contexts, true background daemons running between tool calls), see the In-Process State escape hatch in the concepts docs. The default answer should still be MeshJob.
+For the narrow case where neither fits (sub-10ms state-mutation latency, unportable loop-bound resources like GPU contexts, true background daemons), see the In-Process State escape hatch. The default answer should still be MeshJob.
 
 ## Declaring Dependencies
 
@@ -225,4 +236,4 @@ No code changes needed - happens transparently.
 - `meshctl man proxies` - Proxy details
 - `meshctl man jobs` - MeshJob primitive for long-running stateful work
 - Stateful Agents concept doc - State agent + MeshJob orchestrator decomposition
-- In-Process State concept doc - Escape hatch for the narrow cases neither MeshJob nor `WORKERS=1` cover
+- In-Process State concept doc - Escape hatch for narrow cases where neither MeshJob nor the standard FastAPI `lifespan` pattern fits

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -88,6 +88,26 @@ export MCP_MESH_AUTH_TOKEN=secret-token
 export MCP_MESH_DEBOUNCE_DELAY=1.0
 ```
 
+### Tool Dispatch (Python)
+
+```bash
+# Worker loops for @mesh.tool / @app.tool body dispatch.
+# Default: 1 (since v2.2.1; previously min(8, max(2, cpu_count()))).
+#
+# N=1 (default): FastAPI lifespan startup, all tool bodies, and lifespan
+# exit share one user loop. Loop-bound resources (asyncpg.Pool,
+# redis.asyncio, aiohttp.ClientSession) created in lifespan work across
+# every tool body. /health, /ready, /livez stay responsive on a separate
+# framework loop.
+#
+# N>1: opt-in for tool bodies doing sync blocking work (time.sleep, sync
+# HTTP client, CPU-bound). N worker loops dispatched round-robin.
+# Caveat: resources created in lifespan bind to worker-0 only — use a
+# per-loop dict cache for cross-worker access. Prefer
+# `await asyncio.to_thread(blocking_call)` when feasible.
+export MCP_MESH_TOOL_WORKERS=1
+```
+
 ### Schema Verdict Policy (issue #547)
 
 ```bash

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/lifespan_factory.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/lifespan_factory.py
@@ -3,6 +3,27 @@
 Provides clean separation of lifespan creation logic from FastAPI app setup.
 Handles single FastMCP, multiple FastMCP, and minimal (no FastMCP) scenarios.
 
+Lifespan / user-loop hijack (v2.3, issue #1061)
+-----------------------------------------------
+
+The :func:`wrap_lifespan_for_user_loop` helper is the *single* entry point
+that wraps a user-supplied lifespan so its body runs on the user loop
+(worker-0 of the tool_executor pool). Tools and lifespan therefore share
+the same asyncio loop, so loop-bound resources (``asyncpg.Pool``,
+``redis.asyncio.Redis``, ``aiohttp.ClientSession``) created during lifespan
+startup are safely usable from tool bodies. Both wrap sites
+(:mod:`_mcp_mesh.pipeline.mcp_startup.lifespan_factory` and
+:mod:`mesh.decorators` ``_start_uvicorn_immediately``) call this helper —
+the hijack logic lives in exactly one place.
+
+If you hit a problem with this hijack (e.g., an exotic lifespan that uses
+contextvars in a non-PEP-567-compatible way, or a third-party library that
+captures the loop ref at module import), the recommended escape is to STOP
+using FastMCP/FastAPI ``lifespan=`` for loop-bound resources and switch to
+mesh-native startup hooks: ``@mesh.on_startup`` / ``@mesh.on_shutdown``
+(planned for a future minor release). These hooks run on the user loop
+natively and don't depend on uvicorn's lifespan invocation pattern.
+
 Phase 1 MeshJob substrate (#bug 2 — backup path)
 ------------------------------------------------
 
@@ -15,21 +36,241 @@ which starts the dispatchers on the long-lived heartbeat-thread loop.
 The backup matters for non-immediate-uvicorn flows where the
 lifespan-factory app *is* the serving app and the lifespan startup
 section runs *after* the pipeline has stashed dispatchers on
-``app.state``.
-
-For the immediate-uvicorn flow this code path is effectively dead
-weight (the immediate-uvicorn FastAPI app uses its own FastMCP
-lifespan, not the lifespan-factory one), but
+``app.state``. For the immediate-uvicorn flow this code path is
+effectively dead weight (the immediate-uvicorn FastAPI app uses its own
+FastMCP lifespan, not the lifespan-factory one), but
 :meth:`PythonClaimDispatcher.start` is idempotent so leaving it in
 place is harmless.
 """
 
+import asyncio
+import contextvars
 import logging
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+def _log_hijack_startup_failure(exc: BaseException) -> None:
+    """Warn when the user-loop hijack fails to enter the user lifespan.
+
+    ``exc`` IS the user's ``__aenter__`` failure (or a framework-side
+    abort before enter completed), which is what the caller re-raises.
+    """
+    logger.warning(
+        "Lifespan hijack failed during startup __aenter__ on the user loop. "
+        "Re-raising the user exception below. If this keeps happening, "
+        "consider moving loop-bound resource init (asyncpg.Pool, redis, "
+        "aiohttp.ClientSession) out of FastMCP/FastAPI lifespan and using "
+        "@mesh.on_startup / @mesh.on_shutdown hooks (planned for a future "
+        "release). Original exception: %s",
+        type(exc).__name__ + ": " + str(exc),
+    )
+
+
+def _log_hijack_shutdown_failure(exit_exc: BaseException) -> None:
+    """Warn when the user-loop hijack fails during ``__aexit__``.
+
+    ``exit_exc`` is the failure of ``__aexit__`` OR a framework-side
+    abort (e.g., uvicorn shutdown timeout cancelling our wait). It is
+    NOT necessarily the user's original body exception — the body
+    exception (if any) is preserved as ``__context__`` of ``exit_exc``
+    when we re-raise.
+    """
+    logger.warning(
+        "Lifespan hijack failed during shutdown __aexit__ on the user loop. "
+        "The framework will re-raise the exit-side exception; the user's "
+        "original body exception (if any) is preserved as the __context__. "
+        "If this keeps happening, consider moving loop-bound resource init "
+        "(asyncpg.Pool, redis, aiohttp.ClientSession) out of FastMCP/FastAPI "
+        "lifespan and using @mesh.on_startup / @mesh.on_shutdown hooks "
+        "(planned for a future release). Exit exception: %s",
+        type(exit_exc).__name__ + ": " + str(exit_exc),
+    )
+
+
+def wrap_lifespan_for_user_loop(user_lifespan: Callable) -> Callable:
+    """Wrap a user-supplied lifespan so its body runs on the user loop.
+
+    The user's ``lifespan`` is the right place to construct loop-bound
+    resources (``asyncpg.Pool``, ``redis.asyncio.Redis``,
+    ``aiohttp.ClientSession``). For tools to safely share those
+    resources, the lifespan body and tool bodies must run on the same
+    asyncio event loop.
+
+    This wrapper:
+      1. Eagerly starts the worker loop pool (so worker-0 — the "user
+         loop" — exists before lifespan enter runs).
+      2. Drives the user lifespan's ``__aenter__`` on the user loop via
+         ``run_coroutine_threadsafe`` + ``wrap_future``. The framework
+         loop (uvicorn's loop) awaits the resulting future without
+         blocking, so ``/health`` / ``/ready`` / ``/livez`` stay
+         responsive even if user startup is slow.
+      3. Yields control to FastAPI/uvicorn for normal request handling.
+      4. Drives ``__aexit__`` on the same user loop on shutdown,
+         forwarding any exception raised between yield and exit so the
+         user lifespan can react (PEP 343 semantics).
+
+    Contextvar propagation:
+        ``contextvars.copy_context()`` is captured on the framework
+        (outer) side before crossing the loop boundary, then re-applied
+        inside the user-loop worker via ``loop.create_task(coro,
+        context=ctx)``. This means a trace ID / propagated header
+        seeded on the framework loop is visible inside the user's
+        lifespan body. Same pattern as :func:`tool_executor.dispatch`.
+
+    Exception forwarding:
+        If uvicorn/FastAPI raises between ``__aenter__`` and the body
+        completing (cancelled shutdown, outer composer failure, etc.),
+        the exception is forwarded into the user's ``__aexit__`` with
+        proper ``exc_type``, ``exc_val``, ``exc_tb`` so it can react.
+        If ``__aexit__`` returns truthy the exception is suppressed;
+        otherwise it propagates normally to uvicorn. This implements
+        the standard async-context-manager contract.
+
+    Partial-startup unwind:
+        The ``try/except/else`` shape below guarantees that if
+        ``__aenter__`` succeeded but the yielded body raises (e.g., the
+        outer composer's claim-dispatcher startup blew up), the user's
+        ``__aexit__`` still runs with the exception forwarded. The
+        ``else`` branch (clean exit) only fires when the body returned
+        without raising.
+
+    Forward-looking escape hatch:
+        If you hit a problem with this hijack (e.g., an exotic
+        lifespan that uses contextvars in a non-PEP-567-compatible
+        way, or a third-party library that captures the loop ref at
+        module import), the recommended escape is to STOP using
+        FastMCP/FastAPI ``lifespan=`` for loop-bound resources and
+        switch to mesh-native startup hooks: ``@mesh.on_startup`` /
+        ``@mesh.on_shutdown`` (planned for a future minor release).
+        These hooks run on the user loop natively and don't depend on
+        uvicorn's lifespan invocation pattern.
+    """
+
+    @asynccontextmanager
+    async def wrapper(app):
+        # Local import to avoid widening the import surface at module load.
+        from ...shared.tool_executor import _start_workers, get_worker_loops
+
+        _start_workers()
+        user_loops = get_worker_loops()
+        if not user_loops:
+            raise RuntimeError(
+                "user loop pool failed to start before lifespan; "
+                "tool_executor returned no worker loops"
+            )
+        # With default N=1 the first worker IS the user loop. With N>1
+        # override, we pin lifespan to worker-0 by convention — multi-loop
+        # affinity selection is a follow-up.
+        user_loop = user_loops[0]
+
+        cm = user_lifespan(app)
+
+        # Capture contextvars on the framework (outer) side BEFORE crossing
+        # the loop boundary. Same pattern as tool_executor.dispatch — see
+        # PEP 567 / Python 3.11+ ``loop.create_task(coro, context=ctx)``.
+        startup_ctx = contextvars.copy_context()
+
+        async def _enter_on_user_loop():
+            loop = asyncio.get_running_loop()
+            task = loop.create_task(cm.__aenter__(), context=startup_ctx)
+            return await task
+
+        startup_fut = asyncio.run_coroutine_threadsafe(
+            _enter_on_user_loop(), user_loop
+        )
+        try:
+            cm_state = await asyncio.wrap_future(startup_fut)
+        except BaseException as exc:
+            # Framework side aborted (e.g., uvicorn cancellation) or
+            # __aenter__ raised. Cancel the user-loop task defensively
+            # so it doesn't keep running past the parent's "done".
+            # ``concurrent.futures.Future.cancel()`` returns bool and
+            # does not itself raise.
+            startup_fut.cancel()
+            _log_hijack_startup_failure(exc)
+            raise
+
+        try:
+            yield cm_state
+        except BaseException as exc:
+            # PEP 343: forward exception info into user __aexit__ so the
+            # user lifespan can react (cleanup, suppression, etc.). This
+            # also covers Gap 3 (partial-startup unwind) — if the outer
+            # composer raises after our __aenter__ succeeded, control
+            # lands here and we still drive __aexit__ on the user loop.
+            exc_type = type(exc)
+            exc_val = exc
+            exc_tb = exc.__traceback__
+
+            # Re-capture context for the shutdown side. The yielded body
+            # may have seeded contextvars the user wants visible during
+            # cleanup (e.g., a trace ID set by the request that triggered
+            # shutdown). copy_context() snapshots whatever is current on
+            # the framework loop right now.
+            shutdown_ctx = contextvars.copy_context()
+
+            async def _exit_with_exc_on_user_loop():
+                loop = asyncio.get_running_loop()
+                task = loop.create_task(
+                    cm.__aexit__(exc_type, exc_val, exc_tb),
+                    context=shutdown_ctx,
+                )
+                return await task
+
+            suppress_fut = asyncio.run_coroutine_threadsafe(
+                _exit_with_exc_on_user_loop(), user_loop
+            )
+            try:
+                suppressed = await asyncio.wrap_future(suppress_fut)
+            except BaseException as exit_exc:
+                # Framework side aborted (e.g., uvicorn shutdown timeout)
+                # or __aexit__ raised. Cancel the user-loop __aexit__
+                # task so it doesn't keep running past the parent's
+                # "done", leaking wall-clock and resources.
+                suppress_fut.cancel()
+                _log_hijack_shutdown_failure(exit_exc)
+                raise
+
+            if not suppressed:
+                raise
+        else:
+            # Clean-exit path: __aexit__(None, None, None) on the user loop.
+            shutdown_ctx = contextvars.copy_context()
+
+            async def _exit_clean_on_user_loop():
+                loop = asyncio.get_running_loop()
+                task = loop.create_task(
+                    cm.__aexit__(None, None, None),
+                    context=shutdown_ctx,
+                )
+                return await task
+
+            shutdown_fut = asyncio.run_coroutine_threadsafe(
+                _exit_clean_on_user_loop(), user_loop
+            )
+            try:
+                await asyncio.wrap_future(shutdown_fut)
+            except BaseException as exit_exc:
+                # Framework side aborted (e.g., uvicorn shutdown timeout)
+                # or __aexit__ raised. Cancel the user-loop __aexit__
+                # task so it doesn't keep running past the parent's
+                # "done", leaking wall-clock and resources.
+                shutdown_fut.cancel()
+                _log_hijack_shutdown_failure(exit_exc)
+                raise
+
+    return wrapper
+
+
+# Back-compat alias: prior code referenced ``_user_loop_dispatched`` (the
+# v2.3 prototype name). The canonical name is now
+# ``wrap_lifespan_for_user_loop``; existing callers continue to work
+# through the alias. Both refer to the same wrapper implementation.
+_user_loop_dispatched = wrap_lifespan_for_user_loop
 
 
 def _start_claim_dispatchers(app: Any) -> list:
@@ -118,15 +359,30 @@ def create_single_fastmcp_lifespan(
         get_shutdown_context: Callback to get registry_url and agent_id at shutdown time
     """
 
+    # Hijack the user/FastMCP lifespan so its body runs on the user loop
+    # (worker-0 of the tool_executor pool). Tools and lifespan now share
+    # the same asyncio loop, so loop-bound resources created in lifespan
+    # startup are safely usable from tool bodies. See issue #1061. The
+    # hijack logic lives in wrap_lifespan_for_user_loop — single entry
+    # point shared with mesh.decorators._start_uvicorn_immediately.
+    user_loop_lifespan = wrap_lifespan_for_user_loop(fastmcp_lifespan)
+
     @asynccontextmanager
     async def lifespan(app):
         fastmcp_ctx = None
         try:
-            fastmcp_ctx = fastmcp_lifespan(app)
+            fastmcp_ctx = user_loop_lifespan(app)
             await fastmcp_ctx.__aenter__()
-            logger.debug("Started FastMCP lifespan")
+            logger.debug("Started FastMCP lifespan on user loop")
         except Exception as e:
-            logger.error(f"Failed to start FastMCP lifespan: {e}")
+            logger.error(
+                f"Failed to start FastMCP lifespan via user-loop hijack: {e}. "
+                f"Agent will fail to start. If this keeps happening, "
+                f"consider moving loop-bound resource init out of "
+                f"FastMCP/FastAPI lifespan and using @mesh.on_startup / "
+                f"@mesh.on_shutdown hooks (planned for a future release)."
+            )
+            raise
 
         # Phase 1 MeshJob substrate: start claim dispatchers on the
         # persistent uvicorn loop (not the one-shot startup loop).
@@ -170,16 +426,28 @@ def create_multiple_fastmcp_lifespan(
         get_shutdown_context: Callback to get registry_url and agent_id at shutdown time
     """
 
+    # Hijack each user/FastMCP lifespan so its body runs on the user loop.
+    # See wrap_lifespan_for_user_loop / issue #1061.
+    user_loop_lifespans = [wrap_lifespan_for_user_loop(ls) for ls in fastmcp_lifespans]
+
     @asynccontextmanager
     async def lifespan(app):
         lifespan_contexts = []
-        for ls in fastmcp_lifespans:
+        for ls in user_loop_lifespans:
             try:
                 ctx = ls(app)
                 await ctx.__aenter__()
                 lifespan_contexts.append(ctx)
             except Exception as e:
-                logger.error(f"Failed to start FastMCP lifespan: {e}")
+                logger.error(
+                    f"Failed to start FastMCP lifespan via user-loop "
+                    f"hijack: {e}. Agent will fail to start. If this keeps "
+                    f"happening, consider moving loop-bound resource init "
+                    f"out of FastMCP/FastAPI lifespan and using "
+                    f"@mesh.on_startup / @mesh.on_shutdown hooks (planned "
+                    f"for a future release)."
+                )
+                raise
 
         # Phase 1 MeshJob substrate: see single-fastmcp lifespan note.
         claim_dispatchers = _start_claim_dispatchers(app)

--- a/src/runtime/python/_mcp_mesh/shared/tool_executor.py
+++ b/src/runtime/python/_mcp_mesh/shared/tool_executor.py
@@ -22,8 +22,14 @@ loops via ``asyncio.run_coroutine_threadsafe``, then awaits the resulting
 workers remain free to service concurrent calls.
 
 Pool size:
-    Default ``N = min(8, max(2, os.cpu_count() or 2))``.
-    Override at startup via ``MCP_MESH_TOOL_WORKERS=<N>`` env var.
+    Default ``N = 1`` — a single worker loop shared by the user's
+    ``lifespan`` body and all tool invocations. This makes the worker
+    loop the "user loop": loop-bound resources created in lifespan
+    startup (asyncpg pools, redis clients, aiohttp sessions, etc.) can
+    be safely used from tool bodies because they share the same loop.
+    Override at startup via ``MCP_MESH_TOOL_WORKERS=<N>`` env var (N > 1
+    re-enables parallel tool execution but breaks lifespan/tool loop
+    affinity for shared loop-bound resources).
 
     The pool size is read ONCE on first dispatch and cached. Changing the
     env var at runtime has no effect.
@@ -60,7 +66,14 @@ _shutdown_registered = False
 
 
 def _resolve_pool_size() -> int:
-    """Read pool size from env or compute default. Called once at first init."""
+    """Read pool size from env or use default. Called once at first init.
+
+    Default is ``1``: a single worker loop ("user loop") shared by the
+    user's lifespan body and tool invocations. This keeps loop-bound
+    resources (asyncpg pools, redis clients, aiohttp sessions) usable
+    across lifespan startup and tool bodies. Override with
+    ``MCP_MESH_TOOL_WORKERS=<N>`` to re-enable a multi-worker pool.
+    """
     env_val = os.environ.get("MCP_MESH_TOOL_WORKERS")
     if env_val:
         try:
@@ -75,8 +88,7 @@ def _resolve_pool_size() -> int:
                 "MCP_MESH_TOOL_WORKERS=%r is not an int; falling back to default",
                 env_val,
             )
-    cpu = os.cpu_count() or 2
-    return min(8, max(2, cpu))
+    return 1
 
 
 def _start_workers() -> list[tuple[threading.Thread, asyncio.AbstractEventLoop]]:

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -93,9 +93,27 @@ def _start_uvicorn_immediately(http_host: str, http_port: int):
 
         # Create FastAPI app with FastMCP lifespan if available
         if fastmcp_lifespan:
-            app = FastAPI(title="MCP Mesh Agent (Starting)", lifespan=fastmcp_lifespan)
+            # Hijack the FastMCP/user lifespan so its body runs on the user
+            # loop (worker-0 of the tool_executor pool). Tools and lifespan
+            # then share the same asyncio loop, so loop-bound resources
+            # (asyncpg pools, redis clients, aiohttp sessions) created in
+            # lifespan startup are safely usable from tool bodies. The
+            # framework loop (uvicorn) stays free to service /health,
+            # /ready, /livez. See issue #1061.
+            #
+            # Both wrap sites (this one and the lifespan_factory composers)
+            # call the same wrap_lifespan_for_user_loop helper — the
+            # hijack logic lives in exactly one place.
+            from _mcp_mesh.pipeline.mcp_startup.lifespan_factory import (
+                wrap_lifespan_for_user_loop,
+            )
+
+            user_loop_lifespan = wrap_lifespan_for_user_loop(fastmcp_lifespan)
+            app = FastAPI(
+                title="MCP Mesh Agent (Starting)", lifespan=user_loop_lifespan
+            )
             logger.debug(
-                "📦 IMMEDIATE UVICORN: Created FastAPI app with FastMCP lifespan integration"
+                "📦 IMMEDIATE UVICORN: Created FastAPI app with user-loop-dispatched FastMCP lifespan"
             )
         else:
             app = FastAPI(title="MCP Mesh Agent (Starting)")

--- a/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-lazy-pool-agent/main.py
+++ b/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-lazy-pool-agent/main.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Test agent for the lazy-init-pool pattern under the user-loop default.
+
+A common workaround for the cross-loop hazard (issue #1061) is to skip
+``lifespan`` startup entirely and instead lazily construct loop-bound
+resources on first tool invocation. Under the v2.2.1 default
+``MCP_MESH_TOOL_WORKERS=1`` there is a single shared user loop, so the
+lazy pool gets constructed once and reused across all subsequent tool
+calls.
+
+The ``FakePool`` stand-in mirrors the loop-affinity invariant of real
+resources like ``asyncpg.Pool`` without requiring a database.
+"""
+import asyncio
+
+import mesh
+from fastmcp import FastMCP
+
+
+app = FastMCP("lazy-pool-agent")
+
+
+_pool = None
+_pool_created_count = 0
+_pool_loop_id: int | None = None
+
+
+class FakePool:
+    """Loop-affine resource mirroring asyncpg.Pool semantics."""
+
+    def __init__(self):
+        self._loop_id = id(asyncio.get_running_loop())
+
+    async def acquire(self) -> str:
+        if id(asyncio.get_running_loop()) != self._loop_id:
+            raise RuntimeError("cross-loop pool access")
+        return "conn"
+
+
+async def get_pool() -> FakePool:
+    global _pool, _pool_created_count, _pool_loop_id
+    if _pool is None:
+        _pool = FakePool()
+        _pool_created_count += 1
+        _pool_loop_id = _pool._loop_id
+    return _pool
+
+
+@app.tool()
+@mesh.tool(capability="use_lazy_pool")
+async def use_lazy_pool() -> dict:
+    """Lazily create-or-reuse the pool on the current loop and acquire a conn."""
+    pool = await get_pool()
+    conn = await pool.acquire()
+    return {
+        "conn": conn,
+        "pool_created_count": _pool_created_count,
+        "pool_loop_id": _pool_loop_id,
+        "this_call_loop_id": id(asyncio.get_running_loop()),
+    }
+
+
+@mesh.agent(name="lazy-pool-agent", auto_run=True)
+class LazyPoolAgent:
+    pass

--- a/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-lifespan-loop-affine-agent/main.py
+++ b/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-lifespan-loop-affine-agent/main.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Test agent: lifespan creates a loop-affine resource, tool tries to use it.
+
+Reproduces the cross-loop failure mode that bites real apps using
+asyncpg.Pool / redis.asyncio.Redis / aiohttp.ClientSession when the
+resource is created in lifespan startup (uvicorn loop) and used from
+a tool body (worker loop). See issue #1061.
+
+The LoopAffineResource here is a minimal stand-in - it records the
+loop it was constructed on and raises on use from a different loop.
+asyncpg.Pool exhibits the exact same affinity via its internal
+Future caching; we don't need a real Postgres to exercise the bug.
+"""
+import asyncio
+from contextlib import asynccontextmanager
+
+import mesh
+from fastmcp import FastMCP
+
+
+class LoopAffineResource:
+    """Mimics asyncpg.Pool / redis.asyncio loop-affinity behavior."""
+
+    def __init__(self):
+        loop = asyncio.get_running_loop()
+        self._owner_loop_id = id(loop)
+        self._owner_loop_name = repr(loop)
+
+    async def use(self) -> dict:
+        current = asyncio.get_running_loop()
+        if id(current) != self._owner_loop_id:
+            raise RuntimeError(
+                f"LoopAffineResource bound to loop {self._owner_loop_id} "
+                f"({self._owner_loop_name!r}); called from loop {id(current)} "
+                f"({current!r}). This is the same shape of failure asyncpg.Pool "
+                f"would raise via 'Task got Future attached to a different loop'."
+            )
+        return {
+            "ok": True,
+            "owner_loop_id": self._owner_loop_id,
+            "called_from_loop_id": id(current),
+        }
+
+
+_resource: LoopAffineResource | None = None
+_lifespan_loop_id: int | None = None
+
+
+@asynccontextmanager
+async def _lifespan(server):
+    global _resource, _lifespan_loop_id
+    _lifespan_loop_id = id(asyncio.get_running_loop())
+    _resource = LoopAffineResource()
+    try:
+        yield
+    finally:
+        # Nothing async to close on the resource; the close pattern would
+        # face the same cross-loop hazard if we tried to call it from a
+        # worker loop. See issue #1061 for the structural fix.
+        pass
+
+
+app = FastMCP("lifespan-loop-affine-agent", lifespan=_lifespan)
+
+
+@app.tool()
+@mesh.tool(capability="lifespan.use_resource")
+async def use_resource() -> dict:
+    """Try to use the lifespan-created resource from a tool body."""
+    if _resource is None:
+        return {"error": "resource_not_initialized"}
+    tool_loop_id = id(asyncio.get_running_loop())
+    try:
+        result = await _resource.use()
+        return {
+            "tool_loop_id": tool_loop_id,
+            "lifespan_loop_id": _lifespan_loop_id,
+            "same_loop": tool_loop_id == _lifespan_loop_id,
+            "resource_result": result,
+        }
+    except RuntimeError as exc:
+        return {
+            "tool_loop_id": tool_loop_id,
+            "lifespan_loop_id": _lifespan_loop_id,
+            "same_loop": tool_loop_id == _lifespan_loop_id,
+            "error": str(exc),
+        }
+
+
+@mesh.agent(name="lifespan-loop-affine-agent", auto_run=True)
+class LifespanLoopAffineAgent:
+    pass

--- a/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-lifespan-raising-agent/main.py
+++ b/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-lifespan-raising-agent/main.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Test agent: lifespan startup raises — exercises Gap 2 exception propagation.
+
+The user's ``__aenter__`` raises a synthetic ``RuntimeError``. With the
+v2.2.1 hijack, the exception must propagate cleanly through the wrap +
+``run_coroutine_threadsafe`` + ``wrap_future`` chain back to uvicorn,
+which then surfaces it as a startup failure. The WARNING log emitted by
+the wrap site must also appear, naming the startup phase and pointing
+at ``@mesh.on_startup`` / ``@mesh.on_shutdown`` as the forward-looking
+escape hatch. See issue #1061.
+"""
+import asyncio
+from contextlib import asynccontextmanager
+
+import mesh
+from fastmcp import FastMCP
+
+
+@asynccontextmanager
+async def _lifespan(server):
+    # Force a synthetic failure on startup. The exact string must surface
+    # in the agent logs so the test can assert the user-visible error
+    # text wasn't swallowed by the hijack layer.
+    raise RuntimeError("synthetic startup failure")
+    yield  # pragma: no cover
+
+
+app = FastMCP("lifespan-raising-agent", lifespan=_lifespan)
+
+
+@app.tool()
+@mesh.tool(capability="lifespan.never_reached")
+async def never_reached() -> dict:
+    """This tool should never be callable — startup must fail first."""
+    return {"unreachable": True}
+
+
+@mesh.agent(name="lifespan-raising-agent", auto_run=True)
+class LifespanRaisingAgent:
+    pass

--- a/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-long-tool-agent/main.py
+++ b/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-long-tool-agent/main.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Test agent with a tool that holds the user loop for ~10s.
+
+Used to prove that the framework loop (uvicorn) remains responsive
+to /health / /ready / /livez probes even when the user loop is busy
+servicing a long tool call. See issue #1061.
+"""
+import asyncio
+
+import mesh
+from fastmcp import FastMCP
+
+
+app = FastMCP("long-tool-agent")
+
+
+@app.tool()
+@mesh.tool(capability="long.slow_tool")
+async def slow_tool() -> dict:
+    """Sleep on the user loop for ~10s, then return."""
+    await asyncio.sleep(10)
+    return {"status": "done"}
+
+
+@mesh.agent(name="long-tool-agent", auto_run=True)
+class LongToolAgent:
+    pass

--- a/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-multi-slow-tool-agent/main.py
+++ b/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-multi-slow-tool-agent/main.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Test agent with two long-running tools (async-yielding and sync-blocking).
+
+Used to characterise the trade-off of the v2.2.1 default
+``MCP_MESH_TOOL_WORKERS=1`` (issue #1061):
+
+* ``async_sleep_5``: awaits ``asyncio.sleep(5)``. Yields the loop.
+  Two concurrent invocations under N=1 still interleave fine — both
+  complete in ~5s wall clock.
+* ``sync_sleep_5``: calls ``time.sleep(5)``. Blocks the loop. Two
+  concurrent invocations under N=1 serialize — the second waits for
+  the first, total ~10s. With ``MCP_MESH_TOOL_WORKERS=2`` they run
+  on separate worker loops and both complete in ~5s.
+
+The agent's purpose is to surface the structural cost of N=1 (sync
+work that doesn't yield) and the structural win of opt-in N>1.
+"""
+import asyncio
+import time
+
+import mesh
+from fastmcp import FastMCP
+
+
+app = FastMCP("multi-slow-tool-agent")
+
+
+@app.tool()
+@mesh.tool(capability="async_sleep_5")
+async def async_sleep_5() -> dict:
+    """Yield the user loop for ~5s via ``asyncio.sleep``."""
+    start = time.monotonic()
+    await asyncio.sleep(5)
+    return {"kind": "async", "elapsed_s": time.monotonic() - start}
+
+
+@app.tool()
+@mesh.tool(capability="sync_sleep_5")
+async def sync_sleep_5() -> dict:
+    """Block the running loop for ~5s via ``time.sleep`` (no yield)."""
+    start = time.monotonic()
+    time.sleep(5)
+    return {"kind": "sync", "elapsed_s": time.monotonic() - start}
+
+
+@mesh.agent(name="multi-slow-tool-agent", auto_run=True)
+class MultiSlowToolAgent:
+    pass

--- a/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-parallel-orchestrator-agent/main.py
+++ b/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-parallel-orchestrator-agent/main.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Orchestrator agent for parallel fan-out tests.
+
+Exposes ``parallel_fanout`` which depends on the ``slow_leaf``
+capability and issues three concurrent invocations via
+``asyncio.gather`` inside a single tool body. Measures wall-clock
+elapsed time so callers can assert the calls truly ran in parallel
+(elapsed ~2s) rather than serially (elapsed ~6s).
+
+This is the load-bearing claim from issue #1061 that the default
+``MCP_MESH_TOOL_WORKERS=1`` does not hurt LLM-style parallel
+tool-calling: parallelism on outbound calls comes from cooperative
+async I/O on a single loop, not from multiple worker loops.
+"""
+import asyncio
+import time
+
+import mesh
+from fastmcp import FastMCP
+from mesh.types import McpMeshTool
+
+
+app = FastMCP("parallel-orchestrator-agent")
+
+
+@app.tool()
+@mesh.tool(
+    capability="parallel_fanout",
+    dependencies=["slow_leaf"],
+)
+async def parallel_fanout(slow_leaf: McpMeshTool = None) -> dict:
+    """Fan out three ``slow_leaf`` calls concurrently and report elapsed time."""
+    if slow_leaf is None:
+        return {"error": "slow_leaf_dependency_unresolved"}
+
+    start = time.monotonic()
+    results = await asyncio.gather(
+        slow_leaf(),
+        slow_leaf(),
+        slow_leaf(),
+    )
+    elapsed_ms = (time.monotonic() - start) * 1000
+    return {
+        "elapsed_ms": elapsed_ms,
+        "results": results,
+        "count": len(results),
+    }
+
+
+@mesh.agent(name="parallel-orchestrator-agent", auto_run=True)
+class ParallelOrchestratorAgent:
+    pass

--- a/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-per-loop-dict-agent/main.py
+++ b/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-per-loop-dict-agent/main.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Test agent for the per-loop dict workaround pattern (issue #1061).
+
+When ``MCP_MESH_TOOL_WORKERS`` is set above 1, tool invocations are
+dispatched across multiple worker loops. A common pattern to deal with
+loop-affine resources in that environment is to key a dict by
+``id(asyncio.get_running_loop())`` and lazily build one resource per
+loop. The structural side effect is one resource per worker loop — for
+a real DB this is a connection-pool multiplier.
+
+This agent exposes ``use_per_loop_pool`` so a test can drive many
+concurrent calls and observe ``total_pools_created`` grow with the
+number of distinct worker loops.
+"""
+import asyncio
+import threading
+
+import mesh
+from fastmcp import FastMCP
+
+
+app = FastMCP("per-loop-dict-agent")
+
+
+_pools: dict[int, "FakePool"] = {}
+_pools_lock = threading.Lock()
+_total_pools_created = 0
+
+
+class FakePool:
+    """Loop-affine resource stand-in (no real I/O)."""
+
+    def __init__(self):
+        self._loop_id = id(asyncio.get_running_loop())
+
+    async def acquire(self) -> str:
+        return "conn"
+
+
+async def get_pool() -> FakePool:
+    global _total_pools_created
+    loop_id = id(asyncio.get_running_loop())
+    with _pools_lock:
+        existing = _pools.get(loop_id)
+    if existing is not None:
+        return existing
+    new_pool = FakePool()
+    with _pools_lock:
+        if loop_id not in _pools:
+            _pools[loop_id] = new_pool
+            _total_pools_created += 1
+    return _pools[loop_id]
+
+
+@app.tool()
+@mesh.tool(capability="use_per_loop_pool")
+async def use_per_loop_pool() -> dict:
+    """Acquire a connection from the per-loop pool and report state."""
+    pool = await get_pool()
+    _ = await pool.acquire()
+    with _pools_lock:
+        return {
+            "this_call_loop_id": id(asyncio.get_running_loop()),
+            "total_pools_created": _total_pools_created,
+            "pool_loops": sorted(_pools.keys()),
+        }
+
+
+@mesh.agent(name="per-loop-dict-agent", auto_run=True)
+class PerLoopDictAgent:
+    pass

--- a/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-slow-leaf-agent/main.py
+++ b/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-slow-leaf-agent/main.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Leaf agent for parallel fan-out tests.
+
+Exposes a single ``slow_leaf`` capability that sleeps ~2s on its
+caller's event loop and returns. Used to prove that ``asyncio.gather``
+over outbound mesh calls inside one tool body delivers full parallelism
+regardless of how many tool-worker loops the framework runs.
+
+See issue #1061 for the broader lifespan/loop-affinity context.
+"""
+import asyncio
+
+import mesh
+from fastmcp import FastMCP
+
+
+app = FastMCP("slow-leaf-agent")
+
+
+@app.tool()
+@mesh.tool(capability="slow_leaf")
+async def slow_leaf() -> dict:
+    """Sleep ~2s and return."""
+    await asyncio.sleep(2)
+    return {"ms": 2000}
+
+
+@mesh.agent(name="slow-leaf-agent", auto_run=True)
+class SlowLeafAgent:
+    pass

--- a/tests/integration/suites/uc02_agent_lifecycle/tc12_lifespan_loop_affinity/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc12_lifespan_loop_affinity/test.yaml
@@ -1,0 +1,92 @@
+# tc12 - lifespan/tool loop affinity (issue #1061, v2.2.1 fix verification).
+#
+# Asserts the FIXED behavior: the user's `lifespan` body and tool
+# invocations share a single asyncio event loop ("the user loop"), so
+# loop-bound resources created during lifespan startup (asyncpg pools,
+# redis clients, aiohttp sessions, etc.) are safely usable from tool
+# bodies. With the v2.2.1 default of MCP_MESH_TOOL_WORKERS=1, the user
+# loop is the lone worker loop the framework dispatches lifespan +
+# tools onto.
+#
+# Test passes when:
+#   - tool_loop_id == lifespan_loop_id  (same_loop: true)
+#   - the lifespan-created resource works from the tool (no error)
+#   - resource_result.ok is true
+
+name: "FastMCP Lifespan/Tool Loop Affinity"
+description: "Verify lifespan and tools share the user loop so loop-bound resources work end-to-end (issue #1061)"
+tags:
+  - lifecycle
+  - lifespan
+  - loop-affinity
+  - python
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy lifespan loop-affine agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-lifespan-loop-affine-agent /workspace/"
+    capture: copy_output
+
+  - name: "Start lifespan loop-affine agent"
+    handler: shell
+    command: "meshctl start py-lifespan-loop-affine-agent/main.py -d"
+    workdir: /workspace
+    capture: start_output
+
+  - name: "Wait for agent to start"
+    handler: wait
+    seconds: 15
+
+  - name: "Check agent is running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: list_output
+
+  - name: "Call use_resource tool"
+    handler: shell
+    command: "meshctl call use_resource '{}'"
+    workdir: /workspace
+    capture: tool_result
+
+  - name: "Show agent logs for debugging"
+    handler: shell
+    command: "meshctl logs lifespan-loop-affine-agent 2>/dev/null | tail -30 || echo 'no logs'"
+    workdir: /workspace
+    capture: agent_logs
+
+assertions:
+  - expr: ${captured.list_output} contains 'lifespan-loop-affine-agent'
+    message: "Agent should be registered"
+
+  - expr: ${captured.tool_result} contains 'tool_loop_id'
+    message: "Tool should return tool_loop_id field"
+
+  - expr: ${captured.tool_result} contains 'lifespan_loop_id'
+    message: "Tool should return lifespan_loop_id field"
+
+  - expr: "${captured.tool_result} contains '\"same_loop\": true'"
+    message: "tool_loop_id MUST equal lifespan_loop_id - lifespan body and tools must share the user loop (issue #1061)"
+
+  - expr: "${captured.tool_result} not contains 'different loop'"
+    message: "No cross-loop failure should occur"
+
+  - expr: ${captured.tool_result} contains 'resource_result'
+    message: "Tool should return resource_result on success path"
+
+  - expr: "${captured.tool_result} contains '\"ok\": true'"
+    message: "Lifespan-created loop-affine resource MUST be usable from tool body"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc02_agent_lifecycle/tc13_lifespan_loop_affinity_workers_one/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc13_lifespan_loop_affinity_workers_one/test.yaml
@@ -1,0 +1,86 @@
+# tc13 - lifespan/tool loop affinity with explicit MCP_MESH_TOOL_WORKERS=1
+# (issue #1061, v2.2.1 fix verification).
+#
+# Same agent as tc12, but with MCP_MESH_TOOL_WORKERS=1 set explicitly.
+# Post-fix, the default IS 1 — this test ensures the explicit-override
+# path still produces the same correct behavior: lifespan body and
+# tools share the user loop. Acts as a guard that the env-var path
+# doesn't accidentally regress when the default flips.
+
+name: "FastMCP Lifespan/Tool Loop Affinity (TOOL_WORKERS=1)"
+description: "Verify MCP_MESH_TOOL_WORKERS=1 produces lifespan/tool loop affinity (issue #1061)"
+tags:
+  - lifecycle
+  - lifespan
+  - loop-affinity
+  - python
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy lifespan loop-affine agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-lifespan-loop-affine-agent /workspace/"
+    capture: copy_output
+
+  - name: "Start lifespan loop-affine agent with MCP_MESH_TOOL_WORKERS=1"
+    handler: shell
+    command: "meshctl start py-lifespan-loop-affine-agent/main.py --env MCP_MESH_TOOL_WORKERS=1 -d"
+    workdir: /workspace
+    capture: start_output
+
+  - name: "Wait for agent to start"
+    handler: wait
+    seconds: 15
+
+  - name: "Check agent is running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: list_output
+
+  - name: "Call use_resource tool"
+    handler: shell
+    command: "meshctl call use_resource '{}'"
+    workdir: /workspace
+    capture: tool_result
+
+  - name: "Show agent logs for debugging"
+    handler: shell
+    command: "meshctl logs lifespan-loop-affine-agent 2>/dev/null | tail -30 || echo 'no logs'"
+    workdir: /workspace
+    capture: agent_logs
+
+assertions:
+  - expr: ${captured.list_output} contains 'lifespan-loop-affine-agent'
+    message: "Agent should be registered"
+
+  - expr: ${captured.tool_result} contains 'tool_loop_id'
+    message: "Tool should return tool_loop_id field"
+
+  - expr: ${captured.tool_result} contains 'lifespan_loop_id'
+    message: "Tool should return lifespan_loop_id field"
+
+  - expr: "${captured.tool_result} contains '\"same_loop\": true'"
+    message: "With explicit MCP_MESH_TOOL_WORKERS=1, tool_loop_id MUST equal lifespan_loop_id (issue #1061)"
+
+  - expr: "${captured.tool_result} not contains 'different loop'"
+    message: "No cross-loop failure should occur with TOOL_WORKERS=1"
+
+  - expr: ${captured.tool_result} contains 'resource_result'
+    message: "Tool should return resource_result on success path"
+
+  - expr: "${captured.tool_result} contains '\"ok\": true'"
+    message: "Lifespan-created loop-affine resource MUST be usable from tool body with TOOL_WORKERS=1"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc02_agent_lifecycle/tc14_health_responsive_during_tool/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc14_health_responsive_during_tool/test.yaml
@@ -1,0 +1,126 @@
+# tc14 - /health responsiveness while a tool holds the user loop
+# (issue #1061, v2.2.1 fix verification).
+#
+# The v2.2.1 architecture splits the framework loop (uvicorn — owns
+# /health, /ready, /livez, heartbeats) from the user loop (lifespan
+# body + tool bodies). This test proves the split:
+#
+#   1. Start an agent whose `slow_tool` does `await asyncio.sleep(10)`
+#      on the user loop.
+#   2. Fire the tool call in the background.
+#   3. While it's still running, hit `/health` on the framework loop
+#      and assert a 200 response within 1 second.
+#
+# If `/health` is queued behind the tool, the curl will take ~10s and
+# the elapsed-time guard will fail.
+
+name: "Framework Loop /health Responsive During Long Tool"
+description: "Verify /health stays responsive on the framework loop while the user loop is busy in a tool (issue #1061)"
+tags:
+  - lifecycle
+  - lifespan
+  - loop-affinity
+  - health
+  - python
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy long-tool agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-long-tool-agent /workspace/"
+    capture: copy_output
+
+  - name: "Start long-tool agent on port 3014"
+    handler: shell
+    command: "meshctl start py-long-tool-agent/main.py --env MCP_MESH_HTTP_PORT=3014 -d"
+    workdir: /workspace
+    capture: start_output
+
+  - name: "Wait for agent to start"
+    handler: wait
+    seconds: 15
+
+  - name: "Check agent is running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: list_output
+
+  - name: "Baseline /health probe (no tool in flight)"
+    handler: shell
+    command: |
+      curl -s -o /tmp/health_baseline.out -w "%{http_code} %{time_total}" \
+        http://localhost:3014/health
+    capture: health_baseline
+
+  - name: "Kick slow_tool in background + probe /health mid-flight"
+    handler: shell
+    command: |
+      # Fire the tool in background — it will block ~10s on the user loop.
+      ( meshctl call slow_tool '{}' > /tmp/slow_tool.out 2>&1 ) &
+      SLOW_PID=$!
+
+      # Give the tool a moment to actually start executing on the user loop.
+      sleep 2
+
+      # Now probe /health on the framework loop — must come back fast.
+      # Capture time_total separately so we can bound it (a 2.9s response
+      # would still fit under --max-time 3, but indicates the framework
+      # loop IS being blocked).
+      HEALTH_BODY=$(curl -s -o /tmp/health_during.out \
+        -w "%{http_code} %{time_total}\nTIME_TOTAL=%{time_total}\n" \
+        --max-time 3 \
+        http://localhost:3014/health)
+      echo "$HEALTH_BODY"
+      echo "SLOW_PID=$SLOW_PID"
+
+      TIME_S=$(echo "$HEALTH_BODY" | grep '^TIME_TOTAL=' | head -1 | cut -d= -f2)
+      TIME_MS=$(awk -v t="$TIME_S" 'BEGIN { printf "%.0f", t * 1000 }')
+      echo "HEALTH_TIME_MS=$TIME_MS"
+      if [ -z "$TIME_MS" ] || [ "$TIME_MS" -ge 500 ]; then
+        echo "HEALTH_TOO_SLOW: ${TIME_MS}ms >= 500ms (framework loop appears blocked by user-loop tool)"
+      else
+        echo "HEALTH_FAST_OK"
+      fi
+
+      # Wait for the slow_tool call to complete cleanly.
+      wait $SLOW_PID || true
+      echo "---SLOW_TOOL_OUTPUT---"
+      cat /tmp/slow_tool.out
+    workdir: /workspace
+    capture: health_during
+
+  - name: "Show agent logs for debugging"
+    handler: shell
+    command: "meshctl logs long-tool-agent 2>/dev/null | tail -40 || echo 'no logs'"
+    workdir: /workspace
+    capture: agent_logs
+
+assertions:
+  - expr: ${captured.list_output} contains 'long-tool-agent'
+    message: "Agent should be registered"
+
+  - expr: ${captured.health_baseline} contains '200'
+    message: "Baseline /health probe must return 200"
+
+  - expr: ${captured.health_during} contains '200'
+    message: "/health MUST return 200 even while a tool is holding the user loop (issue #1061)"
+
+  - expr: ${captured.health_during} contains 'HEALTH_FAST_OK'
+    message: "/health MUST respond in <500ms while a tool holds the user loop (issue #1061: framework loop independence — typical observed is <5ms; a near-3s response would still fit the curl timeout but indicates the framework loop is being blocked)"
+
+  - expr: ${captured.health_during} contains 'done'
+    message: "slow_tool should still complete after /health returns (no deadlock)"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc02_agent_lifecycle/tc15_parallel_fanout/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc15_parallel_fanout/test.yaml
@@ -1,0 +1,230 @@
+# tc15 - parallel LLM-style fan-out within a single tool (issue #1061).
+#
+# Asserts that ``asyncio.gather`` over outbound mesh calls inside one
+# tool body delivers full parallelism, irrespective of the tool-worker
+# pool size. This is the load-bearing claim from #1061 that the v2.2.1
+# default ``MCP_MESH_TOOL_WORKERS=1`` does NOT regress parallel
+# tool-calling (e.g., LLM agents fanning out N tool calls in parallel):
+# parallelism on outbound calls comes from cooperative async I/O on a
+# single loop, not from multiple worker loops.
+#
+# Two phases in the same test:
+#   Phase A: default pool size (v2.2.1 default = 1).
+#   Phase B: explicit MCP_MESH_TOOL_WORKERS=8.
+#
+# Both phases must complete three concurrent ``slow_leaf`` calls
+# (each ``await asyncio.sleep(2)``) in well under 3000ms wall-clock.
+# Serial execution would take ~6000ms.
+
+name: "Parallel Fan-out Across Worker Pool Sizes"
+description: "Verify asyncio.gather on mesh calls runs in parallel at N=1 and N=8 worker loops (issue #1061)"
+tags:
+  - lifecycle
+  - parallel
+  - python
+  - fanout
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy leaf agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-slow-leaf-agent /workspace/"
+    capture: copy_leaf_output
+
+  - name: "Copy orchestrator agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-parallel-orchestrator-agent /workspace/"
+    capture: copy_orch_output
+
+  # -------- Phase A: default worker pool (N=1 in v2.2.1) --------
+
+  - name: "Phase A: start leaf agent (default workers)"
+    handler: shell
+    command: "meshctl start py-slow-leaf-agent/main.py --env MCP_MESH_HTTP_PORT=3150 -d"
+    workdir: /workspace
+    capture: start_leaf_a
+
+  - name: "Phase A: start orchestrator agent (default workers)"
+    handler: shell
+    command: "meshctl start py-parallel-orchestrator-agent/main.py --env MCP_MESH_HTTP_PORT=3151 -d"
+    workdir: /workspace
+    capture: start_orch_a
+
+  - name: "Phase A: wait for both agents to register and resolve dependencies"
+    handler: shell
+    workdir: /workspace
+    command: |
+      EXPECTED="slow-leaf-agent parallel-orchestrator-agent"
+      EXPECTED_COUNT=2
+      for i in $(seq 1 30); do
+        AGENTS=$(meshctl list 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' || true)
+        READY_COUNT=0
+        for agent in $EXPECTED; do
+          LINE=$(echo "$AGENTS" | grep -E "^${agent}" || true)
+          if [ -n "$LINE" ]; then
+            DEPS=$(echo "$LINE" | awk '{print $5}')
+            RESOLVED=$(echo "$DEPS" | cut -d/ -f1)
+            TOTAL=$(echo "$DEPS" | cut -d/ -f2)
+            if [ "$RESOLVED" = "$TOTAL" ]; then
+              READY_COUNT=$((READY_COUNT + 1))
+            fi
+          fi
+        done
+        if [ "$READY_COUNT" -ge "$EXPECTED_COUNT" ]; then
+          echo "READY_PHASE_A after $((i * 2))s"
+          meshctl list
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR_PHASE_A: only $READY_COUNT/$EXPECTED_COUNT agents ready"
+      meshctl list 2>/dev/null || true
+      exit 1
+    capture: wait_phase_a
+    timeout: 90
+
+  - name: "Phase A: call parallel_fanout (default workers)"
+    handler: shell
+    command: "meshctl call parallel_fanout '{}'"
+    workdir: /workspace
+    capture: fanout_result_a
+
+  - name: "Phase A: agent logs"
+    handler: shell
+    command: "meshctl logs parallel-orchestrator-agent 2>/dev/null | tail -30 || echo 'no logs'"
+    workdir: /workspace
+    capture: orch_logs_a
+
+  - name: "Phase A: stop all agents"
+    handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+
+  - name: "Phase A: settle"
+    handler: wait
+    seconds: 3
+
+  # -------- Phase B: explicit MCP_MESH_TOOL_WORKERS=8 --------
+
+  - name: "Phase B: start leaf agent with TOOL_WORKERS=8"
+    handler: shell
+    command: "meshctl start py-slow-leaf-agent/main.py --env MCP_MESH_HTTP_PORT=3152 --env MCP_MESH_TOOL_WORKERS=8 -d"
+    workdir: /workspace
+    capture: start_leaf_b
+
+  - name: "Phase B: start orchestrator agent with TOOL_WORKERS=8"
+    handler: shell
+    command: "meshctl start py-parallel-orchestrator-agent/main.py --env MCP_MESH_HTTP_PORT=3153 --env MCP_MESH_TOOL_WORKERS=8 -d"
+    workdir: /workspace
+    capture: start_orch_b
+
+  - name: "Phase B: wait for both agents to register and resolve dependencies"
+    handler: shell
+    workdir: /workspace
+    command: |
+      EXPECTED="slow-leaf-agent parallel-orchestrator-agent"
+      EXPECTED_COUNT=2
+      for i in $(seq 1 30); do
+        AGENTS=$(meshctl list 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' || true)
+        READY_COUNT=0
+        for agent in $EXPECTED; do
+          LINE=$(echo "$AGENTS" | grep -E "^${agent}" || true)
+          if [ -n "$LINE" ]; then
+            DEPS=$(echo "$LINE" | awk '{print $5}')
+            RESOLVED=$(echo "$DEPS" | cut -d/ -f1)
+            TOTAL=$(echo "$DEPS" | cut -d/ -f2)
+            if [ "$RESOLVED" = "$TOTAL" ]; then
+              READY_COUNT=$((READY_COUNT + 1))
+            fi
+          fi
+        done
+        if [ "$READY_COUNT" -ge "$EXPECTED_COUNT" ]; then
+          echo "READY_PHASE_B after $((i * 2))s"
+          meshctl list
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR_PHASE_B: only $READY_COUNT/$EXPECTED_COUNT agents ready"
+      meshctl list 2>/dev/null || true
+      exit 1
+    capture: wait_phase_b
+    timeout: 90
+
+  - name: "Phase B: call parallel_fanout (TOOL_WORKERS=8)"
+    handler: shell
+    command: "meshctl call parallel_fanout '{}'"
+    workdir: /workspace
+    capture: fanout_result_b
+
+  - name: "Phase B: agent logs"
+    handler: shell
+    command: "meshctl logs parallel-orchestrator-agent 2>/dev/null | tail -30 || echo 'no logs'"
+    workdir: /workspace
+    capture: orch_logs_b
+
+  # -------- Elapsed-time guards (run after both phases) --------
+
+  - name: "Extract elapsed_ms from both phases and assert parallelism"
+    handler: shell
+    command: |
+      RESULT_A='${captured.fanout_result_a}'
+      RESULT_B='${captured.fanout_result_b}'
+      ELAPSED_A=$(echo "$RESULT_A" | grep -oE '"elapsed_ms":[[:space:]]*[0-9]+(\.[0-9]+)?' | head -1 | sed 's/.*: *//')
+      ELAPSED_B=$(echo "$RESULT_B" | grep -oE '"elapsed_ms":[[:space:]]*[0-9]+(\.[0-9]+)?' | head -1 | sed 's/.*: *//')
+      echo "PHASE_A_ELAPSED_MS=$ELAPSED_A"
+      echo "PHASE_B_ELAPSED_MS=$ELAPSED_B"
+      # Numeric check (truncate fraction)
+      A_INT=${ELAPSED_A%.*}
+      B_INT=${ELAPSED_B%.*}
+      if [ -z "$A_INT" ] || [ -z "$B_INT" ]; then
+        echo "MISSING_ELAPSED_MS"
+        exit 1
+      fi
+      if [ "$A_INT" -ge 3000 ]; then
+        echo "PHASE_A_TOO_SLOW: ${A_INT}ms >= 3000ms (gather did not fan out at N=1)"
+        exit 1
+      fi
+      if [ "$B_INT" -ge 3000 ]; then
+        echo "PHASE_B_TOO_SLOW: ${B_INT}ms >= 3000ms (gather did not fan out at N=8)"
+        exit 1
+      fi
+      echo "PARALLEL_OK"
+    workdir: /workspace
+    capture: elapsed_check
+
+assertions:
+  - expr: ${captured.wait_phase_a} contains 'READY_PHASE_A'
+    message: "Phase A agents must register and resolve dependencies"
+
+  - expr: ${captured.fanout_result_a} contains 'elapsed_ms'
+    message: "Phase A parallel_fanout must return elapsed_ms"
+
+  - expr: "${captured.fanout_result_a} contains '\"count\": 3'"
+    message: "Phase A must return three gathered results"
+
+  - expr: ${captured.wait_phase_b} contains 'READY_PHASE_B'
+    message: "Phase B agents must register and resolve dependencies"
+
+  - expr: ${captured.fanout_result_b} contains 'elapsed_ms'
+    message: "Phase B parallel_fanout must return elapsed_ms"
+
+  - expr: "${captured.fanout_result_b} contains '\"count\": 3'"
+    message: "Phase B must return three gathered results"
+
+  - expr: ${captured.elapsed_check} contains 'PARALLEL_OK'
+    message: "Both N=1 and N=8 fan-outs must complete in <3000ms (issue #1061: N=1 default does not regress parallel fan-out)"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc02_agent_lifecycle/tc16_lazy_pool_single_init/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc16_lazy_pool_single_init/test.yaml
@@ -1,0 +1,148 @@
+# tc16 - lazy-init pool pattern works correctly under the user-loop default
+# (issue #1061, v2.2.1 fix verification).
+#
+# A common workaround for the cross-loop hazard is to skip ``lifespan``
+# startup and lazily create loop-bound resources on first tool call.
+# Under the v2.2.1 default ``MCP_MESH_TOOL_WORKERS=1`` there is a single
+# shared user loop, so the pool is constructed once and reused on every
+# subsequent tool invocation.
+#
+# Test invariants across three sequential calls:
+#   - All calls succeed.
+#   - ``pool_created_count`` is 1 on every call (pool reused, not rebuilt).
+#   - ``pool_loop_id == this_call_loop_id`` on every call (single user loop).
+
+name: "Lazy Pool Single-Init Under User-Loop Default"
+description: "Verify the lazy-init pool pattern creates exactly one pool and reuses it across tool calls (issue #1061)"
+tags:
+  - lifecycle
+  - lazy-init
+  - python
+  - pool-reuse
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy lazy-pool agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-lazy-pool-agent /workspace/"
+    capture: copy_output
+
+  - name: "Start lazy-pool agent"
+    handler: shell
+    command: "meshctl start py-lazy-pool-agent/main.py --env MCP_MESH_HTTP_PORT=3160 -d"
+    workdir: /workspace
+    capture: start_output
+
+  - name: "Wait for agent to start"
+    handler: wait
+    seconds: 15
+
+  - name: "Check agent is running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: list_output
+
+  - name: "Call use_lazy_pool (1/3)"
+    handler: shell
+    command: "meshctl call use_lazy_pool '{}'"
+    workdir: /workspace
+    capture: call_1
+
+  - name: "Call use_lazy_pool (2/3)"
+    handler: shell
+    command: "meshctl call use_lazy_pool '{}'"
+    workdir: /workspace
+    capture: call_2
+
+  - name: "Call use_lazy_pool (3/3)"
+    handler: shell
+    command: "meshctl call use_lazy_pool '{}'"
+    workdir: /workspace
+    capture: call_3
+
+  - name: "Cross-call loop affinity check (single user loop)"
+    handler: shell
+    command: |
+      # Re-issue the three calls, drop each response to a file, then
+      # parse the inner JSON from content[0].text (clean compact JSON).
+      # Assert pool_loop_id == this_call_loop_id on every call.
+      rm -f /tmp/tc16_call_*.out
+      for i in 1 2 3; do
+        meshctl call use_lazy_pool '{}' > /tmp/tc16_call_$i.out 2>&1
+      done
+      python3 - <<'PY'
+      import json, re, sys
+      ok = True
+      for i in (1, 2, 3):
+          raw = open(f"/tmp/tc16_call_{i}.out").read()
+          # The compact inner JSON lives in content[0].text — pull it
+          # out via regex (the outer wrapper has \"-escaped quotes).
+          m = re.search(r'\{\\"conn\\".*?\\"this_call_loop_id\\":[0-9]+\}', raw)
+          if not m:
+              print(f"NO_INNER_JSON_CALL_{i}")
+              print(raw)
+              ok = False
+              continue
+          inner = m.group(0).replace('\\"', '"')
+          obj = json.loads(inner)
+          if obj.get("pool_loop_id") != obj.get("this_call_loop_id"):
+              print(f"LOOP_MISMATCH_CALL_{i}: pool={obj.get('pool_loop_id')} this={obj.get('this_call_loop_id')}")
+              ok = False
+              continue
+          if obj.get("pool_created_count") != 1:
+              print(f"POOL_RECREATED_CALL_{i}: count={obj.get('pool_created_count')}")
+              ok = False
+              continue
+          print(f"OK_CALL_{i}: pool_loop_id={obj.get('pool_loop_id')} count={obj.get('pool_created_count')}")
+      if ok:
+          print("LAZY_POOL_REUSE_OK")
+      else:
+          sys.exit(1)
+      PY
+    workdir: /workspace
+    capture: affinity_check
+
+  - name: "Show agent logs"
+    handler: shell
+    command: "meshctl logs lazy-pool-agent 2>/dev/null | tail -30 || echo 'no logs'"
+    workdir: /workspace
+    capture: agent_logs
+
+assertions:
+  - expr: ${captured.list_output} contains 'lazy-pool-agent'
+    message: "Agent should be registered"
+
+  - expr: "${captured.call_1} contains '\"conn\": \"conn\"'"
+    message: "Call 1 must acquire a connection"
+
+  - expr: "${captured.call_2} contains '\"conn\": \"conn\"'"
+    message: "Call 2 must acquire a connection"
+
+  - expr: "${captured.call_3} contains '\"conn\": \"conn\"'"
+    message: "Call 3 must acquire a connection"
+
+  - expr: "${captured.call_1} contains '\"pool_created_count\": 1'"
+    message: "Call 1 must report pool_created_count=1"
+
+  - expr: "${captured.call_2} contains '\"pool_created_count\": 1'"
+    message: "Call 2 must still report pool_created_count=1 (pool reused)"
+
+  - expr: "${captured.call_3} contains '\"pool_created_count\": 1'"
+    message: "Call 3 must still report pool_created_count=1 (pool reused)"
+
+  - expr: ${captured.affinity_check} contains 'LAZY_POOL_REUSE_OK'
+    message: "pool_loop_id MUST equal this_call_loop_id on every call (single user loop, issue #1061)"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc02_agent_lifecycle/tc17_per_loop_dict_multiplier/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc17_per_loop_dict_multiplier/test.yaml
@@ -1,0 +1,136 @@
+# tc17 - per-loop dict pattern creates N pools under MCP_MESH_TOOL_WORKERS=N>1
+# (issue #1061 cost-of-multi-worker reproducer).
+#
+# Documents the structural side-effect of the per-loop dict workaround
+# (keying a resource cache by ``id(asyncio.get_running_loop())``) when
+# the framework runs more than one tool-worker loop: one pool is built
+# per worker loop the calls land on. For real resources (asyncpg pools,
+# redis clients, aiohttp sessions) this is a connection-pool multiplier
+# — the cost we are paying for tool-level parallelism.
+#
+# Test passes when, after driving many concurrent calls with
+# ``MCP_MESH_TOOL_WORKERS=4``, ``total_pools_created`` is >= 2.
+
+name: "Per-Loop Dict Connection Multiplier (TOOL_WORKERS=4)"
+description: "Verify the per-loop dict workaround creates multiple pools with multi-worker tool pool (issue #1061)"
+tags:
+  - lifecycle
+  - per-loop-dict
+  - python
+  - connection-waste
+  - workers-multi
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy per-loop-dict agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-per-loop-dict-agent /workspace/"
+    capture: copy_output
+
+  - name: "Start per-loop-dict agent with MCP_MESH_TOOL_WORKERS=4"
+    handler: shell
+    command: "meshctl start py-per-loop-dict-agent/main.py --env MCP_MESH_HTTP_PORT=3170 --env MCP_MESH_TOOL_WORKERS=4 -d"
+    workdir: /workspace
+    capture: start_output
+
+  - name: "Wait for agent to start"
+    handler: wait
+    seconds: 15
+
+  - name: "Check agent is running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: list_output
+
+  - name: "Drive 20 concurrent calls to spray across worker loops"
+    handler: shell
+    workdir: /workspace
+    command: |
+      mkdir -p /tmp/tc17_results
+      rm -f /tmp/tc17_results/*.out
+      # Fire 20 concurrent calls. With TOOL_WORKERS=4, calls should
+      # spread across multiple worker loops; the per-loop dict will
+      # therefore build more than one FakePool.
+      PIDS=()
+      for i in $(seq 1 20); do
+        ( meshctl call use_per_loop_pool '{}' > /tmp/tc17_results/call_$i.out 2>&1 ) &
+        PIDS+=($!)
+      done
+      FAILED=0
+      for pid in "${PIDS[@]}"; do
+        if ! wait "$pid"; then
+          FAILED=$((FAILED + 1))
+        fi
+      done
+      echo "FAILED_COUNT=$FAILED"
+      if [ "$FAILED" -gt 0 ]; then
+        echo "ABORT: $FAILED of 20 calls returned non-zero"
+        exit 1
+      fi
+      echo "ALL_CALLS_DONE"
+      # Pick the most recent observation (highest total_pools_created)
+      MAX_POOLS=0
+      for f in /tmp/tc17_results/call_*.out; do
+        N=$(grep -oE '"total_pools_created":[[:space:]]*[0-9]+' "$f" | head -1 | sed 's/.*: *//')
+        if [ -n "$N" ] && [ "$N" -gt "$MAX_POOLS" ]; then
+          MAX_POOLS=$N
+        fi
+      done
+      echo "MAX_TOTAL_POOLS_CREATED=$MAX_POOLS"
+      # Also dump distinct loop ids seen in any one response
+      LARGEST=$(grep -l "total_pools_created\": $MAX_POOLS" /tmp/tc17_results/call_*.out | head -1)
+      if [ -n "$LARGEST" ]; then
+        echo "---LARGEST_RESPONSE---"
+        cat "$LARGEST"
+      fi
+    capture: fanout_output
+    timeout: 120
+
+  - name: "Assert multi-pool multiplier observed"
+    handler: shell
+    workdir: /workspace
+    command: |
+      OUT='${captured.fanout_output}'
+      MAX=$(echo "$OUT" | grep -oE 'MAX_TOTAL_POOLS_CREATED=[0-9]+' | head -1 | sed 's/.*=//')
+      if [ -z "$MAX" ]; then
+        echo "MISSING_MAX"
+        exit 1
+      fi
+      echo "OBSERVED_MAX_POOLS=$MAX"
+      if [ "$MAX" -ge 2 ]; then
+        echo "MULTI_POOL_CONFIRMED"
+      else
+        echo "ONLY_ONE_POOL: per-loop dict did not multiply (max=$MAX) - did MCP_MESH_TOOL_WORKERS=4 take effect?"
+        exit 1
+      fi
+    capture: multi_pool_check
+
+  - name: "Show agent logs"
+    handler: shell
+    command: "meshctl logs per-loop-dict-agent 2>/dev/null | tail -40 || echo 'no logs'"
+    workdir: /workspace
+    capture: agent_logs
+
+assertions:
+  - expr: ${captured.list_output} contains 'per-loop-dict-agent'
+    message: "Agent should be registered"
+
+  - expr: ${captured.fanout_output} contains 'ALL_CALLS_DONE'
+    message: "All 20 concurrent calls should complete"
+
+  - expr: ${captured.multi_pool_check} contains 'MULTI_POOL_CONFIRMED'
+    message: "Per-loop dict with MCP_MESH_TOOL_WORKERS=4 MUST create >= 2 pools (issue #1061 connection-pool multiplier)"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc02_agent_lifecycle/tc18a_async_concurrent_interleave/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc18a_async_concurrent_interleave/test.yaml
@@ -1,0 +1,112 @@
+# tc18a - two async-yielding tools concurrent under N=1 interleave fine
+# (issue #1061 trade-off characterisation).
+#
+# Documents the GOOD case under the v2.2.1 default ``MCP_MESH_TOOL_WORKERS=1``:
+# tools that ``await asyncio.sleep`` (or any other awaitable that yields
+# the loop) cooperate on a single user loop. Two concurrent calls to
+# ``async_sleep_5`` both complete in ~5s wall clock — no need for
+# N>1 to get this kind of concurrency.
+
+name: "Async-Yielding Tools Interleave at N=1"
+description: "Verify two concurrent await-asyncio.sleep tools complete in <7s on the single user loop (issue #1061; ideal ~5s)"
+tags:
+  - lifecycle
+  - serialization
+  - python
+  - workers-trade-off
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy multi-slow-tool agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-multi-slow-tool-agent /workspace/"
+    capture: copy_output
+
+  - name: "Start multi-slow-tool agent (default N=1)"
+    handler: shell
+    command: "meshctl start py-multi-slow-tool-agent/main.py --env MCP_MESH_HTTP_PORT=3180 -d"
+    workdir: /workspace
+    capture: start_output
+
+  - name: "Wait for agent to start"
+    handler: wait
+    seconds: 15
+
+  - name: "Check agent is running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: list_output
+
+  - name: "Fire two async_sleep_5 calls concurrently and measure wall-clock"
+    handler: shell
+    workdir: /workspace
+    command: |
+      START=$(date +%s)
+      ( meshctl call async_sleep_5 '{}' > /tmp/tc18a_call1.out 2>&1 ) &
+      P1=$!
+      ( meshctl call async_sleep_5 '{}' > /tmp/tc18a_call2.out 2>&1 ) &
+      P2=$!
+      wait $P1; RC1=$?
+      wait $P2; RC2=$?
+      if [ "$RC1" -ne 0 ] || [ "$RC2" -ne 0 ]; then
+        echo "ABORT: P1 rc=$RC1, P2 rc=$RC2"
+        exit 1
+      fi
+      END=$(date +%s)
+      ELAPSED=$((END - START))
+      echo "WALL_CLOCK_S=$ELAPSED"
+      echo "---CALL1---"
+      cat /tmp/tc18a_call1.out
+      echo "---CALL2---"
+      cat /tmp/tc18a_call2.out
+    capture: wall_clock_output
+    timeout: 60
+
+  - name: "Assert interleaving (wall clock < 7s, generous margin over 5s ideal)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      OUT='${captured.wall_clock_output}'
+      ELAPSED=$(echo "$OUT" | grep -oE 'WALL_CLOCK_S=[0-9]+' | head -1 | sed 's/.*=//')
+      if [ -z "$ELAPSED" ]; then
+        echo "MISSING_WALL_CLOCK"
+        exit 1
+      fi
+      echo "OBSERVED_WALL_CLOCK_S=$ELAPSED"
+      if [ "$ELAPSED" -lt 7 ]; then
+        echo "INTERLEAVE_OK"
+      else
+        echo "DEGRADED: ${ELAPSED}s >= 7s (async tools did NOT cleanly interleave on user loop; ideal ~5s)"
+        exit 1
+      fi
+    capture: interleave_check
+
+  - name: "Show agent logs"
+    handler: shell
+    command: "meshctl logs multi-slow-tool-agent 2>/dev/null | tail -30 || echo 'no logs'"
+    workdir: /workspace
+    capture: agent_logs
+
+assertions:
+  - expr: ${captured.list_output} contains 'multi-slow-tool-agent'
+    message: "Agent should be registered"
+
+  - expr: "${captured.wall_clock_output} contains '\"kind\": \"async\"'"
+    message: "Both async_sleep_5 calls should return"
+
+  - expr: ${captured.interleave_check} contains 'INTERLEAVE_OK'
+    message: "Two concurrent await-asyncio.sleep tools MUST complete in <7s at N=1 (issue #1061: async-yielding tools interleave fine on a single user loop; ideal ~5s)"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc02_agent_lifecycle/tc18b_sync_concurrent_serialize/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc18b_sync_concurrent_serialize/test.yaml
@@ -1,0 +1,117 @@
+# tc18b - two sync-blocking tools concurrent under N=1 serialize
+# (issue #1061 cost-of-default reproducer).
+#
+# Documents the trade-off cost of the v2.2.1 default
+# ``MCP_MESH_TOOL_WORKERS=1``: tools that do sync blocking work
+# (``time.sleep``, blocking DB drivers, CPU-bound numpy, etc.) hold the
+# single user loop for their full duration. A second concurrent call
+# of the same shape queues behind the first.
+#
+# Two concurrent calls to ``sync_sleep_5`` (each ``time.sleep(5)``)
+# observe wall-clock ~10s — half the parallelism gone. This is the
+# motivation for keeping ``MCP_MESH_TOOL_WORKERS`` as an opt-in
+# override (covered in tc18c).
+
+name: "Sync-Blocking Tools Serialize at N=1"
+description: "Verify two concurrent time.sleep tools serialize on the single user loop at N=1 (issue #1061 trade-off)"
+tags:
+  - lifecycle
+  - serialization
+  - python
+  - workers-trade-off
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy multi-slow-tool agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-multi-slow-tool-agent /workspace/"
+    capture: copy_output
+
+  - name: "Start multi-slow-tool agent (default N=1)"
+    handler: shell
+    command: "meshctl start py-multi-slow-tool-agent/main.py --env MCP_MESH_HTTP_PORT=3181 -d"
+    workdir: /workspace
+    capture: start_output
+
+  - name: "Wait for agent to start"
+    handler: wait
+    seconds: 15
+
+  - name: "Check agent is running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: list_output
+
+  - name: "Fire two sync_sleep_5 calls concurrently and measure wall-clock"
+    handler: shell
+    workdir: /workspace
+    command: |
+      START=$(date +%s)
+      ( meshctl call sync_sleep_5 '{}' > /tmp/tc18b_call1.out 2>&1 ) &
+      P1=$!
+      ( meshctl call sync_sleep_5 '{}' > /tmp/tc18b_call2.out 2>&1 ) &
+      P2=$!
+      wait $P1; RC1=$?
+      wait $P2; RC2=$?
+      if [ "$RC1" -ne 0 ] || [ "$RC2" -ne 0 ]; then
+        echo "ABORT: P1 rc=$RC1, P2 rc=$RC2"
+        exit 1
+      fi
+      END=$(date +%s)
+      ELAPSED=$((END - START))
+      echo "WALL_CLOCK_S=$ELAPSED"
+      echo "---CALL1---"
+      cat /tmp/tc18b_call1.out
+      echo "---CALL2---"
+      cat /tmp/tc18b_call2.out
+    capture: wall_clock_output
+    timeout: 90
+
+  - name: "Assert serialization (wall clock >= 9s, demonstrating the cost)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      OUT='${captured.wall_clock_output}'
+      ELAPSED=$(echo "$OUT" | grep -oE 'WALL_CLOCK_S=[0-9]+' | head -1 | sed 's/.*=//')
+      if [ -z "$ELAPSED" ]; then
+        echo "MISSING_WALL_CLOCK"
+        exit 1
+      fi
+      echo "OBSERVED_WALL_CLOCK_S=$ELAPSED"
+      if [ "$ELAPSED" -ge 9 ]; then
+        echo "SERIALIZE_CONFIRMED"
+      else
+        echo "UNEXPECTED_PARALLEL: ${ELAPSED}s < 9s at N=1 — did MCP_MESH_TOOL_WORKERS default get clobbered?"
+        exit 1
+      fi
+    capture: serialize_check
+
+  - name: "Show agent logs"
+    handler: shell
+    command: "meshctl logs multi-slow-tool-agent 2>/dev/null | tail -30 || echo 'no logs'"
+    workdir: /workspace
+    capture: agent_logs
+
+assertions:
+  - expr: ${captured.list_output} contains 'multi-slow-tool-agent'
+    message: "Agent should be registered"
+
+  - expr: "${captured.wall_clock_output} contains '\"kind\": \"sync\"'"
+    message: "Both sync_sleep_5 calls should return"
+
+  - expr: ${captured.serialize_check} contains 'SERIALIZE_CONFIRMED'
+    message: "Two concurrent time.sleep tools MUST serialize (>=9s wall-clock) at N=1 (issue #1061 trade-off cost)"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc02_agent_lifecycle/tc18c_sync_concurrent_workers_two/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc18c_sync_concurrent_workers_two/test.yaml
@@ -1,0 +1,137 @@
+# tc18c - two sync-blocking tools concurrent with MCP_MESH_TOOL_WORKERS=2
+# parallelize (issue #1061 opt-in N>1 win).
+#
+# Documents the opt-in MCP_MESH_TOOL_WORKERS=N>1 win: when tools do
+# sync blocking work, raising the pool size lets distinct calls land
+# on distinct worker loops and run truly in parallel.
+#
+# Two concurrent ``sync_sleep_5`` (each ``time.sleep(5)``) with
+# ``MCP_MESH_TOOL_WORKERS=2`` complete in ~5s wall clock — the
+# parallel speed-up over tc18b's N=1 serialization.
+#
+# Trade-off: with N>1 the user loop is no longer unique, so
+# loop-affine resources (asyncpg pools, redis clients, aiohttp
+# sessions) created in lifespan startup are NOT safely reusable from
+# tool bodies. Operators opt into this when their workload is
+# sync-blocking-heavy and they accept owning the cross-loop coordination
+# themselves (e.g. via per-loop resource caches).
+
+name: "Sync-Blocking Tools Parallelize at TOOL_WORKERS=2"
+description: "Verify two concurrent time.sleep tools complete in ~5s when MCP_MESH_TOOL_WORKERS=2 (issue #1061 opt-in win)"
+tags:
+  - lifecycle
+  - serialization
+  - python
+  - workers-trade-off
+  - workers-multi
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy multi-slow-tool agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-multi-slow-tool-agent /workspace/"
+    capture: copy_output
+
+  - name: "Start multi-slow-tool agent with MCP_MESH_TOOL_WORKERS=2"
+    handler: shell
+    command: "meshctl start py-multi-slow-tool-agent/main.py --env MCP_MESH_HTTP_PORT=3182 --env MCP_MESH_TOOL_WORKERS=2 -d"
+    workdir: /workspace
+    capture: start_output
+
+  - name: "Wait for agent to start"
+    handler: wait
+    seconds: 15
+
+  - name: "Check agent is running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: list_output
+
+  - name: "Fire two sync_sleep_5 calls concurrently and measure wall-clock"
+    handler: shell
+    workdir: /workspace
+    command: |
+      START=$(date +%s)
+      ( meshctl call sync_sleep_5 '{}' > /tmp/tc18c_call1.out 2>&1 ) &
+      P1=$!
+      ( meshctl call sync_sleep_5 '{}' > /tmp/tc18c_call2.out 2>&1 ) &
+      P2=$!
+      wait $P1; RC1=$?
+      wait $P2; RC2=$?
+      if [ "$RC1" -ne 0 ] || [ "$RC2" -ne 0 ]; then
+        echo "ABORT: P1 rc=$RC1, P2 rc=$RC2"
+        exit 1
+      fi
+      END=$(date +%s)
+      ELAPSED=$((END - START))
+      echo "WALL_CLOCK_S=$ELAPSED"
+      echo "---CALL1---"
+      cat /tmp/tc18c_call1.out
+      echo "---CALL2---"
+      cat /tmp/tc18c_call2.out
+    capture: wall_clock_output
+    timeout: 90
+
+  - name: "Assert parallelism (wall clock < 7s, generous margin over 5s ideal)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      OUT='${captured.wall_clock_output}'
+      ELAPSED=$(echo "$OUT" | grep -oE 'WALL_CLOCK_S=[0-9]+' | head -1 | sed 's/.*=//')
+      if [ -z "$ELAPSED" ]; then
+        echo "MISSING_WALL_CLOCK"
+        exit 1
+      fi
+      echo "OBSERVED_WALL_CLOCK_S=$ELAPSED"
+      if [ "$ELAPSED" -lt 7 ]; then
+        echo "PARALLEL_CONFIRMED"
+      else
+        echo "DEGRADED: ${ELAPSED}s >= 7s with TOOL_WORKERS=2 — parallelism did not engage cleanly (ideal ~5s)"
+        exit 1
+      fi
+    capture: parallel_check
+
+  - name: "Capture call1 output for independent assertion"
+    handler: shell
+    command: "cat /tmp/tc18c_call1.out"
+    workdir: /workspace
+    capture: call1_output
+
+  - name: "Capture call2 output for independent assertion"
+    handler: shell
+    command: "cat /tmp/tc18c_call2.out"
+    workdir: /workspace
+    capture: call2_output
+
+  - name: "Show agent logs"
+    handler: shell
+    command: "meshctl logs multi-slow-tool-agent 2>/dev/null | tail -30 || echo 'no logs'"
+    workdir: /workspace
+    capture: agent_logs
+
+assertions:
+  - expr: ${captured.list_output} contains 'multi-slow-tool-agent'
+    message: "Agent should be registered"
+
+  - expr: "${captured.call1_output} contains '\"kind\": \"sync\"'"
+    message: "First sync_sleep_5 call MUST succeed independently"
+
+  - expr: "${captured.call2_output} contains '\"kind\": \"sync\"'"
+    message: "Second sync_sleep_5 call MUST succeed independently"
+
+  - expr: ${captured.parallel_check} contains 'PARALLEL_CONFIRMED'
+    message: "Two concurrent time.sleep tools MUST parallelize (<7s wall-clock; ideal ~5s) with MCP_MESH_TOOL_WORKERS=2 (issue #1061 opt-in win)"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc02_agent_lifecycle/tc19_lifespan_exception_propagation/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc19_lifespan_exception_propagation/test.yaml
@@ -1,0 +1,110 @@
+# tc19 - lifespan startup exception propagation (issue #1061, Gap 2).
+#
+# The wrap site (`wrap_lifespan_for_user_loop`) drives the user's
+# lifespan ``__aenter__`` on the user loop via run_coroutine_threadsafe
+# + wrap_future. A startup-side raise must:
+#   1. Propagate cleanly back to uvicorn/FastAPI (visible in logs),
+#   2. Trigger the wrap-site WARNING with the forward-looking hint at
+#      @mesh.on_startup / @mesh.on_shutdown,
+#   3. Prevent the agent from registering — it never reaches the
+#      heartbeat / health-serving steady state.
+#
+# This is the highest-value new test for the v2.2.1 hijack hardening
+# because exception forwarding through a cross-loop bridge is the
+# subtlest of the four prototype gaps.
+
+name: "Lifespan Startup Exception Propagation"
+description: "Verify a user lifespan __aenter__ raise propagates cleanly through the user-loop hijack with a warning hint (issue #1061)"
+tags:
+  - lifecycle
+  - lifespan
+  - error-path
+  - python
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy lifespan-raising agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-lifespan-raising-agent /workspace/"
+    capture: copy_output
+
+  - name: "Start lifespan-raising agent (expected to fail startup)"
+    handler: shell
+    command: "meshctl start py-lifespan-raising-agent/main.py -d 2>&1 || true"
+    workdir: /workspace
+    capture: start_output
+
+  - name: "Wait for startup to fail"
+    handler: wait
+    seconds: 10
+
+  - name: "Check agent is NOT registered (or transient/exited)"
+    handler: shell
+    command: "meshctl list 2>&1 || echo 'no agents'"
+    workdir: /workspace
+    capture: list_output
+
+  # The agent log file lives at ~/.mcp-mesh/logs/<agent>.log. Read it
+  # directly rather than via `meshctl logs` so we don't depend on the
+  # CLI's lookup-by-name working for a half-registered agent.
+  - name: "Dump full agent log file for debugging"
+    handler: shell
+    command: "ls -la /root/.mcp-mesh/logs/ 2>/dev/null; cat /root/.mcp-mesh/logs/lifespan-raising-agent.log 2>/dev/null | head -200 || echo 'log file missing'"
+    workdir: /workspace
+    capture: agent_log_head
+
+  # Greps below filter the full log file (not tail) — the warning and the
+  # user RuntimeError fire during uvicorn startup, which is buried under
+  # the noisier heartbeat/registry output that follows.
+  - name: "Grep for synthetic startup failure (user exception surfaced)"
+    handler: shell
+    command: "grep -q 'synthetic startup failure' /root/.mcp-mesh/logs/lifespan-raising-agent.log 2>/dev/null && echo MATCH_FOUND || echo MATCH_MISSING"
+    workdir: /workspace
+    capture: grep_user_exc
+
+  - name: "Grep for wrap-site WARNING (Directive B)"
+    handler: shell
+    command: "grep -q 'Lifespan hijack failed during startup' /root/.mcp-mesh/logs/lifespan-raising-agent.log 2>/dev/null && echo MATCH_FOUND || echo MATCH_MISSING"
+    workdir: /workspace
+    capture: grep_warning
+
+  - name: "Grep for @mesh.on_startup hint"
+    handler: shell
+    command: "grep -q '@mesh.on_startup' /root/.mcp-mesh/logs/lifespan-raising-agent.log 2>/dev/null && echo MATCH_FOUND || echo MATCH_MISSING"
+    workdir: /workspace
+    capture: grep_on_startup
+
+  - name: "Grep for @mesh.on_shutdown hint"
+    handler: shell
+    command: "grep -q '@mesh.on_shutdown' /root/.mcp-mesh/logs/lifespan-raising-agent.log 2>/dev/null && echo MATCH_FOUND || echo MATCH_MISSING"
+    workdir: /workspace
+    capture: grep_on_shutdown
+
+assertions:
+  - expr: ${captured.grep_user_exc} contains 'MATCH_FOUND'
+    message: "Original user RuntimeError message must reach the logs (not be swallowed by the hijack)"
+
+  - expr: ${captured.grep_warning} contains 'MATCH_FOUND'
+    message: "Wrap site must emit the WARNING when __aenter__ raises (Directive B)"
+
+  - expr: ${captured.grep_on_startup} contains 'MATCH_FOUND'
+    message: "Warning must include the forward-looking @mesh.on_startup hint"
+
+  - expr: ${captured.grep_on_shutdown} contains 'MATCH_FOUND'
+    message: "Warning must include the forward-looking @mesh.on_shutdown hint"
+
+  - expr: ${captured.list_output} not contains 'lifespan-raising-agent'
+    message: "Agent must NOT reach steady-state registration when lifespan startup raises"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

v2.2.1 patch fixing cross-loop affinity for FastAPI's standard pattern (`asyncpg.Pool` / `redis.asyncio` / `aiohttp.ClientSession` created in `lifespan` startup, used from tool bodies). Apps adopting v2.2 features hit cross-loop errors despite the documented `MCP_MESH_TOOL_WORKERS=1` "escape hatch" — that flag only collapsed worker loops, but the lifespan loop remained distinct.

This PR introduces a two-loop topology:

- **Framework loop** (uvicorn main): `/health`, `/ready`, `/livez`, MCP protocol routing. Always responsive.
- **User loop** (single, dedicated): `lifespan` startup, all `@mesh.tool` / `@app.tool` bodies, `lifespan` exit. One loop for everything you write.

Standard FastAPI patterns now just work. K8s probe responsiveness preserved (measured: `/health` 2ms during a 10s `await asyncio.sleep(10)` tool).

## What changed

- **`src/runtime/python/_mcp_mesh/shared/tool_executor.py`** — `MCP_MESH_TOOL_WORKERS` default `min(8, max(2, cpu_count()))` → `1`. Env override (`MCP_MESH_TOOL_WORKERS=N`, N>1) remains for sync-blocking parallel workloads.
- **`src/runtime/python/_mcp_mesh/pipeline/mcp_startup/lifespan_factory.py`** — new `wrap_lifespan_for_user_loop()` helper. Single source of truth for the lifespan hijack. Contextvar propagation (`contextvars.copy_context()` + `loop.create_task(coro, context=ctx)`, mirroring `tool_executor._invoke_with_context`), exception forwarding through `__aexit__` (PEP 343 suppression semantics honored), partial-startup unwind, per-future `.cancel()` on framework-side abort to avoid leaking the user-loop task past parent's "done", WARNING log on hijack failure with `@mesh.on_startup` / `@mesh.on_shutdown` forward-looking hint. `_user_loop_dispatched` kept as back-compat alias.
- **`src/runtime/python/mesh/decorators.py`** — `_start_uvicorn_immediately` now imports and uses `wrap_lifespan_for_user_loop()`. Single canonical wrap site.
- **Tests** — 8 new `uc02_agent_lifecycle` cases (`tc12`–`tc19`) covering: FastAPI lifespan loop affinity (fixed + proof that `WORKERS=1` alone was insufficient), `/health` responsiveness with a 10s tool, `asyncio.gather` parallel fan-out at N=1 vs N=8 (2.04s vs 2.04s), lazy pool reuse single-init, per-loop dict pattern's N-pool DB-connection multiplier cost, async/sync concurrent serialize vs interleave at N=1 and `WORKERS=2`, exception propagation through hijack with warning log assertion.
- **Docs** — `docs/concepts/stateful-agents.md`, `docs/python/dependency-injection.md`, `docs/concepts/in-process-state.md`, `docs/environment-variables.md` + `src/core/cli/man/content/dependency-injection.md` + `src/core/cli/man/content/environment.md` rewritten to drop the misleading "`MCP_MESH_TOOL_WORKERS=1` escape hatch" framing and document the two-loop topology + new default.
- **`RELEASE_NOTES.md`** — v2.2.1 entry at top with explicit sync-blocking-app remediation guidance.

## Review notes

Independent review caught 6 WARNINGs + 7 INFOs (0 BLOCKERs). Addressed in the amended commit:

- **W1 — Cross-loop cancellation leak**: `suppress_fut` / `enter_fut` now `.cancel()`-ed when framework-side `wrap_future` await raises, so the user-loop `__aexit__` / `__aenter__` task doesn't run past parent's "done" on uvicorn shutdown timeout.
- **W2 — Misleading "user exception" wording in shutdown warnings**: startup warning kept (correct); shutdown warnings rewritten to clarify they re-raise the exit-side exception with the body exception preserved as `__context__`. Helpers `_log_hijack_startup_failure` + `_log_hijack_shutdown_failure` extracted to avoid duplication.
- **W3 — Composer-path silent swallow (load-bearing)**: `create_single_fastmcp_lifespan` AND `create_multiple_fastmcp_lifespan` both had `except Exception` blocks that silently downgraded hijack startup failure to a degraded-but-running agent. Now log + re-raise. tc19's "agent must NOT register" contract holds across all lifespan paths.
- **W5 — tc18a interleave threshold tightened**: `< 9s` → `< 7s`. Same tightening on tc18c.
- **W6 — tc14 `/health` time bound**: now parses `curl -w "TIME_TOTAL=%{time_total}"`, asserts `< 500ms`. Measured 2ms; rejects "barely-responsive" failures.

Skipped: W4 (cosmetic Full Changelog link doubled, will normalize at v2.2.1 tag time), 7 INFOs (cosmetic).

Closes #1061

## Test plan

- [x] uc02_agent_lifecycle: 21/21 pass (including 8 new `tc12`–`tc19`)
- [x] src-tests: 12/12 pass
- [x] `mkdocs build` clean
- [x] `meshctl man dependency-injection --raw` and `meshctl man environment --raw` reflect new content (requires fresh `make build` of meshctl binary since man pages are go:embed compiled — local dev workflow)
- [x] `grep -rni "MCP_MESH_TOOL_WORKERS=1" docs/ src/core/cli/man/content/` — no remaining stale "escape hatch" framing
- [ ] After merge: separate `chore(release): bump version 2.2.0 → 2.2.1` PR (per project release cadence)
- [ ] After merge + version bump: tag `v2.2.1` (stable-release gate — push tag, inspect, then fire publish workflow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed cross-loop affinity errors preventing proper resource binding between FastAPI lifespan and tool execution

* **Documentation**
  * Updated guidance on loop topology and in-process state patterns
  * Added tool worker pool configuration documentation with environment variable reference
  * Enhanced stateful agent and dependency-injection examples

* **Tests**
  * Added 8 new integration test cases covering lifecycle, resource affinity, parallel execution, and tool behavior scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1062?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->