### PR TITLE
docs(java): document @MeshLlm response-model vs tool-output separation (#1095)

### DIFF
--- a/docs/java/llm/index.md
+++ b/docs/java/llm/index.md
@@ -92,6 +92,31 @@ AnalysisResult result = llm.request()
     .generate(AnalysisResult.class);
 ```
 
+### Separating LLM output from deterministic fields
+
+The class passed to `generate(X.class)` is the **response model** — the schema the
+LLM must emit and is validated against. It is independent of `@MeshTool(outputType = Y.class)`,
+which sets the tool's published output schema (what callers receive). Have the LLM emit only
+a focused subset of fields, then return a fuller payload that combines those with
+deterministic, function-computed fields:
+
+```java
+public record AnalystOutput(String summary, List<String> riskFlags) {}            // LLM emits this (focused)
+public record RunDailyResult(String email, String date, double totalValue,
+                             String summary, List<String> riskFlags) {}           // tool returns this
+
+@MeshLlm(
+    providerSelector = @Selector(capability = "llm", tags = {"+openai"}),
+    systemPrompt = "classpath:prompts/analyst.ftl"
+)
+@MeshTool(capability = "analysis.run_daily", outputType = RunDailyResult.class)   // tool outputSchema
+public RunDailyResult runDaily(RunDailyContext ctx, MeshLlmAgent llm) {
+    AnalystOutput analyst = llm.generate("Analyze the portfolio", AnalystOutput.class);  // LLM emits the focused schema
+    return new RunDailyResult(ctx.email(), today(), ctx.totalValue(),
+                              analyst.summary(), analyst.riskFlags());            // tool returns the full payload
+}
+```
+
 ### With System Prompt Override
 
 ```java

--- a/src/core/cli/man/content/decorators_java.md
+++ b/src/core/cli/man/content/decorators_java.md
@@ -280,6 +280,11 @@ if (llm != null && llm.isAvailable()) { /* ... */ }
 llm.request().lastMeta();
 ```
 
+The class passed to `generate(X.class)` is the **response model** the LLM must emit, and is
+independent of `@MeshTool(outputType = Y.class)` (the tool's published output schema) and the
+method's return type — so a tool can have the LLM emit a focused subset and return a fuller
+payload that adds deterministic fields. See `meshctl man llm --java` for a worked example.
+
 ## @MeshLlmProvider
 
 Creates a zero-code LLM provider. No implementation needed - the annotation handles everything.

--- a/src/core/cli/man/content/llm_java.md
+++ b/src/core/cli/man/content/llm_java.md
@@ -130,6 +130,31 @@ AnalysisResult result = llm.request()
     .generate(AnalysisResult.class);
 ```
 
+### Separating LLM output from deterministic fields
+
+The class passed to `generate(X.class)` is the **response model** — the schema the
+LLM must emit and is validated against. It is independent of `@MeshTool(outputType = Y.class)`,
+which sets the tool's published output schema (what callers receive). Have the LLM emit only
+a focused subset of fields, then return a fuller payload that combines those with
+deterministic, function-computed fields:
+
+```java
+public record AnalystOutput(String summary, List<String> riskFlags) {}            // LLM emits this (focused)
+public record RunDailyResult(String email, String date, double totalValue,
+                             String summary, List<String> riskFlags) {}           // tool returns this
+
+@MeshLlm(
+    providerSelector = @Selector(capability = "llm", tags = {"+openai"}),
+    systemPrompt = "classpath:prompts/analyst.ftl"
+)
+@MeshTool(capability = "analysis.run_daily", outputType = RunDailyResult.class)   // tool outputSchema
+public RunDailyResult runDaily(RunDailyContext ctx, MeshLlmAgent llm) {
+    AnalystOutput analyst = llm.generate("Analyze the portfolio", AnalystOutput.class);  // LLM emits the focused schema
+    return new RunDailyResult(ctx.email(), today(), ctx.totalValue(),
+                              analyst.summary(), analyst.riskFlags());            // tool returns the full payload
+}
+```
+
 ### With System Prompt Override
 
 ```java

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlm.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlm.java
@@ -30,6 +30,37 @@ import java.lang.annotation.Target;
  * }
  * }</pre>
  *
+ * <h2>Response model vs tool output</h2>
+ * <p>Three types are involved in an LLM-powered tool, and they are independent:
+ * <ul>
+ *   <li>The {@code Class<T>} passed to {@code llm.generate(..., T.class)} is the
+ *       <b>response model</b> — the schema the LLM must <i>emit</i>, which the
+ *       provider's structured-output schema is built from and which the result
+ *       is validated/deserialized against.</li>
+ *   <li>{@link MeshTool#outputType()} is the tool's published {@code outputSchema}
+ *       — what <i>callers</i> receive.</li>
+ *   <li>The method's return type is what the method actually returns.</li>
+ * </ul>
+ * <p>Because they are separate, a tool can have the LLM emit only a focused
+ * subset of fields while the tool returns a fuller payload that combines those
+ * LLM-produced fields with deterministic, function-computed fields:
+ * <pre>{@code
+ * public record AnalystOutput(String summary, java.util.List<String> riskFlags) {}      // LLM emits this (focused)
+ * public record RunDailyResult(String email, String date, double totalValue,
+ *                              String summary, java.util.List<String> riskFlags) {}      // tool returns this
+ *
+ * @MeshLlm(
+ *     providerSelector = @Selector(capability = "llm", tags = {"+openai"}),
+ *     systemPrompt = "classpath://prompts/analyst.ftl"
+ * )
+ * @MeshTool(capability = "analysis.run_daily", outputType = RunDailyResult.class)        // tool outputSchema
+ * public RunDailyResult runDaily(RunDailyContext ctx, MeshLlmAgent llm) {
+ *     AnalystOutput analyst = llm.generate("Analyze the portfolio", AnalystOutput.class); // LLM emits the focused schema
+ *     return new RunDailyResult(ctx.email(), today(), ctx.totalValue(),
+ *                               analyst.summary(), analyst.riskFlags());                   // tool returns the full payload
+ * }
+ * }</pre>
+ *
  * <h2>System Prompts</h2>
  * <p>System prompts can be:
  * <ul>


### PR DESCRIPTION
## Summary

Cross-runtime parity with the Python `response_model=` (#1085) and TypeScript `responseModel` (#1094) features — **documentation only, no runtime/API change.**

Unlike Python and TypeScript (which forced `LLM schema == return type` and needed a new option), the Java runtime **already separates** the two concerns:

- `llm.generate(ResponseModel.class)` — the schema the LLM must **emit** and is validated/deserialized against (builds the provider's structured-output schema).
- `@MeshTool(outputType = ReturnType.class)` — the tool's published `outputSchema` (what **callers** receive).
- The method's return type — what the method actually returns.

Because these are independent, a Java tool can have the LLM emit only a focused subset while returning a fuller payload that combines LLM-produced fields with deterministic, function-computed fields — the same capability the other two runtimes just gained.

```java
public record AnalystOutput(String summary, List<String> riskFlags) {}      // LLM emits this (focused)
public record RunDailyResult(String email, String date, double totalValue,
                             String summary, List<String> riskFlags) {}      // tool returns this

@MeshLlm(providerSelector = @Selector(capability = "llm", tags = {"+openai"}),
         systemPrompt = "classpath://prompts/analyst.ftl")
@MeshTool(capability = "analysis.run_daily", outputType = RunDailyResult.class)  // tool outputSchema
public RunDailyResult runDaily(RunDailyContext ctx, MeshLlmAgent llm) {
    AnalystOutput analyst = llm.generate("Analyze the portfolio", AnalystOutput.class); // LLM emits focused schema
    return new RunDailyResult(ctx.email(), today(), ctx.totalValue(),
                              analyst.summary(), analyst.riskFlags());                   // tool returns full payload
}
```

## Where documented (parallel man + docs)

- `@MeshLlm` javadoc — new "Response model vs tool output" section (**javadoc-only**, verified additive).
- man `llm_java.md` — "Separating LLM output from deterministic fields" subsection.
- `docs/java/llm/index.md` — parallel subsection.
- man `decorators_java.md` — brief note pointing at the llm page.

## Cross-runtime standardization — complete

| Runtime | Mechanism | Status |
|---|---|---|
| Python | `response_model=` | merged (#1085 / #1096) |
| TypeScript | `responseModel` | merged (#1094 / #1097) |
| Java | `generate(Class<T>)` + `@MeshTool(outputType=…)` (already supported) | **this PR** (docs) |

## Out of scope

No runtime/SDK code, annotation attributes, or example projects changed (the combined-fields example lives in the doc prose). `mvn compile` on the SDK module was clean (javadoc-only sanity check).

Closes #1095

🤖 Generated with [Claude Code](https://claude.com/claude-code)
