### PR TITLE
fix(di): harden untouched-slots diagnostic against hidden-param wrappers (#1104)

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
@@ -483,15 +483,37 @@ def _prepare_injection_kwargs(
     # ``analyze_injection_strategy`` can't see, because it counts MeshJob
     # positions too rather than McpMeshTool only.
     if len(eligible_positions) > len(dependencies):
-        untouched_positions = eligible_positions[len(dependencies):]
-        sig_params = list(sig.parameters.values())
-        untouched_param_names = [sig_params[pos].name for pos in untouched_positions]
-        log.warning(
-            f"⚠️ Function '{func.__name__}' has {len(eligible_positions)} "
-            f"injection-eligible parameters (McpMeshTool/MeshJob) but only "
-            f"{len(dependencies)} dependency(ies) declared. Parameters "
-            f"{untouched_param_names} will remain None."
-        )
+        try:
+            untouched_positions = eligible_positions[len(dependencies):]
+            # Positions are derived from the resolved/original signature
+            # (via ``analyze_mesh_job_signature``, which follows the
+            # ``__wrapped__``/``_mesh_original_func`` chain), which may have
+            # MORE params than the wrapper ``sig`` when a decorator (e.g.
+            # @mesh.a2a_consumer) rewrites ``__signature__`` to hide an
+            # injected param. Name the slots from that SAME original signature
+            # so positions line up — and bounds-guard regardless.
+            from .signature_analyzer import _get_original_func
+
+            diag_params = list(
+                inspect.signature(_get_original_func(func)).parameters.values()
+            )
+            untouched_param_names = [
+                diag_params[pos].name if pos < len(diag_params) else f"<arg {pos}>"
+                for pos in untouched_positions
+            ]
+            log.warning(
+                f"{tp}⚠️ Function '{func.__name__}' has {len(eligible_positions)} "
+                f"injection-eligible parameters (McpMeshTool/MeshJob) but only "
+                f"{len(dependencies)} dependency(ies) declared. Parameters "
+                f"{untouched_param_names} will remain None."
+            )
+        except (TypeError, ValueError, IndexError) as e:
+            # The diagnostic is purely informational and must never crash
+            # dispatch regardless of wrapper/original signature shape.
+            log.debug(
+                f"{tp}untouched-positional diagnostic skipped for "
+                f"{func.__name__}: {e}"
+            )
 
     injected_count = 0
     injected_deps: list[str] = []

--- a/src/runtime/python/tests/unit/test_12_dependency_injector.py
+++ b/src/runtime/python/tests/unit/test_12_dependency_injector.py
@@ -8,6 +8,7 @@ function finding without requiring actual MCP mesh infrastructure.
 
 import asyncio
 import inspect
+import logging
 import weakref
 from typing import Any
 from unittest.mock import MagicMock, call, patch
@@ -1146,3 +1147,67 @@ class TestUnifiedPositionalInjection:
         # Framework didn't construct a MeshJobSubmitter (registry URL
         # was unavailable), so injected_count stays at 0.
         assert injected_count == 0
+
+    def test_hidden_wrapper_param_diagnostic_does_not_raise(self, caplog):
+        """Regression for #1104 (from #1082): when a decorator like
+        @mesh.a2a_consumer rewrites the WRAPPER ``__signature__`` to hide
+        an injected param (``_a2a``), the wrapper signature has FEWER
+        params than the resolved/original function. The MeshJob position
+        is derived from the ORIGINAL signature, so the untouched-positional
+        diagnostic must NOT index the shorter wrapper signature with an
+        original-derived position (IndexError). With zero declared
+        dependencies the diagnostic always runs for such handlers.
+        """
+        from functools import wraps as _wraps
+        import inspect as _inspect
+
+        from mesh import MeshJob
+
+        # Original func: (user_id, sections, _a2a, job) — _a2a is the
+        # consumer-injected client; job is the MeshJob at ORIGINAL pos 3.
+        async def original(user_id: str, sections: list, _a2a=None, job: MeshJob = None):
+            return (user_id, sections, _a2a, job)
+
+        # Mimic the @mesh.a2a_consumer bridge: @wraps sets __wrapped__ to
+        # the original; __signature__ hides _a2a so the wrapper exposes
+        # only (user_id, sections, job) — three params, vs original's four.
+        # The MeshJob position (3) is resolved through __wrapped__ to the
+        # ORIGINAL signature, while the wrapper signature has only 3 params.
+        @_wraps(original)
+        async def bridge(*args, **call_kwargs):
+            call_kwargs.setdefault("_a2a", object())
+            return await original(*args, **call_kwargs)
+
+        user_sig = _inspect.signature(original)
+        cleaned = [p for n, p in user_sig.parameters.items() if n != "_a2a"]
+        bridge.__signature__ = user_sig.replace(parameters=cleaned)
+
+        # Sanity-check the precondition the regression depends on: the
+        # MeshJob is resolved (through __wrapped__) at ORIGINAL position 3,
+        # beyond the 3-param wrapper signature. This is what made the
+        # pre-fix diagnostic index out of bounds.
+        from _mcp_mesh.engine.signature_analyzer import analyze_mesh_job_signature
+
+        assert analyze_mesh_job_signature(original).mesh_job_param_index == 3
+
+        # a2a_consumer passes NO dependencies to the inner tool. Position 3
+        # (MeshJob, from the original sig) would index the 3-element wrapper
+        # signature → IndexError in the pre-fix diagnostic. Must not raise.
+        with caplog.at_level(logging.WARNING):
+            final_kwargs, count = self._prep(bridge, [], injected_deps_array=[])
+
+        # With zero declared dependencies the functional loop breaks before
+        # injecting; the diagnostic simply must not crash dispatch.
+        assert count == 0
+
+        # Positively confirm the formerly-crashing diagnostic branch ran:
+        # ``len(eligible_positions) > len(dependencies)`` was true (MeshJob
+        # slot present, zero deps), so the "untouched positional slots"
+        # warning fired without raising. Without this assertion a future
+        # signature-analysis regression could skip the branch and the test
+        # would still pass green while no longer guarding #1104.
+        assert any(
+            "injection-eligible parameters (McpMeshTool/MeshJob)" in r.message
+            and "will remain None" in r.message
+            for r in caplog.records
+        )


### PR DESCRIPTION
## Summary

A `task=True` `@mesh.a2a_consumer` job failed at dispatch with **`IndexError: list index out of range`** — recorded as the MeshJob's terminal `error`, so the handler body never ran. **Regression from #1082.**

## Root cause
The purely-informational "untouched positional slots" diagnostic in `_prepare_injection_kwargs` (`dependency_injector.py`) indexed the **wrapper** signature's param list with positions derived from the **resolved/original** signature. `@mesh.a2a_consumer` rewrites the wrapper `__signature__` to **hide the injected `A2AClient` (`_a2a`) param**, so the wrapper has fewer params than the original; the `MeshJob` position (e.g. 3) then indexed a shorter list → `IndexError`. With zero declared dependencies (a2a_consumer passes none to the inner tool), the diagnostic always ran for such handlers.

The **functional injection loop is already bounds-safe** (`break` on overflow) and is **unchanged** — only this informational diagnostic crashed.

## Fix (diagnostic-only)
- Name the untouched slots from the **same resolved/original signature** the positions came from (`_get_original_func`), so positions and names line up.
- **Bounds-guard** each lookup with an `<arg N>` placeholder fallback.
- Wrap the diagnostic in a narrow `try/except` that downgrades any failure to a debug log — dispatch can never crash on it again.
- Add the `{tp}` trace prefix to the warning for consistency.

## Validation
- **Unit:** new `test_hidden_wrapper_param_diagnostic_does_not_raise` reproduces the hidden-param wrapper + zero deps; asserts no IndexError, injection outcome unchanged, **and** (via `caplog` + the `mesh_job_param_index==3` precondition) that the formerly-crashing diagnostic branch actually executes — so the guard can't silently rot. Full unit suite green (1032).
- **Integration:** `uc25_a2a_consumer_python` **tc04** (long-running bridge), **tc06** (SSE bridge), **tc07** (consumer-death orphan-reset) — all **PASS** on an image built with the fix (were consistently failing); tc04/tc06 reach `status: completed` with producer sections, tc07 nulls `owner_instance_id`; no `list index out of range` anywhere in logs.

## Review
Independent review: 0 blockers. Confirmed the functional injection path is byte-for-byte unchanged, the `try/except` is narrow (diagnostic-only), names are consistent with the position source, and edge cases (unresolvable original sig, still-OOB position, empty params) are handled. The one WARNING (test could silently rot) was addressed by the caplog/precondition assertions above.

Closes #1104

## Test plan
- [x] Unit: hidden-param-wrapper diagnostic no longer raises; branch-execution asserted; injection unchanged; full suite 1032 green
- [x] Integration: uc25 tc04 / tc06 / tc07 pass on a fix-built image (previously failing)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
