### PR TITLE
fix(java/spring): apply schema-matching to @MeshA2A dependencies (#1089)

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ARegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ARegistry.java
@@ -1,6 +1,7 @@
 package io.mcpmesh.spring.web;
 
 import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.spring.MeshSchemaSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -131,11 +132,18 @@ public class MeshA2ARegistry {
      * {@code __mesh_a2a_deps} tool on the heartbeat envelope (built by
      * {@code MeshAutoConfiguration}) so the Rust core can drive
      * {@code dependency_available} events for them — the same mechanism
-     * that powers {@code @MeshRoute} dependency wiring.
+     * that powers {@code @MeshRoute} dependency wiring. The issue #547
+     * schema-matching fields ({@code expectedSchemaCanonical},
+     * {@code expectedSchemaHash}, {@code matchMode}) are stamped identically
+     * to the route path via {@link MeshRouteRegistry#applySchemaMatching}, so
+     * {@code @MeshA2A} dependencies are no longer skipped by the registry's
+     * schema-compatibility stage (issue #1089).
      */
     public List<AgentSpec.DependencySpec> getUniqueDependencySpecs() {
         Set<String> seenCapabilities = new HashSet<>();
         List<AgentSpec.DependencySpec> specs = new ArrayList<>();
+        // Issue #547 Phase 4: cluster-wide strict knob promotes WARN→BLOCK.
+        boolean clusterStrict = MeshSchemaSupport.clusterStrictEnabled();
         for (SurfaceMetadata surface : getAllSurfaces()) {
             for (MeshRouteRegistry.DependencySpec dep : surface.dependencies()) {
                 if (seenCapabilities.add(dep.getCapability())) {
@@ -147,6 +155,7 @@ public class MeshA2ARegistry {
                     if (dep.hasVersion()) {
                         agentDep.setVersion(dep.getVersion());
                     }
+                    MeshRouteRegistry.applySchemaMatching(agentDep, dep, clusterStrict);
                     specs.add(agentDep);
                 }
             }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
@@ -180,8 +180,12 @@ public class MeshRouteRegistry {
      *
      * <p>Phase 4: cluster-wide strict knob promotes WARN→BLOCK on the consumer
      * side too. There's no per-tool override here — the override is producer-side.
+     *
+     * <p>Package-private convenience overload shared by the {@code @MeshRoute},
+     * {@code @MeshDependsOn}, AND {@code @MeshA2A} wiring paths — they all hold a
+     * {@link DependencySpec} and need the same schema-matching fields stamped.
      */
-    private static void applySchemaMatching(
+    static void applySchemaMatching(
             AgentSpec.DependencySpec target, DependencySpec source, boolean clusterStrict) {
         applySchemaMatching(target, source.getCapability(), source.getExpectedType(),
             source.getSchemaMode(), clusterStrict);
@@ -189,10 +193,11 @@ public class MeshRouteRegistry {
 
     /**
      * Canonical schema-aware matching helper, shared between the
-     * {@code @MeshRoute} and {@code @MeshDependsOn} wiring paths (issue #547,
-     * issue #1086). Both surfaces must stamp {@code expectedSchemaCanonical},
-     * {@code expectedSchemaHash}, and {@code matchMode} the same way so the
-     * registry's schema stage sees identical shapes regardless of the source.
+     * {@code @MeshRoute}, {@code @MeshDependsOn}, and {@code @MeshA2A} wiring
+     * paths (issue #547, issue #1086, issue #1089). All surfaces must stamp
+     * {@code expectedSchemaCanonical}, {@code expectedSchemaHash}, and
+     * {@code matchMode} the same way so the registry's schema stage sees
+     * identical shapes regardless of the source.
      *
      * <p>Caller passes raw inputs (capability name, expected type class,
      * schema mode, cluster-strict flag) so {@code @MeshDependsOn}'s code path

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ASchemaMatchingParityTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ASchemaMatchingParityTest.java
@@ -1,0 +1,189 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.core.MeshCoreBridge;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #1089: {@code @MeshA2A}-declared mesh dependencies previously bypassed
+ * the {@code expectedType}/{@code schemaMode} schema-matching that
+ * {@code @MeshRoute} and {@code @MeshDependsOn} apply, so they shipped with an
+ * empty {@code matchMode} and the registry's schema-compatibility stage (gated
+ * on {@code matchMode != ""}) was skipped for them.
+ *
+ * <p>These tests pin {@link MeshA2ARegistry#getUniqueDependencySpecs()} to the
+ * same schema-stamping behaviour as {@link MeshRouteRegistry#getUniqueDependencySpecs()}
+ * — including a cross-source PARITY assertion that the two paths produce byte
+ * identical {@code matchMode}/{@code expectedSchemaCanonical}/{@code expectedSchemaHash}
+ * for an identical capability + expectedType + schemaMode.
+ *
+ * <p>No Spring context or running registry is required: the registries are
+ * driven directly with hand-built metadata. The canonical-schema assertions
+ * depend on the Rust core native normalizer; when it isn't available the schema
+ * generation returns null and {@code matchMode} stays empty, so those tests
+ * skip cleanly via {@link Assumptions} (same guard pattern as
+ * {@code MeshSchemaSupportTest}).
+ */
+@DisplayName("Issue #1089 — @MeshA2A dependency schema-matching parity with @MeshRoute")
+class MeshA2ASchemaMatchingParityTest {
+
+    /** Typed payload with at least one field — drives expectedType schema generation. */
+    public record SchemaPayload(String id, int weight) {}
+
+    /**
+     * Annotation-bearing fixture. We read the {@link MeshDependency} declarations
+     * off these {@code @MeshA2A} surfaces via reflection and turn them into
+     * {@link MeshRouteRegistry.DependencySpec} the same way the bean
+     * post-processor does ({@link MeshRouteRegistry.DependencySpec#fromAnnotation}).
+     */
+    static class Fixtures {
+
+        @MeshA2A(
+            path = "/agents/typed",
+            skillId = "typed-skill",
+            skillName = "Typed Skill",
+            dependencies = @MeshDependency(
+                capability = "schema_cap",
+                expectedType = SchemaPayload.class,
+                schemaMode = io.mcpmesh.SchemaMode.SUBSET))
+        public Object typedSurface(java.util.Map<String, Object> message) {
+            return "ok";
+        }
+
+        @MeshA2A(
+            path = "/agents/plain",
+            skillId = "plain-skill",
+            skillName = "Plain Skill",
+            dependencies = @MeshDependency(capability = "plain_cap"))
+        public Object plainSurface(java.util.Map<String, Object> message) {
+            return "ok";
+        }
+    }
+
+    private static boolean nativeNormalizerAvailable() {
+        try {
+            MeshCoreBridge.normalizeSchema(
+                "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"}}}", "java");
+            return true;
+        } catch (UnsatisfiedLinkError e) {
+            return false;
+        }
+    }
+
+    /** Read the @MeshDependency declarations off a fixture method's @MeshA2A. */
+    private static List<MeshRouteRegistry.DependencySpec> depsOf(String fixtureMethod) {
+        try {
+            Method m = Fixtures.class.getDeclaredMethod(fixtureMethod, java.util.Map.class);
+            MeshA2A a2a = m.getAnnotation(MeshA2A.class);
+            List<MeshRouteRegistry.DependencySpec> specs = new java.util.ArrayList<>();
+            for (MeshDependency dep : a2a.dependencies()) {
+                specs.add(MeshRouteRegistry.DependencySpec.fromAnnotation(dep));
+            }
+            return specs;
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError("Fixture method not found: " + fixtureMethod, e);
+        }
+    }
+
+    private static MeshA2ARegistry.SurfaceMetadata surfaceWithDeps(
+            String path, String skillId, String fixtureMethod,
+            List<MeshRouteRegistry.DependencySpec> deps) {
+        Fixtures bean = new Fixtures();
+        Method method;
+        try {
+            method = Fixtures.class.getDeclaredMethod(fixtureMethod, java.util.Map.class);
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError("Fixture method not found: " + fixtureMethod, e);
+        }
+        return new MeshA2ARegistry.SurfaceMetadata(
+            path, skillId, skillId, "", List.of(), deps, "",
+            "Fixtures." + fixtureMethod, bean, method);
+    }
+
+    @Test
+    @DisplayName("expectedType + schemaMode=SUBSET stamps matchMode + canonical schema + hash")
+    void typedDependencyGetsSchemaMatchingFields() {
+        Assumptions.assumeTrue(nativeNormalizerAvailable(),
+            "Rust core native library not available — schema normalization is required for this assertion");
+
+        MeshA2ARegistry registry = new MeshA2ARegistry();
+        registry.register(surfaceWithDeps("/agents/typed", "typed-skill", "typedSurface", depsOf("typedSurface")));
+
+        List<AgentSpec.DependencySpec> specs = registry.getUniqueDependencySpecs();
+        assertThat(specs).hasSize(1);
+        AgentSpec.DependencySpec dep = specs.get(0);
+
+        assertThat(dep.getCapability()).isEqualTo("schema_cap");
+        assertThat(dep.getMatchMode())
+            .as("@MeshA2A dependency with expectedType+SUBSET must stamp matchMode")
+            .isEqualTo("subset");
+        assertThat(dep.getExpectedSchemaCanonical())
+            .as("expectedSchemaCanonical must be populated")
+            .isNotNull()
+            .isNotEmpty();
+        assertThat(dep.getExpectedSchemaHash())
+            .as("expectedSchemaHash must be populated")
+            .isNotNull()
+            .isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("No expectedType + no schemaMode → backward-compatible no-op (empty matchMode)")
+    void plainDependencyStaysBackwardCompatible() {
+        MeshA2ARegistry registry = new MeshA2ARegistry();
+        registry.register(surfaceWithDeps("/agents/plain", "plain-skill", "plainSurface", depsOf("plainSurface")));
+
+        List<AgentSpec.DependencySpec> specs = registry.getUniqueDependencySpecs();
+        assertThat(specs).hasSize(1);
+        AgentSpec.DependencySpec dep = specs.get(0);
+
+        assertThat(dep.getCapability()).isEqualTo("plain_cap");
+        assertThat(dep.getMatchMode())
+            .as("dependency without expectedType/schemaMode must leave matchMode empty/null")
+            .satisfiesAnyOf(
+                m -> assertThat(m).isNull(),
+                m -> assertThat(m).isEmpty());
+        assertThat(dep.getExpectedSchemaCanonical())
+            .as("no expected schema when no expectedType is declared")
+            .isNull();
+        assertThat(dep.getExpectedSchemaHash())
+            .as("no expected schema hash when no expectedType is declared")
+            .isNull();
+    }
+
+    @Test
+    @DisplayName("PARITY: @MeshA2A and @MeshRoute produce identical schema-matching fields")
+    void a2aMatchesRouteForIdenticalDependency() {
+        Assumptions.assumeTrue(nativeNormalizerAvailable(),
+            "Rust core native library not available — schema normalization is required for this assertion");
+
+        // A2A side: same capability + expectedType + schemaMode as the route below.
+        MeshA2ARegistry a2aRegistry = new MeshA2ARegistry();
+        a2aRegistry.register(surfaceWithDeps("/agents/typed", "typed-skill", "typedSurface", depsOf("typedSurface")));
+        AgentSpec.DependencySpec a2aDep = a2aRegistry.getUniqueDependencySpecs().get(0);
+
+        // Route side: build a RouteMetadata carrying the IDENTICAL dependency spec.
+        MeshRouteRegistry routeRegistry = new MeshRouteRegistry();
+        MeshRouteRegistry.RouteMetadata route = new MeshRouteRegistry.RouteMetadata(
+            "Fixtures.typedSurface", depsOf("typedSurface"), "", true);
+        routeRegistry.register("POST", "/route-typed", route);
+        AgentSpec.DependencySpec routeDep = routeRegistry.getUniqueDependencySpecs().get(0);
+
+        assertThat(a2aDep.getMatchMode())
+            .as("matchMode must match the @MeshRoute path exactly")
+            .isEqualTo(routeDep.getMatchMode());
+        assertThat(a2aDep.getExpectedSchemaCanonical())
+            .as("expectedSchemaCanonical must match the @MeshRoute path exactly")
+            .isEqualTo(routeDep.getExpectedSchemaCanonical());
+        assertThat(a2aDep.getExpectedSchemaHash())
+            .as("expectedSchemaHash must match the @MeshRoute path exactly")
+            .isEqualTo(routeDep.getExpectedSchemaHash());
+    }
+}

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/pom.xml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.a2astrict</groupId>
+    <artifactId>a2a-strict-consumer</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>A2aStrictConsumer Agent</name>
+    <description>uc31 PAYOFF: @MeshA2A consumer whose incompatible provider is evicted after #1089</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.2</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.3.0</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web (for HTTP server) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Bean Validation — provides jakarta.validation.constraints.@NotNull
+             so the schema generator emits non-nullable fields (SUBSET match) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.a2astrict.A2aStrictConsumerApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/pom.xml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.6</version>
         <relativePath/>
     </parent>
 

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/src/main/java/com/example/a2astrict/A2aStrictConsumerApplication.java
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/src/main/java/com/example/a2astrict/A2aStrictConsumerApplication.java
@@ -1,0 +1,132 @@
+package com.example.a2astrict;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.SchemaMode;
+import io.mcpmesh.spring.web.MeshA2A;
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.types.McpMeshTool;
+import jakarta.validation.constraints.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * uc31 fixture — PAYOFF for issue #1089 (@MeshA2A source).
+ *
+ * <p>Declares the {@code parity_cap} dependency via {@code @MeshA2A} with
+ * {@code expectedType=StrictResponse.class} (a record with a required
+ * {@code value: String}) and {@code schemaMode=SchemaMode.SUBSET} — IDENTICAL
+ * to the {@code @MeshRoute} control in {@code route-strict-consumer}.
+ *
+ * <p>BEFORE #1089: {@code MeshA2ARegistry.getUniqueDependencySpecs()} did NOT
+ * stamp the schema-matching fields ({@code expectedSchemaCanonical},
+ * {@code expectedSchemaHash}, {@code matchMode}) onto the A2A dependency, so the
+ * registry's schema-compatibility stage SKIPPED it: the incompatible
+ * {@code parity-provider} resolved anyway (DEPS 1/1) and a call would later hit
+ * a runtime deserialization error (no {@code value} field).
+ *
+ * <p>AFTER #1089: {@code getUniqueDependencySpecs()} calls
+ * {@code MeshRouteRegistry.applySchemaMatching(...)}, so the A2A dependency
+ * ships {@code matchMode=subset} exactly like the route source. The registry's
+ * schema stage now computes {@code missing_field} and EVICTS the incompatible
+ * provider — DEPS 0/1 — and {@code forward_a2a_strict} returns "unavailable".
+ * This is the parity the suite proves.
+ *
+ * <p>GRANULAR: this agent has NO {@code @MeshRoute} anywhere.
+ */
+@MeshAgent(
+    name = "a2a-strict-consumer",
+    version = "1.0.0",
+    description = "uc31 PAYOFF: @MeshA2A consumer whose incompatible provider is evicted after #1089",
+    port = 9202
+)
+@SpringBootApplication
+public class A2aStrictConsumerApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(A2aStrictConsumerApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting a2a-strict-consumer (uc31 #1089, @MeshA2A source, PAYOFF)...");
+        SpringApplication.run(A2aStrictConsumerApplication.class, args);
+    }
+
+    // ---- Strict expected type: requires a `value` the provider does NOT publish ----
+
+    /**
+     * Strict shape the consumer EXPECTS from {@code parity_cap} — IDENTICAL to
+     * the route control's {@code StrictResponse}.
+     *
+     * <p>{@code @NotNull} keeps the Java schema generator from emitting a
+     * {@code "null"} branch, so the SUBSET constraint requires a non-nullable
+     * {@code value: string}. The uc31 provider publishes {@code other} only and
+     * NO {@code value}; after #1089 the A2A dependency carries the same
+     * {@code matchMode=subset} the route source does, so SUBSET matching yields
+     * {@code missing_field} and the registry evicts the provider. Mirrors
+     * {@code examples/schema/java/consumer/Employee}.
+     */
+    public record StrictResponse(@NotNull String value) {}
+
+    // ---- Declaration source: @MeshA2A declares parity_cap ----
+
+    /**
+     * The {@code @MeshA2A} method is the DECLARATION SOURCE for the
+     * {@code parity_cap} dependency. Carries the required A2A surface metadata
+     * (path / skillId / skillName). Not invoked by the test.
+     */
+    @Component
+    static class A2aStrictSurface {
+
+        @MeshA2A(
+            path = "/a2a-strict",
+            skillId = "a2a-strict",
+            skillName = "A2A Strict",
+            description = "Declares the parity_cap dependency for uc31 #1089",
+            dependencies = @MeshDependency(
+                capability = "parity_cap",
+                expectedType = StrictResponse.class,
+                schemaMode = SchemaMode.SUBSET))
+        public Map<String, Object> a2aStrict(Map<String, Object> message) {
+            return Map.of("ok", true);
+        }
+    }
+
+    // ---- Consumer: CONSTRUCTOR injection of the @MeshA2A-declared cap ----
+
+    /**
+     * Constructor-injects the qualified {@code parity_cap} proxy declared via
+     * {@code @MeshA2A}. The proxy bean exists (#1088), but after #1089 the
+     * dependency never resolves because the only provider is schema-incompatible
+     * — so {@code parity.call(...)} surfaces an "unavailable" error rather than a
+     * value, mirroring the {@code @MeshRoute} control.
+     */
+    @Service
+    static class A2aStrictForwarder {
+
+        private final McpMeshTool<StrictResponse> parity;
+
+        A2aStrictForwarder(@Qualifier("parity_cap") McpMeshTool<StrictResponse> parity) {
+            this.parity = parity;
+        }
+
+        @MeshTool(
+            capability = "forward_a2a_strict",
+            description = "Call the @MeshA2A-declared parity_cap proxy (expected: unavailable, provider evicted after #1089)",
+            tags = {"forward"})
+        public Map<String, Object> forwardA2aStrict(
+                @Param(value = "name", description = "Name to pass to parity_cap") String name) {
+            StrictResponse r = parity.call(Map.of("name", name));
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("forwarded", r.value());
+            return out;
+        }
+    }
+}

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/src/main/resources/application.yml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: a2a-strict-consumer
+  main:
+    banner-mode: "off"
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9202}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:a2a-strict-consumer}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    root: INFO
+    io.mcpmesh: DEBUG
+    com.example: DEBUG

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/parity-provider/main.py
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/parity-provider/main.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+parity-provider - MCP Mesh Agent (uc31 fixture for issue #1089).
+
+NEGATIVE counterpart to uc30's greeting-provider. Exposes ONE capability
+`parity_cap` whose published OUTPUT SCHEMA is INTENTIONALLY INCOMPATIBLE (under
+SUBSET matching) with what the two Java Spring consumers declare.
+
+Both consumers declare the dependency with:
+    expectedType = StrictResponse.class   // record StrictResponse(@NotNull String value)
+    schemaMode   = SchemaMode.SUBSET
+which stamps a SUBSET constraint requiring a `value: string` field on the
+provider's output.
+
+This provider instead returns a typed Pydantic model `MismatchResponse` that
+has an `other: str` field and NO `value` field. Because the function is
+annotated with that model as its return type, the Python SDK's
+FastMCPSchemaExtractor publishes a CLOSED object output schema
+({properties:{other:string}, required:["other"]}) that LACKS the consumer's
+required `value`. Under SUBSET matching the registry computes `missing_field`
+(the consumer requires `value`, the provider does not publish it) and EVICTS
+the provider from the dependency — the dependency resolves 0/1.
+
+This is the faithful negative contract: a capability consumed as StrictResponse
+(requiring `value`) must publish a schema that contains `value`; this provider
+deliberately does not, so a correct registry evicts it for BOTH @MeshRoute and
+@MeshA2A consumers (after #1089 the A2A source matches identically to route).
+
+The tool accepts a `name` arg so the consumers can call
+`.call(Map.of("name", name))` exactly as in uc30.
+"""
+
+import mesh
+from fastmcp import FastMCP
+from pydantic import BaseModel
+
+# FastMCP server instance
+app = FastMCP("ParityProvider Service")
+
+
+class MismatchResponse(BaseModel):
+    """Typed output for parity_cap.
+
+    Publishes a CLOSED schema {properties:{other:string}, required:["other"]}.
+    It deliberately has NO `value` field, so a consumer declaring
+    expectedType=StrictResponse (record with required `value: String`) under
+    SUBSET matching gets a `missing_field` and the registry evicts this
+    provider (DEPS 0/1).
+    """
+
+    other: str
+
+
+@app.tool()
+@mesh.tool(
+    capability="parity_cap",
+    description="Schema-incompatible capability for uc31 #1089 (returns `other`, not `value`)",
+    tags=["parity"],
+)
+async def parity_cap(name: str = "world") -> MismatchResponse:
+    """Provide the 'parity_cap' capability with an INCOMPATIBLE output schema."""
+    return MismatchResponse(other=f"incompatible-{name}")
+
+
+@mesh.agent(
+    name="parity-provider",
+    version="1.0.0",
+    description="Provider with schema-INCOMPATIBLE parity_cap (uc31 #1089)",
+    http_port=9100,
+    enable_http=True,
+    auto_run=True,
+)
+class ParityProviderAgent:
+    """Configures how mesh runs the FastMCP server for this provider."""
+
+    pass

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/pom.xml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.routestrict</groupId>
+    <artifactId>route-strict-consumer</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>RouteStrictConsumer Agent</name>
+    <description>uc31 CONTROL: @MeshRoute consumer whose incompatible provider is evicted (#1089)</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.2</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.3.0</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web (for HTTP server) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Bean Validation — provides jakarta.validation.constraints.@NotNull
+             so the schema generator emits non-nullable fields (SUBSET match) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.routestrict.RouteStrictConsumerApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/pom.xml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.6</version>
         <relativePath/>
     </parent>
 

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/src/main/java/com/example/routestrict/RouteStrictConsumerApplication.java
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/src/main/java/com/example/routestrict/RouteStrictConsumerApplication.java
@@ -1,0 +1,125 @@
+package com.example.routestrict;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.SchemaMode;
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshRoute;
+import io.mcpmesh.types.McpMeshTool;
+import jakarta.validation.constraints.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * uc31 fixture — CONTROL for issue #1089 (@MeshRoute source).
+ *
+ * <p>Declares the {@code parity_cap} dependency via {@code @MeshRoute} with
+ * {@code expectedType=StrictResponse.class} (a record with a required
+ * {@code value: String}) and {@code schemaMode=SchemaMode.SUBSET}. The
+ * uc31 {@code parity-provider} deliberately publishes an INCOMPATIBLE output
+ * schema (a field {@code other}, no {@code value}), so the registry's SUBSET
+ * schema stage computes a {@code missing_field} and EVICTS the provider — this
+ * is the long-standing {@code @MeshRoute} behavior the #1089 fix brings to
+ * {@code @MeshA2A}.
+ *
+ * <p>Because of #1088, the early-phase registrar still registers the qualified
+ * {@code McpMeshTool} proxy bean from the {@code @MeshRoute} declaration, so the
+ * Spring context refreshes and the agent boots healthy (no
+ * {@code NoSuchBeanDefinitionException}). The dependency simply never resolves
+ * (DEPS 0/1) because the only candidate provider is schema-incompatible, and a
+ * call to {@code forward_route_strict} therefore returns "unavailable".
+ *
+ * <p>GRANULAR: this agent has NO {@code @MeshA2A} anywhere. The companion
+ * {@code a2a-strict-consumer} covers the {@code @MeshA2A} source (the payoff).
+ */
+@MeshAgent(
+    name = "route-strict-consumer",
+    version = "1.0.0",
+    description = "uc31 CONTROL: @MeshRoute consumer whose incompatible provider is evicted (#1089)",
+    port = 9201
+)
+@SpringBootApplication
+public class RouteStrictConsumerApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(RouteStrictConsumerApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting route-strict-consumer (uc31 #1089, @MeshRoute source, CONTROL)...");
+        SpringApplication.run(RouteStrictConsumerApplication.class, args);
+    }
+
+    // ---- Strict expected type: requires a `value` the provider does NOT publish ----
+
+    /**
+     * Strict shape the consumer EXPECTS from {@code parity_cap}.
+     *
+     * <p>{@code @NotNull} keeps the Java schema generator from emitting a
+     * {@code "null"} branch, so the SUBSET constraint requires a non-nullable
+     * {@code value: string}. The uc31 provider publishes {@code other} only and
+     * NO {@code value}, so SUBSET matching yields {@code missing_field} and the
+     * registry evicts the provider. Mirrors
+     * {@code examples/schema/java/consumer/Employee}.
+     */
+    public record StrictResponse(@NotNull String value) {}
+
+    // ---- Declaration source: @MeshRoute declares parity_cap ----
+
+    /**
+     * The {@code @MeshRoute} method is the DECLARATION SOURCE for the
+     * {@code parity_cap} dependency. Not invoked by the test — its only job is
+     * to declare the dependency with the strict expectedType so the registry's
+     * schema stage evicts the incompatible provider.
+     */
+    @RestController
+    static class RouteStrictController {
+
+        @PostMapping("/route-strict")
+        @MeshRoute(dependencies = @MeshDependency(
+            capability = "parity_cap",
+            expectedType = StrictResponse.class,
+            schemaMode = SchemaMode.SUBSET))
+        public String routeStrict() {
+            return "ok";
+        }
+    }
+
+    // ---- Consumer: CONSTRUCTOR injection of the @MeshRoute-declared cap ----
+
+    /**
+     * Constructor-injects the qualified {@code parity_cap} proxy. The proxy
+     * bean exists (#1088), but the dependency never resolves because the only
+     * provider is schema-incompatible — so {@code parity.call(...)} surfaces an
+     * "unavailable" error rather than a value.
+     */
+    @Service
+    static class RouteStrictForwarder {
+
+        private final McpMeshTool<StrictResponse> parity;
+
+        RouteStrictForwarder(@Qualifier("parity_cap") McpMeshTool<StrictResponse> parity) {
+            this.parity = parity;
+        }
+
+        @MeshTool(
+            capability = "forward_route_strict",
+            description = "Call the @MeshRoute-declared parity_cap proxy (expected: unavailable, provider evicted)",
+            tags = {"forward"})
+        public Map<String, Object> forwardRouteStrict(
+                @Param(value = "name", description = "Name to pass to parity_cap") String name) {
+            StrictResponse r = parity.call(Map.of("name", name));
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("forwarded", r.value());
+            return out;
+        }
+    }
+}

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/src/main/resources/application.yml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: route-strict-consumer
+  main:
+    banner-mode: "off"
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9201}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:route-strict-consumer}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    root: INFO
+    io.mcpmesh: DEBUG
+    com.example: DEBUG

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/routines.yaml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/routines.yaml
@@ -1,0 +1,51 @@
+# UC-level routines for uc31_a2a_schema_match_parity (issue #1089).
+#
+# Proves the #1089 fix: @MeshA2A dependencies now flow through the SAME
+# expectedType/schemaMode schema-matching pipeline as @MeshRoute, so a
+# schema-INCOMPATIBLE provider is EVICTED identically for both sources.
+#
+# This suite is the NEGATIVE counterpart to uc30 (which proves a COMPATIBLE
+# provider resolves for both sources). Here the provider publishes an output
+# schema that does NOT satisfy the consumers' expected type, so the registry's
+# schema stage evicts it — DEPS 0/1 — and the forwarding tool call returns
+# "unavailable" for BOTH the @MeshRoute consumer (control) and the @MeshA2A
+# consumer (the payoff: only true after #1089).
+#
+#   tc01 — route-strict-consumer: @MeshRoute-declared cap, incompatible -> evicted
+#   tc02 — a2a-strict-consumer:   @MeshA2A-declared cap, incompatible -> evicted
+#
+# Both reuse the same parity-provider (parity_cap on port 9100); each tc
+# consumes the cap via exactly ONE source.
+
+routines:
+  start_registry:
+    description: "Start the registry with fast-sweep timing for Java cold-start tolerance"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: |
+          MCP_MESH_SWEEP_INTERVAL=10s \
+          MCP_MESH_RETENTION=10s \
+          MCP_MESH_HEALTH_CHECK_INTERVAL=5 \
+          DEFAULT_TIMEOUT_THRESHOLD=15 \
+            meshctl start --registry-only -d
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "registry ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: registry did not become ready in 20s"
+          tail -50 ~/.mcp-mesh/logs/registry.log 2>/dev/null || true
+          exit 1
+        capture: registry_start
+        timeout: 30
+
+  stop_all:
+    description: "Stop all mesh processes started by this test"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: meshctl stop 2>/dev/null || true
+        ignore_errors: true

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/tc01_meshroute_incompatible_evicts/test.yaml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/tc01_meshroute_incompatible_evicts/test.yaml
@@ -1,0 +1,175 @@
+# tc01_meshroute_incompatible_evicts — issue #1089 (CONTROL, @MeshRoute source).
+#
+# Establishes the long-standing @MeshRoute baseline that #1089 brings @MeshA2A
+# into parity with: a consumer declaring expectedType=StrictResponse (required
+# `value: String`) under SchemaMode.SUBSET against a provider that publishes an
+# INCOMPATIBLE output schema (parity_cap returns `other`, no `value`) has its
+# provider EVICTED by the registry's schema stage — the dependency resolves
+# 0/1 and the forwarding call returns "unavailable".
+#
+# Because of #1088 the early-phase registrar still registers the @MeshRoute
+# proxy bean, so the Spring context refreshes and the agent boots healthy with
+# NO NoSuchBeanDefinitionException — the eviction is purely a schema-matching
+# (resolution) outcome, not a boot failure.
+#
+# GRANULAR: route-strict-consumer declares ONLY a @MeshRoute dependency (no
+# @MeshA2A anywhere). The companion tc02 runs the IDENTICAL scenario through the
+# @MeshA2A source; both producing 0/1 + unavailable is the parity #1089 proves.
+
+name: "@MeshRoute incompatible provider is evicted (#1089 control)"
+description: "Java @MeshRoute consumer declaring a strict expectedType against a schema-incompatible provider: provider evicted (DEPS 0/1) and the call is unavailable"
+tags:
+  - java
+  - spring
+  - a2a
+  - schema-match
+  - parity
+  - issue-1089
+  - smoke
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/parity-provider /workspace/
+      cp -rL /uc-artifacts/route-strict-consumer /workspace/
+
+  - name: "Install parity-provider deps"
+    handler: pip-install
+    path: /workspace/parity-provider
+
+  - name: "Install route-strict-consumer deps"
+    handler: maven-install
+    path: /workspace/route-strict-consumer
+    timeout: 600
+
+  - routine: start_registry
+
+  - name: "Start parity-provider (Python, port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start parity-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for parity-provider to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null \
+          | jq -r '.agents[]|select(.name=="parity-provider")|.status' 2>/dev/null || echo "")
+        [ "$STATUS" = "healthy" ] && { echo "parity-provider healthy after ${i}x2s"; exit 0; }
+        sleep 2
+      done
+      echo "ERROR: parity-provider not healthy within 120s (last status='$STATUS')"
+      meshctl logs parity-provider 2>&1 | tail -120 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start route-strict-consumer (Java, port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/route-strict-consumer --env MCP_MESH_HTTP_PORT=9201 -d
+
+  # The consumer must boot healthy (proxy bean still registers via #1088); the
+  # eviction is a resolution outcome, not a boot failure.
+  - name: "Wait for route-strict-consumer to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null \
+          | jq -r '.agents[]|select(.name=="route-strict-consumer")|.status' 2>/dev/null || echo "")
+        [ "$STATUS" = "healthy" ] && { echo "route-strict-consumer healthy after ${i}x2s"; exit 0; }
+        sleep 2
+      done
+      echo "ERROR: route-strict-consumer not healthy within 120s (last status='$STATUS')"
+      echo "===== route-strict-consumer log (last 120 lines) ====="
+      meshctl logs route-strict-consumer 2>&1 | tail -120 || true
+      exit 1
+    timeout: 150
+
+  - name: "Verify both agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  # Resolution is heartbeat-driven and the schema stage runs on the registry.
+  # Read a SETTLED DEPS cell rather than the first transient sample: require the
+  # value to be non-empty, non-0/0, and IDENTICAL across 3 consecutive reads
+  # (spaced 3s apart) before capturing. This spans several heartbeat cycles, so a
+  # provider that was ever going to resolve would have changed the cell within
+  # the window. We expect the settled value to be 0/1: the only provider is
+  # schema-incompatible and is evicted.
+  - name: "Read settled route-strict-consumer DEPS cell (expected 0/1: provider evicted)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      read_deps() {
+        meshctl list 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' \
+          | grep -E '^route-strict-consumer' | awk '{print $5}' || true
+      }
+      DEPS=""
+      STABLE=0
+      for i in $(seq 1 20); do
+        CUR=$(read_deps)
+        if [ -n "$CUR" ] && [ "$CUR" != "0/0" ] && [ "$CUR" = "$DEPS" ]; then
+          STABLE=$((STABLE + 1))
+        else
+          STABLE=0
+        fi
+        DEPS="$CUR"
+        [ "$STABLE" -ge 2 ] && { echo "DEPS settled at '$DEPS' after ${i} reads"; break; }
+        sleep 3
+      done
+      echo "DEPS=${DEPS}"
+    capture: route_deps
+    timeout: 90
+
+  # The forwarding call must surface the unresolved proxy: parity.call(...) on a
+  # proxy with no resolved provider throws MeshToolUnavailableException
+  # ("Mesh tool unavailable: parity_cap"), which meshctl renders as a tool error.
+  - name: "Call forward_route_strict (expected: unavailable, provider evicted)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=$(meshctl call forward_route_strict '{"name":"x"}' --raw 2>&1 || true)
+      echo "$RESP"
+    capture: route_response
+    timeout: 90
+
+  - name: "Capture consumer log (negative NoSuchBeanDefinitionException guard)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl logs route-strict-consumer 2>&1 | tail -300
+    capture: consumer_log
+
+assertions:
+  - expr: "${captured.agent_list} contains 'parity-provider'"
+    message: "parity-provider should be registered"
+  - expr: "${captured.agent_list} contains 'route-strict-consumer'"
+    message: "route-strict-consumer should be registered (proves the Spring context refreshed)"
+
+  # The proxy bean still registers via #1088; a healthy boot must not log the failure.
+  - expr: "${captured.consumer_log} not contains 'NoSuchBeanDefinitionException'"
+    message: "consumer startup must NOT log NoSuchBeanDefinitionException (#1088 keeps the proxy bean)"
+
+  # Core: the incompatible provider is EVICTED — dependency resolves 0/1.
+  - expr: "${captured.route_deps} contains '0/1'"
+    message: "route-strict-consumer should show DEPS 0/1 (schema-incompatible parity_cap provider evicted)"
+
+  # The unresolved proxy surfaces as unavailable when called.
+  - expr: "${captured.route_response} icontains 'unavailable'"
+    message: "forward_route_strict should be unavailable (parity_cap proxy never resolved a provider)"
+  - expr: "${captured.route_response} not contains 'incompatible-x'"
+    message: "the incompatible provider's value must NOT be returned (it was evicted, not deserialized)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/tc02_mesha2a_incompatible_evicts/test.yaml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/tc02_mesha2a_incompatible_evicts/test.yaml
@@ -1,0 +1,188 @@
+# tc02_mesha2a_incompatible_evicts — issue #1089 (THE PAYOFF, @MeshA2A source).
+#
+# Runs the EXACT scenario of tc01 (CONTROL) but through the @MeshA2A
+# declaration source instead of @MeshRoute. The a2a-strict-consumer declares
+# parity_cap with the IDENTICAL expectedType=StrictResponse (required
+# `value: String`) and SchemaMode.SUBSET; the parity-provider publishes the
+# same INCOMPATIBLE schema (`other`, no `value`).
+#
+# BEFORE #1089: MeshA2ARegistry.getUniqueDependencySpecs() did NOT stamp the
+# schema-matching fields, so the registry SKIPPED schema matching for the A2A
+# dependency — the incompatible provider resolved anyway (DEPS 1/1) and a call
+# would later hit a runtime deserialization error (missing `value`). The
+# behavior DIVERGED from @MeshRoute.
+#
+# AFTER #1089: getUniqueDependencySpecs() calls
+# MeshRouteRegistry.applySchemaMatching(...), so the A2A dependency ships
+# matchMode=subset exactly like the route source. The registry's schema stage
+# now evicts the incompatible provider — DEPS 0/1 — and the forwarding call
+# returns "unavailable", IDENTICAL to tc01. That identical outcome IS the parity
+# #1089 establishes.
+#
+# If this tc shows DEPS 1/1 / the dep still resolving, the fix is NOT in the
+# image — rebuild tsuite-mesh:local from source and re-run. Do NOT weaken the
+# assertions.
+#
+# GRANULAR: a2a-strict-consumer declares ONLY a @MeshA2A dependency (no
+# @MeshRoute anywhere).
+
+name: "@MeshA2A incompatible provider is evicted — parity with @MeshRoute (#1089)"
+description: "Java @MeshA2A consumer declaring a strict expectedType against a schema-incompatible provider: provider evicted (DEPS 0/1) and the call is unavailable, identical to the @MeshRoute control — only true AFTER the #1089 fix"
+tags:
+  - java
+  - spring
+  - a2a
+  - schema-match
+  - parity
+  - issue-1089
+  - smoke
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/parity-provider /workspace/
+      cp -rL /uc-artifacts/a2a-strict-consumer /workspace/
+
+  - name: "Install parity-provider deps"
+    handler: pip-install
+    path: /workspace/parity-provider
+
+  - name: "Install a2a-strict-consumer deps"
+    handler: maven-install
+    path: /workspace/a2a-strict-consumer
+    timeout: 600
+
+  - routine: start_registry
+
+  - name: "Start parity-provider (Python, port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start parity-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Wait for parity-provider to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null \
+          | jq -r '.agents[]|select(.name=="parity-provider")|.status' 2>/dev/null || echo "")
+        [ "$STATUS" = "healthy" ] && { echo "parity-provider healthy after ${i}x2s"; exit 0; }
+        sleep 2
+      done
+      echo "ERROR: parity-provider not healthy within 120s (last status='$STATUS')"
+      meshctl logs parity-provider 2>&1 | tail -120 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start a2a-strict-consumer (Java, port 9202)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/a2a-strict-consumer --env MCP_MESH_HTTP_PORT=9202 -d
+
+  # The consumer must boot healthy (proxy bean still registers via #1088); the
+  # eviction is a resolution outcome, not a boot failure.
+  - name: "Wait for a2a-strict-consumer to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -fsS --max-time 10 http://localhost:8000/agents 2>/dev/null \
+          | jq -r '.agents[]|select(.name=="a2a-strict-consumer")|.status' 2>/dev/null || echo "")
+        [ "$STATUS" = "healthy" ] && { echo "a2a-strict-consumer healthy after ${i}x2s"; exit 0; }
+        sleep 2
+      done
+      echo "ERROR: a2a-strict-consumer not healthy within 120s (last status='$STATUS')"
+      echo "===== a2a-strict-consumer log (last 120 lines) ====="
+      meshctl logs a2a-strict-consumer 2>&1 | tail -120 || true
+      exit 1
+    timeout: 150
+
+  - name: "Verify both agents registered"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list
+    capture: agent_list
+
+  # THE PAYOFF: after #1089 the A2A dependency carries matchMode=subset, so the
+  # registry's schema stage evicts the incompatible provider exactly like route.
+  # Read a SETTLED DEPS cell rather than the first transient sample: require the
+  # value to be non-empty, non-0/0, and IDENTICAL across 3 consecutive reads
+  # (spaced 3s apart) before capturing. This spans several heartbeat cycles, so a
+  # provider that was ever going to resolve would have changed the cell within
+  # the window. We expect the settled value to be 0/1; pre-fix this would settle
+  # at 1/1 (schema matching skipped for A2A).
+  - name: "Read settled a2a-strict-consumer DEPS cell (expected 0/1: provider evicted after #1089)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      read_deps() {
+        meshctl list 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' \
+          | grep -E '^a2a-strict-consumer' | awk '{print $5}' || true
+      }
+      DEPS=""
+      STABLE=0
+      for i in $(seq 1 20); do
+        CUR=$(read_deps)
+        if [ -n "$CUR" ] && [ "$CUR" != "0/0" ] && [ "$CUR" = "$DEPS" ]; then
+          STABLE=$((STABLE + 1))
+        else
+          STABLE=0
+        fi
+        DEPS="$CUR"
+        [ "$STABLE" -ge 2 ] && { echo "DEPS settled at '$DEPS' after ${i} reads"; break; }
+        sleep 3
+      done
+      echo "DEPS=${DEPS}"
+    capture: a2a_deps
+    timeout: 90
+
+  # The forwarding call must surface the unresolved proxy: parity.call(...) on a
+  # proxy with no resolved provider throws MeshToolUnavailableException
+  # ("Mesh tool unavailable: parity_cap"), which meshctl renders as a tool error.
+  - name: "Call forward_a2a_strict (expected: unavailable, provider evicted after #1089)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=$(meshctl call forward_a2a_strict '{"name":"x"}' --raw 2>&1 || true)
+      echo "$RESP"
+    capture: a2a_response
+    timeout: 90
+
+  - name: "Capture consumer log (negative NoSuchBeanDefinitionException guard)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl logs a2a-strict-consumer 2>&1 | tail -300
+    capture: consumer_log
+
+assertions:
+  - expr: "${captured.agent_list} contains 'parity-provider'"
+    message: "parity-provider should be registered"
+  - expr: "${captured.agent_list} contains 'a2a-strict-consumer'"
+    message: "a2a-strict-consumer should be registered (proves the Spring context refreshed)"
+
+  # The proxy bean still registers via #1088; a healthy boot must not log the failure.
+  - expr: "${captured.consumer_log} not contains 'NoSuchBeanDefinitionException'"
+    message: "consumer startup must NOT log NoSuchBeanDefinitionException (#1088 keeps the proxy bean)"
+
+  # Core PAYOFF: after #1089 the A2A schema matching evicts the incompatible
+  # provider — dependency resolves 0/1, identical to the @MeshRoute control.
+  # Pre-fix this would be 1/1.
+  - expr: "${captured.a2a_deps} contains '0/1'"
+    message: "a2a-strict-consumer should show DEPS 0/1 (schema-incompatible parity_cap evicted via #1089 A2A schema matching); 1/1 means the fix is NOT in the image"
+
+  # The unresolved proxy surfaces as unavailable when called — same as route.
+  - expr: "${captured.a2a_response} icontains 'unavailable'"
+    message: "forward_a2a_strict should be unavailable (parity_cap proxy never resolved a provider after eviction)"
+  - expr: "${captured.a2a_response} not contains 'incompatible-x'"
+    message: "the incompatible provider's value must NOT be returned (it was evicted, not deserialized)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

Fixes a cross-source inconsistency in the Spring starter: `@MeshA2A`-declared mesh dependencies bypassed the `expectedType`/`schemaMode` schema-matching that `@MeshRoute` and `@MeshDependsOn` apply.

- `MeshA2ARegistry.getUniqueDependencySpecs()` now calls `MeshRouteRegistry.applySchemaMatching(agentDep, dep, clusterStrict)`, mirroring `MeshRouteRegistry.getUniqueDependencySpecs()`, so all three declaration sources stamp `expectedSchemaCanonical` / `expectedSchemaHash` / `matchMode` identically.
- The shared 3-arg `applySchemaMatching` overload is widened from `private` to package-private `static` for reuse within `io.mcpmesh.spring.web` (no public surface added; the raw-input overload was already public).

Previously, because the `@MeshA2A` dep shipped with empty `matchMode`, the registry's schema-compatibility stage (gated on `matchMode != ""`) was skipped — an `@MeshA2A` consumer declaring `expectedType` would bind a schema-incompatible provider and surface the mismatch as a runtime deserialization error rather than evicting it at resolution time.

## ⚠️ Behavior change

An `@MeshA2A` consumer declaring `expectedType`/`schemaMode` that **previously resolved against a schema-incompatible provider will now correctly evict it** (`DEPS 0/1`) at resolution time — matching `@MeshRoute`. Plain `@MeshA2A` deps with neither `expectedType` nor `schemaMode` are unaffected (early `return` in `applySchemaMatching`) — backward compatible.

## Tests

- **Unit** (`MeshA2ASchemaMatchingParityTest`): a typed `@MeshA2A` dep stamps `matchMode="subset"` + non-null canonical/hash; a plain dep stays a no-op; and an `@MeshA2A` dep produces fields **equal** to `@MeshRoute` for an identical declaration (the acceptance parity check). 3/3 pass (142 pass across `MeshA2A*` + `MeshDependsOnIntegrationTest`).
- **Integration** (new suite `uc31_a2a_schema_match_parity`): a schema-incompatible provider drives a `@MeshRoute` consumer (`tc01`, control) and an `@MeshA2A` consumer (`tc02`, payoff) — **both evict identically** (`DEPS 0/1` → tool unavailable, no value leak). Combined with `uc30 tc02` (compatible provider → `@MeshA2A` still resolves), this completes the parity matrix. Validated against `tsuite-mesh:local` built from this branch.

## Review notes

Independent review: 0 blockers. Two test-side warnings were both fixed and re-validated:
- Unit fixture now binds the correct reflected `method` per surface (was hardcoded).
- The `uc31` DEPS poll now confirms a settled value (3 consecutive identical reads) instead of sampling the first non-`0/0` reading.

Closes #1089

## Test plan

- [x] `mvn -pl mcp-mesh-spring-boot-starter test -Dtest=MeshA2ASchemaMatchingParityTest` → 3/3
- [x] `mvn -pl mcp-mesh-spring-boot-starter test -Dtest='MeshA2A*,MeshDependsOnIntegrationTest'` → 142/142
- [x] `tsuite run --tc uc31_a2a_schema_match_parity/tc01_meshroute_incompatible_evicts` → pass (DEPS 0/1)
- [x] `tsuite run --tc uc31_a2a_schema_match_parity/tc02_mesha2a_incompatible_evicts` → pass (DEPS 0/1)
- [x] `tsuite run --tc uc30_spring_constructor_inject_java/tc02_mesha2a_constructor_injection` → pass (compatible → still resolves)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MeshA2A dependency handling to validate schemas consistently with MeshRoute, ensuring incompatible providers are properly identified and excluded.

* **Tests**
  * Added comprehensive test coverage for schema-matching behavior and dependency validation parity across different dependency types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->