### PR TITLE
feat(python/llm): server-enforced output_config on Claude streaming structured output (#1100)

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
@@ -900,23 +900,25 @@ def _build_create_kwargs(
             )
         else:
             schema = _extract_schema_from_response_format(response_format)
-            if schema is not None and _supports_native_output_format(model) and not stream:
+            if schema is not None and _supports_native_output_format(model):
                 # Native output_config branch — Sonnet 4.5+ / Opus 4.1+
                 # accept ``output_config.format`` as a first-class
                 # structured-output primitive. Cheaper than the synthetic-
                 # tool path (no extra tool slot, no system-instruction
                 # addendum, no agentic-loop tool_use→JSON unwrap) and
                 # enforced by the API rather than by a prompt hint.
-                # Streaming is intentionally NOT routed here —
-                # ``client.messages.stream`` requires separate wire-up
-                # (deferred to a follow-up PR); the handler at
-                # claude_handler.py:426 should have already forced HINT
-                # mode for stream=True, but the guard above is a safety
-                # net. ``maxItems`` / ``minItems`` are stripped because
-                # native output_config rejects them
-                # (Anthropic-cookbook issue #19444); the synthetic-tool
-                # path accepts them silently, so the strip is scoped to
-                # this branch.
+                # This branch is used for BOTH buffered and streaming
+                # (RFC #1100): ``client.messages.stream`` accepts
+                # ``output_config`` on the wire and the structured JSON
+                # arrives as ordinary ``text_delta`` chunks that
+                # accumulate into the final ``TextBlock`` — no separate
+                # event type or special assembly is needed. The resolver
+                # only routes capable models here for streaming; older
+                # models stay on HINT (synthetic-tool doesn't chunk).
+                # ``maxItems`` / ``minItems`` are stripped because native
+                # output_config rejects them (Anthropic-cookbook issue
+                # #19444); the synthetic-tool path accepts them silently,
+                # so the strip is scoped to this branch.
                 filtered_schema = _filter_anthropic_output_schema(schema)
                 request_params["output_config"] = {
                     "format": {

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native_output_format.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native_output_format.py
@@ -417,9 +417,11 @@ class TestNativeOutputConfigRouting:
         assert synthetic_count == 1
 
     @pytest.mark.asyncio
-    async def test_stream_true_falls_through_to_synthetic_tool(self):
-        """Defensive: ``stream=True`` MUST fall through to synthetic-tool
-        path. Streaming output_config requires separate wire-up (deferred)."""
+    async def test_stream_true_capable_model_emits_output_config(self):
+        """RFC #1100: ``stream=True`` on a capable model (Sonnet 4.6) MUST
+        emit native ``output_config`` — ``client.messages.stream`` accepts the
+        primitive and the structured JSON arrives as ``text_delta`` chunks. No
+        synthetic tool is injected on this path."""
         # Direct call to _build_create_kwargs to inject stream=True without
         # actually opening a streaming context.
         create_kwargs = anthropic_native._build_create_kwargs(
@@ -430,7 +432,29 @@ class TestNativeOutputConfigRouting:
             model="anthropic/claude-sonnet-4-6",
             stream=True,
         )
-        # No native output_config — streaming branch defers.
+        # Native output_config engaged on the streaming path.
+        assert "output_config" in create_kwargs
+        assert create_kwargs["output_config"]["format"]["type"] == "json_schema"
+        # No synthetic tool (output_config path doesn't inject one).
+        tools = create_kwargs.get("tools") or []
+        assert not any(t.get("name") == SYNTHETIC_FORMAT_TOOL_NAME for t in tools)
+
+    @pytest.mark.asyncio
+    async def test_stream_true_older_model_uses_synthetic_tool(self):
+        """``stream=True`` on an older (non-output_config-capable) model still
+        falls through to the synthetic-tool path — native output_config is
+        only emitted for capable models. (The resolver routes older-model
+        streaming to HINT upstream, but the adapter remains correct if reached
+        directly.)"""
+        create_kwargs = anthropic_native._build_create_kwargs(
+            {
+                "messages": [{"role": "user", "content": "Hi."}],
+                "response_format": _RESPONSE_FORMAT,
+            },
+            model="anthropic/claude-3-5-sonnet-20241022",
+            stream=True,
+        )
+        # No native output_config for older model.
         assert "output_config" not in create_kwargs
         # Synthetic-tool path engaged instead.
         tools = create_kwargs.get("tools") or []

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/capabilities.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/capabilities.py
@@ -178,10 +178,16 @@ def _resolve_anthropic(
     """Reproduce ``ClaudeHandler.apply_structured_output`` selection.
 
     - ``str`` output → TEXT.
-    - BaseModel + ``has_native`` + not ``streaming``:
-        - ``_supports_native_output_format(model)`` → OUTPUT_CONFIG
-        - else → SYNTHETIC_TOOL
-    - BaseModel otherwise (no native, or streaming) → PROSE_HINT.
+    - BaseModel + ``has_native``:
+        - buffered + ``_supports_native_output_format(model)`` → OUTPUT_CONFIG
+        - streaming + ``_supports_native_output_format(model)`` → OUTPUT_CONFIG
+          (RFC #1100: ``client.messages.stream`` accepts ``output_config`` and
+          delivers the structured JSON as ordinary ``text_delta`` chunks that
+          accumulate into the final ``TextBlock`` — no synthetic tool, which
+          does not chunk)
+        - buffered + older model → SYNTHETIC_TOOL
+        - streaming + older model → PROSE_HINT (synthetic-tool does not stream)
+    - BaseModel otherwise (no native) → PROSE_HINT.
     """
     # Reuse the single source of truth for the output_config model gate.
     from _mcp_mesh.engine.native_clients.anthropic_native import (
@@ -197,13 +203,20 @@ def _resolve_anthropic(
             recovery=RECOVERY_NONE,
         )
 
-    if has_native and not streaming:
+    if has_native:
         # OUTPUT_CONFIG requires anthropic >= 0.77 (stable ``output_config``).
         # With the dependency floor now 0.77 this gate never trips in
         # conforming installs; it makes the resolver correct for constrained
         # installs that pin an older SDK by degrading to the next-best native
         # mode (SYNTHETIC_TOOL, issue #834) rather than emitting a primitive
         # the SDK cannot serialize.
+        #
+        # RFC #1100: output_config is now allowed on the streaming path for
+        # capable models. ``client.messages.stream`` accepts the primitive and
+        # the structured JSON arrives as ordinary ``text_delta`` chunks. Older
+        # models stay on PROSE_HINT for streaming (synthetic-tool injection
+        # produces a single forced tool call that arrives discrete, not
+        # chunked) — see the streaming fall-through below.
         if _supports_native_output_format(model) and _sdk_at_least(
             "anthropic", _ANTHROPIC_OUTPUT_CONFIG_FLOOR
         ):
@@ -211,7 +224,7 @@ def _resolve_anthropic(
                 structured_output=StructuredOutputMode.OUTPUT_CONFIG,
                 server_enforced=True,
                 schema_with_tools=True,
-                streaming_structured=False,
+                streaming_structured=streaming,
                 min_sdk_version="0.77",
                 recovery=RECOVERY_NONE,
             )
@@ -219,15 +232,19 @@ def _resolve_anthropic(
         # decline to call the injected ``__mesh_format_response`` tool or emit
         # invalid args, so it relies on corrective response_format retries
         # (paths C/D). Hence server_enforced=False and a retry recovery value.
-        return ModelCapabilities(
-            structured_output=StructuredOutputMode.SYNTHETIC_TOOL,
-            server_enforced=False,
-            schema_with_tools=True,
-            streaming_structured=False,
-            recovery=RECOVERY_RESPONSE_FORMAT_RETRY,
-        )
+        if not streaming:
+            return ModelCapabilities(
+                structured_output=StructuredOutputMode.SYNTHETIC_TOOL,
+                server_enforced=False,
+                schema_with_tools=True,
+                streaming_structured=False,
+                recovery=RECOVERY_RESPONSE_FORMAT_RETRY,
+            )
+        # Streaming + native but older model: synthetic-tool can't chunk, so
+        # fall through to PROSE_HINT below.
 
-    # LiteLLM path (no native) or streaming → HINT, with response_format retry.
+    # LiteLLM path (no native) or streaming-on-older-model → HINT, with
+    # response_format retry.
     return ModelCapabilities(
         structured_output=StructuredOutputMode.PROSE_HINT,
         server_enforced=False,

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
@@ -421,8 +421,10 @@ class ClaudeHandler(BaseProviderHandler):
             output_schema: JSON schema dict from consumer
             output_type_name: Name of the output type (e.g., "TripPlan")
             model_params: Current model parameters dict (will be modified)
-            streaming: When True, force HINT mode even when the native SDK is
-                available. See note below.
+            streaming: When True, route capable models (Sonnet 4.5+ /
+                Opus 4.1+) to native ``output_config`` (it streams as
+                ``text_delta`` chunks) and older models to HINT (synthetic-tool
+                doesn't chunk). See note below.
             model: Effective LiteLLM-style model id (e.g.
                 ``anthropic/claude-sonnet-4-6``). Used to gate the native
                 ``output_config`` branch — Sonnet 4.5+ / Opus 4.1+ accept the
@@ -434,18 +436,22 @@ class ClaudeHandler(BaseProviderHandler):
         """
         sanitized_schema = sanitize_schema_for_structured_output(output_schema)
 
-        # Streaming + structured output prefers HINT mode regardless of native
-        # SDK availability. Synthetic-tool injection produces a single forced
-        # tool call that arrives discrete (not chunked) — it doesn't actually
-        # stream. HINT mode emits JSON as plain text which flows naturally
-        # through stream chunks; the existing HINT-fallback machinery handles
-        # parse failures.
-        # Centralized mode selection (RFC #1100). The resolver reproduces the
-        # exact decision this block made inline: BaseModel + native + buffered
-        # routes to output_config (Sonnet 4.5+ / Opus 4.1+) or synthetic-tool
-        # (older models); streaming or no-native falls through to HINT below.
-        # The mode-implementation bodies are unchanged — we only switch on the
-        # resolved mode here.
+        # Centralized mode selection (RFC #1100). The resolver owns the full
+        # decision:
+        #   - BaseModel + native + capable model (Sonnet 4.5+ / Opus 4.1+) →
+        #     OUTPUT_CONFIG, for BOTH buffered and streaming. On streaming,
+        #     ``client.messages.stream`` accepts ``output_config`` and the
+        #     structured JSON arrives as ordinary ``text_delta`` chunks that
+        #     accumulate into the final ``TextBlock`` (RFC #1100 follow-up).
+        #   - BaseModel + native + older model, buffered → SYNTHETIC_TOOL.
+        #   - BaseModel + native + older model, streaming → PROSE_HINT
+        #     (synthetic-tool injection produces a single forced tool call that
+        #     arrives discrete, not chunked — it doesn't actually stream).
+        #   - no-native (LiteLLM) → PROSE_HINT.
+        # HINT mode emits JSON as plain text which flows naturally through
+        # stream chunks; the existing HINT-fallback machinery handles parse
+        # failures. The mode-implementation bodies are unchanged — we only
+        # switch on the resolved mode here.
         from .capabilities import StructuredOutputMode, resolve_capabilities
 
         caps = resolve_capabilities(

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_capability_resolver.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_capability_resolver.py
@@ -97,10 +97,45 @@ class TestAnthropicResolver:
         "model",
         [
             "anthropic/claude-sonnet-4-5",
-            "anthropic/claude-3-5-haiku-20241022",
+            "anthropic/claude-sonnet-4-5-20250101",
+            "anthropic/claude-sonnet-4-6",
+            "anthropic/claude-opus-4-1",
+            "anthropic/claude-opus-4-5",
+            "anthropic/claude-opus-4-7",
+            "anthropic.claude-sonnet-4-6-20260301-v1:0",
+            "anthropic/claude-sonnet-4.5",
         ],
     )
-    def test_basemodel_native_streaming_is_prose_hint(self, model):
+    def test_basemodel_native_streaming_supported_model_is_output_config(
+        self, model, _anthropic_floor_met
+    ):
+        """RFC #1100: streaming + native + capable model → OUTPUT_CONFIG.
+        ``client.messages.stream`` accepts ``output_config`` and the structured
+        JSON streams as ``text_delta`` chunks."""
+        caps = resolve_capabilities(
+            "anthropic",
+            model,
+            output_is_basemodel=True,
+            has_native=True,
+            streaming=True,
+        )
+        assert caps.structured_output == StructuredOutputMode.OUTPUT_CONFIG
+        assert caps.server_enforced is True
+        assert caps.streaming_structured is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "anthropic/claude-3-5-sonnet-20241022",
+            "anthropic/claude-sonnet-4-0",
+            "anthropic/claude-3-opus-20240229",
+            "anthropic/claude-3-5-haiku-20241022",
+            "anthropic/claude-opus-4-10",
+        ],
+    )
+    def test_basemodel_native_streaming_older_model_is_prose_hint(self, model):
+        """Streaming + native but older (non-output_config-capable) model stays
+        on PROSE_HINT — synthetic-tool injection doesn't chunk."""
         caps = resolve_capabilities(
             "anthropic",
             model,

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_claude_handler_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_claude_handler_native.py
@@ -534,20 +534,25 @@ class TestApplyStructuredOutputNative:
 
 
 class TestApplyStructuredOutputStreamingRouting:
-    """Phase C: streaming + structured output prefers HINT mode regardless of
-    native SDK availability. Synthetic-tool injection is a single forced tool
-    call that doesn't actually stream — HINT mode is the natural fit for
-    streaming (schema in prompt → JSON text → flows through chunks).
+    """Streaming + structured output mode selection.
+
+    - Capable models (Sonnet 4.5+ / Opus 4.1+) route to native
+      ``output_config`` on streaming (RFC #1100) — ``client.messages.stream``
+      accepts the primitive and the structured JSON streams as ``text_delta``
+      chunks.
+    - Older / unknown models (and the ``model=None`` default) route to HINT —
+      synthetic-tool injection is a single forced tool call that doesn't
+      actually stream, so HINT (schema in prompt → JSON text → chunks) is the
+      natural fit.
     """
 
-    def test_streaming_true_routes_to_hint_even_when_native_available(
-        self, _native_on
-    ):
-        """``streaming=True`` MUST take the HINT path on the native handler.
+    # Capable-model streaming → output_config is asserted in
+    # test_claude_handler_output_config.py (which carries the SDK-floor fixture).
 
-        Without this routing, synthetic-tool injection would fire and emit a
-        single discrete tool_use block — defeating the point of streaming.
-        """
+    def test_streaming_true_older_model_routes_to_hint(self, _native_on):
+        """``streaming=True`` on an older / unknown model (``model=None``
+        default) MUST take the HINT path — synthetic-tool injection emits a
+        single discrete tool_use block, defeating the point of streaming."""
         handler = ClaudeHandler()
         params: dict = {
             "messages": [{"role": "system", "content": "You are helpful."}]

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_claude_handler_output_config.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_claude_handler_output_config.py
@@ -134,6 +134,48 @@ class TestApplyStructuredOutputOutputConfig:
         assert result["_mesh_output_config_mode"] is True
         assert "_mesh_synthetic_format_tool" not in result
 
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "anthropic/claude-sonnet-4-5",
+            "anthropic/claude-sonnet-4-6",
+            "anthropic/claude-opus-4-1",
+            "anthropic/claude-opus-4-7",
+            "anthropic.claude-sonnet-4-6-20260301-v1:0",
+        ],
+    )
+    def test_streaming_capable_model_sets_output_config_not_hint(
+        self, _native_on, model
+    ):
+        """RFC #1100: streaming + native + capable model routes to native
+        ``output_config`` (NOT HINT). ``client.messages.stream`` accepts the
+        primitive and the structured JSON arrives as ``text_delta`` chunks, so
+        capable models get server-enforced structured output on streaming —
+        no synthetic tool, no prompt-hint fallback machinery.
+        """
+        handler = ClaudeHandler()
+        params: dict = {
+            "messages": [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Plan a trip."},
+            ]
+        }
+        result = handler.apply_structured_output(
+            _trip_schema(), "Trip", params, streaming=True, model=model
+        )
+
+        # response_format set (adapter translates to output_config.format) and
+        # the output_config sentinel is stamped.
+        assert "response_format" in result
+        assert result["response_format"]["type"] == "json_schema"
+        assert result["_mesh_output_config_mode"] is True
+        assert result["_mesh_output_config_output_type_name"] == "Trip"
+        # HINT and synthetic sentinels MUST NOT be present — output_config
+        # supersedes both on the streaming capable-model path.
+        assert "_mesh_hint_mode" not in result
+        assert "_mesh_synthetic_format_tool" not in result
+        assert "_mesh_synthetic_format_tool_name" not in result
+
     def test_output_config_does_not_inject_system_addendum(self, _native_on):
         """``output_config`` mode must NOT append the synthetic "must call this
         tool" instruction to the system message — the API enforces the schema
@@ -354,17 +396,24 @@ class TestApplyStructuredOutputHaikuFallsThroughToSynthetic:
 
 
 class TestApplyStructuredOutputStreamingRoutingPreserved:
-    """Phase C: streaming + structured output prefers HINT mode regardless of
-    the new output_config branch. The model gate is only consulted when
-    ``streaming=False``."""
+    """Streaming mode selection. Capable models stream native output_config
+    (RFC #1100, asserted in
+    ``test_streaming_capable_model_sets_output_config_not_hint`` above); older
+    / unknown models and the no-native path stay on HINT — synthetic-tool
+    doesn't chunk and the LiteLLM path has no native primitive."""
 
     @pytest.mark.parametrize(
         "model",
-        ["anthropic/claude-sonnet-4-6", "anthropic/claude-opus-4-7"],
+        [
+            "anthropic/claude-3-5-sonnet-20241022",
+            "anthropic/claude-3-5-haiku-20241022",
+            "anthropic/claude-opus-4-10",
+        ],
     )
-    def test_streaming_sonnet_4_6_still_routes_to_hint(self, _native_on, model):
-        """Streaming MUST take the HINT path even on output_config-capable
-        models — the API's output_config is buffered-only in this design."""
+    def test_streaming_older_model_still_routes_to_hint(self, _native_on, model):
+        """Streaming on an older (non-output_config-capable) model MUST take
+        the HINT path — synthetic-tool injection emits a single discrete
+        tool_use block, defeating the point of streaming."""
         handler = ClaudeHandler()
         params: dict = {
             "messages": [{"role": "system", "content": "S"}]
@@ -379,6 +428,26 @@ class TestApplyStructuredOutputStreamingRoutingPreserved:
         assert "_mesh_output_config_mode" not in result
         # response_format must NOT leak through (issue #820 silent hang).
         assert "response_format" not in result
+
+    def test_streaming_capable_model_without_native_falls_through_to_hint(
+        self, _native_off
+    ):
+        """``has_native()`` False — even a capable model on the LiteLLM path
+        streams via HINT (no native output_config primitive available)."""
+        handler = ClaudeHandler()
+        params: dict = {
+            "messages": [{"role": "system", "content": "S"}]
+        }
+        result = handler.apply_structured_output(
+            _trip_schema(),
+            "Trip",
+            params,
+            streaming=True,
+            model="anthropic/claude-sonnet-4-6",
+        )
+
+        assert result["_mesh_hint_mode"] is True
+        assert "_mesh_output_config_mode" not in result
 
     def test_buffered_haiku_without_native_falls_through_to_hint(
         self, _native_off

--- a/src/runtime/python/tests/unit/test_phase_c_streaming_routing.py
+++ b/src/runtime/python/tests/unit/test_phase_c_streaming_routing.py
@@ -3,12 +3,16 @@
 Phase C ties together three changes:
 
 1. ``BaseProviderHandler.apply_structured_output`` gains a ``streaming``
-   kwarg. ``ClaudeHandler`` consumes it: ``streaming=True`` forces HINT mode
-   even when the native Anthropic SDK is available, because synthetic-tool
-   injection (the buffered native path) is a single discrete forced tool
-   call that doesn't actually stream as text chunks. HINT mode (schema in
-   prompt, JSON-as-text) is the natural fit for streaming and reuses the
-   existing HINT-fallback machinery for parse failures.
+   kwarg. ``ClaudeHandler`` consumes it: ``streaming=True`` on an older /
+   unknown model routes to HINT mode, because synthetic-tool injection (the
+   buffered native path) is a single discrete forced tool call that doesn't
+   actually stream as text chunks. HINT mode (schema in prompt, JSON-as-text)
+   is the natural fit for those and reuses the existing HINT-fallback
+   machinery for parse failures. (RFC #1100 follow-up: capable models —
+   Sonnet 4.5+ / Opus 4.1+ — instead stream native ``output_config``, since
+   ``client.messages.stream`` accepts the primitive and the structured JSON
+   arrives as ``text_delta`` chunks. The tests in this module exercise the
+   older-model / Haiku paths, which still route to HINT.)
 
 2. The legacy buffered ``process_chat`` final-response branch in
    ``mesh.helpers`` gains a ``_maybe_run_synthetic_fallback`` call, mirroring

--- a/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/calculator-agent
+++ b/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/calculator-agent
@@ -1,0 +1,1 @@
+../../tc27_structured_output_tools_cross_runtime_py/artifacts/calculator-agent

--- a/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/streaming-structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/streaming-structured-consumer-ts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "streaming-structured-consumer-ts",
+  "version": "1.0.0",
+  "description": "MCP Mesh streaming + structured output consumer (RFC #1100 validation)",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^2.3.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/streaming-structured-consumer-ts/src/index.ts
+++ b/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/streaming-structured-consumer-ts/src/index.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env npx tsx
+/**
+ * streaming-structured-consumer-ts - RFC #1100 validation consumer.
+ *
+ * Drives the STREAMING + STRUCTURED-OUTPUT combination against a Python
+ * Claude provider on a capable model (anthropic/claude-sonnet-4-5):
+ *
+ *   - provider tags include "ai.mcpmesh.stream" → the registry resolver
+ *     hands back the provider's auto-generated process_chat_stream tool.
+ *   - `returns` is a Zod object → the TS MeshLlmAgent.stream() path forwards
+ *     `output_schema` in model_params (TS, unlike Python, does NOT gate
+ *     stream() on str output_type — see src/runtime/typescript/src/llm-agent.ts).
+ *   - `filter: [{ capability: "calculator" }]` wires a real mesh tool so the
+ *     provider runs its NATIVE streaming agentic loop (process_chat_stream's
+ *     tool-endpoints branch → anthropic_native.complete_stream →
+ *     _build_create_kwargs), which is the exact code path RFC #1100 changed.
+ *     (A no-tools consumer would hit the LiteLLM no-tools branch instead and
+ *     never exercise the native output_config adapter.)
+ *
+ * The handler consumes llm.stream() chunk-by-chunk, accumulates the
+ * text_delta chunks into a single string, parses it as JSON, validates
+ * against the schema, and returns the structured object. It also echoes
+ * diagnostics (chunk count, raw accumulated text) so the test can assert
+ * the stream actually chunked and the JSON parsed cleanly.
+ */
+
+import { FastMCP, mesh } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const server = new FastMCP({
+  name: "Streaming Structured Consumer TS",
+  version: "1.0.0",
+});
+
+// Structured output schema the model must emit as streamed JSON.
+const CalcReport = z.object({
+  expression: z.string().describe("The arithmetic expression that was computed"),
+  result: z.number().describe("The numeric result"),
+  explanation: z.string().describe("One short sentence explaining the calculation"),
+});
+
+const streamingCalc = mesh.llm({
+  name: "streaming_calc_report",
+  capability: "streaming_calc_report",
+  description:
+    "Compute an arithmetic expression using mesh calculator tools and return " +
+    "a structured report — streamed token-by-token from a Claude provider.",
+  tags: ["structured", "streaming", "claude", "cross-runtime", "typescript"],
+  version: "1.0.0",
+
+  // Mesh delegation to the Python Claude provider. The ai.mcpmesh.stream tag
+  // opt-in is REQUIRED in TS to resolve the streaming provider variant.
+  provider: { capability: "llm", tags: ["+claude", "ai.mcpmesh.stream"] },
+
+  // Wire the real calculator mesh tools so the provider runs its NATIVE
+  // streaming agentic loop (forces the anthropic_native output_config path).
+  filter: [{ capability: "calculator" }],
+  filterMode: "all",
+  maxIterations: 5,
+
+  // Structured output via Zod schema → drives output_schema in model_params.
+  returns: CalcReport,
+
+  parameters: z.object({
+    ctx: z.object({
+      a: z.number().describe("First operand"),
+      b: z.number().describe("Second operand"),
+    }),
+  }),
+  contextParam: "ctx",
+
+  execute: async ({ ctx }, { llm }) => {
+    const prompt =
+      `Use the calculator tools to multiply ${ctx.a} by ${ctx.b}, then add ${ctx.a}. ` +
+      `Report the final arithmetic expression, the numeric result, and a one-sentence explanation.`;
+
+    // Consume the streaming provider chunk-by-chunk. With RFC #1100 these
+    // are Anthropic text_delta chunks carrying the structured JSON.
+    const chunks: string[] = [];
+    for await (const chunk of llm.stream(prompt)) {
+      chunks.push(chunk);
+    }
+    const accumulated = chunks.join("");
+
+    // The streamed text_delta chunks accumulate into the final JSON object.
+    // Parse + validate against the schema (this is what proves the streamed
+    // JSON is well-formed and schema-valid — no thinking text leaked in).
+    let parsedOk = false;
+    let parseError = "";
+    let report: z.infer<typeof CalcReport> | null = null;
+    try {
+      const obj = JSON.parse(accumulated.trim());
+      report = CalcReport.parse(obj);
+      parsedOk = true;
+    } catch (e) {
+      parseError = String(e);
+    }
+
+    // Surface diagnostics in the returned object so the test can assert on
+    // streaming behavior AND the structured result in one tool call.
+    return {
+      expression: report?.expression ?? "",
+      result: report?.result ?? 0,
+      explanation: report?.explanation ?? "",
+      // Diagnostics (extra keys are fine — returns schema is for the model,
+      // the tool return is serialized as-is to the caller).
+      _diag_chunk_count: chunks.length,
+      _diag_accumulated: accumulated,
+      _diag_parsed_ok: parsedOk,
+      _diag_parse_error: parseError,
+    } as unknown as z.infer<typeof CalcReport>;
+  },
+});
+
+server.addTool(streamingCalc);
+
+const agent = mesh(server, {
+  name: "streaming-structured-consumer-ts",
+  version: "1.0.0",
+  description: "TS consumer driving streaming + structured output (RFC #1100)",
+  httpPort: 9042,
+});
+
+console.log(
+  "streaming-structured-consumer-ts initialized. Waiting for mesh connections..."
+);

--- a/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/streaming-structured-consumer-ts/tsconfig.json
+++ b/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/streaming-structured-consumer-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/test.yaml
@@ -1,0 +1,282 @@
+# Test Case: Streaming + Structured Output via native output_config (RFC #1100)
+#
+# Validates the RFC #1100 change: Claude STREAMING structured output now uses
+# the server-enforced native ``output_config`` primitive for capable models
+# (Sonnet 4.5+ / Opus 4.1+) instead of being forced onto PROSE_HINT.
+#
+# Reachability: this combination is reachable through the TS consumer API only.
+#   - The Python consumer MeshLlmAgent.stream() hard-rejects non-str output_type
+#     (raises NotImplementedError), so a Python consumer can NEVER drive
+#     streaming + structured output.
+#   - The Java consumer explicitly does NOT add output_schema on the streaming
+#     path ("Buffered-path only" — MeshLlmAgentProxy).
+#   - The TypeScript consumer MeshLlmAgent.stream() does NOT gate on output type
+#     and forwards the Zod returnSchema as output_schema to the provider's
+#     process_chat_stream tool. This is the ONLY reachable driver.
+#
+# Native vs LiteLLM: the consumer wires a real mesh tool (calculator) so the
+# provider runs its NATIVE streaming agentic loop (anthropic_native.complete_stream
+# → _build_create_kwargs), which is the exact path RFC #1100 changed. A no-tools
+# consumer would hit the provider's LiteLLM no-tools streaming branch instead and
+# never reach the native output_config adapter.
+#
+# Topology:
+#   calculator-agent (Py tool)  ─┐
+#   claude-provider  (Py, sonnet-4-5, streaming variant auto-generated)
+#   streaming-structured-consumer-ts (TS, returns Zod, llm.stream())  ──┘
+#
+# Verifies:
+#   1. Provider log shows "output_config mode" engaged on the streaming call,
+#      NOT "HINT mode" and NOT "synthetic-tool mode".
+#   2. The streamed text_delta chunks accumulated into valid JSON that parsed
+#      to the schema (consumer reports _diag_parsed_ok=true, multiple chunks).
+#   3. The structured result is correct (multiply then add: a*b + a).
+#   4. No thinking-delta contamination (parsed JSON is clean).
+
+name: "Streaming + Structured Output via native output_config (RFC #1100)"
+description: "TS consumer drives streaming + structured output against Py Claude sonnet-4-5; verify native output_config path engages and JSON streams clean"
+tags:
+  - llm
+  - claude
+  - structured-output
+  - streaming
+  - cross-runtime
+  - typescript
+  - python
+  - rfc-1100
+timeout: 240
+
+pre_run:
+  # Python setup for Claude provider + calculator tool agent
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+  # Node.js/TypeScript setup for consumer
+  - routine: global.setup_for_typescript_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  # Copy UC-level Python Claude provider (uses anthropic/claude-sonnet-4-5)
+  - name: "Copy Python Claude provider to workspace"
+    handler: shell
+    command: "cp -rL /uc-artifacts/claude-provider /workspace/"
+    capture: copy_provider_output
+
+  # Copy TC-level calculator tool agent (symlink → resolve with -L)
+  - name: "Copy calculator tool agent to workspace"
+    handler: shell
+    command: "cp -rL /artifacts/calculator-agent /workspace/"
+    capture: copy_calc_output
+
+  # Copy TC-level TypeScript streaming+structured consumer
+  - name: "Copy streaming structured consumer to workspace"
+    handler: shell
+    command: "cp -rL /artifacts/streaming-structured-consumer-ts /workspace/"
+    capture: copy_consumer_output
+
+  # Create env file with secrets (ANTHROPIC_API_KEY)
+  - name: "Create env file with secrets"
+    handler: secrets
+    target: /workspace/.env
+
+  - name: "Verify workspace files"
+    handler: shell
+    command: "ls -la /workspace/"
+    capture: ls_output
+
+  # Install npm dependencies for TS consumer
+  - name: "Install npm dependencies"
+    handler: npm-install
+    path: /workspace/streaming-structured-consumer-ts
+
+  # Start Python Claude provider (DEBUG logs so the output_config / HINT mode
+  # log line is captured by meshctl logs).
+  - name: "Start Python Claude provider"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start claude-provider/main.py --env-file .env --env MCP_MESH_LOG_LEVEL=DEBUG --env MCP_MESH_HTTP_PORT=9001 -d"
+    capture: start_provider_output
+
+  # Start calculator tool agent
+  - name: "Start calculator tool agent"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start calculator-agent/main.py --env MCP_MESH_HTTP_PORT=9048 -d"
+    capture: start_calc_output
+
+  # Wait for provider + calculator to register and resolve deps
+  - name: "Wait for provider + calculator to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      EXPECTED="claude-provider calculator-agent"
+      EXPECTED_COUNT=2
+      echo "Waiting for $EXPECTED_COUNT agents to register with resolved deps..."
+      for i in $(seq 1 30); do
+        AGENTS=$(meshctl list 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' || true)
+        READY_COUNT=0
+        for agent in $EXPECTED; do
+          LINE=$(echo "$AGENTS" | grep -E "^${agent}" || true)
+          if [ -n "$LINE" ]; then
+            DEPS=$(echo "$LINE" | awk '{print $5}')
+            RESOLVED=$(echo "$DEPS" | cut -d/ -f1)
+            TOTAL=$(echo "$DEPS" | cut -d/ -f2)
+            if [ "$RESOLVED" = "$TOTAL" ]; then
+              READY_COUNT=$((READY_COUNT + 1))
+            fi
+          fi
+        done
+        if [ "$READY_COUNT" -ge "$EXPECTED_COUNT" ]; then
+          echo "All $EXPECTED_COUNT agents ready after $((i * 2))s"
+          meshctl list
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: Only $READY_COUNT/$EXPECTED_COUNT agents ready within 60s"
+      meshctl list 2>/dev/null || true
+      exit 1
+    capture: wait_provider_output
+    timeout: 90
+
+  - name: "List provider tools (confirm streaming variant registered)"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list -t"
+    capture: provider_tools_output
+
+  # Start TypeScript streaming+structured consumer
+  - name: "Start streaming structured consumer"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start streaming-structured-consumer-ts/src/index.ts --env-file .env --env MCP_MESH_HTTP_PORT=9042 -d"
+    capture: start_consumer_output
+
+  # Wait for consumer to register and resolve deps
+  - name: "Wait for streaming-structured-consumer-ts to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      EXPECTED="streaming-structured-consumer-ts"
+      EXPECTED_COUNT=1
+      echo "Waiting for $EXPECTED_COUNT agents to register with resolved deps..."
+      for i in $(seq 1 30); do
+        AGENTS=$(meshctl list 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' || true)
+        READY_COUNT=0
+        for agent in $EXPECTED; do
+          LINE=$(echo "$AGENTS" | grep -E "^${agent}" || true)
+          if [ -n "$LINE" ]; then
+            DEPS=$(echo "$LINE" | awk '{print $5}')
+            RESOLVED=$(echo "$DEPS" | cut -d/ -f1)
+            TOTAL=$(echo "$DEPS" | cut -d/ -f2)
+            if [ "$RESOLVED" = "$TOTAL" ]; then
+              READY_COUNT=$((READY_COUNT + 1))
+            fi
+          fi
+        done
+        if [ "$READY_COUNT" -ge "$EXPECTED_COUNT" ]; then
+          echo "Consumer ready after $((i * 2))s"
+          meshctl list
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: consumer not ready within 60s"
+      meshctl list 2>/dev/null || true
+      exit 1
+    capture: wait_consumer_output
+    timeout: 90
+
+  - name: "List all tools"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list -t"
+    capture: all_tools_output
+
+  # Drive the streaming + structured-output call: multiply 7 by 6 then add 7
+  # → 7*6 + 7 = 49. The consumer streams the JSON, accumulates, parses, and
+  # returns the structured report plus streaming diagnostics.
+  - name: "Call streaming_calc_report (a=7, b=6)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call streaming_calc_report '{"ctx": {"a": 7, "b": 6}}'
+    capture: calc_response
+    timeout: 150
+
+  # Capture provider logs to inspect which structured-output mode engaged.
+  - name: "Capture provider logs (mode selection)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # Grep to the runtime log lines that matter (the raw log also contains
+      # large tool-registration schema dumps that would otherwise crowd out
+      # the structured-output mode lines under any --tail window).
+      meshctl logs claude-provider --tail=2000 2>/dev/null \
+        | sed 's/\x1b\[[0-9;]*m//g' \
+        | grep -iE "output_config|HINT mode|synthetic-tool|Native Anthropic adapter|claude-sonnet-4-5|tokens?|usage|Heartbeat successful" \
+        || true
+    capture: provider_logs
+
+  - name: "Stop all agents"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl stop 2>/dev/null || true"
+    ignore_errors: true
+
+assertions:
+  # --- Registration / wiring ---
+  - expr: "${captured.provider_tools_output} contains 'claude_provider'"
+    message: "claude_provider tool should be listed"
+  - expr: "${captured.provider_tools_output} contains 'claude_provider_stream'"
+    message: "Provider must expose the auto-generated streaming variant (process_chat_stream / claude_provider_stream)"
+  - expr: "${captured.all_tools_output} contains 'streaming_calc_report'"
+    message: "TS streaming+structured consumer tool should be listed"
+  - expr: "${captured.all_tools_output} contains 'calc_multiply'"
+    message: "Calculator mesh tool should be available to the LLM"
+
+  # --- RFC #1100: native output_config path engaged on the streaming call ---
+  # Authoritative proof: anthropic_native._build_create_kwargs (the exact
+  # function RFC #1100 changed by removing the `not stream` guard) logs this
+  # line at the moment it places output_config on the wire for the stream call.
+  - expr: "${captured.provider_logs} contains 'output_config.format (native structured output)'"
+    message: "Native Anthropic adapter must place output_config on the wire for the streaming call (RFC #1100)"
+  - expr: "${captured.provider_logs} not contains 'HINT mode'"
+    message: "Provider must NOT fall back to HINT mode for streaming+structured on a capable model (RFC #1100)"
+  - expr: "${captured.provider_logs} not contains 'synthetic-tool mode'"
+    message: "Provider must NOT use synthetic-tool mode (does not chunk)"
+
+  # --- Streaming actually chunked + JSON parsed clean (no thinking contamination) ---
+  # The tool result is an MCP content envelope: .content[0].text is a JSON
+  # string holding the consumer's returned object (incl. _diag_* fields).
+  - expr: "${captured.calc_response} contains '_diag_parsed_ok'"
+    message: "Consumer diagnostics should be present in the response"
+  - expr: "${jq:captured.calc_response:.content[0].text | fromjson | ._diag_parsed_ok} == 'true'"
+    message: "Accumulated streamed text_delta chunks must parse to valid schema-conforming JSON (no thinking/signature deltas leaking in)"
+  - expr: "${jq:captured.calc_response:.content[0].text | fromjson | ._diag_chunk_count} >= 1"
+    message: "Structured JSON must flow through the streaming text_delta accumulator (>=1 chunk); the authoritative 'output_config engaged on the stream call' proof is the provider-log assertion above — chunk count is nondeterministic for short payloads"
+  - expr: "${jq:captured.calc_response:.content[0].text | fromjson | ._diag_parse_error} == ''"
+    message: "No JSON parse error on the accumulated stream"
+
+  # --- Structured result correct (7*6 + 7 = 49) ---
+  - expr: "${jq:captured.calc_response:.content[0].text | fromjson | .result} == '49'"
+    message: "Structured result must be the correct computed value (7*6 + 7 = 49)"
+  - expr: "${captured.calc_response} contains 'expression'"
+    message: "Structured object must contain the 'expression' field"
+  - expr: "${captured.calc_response} contains 'explanation'"
+    message: "Structured object must contain the 'explanation' field"
+
+  # --- Live-call proof: the correct computed result (49) requires the model
+  # to actually call the calculator tool and reason, and the provider log
+  # references the live sonnet-4-5 model id. Together these prove a live call. ---
+  - expr: "${captured.provider_logs} contains 'claude-sonnet-4-5'"
+    message: "Provider logs should reference the live anthropic/claude-sonnet-4-5 model id (proves a live Claude call)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary
- Capable Claude models (Sonnet-4.5+/Opus-4.1+) now use the **server-enforced native `output_config`** primitive for **streaming + structured output**, instead of being forced onto best-effort `PROSE_HINT` (parse-and-retry). `client.messages.stream` accepts `output_config` and the structured JSON arrives as ordinary `text_delta` chunks that accumulate into a clean object.
- `capabilities.py` (`_resolve_anthropic`): relax the `not streaming` gate — capable models return `OUTPUT_CONFIG` with `streaming_structured=streaming`; **older** native models on the streaming path still fall through to `PROSE_HINT` (synthetic-tool can't chunk). The non-streaming `SYNTHETIC_TOOL` descriptor is unchanged (keeps #1106's `server_enforced=False` + response_format retry).
- `claude_handler.py`: delegate mode selection to the resolver; drop the local HINT-forcing gate.
- `anthropic_native.py` (`_build_create_kwargs`): drop the `and not stream` guard so `output_config.format` flows on stream calls for capable models.

This is the final provider-handler item of RFC #1100. With it, all big-3 are server-enforced-by-default for structured output (OpenAI strict / Claude output_config / Gemini response_json_schema) on **both** buffered and streaming paths for capable models; fallback remains only on the genuinely best-effort paths (Haiku synthetic/HINT, gemini-2.x, non-big-3 tail).

### Reachability
Streaming + structured output is reachable **only via the TypeScript consumer** — the Python consumer hard-rejects non-`str` output_type on `stream()`, and the Java consumer omits `output_schema` on its streaming path. The new integration test therefore uses a TS consumer → Python Claude provider.

## Review Notes
Independent review found **no blockers**. WARNING dispositions:
- *Streaming relies on output_config JSON arriving as `text_delta`* — validated live (sonnet-4-5: output_config path engaged, 3 chunks, clean parse, no thinking-delta contamination). Kept the change surgical; no speculative guard added to the shared `complete_stream` path absent a failing case.
- *`_diag_chunk_count > 1` flaky* — **fixed**: relaxed to `>= 1`; the authoritative streaming proof is the `output_config.format (native structured output)` provider-log assertion, not chunk count (nondeterministic for short payloads).
- *TS consumer fabricates a zero `CalcReport` on parse failure* — test-only diagnostic by design; `_diag_parsed_ok` + `result == 49` assertions catch any bad parse.
- A review of the diff against a stale local `main` surfaced a "SYNTHETIC_TOOL descriptor changed" finding — moot: that change is #1106 (already merged); the true diff vs `main` only wraps it in the streaming gate.

## Test plan
- [x] Unit: 158 passed / 1 env-skip across the 4 affected resolver/adapter test files
- [x] Integration tc38 (new, live sonnet-4-5): `output_config.format` engaged on the stream call (no HINT / no synthetic-tool), JSON streamed + parsed clean, result `49`
- [x] Regression: `uc18_streaming` 5/5 (plain-text `Stream[str]` unchanged); `uc04` Claude non-streaming structured 3/3 (buffered output_config unchanged)

Part of #1100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for streaming structured output using native output configuration for newer Claude models.
  * Older Claude models gracefully fall back to alternative structured output approaches when streaming.

* **Tests**
  * Expanded test coverage for streaming structured output routing across model versions and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->