### PR TITLE
fix(di): unify positional injection for MeshJob + McpMeshTool params

### DIFF
--- a/MESHJOB_DDDI_CONTRACT.md
+++ b/MESHJOB_DDDI_CONTRACT.md
@@ -2,29 +2,50 @@
 
 Each language SDK (Python, TypeScript, Java) implements parameter resolution
 for tools decorated with `@mesh.tool`. With MeshJob added to the type system,
-the resolver MUST handle two distinct injectable types:
+the resolver MUST handle two distinct injectable types under a unified
+positional contract:
 
 - `MeshTool`: remote capability proxy → positional dependency injection
-- `MeshJob`: job controller (producer-side) or proxy (consumer-side) → orthogonal injection (no positional cost)
+- `MeshJob`: job submitter (consumer-side) / controller (producer-side) → positional dependency injection (same `dep_index` namespace as `MeshTool`)
 
 This document defines the resolver behavior all three SDKs must match.
 
+## Injection rule (unified positional)
+
+Dependencies inject positionally into `MeshTool` OR `MeshJob` parameters in
+**parameter declaration order**. The slot's type determines what gets
+injected (`MeshTool` proxy vs `MeshJob` submitter). Parameter names are
+free-form; capability names in `dependencies[]` match by position, not by
+name.
+
+Iterate parameters in declaration order, maintaining a single
+`dep_index_counter` starting at 0. For each parameter annotated as either
+`MeshTool` or `MeshJob`, assign the current counter value and increment.
+For any other annotation (user argument), do NOT touch the counter.
+
 ## Classification
 
-For each parameter in the tool function signature:
-
-| Annotation | Classification | Positional? |
+| Annotation | Classification | Consumes `dep_index`? |
 |---|---|---|
-| `MeshTool` | Mesh dependency | Yes — assigns next positional slot |
-| `MeshJob` | Job injectable | No — recorded by signature position only |
-| Other | User argument | N/A — passed by caller |
+| `MeshTool` | Mesh dependency | Yes — next positional slot |
+| `MeshJob` | Job injectable | Yes — next positional slot |
+| Other | User argument | No — passed by caller |
 
-## Positional indexing rule
+## Unresolved dependencies
 
-Iterate parameters in declaration order. Maintain a `mesh_tool_position_counter`
-starting at 0. For each `MeshTool`-annotated param, assign current counter and
-increment. For `MeshJob`-annotated params, do NOT touch the counter — instead
-record the param's signature position in a separate `mesh_job_param_index` field.
+If `dependencies[i]` cannot be resolved at injection time (no agent
+advertises that capability), the corresponding parameter slot stays
+`None`. Positions do NOT shift to fill the gap; each `dep_index` strictly
+pairs with one parameter position.
+
+## MeshJob slots specifically
+
+A `MeshJob` slot at `dep_index = i` receives a `MeshJobSubmitter` (or
+language equivalent) bound to `capability=dependencies[i]` whenever the
+runtime knows where to submit (e.g. Python: `MCP_MESH_REGISTRY_URL`
+environment variable is set). Runtime claim availability — whether an
+agent picks up the submitted job — is a separate concern handled at
+`submitter.submit(...)` time.
 
 ## Reference example
 
@@ -33,18 +54,18 @@ Function signature:
 ```python
 async def plan_trip(
     user_id: str,                          # signature pos 0 — user arg
-    weather_lookup: MeshTool = None,       # signature pos 1 — MeshTool position 0
-    job: MeshJob = None,                   # signature pos 2 — MeshJob param
-    flight_search: MeshTool = None,        # signature pos 3 — MeshTool position 1
+    weather_lookup: MeshTool = None,       # signature pos 1 — dep_index 0
+    job: MeshJob = None,                   # signature pos 2 — dep_index 1
+    flight_search: MeshTool = None,        # signature pos 3 — dep_index 2
 ):
     ...
 ```
 
-Resolver output:
+With `dependencies = ["weather_capability", "trip_workflow", "flight_capability"]`:
 
-- `mesh_tool_deps[0]` = weather_lookup metadata, signature position 1
-- `mesh_tool_deps[1]` = flight_search metadata, signature position 3 (NOT 2 — MeshJob skipped)
-- `mesh_job_param_index = Some(2)`
+- `dep_index 0 → weather_lookup` receives a `MeshTool` proxy for `weather_capability`
+- `dep_index 1 → job` receives a `MeshJobSubmitter` for `trip_workflow`
+- `dep_index 2 → flight_search` receives a `MeshTool` proxy for `flight_capability`
 - User passes `user_id` at signature position 0
 
 ## Tool invocation
@@ -52,10 +73,17 @@ Resolver output:
 When the runtime invokes the tool:
 
 - User-arg slots: filled from caller payload
-- `mesh_tool_deps` slots: filled from resolved capability proxies
-- `mesh_job_param_index` slot: filled from `JobController` (if invoked as a job — `X-Mesh-Job-Id` header present OR claim path) or `None` (if invoked as a regular tool call)
+- `MeshTool` slots: filled from resolved capability proxies (or `None` if unresolved)
+- `MeshJob` slots: filled from a `MeshJobSubmitter` constructed for the bound capability (or `None` when the runtime can't construct one — e.g. registry URL unset)
+
+If the call is itself a job (producer-side, `X-Mesh-Job-Id` header
+present OR claim path), the runtime additionally binds the
+`JobController` contextvar so the user function can read job context via
+`mesh.jobs.current_job()` / write progress via the appropriate helper.
 
 ## Equivalence across SDKs
+
+> **Note (status of cross-SDK parity)**: This unified positional contract is currently implemented in the Python SDK only. The TypeScript and Java SDKs are tracked under separate work; their dependency-injection paths may still resolve MeshJob params orthogonally to McpMeshTool slots. Cross-SDK alignment of the unified positional contract is a follow-up.
 
 | SDK | Annotation lookup | Test seam |
 |---|---|---|
@@ -65,11 +93,11 @@ When the runtime invokes the tool:
 
 All three test files MUST cover the same scenarios:
 
-1. Function with MeshTool only → unchanged from prior behavior
-2. Function with MeshJob only → MeshTool count = 0, MeshJob index recorded
-3. Function with both, MeshJob in middle → MeshTool positions correct (skip MeshJob)
+1. Function with MeshTool only → each MeshTool slot consumes the next `dep_index`
+2. Function with MeshJob only → the single MeshJob slot consumes `dep_index 0`
+3. Function with both, MeshJob in middle → slots take `dep_index` in declaration order; the MeshJob slot's `dep_index` matches its place in the parameter list
 4. Function with neither → no DDDI metadata
-5. Function with MeshJob trailing → MeshJob index = last signature position
+5. Function with MeshJob trailing → the MeshJob slot consumes the last `dep_index`
 
 ## Edge cases (REQUIRED)
 
@@ -87,8 +115,17 @@ evaluation rather than silently picking one.
 
 Permitted. The resolver MUST NOT enforce a trailing-position rule for
 `MeshJob`. Producer/consumer functions are ergonomic to write with the
-job param wherever it reads naturally; the resolver decouples
-declaration order from positional indexing per the rule above.
+job param wherever it reads naturally. Under the unified positional
+contract each typed slot — `MeshTool` or `MeshJob` — consumes the next
+`dep_index` in declaration order.
+
+### Parameter name vs capability name
+
+`MeshJob` parameter names are free-form. The binding from
+`dependencies[i]` to a parameter is **positional only** — the parameter
+name does NOT need to match the capability string. A parameter named
+`workflow` paired with `dependencies=["run_my_thing"]` receives a
+submitter bound to capability `"run_my_thing"`.
 
 ### Default values
 
@@ -104,14 +141,26 @@ or `None`).
 resolver unwraps the Optional/Union before annotation matching. Same
 behavior already applies to `Optional[MeshTool]` per existing semantics.
 
-## Tool invocation: when `MeshJob` is present but the call is NOT a job
+## Tool invocation: producer-side vs consumer-side `MeshJob`
 
-Any tool with a `MeshJob` parameter can still be invoked as a regular
-synchronous `tools/call` (no `X-Mesh-Job-Id` header, no claim path). In
-that case the runtime passes `None` (or the language equivalent) for the
-`MeshJob` slot. The user function MUST handle `None` — typically by
-treating the call as a "fast path" execution that doesn't update progress
-or check cancellation.
+A `MeshJob` parameter plays two distinct roles depending on the call path:
+
+- **Consumer-side** (this tool *submits* jobs to a remote `task=True`
+  capability): the runtime injects a `MeshJobSubmitter` bound to the
+  capability at this slot's `dep_index`. The user calls
+  `await submitter.submit(...)` to enqueue work.
+- **Producer-side** (this tool *is* the `task=True` target being claimed
+  / dispatched as a job): the runtime injects the per-call
+  `JobController` so the function can write progress, check
+  cancellation, and emit events. This applies when the tool is invoked
+  with `X-Mesh-Job-Id` (or via the claim path).
+
+Any tool with a `MeshJob` parameter can also be invoked as a regular
+synchronous `tools/call` (no `X-Mesh-Job-Id` header, not a consumer
+submission). In that case the runtime passes `None` for the `MeshJob`
+slot, and the user function MUST handle `None` — typically by treating
+the call as a "fast path" execution that doesn't update progress or
+check cancellation.
 
 ## Implementation sequence
 

--- a/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
@@ -310,25 +310,45 @@ def _build_clean_signature(func: Any) -> inspect.Signature | None:
 
 def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[int]:
     """
-    Analyze function signature and determine injection strategy.
+    Analyze function signature and determine McpMeshTool injection positions.
 
     Rules:
     1. Single parameter: inject regardless of typing (with warning if not McpMeshTool)
     2. Multiple parameters: only inject into McpMeshTool typed parameters
     3. Log warnings for mismatches and edge cases
 
+    Returns ONLY ``McpMeshTool`` positions — ``MeshJob`` positions are
+    computed independently in :func:`_prepare_injection_kwargs` so the
+    diagnostic warnings below stay scoped to the proxy-injection path.
+
     Args:
         func: Function to analyze
         dependencies: List of dependency names to inject
 
     Returns:
-        List of parameter positions to inject into
+        List of McpMeshTool parameter positions to inject into
     """
     sig = inspect.signature(func)
     params = list(sig.parameters.values())
     param_count = len(params)
     mesh_positions = get_mesh_agent_positions(func)
     func_name = f"{func.__module__}.{func.__qualname__}"
+
+    # Detect whether the function declares any MeshJob param. The unified
+    # positional injection path handles those alongside McpMeshTool slots,
+    # so this function's diagnostics must NOT shout about "no injection
+    # target" when a MeshJob slot will consume the dependency.
+    has_mesh_job_param = False
+    try:
+        from .signature_analyzer import analyze_mesh_job_signature
+
+        _mj = analyze_mesh_job_signature(func)
+        has_mesh_job_param = _mj.mesh_job_param_name is not None
+    except (TypeError, AttributeError):
+        # Only narrow signature-introspection errors swallow silently;
+        # ValueError (Phase-1 multiple-MeshJob contract violation) MUST
+        # propagate per the resolver contract.
+        pass
 
     # No parameters at all
     if param_count == 0:
@@ -342,24 +362,11 @@ def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[
     # Single parameter rule: inject regardless of typing
     if param_count == 1:
         if not mesh_positions:
-            # Phase 1 MeshJob substrate: a function may declare a single
-            # MeshJob param without any McpMeshTool param — that's the
-            # consumer pattern (commission a remote job). Don't inject a
-            # dependency proxy into that slot; the MeshJob param is wired
-            # by ``_prepare_injection_kwargs`` via a different code path.
-            try:
-                from .signature_analyzer import analyze_mesh_job_signature
-
-                _mj = analyze_mesh_job_signature(func)
-                if _mj.mesh_job_param_name is not None:
-                    logger.debug(
-                        f"Function '{func_name}' has a single MeshJob param; "
-                        f"injection of {len(dependencies)} declared dependency(ies) "
-                        f"will be handled via the MeshJob auto-injection path."
-                    )
-                    return []
-            except Exception:
-                pass
+            if has_mesh_job_param:
+                # The single parameter is a MeshJob — the unified injection
+                # path constructs a MeshJobSubmitter for it. No McpMeshTool
+                # position to record here.
+                return []
 
             param_name = params[0].name
             logger.warning(
@@ -372,28 +379,7 @@ def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[
     # Multiple parameters rule: only inject into McpMeshTool typed parameters
     if param_count > 1:
         if not mesh_positions:
-            # Phase 1 MeshJob substrate: a function may declare a MeshJob
-            # param without any McpMeshTool params — that's the consumer
-            # pattern (commission a remote job). Don't shout WARNING in
-            # that case; the MeshJob slot is wired by ``_prepare_injection_kwargs``
-            # via a different code path.
-            has_mesh_job_param = False
-            try:
-                from .signature_analyzer import analyze_mesh_job_signature
-
-                _mj = analyze_mesh_job_signature(func)
-                has_mesh_job_param = _mj.mesh_job_param_name is not None
-            except Exception:
-                pass
-
-            if has_mesh_job_param:
-                logger.debug(
-                    f"Function '{func_name}' declares a MeshJob param but no "
-                    f"McpMeshTool params; injection of {len(dependencies)} "
-                    f"declared dependency(ies) will be handled via the "
-                    f"MeshJob auto-injection path."
-                )
-            else:
+            if not has_mesh_job_param:
                 logger.warning(
                     f"⚠️ Function '{func_name}' has {param_count} parameters but none are "
                     f"typed as McpMeshTool. Skipping injection of {len(dependencies)} dependencies. "
@@ -401,26 +387,26 @@ def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[
                 )
             return []
 
-        # Check for dependency/parameter count mismatches
-        if len(dependencies) != len(mesh_positions):
-            if len(dependencies) > len(mesh_positions):
-                excess_deps = dependencies[len(mesh_positions) :]
-                logger.warning(
-                    f"Function '{func_name}' has {len(dependencies)} dependencies "
-                    f"but only {len(mesh_positions)} McpMeshTool parameters. "
-                    f"Dependencies {excess_deps} will not be injected."
-                )
-            else:
-                excess_params = [
-                    params[pos].name for pos in mesh_positions[len(dependencies) :]
-                ]
-                logger.warning(
-                    f"Function '{func_name}' has {len(mesh_positions)} McpMeshTool parameters "
-                    f"but only {len(dependencies)} dependencies declared. "
-                    f"Parameters {excess_params} will remain None."
-                )
+        # Check for excess-dependency mismatch. Eligible slots =
+        # McpMeshTool + MeshJob positions taken together, so MeshJob slots
+        # don't trigger spurious "excess dependencies" warnings.
+        # NOTE: the inverse case (more eligible slots than dependencies) is
+        # diagnosed at injection time inside ``_prepare_injection_kwargs``
+        # so it can name BOTH untouched McpMeshTool *and* MeshJob params —
+        # this strategy-time site sees McpMeshTool positions only.
+        eligible_count = len(mesh_positions) + (1 if has_mesh_job_param else 0)
+        if len(dependencies) > eligible_count:
+            excess_deps = dependencies[eligible_count:]
+            logger.warning(
+                f"Function '{func_name}' has {len(dependencies)} dependencies "
+                f"but only {eligible_count} injectable parameter(s) "
+                f"(McpMeshTool + MeshJob). "
+                f"Dependencies {excess_deps} will not be injected."
+            )
 
-        # Return positions we can actually inject into
+        # Return McpMeshTool positions we can actually inject into. The
+        # MeshJob slot's index in ``dependencies`` is computed positionally
+        # at injection time by :func:`_prepare_injection_kwargs`.
         return mesh_positions[: len(dependencies)]
 
     return mesh_positions
@@ -437,16 +423,24 @@ def _prepare_injection_kwargs(
 ) -> tuple[dict, int]:
     """Prepare kwargs with injected dependencies and LLM agent.
 
-    This contains the shared logic between async and sync dependency wrappers:
-    dependency resolution, LLM agent injection, and invocation logging.
+    Unified positional injection — ``McpMeshTool`` and ``MeshJob`` params
+    share a single ``dep_index`` namespace in declaration order. Each
+    ``dependencies[i]`` strictly pairs with ONE parameter position; the
+    slot's type (proxy vs submitter) determines what gets constructed.
+    Unresolved deps leave their slot ``None`` — positions never shift.
+
+    The ``mesh_positions`` argument carries the McpMeshTool positions
+    pre-computed by :func:`analyze_injection_strategy` (used for cache
+    indexing into ``injected_deps_array``); the MeshJob positions are
+    re-derived here from the live signature.
 
     Args:
         func: The original function being wrapped
         kwargs: Caller-supplied keyword arguments
-        mesh_positions: Parameter positions that accept mesh dependencies
-        dependencies: Dependency names declared on the function
-        injected_deps_array: Wrapper's mutable array of cached dependency instances
-        get_dependency_fn: Fallback lookup for dependencies not in the array
+        mesh_positions: McpMeshTool parameter positions (from analyze step)
+        dependencies: Dependency capability names declared on the function
+        injected_deps_array: Wrapper's mutable array of cached proxy instances
+        get_dependency_fn: Fallback lookup for proxies not in the array
         log: Logger instance for debug output
 
     Returns:
@@ -464,27 +458,130 @@ def _prepare_injection_kwargs(
     params = list(sig.parameters.keys())
     final_kwargs = kwargs.copy()
 
+    # Build the unified eligible-positions list from the live signature.
+    # Order is declaration order; the set is used inside the loop to
+    # branch between proxy- and submitter-construction.
+    mesh_job_positions: set[int] = set()
+    try:
+        from .signature_analyzer import analyze_mesh_job_signature
+
+        sig_target = getattr(func, "_mesh_original_func", func)
+        _mj_resolution = analyze_mesh_job_signature(sig_target)
+        if _mj_resolution.mesh_job_param_index is not None:
+            mesh_job_positions.add(_mj_resolution.mesh_job_param_index)
+    except (TypeError, AttributeError) as e:
+        # Only narrow signature-introspection errors swallow silently;
+        # ValueError (Phase-1 multiple-MeshJob contract violation) MUST
+        # propagate per the resolver contract.
+        log.debug(f"{tp}MeshJob analysis skipped for {func.__name__}: {e}")
+
+    eligible_positions = sorted(set(mesh_positions) | mesh_job_positions)
+
+    # Diagnostic: more eligible (McpMeshTool + MeshJob) slots than declared
+    # dependencies — the trailing slots will silently stay None. Flagging
+    # here (at injection time) covers cases the strategy-time warning at
+    # ``analyze_injection_strategy`` can't see, because it counts MeshJob
+    # positions too rather than McpMeshTool only.
+    if len(eligible_positions) > len(dependencies):
+        untouched_positions = eligible_positions[len(dependencies):]
+        sig_params = list(sig.parameters.values())
+        untouched_param_names = [sig_params[pos].name for pos in untouched_positions]
+        log.warning(
+            f"⚠️ Function '{func.__name__}' has {len(eligible_positions)} "
+            f"injection-eligible parameters (McpMeshTool/MeshJob) but only "
+            f"{len(dependencies)} dependency(ies) declared. Parameters "
+            f"{untouched_param_names} will remain None."
+        )
+
     injected_count = 0
     injected_deps: list[str] = []
 
-    for dep_index, param_position in enumerate(mesh_positions):
-        if dep_index < len(dependencies):
-            dep_name = dependencies[dep_index]
-            param_name = params[param_position]
+    # MeshJobSubmitter construction needs the registry URL + agent_id;
+    # resolve lazily on first MeshJob slot so non-job tools pay nothing.
+    _submitter_ctx: Optional[tuple[Optional[str], str]] = None
 
-            if param_name not in final_kwargs or final_kwargs.get(param_name) is None:
-                dependency = None
-                if dep_index < len(injected_deps_array):
-                    dependency = injected_deps_array[dep_index]
+    def _resolve_submitter_ctx() -> tuple[Optional[str], str]:
+        nonlocal _submitter_ctx
+        if _submitter_ctx is not None:
+            return _submitter_ctx
+        import os as _os
 
-                if dependency is None:
-                    dep_key = f"{func.__module__}.{func.__qualname__}:dep_{dep_index}"
-                    dependency = get_dependency_fn(dep_key)
+        from .decorator_registry import DecoratorRegistry
 
-                final_kwargs[param_name] = dependency
+        registry_url = _os.environ.get("MCP_MESH_REGISTRY_URL")
+        instance_id = "unknown"
+        try:
+            cfg = DecoratorRegistry.get_resolved_agent_config()
+            if isinstance(cfg, dict):
+                candidate = cfg.get("agent_id")
+                if candidate:
+                    instance_id = candidate
+        except Exception as exc:
+            log.debug(
+                f"{tp}MeshJob: DecoratorRegistry agent_id lookup failed "
+                f"({exc}); using 'unknown'"
+            )
+        _submitter_ctx = (registry_url, instance_id)
+        return _submitter_ctx
+
+    for dep_index, position in enumerate(eligible_positions):
+        if dep_index >= len(dependencies):
+            break
+
+        dep_name = dependencies[dep_index]
+        param_name = params[position]
+
+        # Skip if user explicitly passed a value — preserves the
+        # test-friendly contract that callers can supply a fake/mock for
+        # either a proxy or a submitter slot.
+        if param_name in final_kwargs and final_kwargs.get(param_name) is not None:
+            continue
+
+        if position in mesh_job_positions:
+            # MeshJob slot — construct a MeshJobSubmitter for the
+            # capability at this dep_index. Param NAME does not matter;
+            # the binding is positional.
+            registry_url, instance_id = _resolve_submitter_ctx()
+            if registry_url:
+                from .mesh_job_submitter import MeshJobSubmitter
+
+                submitter = MeshJobSubmitter(
+                    capability=dep_name,
+                    submitted_by=instance_id,
+                    registry_url=registry_url,
+                )
+                final_kwargs[param_name] = submitter
                 injected_count += 1
-                proxy_type = type(dependency).__name__ if dependency else "None"
-                injected_deps.append(f"{dep_name} → {proxy_type}")
+                injected_deps.append(f"{dep_name} → MeshJobSubmitter")
+                log.debug(
+                    f"{tp}📨 MESH_JOB_INJECTION: Injected MeshJobSubmitter "
+                    f"for capability={dep_name!r} into param={param_name!r}"
+                )
+            else:
+                log.warning(
+                    f"{tp}MeshJob param {param_name!r} on {func.__name__} "
+                    f"could not be wired: MCP_MESH_REGISTRY_URL not set"
+                )
+                # Set the slot explicitly to None so the user function's
+                # call signature is satisfied even when the MeshJob param
+                # has no default. Mirrors the McpMeshTool branch's behavior
+                # of always assigning into final_kwargs.
+                final_kwargs[param_name] = None
+        else:
+            # McpMeshTool slot — use the cached proxy / get_dependency_fn
+            # fallback. The dep_index lines up with the wrapper's
+            # injected_deps_array slot allocated at decoration time.
+            dependency = None
+            if dep_index < len(injected_deps_array):
+                dependency = injected_deps_array[dep_index]
+            if dependency is None:
+                dep_key = f"{func.__module__}.{func.__qualname__}:dep_{dep_index}"
+                dependency = get_dependency_fn(dep_key)
+
+            final_kwargs[param_name] = dependency
+            injected_count += 1
+            proxy_type = type(dependency).__name__ if dependency else "None"
+            injected_deps.append(f"{dep_name} → {proxy_type}")
 
     if injected_count > 0:
         log.debug(
@@ -498,74 +595,6 @@ def _prepare_injection_kwargs(
             llm_agent = getattr(func, "_mesh_llm_agent", None)
             final_kwargs[llm_param] = llm_agent
             log.debug(f"{tp}🤖 LLM_INJECTION: Injected {llm_param}={llm_agent}")
-
-    # Phase 1 MeshJob substrate: consumer-side injection.
-    # If the function declares a MeshJob-typed parameter whose name matches
-    # one of its declared dependency capabilities, inject a
-    # MeshJobSubmitter for that capability so the consumer can call
-    # ``await submitter.submit(...)``. Per the resolver contract
-    # (MESHJOB_DDDI_CONTRACT.md), MeshJob params are orthogonal to
-    # McpMeshTool position-indexing — they're identified by name, not slot.
-    try:
-        from .signature_analyzer import analyze_mesh_job_signature
-
-        # Use _mesh_original_func if present (set by injection wrapper) so
-        # we read the user's source-level annotations, not the wrapper's.
-        sig_target = getattr(func, "_mesh_original_func", func)
-        resolution = analyze_mesh_job_signature(sig_target)
-        mesh_job_param = resolution.mesh_job_param_name
-    except Exception as e:
-        log.debug(f"{tp}MeshJob analysis skipped for {func.__name__}: {e}")
-        mesh_job_param = None
-
-    if mesh_job_param and mesh_job_param in dependencies:
-        # Only inject when the slot is currently empty / None — preserves
-        # the test-friendly contract that callers can pass an explicit
-        # MeshJob (e.g. a fake) and bypass the framework's auto-wiring.
-        if (
-            mesh_job_param not in final_kwargs
-            or final_kwargs.get(mesh_job_param) is None
-        ):
-            from .mesh_job_submitter import MeshJobSubmitter
-            import os as _os
-
-            from .decorator_registry import DecoratorRegistry
-
-            registry_url = _os.environ.get("MCP_MESH_REGISTRY_URL")
-            # Single source of truth: the same DecoratorRegistry-resolved
-            # agent_id that the heartbeat registers, the claim worker
-            # sends on POST /jobs/claim, and the JobController stamps on
-            # batch deltas. Reading from it here means submitted_by
-            # lines up exactly with the eventual claim's
-            # owner_instance_id when this agent submits to itself.
-            instance_id = "unknown"
-            try:
-                cfg = DecoratorRegistry.get_resolved_agent_config()
-                if isinstance(cfg, dict):
-                    candidate = cfg.get("agent_id")
-                    if candidate:
-                        instance_id = candidate
-            except Exception as exc:
-                log.debug(
-                    f"{tp}MeshJob param {mesh_job_param!r}: DecoratorRegistry "
-                    f"agent_id lookup failed ({exc}); using 'unknown'"
-                )
-            if registry_url:
-                submitter = MeshJobSubmitter(
-                    capability=mesh_job_param,
-                    submitted_by=instance_id,
-                    registry_url=registry_url,
-                )
-                final_kwargs[mesh_job_param] = submitter
-                log.debug(
-                    f"{tp}📨 MESH_JOB_INJECTION: Injected MeshJobSubmitter "
-                    f"for capability={mesh_job_param!r}"
-                )
-            else:
-                log.warning(
-                    f"{tp}MeshJob param {mesh_job_param!r} on {func.__name__} "
-                    f"could not be wired: MCP_MESH_REGISTRY_URL not set"
-                )
 
     return final_kwargs, injected_count
 
@@ -897,7 +926,10 @@ class DependencyInjector:
 
             _mj = analyze_mesh_job_signature(func)
             has_mesh_job_param = _mj.mesh_job_param_name is not None
-        except Exception:
+        except (TypeError, AttributeError):
+            # Narrow catch: only swallow signature-introspection errors.
+            # ValueError (multi-MeshJob contract violation per the Phase-1
+            # resolver) MUST propagate so the wrapper fails fast.
             pass
 
         # If no mesh positions to inject AND no MeshJob slot, fall back to

--- a/src/runtime/python/_mcp_mesh/engine/signature_analyzer.py
+++ b/src/runtime/python/_mcp_mesh/engine/signature_analyzer.py
@@ -122,10 +122,13 @@ def _is_mesh_job_type(param_type: Any) -> bool:
 class MeshJobResolution:
     """Resolver output for ``MeshJob`` parameter classification.
 
-    Per ``MESHJOB_DDDI_CONTRACT.md``: ``MeshJob`` is **orthogonal** to
-    ``MeshTool`` positional indexing — its signature position is recorded
-    separately so adding/removing a ``MeshJob`` parameter does not shift
-    the slot numbers used to inject mesh-tool dependencies.
+    Per ``MESHJOB_DDDI_CONTRACT.md``: ``MeshJob`` and ``McpMeshTool``
+    parameters share a **single unified positional ``dep_index``
+    namespace**. Adding or removing a ``MeshJob`` parameter shifts the
+    shared slot numbering used to inject all mesh dependencies; the
+    ``MeshJob`` position is recorded here so the dispatch at injection
+    time can identify which slot to construct a ``MeshJobSubmitter``
+    for (vs an ``McpMeshTool`` proxy).
 
     Attributes:
         mesh_tool_positions: Signature positions (0-indexed) of
@@ -307,14 +310,15 @@ def validate_mesh_dependencies(func: Any, dependencies: list[dict]) -> tuple[boo
     Validate that the number of dependencies matches the function's
     injectable slots.
 
-    A function may declare two kinds of typed dependency slot:
+    A function may declare two kinds of typed dependency slot, both
+    consuming a positional dependency entry (in declaration order):
 
-    * ``McpMeshTool`` — positional, dispatch via remote tools/call. Counted
-      via :func:`get_mesh_agent_positions`.
-    * ``MeshJob`` — name-matched (by parameter name == dependency
-      capability), dispatch via job submit. Counted by inspecting whether
-      the function declares any ``MeshJob`` param whose name appears in the
-      declared dependency capabilities (see MeshJob DDDI contract).
+    * ``McpMeshTool`` — dispatched via remote ``tools/call``. Counted via
+      :func:`get_mesh_agent_positions`.
+    * ``MeshJob`` — dispatched via job submit. Counted by the presence of
+      a single ``MeshJob`` parameter (Phase 1 enforces at most one). The
+      parameter name is free-form; binding is positional per
+      ``MESHJOB_DDDI_CONTRACT.md``.
 
     Validation passes when ``len(dependencies) == mcp_slots + job_slots``
     so consumer functions that only depend on a remote ``task=True`` tool
@@ -332,10 +336,8 @@ def validate_mesh_dependencies(func: Any, dependencies: list[dict]) -> tuple[boo
     func = _get_original_func(func)
     mesh_positions = get_mesh_agent_positions(func)
 
-    # Count MeshJob slots that match a declared dependency capability.
-    # MeshJob params are name-matched (not positional) so an unmatched
-    # MeshJob param does NOT consume a dependency slot — only the matched
-    # ones do.
+    # Count MeshJob slots positionally — name does not matter under the
+    # unified positional contract.
     #
     # Errors: ``analyze_mesh_job_signature`` raises ``ValueError`` when a
     # function declares multiple MeshJob parameters (Phase 1 contract).
@@ -358,18 +360,14 @@ def validate_mesh_dependencies(func: Any, dependencies: list[dict]) -> tuple[boo
         )
         resolution = None
 
-    if resolution is not None and resolution.mesh_job_param_name:
-        dep_caps = {
-            d.get("capability") for d in dependencies if isinstance(d, dict)
-        }
-        if resolution.mesh_job_param_name in dep_caps:
-            job_slots = 1
+    if resolution is not None and resolution.mesh_job_param_name is not None:
+        job_slots = 1
 
     expected = len(mesh_positions) + job_slots
     if len(dependencies) != expected:
         return False, (
             f"Function {func.__name__} has {len(mesh_positions)} McpMeshTool "
-            f"parameter(s) and {job_slots} matched MeshJob slot(s) "
+            f"parameter(s) and {job_slots} MeshJob slot(s) "
             f"but {len(dependencies)} dependencies declared. "
             f"Each typed slot needs a corresponding dependency."
         )

--- a/src/runtime/python/tests/unit/test_12_dependency_injector.py
+++ b/src/runtime/python/tests/unit/test_12_dependency_injector.py
@@ -889,3 +889,260 @@ class TestDebugLogging:
             assert "dep1" in caplog.text
             assert "Tool 'test_func' returned:" in caplog.text
             assert "Tool 'test_func' result:" in caplog.text
+
+
+class TestUnifiedPositionalInjection:
+    """Cover the unified positional injection contract — McpMeshTool and
+    MeshJob parameters share a single ``dep_index`` namespace in
+    declaration order. Each ``dependencies[i]`` strictly pairs with ONE
+    parameter position; unresolved deps leave the slot ``None`` without
+    shifting later positions.
+
+    The tests exercise :func:`_prepare_injection_kwargs` directly so the
+    assertions don't have to navigate the async wrapper plumbing — the
+    function under test is the contract surface.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _registry_url(self, monkeypatch):
+        # MeshJob injection requires MCP_MESH_REGISTRY_URL to construct a
+        # MeshJobSubmitter; without it the framework logs a warning and
+        # leaves the slot None. Set it once for the whole class.
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://registry.local:8000")
+
+    @staticmethod
+    def _prep(func, dependencies, injected_deps_array=None):
+        """Invoke _prepare_injection_kwargs against a user function.
+
+        Mirrors what the real wrapper does during runtime injection so
+        we can assert each slot receives exactly the right value type.
+        """
+        import logging as _log
+        from _mcp_mesh.engine.dependency_injector import _prepare_injection_kwargs
+        from _mcp_mesh.engine.signature_analyzer import get_mesh_agent_positions
+
+        if injected_deps_array is None:
+            injected_deps_array = [None] * len(dependencies)
+        mesh_positions = get_mesh_agent_positions(func)
+        return _prepare_injection_kwargs(
+            func,
+            {},
+            mesh_positions,
+            dependencies,
+            injected_deps_array,
+            lambda _key: None,
+            _log.getLogger("test"),
+        )
+
+    def test_mesh_job_first_then_mesh_tool(self):
+        """The exact #1075 shape: MeshJob dep listed FIRST in deps[],
+        McpMeshTool dep second. Each param must receive the RIGHT slot
+        type — submitter into MeshJob, proxy into McpMeshTool."""
+        from mesh import MeshJob
+        from mesh.types import McpMeshTool
+        from _mcp_mesh.engine.mesh_job_submitter import MeshJobSubmitter
+
+        async def consumer(
+            user_id: str,
+            job: MeshJob = None,         # sig pos 1 → dep_index 0
+            tool: McpMeshTool = None,    # sig pos 2 → dep_index 1
+        ):
+            return (user_id, job, tool)
+
+        mock_proxy = MagicMock(name="fetch_data_proxy")
+        # The McpMeshTool's dep_index is 1 — slot 1 of the cache array.
+        final_kwargs, count = self._prep(
+            consumer,
+            ["run_workflow", "fetch_data"],
+            injected_deps_array=[None, mock_proxy],
+        )
+
+        assert isinstance(final_kwargs["job"], MeshJobSubmitter)
+        assert final_kwargs["job"].capability == "run_workflow"
+        assert final_kwargs["tool"] is mock_proxy
+        assert count == 2
+
+    def test_mesh_tool_first_then_mesh_job(self):
+        """Reversed order: McpMeshTool first, MeshJob second. Same
+        per-slot type assertion — confirms the binding is positional,
+        not type-prioritised."""
+        from mesh import MeshJob
+        from mesh.types import McpMeshTool
+        from _mcp_mesh.engine.mesh_job_submitter import MeshJobSubmitter
+
+        async def consumer(
+            user_id: str,
+            tool: McpMeshTool = None,   # sig pos 1 → dep_index 0
+            job: MeshJob = None,        # sig pos 2 → dep_index 1
+        ):
+            return (user_id, tool, job)
+
+        mock_proxy = MagicMock(name="fetch_data_proxy")
+        final_kwargs, count = self._prep(
+            consumer,
+            ["fetch_data", "run_workflow"],
+            injected_deps_array=[mock_proxy, None],
+        )
+
+        assert final_kwargs["tool"] is mock_proxy
+        assert isinstance(final_kwargs["job"], MeshJobSubmitter)
+        assert final_kwargs["job"].capability == "run_workflow"
+        assert count == 2
+
+    def test_unresolved_middle_dependency_does_not_shift(self):
+        """Three McpMeshTool params; the middle dep is unresolved (no
+        proxy registered). Positions 0 and 2 must still receive their
+        proxies — position 1 stays ``None`` rather than shifting up to
+        consume the position-2 proxy."""
+        from mesh.types import McpMeshTool
+
+        async def fan_out(
+            a: str,
+            dep0: McpMeshTool = None,
+            dep1: McpMeshTool = None,
+            dep2: McpMeshTool = None,
+        ):
+            return (dep0, dep1, dep2)
+
+        proxy_a = MagicMock(name="proxy_a")
+        proxy_c = MagicMock(name="proxy_c")
+        # Position 1 stays None (unresolved); positions 0 and 2 have proxies.
+        final_kwargs, _ = self._prep(
+            fan_out,
+            ["cap_a", "cap_b", "cap_c"],
+            injected_deps_array=[proxy_a, None, proxy_c],
+        )
+
+        assert final_kwargs["dep0"] is proxy_a
+        assert final_kwargs["dep1"] is None   # No shifting
+        assert final_kwargs["dep2"] is proxy_c
+
+    def test_unresolved_mixed_mesh_tool_with_mesh_job(self):
+        """MeshJob + McpMeshTool; the McpMeshTool dep is unresolved.
+        MeshJob still gets its submitter (registry URL set, name
+        free-form), McpMeshTool param stays ``None``."""
+        from mesh import MeshJob
+        from mesh.types import McpMeshTool
+        from _mcp_mesh.engine.mesh_job_submitter import MeshJobSubmitter
+
+        async def consumer(
+            a: str,
+            job: MeshJob = None,        # sig pos 1 → dep_index 0
+            tool: McpMeshTool = None,   # sig pos 2 → dep_index 1
+        ):
+            return (job, tool)
+
+        # No proxy for the McpMeshTool slot — leave None.
+        final_kwargs, _ = self._prep(
+            consumer,
+            ["run_workflow", "missing_tool"],
+            injected_deps_array=[None, None],
+        )
+
+        assert isinstance(final_kwargs["job"], MeshJobSubmitter)
+        assert final_kwargs["job"].capability == "run_workflow"
+        assert final_kwargs["tool"] is None
+
+    def test_mesh_job_param_name_is_free_form(self):
+        """The MeshJob param name no longer must match a capability —
+        positional binding only. A param named ``workflow`` paired with
+        dependency capability ``run_my_thing`` MUST receive a
+        MeshJobSubmitter with ``capability='run_my_thing'``."""
+        from mesh import MeshJob
+        from _mcp_mesh.engine.mesh_job_submitter import MeshJobSubmitter
+
+        async def consumer(
+            user_id: str,
+            workflow: MeshJob = None,
+        ):
+            return workflow
+
+        final_kwargs, _ = self._prep(
+            consumer,
+            ["run_my_thing"],
+            injected_deps_array=[None],
+        )
+
+        assert isinstance(final_kwargs["workflow"], MeshJobSubmitter)
+        # Name mismatch is fine — binding is positional.
+        assert final_kwargs["workflow"].capability == "run_my_thing"
+
+    def test_pure_mesh_tool_positional_unchanged(self):
+        """Regression: a pure-McpMeshTool function still injects each
+        proxy into its positional slot exactly as before the
+        unification."""
+        from mesh.types import McpMeshTool
+
+        async def fan_out(
+            a: str, dep0: McpMeshTool = None, dep1: McpMeshTool = None
+        ):
+            return (dep0, dep1)
+
+        proxy0 = MagicMock(name="proxy0")
+        proxy1 = MagicMock(name="proxy1")
+        final_kwargs, count = self._prep(
+            fan_out,
+            ["cap0", "cap1"],
+            injected_deps_array=[proxy0, proxy1],
+        )
+
+        assert final_kwargs["dep0"] is proxy0
+        assert final_kwargs["dep1"] is proxy1
+        assert count == 2
+
+    def test_explicit_kwarg_skips_meshjob_injection(self):
+        """Test-friendly contract: when the caller passes an explicit
+        value for a MeshJob param (e.g. a fake), the framework MUST NOT
+        overwrite it with a MeshJobSubmitter."""
+        import logging as _log
+        from mesh import MeshJob
+        from _mcp_mesh.engine.dependency_injector import _prepare_injection_kwargs
+        from _mcp_mesh.engine.signature_analyzer import get_mesh_agent_positions
+
+        async def consumer(a: str, job: MeshJob = None):
+            return job
+
+        fake_job = MagicMock(name="fake_job")
+        mesh_positions = get_mesh_agent_positions(consumer)
+        final_kwargs, injected_count = _prepare_injection_kwargs(
+            consumer,
+            {"job": fake_job},  # caller-supplied
+            mesh_positions,
+            ["run_workflow"],
+            [None],
+            lambda _key: None,
+            _log.getLogger("test"),
+        )
+
+        assert final_kwargs["job"] is fake_job
+        # Framework MUST NOT have injected anything — the caller-supplied
+        # value was preserved verbatim, no MeshJobSubmitter constructed.
+        assert injected_count == 0
+
+    def test_meshjob_slot_is_none_when_registry_url_unset(self, monkeypatch):
+        """When MCP_MESH_REGISTRY_URL is missing, the MeshJob slot must
+        be explicitly set to None (not omitted from final_kwargs) so the
+        consumer function's call signature is satisfied. Mirrors the
+        McpMeshTool branch's behavior of always assigning into kwargs."""
+        from mesh import MeshJob
+
+        # Override the class-wide _registry_url fixture for this test.
+        monkeypatch.delenv("MCP_MESH_REGISTRY_URL", raising=False)
+
+        async def consumer(user_id: str, job: MeshJob = None):
+            return job
+
+        final_kwargs, injected_count = self._prep(
+            consumer,
+            ["run_workflow"],
+            injected_deps_array=[None],
+        )
+
+        # The job slot is present in final_kwargs and is None — not
+        # missing-from-dict, which would surface as TypeError on call
+        # if the user's MeshJob param had no default.
+        assert "job" in final_kwargs
+        assert final_kwargs["job"] is None
+        # Framework didn't construct a MeshJobSubmitter (registry URL
+        # was unavailable), so injected_count stays at 0.
+        assert injected_count == 0


### PR DESCRIPTION
## Summary

Unifies dependency injection for `mesh.McpMeshTool` AND `mesh.MeshJob` params under a single positional rule. Drops the previous by-name MeshJob resolution that caused wrong-proxy injection when mixed with `McpMeshTool` params.

**The bug**: `_prepare_injection_kwargs` had two injection paths — McpMeshTool matched by position, MeshJob matched by capability name. When a tool declared `(run_debate: mesh.MeshJob, debate_state: mesh.McpMeshTool)` with `dependencies=[{capability:"run_debate"}, {capability:"debate_state"}]`, the McpMeshTool slot picked up `dependencies[0]` (which sat at the MeshJob's position), so `debate_state` ended up bound to the `run_debate` proxy. Downstream calls then failed with Pydantic errors on the wrong capability name.

**The fix**: Single unified loop. `eligible_positions` = sorted union of McpMeshTool + MeshJob param positions (declaration order). Each `dep_index` strictly pairs with `eligible_positions[dep_index]`; param type determines whether to construct a `MeshJobSubmitter` or use the cached proxy from `injected_deps_array`. The entire separate by-name MeshJob block is removed.

**Unresolved-dep invariant**: If `dependencies[i]` is unresolved, the corresponding parameter slot stays `None`. Positions do NOT shift to fill the gap.

## What changes for users

| Before | After |
|---|---|
| McpMeshTool: positional matching | McpMeshTool: positional matching (unchanged) |
| MeshJob: by-name (param name ↔ capability name) | MeshJob: positional matching by declaration order |
| Mixed types: silent wrong-proxy bug | Mixed types: each slot binds to its own dep, correctly |
| MeshJob param name must match capability name | MeshJob param name is free-form; only position matters |

**Backward compatibility note**: v2.2.4 (where the MeshJob substrate became GA) shipped 2026-05-21 — recent enough that user explicitly chose clean implementation over a compatibility shim. Users who deliberately wrote MeshJob params out-of-order with dependencies relying on by-name resolution would need to reorder; the natural same-order case continues to work unchanged.

## Out of scope

- TypeScript and Java SDK DI paths — they may still have similar issues but ship separately if needed
- Lifting the "max 1 MeshJob param per tool" restriction — positional semantics would technically allow it, but the existing single-MeshJob design constraint stays for this PR

## Review Notes

Independent review: 0 BLOCKER, 2 WARNING (addressed), 4 INFOs (2 addressed, 2 skipped).

- **W1 — ValueError swallow at injection time fixed**: `analyze_mesh_job_signature` raises `ValueError` per the Phase-1 multi-MeshJob contract. The injection-time call wrapped in broad `except Exception` was silently demoting MeshJob slots to McpMeshTool. Narrowed both catch sites (in `analyze_injection_strategy` and `_prepare_injection_kwargs`) to `(TypeError, AttributeError)` matching the pattern already used in `signature_analyzer.validate_mesh_dependencies`. `ValueError` now propagates loudly.
- **W2 — Silent excess-slot diagnostic fixed**: when `eligible_positions` count exceeded `dependencies` count AND a MeshJob was present, the old McpMeshTool-only excess warning didn't fire. Replaced with a new injection-time warning that counts MeshJob + McpMeshTool together. Old warning removed (the new one is a strict superset). New text: `"Function 'X' has N injection-eligible parameters (McpMeshTool/MeshJob) but only M dependency(ies) declared. Parameters [...] will remain None."`
- **I3 — Test strengthening**: `test_explicit_kwarg_skips_meshjob_injection` now asserts `injected_count == 0` (proves framework did NOT inject, not just that the kwarg was preserved).
- **I4 — Contract doc note**: added cross-runtime parity note to `MESHJOB_DDDI_CONTRACT.md` clarifying this PR ports Python only; TS/Java tracked separately.

INFOs skipped: I1 (import location — cosmetic), I2 (caching `analyze_mesh_job_signature` result — perf optimization deferred until hot-path profile shows it matters).

Closes #1075

## Test plan

- [x] Python unit tests: 1009 / 1009 (was 1002, +7 new in `TestUnifiedPositionalInjection`)
- [x] `tests/src-tests`: 12/12
- [x] `tests/integration --uc uc02_agent_lifecycle`: 23/23
- [x] `tests/integration --uc uc21_meshjob`: 21/21 (one flake on tc26 on initial run, passed clean on rerun — unrelated to DI changes)
- [x] `mkdocs build` clean
- [x] Cross-runtime scope: no edits to TypeScript or Java DI paths
- [x] Public-artifact framing: structural language throughout; no naming downstream consumers

## New test coverage

`TestUnifiedPositionalInjection` (7 tests):
- The exact #1075 shape (MeshJob first in deps, McpMeshTool second) — assert correct binding
- Reversed order — assert correct binding
- Unresolved middle dep — slot stays `None`, no shifting
- Mixed unresolved — MeshJob slot still gets submitter
- Free-form MeshJob param name — proves by-name dependence is gone
- Pure McpMeshTool regression
- Explicit-kwarg passthrough (test-friendly contract preserved)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified dependency injection contract specifications for consistent parameter binding semantics.

* **Improvements**
  * Enhanced MeshJob parameter injection using a unified positional model, ensuring predictable behavior when mixing different parameter types.
  * Refined validation logic to prevent dependency configuration edge cases.

* **Tests**
  * Added comprehensive test coverage for unified positional dependency injection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhyansraj/mcp-mesh/pull/1082?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->