### PR TITLE
fix(llm): correct SYNTHETIC_TOOL capability descriptor (server_enforced/recovery) (#1100)

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/capabilities.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/capabilities.py
@@ -215,12 +215,16 @@ def _resolve_anthropic(
                 min_sdk_version="0.77",
                 recovery=RECOVERY_NONE,
             )
+        # SYNTHETIC_TOOL is best-effort, not server-enforced: the model may
+        # decline to call the injected ``__mesh_format_response`` tool or emit
+        # invalid args, so it relies on corrective response_format retries
+        # (paths C/D). Hence server_enforced=False and a retry recovery value.
         return ModelCapabilities(
             structured_output=StructuredOutputMode.SYNTHETIC_TOOL,
-            server_enforced=True,
+            server_enforced=False,
             schema_with_tools=True,
             streaming_structured=False,
-            recovery=RECOVERY_NONE,
+            recovery=RECOVERY_RESPONSE_FORMAT_RETRY,
         )
 
     # LiteLLM path (no native) or streaming → HINT, with response_format retry.

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_capability_resolver.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_capability_resolver.py
@@ -13,6 +13,8 @@ import pytest
 
 from _mcp_mesh.engine.provider_handlers import capabilities as caps_mod
 from _mcp_mesh.engine.provider_handlers.capabilities import (
+    RECOVERY_NONE,
+    RECOVERY_RESPONSE_FORMAT_RETRY,
     StructuredOutputMode,
     resolve_capabilities,
 )
@@ -188,6 +190,51 @@ class TestOpenAIResolver:
             "openai", None, output_is_basemodel=True, has_tools=has_tools
         )
         assert caps.structured_output == StructuredOutputMode.RESPONSE_FORMAT_STRICT
+
+
+class TestServerEnforcementMetadata:
+    """Descriptor-metadata correctness for ``server_enforced``/``recovery``.
+
+    These fields are currently descriptive-only (no control flow reads them),
+    but must be accurate before a future phase makes them load-bearing.
+    """
+
+    def test_synthetic_tool_is_best_effort_with_retry_recovery(self):
+        """SYNTHETIC_TOOL is NOT server-enforced: the model may decline the
+        injected ``__mesh_format_response`` tool or emit invalid args, so it
+        relies on corrective response_format retries (paths C/D)."""
+        caps = resolve_capabilities(
+            "anthropic",
+            "anthropic/claude-3-5-sonnet-20241022",  # older model → SYNTHETIC_TOOL
+            output_is_basemodel=True,
+            has_native=True,
+            streaming=False,
+        )
+        assert caps.structured_output == StructuredOutputMode.SYNTHETIC_TOOL
+        assert caps.server_enforced is False
+        assert caps.recovery == RECOVERY_RESPONSE_FORMAT_RETRY
+
+    def test_output_config_is_server_enforced_no_recovery(
+        self, _anthropic_floor_met
+    ):
+        caps = resolve_capabilities(
+            "anthropic",
+            "anthropic/claude-sonnet-4-5",
+            output_is_basemodel=True,
+            has_native=True,
+            streaming=False,
+        )
+        assert caps.structured_output == StructuredOutputMode.OUTPUT_CONFIG
+        assert caps.server_enforced is True
+        assert caps.recovery == RECOVERY_NONE
+
+    def test_response_format_strict_is_server_enforced_no_recovery(self):
+        caps = resolve_capabilities(
+            "openai", None, output_is_basemodel=True
+        )
+        assert caps.structured_output == StructuredOutputMode.RESPONSE_FORMAT_STRICT
+        assert caps.server_enforced is True
+        assert caps.recovery == RECOVERY_NONE
 
 
 class TestGeminiResolver:


### PR DESCRIPTION
## Summary

The Anthropic `SYNTHETIC_TOOL` `ModelCapabilities` descriptor was mislabeled `server_enforced=True, recovery=RECOVERY_NONE`. But the synthetic-tool path (injecting `__mesh_format_response`) is **best-effort**: the model can decline to call the synthetic tool (→ `response_format` retry) or emit invalid args (→ corrective retry). Corrected to `server_enforced=False, recovery=RECOVERY_RESPONSE_FORMAT_RETRY`.

## Why now / why it's safe
`server_enforced` and `recovery` are **descriptive-only today** (nothing reads them for control flow), so this is **behavior-neutral**. But it's the documented "tidy the mislabel **before** making those fields load-bearing" cleanup — a future phase that gates the corrective retries on `recovery`/`server_enforced` would otherwise wrongly skip the synthetic path's retries.

Verified the genuinely server-enforced descriptors are correct and left unchanged: `OUTPUT_CONFIG` and `RESPONSE_FORMAT_STRICT` (both `server_enforced=True, recovery=RECOVERY_NONE`); `PROSE_HINT`/`TEXT` consistent. No other descriptor is mislabeled.

## Tests
Added `TestServerEnforcementMetadata` pinning SYNTHETIC_TOOL (`False`/retry) and OUTPUT_CONFIG + RESPONSE_FORMAT_STRICT (`True`/none). 76 resolver tests green; no control-flow change.

Part of #1100

## Test plan
- [x] `pytest test_capability_resolver.py` — 76 green (incl. new metadata assertions)
- [x] Behavior-neutral (descriptive-only fields; no resolver logic changed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery behavior for structured output with synthetic tools. The system now retries with corrected response formats instead of treating failures as final, enabling more robust API interactions.

* **Tests**
  * Added comprehensive tests validating capability metadata population across different model configurations and output modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->