### PR TITLE
feat(python): add response_model= to @mesh.llm (#1085)

### DIFF
--- a/docs/mesh-decorators.md
+++ b/docs/mesh-decorators.md
@@ -927,6 +927,7 @@ The `@mesh.llm` decorator enables LLM integration as first-class mesh capabiliti
 | ---------------- | ------ | ------- | ------------------------------------------------------------ |
 | `provider`       | `dict` | `None`  | Provider selector — `{"capability": "llm", "tags": [...]}`   |
 | `system_prompt`  | `str`  | `None`  | Literal prompt or `file://path/to/template.jinja2`           |
+| `response_model` | `type` | `None`  | Pydantic model the LLM must emit and is validated against. Drives the LLM schema separately from the return annotation; when omitted, falls back to the return type. |
 | `filter`         | `list` | `None`  | Tool discovery filter (capability, tags, version)            |
 | `filter_mode`    | `str`  | `"all"` | `"all"`, `"best_match"`, or `"*"` (wildcard)                 |
 | `context_param`  | `str`  | `None`  | Parameter name containing template context                   |

--- a/docs/python/decorators.md
+++ b/docs/python/decorators.md
@@ -96,6 +96,7 @@ Enables LLM-powered tools with automatic tool discovery.
     provider={"capability": "llm", "tags": ["+claude"]},  # LLM provider selector
     max_iterations=5,                    # Max agentic loop iterations
     system_prompt="file://prompts/agent.jinja2",  # Jinja2 template
+    response_model=AssistResponse,       # Pydantic model the LLM must emit (optional)
     context_param="ctx",                 # Parameter name for context
     filter=[{"tags": ["tools"]}],        # Tool filter for discovery
     filter_mode="all",                   # "all", "best_match", or "*"
@@ -108,7 +109,7 @@ def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
     return llm("Help the user with their request")
 ```
 
-**Note**: Response format is determined by return type: `-> str` for text, `-> PydanticModel` for JSON.
+**Note**: Response format is determined by return type: `-> str` for text, `-> PydanticModel` for JSON. Use `response_model` to make the LLM emit a focused subset (validated against that model) while the return annotation still drives the tool's `outputSchema`; when omitted, the LLM schema falls back to the return annotation.
 
 ### Filter Modes
 

--- a/docs/python/llm/index.md
+++ b/docs/python/llm/index.md
@@ -67,7 +67,7 @@ def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
 
 **Note**: `provider` and `filter` use the capability selector syntax (`capability`, `tags`, `version`). See `meshctl man capabilities` for details.
 
-**Note**: Response format is determined by the function's return type annotation, not a parameter. See [Response Formats](#response-formats).
+**Note**: The return type annotation always drives the tool's `outputSchema` (what callers receive). The LLM-emitted/validated schema follows that return annotation by default, but is overridden by `response_model` when provided. See [Response Formats](#response-formats) and [Focusing the LLM Schema with `response_model`](#focusing-the-llm-schema-with-response_model).
 
 ## LLM Model Parameters
 
@@ -321,7 +321,7 @@ def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None):
 
 ## Response Formats
 
-Response format is determined by the **return type annotation** - not a decorator parameter.
+The **return type annotation** always drives the tool's `outputSchema` (what callers receive). The LLM-emitted/validated schema follows the return annotation by default, and is overridden by `response_model` when provided — see [Focusing the LLM Schema with `response_model`](#focusing-the-llm-schema-with-response_model).
 
 | Return Type        | Output          | Description                   |
 | ------------------ | --------------- | ----------------------------- |

--- a/docs/python/llm/index.md
+++ b/docs/python/llm/index.md
@@ -39,6 +39,7 @@ export OPENAI_API_KEY=sk-...
     provider={"capability": "llm", "tags": ["+claude"]},
     max_iterations=5,
     system_prompt="file://prompts/assistant.jinja2",
+    response_model=AssistResponse,
     context_param="ctx",
     filter=[{"tags": ["tools"]}],
     filter_mode="all",
@@ -58,6 +59,7 @@ def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
 | `provider`       | dict | LLM provider selector (capability + tags)         |
 | `max_iterations` | int  | Max agentic loop iterations (default: 1)          |
 | `system_prompt`  | str  | Inline prompt or `file://path` to Jinja2 template |
+| `response_model` | type | Pydantic model the LLM must emit and is validated against (separate from the return type) |
 | `context_param`  | str  | Parameter name receiving context object           |
 | `filter`         | list | Tool filter criteria                              |
 | `filter_mode`    | str  | `"all"`, `"best_match"`, or `"*"`                 |
@@ -347,6 +349,31 @@ class AssistResponse(BaseModel):
 @mesh.tool(capability="smart_assistant")
 def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
     return llm("Analyze and respond")  # Returns validated Pydantic object
+```
+
+### Focusing the LLM Schema with `response_model`
+
+By default the LLM is asked to emit the function's return type. Use
+`response_model` to specify a separate Pydantic model the LLM must emit and is
+validated against. The return annotation continues to drive the tool's
+`outputSchema` (what callers receive); when `response_model` is omitted, the LLM
+schema falls back to the return annotation.
+
+This is useful when a tool combines LLM-produced fields with deterministic,
+function-computed fields: the LLM emits only the focused subset it should reason
+about, instead of being forced to emit (and possibly hallucinate) the
+deterministic fields too.
+
+```python
+@mesh.llm(
+    provider={"capability": "llm", "tags": ["+openai"]},
+    response_model=AnalystOutput,        # what the LLM must emit (focused)
+    system_prompt="file://prompts/analyst.jinja2",
+)
+@mesh.tool(capability="analysis.run_daily")
+async def run_daily(...) -> RunDailyResult:   # tool output = LLM fields + deterministic context
+    analyst = await llm("...")                # validated against AnalystOutput
+    return RunDailyResult(email=email, date=str(date.today()), total_value=total_value, **analyst.model_dump())
 ```
 
 ## Agentic Loops

--- a/src/core/cli/man/content/decorators.md
+++ b/src/core/cli/man/content/decorators.md
@@ -128,6 +128,7 @@ Enables LLM-powered tools with automatic tool discovery.
     provider={"capability": "llm", "tags": ["+claude"]},  # LLM provider selector
     max_iterations=5,                    # Max agentic loop iterations
     system_prompt="file://prompts/agent.jinja2",  # Jinja2 template
+    response_model=AssistResponse,       # Pydantic model the LLM must emit (optional)
     context_param="ctx",                 # Parameter name for context
     filter=[{"tags": ["tools"]}],        # Tool filter for discovery
     filter_mode="all",                   # "all", "best_match", or "*"
@@ -140,7 +141,7 @@ def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
     return llm("Help the user with their request")
 ```
 
-**Note**: Response format is determined by return type: `-> str` for text, `-> PydanticModel` for JSON.
+**Note**: Response format is determined by return type: `-> str` for text, `-> PydanticModel` for JSON. Use `response_model` to make the LLM emit a focused subset (validated against that model) while the return annotation still drives the tool's `outputSchema`; when omitted, the LLM schema falls back to the return annotation.
 
 ### Filter Modes
 

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -29,6 +29,7 @@ export OPENAI_API_KEY=sk-...
     provider={"capability": "llm", "tags": ["+claude"]},
     max_iterations=5,
     system_prompt="file://prompts/assistant.jinja2",
+    response_model=AssistResponse,
     context_param="ctx",
     filter=[{"tags": ["tools"]}],
     filter_mode="all",
@@ -48,6 +49,7 @@ async def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistRes
 | `provider`       | dict | LLM provider selector (capability + tags)         |
 | `max_iterations` | int  | Max agentic loop iterations (default: 5)          |
 | `system_prompt`  | str  | Inline prompt or `file://path` to Jinja2 template |
+| `response_model` | type | Pydantic model the LLM must emit (validated). Separate from the return type. |
 | `context_param`  | str  | Parameter name receiving context object           |
 | `filter`              | list | Tool filter criteria                              |
 | `filter_mode`         | str  | `"all"`, `"best_match"`, or `"*"`                 |
@@ -311,6 +313,32 @@ class AssistResponse(BaseModel):
 @mesh.tool(capability="smart_assistant")
 async def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
     return await llm("Analyze and respond")  # Returns validated Pydantic object
+```
+
+### Focusing the LLM Schema with `response_model`
+
+By default the LLM is asked to emit the function's return type. Use
+`response_model` to make the LLM emit only a focused subset — the schema the LLM
+must produce (and is validated against) becomes `response_model`, while the
+return annotation continues to drive the tool's `outputSchema` (what callers
+receive). When `response_model` is omitted, the LLM schema falls back to the
+return annotation.
+
+This is useful when a tool combines LLM-produced fields with deterministic,
+function-computed fields: the LLM emits only the fields it should reason about
+instead of being forced to emit (and possibly hallucinate) the deterministic
+ones.
+
+```python
+@mesh.llm(
+    provider={"capability": "llm", "tags": ["+openai"]},
+    response_model=AnalystOutput,        # what the LLM must emit (focused)
+    system_prompt="file://prompts/analyst.jinja2",
+)
+@mesh.tool(capability="analysis.run_daily")
+async def run_daily(...) -> RunDailyResult:   # tool output = LLM fields + deterministic context
+    analyst = await llm("...")                # validated against AnalystOutput
+    return RunDailyResult(email=email, date=str(date.today()), total_value=total_value, **analyst.model_dump())
 ```
 
 ## Agentic Loops

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -58,7 +58,7 @@ async def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistRes
 
 **Note**: `provider` and `filter` use the capability selector syntax (`capability`, `tags`, `version`). See `meshctl man capabilities` for details.
 
-**Note**: Response format is determined by the function's return type annotation, not a parameter. See [Response Formats](#response-formats).
+**Note**: The return type annotation always drives the tool's `outputSchema` (what callers receive). The LLM-emitted/validated schema follows that return annotation by default, but is overridden by `response_model` when provided. See [Response Formats](#response-formats) and [Focusing the LLM Schema with `response_model`](#focusing-the-llm-schema-with-response_model).
 
 ## Calling llm()
 
@@ -285,7 +285,7 @@ at call time, use the `context=` argument on `llm()` — see
 
 ## Response Formats
 
-Response format is determined by the **return type annotation** - not a decorator parameter.
+The **return type annotation** always drives the tool's `outputSchema` (what callers receive). The LLM-emitted/validated schema follows the return annotation by default, and is overridden by `response_model` when provided — see [Focusing the LLM Schema with `response_model`](#focusing-the-llm-schema-with-response_model).
 
 | Return Type        | Output          | Description                   |
 | ------------------ | --------------- | ----------------------------- |

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -2664,8 +2664,9 @@ def llm(
                         inspect.isclass(output_type) and issubclass(output_type, BaseModel)
                     ):
                         warnings.warn(
-                            f"Function '{func.__name__}' decorated with @mesh.llm should return a Pydantic BaseModel subclass, "
-                            f"got {output_type}. This may cause validation errors at runtime.",
+                            f"@mesh.llm tool '{func.__name__}': the resolved LLM response schema {output_type} "
+                            f"is not a Pydantic BaseModel subclass (it comes from response_model= when set, "
+                            f"otherwise the function return annotation). LLM structured-output validation may fail at runtime.",
                             UserWarning,
                             stacklevel=2,
                         )

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -2446,6 +2446,7 @@ def llm(
     max_iterations: int = 10,
     system_prompt: str | None = None,
     system_prompt_file: str | None = None,
+    response_model: type | None = None,
     context_param: str | None = None,
     parallel_tool_calls: bool = False,
     **kwargs: Any,
@@ -2496,6 +2497,12 @@ def llm(
         max_iterations: Max agentic loop iterations (can be overridden by MESH_LLM_MAX_ITERATIONS)
         system_prompt: Default system prompt (literal string or ``file://`` template)
         system_prompt_file: Path to Jinja2 template file (deprecated — use system_prompt="file://...")
+        response_model: Schema the LLM is required to emit and validate against. When
+                        set, it drives the provider structured-output schema and response
+                        validation independently of the function's return annotation.
+                        When omitted, falls back to the return annotation (current
+                        behavior). The return annotation continues to drive the tool
+                        ``outputSchema`` regardless.
         context_param: Function parameter name to auto-extract template context from
         parallel_tool_calls: Encourage the LLM to emit independent tool_calls in parallel
         **kwargs: Additional model parameters forwarded to the provider as defaults
@@ -2633,12 +2640,22 @@ def llm(
                 f"@mesh.llm '{func.__name__}': {e}"
             ) from None
 
-        output_type = None
-        if return_annotation and return_annotation != inspect.Signature.empty:
+        # Issue #1085: response_model takes precedence as the LLM-emitted/validated
+        # schema. When omitted, fall back to the return annotation (back-compat).
+        # The return annotation independently drives the tool outputSchema at
+        # heartbeat time, so that path is unaffected by this choice.
+        output_type = response_model
+        if (
+            output_type is None
+            and return_annotation
+            and return_annotation != inspect.Signature.empty
+        ):
             output_type = return_annotation
 
-            # Warn if not a Pydantic model — but skip the warning for streaming
-            # tools where the return annotation is intentionally Stream[str].
+        if output_type is not None:
+            # Warn if the resolved LLM-output type is not a Pydantic model — but
+            # skip the warning for streaming tools where the return annotation is
+            # intentionally Stream[str].
             if llm_stream_type is None:
                 try:
                     from pydantic import BaseModel

--- a/src/runtime/python/tests/unit/test_mesh_llm_decorator.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_decorator.py
@@ -226,7 +226,7 @@ class TestMeshLlmDecoratorOutputTypeExtraction:
     def test_warns_on_non_pydantic_return_type(self):
         """Test warning when return type is not Pydantic BaseModel."""
 
-        with pytest.warns(UserWarning, match="should return a Pydantic BaseModel"):
+        with pytest.warns(UserWarning, match="not a Pydantic BaseModel subclass"):
 
             @mesh.llm(provider={"capability": "llm"}, filter={"capability": "document"})
             def chat(message: str, llm: mesh.MeshLlmAgent = None) -> dict:

--- a/src/runtime/python/tests/unit/test_mesh_llm_response_model.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_response_model.py
@@ -139,7 +139,7 @@ class TestMeshLlmResponseModel:
     def test_non_basemodel_response_model_warns(self):
         """A response_model that isn't a BaseModel triggers the BaseModel warning."""
 
-        with pytest.warns(UserWarning, match="should return a Pydantic BaseModel"):
+        with pytest.warns(UserWarning, match="not a Pydantic BaseModel subclass"):
 
             @mesh.llm(
                 provider={"capability": "llm"},

--- a/src/runtime/python/tests/unit/test_mesh_llm_response_model.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_response_model.py
@@ -1,0 +1,168 @@
+"""
+Unit tests for @mesh.llm `response_model=` kwarg (issue #1085).
+
+`response_model` lets the LLM-emitted/validated schema be specified separately
+from the function's return annotation. The return annotation independently drives
+the tool `outputSchema`.
+"""
+
+import warnings
+
+import pytest
+from pydantic import BaseModel
+
+import mesh
+from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+from _mcp_mesh.utils.fastmcp_schema_extractor import FastMCPSchemaExtractor
+
+
+class SmallModel(BaseModel):
+    """The schema the LLM is asked to emit."""
+
+    summary: str
+
+
+class BigModel(BaseModel):
+    """The full tool result type (return annotation)."""
+
+    summary: str
+    email: str
+    total: float
+
+
+class TestMeshLlmResponseModel:
+    """Test response_model precedence over the return annotation."""
+
+    def setup_method(self):
+        """Clear registry before each test."""
+        DecoratorRegistry._mesh_llm_agents = {}
+
+    def test_response_model_overrides_return_annotation_for_output_type(self):
+        """response_model drives the LLM output_type, return annotation drives outputSchema."""
+
+        @mesh.llm(
+            provider={"capability": "llm"},
+            filter={"capability": "document"},
+            response_model=SmallModel,
+        )
+        def chat(message: str, llm: mesh.MeshLlmAgent = None) -> BigModel:
+            return llm(message)
+
+        llm_agents = DecoratorRegistry.get_mesh_llm_agents()
+        agent_data = next(iter(llm_agents.values()))
+
+        # LLM-emitted/validated schema is response_model, NOT the return
+        # annotation — guard against silent precedence inversion.
+        assert agent_data.output_type is SmallModel
+        assert agent_data.output_type is not BigModel
+
+        # Tool outputSchema is extracted INDEPENDENTLY from the return annotation.
+        output_schema = FastMCPSchemaExtractor.extract_output_schema(
+            agent_data.function
+        )
+        big_schema = BigModel.model_json_schema()
+        assert set(output_schema["properties"].keys()) == set(
+            big_schema["properties"].keys()
+        )
+        assert "email" in output_schema["properties"]
+        assert "total" in output_schema["properties"]
+
+    def test_text_streaming_overrides_response_model_output_type(self):
+        """A text-streaming tool collapses output_type to str even when
+        response_model is set — the streaming override wins.
+
+        ``Stream[str]`` is a string-typed contract (str chunks accumulating to a
+        str result); ``MeshLlmAgent.stream()`` rejects any other output_type.
+        So response_model is intentionally discarded for text streams.
+        """
+
+        @mesh.llm(
+            provider={"capability": "llm"},
+            filter={"capability": "document"},
+            response_model=SmallModel,
+        )
+        async def chat(
+            message: str, llm: mesh.MeshLlmAgent = None
+        ) -> mesh.Stream[str]:
+            yield message
+
+        llm_agents = DecoratorRegistry.get_mesh_llm_agents()
+        agent_data = next(iter(llm_agents.values()))
+        assert agent_data.output_type is str
+        assert agent_data.output_type is not SmallModel
+
+    def test_no_response_model_falls_back_to_return_annotation(self):
+        """Without response_model, output_type == return annotation (back-compat)."""
+
+        @mesh.llm(
+            provider={"capability": "llm"},
+            filter={"capability": "document"},
+        )
+        def chat(message: str, llm: mesh.MeshLlmAgent = None) -> BigModel:
+            return llm(message)
+
+        llm_agents = DecoratorRegistry.get_mesh_llm_agents()
+        agent_data = next(iter(llm_agents.values()))
+        assert agent_data.output_type is BigModel
+
+    def test_response_model_not_forwarded_to_provider_params(self):
+        """response_model is consumed as the LLM output type, not passed through
+        as a provider model param.
+
+        Extra **kwargs (genuine model params like ``temperature``) land in the
+        resolved config that is forwarded to the provider. ``response_model`` is
+        a named decorator kwarg with a dedicated meaning, so it must NOT appear
+        in that passthrough — it must instead drive the resolved ``output_type``.
+        Asserting against the same dict that a real model param lands in proves
+        the exclusion is real, not structural.
+        """
+
+        @mesh.llm(
+            provider={"capability": "llm"},
+            filter={"capability": "document"},
+            response_model=SmallModel,
+            temperature=0.7,
+        )
+        def chat(message: str, llm: mesh.MeshLlmAgent = None) -> BigModel:
+            return llm(message)
+
+        llm_agents = DecoratorRegistry.get_mesh_llm_agents()
+        agent_data = next(iter(llm_agents.values()))
+
+        # A genuine model param IS forwarded to the provider via the config.
+        assert agent_data.config.get("temperature") == 0.7
+        # response_model is NOT forwarded as a provider model param...
+        assert "response_model" not in agent_data.config
+        # ...it is consumed as the resolved LLM output type instead.
+        assert agent_data.output_type is SmallModel
+
+    def test_non_basemodel_response_model_warns(self):
+        """A response_model that isn't a BaseModel triggers the BaseModel warning."""
+
+        with pytest.warns(UserWarning, match="should return a Pydantic BaseModel"):
+
+            @mesh.llm(
+                provider={"capability": "llm"},
+                filter={"capability": "document"},
+                response_model=dict,
+            )
+            def chat(message: str, llm: mesh.MeshLlmAgent = None) -> BigModel:
+                return llm(message)
+
+    def test_basemodel_response_model_with_nonllm_return_does_not_warn(self):
+        """response_model=BaseModel + non-BaseModel return annotation should NOT warn."""
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
+            @mesh.llm(
+                provider={"capability": "llm"},
+                filter={"capability": "document"},
+                response_model=SmallModel,
+            )
+            def chat(message: str, llm: mesh.MeshLlmAgent = None) -> dict:
+                return llm(message)
+
+        llm_agents = DecoratorRegistry.get_mesh_llm_agents()
+        agent_data = next(iter(llm_agents.values()))
+        assert agent_data.output_type is SmallModel


### PR DESCRIPTION
## Summary

`@mesh.llm` derived the LLM-emitted/validated schema from the function's **return annotation**, conflating two distinct concerns: what the LLM must emit, and what the tool returns to callers. Tools that combine LLM-produced fields with deterministic, function-computed fields were forced to make the LLM emit (and potentially hallucinate) the deterministic fields too.

Add a keyword-only `response_model=` kwarg to `@mesh.llm`:
- When set, `response_model` is the schema the LLM must emit and is validated against.
- The function's return annotation continues to drive the tool `outputSchema` **independently** (extracted separately at heartbeat time via `FastMCPSchemaExtractor.extract_output_schema` — unchanged).
- When omitted, the LLM `output_type` falls back to the return annotation — **fully additive, no behavior change** for existing code.

```python
@mesh.llm(provider={"capability": "llm", "tags": ["+openai"]},
          response_model=AnalystOutput,                 # what the LLM must emit (focused)
          system_prompt="file://prompts/analyst.jinja2")
@mesh.tool(capability="analysis.run_daily")
async def run_daily(...) -> RunDailyResult:              # tool output = LLM fields + deterministic context
    analyst = await llm("...")                           # validated against AnalystOutput
    return RunDailyResult(email=email, date=str(date.today()), total_value=total_value, **analyst.model_dump())
```

## Cross-runtime standardization

Audited all three runtimes for this conflation:
- **Python** (this PR): adds `response_model=`.
- **TypeScript** (#1094): same conflation (`MeshLlmConfig.returns` is the single source) — companion `responseModel` feature filed.
- **Java** (#1095): **no conflation** — already separable via `llm.generate(Class<T>)` + `@MeshTool(outputType=…)`; docs/examples parity filed.

## Implementation notes

- The streaming text override (`output_type = str`) still runs after the derivation, so text-streaming is unaffected.
- The Pydantic-BaseModel warning keys off the **resolved** `output_type` (a non-BaseModel `response_model` warns; a non-BaseModel return annotation does not spuriously warn when a valid `response_model` is set).
- `response_model` is a named kwarg, so it never leaks into `**kwargs`/provider `model_params`.

## Tests

`tests/unit/test_mesh_llm_response_model.py`: precedence (response_model wins, with negative assertion), back-compat fallback, BaseModel-warning predicate (both directions), text-streaming override collapses to `str`, and response_model consumed as `output_type` while excluded from provider `model_params`. `43 passed` (with the existing `@mesh.llm` decorator suite).

## Docs

`response_model` added to the `@mesh.llm` man pages (`decorators.md`, `llm.md`) and docs (`mesh-decorators.md`, `python/decorators.md`, `python/llm/index.md`), incl. the combined-fields example. (The two `kwargs` reference pages were intentionally not touched — they document vendor `model_params`, not decorator kwargs.)

## Review notes

Independent review: 0 blockers. The one WARNING (a tautological "not forwarded" test) and two coverage INFOs were all addressed in the test-hardening pass before this PR.

Closes #1085

## Test plan

- [x] `pytest tests/unit/test_mesh_llm_response_model.py tests/unit/test_mesh_llm_decorator.py` → 43 passed
- [x] Back-compat: no `response_model` → `output_type` == return annotation (pinned)
- [x] Docs updated on canonical man + docs surfaces
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `response_model` parameter to `@mesh.llm` decorator, enabling users to specify a Pydantic model for LLM output validation and schema enforcement independently from the function return type.

* **Documentation**
  * Updated decorator documentation across multiple guides with examples and explanations of the new `response_model` option and its interaction with return annotations.

* **Tests**
  * Added comprehensive unit tests verifying `response_model` precedence, fallback behavior, validation warnings, and interaction with streaming tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->