### PR TITLE
feat(python/llm): gated server-enforced Gemini-3 structured output with tools (#1100)

### DIFF
--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -1,7 +1,7 @@
 # MCP Mesh Python Package Configuration
 
 [build-system]
-requires = ["hatchling>=1.21.0"]
+requires = ["hatchling>=1.21.0,<1.30"]  # <1.30: hatchling 1.30.0 emits Metadata-Version 2.5 which twine rejects (revert when twine supports 2.5)
 build-backend = "hatchling.build"
 
 [project]

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
@@ -1191,15 +1191,29 @@ def _build_create_kwargs(
     # (snake_case) — Gemini rejects both with HTTP 400 INVALID_ARGUMENT
     # ("Unknown name 'additional_properties'..."). The whitelist sanitizer
     # strips both casings (snake_case keys aren't in the whitelist either).
+    #
+    # GATED Gemini-3 path (RFC #1100 follow-up, default OFF): when the
+    # ``_mesh_gemini_response_json_schema`` marker is set (stamped by
+    # GeminiHandler when MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS is enabled and
+    # the model/SDK qualify), emit ``response_json_schema`` — the stricter
+    # Gemini-3 server-side primitive — INSTEAD of ``response_schema``. The
+    # documented infinite-tool-loop bug is specific to ``response_schema`` +
+    # tools; this path deliberately avoids that translation. Tools (set above)
+    # are left intact alongside it.
+    use_response_json_schema = bool(
+        request_params.get("_mesh_gemini_response_json_schema")
+    )
     rf = request_params.get("response_format")
     if isinstance(rf, dict):
         if rf.get("type") == "json_schema":
             schema = (rf.get("json_schema") or {}).get("schema") or {}
             config["response_mime_type"] = "application/json"
             if schema:
-                config["response_schema"] = _sanitize_gemini_parameters_schema(
-                    schema
-                )
+                sanitized = _sanitize_gemini_parameters_schema(schema)
+                if use_response_json_schema:
+                    config["response_json_schema"] = sanitized
+                else:
+                    config["response_schema"] = sanitized
         elif rf.get("type") == "json_object":
             config["response_mime_type"] = "application/json"
     # Allow callers to set response_mime_type directly too.

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
@@ -1238,6 +1238,122 @@ class TestBuildCreateKwargs:
         assert "definitions" not in rs
         assert rs["type"] == "object"
 
+    def test_marker_emits_response_json_schema_not_response_schema(self):
+        """GATED Gemini-3 path (RFC #1100 follow-up): with the
+        ``_mesh_gemini_response_json_schema`` marker set, emit the stricter
+        ``response_json_schema`` from the response_format envelope (sanitized)
+        and NOT the legacy ``response_schema`` translation. Tools preserved."""
+        out = gemini_native._build_create_kwargs(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "_mesh_gemini_response_json_schema": True,
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "description": "d",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "Plan",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "title": "Plan",
+                            "properties": {"answer": {"type": "string"}},
+                            "required": ["answer"],
+                        },
+                    },
+                },
+            },
+            model="gemini/gemini-3-pro-preview",
+        )
+        cfg = out["config"]
+        assert "response_json_schema" in cfg
+        assert "response_schema" not in cfg
+        assert cfg["response_mime_type"] == "application/json"
+        # Sanitized (rejected keys stripped).
+        rjs = cfg["response_json_schema"]
+        assert "additionalProperties" not in rjs
+        assert "title" not in rjs
+        assert rjs["type"] == "object"
+        assert rjs["properties"] == {"answer": {"type": "string"}}
+        assert rjs["required"] == ["answer"]
+        # Tools preserved alongside the schema.
+        assert "tools" in cfg
+
+    def test_no_marker_emits_response_schema_unchanged(self):
+        """Without the marker, the response_format envelope still translates to
+        ``response_schema`` (no tools case) — byte-identical to today."""
+        out = gemini_native._build_create_kwargs(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "Plan",
+                        "schema": {"type": "object"},
+                    },
+                },
+            },
+            model="gemini/gemini-3-pro-preview",
+        )
+        cfg = out["config"]
+        assert cfg["response_schema"] == {"type": "object"}
+        assert "response_json_schema" not in cfg
+
+    def test_marker_does_not_leak_as_literal_kwarg_no_warn(self):
+        """The ``_mesh_``-prefixed marker is skipped by the WARN filter and is
+        never forwarded to the SDK as a literal kwarg."""
+        gemini_native._logged_unsupported_kwargs.clear()
+        out = gemini_native._build_create_kwargs(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "_mesh_gemini_response_json_schema": True,
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "Plan",
+                        "schema": {"type": "object"},
+                    },
+                },
+            },
+            model="gemini/gemini-3-pro-preview",
+        )
+        # Marker not warned, not present in returned kwargs/config.
+        assert all(
+            not k.startswith("_mesh_")
+            for k in gemini_native._logged_unsupported_kwargs
+        )
+        assert "_mesh_gemini_response_json_schema" not in out
+        assert "_mesh_gemini_response_json_schema" not in out["config"]
+
+    def test_bare_response_json_schema_dropped_with_warn(self):
+        """A caller-supplied bare ``response_json_schema`` (no marker) is NOT
+        forwarded to the SDK — it's dropped with an unsupported-kwarg WARN.
+        The gated feature works only via the marker-driven derivation, so a
+        direct caller knob is treated as an unsupported kwarg (pre-RFC #1100
+        behavior)."""
+        gemini_native._logged_unsupported_kwargs.clear()
+        out = gemini_native._build_create_kwargs(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "response_json_schema": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {"x": {"type": "string"}},
+                },
+            },
+            model="gemini/gemini-3-pro-preview",
+        )
+        assert "response_json_schema" not in out["config"]
+        assert "response_json_schema" in gemini_native._logged_unsupported_kwargs
+
     def test_drops_internal_mesh_sentinels(self):
         """``_mesh_*`` sentinels must NOT trigger a WARN — they're handled
         upstream in helpers._pop_mesh_*_flags."""

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/capabilities.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/capabilities.py
@@ -31,6 +31,28 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 # degrades gracefully to the next-best native mode when an installed SDK is
 # below its floor (e.g. a constrained install that pins an older SDK).
 _ANTHROPIC_OUTPUT_CONFIG_FLOOR = (0, 77)  # anthropic >= 0.77 → output_config
+_GEMINI_RESPONSE_JSON_SCHEMA_FLOOR = (1, 22)  # google-genai >= 1.22 → response_json_schema
+
+
+# Matches a leading ``gemini-<major>`` token in a LiteLLM-style model id, after
+# any backend prefix (``gemini/``, ``vertex_ai/``). Examples:
+# ``gemini/gemini-3-pro-preview`` → 3; ``vertex_ai/gemini-2.5-flash`` → 2;
+# ``gemini/gemini-1.5-pro`` → 1. Returns None when no gemini-major token is
+# present (unknown / unparseable model id → conservative degrade).
+_GEMINI_MAJOR_RE = re.compile(r"gemini-(\d+)")
+
+
+def _gemini_major(model: str | None) -> int | None:
+    """Return the Gemini major version from a model id, or ``None``.
+
+    Conservative on uncertainty: an absent / unparseable model id returns
+    ``None`` so the resolver does not select a Gemini-3-only primitive for a
+    model whose generation cannot be confirmed.
+    """
+    if not model:
+        return None
+    m = _GEMINI_MAJOR_RE.search(model)
+    return int(m.group(1)) if m else None
 
 
 @lru_cache(maxsize=None)
@@ -94,11 +116,13 @@ class StructuredOutputMode:
     - ``RESPONSE_FORMAT_STRICT`` — OpenAI / Gemini (no tools, Gemini 2.x or
       older SDK) native ``response_format`` with ``strict: true``. For Gemini
       this flows to the adapter's ``response_schema`` field.
-    - ``RESPONSE_JSON_SCHEMA`` — reserved for the Gemini 3.x+ (no tools)
-      google-genai ``response_json_schema`` field (stricter server-side
-      enforcement than ``response_schema``). Defined but not yet selected by
-      any resolver: wiring it into the mesh-delegated provider path needs
-      live-Gemini validation (RFC #1100 follow-up). Unused.
+    - ``RESPONSE_JSON_SCHEMA`` — Gemini 3+ WITH tools, google-genai
+      ``response_json_schema`` field (stricter server-side enforcement than
+      ``response_schema``, and avoids the ``response_schema`` + tools
+      infinite-loop bug). Selected by the resolver only when
+      ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS`` is enabled and google-genai
+      >= 1.22 (server-enforced); otherwise the Gemini-with-tools path falls
+      back to ``PROSE_HINT``.
     - ``RESPONSE_SCHEMA`` — reserved for future vendor variants of
       server-side schema enforcement. Unused.
     - ``PROSE_HINT`` — schema-in-prompt HINT mode (Claude LiteLLM path,
@@ -235,6 +259,7 @@ def _resolve_gemini(
     *,
     output_is_basemodel: bool,
     has_tools: bool,
+    gemini_native_structured_tools: bool = False,
 ) -> ModelCapabilities:
     """Reproduce ``GeminiHandler.prepare_request`` selection.
 
@@ -244,6 +269,15 @@ def _resolve_gemini(
     - BaseModel + tools → PROSE_HINT (response_format stripped; the
       response_format + tools combo triggers Gemini's infinite-tool-loop bug).
       The tools path never selects a server-side schema primitive.
+
+    GATED EXCEPTION (RFC #1100 follow-up, default OFF): when
+    ``gemini_native_structured_tools`` is True AND tools are present AND the
+    model is Gemini-3+ AND google-genai >= 1.22, select RESPONSE_JSON_SCHEMA —
+    the stricter Gemini-3 server-side primitive. This is the LIVE EXPERIMENT
+    path: it tests whether ``response_json_schema`` + tools is loop-safe (the
+    documented infinite-loop bug is specific to the OLDER ``response_schema``
+    primitive, which this path deliberately avoids). Off by default → the
+    tools path stays on PROSE_HINT exactly as today.
     """
     if not output_is_basemodel:
         return ModelCapabilities(
@@ -259,6 +293,20 @@ def _resolve_gemini(
             server_enforced=True,
             schema_with_tools=False,
             streaming_structured=True,
+            recovery=RECOVERY_NONE,
+        )
+    if (
+        gemini_native_structured_tools
+        and (major := _gemini_major(model)) is not None
+        and major >= 3
+        and _sdk_at_least("google-genai", _GEMINI_RESPONSE_JSON_SCHEMA_FLOOR)
+    ):
+        return ModelCapabilities(
+            structured_output=StructuredOutputMode.RESPONSE_JSON_SCHEMA,
+            server_enforced=True,
+            schema_with_tools=True,
+            streaming_structured=False,
+            min_sdk_version="1.22",
             recovery=RECOVERY_NONE,
         )
     return ModelCapabilities(
@@ -300,6 +348,7 @@ def resolve_capabilities(
     has_native: bool = False,
     streaming: bool = False,
     has_tools: bool = False,
+    gemini_native_structured_tools: bool = False,
 ) -> ModelCapabilities:
     """Resolve the structured-output capabilities for a request.
 
@@ -319,6 +368,10 @@ def resolve_capabilities(
             (Anthropic only consults this).
         streaming: True on the streaming dispatch path (Anthropic only).
         has_tools: True when real user tools are present (Gemini only).
+        gemini_native_structured_tools: GATED, default OFF. When True (set by
+            the ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS`` env flag), unlocks
+            the Gemini-3 ``response_json_schema`` + tools experiment path
+            (Gemini only). Off → no behavior change anywhere.
     """
     v = (vendor or "").strip().lower()
 
@@ -336,5 +389,6 @@ def resolve_capabilities(
             model,
             output_is_basemodel=output_is_basemodel,
             has_tools=has_tools,
+            gemini_native_structured_tools=gemini_native_structured_tools,
         )
     return _resolve_generic(output_is_basemodel=output_is_basemodel)

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
@@ -49,6 +49,31 @@ OUTPUT_MODE_HINT = "hint"
 logger = logging.getLogger(__name__)
 
 
+def _gemini_native_structured_tools_enabled() -> bool:
+    """Read the ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS`` gate.
+
+    DEFAULT OFF (RFC #1100 follow-up). When unset / falsy, every Gemini path
+    is byte-identical to today (tools → HINT). Accepts ``1/true/yes/on``
+    (case-insensitive) as enable — mirrors the ``MCP_MESH_NATIVE_LLM``
+    parsing style. When ON, unlocks the Gemini-3 ``response_json_schema`` +
+    tools experiment on the mesh-delegated provider path; the resolver still
+    gates on model major version (>=3) and google-genai >= 1.22, so an
+    unsupported model/SDK silently stays on HINT.
+    """
+    return os.environ.get(
+        "MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS", ""
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+# Internal marker stamped on ``model_params`` when the gated
+# ``response_json_schema`` path is active. The ``gemini_native`` adapter reads
+# it to emit ``config["response_json_schema"]`` (the Gemini-3 strict primitive)
+# instead of the ``response_schema`` translation. ``_mesh_``-prefixed so the
+# native adapter's unsupported-kwarg WARN filter skips it and it is never
+# forwarded to the SDK as a literal kwarg.
+RESPONSE_JSON_SCHEMA_MARKER = "_mesh_gemini_response_json_schema"
+
+
 # One-time guard so the dispatch-status DEBUG log fires exactly once per
 # process. Mirrors ``_logged_fallback_once`` in gemini_native — we
 # deliberately keep the state at module level (not on the handler instance)
@@ -191,8 +216,9 @@ class GeminiHandler(BaseProviderHandler):
 
         # Configured model id is passed by the agent for resolver symmetry with
         # the other handlers. Popped here so it does not flow into
-        # request_params (model is stamped separately downstream).
-        kwargs.pop("model", None)
+        # request_params (model is stamped separately downstream). Captured for
+        # the resolver's Gemini-major gate (gated response_json_schema path).
+        configured_model = kwargs.pop("model", None)
 
         # Build base request
         request_params = {
@@ -227,9 +253,12 @@ class GeminiHandler(BaseProviderHandler):
 
             caps = resolve_capabilities(
                 self.vendor,
-                None,
+                configured_model,
                 output_is_basemodel=True,
                 has_tools=bool(tools),
+                gemini_native_structured_tools=(
+                    _gemini_native_structured_tools_enabled()
+                ),
             )
 
             if caps.structured_output == StructuredOutputMode.RESPONSE_FORMAT_STRICT:
@@ -244,6 +273,27 @@ class GeminiHandler(BaseProviderHandler):
                 }
                 logger.debug(
                     "Gemini: Using response_format with strict schema for '%s' (no tools)",
+                    output_type.__name__,
+                )
+            elif caps.structured_output == StructuredOutputMode.RESPONSE_JSON_SCHEMA:
+                # GATED (default OFF): Gemini-3 server-enforced structured
+                # output WITH tools via ``response_json_schema``. Stamp the
+                # marker + carry the strict schema in ``response_format`` (the
+                # adapter reads it but emits ``response_json_schema``, NOT the
+                # legacy ``response_schema`` translation). Tools stay intact.
+                strict_schema = make_schema_strict(schema, add_all_required=True)
+                request_params["response_format"] = {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": output_type.__name__,
+                        "schema": strict_schema,
+                        "strict": True,
+                    },
+                }
+                request_params[RESPONSE_JSON_SCHEMA_MARKER] = True
+                logger.info(
+                    "Gemini: GATED response_json_schema + tools for '%s' "
+                    "(MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS enabled, Gemini-3+)",
                     output_type.__name__,
                 )
             else:
@@ -372,8 +422,61 @@ class GeminiHandler(BaseProviderHandler):
         The ``streaming`` kwarg is accepted for API symmetry with the other
         vendor handlers; Gemini is HINT-only here regardless, so the flag is
         a no-op.
+
+        GATED EXCEPTION (RFC #1100 follow-up, default OFF): when
+        ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS`` is enabled AND the resolver
+        confirms Gemini-3+ with google-genai >= 1.22, this stamps a
+        ``response_json_schema`` marker + the strict schema (as a
+        ``response_format`` carrier) and KEEPS tools — letting the native
+        adapter emit Gemini's stricter server-side primitive instead of HINT.
+        With the flag off, the resolver returns PROSE_HINT and the path below
+        is byte-identical to today (HINT injected, response_format popped).
         """
         sanitized_schema = sanitize_schema_for_structured_output(output_schema)
+
+        # Gated mode selection (RFC #1100 follow-up). Default OFF →
+        # PROSE_HINT (the resolver's tools-path default), so the HINT block
+        # below runs exactly as today. When the gate is open AND the model /
+        # SDK qualify, the resolver returns RESPONSE_JSON_SCHEMA and we take
+        # the server-enforced branch instead.
+        from .capabilities import StructuredOutputMode, resolve_capabilities
+
+        caps = resolve_capabilities(
+            self.vendor,
+            model,
+            output_is_basemodel=True,
+            has_tools=True,  # mesh delegation always attaches tools
+            gemini_native_structured_tools=(
+                _gemini_native_structured_tools_enabled()
+            ),
+        )
+
+        if caps.structured_output == StructuredOutputMode.RESPONSE_JSON_SCHEMA:
+            # Server-enforced structured output WITH tools. Do NOT set
+            # _mesh_hint_mode, do NOT pop response_format. Stamp the marker and
+            # carry the strict schema in response_format (the adapter reads it
+            # but emits ``response_json_schema``, NOT the legacy
+            # ``response_schema`` translation documented to infinite-loop with
+            # tools). Tools are left untouched in model_params.
+            strict_schema = make_schema_strict(
+                sanitized_schema, add_all_required=True
+            )
+            model_params["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": output_type_name or "Response",
+                    "schema": strict_schema,
+                    "strict": True,
+                },
+            }
+            model_params[RESPONSE_JSON_SCHEMA_MARKER] = True
+            logger.info(
+                "Gemini GATED response_json_schema + tools for '%s' "
+                "(mesh delegation; MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS "
+                "enabled, Gemini-3+ server-enforced, tools intact)",
+                output_type_name or "Response",
+            )
+            return model_params
 
         # Store for format_system_prompt (per-async-context to avoid races
         # across concurrent requests sharing this singleton handler).

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_capability_resolver.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_capability_resolver.py
@@ -249,6 +249,155 @@ class TestGeminiResolver:
         assert caps.structured_output == StructuredOutputMode.PROSE_HINT
 
 
+class TestGeminiNativeStructuredToolsGate:
+    """GATED Gemini-3 ``response_json_schema`` + tools path (RFC #1100
+    follow-up, default OFF). Off → PROSE_HINT exactly as today; on → only
+    Gemini-3+ with google-genai >= 1.22 unlocks RESPONSE_JSON_SCHEMA."""
+
+    @pytest.fixture
+    def _genai_floor_met(self, monkeypatch):
+        # CI may pin an older google-genai; assert SELECTION, not detection.
+        monkeypatch.setattr(caps_mod, "_sdk_at_least", lambda dist, floor: True)
+        yield
+
+    def test_flag_off_with_tools_is_prose_hint_unchanged(self, _genai_floor_met):
+        """Default OFF: even Gemini-3 + tools + new SDK stays on PROSE_HINT —
+        byte-identical to today's behavior."""
+        caps = resolve_capabilities(
+            "gemini",
+            "gemini/gemini-3-pro-preview",
+            output_is_basemodel=True,
+            has_tools=True,
+            gemini_native_structured_tools=False,
+        )
+        assert caps.structured_output == StructuredOutputMode.PROSE_HINT
+
+    def test_flag_on_gemini3_tools_sdk_ok_is_response_json_schema(
+        self, _genai_floor_met
+    ):
+        caps = resolve_capabilities(
+            "gemini",
+            "gemini/gemini-3-pro-preview",
+            output_is_basemodel=True,
+            has_tools=True,
+            gemini_native_structured_tools=True,
+        )
+        assert caps.structured_output == StructuredOutputMode.RESPONSE_JSON_SCHEMA
+        assert caps.server_enforced is True
+        assert caps.schema_with_tools is True
+        assert caps.min_sdk_version == "1.22"
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gemini/gemini-3-pro-preview",
+            "gemini/gemini-3.0-flash",
+            "vertex_ai/gemini-3-flash",
+        ],
+    )
+    def test_flag_on_various_gemini3_ids_is_response_json_schema(
+        self, _genai_floor_met, model
+    ):
+        caps = resolve_capabilities(
+            "gemini",
+            model,
+            output_is_basemodel=True,
+            has_tools=True,
+            gemini_native_structured_tools=True,
+        )
+        assert caps.structured_output == StructuredOutputMode.RESPONSE_JSON_SCHEMA
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gemini/gemini-2.5-flash",
+            "gemini/gemini-2.0-flash-lite",
+            "gemini/gemini-1.5-pro",
+        ],
+    )
+    def test_flag_on_gemini2x_tools_is_prose_hint(self, _genai_floor_met, model):
+        """Only Gemini-3+ unlocks the gated path; 2.x / 1.x with tools stays
+        on PROSE_HINT even with the flag on."""
+        caps = resolve_capabilities(
+            "gemini",
+            model,
+            output_is_basemodel=True,
+            has_tools=True,
+            gemini_native_structured_tools=True,
+        )
+        assert caps.structured_output == StructuredOutputMode.PROSE_HINT
+
+    def test_flag_on_unknown_model_is_prose_hint(self, _genai_floor_met):
+        """model=None → major version unknown → conservative PROSE_HINT."""
+        caps = resolve_capabilities(
+            "gemini",
+            None,
+            output_is_basemodel=True,
+            has_tools=True,
+            gemini_native_structured_tools=True,
+        )
+        assert caps.structured_output == StructuredOutputMode.PROSE_HINT
+
+    def test_flag_on_gemini3_but_sdk_too_old_is_prose_hint(self, monkeypatch):
+        """genai < 1.22 → degrade to PROSE_HINT even on Gemini-3 + flag on."""
+        monkeypatch.setattr(caps_mod, "_sdk_at_least", lambda dist, floor: False)
+        caps = resolve_capabilities(
+            "gemini",
+            "gemini/gemini-3-pro-preview",
+            output_is_basemodel=True,
+            has_tools=True,
+            gemini_native_structured_tools=True,
+        )
+        assert caps.structured_output == StructuredOutputMode.PROSE_HINT
+
+    def test_flag_on_gemini3_NO_tools_is_response_format_strict(
+        self, _genai_floor_met
+    ):
+        """No-tools path is unaffected by the gate — still RESPONSE_FORMAT_STRICT
+        (the no-tools branch never reaches the gated check)."""
+        caps = resolve_capabilities(
+            "gemini",
+            "gemini/gemini-3-pro-preview",
+            output_is_basemodel=True,
+            has_tools=False,
+            gemini_native_structured_tools=True,
+        )
+        assert caps.structured_output == StructuredOutputMode.RESPONSE_FORMAT_STRICT
+
+    def test_flag_on_str_output_is_text(self, _genai_floor_met):
+        caps = resolve_capabilities(
+            "gemini",
+            "gemini/gemini-3-pro-preview",
+            output_is_basemodel=False,
+            has_tools=True,
+            gemini_native_structured_tools=True,
+        )
+        assert caps.structured_output == StructuredOutputMode.TEXT
+
+
+class TestGeminiMajorParser:
+    """Unit tests for the Gemini major-version parser used by the gate."""
+
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
+            ("gemini/gemini-3-pro-preview", 3),
+            ("gemini/gemini-3.0-flash", 3),
+            ("vertex_ai/gemini-3-flash", 3),
+            ("gemini/gemini-2.5-flash", 2),
+            ("gemini/gemini-2.0-flash-lite", 2),
+            ("gemini/gemini-1.5-pro", 1),
+            ("gemini/gemini-10-future", 10),
+            (None, None),
+            ("", None),
+            ("gpt-4o", None),
+            ("claude-sonnet-4-5", None),
+        ],
+    )
+    def test_gemini_major(self, model, expected):
+        assert caps_mod._gemini_major(model) == expected
+
+
 class TestVersionHelpers:
     """Unit tests for the SDK-version detection / compare helpers."""
 

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_gemini_handler_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_gemini_handler_native.py
@@ -34,6 +34,7 @@ pytest.importorskip(
     reason="GeminiHandler native dispatch tests require the google-genai SDK",
 )
 
+from _mcp_mesh.engine.provider_handlers import capabilities as caps_mod
 from _mcp_mesh.engine.provider_handlers import gemini_handler as gemini_handler_module
 from _mcp_mesh.engine.provider_handlers.gemini_handler import GeminiHandler
 
@@ -441,3 +442,180 @@ class TestHintModePreservation:
             output_type=str,
         )
         assert "response_format" not in params
+
+
+_GATE = "MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS"
+_MARKER = "_mesh_gemini_response_json_schema"
+
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "noop",
+            "description": "",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_gate_env():
+    """Ensure the gated-path flag never leaks across these tests."""
+    original = os.environ.pop(_GATE, None)
+    yield
+    if original is not None:
+        os.environ[_GATE] = original
+    else:
+        os.environ.pop(_GATE, None)
+
+
+class TestGatedResponseJsonSchemaApplyStructuredOutput:
+    """``apply_structured_output`` is the provider-delegated path. With the
+    gate OFF it must behave EXACTLY as today (HINT, response_format popped);
+    with the gate ON + Gemini-3 it stamps the marker, keeps response_format,
+    does NOT set _mesh_hint_mode, and keeps tools intact."""
+
+    def test_gate_off_is_hint_exactly_as_today(self, monkeypatch):
+        monkeypatch.setattr(
+            caps_mod, "_sdk_at_least", lambda dist, floor: True
+        )
+        handler = GeminiHandler()
+        model_params = {
+            "messages": [{"role": "system", "content": "base"}],
+            "tools": _TOOLS,
+            "response_format": {"type": "json_schema", "json_schema": {}},
+        }
+        out = handler.apply_structured_output(
+            {"type": "object", "properties": {"answer": {"type": "string"}}},
+            "Plan",
+            model_params,
+            model="gemini/gemini-3-pro-preview",
+        )
+        # HINT mode set, response_format popped, marker absent.
+        assert out["_mesh_hint_mode"] is True
+        assert "response_format" not in out
+        assert _MARKER not in out
+        # Tools untouched.
+        assert out["tools"] == _TOOLS
+
+    def test_gate_on_gemini3_stamps_marker_keeps_response_format_and_tools(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv(_GATE, "true")
+        monkeypatch.setattr(
+            caps_mod, "_sdk_at_least", lambda dist, floor: True
+        )
+        handler = GeminiHandler()
+        model_params = {
+            "messages": [{"role": "system", "content": "base"}],
+            "tools": _TOOLS,
+        }
+        out = handler.apply_structured_output(
+            {"type": "object", "properties": {"answer": {"type": "string"}}},
+            "Plan",
+            model_params,
+            model="gemini/gemini-3-pro-preview",
+        )
+        # Server-enforced branch: marker stamped, NO hint mode.
+        assert out[_MARKER] is True
+        assert "_mesh_hint_mode" not in out
+        # response_format carrier present (json_schema envelope).
+        assert out["response_format"]["type"] == "json_schema"
+        assert out["response_format"]["json_schema"]["name"] == "Plan"
+        # Tools intact.
+        assert out["tools"] == _TOOLS
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "ON", "True"])
+    def test_gate_accepts_truthy_values(self, monkeypatch, value):
+        monkeypatch.setenv(_GATE, value)
+        monkeypatch.setattr(
+            caps_mod, "_sdk_at_least", lambda dist, floor: True
+        )
+        handler = GeminiHandler()
+        model_params = {
+            "messages": [{"role": "system", "content": "base"}],
+            "tools": _TOOLS,
+        }
+        out = handler.apply_structured_output(
+            {"type": "object", "properties": {}},
+            "Plan",
+            model_params,
+            model="gemini/gemini-3-pro-preview",
+        )
+        assert out[_MARKER] is True
+
+    def test_gate_on_gemini2x_falls_back_to_hint(self, monkeypatch):
+        monkeypatch.setenv(_GATE, "true")
+        monkeypatch.setattr(
+            caps_mod, "_sdk_at_least", lambda dist, floor: True
+        )
+        handler = GeminiHandler()
+        model_params = {
+            "messages": [{"role": "system", "content": "base"}],
+            "tools": _TOOLS,
+        }
+        out = handler.apply_structured_output(
+            {"type": "object", "properties": {}},
+            "Plan",
+            model_params,
+            model="gemini/gemini-2.5-flash",
+        )
+        # 2.x → resolver returns PROSE_HINT → HINT path.
+        assert out["_mesh_hint_mode"] is True
+        assert _MARKER not in out
+
+    def test_gate_on_gemini3_but_old_sdk_falls_back_to_hint(self, monkeypatch):
+        monkeypatch.setenv(_GATE, "true")
+        monkeypatch.setattr(
+            caps_mod, "_sdk_at_least", lambda dist, floor: False
+        )
+        handler = GeminiHandler()
+        model_params = {
+            "messages": [{"role": "system", "content": "base"}],
+            "tools": _TOOLS,
+        }
+        out = handler.apply_structured_output(
+            {"type": "object", "properties": {}},
+            "Plan",
+            model_params,
+            model="gemini/gemini-3-pro-preview",
+        )
+        assert out["_mesh_hint_mode"] is True
+        assert _MARKER not in out
+
+
+class TestGatedResponseJsonSchemaPrepareRequest:
+    """``prepare_request`` mirrors the gated behavior for consistency."""
+
+    def test_gate_off_tools_omits_response_format(self, monkeypatch):
+        monkeypatch.setattr(
+            caps_mod, "_sdk_at_least", lambda dist, floor: True
+        )
+        handler = GeminiHandler()
+        params = handler.prepare_request(
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=_TOOLS,
+            output_type=_SamplePydantic,
+            model="gemini/gemini-3-pro-preview",
+        )
+        assert "response_format" not in params
+        assert _MARKER not in params
+
+    def test_gate_on_gemini3_tools_stamps_marker_and_response_format(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv(_GATE, "on")
+        monkeypatch.setattr(
+            caps_mod, "_sdk_at_least", lambda dist, floor: True
+        )
+        handler = GeminiHandler()
+        params = handler.prepare_request(
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=_TOOLS,
+            output_type=_SamplePydantic,
+            model="gemini/gemini-3-pro-preview",
+        )
+        assert params[_MARKER] is True
+        assert params["response_format"]["type"] == "json_schema"
+        assert params["tools"] == _TOOLS

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -1,7 +1,7 @@
 # MCP Mesh Python Package Configuration
 
 [build-system]
-requires = ["hatchling>=1.21.0"]
+requires = ["hatchling>=1.21.0,<1.30"]  # <1.30: hatchling 1.30.0 emits Metadata-Version 2.5 which twine rejects (revert when twine supports 2.5)
 build-backend = "hatchling.build"
 
 [project]

--- a/tests/integration/suites/uc04_llm_integration/tc36_gemini3_response_json_schema_tools_py/artifacts/calculator-agent/main.py
+++ b/tests/integration/suites/uc04_llm_integration/tc36_gemini3_response_json_schema_tools_py/artifacts/calculator-agent/main.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+calculator-agent - Simple MCP Mesh tool provider for the RFC #1100 experiment.
+
+Provides a basic calculator tool (add) that the LLM consumer can discover and
+call inside its agentic loop. Keeping a single deterministic tool keeps the
+experiment focused: does Gemini-3 response_json_schema + tools loop?
+"""
+
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+import mesh
+
+app = FastMCP("CalculatorAgent")
+
+
+class CalcInput(BaseModel):
+    """Input for calculator operations."""
+
+    a: float = Field(..., description="First number")
+    b: float = Field(..., description="Second number")
+
+
+@app.tool()
+@mesh.tool(
+    capability="calculator",
+    description="Add two numbers",
+    version="1.0.0",
+    tags=["calculator", "math"],
+)
+def calc_add(a: float, b: float) -> float:
+    """Add two numbers together."""
+    return a + b
+
+
+@mesh.agent(
+    name="calculator-agent",
+    version="1.0.0",
+    description="Simple calculator tool provider",
+    http_port=9030,
+    enable_http=True,
+    auto_run=True,
+)
+class CalculatorAgentConfig:
+    """Calculator tool provider agent."""
+
+    pass

--- a/tests/integration/suites/uc04_llm_integration/tc36_gemini3_response_json_schema_tools_py/artifacts/chat-tools-agent/main.py
+++ b/tests/integration/suites/uc04_llm_integration/tc36_gemini3_response_json_schema_tools_py/artifacts/chat-tools-agent/main.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+chat-tools-agent - MCP Mesh consumer for the RFC #1100 live experiment.
+
+LIVE EXPERIMENT (RFC #1100 follow-up): does Gemini-3 + response_json_schema +
+tools trigger the documented infinite-tool-loop bug, or is it loop-safe?
+
+This consumer:
+  (a) declares a Pydantic structured return type (AnalysisResponse), AND
+  (b) has a mesh tool available to the LLM (calculator capability),
+so the provider-side agentic loop runs WITH tools + structured output.
+
+The provider it targets is the Gemini-3 provider, started with
+MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=1 so the gated response_json_schema
+path is exercised instead of the default PROSE_HINT.
+
+max_iterations is set modestly (6) so a runaway loop hits the cap fast rather
+than running forever; the test step itself also has a bounded timeout so a loop
+fails fast.
+
+Modeled on uc04 tc18_structured_multi_turn_tools_py / tc27, but pointed at the
+Gemini provider via the +gemini provider tag.
+"""
+
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+import mesh
+
+app = FastMCP("ChatToolsAgent")
+
+
+# ===== STRUCTURED OUTPUT MODEL =====
+
+
+class AnalysisResponse(BaseModel):
+    """Structured output for the analysis response."""
+
+    answer: str = Field(..., description="The direct answer to the question")
+    reasoning: str = Field(
+        ..., description="Brief explanation of how the answer was derived"
+    )
+    used_tools: bool = Field(..., description="Whether the calculator tool was used")
+    confidence: float = Field(..., description="Confidence score from 0.0 to 1.0")
+
+
+class AnalysisContext(BaseModel):
+    """Context for the analysis request."""
+
+    question: str = Field(
+        ..., description="Question to analyze, may require a calculation"
+    )
+
+
+# ===== LLM FUNCTION WITH TOOLS AND STRUCTURED OUTPUT =====
+
+
+@app.tool()
+@mesh.llm(
+    provider={"capability": "llm", "tags": ["+gemini", "+provider"]},
+    filter={"capability": "calculator"},
+    max_iterations=6,
+    context_param="ctx",
+)
+@mesh.tool(
+    capability="analyze",
+    description="Analyze a question using the LLM with the calculator tool",
+    version="1.0.0",
+    tags=["llm", "analysis", "structured", "tools"],
+)
+async def analyze(
+    ctx: AnalysisContext,
+    llm: mesh.MeshLlmAgent = None,
+) -> AnalysisResponse:
+    """
+    Analyze a question with tools + structured output via the Gemini provider.
+
+    The prompt deliberately requires a single tool call (the calculator) and
+    then a structured return, so the agentic loop runs WITH tools + structured
+    output. A loop-safe path completes in a small number of iterations; a
+    looping path will keep calling the tool until max_iterations.
+    """
+    if llm is None:
+        raise RuntimeError("Mesh provider not resolved for analyze")
+
+    response = await llm(ctx.question)
+    return response
+
+
+# ===== AGENT CONFIGURATION =====
+
+
+@mesh.agent(
+    name="chat-tools-agent",
+    version="1.0.0",
+    description="Consumer for the Gemini-3 response_json_schema + tools experiment",
+    http_port=9034,
+    enable_http=True,
+    auto_run=True,
+)
+class ChatToolsAgentConfig:
+    """Consumer agent for the RFC #1100 live experiment."""
+
+    pass

--- a/tests/integration/suites/uc04_llm_integration/tc36_gemini3_response_json_schema_tools_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc36_gemini3_response_json_schema_tools_py/test.yaml
@@ -1,0 +1,244 @@
+# Test Case: Gemini-3 response_json_schema + tools loop experiment
+# LIVE EXPERIMENT for RFC #1100 follow-up.
+#
+# Open question: does Gemini-3 + response_json_schema + tools trigger the
+# documented infinite-tool-loop bug, or is it loop-safe?
+#
+# Today (flag OFF) Gemini-with-tools uses PROSE_HINT specifically because the
+# legacy response_schema + tools combo infinite-loops. This TC turns ON the
+# gated path (MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=1) on a Gemini-3 provider
+# and runs a structured-output consumer that ALSO has a tool available, so the
+# agentic loop runs WITH tools + server-enforced response_json_schema.
+#
+# OUTCOME A (LOOP / FAIL): the call times out / hits max_iterations / never
+#   returns the structured object -> response_json_schema + tools STILL loops.
+#   Valid negative result. Provider log tail shows repeated tool calls.
+# OUTCOME B (SUCCESS): the call returns a valid structured object within the
+#   bounded timeout and the provider log shows the loop completed in a small
+#   number of iterations -> response_json_schema + tools is loop-safe.
+#
+# Control: the same consumer/provider is also run with the flag OFF (default
+# HINT) to confirm the baseline still works.
+
+name: "Gemini-3 response_json_schema + tools loop experiment"
+description: "RFC #1100: does Gemini-3 response_json_schema + tools loop or is it loop-safe?"
+tags:
+  - llm
+  - gemini
+  - structured
+  - python
+  - tools
+  - experiment
+timeout: 400
+# Skip with --skip-tag llm if no API key is available.
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+test:
+  # --- Copy artifacts ---
+  - name: "Copy Gemini provider to workspace"
+    handler: shell
+    command: "cp -r /uc-artifacts/gemini-provider /workspace/"
+    capture: copy_provider_output
+  - name: "Copy calculator-agent to workspace"
+    handler: shell
+    command: "cp -r /artifacts/calculator-agent /workspace/"
+    capture: copy_calc_output
+  - name: "Copy chat-tools-agent to workspace"
+    handler: shell
+    command: "cp -r /artifacts/chat-tools-agent /workspace/"
+    capture: copy_agent_output
+  - name: "Create env file with secrets"
+    handler: secrets
+    target: /workspace/.env
+  - name: "Verify workspace files"
+    handler: shell
+    command: "ls -la /workspace/"
+    capture: ls_output
+
+  # ============================================================
+  # PHASE 1: FLAG ON -> gated response_json_schema + tools path
+  # ============================================================
+  - name: "Start calculator-agent (tools)"
+    handler: shell
+    command: "meshctl start calculator-agent/main.py -d"
+    workdir: /workspace
+    capture: start_calc_output
+  - name: "Wait for calculator to register"
+    handler: wait
+    seconds: 3
+  # Provider started WITH the gated flag AND a Gemini-3 model (gemini-provider
+  # artifact already pins gemini/gemini-3-flash-preview). --debug so the gated
+  # "response_json_schema + tools" log line and per-iteration tool calls show.
+  - name: "Start Gemini-3 provider with NATIVE_STRUCTURED_TOOLS flag ON"
+    handler: shell
+    command: "meshctl start gemini-provider/main.py --env-file .env --env MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=1 -d --debug"
+    workdir: /workspace
+    capture: start_provider_output
+  - name: "Wait for provider to register"
+    handler: wait
+    seconds: 15
+  - name: "Verify calculator and provider running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: pre_agent_list_output
+  - name: "Start chat-tools-agent (consumer: structured + tools)"
+    handler: shell
+    command: "meshctl start chat-tools-agent/main.py -d"
+    workdir: /workspace
+    capture: start_agent_output
+  - name: "Wait for agent to register and resolve dependencies"
+    handler: wait
+    seconds: 15
+  - name: "Verify all agents running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: all_list_output
+  - name: "List available tools"
+    handler: shell
+    command: "meshctl list -t"
+    workdir: /workspace
+    capture: tools_output
+
+  # THE EXPERIMENT CALL. Bounded timeout so a loop FAILS FAST instead of
+  # hanging the run. A deterministic single-tool prompt: add two numbers, then
+  # return the structured result.
+  - name: "EXPERIMENT call (flag ON): structured output + tool"
+    handler: shell
+    command: |
+      meshctl call analyze '{"ctx": {"question": "Use the calculator to add 137 and 246, then return the structured analysis result."}}'
+    workdir: /workspace
+    capture: experiment_response
+    timeout: 110
+
+  # Capture provider log tail REGARDLESS of call outcome (evidence for both
+  # the LOOP and SUCCESS outcomes). Looking for: the gated response_json_schema
+  # log line, per-iteration tool-call markers, and the final iteration count.
+  - name: "Capture Gemini provider log tail (flag ON)"
+    handler: shell
+    command: |
+      meshctl logs gemini-provider 2>/dev/null | tail -120 || true
+    workdir: /workspace
+    capture: provider_log_on
+    ignore_errors: true
+  - name: "Count tool-call iterations in provider log (flag ON)"
+    handler: shell
+    command: |
+      meshctl logs gemini-provider 2>/dev/null | grep -ciE "iteration|tool.call|calc_add|response_json_schema" || true
+    workdir: /workspace
+    capture: iteration_count_on
+    ignore_errors: true
+  - name: "Capture consumer (chat-tools-agent) log tail (flag ON)"
+    handler: shell
+    command: |
+      meshctl logs chat-tools-agent 2>/dev/null | tail -80 || true
+    workdir: /workspace
+    capture: consumer_log_on
+    ignore_errors: true
+
+  - name: "Stop all agents (end of phase 1)"
+    handler: shell
+    command: "meshctl stop"
+    workdir: /workspace
+    ignore_errors: true
+  - name: "Wait for clean shutdown"
+    handler: wait
+    seconds: 5
+
+  # ============================================================
+  # PHASE 2 (CONTROL): FLAG OFF -> default PROSE_HINT baseline
+  # ============================================================
+  - name: "Start calculator-agent (control)"
+    handler: shell
+    command: "meshctl start calculator-agent/main.py -d"
+    workdir: /workspace
+    capture: start_calc_control
+  - name: "Wait for calculator to register (control)"
+    handler: wait
+    seconds: 3
+  - name: "Start Gemini-3 provider with flag OFF (control)"
+    handler: shell
+    command: "meshctl start gemini-provider/main.py --env-file .env -d --debug"
+    workdir: /workspace
+    capture: start_provider_control
+  - name: "Wait for provider to register (control)"
+    handler: wait
+    seconds: 15
+  - name: "Start chat-tools-agent (control)"
+    handler: shell
+    command: "meshctl start chat-tools-agent/main.py -d"
+    workdir: /workspace
+    capture: start_agent_control
+  - name: "Wait for resolution (control)"
+    handler: wait
+    seconds: 15
+  - name: "CONTROL call (flag OFF): structured output + tool (HINT baseline)"
+    handler: shell
+    command: |
+      meshctl call analyze '{"ctx": {"question": "Use the calculator to add 137 and 246, then return the structured analysis result."}}'
+    workdir: /workspace
+    capture: control_response
+    timeout: 110
+  - name: "Capture Gemini provider log tail (control)"
+    handler: shell
+    command: |
+      meshctl logs gemini-provider 2>/dev/null | tail -80 || true
+    workdir: /workspace
+    capture: provider_log_off
+    ignore_errors: true
+  - name: "Stop all agents (end of phase 2)"
+    handler: shell
+    command: "meshctl stop"
+    workdir: /workspace
+    ignore_errors: true
+
+assertions:
+  # --- Infrastructure (must hold for the experiment to be valid) ---
+  - expr: ${captured.pre_agent_list_output} contains 'calculator-agent'
+    message: "calculator-agent should be registered"
+  - expr: ${captured.pre_agent_list_output} contains 'gemini-provider'
+    message: "gemini-provider should be registered"
+  - expr: ${captured.all_list_output} contains 'chat-tools-agent'
+    message: "chat-tools-agent should be registered"
+  - expr: ${captured.tools_output} contains 'analyze'
+    message: "analyze tool should be listed"
+  - expr: ${captured.tools_output} contains 'calc_add'
+    message: "calc_add tool should be listed"
+
+  # --- Confirm the GATED path actually engaged (real exercise, not a no-op) ---
+  - expr: ${captured.provider_log_on} icontains 'response_json_schema'
+    message: "Provider log (flag ON) should show the gated response_json_schema path engaged"
+
+  # --- OUTCOME B (SUCCESS / loop-safe) assertions ---
+  # These PASS only if response_json_schema + tools is loop-safe: a valid
+  # structured object returns within the bounded timeout. If the path LOOPS,
+  # these FAIL (the call times out / never returns the object) -> the negative
+  # result. We do NOT weaken these to force a pass; the log evidence is
+  # captured regardless of which way they go.
+  - expr: ${captured.experiment_response} contains '383'
+    message: "EXPERIMENT (flag ON): structured result should contain the computed sum 383 (137+246)"
+  - expr: ${captured.experiment_response} contains '"answer"'
+    message: "EXPERIMENT (flag ON): should return the structured 'answer' field"
+  - expr: ${captured.experiment_response} contains '"confidence"'
+    message: "EXPERIMENT (flag ON): should return the structured 'confidence' field"
+  - expr: ${captured.experiment_response} not contains 'max_iterations'
+    message: "EXPERIMENT (flag ON): should NOT hit max_iterations (loop indicator)"
+  - expr: ${captured.experiment_response} not contains 'timed out'
+    message: "EXPERIMENT (flag ON): call should NOT time out (loop indicator)"
+
+  # --- CONTROL (flag OFF / HINT baseline) should still work ---
+  - expr: ${captured.control_response} contains '383'
+    message: "CONTROL (flag OFF): HINT-mode baseline should still return the sum 383"
+  - expr: ${captured.control_response} contains '"answer"'
+    message: "CONTROL (flag OFF): HINT-mode baseline should return structured 'answer' field"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
RFC #1100 follow-up — the genuine fallback-elimination for the high-value Gemini case.

## Headline
**Empirically resolved a long-open question:** Gemini-3 + `response_json_schema` + tools is **LOOP-SAFE.** A live experiment (`gemini-3-flash-preview`, real token usage) showed the agentic loop completing in **2 iterations** with a correct structured result — no runaway. The years-old reason Gemini-with-tools was forced onto best-effort HINT was that `response_format`→`response_schema` + tools infinite-loops; the newer `response_json_schema` field was simply never tested with tools. Now it has been.

## What this adds (DEFAULT-OFF, gated)
A `MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS` env flag (default off). When **on** + the request has tools + the model is Gemini-3+ + `google-genai>=1.22`, a Gemini structured-output request emits the **server-enforced `response_json_schema`** instead of PROSE_HINT — wired into the mesh-delegated provider path (`apply_structured_output`), which is exactly where the earlier Part C attempt was inert.

- **Flag OFF (default): byte-identical to today** — Gemini-with-tools → PROSE_HINT (`_mesh_hint_mode`, `response_format` popped, adapter emits `response_schema`). Verified by independent review + unit tests.
- **Flag ON:** resolver returns `RESPONSE_JSON_SCHEMA`; handler keeps `response_format`+`tools` and stamps the `_mesh_gemini_response_json_schema` marker (no HINT, no pop); `gemini_native` emits `config["response_json_schema"]` (sanitized) alongside `tools`, never `response_schema`. Marker is `_mesh_`-prefixed (never forwarded to the SDK).

No user-contract change; opt-in via the flag only.

## Tests
- **Unit:** resolver gating (flag ∧ has_tools ∧ gemini-3+ ∧ genai≥1.22), handler honoring the gate in both `prepare_request` and `apply_structured_output`, native adapter marker emission (`response_json_schema` XOR `response_schema`; bare kwarg dropped-with-WARN when off). Existing tests pass unchanged with the flag off.
- **Integration:** new `uc04_llm_integration/tc36_gemini3_response_json_schema_tools_py` — the live loop-safety experiment (flag-on + flag-off control), now a permanent regression guard. Ran live: flag-on completed in 2 iterations returning the correct structured object; flag-off control (HINT) also passed.

## Review
Independent review: 0 blockers; flag-off byte-identical guarantee verified. Two findings fixed: stale enum docstring; removed an ungated bare `response_json_schema` passthrough so flag-off stays strictly byte-identical.

## Recommendation
Default stays **OFF** pending broader soak (multi-tool / multi-turn / more Gemini-3 variants). Recommend flipping the default in a follow-up once that soak is green — at which point Gemini-with-tools structured output becomes server-enforced by default (eliminating the best-effort HINT path + its corrective retry for the motivating cases).

Part of #1100

## Test plan
- [x] Unit suite green (resolver/handler/native gating; flag-off byte-identical)
- [x] Live integration tc36: flag-on loop-safe (2 iterations, correct structured output) + flag-off control pass
- [x] src-tests build 12/12
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental Gemini-3 native structured output support that preserves tool-calling capabilities (gated by environment flag; falls back gracefully on older versions).

* **Tests**
  * Comprehensive test coverage for new structured output mode with Gemini-3, including capability resolution, version gating, and integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->