### PR TITLE
feat(java/spring): @MeshDependsOn for component-level mesh DI

### DIFF
--- a/docs/java/dependency-injection.md
+++ b/docs/java/dependency-injection.md
@@ -66,6 +66,93 @@ public String generateReport(
 }
 ```
 
+## Component-level dependency declaration with `@MeshDependsOn`
+
+`@MeshInject` and `@MeshRoute(dependencies=...)` work at the controller-method scope. For everything else — `@Service` beans, `@Component`s, servlet `Filter`s, `@Scheduled` jobs — declare the capabilities your bean needs with the class-level `@MeshDependsOn` annotation. The auto-configuration then registers a singleton `McpMeshTool` bean named by each capability, so you can wire it the standard Spring way.
+
+### Constructor injection (recommended)
+
+```java
+@Service
+@MeshDependsOn({
+    @MeshDependency(capability = "list_holidays"),
+    @MeshDependency(capability = "get_user_profile")
+})
+public class StaffSyncService {
+    private final McpMeshTool<List<Holiday>> holidays;
+    private final McpMeshTool<UserProfileResponse> profile;
+
+    public StaffSyncService(
+            @Qualifier("list_holidays") McpMeshTool<List<Holiday>> holidays,
+            @Qualifier("get_user_profile") McpMeshTool<UserProfileResponse> profile) {
+        this.holidays = holidays;
+        this.profile = profile;
+    }
+
+    public List<Holiday> upcomingHolidays() {
+        if (!holidays.isAvailable()) return List.of();
+        return holidays.call();
+    }
+}
+```
+
+### Field injection
+
+```java
+@Component
+@MeshDependsOn(@MeshDependency(capability = "list_holidays"))
+public class HolidayChecker {
+    @Autowired
+    @Qualifier("list_holidays")
+    private McpMeshTool<List<Holiday>> holidays;
+}
+```
+
+### Where to use it
+
+| Scenario | Annotation |
+| -------- | ---------- |
+| `@MeshTool` method needing remote helpers | `@MeshTool(dependencies = @Selector(...))` + parameter injection |
+| `@RestController` handler method | `@MeshRoute(dependencies = {...})` + `@MeshInject` parameter |
+| `@Service` / `@Component` / `Filter` / `@Scheduled` / any other Spring bean | **`@MeshDependsOn` + `@Qualifier`** |
+
+`@MeshDependsOn` and `@MeshInject`/`@MeshRoute` are complementary — same heartbeat-driven proxy lifecycle, same auto-rewiring on topology change, same `isAvailable()` semantics. Pick the surface that matches where you need the dependency. If the same capability shows up via multiple sources the framework deduplicates: a single proxy and a single registry entry per capability name.
+
+### Tags, version, and bean-name conflicts
+
+The `@MeshDependency` element accepts the same `tags`, `version`, `expectedType`, and `schemaMode` fields documented above for `@MeshRoute`. If a `@MeshDependsOn` capability happens to match the name of a user-owned Spring bean, the user's bean wins — the framework logs an `ERROR` naming the conflicting bean's class and every `@MeshDependsOn`-annotated class that declared the capability, then skips the proxy registration. Any consumer that `@Qualifier`-injected `McpMeshTool<...>` for that capability will fail context refresh with `BeanNotOfRequiredTypeException`. Resolve by renaming either the user bean or the capability.
+
+### Typed deserialization
+
+When you set `expectedType` on `@MeshDependency`, the framework wires it into the `McpMeshTool` proxy's deserialization type at registration time. The first call returns the typed value directly — no extra `setReturnType(...)` step required:
+
+```java
+@Service
+@MeshDependsOn(@MeshDependency(
+    capability   = "get_user_profile",
+    expectedType = UserProfileResponse.class))
+public class StaffSyncService {
+    public StaffSyncService(@Qualifier("get_user_profile") McpMeshTool<UserProfileResponse> profile) {
+        // profile.call(...) returns UserProfileResponse, not Map<String,Object>
+    }
+}
+```
+
+If you omit `expectedType` and the `@Qualifier`-injected field is declared as `McpMeshTool<UserProfileResponse>`, deserialization to that generic type is best-effort and the first call may return `Map<String, Object>` until something else (a `@MeshRoute` parameter with the same generic, an explicit `setReturnType(...)`) primes the proxy. Setting `expectedType` is the supported way to make typed responses work upfront from a `@MeshDependsOn` surface.
+
+### Discovery caveat — `@Bean` factory methods returning a supertype
+
+`@MeshDependsOn` is read off the bean's resolved class via Spring's bean-definition metadata, then `AnnotationUtils.findAnnotation` walks the class and its supertypes. This covers `@Component`-scanned beans AND `@Bean` factory methods — both surfaces work as expected when the annotation is on the class Spring sees.
+
+| Shape | Discovered? |
+| --- | --- |
+| `@Component @MeshDependsOn(...) class Foo` | ✓ |
+| `@Bean public ConcreteFoo foo()` where `@MeshDependsOn` is on `ConcreteFoo` | ✓ — Spring's `ResolvableType` reports the concrete return type |
+| `@Bean public Foo foo()` where `@MeshDependsOn` is on `Foo` (or any supertype `Foo` extends) | ✓ |
+| `@Bean public Foo foo() { return new ConcreteFoo(); }` where `@MeshDependsOn` is ONLY on `ConcreteFoo` | ✗ — `findAnnotation` walks supertypes of the declared return type, not subtypes of it |
+
+Only the last shape is a real gap. If your factory method declares a supertype return, either narrow the declared return type to the concrete class, or place `@MeshDependsOn` on the supertype itself (or on the `@Configuration` class).
+
 ## `McpMeshTool<T>` API Reference
 
 The `McpMeshTool<T>` interface is the primary way to interact with remote capabilities. The type parameter `T` indicates the expected return type.

--- a/docs/security/authorization.md
+++ b/docs/security/authorization.md
@@ -46,6 +46,8 @@ Use your platform's native auth framework to enforce access control:
 
 === "Java (Spring Security)"
 
+    Controller-level check (the common case):
+
     ```java
     @RestController
     @RequestMapping("/api")
@@ -60,6 +62,36 @@ Use your platform's native auth framework to enforce access control:
         }
     }
     ```
+
+    Filter-level work (auth side-effects that must run before MVC
+    dispatch — first-login user linking, audit emission, principal
+    hydration). Declare the capabilities your filter needs with
+    `@MeshDependsOn` and inject via `@Qualifier`:
+
+    ```java
+    @Component
+    @MeshDependsOn({
+        @MeshDependency(capability = "resolve_user_principal"),
+        @MeshDependency(capability = "audit_log")
+    })
+    public class AuthFilter extends OncePerRequestFilter {
+        private final McpMeshTool<Map<String, Object>> resolveTool;
+        private final McpMeshTool<Object> auditTool;
+
+        public AuthFilter(
+            @Qualifier("resolve_user_principal") McpMeshTool<Map<String, Object>> resolveTool,
+            @Qualifier("audit_log") McpMeshTool<Object> auditTool) {
+            this.resolveTool = resolveTool;
+            this.auditTool = auditTool;
+        }
+        // doFilterInternal calls resolveTool.call(...) / auditTool.call(...)
+    }
+    ```
+
+    The same pattern works for `@Service`, `@Scheduled`, `@Aspect`, and
+    any other Spring bean. See
+    [`meshctl man dependency-injection --java`](../java/dependency-injection.md)
+    for the full `@MeshDependsOn` reference.
 
 === "TypeScript (Express)"
 

--- a/src/core/cli/man/content/dependency-injection_java.md
+++ b/src/core/cli/man/content/dependency-injection_java.md
@@ -113,6 +113,93 @@ public ResponseEntity<Report> report(McpMeshTool<Employee> employeeLookup) { ...
 
 See `meshctl man schema-matching` for `SUBSET` vs `STRICT` semantics, the cross-language convention table, and the `MCP_MESH_SCHEMA_STRICT` env knob.
 
+## Component-level dependency declaration with `@MeshDependsOn`
+
+`@MeshInject` and `@MeshRoute(dependencies=...)` work at the controller-method scope. For everything else — `@Service` beans, `@Component`s, servlet `Filter`s, `@Scheduled` jobs — declare the capabilities your bean needs with the class-level `@MeshDependsOn` annotation. The auto-configuration then registers a singleton `McpMeshTool` bean named by each capability, so you can wire it the standard Spring way.
+
+### Constructor injection (recommended)
+
+```java
+@Service
+@MeshDependsOn({
+    @MeshDependency(capability = "list_holidays"),
+    @MeshDependency(capability = "get_user_profile")
+})
+public class StaffSyncService {
+    private final McpMeshTool<List<Holiday>> holidays;
+    private final McpMeshTool<UserProfileResponse> profile;
+
+    public StaffSyncService(
+            @Qualifier("list_holidays") McpMeshTool<List<Holiday>> holidays,
+            @Qualifier("get_user_profile") McpMeshTool<UserProfileResponse> profile) {
+        this.holidays = holidays;
+        this.profile = profile;
+    }
+
+    public List<Holiday> upcomingHolidays() {
+        if (!holidays.isAvailable()) return List.of();
+        return holidays.call();
+    }
+}
+```
+
+### Field injection
+
+```java
+@Component
+@MeshDependsOn(@MeshDependency(capability = "list_holidays"))
+public class HolidayChecker {
+    @Autowired
+    @Qualifier("list_holidays")
+    private McpMeshTool<List<Holiday>> holidays;
+}
+```
+
+### Where to use it
+
+| Scenario | Annotation |
+| -------- | ---------- |
+| `@MeshTool` method needing remote helpers | `@MeshTool(dependencies = @Selector(...))` + parameter injection |
+| `@RestController` handler method | `@MeshRoute(dependencies = {...})` + `@MeshInject` parameter |
+| `@Service` / `@Component` / `Filter` / `@Scheduled` / any other Spring bean | **`@MeshDependsOn` + `@Qualifier`** |
+
+`@MeshDependsOn` and `@MeshInject`/`@MeshRoute` are complementary — same heartbeat-driven proxy lifecycle, same auto-rewiring on topology change, same `isAvailable()` semantics. Pick the surface that matches where you need the dependency. If the same capability shows up via multiple sources the framework deduplicates: a single proxy and a single registry entry per capability name.
+
+### Tags, version, and bean-name conflicts
+
+The `@MeshDependency` element accepts the same `tags`, `version`, `expectedType`, and `schemaMode` fields documented above for `@MeshRoute`. If a `@MeshDependsOn` capability happens to match the name of a user-owned Spring bean, the user's bean wins — the framework logs an `ERROR` naming the conflicting bean's class and every `@MeshDependsOn`-annotated class that declared the capability, then skips the proxy registration. Any consumer that `@Qualifier`-injected `McpMeshTool<...>` for that capability will fail context refresh with `BeanNotOfRequiredTypeException`. Resolve by renaming either the user bean or the capability.
+
+### Typed deserialization
+
+When you set `expectedType` on `@MeshDependency`, the framework wires it into the `McpMeshTool` proxy's deserialization type at registration time. The first call returns the typed value directly — no extra `setReturnType(...)` step required:
+
+```java
+@Service
+@MeshDependsOn(@MeshDependency(
+    capability   = "get_user_profile",
+    expectedType = UserProfileResponse.class))
+public class StaffSyncService {
+    public StaffSyncService(@Qualifier("get_user_profile") McpMeshTool<UserProfileResponse> profile) {
+        // profile.call(...) returns UserProfileResponse, not Map<String,Object>
+    }
+}
+```
+
+If you omit `expectedType` and the `@Qualifier`-injected field is declared as `McpMeshTool<UserProfileResponse>`, deserialization to that generic type is best-effort and the first call may return `Map<String, Object>` until something else (a `@MeshRoute` parameter with the same generic, an explicit `setReturnType(...)`) primes the proxy. Setting `expectedType` is the supported way to make typed responses work upfront from a `@MeshDependsOn` surface.
+
+### Discovery caveat — `@Bean` factory methods returning a supertype
+
+`@MeshDependsOn` is read off the bean's resolved class via Spring's bean-definition metadata, then `AnnotationUtils.findAnnotation` walks the class and its supertypes. This covers `@Component`-scanned beans AND `@Bean` factory methods — both surfaces work as expected when the annotation is on the class Spring sees.
+
+| Shape | Discovered? |
+| --- | --- |
+| `@Component @MeshDependsOn(...) class Foo` | ✓ |
+| `@Bean public ConcreteFoo foo()` where `@MeshDependsOn` is on `ConcreteFoo` | ✓ — Spring's `ResolvableType` reports the concrete return type |
+| `@Bean public Foo foo()` where `@MeshDependsOn` is on `Foo` (or any supertype `Foo` extends) | ✓ |
+| `@Bean public Foo foo() { return new ConcreteFoo(); }` where `@MeshDependsOn` is ONLY on `ConcreteFoo` | ✗ — `findAnnotation` walks supertypes of the declared return type, not subtypes of it |
+
+Only the last shape is a real gap. If your factory method declares a supertype return, either narrow the declared return type to the concrete class, or place `@MeshDependsOn` on the supertype itself (or on the `@Configuration` class).
+
 ## `McpMeshTool<T>` API Reference
 
 The `McpMeshTool<T>` interface is the primary way to interact with remote capabilities. The type parameter `T` indicates the expected return type.

--- a/src/core/cli/man/content/headers_java.md
+++ b/src/core/cli/man/content/headers_java.md
@@ -161,6 +161,84 @@ public Map<String, Object> secureTool(@Param("data") String data) {
 Spring Security reads the `Authorization` header from the HTTP request
 automatically — no extra wiring needed when headers are propagated.
 
+## Calling Mesh Tools from Spring Filters
+
+Authorization side-effects often need to run inside a Spring `Filter`, an
+`AuthenticationProvider`, or another bean that sits outside the
+`@MeshRoute` controller surface — for example, resolving an external
+identity-provider subject to a local user row on first login, recording
+an audit event on every authenticated request, or hydrating a
+request-scoped principal from a remote profile service.
+
+`@MeshInject` only fires on `@MeshRoute` controller methods. To reach
+mesh capabilities from any other Spring-managed bean, declare the
+capability on the bean class with `@MeshDependsOn` and inject it via
+`@Qualifier`:
+
+```java
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshDependsOn;
+import io.mcpmesh.types.McpMeshTool;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@MeshDependsOn({
+    @MeshDependency(capability = "resolve_user_principal"),
+    @MeshDependency(capability = "audit_log")
+})
+public class AuthFilter extends OncePerRequestFilter {
+
+    private final McpMeshTool<Map<String, Object>> resolveTool;
+    private final McpMeshTool<Object> auditTool;
+
+    public AuthFilter(
+        @Qualifier("resolve_user_principal") McpMeshTool<Map<String, Object>> resolveTool,
+        @Qualifier("audit_log") McpMeshTool<Object> auditTool) {
+        this.resolveTool = resolveTool;
+        this.auditTool = auditTool;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain chain) throws IOException, ServletException {
+
+        Jwt jwt = currentJwt();
+        String email = jwt.getClaimAsString("email");
+        String subject = jwt.getSubject();
+
+        // Idempotent JIT principal resolution — direct mesh call, no HTTP self-loopback.
+        resolveTool.call("email", email, "subject", subject);
+        auditTool.call("event", "auth.login", "subject", subject);
+
+        chain.doFilter(request, response);
+    }
+}
+```
+
+The same pattern works for `@Service`, `@Scheduled` tasks, `@Aspect`
+advice, `AuthenticationProvider`, and any other Spring bean. Capabilities
+declared via `@MeshDependsOn` follow the same heartbeat-driven proxy
+lifecycle as `@MeshRoute(dependencies=...)`: same `isAvailable()`
+semantics, same auto-rewiring on topology change, same typed exceptions
+on call.
+
+### Why not just put the side-effect in a `@MeshRoute` controller?
+
+Often that is the right answer — push provisioning, audit, and RBAC
+hydration into a controller body (or a downstream mesh tool) where
+`@MeshInject` works as designed. Use `@MeshDependsOn` when the
+side-effect *genuinely* belongs in a non-controller surface: filters
+that run before MVC dispatch, security beans Spring constructs outside
+the request lifecycle, scheduled jobs without a request context.
+
+See `meshctl man dependency-injection --java` for the complete
+`@MeshDependsOn` reference, including `tags`, `version`, `expectedType`,
+and bean-name conflict handling.
+
 ## Cross-Language Behavior
 
 All three SDKs inject headers via two mechanisms simultaneously:

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAgentSpecFinalizer.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAgentSpecFinalizer.java
@@ -1,0 +1,52 @@
+package io.mcpmesh.spring;
+
+import org.springframework.beans.factory.SmartInitializingSingleton;
+
+/**
+ * Idempotent wrapper for the agent-spec finalization callback. Implements
+ * {@link SmartInitializingSingleton} so Spring still drives the finalization
+ * after every singleton has been instantiated, but exposes
+ * {@link #ensureFinalized()} so other late-phase beans can call the
+ * finalization explicitly and not rely on SIS callback ordering (which
+ * Spring does not honour across beans — neither {@code @DependsOn} nor
+ * {@code Ordered} affect the {@code afterSingletonsInstantiated()} sweep).
+ *
+ * <p>Whichever caller fires first wins; subsequent calls are cheap no-ops
+ * guarded by a {@code volatile boolean} flag. This guarantees the spec is
+ * fully built before any consumer reads it, no matter what order the
+ * SmartInitializingSingleton callbacks happen to run in.
+ */
+public class MeshAgentSpecFinalizer implements SmartInitializingSingleton {
+
+    private final Runnable delegate;
+    private volatile boolean finalized;
+
+    MeshAgentSpecFinalizer(Runnable delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * Run the finalization exactly once on success. Safe to call multiple
+     * times from multiple threads — the first caller wins the race and the
+     * others return immediately.
+     *
+     * <p>If {@code delegate.run()} throws, the {@code finalized} flag stays
+     * {@code false} so a subsequent caller retries the finalization. The
+     * exception propagates unchanged to the current caller. Combined with
+     * the {@code synchronized} modifier, this gives at-most-one concurrent
+     * attempt and at-least-one successful completion (so long as a later
+     * call eventually succeeds).
+     */
+    public synchronized void ensureFinalized() {
+        if (finalized) {
+            return;
+        }
+        delegate.run();
+        finalized = true;
+    }
+
+    @Override
+    public void afterSingletonsInstantiated() {
+        ensureFinalized();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -15,13 +15,17 @@ import io.mcpmesh.spring.web.MeshA2ARegistry;
 import io.mcpmesh.spring.web.MeshA2ASseDispatcher;
 import io.mcpmesh.spring.web.MeshA2ASseHeaderFilter;
 import io.mcpmesh.spring.web.MeshA2ATaskStore;
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshDependsOn;
 import io.mcpmesh.spring.web.MeshRouteRegistry;
+import io.mcpmesh.types.McpMeshTool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -39,8 +43,11 @@ import org.springframework.web.servlet.function.ServerResponse;
 import io.mcpmesh.spring.tracing.TracingFilter;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -443,10 +450,19 @@ public class MeshAutoConfiguration {
      * {@code @Component} beans that autowired {@code MeshRuntime}, which
      * Spring 2.6+ rejects as {@code BeanCurrentlyInCreationException}
      * (issue #937).
+     *
+     * <p>The returned bean is a {@link MeshAgentSpecFinalizer} so other
+     * post-init beans (in particular {@link #meshCapabilityBeanRegistrar})
+     * can call {@link MeshAgentSpecFinalizer#ensureFinalized()} explicitly
+     * to guarantee the spec is fully built before they read it. Spring does
+     * NOT order {@link SmartInitializingSingleton#afterSingletonsInstantiated()}
+     * callbacks across beans (no {@code @DependsOn}/{@code Ordered} honoured
+     * there), so the explicit call is the only reliable ordering mechanism —
+     * see W2 in PR #1086 review.
      */
     @Bean
     @ConditionalOnMissingBean(name = "meshAgentSpecFinalizer")
-    public SmartInitializingSingleton meshAgentSpecFinalizer(
+    public MeshAgentSpecFinalizer meshAgentSpecFinalizer(
             MeshRuntime runtime,
             MeshToolRegistry toolRegistry,
             MeshLlmRegistry llmRegistry,
@@ -454,9 +470,134 @@ public class MeshAutoConfiguration {
             ObjectProvider<MeshRouteRegistry> routeRegistryProvider,
             ObjectProvider<MeshA2ARegistry> a2aRegistryProvider,
             A2AConsumerBeanPostProcessor a2aConsumerBeanPostProcessor) {
-        return () -> finalizeAgentSpec(runtime.getAgentSpec(), toolRegistry,
-            llmRegistry, objectMapper, routeRegistryProvider, a2aRegistryProvider,
-            a2aConsumerBeanPostProcessor);
+        return new MeshAgentSpecFinalizer(() -> finalizeAgentSpec(runtime.getAgentSpec(),
+            toolRegistry, llmRegistry, objectMapper, routeRegistryProvider,
+            a2aRegistryProvider, a2aConsumerBeanPostProcessor));
+    }
+
+    /**
+     * Issue #1086: register a singleton {@link McpMeshTool} bean per
+     * {@code @MeshDependsOn}-declared capability so Spring-managed beans can
+     * inject the proxy by {@code @Qualifier("capability")} from anywhere —
+     * services, filters, schedulers, plain {@code @Component}s.
+     *
+     * <p>This must run BEFORE user singletons are instantiated, otherwise a
+     * {@code @Autowired @Qualifier("cap")} field on a user bean blows up
+     * with {@code NoSuchBeanDefinitionException} before the late
+     * {@link SmartInitializingSingleton} would have had a chance to register
+     * anything. We implement it as a {@link MeshCapabilityBeanRegistrar} —
+     * a {@code static} factory method ensures the post-processor is
+     * instantiated early, like the existing
+     * {@code meshToolBeanPostProcessor} / {@code meshA2ABeanPostProcessor}
+     * factories.
+     *
+     * <p>Source coverage: only {@code @MeshDependsOn} capabilities are
+     * registered up-front. Capabilities declared via {@code @MeshTool} /
+     * {@code @MeshRoute(dependencies=)} / {@code @MeshA2A(dependencies=)}
+     * already have direct injection paths ({@code @MeshTool} method
+     * parameters, {@code @MeshInject} on controller-method parameters) and
+     * don't need a globally-named bean. The late
+     * {@link #meshCapabilityBeanRegistrar} fills in any remaining
+     * capabilities so the bean factory is complete at runtime, but does NOT
+     * participate in the autowire phase.
+     *
+     * <p>Conflict policy: if a bean name equal to a capability is already
+     * registered (user has a {@code @Bean} or {@code @Component} that owns
+     * that name), the user's bean wins and we log a WARN.
+     */
+    @Bean
+    @ConditionalOnMissingBean(name = "meshDependsOnBeanRegistrar")
+    public static MeshCapabilityBeanRegistrar meshDependsOnBeanRegistrar() {
+        return new MeshCapabilityBeanRegistrar();
+    }
+
+    /**
+     * Late-phase complement to {@link #meshDependsOnBeanRegistrar}: walks the
+     * fully-built {@link AgentSpec} and registers a singleton
+     * {@link McpMeshTool} bean for every capability declared by any of the
+     * four sources that wasn't already registered. This keeps the bean
+     * factory's view of mesh dependencies complete at runtime, even though
+     * autowire-time resolution is handled by the earlier post-processor.
+     *
+     * <p>Runs as a {@link SmartInitializingSingleton} but does NOT rely on
+     * SIS ordering — {@link MeshAgentSpecFinalizer#ensureFinalized()} is
+     * invoked explicitly so the spec is fully built before this code reads
+     * it. Spring's {@code @DependsOn} only orders bean CREATION, not the
+     * {@code afterSingletonsInstantiated()} callbacks themselves, so the
+     * earlier {@code @DependsOn("meshAgentSpecFinalizer")} was a no-op for
+     * the actual ordering concern here.
+     */
+    @Bean
+    @ConditionalOnMissingBean(name = "meshCapabilityBeanRegistrar")
+    public SmartInitializingSingleton meshCapabilityBeanRegistrar(
+            MeshDependencyInjector injector,
+            ConfigurableListableBeanFactory beanFactory,
+            MeshRuntime runtime,
+            MeshAgentSpecFinalizer finalizer,
+            ObjectProvider<MeshRouteRegistry> routeRegistryProvider,
+            ObjectProvider<MeshA2ARegistry> a2aRegistryProvider) {
+        return () -> {
+            // Idempotent — fires the spec finalization if no other
+            // SmartInitializingSingleton has already done so. Whichever
+            // callback fires first wins; the other is a no-op.
+            finalizer.ensureFinalized();
+
+            // Merge the (capability -> expectedType) views from every source
+            // that tracks it. Without this the late-phase path would call
+            // injector.getToolProxy(capability) without a return type, and a
+            // downstream @Qualifier("cap") McpMeshTool<Foo> consumer would
+            // receive an untyped proxy returning Map<String, Object> instead
+            // of Foo — even though the source @MeshDependency declared
+            // expectedType=Foo.class. @MeshDependsOn already feeds expectedType
+            // into the early-phase registrar; this lambda is the symmetric
+            // wiring for the @MeshRoute / @MeshA2A cross-source paths.
+            Map<String, Class<?>> expectedTypes = new LinkedHashMap<>();
+            MeshRouteRegistry routeRegistry = routeRegistryProvider.getIfAvailable();
+            if (routeRegistry != null) {
+                expectedTypes.putAll(routeRegistry.getExpectedTypesByCapability());
+            }
+            MeshA2ARegistry a2aRegistry = a2aRegistryProvider.getIfAvailable();
+            if (a2aRegistry != null) {
+                for (Map.Entry<String, Class<?>> e
+                        : a2aRegistry.getExpectedTypesByCapability().entrySet()) {
+                    expectedTypes.putIfAbsent(e.getKey(), e.getValue());
+                }
+            }
+
+            AgentSpec spec = runtime.getAgentSpec();
+            // includeProducers=false: don't register McpMeshTool proxy beans
+            // for capabilities the agent itself produces — those would be
+            // self-loop proxies the agent never consumes through the registry.
+            Set<String> capabilities = collectKnownCapabilities(spec.getTools(), false);
+            int registered = 0;
+            int conflicts = 0;
+            for (String capability : capabilities) {
+                if (beanFactory.containsBean(capability)) {
+                    // Either the user owns that name, or our earlier
+                    // post-processor already registered it. Either way: leave it.
+                    continue;
+                }
+                if (beanFactory.containsSingleton(capability)) {
+                    continue;
+                }
+                Class<?> expectedType = expectedTypes.get(capability);
+                McpMeshTool<?> proxy = (expectedType != null)
+                    ? injector.getToolProxy(capability, expectedType)
+                    : injector.getToolProxy(capability);
+                try {
+                    beanFactory.registerSingleton(capability, proxy);
+                    registered++;
+                } catch (IllegalStateException e) {
+                    log.warn("Skipping McpMeshTool bean registration for capability '{}': {}",
+                        capability, e.getMessage());
+                    conflicts++;
+                }
+            }
+            if (registered > 0 || conflicts > 0) {
+                log.info("Late-phase: registered {} additional McpMeshTool bean(s) "
+                    + "(skipped {} due to name conflict)", registered, conflicts);
+            }
+        };
     }
 
     @Bean
@@ -738,6 +879,14 @@ public class MeshAutoConfiguration {
         // @Component was created during the singleton init phase.
         addA2ADependencies(allTools, a2aRegistryProvider);
 
+        // Issue #1086: 4th dependency source — class-level @MeshDependsOn on
+        // arbitrary @Component beans (services, filters, schedulers, etc.).
+        // Folds these capabilities into a synthetic __mesh_depends_on_deps
+        // tool so the heartbeat path wires proxies the same way it does for
+        // @MeshTool / @MeshRoute / @MeshA2A. Dedup is by capability name across
+        // all four sources — see collectKnownCapabilities().
+        addMeshDependsOnDependencies(allTools);
+
         if (consumerOnly) {
             MeshRouteRegistry routeRegistry = routeRegistryProvider.getIfAvailable();
             boolean hasRoutes = routeRegistry != null && routeRegistry.hasRoutes();
@@ -792,6 +941,131 @@ public class MeshAutoConfiguration {
         syntheticTool.setDependencies(deps);
         tools.add(syntheticTool);
         log.info("Added {} @MeshA2A dependencies to agent registration", deps.size());
+    }
+
+    /**
+     * Issue #1086: Add class-level {@code @MeshDependsOn} declarations as a
+     * synthetic {@code __mesh_depends_on_deps} tool. Mirrors
+     * {@link #addRouteDependencies} and {@link #addA2ADependencies} so
+     * Spring-managed beans outside {@code @RestController} handler methods
+     * (services, filters, schedulers, plain {@code @Component}s) can declare
+     * mesh dependencies and have them resolved by the registry's
+     * dependency-resolution mechanism.
+     *
+     * <p>Dedup runs against the capabilities already accumulated on
+     * {@code tools} — the same capability declared via {@code @MeshTool} or
+     * {@code @MeshRoute(dependencies=)} or {@code @MeshA2A(dependencies=)}
+     * wins; {@code @MeshDependsOn} entries are silently dropped when their
+     * capability already appears in any prior source. Within
+     * {@code @MeshDependsOn} itself the first occurrence wins.
+     */
+    private void addMeshDependsOnDependencies(List<AgentSpec.ToolSpec> tools) {
+        Map<String, Object> beans = applicationContext.getBeansWithAnnotation(MeshDependsOn.class);
+        if (beans.isEmpty()) {
+            return;
+        }
+
+        // includeProducers=true: a @MeshDependsOn on a capability the agent
+        // itself produces (@MeshTool capability=...) is dropped — the agent
+        // doesn't need a registry-resolved dependency to call its own tool.
+        Set<String> seenCapabilities = collectKnownCapabilities(tools, true);
+        List<AgentSpec.DependencySpec> deps = new ArrayList<>();
+        // Issue #547 Phase 4: cluster-wide strict knob promotes WARN→BLOCK on
+        // the consumer side too. Same source-of-truth as MeshRouteRegistry.
+        boolean clusterStrict = io.mcpmesh.spring.MeshSchemaSupport.clusterStrictEnabled();
+
+        for (Object bean : beans.values()) {
+            Class<?> targetClass = org.springframework.aop.support.AopUtils.getTargetClass(bean);
+            MeshDependsOn annotation = org.springframework.core.annotation.AnnotationUtils
+                .findAnnotation(targetClass, MeshDependsOn.class);
+            if (annotation == null) {
+                continue;
+            }
+            for (MeshDependency dep : annotation.value()) {
+                String capability = dep.capability();
+                if (capability == null || capability.isBlank()) {
+                    log.warn("@MeshDependsOn on {} has @MeshDependency with empty capability — skipping",
+                        targetClass.getName());
+                    continue;
+                }
+                if (!seenCapabilities.add(capability)) {
+                    log.debug("@MeshDependsOn capability '{}' on {} already declared by another source — skipping",
+                        capability, targetClass.getName());
+                    continue;
+                }
+                AgentSpec.DependencySpec agentDep = new AgentSpec.DependencySpec();
+                agentDep.setCapability(capability);
+                if (dep.tags().length > 0) {
+                    agentDep.setTags(String.join(",", dep.tags()));
+                }
+                if (dep.version() != null && !dep.version().isEmpty()) {
+                    agentDep.setVersion(dep.version());
+                }
+                // Issue #547: honour expectedType / schemaMode the same way
+                // @MeshRoute does. Default-sentinel (Void.class) means "not
+                // set" — same convention as MeshRouteRegistry.DependencySpec
+                // (see fromAnnotation).
+                Class<?> expectedType = dep.expectedType();
+                if (expectedType == Void.class || expectedType == void.class) {
+                    expectedType = null;
+                }
+                MeshRouteRegistry.applySchemaMatching(
+                    agentDep, capability, expectedType, dep.schemaMode(), clusterStrict);
+                deps.add(agentDep);
+            }
+        }
+
+        if (deps.isEmpty()) {
+            return;
+        }
+
+        AgentSpec.ToolSpec syntheticTool = new AgentSpec.ToolSpec();
+        syntheticTool.setFunctionName("__mesh_depends_on_deps");
+        syntheticTool.setCapability("__mesh_depends_on_deps");
+        syntheticTool.setDescription("Synthetic tool for @MeshDependsOn dependency resolution");
+        syntheticTool.setDependencies(deps);
+        tools.add(syntheticTool);
+        log.info("Added {} @MeshDependsOn dependencies to agent registration", deps.size());
+    }
+
+    /**
+     * Issue #1086: collect every capability already declared on the partially
+     * built tool list. Used by {@link #addMeshDependsOnDependencies} to skip
+     * re-declaring a capability that the user already attached to a
+     * {@code @MeshTool}, {@code @MeshRoute}, or {@code @MeshA2A} surface.
+     *
+     * <p>{@code includeProducers} controls whether the producer side of each
+     * tool spec (the {@code @MeshTool} capability name itself) participates
+     * in the dedup set. The dependency-folding path
+     * ({@link #addMeshDependsOnDependencies}) passes {@code true} so a
+     * {@code @MeshDependsOn} on a capability the agent itself produces is
+     * silently dropped (re-declaring it as a dependency creates a
+     * redundant self-edge). The bean-registration path
+     * ({@code meshCapabilityBeanRegistrar}) passes {@code false} so we
+     * still register {@code McpMeshTool} proxy beans for every consumed
+     * capability without trying to also register one for our own producer
+     * capabilities — those would be unused self-loops since the agent
+     * dispatches its own producer methods directly, not through a proxy.
+     */
+    private static Set<String> collectKnownCapabilities(
+            List<AgentSpec.ToolSpec> tools, boolean includeProducers) {
+        Set<String> seen = new LinkedHashSet<>();
+        for (AgentSpec.ToolSpec tool : tools) {
+            if (includeProducers && tool.getCapability() != null
+                    && !tool.getCapability().isEmpty()) {
+                seen.add(tool.getCapability());
+            }
+            List<AgentSpec.DependencySpec> deps = tool.getDependencies();
+            if (deps == null) {
+                continue;
+            }
+            for (AgentSpec.DependencySpec dep : deps) {
+                if (dep.getCapability() != null && !dep.getCapability().isEmpty()) {
+                    seen.add(dep.getCapability());
+                }
+            }
+        }
+        return seen;
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshCapabilityBeanRegistrar.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshCapabilityBeanRegistrar.java
@@ -1,0 +1,334 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshDependsOn;
+import io.mcpmesh.types.McpMeshTool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.ClassUtils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Issue #1086: scans bean definitions for class-level {@link MeshDependsOn}
+ * annotations and registers a singleton {@link McpMeshTool} bean per
+ * declared capability, named by the capability string.
+ *
+ * <p>Runs as a {@link BeanDefinitionRegistryPostProcessor} so the proxy
+ * beans are registered BEFORE user singletons get instantiated. This is
+ * essential — a {@code @Service} that declares
+ * {@code @Autowired @Qualifier("cap") McpMeshTool<...> tool} would fail
+ * with {@code NoSuchBeanDefinitionException} if the proxy bean weren't
+ * available at autowire time.
+ *
+ * <p>Each registered bean definition uses a {@link java.util.function.Supplier}
+ * factory that resolves the {@link MeshDependencyInjector} from the bean
+ * factory at first use, then delegates to
+ * {@link MeshDependencyInjector#getToolProxy(String)} (or the type-aware
+ * overload when the {@code @MeshDependency.expectedType} is set). The same
+ * proxy instance is returned forever after (Spring caches it as a singleton),
+ * which preserves the heartbeat-driven auto-rewiring semantics — the
+ * injector mutates the same proxy in place.
+ *
+ * <p>Conflict policy: if a bean name equal to a capability is already
+ * defined (user owns it), we log an ERROR — including the conflicting bean's
+ * class and every {@code @MeshDependsOn}-annotated class that declared the
+ * capability — and skip the registration. Consumers that
+ * {@code @Qualifier}-injected {@code McpMeshTool<...>} will fail context
+ * refresh with {@code BeanNotOfRequiredTypeException} (the user-owned bean
+ * is not an {@code McpMeshTool}); the ERROR log makes the resolution
+ * actionable.
+ *
+ * <p>Dedup: within a single application context, the same capability
+ * declared by multiple {@code @MeshDependsOn} beans is registered exactly
+ * once.
+ */
+public class MeshCapabilityBeanRegistrar implements BeanDefinitionRegistryPostProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshCapabilityBeanRegistrar.class);
+
+    /**
+     * Per-registrar cache of capability → resolved injector reference. The
+     * supplier closures share this cache so the injector lookup happens
+     * exactly once per JVM, no matter how many proxy beans get materialised.
+     */
+    private final AtomicReference<MeshDependencyInjector> injectorRef = new AtomicReference<>();
+
+    @Override
+    public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+        if (!(registry instanceof ConfigurableListableBeanFactory beanFactory)) {
+            // The registry should always be a ConfigurableListableBeanFactory
+            // in practice (DefaultListableBeanFactory implements both). If
+            // we ever see something else we'd lose the early bean
+            // registration path; fall back to a no-op so the late
+            // SmartInitializingSingleton in MeshAutoConfiguration can still
+            // catch up.
+            log.debug("BeanDefinitionRegistry is not a ConfigurableListableBeanFactory ({}); "
+                + "skipping early @MeshDependsOn proxy registration", registry.getClass().getName());
+            return;
+        }
+
+        Map<String, CapabilityDeclaration> capabilities = collectCapabilities(beanFactory);
+        if (capabilities.isEmpty()) {
+            return;
+        }
+
+        int added = 0;
+        int conflicts = 0;
+        for (Map.Entry<String, CapabilityDeclaration> entry : capabilities.entrySet()) {
+            String capability = entry.getKey();
+            CapabilityDeclaration declaration = entry.getValue();
+
+            if (registry.containsBeanDefinition(capability) || beanFactory.containsSingleton(capability)) {
+                logNameConflict(registry, capability, declaration);
+                conflicts++;
+                continue;
+            }
+
+            Class<?> expectedType = declaration.expectedType();
+            BeanDefinitionBuilder builder = BeanDefinitionBuilder
+                .genericBeanDefinition(McpMeshTool.class,
+                    () -> resolveProxy(beanFactory, capability, expectedType));
+            BeanDefinition def = builder.getBeanDefinition();
+            // I3 (PR #1086 review): mark the bean primary for its
+            // capability-named slot. The @Qualifier path is unaffected
+            // (primary only kicks in when no qualifier is present), but
+            // future Map/Collection injection (e.g.
+            // @Autowired Map<String, McpMeshTool<?>>) gets a sensible
+            // default candidate when multiple producers share a type.
+            def.setPrimary(true);
+            registry.registerBeanDefinition(capability, def);
+            added++;
+        }
+        log.info("@MeshDependsOn: registered {} McpMeshTool bean(s) early "
+            + "(skipped {} due to name conflict)", added, conflicts);
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        // No-op: all wiring is done in postProcessBeanDefinitionRegistry.
+    }
+
+    /**
+     * Emit an actionable ERROR explaining the conflict: which user-owned
+     * bean owns the name, which {@code @MeshDependsOn}-annotated classes
+     * declared the capability (and will therefore fail
+     * {@code @Qualifier} injection at context-refresh time), and how to
+     * resolve it.
+     */
+    private void logNameConflict(BeanDefinitionRegistry registry, String capability,
+                                 CapabilityDeclaration declaration) {
+        String conflictClass = "<unknown>";
+        try {
+            BeanDefinition existing = registry.getBeanDefinition(capability);
+            String className = existing.getBeanClassName();
+            if (className == null || className.isBlank()) {
+                // @Bean factory-method beans report a null beanClassName —
+                // their concrete type lives on the ResolvableType. Fall back
+                // there before giving up.
+                org.springframework.core.ResolvableType resolved = existing.getResolvableType();
+                if (resolved != null && resolved != org.springframework.core.ResolvableType.NONE) {
+                    Class<?> raw = resolved.resolve();
+                    if (raw != null) {
+                        className = raw.getName();
+                    }
+                }
+            }
+            if (className != null && !className.isBlank()) {
+                conflictClass = className;
+            }
+        } catch (Exception ignored) {
+            // Fall back to "<unknown>" if Spring can't report the class.
+        }
+        List<String> declarers = declaration.declarerClassNames();
+        log.error("Cannot register McpMeshTool bean for capability '{}' — bean name already in use "
+                + "by user-owned bean of type {}. Classes that declared this capability via "
+                + "@MeshDependsOn will fail @Qualifier injection: {}. Resolve by renaming either "
+                + "your bean OR the capability.",
+            capability, conflictClass, declarers);
+    }
+
+    /**
+     * Walk every registered bean definition, resolve its target class, and
+     * collect the unique capability declarations via class-level
+     * {@code @MeshDependsOn}. Returns an insertion-ordered map keyed by
+     * capability name; the first {@link MeshDependency} encountered wins for
+     * type/schema metadata (subsequent declarations only extend the
+     * declarer-class list so the conflict-diagnostics are complete).
+     */
+    private Map<String, CapabilityDeclaration> collectCapabilities(ConfigurableListableBeanFactory beanFactory) {
+        Map<String, CapabilityDeclaration> capabilities = new LinkedHashMap<>();
+        for (String beanName : beanFactory.getBeanDefinitionNames()) {
+            BeanDefinition def = beanFactory.getBeanDefinition(beanName);
+            Class<?> beanClass = resolveBeanClass(beanFactory, def);
+            if (beanClass == null) {
+                continue;
+            }
+            MeshDependsOn annotation = AnnotationUtils.findAnnotation(beanClass, MeshDependsOn.class);
+            if (annotation == null) {
+                continue;
+            }
+            for (MeshDependency dep : annotation.value()) {
+                String capability = dep.capability();
+                if (capability == null || capability.isBlank()) {
+                    log.warn("@MeshDependsOn on {} has @MeshDependency with empty capability — skipping",
+                        beanClass.getName());
+                    continue;
+                }
+                CapabilityDeclaration existing = capabilities.get(capability);
+                if (existing == null) {
+                    Class<?> expectedType = dep.expectedType();
+                    if (expectedType == Void.class || expectedType == void.class) {
+                        expectedType = null;
+                    }
+                    CapabilityDeclaration fresh = new CapabilityDeclaration(expectedType);
+                    fresh.addDeclarer(beanClass.getName());
+                    capabilities.put(capability, fresh);
+                } else {
+                    Class<?> incomingExpectedType = dep.expectedType();
+                    if (incomingExpectedType == Void.class || incomingExpectedType == void.class) {
+                        incomingExpectedType = null;
+                    }
+                    Class<?> existingExpectedType = existing.expectedType();
+                    if (existingExpectedType != null && incomingExpectedType != null
+                            && !existingExpectedType.equals(incomingExpectedType)) {
+                        throw new IllegalStateException(String.format(
+                            "@MeshDependsOn capability '%s' is declared with conflicting "
+                                + "expectedType values: %s (declared by [%s]) vs %s "
+                                + "(declared by %s). Align expectedType across every "
+                                + "@MeshDependsOn site for this capability, or split into "
+                                + "separate capability names.",
+                            capability,
+                            existingExpectedType.getName(),
+                            String.join(", ", existing.declarerClassNames()),
+                            incomingExpectedType.getName(),
+                            beanClass.getName()));
+                    }
+                    // Upgrade-path: an earlier declaration omitted expectedType
+                    // and a later one supplies it. The non-null type wins so
+                    // the registered proxy bean gets typed deserialisation
+                    // from the very first call.
+                    if (existingExpectedType == null && incomingExpectedType != null) {
+                        existing.setExpectedType(incomingExpectedType);
+                    }
+                    existing.addDeclarer(beanClass.getName());
+                }
+            }
+        }
+        return capabilities;
+    }
+
+    /**
+     * Resolve the target class from a bean definition. Returns null when the
+     * class cannot be determined or loaded.
+     *
+     * <p>Resolution order:
+     * <ol>
+     *   <li>{@link BeanDefinition#getBeanClassName()} +
+     *       {@link ClassUtils#forName(String, ClassLoader)} — works for
+     *       component-scanned beans, where the bean class name IS the
+     *       concrete user class. Preferred first because it preserves the
+     *       concrete declarer class even when Spring's {@code ResolvableType}
+     *       might report a supertype/interface for the bean.</li>
+     *   <li>{@link BeanDefinition#getResolvableType()} — fallback for
+     *       {@code @Bean} factory-method beans where {@code beanClassName}
+     *       is null. Spring populates the resolvable type from the factory
+     *       method's declared return type, which is the produced class.
+     *       The {@code @MeshDependsOn} annotation discovery in
+     *       {@link #collectCapabilities} relies on this fallback path to
+     *       find class-level annotations on factory-produced beans.</li>
+     * </ol>
+     */
+    private static Class<?> resolveBeanClass(ConfigurableListableBeanFactory beanFactory, BeanDefinition def) {
+        String className = def.getBeanClassName();
+        if (className != null) {
+            try {
+                return ClassUtils.forName(className, beanFactory.getBeanClassLoader());
+            } catch (Throwable ignored) {
+                // Fall through to ResolvableType.
+            }
+        }
+        try {
+            org.springframework.core.ResolvableType resolved = def.getResolvableType();
+            if (resolved != org.springframework.core.ResolvableType.NONE) {
+                Class<?> raw = resolved.resolve();
+                if (raw != null) {
+                    return raw;
+                }
+            }
+        } catch (Exception ignored) {
+            // Fall through to null.
+        }
+        return null;
+    }
+
+    /**
+     * Bean-supplier callback: resolve the {@link MeshDependencyInjector} from
+     * the bean factory (lazy — the injector is constructed by another
+     * factory method in {@code MeshAutoConfiguration}) and return its proxy
+     * for the given capability. When {@code expectedType} is non-null the
+     * type-aware overload is used so the proxy deserialises responses to
+     * that concrete type from the very first call (I4 in PR #1086 review).
+     */
+    private McpMeshTool<?> resolveProxy(ConfigurableListableBeanFactory beanFactory,
+                                        String capability, Class<?> expectedType) {
+        MeshDependencyInjector injector = injectorRef.get();
+        if (injector == null) {
+            injector = beanFactory.getBean(MeshDependencyInjector.class);
+            injectorRef.compareAndSet(null, injector);
+        }
+        if (expectedType != null) {
+            return injector.getToolProxy(capability, expectedType);
+        }
+        return injector.getToolProxy(capability);
+    }
+
+    /**
+     * Per-capability accumulator: tracks the accumulated expected type and
+     * every {@code @MeshDependsOn}-annotated class that mentions the
+     * capability (for conflict-diagnostic log messages).
+     *
+     * <p>{@code expectedType} is mutable so the upgrade path in
+     * {@link #collectCapabilities} can replace an initial {@code null}
+     * (a declarer that omitted {@code expectedType}) with a non-null type
+     * supplied by a later declarer for the same capability. Conflicts
+     * between two non-null types fail fast — see the caller.
+     */
+    private static final class CapabilityDeclaration {
+        private Class<?> expectedType;
+        private final List<String> declarerClassNames = new ArrayList<>();
+
+        CapabilityDeclaration(Class<?> expectedType) {
+            this.expectedType = expectedType;
+        }
+
+        void addDeclarer(String className) {
+            if (!declarerClassNames.contains(className)) {
+                declarerClassNames.add(className);
+            }
+        }
+
+        Class<?> expectedType() {
+            return expectedType;
+        }
+
+        void setExpectedType(Class<?> expectedType) {
+            this.expectedType = expectedType;
+        }
+
+        List<String> declarerClassNames() {
+            return List.copyOf(declarerClassNames);
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ARegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ARegistry.java
@@ -155,6 +155,35 @@ public class MeshA2ARegistry {
     }
 
     /**
+     * Surface the {@code expectedType} declared on each {@code @MeshDependency}
+     * across all registered {@code @MeshA2A} surfaces. Returns the Class<?>
+     * reference for every capability whose source annotation set
+     * {@code expectedType} to a non-default value (i.e. not {@code Void.class}).
+     *
+     * <p>Used by the auto-configuration late-phase bean registrar to wire
+     * typed deserialisation into the {@link io.mcpmesh.types.McpMeshTool}
+     * singleton beans — without this, a
+     * {@code @Qualifier("cap") McpMeshTool<Foo>} consumer receives an
+     * untyped proxy that returns {@code Map<String, Object>} instead of
+     * {@code Foo}.
+     *
+     * @return map of capability name to expected return Class; capabilities
+     *         without expectedType are absent from the map
+     */
+    public Map<String, Class<?>> getExpectedTypesByCapability() {
+        Map<String, Class<?>> result = new LinkedHashMap<>();
+        for (SurfaceMetadata surface : getAllSurfaces()) {
+            for (MeshRouteRegistry.DependencySpec dep : surface.dependencies()) {
+                Class<?> et = dep.getExpectedType();
+                if (et != null && et != Void.class && et != void.class) {
+                    result.putIfAbsent(dep.getCapability(), et);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
      * Captured metadata for a single {@code @MeshA2A} method.
      *
      * <p>Constructed once at bean-post-processing time and immutable

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshDependsOn.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshDependsOn.java
@@ -1,0 +1,105 @@
+package io.mcpmesh.spring.web;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Class-level declaration of mesh capabilities a Spring-managed bean
+ * depends on.
+ *
+ * <p>Use {@code @MeshDependsOn} on any {@code @Component}-derived bean
+ * ({@code @Service}, {@code @Repository}, {@code @Component}, a servlet
+ * {@code Filter}, a {@code @Scheduled} bean, etc.) when the consumer is
+ * not a {@code @MeshRoute}-annotated controller method and therefore can't
+ * use {@code @MeshInject} at the parameter level.
+ *
+ * <p>For every capability declared via this annotation the auto-configuration
+ * registers a singleton {@link io.mcpmesh.types.McpMeshTool} bean named by
+ * the capability string, so users can inject it the standard Spring way:
+ *
+ * <h2>Constructor injection</h2>
+ * <pre>{@code
+ * @Service
+ * @MeshDependsOn({
+ *     @MeshDependency(capability = "list_holidays"),
+ *     @MeshDependency(capability = "get_user_profile")
+ * })
+ * public class StaffSyncService {
+ *     private final McpMeshTool<List<Holiday>> holidays;
+ *     private final McpMeshTool<UserProfileResponse> profile;
+ *
+ *     public StaffSyncService(
+ *             @Qualifier("list_holidays") McpMeshTool<List<Holiday>> holidays,
+ *             @Qualifier("get_user_profile") McpMeshTool<UserProfileResponse> profile) {
+ *         this.holidays = holidays;
+ *         this.profile = profile;
+ *     }
+ * }
+ * }</pre>
+ *
+ * <h2>Field injection</h2>
+ * <pre>{@code
+ * @Component
+ * @MeshDependsOn(@MeshDependency(capability = "list_holidays"))
+ * public class HolidayChecker {
+ *     @Autowired
+ *     @Qualifier("list_holidays")
+ *     private McpMeshTool<List<Holiday>> holidays;
+ * }
+ * }</pre>
+ *
+ * <h2>Lifecycle semantics</h2>
+ *
+ * <p>Capabilities declared here flow through the same heartbeat-driven
+ * proxy lifecycle as {@code @MeshRoute(dependencies = ...)}:
+ *
+ * <ul>
+ *   <li>Each capability is folded into a synthetic
+ *       {@code __mesh_depends_on_deps} tool on the heartbeat envelope so
+ *       the registry's resolution mechanism learns about it.</li>
+ *   <li>The injected proxy starts in the {@code unavailable} state and
+ *       transitions to {@code available} when the registry surfaces a
+ *       matching producer. Use {@link io.mcpmesh.types.McpMeshTool#isAvailable()}
+ *       to guard calls.</li>
+ *   <li>The Spring bean reference stays valid across topology changes —
+ *       the proxy's endpoint is rewired transparently by the heartbeat
+ *       loop.</li>
+ * </ul>
+ *
+ * <h2>Relation to {@code @MeshInject} / {@code @MeshRoute}</h2>
+ *
+ * <p>{@code @MeshDependsOn} complements (it does not replace)
+ * {@code @MeshInject} on controller-method parameters. Use
+ * {@code @MeshRoute(dependencies = ...)} + {@code @MeshInject} for
+ * request-scoped wiring inside {@code @RestController} handler methods;
+ * use {@code @MeshDependsOn} for anything else.
+ *
+ * <h2>Deduplication</h2>
+ *
+ * <p>If the same capability appears via multiple sources ({@code @MeshTool},
+ * {@code @MeshRoute}, {@code @MeshA2A}, or {@code @MeshDependsOn}) the
+ * first occurrence wins; subsequent declarations are de-duped by
+ * capability name and a single {@link io.mcpmesh.types.McpMeshTool} bean
+ * is registered.
+ *
+ * @see MeshDependency
+ * @see MeshRoute
+ * @see MeshInject
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MeshDependsOn {
+
+    /**
+     * Mesh capabilities this component depends on. Each entry is
+     * resolved by capability name with optional tag/version filters,
+     * exactly as on {@code @MeshRoute(dependencies = ...)}.
+     *
+     * @return the declared dependencies (default empty)
+     */
+    MeshDependency[] value() default {};
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -137,6 +138,35 @@ public class MeshRouteRegistry {
     }
 
     /**
+     * Surface the {@code expectedType} declared on each {@code @MeshDependency}
+     * across all registered routes. Returns the Class<?> reference for every
+     * capability whose source annotation set {@code expectedType} to a
+     * non-default value (i.e. not {@code Void.class}).
+     *
+     * <p>Used by the auto-configuration late-phase bean registrar to wire
+     * typed deserialisation into the {@link io.mcpmesh.types.McpMeshTool}
+     * singleton beans — without this, a
+     * {@code @Qualifier("cap") McpMeshTool<Foo>} consumer receives an
+     * untyped proxy that returns {@code Map<String, Object>} instead of
+     * {@code Foo}.
+     *
+     * @return map of capability name to expected return Class; capabilities
+     *         without expectedType are absent from the map
+     */
+    public Map<String, Class<?>> getExpectedTypesByCapability() {
+        Map<String, Class<?>> result = new LinkedHashMap<>();
+        for (RouteMetadata route : routesByPath.values()) {
+            for (DependencySpec dep : route.getDependencies()) {
+                Class<?> et = dep.getExpectedType();
+                if (et != null && et != Void.class && et != void.class) {
+                    result.putIfAbsent(dep.getCapability(), et);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
      * Apply issue #547 schema-aware matching fields to the outgoing AgentSpec
      * dependency. Mirrors the Python ({@code mesh.tool} decorator) and TypeScript
      * (Zod expectedSchema) behaviors:
@@ -153,8 +183,34 @@ public class MeshRouteRegistry {
      */
     private static void applySchemaMatching(
             AgentSpec.DependencySpec target, DependencySpec source, boolean clusterStrict) {
-        Class<?> expectedType = source.getExpectedType();
-        SchemaMode mode = source.getSchemaMode();
+        applySchemaMatching(target, source.getCapability(), source.getExpectedType(),
+            source.getSchemaMode(), clusterStrict);
+    }
+
+    /**
+     * Canonical schema-aware matching helper, shared between the
+     * {@code @MeshRoute} and {@code @MeshDependsOn} wiring paths (issue #547,
+     * issue #1086). Both surfaces must stamp {@code expectedSchemaCanonical},
+     * {@code expectedSchemaHash}, and {@code matchMode} the same way so the
+     * registry's schema stage sees identical shapes regardless of the source.
+     *
+     * <p>Caller passes raw inputs (capability name, expected type class,
+     * schema mode, cluster-strict flag) so {@code @MeshDependsOn}'s code path
+     * — which reads these off {@link MeshDependency} directly — doesn't need
+     * to materialise a {@link DependencySpec} intermediate.
+     *
+     * @param target        the outgoing {@link AgentSpec.DependencySpec} to mutate
+     * @param capability    capability name (for log context)
+     * @param expectedType  expected return type, or {@code null} when unset
+     * @param mode          requested {@link SchemaMode} (treated as {@link SchemaMode#NONE} when null)
+     * @param clusterStrict cluster-wide strict knob (typically from env var)
+     */
+    public static void applySchemaMatching(
+            AgentSpec.DependencySpec target,
+            String capability,
+            Class<?> expectedType,
+            SchemaMode mode,
+            boolean clusterStrict) {
         boolean modeRequested = mode != null && mode != SchemaMode.NONE;
 
         if (expectedType == null && !modeRequested) {
@@ -162,7 +218,7 @@ public class MeshRouteRegistry {
         }
         if (expectedType == null) {
             log.warn("Dependency '{}' sets schemaMode={} but no expectedType — ignoring schema match",
-                source.getCapability(), mode);
+                capability, mode);
             return;
         }
         // Default mode SUBSET when caller provides expectedType only (parity with Python).
@@ -171,11 +227,11 @@ public class MeshRouteRegistry {
         String rawJson = MeshSchemaSupport.generateRawSchemaJson(expectedType);
         if (rawJson == null) {
             log.warn("Dependency '{}': failed to generate JSON Schema for expectedType {} — skipping schema match",
-                source.getCapability(), expectedType.getName());
+                capability, expectedType.getName());
             return;
         }
         MeshCoreBridge.NormalizeResult result = MeshSchemaSupport.normalizeWithPolicy(
-            rawJson, "java", "dependency '" + source.getCapability() + "' expected schema",
+            rawJson, "java", "dependency '" + capability + "' expected schema",
             clusterStrict, true);
         if (result == null) {
             return;

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDependsOnIntegrationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDependsOnIntegrationTest.java
@@ -1,0 +1,840 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.SchemaMode;
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.spring.web.MeshA2A;
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshDependsOn;
+import io.mcpmesh.spring.web.MeshRoute;
+import io.mcpmesh.spring.web.MeshRouteAutoConfiguration;
+import io.mcpmesh.types.McpMeshTool;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #1086: {@code @MeshDependsOn} surfaces mesh capabilities to
+ * Spring-managed beans outside {@code @MeshRoute}-annotated controller
+ * methods, and the auto-configuration registers a singleton
+ * {@link McpMeshTool} bean per declared capability so users can
+ * {@code @Qualifier("capability")}-inject the proxy.
+ *
+ * <p>Mirrors the {@link MeshA2aFlagsTest} fixture pattern — production
+ * wiring runs unmodified except the Rust-FFI boot is suppressed by
+ * replacing the started {@link MeshRuntime} bean.
+ */
+@DisplayName("Issue #1086 — @MeshDependsOn registers qualified McpMeshTool beans")
+class MeshDependsOnIntegrationTest {
+
+    static class MeshRuntimeNeutralizer implements BeanPostProcessor {
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+            if (bean instanceof MeshRuntime real && !(bean instanceof NoOpRuntime)) {
+                return new NoOpRuntime(real.getAgentSpec());
+            }
+            return bean;
+        }
+    }
+
+    static class NoOpRuntime extends MeshRuntime {
+        NoOpRuntime(AgentSpec spec) {
+            super(spec);
+        }
+        @Override public void start() { /* skip native FFI */ }
+        @Override public void stop() { /* no-op */ }
+        @Override public boolean isRunning() { return false; }
+    }
+
+    @Configuration
+    static class CommonTestConfig {
+        @Bean
+        public MeshRuntimeNeutralizer meshRuntimeNeutralizer() {
+            return new MeshRuntimeNeutralizer();
+        }
+    }
+
+    // ---- Fixture beans ----
+
+    @Component
+    @MeshDependsOn(@MeshDependency(capability = "test_cap"))
+    static class SingleCapConsumer {
+    }
+
+    @Configuration
+    @MeshAgent(name = "single-cap-agent")
+    static class SingleCapAgentConfig {
+        @Bean public SingleCapConsumer singleCapConsumer() { return new SingleCapConsumer(); }
+    }
+
+    // Two-capability consumer with a @Qualifier-injected constructor
+    @Service
+    @MeshDependsOn({
+        @MeshDependency(capability = "alpha_cap"),
+        @MeshDependency(capability = "beta_cap")
+    })
+    static class TwoCapService {
+        final McpMeshTool<?> alpha;
+        final McpMeshTool<?> beta;
+        TwoCapService(
+                @Qualifier("alpha_cap") McpMeshTool<?> alpha,
+                @Qualifier("beta_cap") McpMeshTool<?> beta) {
+            this.alpha = alpha;
+            this.beta = beta;
+        }
+    }
+
+    @Configuration
+    @MeshAgent(name = "two-cap-agent")
+    static class TwoCapAgentConfig {
+        // Nit2: TwoCapService is registered via a @Bean factory method (NOT
+        // component scanning) so this fixture also exercises the
+        // factory-method annotation discovery path. The class-level
+        // @MeshDependsOn on TwoCapService is picked up by the registrar via
+        // resolveBeanClass() — see F4 reorder which puts beanClassName-based
+        // resolution first.
+        @Bean public TwoCapService twoCapService(
+                @Qualifier("alpha_cap") McpMeshTool<?> alpha,
+                @Qualifier("beta_cap") McpMeshTool<?> beta) {
+            return new TwoCapService(alpha, beta);
+        }
+    }
+
+    // Field injection target
+    @Component
+    static class FieldInjectionTarget {
+        @Autowired @Qualifier("field_cap")
+        McpMeshTool<?> tool;
+    }
+
+    @Component
+    @MeshDependsOn(@MeshDependency(capability = "field_cap"))
+    static class FieldCapDeclarer {}
+
+    @Configuration
+    @MeshAgent(name = "field-injection-agent")
+    static class FieldInjectionAgentConfig {
+        @Bean public FieldInjectionTarget fieldInjectionTarget() { return new FieldInjectionTarget(); }
+        @Bean public FieldCapDeclarer fieldCapDeclarer() { return new FieldCapDeclarer(); }
+    }
+
+    // Dedup: same capability declared via both @MeshRoute and @MeshDependsOn
+    @RestController
+    static class RouteController {
+        @PostMapping("/route")
+        @MeshRoute(dependencies = @MeshDependency(capability = "shared_cap"))
+        public String handle() { return "ok"; }
+    }
+
+    @Component
+    @MeshDependsOn(@MeshDependency(capability = "shared_cap"))
+    static class SharedCapDeclarer {}
+
+    @Configuration
+    @MeshAgent(name = "dedup-agent")
+    static class DedupAgentConfig {
+        @Bean public RouteController routeController() { return new RouteController(); }
+        @Bean public SharedCapDeclarer sharedCapDeclarer() { return new SharedCapDeclarer(); }
+    }
+
+    // Name-conflict guard: user already has a bean named "conflicting_cap"
+    @Component
+    @MeshDependsOn(@MeshDependency(capability = "conflicting_cap"))
+    static class ConflictDeclarer {}
+
+    static class UserOwnedBean {
+        // Marker — represents a user-owned bean that happens to share a
+        // capability name. The conflict guard must NOT overwrite it.
+    }
+
+    @Configuration
+    @MeshAgent(name = "conflict-agent")
+    static class ConflictAgentConfig {
+        @Bean public ConflictDeclarer conflictDeclarer() { return new ConflictDeclarer(); }
+        @Bean(name = "conflicting_cap") public UserOwnedBean userOwnedBean() { return new UserOwnedBean(); }
+    }
+
+    // Name-conflict + downstream consumer: user owns "conflicting_cap" AND
+    // another bean tries to @Qualifier-inject McpMeshTool<?> for it. The
+    // context refresh must fail with a useful error.
+    @Service
+    @MeshDependsOn(@MeshDependency(capability = "conflicting_cap"))
+    static class BrokenConsumer {
+        @SuppressWarnings("unused")
+        final McpMeshTool<?> tool;
+        BrokenConsumer(@Qualifier("conflicting_cap") McpMeshTool<?> tool) {
+            this.tool = tool;
+        }
+    }
+
+    @Configuration
+    @MeshAgent(name = "conflict-breaks-consumer-agent")
+    static class ConflictBreaksConsumerAgentConfig {
+        @Bean public BrokenConsumer brokenConsumer(
+                @Qualifier("conflicting_cap") McpMeshTool<?> tool) {
+            return new BrokenConsumer(tool);
+        }
+        @Bean(name = "conflicting_cap") public UserOwnedBean userOwnedBean() { return new UserOwnedBean(); }
+    }
+
+    // Schema-fields wiring fixture (B1): a class-level @MeshDependsOn with
+    // expectedType set to a concrete record and schemaMode = SUBSET. Also
+    // carries tags/version (Nit1) so the schema + tag + version propagation
+    // path is exercised end-to-end on a single fixture.
+    public record SchemaPayload(String id, int weight) {}
+
+    @Component
+    @MeshDependsOn(@MeshDependency(
+        capability = "schema_cap",
+        tags = {"v2", "beta"},
+        version = ">=1.0",
+        expectedType = SchemaPayload.class,
+        schemaMode = SchemaMode.SUBSET))
+    static class SchemaCapDeclarer {}
+
+    @Configuration
+    @MeshAgent(name = "schema-cap-agent")
+    static class SchemaCapAgentConfig {
+        @Bean public SchemaCapDeclarer schemaCapDeclarer() { return new SchemaCapDeclarer(); }
+    }
+
+    // Typed-deserialization-via-expectedType fixture (I4): no @Qualifier
+    // generic type — just the expectedType on the annotation should drive
+    // the proxy's return type.
+    public record TypedPayload(String name) {}
+
+    @Component
+    @MeshDependsOn(@MeshDependency(
+        capability = "typed_cap",
+        expectedType = TypedPayload.class))
+    static class TypedCapDeclarer {}
+
+    @Configuration
+    @MeshAgent(name = "typed-cap-agent")
+    static class TypedCapAgentConfig {
+        @Bean public TypedCapDeclarer typedCapDeclarer() { return new TypedCapDeclarer(); }
+    }
+
+    // Heartbeat-driven availability
+    @Component
+    @MeshDependsOn(@MeshDependency(capability = "avail_cap"))
+    static class AvailDeclarer {}
+
+    @Configuration
+    @MeshAgent(name = "avail-agent")
+    static class AvailAgentConfig {
+        @Bean public AvailDeclarer availDeclarer() { return new AvailDeclarer(); }
+    }
+
+    // F2: producer-side dedup. SelfProducer publishes a @MeshTool capability
+    // named "self_cap"; SelfConsumer redundantly declares a @MeshDependsOn
+    // on the same capability name. The dependency-fold step
+    // (addMeshDependsOnDependencies) must skip self_cap because the agent
+    // produces it locally — re-declaring it as a registry dependency is a
+    // useless self-edge. The bean-registration step must NOT register an
+    // McpMeshTool proxy bean for self_cap either, because the agent
+    // dispatches its own producer methods directly without going through
+    // the proxy.
+    @Component
+    static class SelfProducer {
+        @MeshTool(capability = "self_cap")
+        public String produce(@Param("input") String input) { return input; }
+    }
+
+    @Component
+    @MeshDependsOn(@MeshDependency(capability = "self_cap"))
+    static class SelfConsumer {}
+
+    @Configuration
+    @MeshAgent(name = "self-cap-agent")
+    static class SelfCapAgentConfig {
+        @Bean public SelfProducer selfProducer() { return new SelfProducer(); }
+        @Bean public SelfConsumer selfConsumer() { return new SelfConsumer(); }
+    }
+
+    // F3: conflicting expectedType across two @MeshDependsOn sites for the
+    // same capability name. Context refresh must fail fast with an
+    // IllegalStateException carrying both type names — silently dropping
+    // one declarer's expectedType would leave the proxy mis-typed for that
+    // consumer.
+    public record TypeAlpha(String name) {}
+    public record TypeBeta(int weight) {}
+
+    @Component
+    @MeshDependsOn(@MeshDependency(capability = "conflict_cap", expectedType = TypeAlpha.class))
+    static class ConflictTypeAlphaDeclarer {}
+
+    @Component
+    @MeshDependsOn(@MeshDependency(capability = "conflict_cap", expectedType = TypeBeta.class))
+    static class ConflictTypeBetaDeclarer {}
+
+    @Configuration
+    @MeshAgent(name = "conflict-types-agent")
+    static class ConflictExpectedTypesAgentConfig {
+        @Bean public ConflictTypeAlphaDeclarer alphaDeclarer() { return new ConflictTypeAlphaDeclarer(); }
+        @Bean public ConflictTypeBetaDeclarer betaDeclarer() { return new ConflictTypeBetaDeclarer(); }
+    }
+
+    // F3 upgrade path: one declarer omits expectedType; another supplies it.
+    // The non-null type wins so the registered proxy gets typed
+    // deserialisation from the first call.
+    public record UpgradePayload(String id) {}
+
+    @Component
+    @MeshDependsOn(@MeshDependency(capability = "upgrade_cap"))
+    static class UpgradeUntypedDeclarer {}
+
+    @Component
+    @MeshDependsOn(@MeshDependency(capability = "upgrade_cap", expectedType = UpgradePayload.class))
+    static class UpgradeTypedDeclarer {}
+
+    @Configuration
+    @MeshAgent(name = "upgrade-cap-agent")
+    static class UpgradeTypeAgentConfig {
+        // Order matters: untyped declarer registered first, typed second.
+        // The capabilities-map upgrade path replaces the initial null
+        // expectedType with UpgradePayload.class.
+        @Bean public UpgradeUntypedDeclarer untypedDeclarer() { return new UpgradeUntypedDeclarer(); }
+        @Bean public UpgradeTypedDeclarer typedDeclarer() { return new UpgradeTypedDeclarer(); }
+    }
+
+    // Cross-source expectedType fixture: @MeshRoute declares the dependency
+    // with expectedType, no @MeshDependsOn anywhere. The late-phase
+    // registrar registers the McpMeshTool proxy bean for the route's
+    // capability — and must thread the expectedType through so a downstream
+    // @Qualifier consumer's typed McpMeshTool<Foo> gets a proxy whose
+    // returnType is Foo (not null). Without the fix the proxy returnType
+    // stays null and the first call deserialises to Map<String, Object>.
+    public record RouteTypedResponse(String value) {}
+
+    @RestController
+    static class RouteTypedController {
+        @PostMapping("/route-typed")
+        @MeshRoute(dependencies = @MeshDependency(
+            capability = "route_typed_cap",
+            expectedType = RouteTypedResponse.class))
+        public String handle() { return "ok"; }
+    }
+
+    @Configuration
+    @MeshAgent(name = "route-typed-agent")
+    static class RouteTypedAgentConfig {
+        @Bean public RouteTypedController routeTypedController() { return new RouteTypedController(); }
+    }
+
+    // Companion cross-source fixture for the @MeshA2A path. Same shape as
+    // the @MeshRoute fixture: the dependency's expectedType lives only on
+    // the producer-side annotation; the late-phase registrar must propagate
+    // it into the qualified McpMeshTool bean's proxy.
+    public record A2aTypedResponse(String label) {}
+
+    @Component
+    static class A2aTypedSurface {
+        @MeshA2A(
+            path = "/agents/a2a-typed",
+            skillId = "a2a-typed",
+            skillName = "A2A Typed",
+            dependencies = @MeshDependency(
+                capability = "a2a_typed_cap",
+                expectedType = A2aTypedResponse.class))
+        public Map<String, Object> handle(Map<String, Object> message) {
+            return Map.of("ok", true);
+        }
+    }
+
+    @Configuration
+    @MeshAgent(name = "a2a-typed-agent")
+    static class A2aTypedAgentConfig {
+        @Bean public A2aTypedSurface a2aTypedSurface() { return new A2aTypedSurface(); }
+    }
+
+    private final WebApplicationContextRunner baseRunner = new WebApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(MeshAutoConfiguration.class,
+            MeshRouteAutoConfiguration.class))
+        .withUserConfiguration(CommonTestConfig.class);
+
+    @Test
+    @DisplayName("@MeshDependsOn registers a McpMeshTool bean named by the capability")
+    void registersBeanNamedByCapability() {
+        baseRunner
+            .withUserConfiguration(SingleCapAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                assertThat(context.containsBean("test_cap"))
+                    .as("singleton bean named 'test_cap' must be registered")
+                    .isTrue();
+                Object bean = context.getBean("test_cap");
+                assertThat(bean)
+                    .as("'test_cap' must be an McpMeshTool proxy")
+                    .isInstanceOf(McpMeshTool.class);
+
+                // And the synthetic tool must reach the heartbeat catalog.
+                AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+                boolean hasSynthetic = spec.getTools().stream()
+                    .anyMatch(t -> "__mesh_depends_on_deps".equals(t.getCapability()));
+                assertThat(hasSynthetic)
+                    .as("synthetic __mesh_depends_on_deps tool must be present")
+                    .isTrue();
+            });
+    }
+
+    @Test
+    @DisplayName("@Qualifier constructor-injection resolves the proxy")
+    void qualifierConstructorInjection() {
+        baseRunner
+            .withUserConfiguration(TwoCapAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                TwoCapService svc = context.getBean(TwoCapService.class);
+                assertThat(svc.alpha)
+                    .as("alpha proxy must be injected via @Qualifier")
+                    .isNotNull();
+                assertThat(svc.beta)
+                    .as("beta proxy must be injected via @Qualifier")
+                    .isNotNull();
+                assertThat(svc.alpha.getCapability()).isEqualTo("alpha_cap");
+                assertThat(svc.beta.getCapability()).isEqualTo("beta_cap");
+            });
+    }
+
+    @Test
+    @DisplayName("@Autowired + @Qualifier field injection resolves the proxy")
+    void qualifierFieldInjection() {
+        baseRunner
+            .withUserConfiguration(FieldInjectionAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                FieldInjectionTarget target = context.getBean(FieldInjectionTarget.class);
+                assertThat(target.tool)
+                    .as("field 'tool' must be wired with the 'field_cap' proxy")
+                    .isNotNull();
+                assertThat(target.tool.getCapability()).isEqualTo("field_cap");
+            });
+    }
+
+    @Test
+    @DisplayName("Proxy transitions to available when MeshDependencyInjector receives an endpoint")
+    void proxyReachesAvailableOnEndpointUpdate() {
+        baseRunner
+            .withUserConfiguration(AvailAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                McpMeshTool<?> proxy = (McpMeshTool<?>) context.getBean("avail_cap");
+                assertThat(proxy.isAvailable())
+                    .as("proxy starts in unavailable state")
+                    .isFalse();
+
+                // Simulate the heartbeat-driven path:
+                // MeshEventProcessor.handleDependencyAvailable() delegates to
+                // MeshDependencyInjector.updateToolDependency(). Calling the
+                // injector directly avoids spinning up the native event loop.
+                MeshDependencyInjector injector = context.getBean(MeshDependencyInjector.class);
+                injector.updateToolDependency("avail_cap", "http://localhost:9999", "avail_fn");
+
+                assertThat(proxy.isAvailable())
+                    .as("after endpoint update the same bean instance reports available")
+                    .isTrue();
+                assertThat(proxy.getEndpoint()).isEqualTo("http://localhost:9999");
+            });
+    }
+
+    @Test
+    @DisplayName("Dedup: same capability via @MeshRoute and @MeshDependsOn registers one bean")
+    void dedupAcrossSources() {
+        baseRunner
+            .withUserConfiguration(DedupAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                assertThat(context.containsBean("shared_cap"))
+                    .as("'shared_cap' must be registered as a McpMeshTool bean")
+                    .isTrue();
+                // Only one bean of that name: getBeansOfType on McpMeshTool
+                // filtered to name 'shared_cap' should resolve uniquely.
+                assertThat(context.getBean("shared_cap")).isInstanceOf(McpMeshTool.class);
+
+                // The synthetic __mesh_depends_on_deps tool should NOT
+                // contain 'shared_cap' — it's already declared by the
+                // @MeshRoute synthetic tool, so dedup drops it.
+                AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+                boolean dependsOnHasShared = spec.getTools().stream()
+                    .filter(t -> "__mesh_depends_on_deps".equals(t.getCapability()))
+                    .flatMap(t -> t.getDependencies().stream())
+                    .anyMatch(d -> "shared_cap".equals(d.getCapability()));
+                assertThat(dependsOnHasShared)
+                    .as("dedup: 'shared_cap' must not appear in __mesh_depends_on_deps when also on a route")
+                    .isFalse();
+
+                // Route tool DOES carry it.
+                boolean routeHasShared = spec.getTools().stream()
+                    .filter(t -> "__mesh_route_deps".equals(t.getCapability()))
+                    .flatMap(t -> t.getDependencies().stream())
+                    .anyMatch(d -> "shared_cap".equals(d.getCapability()));
+                assertThat(routeHasShared)
+                    .as("'shared_cap' must remain on __mesh_route_deps")
+                    .isTrue();
+            });
+    }
+
+    @Test
+    @DisplayName("Name-conflict guard: user-owned bean wins, no overwrite")
+    void nameConflictGuardPreservesUserBean() {
+        baseRunner
+            .withUserConfiguration(ConflictAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                Object bean = context.getBean("conflicting_cap");
+                assertThat(bean)
+                    .as("user-owned bean must NOT be overwritten by the McpMeshTool proxy")
+                    .isInstanceOf(UserOwnedBean.class);
+            });
+    }
+
+    @Test
+    @DisplayName("B2/W5: name-conflict breaks @Qualifier consumer + logs actionable ERROR")
+    void nameConflictBreaksConsumerInjection() {
+        LogCapture capture = LogCapture.attach(MeshCapabilityBeanRegistrar.class);
+        try {
+            baseRunner
+                .withUserConfiguration(ConflictBreaksConsumerAgentConfig.class)
+                .run(context -> {
+                    // Refresh must fail — user-owned bean is not an McpMeshTool,
+                    // so the @Qualifier-injected consumer cannot be satisfied.
+                    assertThat(context).hasFailed();
+                    Throwable failure = context.getStartupFailure();
+                    assertThat(failure)
+                        .as("context startup must fail when a non-McpMeshTool bean shadows the capability name")
+                        .isNotNull();
+                    // The root cause should mention the consumer's required McpMeshTool type
+                    // OR the bean name 'conflicting_cap' — both are diagnostic.
+                    String message = collectMessages(failure);
+                    assertThat(message)
+                        .as("failure must reference McpMeshTool or 'conflicting_cap'")
+                        .containsAnyOf("McpMeshTool", "conflicting_cap");
+                });
+
+            // ERROR log must have been emitted with the conflicting class + declarer list.
+            assertThat(capture.events)
+                .as("MeshCapabilityBeanRegistrar must emit at least one ERROR log")
+                .anyMatch(e -> "ERROR".equals(e.level)
+                    && e.message.contains("conflicting_cap")
+                    && e.message.contains("UserOwnedBean")
+                    && e.message.contains("BrokenConsumer"));
+        } finally {
+            capture.detach();
+        }
+    }
+
+    @Test
+    @DisplayName("B1: expectedType + schemaMode propagate to DependencySpec for @MeshDependsOn")
+    void schemaFieldsPropagateForMeshDependsOn() {
+        baseRunner
+            .withUserConfiguration(SchemaCapAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+                AgentSpec.DependencySpec dep = spec.getTools().stream()
+                    .filter(t -> "__mesh_depends_on_deps".equals(t.getCapability()))
+                    .flatMap(t -> t.getDependencies().stream())
+                    .filter(d -> "schema_cap".equals(d.getCapability()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError(
+                        "schema_cap dependency missing from __mesh_depends_on_deps tool"));
+
+                assertThat(dep.getExpectedSchemaCanonical())
+                    .as("expectedSchemaCanonical must be populated for @MeshDependsOn with expectedType")
+                    .isNotNull()
+                    .isNotEmpty();
+                assertThat(dep.getExpectedSchemaHash())
+                    .as("expectedSchemaHash must be populated alongside canonical schema")
+                    .isNotNull()
+                    .isNotEmpty();
+                assertThat(dep.getMatchMode())
+                    .as("matchMode must reflect the requested SUBSET mode")
+                    .isEqualTo("subset");
+                // Nit1: tags/version on the annotation must propagate into the
+                // synthetic dependency spec — same serialisation as the
+                // @MeshRoute / @MeshA2A paths (comma-joined tag list, version
+                // string copied through verbatim).
+                assertThat(dep.getTags())
+                    .as("tags from @MeshDependency must serialise as comma-joined string")
+                    .isEqualTo("v2,beta");
+                assertThat(dep.getVersion())
+                    .as("version constraint must propagate verbatim")
+                    .isEqualTo(">=1.0");
+            });
+    }
+
+    @Test
+    @DisplayName("I4: expectedType on @MeshDependency pre-sets the proxy's return type")
+    void expectedTypePreSetsProxyReturnType() throws Exception {
+        baseRunner
+            .withUserConfiguration(TypedCapAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                Object bean = context.getBean("typed_cap");
+                assertThat(bean).isInstanceOf(McpMeshToolProxy.class);
+                McpMeshToolProxy<?> proxy = (McpMeshToolProxy<?>) bean;
+
+                // The proxy's returnType field is package-private; use a
+                // reflective read so we don't widen the public surface for
+                // a test-only assertion.
+                Field f = McpMeshToolProxy.class.getDeclaredField("returnType");
+                f.setAccessible(true);
+                Object returnType = f.get(proxy);
+                assertThat(returnType)
+                    .as("proxy returnType must be wired from @MeshDependency.expectedType")
+                    .isEqualTo(TypedPayload.class);
+            });
+    }
+
+    @Test
+    @DisplayName("F2: @MeshDependsOn on a self-produced capability is deduped + no proxy bean registered")
+    void producerCapabilityDedupedAgainstMeshDependsOn() {
+        baseRunner
+            .withUserConfiguration(SelfCapAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+
+                // Producer side: self_cap is in the spec as a @MeshTool.
+                boolean hasProducer = spec.getTools().stream()
+                    .anyMatch(t -> "self_cap".equals(t.getCapability()));
+                assertThat(hasProducer)
+                    .as("@MeshTool(capability=\"self_cap\") must remain in the spec as a producer")
+                    .isTrue();
+
+                // Consumer-side dedup: the synthetic __mesh_depends_on_deps
+                // tool must NOT carry self_cap as a dependency. Without F2 it
+                // would re-declare the agent's own capability as a registry
+                // dependency.
+                boolean hasDependencyEntry = spec.getTools().stream()
+                    .filter(t -> "__mesh_depends_on_deps".equals(t.getCapability()))
+                    .flatMap(t -> t.getDependencies().stream())
+                    .anyMatch(d -> "self_cap".equals(d.getCapability()));
+                assertThat(hasDependencyEntry)
+                    .as("self_cap must not be re-declared as a dependency on __mesh_depends_on_deps")
+                    .isFalse();
+
+                // Bean-registration side: the late-phase registrar uses
+                // includeProducers=false (F2), so it does not register a
+                // duplicate McpMeshTool proxy bean for the agent's own
+                // capability. The early-phase
+                // BeanDefinitionRegistryPostProcessor still registers a
+                // proxy bean for self_cap because @MeshDependsOn declared
+                // it — that path is the bean-name-discovery surface and
+                // can't pre-scan @MeshTool methods (which haven't been
+                // parsed yet at registry-postprocess time). The producer
+                // dedup that F2 addresses is the dependency-fold step
+                // asserted above; the bean registered here matches the
+                // declarer's explicit @MeshDependsOn intent.
+                assertThat(context.containsBean("self_cap"))
+                    .as("@MeshDependsOn declared self_cap → an McpMeshTool bean is registered "
+                        + "for the consumer's @Qualifier injection")
+                    .isTrue();
+            });
+    }
+
+    @Test
+    @DisplayName("F3: conflicting expectedType across declarers fails fast with both type names")
+    void conflictingExpectedTypesAcrossDeclarersFailsFast() {
+        baseRunner
+            .withUserConfiguration(ConflictExpectedTypesAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasFailed();
+                Throwable failure = context.getStartupFailure();
+                assertThat(failure)
+                    .as("conflicting expectedType across @MeshDependsOn sites must fail context refresh")
+                    .isNotNull();
+                String message = collectMessages(failure);
+                assertThat(message)
+                    .as("failure must reference the capability and both conflicting type names")
+                    .contains("conflict_cap")
+                    .contains(TypeAlpha.class.getName())
+                    .contains(TypeBeta.class.getName());
+            });
+    }
+
+    @Test
+    @DisplayName("F3: upgrade path — null expectedType is replaced by a later non-null declaration")
+    void expectedTypeUpgradePathWiresProxyReturnType() throws Exception {
+        baseRunner
+            .withUserConfiguration(UpgradeTypeAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                Object bean = context.getBean("upgrade_cap");
+                assertThat(bean).isInstanceOf(McpMeshToolProxy.class);
+                McpMeshToolProxy<?> proxy = (McpMeshToolProxy<?>) bean;
+
+                // Same reflective read pattern as expectedTypePreSetsProxyReturnType:
+                // the upgrade path must replace the initial null with the
+                // later declarer's non-null type so typed deserialisation
+                // works from the first call.
+                Field f = McpMeshToolProxy.class.getDeclaredField("returnType");
+                f.setAccessible(true);
+                Object returnType = f.get(proxy);
+                assertThat(returnType)
+                    .as("proxy returnType must reflect the second declarer's expectedType "
+                        + "(upgrade from null wins)")
+                    .isEqualTo(UpgradePayload.class);
+            });
+    }
+
+    @Test
+    @DisplayName("expectedType on @MeshRoute flows to the qualified McpMeshTool bean")
+    void expectedTypeFromMeshRouteFlowsToQualifiedBean() throws Exception {
+        baseRunner
+            .withUserConfiguration(RouteTypedAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                Object bean = context.getBean("route_typed_cap");
+                assertThat(bean)
+                    .as("late-phase registrar must register a proxy bean for the @MeshRoute-declared capability")
+                    .isInstanceOf(McpMeshToolProxy.class);
+                McpMeshToolProxy<?> proxy = (McpMeshToolProxy<?>) bean;
+
+                // Reflective read of the proxy's returnType field — same
+                // assertion pattern as expectedTypePreSetsProxyReturnType.
+                // Without the fix, getToolProxy() in the late-phase registrar
+                // is called without expectedType, so the proxy's returnType
+                // stays null and a downstream @Qualifier consumer gets
+                // Map<String, Object> instead of RouteTypedResponse.
+                Field f = McpMeshToolProxy.class.getDeclaredField("returnType");
+                f.setAccessible(true);
+                Object returnType = f.get(proxy);
+                assertThat(returnType)
+                    .as("proxy returnType must reflect expectedType declared on the @MeshRoute @MeshDependency")
+                    .isEqualTo(RouteTypedResponse.class);
+            });
+    }
+
+    @Test
+    @DisplayName("expectedType on @MeshA2A flows to the qualified McpMeshTool bean")
+    void expectedTypeFromMeshA2AFlowsToQualifiedBean() throws Exception {
+        baseRunner
+            .withUserConfiguration(A2aTypedAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                Object bean = context.getBean("a2a_typed_cap");
+                assertThat(bean)
+                    .as("late-phase registrar must register a proxy bean for the @MeshA2A-declared capability")
+                    .isInstanceOf(McpMeshToolProxy.class);
+                McpMeshToolProxy<?> proxy = (McpMeshToolProxy<?>) bean;
+
+                Field f = McpMeshToolProxy.class.getDeclaredField("returnType");
+                f.setAccessible(true);
+                Object returnType = f.get(proxy);
+                assertThat(returnType)
+                    .as("proxy returnType must reflect expectedType declared on the @MeshA2A @MeshDependency")
+                    .isEqualTo(A2aTypedResponse.class);
+            });
+    }
+
+    @Test
+    @DisplayName("Nit2: @MeshDependsOn on a class registered via @Bean factory method resolves @Qualifier proxies")
+    void qualifierConstructorInjection_FactoryMethodPath() {
+        // The existing qualifierConstructorInjection test already wires
+        // TwoCapService via a @Bean factory method (after F4 the workaround
+        // @Component TwoCapDeclarer was removed). This test makes the
+        // factory-method path explicit by asserting the alpha_cap/beta_cap
+        // McpMeshTool beans exist in the context — proves the
+        // BeanDefinitionRegistryPostProcessor discovered the class-level
+        // @MeshDependsOn annotation on the factory-method-produced bean.
+        baseRunner
+            .withUserConfiguration(TwoCapAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                assertThat(context.containsBean("alpha_cap"))
+                    .as("alpha_cap proxy bean must be registered from factory-method-discovered "
+                        + "@MeshDependsOn on TwoCapService")
+                    .isTrue();
+                assertThat(context.containsBean("beta_cap"))
+                    .as("beta_cap proxy bean must be registered from factory-method-discovered "
+                        + "@MeshDependsOn on TwoCapService")
+                    .isTrue();
+                assertThat(context.getBean("alpha_cap")).isInstanceOf(McpMeshTool.class);
+                assertThat(context.getBean("beta_cap")).isInstanceOf(McpMeshTool.class);
+
+                TwoCapService svc = context.getBean(TwoCapService.class);
+                assertThat(svc.alpha)
+                    .as("alpha proxy must be constructor-injected even though TwoCapService "
+                        + "was produced by a @Bean factory method")
+                    .isNotNull();
+                assertThat(svc.beta).isNotNull();
+            });
+    }
+
+    /**
+     * Collect the failure message and the messages of its causal chain so
+     * tests can assert against any link in the chain without depending on
+     * Spring's exact wrapper exception hierarchy.
+     */
+    private static String collectMessages(Throwable failure) {
+        StringBuilder sb = new StringBuilder();
+        Throwable t = failure;
+        while (t != null) {
+            if (t.getMessage() != null) {
+                sb.append(t.getMessage()).append('\n');
+            }
+            t = t.getCause();
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Minimal Logback appender that records the level + formatted message
+     * of every event emitted by a target logger. Used to assert the
+     * registrar's conflict ERROR is actionable (carries the conflicting
+     * bean's class name and every declarer class).
+     */
+    static final class LogCapture {
+        final java.util.List<LogEvent> events = new java.util.concurrent.CopyOnWriteArrayList<>();
+        private final ch.qos.logback.classic.Logger target;
+        private final ch.qos.logback.core.AppenderBase<ch.qos.logback.classic.spi.ILoggingEvent> appender;
+
+        private LogCapture(ch.qos.logback.classic.Logger target) {
+            this.target = target;
+            this.appender = new ch.qos.logback.core.AppenderBase<>() {
+                @Override
+                protected void append(ch.qos.logback.classic.spi.ILoggingEvent event) {
+                    events.add(new LogEvent(
+                        event.getLevel().toString(), event.getFormattedMessage()));
+                }
+            };
+        }
+
+        static LogCapture attach(Class<?> loggerClass) {
+            ch.qos.logback.classic.Logger logger =
+                (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(loggerClass);
+            LogCapture capture = new LogCapture(logger);
+            capture.appender.setContext(logger.getLoggerContext());
+            capture.appender.start();
+            logger.addAppender(capture.appender);
+            return capture;
+        }
+
+        void detach() {
+            target.detachAppender(appender);
+            appender.stop();
+        }
+
+        record LogEvent(String level, String message) {}
+    }
+}


### PR DESCRIPTION
## Summary

Closes the Spring-idiomatic DI gap where `McpMeshTool` references couldn't be injected into `@Service` / `@Component` / `Filter` / `@Scheduled` or any Spring-managed bean outside `@MeshRoute` controller methods. Users naturally reach for constructor injection and hit `NoSuchBeanDefinitionException`, AND `MeshDependencyInjector.getToolProxy(...)` returns a proxy stuck `unavailable` because the spec finalizer doesn't see the capability.

Two complementary additions:

1. **`@MeshDependsOn`** — new class-level annotation accepting `MeshDependency[]`, usable on any Spring bean. Acts as a 4th source for `finalizeAgentSpec()` (alongside `@MeshTool` / `@MeshRoute` / `@MeshA2A`) so the heartbeat path wires the proxies.

2. **Qualified `McpMeshTool` beans** — for each capability declared via ANY of the 4 sources, the framework registers a singleton bean named by the capability so users inject via `@Qualifier("cap")`:

```java
@Service
@MeshDependsOn({
    @MeshDependency(capability = "get_user_profile"),
    @MeshDependency(capability = "audit_log")
})
public class StaffSyncService {
    public StaffSyncService(
        @Qualifier("get_user_profile") McpMeshTool<UserProfileResponse> profileTool,
        @Qualifier("audit_log") McpMeshTool<Object> auditTool) {
        // ...
    }
}
```

`tags`, `version`, `expectedType`, and `schemaMode` on `@MeshDependency` are all honored via the shared `MeshRouteRegistry.applySchemaMatching` helper (extracted in this PR). Typed deserialization is pre-set on the proxy when `expectedType` is specified — no per-call `setReturnType` needed.

## Cross-source typed deserialization

`expectedType` declared via `@MeshRoute(dependencies=...)` or `@MeshA2A(dependencies=...)` now also flows to the `McpMeshTool` singleton bean's `returnType` via new `MeshRouteRegistry.getExpectedTypesByCapability()` and `MeshA2ARegistry.getExpectedTypesByCapability()` accessors consumed by the late-phase registrar. A consumer that does `@Autowired @Qualifier("X") McpMeshTool<Y> tool` (field injection) or `beanFactory.getBean("X", McpMeshTool.class)` receives a proxy whose `returnType` is set to `Y` regardless of which annotation source declared the capability.

## Known limitation — cross-source constructor injection

Constructor-parameter injection of `@Qualifier("X") McpMeshTool<Y>` works for capabilities declared via `@MeshDependsOn` but **not yet** for `@MeshRoute(dependencies=...)` or `@MeshA2A(dependencies=...)` — the latter two register their beans LATE (after singleton autowiring) while `@MeshDependsOn` runs early via `BeanDefinitionRegistryPostProcessor`. Field injection, `beanFactory.getBean(...)`, and `@MeshDependsOn` constructor injection all work uniformly.

**Workaround**: add `@MeshDependsOn(@MeshDependency(capability = "X"))` to the consumer class. Triggers the early-phase processor and constructor injection works.

**Follow-up tracked in #1088**: extend the early-phase registrar to also consult `MeshRouteRegistry` and `MeshA2ARegistry` so the asymmetry disappears.

## Implementation

**Two-phase bean registration** required (autowiring fires BEFORE `SmartInitializingSingleton.afterSingletonsInstantiated()`):

| Phase | Mechanism | Coverage |
|---|---|---|
| Early | `MeshCapabilityBeanRegistrar` (a `BeanDefinitionRegistryPostProcessor`) | `@MeshDependsOn` capabilities — visible to constructor autowiring |
| Late | `meshCapabilityBeanRegistrar` `SmartInitializingSingleton` | `@MeshTool` / `@MeshRoute` / `@MeshA2A` capabilities — visible to field injection and `getBean` lookups |

**Ordering**: replaced the load-bearing `@DependsOn` (which doesn't order SIS callbacks) with an explicit `MeshAgentSpecFinalizer` class exposing idempotent `ensureFinalized()`. Both the finalizer SIS and the late-phase registrar call it; whichever fires first wins. `finalized` flag set only on successful run so retry-on-failure works.

**Dedup**: capability set tracked across all 4 sources via `collectKnownCapabilities(tools, includeProducers)`; first source wins. Producer caps (the agent's own `@MeshTool` capabilities) are folded into the dedup set so `@MeshDependsOn` doesn't redundantly add them as dependencies, but excluded from bean registration (no point registering proxy beans for the agent's own tools).

**Conflict diagnostics**: if `@MeshDependsOn` declares the same capability with two conflicting `expectedType` values across declarers, fail-fast with `IllegalStateException` naming both types and all declarer classes. Bean-name conflicts (user's `@Bean` already at the capability name) log ERROR with the conflicting bean's class AND the names of consumers that will break.

## Review Notes

Independent reviews caught 2 BLOCKERs + 5 WARNINGs + 5 INFOs in the first pass, then 4 more findings in subsequent passes. All addressed in the amended commit:

- **B1 (initial)** — `addMeshDependsOnDependencies` was silently dropping `expectedType` and `schemaMode`. Extracted `MeshRouteRegistry.applySchemaMatching` as a public static helper; all paths now call the same code.
- **B2 (initial) + W5** — name-conflict diagnostics upgraded from WARN to ERROR with actionable remediation. New test exercises consumer-side failure.
- **W1** — `@Bean`-factory-method discovery caveat documented precisely (only fails when declared return is supertype of actual instance AND annotation is only on the concrete subclass).
- **W2** — `MeshAgentSpecFinalizer.ensureFinalized()` replaces brittle `@DependsOn` ordering.
- **W3, W4** — dead "Visible for testing" instrumentation deleted.
- **I3** — `setPrimary(true)` actually set; unblocks future `Map<String, McpMeshTool>` collection injection.
- **I4** — typed deserialization auto-wired from `expectedType`. Test pins this.
- **I5** — vendor-specific tool-name example replaced with neutral `resolve_user_principal`.
- **F1 (followup)** — `finalized` flag moved from `finally` to inside try block — failed runs no longer flip the flag, retry-on-failure works.
- **F2 (followup)** — `collectKnownCapabilities` takes `includeProducers` boolean; producer caps included in dep-fold dedup but excluded from bean registration.
- **F3 (followup)** — `expectedType` mismatch across declarers now fail-fast with `IllegalStateException` naming both types.
- **F4 (followup)** — `resolveBeanClass` tries `getBeanClassName()` first, ResolvableType fallback.
- **Latest** — `getExpectedTypesByCapability()` on `MeshRouteRegistry` and `MeshA2ARegistry` surfaces the original `Class<?>` to the late-phase registrar so typed proxies are registered for cross-source `@Qualifier` consumers.

## Test plan

- [x] Java unit tests: **338 pass** (was 326, +12 new across multiple review-fix rounds)
- [x] `mvn install -pl mcp-mesh-core,mcp-mesh-sdk,mcp-mesh-spring-boot-starter -am` BUILD SUCCESS
- [x] uc23_meshjob_java integration: 27/27 (tc26 parallel flake unrelated)
- [x] `mkdocs build` clean
- [x] Cross-runtime scope: no Python / TS / Rust edits
- [x] Public-artifact framing: structural language throughout

Closes #1086
