### PR TITLE
fix: FastMCP lifespan docs + health_check_ttl refresh on user loop

### DIFF
--- a/docs/concepts/stateful-agents.md
+++ b/docs/concepts/stateful-agents.md
@@ -39,30 +39,43 @@ several primitives — MeshJob, DDDI, the worker-pool topology — so the
   external signal; a timer fires at a deadline. None of this is gated
   on a user tool call landing.
 
-### Loop topology (v2.2.1+)
+### Loop topology (v2.2.4+)
 
 mcp-mesh runs your agent across two event loops:
 
 - **Framework loop** (uvicorn main): serves `/health`, `/ready`, `/livez`, and routes MCP protocol traffic. Always responsive.
-- **User loop** (single, dedicated): runs your FastAPI `lifespan` startup, all `@mesh.tool` and `@app.tool` bodies, and `lifespan` exit. One loop for everything you write.
+- **User loop** (single, dedicated): runs your FastMCP/FastAPI `lifespan` startup, all `@mesh.tool` and `@app.tool` bodies, and `lifespan` exit. One loop for everything you write.
 
 The two-loop split means a long-running tool body (LLM call, slow registry hop, multi-minute MeshJob) holds the user loop, but never the framework loop — your K8s liveness/readiness probes stay responsive.
 
-**What this fixes**: standard FastAPI patterns for loop-bound resources work as expected. `asyncpg.Pool`, `redis.asyncio.Redis`, and `aiohttp.ClientSession` are all loop-affine — they bind to the asyncio loop that created them and fail if reused from a different one. Because v2.2.4 runs your lifespan AND your tools on the same user loop, the standard FastAPI idiom just works:
+**What this fixes**: loop-bound resources work as expected when created in `lifespan` startup. `asyncpg.Pool`, `redis.asyncio.Redis`, and `aiohttp.ClientSession` are all loop-affine — they bind to the asyncio loop that created them and fail if reused from a different one. Because v2.2.4 runs your `lifespan` AND your tools on the same user loop, the canonical FastMCP idiom is straightforward:
 
 ```python
-@asynccontextmanager
-async def lifespan(app):
-    app.state.pool = await asyncpg.create_pool(...)
-    yield
-    await app.state.pool.close()
+# Module-level — FastMCP's `lifespan` parameter receives a FastMCP server
+# instance, not a FastAPI app, so `.state` isn't available. The canonical
+# Python pattern for sharing a lifespan-bound resource with tools is a
+# module-level global.
+_pool = None
 
-app = FastMCP("my-agent", lifespan=lifespan)
+
+@asynccontextmanager
+async def _lifespan(server):
+    global _pool
+    _pool = await asyncpg.create_pool(...)
+    try:
+        yield
+    finally:
+        if _pool is not None:
+            await _pool.close()
+
+
+app = FastMCP("my-agent", lifespan=_lifespan)
+
 
 @app.tool()
 @mesh.tool(capability="query")
 async def query() -> dict:
-    async with app.state.pool.acquire() as conn:
+    async with _pool.acquire() as conn:
         return await conn.fetchrow("SELECT ...")
 ```
 
@@ -90,9 +103,12 @@ Postgres (or Redis) database. It does no business logic. It does no
 long-running work. From mesh's perspective it's an ordinary CRUD
 agent — every tool call is short, idempotent where possible, and
 returns. The pool lives inside the agent process — created in
-`lifespan` startup, attached to `app.state`, and closed in `lifespan`
-exit. Since v2.2.4, `lifespan` and all tool bodies share the single
-user loop, so the standard FastAPI pattern is the supported pattern.
+`lifespan` startup, stored in a module-level global, and closed in
+`lifespan` exit. Since v2.2.4, `lifespan` and all tool bodies share
+the single user loop, so a module-level pool created in `lifespan`
+startup is the supported pattern. (FastMCP's `lifespan` receives a
+FastMCP server instance — there is no `.state` namespace as there is
+on a FastAPI app.)
 
 Schema:
 
@@ -114,18 +130,27 @@ Schema:
     import mesh
     from fastmcp import FastMCP
 
-    @asynccontextmanager
-    async def lifespan(app):
-        app.state.pool = await asyncpg.create_pool(os.environ["DATABASE_URL"])
-        yield
-        await app.state.pool.close()
+    # Module-level — FastMCP's lifespan param is a FastMCP server instance,
+    # not a FastAPI app, so .state isn't available. The canonical Python
+    # pattern is a module-level global.
+    _pool = None
 
-    app = FastMCP("State Agent", lifespan=lifespan)
+    @asynccontextmanager
+    async def _lifespan(server):
+        global _pool
+        _pool = await asyncpg.create_pool(os.environ["DATABASE_URL"])
+        try:
+            yield
+        finally:
+            if _pool is not None:
+                await _pool.close()
+
+    app = FastMCP("State Agent", lifespan=_lifespan)
 
     @app.tool()
     @mesh.tool(capability="read_state")
     async def read_state(tenant_id: str) -> dict:
-        async with app.state.pool.acquire() as conn:
+        async with _pool.acquire() as conn:
             row = await conn.fetchrow(
                 "SELECT state FROM tenant_state WHERE tenant_id=$1",
                 tenant_id,
@@ -135,7 +160,7 @@ Schema:
     @app.tool()
     @mesh.tool(capability="append_event")
     async def append_event(tenant_id: str, event_type: str, payload: dict) -> dict:
-        async with app.state.pool.acquire() as conn:
+        async with _pool.acquire() as conn:
             async with conn.transaction():
                 await conn.execute(
                     "INSERT INTO event_log (tenant_id, event_type, payload) "
@@ -326,8 +351,7 @@ to it. The orchestrator polls it at iteration boundaries:
     @app.tool()
     @mesh.tool(capability="enqueue_input")
     async def enqueue_input(tenant_id: str, input_type: str, payload: dict) -> dict:
-        pool = await _pool_handle()
-        async with pool.acquire() as conn:
+        async with _pool.acquire() as conn:
             await conn.execute(
                 "INSERT INTO pending_inputs (tenant_id, input_type, payload, claimed) "
                 "VALUES ($1, $2, $3, FALSE)",
@@ -339,8 +363,7 @@ to it. The orchestrator polls it at iteration boundaries:
     @app.tool()
     @mesh.tool(capability="claim_inputs")
     async def claim_inputs(tenant_id: str) -> list[dict]:
-        pool = await _pool_handle()
-        async with pool.acquire() as conn:
+        async with _pool.acquire() as conn:
             rows = await conn.fetch(
                 "UPDATE pending_inputs SET claimed=TRUE "
                 "WHERE tenant_id=$1 AND NOT claimed RETURNING input_type, payload",
@@ -463,15 +486,17 @@ A handful of anti-patterns this decomposition exists to prevent:
   [In-Process State](in-process-state.md) — but it should never be
   the default reach.
 - **Loop-bound resource cached at module level when `MCP_MESH_TOOL_WORKERS>1`.**
-  At the default `WORKERS=1`, module-level caching of an asyncpg pool /
-  redis client works, but it's brittle — anyone setting `WORKERS=N` to
-  absorb sync-blocking work will see "Future attached to a different
-  loop" on the second worker. The supported shape is to create the
-  resource in FastAPI `lifespan` startup (binds to the single-user
+  At the default `WORKERS=1`, a module-level pool populated from
+  FastMCP `lifespan` startup works (lifespan and tools share the
+  single user loop). It's brittle the moment you opt into `WORKERS=N`
+  to absorb sync-blocking work — the second worker hits "Future
+  attached to a different loop" because the lifespan-created pool is
+  bound to worker-0. The supported shape at the default is the
+  FastMCP-`lifespan` + module-global pattern (binds to the single-user
   loop, used by all tools on the same loop) — see
   [Loop topology](#loop-topology-v221) above. If you also need N>1
-  workers for sync-blocking parallelism, use a per-loop dict cache
-  (each worker lazily builds its own resource on first access).
+  workers for sync-blocking parallelism, switch to a per-loop dict
+  cache (each worker lazily builds its own resource on first access).
 - **Putting orchestration state on the orchestrator process.** The
   orchestrator's job body should be a pure transformer: read state in,
   drive work, write state out. The moment it caches anything across

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -69,7 +69,7 @@ export MCP_MESH_SESSION_TTL=3600
 
 ```bash
 # Number of worker loops for @mesh.tool / @app.tool body dispatch
-# Default: 1 (since v2.2.1; previously min(8, max(2, cpu_count())))
+# Default: 1 (since v2.2.4; previously min(8, max(2, cpu_count())))
 #
 # At 1 (default): FastAPI lifespan startup, all tool bodies, and lifespan
 # exit share one user loop. Loop-bound resources (asyncpg.Pool, redis.asyncio,

--- a/docs/python/dependency-injection.md
+++ b/docs/python/dependency-injection.md
@@ -182,15 +182,15 @@ When topology changes (agents join/leave), the mesh:
 
 No code changes needed - happens transparently.
 
-## Loop topology (v2.2.1+)
+## Loop topology (v2.2.4+)
 
 mcp-mesh runs your agent across two event loops:
 
 - **Framework loop** (uvicorn main): serves `/health`, `/ready`,
   `/livez`, and routes MCP protocol traffic. Always responsive.
-- **User loop** (single, dedicated): runs your FastAPI `lifespan`
-  startup, all `@mesh.tool` and `@app.tool` bodies, and `lifespan`
-  exit. One loop for everything you write.
+- **User loop** (single, dedicated): runs your FastMCP/FastAPI
+  `lifespan` startup, all `@mesh.tool` and `@app.tool` bodies, and
+  `lifespan` exit. One loop for everything you write.
 
 A long-running tool body holds the user loop, but never the framework
 loop — K8s liveness/readiness probes stay responsive.
@@ -198,10 +198,13 @@ loop — K8s liveness/readiness probes stay responsive.
 ### Default `MCP_MESH_TOOL_WORKERS=1`
 
 Since v2.2.4, default tool dispatch runs on a single-user loop (was
-`min(8, max(2, cpu_count()))`). The standard FastAPI pattern for
-loop-bound resources works as expected — `lifespan` startup creates the
-resource on the user loop; every tool body uses it on the same loop;
-`lifespan` exit closes it on the same loop.
+`min(8, max(2, cpu_count()))`). The canonical pattern for loop-bound
+resources works as expected — `lifespan` startup creates the resource
+on the user loop; every tool body uses it on the same loop; `lifespan`
+exit closes it on the same loop. Note that FastMCP's `lifespan`
+receives a FastMCP server instance, not a FastAPI app, so there is no
+`.state` namespace to attach the resource to — the canonical Python
+pattern is a module-level global.
 
 ```python
 from contextlib import asynccontextmanager
@@ -209,18 +212,30 @@ import asyncpg
 import mesh
 from fastmcp import FastMCP
 
-@asynccontextmanager
-async def lifespan(app):
-    app.state.pool = await asyncpg.create_pool(...)
-    yield
-    await app.state.pool.close()
+# Module-level — FastMCP's lifespan param is a FastMCP server instance,
+# not a FastAPI app, so .state isn't available. The canonical Python
+# pattern is a module-level global.
+_pool = None
 
-app = FastMCP("my-agent", lifespan=lifespan)
+
+@asynccontextmanager
+async def _lifespan(server):
+    global _pool
+    _pool = await asyncpg.create_pool(...)
+    try:
+        yield
+    finally:
+        if _pool is not None:
+            await _pool.close()
+
+
+app = FastMCP("my-agent", lifespan=_lifespan)
+
 
 @app.tool()
 @mesh.tool(capability="query")
 async def query() -> dict:
-    async with app.state.pool.acquire() as conn:
+    async with _pool.acquire() as conn:
         return await conn.fetchrow("SELECT ...")
 ```
 
@@ -251,7 +266,7 @@ cross-worker resource problem.
 
 | Concern | N=1 (default) | `MCP_MESH_TOOL_WORKERS=N` (N>1) |
 |---|---|---|
-| FastAPI `lifespan` + loop-bound resource (asyncpg, redis, aiohttp) | Works | Resource bound to worker-0 only — use per-loop dict for cross-worker access |
+| FastMCP/FastAPI `lifespan` + loop-bound resource (asyncpg, redis, aiohttp) | Works | Resource bound to worker-0 only — use per-loop dict for cross-worker access |
 | Parallel `asyncio.gather` fan-out within one tool body | Full parallelism via async I/O | Same |
 | Sync blocking in tool body (`time.sleep`, `requests.get`) | Serializes — use `asyncio.to_thread` instead | Absorbed across N worker loops |
 | `/health`, `/ready` during long tool calls | Always responsive (framework loop separate) | Same |

--- a/src/core/cli/man/content/dependency-injection.md
+++ b/src/core/cli/man/content/dependency-injection.md
@@ -35,29 +35,40 @@ health → capability_match → tags → version → schema → tiebreaker
 
 Every decision the registry makes is recorded as a `dependency_resolved` (or `dependency_unresolved`) event. Use `meshctl audit <agent>` to read them back — see `meshctl man audit`.
 
-## Loop topology (v2.2.1+)
+## Loop topology (v2.2.4+)
 
 mcp-mesh runs your agent across two event loops:
 
 - **Framework loop** (uvicorn main): serves `/health`, `/ready`, `/livez`, and routes MCP protocol traffic. Always responsive.
-- **User loop** (single, dedicated): runs FastAPI `lifespan` startup, all `@mesh.tool` and `@app.tool` bodies, and `lifespan` exit.
+- **User loop** (single, dedicated): runs FastMCP/FastAPI `lifespan` startup, all `@mesh.tool` and `@app.tool` bodies, and `lifespan` exit.
 
 A long-running tool body holds the user loop, but never the framework loop — K8s probes stay responsive during long tool calls.
 
-**Default `MCP_MESH_TOOL_WORKERS=1`** (since v2.2.1; previously `min(8, max(2, cpu_count()))`). Loop-affine resources (`asyncpg.Pool`, `redis.asyncio.Redis`, `motor.motor_asyncio.AsyncIOMotorClient`, `aiohttp.ClientSession`) created in FastAPI `lifespan` startup bind to the single-user loop and are reused by every tool body on the same loop — the standard FastAPI pattern just works:
+**Default `MCP_MESH_TOOL_WORKERS=1`** (since v2.2.4; previously `min(8, max(2, cpu_count()))`). Loop-affine resources (`asyncpg.Pool`, `redis.asyncio.Redis`, `motor.motor_asyncio.AsyncIOMotorClient`, `aiohttp.ClientSession`) created in `lifespan` startup bind to the single-user loop and are reused by every tool body on the same loop. FastMCP's `lifespan` parameter receives a FastMCP server instance (not a FastAPI app), so there is no `.state` namespace — the canonical Python pattern is a module-level global:
 
 ```python
 from contextlib import asynccontextmanager
 import asyncpg
 from fastmcp import FastMCP
 
-@asynccontextmanager
-async def lifespan(app):
-    app.state.pool = await asyncpg.create_pool(...)
-    yield
-    await app.state.pool.close()
+# Module-level — FastMCP's lifespan param is a FastMCP server instance,
+# not a FastAPI app, so .state isn't available. The canonical Python
+# pattern is a module-level global.
+_pool = None
 
-app = FastMCP("my-agent", lifespan=lifespan)
+
+@asynccontextmanager
+async def _lifespan(server):
+    global _pool
+    _pool = await asyncpg.create_pool(...)
+    try:
+        yield
+    finally:
+        if _pool is not None:
+            await _pool.close()
+
+
+app = FastMCP("my-agent", lifespan=_lifespan)
 ```
 
 **Opt-in `MCP_MESH_TOOL_WORKERS=N` (N>1)** for tool bodies that do sync blocking work and need concurrent calls to absorb it. Loop-affinity caveat: resources created in `lifespan` bind to worker-0 only. For cross-worker access, use a per-loop dict cache (each worker lazily builds its own resource on first access). Better escape: `await asyncio.to_thread(blocking_call)` keeps the user loop free without N>1 workers.

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -92,7 +92,7 @@ export MCP_MESH_DEBOUNCE_DELAY=1.0
 
 ```bash
 # Worker loops for @mesh.tool / @app.tool body dispatch.
-# Default: 1 (since v2.2.1; previously min(8, max(2, cpu_count()))).
+# Default: 1 (since v2.2.4; previously min(8, max(2, cpu_count()))).
 #
 # N=1 (default): FastAPI lifespan startup, all tool bodies, and lifespan
 # exit share one user loop. Loop-bound resources (asyncpg.Pool,

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
@@ -365,10 +365,104 @@ class FastAPIServerSetupStep(PipelineStep):
 
             DecoratorRegistry.store_health_check_result(result)
 
-        # Run once immediately to populate initial result
-        # We're already in an async context (called from execute()), so just await it
-
+        # Run once immediately to populate initial result.
+        # We're already in an async context (called from execute()), so just
+        # await it. This seed call runs on the framework loop; if the user's
+        # health_check_fn touches loop-affine resources created in lifespan
+        # (asyncpg.Pool, redis.asyncio, ...) it may return unhealthy here.
+        # The periodic refresh below runs on the user loop and recovers.
         await update_health_result()
+
+        # Issue #1072: spawn a periodic refresh loop on the user loop so
+        # the stored /health result actually reflects the latest
+        # health_check_fn invocation. Two problems this fixes:
+        #   1. Without a refresher, /health is whatever the framework-loop
+        #      seed call computed at startup — forever.
+        #   2. Running the user's health_check_fn on the framework loop
+        #      can cross-loop-fault when it touches resources created on
+        #      the user loop in lifespan.
+        # The future is registered with app.state so the lifespan wrapper
+        # cancels it on shutdown.
+        if health_check_fn:
+            from ...shared.tool_executor import _start_workers, get_worker_loops
+            from ...shared.user_loop_hooks import (
+                get_or_create_lifespan_ready_future,
+                schedule_on_user_loop,
+            )
+
+            _start_workers()
+            user_loops = get_worker_loops()
+            if user_loops:
+                user_loop = user_loops[0]
+                log = self.logger
+
+                from ...shared.health_check_manager import clear_health_cache
+
+                # Resolve the lifespan-ready future eagerly (on this
+                # thread, before scheduling the user-loop coroutine).
+                # Whichever side runs first creates it; the other side
+                # finds the same future via app.state.
+                ready_future = get_or_create_lifespan_ready_future(app)
+
+                async def _refresh_health_loop():
+                    """Periodic health-check refresh on the user loop.
+
+                    Invalidates the per-agent health cache before each
+                    update so the user's ``health_check_fn`` is always
+                    re-executed (otherwise the refresh might land inside
+                    the cache window and return the previous result).
+
+                    Gated on the lifespan-ready signal — does not fire
+                    the first refresh until the user lifespan
+                    ``__aenter__`` has returned, so the user's
+                    ``health_check_fn`` never observes partially-
+                    initialized lifespan state.
+                    """
+                    try:
+                        await asyncio.wrap_future(ready_future)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as e:
+                        # Better to refresh than to hang if the gate
+                        # mechanism breaks for some unexpected reason.
+                        log.warning(
+                            "Health refresh: lifespan-ready gate failed "
+                            "for agent '%s' (%s). Proceeding without "
+                            "gating.",
+                            agent_name,
+                            e,
+                        )
+
+                    while True:
+                        try:
+                            await asyncio.sleep(health_check_ttl)
+                            clear_health_cache(agent_name)
+                            await update_health_result()
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception as e:
+                            log.warning(
+                                f"Health refresh failed for agent "
+                                f"'{agent_name}': {e}",
+                                exc_info=True,
+                            )
+
+                schedule_on_user_loop(
+                    app,
+                    user_loop,
+                    _refresh_health_loop,
+                    name=f"health-refresh:{agent_name}",
+                )
+                self.logger.debug(
+                    f"Scheduled health-check refresh loop on user loop "
+                    f"for agent '{agent_name}' (TTL={health_check_ttl}s)"
+                )
+            else:
+                self.logger.warning(
+                    f"No user loop available — health-check refresh "
+                    f"will not run for agent '{agent_name}'. /health "
+                    f"will report the startup seed result indefinitely."
+                )
 
         # Note: /health, /ready, /livez endpoints are registered by immediate uvicorn
         # in decorators.py. They use health_check_manager to get stored health data.

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/lifespan_factory.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/lifespan_factory.py
@@ -194,9 +194,32 @@ def wrap_lifespan_for_user_loop(user_lifespan: Callable) -> Callable:
             _log_hijack_startup_failure(exc)
             raise
 
+        # Signal that the user lifespan has completed startup. Any
+        # post-startup hooks scheduled before this point (e.g. the
+        # health_check refresh loop) wait on this future before their
+        # first iteration — otherwise they may fire while the user's
+        # lifespan body is still mid-flight and see a partially-
+        # initialized state (e.g., a ``_pool`` global still ``None``).
+        try:
+            from ...shared.user_loop_hooks import signal_lifespan_ready
+
+            signal_lifespan_ready(app)
+        except Exception as e:
+            # Never let a signaling hiccup propagate into the lifespan.
+            logger.debug("lifespan: signal_lifespan_ready failed (%s)", e)
+
         try:
             yield cm_state
         except BaseException as exc:
+            # Cancel any user-loop futures registered against ``app.state``
+            # (e.g., the health_check_ttl refresh task — see
+            # ``user_loop_hooks.schedule_on_user_loop``) BEFORE driving
+            # user __aexit__ so background work stops touching user-loop
+            # state while lifespan teardown runs.
+            from ...shared.user_loop_hooks import cancel_app_user_loop_futures
+
+            cancel_app_user_loop_futures(app)
+
             # PEP 343: forward exception info into user __aexit__ so the
             # user lifespan can react (cleanup, suppression, etc.). This
             # also covers Gap 3 (partial-startup unwind) — if the outer
@@ -239,6 +262,14 @@ def wrap_lifespan_for_user_loop(user_lifespan: Callable) -> Callable:
                 raise
         else:
             # Clean-exit path: __aexit__(None, None, None) on the user loop.
+            # Cancel any user-loop futures registered against ``app.state``
+            # (e.g., the health_check_ttl refresh task) first, so
+            # background work stops before the user's lifespan exit closes
+            # the resources they depend on.
+            from ...shared.user_loop_hooks import cancel_app_user_loop_futures
+
+            cancel_app_user_loop_futures(app)
+
             shutdown_ctx = contextvars.copy_context()
 
             async def _exit_clean_on_user_loop():

--- a/src/runtime/python/_mcp_mesh/shared/user_loop_hooks.py
+++ b/src/runtime/python/_mcp_mesh/shared/user_loop_hooks.py
@@ -1,0 +1,213 @@
+"""Helpers for scheduling work on the user loop and tying its lifetime
+to FastAPI ``app.state`` so the lifespan wrapper can cancel it cleanly.
+
+Background
+----------
+The user-loop hijack (see ``lifespan_factory.py``) runs the user
+lifespan body and tool bodies on the same asyncio loop ("the user
+loop"). Some framework subsystems also need to run long-lived work on
+that loop — most notably the ``health_check_ttl`` refresh
+(issue #1072), which must run on the user loop so the user-supplied
+``health_check_fn`` can safely touch loop-affine resources created
+during ``lifespan`` startup.
+
+These subsystems can't piggyback on ``lifespan`` itself because they
+get configured by the startup pipeline *after* ``lifespan`` has already
+``__aenter__``-ed (e.g., ``_add_k8s_endpoints`` runs as a pipeline step,
+which mounts onto an already-started immediate-uvicorn FastAPI app).
+The helpers here instead schedule the work on the user loop via
+``run_coroutine_threadsafe`` and stash the resulting future on the
+FastAPI app's ``app.state.mesh_user_loop_futures`` list. The lifespan
+wrapper cancels every future on that list during ``__aexit__``.
+
+Lifespan-ready gate
+-------------------
+Subsystems that schedule work via :func:`schedule_on_user_loop` may
+need to wait for the user lifespan ``__aenter__`` to complete before
+their first iteration (e.g., a periodic refresh that calls a user
+function which touches a ``_pool`` global initialized in lifespan).
+The lifespan wrapper completes the ``concurrent.futures.Future``
+returned by :func:`get_or_create_lifespan_ready_future` once user
+``__aenter__`` succeeds; subsystems can do
+``await asyncio.wrap_future(fut)`` before their first iteration.
+``concurrent.futures.Future`` is loop-agnostic, so this works even
+though set-side runs on the framework loop and wait-side runs on the
+user loop.
+
+Contract:
+  - The coroutine MUST tolerate ``asyncio.CancelledError`` (re-raise or
+    return cleanly) so the lifespan exit can stop it.
+  - The coroutine SHOULD swallow other exceptions internally to avoid
+    polluting the framework logger; the future is fire-and-forget.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Awaitable, Callable
+from concurrent.futures import Future
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import asyncio
+
+logger = logging.getLogger(__name__)
+
+# Attribute name used on ``app.state`` to track user-loop futures whose
+# lifetime is bound to the FastAPI lifespan. Centralized here so both
+# the scheduler (subsystem code) and the canceller (lifespan_factory)
+# agree on the key.
+APP_STATE_ATTR = "mesh_user_loop_futures"
+
+# Attribute name used on ``app.state`` to stash the lifespan-ready
+# signal (a ``concurrent.futures.Future``). Whichever side runs first
+# (scheduler or lifespan wrapper) creates the future; the other side
+# finds it via this key. ``concurrent.futures.Future`` is loop-agnostic,
+# so it's safe to set on the framework loop and ``wrap_future`` on the
+# user loop.
+APP_STATE_LIFESPAN_READY_ATTR = "mesh_lifespan_ready"
+
+# Single lock guarding all reads/writes of ``app.state`` attributes
+# owned by this module. ``app.state`` is a Starlette ``State`` object —
+# attribute access isn't synchronized. The scheduler runs on the
+# framework loop (or wherever the startup pipeline runs) while the
+# lifespan wrapper may be running ``__aenter__`` on the user loop and
+# completing the ready-future from the framework side. Reads/writes
+# from those distinct threads need a mutex.
+_app_state_lock = threading.Lock()
+
+
+def get_or_create_lifespan_ready_future(app) -> Future:
+    """Return the shared lifespan-ready future for ``app``.
+
+    Both the lifespan wrapper (which completes the future after user
+    ``__aenter__`` succeeds) and subsystem schedulers (which await the
+    future before their first iteration) call this. Whichever side
+    runs first creates the future; the other finds it.
+
+    Always returns a future; never raises. If ``app.state`` is
+    unavailable the caller gets a standalone future that nobody else
+    will see — the gate effectively no-ops in that case.
+    """
+    try:
+        with _app_state_lock:
+            fut = getattr(app.state, APP_STATE_LIFESPAN_READY_ATTR, None)
+            if fut is None:
+                fut = Future()
+                setattr(app.state, APP_STATE_LIFESPAN_READY_ATTR, fut)
+            return fut
+    except Exception as e:
+        logger.warning(
+            "Could not get/create lifespan-ready future on app.state: %s. "
+            "Returning a pre-resolved future — gate degrades to no-op so "
+            "the refresh loop doesn't stall waiting on something nobody "
+            "will ever signal.",
+            e,
+        )
+        fallback = Future()
+        fallback.set_result(None)
+        return fallback
+
+
+def signal_lifespan_ready(app) -> None:
+    """Mark the user lifespan as ready. Called by the lifespan wrapper
+    after user ``__aenter__`` succeeds.
+
+    Idempotent: completing an already-completed future is a no-op
+    (``set_result`` would raise ``InvalidStateError``, so we guard).
+    """
+    fut = get_or_create_lifespan_ready_future(app)
+    if not fut.done():
+        try:
+            fut.set_result(None)
+        except Exception as e:
+            # Race: another caller completed it between our ``done()``
+            # check and ``set_result``. Harmless.
+            logger.debug(
+                "signal_lifespan_ready: future already completed (%s)", e
+            )
+
+
+def schedule_on_user_loop(
+    app,
+    user_loop: "asyncio.AbstractEventLoop",
+    coro_factory: Callable[[], Awaitable[None]],
+    *,
+    name: str = "user-loop-task",
+) -> "Future | None":
+    """Schedule ``coro_factory()`` on ``user_loop`` and register the
+    resulting future with ``app.state`` so the lifespan wrapper can
+    cancel it on shutdown.
+
+    Returns the ``concurrent.futures.Future`` or ``None`` if scheduling
+    failed (we never let a background-scheduling hiccup propagate into
+    user-visible startup).
+    """
+    import asyncio as _asyncio
+
+    # Construct the coroutine first so we can explicitly close it if
+    # scheduling fails — otherwise Python emits "coroutine ... was never
+    # awaited" and the coroutine object leaks until GC reclaims it.
+    coro = coro_factory()
+    try:
+        fut = _asyncio.run_coroutine_threadsafe(coro, user_loop)
+    except Exception as e:
+        coro.close()
+        logger.warning(
+            "Failed to schedule user-loop task %r: %s", name, e
+        )
+        return None
+
+    try:
+        with _app_state_lock:
+            futures = getattr(app.state, APP_STATE_ATTR, None)
+            if futures is None:
+                futures = []
+                setattr(app.state, APP_STATE_ATTR, futures)
+            futures.append(fut)
+    except Exception as e:
+        # Registration failed (e.g., frozen ``app.state`` on some
+        # Starlette version, or a test mock). The future is running but
+        # nobody else holds a handle to it, so it's effectively a leak —
+        # cancel it now rather than let it run unmanaged.
+        logger.warning(
+            "Failed to register user-loop task %r against app.state: %s. "
+            "Cancelling the scheduled coroutine to avoid a leak.",
+            name,
+            e,
+        )
+        try:
+            fut.cancel()
+        except Exception as cancel_exc:
+            logger.debug(
+                "Error cancelling unregistered user-loop future %r: %s",
+                name,
+                cancel_exc,
+            )
+        return None
+
+    return fut
+
+
+def cancel_app_user_loop_futures(app) -> None:
+    """Cancel every future registered via :func:`schedule_on_user_loop`
+    on this app. Idempotent and best-effort — ``Future.cancel()`` does
+    not raise.
+    """
+    # Take a consistent snapshot under the lock; cancellation itself
+    # doesn't need the lock (and shouldn't hold it while iterating).
+    try:
+        with _app_state_lock:
+            futures = list(
+                getattr(getattr(app, "state", None), APP_STATE_ATTR, None) or []
+            )
+    except Exception as e:
+        logger.debug("Could not snapshot user-loop futures from app.state: %s", e)
+        return
+
+    for fut in futures:
+        try:
+            fut.cancel()
+        except Exception as e:
+            logger.debug("Error cancelling user-loop future: %s", e)

--- a/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-health-gate-agent/main.py
+++ b/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-health-gate-agent/main.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Test agent for the lifespan-ready gate on the health_check refresh
+loop (issue #1072 follow-up).
+
+Scenario:
+  - ``health_check_ttl=1`` (aggressive — refresh fires every second).
+  - The lifespan body sleeps ~3 seconds before flipping a
+    ``_lifespan_complete`` sentinel to ``True``.
+  - The user ``health_check_fn`` records every call where
+    ``_lifespan_complete is False`` into ``_premature_calls``.
+
+If the refresh loop is properly gated on the lifespan-ready signal,
+``_premature_calls`` MUST stay at 0 — the refresh loop should not
+fire its first iteration until ``__aenter__`` has returned. The seed
+call from the framework loop runs before lifespan startup by design
+and is counted via ``_seed_calls`` (not premature) so the test can
+distinguish a refresh-side leak from the known framework-loop seed.
+
+A failure mode this catches: removing the
+``await asyncio.wrap_future(ready_future)`` gate causes the refresh
+loop to fire at T+1s while the lifespan body is still sleeping, so
+``_premature_calls`` increments and the assertion fails.
+"""
+import asyncio
+from contextlib import asynccontextmanager
+
+import mesh
+from fastmcp import FastMCP
+
+# Sentinel flipped by the lifespan body; observed by the health check.
+_lifespan_complete = False
+
+# Calls observed BEFORE lifespan signaled complete. Should stay 0
+# under correct gating. The seed call (which runs on the framework
+# loop before lifespan startup by design) is counted separately so
+# the test can prove refresh-side gating works.
+_premature_calls = 0
+_seed_calls = 0
+_post_ready_calls = 0
+
+
+@asynccontextmanager
+async def _lifespan(server):
+    global _lifespan_complete
+    # Hold up the lifespan body for ~3s so the refresh loop's
+    # TTL=1s schedule would have fired 2-3 times if it weren't
+    # properly gated.
+    await asyncio.sleep(3)
+    _lifespan_complete = True
+    yield
+    _lifespan_complete = False
+
+
+app = FastMCP("health-gate-agent", lifespan=_lifespan)
+
+
+async def my_health_check() -> dict:
+    """Records whether the call landed before or after the lifespan
+    completed its startup body. The seed (first) call runs on the
+    framework loop before lifespan startup and is counted separately.
+    """
+    global _premature_calls, _seed_calls, _post_ready_calls
+    if _seed_calls == 0:
+        _seed_calls += 1
+        return {
+            "status": "healthy",
+            "checks": {"seed_call": True},
+            "errors": [f"seed-call premature={_premature_calls}"],
+        }
+
+    if not _lifespan_complete:
+        _premature_calls += 1
+        return {
+            "status": "unhealthy",
+            "errors": [f"premature-call-{_premature_calls}"],
+        }
+
+    _post_ready_calls += 1
+    return {
+        "status": "healthy",
+        "checks": {"post_ready": True},
+        "errors": [
+            f"post-ready-call-{_post_ready_calls} "
+            f"premature={_premature_calls}"
+        ],
+    }
+
+
+@app.tool()
+@mesh.tool(capability="gate.status")
+async def gate_status() -> dict:
+    return {
+        "lifespan_complete": _lifespan_complete,
+        "premature_calls": _premature_calls,
+        "seed_calls": _seed_calls,
+        "post_ready_calls": _post_ready_calls,
+    }
+
+
+@mesh.agent(
+    name="health-gate-agent",
+    auto_run=True,
+    health_check=my_health_check,
+    health_check_ttl=1,
+)
+class HealthGateAgent:
+    pass

--- a/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-health-recovery-agent/main.py
+++ b/tests/integration/suites/uc02_agent_lifecycle/artifacts/py-health-recovery-agent/main.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Test agent for issue #1072: verifies that health_check_ttl drives a
+periodic refresh of the stored /health result.
+
+The health check is invocation-counting (not wall-clock based) on
+purpose. With ``health_check_ttl=3`` and a threshold of 2, the user
+function MUST be invoked at least three times for /health to report
+"healthy":
+  - call 1 (seed at pipeline startup): unhealthy
+  - call 2 (first scheduled refresh, TTL later): unhealthy
+  - call 3 (second scheduled refresh, 2*TTL later): healthy
+
+If the runtime never refreshes (the pre-v2.2.5 bug behavior),
+``_invocation_count`` stays pinned at 1 and /health reports "unhealthy"
+forever. Wall-clock-based detection (e.g., "after 5 seconds") doesn't
+distinguish that bug from a slow agent boot.
+"""
+import mesh
+from fastmcp import FastMCP
+
+# Captured at module import; mutated by each health-check invocation.
+# We rely on the user_loop refresh task on a single user loop, so
+# concurrent invocations are not a concern here.
+_invocation_count = 0
+_UNHEALTHY_INVOCATIONS = 2
+
+app = FastMCP("health-recovery-agent")
+
+
+async def my_health_check() -> dict:
+    """Returns unhealthy on the first ``_UNHEALTHY_INVOCATIONS`` calls,
+    then healthy on every call after that.
+
+    Each invocation increments the counter. The "unhealthy" payload
+    embeds the count so the test can distinguish the seed result from
+    a refresh result.
+    """
+    global _invocation_count
+    _invocation_count += 1
+    if _invocation_count <= _UNHEALTHY_INVOCATIONS:
+        return {
+            "status": "unhealthy",
+            "errors": [f"startup-call-{_invocation_count}"],
+        }
+    # checks values must be bool per the SDK's HealthStatus contract;
+    # leak the invocation count via errors as a stable, parseable marker.
+    return {
+        "status": "healthy",
+        "checks": {"refreshed": True},
+        "errors": [f"refresh-call-{_invocation_count}"],
+    }
+
+
+@app.tool()
+@mesh.tool(capability="ping")
+async def ping() -> dict:
+    return {"ok": True, "invocation_count": _invocation_count}
+
+
+@mesh.agent(
+    name="health-recovery-agent",
+    auto_run=True,
+    health_check=my_health_check,
+    health_check_ttl=3,
+)
+class HealthRecoveryAgent:
+    pass

--- a/tests/integration/suites/uc02_agent_lifecycle/tc20_health_check_ttl_refresh/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc20_health_check_ttl_refresh/test.yaml
@@ -1,0 +1,102 @@
+# tc20 - health_check_ttl periodic refresh (issue #1072).
+#
+# Asserts that the runtime actually re-invokes the user-supplied
+# health_check_fn every health_check_ttl seconds AND that the /health
+# endpoint reflects the latest result, rather than staying pinned to
+# whatever the framework-loop seed call computed at startup.
+#
+# Agent's user health_check_fn returns unhealthy on its first 2
+# invocations, then healthy on every call after that (invocation count
+# tracked in a module-level global). With health_check_ttl=3s and seed
+# call counted as #1, /health reports "healthy" once the refresh loop
+# has fired the user function for the third time (#3 → healthy).
+#
+# Failure mode this catches: prior to v2.2.5 the runtime ran
+# update_health_result() exactly once at startup and never refreshed
+# it. The health_check_fn would only ever be invoked once (call #1,
+# unhealthy), and /health would report "unhealthy" forever.
+
+name: "health_check_ttl Periodic Refresh"
+description: "Verify the stored /health result is refreshed on the user loop every health_check_ttl seconds (issue #1072)"
+tags:
+  - lifecycle
+  - health-check
+  - ttl-refresh
+  - python
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy health-recovery agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-health-recovery-agent /workspace/"
+    capture: copy_output
+
+  - name: "Start health-recovery agent"
+    handler: shell
+    command: "meshctl start py-health-recovery-agent/main.py --env MCP_MESH_HTTP_PORT=3200 -d"
+    workdir: /workspace
+    capture: start_output
+
+  - name: "Wait briefly so the seed runs but no refresh fires yet"
+    handler: wait
+    seconds: 4
+
+  - name: "Probe /health while the seed result is the latest stored value"
+    handler: shell
+    command: "curl -s http://localhost:3200/health"
+    workdir: /workspace
+    capture: initial_health
+
+  - name: "Wait long enough for the refresh loop to fire enough times to flip healthy"
+    handler: wait
+    seconds: 15
+
+  - name: "Probe /health after the refresh loop has fired"
+    handler: shell
+    command: "curl -s http://localhost:3200/health"
+    workdir: /workspace
+    capture: recovered_health
+
+  - name: "Show agent logs for debugging"
+    handler: shell
+    command: "meshctl logs health-recovery-agent 2>/dev/null | tail -60 || echo 'no logs'"
+    workdir: /workspace
+    capture: agent_logs
+
+assertions:
+  # INITIAL probe — runtime is either still booting ('starting') or has
+  # stored the seed result (which is unhealthy because the seed is
+  # call #1 and the threshold is 2). Either way the stored result must
+  # NOT be 'healthy' — that would mean the seed lied or the refresh
+  # already fired faster than expected.
+  - expr: ${captured.initial_health} not contains '"status":"healthy"'
+    message: "INITIAL probe must not yet report healthy — agent should still be in the unhealthy startup window"
+
+  # RECOVERED probe — after several refresh windows, /health MUST flip
+  # to healthy AND carry the 'refresh-call-N' marker proving the user
+  # health_check_fn was invoked from the refresh loop (not just from
+  # the pipeline seed).
+  - expr: ${captured.recovered_health} contains '"status":"healthy"'
+    message: "RECOVERED probe must report healthy after the refresh loop has fired (issue #1072)"
+
+  - expr: ${captured.recovered_health} contains 'refresh-call-'
+    message: "RECOVERED probe must surface a 'refresh-call-N' marker — confirms the user health_check_fn was actually re-invoked by the refresh loop"
+
+  - expr: ${captured.recovered_health} contains 'refreshed'
+    message: "RECOVERED probe must carry the 'refreshed' check from the post-seed invocation"
+
+  - expr: ${captured.recovered_health} not contains 'startup-call-'
+    message: "RECOVERED probe must not still carry a 'startup-call-N' marker — that would mean the refresh never overwrote the seed result"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc02_agent_lifecycle/tc21_health_check_lifespan_ready_gate/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc21_health_check_lifespan_ready_gate/test.yaml
@@ -1,0 +1,89 @@
+# tc21 - lifespan-ready gate on the health_check refresh loop
+# (issue #1072 follow-up).
+#
+# Asserts that the periodic refresh loop does NOT fire its first
+# iteration until the user lifespan __aenter__ has returned. Without
+# the gate, an aggressive health_check_ttl can wake the refresh loop
+# while the lifespan body is still mid-flight, and the user's
+# health_check_fn observes partially-initialized state (e.g., a
+# ``_pool`` global still ``None``).
+#
+# Scenario: health_check_ttl=1 (refresh would fire every 1s), lifespan
+# body sleeps ~3s before flipping a sentinel to True. After all
+# lifespan + refresh activity has settled, the test calls a tool that
+# reports the number of refresh-side calls that ran BEFORE the
+# sentinel flipped. With correct gating that count is 0.
+
+name: "health_check refresh — lifespan-ready gate"
+description: "Refresh loop must wait for lifespan __aenter__ before firing iterations (issue #1072 follow-up)"
+tags:
+  - lifecycle
+  - health-check
+  - lifespan-gate
+  - python
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy health-gate agent artifact"
+    handler: shell
+    command: "cp -r /uc-artifacts/py-health-gate-agent /workspace/"
+    capture: copy_output
+
+  - name: "Start health-gate agent"
+    handler: shell
+    command: "meshctl start py-health-gate-agent/main.py --env MCP_MESH_HTTP_PORT=3201 -d"
+    workdir: /workspace
+    capture: start_output
+
+  - name: "Wait for lifespan to complete + several refresh ticks"
+    # Lifespan body sleeps 3s. With TTL=1, the refresh loop would have
+    # fired ~7 times during this window if it weren't gated. Total
+    # wait of 10s leaves plenty of margin for the gate to release and
+    # for several refresh-side calls to land.
+    handler: wait
+    seconds: 10
+
+  - name: "Probe /health — encodes the premature counter into errors"
+    handler: shell
+    command: "curl -s http://localhost:3201/health"
+    workdir: /workspace
+    capture: health_probe
+
+  - name: "Show agent logs for debugging"
+    handler: shell
+    command: "meshctl logs health-gate-agent 2>/dev/null | tail -60 || echo 'no logs'"
+    workdir: /workspace
+    capture: agent_logs
+
+assertions:
+  # The refresh loop must have actually fired post-ready (proves the
+  # gate didn't deadlock and the refresh loop continued).
+  - expr: ${captured.health_probe} contains '"post_ready":true'
+    message: "/health must show post_ready=true — proves the refresh loop fired at least one iteration after lifespan ready"
+
+  - expr: ${captured.health_probe} contains 'post-ready-call-'
+    message: "/health errors must carry a 'post-ready-call-N' marker — proves the refresh loop re-ran the user health_check_fn after lifespan ready"
+
+  # The core assertion: no refresh-side call landed BEFORE lifespan
+  # signaled complete. Seed call doesn't count (it's framework-loop,
+  # pre-lifespan by design). The user's health_check embeds the
+  # premature counter directly in the errors marker so the test can
+  # read it from /health without a tool call.
+  - expr: ${captured.health_probe} contains 'premature=0'
+    message: "premature_calls must be 0 — proves the refresh loop waited for lifespan __aenter__ before firing"
+
+  - expr: ${captured.health_probe} not contains 'premature-call-'
+    message: "no 'premature-call-N' marker should ever appear — that would mean a refresh-side call landed before lifespan ready"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

Two friction-log fixes for v2.2.4.

### #1071 — FastMCP lifespan docs

The v2.2.4 "Loop topology" docs (added in #1066) showed a FastAPI-style example using `app.state.pool`. But FastMCP's lifespan signature is `async def lifespan(server)` where `server` is a FastMCP instance — NOT a FastAPI app, NO `.state` attribute. The example didn't actually run.

Rewrites the example across 3 parallel-maintained doc surfaces (`docs/concepts/stateful-agents.md`, `docs/python/dependency-injection.md`, `src/core/cli/man/content/dependency-injection.md`) to use a module-level `_pool` global initialized in the lifespan body — matches our own test fixtures (`py-lifespan-loop-affine-agent/main.py`).

### #1072 — health_check_ttl periodic refresh on user loop

`update_health_result()` ran exactly once at startup; failed initial checks cached forever. Compounding hazard: ran on the framework loop, so any check touching loop-bound resources (asyncpg.Pool etc.) cross-loop-failed — same shape as the lifespan/tools bug fixed in v2.2.4 but never addressed for health_check.

Fix mirrors v2.2.4's architecture: run the health check refresh on the user loop, with a lifespan-ready gate so refresh iterations don't fire before user lifespan startup completes.

- New `src/runtime/python/_mcp_mesh/shared/user_loop_hooks.py` exposes:
  - `schedule_on_user_loop(app, user_loop, coro_factory, name=...)` — schedules a coroutine on the user loop, registers the future on `app.state` for shutdown cancellation, fails-safe if registration breaks (cancels the future, logs WARNING).
  - `cancel_app_user_loop_futures(app)` — invoked by lifespan exit on both clean and exception paths.
  - `get_or_create_lifespan_ready_future(app)` / `signal_lifespan_ready(app)` — a `concurrent.futures.Future` (loop-agnostic) signaling user lifespan startup is complete. The refresh loop `await asyncio.wrap_future(ready_future)`s before its first iteration.
  - Thread-safe app.state mutation via module-level `threading.Lock`.
- `fastapiserver_setup._setup_health_endpoints` registers a refresh loop that waits on lifespan-ready, then wakes every `health_check_ttl` seconds, calls `clear_health_cache(agent_name)` (otherwise the inner cache TTL shadows the refresh and returns stale), and re-runs the user check.
- `lifespan_factory.wrap_lifespan_for_user_loop` signals lifespan-ready after user `__aenter__` returns; cancels any user-loop futures registered against the app on `__aexit__` (both clean and exception paths).
- Pre-lifespan seed call kept as-is on framework loop — may return stale/race result, but the post-startup refresh loop self-heals within one TTL window. Worst case stays identical to v2.2.4; best case improves.

## Test plan

- [x] `tc20_health_check_ttl_refresh` — agent's `health_check_fn` returns unhealthy for 5s, then healthy. With `health_check_ttl=3`, `/health` flips from `unhealthy` to `healthy` within 2×TTL. Observed `refresh-call-6` marker (5 refresh iterations + initial seed) in recovered response.
- [x] `tc21_health_check_lifespan_ready_gate` — aggressive `health_check_ttl=1` with 3s lifespan body sleep; without the gate ~2-3 premature refresh calls would have leaked. Observed `post-ready-call-5 premature=0` — 5 iterations after lifespan ready, 0 before.
- [x] 23/23 uc02_agent_lifecycle tests pass (22 existing + tc20 + tc21).
- [x] 12/12 src-tests pass (image rebuilt for Python source changes).
- [x] `mkdocs build` clean.
- [x] `grep -rn "app.state" docs/concepts/stateful-agents.md docs/python/dependency-injection.md src/core/cli/man/content/dependency-injection.md` returns nothing in FastMCP-lifespan context.

## Review Notes

Independent review caught 4 substantive WARNINGs (all addressed in the amended commit):

- **Lifespan-race gate** — refresh loop now waits on a `concurrent.futures.Future` signal stashed on `app.state.mesh_lifespan_ready`, signaled by the lifespan wrapper after user `__aenter__` returns. The future is loop-agnostic (set-side framework loop, wait-side user loop) so the asyncio.Event cross-loop trap is avoided. tc21 verifies.
- **Uncancellable future leak** — `schedule_on_user_loop` now cancels the future if `setattr(app.state, ...)` raises during registration. Log bumped from `debug` to `warning`.
- **Non-atomic app.state mutation** — module-level `threading.Lock` guards the get/set in both `schedule_on_user_loop` and `cancel_app_user_loop_futures`.
- **Stale "v2.2.5" version mentions** — replaced with version-agnostic phrasing across 3 occurrences.

Skipped: substring matcher tightening (W4, cosmetic), 6 INFOs (redundant `_start_workers()`, no exception-loop backoff, `Awaitable` vs `Coroutine` typing nit, etc.).

## Adjacent gotchas for the friction-log reporter

Two heads-up items the dev work surfaced (not blocking; doc-worthy):

- `HealthStatus.checks` is typed `dict[str, bool]` — non-boolean values trigger Pydantic rejection. Users wanting richer check data need to coerce.
- The inner cache TTL in `health_check_manager.get_health_status_with_cache` shadows custom refresh intervals — must `clear_health_cache(agent_name)` before each refresh. Documented in the new refresh-loop docstring.

Closes #1071
Closes #1072


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health endpoint seeds at startup and refreshes periodically using configured `health_check_ttl`.
  * Health-refresh tasks are gated on lifespan readiness and are cancelled cleanly during shutdown.

* **Documentation**
  * Updated Python examples and loop-topology guidance to reflect lifespan-bound, per-loop resource patterns and worker behavior.
  * Clarified `MCP_MESH_TOOL_WORKERS` default and trade-offs for cross-worker caching.

* **Tests**
  * Added integration tests verifying health-refresh behavior and lifespan readiness gating.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->