### PR TITLE
fix(meshctl): bump Java scaffold templates to Spring Boot 4.0.6 (#1092)

### DIFF
--- a/cmd/meshctl/templates/java/api/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/api/pom.xml.tmpl
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.6</version>
         <relativePath/>
     </parent>
 

--- a/cmd/meshctl/templates/java/basic/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/basic/pom.xml.tmpl
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.6</version>
         <relativePath/>
     </parent>
 

--- a/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.6</version>
         <relativePath/>
     </parent>
 

--- a/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.6</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
## Summary

The `meshctl scaffold` Java templates hardcoded an outdated Spring Boot parent, so every freshly-scaffolded Java agent started on a stale, advisory-flagged release. Bump the four affected templates' `spring-boot-starter-parent` from `4.0.2` to `4.0.6`:

- `cmd/meshctl/templates/java/basic/pom.xml.tmpl`
- `cmd/meshctl/templates/java/api/pom.xml.tmpl`
- `cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl`
- `cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl`

This aligns them with the already-updated `a2a-consumer` template and the `4.0.6` used across the repo's uc28/uc27/uc23 Java fixtures (same `mcp-mesh 2.3.0` starter), making `4.0.6` the source-of-truth for new scaffolds and stopping the recurring `4.0.2` pin.

## Validation

Templates are `go:embed`'d into the meshctl binary, so the binary was rebuilt (`go build -o bin/meshctl ./cmd/meshctl`) and the freshly-built binary (invoked by explicit path to avoid the npm `@mcpmesh/cli` PATH shadow) was used to:
- scaffold `basic`, `api`, `llm-agent`, `llm-provider` Java agents → all generated poms confirmed at `<version>4.0.6</version>`;
- `mvn -B -ntp compile` the `basic` and `api` generated projects → **BUILD SUCCESS** under Spring Boot 4.0.6 with the `mcp-mesh 2.3.0` starter.

Closes #1092

## Test plan

- [x] All four templates pin `4.0.6` (a2a-consumer already on 4.0.6)
- [x] Rebuilt meshctl picks up embedded template change
- [x] Scaffolded agents from each affected template generate `4.0.6` poms
- [x] `basic` + `api` scaffolded projects compile under 4.0.6 + mcp-mesh 2.3.0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
