### PR TITLE
feat(meshctl): add --header/-H flag to meshctl call (#1084)

### DIFF
--- a/src/core/cli/call.go
+++ b/src/core/cli/call.go
@@ -149,6 +149,9 @@ Ingress mode (for Kubernetes clusters with ingress configured):
 	// Tracing flag (Issue #310)
 	cmd.Flags().Bool("trace", false, "Display trace ID for distributed tracing (use with 'meshctl trace <id>' to view call tree)")
 
+	// Arbitrary outbound HTTP headers (Issue #1084)
+	cmd.Flags().StringArrayP("header", "H", nil, "HTTP header to add to the outbound request, repeatable (format: 'Key: Value')")
+
 	return cmd
 }
 
@@ -198,6 +201,14 @@ func runCallCommand(cmd *cobra.Command, args []string) error {
 	ingressURL, _ := cmd.Flags().GetString("ingress-url")
 	useProxy, _ := cmd.Flags().GetBool("use-proxy")
 	traceFlag, _ := cmd.Flags().GetBool("trace")
+
+	// Parse and validate user-supplied headers early so we fail fast on
+	// malformed input before making any network call (Issue #1084).
+	headerFlags, _ := cmd.Flags().GetStringArray("header")
+	userHeaders, err := parseHeaderFlags(headerFlags)
+	if err != nil {
+		return err
+	}
 
 	// Generate trace context if --trace flag is set (Issue #310)
 	var traceCtx *TraceContext
@@ -261,9 +272,9 @@ func runCallCommand(cmd *cobra.Command, args []string) error {
 	var callResult *MCPCallResult
 	if ingressDomain != "" && agentURL == "" {
 		// Ingress mode: need Host header
-		callResult, err = callMCPToolWithHost(httpClient, agentEndpoint, agentHostHeader, resolvedToolName, toolArgs, traceCtx, timeout)
+		callResult, err = callMCPToolWithHost(httpClient, agentEndpoint, agentHostHeader, resolvedToolName, toolArgs, userHeaders, traceCtx, timeout)
 	} else {
-		callResult, err = callMCPTool(httpClient, agentEndpoint, resolvedToolName, toolArgs, traceCtx, timeout)
+		callResult, err = callMCPTool(httpClient, agentEndpoint, resolvedToolName, toolArgs, userHeaders, traceCtx, timeout)
 	}
 	if err != nil {
 		return fmt.Errorf("MCP call failed: %w", err)
@@ -298,6 +309,31 @@ func parseToolSpecifier(spec string) (agentName, toolName string) {
 		return parts[0], parts[1]
 	}
 	return "", parts[0]
+}
+
+// parseHeaderFlags converts repeatable "Key: Value" strings (from --header/-H,
+// Issue #1084) into an http.Header. Splits on the FIRST colon; trims surrounding
+// whitespace from key and value; rejects entries with no colon or an empty key.
+// An empty value is allowed. Repeated same-key flags accumulate via Add.
+// Returns nil, nil for empty input.
+func parseHeaderFlags(raw []string) (http.Header, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	headers := http.Header{}
+	for _, s := range raw {
+		parts := strings.SplitN(s, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid header %q: expected format 'Key: Value'", s)
+		}
+		key := strings.TrimSpace(parts[0])
+		if key == "" {
+			return nil, fmt.Errorf("invalid header %q: empty key", s)
+		}
+		value := strings.TrimSpace(parts[1])
+		headers.Add(key, value)
+	}
+	return headers, nil
 }
 
 // createHTTPClient returns an HTTP client with the specified timeout.
@@ -661,7 +697,7 @@ func isIPAddress(s string) bool {
 }
 
 // callMCPToolWithHost makes an MCP tools/call request with a custom Host header (for ingress)
-func callMCPToolWithHost(client *http.Client, endpoint, hostHeader, toolName string, args map[string]interface{}, traceCtx *TraceContext, timeout int) (*MCPCallResult, error) {
+func callMCPToolWithHost(client *http.Client, endpoint, hostHeader, toolName string, args map[string]interface{}, userHeaders http.Header, traceCtx *TraceContext, timeout int) (*MCPCallResult, error) {
 	// Inject trace context into arguments (for agents that can't access HTTP headers)
 	// This is in addition to HTTP headers for maximum compatibility
 	argsWithTrace := args
@@ -694,6 +730,15 @@ func callMCPToolWithHost(client *http.Client, endpoint, hostHeader, toolName str
 	req, err := http.NewRequest("POST", mcpURL, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// User-supplied headers (#1084) are applied first so framework-managed
+	// headers below (Content-Type, Accept, X-Mesh-Timeout, X-Trace-ID, Host)
+	// always win on conflict and can't be broken by user input.
+	for k, vs := range userHeaders {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -772,7 +817,7 @@ func callMCPToolWithHost(client *http.Client, endpoint, hostHeader, toolName str
 }
 
 // callMCPTool makes an MCP tools/call request to the agent
-func callMCPTool(client *http.Client, endpoint, toolName string, args map[string]interface{}, traceCtx *TraceContext, timeout int) (*MCPCallResult, error) {
+func callMCPTool(client *http.Client, endpoint, toolName string, args map[string]interface{}, userHeaders http.Header, traceCtx *TraceContext, timeout int) (*MCPCallResult, error) {
 	// Inject trace context into arguments (for agents that can't access HTTP headers)
 	// This is in addition to HTTP headers for maximum compatibility
 	argsWithTrace := args
@@ -805,6 +850,15 @@ func callMCPTool(client *http.Client, endpoint, toolName string, args map[string
 	req, err := http.NewRequest("POST", mcpURL, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// User-supplied headers (#1084) are applied first so framework-managed
+	// headers below (Content-Type, Accept, X-Mesh-Timeout, X-Trace-ID, Host)
+	// always win on conflict and can't be broken by user input.
+	for k, vs := range userHeaders {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
 	}
 
 	req.Header.Set("Content-Type", "application/json")

--- a/src/core/cli/call_test.go
+++ b/src/core/cli/call_test.go
@@ -351,6 +351,171 @@ func TestFindAgentWithToolIngress_CapabilityToolStillAmbiguous(t *testing.T) {
 	}
 }
 
+// TestParseHeaderFlags covers --header/-H parsing (Issue #1084): malformed
+// entries error, valid entries set headers, whitespace is trimmed, empty
+// values are allowed, repeated keys accumulate, and empty input is a no-op.
+func TestParseHeaderFlags(t *testing.T) {
+	t.Run("no colon errors", func(t *testing.T) {
+		_, err := parseHeaderFlags([]string{"Authorization Bearer abc"})
+		if err == nil {
+			t.Fatal("expected error for header with no colon")
+		}
+	})
+
+	t.Run("empty key errors", func(t *testing.T) {
+		_, err := parseHeaderFlags([]string{": value"})
+		if err == nil {
+			t.Fatal("expected error for empty key")
+		}
+	})
+
+	t.Run("valid single header", func(t *testing.T) {
+		h, err := parseHeaderFlags([]string{"Authorization: Bearer abc"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := h.Get("Authorization"); got != "Bearer abc" {
+			t.Errorf("got %q, want %q", got, "Bearer abc")
+		}
+	})
+
+	t.Run("whitespace trimmed", func(t *testing.T) {
+		h, err := parseHeaderFlags([]string{"  Key :  val "})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := h["Key"]; !ok {
+			t.Errorf("expected canonical key %q in %v", "Key", h)
+		}
+		if got := h.Get("Key"); got != "val" {
+			t.Errorf("got %q, want %q", got, "val")
+		}
+	})
+
+	t.Run("empty value allowed", func(t *testing.T) {
+		h, err := parseHeaderFlags([]string{"X-Flag:"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		vals, ok := h["X-Flag"]
+		if !ok || len(vals) != 1 || vals[0] != "" {
+			t.Errorf("expected one empty value for X-Flag, got %v", h)
+		}
+	})
+
+	t.Run("repeated key accumulates", func(t *testing.T) {
+		h, err := parseHeaderFlags([]string{"X-Multi: a", "X-Multi: b"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		vals := h["X-Multi"]
+		if len(vals) != 2 || vals[0] != "a" || vals[1] != "b" {
+			t.Errorf("expected [a b] for X-Multi, got %v", vals)
+		}
+	})
+
+	t.Run("value with colon preserved", func(t *testing.T) {
+		h, err := parseHeaderFlags([]string{"X-URL: http://example.com:8080"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := h.Get("X-URL"); got != "http://example.com:8080" {
+			t.Errorf("got %q, want %q", got, "http://example.com:8080")
+		}
+	})
+
+	t.Run("empty input is nil no error", func(t *testing.T) {
+		h, err := parseHeaderFlags(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if h != nil {
+			t.Errorf("expected nil header for empty input, got %v", h)
+		}
+	})
+}
+
+// mockMCPAgent returns an httptest server that captures the headers of the
+// last received request and replies with a minimal valid MCP result.
+func mockMCPAgent(t *testing.T, captured *http.Header) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*captured = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(MCPResponse{
+			JSONRPC: "2.0",
+			ID:      1,
+			Result:  json.RawMessage(`{"ok":true}`),
+		})
+	}))
+}
+
+// TestCallMCPTool_UserHeadersAndFrameworkPrecedence covers Issue #1084:
+// user-supplied headers reach the agent, but framework-managed headers
+// (Content-Type, X-Trace-ID, X-Mesh-Timeout) always win on conflict.
+func TestCallMCPTool_UserHeadersAndFrameworkPrecedence(t *testing.T) {
+	var got http.Header
+	srv := mockMCPAgent(t, &got)
+	defer srv.Close()
+
+	traceCtx := &TraceContext{TraceID: "real-framework-trace", SpanID: "span-1"}
+	userHeaders, err := parseHeaderFlags([]string{
+		"Authorization: Bearer abc",
+		"X-Trace-ID: user-should-lose",
+		"Content-Type: text/plain",
+	})
+	if err != nil {
+		t.Fatalf("parseHeaderFlags failed: %v", err)
+	}
+
+	_, err = callMCPTool(http.DefaultClient, srv.URL, "do_thing", map[string]interface{}{}, userHeaders, traceCtx, 30)
+	if err != nil {
+		t.Fatalf("callMCPTool failed: %v", err)
+	}
+
+	if got.Get("Authorization") != "Bearer abc" {
+		t.Errorf("custom header not forwarded: Authorization=%q", got.Get("Authorization"))
+	}
+	if got.Get("X-Trace-ID") != "real-framework-trace" {
+		t.Errorf("framework X-Trace-ID should win, got %q", got.Get("X-Trace-ID"))
+	}
+	if got.Get("Content-Type") != "application/json" {
+		t.Errorf("framework Content-Type should win, got %q", got.Get("Content-Type"))
+	}
+	if got.Get("X-Mesh-Timeout") != "30" {
+		t.Errorf("framework X-Mesh-Timeout should be set, got %q", got.Get("X-Mesh-Timeout"))
+	}
+}
+
+// TestCallMCPToolWithHost_UserHeadersAndFrameworkPrecedence is the
+// ingress-path counterpart for Issue #1084.
+func TestCallMCPToolWithHost_UserHeadersAndFrameworkPrecedence(t *testing.T) {
+	var got http.Header
+	srv := mockMCPAgent(t, &got)
+	defer srv.Close()
+
+	traceCtx := &TraceContext{TraceID: "real-framework-trace", SpanID: "span-1"}
+	userHeaders, err := parseHeaderFlags([]string{
+		"Authorization: Bearer abc",
+		"X-Trace-ID: user-should-lose",
+	})
+	if err != nil {
+		t.Fatalf("parseHeaderFlags failed: %v", err)
+	}
+
+	_, err = callMCPToolWithHost(http.DefaultClient, srv.URL, "", "do_thing", map[string]interface{}{}, userHeaders, traceCtx, 30)
+	if err != nil {
+		t.Fatalf("callMCPToolWithHost failed: %v", err)
+	}
+
+	if got.Get("Authorization") != "Bearer abc" {
+		t.Errorf("custom header not forwarded: Authorization=%q", got.Get("Authorization"))
+	}
+	if got.Get("X-Trace-ID") != "real-framework-trace" {
+		t.Errorf("framework X-Trace-ID should win, got %q", got.Get("X-Trace-ID"))
+	}
+}
+
 // TestAuditShortIsHelpful covers issue #956 item #22: the audit command's
 // Short text must convey when a user would reach for it (routing/why).
 func TestAuditShortIsHelpful(t *testing.T) {

--- a/src/core/cli/man/content/cli.md
+++ b/src/core/cli/man/content/cli.md
@@ -142,7 +142,23 @@ meshctl call get_weather --agent-url http://localhost:8080
 # Capture a trace ID for distributed tracing
 meshctl call smart_analyze '{"query": "test"}' --trace
 # Output includes: Trace ID: abc123...
+
+# Add arbitrary outbound HTTP headers (-H is repeatable)
+meshctl call get_weather -H "Authorization: Bearer $TOKEN"
+meshctl call get_weather -H "Authorization: Bearer $TOKEN" -H "X-Tenant: acme"
+# Framework-managed headers (X-Trace-ID, X-Mesh-Timeout, Host) always take
+# precedence and cannot be overridden by --header.
 ```
+
+**Flags**
+
+| Flag                | Description                                                                       |
+| ------------------- | --------------------------------------------------------------------------------- |
+| `--header`, `-H`    | HTTP header to add to the outbound request, repeatable (format: `'Key: Value'`)   |
+| `--trace`           | Display a trace ID for distributed tracing                                        |
+| `--use-proxy`       | Route through the registry proxy (default true)                                   |
+| `--agent-url`       | Call an agent directly, bypassing registry endpoint lookup                        |
+| `--file`            | Read tool arguments from a JSON file                                              |
 
 ### `meshctl trace`
 


### PR DESCRIPTION
## Summary

`meshctl call` had no way to pass arbitrary outbound HTTP headers (e.g. `Authorization: Bearer <token>`), so exercising auth/tenancy-protected mesh tools meant dropping down to `curl` — losing agent-name→endpoint resolution, ingress Host construction, JSON arg shaping, and trace propagation.

Add a repeatable `--header`/`-H` flag, reusing the same `req.Header` mechanism already used for `X-Trace-ID`:

```bash
meshctl call create_debate -H "Authorization: Bearer tok_abc123" --json '{"topic":"..."}'
meshctl call run_workflow \
  -H "Authorization: Bearer tok_abc123" \
  -H "X-Tenant-Id: acme-corp" \
  --json '{...}'
```

## Implementation

- `parseHeaderFlags()` — splits each entry on the **first** colon (so values like `http://host:8080` survive), trims key/value, rejects entries with no colon or an empty key (error names the offending entry), allows empty values, and accumulates repeated keys. Parsed/validated **early** in `runCallCommand` so malformed input fails before any network call.
- `userHeaders` threaded into both `callMCPTool` and `callMCPToolWithHost`, applied via `req.Header.Add` **immediately after `http.NewRequest` and before** the framework `Set(...)` calls — so framework-managed headers (`Content-Type`, `Accept`, `X-Mesh-Timeout`, `X-Trace-ID`, `Host`) always win on conflict and can't be broken by user input.

## Docs

Documented `-H` on the `meshctl call` man section (`cli.md`) with bearer, multi-header, and precedence examples. (`docs/meshctl-cli.md` only mentions `call` in passing — no flag table — so it was left alone.)

## Tests

- `parseHeaderFlags` edge cases: no-colon / empty-key rejection, whitespace trim, value-with-colon preserved, empty value allowed, repeated-key accumulation, empty input → nil.
- httptest precedence tests for **both** call paths: the custom header (`Authorization`) arrives on the wire, and conflicting framework keys (`X-Trace-ID`, `Content-Type`) keep their framework values.

## Review notes

Independent review: 0 blockers, 0 warnings. Confirmed first-colon split, framework-precedence ordering in both functions, nil-header no-op back-compat, and no CRLF-injection or secret-logging risk (Go's net/http validates header values at write time; no header values are logged).

## Out of scope

- TS/Java CLI parity (separate work).
- Server-side auth enforcement (already covered by the header-propagation chain).

Closes #1084

## Test plan

- [x] `go build ./src/core/cli/...` — clean
- [x] `go test ./src/core/cli/...` — pass (parse + precedence)
- [x] `meshctl call <tool> -H "Authorization: Bearer ..."` passes the header; repeatable; malformed rejected with a clear error; framework headers unbreakable
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
