### PR TITLE
chore(release): bump 2.2.3 → 2.2.4 + Node 24 in npm publish jobs

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version tag (e.g., v2.2.3)"
+        description: "Version tag (e.g., v2.2.4)"
         required: true
-        default: "v2.2.3"
+        default: "v2.2.4"
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version (e.g., v2.2.3)"
+        description: "Version (e.g., v2.2.4)"
         required: true
-        default: "v2.2.3"
+        default: "v2.2.4"
       environment:
         description: "Environment"
         type: choice
@@ -606,14 +606,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          # Node 24 ships npm 11.x natively. npm 11.5.1+ is required for full
+          # Trusted Publishing — the auto-OIDC handshake for the actual publish
+          # PUT, not just --provenance (Sigstore signing). Node 22 bundles
+          # npm 10.x and `npm install -g npm@11` hit a known npm 10.9.x
+          # transitive-dep bug (`Cannot find module 'promise-retry'`). See #1067.
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Upgrade npm to 11.x for Trusted Publishing
-        # Node 22 ships npm 10.x which supports --provenance (Sigstore signing)
-        # but NOT the auto-OIDC handshake for the actual publish PUT. npm 11.x
-        # adds full Trusted Publishing (no-token publish via OIDC). See #1061.
-        run: npm install -g npm@11
 
       - name: Determine version
         id: version
@@ -734,14 +733,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          # Node 24 ships npm 11.x natively. npm 11.5.1+ is required for full
+          # Trusted Publishing — the auto-OIDC handshake for the actual publish
+          # PUT, not just --provenance (Sigstore signing). Node 22 bundles
+          # npm 10.x and `npm install -g npm@11` hit a known npm 10.9.x
+          # transitive-dep bug (`Cannot find module 'promise-retry'`). See #1067.
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Upgrade npm to 11.x for Trusted Publishing
-        # Node 22 ships npm 10.x which supports --provenance (Sigstore signing)
-        # but NOT the auto-OIDC handshake for the actual publish PUT. npm 11.x
-        # adds full Trusted Publishing (no-token publish via OIDC). See #1061.
-        run: npm install -g npm@11
 
       - name: Determine version
         id: version
@@ -920,14 +918,13 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          # Node 24 ships npm 11.x natively. npm 11.5.1+ is required for full
+          # Trusted Publishing — the auto-OIDC handshake for the actual publish
+          # PUT, not just --provenance (Sigstore signing). Node 22 bundles
+          # npm 10.x and `npm install -g npm@11` hit a known npm 10.9.x
+          # transitive-dep bug (`Cannot find module 'promise-retry'`). See #1067.
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Upgrade npm to 11.x for Trusted Publishing
-        # Node 22 ships npm 10.x which supports --provenance (Sigstore signing)
-        # but NOT the auto-OIDC handshake for the actual publish PUT. npm 11.x
-        # adds full Trusted Publishing (no-token publish via OIDC). See #1061.
-        run: npm install -g npm@11
 
       - name: Determine version
         id: version

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,12 @@
 # MCP Mesh Release Notes
 
-[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v2.2.3...HEAD)
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v2.2.4...HEAD)
 
-[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v2.2.0...v2.2.3)
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v2.2.0...v2.2.4)
 
-## v2.2.3 (2026-05-21)
+## v2.2.4 (2026-05-21)
 
-Cross-loop affinity fix for v2.2 adopters using FastAPI lifespan patterns. Apps that create loop-bound resources (`asyncpg.Pool`, `redis.asyncio.Redis`, `aiohttp.ClientSession`) in `lifespan` startup and use them from tool bodies hit "Future attached to a different loop" errors in v2.2.0 — the documented `MCP_MESH_TOOL_WORKERS=1` "escape hatch" did not actually solve it. v2.2.3 fixes the topology so standard FastAPI patterns work as expected.
+Cross-loop affinity fix for v2.2 adopters using FastAPI lifespan patterns. Apps that create loop-bound resources (`asyncpg.Pool`, `redis.asyncio.Redis`, `aiohttp.ClientSession`) in `lifespan` startup and use them from tool bodies hit "Future attached to a different loop" errors in v2.2.0 — the documented `MCP_MESH_TOOL_WORKERS=1` "escape hatch" did not actually solve it. v2.2.4 fixes the topology so standard FastAPI patterns work as expected.
 
 ### 🪢 Loop topology fix (#1061)
 
@@ -22,7 +22,7 @@ Cross-loop affinity fix for v2.2 adopters using FastAPI lifespan patterns. Apps 
 - **Apps with sync-blocking calls in tool bodies** (`time.sleep`, `requests.get`, CPU-bound work) that relied on `cpu_count()` worker pool absorbing concurrent load **must either**:
     - Refactor the blocking call to `await asyncio.to_thread(blocking_call)` (recommended — Python idiom; user loop stays free).
     - Or set `MCP_MESH_TOOL_WORKERS=N` (N>1) in the agent's environment to restore N worker loops. The loop-affinity caveat applies — resources created in `lifespan` startup bind to worker-0 only.
-- **Apps that set `MCP_MESH_TOOL_WORKERS=1` as the documented escape hatch in v2.0/v2.1** are source-compatible in v2.2.3 — no code edits are required. The setting was previously insufficient for FastAPI `lifespan` + loop-bound resource patterns: it collapsed worker loops but did not unify the lifespan loop with the tool loop, so cross-loop errors still surfaced. v2.2.3 fixes the underlying lifespan-loop topology, so those same apps now function correctly without any changes — the previous escape hatch becomes a no-op duplication of the new default.
+- **Apps that set `MCP_MESH_TOOL_WORKERS=1` as the documented escape hatch in v2.0/v2.1** are source-compatible in v2.2.4 — no code edits are required. The setting was previously insufficient for FastAPI `lifespan` + loop-bound resource patterns: it collapsed worker loops but did not unify the lifespan loop with the tool loop, so cross-loop errors still surfaced. v2.2.4 fixes the underlying lifespan-loop topology, so those same apps now function correctly without any changes — the previous escape hatch becomes a no-op duplication of the new default.
 
 ### 📚 Documentation
 

--- a/cmd/meshctl/templates/java/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge (Java/Spring Boot)
-FROM mcpmesh/java-runtime:2.2.3
+FROM mcpmesh/java-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/a2a-consumer/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/a2a-consumer/pom.xml.tmpl
@@ -26,7 +26,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway (Java/Spring Boot)
-FROM mcpmesh/java-runtime:2.2.3
+FROM mcpmesh/java-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/api/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/api/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:2.2.3
+FROM mcpmesh/java-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/basic/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/basic/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:2.2.3
+FROM mcpmesh/java-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:2.2.3
+FROM mcpmesh/java-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/python/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/a2a-consumer/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/a2a-consumer/package.json.tmpl
@@ -13,7 +13,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/cmd/meshctl/templates/typescript/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/api/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/api/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/cmd/meshctl/templates/typescript/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/basic/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/cmd/meshctl/templates/typescript/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/llm-agent/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/cmd/meshctl/templates/typescript/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/llm-provider/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/docs/00-why-mcp-mesh/index.md
+++ b/docs/00-why-mcp-mesh/index.md
@@ -111,7 +111,7 @@ meshctl scaffold --compose --observability
 
 # Or deploy to Kubernetes (OCI registry)
 helm install my-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 -n mcp-mesh --create-namespace
+  --version 2.2.4 -n mcp-mesh --create-namespace
 ```
 
 ### 5. Built-in Observability

--- a/docs/02-local-development.md
+++ b/docs/02-local-development.md
@@ -97,7 +97,7 @@ graph LR
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </dependency>
     ```
 

--- a/docs/03-docker-deployment.md
+++ b/docs/03-docker-deployment.md
@@ -24,10 +24,10 @@ MCP Mesh publishes official images to Docker Hub:
 
 | Image                            | Purpose                                          |
 | -------------------------------- | ------------------------------------------------ |
-| `mcpmesh/registry:2.2.3`           | Go-based registry service                        |
-| `mcpmesh/python-runtime:2.2.3`     | Python agent runtime (includes mcp-mesh SDK)     |
-| `mcpmesh/java-runtime:2.2.3`       | Java agent runtime (includes mcp-mesh SDK)       |
-| `mcpmesh/typescript-runtime:2.2.3` | TypeScript agent runtime (includes @mcpmesh/sdk) |
+| `mcpmesh/registry:2.2.4`           | Go-based registry service                        |
+| `mcpmesh/python-runtime:2.2.4`     | Python agent runtime (includes mcp-mesh SDK)     |
+| `mcpmesh/java-runtime:2.2.4`       | Java agent runtime (includes mcp-mesh SDK)       |
+| `mcpmesh/typescript-runtime:2.2.4` | TypeScript agent runtime (includes @mcpmesh/sdk) |
 
 ## Using Scaffold to Generate Compose Files
 
@@ -53,7 +53,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:2.2.3
+        image: mcpmesh/registry:2.2.4
         ports:
           - "8000:8000"
         healthcheck:
@@ -63,7 +63,7 @@ meshctl scaffold --compose --dry-run -d ./agents
           retries: 3
 
       my-agent:
-        image: mcpmesh/python-runtime:2.2.3
+        image: mcpmesh/python-runtime:2.2.4
         ports:
           - "8080:8080"
         volumes:
@@ -88,7 +88,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:2.2.3
+        image: mcpmesh/registry:2.2.4
         ports:
           - "8000:8000"
         healthcheck:
@@ -122,7 +122,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:2.2.3
+        image: mcpmesh/registry:2.2.4
         ports:
           - "8000:8000"
         healthcheck:
@@ -132,7 +132,7 @@ meshctl scaffold --compose --dry-run -d ./agents
           retries: 3
 
       my-agent:
-        image: mcpmesh/typescript-runtime:2.2.3
+        image: mcpmesh/typescript-runtime:2.2.4
         ports:
           - "8080:8080"
         volumes:
@@ -161,12 +161,12 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:2.2.3
+        image: mcpmesh/registry:2.2.4
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/python-runtime:2.2.3
+        image: mcpmesh/python-runtime:2.2.4
         volumes:
           - ./agent.py:/app/agent.py:ro
         command: ["python", "/app/agent.py"]
@@ -185,7 +185,7 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:2.2.3
+        image: mcpmesh/registry:2.2.4
         ports:
           - "8000:8000"
 
@@ -206,12 +206,12 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:2.2.3
+        image: mcpmesh/registry:2.2.4
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/typescript-runtime:2.2.3
+        image: mcpmesh/typescript-runtime:2.2.4
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]
@@ -232,7 +232,7 @@ If you didn't use scaffold, here's a sample Dockerfile:
 === "Python"
 
     ```dockerfile
-    FROM mcpmesh/python-runtime:2.2.3
+    FROM mcpmesh/python-runtime:2.2.4
 
     COPY ./my-agent /app/agent
 
@@ -257,7 +257,7 @@ If you didn't use scaffold, here's a sample Dockerfile:
 === "TypeScript"
 
     ```dockerfile
-    FROM mcpmesh/typescript-runtime:2.2.3
+    FROM mcpmesh/typescript-runtime:2.2.4
 
     WORKDIR /app/agent
     COPY ./my-agent/package*.json ./
@@ -284,12 +284,12 @@ version: "3.8"
 
 services:
   registry:
-    image: mcpmesh/registry:2.2.3
+    image: mcpmesh/registry:2.2.4
     ports:
       - "8000:8000"
 
   auth-agent:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     volumes:
       - ./agents/auth:/app/agent:ro
     command: ["python", "/app/agent/main.py"]
@@ -298,7 +298,7 @@ services:
       - MCP_MESH_HTTP_PORT=8080
 
   data-agent:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     volumes:
       - ./agents/data:/app/agent:ro
     command: ["python", "/app/agent/main.py"]
@@ -307,7 +307,7 @@ services:
       - MCP_MESH_HTTP_PORT=8080
 
   api-agent:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     volumes:
       - ./agents/api:/app/agent:ro
     command: ["python", "/app/agent/main.py"]

--- a/docs/03-docker-deployment/04-networking.md
+++ b/docs/03-docker-deployment/04-networking.md
@@ -31,12 +31,12 @@ graph TD
     # docker-compose.yml
     services:
       registry:
-        image: mcpmesh/registry:2.2.3
+        image: mcpmesh/registry:2.2.4
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/python-runtime:2.2.3
+        image: mcpmesh/python-runtime:2.2.4
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["python", "/app/agent/main.py"]
@@ -44,7 +44,7 @@ graph TD
           - MCP_MESH_REGISTRY_URL=http://registry:8000
 
       another-agent:
-        image: mcpmesh/python-runtime:2.2.3
+        image: mcpmesh/python-runtime:2.2.4
         volumes:
           - ./another-agent:/app/agent:ro
         command: ["python", "/app/agent/main.py"]
@@ -62,12 +62,12 @@ graph TD
     # docker-compose.yml
     services:
       registry:
-        image: mcpmesh/registry:2.2.3
+        image: mcpmesh/registry:2.2.4
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/typescript-runtime:2.2.3
+        image: mcpmesh/typescript-runtime:2.2.4
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]
@@ -75,7 +75,7 @@ graph TD
           - MCP_MESH_REGISTRY_URL=http://registry:8000
 
       another-agent:
-        image: mcpmesh/typescript-runtime:2.2.3
+        image: mcpmesh/typescript-runtime:2.2.4
         volumes:
           - ./another-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]

--- a/docs/04-kubernetes-basics.md
+++ b/docs/04-kubernetes-basics.md
@@ -21,7 +21,7 @@ kubectl create namespace mcp-mesh
 
 # Deploy core (OCI registry - no "helm repo add" needed)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   --namespace mcp-mesh
 
 # Wait for registry
@@ -65,7 +65,7 @@ Build the image:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 \
+  --version 2.2.4 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=my-agent \
@@ -76,7 +76,7 @@ For cloud deployments, use your full registry path:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 \
+  --version 2.2.4 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
@@ -138,7 +138,7 @@ resources:
 ```bash
 # Core without Grafana/Tempo (lighter footprint)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   --namespace mcp-mesh \
   --set grafana.enabled=false \
   --set tempo.enabled=false
@@ -149,7 +149,7 @@ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
 ```bash
 # Just the registry, no database or observability
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 2.2.3 \
+  --version 2.2.4 \
   --namespace mcp-mesh
 ```
 
@@ -161,13 +161,13 @@ just match `-n` with `--set global.namespace`:
 ```bash
 # Deploy core to a custom namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n my-namespace --create-namespace \
   --set global.namespace=my-namespace
 
 # Deploy agent to the same namespace
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n my-namespace \
   -f helm-values.yaml
 ```
@@ -180,12 +180,12 @@ For **multi-tenant** clusters (separate core per team), deploy each core to its 
 ```bash
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n team-a --create-namespace --set global.namespace=team-a
 
 # Team B — same values, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n team-b --create-namespace --set global.namespace=team-b
 ```
 
@@ -193,7 +193,7 @@ For **cross-namespace** access (agent in one namespace, core in another), use FQ
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 -n other-ns \
+  --version 2.2.4 -n other-ns \
   --set mesh.registryUrl=http://mcp-core-mcp-mesh-registry.team-a.svc.cluster.local:8000
 ```
 
@@ -205,13 +205,13 @@ helm list -n mcp-mesh
 
 # Upgrade an agent
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 \
+  --version 2.2.4 \
   --namespace mcp-mesh \
   --set image.tag=v2
 
 # Scale replicas
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 \
+  --version 2.2.4 \
   --namespace mcp-mesh \
   --reuse-values \
   --set replicaCount=3

--- a/docs/04-kubernetes-basics/05-troubleshooting.md
+++ b/docs/04-kubernetes-basics/05-troubleshooting.md
@@ -373,7 +373,7 @@ kubectl exec <pod-name> -n mcp-mesh -- df -h
 **Symptoms:**
 
 ```
-Failed to pull image "mcpmesh/python-runtime:2.2.3": rpc error: code = Unknown desc = Error response from daemon: pull access denied
+Failed to pull image "mcpmesh/python-runtime:2.2.4": rpc error: code = Unknown desc = Error response from daemon: pull access denied
 ```
 
 **Solutions:**

--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -19,7 +19,7 @@ The data flows: **Agents → Redis → Registry → Tempo → Grafana**
 ```bash
 # Deploy core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   --namespace mcp-mesh \
   --set redis.enabled=true \
   --set tempo.enabled=true \

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -216,7 +216,7 @@ Designed for containers and Kubernetes.
 
 ## Multimodal Pipeline
 
-MCP Mesh v2.2.3 adds a media pipeline that lets tools produce and LLMs consume binary content:
+MCP Mesh v2.2.4 adds a media pipeline that lets tools produce and LLMs consume binary content:
 
 ```
 Tool produces media

--- a/docs/concepts/stateful-agents.md
+++ b/docs/concepts/stateful-agents.md
@@ -48,7 +48,7 @@ mcp-mesh runs your agent across two event loops:
 
 The two-loop split means a long-running tool body (LLM call, slow registry hop, multi-minute MeshJob) holds the user loop, but never the framework loop — your K8s liveness/readiness probes stay responsive.
 
-**What this fixes**: standard FastAPI patterns for loop-bound resources work as expected. `asyncpg.Pool`, `redis.asyncio.Redis`, and `aiohttp.ClientSession` are all loop-affine — they bind to the asyncio loop that created them and fail if reused from a different one. Because v2.2.3 runs your lifespan AND your tools on the same user loop, the standard FastAPI idiom just works:
+**What this fixes**: standard FastAPI patterns for loop-bound resources work as expected. `asyncpg.Pool`, `redis.asyncio.Redis`, and `aiohttp.ClientSession` are all loop-affine — they bind to the asyncio loop that created them and fail if reused from a different one. Because v2.2.4 runs your lifespan AND your tools on the same user loop, the standard FastAPI idiom just works:
 
 ```python
 @asynccontextmanager
@@ -91,7 +91,7 @@ long-running work. From mesh's perspective it's an ordinary CRUD
 agent — every tool call is short, idempotent where possible, and
 returns. The pool lives inside the agent process — created in
 `lifespan` startup, attached to `app.state`, and closed in `lifespan`
-exit. Since v2.2.3, `lifespan` and all tool bodies share the single
+exit. Since v2.2.4, `lifespan` and all tool bodies share the single
 user loop, so the standard FastAPI pattern is the supported pattern.
 
 Schema:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,7 +44,7 @@ docker-compose up
 ```bash
 # Quick start (OCI registry - no helm repo add needed)
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 2.2.3 -n mcp-mesh --create-namespace
+  --version 2.2.4 -n mcp-mesh --create-namespace
 ```
 
 [:material-arrow-right: Kubernetes Guide](04-kubernetes-basics.md){ .md-button .md-button--primary }
@@ -117,7 +117,7 @@ For Kubernetes, configure TLS via Helm values:
 
 ```bash
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 2.2.3 -n mcp-mesh --create-namespace \
+  --version 2.2.4 -n mcp-mesh --create-namespace \
   --set registry.security.tls.mode=strict \
   --set registry.security.trust.backend=k8s-secrets
 ```

--- a/docs/dev-to-production.md
+++ b/docs/dev-to-production.md
@@ -85,10 +85,10 @@ The [TSuite](https://github.com/dhyansraj/mcp-mesh-test-suite) integration testi
 
     ```bash
     helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-      --version 2.2.3 -n mcp-mesh --create-namespace
+      --version 2.2.4 -n mcp-mesh --create-namespace
 
     helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 2.2.3 -n mcp-mesh -f helm-values.yaml
+      --version 2.2.4 -n mcp-mesh -f helm-values.yaml
     ```
 
 Same agent code runs locally, in Docker, and in Kubernetes — no changes needed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,7 @@ Build multi-agent systems that are production-ready from day one. Mesh handles t
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </dependency>
     ```
 
@@ -364,7 +364,7 @@ A `kubectl`-style command-line tool that follows you from first agent to product
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </dependency>
     ```
 
@@ -383,10 +383,10 @@ A `kubectl`-style command-line tool that follows you from first agent to product
 === "Docker Images"
 
     ```bash
-    docker pull mcpmesh/registry:2.2.3
-    docker pull mcpmesh/python-runtime:2.2.3
-    docker pull mcpmesh/java-runtime:2.2.3
-    docker pull mcpmesh/typescript-runtime:2.2.3
+    docker pull mcpmesh/registry:2.2.4
+    docker pull mcpmesh/python-runtime:2.2.4
+    docker pull mcpmesh/java-runtime:2.2.4
+    docker pull mcpmesh/typescript-runtime:2.2.4
     ```
 
     Official container images for production deployments.
@@ -412,7 +412,7 @@ A `kubectl`-style command-line tool that follows you from first agent to product
 
 ## :star: Project Status
 
-- **Latest Release**: v2.2.3 (March 2026)
+- **Latest Release**: v2.2.4 (March 2026)
 - **License**: MIT
 - **Languages**: Python 3.11+, TypeScript/Node.js 18+, and Java 17+ (runtime), Go 1.23+ (registry)
 - **Status**: Production-ready, actively developed

--- a/docs/java/examples.md
+++ b/docs/java/examples.md
@@ -132,7 +132,7 @@ class AssistantAgentTest {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:2.2.3
+    image: mcpmesh/registry:2.2.4
     ports:
       - "8000:8000"
     healthcheck:

--- a/docs/java/getting-started/index.md
+++ b/docs/java/getting-started/index.md
@@ -83,13 +83,13 @@ Create `pom.xml`:
 
     <groupId>com.example</groupId>
     <artifactId>greeter-agent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4</version>
 
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>2.2.3</version>
+            <version>2.2.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/docs/java/getting-started/prerequisites.md
+++ b/docs/java/getting-started/prerequisites.md
@@ -60,7 +60,7 @@ Add the Spring Boot starter to your `pom.xml`:
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -108,10 +108,10 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:2.2.3`           | Registry service            |
-| `mcpmesh/python-runtime:2.2.3`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:2.2.3`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:2.2.3` | TypeScript runtime with SDK |
+| `mcpmesh/registry:2.2.4`           | Registry service            |
+| `mcpmesh/python-runtime:2.2.4`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:2.2.4`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:2.2.4` | TypeScript runtime with SDK |
 
 Java agents use standard Maven-based Docker builds (see Docker Deployment guide).
 

--- a/docs/java/local-development/01-getting-started.md
+++ b/docs/java/local-development/01-getting-started.md
@@ -45,7 +45,7 @@ The recommended way is to use `meshctl scaffold` (see next page). If you prefer 
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/docs/java/local-development/troubleshooting.md
+++ b/docs/java/local-development/troubleshooting.md
@@ -38,7 +38,7 @@ Ensure the dependency version matches an available release:
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4</version>
 </dependency>
 ```
 

--- a/docs/java/spring-boot-integration.md
+++ b/docs/java/spring-boot-integration.md
@@ -23,7 +23,7 @@ MCP Mesh provides `@MeshRoute` and `@MeshInject` annotations for Spring Boot RES
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/docs/python/dependency-injection.md
+++ b/docs/python/dependency-injection.md
@@ -197,7 +197,7 @@ loop — K8s liveness/readiness probes stay responsive.
 
 ### Default `MCP_MESH_TOOL_WORKERS=1`
 
-Since v2.2.3, default tool dispatch runs on a single-user loop (was
+Since v2.2.4, default tool dispatch runs on a single-user loop (was
 `min(8, max(2, cpu_count()))`). The standard FastAPI pattern for
 loop-bound resources works as expected — `lifespan` startup creates the
 resource on the user loop; every tool body uses it on the same loop;

--- a/docs/python/getting-started/prerequisites.md
+++ b/docs/python/getting-started/prerequisites.md
@@ -97,17 +97,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:2.2.3`           | Registry service            |
-| `mcpmesh/python-runtime:2.2.3`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:2.2.3`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:2.2.3` | TypeScript runtime with SDK |
+| `mcpmesh/registry:2.2.4`           | Registry service            |
+| `mcpmesh/python-runtime:2.2.4`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:2.2.4`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:2.2.4` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:2.2.3
-docker pull mcpmesh/python-runtime:2.2.3
-docker pull mcpmesh/java-runtime:2.2.3
-docker pull mcpmesh/typescript-runtime:2.2.3
+docker pull mcpmesh/registry:2.2.4
+docker pull mcpmesh/python-runtime:2.2.4
+docker pull mcpmesh/java-runtime:2.2.4
+docker pull mcpmesh/typescript-runtime:2.2.4
 ```
 
 ### Generate Docker Compose
@@ -145,12 +145,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/docs/tutorial/day-08-docker-compose.md
+++ b/docs/tutorial/day-08-docker-compose.md
@@ -379,7 +379,7 @@ $ docker compose down -v
 ## Troubleshooting
 
 **Docker build fails with missing requirements.** The compose file uses
-`mcpmesh/python-runtime:2.2.3` images with a dev-mode entrypoint that
+`mcpmesh/python-runtime:2.2.4` images with a dev-mode entrypoint that
 installs `requirements.txt` on startup. If an agent has dependencies not
 in the base image, check that `requirements.txt` exists in the agent
 directory and lists all dependencies.

--- a/docs/tutorial/day-09-kubernetes.md
+++ b/docs/tutorial/day-09-kubernetes.md
@@ -212,7 +212,7 @@ and Grafana as a single Helm release:
 
 ```shell
 $ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-    --version 2.2.3 \
+    --version 2.2.4 \
     -n trip-planner \
     -f helm/values-core.yaml \
     --wait --timeout 5m
@@ -246,7 +246,7 @@ $ for agent in "${AGENTS[@]}"; do
     echo "Installing $agent..."
     helm install "$agent" \
       oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 2.2.3 \
+      --version 2.2.4 \
       -n trip-planner \
       -f "helm/values-${agent}.yaml"
   done

--- a/docs/typescript/examples.md
+++ b/docs/typescript/examples.md
@@ -128,7 +128,7 @@ describe("Agent Integration", () => {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:2.2.3
+    image: mcpmesh/registry:2.2.4
     ports:
       - "8000:8000"
     healthcheck:

--- a/docs/typescript/getting-started/prerequisites.md
+++ b/docs/typescript/getting-started/prerequisites.md
@@ -85,17 +85,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:2.2.3`           | Registry service            |
-| `mcpmesh/python-runtime:2.2.3`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:2.2.3`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:2.2.3` | TypeScript runtime with SDK |
+| `mcpmesh/registry:2.2.4`           | Registry service            |
+| `mcpmesh/python-runtime:2.2.4`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:2.2.4`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:2.2.4` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:2.2.3
-docker pull mcpmesh/python-runtime:2.2.3
-docker pull mcpmesh/java-runtime:2.2.3
-docker pull mcpmesh/typescript-runtime:2.2.3
+docker pull mcpmesh/registry:2.2.4
+docker pull mcpmesh/python-runtime:2.2.4
+docker pull mcpmesh/java-runtime:2.2.4
+docker pull mcpmesh/typescript-runtime:2.2.4
 ```
 
 ### Generate Docker Compose

--- a/examples/docker-examples/agents/claude-provider/Dockerfile
+++ b/examples/docker-examples/agents/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/docker-examples/agents/claude-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/claude-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying claude-provider with mcp-mesh-agent chart
 # Usage: helm install claude-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 2.2.3 -f helm-values.yaml
+#        --version 2.2.4 -f helm-values.yaml
 
 image:
   repository: your-registry/claude-provider

--- a/examples/docker-examples/agents/claude-provider/requirements.txt
+++ b/examples/docker-examples/agents/claude-provider/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Mesh SDK
-mcp-mesh>=2.2.3
+mcp-mesh>=2.2.4
 
 # FastMCP for MCP server
 fastmcp>=3.0.0,<4.0.0

--- a/examples/docker-examples/agents/openai-provider/Dockerfile
+++ b/examples/docker-examples/agents/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/docker-examples/agents/openai-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/openai-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying openai-provider with mcp-mesh-agent chart
 # Usage: helm install openai-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 2.2.3 -f helm-values.yaml
+#        --version 2.2.4 -f helm-values.yaml
 
 image:
   repository: your-registry/openai-provider

--- a/examples/docker-examples/agents/openai-provider/requirements.txt
+++ b/examples/docker-examples/agents/openai-provider/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Mesh SDK
-mcp-mesh>=2.2.3
+mcp-mesh>=2.2.4
 
 # FastMCP for MCP server
 fastmcp>=3.0.0,<4.0.0

--- a/examples/docker-examples/docker-compose.yml
+++ b/examples/docker-examples/docker-compose.yml
@@ -2,12 +2,12 @@
 # Demonstrates Go registry + Python agents architecture using published Docker images
 #
 # Services:
-# - registry: Go-based registry with SQLite storage (mcpmesh/registry:2.2.3)
-# - hello-world-agent: Python agent with greeting capabilities (mcpmesh/python-runtime:2.2.3)
-# - system-agent: Python agent with system monitoring capabilities (mcpmesh/python-runtime:2.2.3)
-# - fastmcp-agent: FastMCP service with mesh integration (mcpmesh/python-runtime:2.2.3)
-# - dependent-agent: Service that depends on fastmcp-agent (mcpmesh/python-runtime:2.2.3)
-# - fastapi-app: FastAPI application with mesh integration (mcpmesh/python-runtime:2.2.3)
+# - registry: Go-based registry with SQLite storage (mcpmesh/registry:2.2.4)
+# - hello-world-agent: Python agent with greeting capabilities (mcpmesh/python-runtime:2.2.4)
+# - system-agent: Python agent with system monitoring capabilities (mcpmesh/python-runtime:2.2.4)
+# - fastmcp-agent: FastMCP service with mesh integration (mcpmesh/python-runtime:2.2.4)
+# - dependent-agent: Service that depends on fastmcp-agent (mcpmesh/python-runtime:2.2.4)
+# - fastapi-app: FastAPI application with mesh integration (mcpmesh/python-runtime:2.2.4)
 #
 # Usage:
 #   docker-compose up

--- a/examples/java/basic-tool-agent/pom.xml
+++ b/examples/java/basic-tool-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/consumer-date-agent/pom.xml
+++ b/examples/java/consumer-date-agent/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/consumer-report-agent-sse/pom.xml
+++ b/examples/java/consumer-report-agent-sse/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/consumer-report-agent/pom.xml
+++ b/examples/java/consumer-report-agent/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/dependency-agent/pom.xml
+++ b/examples/java/dependency-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/direct-openai-agent/pom.xml
+++ b/examples/java/direct-openai-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 

--- a/examples/java/employee-service/pom.xml
+++ b/examples/java/employee-service/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/gemini-provider-agent/pom.xml
+++ b/examples/java/gemini-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 

--- a/examples/java/gpt-provider-agent/pom.xml
+++ b/examples/java/gpt-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 

--- a/examples/java/header-api/pom.xml
+++ b/examples/java/header-api/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/health-block-test-agent/pom.xml
+++ b/examples/java/health-block-test-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-accurate-provider/pom.xml
+++ b/examples/java/java-accurate-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-alpha-provider/pom.xml
+++ b/examples/java/java-alpha-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-beta-provider/pom.xml
+++ b/examples/java/java-beta-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-booking-consumer/pom.xml
+++ b/examples/java/java-booking-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-calculator/pom.xml
+++ b/examples/java/java-calculator/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-deprecated-provider/pom.xml
+++ b/examples/java/java-deprecated-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-dual-consumer/pom.xml
+++ b/examples/java/java-dual-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-fast-provider/pom.xml
+++ b/examples/java/java-fast-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-math-agent/pom.xml
+++ b/examples/java/java-math-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-schedule-agent/pom.xml
+++ b/examples/java/java-schedule-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-tag-consumer/pom.xml
+++ b/examples/java/java-tag-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-weather-agent/pom.xml
+++ b/examples/java/java-weather-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/llm-mesh-agent/pom.xml
+++ b/examples/java/llm-mesh-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/llm-provider-agent/pom.xml
+++ b/examples/java/llm-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 

--- a/examples/java/media-consumer-agent/pom.xml
+++ b/examples/java/media-consumer-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/media-producer-agent/pom.xml
+++ b/examples/java/media-producer-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/multijar-api-gateway/pom.xml
+++ b/examples/java/multijar-api-gateway/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/multijar-payment-service/pom.xml
+++ b/examples/java/multijar-payment-service/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/producer-date-agent/pom.xml
+++ b/examples/java/producer-date-agent/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/producer-report-agent/pom.xml
+++ b/examples/java/producer-report-agent/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/rest-api-consumer/pom.xml
+++ b/examples/java/rest-api-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/parallel-tools/consumer-gemini-java/pom.xml
+++ b/examples/parallel-tools/consumer-gemini-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-gemini-ts/package.json
+++ b/examples/parallel-tools/consumer-gemini-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/consumer-openai-java/pom.xml
+++ b/examples/parallel-tools/consumer-openai-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-openai-ts/package.json
+++ b/examples/parallel-tools/consumer-openai-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/parallel-consumer-java/pom.xml
+++ b/examples/parallel-tools/parallel-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/parallel-consumer-ts/package.json
+++ b/examples/parallel-tools/parallel-consumer-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/slow-tool-java/pom.xml
+++ b/examples/parallel-tools/slow-tool-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/slow-tool-ts/package.json
+++ b/examples/parallel-tools/slow-tool-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/schema-corpus/java/pom.xml
+++ b/examples/schema-corpus/java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/consumer/pom.xml
+++ b/examples/schema/java/consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/producer-bad/pom.xml
+++ b/examples/schema/java/producer-bad/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/producer-good/pom.xml
+++ b/examples/schema/java/producer-good/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/streaming/chatbot-demo/chatbot-agent/Dockerfile
+++ b/examples/streaming/chatbot-demo/chatbot-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chatbot-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/streaming/chatbot-demo/gateway/Dockerfile
+++ b/examples/streaming/chatbot-demo/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/streaming/chatbot-demo/weather-tool/Dockerfile
+++ b/examples/streaming/chatbot-demo/weather-tool/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/chatbot-agent/Dockerfile
+++ b/examples/streaming/fixtures/chatbot-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chatbot-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/gateway-agent/Dockerfile
+++ b/examples/streaming/fixtures/gateway-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway-agent MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/passthrough-agent/Dockerfile
+++ b/examples/streaming/fixtures/passthrough-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for passthrough-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-java/pom.xml
+++ b/examples/toolcalls/analyst-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/toolcalls/analyst-py/Dockerfile
+++ b/examples/toolcalls/analyst-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for analyst-py MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-ts/Dockerfile
+++ b/examples/toolcalls/analyst-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for analyst-ts MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-ts/package.json
+++ b/examples/toolcalls/analyst-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/claude-provider-java/pom.xml
+++ b/examples/toolcalls/claude-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/claude-provider-py/Dockerfile
+++ b/examples/toolcalls/claude-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/toolcalls/claude-provider-ts/Dockerfile
+++ b/examples/toolcalls/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/toolcalls/claude-provider-ts/package.json
+++ b/examples/toolcalls/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/gemini-provider-java/pom.xml
+++ b/examples/toolcalls/gemini-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/gemini-provider-py/Dockerfile
+++ b/examples/toolcalls/gemini-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/toolcalls/gemini-provider-ts/Dockerfile
+++ b/examples/toolcalls/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/toolcalls/gemini-provider-ts/package.json
+++ b/examples/toolcalls/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/openai-provider-java/pom.xml
+++ b/examples/toolcalls/openai-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/openai-provider-py/Dockerfile
+++ b/examples/toolcalls/openai-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/toolcalls/openai-provider-ts/Dockerfile
+++ b/examples/toolcalls/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/toolcalls/openai-provider-ts/package.json
+++ b/examples/toolcalls/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/weather-tool-java/pom.xml
+++ b/examples/toolcalls/weather-tool-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/toolcalls/weather-tool-py/Dockerfile
+++ b/examples/toolcalls/weather-tool-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool-py MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/toolcalls/weather-tool-ts/Dockerfile
+++ b/examples/toolcalls/weather-tool-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool-ts MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/toolcalls/weather-tool-ts/package.json
+++ b/examples/toolcalls/weather-tool-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/tutorial/trip-planner/day-01/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-01/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/docker-compose.yml
+++ b/examples/tutorial/trip-planner/day-08/python/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - trip-planner-network
 
   registry:
-    image: mcpmesh/registry:2.2.3
+    image: mcpmesh/registry:2.2.4
     container_name: trip-planner-registry
     hostname: registry
     ports:
@@ -81,7 +81,7 @@ services:
 
   # --8<-- [start:mesh_ui]
   mesh-ui:
-    image: mcpmesh/ui:2.2.3
+    image: mcpmesh/ui:2.2.4
     container_name: trip-planner-mesh-ui
     hostname: mesh-ui
     ports:
@@ -172,7 +172,7 @@ services:
   # --8<-- [start:gateway]
   # FastAPI Gateway: manually added (scaffold detects @mesh.agent, not @mesh.route)
   gateway:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: trip-planner-gateway
     hostname: gateway
     user: root
@@ -213,7 +213,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   adventure-advisor:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: trip-planner-adventure-advisor
     hostname: adventure-advisor
     user: root
@@ -256,7 +256,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   budget-analyst:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: trip-planner-budget-analyst
     hostname: budget-analyst
     user: root
@@ -299,7 +299,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   chat-history-agent:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: trip-planner-chat-history-agent
     hostname: chat-history-agent
     user: root
@@ -342,7 +342,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   claude-provider:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: trip-planner-claude-provider
     hostname: claude-provider
     user: root
@@ -386,7 +386,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   flight-agent:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: trip-planner-flight-agent
     hostname: flight-agent
     user: root
@@ -429,7 +429,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   hotel-agent:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: trip-planner-hotel-agent
     hostname: hotel-agent
     user: root
@@ -472,7 +472,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   logistics-planner:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: trip-planner-logistics-planner
     hostname: logistics-planner
     user: root
@@ -515,7 +515,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   openai-provider:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: trip-planner-openai-provider
     hostname: openai-provider
     user: root
@@ -559,7 +559,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   planner-agent:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: trip-planner-planner-agent
     hostname: planner-agent
     user: root
@@ -602,7 +602,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   poi-agent:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: trip-planner-poi-agent
     hostname: poi-agent
     user: root
@@ -645,7 +645,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   user-prefs-agent:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: trip-planner-user-prefs-agent
     hostname: user-prefs-agent
     user: root
@@ -688,7 +688,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   weather-agent:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: trip-planner-weather-agent
     hostname: weather-agent
     user: root

--- a/examples/tutorial/trip-planner/day-08/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh streaming API gateway
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh streaming LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/typescript/context-self-dep-ts-mesh/Dockerfile
+++ b/examples/typescript/context-self-dep-ts-mesh/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for context-self-dep-ts-mesh MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/examples/typescript/header-api/package.json
+++ b/examples/typescript/header-api/package.json
@@ -11,7 +11,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/examples/typescript/llm-consumer/package.json
+++ b/examples/typescript/llm-consumer/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/examples/typescript/llm-provider/package.json
+++ b/examples/typescript/llm-provider/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/helm/mcp-mesh-agent/Chart.yaml
+++ b/helm/mcp-mesh-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-agent
 description: MCP Mesh Agent - Python runtime for MCP agents with mesh capabilities
 type: application
-version: 2.2.3
-appVersion: "2.2.3"
+version: 2.2.4
+appVersion: "2.2.4"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-agent/README.md
+++ b/helm/mcp-mesh-agent/README.md
@@ -230,7 +230,7 @@ existingSecret: my-secret
 ### Python
 
 ```dockerfile
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 COPY . /app/
 CMD ["-m", "myagent"]
@@ -239,7 +239,7 @@ CMD ["-m", "myagent"]
 ### TypeScript
 
 ```dockerfile
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 COPY . /app/
 CMD ["src/index.ts"]
@@ -248,7 +248,7 @@ CMD ["src/index.ts"]
 ### Java
 
 ```dockerfile
-FROM mcpmesh/java-runtime:2.2.3
+FROM mcpmesh/java-runtime:2.2.4
 
 COPY target/myagent.jar /app/
 CMD ["/app/myagent.jar"]

--- a/helm/mcp-mesh-core/Chart.lock
+++ b/helm/mcp-mesh-core/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: mcp-mesh-postgres
   repository: file://../mcp-mesh-postgres
-  version: 2.2.3
+  version: 2.2.4
 - name: mcp-mesh-redis
   repository: file://../mcp-mesh-redis
-  version: 2.2.3
+  version: 2.2.4
 - name: mcp-mesh-registry
   repository: file://../mcp-mesh-registry
-  version: 2.2.3
+  version: 2.2.4
 - name: mcp-mesh-grafana
   repository: file://../mcp-mesh-grafana
-  version: 2.2.3
+  version: 2.2.4
 - name: mcp-mesh-tempo
   repository: file://../mcp-mesh-tempo
-  version: 2.2.3
+  version: 2.2.4
 - name: mcp-mesh-ui
   repository: file://../mcp-mesh-ui
-  version: 2.2.3
-digest: sha256:381eb9f5344270e695b52b67685132ff3b4a8cf36d9759f9de57eda67acb4e6a
-generated: "2026-05-21T07:21:22.146183-04:00"
+  version: 2.2.4
+digest: sha256:d00d4e5c61de6322d2ee1879c9f0627afa6448676846732cb5707815cd8a3227
+generated: "2026-05-21T07:51:27.902081-04:00"

--- a/helm/mcp-mesh-core/Chart.yaml
+++ b/helm/mcp-mesh-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-core
 description: MCP Mesh Core Infrastructure - Registry, PostgreSQL, Redis, and Observability
 type: application
-version: 2.2.3
-appVersion: "2.2.3"
+version: 2.2.4
+appVersion: "2.2.4"
 keywords:
   - mcp
   - mesh
@@ -28,26 +28,26 @@ annotations:
   "artifacthub.io/containsSecurityUpdates": "false"
 dependencies:
   - name: mcp-mesh-postgres
-    version: "2.2.3"
+    version: "2.2.4"
     repository: "file://../mcp-mesh-postgres"
     condition: postgres.enabled
   - name: mcp-mesh-redis
-    version: "2.2.3"
+    version: "2.2.4"
     repository: "file://../mcp-mesh-redis"
     condition: redis.enabled
   - name: mcp-mesh-registry
-    version: "2.2.3"
+    version: "2.2.4"
     repository: "file://../mcp-mesh-registry"
     condition: registry.enabled
   - name: mcp-mesh-grafana
-    version: "2.2.3"
+    version: "2.2.4"
     repository: "file://../mcp-mesh-grafana"
     condition: grafana.enabled
   - name: mcp-mesh-tempo
-    version: "2.2.3"
+    version: "2.2.4"
     repository: "file://../mcp-mesh-tempo"
     condition: tempo.enabled
   - name: mcp-mesh-ui
-    version: "2.2.3"
+    version: "2.2.4"
     repository: "file://../mcp-mesh-ui"
     condition: ui.enabled

--- a/helm/mcp-mesh-grafana/Chart.yaml
+++ b/helm/mcp-mesh-grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-grafana
 description: Grafana observability component for MCP Mesh
 type: application
-version: 2.2.3
+version: 2.2.4
 appVersion: "12.3.1"
 keywords:
   - grafana

--- a/helm/mcp-mesh-ingress/Chart.yaml
+++ b/helm/mcp-mesh-ingress/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ingress
 description: Ingress configuration for MCP Mesh services with flexible DNS routing
 type: application
-version: 2.2.3
-appVersion: "2.2.3"
+version: 2.2.4
+appVersion: "2.2.4"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-postgres/Chart.yaml
+++ b/helm/mcp-mesh-postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-postgres
 description: PostgreSQL database for MCP Mesh Registry
 type: application
-version: 2.2.3
+version: 2.2.4
 appVersion: "15"
 keywords:
   - mcp

--- a/helm/mcp-mesh-redis/Chart.yaml
+++ b/helm/mcp-mesh-redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-redis
 description: Redis cache for MCP Mesh session storage
 type: application
-version: 2.2.3
+version: 2.2.4
 appVersion: "7"
 keywords:
   - mcp

--- a/helm/mcp-mesh-registry/Chart.yaml
+++ b/helm/mcp-mesh-registry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-registry
 description: MCP Mesh Registry Service - Central service registry for MCP agents
 type: application
-version: 2.2.3
-appVersion: "2.2.3"
+version: 2.2.4
+appVersion: "2.2.4"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-tempo/Chart.yaml
+++ b/helm/mcp-mesh-tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-tempo
 description: Tempo distributed tracing component for MCP Mesh
 type: application
-version: 2.2.3
+version: 2.2.4
 appVersion: "2.9.0"
 keywords:
   - tempo

--- a/helm/mcp-mesh-ui/Chart.yaml
+++ b/helm/mcp-mesh-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ui
 description: MCP Mesh Dashboard UI Server - Web dashboard for monitoring MCP agents
 type: application
-version: 2.2.3
-appVersion: "2.2.3"
+version: 2.2.4
+appVersion: "2.2.4"
 keywords:
   - mcp
   - mesh

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/cli",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "CLI for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration",
   "license": "MIT",
   "repository": {
@@ -23,10 +23,10 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@mcpmesh/cli-linux-x64": "2.2.3",
-    "@mcpmesh/cli-linux-arm64": "2.2.3",
-    "@mcpmesh/cli-darwin-x64": "2.2.3",
-    "@mcpmesh/cli-darwin-arm64": "2.2.3"
+    "@mcpmesh/cli-linux-x64": "2.2.4",
+    "@mcpmesh/cli-linux-arm64": "2.2.4",
+    "@mcpmesh/cli-darwin-x64": "2.2.4",
+    "@mcpmesh/cli-darwin-arm64": "2.2.4"
   },
   "keywords": [
     "mcp",

--- a/packaging/homebrew/mcp-mesh.rb
+++ b/packaging/homebrew/mcp-mesh.rb
@@ -2,7 +2,7 @@
 class McpMesh < Formula
   desc "Kubernetes-native platform for distributed MCP applications"
   homepage "https://github.com/dhyansraj/mcp-mesh"
-  version "2.2.3"  # Will be updated by release automation
+  version "2.2.4"  # Will be updated by release automation
 
   if OS.mac?
     if Hardware::CPU.arm?

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "2.2.3"
+version = "2.2.4"
 description = "Python SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration"
 readme = "README.md"
 license = { text = "MIT" }
@@ -58,7 +58,7 @@ requires-python = ">=3.11"
 # LiteLLM.
 dependencies = [
     # Rust core runtime (required - no Python fallback)
-    "mcp-mesh-core>=2.2.3",
+    "mcp-mesh-core>=2.2.4",
     "fastapi>=0.104.0,<1.0.0",
     "uvicorn>=0.24.0,<1.0.0",
     "httpx>=0.25.0,<1.0.0",

--- a/packaging/scoop/mcp-mesh.json
+++ b/packaging/scoop/mcp-mesh.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Kubernetes-native platform for distributed MCP applications",
   "homepage": "https://github.com/dhyansraj/mcp-mesh",
   "license": "MIT",

--- a/src/core/cli/handlers/java_handler.go
+++ b/src/core/cli/handlers/java_handler.go
@@ -79,7 +79,7 @@ func (h *JavaHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns Java Dockerfile content
 func (h *JavaHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh Java agent
-FROM mcpmesh/java-runtime:2.2.3
+FROM mcpmesh/java-runtime:2.2.4
 
 WORKDIR /app
 
@@ -156,7 +156,7 @@ func (h *JavaHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the Java runtime Docker image
 func (h *JavaHandler) GetDockerImage() string {
-	return "mcpmesh/java-runtime:2.2.3"
+	return "mcpmesh/java-runtime:2.2.4"
 }
 
 // ValidatePrerequisites checks Java environment
@@ -304,7 +304,7 @@ const javaPomTemplate = `<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>2.2.3</version>
+            <version>2.2.4</version>
         </dependency>
     </dependencies>
 

--- a/src/core/cli/handlers/language_test.go
+++ b/src/core/cli/handlers/language_test.go
@@ -202,7 +202,7 @@ func TestDetectLanguage_PythonDirectoryRequirements(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Create requirements.txt
-	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("mcp-mesh==2.2.3"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("mcp-mesh==2.2.4"), 0644); err != nil {
 		t.Fatalf("Failed to create requirements.txt: %v", err)
 	}
 

--- a/src/core/cli/handlers/python_handler.go
+++ b/src/core/cli/handlers/python_handler.go
@@ -86,7 +86,7 @@ func (h *PythonHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns Python Dockerfile content
 func (h *PythonHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh Python agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 
@@ -170,7 +170,7 @@ func (h *PythonHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the Python runtime Docker image
 func (h *PythonHandler) GetDockerImage() string {
-	return "mcpmesh/python-runtime:2.2.3"
+	return "mcpmesh/python-runtime:2.2.4"
 }
 
 // ValidatePrerequisites checks Python environment
@@ -248,5 +248,5 @@ const pythonInitTemplate = `# {{.Name}} MCP Mesh Agent
 const pythonMainModuleTemplate = `from .main import *
 `
 
-const pythonRequirementsTemplate = `mcp-mesh>=2.2.3
+const pythonRequirementsTemplate = `mcp-mesh>=2.2.4
 `

--- a/src/core/cli/handlers/typescript_handler.go
+++ b/src/core/cli/handlers/typescript_handler.go
@@ -92,7 +92,7 @@ func (h *TypeScriptHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns TypeScript Dockerfile content
 func (h *TypeScriptHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh TypeScript agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 
@@ -167,7 +167,7 @@ func (h *TypeScriptHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the TypeScript runtime Docker image
 func (h *TypeScriptHandler) GetDockerImage() string {
-	return "mcpmesh/typescript-runtime:2.2.3"
+	return "mcpmesh/typescript-runtime:2.2.4"
 }
 
 // ValidatePrerequisites checks TypeScript environment
@@ -269,7 +269,7 @@ const typescriptPackageTemplate = `{
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "fastmcp": "^3.26.0",
     "zod": "^3.23.0"
   },

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -10,12 +10,12 @@ MCP Mesh supports multiple deployment patterns from local development to product
 
 | Image                              | Description                                        |
 | ---------------------------------- | -------------------------------------------------- |
-| `mcpmesh/registry:2.2.3`             | Registry service for agent discovery               |
-| `mcpmesh/python-runtime:2.2.3`       | Python runtime with mcp-mesh SDK pre-installed     |
-| `mcpmesh/typescript-runtime:2.2.3`   | TypeScript runtime with @mcpmesh/sdk pre-installed |
-| `mcpmesh/java-runtime:2.2.3`         | Java runtime with mcp-mesh Spring Boot starter     |
-| `mcpmesh/ui:2.2.3`                   | Dashboard UI server (basePath: /ops/dashboard)     |
-| `mcpmesh/cli:2.2.3`                  | meshctl CLI for management                         |
+| `mcpmesh/registry:2.2.4`             | Registry service for agent discovery               |
+| `mcpmesh/python-runtime:2.2.4`       | Python runtime with mcp-mesh SDK pre-installed     |
+| `mcpmesh/typescript-runtime:2.2.4`   | TypeScript runtime with @mcpmesh/sdk pre-installed |
+| `mcpmesh/java-runtime:2.2.4`         | Java runtime with mcp-mesh Spring Boot starter     |
+| `mcpmesh/ui:2.2.4`                   | Dashboard UI server (basePath: /ops/dashboard)     |
+| `mcpmesh/cli:2.2.4`                  | meshctl CLI for management                         |
 
 ## Local Development
 
@@ -104,7 +104,7 @@ meshctl scaffold basic --name my-agent
 The generated Dockerfile uses the official runtime:
 
 ```dockerfile
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
@@ -132,7 +132,7 @@ meshctl scaffold --compose --observability
 Generated docker-compose.yml includes:
 
 - PostgreSQL database for registry
-- Registry service (`mcpmesh/registry:2.2.3`)
+- Registry service (`mcpmesh/registry:2.2.4`)
 - All detected agents with proper networking
 - Health checks and dependency ordering
 - Optional: Redis, Tempo, Grafana (with `--observability`)
@@ -155,12 +155,12 @@ For production Kubernetes deployment, use the official Helm charts from the MCP 
 # Install core infrastructure (registry + database + observability)
 # No "helm repo add" needed - uses OCI registry directly
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh --create-namespace
 
 # Deploy agent using scaffold-generated helm-values.yaml
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -171,12 +171,12 @@ Deploy into any namespace — just match `-n` with `--set global.namespace`:
 
 ```bash
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n my-namespace --create-namespace \
   --set global.namespace=my-namespace
 
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n my-namespace \
   -f helm-values.yaml
 ```
@@ -195,19 +195,19 @@ its own namespace. Short service names resolve independently within each namespa
 ```bash
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n team-a --create-namespace --set global.namespace=team-a
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 -n team-a -f greeter/helm-values.yaml
+  --version 2.2.4 -n team-a -f greeter/helm-values.yaml
 
 # Team B — same helm-values.yaml, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n team-b --create-namespace --set global.namespace=team-b
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 -n team-b -f greeter/helm-values.yaml
+  --version 2.2.4 -n team-b -f greeter/helm-values.yaml
 ```
 
 ### Available Helm Charts
@@ -256,16 +256,16 @@ meshctl scaffold basic --name my-agent
 
 # 2. Build and push Docker image (works on all platforms)
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v2.2.3 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v2.2.4 --push .
 
 # 3. Update helm-values.yaml with your image repository
 # 4. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v2.2.3
+  --set image.tag=v2.2.4
 ```
 
 ### Disable Optional Components
@@ -273,14 +273,14 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 ```bash
 # Core without observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh --create-namespace \
   --set grafana.enabled=false \
   --set tempo.enabled=false
 
 # Core without PostgreSQL (in-memory registry)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh --create-namespace \
   --set postgres.enabled=false
 ```
@@ -429,7 +429,7 @@ Or use the `mcp-mesh-ingress` chart which handles routing automatically.
 
 ```bash
 # Docker
-docker run -e MCP_MESH_UI_BASE_PATH=/my/custom/path mcpmesh/ui:2.2.3
+docker run -e MCP_MESH_UI_BASE_PATH=/my/custom/path mcpmesh/ui:2.2.4
 
 # Helm
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -16,7 +16,7 @@ MCP Mesh supports multiple deployment patterns for Java/Spring Boot agents. The 
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4</version>
 </dependency>
 ```
 
@@ -152,7 +152,7 @@ services:
       retries: 5
 
   registry:
-    image: mcpmesh/registry:2.2.3
+    image: mcpmesh/registry:2.2.4
     ports:
       - "8000:8000"
     environment:
@@ -204,12 +204,12 @@ For production Kubernetes deployment:
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh --create-namespace
 
 # Deploy Java agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -242,15 +242,15 @@ resources:
 ```bash
 # 1. Build and push Docker image
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v2.2.3 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v2.2.4 --push .
 
 # 2. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v2.2.3
+  --set image.tag=v2.2.4
 ```
 
 ## Port Strategy

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -10,8 +10,8 @@ MCP Mesh supports multiple deployment patterns for TypeScript agents. Use `meshc
 
 | Image                            | Description                                        |
 | -------------------------------- | -------------------------------------------------- |
-| `mcpmesh/registry:2.2.3`           | Registry service for agent discovery               |
-| `mcpmesh/typescript-runtime:2.2.3` | TypeScript runtime with @mcpmesh/sdk pre-installed |
+| `mcpmesh/registry:2.2.4`           | Registry service for agent discovery               |
+| `mcpmesh/typescript-runtime:2.2.4` | TypeScript runtime with @mcpmesh/sdk pre-installed |
 
 ## Local Development
 
@@ -75,7 +75,7 @@ meshctl stop               # Stop all
 
 ```dockerfile
 # Dockerfile for my-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 
@@ -123,8 +123,8 @@ meshctl scaffold --compose --observability
 Generated `docker-compose.yml` includes:
 
 - PostgreSQL database for registry
-- Registry service (`mcpmesh/registry:2.2.3`)
-- TypeScript agents with `mcpmesh/typescript-runtime:2.2.3`
+- Registry service (`mcpmesh/registry:2.2.4`)
+- TypeScript agents with `mcpmesh/typescript-runtime:2.2.4`
 - Health checks and dependency ordering
 - Optional: Redis, Tempo, Grafana (with `--observability`)
 
@@ -145,12 +145,12 @@ For production Kubernetes deployment:
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh --create-namespace
 
 # Deploy TypeScript agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -192,15 +192,15 @@ meshctl scaffold basic --name my-agent --lang typescript
 
 # 2. Build and push Docker image
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v2.2.3 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v2.2.4 --push .
 
 # 3. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v2.2.3
+  --set image.tag=v2.2.4
 ```
 
 ## Port Strategy

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -65,12 +65,12 @@ docker compose up -d
 ```bash
 # Install core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh --create-namespace
 
 # Or disable observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh --create-namespace \
   --set tempo.enabled=false \
   --set grafana.enabled=false

--- a/src/core/cli/man/content/prerequisites.md
+++ b/src/core/cli/man/content/prerequisites.md
@@ -89,17 +89,17 @@ docker compose version
 
 | Image                              | Description                 |
 | ---------------------------------- | --------------------------- |
-| `mcpmesh/registry:2.2.3`           | Registry service            |
-| `mcpmesh/python-runtime:2.2.3`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:2.2.3`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:2.2.3` | TypeScript runtime with SDK |
+| `mcpmesh/registry:2.2.4`           | Registry service            |
+| `mcpmesh/python-runtime:2.2.4`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:2.2.4`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:2.2.4` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:2.2.3
-docker pull mcpmesh/python-runtime:2.2.3
-docker pull mcpmesh/java-runtime:2.2.3
-docker pull mcpmesh/typescript-runtime:2.2.3
+docker pull mcpmesh/registry:2.2.4
+docker pull mcpmesh/python-runtime:2.2.4
+docker pull mcpmesh/java-runtime:2.2.4
+docker pull mcpmesh/typescript-runtime:2.2.4
 ```
 
 ### Generate Docker Compose
@@ -137,12 +137,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/src/core/cli/man/content/prerequisites_java.md
+++ b/src/core/cli/man/content/prerequisites_java.md
@@ -52,7 +52,7 @@ Add the Spring Boot starter to your `pom.xml`:
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -100,10 +100,10 @@ docker compose version
 
 | Image                              | Description                 |
 | ---------------------------------- | --------------------------- |
-| `mcpmesh/registry:2.2.3`           | Registry service            |
-| `mcpmesh/python-runtime:2.2.3`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:2.2.3`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:2.2.3` | TypeScript runtime with SDK |
+| `mcpmesh/registry:2.2.4`           | Registry service            |
+| `mcpmesh/python-runtime:2.2.4`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:2.2.4`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:2.2.4` | TypeScript runtime with SDK |
 
 Java agents use standard Maven-based Docker builds (see Docker Deployment guide).
 

--- a/src/core/cli/man/content/prerequisites_typescript.md
+++ b/src/core/cli/man/content/prerequisites_typescript.md
@@ -77,17 +77,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:2.2.3`           | Registry service            |
-| `mcpmesh/python-runtime:2.2.3`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:2.2.3`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:2.2.3` | TypeScript runtime with SDK |
+| `mcpmesh/registry:2.2.4`           | Registry service            |
+| `mcpmesh/python-runtime:2.2.4`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:2.2.4`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:2.2.4` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:2.2.3
-docker pull mcpmesh/python-runtime:2.2.3
-docker pull mcpmesh/java-runtime:2.2.3
-docker pull mcpmesh/typescript-runtime:2.2.3
+docker pull mcpmesh/registry:2.2.4
+docker pull mcpmesh/python-runtime:2.2.4
+docker pull mcpmesh/java-runtime:2.2.4
+docker pull mcpmesh/typescript-runtime:2.2.4
 ```
 
 ### Generate Docker Compose

--- a/src/core/cli/man/content/quickstart_java.md
+++ b/src/core/cli/man/content/quickstart_java.md
@@ -75,13 +75,13 @@ Create `pom.xml`:
 
     <groupId>com.example</groupId>
     <artifactId>greeter-agent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4</version>
 
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>2.2.3</version>
+            <version>2.2.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/core/cli/man/content/registry.md
+++ b/src/core/cli/man/content/registry.md
@@ -173,7 +173,7 @@ The registry supports multiple replicas for high availability. All replicas shar
 ```bash
 # Scale registry replicas
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.2.3 \
+  --version 2.2.4 \
   -n mcp-mesh --create-namespace \
   --set registry.replicas=3
 ```

--- a/src/core/cli/man/content/security.md
+++ b/src/core/cli/man/content/security.md
@@ -208,7 +208,7 @@ Admin endpoints (`/admin/rotate`, `/admin/entities`) are served only on the admi
 ```yaml
 services:
   registry:
-    image: mcpmesh/registry:2.2.3
+    image: mcpmesh/registry:2.2.4
     command: ["--tls-auto"]
     ports: ["8000:8000"]
     volumes:

--- a/src/core/cli/man/content/testing_java.md
+++ b/src/core/cli/man/content/testing_java.md
@@ -124,7 +124,7 @@ class AssistantAgentTest {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:2.2.3
+    image: mcpmesh/registry:2.2.4
     ports:
       - "8000:8000"
     healthcheck:

--- a/src/core/cli/man/content/testing_typescript.md
+++ b/src/core/cli/man/content/testing_typescript.md
@@ -120,7 +120,7 @@ describe("Agent Integration", () => {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:2.2.3
+    image: mcpmesh/registry:2.2.4
     ports:
       - "8000:8000"
     healthcheck:

--- a/src/core/cli/man/content/tutorial.md
+++ b/src/core/cli/man/content/tutorial.md
@@ -1683,7 +1683,7 @@ $ kubectl -n trip-planner create secret generic llm-keys \
 
 ```shell
 $ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-    --version 2.2.3 \
+    --version 2.2.4 \
     -n trip-planner \
     -f helm/values-core.yaml \
     --wait --timeout 5m
@@ -1702,7 +1702,7 @@ $ for agent in "${AGENTS[@]}"; do
     echo "Installing $agent..."
     helm install "$agent" \
       oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 2.2.3 \
+      --version 2.2.4 \
       -n trip-planner \
       -f "helm/values-${agent}.yaml"
   done

--- a/src/core/cli/scaffold.go
+++ b/src/core/cli/scaffold.go
@@ -72,9 +72,9 @@ Documentation:
 
 Infrastructure:
   Docker Images:
-    mcpmesh/registry:2.2.3            - Registry service
-    mcpmesh/python-runtime:2.2.3      - Python agent runtime (has mcp-mesh SDK)
-    mcpmesh/typescript-runtime:2.2.3  - TypeScript agent runtime (has @mcpmesh/sdk)
+    mcpmesh/registry:2.2.4            - Registry service
+    mcpmesh/python-runtime:2.2.4      - Python agent runtime (has mcp-mesh SDK)
+    mcpmesh/typescript-runtime:2.2.4  - TypeScript agent runtime (has @mcpmesh/sdk)
 
   Helm Charts (for Kubernetes - OCI registry, no helm repo add needed):
     oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core   - Registry + PostgreSQL + observability

--- a/src/core/cli/scaffold/compose.go
+++ b/src/core/cli/scaffold/compose.go
@@ -1087,7 +1087,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
 #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
 {{ .Name }}:
-  image: mcpmesh/python-runtime:2.2.3
+  image: mcpmesh/python-runtime:2.2.4
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1132,7 +1132,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # NOTE: In dev mode, npm install runs on startup and source is mounted.
 #       In production (Dockerfile), dependencies are pre-installed in the image.
 {{ .Name }}:
-  image: mcpmesh/typescript-runtime:2.2.3
+  image: mcpmesh/typescript-runtime:2.2.4
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1175,7 +1175,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # Agent: {{ .Name }} (Java/Spring Boot)
 # NOTE: In dev mode, maven builds on startup. In production, use the Dockerfile.
 {{ .Name }}:
-  image: mcpmesh/java-runtime:2.2.3
+  image: mcpmesh/java-runtime:2.2.4
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1856,7 +1856,7 @@ services:
       - {{ .NetworkName }}
 
   registry:
-    image: mcpmesh/registry:2.2.3
+    image: mcpmesh/registry:2.2.4
     container_name: {{ .ProjectName }}-registry
     hostname: registry
     ports:
@@ -1965,7 +1965,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   {{ .Name }}:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root
@@ -2011,7 +2011,7 @@ services:
   # NOTE: In dev mode, npm install runs on startup and source is mounted.
   #       In production (Dockerfile), dependencies are pre-installed in the image.
   {{ .Name }}:
-    image: mcpmesh/typescript-runtime:2.2.3
+    image: mcpmesh/typescript-runtime:2.2.4
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root
@@ -2055,7 +2055,7 @@ services:
   # Java Agent: {{ .Name }}
   # NOTE: In dev mode, maven builds on startup. In production, use the Dockerfile.
   {{ .Name }}:
-    image: mcpmesh/java-runtime:2.2.3
+    image: mcpmesh/java-runtime:2.2.4
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root

--- a/src/core/cli/scaffold/compose_test.go
+++ b/src/core/cli/scaffold/compose_test.go
@@ -52,9 +52,9 @@ services:
     environment:
       POSTGRES_USER: customuser
   registry:
-    image: mcpmesh/registry:2.2.3
+    image: mcpmesh/registry:2.2.4
   agent1:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     container_name: test-agent1
     environment:
       CUSTOM_VAR: "user-added-value"
@@ -110,9 +110,9 @@ func TestGenerateDockerCompose_ForceRegenerate(t *testing.T) {
   postgres:
     image: postgres:15-alpine
   registry:
-    image: mcpmesh/registry:2.2.3
+    image: mcpmesh/registry:2.2.4
   agent1:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     environment:
       CUSTOM_VAR: "should-be-gone"
 networks:
@@ -157,9 +157,9 @@ func TestGenerateDockerCompose_NoNewAgents(t *testing.T) {
   postgres:
     image: postgres:15-alpine
   registry:
-    image: mcpmesh/registry:2.2.3
+    image: mcpmesh/registry:2.2.4
   agent1:
-    image: mcpmesh/python-runtime:2.2.3
+    image: mcpmesh/python-runtime:2.2.4
     environment:
       CUSTOM_VAR: "preserved"
 networks:

--- a/src/runtime/core/Cargo.lock
+++ b/src/runtime/core/Cargo.lock
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-mesh-core"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "async-trait",
  "base64",

--- a/src/runtime/core/Cargo.toml
+++ b/src/runtime/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-mesh-core"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2021"
 description = "Rust core runtime for MCP Mesh agents"
 license = "MIT"

--- a/src/runtime/core/pyproject.toml
+++ b/src/runtime/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mcp-mesh-core"
-version = "2.2.3"
+version = "2.2.4"
 description = "Rust core runtime for MCP Mesh agents"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/core/typescript/package.json
+++ b/src/runtime/core/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/core",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "MCP Mesh Rust core bindings for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/runtime/java/mcp-mesh-bom/pom.xml
+++ b/src/runtime/java/mcp-mesh-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-bom</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4</version>
     <packaging>pom</packaging>
 
     <name>MCP Mesh BOM</name>

--- a/src/runtime/java/mcp-mesh-core/pom.xml
+++ b/src/runtime/java/mcp-mesh-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </parent>
 
     <artifactId>mcp-mesh-core</artifactId>

--- a/src/runtime/java/mcp-mesh-native/pom.xml
+++ b/src/runtime/java/mcp-mesh-native/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </parent>
 
     <artifactId>mcp-mesh-native</artifactId>

--- a/src/runtime/java/mcp-mesh-sdk/pom.xml
+++ b/src/runtime/java/mcp-mesh-sdk/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </parent>
 
     <artifactId>mcp-mesh-sdk</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-ai/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-ai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </parent>
 
     <artifactId>mcp-mesh-spring-ai</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>2.2.3</version>
+        <version>2.2.4</version>
     </parent>
 
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>

--- a/src/runtime/java/pom.xml
+++ b/src/runtime/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4</version>
     <packaging>pom</packaging>
 
     <name>MCP Mesh Java SDK</name>

--- a/src/runtime/python/_mcp_mesh/__init__.py
+++ b/src/runtime/python/_mcp_mesh/__init__.py
@@ -31,7 +31,7 @@ from .engine.decorator_registry import (
     get_decorator_stats,
 )
 
-__version__ = "2.2.3"
+__version__ = "2.2.4"
 
 # Store reference to runtime processor if initialized
 _runtime_processor = None

--- a/src/runtime/python/mesh/__init__.py
+++ b/src/runtime/python/mesh/__init__.py
@@ -34,7 +34,7 @@ from .types import (
 # Note: helpers.llm_provider is imported lazily in __getattr__ to avoid
 # initialization timing issues with @mesh.agent auto_run in tests
 
-__version__ = "2.2.3"
+__version__ = "2.2.4"
 
 
 # Helper function to create FastMCP server with proper naming

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "2.2.3"
+version = "2.2.4"
 description = "Python SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/typescript/package.json
+++ b/src/runtime/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/sdk",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "TypeScript SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -102,12 +102,12 @@ Edit `config.yaml` to set versions:
 
 ```yaml
 packages:
-  cli_version: "2.2.3" # @mcpmesh/cli
-  sdk_python_version: "2.2.3" # mcp-mesh (pip) - PEP 440 format
-  sdk_typescript_version: "2.2.3" # @mcpmesh/sdk
+  cli_version: "2.2.4" # @mcpmesh/cli
+  sdk_python_version: "2.2.4" # mcp-mesh (pip) - PEP 440 format
+  sdk_typescript_version: "2.2.4" # @mcpmesh/sdk
 
 docker:
-  base_image: "tsuite-mesh:2.2.3"
+  base_image: "tsuite-mesh:2.2.4"
 ```
 
 ## Environment Variables

--- a/tests/integration/suites/README.md
+++ b/tests/integration/suites/README.md
@@ -108,7 +108,7 @@ const agent = mesh(server, {
 ```bash
 docker run --rm -it \
   -v $(pwd)/suites/uc01_registry/artifacts:/uc-artifacts:ro \
-  tsuite-mesh:2.2.3 bash
+  tsuite-mesh:2.2.4 bash
 ```
 
 ### Common issues:
@@ -123,9 +123,9 @@ Available in test.yaml via `${config.X}`:
 
 | Variable                                 | Example      |
 | ---------------------------------------- | ------------ |
-| `config.packages.cli_version`            | 2.2.3 |
-| `config.packages.sdk_python_version`     | 2.2.3 |
-| `config.packages.sdk_typescript_version` | 2.2.3 |
+| `config.packages.cli_version`            | 2.2.4 |
+| `config.packages.sdk_python_version`     | 2.2.4 |
+| `config.packages.sdk_typescript_version` | 2.2.4 |
 
 ## Issue Reporting Policy
 

--- a/tests/integration/suites/uc01_registry/artifacts/ts-multi-agent/package.json
+++ b/tests/integration/suites/uc01_registry/artifacts/ts-multi-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc01_registry/artifacts/ts-simple-agent/package.json
+++ b/tests/integration/suites/uc01_registry/artifacts/ts-simple-agent/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-calculator-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-optional-dep-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-report-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-accurate-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-accurate-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-deprecated-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-deprecated-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-fast-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-fast-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-tag-consumer/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-tag-consumer/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-calculator-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-calculator-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-calculator-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-alpha-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-alpha-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-beta-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-beta-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-dual-consumer/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-dual-consumer/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-caller/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-caller/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-provider/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-provider/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-caller/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-caller/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-provider/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/java-slow-agent/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/java-slow-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/ts-slow-agent/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/ts-slow-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "@ai-sdk/anthropic": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "@ai-sdk/google": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc01_claude_provider_py/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc01_claude_provider_py/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "@ai-sdk/anthropic": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc03_openai_provider/artifacts/openai-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc03_openai_provider/artifacts/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc05_gemini_provider_py/artifacts/gemini-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc05_gemini_provider_py/artifacts/gemini-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "@ai-sdk/google": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc07_llm_agent_py/artifacts/llm-agent/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc07_llm_agent_py/artifacts/llm-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for llm-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc23_structured_output_ts_consumer_py_provider/artifacts/structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc23_structured_output_ts_consumer_py_provider/artifacts/structured-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc28_structured_output_ts_consumer_java_provider/artifacts/structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc28_structured_output_ts_consumer_java_provider/artifacts/structured-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc32_structured_output_ts_consumer_py_openai_provider/artifacts/structured-consumer-openai-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc32_structured_output_ts_consumer_py_openai_provider/artifacts/structured-consumer-openai-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/artifacts/java-non-mesh-app/pom.xml
+++ b/tests/integration/suites/uc05_meshctl/artifacts/java-non-mesh-app/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/Dockerfile
+++ b/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-auto-port-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc05_meshctl/tc33_ts_api_port_isolation/artifacts/ts-api-app/package.json
+++ b/tests/integration/suites/uc05_meshctl/tc33_ts_api_port_isolation/artifacts/ts-api-app/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.2.3",
+    "@mcpmesh/sdk": "2.2.4",
     "express": "^4.21.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc06_observability/artifacts/express-api/package.json
+++ b/tests/integration/suites/uc06_observability/artifacts/express-api/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc06_observability/artifacts/py-calculator/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/py-calculator/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for py-calculator MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/py-math-agent/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/py-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for py-math-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.2.3
+FROM mcpmesh/typescript-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc08_llm_prompt_templates/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc08_llm_prompt_templates/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-echo-ts/package.json
+++ b/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-echo-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-relay-ts/package.json
+++ b/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-relay-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-echo-java/pom.xml
+++ b/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-echo-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-relay-java/pom.xml
+++ b/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-relay-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc12_registration_trust/artifacts/java-greeter/pom.xml
+++ b/tests/integration/suites/uc12_registration_trust/artifacts/java-greeter/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc14_multimedia/tc30_download_media_typescript/artifacts/ts-download-agent/package.json
+++ b/tests/integration/suites/uc14_multimedia/tc30_download_media_typescript/artifacts/ts-download-agent/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc14_multimedia/tc31_download_media_java/artifacts/java-download-agent/pom.xml
+++ b/tests/integration/suites/uc14_multimedia/tc31_download_media_java/artifacts/java-download-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc15_parallel_tool_calls/artifacts/gemini-provider-py/Dockerfile
+++ b/tests/integration/suites/uc15_parallel_tool_calls/artifacts/gemini-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc15_parallel_tool_calls/artifacts/openai-provider-py/Dockerfile
+++ b/tests/integration/suites/uc15_parallel_tool_calls/artifacts/openai-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.2.3
+FROM mcpmesh/python-runtime:2.2.4
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc16_schema_filtering/artifacts/java-schema-agent/pom.xml
+++ b/tests/integration/suites/uc16_schema_filtering/artifacts/java-schema-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc16_schema_filtering/artifacts/ts-schema-agent/package.json
+++ b/tests/integration/suites/uc16_schema_filtering/artifacts/ts-schema-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3"
+    "@mcpmesh/sdk": "^2.2.4"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc17_ui_server/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc17_ui_server/artifacts/ts-math-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc18_streaming/artifacts/streaming/java-stream-gateway/pom.xml
+++ b/tests/integration/suites/uc18_streaming/artifacts/streaming/java-stream-gateway/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java-sse/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java-sse/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.2.3</mcp-mesh.version>
+        <mcp-mesh.version>2.2.4</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-auth-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-auth-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-report-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-report-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.2.3",
+    "@mcpmesh/sdk": "^2.2.4",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/lib-tests/README.md
+++ b/tests/lib-tests/README.md
@@ -68,7 +68,7 @@ tsuite --uc uc04_build_image
 
 After successful run, you'll have:
 
-- `tsuite-mesh:2.2.3` (or current version) Docker image
+- `tsuite-mesh:2.2.4` (or current version) Docker image
 
 Verify with:
 
@@ -82,11 +82,11 @@ Edit `config.yaml` to update versions:
 
 ```yaml
 packages:
-  cli_version: "2.2.3"
-  sdk_python_version: "2.2.3" # PEP 440 format for Python
-  sdk_typescript_version: "2.2.3"
-  core_version: "2.2.3"
-  sdk_java_version: "2.2.3"
+  cli_version: "2.2.4"
+  sdk_python_version: "2.2.4" # PEP 440 format for Python
+  sdk_typescript_version: "2.2.4"
+  core_version: "2.2.4"
+  sdk_java_version: "2.2.4"
 ```
 
 ## Next Steps

--- a/tests/lib-tests/config.yaml
+++ b/tests/lib-tests/config.yaml
@@ -10,11 +10,11 @@ suite:
 
 packages:
   # Version to test - update this for each release
-  cli_version: "2.2.3"
-  sdk_python_version: "2.2.3" # PEP 440 format for pip
-  sdk_typescript_version: "2.2.3"
-  core_version: "2.2.3"
-  sdk_java_version: "2.2.3"
+  cli_version: "2.2.4"
+  sdk_python_version: "2.2.4" # PEP 440 format for pip
+  sdk_typescript_version: "2.2.4"
+  core_version: "2.2.4"
+  sdk_java_version: "2.2.4"
 
 # Docker settings for the base image build
 docker:


### PR DESCRIPTION
## Summary

v2.2.3 release [run 26223573459](https://github.com/dhyansraj/mcp-mesh/actions/runs/26223573459) hit a known npm 10.9.x bug when PR #1068's `npm install -g npm@11` step fired:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

npm 10.9.x has a documented transitive-dep resolution bug that prevents reliable bootstrap to npm 11.x via global install. PR #1068's workaround was the wrong shape.

`publish-java-sdk` succeeded at v2.2.3 (no npm involvement) — same orphan state as v2.2.2. Bumping to v2.2.4 to consolidate.

## What ships

- **`.github/workflows/release.yml`**: 3 npm publish jobs (`publish-node-core`, `publish-typescript-sdk`, `publish-npm`) bumped from `node-version: "22"` to `"24"`. Node 24 ships npm 11.x natively. The separate `Upgrade npm to 11.x for Trusted Publishing` steps from #1068 are removed (no longer needed). Build jobs stay on Node 22 — they don't publish.
- **Version bump** 2.2.3 → 2.2.4 (396 files via `bump_version.py`, helm dep update, cargo generate-lockfile).
- **`RELEASE_NOTES.md`**: v2.2.3 entry dropped entirely, v2.2.4 entry carries the cross-loop affinity fix narrative. User-facing changelog goes v2.2.0 → v2.2.4 directly (same consolidation pattern used for v2.2.1, v2.2.2, v2.2.3 collapses).

Closes #1069

## Why Node 24 (not deeper workaround on Node 22)

The npm 10.9.x install bug has several known workarounds (curl install script, two-step `npm@latest-10` then `@11`, corepack) — all are more code than just bumping the Node version on the publish jobs. The build jobs stay on Node 22 (no native-binding ABI surprise risk). The publish jobs don't build native code, just consume artifacts and publish — Node 24 is safe there.

Per [npm Trusted Publishing docs](https://docs.npmjs.com/trusted-publishers): "npm CLI version 11.5.1 or later and Node version 22.14.0 or higher." Node 24 satisfies both natively.

## Test plan

- [ ] **After merge**: `gh release create v2.2.4 --target main --latest` (one-shot, same pattern that worked for v2.2.3)
- [ ] All 4 registries publish v2.2.4 (7 npm packages, PyPI, Maven Central, crates.io)
- [ ] `npm view @mcpmesh/core version` returns `2.2.4`

## Post-success cleanup (all in one go this time)

- Delete dangling GitHub tags that never reached npm: `git push origin :refs/tags/v2.2.1 :refs/tags/v2.2.2 :refs/tags/v2.2.3`
- Optionally yank `v2.2.2` and `v2.2.3` from PyPI / Maven Central / crates.io (or leave as orphans)
- Revoke legacy `NPM_TOKEN` GitHub secret (no longer referenced anywhere in `release.yml`)
