### PR TITLE
java: MeshJobs cancel/status/await facades (Java parity for #1074)

### DIFF
--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -689,14 +689,15 @@ cache lookup when you already have a proxy in scope.
 Symmetric to `post_event`: callers that hold a `job_id` but no
 `JobProxy` reference can drive the rest of the post-submit lifecycle
 through module-level facades that share the same registry-URL
-resolution + cached-proxy machinery. Python and TypeScript surfaces
-land in v2.2; Java parity follows in a separate PR.
+resolution + cached-proxy machinery. All three runtimes ship the
+same surface — Python, TypeScript, and Java each implement the same
+DDDI-clean facade pattern.
 
-| Operation                | Python                                             | TypeScript                                       | Returns                       |
-| ------------------------ | -------------------------------------------------- | ------------------------------------------------ | ----------------------------- |
-| Cancel a running job     | `await mesh.jobs.cancel(job_id, reason=None)`      | `await mesh.jobs.cancel(jobId, reason?)`         | `None` / `void`               |
-| Read latest job state    | `await mesh.jobs.status(job_id)`                   | `await mesh.jobs.status(jobId)`                  | `dict` / `JobStatus`          |
-| Wait for terminal state  | `await mesh.jobs.wait(job_id, timeout_secs=None)`  | `await mesh.jobs.wait(jobId, timeoutSecs?)`      | `result` payload on success   |
+| Operation                | Python                                             | TypeScript                                       | Java                                          | Returns                       |
+| ------------------------ | -------------------------------------------------- | ------------------------------------------------ | --------------------------------------------- | ----------------------------- |
+| Cancel a running job     | `await mesh.jobs.cancel(job_id, reason=None)`      | `await mesh.jobs.cancel(jobId, reason?)`         | `MeshJobs.cancel(jobId[, reason])`            | `None` / `void`               |
+| Read latest job state    | `await mesh.jobs.status(job_id)`                   | `await mesh.jobs.status(jobId)`                  | `MeshJobs.status(jobId)`                      | `dict` / `JobStatus` / `Map`  |
+| Wait for terminal state  | `await mesh.jobs.wait(job_id, timeout_secs=None)`  | `await mesh.jobs.wait(jobId, timeoutSecs?)`      | `MeshJobs.await(jobId[, timeoutSecs])`        | `result` payload on success   |
 
 <!-- markdownlint-disable MD046 -->
 === "Python"
@@ -764,6 +765,35 @@ land in v2.2; Java parity follows in a separate PR.
       },
     });
     ```
+
+=== "Java"
+
+    ```java
+    import io.mcpmesh.MeshJobs;
+
+    @MeshTool(capability = "abort_workflow")
+    public Map<String, Object> abortWorkflow(
+        @Param("job_id") String jobId,
+        @Param("reason") String reason) {
+      MeshJobs.cancel(jobId, reason);
+      return Map.of("cancelled", jobId);
+    }
+
+    @MeshTool(capability = "check_progress")
+    public Map<String, Object> checkProgress(@Param("job_id") String jobId) {
+      Map<String, Object> snapshot = MeshJobs.status(jobId);
+      return Map.of(
+          "status", snapshot.get("status"),
+          "progress", snapshot.get("progress"),
+          "message", snapshot.get("progress_message"));
+    }
+
+    @MeshTool(capability = "run_to_completion")
+    public Map<String, Object> runToCompletion(@Param("job_id") String jobId) {
+      Object result = MeshJobs.await(jobId, 300.0);
+      return Map.of("result", result);
+    }
+    ```
 <!-- markdownlint-enable MD046 -->
 
 `cancel` is idempotent — calling it on an already-terminal job returns
@@ -773,10 +803,20 @@ expiry; pass `None` / omit `timeoutSecs` to wait until the job reaches
 a terminal state. `status` returns the same shape `JobProxy.status()`
 exposes (registry `Job` row, field-for-field).
 
+The Java facade is named `MeshJobs.await` (not `wait`) to avoid
+readability confusion with the inherited `Object.wait()` / `wait(long)`
+/ `wait(long, int)` overload family, and to match the existing
+`JobProxy.await(double)` instance method precedent in the SDK. See the
+Javadoc on `MeshJobs.await` and `JobProxy.await` for the detailed
+rationale. `MeshJobs.await(jobId, timeoutSecs)` with `timeoutSecs <= 0.0`
+or non-finite values means "no timeout" (matches the no-arg
+`MeshJobs.await(jobId)` overload).
+
 If the calling code already holds a `JobProxy`, the same surface is
 on the proxy directly: `proxy.cancel(reason)`, `proxy.status()`,
-`proxy.wait(timeout_secs)`. Skip the facade + cache lookup when you
-already have a proxy in scope.
+`proxy.wait(timeout_secs)` (Python / TS) / `proxy.await(timeoutSecs)`
+(Java). Skip the facade + cache lookup when you already have a proxy
+in scope.
 
 ### Typed errors
 

--- a/src/core/cli/man/content/jobs_java.md
+++ b/src/core/cli/man/content/jobs_java.md
@@ -370,6 +370,77 @@ LRU cache keyed by `(registryUrl, jobId)` (default cap 256; tune via
 - `JobNotFoundException` — job swept or id typo
 - `JobTerminalException` — job already terminal, no more events accepted
 
+## Lifecycle facades by `jobId`
+
+Symmetric to `MeshJobs.postEvent` / `MeshJobs.subscribeEvents`: callers
+that hold a `jobId` but no `JobProxy` reference drive the rest of the
+post-submit lifecycle through static facades on `MeshJobs`. Same
+registry-URL resolution + cached-proxy machinery — `cancel`, `status`,
+`await` and `postEvent` all reuse the same underlying `JobProxy` for a
+given `(registryUrl, jobId)`.
+
+| Operation                | Static facade                              | Returns                                   |
+| ------------------------ | ------------------------------------------ | ----------------------------------------- |
+| Cancel a running job     | `MeshJobs.cancel(jobId[, reason])`         | `void`                                    |
+| Read latest job state    | `MeshJobs.status(jobId)`                   | `Map<String, Object>` (registry Job row)  |
+| Wait for terminal state  | `MeshJobs.await(jobId[, timeoutSecs])`     | `Object` (handler's `complete()` payload) |
+
+```java
+import io.mcpmesh.MeshJobs;
+
+@MeshTool(capability = "abort_workflow")
+public Map<String, Object> abortWorkflow(
+    @Param("job_id") String jobId,
+    @Param("reason") String reason) {
+  MeshJobs.cancel(jobId, reason);
+  return Map.of("cancelled", jobId);
+}
+
+@MeshTool(capability = "check_progress")
+public Map<String, Object> checkProgress(@Param("job_id") String jobId) {
+  Map<String, Object> snapshot = MeshJobs.status(jobId);
+  return Map.of(
+      "status", snapshot.get("status"),
+      "progress", snapshot.get("progress"),
+      "message", snapshot.get("progress_message"));
+}
+
+@MeshTool(capability = "run_to_completion")
+public Map<String, Object> runToCompletion(@Param("job_id") String jobId) {
+  Object result = MeshJobs.await(jobId, 300.0);
+  return Map.of("result", result);
+}
+```
+
+**Notes:**
+
+- Named `await` (not `wait`) to avoid readability confusion with the
+  inherited `Object.wait()` / `Object.wait(long)` /
+  `Object.wait(long, int)` overload family, and to match the existing
+  `JobProxy.await(double)` instance method.
+- `cancel` is idempotent per the registry's contract — calling on an
+  already-terminal job returns ok without re-firing. If the registry
+  surfaces a conflict for some other reason, the facade re-classifies
+  it as `JobTerminalException`.
+- `await(jobId, timeoutSecs)` with `timeoutSecs <= 0.0` or non-finite
+  values means "no timeout" (matches `JobProxy.await(double)` and the
+  no-arg `MeshJobs.await(jobId)` overload). Positive finite waits the
+  given seconds before surfacing a timeout error.
+- `status` returns the full registry Job row (same shape
+  `JobProxy.status()` exposes); keys always present include `id`,
+  `capability`, `status`, `progress`, `progress_message`, `result`,
+  `error`, `submitted_payload`, plus lease-tracking fields
+  (`owner_instance_id`, `lease_expires_at`, `last_heartbeat_at`).
+- `JobNotFoundException` is raised from any of the three when the
+  registry doesn't know the `jobId` (sweep already removed it, or id
+  typo). `JobTerminalException` is the conflict surface for `cancel`
+  and `await` when the registry treats the targeted terminal state as
+  a conflict.
+- If the calling code already holds a `JobProxy`, the same surface is
+  on the proxy directly: `proxy.cancel(reason)`, `proxy.status()`,
+  `proxy.await(timeoutSecs)`. Skip the facade + cache lookup when you
+  already have a proxy in scope.
+
 **Synthetic cancel event**. When a consumer calls `proxy.cancel(
 reason)`, the registry writes a synthetic event into the log before
 HTTP-forwarding the cancel signal. A handler parked on `recvEvent(

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobProxy.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobProxy.java
@@ -140,11 +140,11 @@ public final class JobProxy implements MeshJob, AutoCloseable {
      * payload as a generic Java value (Map / List / Number / String /
      * Boolean / null) — Jackson default binding.
      *
-     * <p>Named {@code await} (not {@code wait}) because {@link Object#wait()}
-     * is {@code final} on every Java object — overloading the name on a
-     * subclass is a compile error. Mirrors the Python {@code .wait()} and
-     * TypeScript {@code .wait()} APIs semantically; the rename is purely a
-     * Java language constraint.
+     * <p>Named {@code await} (not {@code wait}) to avoid readability
+     * confusion with the inherited {@link Object#wait()} /
+     * {@link Object#wait(long)} / {@link Object#wait(long, int)}
+     * overload family. Mirrors the Python {@code .wait()} and
+     * TypeScript {@code .wait()} APIs semantically.
      *
      * @param timeoutSecs Wall-clock timeout in seconds.
      *                    <ul>

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJobs.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJobs.java
@@ -131,6 +131,314 @@ public final class MeshJobs {
         return proxy.sendEvent(eventType, payload);
     }
 
+    // ---------------------------------------------------------------------------
+    // cancel / status / await — DDDI-clean lifecycle facades (issue #1080)
+    // ---------------------------------------------------------------------------
+    //
+    // Mirror the postEvent / subscribeEvents pattern: take a jobId as the
+    // first positional arg, resolve the registry URL internally via
+    // resolveRegistryUrl(), dispatch through a cached JobProxy from
+    // getOrCreateProxy(), and re-classify any MeshException raised by the
+    // proxy via substring match (translateJobError).
+    //
+    // These exist so callers that hold only a jobId (e.g. an HTTP route
+    // handler, a tool body whose request payload carries a stashed id) can
+    // operate on the job's lifecycle without constructing a JobProxy
+    // directly — which would leak MCP_MESH_REGISTRY_URL addressing into
+    // user code and break the DDDI contract.
+
+    /**
+     * Cancel a running job by ID.
+     *
+     * <p>Convenience helper for callers that hold a {@code jobId} but do
+     * not have a {@link JobProxy} reference in scope. Constructs (or
+     * reuses, via the LRU cache) a transient proxy bound to the current
+     * agent's registry URL and forwards the call.
+     *
+     * <p>Per the registry's idempotency contract, calling {@code cancel}
+     * on a job that is already in a terminal state returns successfully
+     * without re-firing cancellation. If the registry surfaces a conflict
+     * for some other reason, the facade re-classifies it as
+     * {@link JobTerminalException}. The registry forwards the cancel
+     * signal to the owner replica via {@code POST /jobs/{id}/cancel}; the
+     * running handler's cancel token fires on the next {@code await}
+     * point, and any outbound {@code McpMeshTool} proxy calls abort their
+     * underlying HTTP requests.
+     *
+     * <p>Mirrors Python {@code mesh.jobs.cancel} and TypeScript
+     * {@code mesh.jobs.cancel} one-for-one.
+     *
+     * @param jobId  Target job's server-assigned id
+     * @param reason Optional human-readable reason recorded against the
+     *               cancellation. Surfaces in the synthetic
+     *               {@code {"type":"cancelled"}} event the registry writes
+     *               into the job's event log, so a handler parked on
+     *               {@code recvEvent(List.of("cancelled", ...))} can return
+     *               cleanly with the reason in scope. May be {@code null}.
+     * @throws JobNotFoundException if the registry doesn't know the job
+     *                              (sweep already removed it, or wrong id)
+     * @throws JobTerminalException if the registry surfaces a conflict
+     *                              for this cancel (e.g. the idempotency
+     *                              contract changes upstream or the
+     *                              registry treats the targeted terminal
+     *                              state as a conflict)
+     * @throws MeshException        for transport errors or missing
+     *                              {@code MCP_MESH_REGISTRY_URL}
+     *
+     * @apiNote Example — cancel a job from a tool that receives the id
+     * in its payload:
+     * <pre>{@code
+     * @MeshTool(capability = "abort_workflow")
+     * public Map<String, Object> abortWorkflow(
+     *         @Param("job_id") String jobId,
+     *         @Param("reason") String reason) {
+     *     MeshJobs.cancel(jobId, reason);
+     *     return Map.of("cancelled", jobId);
+     * }
+     * }</pre>
+     */
+    public static void cancel(String jobId, String reason) {
+        if (jobId == null || jobId.isEmpty()) {
+            throw new IllegalArgumentException("jobId is required");
+        }
+        String registryUrl = resolveRegistryUrl();
+        JobProxy proxy = getOrCreateProxy(registryUrl, jobId);
+        try {
+            proxy.cancel(reason);
+        } catch (MeshException exc) {
+            throw translateJobError(exc);
+        }
+    }
+
+    /**
+     * Convenience overload — {@link #cancel(String, String)} with a
+     * {@code null} reason.
+     *
+     * @param jobId Target job's server-assigned id
+     * @throws JobNotFoundException if the registry doesn't know the job
+     * @throws JobTerminalException if the registry surfaces a conflict
+     *                              for this cancel
+     * @throws MeshException        for transport errors or missing
+     *                              {@code MCP_MESH_REGISTRY_URL}
+     */
+    public static void cancel(String jobId) {
+        cancel(jobId, null);
+    }
+
+    /**
+     * Get the current status of a job by ID.
+     *
+     * <p>Convenience helper for callers that hold a {@code jobId} but do
+     * not have a {@link JobProxy} reference in scope. Constructs (or
+     * reuses, via the LRU cache) a transient proxy bound to the current
+     * agent's registry URL and forwards a single {@code GET /jobs/{id}}
+     * to the registry.
+     *
+     * <p>Mirrors Python {@code mesh.jobs.status} and TypeScript
+     * {@code mesh.jobs.status} one-for-one.
+     *
+     * <p>The returned map mirrors the registry's OpenAPI {@code Job}
+     * schema field-for-field. Keys always present on the wire include:
+     * <ul>
+     *   <li>{@code id} — server-assigned job UUID</li>
+     *   <li>{@code capability} — capability the job was submitted against</li>
+     *   <li>{@code owner_instance_id} — instance id of the replica
+     *       currently holding the lease (or {@code null})</li>
+     *   <li>{@code status} — one of {@code "working"},
+     *       {@code "input_required"}, {@code "completed"},
+     *       {@code "failed"}, {@code "cancelled"}</li>
+     *   <li>{@code progress} — latest progress fraction in {@code [0.0, 1.0]}
+     *       (or {@code null})</li>
+     *   <li>{@code progress_message} — latest progress message (or {@code null})</li>
+     *   <li>{@code result} — terminal result payload (set when
+     *       {@code status == "completed"})</li>
+     *   <li>{@code error} — terminal error reason (set when status is
+     *       {@code "failed"} / {@code "cancelled"})</li>
+     *   <li>{@code submitted_payload} — original request payload</li>
+     *   <li>{@code attempt_count} — number of attempts so far (1-indexed)</li>
+     *   <li>{@code max_retries} — maximum retries beyond the initial attempt</li>
+     *   <li>{@code max_duration} — per-attempt soft timeout in seconds
+     *       (or {@code null})</li>
+     *   <li>{@code total_deadline} — hard ceiling across all attempts, as
+     *       a unix epoch second (or {@code null})</li>
+     *   <li>{@code lease_expires_at} — unix epoch second when the current
+     *       lease expires (or {@code null})</li>
+     *   <li>{@code last_heartbeat_at} — unix epoch second of the last
+     *       heartbeat from the owner replica (or {@code null})</li>
+     *   <li>{@code submitted_at} — unix epoch second the job row was created</li>
+     *   <li>{@code submitted_by} — identifier of the agent that submitted
+     *       the job</li>
+     * </ul>
+     *
+     * @param jobId Target job's server-assigned id
+     * @return Job status snapshot — the same shape {@link JobProxy#status()}
+     *         returns, mirroring the registry's {@code Job} schema
+     *         field-for-field.
+     * @throws JobNotFoundException if the registry doesn't know the job
+     *                              (sweep already removed it, or wrong id)
+     * @throws MeshException        for transport errors or missing
+     *                              {@code MCP_MESH_REGISTRY_URL}
+     *
+     * @apiNote Example — poll a job's progress from outside the producer
+     * agent:
+     * <pre>{@code
+     * @MeshTool(capability = "check_progress")
+     * public Map<String, Object> checkProgress(@Param("job_id") String jobId) {
+     *     Map<String, Object> snapshot = MeshJobs.status(jobId);
+     *     return Map.of(
+     *         "status", snapshot.get("status"),
+     *         "progress", snapshot.get("progress"),
+     *         "message", snapshot.get("progress_message"));
+     * }
+     * }</pre>
+     */
+    public static Map<String, Object> status(String jobId) {
+        if (jobId == null || jobId.isEmpty()) {
+            throw new IllegalArgumentException("jobId is required");
+        }
+        String registryUrl = resolveRegistryUrl();
+        JobProxy proxy = getOrCreateProxy(registryUrl, jobId);
+        try {
+            return proxy.status();
+        } catch (MeshException exc) {
+            throw translateJobError(exc);
+        }
+    }
+
+    /**
+     * Wait for a job to complete and return its result.
+     *
+     * <p>Convenience helper for callers that hold a {@code jobId} but do
+     * not have a {@link JobProxy} reference in scope. Constructs (or
+     * reuses, via the LRU cache) a transient proxy bound to the current
+     * agent's registry URL and polls until the job reaches a terminal
+     * state.
+     *
+     * <p>Named {@code await} (not {@code wait}) to avoid readability
+     * confusion with the inherited {@link Object#wait()} /
+     * {@link Object#wait(long)} / {@link Object#wait(long, int)}
+     * overload family, and to match the existing
+     * {@link JobProxy#await(double)} instance method. Mirrors the
+     * Python {@code mesh.jobs.wait} and TypeScript
+     * {@code mesh.jobs.wait} APIs semantically.
+     *
+     * <p>On success, returns the result payload the handler passed to
+     * {@link JobController#complete(Map)} — any JSON-shaped Java value
+     * ({@code Map} / {@code List} / {@code Number} / {@code String} /
+     * {@code Boolean} / {@code null}) per Jackson's default binding.
+     *
+     * @param jobId       Target job's server-assigned id
+     * @param timeoutSecs Wall-clock timeout in seconds.
+     *                    <ul>
+     *                      <li>{@code <= 0.0} (including {@code -0.0})
+     *                          → no timeout (block until terminal).</li>
+     *                      <li>Positive finite → wait that many seconds,
+     *                          then surface a timeout error.</li>
+     *                      <li>Non-finite (NaN, ±Inf) → no timeout.</li>
+     *                    </ul>
+     *                    Matches {@link JobProxy#await(double)}'s contract.
+     * @return The job's result payload (whatever the handler passed to
+     *         {@code complete()}). Shape is application-defined —
+     *         typically a {@code Map<String, Object>}, but any JSON-shaped
+     *         value is valid.
+     * @throws JobNotFoundException if the registry doesn't know the job
+     *                              (sweep already removed it, or wrong id)
+     * @throws JobTerminalException if the job has already reached a
+     *                              non-success terminal state when the
+     *                              call arrives and the registry surfaces
+     *                              that as a terminal-state conflict
+     * @throws MeshException        on timeout, cancellation, transport
+     *                              errors, or missing
+     *                              {@code MCP_MESH_REGISTRY_URL}.
+     *                              The underlying error message is
+     *                              preserved (e.g. messages starting with
+     *                              {@code "timeout: ..."} /
+     *                              {@code "cancelled: ..."} per the
+     *                              {@link JobProxy#await(double)} surface).
+     *
+     * @apiNote Example — submit-then-wait from a tool that doesn't hold
+     * the proxy:
+     * <pre>{@code
+     * @MeshTool(capability = "run_to_completion")
+     * public Map<String, Object> runToCompletion(@Param("job_id") String jobId) {
+     *     Object result = MeshJobs.await(jobId, 300.0);
+     *     return Map.of("result", result);
+     * }
+     * }</pre>
+     */
+    public static Object await(String jobId, double timeoutSecs) {
+        if (jobId == null || jobId.isEmpty()) {
+            throw new IllegalArgumentException("jobId is required");
+        }
+        String registryUrl = resolveRegistryUrl();
+        JobProxy proxy = getOrCreateProxy(registryUrl, jobId);
+        try {
+            return proxy.await(timeoutSecs);
+        } catch (MeshException exc) {
+            throw translateJobError(exc);
+        }
+    }
+
+    /**
+     * Convenience overload — {@link #await(String, double)} without a
+     * timeout. Equivalent to {@code await(jobId, -1.0)} (matches
+     * {@link JobProxy#await()}'s no-arg overload).
+     *
+     * @param jobId Target job's server-assigned id
+     * @return The job's result payload
+     * @throws JobNotFoundException if the registry doesn't know the job
+     * @throws JobTerminalException if the registry surfaces a terminal-
+     *                              state conflict
+     * @throws MeshException        on cancellation, transport errors, or
+     *                              missing {@code MCP_MESH_REGISTRY_URL}
+     */
+    public static Object await(String jobId) {
+        return await(jobId, -1.0);
+    }
+
+    /**
+     * Re-classify a generic {@link MeshException} raised by the proxy
+     * layer into one of the typed subclasses, if the message matches.
+     * Returns the original exception (or a typed clone) — callers should
+     * {@code throw} the returned value.
+     *
+     * <p>Mirrors:
+     * <ul>
+     *   <li>Python {@code mesh.jobs._translate_job_error}</li>
+     *   <li>TypeScript {@code translateJobError}</li>
+     * </ul>
+     *
+     * <p>The {@link JobProxy#cancel(String)}, {@link JobProxy#status()},
+     * and {@link JobProxy#await(double)} surfaces raise a generic
+     * {@link MeshException} for every non-zero rc — unlike
+     * {@link JobProxy#sendEvent(String, Map)}, they do not have explicit
+     * {@code rc == -2} / {@code rc == -3} branches. This helper bridges
+     * that gap by inspecting the registry's stable error-message prefixes
+     * (the Rust core's {@code JobError::Display} format).
+     *
+     * <p>Package-private for tests.
+     */
+    static MeshException translateJobError(MeshException exc) {
+        if (exc instanceof JobNotFoundException || exc instanceof JobTerminalException) {
+            return exc;
+        }
+        String msg = exc.getMessage();
+        if (msg == null) {
+            return exc;
+        }
+        String msgLower = msg.toLowerCase();
+        // Order matters: "job is terminal" is the JobTerminal variant's
+        // Display prefix (see jobs.rs::JobError::Display); "job not found"
+        // is BackendError::NotFound's Display prefix.
+        if (msgLower.contains("job is terminal")) {
+            return new JobTerminalException(msg, exc);
+        }
+        if (msgLower.contains("job not found")) {
+            return new JobNotFoundException(msg, exc);
+        }
+        return exc;
+    }
+
     /**
      * Subscribe to events posted to a running job by ID.
      *
@@ -215,7 +523,7 @@ public final class MeshJobs {
         String url = System.getenv("MCP_MESH_REGISTRY_URL");
         if (url == null || url.isEmpty()) {
             throw new MeshException(
-                "MeshJobs.postEvent: MCP_MESH_REGISTRY_URL is not set; "
+                "MeshJobs: MCP_MESH_REGISTRY_URL is not set; "
                     + "cannot resolve registry base URL. Ensure the calling "
                     + "process is running inside a mesh agent.");
         }

--- a/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/MeshJobsTest.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/MeshJobsTest.java
@@ -4,6 +4,7 @@ import io.mcpmesh.core.MeshException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import java.util.Map;
 
@@ -305,5 +306,192 @@ class MeshJobsTest {
             () -> MeshJobs.postEvent(null, "signal", payload));
         assertThrows(IllegalArgumentException.class,
             () -> MeshJobs.postEvent("j", null, payload));
+    }
+
+    // -----------------------------------------------------------------
+    // cancel / status / await — issue #1080 lifecycle facades
+    // -----------------------------------------------------------------
+    //
+    // The FFI round-trip (cancel POST, status GET, await poll) needs a
+    // live registry and is exercised by uc23_meshjob_java in the
+    // integration suite. The unit tests below only assert the static-
+    // facade layer that wraps the proxy: arg validation, env-var
+    // resolution, and proxy-cache reuse. Mocking the JNR-FFI binding
+    // here is not a pattern this codebase uses.
+
+    @Test
+    void cancel_rejectsNullJobId() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.cancel(null, "reason"));
+        assertTrue(e.getMessage().toLowerCase().contains("jobid"),
+            "error should mention jobId; got: " + e.getMessage());
+    }
+
+    @Test
+    void cancel_rejectsEmptyJobId() {
+        assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.cancel("", "reason"));
+    }
+
+    @Test
+    void cancel_noArgOverloadRejectsNullJobId() {
+        assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.cancel(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.cancel(""));
+    }
+
+    @Test
+    void status_rejectsNullJobId() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.status(null));
+        assertTrue(e.getMessage().toLowerCase().contains("jobid"),
+            "error should mention jobId; got: " + e.getMessage());
+    }
+
+    @Test
+    void status_rejectsEmptyJobId() {
+        assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.status(""));
+    }
+
+    @Test
+    void await_rejectsNullJobId() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.await(null, 5.0));
+        assertTrue(e.getMessage().toLowerCase().contains("jobid"),
+            "error should mention jobId; got: " + e.getMessage());
+    }
+
+    @Test
+    void await_rejectsEmptyJobId() {
+        assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.await("", 5.0));
+    }
+
+    @Test
+    void await_noArgOverloadRejectsNullJobId() {
+        assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.await(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> MeshJobs.await(""));
+    }
+
+    /**
+     * {@code MCP_MESH_REGISTRY_URL} unset must surface a clean
+     * MeshException through every lifecycle facade, exercising the same
+     * {@code resolveRegistryUrl()} pre-flight that {@code postEvent}
+     * uses.
+     */
+    @Test
+    @DisabledIfEnvironmentVariable(named = "MCP_MESH_REGISTRY_URL", matches = ".+")
+    void cancel_failsCleanlyWhenRegistryUrlUnset() {
+        MeshException e = assertThrows(MeshException.class,
+            () -> MeshJobs.cancel("job-x", "reason"));
+        assertTrue(e.getMessage().contains("MCP_MESH_REGISTRY_URL"),
+            "error should reference the env var name; got: " + e.getMessage());
+    }
+
+    @Test
+    @DisabledIfEnvironmentVariable(named = "MCP_MESH_REGISTRY_URL", matches = ".+")
+    void status_failsCleanlyWhenRegistryUrlUnset() {
+        MeshException e = assertThrows(MeshException.class,
+            () -> MeshJobs.status("job-x"));
+        assertTrue(e.getMessage().contains("MCP_MESH_REGISTRY_URL"),
+            "error should reference the env var name; got: " + e.getMessage());
+    }
+
+    @Test
+    @DisabledIfEnvironmentVariable(named = "MCP_MESH_REGISTRY_URL", matches = ".+")
+    void await_failsCleanlyWhenRegistryUrlUnset() {
+        MeshException e = assertThrows(MeshException.class,
+            () -> MeshJobs.await("job-x"));
+        assertTrue(e.getMessage().contains("MCP_MESH_REGISTRY_URL"),
+            "error should reference the env var name; got: " + e.getMessage());
+    }
+
+    /**
+     * Cross-facade cache sharing (mirror of Python's W6 review test
+     * from #1077): two different lifecycle facades targeting the same
+     * jobId share a single cached proxy — the cache key is
+     * {@code (registryUrl, jobId)} only, so {@code postEvent},
+     * {@code cancel}, {@code status}, {@code await} and
+     * {@code subscribeEvents} all reuse the same underlying
+     * {@link JobProxy}.
+     *
+     * <p>We exercise the cache via {@code getOrCreateProxy} directly
+     * because the facades' FFI call paths would fail without a live
+     * registry — the cache lookup itself runs before any FFI call, so
+     * this assertion holds without HTTP traffic.
+     */
+    @Test
+    void getOrCreateProxy_sharesAcrossLifecycleFacades() {
+        // First lookup — populates the cache.
+        JobProxy first = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "shared-job");
+        // Subsequent lookups for the same (registryUrl, jobId) — the
+        // four facades (cancel, status, await, postEvent) all funnel
+        // through getOrCreateProxy with the same key, so each call
+        // returns the same instance.
+        JobProxy second = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "shared-job");
+        JobProxy third = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "shared-job");
+        JobProxy fourth = MeshJobs.getOrCreateProxy(FAKE_REGISTRY, "shared-job");
+        assertSame(first, second,
+            "second facade lookup must reuse the cached proxy");
+        assertSame(first, third,
+            "third facade lookup must reuse the cached proxy");
+        assertSame(first, fourth,
+            "fourth facade lookup must reuse the cached proxy");
+        assertEquals(1, MeshJobs.cacheSizeForTest(),
+            "cache should hold exactly one entry across facade reuse");
+    }
+
+    /**
+     * Substring-based translation of generic {@code MeshException} into
+     * {@link JobNotFoundException} / {@link JobTerminalException} — the
+     * same contract Python's {@code _translate_job_error} and TypeScript's
+     * {@code translateJobError} implement against the registry's stable
+     * error-message prefixes. The proxy-level
+     * {@link JobProxy#cancel(String)}, {@link JobProxy#status()}, and
+     * {@link JobProxy#await(double)} surfaces all raise a generic
+     * {@code MeshException} on non-zero rc (unlike {@code sendEvent} /
+     * {@code listEvents} which dispatch on rc directly); the facade
+     * layer must close that gap.
+     */
+    @Test
+    void translateJobError_classifiesByMessageSubstring() {
+        // Pure MeshException with no marker → passes through unchanged.
+        MeshException plain = new MeshException("registry unreachable");
+        assertSame(plain, MeshJobs.translateJobError(plain));
+
+        // "job not found" → JobNotFoundException, preserving cause.
+        MeshException nf = new MeshException(
+            "mesh_job_proxy_cancel failed: job not found: job-x");
+        MeshException nfTranslated = MeshJobs.translateJobError(nf);
+        assertNotSame(nf, nfTranslated);
+        assertTrue(nfTranslated instanceof JobNotFoundException,
+            "expected JobNotFoundException; got: " + nfTranslated.getClass());
+        assertSame(nf, nfTranslated.getCause());
+        assertEquals(nf.getMessage(), nfTranslated.getMessage());
+
+        // "job is terminal" → JobTerminalException, preserving cause.
+        MeshException term = new MeshException(
+            "mesh_job_proxy_cancel failed: job is terminal: job-x");
+        MeshException termTranslated = MeshJobs.translateJobError(term);
+        assertNotSame(term, termTranslated);
+        assertTrue(termTranslated instanceof JobTerminalException,
+            "expected JobTerminalException; got: " + termTranslated.getClass());
+        assertSame(term, termTranslated.getCause());
+        assertEquals(term.getMessage(), termTranslated.getMessage());
+
+        // Case-insensitive match — substring contract documents
+        // lowercase comparison.
+        MeshException upper = new MeshException("JOB NOT FOUND in registry");
+        assertTrue(MeshJobs.translateJobError(upper) instanceof JobNotFoundException);
+
+        // Already-typed exception passes through (no double-wrap).
+        JobNotFoundException already = new JobNotFoundException("job not found: pre-typed");
+        assertSame(already, MeshJobs.translateJobError(already));
+        JobTerminalException alreadyTerm = new JobTerminalException("job is terminal: pre-typed");
+        assertSame(alreadyTerm, MeshJobs.translateJobError(alreadyTerm));
     }
 }


### PR DESCRIPTION
## Summary

Java parity for the `mesh.jobs.cancel/status/wait` facades shipped in Python (#1077) and TypeScript (#1079). Three new static methods (with overloads) on `MeshJobs` mirror the existing `postEvent` / `subscribeEvents` DDDI-clean pattern — callers with only a `jobId` no longer need to construct `new JobProxy(jobId, registryUrl)` and pass `MCP_MESH_REGISTRY_URL` explicitly.

```java
public static void cancel(String jobId, String reason) throws MeshException
public static void cancel(String jobId) throws MeshException
public static Map<String, Object> status(String jobId) throws MeshException
public static Object await(String jobId, double timeoutSecs) throws MeshException
public static Object await(String jobId) throws MeshException
```

Each: `resolveRegistryUrl()` → `getOrCreateProxy()` (LRU-cached) → dispatch to the existing `JobProxy` instance method → substring-match translation to typed exceptions via a new package-private `translateJobError` helper.

**Java naming nuance**: `await` (not `wait`) to avoid readability confusion with the inherited `Object.wait()` / `wait(long)` / `wait(long, int)` overload family, and to match the existing `JobProxy.await(double)` precedent.

## What was already in place (no work needed)

- FFI: `mesh_job_proxy_cancel/status/wait` in `jobs_ffi.rs`
- JNR: declarations in `MeshCore.java:648-670`
- `JobProxy.cancel/status/await` instance methods
- `JobNotFoundException`, `JobTerminalException`, `MeshException` classes
- LRU proxy cache infrastructure

## Bonus generalization

`resolveRegistryUrl`'s error message prefix generalized from `"MeshJobs.postEvent:"` → `"MeshJobs:"`. Now accurate for all four facades. Mirrors the same generalization the Python BLOCKER fix made in #1077 and the TS bonus in #1079 — the trilogy is now consistent across all three runtimes in this respect.

## Trilogy complete

- Python facades (#1077) ✓ merged
- TypeScript facades (#1079) ✓ merged
- **Java facades (this PR)** ← closes the trilogy

## Out of scope

- Strongly-typed `JobStatus` record — returns `Map<String, Object>` matching the existing `JobProxy.status()` shape. A record with typed fields is a follow-up if usage warrants.
- Caller authorization on lifecycle ops — design discussion at **#1076**.

## Review Notes

Independent review: 0 BLOCKER, 1 WARNING (addressed), 4 INFOs (3 addressed, 1 skipped as docs cosmetic).

- **W1 — Triplicated try/catch boilerplate fixed**: each facade's translation block collapsed from 6 lines to a one-liner `throw translateJobError(exc);`. The previous indirection (`if (translated != exc) throw translated; throw exc;`) was dead-equivalent on Java because `translateJobError` chains the original exception as `cause` via the typed constructor. Net -12 lines on the facade region.
- **I1 — `await` naming Javadoc accuracy**: the previous text claimed "overloading would be a compile error" (wrong — `wait(double)` is overloading, legal). Updated wording across 3 surfaces (`MeshJobs.java`, `JobProxy.java`, `jobs_java.md`) to cite the real reason: readability confusion with the inherited `Object.wait()` overload family + the existing `JobProxy.await(double)` precedent.
- **I2 — Test message symmetry**: `JobTerminalException` translation test now asserts message preservation matching the `JobNotFoundException` test.
- **I3 — `@DisabledIfEnvironmentVariable`**: the three `*_failsCleanlyWhenRegistryUrlUnset` tests now use JUnit 5's declarative annotation instead of silent `return` — skips are visible in test reports, no green-test illusion in CI shells that export `MCP_MESH_REGISTRY_URL`.

I4 (4-column docs table) skipped as cosmetic.

Closes #1080

## Test plan

- [x] `mvn install -pl mcp-mesh-core,mcp-mesh-sdk -am`: BUILD SUCCESS
- [x] `mvn test -pl mcp-mesh-sdk`: 98 tests pass (`MeshJobsTest` 27/27)
- [x] `@DisabledIfEnvironmentVariable` verified visible in report when env set
- [x] `tsuite uc23_meshjob_java --parallel 4`: 27/27
- [x] `mkdocs build` clean
- [x] Cross-runtime scope: no edits to Python / TS / Rust / FFI / JNR / `JobProxy.cancel/status/await` instance methods / Python `jobs.md` / TS `jobs_typescript.md`
- [x] Public-artifact framing: no naming downstream consumers; structural language throughout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added convenience static methods to manage job lifecycle—cancel, check status, and await completion—using only a job ID, without requiring a JobProxy instance.

* **Documentation**
  * Enhanced job lifecycle documentation with comprehensive examples, detailed timeout semantics, and cross-runtime operation guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->