### PR TITLE
feat(python/llm): default-ON server-enforced Gemini-3 structured output with tools (#1100)

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
@@ -1192,14 +1192,15 @@ def _build_create_kwargs(
     # ("Unknown name 'additional_properties'..."). The whitelist sanitizer
     # strips both casings (snake_case keys aren't in the whitelist either).
     #
-    # GATED Gemini-3 path (RFC #1100 follow-up, default OFF): when the
+    # Gemini-3 server-enforced path (RFC #1100 follow-up, DEFAULT ON): when the
     # ``_mesh_gemini_response_json_schema`` marker is set (stamped by
-    # GeminiHandler when MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS is enabled and
-    # the model/SDK qualify), emit ``response_json_schema`` — the stricter
-    # Gemini-3 server-side primitive — INSTEAD of ``response_schema``. The
-    # documented infinite-tool-loop bug is specific to ``response_schema`` +
-    # tools; this path deliberately avoids that translation. Tools (set above)
-    # are left intact alongside it.
+    # GeminiHandler by default for Gemini-3+ with tools when the model/SDK
+    # qualify; the MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0 kill-switch
+    # disables it), emit ``response_json_schema`` — the stricter Gemini-3
+    # server-side primitive — INSTEAD of ``response_schema``. The documented
+    # infinite-tool-loop bug is specific to ``response_schema`` + tools; this
+    # path deliberately avoids that translation. Tools (set above) are left
+    # intact alongside it.
     use_response_json_schema = bool(
         request_params.get("_mesh_gemini_response_json_schema")
     )

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/capabilities.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/capabilities.py
@@ -119,11 +119,12 @@ class StructuredOutputMode:
     - ``RESPONSE_JSON_SCHEMA`` — Gemini 3+ WITH tools, google-genai
       ``response_json_schema`` field (stricter server-side enforcement than
       ``response_schema``, and avoids the ``response_schema`` + tools
-      infinite-loop bug). DEFAULT for qualifying requests (Gemini-3+ AND
-      google-genai >= 1.22 AND tools). The
-      ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0`` kill-switch reverts these
-      to ``PROSE_HINT``. gemini-2.x, an older SDK, or no-tools requests never
-      reach this mode and keep their prior behavior.
+      infinite-loop bug). Runtime-default for qualifying requests (Gemini-3+
+      AND google-genai >= 1.22 AND tools) — the handler enables it unless the
+      ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0`` kill-switch is set; the
+      resolver parameter's signature default is ``False``. gemini-2.x, an older
+      SDK, or no-tools requests never reach this mode and keep their prior
+      behavior.
     - ``RESPONSE_SCHEMA`` — reserved for future vendor variants of
       server-side schema enforcement. Unused.
     - ``PROSE_HINT`` — schema-in-prompt HINT mode (Claude LiteLLM path,
@@ -272,15 +273,17 @@ def _resolve_gemini(
       The tools path never selects a server-side schema primitive.
 
     DEFAULT-ON EXCEPTION (RFC #1100 follow-up): when
-    ``gemini_native_structured_tools`` is True (its default — the
-    ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0`` kill-switch is NOT set) AND
-    tools are present AND the model is Gemini-3+ AND google-genai >= 1.22,
-    select RESPONSE_JSON_SCHEMA — the stricter Gemini-3 server-side primitive,
-    now validated loop-safe (the documented infinite-loop bug is specific to
-    the OLDER ``response_schema`` primitive, which this path deliberately
-    avoids). The kill-switch (``gemini_native_structured_tools=False``) reverts
-    the tools path to PROSE_HINT exactly as the pre-#1102 default. gemini-2.x,
-    an older SDK, or no-tools requests never reach this branch.
+    ``gemini_native_structured_tools`` is True AND tools are present AND the
+    model is Gemini-3+ AND google-genai >= 1.22, select RESPONSE_JSON_SCHEMA —
+    the stricter Gemini-3 server-side primitive, now validated loop-safe (the
+    documented infinite-loop bug is specific to the OLDER ``response_schema``
+    primitive, which this path deliberately avoids). This parameter's signature
+    default is ``False``; the runtime default-on comes from the handler, which
+    passes ``True`` unless the ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0``
+    kill-switch is set. With the kill-switch set
+    (``gemini_native_structured_tools=False``) the tools path reverts to
+    PROSE_HINT exactly as the pre-#1102 default. gemini-2.x, an older SDK, or
+    no-tools requests never reach this branch.
     """
     if not output_is_basemodel:
         return ModelCapabilities(
@@ -371,11 +374,13 @@ def resolve_capabilities(
             (Anthropic only consults this).
         streaming: True on the streaming dispatch path (Anthropic only).
         has_tools: True when real user tools are present (Gemini only).
-        gemini_native_structured_tools: DEFAULT ON. When True (the default —
-            the ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0`` kill-switch is NOT
-            set), qualifying Gemini-3+ requests with tools use the
-            ``response_json_schema`` server-side primitive (Gemini only). When
-            False (kill-switch set), the tools path reverts to PROSE_HINT.
+        gemini_native_structured_tools: signature default ``False``
+            (pure-function default); the handler passes ``True`` at runtime
+            unless the ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0`` kill-switch
+            is set — i.e. runtime default-on. When True, qualifying Gemini-3+
+            requests with tools use the ``response_json_schema`` server-side
+            primitive (Gemini only); when False (kill-switch set), the tools
+            path reverts to PROSE_HINT.
     """
     v = (vendor or "").strip().lower()
 

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/capabilities.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/capabilities.py
@@ -119,10 +119,11 @@ class StructuredOutputMode:
     - ``RESPONSE_JSON_SCHEMA`` — Gemini 3+ WITH tools, google-genai
       ``response_json_schema`` field (stricter server-side enforcement than
       ``response_schema``, and avoids the ``response_schema`` + tools
-      infinite-loop bug). Selected by the resolver only when
-      ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS`` is enabled and google-genai
-      >= 1.22 (server-enforced); otherwise the Gemini-with-tools path falls
-      back to ``PROSE_HINT``.
+      infinite-loop bug). DEFAULT for qualifying requests (Gemini-3+ AND
+      google-genai >= 1.22 AND tools). The
+      ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0`` kill-switch reverts these
+      to ``PROSE_HINT``. gemini-2.x, an older SDK, or no-tools requests never
+      reach this mode and keep their prior behavior.
     - ``RESPONSE_SCHEMA`` — reserved for future vendor variants of
       server-side schema enforcement. Unused.
     - ``PROSE_HINT`` — schema-in-prompt HINT mode (Claude LiteLLM path,
@@ -270,14 +271,16 @@ def _resolve_gemini(
       response_format + tools combo triggers Gemini's infinite-tool-loop bug).
       The tools path never selects a server-side schema primitive.
 
-    GATED EXCEPTION (RFC #1100 follow-up, default OFF): when
-    ``gemini_native_structured_tools`` is True AND tools are present AND the
-    model is Gemini-3+ AND google-genai >= 1.22, select RESPONSE_JSON_SCHEMA —
-    the stricter Gemini-3 server-side primitive. This is the LIVE EXPERIMENT
-    path: it tests whether ``response_json_schema`` + tools is loop-safe (the
-    documented infinite-loop bug is specific to the OLDER ``response_schema``
-    primitive, which this path deliberately avoids). Off by default → the
-    tools path stays on PROSE_HINT exactly as today.
+    DEFAULT-ON EXCEPTION (RFC #1100 follow-up): when
+    ``gemini_native_structured_tools`` is True (its default — the
+    ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0`` kill-switch is NOT set) AND
+    tools are present AND the model is Gemini-3+ AND google-genai >= 1.22,
+    select RESPONSE_JSON_SCHEMA — the stricter Gemini-3 server-side primitive,
+    now validated loop-safe (the documented infinite-loop bug is specific to
+    the OLDER ``response_schema`` primitive, which this path deliberately
+    avoids). The kill-switch (``gemini_native_structured_tools=False``) reverts
+    the tools path to PROSE_HINT exactly as the pre-#1102 default. gemini-2.x,
+    an older SDK, or no-tools requests never reach this branch.
     """
     if not output_is_basemodel:
         return ModelCapabilities(
@@ -368,10 +371,11 @@ def resolve_capabilities(
             (Anthropic only consults this).
         streaming: True on the streaming dispatch path (Anthropic only).
         has_tools: True when real user tools are present (Gemini only).
-        gemini_native_structured_tools: GATED, default OFF. When True (set by
-            the ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS`` env flag), unlocks
-            the Gemini-3 ``response_json_schema`` + tools experiment path
-            (Gemini only). Off → no behavior change anywhere.
+        gemini_native_structured_tools: DEFAULT ON. When True (the default —
+            the ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0`` kill-switch is NOT
+            set), qualifying Gemini-3+ requests with tools use the
+            ``response_json_schema`` server-side primitive (Gemini only). When
+            False (kill-switch set), the tools path reverts to PROSE_HINT.
     """
     v = (vendor or "").strip().lower()
 

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
@@ -50,19 +50,22 @@ logger = logging.getLogger(__name__)
 
 
 def _gemini_native_structured_tools_enabled() -> bool:
-    """Read the ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS`` gate.
+    """Read the ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS`` kill-switch.
 
-    DEFAULT OFF (RFC #1100 follow-up). When unset / falsy, every Gemini path
-    is byte-identical to today (tools → HINT). Accepts ``1/true/yes/on``
-    (case-insensitive) as enable — mirrors the ``MCP_MESH_NATIVE_LLM``
-    parsing style. When ON, unlocks the Gemini-3 ``response_json_schema`` +
-    tools experiment on the mesh-delegated provider path; the resolver still
-    gates on model major version (>=3) and google-genai >= 1.22, so an
-    unsupported model/SDK silently stays on HINT.
+    DEFAULT ON (RFC #1100 follow-up). The Gemini-3 server-enforced
+    ``response_json_schema`` + tools path is now the default for qualifying
+    requests; this env var is an opt-OUT kill-switch. Returns False only when
+    explicitly set to ``0/false/no/off`` (case-insensitive); unset or any
+    other value → enabled (True). The resolver still gates on model major
+    version (>=3), google-genai >= 1.22, and tool presence, so gemini-2.x,
+    an older SDK, or a no-tools request silently keeps the prior behavior
+    (PROSE_HINT for tools / RESPONSE_FORMAT_STRICT for no-tools) even with
+    the default-on flag. Set ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0`` to
+    revert qualifying requests to the pre-#1102 PROSE_HINT path.
     """
     return os.environ.get(
         "MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS", ""
-    ).strip().lower() in ("1", "true", "yes", "on")
+    ).strip().lower() not in ("0", "false", "no", "off")
 
 
 # Internal marker stamped on ``model_params`` when the gated
@@ -276,11 +279,13 @@ class GeminiHandler(BaseProviderHandler):
                     output_type.__name__,
                 )
             elif caps.structured_output == StructuredOutputMode.RESPONSE_JSON_SCHEMA:
-                # GATED (default OFF): Gemini-3 server-enforced structured
-                # output WITH tools via ``response_json_schema``. Stamp the
-                # marker + carry the strict schema in ``response_format`` (the
-                # adapter reads it but emits ``response_json_schema``, NOT the
-                # legacy ``response_schema`` translation). Tools stay intact.
+                # DEFAULT ON for Gemini-3+ with tools (RFC #1100 follow-up):
+                # server-enforced structured output WITH tools via
+                # ``response_json_schema``. Stamp the marker + carry the strict
+                # schema in ``response_format`` (the adapter reads it but emits
+                # ``response_json_schema``, NOT the legacy ``response_schema``
+                # translation). Tools stay intact. Set the kill-switch
+                # MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0 to revert to HINT.
                 strict_schema = make_schema_strict(schema, add_all_required=True)
                 request_params["response_format"] = {
                     "type": "json_schema",
@@ -292,8 +297,9 @@ class GeminiHandler(BaseProviderHandler):
                 }
                 request_params[RESPONSE_JSON_SCHEMA_MARKER] = True
                 logger.info(
-                    "Gemini: GATED response_json_schema + tools for '%s' "
-                    "(MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS enabled, Gemini-3+)",
+                    "Gemini: response_json_schema + tools for '%s' "
+                    "(default-on for Gemini-3+; kill-switch: "
+                    "MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0 to disable)",
                     output_type.__name__,
                 )
             else:
@@ -423,22 +429,25 @@ class GeminiHandler(BaseProviderHandler):
         vendor handlers; Gemini is HINT-only here regardless, so the flag is
         a no-op.
 
-        GATED EXCEPTION (RFC #1100 follow-up, default OFF): when
-        ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS`` is enabled AND the resolver
-        confirms Gemini-3+ with google-genai >= 1.22, this stamps a
-        ``response_json_schema`` marker + the strict schema (as a
+        DEFAULT-ON EXCEPTION (RFC #1100 follow-up): when the resolver confirms
+        Gemini-3+ with google-genai >= 1.22 (and the
+        ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0`` kill-switch is NOT set),
+        this stamps a ``response_json_schema`` marker + the strict schema (as a
         ``response_format`` carrier) and KEEPS tools — letting the native
         adapter emit Gemini's stricter server-side primitive instead of HINT.
-        With the flag off, the resolver returns PROSE_HINT and the path below
-        is byte-identical to today (HINT injected, response_format popped).
+        With the kill-switch set, the resolver returns PROSE_HINT and the path
+        below is byte-identical to the pre-#1102 default (HINT injected,
+        response_format popped).
         """
         sanitized_schema = sanitize_schema_for_structured_output(output_schema)
 
-        # Gated mode selection (RFC #1100 follow-up). Default OFF →
-        # PROSE_HINT (the resolver's tools-path default), so the HINT block
-        # below runs exactly as today. When the gate is open AND the model /
-        # SDK qualify, the resolver returns RESPONSE_JSON_SCHEMA and we take
-        # the server-enforced branch instead.
+        # Mode selection (RFC #1100 follow-up). DEFAULT ON: when the model /
+        # SDK qualify (Gemini-3+, google-genai >= 1.22), the resolver returns
+        # RESPONSE_JSON_SCHEMA and we take the server-enforced branch. The
+        # kill-switch MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0 forces
+        # PROSE_HINT, so the HINT block below runs exactly as the pre-#1102
+        # default. Non-qualifying requests (gemini-2.x, older SDK) also stay
+        # on PROSE_HINT regardless of the flag.
         from .capabilities import StructuredOutputMode, resolve_capabilities
 
         caps = resolve_capabilities(
@@ -471,9 +480,10 @@ class GeminiHandler(BaseProviderHandler):
             }
             model_params[RESPONSE_JSON_SCHEMA_MARKER] = True
             logger.info(
-                "Gemini GATED response_json_schema + tools for '%s' "
-                "(mesh delegation; MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS "
-                "enabled, Gemini-3+ server-enforced, tools intact)",
+                "Gemini response_json_schema + tools for '%s' "
+                "(mesh delegation; default-on for Gemini-3+ server-enforced, "
+                "tools intact; kill-switch: "
+                "MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0 to disable)",
                 output_type_name or "Response",
             )
             return model_params

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_capability_resolver.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_capability_resolver.py
@@ -220,8 +220,8 @@ class TestGeminiResolver:
         """Gemini no-tools BaseModel always selects response_format/strict
         (flows to the adapter's response_schema field), independent of the
         model major version. The stricter ``response_json_schema`` variant is
-        reserved (RFC #1100 follow-up) pending live-Gemini validation, so no
-        resolver selects it yet."""
+        only selected on the WITH-tools path (Gemini-3+), so the no-tools path
+        is unchanged by the RFC #1100 follow-up default-on flip."""
         caps = resolve_capabilities(
             "gemini", model, output_is_basemodel=True, has_tools=False
         )
@@ -233,10 +233,13 @@ class TestGeminiResolver:
         )
         assert caps.structured_output == StructuredOutputMode.PROSE_HINT
 
-    def test_gemini_3_WITH_tools_is_prose_hint_unchanged(self, monkeypatch):
-        """The Gemini-with-tools path is UNCHANGED — even Gemini 3.x with the
-        new SDK stays on PROSE_HINT (the infinite-tool-loop gate). RFC #1100
-        Phase 2 never touches the tools path."""
+    def test_gemini_3_WITH_tools_default_param_is_prose_hint(self, monkeypatch):
+        """The resolver's ``gemini_native_structured_tools`` parameter defaults
+        to False (resolver-level default). Callers pass the env-derived value;
+        the handler reader is now default-ON (kill-switch). With the param
+        left at its resolver default, Gemini 3.x + tools stays on PROSE_HINT —
+        this pins the resolver signature default, not the runtime contract
+        (covered by TestGeminiNativeStructuredToolsGate)."""
         monkeypatch.setattr(
             caps_mod, "_sdk_at_least", lambda dist, floor: True
         )
@@ -250,9 +253,13 @@ class TestGeminiResolver:
 
 
 class TestGeminiNativeStructuredToolsGate:
-    """GATED Gemini-3 ``response_json_schema`` + tools path (RFC #1100
-    follow-up, default OFF). Off → PROSE_HINT exactly as today; on → only
-    Gemini-3+ with google-genai >= 1.22 unlocks RESPONSE_JSON_SCHEMA."""
+    """Gemini-3 ``response_json_schema`` + tools path (RFC #1100 follow-up).
+    Now DEFAULT ON at the runtime layer via a kill-switch
+    (``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0`` disables). At the resolver
+    layer the decision is driven by the ``gemini_native_structured_tools``
+    parameter the handler passes in: True (default / kill-switch unset) +
+    Gemini-3+ + google-genai >= 1.22 → RESPONSE_JSON_SCHEMA; False
+    (kill-switch set) → PROSE_HINT."""
 
     @pytest.fixture
     def _genai_floor_met(self, monkeypatch):
@@ -260,9 +267,10 @@ class TestGeminiNativeStructuredToolsGate:
         monkeypatch.setattr(caps_mod, "_sdk_at_least", lambda dist, floor: True)
         yield
 
-    def test_flag_off_with_tools_is_prose_hint_unchanged(self, _genai_floor_met):
-        """Default OFF: even Gemini-3 + tools + new SDK stays on PROSE_HINT —
-        byte-identical to today's behavior."""
+    def test_kill_switch_with_tools_is_prose_hint(self, _genai_floor_met):
+        """Kill-switch (gemini_native_structured_tools=False): Gemini-3 + tools
+        + new SDK reverts to PROSE_HINT — byte-identical to the pre-#1102
+        default."""
         caps = resolve_capabilities(
             "gemini",
             "gemini/gemini-3-pro-preview",
@@ -316,8 +324,8 @@ class TestGeminiNativeStructuredToolsGate:
         ],
     )
     def test_flag_on_gemini2x_tools_is_prose_hint(self, _genai_floor_met, model):
-        """Only Gemini-3+ unlocks the gated path; 2.x / 1.x with tools stays
-        on PROSE_HINT even with the flag on."""
+        """Only Gemini-3+ unlocks the server-enforced path; 2.x / 1.x with
+        tools stays on PROSE_HINT even with the flag enabled (default)."""
         caps = resolve_capabilities(
             "gemini",
             model,

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_gemini_handler_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_gemini_handler_native.py
@@ -471,12 +471,45 @@ def _clean_gate_env():
 
 
 class TestGatedResponseJsonSchemaApplyStructuredOutput:
-    """``apply_structured_output`` is the provider-delegated path. With the
-    gate OFF it must behave EXACTLY as today (HINT, response_format popped);
-    with the gate ON + Gemini-3 it stamps the marker, keeps response_format,
-    does NOT set _mesh_hint_mode, and keeps tools intact."""
+    """``apply_structured_output`` is the provider-delegated path. DEFAULT ON
+    (RFC #1100 follow-up): with the env var UNSET, Gemini-3 + tools stamps the
+    marker, keeps response_format, does NOT set _mesh_hint_mode, and keeps
+    tools intact. The ``MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0`` kill-switch
+    reverts to HINT (response_format popped) — byte-identical to pre-#1102."""
 
-    def test_gate_off_is_hint_exactly_as_today(self, monkeypatch):
+    def test_default_on_gemini3_stamps_marker(self, monkeypatch):
+        """Default (env unset) → server-enforced response_json_schema for
+        Gemini-3 + tools + modern SDK."""
+        monkeypatch.setattr(
+            caps_mod, "_sdk_at_least", lambda dist, floor: True
+        )
+        assert _GATE not in os.environ
+        handler = GeminiHandler()
+        model_params = {
+            "messages": [{"role": "system", "content": "base"}],
+            "tools": _TOOLS,
+        }
+        out = handler.apply_structured_output(
+            {"type": "object", "properties": {"answer": {"type": "string"}}},
+            "Plan",
+            model_params,
+            model="gemini/gemini-3-pro-preview",
+        )
+        # Server-enforced branch by default: marker stamped, NO hint mode.
+        assert out[_MARKER] is True
+        assert "_mesh_hint_mode" not in out
+        assert out["response_format"]["type"] == "json_schema"
+        assert out["tools"] == _TOOLS
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "OFF", "False"])
+    def test_kill_switch_reverts_to_hint_exactly_as_pre_1102(
+        self, monkeypatch, value
+    ):
+        """Kill-switch MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0 (or
+        false/no/off) reverts Gemini-3 + tools to the HINT path:
+        _mesh_hint_mode set, response_format popped, marker absent — byte-
+        identical to the pre-#1102 default."""
+        monkeypatch.setenv(_GATE, value)
         monkeypatch.setattr(
             caps_mod, "_sdk_at_least", lambda dist, floor: True
         )
@@ -492,14 +525,12 @@ class TestGatedResponseJsonSchemaApplyStructuredOutput:
             model_params,
             model="gemini/gemini-3-pro-preview",
         )
-        # HINT mode set, response_format popped, marker absent.
         assert out["_mesh_hint_mode"] is True
         assert "response_format" not in out
         assert _MARKER not in out
-        # Tools untouched.
         assert out["tools"] == _TOOLS
 
-    def test_gate_on_gemini3_stamps_marker_keeps_response_format_and_tools(
+    def test_explicit_on_gemini3_stamps_marker_keeps_response_format_and_tools(
         self, monkeypatch
     ):
         monkeypatch.setenv(_GATE, "true")
@@ -586,9 +617,12 @@ class TestGatedResponseJsonSchemaApplyStructuredOutput:
 
 
 class TestGatedResponseJsonSchemaPrepareRequest:
-    """``prepare_request`` mirrors the gated behavior for consistency."""
+    """``prepare_request`` mirrors the default-on behavior for consistency."""
 
-    def test_gate_off_tools_omits_response_format(self, monkeypatch):
+    def test_kill_switch_tools_omits_response_format(self, monkeypatch):
+        """Kill-switch MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0 → Gemini-3 +
+        tools omits response_format (HINT path), no marker."""
+        monkeypatch.setenv(_GATE, "0")
         monkeypatch.setattr(
             caps_mod, "_sdk_at_least", lambda dist, floor: True
         )
@@ -602,13 +636,15 @@ class TestGatedResponseJsonSchemaPrepareRequest:
         assert "response_format" not in params
         assert _MARKER not in params
 
-    def test_gate_on_gemini3_tools_stamps_marker_and_response_format(
+    def test_default_on_gemini3_tools_stamps_marker_and_response_format(
         self, monkeypatch
     ):
-        monkeypatch.setenv(_GATE, "on")
+        """Default (env unset) → Gemini-3 + tools stamps the marker and keeps
+        response_format as the response_json_schema carrier."""
         monkeypatch.setattr(
             caps_mod, "_sdk_at_least", lambda dist, floor: True
         )
+        assert _GATE not in os.environ
         handler = GeminiHandler()
         params = handler.prepare_request(
             messages=[{"role": "user", "content": "Hi"}],

--- a/tests/integration/suites/uc04_llm_integration/tc37_gemini3_multiturn_tools_loop_stress_py/artifacts/calculator-agent/main.py
+++ b/tests/integration/suites/uc04_llm_integration/tc37_gemini3_multiturn_tools_loop_stress_py/artifacts/calculator-agent/main.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+calculator-agent - MCP Mesh tool provider for the RFC #1100 loop-stress TC.
+
+Exposes TWO distinct deterministic tools (add, multiply) so the LLM consumer's
+agentic loop is forced through MULTIPLE sequential tool-call rounds when given a
+prompt with a data dependency ("first add, then multiply the result"). This
+stresses the Gemini-3 server-enforced response_json_schema + tools path (now
+default-on per RFC #1100) against the documented infinite-tool-loop risk: a
+loop-safe path terminates in a small number of iterations; a runaway path keeps
+calling tools until max_iterations.
+"""
+
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+import mesh
+
+app = FastMCP("CalculatorAgent")
+
+
+class CalcInput(BaseModel):
+    """Input for calculator operations."""
+
+    a: float = Field(..., description="First number")
+    b: float = Field(..., description="Second number")
+
+
+@app.tool()
+@mesh.tool(
+    capability="calculator",
+    description="Add two numbers",
+    version="1.0.0",
+    tags=["calculator", "math"],
+)
+def calc_add(a: float, b: float) -> float:
+    """Add two numbers together."""
+    return a + b
+
+
+@app.tool()
+@mesh.tool(
+    capability="calculator",
+    description="Multiply two numbers",
+    version="1.0.0",
+    tags=["calculator", "math"],
+)
+def calc_multiply(a: float, b: float) -> float:
+    """Multiply two numbers together."""
+    return a * b
+
+
+@mesh.agent(
+    name="calculator-agent",
+    version="1.0.0",
+    description="Calculator tool provider with add + multiply",
+    http_port=9030,
+    enable_http=True,
+    auto_run=True,
+)
+class CalculatorAgentConfig:
+    """Calculator tool provider agent (two distinct tools)."""
+
+    pass

--- a/tests/integration/suites/uc04_llm_integration/tc37_gemini3_multiturn_tools_loop_stress_py/artifacts/chat-tools-agent/main.py
+++ b/tests/integration/suites/uc04_llm_integration/tc37_gemini3_multiturn_tools_loop_stress_py/artifacts/chat-tools-agent/main.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+chat-tools-agent - MCP Mesh consumer for the RFC #1100 loop-stress TC (tc37).
+
+This is the multi-tool / multi-turn agentic-LOOP-STRESS consumer for the
+Gemini-3 server-enforced response_json_schema + tools path, which is now
+DEFAULT-ON (RFC #1100; kill-switch MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0).
+
+Risk vector: the documented response_format + tools non-deterministic infinite-
+tool-loop bug. tc36 only covers a single tool / ~2 iterations. This consumer:
+  (a) declares a Pydantic structured return type (CalcAnalysis), AND
+  (b) has TWO distinct mesh tools available (calc_add, calc_multiply),
+  (c) and is driven by a prompt with a hard data dependency that forces
+      MULTIPLE sequential tool-call rounds in the provider-side agentic loop:
+      "first add X and Y, then multiply that result by Z".
+
+The provider targeted is the Gemini-3 provider (gemini/gemini-3-flash-preview)
+started WITHOUT any structured-tools env flag, so it uses the new DEFAULT
+response_json_schema + tools path.
+
+max_iterations is set modestly (8) so a runaway loop hits the cap fast rather
+than running forever; the test step also has a bounded timeout so a loop fails
+fast instead of hanging the run.
+
+Modeled on uc04 tc18_structured_multi_turn_tools_py (multi-turn-tools, Claude)
+and tc36 (Gemini-3 single tool) — but Gemini-3 + two tools + forced sequential
+rounds.
+"""
+
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+import mesh
+
+app = FastMCP("ChatToolsAgent")
+
+
+# ===== STRUCTURED OUTPUT MODEL =====
+
+
+class CalcAnalysis(BaseModel):
+    """Structured output for the multi-step calculation analysis."""
+
+    answer: str = Field(..., description="The final numeric answer to the question")
+    reasoning: str = Field(
+        ..., description="Brief explanation of the step-by-step calculation"
+    )
+    steps: int = Field(..., description="Number of calculation steps performed")
+    used_tools: bool = Field(..., description="Whether the calculator tools were used")
+    confidence: float = Field(..., description="Confidence score from 0.0 to 1.0")
+
+
+class AnalysisContext(BaseModel):
+    """Context for the analysis request."""
+
+    question: str = Field(
+        ..., description="A multi-step arithmetic question requiring sequential tools"
+    )
+
+
+# ===== LLM FUNCTION WITH TWO TOOLS + STRUCTURED OUTPUT =====
+
+
+@app.tool()
+@mesh.llm(
+    provider={"capability": "llm", "tags": ["+gemini", "+provider"]},
+    filter={"capability": "calculator"},
+    max_iterations=8,
+    context_param="ctx",
+)
+@mesh.tool(
+    capability="analyze",
+    description="Analyze a multi-step math question using the LLM with calculator tools",
+    version="1.0.0",
+    tags=["llm", "analysis", "structured", "tools"],
+)
+async def analyze(
+    ctx: AnalysisContext,
+    llm: mesh.MeshLlmAgent = None,
+) -> CalcAnalysis:
+    """
+    Multi-step calc with two tools + structured output via the Gemini provider.
+
+    The prompt deliberately requires SEQUENTIAL tool calls with a data
+    dependency (add, then multiply the sum), so the agentic loop must run
+    through several iterations WITH tools + server-enforced structured output.
+    A loop-safe path completes in a small number of iterations and returns a
+    valid structured object; a looping path keeps calling tools until
+    max_iterations (8) and fails fast.
+    """
+    if llm is None:
+        raise RuntimeError("Mesh provider not resolved for analyze")
+
+    response = await llm(ctx.question)
+    return response
+
+
+# ===== AGENT CONFIGURATION =====
+
+
+@mesh.agent(
+    name="chat-tools-agent",
+    version="1.0.0",
+    description="Loop-stress consumer for Gemini-3 response_json_schema + tools",
+    http_port=9034,
+    enable_http=True,
+    auto_run=True,
+)
+class ChatToolsAgentConfig:
+    """Consumer agent for the RFC #1100 loop-stress TC."""
+
+    pass

--- a/tests/integration/suites/uc04_llm_integration/tc37_gemini3_multiturn_tools_loop_stress_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc37_gemini3_multiturn_tools_loop_stress_py/test.yaml
@@ -1,0 +1,261 @@
+# Test Case: Gemini-3 multi-tool / multi-turn agentic LOOP-STRESS (RFC #1100)
+#
+# The Gemini-3 server-enforced response_json_schema + tools path is now
+# DEFAULT-ON (RFC #1100; kill-switch MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS=0).
+# The flip's risk vector is the documented response_format + tools
+# non-deterministic infinite-tool-loop bug. Existing structured Gemini-with-tools
+# coverage (tc36) is only a single tool / ~2 iterations -- too thin to catch a
+# loop. This TC stresses the agentic loop:
+#
+#   - Gemini-3 provider (gemini/gemini-3-flash-preview), DEFAULT flag (no env):
+#     so it uses response_json_schema + tools by default.
+#   - Consumer (@mesh.llm, structured return CalcAnalysis) with TWO distinct
+#     mesh tools (calc_add, calc_multiply) and a prompt with a hard data
+#     dependency that forces MULTIPLE sequential tool-call rounds:
+#     "first add 137 and 246, then multiply that sum by 4".
+#       137 + 246 = 383 ; 383 * 4 = 1532
+#   - max_iterations=8 (modest) so a runaway loop hits the cap fast; the call
+#     step has a bounded timeout (120s) so a runaway FAILS FAST instead of
+#     hanging the run.
+#
+# PASS (loop-safe): the call returns a valid structured object containing 1532
+#   within the bounded timeout; the provider log shows the gated
+#   response_json_schema + tools path engaged (server-enforced); the consumer
+#   log shows the agentic loop ran multiple iterations and TERMINATED (no
+#   "Max iterations" / no MaxIterationsError / no timeout).
+# FAIL (runaway): the call times out / hits max_iterations / never returns the
+#   object -> response_json_schema + tools STILL loops under the new default.
+#   We do NOT weaken these assertions to force a pass; that would mean the flip
+#   is NOT safe to land. Log evidence is captured regardless of outcome.
+
+name: "Gemini-3 multi-tool multi-turn agentic loop-stress (default response_json_schema + tools)"
+description: "RFC #1100: stress the default-on Gemini-3 response_json_schema + tools agentic loop with 2 tools + forced sequential rounds; confirm it terminates and returns the structured object (no runaway)"
+tags:
+  - llm
+  - gemini
+  - structured
+  - python
+  - tools
+  - loop-stress
+  - issue-1100
+  - smoke
+timeout: 400
+# Skip with --skip-tag llm if no API key is available.
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+test:
+  # --- Copy artifacts ---
+  - name: "Copy Gemini provider to workspace"
+    handler: shell
+    command: "cp -r /uc-artifacts/gemini-provider /workspace/"
+    capture: copy_provider_output
+  - name: "Copy calculator-agent to workspace"
+    handler: shell
+    command: "cp -r /artifacts/calculator-agent /workspace/"
+    capture: copy_calc_output
+  - name: "Copy chat-tools-agent to workspace"
+    handler: shell
+    command: "cp -r /artifacts/chat-tools-agent /workspace/"
+    capture: copy_agent_output
+  - name: "Create env file with secrets"
+    handler: secrets
+    target: /workspace/.env
+  - name: "Verify workspace files"
+    handler: shell
+    command: "ls -la /workspace/"
+    capture: ls_output
+
+  # --- Start tool provider (two distinct tools) ---
+  - name: "Start calculator-agent (calc_add + calc_multiply)"
+    handler: shell
+    command: "meshctl start calculator-agent/main.py -d"
+    workdir: /workspace
+    capture: start_calc_output
+  - name: "Wait for calculator to register"
+    handler: wait
+    seconds: 3
+
+  # Provider started WITHOUT any structured-tools env flag: the gated
+  # response_json_schema + tools path is the DEFAULT for Gemini-3+ now.
+  # --debug so the provider-side "response_json_schema + tools" log line shows.
+  - name: "Start Gemini-3 provider (DEFAULT flag, no env)"
+    handler: shell
+    command: "meshctl start gemini-provider/main.py --env-file .env -d --debug"
+    workdir: /workspace
+    capture: start_provider_output
+  - name: "Wait for provider to register"
+    handler: wait
+    seconds: 15
+  - name: "Verify calculator and provider running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: pre_agent_list_output
+
+  # Consumer started --debug. NOTE: this is a mesh-delegation setup, so the
+  # multi-round agentic loop actually runs PROVIDER-SIDE (provider-managed
+  # loop); the per-round tool-call markers + completion line are asserted on
+  # the PROVIDER log below, not here.
+  - name: "Start chat-tools-agent (consumer: structured + 2 tools)"
+    handler: shell
+    command: "meshctl start chat-tools-agent/main.py -d --debug"
+    workdir: /workspace
+    capture: start_agent_output
+  - name: "Wait for agent to register and resolve dependencies"
+    handler: wait
+    seconds: 15
+  - name: "Verify all agents running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: all_list_output
+  - name: "List available tools"
+    handler: shell
+    command: "meshctl list -t"
+    workdir: /workspace
+    capture: tools_output
+
+  # THE LOOP-STRESS CALL. Two sequential tool rounds forced by the data
+  # dependency. Bounded timeout so a runaway FAILS FAST.
+  #   137 + 246 = 383 ; 383 * 4 = 1532
+  - name: "LOOP-STRESS call (default): multi-step structured output + 2 tools"
+    handler: shell
+    command: |
+      meshctl call analyze '{"ctx": {"question": "First use the calculator to add 137 and 246. Then use the calculator to multiply that sum by 4. Then return the structured analysis with the final number as the answer."}}'
+    workdir: /workspace
+    capture: stress_response
+    timeout: 120
+
+  # Capture provider log tail REGARDLESS of outcome: looking for the gated
+  # response_json_schema + tools line (server-enforced path engaged).
+  - name: "Capture Gemini provider log tail"
+    handler: shell
+    command: |
+      meshctl logs gemini-provider 2>/dev/null | tail -150 || true
+    workdir: /workspace
+    capture: provider_log
+    ignore_errors: true
+  - name: "Confirm gated response_json_schema path engaged in provider log"
+    handler: shell
+    command: |
+      meshctl logs gemini-provider 2>/dev/null | grep -iE "response_json_schema" || true
+    workdir: /workspace
+    capture: provider_json_schema_lines
+    ignore_errors: true
+
+  # This is a MESH-DELEGATION setup: the consumer's @mesh.llm delegates to the
+  # gemini-provider, which runs its OWN provider-managed agentic loop. So the
+  # per-round tool-call iteration markers and the loop-termination line live in
+  # the PROVIDER log, not the consumer log. Grep the provider log for the
+  # provider-managed loop markers (server-enforced multi-round tool use) and the
+  # explicit completion line.
+  - name: "Confirm provider-managed loop completed (provider log)"
+    handler: shell
+    command: |
+      meshctl logs gemini-provider 2>/dev/null | grep -iE "Provider-managed loop completed in [0-9]+ iterations" || true
+    workdir: /workspace
+    capture: loop_completed_line
+    ignore_errors: true
+  # Count tool-call rounds and emit an explicit newline-safe marker: a
+  # multi-round loop (forced add-then-multiply dependency) must show >= 2
+  # "Provider executing ... tool calls (iteration N/..)" lines.
+  - name: "Count provider-managed tool-call rounds (provider log)"
+    handler: shell
+    command: |
+      ROUNDS=$(meshctl logs gemini-provider 2>/dev/null | grep -cE "Provider executing [0-9]+ tool calls \(iteration" || echo 0)
+      echo "TOOL_ROUNDS=${ROUNDS}"
+      if [ "${ROUNDS}" -ge 2 ]; then echo "MULTI_ROUND_OK"; else echo "MULTI_ROUND_FAIL"; fi
+    workdir: /workspace
+    capture: tool_round_count
+    ignore_errors: true
+  - name: "Check provider log for max-iterations / runaway markers"
+    handler: shell
+    command: |
+      meshctl logs gemini-provider 2>/dev/null | grep -iE "Max iterations|MaxIterationsError|Exceeded maximum" || echo "NO_MAX_ITER"
+    workdir: /workspace
+    capture: max_iter_marker
+    ignore_errors: true
+  # Confirm BOTH distinct tools were actually invoked (not just one tool twice):
+  # emit explicit per-tool markers so the assertion is newline/format safe.
+  - name: "Confirm both distinct tools were actually invoked (provider log)"
+    handler: shell
+    command: |
+      LOG=$(meshctl logs gemini-provider 2>/dev/null || true)
+      echo "$LOG" | grep -q "calc_add"      && echo "CALC_ADD_INVOKED"      || echo "CALC_ADD_MISSING"
+      echo "$LOG" | grep -q "calc_multiply" && echo "CALC_MULTIPLY_INVOKED" || echo "CALC_MULTIPLY_MISSING"
+    workdir: /workspace
+    capture: tool_invocation_marker
+    ignore_errors: true
+
+  - name: "Stop all agents"
+    handler: shell
+    command: "meshctl stop"
+    workdir: /workspace
+    ignore_errors: true
+
+assertions:
+  # --- Infrastructure (must hold for the stress to be valid) ---
+  - expr: ${captured.pre_agent_list_output} contains 'calculator-agent'
+    message: "calculator-agent should be registered"
+  - expr: ${captured.pre_agent_list_output} contains 'gemini-provider'
+    message: "gemini-provider should be registered"
+  - expr: ${captured.all_list_output} contains 'chat-tools-agent'
+    message: "chat-tools-agent should be registered"
+  - expr: ${captured.tools_output} contains 'analyze'
+    message: "analyze tool should be listed"
+  - expr: ${captured.tools_output} contains 'calc_add'
+    message: "calc_add tool should be listed"
+  - expr: ${captured.tools_output} contains 'calc_multiply'
+    message: "calc_multiply tool should be listed (second distinct tool)"
+
+  # --- Confirm the GATED server-enforced path actually engaged by DEFAULT ---
+  # (no env flag was set; this proves the flipped default fired).
+  - expr: ${captured.provider_log} icontains 'response_json_schema'
+    message: "Provider log should show the gated response_json_schema + tools path engaged by default"
+  - expr: ${captured.provider_json_schema_lines} icontains 'response_json_schema'
+    message: "Provider log should contain the server-enforced response_json_schema + tools marker"
+
+  # --- Loop-safety: terminated correctly, returned the structured object ---
+  # 137+246=383 ; 383*4=1532. The final answer must contain 1532.
+  - expr: ${captured.stress_response} contains '1532'
+    message: "LOOP-STRESS: structured result should contain the final computed value 1532 (137+246=383, *4=1532)"
+  - expr: ${captured.stress_response} contains '"answer"'
+    message: "LOOP-STRESS: should return the structured 'answer' field"
+  - expr: ${captured.stress_response} contains '"confidence"'
+    message: "LOOP-STRESS: should return the structured 'confidence' field"
+  - expr: ${captured.stress_response} not contains 'ValidationError'
+    message: "LOOP-STRESS: should not have a ValidationError"
+
+  # --- No runaway: did NOT hit the cap / time out ---
+  - expr: ${captured.stress_response} not contains 'max_iterations'
+    message: "LOOP-STRESS: call should NOT hit max_iterations (runaway-loop indicator)"
+  - expr: ${captured.stress_response} not contains 'Exceeded maximum'
+    message: "LOOP-STRESS: call should NOT raise MaxIterationsError (runaway-loop indicator)"
+  - expr: ${captured.stress_response} not contains 'timed out'
+    message: "LOOP-STRESS: call should NOT time out (runaway-loop indicator)"
+  - expr: ${captured.max_iter_marker} contains 'NO_MAX_ITER'
+    message: "LOOP-STRESS: provider log should NOT show a Max iterations / MaxIterationsError marker (the loop terminated)"
+
+  # --- The provider-managed agentic loop actually ran MULTIPLE sequential tool
+  #     rounds (proves multi-turn stress) and TERMINATED (no runaway). This is a
+  #     mesh-delegation setup, so the loop runs provider-side. ---
+  - expr: ${captured.loop_completed_line} icontains 'Provider-managed loop completed'
+    message: "LOOP-STRESS: provider log should show the provider-managed loop completed (terminated, no runaway)"
+  - expr: ${captured.tool_round_count} contains 'MULTI_ROUND_OK'
+    message: "LOOP-STRESS: provider-managed loop should run at least 2 sequential tool-call rounds (forced data dependency: add then multiply)"
+  - expr: ${captured.tool_round_count} not contains 'MULTI_ROUND_FAIL'
+    message: "LOOP-STRESS: provider-managed loop should not run a single round (must be multi-round)"
+  - expr: ${captured.tool_invocation_marker} contains 'CALC_ADD_INVOKED'
+    message: "LOOP-STRESS: calc_add (tool A) should be invoked in the loop"
+  - expr: ${captured.tool_invocation_marker} contains 'CALC_MULTIPLY_INVOKED'
+    message: "LOOP-STRESS: calc_multiply (tool B) should be invoked in the loop (proves both distinct tools used)"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
Flip the Gemini gated server-enforced structured-output-with-tools path from **default-OFF to default-ON**, validated by the full live LLM integration suite + a new loop-stress test. RFC #1100 follow-up.

## What changes
For **Gemini-3+ models AND `google-genai>=1.22` AND tools present**, the provider now emits the server-enforced `response_json_schema` (one call, schema guaranteed) **by default**, instead of best-effort PROSE_HINT + corrective-retry fallback. `MCP_MESH_GEMINI_NATIVE_STRUCTURED_TOOLS` becomes an **opt-OUT kill-switch**: `=0`/`false`/`no`/`off` reverts to the prior HINT path (byte-identical to pre-#1102).

**Unchanged by the flip** (verified): gemini-2.x + tools → PROSE_HINT; no-tools → `RESPONSE_FORMAT_STRICT`; `google-genai<1.22` → PROSE_HINT. Only gemini-3+with-tools on a modern SDK changes default. The change is just the env-reader inversion; the model/SDK/tools gate and the marker-driven emission are untouched.

## Why it's safe to flip now — validated loop-safe
The path was HINT-only because of a documented `response_format`+tools non-deterministic infinite-loop bug; `response_json_schema` avoids it. Before flipping:
- **New `uc04/tc37_gemini3_multiturn_tools_loop_stress_py`** — Gemini-3 + 2 distinct tools + a forced multi-round agentic loop (`max_iterations=8`). Server-enforced path fires by default; **completes in 3 iterations, no runaway/timeout**, both tools invoked, correct structured result — across 3 live runs. This closes the prior coverage gap (only tc36's single-tool case existed).
- **Full LLM integration suite GREEN under the new default (live):** uc04 **36/36** (incl. tc36 + tc37), uc08 **9/9**, uc15 **15/15**, uc14 26 pass / 5 pre-existing-disabled skips, uc01 **16/16**. Every Gemini-with-tools TC exercises the server-enforced path with no loop.
- Unit tests inverted to the new default (default→`RESPONSE_JSON_SCHEMA`, kill-switch→PROSE_HINT); gemini-2.x / no-tools / old-SDK coverage retained.

## Result
Gemini-3-with-tools structured output joins **OpenAI** (`response_format` strict) and **Claude Sonnet-4.5+/Opus-4.1+** (`output_config`) as **server-enforced by default** — no corrective-retry fallback on the happy path. The kill-switch is the escape hatch.

## Review
Independent review: 0 blockers, 0 warnings. Reader inversion verified exact (enabled unless `{0,false,no,off}`; unset/empty → enabled), four-part gate intact, kill-switch byte-identical revert confirmed, no marker leak, docs updated, no scope creep.

Part of #1100

## Test plan
- [x] Unit suite green under the inverted default (resolver/handler; gemini-2.x/no-tools/old-SDK unchanged; kill-switch reverts)
- [x] New tc37 loop-stress: server-enforced by default, terminates (3<8 iters), no runaway, correct result (live ×3)
- [x] Full LLM integration suite green under the flip (uc04/uc08/uc15/uc14/uc01)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test suite for Gemini-3 multi-turn tool loop stress testing and accompanying sample agent/tool artifacts (calculator and chat-tools) to exercise multi-step tool usage.

* **Configuration Changes**
  * Gemini-3 native structured output with tools is now enabled by default. An environment-variable kill-switch is available to revert to the prior hint-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->