### PR TITLE
fix(rust/core): reconnect-backoff jitter + demote heartbeat payload logging (Part of #1113)

### DIFF
--- a/src/runtime/core/src/heartbeat.rs
+++ b/src/runtime/core/src/heartbeat.rs
@@ -6,6 +6,7 @@
 
 use std::time::{Duration, Instant};
 use tracing::{debug, info, trace, warn};
+use uuid::Uuid;
 
 use crate::events::HealthStatus;
 use crate::registry::{FastHeartbeatResponse, FastHeartbeatStatus};
@@ -274,13 +275,24 @@ impl HeartbeatStateMachine {
     }
 
     fn calculate_backoff(&self) -> Duration {
-        // Exponential backoff with jitter
+        // Exponential backoff with equal jitter.
         let base = self.config.base_backoff.as_millis() as u64;
         let factor = 2u64.saturating_pow(self.retry_attempt);
         let backoff_ms = base.saturating_mul(factor);
         let max_ms = self.config.max_backoff.as_millis() as u64;
 
-        Duration::from_millis(backoff_ms.min(max_ms))
+        let capped = backoff_ms.min(max_ms);
+        let half = capped / 2;
+        // Equal jitter: half deterministic + up to half random (decorrelates
+        // reconnects so agents don't retry in lockstep on registry recovery).
+        let rand_part = if half > 0 {
+            let bytes = Uuid::new_v4().into_bytes();
+            let r = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
+            r % (half + 1)
+        } else {
+            0
+        };
+        Duration::from_millis(half + rand_part)
     }
 }
 
@@ -398,9 +410,39 @@ mod tests {
         sm.retry_attempt = 2;
         let backoff2 = sm.calculate_backoff();
 
-        // Should be exponentially increasing
-        assert!(backoff1 > backoff0);
-        assert!(backoff2 > backoff1);
+        // Should be (non-strictly) increasing — equal jitter floors each
+        // attempt at capped/2, which equals the previous attempt's ceiling, so
+        // adjacent attempts can tie but never invert.
+        assert!(backoff1 >= backoff0);
+        assert!(backoff2 >= backoff1);
+    }
+
+    #[test]
+    fn test_backoff_jitter() {
+        let config = HeartbeatConfig::default();
+        let max_ms = config.max_backoff.as_millis() as u64;
+        let mut sm = HeartbeatStateMachine::new(config);
+        sm.retry_attempt = 2;
+
+        // capped = base(1000) * 2^2 = 4000, floored at capped/2 = 2000.
+        let capped = 4000u64.min(max_ms);
+        let floor = capped / 2;
+
+        let mut values = std::collections::HashSet::new();
+        for _ in 0..20 {
+            let ms = sm.calculate_backoff().as_millis() as u64;
+            assert!(ms <= max_ms, "{} exceeds max_backoff {}", ms, max_ms);
+            assert!(ms <= capped, "{} exceeds capped {}", ms, capped);
+            assert!(ms >= floor, "{} below floor {}", ms, floor);
+            values.insert(ms);
+        }
+
+        // Jitter must produce variation across calls.
+        assert!(
+            values.len() >= 2,
+            "expected jittered backoff to vary, got {:?}",
+            values
+        );
     }
 
     #[test]

--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -175,7 +175,7 @@ fn job_status_to_str(s: JobStatus) -> &'static str {
 /// - finite `>= 0` and convertible → `Ok(Some(Duration::...))`
 fn parse_ffi_timeout_secs(secs: f64) -> Result<Option<Duration>, String> {
     if secs.is_nan() {
-        return Err(format!("timeout_secs must be a finite number, got NaN"));
+        return Err("timeout_secs must be a finite number, got NaN".to_string());
     }
     if secs.is_infinite() {
         return Err(format!(

--- a/src/runtime/core/src/registry.rs
+++ b/src/runtime/core/src/registry.rs
@@ -545,7 +545,7 @@ impl RegistryClient {
 
         // Log the actual JSON being sent for debugging
         if let Ok(json_str) = serde_json::to_string_pretty(request) {
-            info!("Heartbeat request JSON:\n{}", json_str);
+            debug!("Heartbeat request JSON:\n{}", json_str);
         }
         trace!("Heartbeat request: {:?}", request);
 
@@ -560,7 +560,7 @@ impl RegistryClient {
 
         if status.is_success() {
             let body = response.text().await?;
-            info!("Heartbeat response body:\n{}", body);
+            debug!("Heartbeat response body:\n{}", body);
 
             let parsed: HeartbeatResponse = serde_json::from_str(&body)?;
 

--- a/src/runtime/core/src/runtime.rs
+++ b/src/runtime/core/src/runtime.rs
@@ -560,17 +560,17 @@ impl AgentRuntime {
 
         // Find new or changed dependencies
         for (key, value) in &new_deps {
-            let changed = match self.topology.dependencies.get(key) {
-                Some(old_value) => {
+            let (changed, is_new) = match self.topology.dependencies.get(key) {
+                Some(old_value) => (
                     old_value.endpoint != value.endpoint
                         || old_value.function_name != value.function_name
-                        || old_value.kwargs != value.kwargs
-                }
-                None => true,
+                        || old_value.kwargs != value.kwargs,
+                    false,
+                ),
+                None => (true, true),
             };
 
             if changed {
-                let is_new = !self.topology.dependencies.contains_key(key);
                 if is_new {
                     info!(
                         "Dependency '{}' at {}:{} available at {} ({})",


### PR DESCRIPTION
## Summary
Rust core hygiene quick-wins (**Part of #1113**) — all in `src/runtime/core/src/`, no mesh wire/contract change.

- **`heartbeat.rs` `calculate_backoff`** — the comment claimed jitter but the body had **none**, so every agent that lost the registry retried in lockstep (thundering herd exactly when the registry is recovering). Now applies **equal jitter** in `[capped/2, capped]` using `uuid` v4 bytes as the entropy source (`uuid` is already a dependency — no new dep). New `test_backoff_jitter`; relaxed `test_backoff_calculation`'s adjacent-attempt assertion `>` → `>=` (with jitter, attempt N's floor equals attempt N-1's ceiling — adjacent values can tie but never invert).
- **`registry.rs` `send_heartbeat`** — demoted the two `info!` logs of the full request JSON and response body to `debug!`. These dump multi-KB payloads (full schemas, provider kwargs) on every heartbeat → hot-path noise + a low-grade provider-config leak into operator logs. The `debug!` summary and `trace!` lines are unchanged.
- **`runtime.rs` `process_dependency_changes`** — eliminated a redundant `HashMap` double-lookup (`.get(key)` then `.contains_key(key)`); `is_new` now comes from the same `match` arm. Semantics identical.
- **`jobs_ffi.rs`** — fixed `clippy::useless_format` (`format!` with no interpolation args → `.to_string()`).

## Review Notes
Independent review: **0 blockers, 0 warnings, 2 INFO** (non-blocking):
- A degenerate near-zero backoff config (`capped <= 1`) could yield 0ms — not a real-world concern.
- `test_backoff_jitter` asserts `>=2` distinct values over 20 draws — statistical, but collision-free in practice (2001-wide range).
Verified: jitter math never exceeds `max_backoff` and can't overflow; `try_into().unwrap()` can't panic (UUID is always 16 bytes); the `runtime.rs` refactor preserves exact semantics; no error path was demoted.

## Test plan
- [x] `cargo test heartbeat::tests` — 11/11 pass (incl. the new `test_backoff_jitter`)
- [x] `cargo check` clean across all binding feature variants (`python` / `typescript` / `ffi`)
- [x] `cargo clippy` — `useless_format` warning gone, no new warnings introduced
- Note: a full `cargo build` can't link locally under the default `python`/`simd` features (pyo3 `extension-module` needs the host interpreter — pre-existing env constraint); CI's Rust Tests job does the authoritative build.

## Out of scope / follow-ups
- The **binding-duplication cluster** of #1113 (canonical job wire-shape via `Serialize`, `json_value_to_py` dedup, timeout-validation dedup) remains as a separate follow-up PR.
- Flagged but not touched: a pre-existing order-dependent flaky test `ffi::tests::test_mesh_is_tracing_enabled_default` (global env-var pollution under parallel runs; passes in isolation).

Part of #1113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance & Reliability**
  * Enhanced heartbeat mechanism with exponential backoff and randomized jitter to improve resilience and reduce retry collisions in distributed environments.

* **Chores**
  * Optimized internal logging levels and refactored dependency change detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->