### PR TITLE
test(uc14): re-enable 5 multimodal Gemini tests — 429 quota stale (#840)

### DIFF
--- a/tests/integration/suites/uc14_multimedia/tc17_llm_chart_gemini/test.yaml
+++ b/tests/integration/suites/uc14_multimedia/tc17_llm_chart_gemini/test.yaml
@@ -200,5 +200,3 @@ post_run:
     command: "meshctl stop 2>/dev/null || true"
     ignore_errors: true
   - routine: global.cleanup_workspace
-
-disabled: true # TEMP disabled: Gemini RESOURCE_EXHAUSTED 429 quota issue (#840)

--- a/tests/integration/suites/uc14_multimedia/tc18_llm_media_gemini/test.yaml
+++ b/tests/integration/suites/uc14_multimedia/tc18_llm_media_gemini/test.yaml
@@ -208,5 +208,3 @@ post_run:
     command: "meshctl stop 2>/dev/null || true"
     ignore_errors: true
   - routine: global.cleanup_workspace
-
-disabled: true # TEMP disabled: Gemini RESOURCE_EXHAUSTED 429 quota issue (#840)

--- a/tests/integration/suites/uc14_multimedia/tc19_llm_multi_image_gemini/test.yaml
+++ b/tests/integration/suites/uc14_multimedia/tc19_llm_multi_image_gemini/test.yaml
@@ -210,5 +210,3 @@ post_run:
     command: "meshctl stop 2>/dev/null || true"
     ignore_errors: true
   - routine: global.cleanup_workspace
-
-disabled: true # TEMP disabled: Gemini RESOURCE_EXHAUSTED 429 quota issue (#840)

--- a/tests/integration/suites/uc14_multimedia/tc20_llm_mixed_gemini/test.yaml
+++ b/tests/integration/suites/uc14_multimedia/tc20_llm_mixed_gemini/test.yaml
@@ -210,5 +210,3 @@ post_run:
     command: "meshctl stop 2>/dev/null || true"
     ignore_errors: true
   - routine: global.cleanup_workspace
-
-disabled: true # TEMP disabled: Gemini RESOURCE_EXHAUSTED 429 quota issue (#840)

--- a/tests/integration/suites/uc14_multimedia/tc21_llm_document_gemini/test.yaml
+++ b/tests/integration/suites/uc14_multimedia/tc21_llm_document_gemini/test.yaml
@@ -200,5 +200,3 @@ post_run:
     command: "meshctl stop 2>/dev/null || true"
     ignore_errors: true
   - routine: global.cleanup_workspace
-
-disabled: true # TEMP disabled: Gemini RESOURCE_EXHAUSTED 429 quota issue (#840)


### PR DESCRIPTION
## Summary
- Re-enables 5 `uc14_multimedia` Gemini multimodal tests disabled in May for `429 RESOURCE_EXHAUSTED`: `tc17_llm_chart_gemini`, `tc18_llm_media_gemini`, `tc19_llm_multi_image_gemini`, `tc20_llm_mixed_gemini`, `tc21_llm_document_gemini`.
- Removes only the trailing `disabled: true` flag from each (no test logic / assertions / source changed).

## Why the 429 no longer applies
Empirically re-validated on current code (provider now on `gemini-2.5-flash`, was `gemini-2.0-flash`):
- **Serial** (`--parallel 1`): 5/5 pass, no 429.
- **Parallel** (`--parallel 8`, all 38 enabled gemini tests under max contention): **38/38 pass, zero 429s** — including these 5.

The shared Gemini quota comfortably absorbs the parallel load (the suite already runs ~33 other enabled gemini tests). The May-era 429 is stale; no throttling needed.

## Review Notes
Independent review: **0 findings** — clean. Each file drops only the `disabled: true` line (+ its trailing blank); YAML well-formed; no lingering `disabled`/`#840`/quota references remain in the suite.

## Scope notes
- The original 6th test from #840 (`uc15_parallel_tool_calls/tc12_direct_gemini_py`) was deleted previously, so this closes #840's live scope.
- The 9 `uc10_toolcalls/*gemini_ts*` tests stay disabled — blocked by an unrelated upstream bug (`@ai-sdk/google` drops `thought_signature`, `vercel/ai#12351`), not #840.

## Test plan
- [x] Serial run of the 5 — 5/5, no 429
- [x] Parallel `--parallel 8` run of all 38 enabled gemini tests — 38/38, no 429
- [x] Independent diff review — clean

Closes #840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled Gemini LLM integration test suites for multimedia, chart resolution, multi-image handling, mixed content, and document processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->