### PR TITLE
refactor(rust/core): unify job serialization across bindings via serde (Closes #1113)

### DIFF
--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -51,7 +51,7 @@ use crate::jobs::{
     BatchingHandle, JobController, JobError, JobProxy, SubmitJobArgs,
 };
 use crate::task_backend::{
-    Job, JobEvent, JobEventReceipt, JobStatus, RegistryHttpBackend, TaskBackend,
+    Job, JobEvent, JobEventReceipt, RegistryHttpBackend, TaskBackend,
 };
 
 // =============================================================================
@@ -124,6 +124,19 @@ unsafe fn write_out_string(out: *mut *mut c_char, value: String) -> i32 {
     }
 }
 
+/// Serialize a value to a JSON string and write it to `out`. On serde
+/// failure, sets the thread-local last-error and returns -1 (no `.unwrap()`
+/// so a serialization bug can't abort the host process).
+unsafe fn write_out_json(out: *mut *mut c_char, value: serde_json::Result<String>) -> i32 {
+    match value {
+        Ok(s) => write_out_string(out, s),
+        Err(e) => {
+            set_last_error(format!("failed to serialize JSON: {}", e));
+            -1
+        }
+    }
+}
+
 /// Build an `Arc<dyn TaskBackend>` from a registry URL. Sets last-error and
 /// returns `None` on transport-construction failure.
 fn backend_from_url(registry_url: &str) -> Option<Arc<dyn TaskBackend>> {
@@ -141,16 +154,6 @@ fn backend_from_url(registry_url: &str) -> Option<Arc<dyn TaskBackend>> {
 fn jobs_set_err(err: JobError) -> i32 {
     set_last_error(err.to_string());
     -1
-}
-
-fn job_status_to_str(s: JobStatus) -> &'static str {
-    match s {
-        JobStatus::Working => "working",
-        JobStatus::InputRequired => "input_required",
-        JobStatus::Completed => "completed",
-        JobStatus::Failed => "failed",
-        JobStatus::Cancelled => "cancelled",
-    }
 }
 
 // Stricter timeout-policy than mesh_job_proxy_wait's predicate (which
@@ -174,74 +177,27 @@ fn job_status_to_str(s: JobStatus) -> &'static str {
 ///   `from_secs_f64` would have aborted the host process)
 /// - finite `>= 0` and convertible → `Ok(Some(Duration::...))`
 fn parse_ffi_timeout_secs(secs: f64) -> Result<Option<Duration>, String> {
-    if secs.is_nan() {
-        return Err("timeout_secs must be a finite number, got NaN".to_string());
-    }
-    if secs.is_infinite() {
-        return Err(format!(
-            "timeout_secs must be a finite number, got {}",
-            secs
-        ));
-    }
-    if secs < 0.0 {
-        return Ok(None);
-    }
-    Duration::try_from_secs_f64(secs)
-        .map(Some)
-        .map_err(|e| format!("timeout_secs out of range: {} (got {})", e, secs))
+    crate::task_backend::validate_secs_to_duration(secs, true)
 }
 
 /// Convert a [`JobEvent`] to a JSON string matching the wire shape that
 /// the Python (`job_event_to_pydict`) and TS (`job_event_to_json`) bindings
 /// expose. Java callers parse this with Jackson on their side.
-fn job_event_to_json_string(ev: JobEvent) -> String {
-    serde_json::json!({
-        "job_id": ev.job_id,
-        "seq": ev.seq,
-        "type": ev.event_type,
-        "payload": ev.payload.unwrap_or(serde_json::Value::Null),
-        "trace_context": ev.trace_context.unwrap_or(serde_json::Value::Null),
-        "posted_by": ev.posted_by,
-        "created_at": ev.created_at,
-    })
-    .to_string()
+fn job_event_to_json_string(ev: JobEvent) -> serde_json::Result<String> {
+    serde_json::to_string(&ev)
 }
 
 /// Convert a [`JobEventReceipt`] to a JSON string matching the wire shape
 /// Python/TS bindings expose.
-fn job_event_receipt_to_json_string(receipt: JobEventReceipt) -> String {
-    serde_json::json!({
-        "job_id": receipt.job_id,
-        "seq": receipt.seq,
-        "created_at": receipt.created_at,
-    })
-    .to_string()
+fn job_event_receipt_to_json_string(receipt: JobEventReceipt) -> serde_json::Result<String> {
+    serde_json::to_string(&receipt)
 }
 
 /// Serialize a [`Job`] row to JSON matching the wire shape Python/TS bindings
 /// expose (and the registry's `Job` schema). Java callers parse this with
 /// Jackson on their side.
-fn job_to_json_string(job: Job) -> String {
-    let value = serde_json::json!({
-        "id": job.id,
-        "capability": job.capability,
-        "owner_instance_id": job.owner_instance_id,
-        "status": job_status_to_str(job.status),
-        "progress": job.progress,
-        "progress_message": job.progress_message,
-        "result": job.result.unwrap_or(serde_json::Value::Null),
-        "error": job.error,
-        "submitted_payload": job.submitted_payload,
-        "attempt_count": job.attempt_count,
-        "max_retries": job.max_retries,
-        "max_duration": job.max_duration,
-        "total_deadline": job.total_deadline,
-        "lease_expires_at": job.lease_expires_at,
-        "last_heartbeat_at": job.last_heartbeat_at,
-        "submitted_at": job.submitted_at,
-        "submitted_by": job.submitted_by,
-    });
-    value.to_string()
+fn job_to_json_string(job: Job) -> serde_json::Result<String> {
+    serde_json::to_string(&job)
 }
 
 // =============================================================================
@@ -631,7 +587,7 @@ pub unsafe extern "C" fn mesh_job_controller_recv_event(
             // checking the out-pointer.
             0
         }
-        Ok(Some(ev)) => write_out_string(out_event_json, job_event_to_json_string(ev)),
+        Ok(Some(ev)) => write_out_json(out_event_json, job_event_to_json_string(ev)),
         Err(JobError::Backend(crate::task_backend::BackendError::NotFound(msg))) => {
             set_last_error(format!("job not found: {}", msg));
             -2
@@ -831,7 +787,7 @@ pub unsafe extern "C" fn mesh_job_proxy_status(
     let inner = handle.inner.clone();
     let result = jobs_runtime().block_on(async move { inner.status().await });
     match result {
-        Ok(job) => write_out_string(out_job_json, job_to_json_string(job)),
+        Ok(job) => write_out_json(out_job_json, job_to_json_string(job)),
         Err(e) => jobs_set_err(e),
     }
 }
@@ -976,7 +932,7 @@ pub unsafe extern "C" fn mesh_job_proxy_send_event(
     let inner = handle.inner.clone();
     let result = jobs_runtime().block_on(async move { inner.send_event(event_type, payload).await });
     match result {
-        Ok(receipt) => write_out_string(out_receipt_json, job_event_receipt_to_json_string(receipt)),
+        Ok(receipt) => write_out_json(out_receipt_json, job_event_receipt_to_json_string(receipt)),
         Err(JobError::JobTerminal(msg)) => {
             set_last_error(format!("job is terminal: {}", msg));
             -3
@@ -1104,19 +1060,16 @@ pub unsafe extern "C" fn mesh_job_proxy_list_events(
         Ok((events, next_after)) => {
             // Build the envelope shape consumed by Java's
             // EventSubscription. snake_case `next_after` keeps the wire
-            // shape consistent with the registry response.
-            let events_values: Vec<serde_json::Value> = events
-                .into_iter()
-                .map(|ev| serde_json::json!({
-                    "job_id": ev.job_id,
-                    "seq": ev.seq,
-                    "type": ev.event_type,
-                    "payload": ev.payload.unwrap_or(serde_json::Value::Null),
-                    "trace_context": ev.trace_context.unwrap_or(serde_json::Value::Null),
-                    "posted_by": ev.posted_by,
-                    "created_at": ev.created_at,
-                }))
-                .collect();
+            // shape consistent with the registry response. Each event is
+            // serialized via serde (single source of truth for the wire
+            // shape — `JobEvent` derives Serialize).
+            let events_values = match serde_json::to_value(&events) {
+                Ok(v) => v,
+                Err(e) => {
+                    set_last_error(format!("failed to serialize events: {}", e));
+                    return -3;
+                }
+            };
             let envelope = serde_json::json!({
                 "events": events_values,
                 "next_after": next_after,

--- a/src/runtime/core/src/jobs_napi.rs
+++ b/src/runtime/core/src/jobs_napi.rs
@@ -40,7 +40,7 @@ use crate::jobs::{
     BatchingHandle, JobController, JobError, JobProxy, SubmitJobArgs,
 };
 use crate::task_backend::{
-    Job, JobEvent, JobEventReceipt, JobStatus, RegistryHttpBackend, TaskBackend,
+    Job, JobEvent, JobEventReceipt, RegistryHttpBackend, TaskBackend,
 };
 
 // =============================================================================
@@ -67,12 +67,8 @@ fn backend_from_url(registry_url: &str) -> napi::Result<Arc<dyn TaskBackend>> {
 fn parse_timeout_secs(secs: Option<f64>) -> napi::Result<Option<Duration>> {
     match secs {
         None => Ok(None),
-        Some(s) if s.is_nan() || s.is_infinite() || s < 0.0 => Err(Error::from_reason(
-            format!("timeoutSecs must be non-negative and finite, got {s}"),
-        )),
-        Some(s) => Duration::try_from_secs_f64(s)
-            .map(Some)
-            .map_err(|e| Error::from_reason(format!("timeoutSecs out of range: {e} (got {s})"))),
+        Some(s) => crate::task_backend::validate_secs_to_duration(s, false)
+            .map_err(Error::from_reason),
     }
 }
 
@@ -110,61 +106,21 @@ fn job_error_to_napi(err: JobError) -> Error {
 /// mirrors the OpenAPI `JobEvent` schema and the Python `job_event_to_pydict`
 /// helper field-for-field so cross-runtime test fixtures can read either.
 fn job_event_to_json(ev: JobEvent) -> serde_json::Value {
-    serde_json::json!({
-        "job_id": ev.job_id,
-        "seq": ev.seq,
-        "type": ev.event_type,
-        "payload": ev.payload.unwrap_or(serde_json::Value::Null),
-        "trace_context": ev.trace_context.unwrap_or(serde_json::Value::Null),
-        "posted_by": ev.posted_by,
-        "created_at": ev.created_at,
-    })
+    serde_json::to_value(&ev).unwrap_or(serde_json::Value::Null)
 }
 
 /// Convert a [`JobEventReceipt`] into a JSON value the TS layer consumes
 /// as a plain JS object. Mirrors `JobEventPostResponse` field-for-field
 /// (= Python's `job_event_receipt_to_pydict`).
 fn job_event_receipt_to_json(receipt: JobEventReceipt) -> serde_json::Value {
-    serde_json::json!({
-        "job_id": receipt.job_id,
-        "seq": receipt.seq,
-        "created_at": receipt.created_at,
-    })
+    serde_json::to_value(&receipt).unwrap_or(serde_json::Value::Null)
 }
 
 /// Convert a [`Job`] into a JSON value the TS layer can `JSON.parse`-style
 /// consume directly. napi-rs's `serde-json` integration converts to a JS
 /// object on the boundary so the SDK doesn't need a separate parse step.
 fn job_to_json(job: Job) -> serde_json::Value {
-    serde_json::json!({
-        "id": job.id,
-        "capability": job.capability,
-        "owner_instance_id": job.owner_instance_id,
-        "status": job_status_to_str(job.status),
-        "progress": job.progress,
-        "progress_message": job.progress_message,
-        "result": job.result.unwrap_or(serde_json::Value::Null),
-        "error": job.error,
-        "submitted_payload": job.submitted_payload,
-        "attempt_count": job.attempt_count,
-        "max_retries": job.max_retries,
-        "max_duration": job.max_duration,
-        "total_deadline": job.total_deadline,
-        "lease_expires_at": job.lease_expires_at,
-        "last_heartbeat_at": job.last_heartbeat_at,
-        "submitted_at": job.submitted_at,
-        "submitted_by": job.submitted_by,
-    })
-}
-
-fn job_status_to_str(s: JobStatus) -> &'static str {
-    match s {
-        JobStatus::Working => "working",
-        JobStatus::InputRequired => "input_required",
-        JobStatus::Completed => "completed",
-        JobStatus::Failed => "failed",
-        JobStatus::Cancelled => "cancelled",
-    }
+    serde_json::to_value(&job).unwrap_or(serde_json::Value::Null)
 }
 
 // =============================================================================

--- a/src/runtime/core/src/jobs_py.rs
+++ b/src/runtime/core/src/jobs_py.rs
@@ -30,7 +30,7 @@ use crate::jobs::{
     BatchingHandle, JobController, JobError, JobProxy, SubmitJobArgs,
 };
 use crate::task_backend::{
-    Job, JobEvent, JobEventReceipt, JobStatus, RegistryHttpBackend, TaskBackend,
+    Job, JobEvent, JobEventReceipt, RegistryHttpBackend, TaskBackend,
 };
 
 // =============================================================================
@@ -47,12 +47,8 @@ use crate::task_backend::{
 fn parse_timeout_secs(secs: Option<f64>) -> PyResult<Option<Duration>> {
     match secs {
         None => Ok(None),
-        Some(s) if s.is_nan() || s.is_infinite() || s < 0.0 => Err(PyValueError::new_err(
-            format!("timeout_secs must be non-negative and finite, got {s}"),
-        )),
-        Some(s) => Duration::try_from_secs_f64(s).map(Some).map_err(|e| {
-            PyValueError::new_err(format!("timeout_secs out of range: {e} (got {s})"))
-        }),
+        Some(s) => crate::task_backend::validate_secs_to_duration(s, false)
+            .map_err(PyValueError::new_err),
     }
 }
 
@@ -87,78 +83,10 @@ fn job_error_to_py(err: JobError) -> PyErr {
 /// Convert a [`Job`] to a Python `dict`. Mirrors the Go registry's `Job`
 /// schema field-for-field so application code can index by the same keys it
 /// would see on the wire.
-fn job_to_pydict<'py>(py: Python<'py>, job: Job) -> PyResult<Bound<'py, PyDict>> {
-    let dict = PyDict::new(py);
-    dict.set_item("id", job.id)?;
-    dict.set_item("capability", job.capability)?;
-    dict.set_item("owner_instance_id", job.owner_instance_id)?;
-    dict.set_item("status", job_status_to_str(job.status))?;
-    dict.set_item("progress", job.progress)?;
-    dict.set_item("progress_message", job.progress_message)?;
-    dict.set_item("result", json_value_to_py(py, job.result.unwrap_or(serde_json::Value::Null))?)?;
-    dict.set_item("error", job.error)?;
-    dict.set_item(
-        "submitted_payload",
-        json_value_to_py(py, job.submitted_payload)?,
-    )?;
-    dict.set_item("attempt_count", job.attempt_count)?;
-    dict.set_item("max_retries", job.max_retries)?;
-    dict.set_item("max_duration", job.max_duration)?;
-    dict.set_item("total_deadline", job.total_deadline)?;
-    dict.set_item("lease_expires_at", job.lease_expires_at)?;
-    dict.set_item("last_heartbeat_at", job.last_heartbeat_at)?;
-    dict.set_item("submitted_at", job.submitted_at)?;
-    dict.set_item("submitted_by", job.submitted_by)?;
-    Ok(dict)
-}
-
-fn job_status_to_str(s: JobStatus) -> &'static str {
-    match s {
-        JobStatus::Working => "working",
-        JobStatus::InputRequired => "input_required",
-        JobStatus::Completed => "completed",
-        JobStatus::Failed => "failed",
-        JobStatus::Cancelled => "cancelled",
-    }
-}
-
-/// Convert a `serde_json::Value` to a `Py<PyAny>`. Same shape as
-/// `lib.rs::json_value_to_pyobject` — duplicated here to avoid threading the
-/// helper across module boundaries.
-fn json_value_to_py(py: Python<'_>, val: serde_json::Value) -> PyResult<Py<PyAny>> {
-    match val {
-        serde_json::Value::Null => Ok(py.None()),
-        serde_json::Value::Bool(b) => {
-            let obj: Py<PyAny> = b.into_pyobject(py)?.to_owned().into_any().unbind();
-            Ok(obj)
-        }
-        serde_json::Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                Ok(i.into_pyobject(py)?.into_any().unbind())
-            } else if let Some(u) = n.as_u64() {
-                Ok(u.into_pyobject(py)?.into_any().unbind())
-            } else if let Some(f) = n.as_f64() {
-                Ok(f.into_pyobject(py)?.into_any().unbind())
-            } else {
-                Ok(py.None())
-            }
-        }
-        serde_json::Value::String(s) => Ok(s.into_pyobject(py)?.into_any().unbind()),
-        serde_json::Value::Array(arr) => {
-            let items: Vec<Py<PyAny>> = arr
-                .into_iter()
-                .map(|v| json_value_to_py(py, v))
-                .collect::<PyResult<_>>()?;
-            Ok(PyList::new(py, &items)?.into_any().unbind())
-        }
-        serde_json::Value::Object(map) => {
-            let dict = PyDict::new(py);
-            for (k, v) in map {
-                dict.set_item(k, json_value_to_py(py, v)?)?;
-            }
-            Ok(dict.into_any().unbind())
-        }
-    }
+fn job_to_pydict(py: Python<'_>, job: Job) -> PyResult<Py<PyAny>> {
+    let value = serde_json::to_value(&job)
+        .map_err(|e| PyValueError::new_err(format!("failed to serialize Job: {e}")))?;
+    crate::json_value_to_pyobject(py, &value)
 }
 
 /// Convert a Python object (dict / list / primitive) to a
@@ -177,35 +105,18 @@ fn pyany_to_json(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<serde_json:
 /// Convert a [`JobEvent`] to a Python `dict`. Field-for-field mirror of
 /// the OpenAPI `JobEvent` schema so application code can index by the
 /// same keys it would see on the wire.
-fn job_event_to_pydict<'py>(py: Python<'py>, ev: JobEvent) -> PyResult<Bound<'py, PyDict>> {
-    let dict = PyDict::new(py);
-    dict.set_item("job_id", ev.job_id)?;
-    dict.set_item("seq", ev.seq)?;
-    dict.set_item("type", ev.event_type)?;
-    dict.set_item(
-        "payload",
-        json_value_to_py(py, ev.payload.unwrap_or(serde_json::Value::Null))?,
-    )?;
-    dict.set_item(
-        "trace_context",
-        json_value_to_py(py, ev.trace_context.unwrap_or(serde_json::Value::Null))?,
-    )?;
-    dict.set_item("posted_by", ev.posted_by)?;
-    dict.set_item("created_at", ev.created_at)?;
-    Ok(dict)
+fn job_event_to_pydict(py: Python<'_>, ev: JobEvent) -> PyResult<Py<PyAny>> {
+    let value = serde_json::to_value(&ev)
+        .map_err(|e| PyValueError::new_err(format!("failed to serialize JobEvent: {e}")))?;
+    crate::json_value_to_pyobject(py, &value)
 }
 
 /// Convert a [`JobEventReceipt`] to a Python `dict`. Mirrors the
 /// `JobEventPostResponse` schema field-for-field.
-fn job_event_receipt_to_pydict<'py>(
-    py: Python<'py>,
-    receipt: JobEventReceipt,
-) -> PyResult<Bound<'py, PyDict>> {
-    let dict = PyDict::new(py);
-    dict.set_item("job_id", receipt.job_id)?;
-    dict.set_item("seq", receipt.seq)?;
-    dict.set_item("created_at", receipt.created_at)?;
-    Ok(dict)
+fn job_event_receipt_to_pydict(py: Python<'_>, receipt: JobEventReceipt) -> PyResult<Py<PyAny>> {
+    let value = serde_json::to_value(&receipt)
+        .map_err(|e| PyValueError::new_err(format!("failed to serialize JobEventReceipt: {e}")))?;
+    crate::json_value_to_pyobject(py, &value)
 }
 
 // =============================================================================
@@ -391,7 +302,7 @@ impl PyJobController {
             let result = inner.recv_event(types, timeout).await.map_err(job_error_to_py)?;
             Python::with_gil(|py| match result {
                 None => Ok::<Py<PyAny>, PyErr>(py.None()),
-                Some(ev) => Ok(job_event_to_pydict(py, ev)?.into_any().unbind()),
+                Some(ev) => job_event_to_pydict(py, ev),
             })
         })
     }
@@ -436,10 +347,7 @@ impl PyJobProxy {
         let inner = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let job = inner.status().await.map_err(job_error_to_py)?;
-            Python::with_gil(|py| {
-                let dict = job_to_pydict(py, job)?;
-                Ok(dict.into_any().unbind())
-            })
+            Python::with_gil(|py| job_to_pydict(py, job))
         })
     }
 
@@ -457,7 +365,7 @@ impl PyJobProxy {
         let timeout = parse_timeout_secs(timeout_secs)?;
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let value = inner.wait(timeout).await.map_err(job_error_to_py)?;
-            Python::with_gil(|py| Ok(json_value_to_py(py, value)?))
+            Python::with_gil(|py| crate::json_value_to_pyobject(py, &value))
         })
     }
 
@@ -498,7 +406,7 @@ impl PyJobProxy {
                 .send_event(event_type, payload_json)
                 .await
                 .map_err(job_error_to_py)?;
-            Python::with_gil(|py| Ok(job_event_receipt_to_pydict(py, receipt)?.unbind()))
+            Python::with_gil(|py| job_event_receipt_to_pydict(py, receipt))
         })
     }
 

--- a/src/runtime/core/src/lib.rs
+++ b/src/runtime/core/src/lib.rs
@@ -399,7 +399,7 @@ fn parse_sse_response_to_dict_py(py: Python<'_>, response_text: &str) -> PyResul
 }
 
 #[cfg(feature = "python")]
-fn json_value_to_pyobject(py: Python<'_>, val: &serde_json::Value) -> PyResult<Py<PyAny>> {
+pub(crate) fn json_value_to_pyobject(py: Python<'_>, val: &serde_json::Value) -> PyResult<Py<PyAny>> {
     use pyo3::types::{PyDict, PyList};
     match val {
         serde_json::Value::Object(map) => {

--- a/src/runtime/core/src/task_backend.rs
+++ b/src/runtime/core/src/task_backend.rs
@@ -227,7 +227,7 @@ pub struct JobEventPostRequest {
 
 /// Response from `POST /jobs/{id}/events`. `seq` is the server-assigned
 /// per-job monotonic sequence number; `created_at` is Unix epoch seconds.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobEventReceipt {
     pub job_id: String,
     pub seq: i64,
@@ -266,7 +266,7 @@ pub struct JobEventListResponse {
 }
 
 /// Full job record (`Job` schema).
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Job {
     pub id: String,
     pub capability: String,
@@ -672,6 +672,43 @@ impl TaskBackend for RegistryHttpBackend {
 }
 
 // =============================================================================
+// Shared helpers
+// =============================================================================
+
+/// Validate a caller-supplied `timeout_secs` (`f64`) and convert it into an
+/// `Option<Duration>`. Shared by the three binding-layer `parse_*timeout_secs`
+/// helpers (`jobs_py.rs`, `jobs_napi.rs`, `jobs_ffi.rs`) so the
+/// NaN/Inf/negative/overflow policy lives in one place.
+///
+/// `Duration::from_secs_f64` panics on negative, NaN, infinite, or
+/// out-of-range inputs; this helper traps those and returns a clean `Err`
+/// string instead so a typo'd literal can't crash the runtime. The final
+/// conversion uses the fallible `try_from_secs_f64` so finite-but-huge values
+/// (e.g. `f64::MAX`) reject cleanly instead of panicking.
+///
+/// `negative_is_none` selects the policy for `secs < 0.0`: the C ABI uses a
+/// negative sentinel to express `Option<Duration>::None` over a boundary that
+/// cannot pass `null` doubles (`true`), whereas the PyO3 / napi helpers treat
+/// negatives as errors (`false`).
+pub(crate) fn validate_secs_to_duration(
+    secs: f64,
+    negative_is_none: bool,
+) -> Result<Option<Duration>, String> {
+    if secs.is_nan() || secs.is_infinite() {
+        return Err(format!("timeout_secs must be a finite number, got {secs}"));
+    }
+    if secs < 0.0 {
+        if negative_is_none {
+            return Ok(None);
+        }
+        return Err(format!("timeout_secs must be non-negative, got {secs}"));
+    }
+    Duration::try_from_secs_f64(secs)
+        .map(Some)
+        .map_err(|e| format!("timeout_secs out of range: {e} (got {secs})"))
+}
+
+// =============================================================================
 // Tests
 // =============================================================================
 
@@ -841,5 +878,207 @@ mod tests {
         let resp: JobEventListResponse = serde_json::from_str(s).unwrap();
         assert!(resp.events.is_empty());
         assert_eq!(resp.next_after, 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Wire-shape byte-identity guard for the binding-layer serializers.
+    //
+    // The Python / Node(napi) / FFI bindings all route `Job` / `JobEvent` /
+    // `JobEventReceipt` through serde (`to_value` / `to_string`). These tests
+    // pin the serialized shape so a future field/attr change that would alter
+    // the dict/JS-object/JSON the SDKs parse fails here first.
+    // -------------------------------------------------------------------------
+
+    fn full_job() -> Job {
+        Job {
+            id: "j-1".into(),
+            capability: "plan_trip".into(),
+            owner_instance_id: Some("inst-7".into()),
+            status: JobStatus::Working,
+            progress: Some(0.5),
+            progress_message: Some("halfway".into()),
+            result: Some(serde_json::json!({"ok": true})),
+            error: Some("boom".into()),
+            submitted_payload: serde_json::json!({"q": 1}),
+            attempt_count: 2,
+            max_retries: 3,
+            max_duration: Some(120),
+            total_deadline: Some(1_730_000_500),
+            lease_expires_at: Some(1_730_000_100),
+            last_heartbeat_at: Some(1_730_000_050),
+            submitted_at: 1_730_000_000,
+            submitted_by: "client-1".into(),
+        }
+    }
+
+    const JOB_KEYS: [&str; 17] = [
+        "id",
+        "capability",
+        "owner_instance_id",
+        "status",
+        "progress",
+        "progress_message",
+        "result",
+        "error",
+        "submitted_payload",
+        "attempt_count",
+        "max_retries",
+        "max_duration",
+        "total_deadline",
+        "lease_expires_at",
+        "last_heartbeat_at",
+        "submitted_at",
+        "submitted_by",
+    ];
+
+    #[test]
+    fn job_serializes_full_shape() {
+        let v = serde_json::to_value(&full_job()).unwrap();
+        let obj = v.as_object().expect("Job serializes to a JSON object");
+        assert_eq!(obj.len(), JOB_KEYS.len());
+        for k in JOB_KEYS {
+            assert!(obj.contains_key(k), "missing key: {k}");
+        }
+        assert_eq!(obj["id"], serde_json::json!("j-1"));
+        assert_eq!(obj["capability"], serde_json::json!("plan_trip"));
+        assert_eq!(obj["owner_instance_id"], serde_json::json!("inst-7"));
+        assert_eq!(obj["status"], serde_json::json!("working"));
+        assert_eq!(obj["progress"], serde_json::json!(0.5));
+        assert_eq!(obj["progress_message"], serde_json::json!("halfway"));
+        assert_eq!(obj["result"], serde_json::json!({"ok": true}));
+        assert_eq!(obj["error"], serde_json::json!("boom"));
+        assert_eq!(obj["submitted_payload"], serde_json::json!({"q": 1}));
+        assert_eq!(obj["attempt_count"], serde_json::json!(2));
+        assert_eq!(obj["max_retries"], serde_json::json!(3));
+        assert_eq!(obj["max_duration"], serde_json::json!(120));
+        assert_eq!(obj["total_deadline"], serde_json::json!(1_730_000_500i64));
+        assert_eq!(obj["lease_expires_at"], serde_json::json!(1_730_000_100i64));
+        assert_eq!(obj["last_heartbeat_at"], serde_json::json!(1_730_000_050i64));
+        assert_eq!(obj["submitted_at"], serde_json::json!(1_730_000_000i64));
+        assert_eq!(obj["submitted_by"], serde_json::json!("client-1"));
+    }
+
+    #[test]
+    fn job_serializes_minimal_shape() {
+        // All Options None: every key MUST still be present (the Python SDK
+        // indexes strictly, e.g. `snapshot["progress"]`); the Option fields
+        // serialize to `null` (NO `skip_serializing_if`).
+        let job = Job {
+            id: "j-2".into(),
+            capability: "cap".into(),
+            owner_instance_id: None,
+            status: JobStatus::Completed,
+            progress: None,
+            progress_message: None,
+            result: None,
+            error: None,
+            submitted_payload: serde_json::json!({}),
+            attempt_count: 0,
+            max_retries: 0,
+            max_duration: None,
+            total_deadline: None,
+            lease_expires_at: None,
+            last_heartbeat_at: None,
+            submitted_at: 1,
+            submitted_by: "c".into(),
+        };
+        let v = serde_json::to_value(&job).unwrap();
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj.len(), JOB_KEYS.len());
+        for k in JOB_KEYS {
+            assert!(obj.contains_key(k), "missing key: {k}");
+        }
+        // The keep-nulls guarantee: present-as-null, not omitted.
+        for k in [
+            "owner_instance_id",
+            "progress",
+            "progress_message",
+            "result",
+            "error",
+            "max_duration",
+            "total_deadline",
+            "lease_expires_at",
+            "last_heartbeat_at",
+        ] {
+            assert_eq!(obj[k], serde_json::Value::Null, "key {k} should be null");
+        }
+        assert_eq!(obj["status"], serde_json::json!("completed"));
+    }
+
+    #[test]
+    fn job_event_serializes_shape() {
+        // Key is `type` (renamed), not `event_type`. payload/trace_context
+        // present-as-null when None.
+        let ev = JobEvent {
+            job_id: "j-1".into(),
+            seq: 7,
+            event_type: "extend_deadline".into(),
+            payload: None,
+            trace_context: None,
+            posted_by: None,
+            created_at: 1_729_999_500,
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj.len(), 7);
+        assert!(obj.contains_key("type"));
+        assert!(!obj.contains_key("event_type"));
+        assert_eq!(obj["type"], serde_json::json!("extend_deadline"));
+        assert_eq!(obj["job_id"], serde_json::json!("j-1"));
+        assert_eq!(obj["seq"], serde_json::json!(7));
+        assert_eq!(obj["payload"], serde_json::Value::Null);
+        assert_eq!(obj["trace_context"], serde_json::Value::Null);
+        assert_eq!(obj["posted_by"], serde_json::Value::Null);
+        assert_eq!(obj["created_at"], serde_json::json!(1_729_999_500i64));
+    }
+
+    #[test]
+    fn job_event_receipt_serializes_shape() {
+        let receipt = JobEventReceipt {
+            job_id: "j-1".into(),
+            seq: 3,
+            created_at: 1_729_999_000,
+        };
+        let v = serde_json::to_value(&receipt).unwrap();
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj.len(), 3);
+        assert_eq!(obj["job_id"], serde_json::json!("j-1"));
+        assert_eq!(obj["seq"], serde_json::json!(3));
+        assert_eq!(obj["created_at"], serde_json::json!(1_729_999_000i64));
+    }
+
+    #[test]
+    fn progress_f32_roundtrips() {
+        let mut job = full_job();
+        job.progress = Some(0.5);
+        let v = serde_json::to_value(&job).unwrap();
+        assert_eq!(v["progress"], serde_json::json!(0.5));
+        assert_eq!(v["progress"].as_f64(), Some(0.5));
+    }
+
+    #[test]
+    fn validate_secs_to_duration_edge_cases() {
+        assert_eq!(
+            validate_secs_to_duration(0.0, false).unwrap(),
+            Some(Duration::from_secs(0))
+        );
+        assert_eq!(
+            validate_secs_to_duration(1.5, false).unwrap(),
+            Some(Duration::from_millis(1500))
+        );
+        // Negative: errors when negative_is_none=false, None when true.
+        assert!(validate_secs_to_duration(-1.0, false).is_err());
+        assert_eq!(validate_secs_to_duration(-1.0, true).unwrap(), None);
+        // NaN / Inf always error regardless of negative policy.
+        assert!(validate_secs_to_duration(f64::NAN, false).is_err());
+        assert!(validate_secs_to_duration(f64::NAN, true).is_err());
+        assert!(validate_secs_to_duration(f64::INFINITY, false).is_err());
+        assert!(validate_secs_to_duration(f64::INFINITY, true).is_err());
+        // Finite-but-huge overflows Duration; message must say "out of range".
+        let err = validate_secs_to_duration(f64::MAX, false).expect_err("overflow");
+        assert!(
+            err.contains("out of range"),
+            "expected 'out of range', got: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
The binding-duplication cluster of #1113 — the second and **final** part (hygiene quick-wins landed in #1119). Unifies job serialization across the three native bindings (Python/pyo3, Node/napi, FFI) by routing them all through **serde** instead of three hand-built per-binding mappers. **Wire-format-preserving — proven byte-identical end-to-end.**

- **Job wire-shape:** add `Serialize` to `Job` and `JobEventReceipt` (`JobStatus`/`JobEvent` already had it); delete the three copied `job_status_to_str` (serde's `rename_all="snake_case"` is the single source of truth — no `as_str()` added). Route each binding through serde: FFI → `serde_json::to_string` (Result handled, no `unwrap`), napi → `serde_json::to_value` (still returns `Value`; signatures unchanged), py → `serde_json::to_value` + the shared `json_value_to_pyobject`.
  - **No `skip_serializing_if`** on `Job`/`JobEvent`/`JobEventReceipt`: their `Option` fields keep emitting `None → null` (all keys present), which the Python SDK's strict `snapshot["progress"]` access depends on. (`#[serde(default)]` is deserialize-only — no serialize effect.)
- **Dedup `json_value_to_py`:** keep the `lib.rs` `&Value` version (now `pub(crate)`), delete the owned-`Value` copy in `jobs_py.rs`.
- **Dedup timeout validators:** three near-identical `parse_*timeout_secs` → one `validate_secs_to_duration(secs, negative_is_none)` (py/napi reject-negative; FFI negative-as-none). `validate_deadline_secs` and the wait / run-as-job deadline blocks left untouched (different shapes).

**Net ~245 lines of duplication removed.**

## Review Notes
Independent review: **0 blockers, 0 warnings, 3 INFO** (all non-defects, left as-is):
- napi serializers use `.unwrap_or(Value::Null)` vs FFI/py error-propagation — cosmetic; these plain structs never fail to serialize.
- Negative-timeout error wording split into clearer per-cause messages (improvement; no test asserts the old string; the `out of range` overflow substring is preserved for the napi test).
- `progress_f32_roundtrips` uses `0.5` (exact) — deterministic by design.
Verified: keep-nulls intact, exact field-set/`"type"`-key match, FFI errors routed (no panic across C ABI), timeout policy preserved per call site (incl. `NEG_INFINITY` ordering), `validate_deadline_secs` not folded in.

## Test plan
- [x] `cargo test` green incl. 6 new shape/helper tests (full + minimal/keep-nulls `Job`, `JobEvent` `"type"` key, `JobEventReceipt` 3-key, `progress` f32 roundtrip, timeout edge cases)
- [x] `cargo check` clean across `python`/`typescript`/`ffi` feature variants; `cargo clippy` no new warnings (one removed)
- [x] **src-tests rebuild 12/12** — incl. `tc02_build_rust_core`, `tc02a_build_rust_core_nodejs` (napi), Python SDK (pyo3 link), Java SDK (FFI)
- [x] **MeshJob suites 72/72** across all three wire paths — `uc21_meshjob` Python 21/21, `uc22_meshjob_ts` 24/24, `uc23_meshjob_java` 27/27 — status snapshots (keep-nulls), events (recv/send/list/subscribe), and long-running lifecycle parse identically in every SDK. Zero serialization/parse mismatches.

Completes #1113 alongside the already-merged #1119 quick-wins.

Closes #1113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and reporting for job data serialization across all language bindings
  * Enhanced timeout validation with consistent error checking and clearer error messages
  * Better error detection for invalid timeout specifications

* **Improvements**
  * Consolidated serialization logic for improved system stability and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->