### PR TITLE
feat(java/llm): align @mesh.llm contract with Python & TS (Part of #1112)

### DIFF
--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshAgent.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshAgent.java
@@ -34,6 +34,7 @@ import java.lang.annotation.Target;
  *   <li>{@code MCP_MESH_HTTP_PORT} → {@link #port()}</li>
  *   <li>{@code MCP_MESH_HTTP_HOST} → {@link #host()}</li>
  *   <li>{@code MCP_MESH_NAMESPACE} → {@link #namespace()}</li>
+ *   <li>{@code MCP_MESH_HEALTH_INTERVAL} → {@link #heartbeatInterval()}</li>
  * </ul>
  */
 @Target(ElementType.TYPE)

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshAgent.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshAgent.java
@@ -49,8 +49,6 @@ public @interface MeshAgent {
 
     /**
      * Agent version (semver format).
-     *
-     * <p>Override with {@code MCP_MESH_AGENT_VERSION} environment variable.
      */
     String version() default "1.0.0";
 
@@ -85,7 +83,7 @@ public @interface MeshAgent {
     /**
      * Heartbeat interval in seconds.
      *
-     * <p>Override with {@code MCP_MESH_HEARTBEAT_INTERVAL} environment variable.
+     * <p>Override with {@code MCP_MESH_HEALTH_INTERVAL} environment variable.
      */
     int heartbeatInterval() default 0;  // 0 = use Rust core default (5 seconds)
 }

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlm.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlm.java
@@ -90,7 +90,7 @@ public @interface MeshLlm {
      *
      * <p>Each iteration allows the LLM to make tool calls.
      */
-    int maxIterations() default 1;
+    int maxIterations() default MeshLlmDefaults.MAX_ITERATIONS;
 
     /**
      * System prompt for the LLM.
@@ -126,16 +126,22 @@ public @interface MeshLlm {
 
     /**
      * Maximum tokens for LLM response.
+     *
+     * <p>If unset ({@code -1}), the provider's own default is used — no
+     * {@code max_tokens} is sent on the wire.
      */
-    int maxTokens() default 4096;
+    int maxTokens() default MeshLlmDefaults.MAX_TOKENS_UNSET;
 
     /**
      * Temperature for LLM generation.
      *
      * <p>Higher values (0.7-1.0) are more creative,
      * lower values (0.0-0.3) are more deterministic.
+     *
+     * <p>If unset ({@code NaN}), the provider's own default is used — no
+     * {@code temperature} is sent on the wire.
      */
-    double temperature() default 0.7;
+    double temperature() default MeshLlmDefaults.TEMPERATURE_UNSET;
 
     /**
      * Enable parallel tool execution.

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlmDefaults.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlmDefaults.java
@@ -1,0 +1,40 @@
+package io.mcpmesh;
+
+/**
+ * Single source of truth for {@link MeshLlm} default values.
+ *
+ * <p>These compile-time constants are referenced both by the annotation
+ * defaults on {@link MeshLlm} and by the starter-side fallbacks (used when no
+ * annotation config is present). Keeping them here guarantees the two surfaces
+ * never drift apart.
+ *
+ * <p>The sentinel constants ({@link #MAX_TOKENS_UNSET}, {@link #TEMPERATURE_UNSET})
+ * encode "unset" for annotation primitives that cannot be {@code null}. When a
+ * value is unset the SDK does NOT inject it into the wire {@code model_params};
+ * the LLM provider's own default is used instead.
+ */
+public final class MeshLlmDefaults {
+
+    /**
+     * Default maximum iterations for the agentic loop. Matches the
+     * Python/TypeScript SDK default of 10.
+     */
+    public static final int MAX_ITERATIONS = 10;
+
+    /**
+     * Sentinel for an unset {@code maxTokens}. When {@code maxTokens} equals
+     * this value, no {@code max_tokens} is sent on the wire and the provider's
+     * own default applies.
+     */
+    public static final int MAX_TOKENS_UNSET = -1;
+
+    /**
+     * Sentinel for an unset {@code temperature}. When {@code temperature} is
+     * {@code NaN}, no {@code temperature} is sent on the wire and the provider's
+     * own default applies.
+     */
+    public static final double TEMPERATURE_UNSET = Double.NaN;
+
+    private MeshLlmDefaults() {
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
@@ -1,5 +1,6 @@
 package io.mcpmesh.spring;
 
+import io.mcpmesh.MeshLlmDefaults;
 import io.mcpmesh.core.MeshEvent;
 import io.mcpmesh.spring.media.MediaStore;
 import io.mcpmesh.spring.web.MeshA2APublicUrlCache;
@@ -321,10 +322,12 @@ public class MeshEventProcessor implements SmartLifecycle {
             // Configure with @MeshLlm settings (or defaults)
             String systemPrompt = config != null ? config.systemPrompt() : "";
             String contextParam = config != null ? config.contextParam() : "ctx";
-            int maxIterations = config != null ? config.maxIterations() : 1;
+            int maxIterations = config != null ? config.maxIterations()
+                : MeshLlmRegistry.resolveMaxIterations(
+                    System.getenv("MESH_LLM_MAX_ITERATIONS"), MeshLlmDefaults.MAX_ITERATIONS);
             boolean parallelToolCalls = config != null && config.parallelToolCalls();
-            int maxTokens = config != null ? config.maxTokens() : 4096;
-            double temperature = config != null ? config.temperature() : 0.7;
+            int maxTokens = config != null ? config.maxTokens() : MeshLlmDefaults.MAX_TOKENS_UNSET;
+            double temperature = config != null ? config.temperature() : MeshLlmDefaults.TEMPERATURE_UNSET;
 
             proxy.configure(mcpClient, proxyFactory, toolInvoker, injector, systemPrompt, contextParam, maxIterations, parallelToolCalls, maxTokens, temperature);
 
@@ -500,10 +503,12 @@ public class MeshEventProcessor implements SmartLifecycle {
             // Configure with @MeshLlm settings (or defaults)
             String systemPrompt = config != null ? config.systemPrompt() : "";
             String contextParam = config != null ? config.contextParam() : "ctx";
-            int maxIterations = config != null ? config.maxIterations() : 1;
+            int maxIterations = config != null ? config.maxIterations()
+                : MeshLlmRegistry.resolveMaxIterations(
+                    System.getenv("MESH_LLM_MAX_ITERATIONS"), MeshLlmDefaults.MAX_ITERATIONS);
             boolean parallelToolCalls = config != null && config.parallelToolCalls();
-            int maxTokens = config != null ? config.maxTokens() : 4096;
-            double temperature = config != null ? config.temperature() : 0.7;
+            int maxTokens = config != null ? config.maxTokens() : MeshLlmDefaults.MAX_TOKENS_UNSET;
+            double temperature = config != null ? config.temperature() : MeshLlmDefaults.TEMPERATURE_UNSET;
 
             proxy.configure(mcpClient, proxyFactory, toolInvoker, injector, systemPrompt, contextParam, maxIterations, parallelToolCalls, maxTokens, temperature);
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -598,7 +598,7 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
             } else if (!modelParams.containsKey("max_tokens") && defaultMaxTokens >= 0) {
                 modelParams.put("max_tokens", defaultMaxTokens);
             }
-            if (temperature != null) {
+            if (temperature != null && !Double.isNaN(temperature)) {
                 modelParams.put("temperature", temperature);
             } else if (!modelParams.containsKey("temperature") && !Double.isNaN(defaultTemperature)) {
                 modelParams.put("temperature", defaultTemperature);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -2,6 +2,7 @@ package io.mcpmesh.spring;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
+import io.mcpmesh.MeshLlmDefaults;
 import io.mcpmesh.core.MeshObjectMappers;
 import io.mcpmesh.core.MeshEvent;
 import io.mcpmesh.spring.media.MediaFetchResult;
@@ -63,9 +64,9 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
     // Configuration from @MeshLlm annotation
     private volatile String systemPromptTemplate = "";
     private volatile String contextParamName = "ctx";
-    private volatile int defaultMaxIterations = 1;
-    private volatile int defaultMaxTokens = 4096;
-    private volatile double defaultTemperature = 0.7;
+    private volatile int defaultMaxIterations = MeshLlmDefaults.MAX_ITERATIONS;
+    private volatile int defaultMaxTokens = MeshLlmDefaults.MAX_TOKENS_UNSET;
+    private volatile double defaultTemperature = MeshLlmDefaults.TEMPERATURE_UNSET;
     private volatile boolean parallelToolCalls = false;
 
     private McpHttpClient mcpClient;
@@ -118,7 +119,7 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
         this.dependencyInjector = dependencyInjector;
         this.systemPromptTemplate = systemPrompt != null ? systemPrompt : "";
         this.contextParamName = contextParamName != null ? contextParamName : "ctx";
-        this.defaultMaxIterations = maxIterations > 0 ? maxIterations : 1;
+        this.defaultMaxIterations = maxIterations > 0 ? maxIterations : MeshLlmDefaults.MAX_ITERATIONS;
     }
 
     /**
@@ -141,7 +142,9 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
      *
      * <p>Wires the annotation values through to the wire {@code model_params} so a
      * user writing {@code @MeshLlm(maxTokens=2000, temperature=0.3)} actually sees
-     * those values on the wire instead of the hardcoded 4096 / 0.7 defaults.
+     * those values on the wire. When {@code maxTokens}/{@code temperature} are left
+     * unset (sentinels {@code -1} / {@code NaN}), neither key is injected and the
+     * provider's own default applies.
      */
     public void configure(McpHttpClient mcpClient, McpMeshToolProxyFactory proxyFactory,
                           ToolInvoker toolInvoker, MeshDependencyInjector dependencyInjector,
@@ -592,12 +595,12 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
             }
             if (maxTokens != null) {
                 modelParams.put("max_tokens", maxTokens);
-            } else if (!modelParams.containsKey("max_tokens")) {
+            } else if (!modelParams.containsKey("max_tokens") && defaultMaxTokens >= 0) {
                 modelParams.put("max_tokens", defaultMaxTokens);
             }
             if (temperature != null) {
                 modelParams.put("temperature", temperature);
-            } else if (!modelParams.containsKey("temperature")) {
+            } else if (!modelParams.containsKey("temperature") && !Double.isNaN(defaultTemperature)) {
                 modelParams.put("temperature", defaultTemperature);
             }
             if (topP != null) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmRegistry.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -166,7 +167,7 @@ public class MeshLlmRegistry {
         if (envVal == null || envVal.isBlank()) {
             return annotationVal.ordinal();
         }
-        switch (envVal.trim().toLowerCase()) {
+        switch (envVal.trim().toLowerCase(Locale.ROOT)) {
             case "all":
                 return FilterMode.ALL.ordinal();
             case "best_match":

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmRegistry.java
@@ -1,5 +1,6 @@
 package io.mcpmesh.spring;
 
+import io.mcpmesh.FilterMode;
 import io.mcpmesh.MeshLlm;
 import io.mcpmesh.Selector;
 import org.slf4j.Logger;
@@ -71,11 +72,11 @@ public class MeshLlmRegistry {
         LlmConfig config = new LlmConfig(
             functionId,
             selector,
-            annotation.maxIterations(),
+            resolveMaxIterations(System.getenv("MESH_LLM_MAX_ITERATIONS"), annotation.maxIterations()),
             annotation.systemPrompt(),
             annotation.contextParam(),
             annotation.filter(),
-            annotation.filterMode().ordinal(),
+            resolveFilterModeOrdinal(System.getenv("MESH_LLM_FILTER_MODE"), annotation.filterMode()),
             annotation.maxTokens(),
             annotation.temperature(),
             annotation.parallelToolCalls()
@@ -117,5 +118,65 @@ public class MeshLlmRegistry {
 
     private String getMethodKey(Method method) {
         return method.getDeclaringClass().getName() + "#" + method.getName();
+    }
+
+    /**
+     * Resolve the effective {@code maxIterations} applying the precedence
+     * ENV &gt; annotation &gt; default.
+     *
+     * <p>Pure function: takes the raw {@code MESH_LLM_MAX_ITERATIONS} value as a
+     * parameter so it is unit-testable without mutating process env.
+     *
+     * @param envVal        raw value of {@code MESH_LLM_MAX_ITERATIONS} (may be null/blank)
+     * @param annotationVal the annotation (or default) value to fall back to
+     * @return the env value if it parses to a positive int; otherwise {@code annotationVal}
+     */
+    static int resolveMaxIterations(String envVal, int annotationVal) {
+        if (envVal == null || envVal.isBlank()) {
+            return annotationVal;
+        }
+        try {
+            int parsed = Integer.parseInt(envVal.trim());
+            if (parsed > 0) {
+                return parsed;
+            }
+            log.warn("MESH_LLM_MAX_ITERATIONS='{}' is not positive; using {}", envVal, annotationVal);
+            return annotationVal;
+        } catch (NumberFormatException e) {
+            log.warn("MESH_LLM_MAX_ITERATIONS='{}' is not a valid integer; using {}", envVal, annotationVal);
+            return annotationVal;
+        }
+    }
+
+    /**
+     * Resolve the effective filter-mode ordinal applying the precedence
+     * ENV &gt; annotation &gt; default.
+     *
+     * <p>Pure function: takes the raw {@code MESH_LLM_FILTER_MODE} value as a
+     * parameter so it is unit-testable without mutating process env. Accepts the
+     * wire vocabulary ({@code all}/{@code best_match}/{@code wildcard},
+     * case-insensitive) — the same vocabulary emitted by MeshAutoConfiguration —
+     * rather than {@link FilterMode#valueOf}.
+     *
+     * @param envVal        raw value of {@code MESH_LLM_FILTER_MODE} (may be null/blank)
+     * @param annotationVal the annotation (or default) FilterMode to fall back to
+     * @return the matching FilterMode ordinal, or {@code annotationVal.ordinal()} if unknown/blank
+     */
+    static int resolveFilterModeOrdinal(String envVal, FilterMode annotationVal) {
+        if (envVal == null || envVal.isBlank()) {
+            return annotationVal.ordinal();
+        }
+        switch (envVal.trim().toLowerCase()) {
+            case "all":
+                return FilterMode.ALL.ordinal();
+            case "best_match":
+                return FilterMode.BEST_MATCH.ordinal();
+            case "wildcard":
+                return FilterMode.WILDCARD.ordinal();
+            default:
+                log.warn("MESH_LLM_FILTER_MODE='{}' is not a recognized mode "
+                    + "(all|best_match|wildcard); using {}", envVal, annotationVal);
+                return annotationVal.ordinal();
+        }
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyModelParamsTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyModelParamsTest.java
@@ -67,7 +67,9 @@ class MeshLlmAgentProxyModelParamsTest {
 
         proxy = new MeshLlmAgentProxy("test.modelparams");
         // Configure with maxIterations=1 so generate() returns after a single LLM call.
-        // Defaults: maxTokens=4096, temperature=0.7, parallelToolCalls=false.
+        // The 8-arg overload leaves maxTokens/temperature at the sentinel defaults
+        // (-1 / NaN), so neither key is injected unless a per-call setter supplies one.
+        // parallelToolCalls=false.
         proxy.configure(client, null, null, null, "", "ctx", 1, false);
         proxy.updateProvider(
             server.url("/").toString().replaceAll("/$", ""),
@@ -93,6 +95,51 @@ class MeshLlmAgentProxyModelParamsTest {
         Map<String, Object> innerPayload = Map.of(
             "role", "assistant",
             "content", reply
+        );
+        String innerJson;
+        try {
+            innerJson = mapper.writeValueAsString(innerPayload);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        Map<String, Object> envelope = Map.of(
+            "jsonrpc", "2.0",
+            "id", id,
+            "result", Map.of(
+                "content", java.util.List.of(
+                    Map.of("type", "text", "text", innerJson)
+                )
+            )
+        );
+        String body;
+        try {
+            body = mapper.writeValueAsString(envelope);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return new MockResponse()
+            .setBody(body)
+            .setHeader("Content-Type", "application/json");
+    }
+
+    /**
+     * Stub an LLM response that requests a single tool call. Mirrors the nested
+     * MCP shape: {@code content[0].text} is a JSON object carrying {@code tool_calls}.
+     */
+    private MockResponse stubToolCallResponse(String callId, String toolName, Map<String, Object> args) {
+        long id = System.currentTimeMillis();
+        Map<String, Object> toolCall = Map.of(
+            "id", callId,
+            "type", "function",
+            "function", Map.of(
+                "name", toolName,
+                "arguments", args
+            )
+        );
+        Map<String, Object> innerPayload = Map.of(
+            "role", "assistant",
+            "content", "",
+            "tool_calls", java.util.List.of(toolCall)
         );
         String innerJson;
         try {
@@ -158,9 +205,10 @@ class MeshLlmAgentProxyModelParamsTest {
         assertEquals(0, thinking.get("thinking_budget").asInt());
         assertEquals("high", modelParams.get("reasoning_effort").asText());
 
-        // Typed defaults still emitted
-        assertTrue(modelParams.has("max_tokens"));
-        assertTrue(modelParams.has("temperature"));
+        // With sentinel defaults and no per-call setter, the typed keys are NOT
+        // injected — the provider's own defaults apply (parity with Python/TS).
+        assertFalse(modelParams.has("max_tokens"));
+        assertFalse(modelParams.has("temperature"));
     }
 
     @Test
@@ -393,5 +441,76 @@ class MeshLlmAgentProxyModelParamsTest {
             "null modelParams must produce the same model_params as no call");
         assertEquals(baseline.toString(), emptyCase.toString(),
             "empty modelParams must produce the same model_params as no call");
+    }
+
+    @Test
+    @DisplayName("unset maxTokens/temperature are deferred to the provider; per-call and annotation values are honored")
+    void sentinelDefaultsDeferToProvider() throws Exception {
+        // Case A: nothing set → neither key on the wire (provider default applies).
+        server.enqueue(stubLlmResponse("ok"));
+        proxy.request().user("hi").generate();
+        JsonNode unset = readModelParams(server.takeRequest());
+        assertFalse(unset.has("max_tokens"),
+            "unset maxTokens must NOT be injected — defer to provider");
+        assertFalse(unset.has("temperature"),
+            "unset temperature must NOT be injected — defer to provider");
+        // NaN must never appear on the wire (would break JSON).
+        assertFalse(unset.toString().contains("NaN"),
+            "NaN must never appear in model_params");
+
+        // Case B: per-call typed setters → both present.
+        server.enqueue(stubLlmResponse("ok"));
+        proxy.request().user("hi").temperature(0.3).maxTokens(2000).generate();
+        JsonNode perCall = readModelParams(server.takeRequest());
+        assertEquals(2000, perCall.get("max_tokens").asInt());
+        assertEquals(0.3, perCall.get("temperature").asDouble(), 1e-9);
+
+        // Case C: explicit annotation values via the 10-arg overload → both present.
+        proxy.configure(client, null, null, null, "", "ctx", 1, false, 1500, 0.2);
+        server.enqueue(stubLlmResponse("ok"));
+        proxy.request().user("hi").generate();
+        JsonNode annotated = readModelParams(server.takeRequest());
+        assertEquals(1500, annotated.get("max_tokens").asInt());
+        assertEquals(0.2, annotated.get("temperature").asDouble(), 1e-9);
+    }
+
+    @Test
+    @DisplayName("agentic loop runs multiple iterations: tool_calls response → tool result fed back → final content (maxIterations=10)")
+    void multiIterationAgenticLoopFeedsToolResultBack() throws Exception {
+        // Default maxIterations is now 10 (parity with Python/TS). With a tool_calls
+        // response followed by a content response, the loop must make TWO LLM calls,
+        // feed the tool result back, and return the final content. With the old
+        // default of 1 this would have stopped after the first call and returned
+        // the (empty) content of the tool_calls response.
+        proxy.configure(client, null, null, null, "", "ctx",
+            io.mcpmesh.MeshLlmDefaults.MAX_ITERATIONS, false);
+
+        // Iteration 1: LLM asks to call a (non-registered) tool.
+        server.enqueue(stubToolCallResponse("call_1", "missing_tool", Map.of("q", "x")));
+        // Iteration 2: LLM produces final content.
+        server.enqueue(stubLlmResponse("final answer"));
+
+        String result = proxy.request().user("do it").generate();
+        assertEquals("final answer", result);
+
+        // Two LLM calls were made.
+        RecordedRequest first = server.takeRequest();
+        RecordedRequest second = server.takeRequest();
+        assertNotNull(first);
+        assertNotNull(second);
+
+        // The second request's messages must include the assistant tool_calls turn
+        // and the fed-back tool result.
+        JsonNode secondBody = mapper.readTree(second.getBody().readUtf8());
+        JsonNode messages = secondBody.get("params").get("arguments").get("request").get("messages");
+        assertNotNull(messages);
+        boolean hasToolResult = false;
+        for (JsonNode m : messages) {
+            if ("tool".equals(m.path("role").asText())) {
+                hasToolResult = true;
+            }
+        }
+        assertTrue(hasToolResult,
+            "second LLM call must include the fed-back tool result message");
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyModelParamsTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyModelParamsTest.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -494,10 +495,10 @@ class MeshLlmAgentProxyModelParamsTest {
         assertEquals("final answer", result);
 
         // Two LLM calls were made.
-        RecordedRequest first = server.takeRequest();
-        RecordedRequest second = server.takeRequest();
-        assertNotNull(first);
-        assertNotNull(second);
+        RecordedRequest first = server.takeRequest(2, TimeUnit.SECONDS);
+        RecordedRequest second = server.takeRequest(2, TimeUnit.SECONDS);
+        assertNotNull(first, "first LLM request must arrive");
+        assertNotNull(second, "second LLM request (tool result fed back) must arrive within timeout");
 
         // The second request's messages must include the assistant tool_calls turn
         // and the fed-back tool result.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyStreamGenerateTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyStreamGenerateTest.java
@@ -73,7 +73,9 @@ class MeshLlmAgentProxyStreamGenerateTest {
         client = new McpHttpClient(mapper);
 
         proxy = new MeshLlmAgentProxy("test.streamGenerate");
-        // Defaults: maxTokens=4096, temperature=0.7, parallelToolCalls=false.
+        // The 8-arg overload leaves maxTokens/temperature at the sentinel defaults
+        // (-1 / NaN), so neither key is injected unless a per-call setter supplies one.
+        // parallelToolCalls=false.
         proxy.configure(client, null, null, null, "", "ctx", 1, false);
         proxy.updateProvider(
             server.url("/").toString().replaceAll("/$", ""),
@@ -174,9 +176,10 @@ class MeshLlmAgentProxyStreamGenerateTest {
         assertNotNull(thinking, "thinking_config must be present in wire model_params");
         assertEquals(0, thinking.get("thinking_budget").asInt());
 
-        // Annotation defaults still present
-        assertTrue(modelParams.has("max_tokens"));
-        assertTrue(modelParams.has("temperature"));
+        // With sentinel defaults and no per-call setter, the typed keys are NOT
+        // injected — the provider's own defaults apply (parity with Python/TS).
+        assertFalse(modelParams.has("max_tokens"));
+        assertFalse(modelParams.has("temperature"));
     }
 
     @Test

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyStreamTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyStreamTest.java
@@ -173,8 +173,9 @@ class MeshLlmAgentProxyStreamTest {
 
         JsonNode modelParams = request.get("model_params");
         assertNotNull(modelParams);
-        assertTrue(modelParams.has("max_tokens"));
-        assertTrue(modelParams.has("temperature"));
+        // Sentinel defaults (-1 / NaN) → neither key injected; provider default applies.
+        assertFalse(modelParams.has("max_tokens"));
+        assertFalse(modelParams.has("temperature"));
     }
 
     @Test

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmRegistryEnvResolutionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmRegistryEnvResolutionTest.java
@@ -1,0 +1,75 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.FilterMode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the {@code MESH_LLM_*} env-override resolution helpers
+ * (issue #1112, finding 2). The helpers are pure functions taking the env
+ * string as a parameter, so they are exercised directly without mutating the
+ * process environment. Precedence is ENV &gt; annotation &gt; default.
+ */
+@DisplayName("MeshLlmRegistry — MESH_LLM_* env resolution")
+class MeshLlmRegistryEnvResolutionTest {
+
+    @Test
+    @DisplayName("resolveMaxIterations: valid positive env wins over annotation")
+    void maxIterationsEnvWins() {
+        assertEquals(3, MeshLlmRegistry.resolveMaxIterations("3", 10));
+    }
+
+    @Test
+    @DisplayName("resolveMaxIterations: null env falls back to annotation")
+    void maxIterationsNullFallsBack() {
+        assertEquals(5, MeshLlmRegistry.resolveMaxIterations(null, 5));
+    }
+
+    @Test
+    @DisplayName("resolveMaxIterations: blank env falls back to annotation")
+    void maxIterationsBlankFallsBack() {
+        assertEquals(5, MeshLlmRegistry.resolveMaxIterations("  ", 5));
+    }
+
+    @Test
+    @DisplayName("resolveMaxIterations: non-numeric env falls back to annotation (warns)")
+    void maxIterationsInvalidFallsBack() {
+        assertEquals(5, MeshLlmRegistry.resolveMaxIterations("abc", 5));
+    }
+
+    @Test
+    @DisplayName("resolveMaxIterations: non-positive env falls back to annotation")
+    void maxIterationsNonPositiveFallsBack() {
+        assertEquals(5, MeshLlmRegistry.resolveMaxIterations("0", 5));
+        assertEquals(5, MeshLlmRegistry.resolveMaxIterations("-2", 5));
+    }
+
+    @Test
+    @DisplayName("resolveFilterModeOrdinal: known env value maps to matching ordinal (case-insensitive)")
+    void filterModeEnvWins() {
+        assertEquals(FilterMode.BEST_MATCH.ordinal(),
+            MeshLlmRegistry.resolveFilterModeOrdinal("best_match", FilterMode.ALL));
+        assertEquals(FilterMode.WILDCARD.ordinal(),
+            MeshLlmRegistry.resolveFilterModeOrdinal("WILDCARD", FilterMode.ALL));
+        assertEquals(FilterMode.ALL.ordinal(),
+            MeshLlmRegistry.resolveFilterModeOrdinal("all", FilterMode.WILDCARD));
+    }
+
+    @Test
+    @DisplayName("resolveFilterModeOrdinal: unknown env value falls back to annotation ordinal (warns)")
+    void filterModeUnknownFallsBack() {
+        assertEquals(FilterMode.ALL.ordinal(),
+            MeshLlmRegistry.resolveFilterModeOrdinal("bogus", FilterMode.ALL));
+    }
+
+    @Test
+    @DisplayName("resolveFilterModeOrdinal: null/blank env falls back to annotation ordinal")
+    void filterModeNullFallsBack() {
+        assertEquals(FilterMode.BEST_MATCH.ordinal(),
+            MeshLlmRegistry.resolveFilterModeOrdinal(null, FilterMode.BEST_MATCH));
+        assertEquals(FilterMode.BEST_MATCH.ordinal(),
+            MeshLlmRegistry.resolveFilterModeOrdinal("  ", FilterMode.BEST_MATCH));
+    }
+}


### PR DESCRIPTION
## Summary
Behavioral-parity cluster (**findings 1–4** of #1112) so identical user code produces identical agent behavior across the Python/TS/Java runtimes.

- **New `MeshLlmDefaults`** (`MAX_ITERATIONS=10`, `MAX_TOKENS_UNSET=-1`, `TEMPERATURE_UNSET=NaN`) — single source of truth referenced by the annotation defaults *and* the starter fallbacks, so the "default in three places" drift that caused finding 1 can't recur.
- **`maxIterations` default 1 → 10** (`@MeshLlm` annotation + `MeshEventProcessor` null-config fallbacks + `MeshLlmAgentProxy` floor). Fixes Java LLM tools that previously **stopped after one turn** without feeding tool results back.
- **Honor `MESH_LLM_MAX_ITERATIONS` / `MESH_LLM_FILTER_MODE`** (precedence `ENV > annotation > default`) via `System.getenv` + package-private pure helpers in `MeshLlmRegistry`. `MESH_LLM_MODEL` intentionally **not** implemented — there's no Java consumer-side `model` field; it's a provider-side concern (deferred).
- **`temperature`/`maxTokens` deferred to the provider when unset** (sentinel `NaN`/`-1`, gated in `MeshLlmAgentProxy.buildMergedModelParams()` — the sole injection site shared by the buffered + streaming paths; `NaN` is guarded off the wire). Matches Python/TS, which defer.
- **Javadoc fixes** in `MeshAgent.java`: `MCP_MESH_HEARTBEAT_INTERVAL` → `MCP_MESH_HEALTH_INTERVAL` (canonical, Rust-honored); removed the non-functional `MCP_MESH_AGENT_VERSION` override claim.

## ⚠️ Behavior changes (Java `@mesh.llm`) — for release notes
1. `maxIterations` default **1 → 10** (tool-using Java LLM tools now complete the multi-turn loop; more LLM round-trips for tools that emit tool calls).
2. `temperature`/`maxTokens` **now defer to the provider when unset** (no longer force-injected at `0.7`/`4096`). Set them explicitly via the annotation or per-call builder to override.

## Review Notes
Independent review: **0 blockers, 0 warnings, 2 INFO** (non-blocking):
- No env override for temp/maxTokens — intentional (Python/TS have none either).
- An explicit annotation `maxTokens=0` would emit `max_tokens:0` (degenerate user-chosen value); the `-1` unset sentinel works correctly.
Verified: `NaN` never reaches the wire (identity check, not magnitude — `temperature=0.0` still emitted), per-call precedence preserved, no default drift, correct loop bound, malformed-env warn-and-fallback.

## Test plan
- [x] **354 Java unit tests pass** — updated `MeshLlmAgentProxyModelParamsTest` + 2 stream tests for the deferral; added a sentinel test, a multi-iteration agentic-loop test, and `MeshLlmRegistryEnvResolutionTest`.
- [x] **Integration green** on a clean `src-tests` rebuild — 11 Java LLM TCs across uc04 + uc10 (multi-turn loops over Claude/OpenAI/Gemini × Py/Java tools), no regression from the temp/maxTokens deferral.
- Note: the integration analyst artifacts hard-code `maxIterations=5`, so the new **default of 10** is covered by unit tests rather than the integration suite (the suite confirms the surrounding deferral/env changes don't regress the working multi-turn path).

Part of #1112 — findings 5–8 (schema generator, `outputMode`, provider default tags incl. provider-side `MESH_LLM_MODEL`, A2A poll knobs) remain as deferred follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable-based configuration overrides with clear precedence (environment variables override annotation values and defaults).
  * LLM parameters (`maxTokens`, `temperature`) can now be left unset to defer to provider defaults instead of forcing hardcoded values.

* **Documentation**
  * Updated configuration documentation to reference correct environment variable names.

* **Refactor**
  * Centralized default configuration values for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->