### PR TITLE
feat(java/spring): constructor injection for @MeshRoute/@MeshA2A capabilities (#1088)

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshCapabilityBeanRegistrar.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshCapabilityBeanRegistrar.java
@@ -1,7 +1,10 @@
 package io.mcpmesh.spring;
 
+import io.mcpmesh.spring.web.MeshA2A;
 import io.mcpmesh.spring.web.MeshDependency;
 import io.mcpmesh.spring.web.MeshDependsOn;
+import io.mcpmesh.spring.web.MeshInject;
+import io.mcpmesh.spring.web.MeshRoute;
 import io.mcpmesh.types.McpMeshTool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,16 +17,34 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProce
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.ClassUtils;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Issue #1086: scans bean definitions for class-level {@link MeshDependsOn}
  * annotations and registers a singleton {@link McpMeshTool} bean per
  * declared capability, named by the capability string.
+ *
+ * <p>Issue #1088: additionally scans each resolved bean class's declared
+ * methods for {@link MeshRoute} and {@link MeshA2A} annotations and feeds
+ * their {@code dependencies()} into the same capability map. This lets
+ * constructor/field injection of {@code @Qualifier("cap") McpMeshTool<...>}
+ * resolve for capabilities declared via {@code @MeshRoute(dependencies=...)}
+ * / {@code @MeshA2A(dependencies=...)}, not just {@code @MeshDependsOn}. The
+ * {@code MeshRouteRegistry} / {@code MeshA2ARegistry} are NOT consulted here
+ * — they are populated by {@link org.springframework.beans.factory.config.BeanPostProcessor}s
+ * in {@code postProcessAfterInitialization}, which runs AFTER this
+ * registry-postprocess phase, so they are still empty. Reflection on the
+ * bean classes is the only data source available this early.
  *
  * <p>Runs as a {@link BeanDefinitionRegistryPostProcessor} so the proxy
  * beans are registered BEFORE user singletons get instantiated. This is
@@ -152,11 +173,12 @@ public class MeshCapabilityBeanRegistrar implements BeanDefinitionRegistryPostPr
             // Fall back to "<unknown>" if Spring can't report the class.
         }
         List<String> declarers = declaration.declarerClassNames();
+        String sources = String.join("/", declaration.sourceLabels());
         log.error("Cannot register McpMeshTool bean for capability '{}' — bean name already in use "
                 + "by user-owned bean of type {}. Classes that declared this capability via "
-                + "@MeshDependsOn will fail @Qualifier injection: {}. Resolve by renaming either "
+                + "{} will fail @Qualifier injection: {}. Resolve by renaming either "
                 + "your bean OR the capability.",
-            capability, conflictClass, declarers);
+            capability, conflictClass, sources, declarers);
     }
 
     /**
@@ -176,57 +198,145 @@ public class MeshCapabilityBeanRegistrar implements BeanDefinitionRegistryPostPr
                 continue;
             }
             MeshDependsOn annotation = AnnotationUtils.findAnnotation(beanClass, MeshDependsOn.class);
-            if (annotation == null) {
-                continue;
-            }
-            for (MeshDependency dep : annotation.value()) {
-                String capability = dep.capability();
-                if (capability == null || capability.isBlank()) {
-                    log.warn("@MeshDependsOn on {} has @MeshDependency with empty capability — skipping",
-                        beanClass.getName());
-                    continue;
+            if (annotation != null) {
+                for (MeshDependency dep : annotation.value()) {
+                    mergeDependency(capabilities, dep, beanClass, "@MeshDependsOn", null);
                 }
-                CapabilityDeclaration existing = capabilities.get(capability);
-                if (existing == null) {
-                    Class<?> expectedType = dep.expectedType();
-                    if (expectedType == Void.class || expectedType == void.class) {
-                        expectedType = null;
+            }
+            // Issue #1088: also scan method-level @MeshRoute / @MeshA2A
+            // dependencies. The registries are not yet populated this early
+            // (their BeanPostProcessors run later), so we read the annotations
+            // straight off the bean class via reflection — mirroring
+            // MeshRouteBeanPostProcessor / MeshA2ABeanPostProcessor.
+            for (Method method : beanClass.getDeclaredMethods()) {
+                MeshRoute meshRoute = AnnotationUtils.findAnnotation(method, MeshRoute.class);
+                if (meshRoute != null) {
+                    for (MeshDependency dep : meshRoute.dependencies()) {
+                        mergeDependency(capabilities, dep, beanClass, "@MeshRoute", method);
                     }
-                    CapabilityDeclaration fresh = new CapabilityDeclaration(expectedType);
-                    fresh.addDeclarer(beanClass.getName());
-                    capabilities.put(capability, fresh);
-                } else {
-                    Class<?> incomingExpectedType = dep.expectedType();
-                    if (incomingExpectedType == Void.class || incomingExpectedType == void.class) {
-                        incomingExpectedType = null;
+                }
+                MeshA2A meshA2A = AnnotationUtils.findAnnotation(method, MeshA2A.class);
+                if (meshA2A != null) {
+                    for (MeshDependency dep : meshA2A.dependencies()) {
+                        mergeDependency(capabilities, dep, beanClass, "@MeshA2A", method);
                     }
-                    Class<?> existingExpectedType = existing.expectedType();
-                    if (existingExpectedType != null && incomingExpectedType != null
-                            && !existingExpectedType.equals(incomingExpectedType)) {
-                        throw new IllegalStateException(String.format(
-                            "@MeshDependsOn capability '%s' is declared with conflicting "
-                                + "expectedType values: %s (declared by [%s]) vs %s "
-                                + "(declared by %s). Align expectedType across every "
-                                + "@MeshDependsOn site for this capability, or split into "
-                                + "separate capability names.",
-                            capability,
-                            existingExpectedType.getName(),
-                            String.join(", ", existing.declarerClassNames()),
-                            incomingExpectedType.getName(),
-                            beanClass.getName()));
-                    }
-                    // Upgrade-path: an earlier declaration omitted expectedType
-                    // and a later one supplies it. The non-null type wins so
-                    // the registered proxy bean gets typed deserialisation
-                    // from the very first call.
-                    if (existingExpectedType == null && incomingExpectedType != null) {
-                        existing.setExpectedType(incomingExpectedType);
-                    }
-                    existing.addDeclarer(beanClass.getName());
                 }
             }
         }
         return capabilities;
+    }
+
+    /**
+     * Merge a single {@link MeshDependency} into the capability map, applying
+     * the shared dedup / expectedType upgrade / conflict-detection logic used
+     * by every source ({@code @MeshDependsOn}, {@code @MeshRoute},
+     * {@code @MeshA2A}).
+     *
+     * <p>{@code expectedType} resolution: an explicit non-{@code Void}
+     * {@link MeshDependency#expectedType()} always wins. When the attribute is
+     * left at its {@code Void.class} default AND the declaration originates
+     * from a {@code @MeshRoute} / {@code @MeshA2A} method (i.e. {@code method}
+     * is non-null), we replicate {@code MeshRouteBeanPostProcessor.enrichDependencyReturnTypes}
+     * by reading the generic type argument from a matching
+     * {@code McpMeshTool<Foo>} parameter (matched by {@code @MeshInject} value
+     * or parameter name against the capability / parameter name) — but only
+     * when {@code Foo} is a concrete {@code Class<?>}.
+     */
+    private void mergeDependency(Map<String, CapabilityDeclaration> capabilities,
+                                 MeshDependency dep, Class<?> declarerClass,
+                                 String sourceLabel, Method method) {
+        String capability = dep.capability();
+        if (capability == null || capability.isBlank()) {
+            log.warn("{} on {} has @MeshDependency with empty capability — skipping",
+                sourceLabel, declarerClass.getName());
+            return;
+        }
+
+        Class<?> incomingExpectedType = dep.expectedType();
+        if (incomingExpectedType == Void.class || incomingExpectedType == void.class) {
+            incomingExpectedType = null;
+        }
+        // Param-generic enrichment only when the attribute was left at default
+        // and we have a @MeshRoute/@MeshA2A method to inspect.
+        if (incomingExpectedType == null && method != null) {
+            incomingExpectedType = resolveParamGenericType(method, dep, capability);
+        }
+
+        CapabilityDeclaration existing = capabilities.get(capability);
+        if (existing == null) {
+            CapabilityDeclaration fresh = new CapabilityDeclaration(incomingExpectedType);
+            fresh.addDeclarer(declarerClass.getName());
+            fresh.addSourceLabel(sourceLabel);
+            capabilities.put(capability, fresh);
+            return;
+        }
+
+        Class<?> existingExpectedType = existing.expectedType();
+        if (existingExpectedType != null && incomingExpectedType != null
+                && !existingExpectedType.equals(incomingExpectedType)) {
+            throw new IllegalStateException(String.format(
+                "Capability '%s' is declared with conflicting expectedType values: "
+                    + "%s (declared via %s by [%s]) vs %s (declared via %s by %s). "
+                    + "Align expectedType across every declaration site for this "
+                    + "capability, or split into separate capability names.",
+                capability,
+                existingExpectedType.getName(),
+                String.join("/", existing.sourceLabels()),
+                String.join(", ", existing.declarerClassNames()),
+                incomingExpectedType.getName(),
+                sourceLabel,
+                declarerClass.getName()));
+        }
+        // Upgrade-path: an earlier declaration omitted expectedType and a
+        // later one supplies it. The non-null type wins so the registered
+        // proxy bean gets typed deserialisation from the very first call.
+        if (existingExpectedType == null && incomingExpectedType != null) {
+            existing.setExpectedType(incomingExpectedType);
+        }
+        existing.addDeclarer(declarerClass.getName());
+        existing.addSourceLabel(sourceLabel);
+    }
+
+    /**
+     * Replicate {@code MeshRouteBeanPostProcessor.enrichDependencyReturnTypes}:
+     * scan ALL {@code McpMeshTool<Foo>} parameters on {@code method} that match
+     * {@code dep} (by {@code @MeshInject} value or parameter name against the
+     * capability or {@link MeshDependency#name()}), and return the concrete
+     * generic type argument {@code Foo} of the first match that has one.
+     * A matched parameter whose generic argument is not a concrete
+     * {@code Class<?>} (raw {@code McpMeshTool} / type variable / wildcard) is
+     * skipped and the scan continues. Returns {@code null} only when no matching
+     * parameter with a concrete {@code Class<?>} generic argument exists.
+     */
+    private Class<?> resolveParamGenericType(Method method, MeshDependency dep, String capability) {
+        Type[] genericTypes = method.getGenericParameterTypes();
+        Parameter[] params = method.getParameters();
+        String depName = dep.name();
+        for (int i = 0; i < params.length; i++) {
+            if (!McpMeshTool.class.isAssignableFrom(params[i].getType())) {
+                continue;
+            }
+            MeshInject meshInject = params[i].getAnnotation(MeshInject.class);
+            String matchKey;
+            if (meshInject != null && !meshInject.value().isEmpty()) {
+                matchKey = meshInject.value();
+            } else {
+                matchKey = params[i].getName();
+            }
+            boolean matches = capability.equals(matchKey)
+                || (depName != null && !depName.isBlank() && depName.equals(matchKey));
+            if (!matches) {
+                continue;
+            }
+            if (genericTypes[i] instanceof ParameterizedType pt) {
+                Type[] typeArgs = pt.getActualTypeArguments();
+                if (typeArgs.length > 0 && typeArgs[0] instanceof Class<?> concrete) {
+                    return concrete;
+                }
+            }
+            continue;
+        }
+        return null;
     }
 
     /**
@@ -308,6 +418,7 @@ public class MeshCapabilityBeanRegistrar implements BeanDefinitionRegistryPostPr
     private static final class CapabilityDeclaration {
         private Class<?> expectedType;
         private final List<String> declarerClassNames = new ArrayList<>();
+        private final Set<String> sourceLabels = new LinkedHashSet<>();
 
         CapabilityDeclaration(Class<?> expectedType) {
             this.expectedType = expectedType;
@@ -317,6 +428,10 @@ public class MeshCapabilityBeanRegistrar implements BeanDefinitionRegistryPostPr
             if (!declarerClassNames.contains(className)) {
                 declarerClassNames.add(className);
             }
+        }
+
+        void addSourceLabel(String label) {
+            sourceLabels.add(label);
         }
 
         Class<?> expectedType() {
@@ -329,6 +444,10 @@ public class MeshCapabilityBeanRegistrar implements BeanDefinitionRegistryPostPr
 
         List<String> declarerClassNames() {
             return List.copyOf(declarerClassNames);
+        }
+
+        Set<String> sourceLabels() {
+            return Set.copyOf(sourceLabels);
         }
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDependsOnIntegrationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDependsOnIntegrationTest.java
@@ -366,6 +366,71 @@ class MeshDependsOnIntegrationTest {
         @Bean public A2aTypedSurface a2aTypedSurface() { return new A2aTypedSurface(); }
     }
 
+    // Issue #1088: real constructor injection driven purely by a
+    // @MeshRoute-declared capability (no @MeshDependsOn anywhere). The
+    // early-phase BeanDefinitionRegistryPostProcessor must register the
+    // route_typed_cap McpMeshTool bean BEFORE this consumer's constructor is
+    // autowired, and the proxy's returnType must reflect the route's
+    // expectedType.
+    @Service
+    static class RouteCapConstructorConsumer {
+        final McpMeshTool<RouteTypedResponse> tool;
+        RouteCapConstructorConsumer(
+                @Qualifier("route_typed_cap") McpMeshTool<RouteTypedResponse> tool) {
+            this.tool = tool;
+        }
+    }
+
+    @Configuration
+    @MeshAgent(name = "route-ctor-inject-agent")
+    static class RouteConstructorInjectAgentConfig {
+        @Bean public RouteTypedController routeTypedController() { return new RouteTypedController(); }
+        @Bean public RouteCapConstructorConsumer routeCapConstructorConsumer(
+                @Qualifier("route_typed_cap") McpMeshTool<RouteTypedResponse> tool) {
+            return new RouteCapConstructorConsumer(tool);
+        }
+    }
+
+    // Issue #1088: analogous constructor-injection fixture for the @MeshA2A
+    // path. Capability declared only on the @MeshA2A surface; a separate
+    // @Service constructor-injects the qualified proxy.
+    @Service
+    static class A2aCapConstructorConsumer {
+        final McpMeshTool<A2aTypedResponse> tool;
+        A2aCapConstructorConsumer(
+                @Qualifier("a2a_typed_cap") McpMeshTool<A2aTypedResponse> tool) {
+            this.tool = tool;
+        }
+    }
+
+    @Configuration
+    @MeshAgent(name = "a2a-ctor-inject-agent")
+    static class A2aConstructorInjectAgentConfig {
+        @Bean public A2aTypedSurface a2aTypedSurface() { return new A2aTypedSurface(); }
+        @Bean public A2aCapConstructorConsumer a2aCapConstructorConsumer(
+                @Qualifier("a2a_typed_cap") McpMeshTool<A2aTypedResponse> tool) {
+            return new A2aCapConstructorConsumer(tool);
+        }
+    }
+
+    // Issue #1088: name-conflict guard for a @MeshRoute-declared capability.
+    // A user @Bean owns the capability name "route_conflict_cap"; the
+    // early-phase registrar must NOT overwrite it and must emit the ERROR
+    // diagnostic naming @MeshRoute as the source.
+    @RestController
+    static class RouteConflictController {
+        @PostMapping("/route-conflict")
+        @MeshRoute(dependencies = @MeshDependency(capability = "route_conflict_cap"))
+        public String handle() { return "ok"; }
+    }
+
+    @Configuration
+    @MeshAgent(name = "route-conflict-agent")
+    static class RouteConflictAgentConfig {
+        @Bean public RouteConflictController routeConflictController() { return new RouteConflictController(); }
+        @Bean(name = "route_conflict_cap") public UserOwnedBean userOwnedBean() { return new UserOwnedBean(); }
+    }
+
     private final WebApplicationContextRunner baseRunner = new WebApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(MeshAutoConfiguration.class,
             MeshRouteAutoConfiguration.class))
@@ -745,6 +810,88 @@ class MeshDependsOnIntegrationTest {
                     .as("proxy returnType must reflect expectedType declared on the @MeshA2A @MeshDependency")
                     .isEqualTo(A2aTypedResponse.class);
             });
+    }
+
+    @Test
+    @DisplayName("#1088: @MeshRoute-declared capability resolves @Qualifier constructor injection")
+    void meshRouteCapabilityResolvesConstructorInjection() throws Exception {
+        baseRunner
+            .withUserConfiguration(RouteConstructorInjectAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                RouteCapConstructorConsumer consumer =
+                    context.getBean(RouteCapConstructorConsumer.class);
+                assertThat(consumer)
+                    .as("consumer bean must be created with the @MeshRoute capability proxy injected")
+                    .isNotNull();
+                assertThat(consumer.tool)
+                    .as("route_typed_cap proxy must be constructor-injected")
+                    .isNotNull();
+                assertThat(consumer.tool.getCapability()).isEqualTo("route_typed_cap");
+
+                // The early-phase registrar must thread expectedType from the
+                // @MeshRoute @MeshDependency into the proxy's returnType.
+                Object bean = context.getBean("route_typed_cap");
+                assertThat(bean).isInstanceOf(McpMeshToolProxy.class);
+                Field f = McpMeshToolProxy.class.getDeclaredField("returnType");
+                f.setAccessible(true);
+                assertThat(f.get(bean))
+                    .as("injected proxy returnType must reflect @MeshRoute expectedType")
+                    .isEqualTo(RouteTypedResponse.class);
+            });
+    }
+
+    @Test
+    @DisplayName("#1088: @MeshA2A-declared capability resolves @Qualifier constructor injection")
+    void meshA2ACapabilityResolvesConstructorInjection() throws Exception {
+        baseRunner
+            .withUserConfiguration(A2aConstructorInjectAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                A2aCapConstructorConsumer consumer =
+                    context.getBean(A2aCapConstructorConsumer.class);
+                assertThat(consumer)
+                    .as("consumer bean must be created with the @MeshA2A capability proxy injected")
+                    .isNotNull();
+                assertThat(consumer.tool)
+                    .as("a2a_typed_cap proxy must be constructor-injected")
+                    .isNotNull();
+                assertThat(consumer.tool.getCapability()).isEqualTo("a2a_typed_cap");
+
+                Object bean = context.getBean("a2a_typed_cap");
+                assertThat(bean).isInstanceOf(McpMeshToolProxy.class);
+                Field f = McpMeshToolProxy.class.getDeclaredField("returnType");
+                f.setAccessible(true);
+                assertThat(f.get(bean))
+                    .as("injected proxy returnType must reflect @MeshA2A expectedType")
+                    .isEqualTo(A2aTypedResponse.class);
+            });
+    }
+
+    @Test
+    @DisplayName("#1088: name-conflict guard for @MeshRoute capability preserves user bean + logs ERROR")
+    void meshRouteCapabilityNameConflictPreservesUserBean() {
+        LogCapture capture = LogCapture.attach(MeshCapabilityBeanRegistrar.class);
+        try {
+            baseRunner
+                .withUserConfiguration(RouteConflictAgentConfig.class)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    Object bean = context.getBean("route_conflict_cap");
+                    assertThat(bean)
+                        .as("user-owned bean must NOT be overwritten by an McpMeshTool proxy")
+                        .isInstanceOf(UserOwnedBean.class);
+                });
+
+            // ERROR diagnostic must fire naming @MeshRoute as the source.
+            assertThat(capture.events)
+                .as("MeshCapabilityBeanRegistrar must emit an ERROR naming @MeshRoute as the source")
+                .anyMatch(e -> "ERROR".equals(e.level)
+                    && e.message.contains("route_conflict_cap")
+                    && e.message.contains("@MeshRoute"));
+        } finally {
+            capture.detach();
+        }
     }
 
     @Test

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/greeting-provider/main.py
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/greeting-provider/main.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+greeting-provider - MCP Mesh Agent (uc30 fixture for issue #1088).
+
+Fast-cold-start Python provider exposing TWO independent capabilities so the
+Java consumer under test can declare each via a DIFFERENT source:
+
+  - greeting_service  -> declared by the consumer's @MeshRoute method
+  - farewell_service  -> declared by the consumer's @MeshA2A method
+
+Each returns a TYPED Pydantic model with a single `message: str` field. Because
+the function is annotated with that model as its return type, the Python SDK's
+FastMCPSchemaExtractor.extract_output_schema publishes a CLOSED object output
+schema (properties.message + required: ["message"]) instead of the open object
+schema that a bare ``dict[str, Any]`` produces. This satisfies the consumers'
+declared expectedType contract — the route consumer's
+@MeshDependency(expectedType=GreetingResponse.class) where
+``record GreetingResponse(String message)`` stamps a subset constraint requiring
+a ``message:string`` field; the registry's subset matcher only resolves the
+provider when its published schema actually contains ``message``. Returning a
+typed model (not a weakening) is the faithful contract: a capability consumed as
+GreetingResponse / FarewellResponse must publish a schema that contains
+``message``.
+
+These typed returns also let the consumer's typed
+McpMeshTool<GreetingResponse> / McpMeshTool<FarewellResponse> proxies prove the
+expectedType flowed through the early-phase bean registration.
+"""
+
+import mesh
+from fastmcp import FastMCP
+from pydantic import BaseModel
+
+# FastMCP server instance
+app = FastMCP("GreetingProvider Service")
+
+
+class GreetingResponse(BaseModel):
+    """Typed output for greeting_service — publishes a closed schema with `message`."""
+
+    message: str
+
+
+class FarewellResponse(BaseModel):
+    """Typed output for farewell_service — publishes a closed schema with `message`."""
+
+    message: str
+
+
+@app.tool()
+@mesh.tool(
+    capability="greeting_service",
+    description="Return a structured greeting for a name",
+    tags=["greeting"],
+)
+async def greeting_service(name: str = "world") -> GreetingResponse:
+    """Greet `name`. Provides the 'greeting_service' capability."""
+    return GreetingResponse(message=f"hello {name}")
+
+
+@app.tool()
+@mesh.tool(
+    capability="farewell_service",
+    description="Return a structured farewell for a name",
+    tags=["farewell"],
+)
+async def farewell_service(name: str = "world") -> FarewellResponse:
+    """Bid farewell to `name`. Provides the 'farewell_service' capability."""
+    return FarewellResponse(message=f"bye {name}")
+
+
+@mesh.agent(
+    name="greeting-provider",
+    version="1.0.0",
+    description="Provider with greeting_service and farewell_service (uc30 #1088)",
+    http_port=9100,
+    enable_http=True,
+    auto_run=True,
+)
+class GreetingProviderAgent:
+    """Configures how mesh runs the FastMCP server for this provider."""
+
+    pass

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/pom.xml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.a2aconsumer</groupId>
+    <artifactId>spring-a2a-consumer</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>SpringA2aConsumer Agent</name>
+    <description>Consumer proving #1088 constructor injection of a @MeshA2A-declared cap</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.2</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.3.0</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web (for HTTP server) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Bean Validation — provides jakarta.validation.constraints.@NotNull
+             so the schema generator emits non-nullable fields (SUBSET match) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.a2aconsumer.SpringA2aConsumerApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/src/main/java/com/example/a2aconsumer/SpringA2aConsumerApplication.java
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/src/main/java/com/example/a2aconsumer/SpringA2aConsumerApplication.java
@@ -1,0 +1,124 @@
+package com.example.a2aconsumer;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.SchemaMode;
+import io.mcpmesh.spring.web.MeshA2A;
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.types.McpMeshTool;
+import jakarta.validation.constraints.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * uc30 fixture — Java Spring Boot agent under test for issue #1088
+ * (GRANULAR, single declaration source: @MeshA2A ONLY).
+ *
+ * <p>Issue #1088: a Spring {@code @Component}/{@code @Service} that does
+ * CONSTRUCTOR injection of {@code @Qualifier("cap") McpMeshTool<T>} for a
+ * capability DECLARED via {@code @MeshA2A(dependencies=...)}. Before the fix
+ * the early-phase {@code BeanDefinitionRegistryPostProcessor} only registered
+ * proxy beans for {@code @MeshDependsOn}-declared capabilities, so a
+ * constructor that required {@code @Qualifier("farewell_service") McpMeshTool}
+ * failed with {@code NoSuchBeanDefinitionException} and the Spring context
+ * never refreshed — the agent never booted (never appears in /agents).
+ *
+ * <p>This agent isolates EXACTLY ONE declaration source — {@code @MeshA2A} —
+ * with NO {@code @MeshRoute} anywhere. The companion
+ * {@code spring-route-consumer} covers the {@code @MeshRoute} source.
+ */
+@MeshAgent(
+    name = "spring-a2a-consumer",
+    version = "1.0.0",
+    description = "uc30 consumer proving #1088 constructor injection of a @MeshA2A-declared cap",
+    port = 9202
+)
+@SpringBootApplication
+public class SpringA2aConsumerApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(SpringA2aConsumerApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting spring-a2a-consumer (uc30 #1088, @MeshA2A source)...");
+        SpringApplication.run(SpringA2aConsumerApplication.class, args);
+    }
+
+    // ---- Typed response record for the provider capability ----
+
+    /**
+     * Typed shape returned by the Python {@code farewell_service} capability.
+     *
+     * <p>{@code @NotNull} on the component keeps the Java schema generator
+     * (NULLABLE_FIELDS_BY_DEFAULT) from emitting a {@code "null"} branch, so the
+     * SUBSET matcher matches the provider's non-nullable {@code message}. The
+     * A2A path currently skips schema matching, so this is a no-op today, but it
+     * keeps the fixture correct and robust if matching is later applied. Mirrors
+     * {@code examples/schema/java/consumer/Employee}.
+     */
+    public record FarewellResponse(@NotNull String message) {}
+
+    // ---- Declaration source: @MeshA2A declares farewell_service ----
+
+    /**
+     * The {@code @MeshA2A} method is the DECLARATION SOURCE for the
+     * {@code farewell_service} capability. Carries the required A2A surface
+     * metadata (path / skillId / skillName). Not invoked by the test.
+     */
+    @Component
+    static class A2aDeclSurface {
+
+        @MeshA2A(
+            path = "/a2a-decl",
+            skillId = "a2a-decl",
+            skillName = "A2A Decl",
+            description = "Declares the farewell_service dependency for #1088",
+            dependencies = @MeshDependency(
+                capability = "farewell_service",
+                expectedType = FarewellResponse.class,
+                schemaMode = SchemaMode.SUBSET))
+        public Map<String, Object> a2aDecl(Map<String, Object> message) {
+            return Map.of("ok", true);
+        }
+    }
+
+    // ---- Consumer: CONSTRUCTOR injection of the @MeshA2A-declared cap ----
+
+    /**
+     * Issue #1088 core (A2A path): constructor injection of a capability
+     * declared ONLY via {@code @MeshA2A}. If the early-phase registrar does not
+     * register the {@code farewell_service} proxy bean, this constructor fails
+     * to autowire with {@code NoSuchBeanDefinitionException} and the whole
+     * context refresh fails — the agent never boots.
+     */
+    @Service
+    static class A2aForwarder {
+
+        private final McpMeshTool<FarewellResponse> farewell;
+
+        A2aForwarder(@Qualifier("farewell_service") McpMeshTool<FarewellResponse> farewell) {
+            this.farewell = farewell;
+        }
+
+        @MeshTool(
+            capability = "forward_via_a2a",
+            description = "Call the @MeshA2A-declared, constructor-injected farewell proxy",
+            tags = {"forward"})
+        public Map<String, Object> forwardViaA2a(
+                @Param(value = "name", description = "Name to bid farewell") String name) {
+            // Typed call proves the expectedType flowed through.
+            FarewellResponse r = farewell.call(Map.of("name", name));
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("forwarded", r.message());
+            return out;
+        }
+    }
+}

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/src/main/resources/application.yml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: spring-a2a-consumer
+  main:
+    banner-mode: off
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9202}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:spring-a2a-consumer}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    root: INFO
+    io.mcpmesh: DEBUG
+    com.example: DEBUG

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/src/main/resources/application.yml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: spring-a2a-consumer
   main:
-    banner-mode: off
+    banner-mode: "off"
 
 server:
   port: ${MCP_MESH_HTTP_PORT:9202}

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/pom.xml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.routeconsumer</groupId>
+    <artifactId>spring-route-consumer</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>SpringRouteConsumer Agent</name>
+    <description>Consumer proving #1088 constructor injection of a @MeshRoute-declared cap</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.2</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.3.0</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web (for HTTP server) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Bean Validation — provides jakarta.validation.constraints.@NotNull
+             so the schema generator emits non-nullable fields (SUBSET match) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.routeconsumer.SpringRouteConsumerApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/src/main/java/com/example/routeconsumer/SpringRouteConsumerApplication.java
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/src/main/java/com/example/routeconsumer/SpringRouteConsumerApplication.java
@@ -1,0 +1,124 @@
+package com.example.routeconsumer;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.SchemaMode;
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshRoute;
+import io.mcpmesh.types.McpMeshTool;
+import jakarta.validation.constraints.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * uc30 fixture — Java Spring Boot agent under test for issue #1088
+ * (GRANULAR, single declaration source: @MeshRoute ONLY).
+ *
+ * <p>Issue #1088: a Spring {@code @Component}/{@code @Service} that does
+ * CONSTRUCTOR injection of {@code @Qualifier("cap") McpMeshTool<T>} for a
+ * capability DECLARED via {@code @MeshRoute(dependencies=...)}. Before the fix
+ * the early-phase {@code BeanDefinitionRegistryPostProcessor} only registered
+ * proxy beans for {@code @MeshDependsOn}-declared capabilities, so a
+ * constructor that required {@code @Qualifier("greeting_service") McpMeshTool}
+ * failed with {@code NoSuchBeanDefinitionException} and the Spring context
+ * never refreshed — the agent never booted (never appears in /agents).
+ *
+ * <p>This agent isolates EXACTLY ONE declaration source — {@code @MeshRoute} —
+ * with NO {@code @MeshA2A} anywhere, so its {@code agent_type} stays a plain
+ * tool agent and the registry resolves the route-declared dependency. The
+ * companion {@code spring-a2a-consumer} covers the {@code @MeshA2A} source.
+ */
+@MeshAgent(
+    name = "spring-route-consumer",
+    version = "1.0.0",
+    description = "uc30 consumer proving #1088 constructor injection of a @MeshRoute-declared cap",
+    port = 9201
+)
+@SpringBootApplication
+public class SpringRouteConsumerApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(SpringRouteConsumerApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting spring-route-consumer (uc30 #1088, @MeshRoute source)...");
+        SpringApplication.run(SpringRouteConsumerApplication.class, args);
+    }
+
+    // ---- Typed response record for the provider capability ----
+
+    /**
+     * Typed shape returned by the Python {@code greeting_service} capability.
+     *
+     * <p>{@code @NotNull} on the component is required so the Java schema
+     * generator (NULLABLE_FIELDS_BY_DEFAULT) emits {@code type: "string"} rather
+     * than {@code type: ["string","null"]}. The provider publishes a
+     * non-nullable {@code message}; without {@code @NotNull} the consumer's
+     * extra {@code "null"} branch has no producer counterpart and the SUBSET
+     * matcher evicts the provider (type_mismatch). Mirrors
+     * {@code examples/schema/java/consumer/Employee}.
+     */
+    public record GreetingResponse(@NotNull String message) {}
+
+    // ---- Declaration source: @MeshRoute declares greeting_service ----
+
+    /**
+     * The {@code @MeshRoute} method is the DECLARATION SOURCE for the
+     * {@code greeting_service} capability. The route itself is not invoked by
+     * the test — its only job is to declare the dependency so the early-phase
+     * registrar registers the qualified {@code McpMeshTool} proxy bean.
+     */
+    @RestController
+    static class RouteDeclController {
+
+        @PostMapping("/route-decl")
+        @MeshRoute(dependencies = @MeshDependency(
+            capability = "greeting_service",
+            expectedType = GreetingResponse.class,
+            schemaMode = SchemaMode.SUBSET))
+        public String routeDecl() {
+            return "ok";
+        }
+    }
+
+    // ---- Consumer: CONSTRUCTOR injection of the @MeshRoute-declared cap ----
+
+    /**
+     * Issue #1088 core: constructor injection of a capability declared ONLY
+     * via {@code @MeshRoute}. If the early-phase registrar does not register
+     * the {@code greeting_service} proxy bean, this constructor fails to
+     * autowire with {@code NoSuchBeanDefinitionException} and the whole
+     * context refresh fails — the agent never boots.
+     */
+    @Service
+    static class RouteForwarder {
+
+        private final McpMeshTool<GreetingResponse> greeting;
+
+        RouteForwarder(@Qualifier("greeting_service") McpMeshTool<GreetingResponse> greeting) {
+            this.greeting = greeting;
+        }
+
+        @MeshTool(
+            capability = "forward_via_route",
+            description = "Call the @MeshRoute-declared, constructor-injected greeting proxy",
+            tags = {"forward"})
+        public Map<String, Object> forwardViaRoute(
+                @Param(value = "name", description = "Name to greet") String name) {
+            // Typed call proves the expectedType flowed through.
+            GreetingResponse r = greeting.call(Map.of("name", name));
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("forwarded", r.message());
+            return out;
+        }
+    }
+}

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/src/main/resources/application.yml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: spring-route-consumer
+  main:
+    banner-mode: off
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9201}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:spring-route-consumer}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    root: INFO
+    io.mcpmesh: DEBUG
+    com.example: DEBUG

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/src/main/resources/application.yml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: spring-route-consumer
   main:
-    banner-mode: off
+    banner-mode: "off"
 
 server:
   port: ${MCP_MESH_HTTP_PORT:9201}

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/routines.yaml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/routines.yaml
@@ -1,0 +1,50 @@
+# UC-level routines for uc30_spring_constructor_inject_java (issue #1088).
+#
+# Proves the #1088 fix end-to-end: a Java Spring Boot agent that does
+# CONSTRUCTOR injection of @Qualifier("cap") McpMeshTool<T> for capabilities
+# DECLARED via @MeshRoute(dependencies=...) and @MeshA2A(dependencies=...).
+# Before the fix the early-phase BeanDefinitionRegistryPostProcessor only
+# covered @MeshDependsOn, so the Spring context failed to refresh
+# (NoSuchBeanDefinitionException) and the agent never booted.
+#
+#   tc01 — spring-route-consumer: @MeshRoute-declared cap, constructor-injected
+#   tc02 — spring-a2a-consumer:   @MeshA2A-declared cap, constructor-injected
+#
+# Each tc uses a GRANULAR single-source consumer (one declaration source only,
+# no @MeshRoute/@MeshA2A coexistence), so a healthy boot proves that source's
+# early-phase registration; the end-to-end call then proves the injected proxy
+# is live and typed. Both reuse the same greeting-provider (greeting_service +
+# farewell_service on port 9100); each tc consumes only the cap it needs.
+
+routines:
+  start_registry:
+    description: "Start the registry with fast-sweep timing for Java cold-start tolerance"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: |
+          MCP_MESH_SWEEP_INTERVAL=10s \
+          MCP_MESH_RETENTION=10s \
+          MCP_MESH_HEALTH_CHECK_INTERVAL=5 \
+          DEFAULT_TIMEOUT_THRESHOLD=15 \
+            meshctl start --registry-only -d
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "registry ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: registry did not become ready in 20s"
+          tail -50 ~/.mcp-mesh/logs/registry.log 2>/dev/null || true
+          exit 1
+        capture: registry_start
+        timeout: 30
+
+  stop_all:
+    description: "Stop all mesh processes started by this test"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: meshctl stop 2>/dev/null || true
+        ignore_errors: true

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/tc01_meshroute_constructor_injection/test.yaml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/tc01_meshroute_constructor_injection/test.yaml
@@ -1,0 +1,147 @@
+# tc01_meshroute_constructor_injection — issue #1088.
+#
+# Proves a Java Spring @Service can CONSTRUCTOR-inject
+# @Qualifier("greeting_service") McpMeshTool<GreetingResponse> for a capability
+# DECLARED via @MeshRoute(dependencies=...). Before the fix the early-phase
+# BeanDefinitionRegistryPostProcessor only registered proxy beans for
+# @MeshDependsOn, so the constructor failed with NoSuchBeanDefinitionException
+# and the Spring context never refreshed — the consumer never appeared in
+# /agents. The healthy-poll therefore IS the regression signal: pre-fix it
+# times out and the log tail shows the Spring stack trace.
+#
+# GRANULAR: spring-route-consumer declares ONLY a @MeshRoute dependency (no
+# @MeshA2A anywhere), isolating the @MeshRoute declaration source from the
+# unrelated route+a2a coexistence interaction.
+#
+# After the fix: the consumer boots healthy AND `forward_via_route` returns the
+# provider's greeting ("hello alice"), proving the @MeshRoute-declared,
+# constructor-injected, typed proxy is live.
+
+name: "Spring constructor injection of @MeshRoute-declared capability (#1088)"
+description: "Java @Service constructor-injects @Qualifier McpMeshTool for a @MeshRoute-declared cap; agent boots healthy and the typed proxy is live"
+tags:
+  - java
+  - spring
+  - di
+  - constructor-injection
+  - issue-1088
+  - smoke
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/greeting-provider /workspace/
+      cp -rL /uc-artifacts/spring-route-consumer /workspace/
+
+  - name: "Install greeting-provider deps"
+    handler: pip-install
+    path: /workspace/greeting-provider
+
+  - name: "Install spring-route-consumer deps"
+    handler: maven-install
+    path: /workspace/spring-route-consumer
+    timeout: 600
+
+  - routine: start_registry
+
+  - name: "Start greeting-provider (Python, port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start greeting-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for greeting-provider to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null \
+          | jq -r '.agents[]|select(.name=="greeting-provider")|.status' 2>/dev/null || echo "")
+        [ "$STATUS" = "healthy" ] && { echo "greeting-provider healthy after ${i}x2s"; exit 0; }
+        sleep 2
+      done
+      echo "ERROR: greeting-provider not healthy within 120s (last status='$STATUS')"
+      meshctl logs greeting-provider 2>&1 | tail -120 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start spring-route-consumer (Java, port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/spring-route-consumer --env MCP_MESH_HTTP_PORT=9201 -d
+
+  # On the #1088 bug the consumer never appears in /agents at all (the Spring
+  # context refresh fails because the @Qualifier constructor cannot resolve the
+  # @MeshRoute-declared greeting_service proxy bean). This loop timing out —
+  # with the log tail showing NoSuchBeanDefinitionException — IS the pre-fix
+  # regression signal.
+  - name: "Wait for spring-route-consumer to be healthy (proves the ctor injection resolved early)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null \
+          | jq -r '.agents[]|select(.name=="spring-route-consumer")|.status' 2>/dev/null || echo "")
+        [ "$STATUS" = "healthy" ] && { echo "spring-route-consumer healthy after ${i}x2s"; exit 0; }
+        sleep 2
+      done
+      echo "ERROR: spring-route-consumer not healthy within 120s (last status='$STATUS')"
+      echo "===== spring-route-consumer log (last 120 lines) ====="
+      meshctl logs spring-route-consumer 2>&1 | tail -120 || true
+      exit 1
+    timeout: 150
+
+  - name: "Verify both agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  # Dependency resolution is async (heartbeat-driven). Poll the call until the
+  # @MeshRoute-declared greeting_service proxy goes live, bounded ~60s — this
+  # mirrors the heartbeat-tolerant polling used elsewhere in the suite and is
+  # NOT an assertion weakening: the final captured response is still asserted
+  # to carry the real provider greeting.
+  - name: "Call forward_via_route until the @MeshRoute-declared proxy is live"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 30); do
+        RESP=$(meshctl call forward_via_route '{"name":"alice"}' --raw 2>&1 || true)
+        echo "$RESP" | grep -q "hello alice" && break
+        sleep 2
+      done
+      echo "$RESP"
+    capture: route_response
+    timeout: 90
+
+  - name: "Capture consumer log (negative NoSuchBeanDefinitionException guard + resolution state)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl logs spring-route-consumer 2>&1 | tail -300
+    capture: consumer_log
+
+assertions:
+  - expr: "${captured.agent_list} contains 'greeting-provider'"
+    message: "greeting-provider should be registered"
+  - expr: "${captured.agent_list} contains 'spring-route-consumer'"
+    message: "spring-route-consumer should be registered (proves the Spring context refreshed)"
+
+  # Negative guard: a healthy boot must not have logged the pre-fix failure.
+  - expr: "${captured.consumer_log} not contains 'NoSuchBeanDefinitionException'"
+    message: "consumer startup must NOT log NoSuchBeanDefinitionException (the #1088 pre-fix symptom)"
+
+  # End-to-end: the @MeshRoute-declared, constructor-injected, typed proxy is live.
+  - expr: "${captured.route_response} contains 'hello alice'"
+    message: "forward_via_route should return the provider greeting 'hello alice'"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/tc02_mesha2a_constructor_injection/test.yaml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/tc02_mesha2a_constructor_injection/test.yaml
@@ -1,0 +1,147 @@
+# tc02_mesha2a_constructor_injection — issue #1088.
+#
+# Companion to tc01 for the @MeshA2A declaration source. Proves a Java Spring
+# @Service can CONSTRUCTOR-inject
+# @Qualifier("farewell_service") McpMeshTool<FarewellResponse> for a capability
+# DECLARED via @MeshA2A(dependencies=...). Before the fix the early-phase
+# BeanDefinitionRegistryPostProcessor only registered proxy beans for
+# @MeshDependsOn, so the constructor failed with NoSuchBeanDefinitionException
+# and the Spring context never refreshed — the consumer never appeared in
+# /agents. The healthy-poll therefore IS the regression signal: pre-fix it
+# times out and the log tail shows the Spring stack trace.
+#
+# GRANULAR: spring-a2a-consumer declares ONLY a @MeshA2A dependency (no
+# @MeshRoute anywhere), isolating the @MeshA2A declaration source.
+#
+# After the fix: the consumer boots healthy AND `forward_via_a2a` returns the
+# provider's farewell ("bye bob"), proving the @MeshA2A-declared,
+# constructor-injected, typed proxy is live.
+
+name: "Spring constructor injection of @MeshA2A-declared capability (#1088)"
+description: "Java @Service constructor-injects @Qualifier McpMeshTool for a @MeshA2A-declared cap; agent boots healthy and the typed proxy is live"
+tags:
+  - java
+  - spring
+  - di
+  - constructor-injection
+  - issue-1088
+  - smoke
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/greeting-provider /workspace/
+      cp -rL /uc-artifacts/spring-a2a-consumer /workspace/
+
+  - name: "Install greeting-provider deps"
+    handler: pip-install
+    path: /workspace/greeting-provider
+
+  - name: "Install spring-a2a-consumer deps"
+    handler: maven-install
+    path: /workspace/spring-a2a-consumer
+    timeout: 600
+
+  - routine: start_registry
+
+  - name: "Start greeting-provider (Python, port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start greeting-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for greeting-provider to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null \
+          | jq -r '.agents[]|select(.name=="greeting-provider")|.status' 2>/dev/null || echo "")
+        [ "$STATUS" = "healthy" ] && { echo "greeting-provider healthy after ${i}x2s"; exit 0; }
+        sleep 2
+      done
+      echo "ERROR: greeting-provider not healthy within 120s (last status='$STATUS')"
+      meshctl logs greeting-provider 2>&1 | tail -120 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start spring-a2a-consumer (Java, port 9202)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/spring-a2a-consumer --env MCP_MESH_HTTP_PORT=9202 -d
+
+  # On the #1088 bug the consumer never appears in /agents at all (the Spring
+  # context refresh fails because the @Qualifier constructor cannot resolve the
+  # @MeshA2A-declared farewell_service proxy bean). This loop timing out — with
+  # the log tail showing NoSuchBeanDefinitionException — IS the pre-fix
+  # regression signal.
+  - name: "Wait for spring-a2a-consumer to be healthy (proves the ctor injection resolved early)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null \
+          | jq -r '.agents[]|select(.name=="spring-a2a-consumer")|.status' 2>/dev/null || echo "")
+        [ "$STATUS" = "healthy" ] && { echo "spring-a2a-consumer healthy after ${i}x2s"; exit 0; }
+        sleep 2
+      done
+      echo "ERROR: spring-a2a-consumer not healthy within 120s (last status='$STATUS')"
+      echo "===== spring-a2a-consumer log (last 120 lines) ====="
+      meshctl logs spring-a2a-consumer 2>&1 | tail -120 || true
+      exit 1
+    timeout: 150
+
+  - name: "Verify both agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  # Dependency resolution is async (heartbeat-driven). Poll the call until the
+  # @MeshA2A-declared farewell_service proxy goes live, bounded ~60s — this
+  # mirrors the heartbeat-tolerant polling used elsewhere in the suite and is
+  # NOT an assertion weakening: the final captured response is still asserted
+  # to carry the real provider farewell.
+  - name: "Call forward_via_a2a until the @MeshA2A-declared proxy is live"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 30); do
+        RESP=$(meshctl call forward_via_a2a '{"name":"bob"}' --raw 2>&1 || true)
+        echo "$RESP" | grep -q "bye bob" && break
+        sleep 2
+      done
+      echo "$RESP"
+    capture: a2a_response
+    timeout: 90
+
+  - name: "Capture consumer log (negative NoSuchBeanDefinitionException guard + resolution state)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl logs spring-a2a-consumer 2>&1 | tail -300
+    capture: consumer_log
+
+assertions:
+  - expr: "${captured.agent_list} contains 'greeting-provider'"
+    message: "greeting-provider should be registered"
+  - expr: "${captured.agent_list} contains 'spring-a2a-consumer'"
+    message: "spring-a2a-consumer should be registered (proves the Spring context refreshed)"
+
+  # Negative guard: a healthy boot must not have logged the pre-fix failure.
+  - expr: "${captured.consumer_log} not contains 'NoSuchBeanDefinitionException'"
+    message: "consumer startup must NOT log NoSuchBeanDefinitionException (the #1088 pre-fix symptom)"
+
+  # End-to-end: the @MeshA2A-declared, constructor-injected, typed proxy is live.
+  - expr: "${captured.a2a_response} contains 'bye bob'"
+    message: "forward_via_a2a should return the provider farewell 'bye bob'"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

Closes the Spring DI asymmetry from #1086: capabilities declared via `@MeshRoute(dependencies=...)` and `@MeshA2A(dependencies=...)` can now be **constructor-injected** as `@Qualifier("cap") McpMeshTool<T>`, the same as `@MeshDependsOn` — not just field-injected / `getBean`-resolved.

- Extend `MeshCapabilityBeanRegistrar` (the early-phase `BeanDefinitionRegistryPostProcessor`) to also scan method-level `@MeshRoute` / `@MeshA2A` annotations for their `@MeshDependency` declarations, registering the `McpMeshTool` proxy beans **before** singleton autowiring so constructor params resolve at context-refresh time.
- The route/A2A registries are intentionally **not** consulted at this phase — they're populated by `BeanPostProcessor`s in `postProcessAfterInitialization`, which runs *after* the registry-postprocess phase, so they're still empty. Annotations are read directly off the resolved bean classes via reflection, mirroring the existing `@MeshDependsOn` handling.
- Shared `mergeDependency()` helper applies the same dedup / `expectedType` upgrade / conflict-detection logic across all three sources; `expectedType` is resolved from the annotation attribute with parameter-generic enrichment (`McpMeshTool<Foo>` on the handler method) so typed deserialization holds on every injection path.
- Conflict diagnostics now name the actual declaration source (`@MeshDependsOn` / `@MeshRoute` / `@MeshA2A`) instead of hardcoding `@MeshDependsOn`.

## Tests

- **Unit** (`MeshDependsOnIntegrationTest`, 18 pass): 3 new tests exercising real `@Autowired` constructor injection for `@MeshRoute` and `@MeshA2A`, plus a bean-name-conflict guard.
- **Integration** (new suite `uc30_spring_constructor_inject_java`): granular per-source agents — `tc01` (`@MeshRoute`) and `tc02` (`@MeshA2A`) prove constructor injection end-to-end across real running agents (healthy boot → resolved typed proxy call → `hello alice` / `bye bob`). Both green against `tsuite-mesh:local` built with this fix.

## Review notes

- **Backward-compat (intended fail-fast):** because the three sources now share one conflict-detection path, an app that declares the *same capability* across sources with *divergent* `expectedType`s (one possibly inferred from a `McpMeshTool<B>` handler param) will now throw `IllegalStateException` at context refresh where it previously booted. That configuration was latently broken (one capability resolving to two types); failing fast at boot is preferable to wrong-typed deserialization at runtime. Existing single-source `@MeshDependsOn` behavior is unchanged.

## Related (not closed by this PR)

- #1089 — separate, pre-existing cross-source inconsistency surfaced while adding the integration suite: `@MeshA2A` dependencies bypass the `expectedType`/`schemaMode` schema-matching that `@MeshRoute` and `@MeshDependsOn` apply. Out of scope here; tracked independently.

Closes #1088

## Test plan

- [x] `mvn -pl mcp-mesh-spring-boot-starter test -Dtest=MeshDependsOnIntegrationTest` → 18/18 pass
- [x] `tsuite run --tc uc30_spring_constructor_inject_java/tc01_meshroute_constructor_injection` → pass
- [x] `tsuite run --tc uc30_spring_constructor_inject_java/tc02_mesha2a_constructor_injection` → pass
- [ ] CI green

## Review feedback addressed

- **`resolveParamGenericType` scan (review WARNING):** now `continue`s past a name-matched-but-non-concrete generic parameter instead of `return null`, matching `MeshRouteBeanPostProcessor.enrichDependencyReturnTypes`; Javadoc corrected. (commit `e1ec724`)
- **`banner-mode: off` (inline comment):** quoted to `"off"` in both `uc30` consumer `application.yml` files so SnakeYAML doesn't coerce it to boolean `false` before Spring binds `Banner.Mode`. Strictly safer than the unquoted form that already booted in integration. (commit `6fb32d6`)
- **Inherited `@MeshRoute`/`@MeshA2A` methods via `getMethods()` (inline comment) — intentionally not changed.** The registrar's `getDeclaredMethods()` scan deliberately mirrors `MeshRouteBeanPostProcessor` and `MeshA2ABeanPostProcessor`, which both use `getDeclaredMethods()`. Switching only the registrar to `getMethods()`/hierarchy-walk would register early proxy beans for capabilities declared on inherited methods that the BPPs never add to the `AgentSpec`/registry — phantom beans that resolve to no provider. Inherited-method support, if wanted, must change all three scanners in lockstep — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Spring applications can now declare capability dependencies via method-level `@MeshRoute` and `@MeshA2A` annotations.
  * Constructor injection of typed capability proxies with `@Qualifier` is now supported.
  * Enhanced conflict detection with improved diagnostic logging.

* **Tests**
  * Added integration tests validating constructor injection patterns for route and agent-to-agent capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
