### PR TITLE
feat(mesh.jobs): cancel/status/wait facades by job_id (Python)

### DIFF
--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -684,6 +684,61 @@ directly: `proxy.send_event(event_type, payload)` (Python) /
 `proxy.sendEvent(eventType, payload)` (TS/Java). Skip the helper +
 cache lookup when you already have a proxy in scope.
 
+### Lifecycle facades by `job_id`
+
+Symmetric to `post_event`: callers that hold a `job_id` but no
+`JobProxy` reference can drive the rest of the post-submit lifecycle
+through module-level facades that share the same registry-URL
+resolution + cached-proxy machinery. The Python surface lands in
+v2.2; TypeScript and Java parity follows in separate PRs.
+
+| Operation                | Facade (Python)                                    | Returns                       |
+| ------------------------ | -------------------------------------------------- | ----------------------------- |
+| Cancel a running job     | `await mesh.jobs.cancel(job_id, reason=None)`      | `None`                        |
+| Read latest job state    | `await mesh.jobs.status(job_id)`                   | `dict` (registry `Job` row)   |
+| Wait for terminal state  | `await mesh.jobs.wait(job_id, timeout_secs=None)`  | `result` payload on success   |
+
+<!-- markdownlint-disable MD046 -->
+=== "Python"
+
+    ```python
+    import mesh
+
+    @app.tool()
+    @mesh.tool(capability="abort_workflow")
+    async def abort_workflow(job_id: str, reason: str) -> dict:
+        await mesh.jobs.cancel(job_id, reason)
+        return {"cancelled": job_id}
+
+    @app.tool()
+    @mesh.tool(capability="check_progress")
+    async def check_progress(job_id: str) -> dict:
+        snapshot = await mesh.jobs.status(job_id)
+        return {
+            "status": snapshot["status"],
+            "progress": snapshot["progress"],
+            "message": snapshot["progress_message"],
+        }
+
+    @app.tool()
+    @mesh.tool(capability="run_to_completion")
+    async def run_to_completion(job_id: str) -> dict:
+        result = await mesh.jobs.wait(job_id, timeout_secs=300.0)
+        return {"result": result}
+    ```
+<!-- markdownlint-enable MD046 -->
+
+`cancel` is idempotent — calling it on an already-terminal job returns
+ok. `wait` raises `TimeoutError` on `timeout_secs` expiry; pass `None`
+(default) to wait until the job reaches a terminal state. `status`
+returns the same shape `JobProxy.status()` exposes (registry `Job`
+row, field-for-field).
+
+If the calling code already holds a `JobProxy`, the same surface is
+on the proxy directly: `proxy.cancel(reason)`, `proxy.status()`,
+`proxy.wait(timeout_secs)`. Skip the facade + cache lookup when you
+already have a proxy in scope.
+
 ### Typed errors
 
 Both `post_event` and `send_event` raise typed errors for the two

--- a/src/core/cli/man/content/jobs.md
+++ b/src/core/cli/man/content/jobs.md
@@ -257,6 +257,27 @@ the registry from `MCP_MESH_REGISTRY_URL` and reuses a process-cached
 calling code already holds a `JobProxy`, use `proxy.send_event(
 event_type, payload)` directly — same wire shape, skip the helper.
 
+**Lifecycle facades by `job_id`.** Same DDDI-clean pattern as
+`post_event` — module-level helpers that take a `job_id` and dispatch
+through the shared proxy cache, for callers that don't hold a
+`JobProxy` reference:
+
+```python
+# Cancel a running job (idempotent — already-terminal jobs return ok)
+await mesh.jobs.cancel(job_id, reason="user requested abort")
+
+# Read latest job state (dict — registry Job row, field-for-field)
+snapshot = await mesh.jobs.status(job_id)
+# snapshot["status"] ∈ {"working","input_required","completed","failed","cancelled"}
+
+# Wait for terminal state and return the result payload
+result = await mesh.jobs.wait(job_id, timeout_secs=300.0)
+```
+
+`wait` raises `TimeoutError` on `timeout_secs` expiry; pass `None`
+(default) to wait until the job reaches a terminal state. All three
+raise `JobNotFoundError` if the registry has reaped the job.
+
 **Typed errors** (both subclass `RuntimeError` for back-compat):
 
 - `mesh.JobNotFoundError` — job swept or id typo

--- a/src/runtime/python/mesh/jobs.py
+++ b/src/runtime/python/mesh/jobs.py
@@ -42,8 +42,11 @@ from typing import Any, AsyncIterator, Optional
 __all__ = [
     "JobNotFoundError",
     "JobTerminalError",
+    "cancel",
     "post_event",
+    "status",
     "subscribe_events",
+    "wait",
 ]
 
 
@@ -117,7 +120,7 @@ async def _get_or_create_proxy(registry_url: str, job_id: str) -> Any:
             from mcp_mesh_core import JobProxy
         except Exception as e:  # pragma: no cover - extension build issue
             raise RuntimeError(
-                f"mesh.jobs.post_event: mcp_mesh_core.JobProxy unavailable "
+                f"mesh.jobs: mcp_mesh_core.JobProxy unavailable "
                 f"({e}); cannot construct a transient proxy"
             ) from e
         proxy = JobProxy(job_id, registry_url)
@@ -216,7 +219,7 @@ def _resolve_registry_url() -> str:
     url = os.environ.get("MCP_MESH_REGISTRY_URL")
     if not url:
         raise RuntimeError(
-            "mesh.jobs.post_event: MCP_MESH_REGISTRY_URL is not set; "
+            "mesh.jobs: MCP_MESH_REGISTRY_URL is not set; "
             "cannot resolve registry base URL. Ensure the calling "
             "process is running inside a mesh agent."
         )
@@ -374,3 +377,187 @@ async def subscribe_events(
         # subsequent polls don't re-scan the same filtered range.
         if next_after > cursor:
             cursor = next_after
+
+
+# ---------------------------------------------------------------------------
+# cancel / status / wait — DDDI-clean lifecycle facades (issue #1074)
+# ---------------------------------------------------------------------------
+#
+# Mirror the ``post_event`` / ``subscribe_events`` pattern: take a
+# ``job_id`` as the first positional arg, resolve the registry URL
+# internally via ``_resolve_registry_url()``, dispatch through a cached
+# ``JobProxy`` from ``_get_or_create_proxy()``, and re-classify the
+# pyo3 layer's ``RuntimeError`` output via ``_translate_job_error``.
+#
+# These exist so callers that hold only a ``job_id`` (e.g. an HTTP route
+# handler, a tool body whose request payload carries a stashed id) can
+# operate on the job's lifecycle without constructing a ``JobProxy``
+# directly — which would leak ``MCP_MESH_REGISTRY_URL`` addressing into
+# user code and break the DDDI contract.
+
+
+async def cancel(job_id: str, reason: Optional[str] = None) -> None:
+    """Cancel a running job by ID.
+
+    Convenience helper for callers that hold a ``job_id`` but do not have
+    a :class:`mcp_mesh_core.JobProxy` reference in scope. Constructs a
+    transient proxy bound to the current agent's registry URL and
+    forwards the call.
+
+    Calling ``cancel`` on a job that is already in a terminal state is
+    a no-op per the registry's idempotency contract — the call returns
+    successfully without re-firing cancellation. If the registry's
+    contract changes or returns a 409 conflict for some other reason,
+    the facade surfaces it as :class:`JobTerminalError`. The registry
+    forwards the cancel signal to the owner replica via
+    ``POST /jobs/{id}/cancel``; the running handler's cancel token
+    fires on the next ``await`` point, and any outbound ``McpMeshTool``
+    proxy calls abort their underlying HTTP requests.
+
+    Args:
+        job_id: Target job's server-assigned id.
+        reason: Optional human-readable reason recorded against the
+            cancellation. Surfaces in the synthetic
+            ``{"type": "cancelled"}`` event the registry writes into
+            the job's event log, so a handler parked on
+            ``recv_event(types=["cancelled"])`` can return cleanly with
+            the reason in scope.
+
+    Raises:
+        JobNotFoundError: If the registry doesn't know the job
+            (sweep already removed it, or wrong id).
+        JobTerminalError: If the registry surfaces a 409 conflict for
+            this cancel (e.g. the idempotency contract changes upstream
+            or the registry treats the targeted terminal state as a
+            conflict).
+        RuntimeError: For transport errors (registry unreachable,
+            5xx after retries, malformed payload, etc.) — the
+            underlying error message is preserved.
+
+    Example:
+        Cancel a job from a tool that receives the id in its payload::
+
+            @mesh.tool(capability="abort_workflow")
+            async def abort_workflow(job_id: str, reason: str) -> dict:
+                await mesh.jobs.cancel(job_id, reason)
+                return {"cancelled": job_id}
+    """
+    registry_url = _resolve_registry_url()
+    proxy = await _get_or_create_proxy(registry_url, job_id)
+    try:
+        await proxy.cancel(reason)
+    except RuntimeError as exc:
+        translated = _translate_job_error(exc)
+        if translated is exc:
+            raise
+        raise translated from exc
+
+
+async def status(job_id: str) -> dict:
+    """Get the current status of a job by ID.
+
+    Convenience helper for callers that hold a ``job_id`` but do not
+    have a :class:`mcp_mesh_core.JobProxy` reference in scope.
+    Constructs a transient proxy bound to the current agent's registry
+    URL and forwards a single ``GET /jobs/{id}`` to the registry.
+
+    Args:
+        job_id: Target job's server-assigned id.
+
+    Returns:
+        Job status dict — the same shape :meth:`JobProxy.status` returns,
+        mirroring the registry's ``Job`` schema field-for-field. Keys
+        include ``id``, ``capability``, ``status`` (one of
+        ``"working" | "input_required" | "completed" | "failed" | "cancelled"``),
+        ``progress``, ``progress_message``, ``result``, ``error``,
+        ``attempt_count``, ``max_retries``, ``max_duration``,
+        ``total_deadline``, ``submitted_at``, ``submitted_by``,
+        ``submitted_payload`` (the request payload the job was created
+        with), plus the lease-tracking fields ``owner_instance_id`` /
+        ``lease_expires_at`` / ``last_heartbeat_at``.
+
+    Raises:
+        JobNotFoundError: If the registry doesn't know the job
+            (sweep already removed it, or wrong id).
+        RuntimeError: For transport errors (registry unreachable,
+            5xx after retries, malformed payload, etc.) — the
+            underlying error message is preserved.
+
+    Example:
+        Poll a job's progress from outside the producer agent::
+
+            @mesh.tool(capability="check_progress")
+            async def check_progress(job_id: str) -> dict:
+                snapshot = await mesh.jobs.status(job_id)
+                return {
+                    "status": snapshot["status"],
+                    "progress": snapshot["progress"],
+                    "message": snapshot["progress_message"],
+                }
+    """
+    registry_url = _resolve_registry_url()
+    proxy = await _get_or_create_proxy(registry_url, job_id)
+    try:
+        return await proxy.status()
+    except RuntimeError as exc:
+        translated = _translate_job_error(exc)
+        if translated is exc:
+            raise
+        raise translated from exc
+
+
+async def wait(job_id: str, timeout_secs: Optional[float] = None) -> Any:
+    """Wait for a job to complete and return its result.
+
+    Convenience helper for callers that hold a ``job_id`` but do not
+    have a :class:`mcp_mesh_core.JobProxy` reference in scope.
+    Constructs a transient proxy bound to the current agent's registry
+    URL and polls until the job reaches a terminal state.
+
+    On success, returns the ``result`` payload the handler passed to
+    :meth:`JobController.complete` — any JSON-shaped Python value (dict /
+    list / primitive). On a non-success terminal (failed / cancelled)
+    the underlying pyo3 layer raises a ``RuntimeError`` carrying the
+    Rust ``JobError`` display string; on ``timeout_secs`` expiry the
+    layer raises :class:`TimeoutError`.
+
+    Args:
+        job_id: Target job's server-assigned id.
+        timeout_secs: Maximum wait duration in seconds. ``None`` ≡ no
+            timeout (default) — wait until the job reaches a terminal
+            state. Negative / NaN / infinite values are rejected by
+            the pyo3 layer with :class:`ValueError`.
+
+    Returns:
+        The job's result payload (whatever the handler passed to
+        ``complete()``). Shape is application-defined — typically a
+        dict, but any JSON-shaped value is valid.
+
+    Raises:
+        TimeoutError: If ``timeout_secs`` elapses before the job reaches
+            a terminal state.
+        ValueError: If ``timeout_secs`` is negative, NaN, or infinite
+            — rejected by the pyo3 layer before any registry call.
+        JobNotFoundError: If the registry doesn't know the job
+            (sweep already removed it, or wrong id).
+        RuntimeError: If the job reached a non-success terminal state
+            (``failed`` / ``cancelled``) or for transport errors —
+            the underlying error message is preserved.
+
+    Example:
+        Submit-then-wait from a tool that doesn't hold the proxy::
+
+            @mesh.tool(capability="run_to_completion")
+            async def run_to_completion(job_id: str) -> dict:
+                result = await mesh.jobs.wait(job_id, timeout_secs=300.0)
+                return {"result": result}
+    """
+    registry_url = _resolve_registry_url()
+    proxy = await _get_or_create_proxy(registry_url, job_id)
+    try:
+        return await proxy.wait(timeout_secs)
+    except RuntimeError as exc:
+        translated = _translate_job_error(exc)
+        if translated is exc:
+            raise
+        raise translated from exc

--- a/src/runtime/python/tests/unit/test_meshjob_events.py
+++ b/src/runtime/python/tests/unit/test_meshjob_events.py
@@ -330,17 +330,28 @@ class TestPublicExports:
         assert sub.__name__ == "mesh.jobs"
         assert callable(sub.post_event)
         assert callable(sub.subscribe_events)
+        # DDDI-clean lifecycle facades (issue #1074) — same access path
+        # as post_event / subscribe_events.
+        assert callable(sub.cancel)
+        assert callable(sub.status)
+        assert callable(sub.wait)
 
     def test_direct_jobs_import(self):
         from mesh.jobs import (
             JobNotFoundError,
             JobTerminalError,
+            cancel,
             post_event,
+            status,
             subscribe_events,
+            wait,
         )
 
         assert callable(post_event)
         assert callable(subscribe_events)
+        assert callable(cancel)
+        assert callable(status)
+        assert callable(wait)
         assert issubclass(JobNotFoundError, RuntimeError)
         assert issubclass(JobTerminalError, RuntimeError)
 
@@ -668,6 +679,338 @@ class TestSubscribeEvents:
                 ):
                     pass  # pragma: no cover - iterator raises on first event
         assert "seq" in str(exc.value)
+
+
+# ===========================================================================
+# mesh.jobs.cancel / status / wait — DDDI-clean lifecycle facades (#1074)
+# ===========================================================================
+
+
+class TestCancelFacade:
+    """``mesh.jobs.cancel`` constructs a transient
+    :class:`mcp_mesh_core.JobProxy` against the running agent's
+    registry URL and forwards a ``cancel(reason)`` call. Mirrors the
+    ``post_event`` dispatch + error-translation pattern."""
+
+    @pytest.mark.asyncio
+    async def test_constructs_proxy_with_registry_url_and_forwards(
+        self, monkeypatch
+    ):
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        captured_construct: dict = {}
+        captured_cancel: dict = {}
+
+        class _FakeJobProxy:
+            def __init__(self, job_id: str, registry_url: str) -> None:
+                captured_construct["job_id"] = job_id
+                captured_construct["registry_url"] = registry_url
+
+            async def cancel(self, reason: Any) -> None:
+                captured_cancel["reason"] = reason
+
+        with mock.patch("mcp_mesh_core.JobProxy", _FakeJobProxy, create=True):
+            result = await mesh_jobs.cancel("job-xyz", "user requested abort")
+
+        assert result is None
+        assert captured_construct == {
+            "job_id": "job-xyz",
+            "registry_url": "http://localhost:9999",
+        }
+        assert captured_cancel == {"reason": "user requested abort"}
+
+    @pytest.mark.asyncio
+    async def test_default_reason_is_none(self, monkeypatch):
+        """``reason`` is optional — omitting it forwards ``None`` to the
+        underlying proxy (the registry treats absent reason as ok)."""
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+        captured: dict = {}
+
+        class _Fake:
+            def __init__(self, _jid, _url):
+                pass
+
+            async def cancel(self, reason):
+                captured["reason"] = reason
+
+        with mock.patch("mcp_mesh_core.JobProxy", _Fake, create=True):
+            await mesh_jobs.cancel("job-xyz")
+
+        assert captured == {"reason": None}
+
+    @pytest.mark.asyncio
+    async def test_translates_job_not_found_runtime_error(self, monkeypatch):
+        """A ``RuntimeError`` shaped like the Rust JobNotFound variant
+        bubbles up as :class:`JobNotFoundError` so callers can
+        ``except`` on the typed class without inspecting strings."""
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        class _Fake:
+            def __init__(self, _jid, _url):
+                pass
+
+            async def cancel(self, _reason):
+                raise RuntimeError("backend error: job not found: gone")
+
+        with mock.patch("mcp_mesh_core.JobProxy", _Fake, create=True):
+            with pytest.raises(mesh_jobs.JobNotFoundError):
+                await mesh_jobs.cancel("gone", "no reason")
+
+    @pytest.mark.asyncio
+    async def test_raises_when_registry_url_missing(self, monkeypatch):
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.delenv("MCP_MESH_REGISTRY_URL", raising=False)
+        with pytest.raises(RuntimeError) as exc:
+            await mesh_jobs.cancel("x")
+        assert "MCP_MESH_REGISTRY_URL" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_translates_job_terminal_runtime_error(self, monkeypatch):
+        """A ``RuntimeError`` shaped like the Rust JobTerminal variant
+        bubbles up as :class:`JobTerminalError` so callers can
+        ``except`` on the typed class without inspecting strings."""
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        class _Fake:
+            def __init__(self, _jid, _url):
+                pass
+
+            async def cancel(self, _reason):
+                raise RuntimeError("job is terminal: completed")
+
+        with mock.patch("mcp_mesh_core.JobProxy", _Fake, create=True):
+            with pytest.raises(mesh_jobs.JobTerminalError):
+                await mesh_jobs.cancel("done", "no reason")
+
+
+class TestStatusFacade:
+    """``mesh.jobs.status`` constructs a transient
+    :class:`mcp_mesh_core.JobProxy` against the running agent's
+    registry URL and forwards a ``status()`` call."""
+
+    @pytest.mark.asyncio
+    async def test_constructs_proxy_with_registry_url_and_returns_dict(
+        self, monkeypatch
+    ):
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        captured_construct: dict = {}
+
+        class _FakeJobProxy:
+            def __init__(self, job_id: str, registry_url: str) -> None:
+                captured_construct["job_id"] = job_id
+                captured_construct["registry_url"] = registry_url
+
+            async def status(self) -> dict:
+                return {
+                    "id": "job-xyz",
+                    "capability": "run_workflow",
+                    "status": "working",
+                    "progress": 0.42,
+                    "progress_message": "halfway there",
+                    "result": None,
+                    "error": None,
+                }
+
+        with mock.patch("mcp_mesh_core.JobProxy", _FakeJobProxy, create=True):
+            snapshot = await mesh_jobs.status("job-xyz")
+
+        assert captured_construct == {
+            "job_id": "job-xyz",
+            "registry_url": "http://localhost:9999",
+        }
+        assert snapshot["id"] == "job-xyz"
+        assert snapshot["status"] == "working"
+        assert snapshot["progress"] == 0.42
+
+    @pytest.mark.asyncio
+    async def test_raises_when_registry_url_missing(self, monkeypatch):
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.delenv("MCP_MESH_REGISTRY_URL", raising=False)
+        with pytest.raises(RuntimeError) as exc:
+            await mesh_jobs.status("x")
+        assert "MCP_MESH_REGISTRY_URL" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_translates_job_not_found_runtime_error(self, monkeypatch):
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        class _Fake:
+            def __init__(self, _jid, _url):
+                pass
+
+            async def status(self):
+                raise RuntimeError("backend error: job not found: missing")
+
+        with mock.patch("mcp_mesh_core.JobProxy", _Fake, create=True):
+            with pytest.raises(mesh_jobs.JobNotFoundError):
+                await mesh_jobs.status("missing")
+
+
+class TestWaitFacade:
+    """``mesh.jobs.wait`` constructs a transient
+    :class:`mcp_mesh_core.JobProxy` against the running agent's
+    registry URL and forwards a ``wait(timeout_secs)`` call. The
+    underlying pyo3 layer raises :class:`TimeoutError` on
+    ``timeout_secs`` expiry; non-success terminals surface as
+    ``RuntimeError`` (potentially translated to typed subclasses)."""
+
+    @pytest.mark.asyncio
+    async def test_forwards_timeout_secs_and_returns_result(self, monkeypatch):
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        captured_wait: dict = {}
+
+        class _FakeJobProxy:
+            def __init__(self, _job_id: str, _registry_url: str) -> None:
+                pass
+
+            async def wait(self, timeout_secs: Any) -> Any:
+                captured_wait["timeout_secs"] = timeout_secs
+                return {"answer": 42}
+
+        with mock.patch("mcp_mesh_core.JobProxy", _FakeJobProxy, create=True):
+            result = await mesh_jobs.wait("job-xyz", timeout_secs=5.0)
+
+        assert captured_wait == {"timeout_secs": 5.0}
+        assert result == {"answer": 42}
+
+    @pytest.mark.asyncio
+    async def test_default_timeout_is_none(self, monkeypatch):
+        """``timeout_secs`` defaults to ``None`` ≡ no timeout — must
+        forward verbatim to the underlying proxy so the pyo3 layer
+        applies the "wait forever" path."""
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+        captured: dict = {}
+
+        class _Fake:
+            def __init__(self, _jid, _url):
+                pass
+
+            async def wait(self, timeout_secs):
+                captured["timeout_secs"] = timeout_secs
+                return "result-value"
+
+        with mock.patch("mcp_mesh_core.JobProxy", _Fake, create=True):
+            result = await mesh_jobs.wait("job-xyz")
+
+        assert captured == {"timeout_secs": None}
+        assert result == "result-value"
+
+    @pytest.mark.asyncio
+    async def test_translates_job_not_found_runtime_error(self, monkeypatch):
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        class _Fake:
+            def __init__(self, _jid, _url):
+                pass
+
+            async def wait(self, _timeout):
+                raise RuntimeError("backend error: job not found: vanished")
+
+        with mock.patch("mcp_mesh_core.JobProxy", _Fake, create=True):
+            with pytest.raises(mesh_jobs.JobNotFoundError):
+                await mesh_jobs.wait("vanished", timeout_secs=1.0)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_registry_url_missing(self, monkeypatch):
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.delenv("MCP_MESH_REGISTRY_URL", raising=False)
+        with pytest.raises(RuntimeError) as exc:
+            await mesh_jobs.wait("x")
+        assert "MCP_MESH_REGISTRY_URL" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_translates_job_terminal_runtime_error(self, monkeypatch):
+        """A ``RuntimeError`` shaped like the Rust JobTerminal variant
+        bubbles up as :class:`JobTerminalError` so callers can
+        ``except`` on the typed class without inspecting strings."""
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        class _Fake:
+            def __init__(self, _jid, _url):
+                pass
+
+            async def wait(self, _timeout):
+                raise RuntimeError("job is terminal: failed")
+
+        with mock.patch("mcp_mesh_core.JobProxy", _Fake, create=True):
+            with pytest.raises(mesh_jobs.JobTerminalError):
+                await mesh_jobs.wait("terminal", timeout_secs=1.0)
+
+
+class TestSharedProxyCache:
+    """The ``(registry_url, job_id)`` LRU cache in ``mesh.jobs`` is
+    shared across every facade that dispatches through
+    ``_get_or_create_proxy``. The first facade call constructs the
+    underlying ``JobProxy``; subsequent calls — regardless of which
+    facade — must reuse the cached instance so callers don't pay a
+    fresh TCP/TLS handshake per lifecycle operation."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_status_wait_share_proxy_cache(self, monkeypatch):
+        """``cancel`` → ``status`` → ``wait`` against the same
+        ``(registry_url, job_id)`` must construct ONE underlying
+        ``JobProxy`` instance. Guards against a refactor that splits
+        the cache per facade."""
+        from mesh import jobs as mesh_jobs
+
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+
+        construct_count = 0
+
+        class _CountingFake:
+            def __init__(self, _job_id: str, _registry_url: str) -> None:
+                nonlocal construct_count
+                construct_count += 1
+
+            async def cancel(self, _reason: Any) -> None:
+                return None
+
+            async def status(self) -> dict:
+                return {"id": "job-A", "status": "working"}
+
+            async def wait(self, _timeout: Any) -> Any:
+                return {"answer": 42}
+
+        with mock.patch("mcp_mesh_core.JobProxy", _CountingFake, create=True):
+            await mesh_jobs.cancel("job-A")
+            assert construct_count == 1, (
+                f"first cancel must construct the proxy; got {construct_count}"
+            )
+            await mesh_jobs.status("job-A")
+            await mesh_jobs.wait("job-A")
+
+        # Three lifecycle calls, ONE proxy construction — the cache hit
+        # on status + wait must reuse the proxy constructed by cancel.
+        assert construct_count == 1, (
+            f"expected the JobProxy cache to be shared across cancel / "
+            f"status / wait; got {construct_count} constructions for the "
+            f"same (registry_url, job_id) key"
+        )
 
 
 # ===========================================================================

--- a/tests/integration/suites/uc02_agent_lifecycle/tc19_lifespan_exception_propagation/test.yaml
+++ b/tests/integration/suites/uc02_agent_lifecycle/tc19_lifespan_exception_propagation/test.yaml
@@ -50,9 +50,11 @@ test:
     workdir: /workspace
     capture: list_output
 
-  # The agent log file lives at ~/.mcp-mesh/logs/<agent>.log. Read it
-  # directly rather than via `meshctl logs` so we don't depend on the
-  # CLI's lookup-by-name working for a half-registered agent.
+  # The agent log file lives at ~/.mcp-mesh/logs/<agent>.log. We read
+  # it directly here for simplicity — `meshctl logs lifespan-raising-agent`
+  # would also work (the CLI reads the same path; no registry dependency),
+  # but direct file access keeps the assertion steps below independent
+  # of the CLI's exit codes / formatting.
   - name: "Dump full agent log file for debugging"
     handler: shell
     command: "ls -la /root/.mcp-mesh/logs/ 2>/dev/null; cat /root/.mcp-mesh/logs/lifespan-raising-agent.log 2>/dev/null | head -200 || echo 'log file missing'"


### PR DESCRIPTION
## Summary

Adds three module-level async functions to `mesh.jobs` that mirror the DDDI-clean `post_event` / `subscribe_events` pattern — callers with only a `job_id` no longer need to pass `MCP_MESH_REGISTRY_URL` explicitly.

```python
async def cancel(job_id: str, reason: Optional[str] = None) -> None
async def status(job_id: str) -> dict
async def wait(job_id: str, timeout_secs: Optional[float] = None) -> Any
```

Each: resolves the registry URL via `_resolve_registry_url()`, gets/creates a `JobProxy` via the shared LRU cache (`_get_or_create_proxy`), dispatches to the underlying pyo3 binding, translates errors via `_translate_job_error`. Signatures verified against `src/runtime/core/src/jobs_py.rs::PyJobProxy`.

The Rust core already exposed `JobProxy.cancel/status/wait` — this PR just adds the Python module-level facades so a caller doesn't need to know about the registry URL. Same shape as `post_event`/`subscribe_events`.

`__all__` extended alphabetically; both `mesh.jobs.X` and `from mesh.jobs import X` paths exercised in tests.

## Scope (out of scope)

- **TypeScript and Java parity** — follows in separate PRs per the polyglot cadence (Python first → TS → Java, mirroring the v2.2 event-injection trilogy).
- **Caller authorization** — who is *allowed* to call `cancel(job_id)` is a separate design discussion tracked in **#1076** (RFC). This PR ships the facades unauthenticated, matching today's `post_event` semantics.

## Review Notes

Independent review caught 1 BLOCKER + 6 WARNINGs (all addressed in the amended commit):

- **BLOCKER fixed**: `_resolve_registry_url()` and `_get_or_create_proxy()` had hardcoded `"mesh.jobs.post_event:"` error prefixes. After this PR they're shared by `cancel/status/wait`, so the wrong prefix would mislead users. Changed to generic `"mesh.jobs:"` at both raise sites.
- **W1** — `cancel` docstring sourced its idempotency claim to the registry-side contract (not a code-level guarantee) and added `JobTerminalError` to the `Raises:` block.
- **W2** — `status` docstring now documents `submitted_payload` (present in `job_to_pydict` but previously undocumented).
- **W3** — `wait` docstring added `ValueError` to `Raises:` (already mentioned in `Args:` for invalid `timeout_secs` but missing from the Raises block).
- **W4** — Added symmetric `test_raises_when_registry_url_missing` tests for `cancel` and `wait` (already existed for `status` and `post_event`). Tests assert on the `"MCP_MESH_REGISTRY_URL"` substring only, surviving the BLOCKER prefix change.
- **W5** — Added `JobTerminalError` translation tests for `cancel` and `wait` (existed for `post_event`).
- **W6** — Added one new test verifying the proxy cache is shared across facades: `cancel("job-A")` → `status("job-A")` → `wait("job-A")` use one cached `JobProxy`.

5 INFOs skipped as cosmetic (table-spacing, TypedDict suggestion, doc redundancy, comment line count, decorator factoring).

Closes #1074

## Bundled (uncommitted comment fix riding along)

`tc19_lifespan_exception_propagation/test.yaml` — 5-line comment cleanup. Removes a misleading note about `meshctl logs` needing registry lookup (the CLI reads `~/.mcp-mesh/logs/<name>.log` directly — verified during disposition of an internal task).

## Test plan

- [x] Python unit tests: 42 pass (was 37, +5 new — W4 ×2, W5 ×2, W6 ×1)
- [x] uc02_agent_lifecycle integration: 23/23 pass
- [x] uc21_meshjob integration: 21/21 pass
- [x] `mkdocs build` clean
- [x] Cross-runtime scope discipline: no edits to TS/Java SDKs or `meshctl man jobs --typescript|--java` man content
- [x] Public-artifact framing: no naming downstream consumers; structural language throughout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added convenience helper functions to manage jobs using only a job ID: cancel, status, and wait operations.
  * Module-level APIs now available for job lifecycle operations without requiring a proxy object.

* **Documentation**
  * Updated job management documentation with lifecycle facade specifications and Python usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1077?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->