### PR TITLE
feat(typescript): add responseModel to mesh.llm (#1094)

### DIFF
--- a/docs/typescript/llm/index.md
+++ b/docs/typescript/llm/index.md
@@ -71,7 +71,10 @@ agent.addTool({
 | `contextParam`  | `string`          | Parameter name passed to template context        |
 | `filter`        | `LlmFilterSpec[]` | Tool filter for discovery                        |
 | `filterMode`    | `string`          | How to select tools: "all", "best_match", "\*"   |
-| `returns`       | `ZodType`         | Optional: Schema for structured output           |
+| `responseModel` | `ZodType`         | Optional: Schema the LLM must emit (drives structured output) |
+| `returns`       | `ZodType`         | Optional: Schema for what `execute` returns to callers |
+
+When `responseModel` is set, it is the schema the LLM is required to emit and is validated against, and it drives the provider's structured-output schema; the injected `llm` callable is typed by it. `returns` independently types what `execute` returns to callers. When `responseModel` is omitted, the LLM schema falls back to `returns`. Separating the two lets a tool combine LLM-produced fields with deterministic, function-computed fields without forcing the LLM to emit the deterministic ones.
 
 ## Provider Selector
 
@@ -140,6 +143,26 @@ agent.addTool({
     // Returns AssistResponse type
     const result = await llm(query);
     return JSON.stringify(result);
+  },
+});
+```
+
+### Separating LLM output from deterministic fields
+
+Use `responseModel` for the schema the LLM must emit and `returns` for what
+`execute` returns to callers. This keeps the LLM focused on the fields it
+should produce, while `execute` adds deterministic, function-computed fields:
+
+```typescript
+const runDaily = mesh.llm({
+  name: "run_daily",
+  provider: { capability: "llm", tags: ["+openai"] },
+  parameters: z.object({ email: z.string() }),
+  responseModel: AnalystOutput,   // what the LLM must emit (focused)
+  returns: RunDailyResult,        // what execute returns to callers (LLM fields + deterministic context)
+  execute: async ({ email }, { llm }) => {
+    const analyst = await llm("...");                 // typed/validated as AnalystOutput
+    return { ...analyst, email, date: today(), totalValue }; // RunDailyResult
   },
 });
 ```

--- a/docs/typescript/mesh-functions.md
+++ b/docs/typescript/mesh-functions.md
@@ -101,6 +101,8 @@ agent.addTool({
     contextParam: "ctx",                 // Parameter name for context
     filter: [{ tags: ["tools"] }],       // Tool filter for discovery
     filterMode: "all",                   // "all", "best_match", or "*"
+    responseModel: AnalystOutput,        // Optional: schema the LLM must emit (drives structured output)
+    returns: RunDailyResult,             // Optional: schema for what execute returns to callers
   }),
   capability: "smart_assistant",
   description: "LLM-powered assistant",
@@ -114,6 +116,8 @@ agent.addTool({
   },
 });
 ```
+
+`responseModel` is the schema the LLM is required to emit and is validated against (and types the injected `llm` callable); `returns` types what `execute` returns to callers. When `responseModel` is omitted, the LLM schema falls back to `returns`. See `meshctl man llm --typescript` for a combined-fields example.
 
 ### Filter Modes
 

--- a/src/core/cli/man/content/decorators_typescript.md
+++ b/src/core/cli/man/content/decorators_typescript.md
@@ -150,6 +150,8 @@ agent.addTool({
     contextParam: "ctx",                 // Parameter name for context
     filter: [{ tags: ["tools"] }],       // Tool filter for discovery
     filterMode: "all",                   // "all", "best_match", or "*"
+    responseModel: AnalystOutput,        // Optional: schema the LLM must emit (drives structured output)
+    returns: RunDailyResult,             // Optional: schema for what execute returns to callers
   }),
   capability: "smart_assistant",
   description: "LLM-powered assistant",
@@ -163,6 +165,8 @@ agent.addTool({
   },
 });
 ```
+
+`responseModel` is the schema the LLM is required to emit and is validated against (and types the injected `llm` callable); `returns` types what `execute` returns to callers. When `responseModel` is omitted, the LLM schema falls back to `returns`. See `meshctl man llm --typescript` for a combined-fields example.
 
 ### Filter Modes
 

--- a/src/core/cli/man/content/llm_typescript.md
+++ b/src/core/cli/man/content/llm_typescript.md
@@ -63,7 +63,10 @@ agent.addTool({
 | `contextParam`  | `string`          | Parameter name passed to template context        |
 | `filter`        | `LlmFilterSpec[]` | Tool filter for discovery                        |
 | `filterMode`    | `string`          | How to select tools: "all", "best_match", "\*"   |
-| `returns`       | `ZodType`         | Optional: Schema for structured output           |
+| `responseModel` | `ZodType`         | Optional: Schema the LLM must emit (drives structured output) |
+| `returns`       | `ZodType`         | Optional: Schema for what `execute` returns to callers |
+
+When `responseModel` is set, it is the schema the LLM is required to emit and is validated against, and it drives the provider's structured-output schema; the injected `llm` callable is typed by it. `returns` independently types what `execute` returns to callers. When `responseModel` is omitted, the LLM schema falls back to `returns`. Separating the two lets a tool combine LLM-produced fields with deterministic, function-computed fields without forcing the LLM to emit the deterministic ones.
 
 ## Calling llm()
 
@@ -150,6 +153,26 @@ agent.addTool({
     // Returns AssistResponse type
     const result = await llm(query);
     return JSON.stringify(result);
+  },
+});
+```
+
+### Separating LLM output from deterministic fields
+
+Use `responseModel` for the schema the LLM must emit and `returns` for what
+`execute` returns to callers. This keeps the LLM focused on the fields it
+should produce, while `execute` adds deterministic, function-computed fields:
+
+```typescript
+const runDaily = mesh.llm({
+  name: "run_daily",
+  provider: { capability: "llm", tags: ["+openai"] },
+  parameters: z.object({ email: z.string() }),
+  responseModel: AnalystOutput,   // what the LLM must emit (focused)
+  returns: RunDailyResult,        // what execute returns to callers (LLM fields + deterministic context)
+  execute: async ({ email }, { llm }) => {
+    const analyst = await llm("...");                 // typed/validated as AnalystOutput
+    return { ...analyst, email, date: today(), totalValue }; // RunDailyResult
   },
 });
 ```

--- a/src/runtime/typescript/src/__tests__/llm-response-model.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-response-model.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for mesh.llm() responseModel option (issue #1094).
+ *
+ * `responseModel` specifies the schema the LLM must emit and is validated
+ * against (it feeds the provider's structured-output schema and the response
+ * parser). When omitted it falls back to `returns`. `returns` continues to
+ * type what `execute` returns to callers.
+ */
+
+import { describe, it, expect, expectTypeOf } from "vitest";
+import { z } from "zod";
+import { llm } from "../llm.js";
+
+const BigSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  body: z.string(),
+  metadata: z.record(z.string(), z.unknown()),
+});
+
+const SmallSchema = z.object({
+  id: z.string(),
+});
+
+const baseConfig = {
+  provider: { capability: "llm-service" },
+  parameters: z.object({ query: z.string() }),
+};
+
+describe("mesh.llm responseModel", () => {
+  it("uses responseModel as returnSchema when both responseModel and returns are provided", () => {
+    const tool = llm({
+      ...baseConfig,
+      name: "tool-with-response-model",
+      responseModel: SmallSchema,
+      returns: BigSchema,
+      execute: async () => ({
+        id: "1",
+        title: "t",
+        body: "b",
+        metadata: {},
+      }),
+    });
+
+    // returnSchema drives provider output schema + ResponseParser; must be the
+    // responseModel, not the (broader) returns type.
+    expect(tool._meshLlmConfig.returnSchema).toBe(SmallSchema);
+    expect(tool._meshLlmConfig.returnSchema).not.toBe(BigSchema);
+  });
+
+  it("falls back to returns when responseModel is omitted (back-compat)", () => {
+    const tool = llm({
+      ...baseConfig,
+      name: "tool-with-returns-only",
+      returns: BigSchema,
+      execute: async () => ({
+        id: "1",
+        title: "t",
+        body: "b",
+        metadata: {},
+      }),
+    });
+
+    expect(tool._meshLlmConfig.returnSchema).toBe(BigSchema);
+  });
+
+  it("leaves returnSchema undefined when neither is provided (string mode)", () => {
+    const tool = llm({
+      ...baseConfig,
+      name: "tool-with-neither",
+      execute: async () => "hello",
+    });
+
+    expect(tool._meshLlmConfig.returnSchema).toBeUndefined();
+  });
+
+  it("types the injected llm callable by responseModel when provided", () => {
+    llm({
+      ...baseConfig,
+      name: "tool-type-response-model",
+      responseModel: SmallSchema,
+      returns: BigSchema,
+      execute: async (_args, { llm: llmCallable }) => {
+        // The injected callable is typed by responseModel (SmallSchema), not returns.
+        expectTypeOf(llmCallable).returns.resolves.toEqualTypeOf<
+          z.infer<typeof SmallSchema>
+        >();
+        // execute's own return type still follows `returns` (BigSchema).
+        return { id: "1", title: "t", body: "b", metadata: {} };
+      },
+    });
+  });
+
+  it("types the injected llm callable by returns when no responseModel", () => {
+    llm({
+      ...baseConfig,
+      name: "tool-type-returns",
+      returns: BigSchema,
+      execute: async (_args, { llm: llmCallable }) => {
+        expectTypeOf(llmCallable).returns.resolves.toEqualTypeOf<
+          z.infer<typeof BigSchema>
+        >();
+        return { id: "1", title: "t", body: "b", metadata: {} };
+      },
+    });
+  });
+});

--- a/src/runtime/typescript/src/llm.ts
+++ b/src/runtime/typescript/src/llm.ts
@@ -210,9 +210,10 @@ export interface FastMcpToolDef {
  */
 export function llm<
   TParams extends ZodType,
-  TReturns extends ZodType | undefined = undefined
+  TReturns extends ZodType | undefined = undefined,
+  TResponse extends ZodType | undefined = undefined
 >(
-  config: MeshLlmConfig<TParams, TReturns>
+  config: MeshLlmConfig<TParams, TReturns, TResponse>
 ): FastMcpToolDef & { _meshLlmConfig: LlmToolConfig } {
   const registry = LlmToolRegistry.getInstance();
 
@@ -239,7 +240,7 @@ export function llm<
     topP: config.topP,
     stop: config.stop,
     inputSchema: JSON.stringify(zodToJsonSchema(config.parameters, { $refStrategy: "none" })),
-    returnSchema: config.returns,
+    returnSchema: config.responseModel ?? config.returns,
     outputMode: config.outputMode ?? "hint",
     parallelToolCalls: config.parallelToolCalls ?? false,
     execute: config.execute as LlmToolConfig["execute"],
@@ -345,7 +346,7 @@ export function llm<
 
             // Call user's execute handler
             debug.llm(`Calling user execute handler`);
-            const result = await llmConfig.execute(cleanArgs, { llm: llmCallable as LlmAgent<TReturns extends ZodType ? z.infer<TReturns> : string> });
+            const result = await llmConfig.execute(cleanArgs, { llm: llmCallable as LlmAgent<TResponse extends ZodType ? z.infer<TResponse> : TReturns extends ZodType ? z.infer<TReturns> : string> });
             debug.llm(`Execute completed successfully`);
 
             // Convert result to string for MCP

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -835,7 +835,11 @@ export interface LlmCompletionResponse {
 /**
  * Configuration for mesh.llm() tool definition.
  */
-export interface MeshLlmConfig<TParams extends z.ZodType, TReturns extends z.ZodType | undefined = undefined> {
+export interface MeshLlmConfig<
+  TParams extends z.ZodType,
+  TReturns extends z.ZodType | undefined = undefined,
+  TResponse extends z.ZodType | undefined = undefined
+> {
   /** Tool name (used in MCP protocol) */
   name: string;
   /** Capability name for mesh discovery. Defaults to tool name */
@@ -885,6 +889,14 @@ export interface MeshLlmConfig<TParams extends z.ZodType, TReturns extends z.Zod
   /** Zod schema for structured output (optional - returns string if not specified) */
   returns?: TReturns;
   /**
+   * Zod schema the LLM must emit and is validated against (feeds the provider's
+   * structured-output schema and the response parser). When omitted, falls back
+   * to `returns`. Use this when the schema the model should produce differs from
+   * the type your `execute` handler returns to callers — `returns` continues to
+   * type what `execute` returns to callers.
+   */
+  responseModel?: TResponse;
+  /**
    * Output mode for response parsing:
    * - "strict": Enforce exact schema compliance (use provider's native structured output if available)
    * - "hint": Include schema in prompt but accept any response (default)
@@ -900,7 +912,13 @@ export interface MeshLlmConfig<TParams extends z.ZodType, TReturns extends z.Zod
     args: z.infer<TParams>,
     context: {
       /** Call the LLM with the user message */
-      llm: LlmAgent<TReturns extends z.ZodType ? z.infer<TReturns> : string>;
+      llm: LlmAgent<
+        TResponse extends z.ZodType
+          ? z.infer<TResponse>
+          : TReturns extends z.ZodType
+          ? z.infer<TReturns>
+          : string
+      >;
     }
   ) => Promise<TReturns extends z.ZodType ? z.infer<TReturns> : string>;
 }


### PR DESCRIPTION
## Summary

Parity with the Python `response_model=` feature (#1085). `mesh.llm()`'s `returns` Zod schema previously served two concerns at once: the schema the LLM must emit (provider structured-output + `ResponseParser` validation) **and** the type the `execute` handler returns to callers. Tools combining LLM-produced fields with deterministic, function-computed fields were forced to make the LLM emit (and possibly hallucinate) the deterministic fields too.

Add an optional `responseModel?: ZodType` to `MeshLlmConfig` (new `TResponse` generic):
- The injected `llm` callable is typed by `responseModel` when provided (else `returns`, else `string`), and the internal `returnSchema` — which feeds the provider structured-output schema and the `ResponseParser` — becomes `responseModel ?? returns`.
- `execute`'s return type stays `returns`-based (unchanged).
- When `responseModel` is omitted, behavior is **byte-for-byte unchanged** — fully additive.

```ts
const runDaily = mesh.llm({
  name: "run_daily",
  provider: { capability: "llm", tags: ["+openai"] },
  parameters: z.object({ email: z.string() }),
  responseModel: AnalystOutput,   // what the LLM must emit (focused)
  returns: RunDailyResult,        // what execute returns to callers
  execute: async ({ email }, { llm }) => {
    const analyst = await llm("...");                       // typed/validated as AnalystOutput
    return { ...analyst, email, date: today(), totalValue }; // RunDailyResult
  },
});
```

TS publishes no separate tool `outputSchema` for LLM tools (only `inputSchema` is registered), so `returnSchema = responseModel ?? returns` is the complete wiring — no other path treats `returns` as a published output schema (verified).

## Cross-runtime standardization

- Python: `response_model=` (#1085, merged)
- **TypeScript: this PR** (`responseModel`)
- Java: already separable via `llm.generate(Class<T>)` + `@MeshTool(outputType=…)`; docs parity tracked in #1095.

## Tests

`src/__tests__/llm-response-model.test.ts`: `responseModel` wins for `returnSchema` (with negative guard), `returns`-only fallback, neither → `undefined`, plus compile-time `expectTypeOf` assertions that the injected callable is typed by `responseModel` while `execute`'s return stays `returns`-typed. `tsc` type-check + build pass; 94 existing llm tests unaffected.

## Docs

`responseModel` added to the TS `mesh.llm` man pages (`llm_typescript.md`, `decorators_typescript.md`) and docs (`typescript/llm/index.md`, `typescript/mesh-functions.md`), with the combined-fields example.

## Review notes

Independent review: 0 blockers, 0 warnings (3 trivial cosmetic INFOs, not actioned). Generic default-param ordering verified non-breaking; `??` precedence and back-compat confirmed.

Closes #1094

## Test plan

- [x] `npm run typecheck` (tsc --noEmit) — passes (generics + expectTypeOf assertions)
- [x] `npm run build` — passes
- [x] `vitest run llm-response-model` — 5/5; regression 94/94
- [x] Back-compat: no `responseModel` → `returnSchema == returns` (pinned)
- [x] Docs updated on canonical TS man + docs surfaces
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `responseModel` parameter to define the schema the LLM must emit, enabling separation of validated LLM output from deterministic computed fields.

* **Documentation**
  * Updated guides explaining `responseModel` configuration and its relationship with the `returns` parameter, including examples of combining both for flexible tool return types.

* **Tests**
  * Added comprehensive test coverage for `responseModel` behavior and type inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->