### PR TITLE
refactor(registry): extract syncCapabilities, dedup getString (Closes #1114)

### DIFF
--- a/src/core/registry/ent_service.go
+++ b/src/core/registry/ent_service.go
@@ -479,6 +479,157 @@ func (s *EntService) upsertSchemaEntry(
 	return nil
 }
 
+// syncCapabilities clears and re-creates all capability rows for agentID from
+// the wire `tools` value, within tx. runtime is the schema-entry origin (#547).
+// Behavior is identical to the inline loops it replaces in RegisterAgent and
+// UpdateHeartbeat (same delete-then-recreate, same per-field setters, same
+// upsertSchemaEntry side effects, same error wrapping). It does NOT compute
+// dependency counts (the caller derives those from the resolution results).
+func (s *EntService) syncCapabilities(ctx context.Context, tx *ent.Tx, agentID string, tools interface{}, runtime string) error {
+	toolsArray, ok := tools.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	// Clear existing capabilities for this agent
+	_, err := tx.Capability.Delete().Where(capability.HasAgentWith(agent.IDEQ(agentID))).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to clear existing capabilities: %w", err)
+	}
+
+	// Add new capabilities
+	for _, tool := range toolsArray {
+		if toolMap, ok := tool.(map[string]interface{}); ok {
+			functionName, _ := toolMap["function_name"].(string)
+			capabilityName, _ := toolMap["capability"].(string)
+			description, _ := toolMap["description"].(string)
+			capVersion := "1.0.0"
+			if v, ok := toolMap["version"].(string); ok && v != "" {
+				capVersion = v
+			}
+
+			tags := []string{}
+			if tagsInterface, ok := toolMap["tags"]; ok {
+				if tagsArray, ok := tagsInterface.([]interface{}); ok {
+					for _, tag := range tagsArray {
+						if tagStr, ok := tag.(string); ok {
+							tags = append(tags, tagStr)
+						}
+					}
+				} else if stringSlice, ok := tagsInterface.([]string); ok {
+					// Handle direct []string case
+					tags = stringSlice
+				}
+			}
+
+			if functionName != "" && capabilityName != "" {
+				capCreate := tx.Capability.Create().
+					SetAgentID(agentID).
+					SetFunctionName(functionName).
+					SetCapability(capabilityName).
+					SetVersion(capVersion).
+					SetNillableDescription(&description).
+					SetTags(tags)
+
+				// Add input_schema if present
+				if inputSchemaInterface, ok := toolMap["inputSchema"]; ok {
+					if inputSchema, ok := inputSchemaInterface.(map[string]interface{}); ok {
+						capCreate = capCreate.SetInputSchema(inputSchema)
+					}
+				}
+
+				// Schema canonical-form storage (issue #547). Producers send
+				// pre-normalized canonical schemas plus their content hash; the
+				// registry dedups via the content-addressed schema_entries table
+				// and stores the hash on the capability for cross-runtime matching.
+				if hashIface, ok := toolMap["inputSchemaHash"].(string); ok && hashIface != "" {
+					if canonical, ok := toolMap["inputSchemaCanonical"].(map[string]interface{}); ok {
+						if err := s.upsertSchemaEntry(ctx, tx, hashIface, canonical, runtime); err != nil {
+							return fmt.Errorf("upsert input schema for %s: %w", functionName, err)
+						}
+						capCreate = capCreate.SetInputSchemaHash(hashIface)
+					}
+				}
+				if hashIface, ok := toolMap["outputSchemaHash"].(string); ok && hashIface != "" {
+					if canonical, ok := toolMap["outputSchemaCanonical"].(map[string]interface{}); ok {
+						if err := s.upsertSchemaEntry(ctx, tx, hashIface, canonical, runtime); err != nil {
+							return fmt.Errorf("upsert output schema for %s: %w", functionName, err)
+						}
+						capCreate = capCreate.SetOutputSchemaHash(hashIface)
+					}
+				}
+				if warningsIface, ok := toolMap["schemaWarnings"]; ok {
+					warnings := []string{}
+					if arr, ok := warningsIface.([]interface{}); ok {
+						for _, w := range arr {
+							if ws, ok := w.(string); ok {
+								warnings = append(warnings, ws)
+							}
+						}
+					} else if arr, ok := warningsIface.([]string); ok {
+						warnings = arr
+					}
+					if len(warnings) > 0 {
+						capCreate = capCreate.SetSchemaWarnings(warnings)
+					}
+				}
+
+				// Add llm_filter if present
+				if llmFilterInterface, ok := toolMap["llm_filter"]; ok {
+					if llmFilter, ok := llmFilterInterface.(map[string]interface{}); ok {
+						capCreate = capCreate.SetLlmFilter(llmFilter)
+					}
+				}
+
+				// Add llm_provider if present (v0.6.1)
+				if llmProviderInterface, ok := toolMap["llm_provider"]; ok {
+					if llmProvider, ok := llmProviderInterface.(map[string]interface{}); ok {
+						capCreate = capCreate.SetLlmProvider(llmProvider)
+					} else if llmProvider, ok := llmProviderInterface.(generated.LLMProvider); ok {
+						// Convert generated.LLMProvider to map for storage
+						providerMap := map[string]interface{}{
+							"capability": llmProvider.Capability,
+						}
+						if llmProvider.Tags != nil {
+							providerMap["tags"] = *llmProvider.Tags
+						}
+						if llmProvider.Version != nil {
+							providerMap["version"] = *llmProvider.Version
+						}
+						if llmProvider.Namespace != nil {
+							providerMap["namespace"] = *llmProvider.Namespace
+						}
+						capCreate = capCreate.SetLlmProvider(providerMap)
+					}
+				}
+
+				// Add kwargs if present
+				if kwargsInterface, ok := toolMap["kwargs"]; ok {
+					if kwargs, ok := kwargsInterface.(map[string]interface{}); ok {
+						capCreate = capCreate.SetKwargs(kwargs)
+					}
+				}
+
+				// Persist dependencies onto the capability row (issue #971
+				// schema browser). The handler already normalizes wire-side
+				// camelCase keys (expectedSchemaHash, matchMode, ...) to
+				// snake_case here; this just plumbs them into the JSON
+				// column so the meshui schemas handler can build the
+				// inverse index of consumers.
+				if depsList := coerceDependencies(toolMap["dependencies"]); len(depsList) > 0 {
+					capCreate = capCreate.SetDependencies(depsList)
+				}
+
+				_, err := capCreate.Save(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to create capability %s: %w", functionName, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // checkEntityOwnership verifies that req's entity_id matches the existing
 // agent's owner. Returns ErrEntityIDMismatch (wrapped) if claimed != stored
 // and stored is non-empty. op is a short caller name for log context.
@@ -635,156 +786,9 @@ func (s *EntService) RegisterAgent(req *AgentRegistrationRequest) (*AgentRegistr
 		}
 
 		// Process tools/capabilities if present
-		totalDeps := 0
 		if tools, ok := req.Metadata["tools"]; ok {
-			if toolsArray, ok := tools.([]interface{}); ok {
-				// Clear existing capabilities for this agent
-				_, err := tx.Capability.Delete().Where(capability.HasAgentWith(agent.IDEQ(req.AgentID))).Exec(ctx)
-				if err != nil {
-					return fmt.Errorf("failed to clear existing capabilities: %w", err)
-				}
-
-				// Add new capabilities
-				for _, tool := range toolsArray {
-					if toolMap, ok := tool.(map[string]interface{}); ok {
-						functionName, _ := toolMap["function_name"].(string)
-						capabilityName, _ := toolMap["capability"].(string)
-						description, _ := toolMap["description"].(string)
-						capVersion := "1.0.0"
-						if v, ok := toolMap["version"].(string); ok && v != "" {
-							capVersion = v
-						}
-
-						tags := []string{}
-						if tagsInterface, ok := toolMap["tags"]; ok {
-							if tagsArray, ok := tagsInterface.([]interface{}); ok {
-								for _, tag := range tagsArray {
-									if tagStr, ok := tag.(string); ok {
-										tags = append(tags, tagStr)
-									}
-								}
-							} else if stringSlice, ok := tagsInterface.([]string); ok {
-								// Handle direct []string case
-								tags = stringSlice
-							}
-						}
-
-						if functionName != "" && capabilityName != "" {
-							capCreate := tx.Capability.Create().
-								SetAgentID(req.AgentID).
-								SetFunctionName(functionName).
-								SetCapability(capabilityName).
-								SetVersion(capVersion).
-								SetNillableDescription(&description).
-								SetTags(tags)
-
-							// Add input_schema if present
-							if inputSchemaInterface, ok := toolMap["inputSchema"]; ok {
-								if inputSchema, ok := inputSchemaInterface.(map[string]interface{}); ok {
-									capCreate = capCreate.SetInputSchema(inputSchema)
-								}
-							}
-
-							// Schema canonical-form storage (issue #547). Producers send
-							// pre-normalized canonical schemas plus their content hash; the
-							// registry dedups via the content-addressed schema_entries table
-							// and stores the hash on the capability for cross-runtime matching.
-							if hashIface, ok := toolMap["inputSchemaHash"].(string); ok && hashIface != "" {
-								if canonical, ok := toolMap["inputSchemaCanonical"].(map[string]interface{}); ok {
-									if err := s.upsertSchemaEntry(ctx, tx, hashIface, canonical, meta.runtime); err != nil {
-										return fmt.Errorf("upsert input schema for %s: %w", functionName, err)
-									}
-									capCreate = capCreate.SetInputSchemaHash(hashIface)
-								}
-							}
-							if hashIface, ok := toolMap["outputSchemaHash"].(string); ok && hashIface != "" {
-								if canonical, ok := toolMap["outputSchemaCanonical"].(map[string]interface{}); ok {
-									if err := s.upsertSchemaEntry(ctx, tx, hashIface, canonical, meta.runtime); err != nil {
-										return fmt.Errorf("upsert output schema for %s: %w", functionName, err)
-									}
-									capCreate = capCreate.SetOutputSchemaHash(hashIface)
-								}
-							}
-							if warningsIface, ok := toolMap["schemaWarnings"]; ok {
-								warnings := []string{}
-								if arr, ok := warningsIface.([]interface{}); ok {
-									for _, w := range arr {
-										if ws, ok := w.(string); ok {
-											warnings = append(warnings, ws)
-										}
-									}
-								} else if arr, ok := warningsIface.([]string); ok {
-									warnings = arr
-								}
-								if len(warnings) > 0 {
-									capCreate = capCreate.SetSchemaWarnings(warnings)
-								}
-							}
-
-							// Add llm_filter if present
-							if llmFilterInterface, ok := toolMap["llm_filter"]; ok {
-								if llmFilter, ok := llmFilterInterface.(map[string]interface{}); ok {
-									capCreate = capCreate.SetLlmFilter(llmFilter)
-								}
-							}
-
-							// Add llm_provider if present (v0.6.1)
-							if llmProviderInterface, ok := toolMap["llm_provider"]; ok {
-								if llmProvider, ok := llmProviderInterface.(map[string]interface{}); ok {
-									capCreate = capCreate.SetLlmProvider(llmProvider)
-								} else if llmProvider, ok := llmProviderInterface.(generated.LLMProvider); ok {
-									// Convert generated.LLMProvider to map for storage
-									providerMap := map[string]interface{}{
-										"capability": llmProvider.Capability,
-									}
-									if llmProvider.Tags != nil {
-										providerMap["tags"] = *llmProvider.Tags
-									}
-									if llmProvider.Version != nil {
-										providerMap["version"] = *llmProvider.Version
-									}
-									if llmProvider.Namespace != nil {
-										providerMap["namespace"] = *llmProvider.Namespace
-									}
-									capCreate = capCreate.SetLlmProvider(providerMap)
-								}
-							}
-
-							// Add kwargs if present
-							if kwargsInterface, ok := toolMap["kwargs"]; ok {
-								if kwargs, ok := kwargsInterface.(map[string]interface{}); ok {
-									capCreate = capCreate.SetKwargs(kwargs)
-								}
-							}
-
-							// Persist dependencies onto the capability row (issue #971
-							// schema browser). The handler already normalizes wire-side
-							// camelCase keys (expectedSchemaHash, matchMode, ...) to
-							// snake_case here; this just plumbs them into the JSON
-							// column so the meshui schemas handler can build the
-							// inverse index of consumers.
-							if depsList := coerceDependencies(toolMap["dependencies"]); len(depsList) > 0 {
-								capCreate = capCreate.SetDependencies(depsList)
-							}
-
-							_, err := capCreate.Save(ctx)
-							if err != nil {
-								return fmt.Errorf("failed to create capability %s: %w", functionName, err)
-							}
-						}
-
-						// Count dependencies
-						if deps, ok := toolMap["dependencies"]; ok {
-							if depsArray, ok := deps.([]interface{}); ok {
-								s.logger.Debug("Function %s has %d dependencies", functionName, len(depsArray))
-								totalDeps += len(depsArray)
-							} else if depsArray, ok := deps.([]map[string]interface{}); ok {
-								s.logger.Debug("Function %s has %d dependencies", functionName, len(depsArray))
-								totalDeps += len(depsArray)
-							}
-						}
-					}
-				}
+			if err := s.syncCapabilities(ctx, tx, req.AgentID, tools, meta.runtime); err != nil {
+				return err
 			}
 		}
 
@@ -1098,7 +1102,7 @@ func (s *EntService) StoreLLMToolResolutions(
 			case string:
 				filterCapability = f
 			case map[string]interface{}:
-				filterCapability = getString(f, "capability")
+				filterCapability = getStringFromMap(f, "capability", "")
 				filterTags = getStringSlice(f, "tags")
 			}
 
@@ -1226,10 +1230,10 @@ func (s *EntService) StoreLLMProviderResolutions(
 		// Handle both map[string]interface{} and generated.LLMProvider types
 		switch p := llmProviderData.(type) {
 		case map[string]interface{}:
-			requiredCapability = getString(p, "capability")
+			requiredCapability = getStringFromMap(p, "capability", "")
 			requiredTags = getStringSlice(p, "tags")
-			requiredVersion = getString(p, "version")
-			requiredNamespace = getString(p, "namespace")
+			requiredVersion = getStringFromMap(p, "version", "")
+			requiredNamespace = getStringFromMap(p, "namespace", "")
 		case generated.LLMProvider:
 			requiredCapability = p.Capability
 			if p.Tags != nil {
@@ -1457,140 +1461,8 @@ func (s *EntService) UpdateHeartbeat(req *HeartbeatRequest) (*HeartbeatResponse,
 
 				// Process tools/capabilities
 				if tools, ok := req.Metadata["tools"]; ok {
-					if toolsArray, ok := tools.([]interface{}); ok {
-						// Clear existing capabilities for this agent
-						_, err := tx.Capability.Delete().Where(capability.HasAgentWith(agent.IDEQ(req.AgentID))).Exec(ctx)
-						if err != nil {
-							return fmt.Errorf("failed to clear existing capabilities: %w", err)
-						}
-
-						// Add new capabilities
-						for _, tool := range toolsArray {
-							if toolMap, ok := tool.(map[string]interface{}); ok {
-								functionName, _ := toolMap["function_name"].(string)
-								capabilityName, _ := toolMap["capability"].(string)
-								description, _ := toolMap["description"].(string)
-								capVersion := "1.0.0"
-								if v, ok := toolMap["version"].(string); ok && v != "" {
-									capVersion = v
-								}
-
-								tags := []string{}
-								if tagsInterface, ok := toolMap["tags"]; ok {
-									if tagsArray, ok := tagsInterface.([]interface{}); ok {
-										for _, tag := range tagsArray {
-											if tagStr, ok := tag.(string); ok {
-												tags = append(tags, tagStr)
-											}
-										}
-									} else if stringSlice, ok := tagsInterface.([]string); ok {
-										tags = stringSlice
-									}
-								}
-
-								if functionName != "" && capabilityName != "" {
-									capCreate := tx.Capability.Create().
-										SetAgentID(req.AgentID).
-										SetFunctionName(functionName).
-										SetCapability(capabilityName).
-										SetVersion(capVersion).
-										SetNillableDescription(&description).
-										SetTags(tags)
-
-									// Add input_schema if present
-									if inputSchemaInterface, ok := toolMap["inputSchema"]; ok {
-										if inputSchema, ok := inputSchemaInterface.(map[string]interface{}); ok {
-											capCreate = capCreate.SetInputSchema(inputSchema)
-										}
-									}
-
-									// Schema canonical-form storage (issue #547). Producers send
-									// pre-normalized canonical schemas plus their content hash; the
-									// registry dedups via the content-addressed schema_entries table
-									// and stores the hash on the capability for cross-runtime matching.
-									if hashIface, ok := toolMap["inputSchemaHash"].(string); ok && hashIface != "" {
-										if canonical, ok := toolMap["inputSchemaCanonical"].(map[string]interface{}); ok {
-											if err := s.upsertSchemaEntry(ctx, tx, hashIface, canonical, meta.runtime); err != nil {
-												return fmt.Errorf("upsert input schema for %s: %w", functionName, err)
-											}
-											capCreate = capCreate.SetInputSchemaHash(hashIface)
-										}
-									}
-									if hashIface, ok := toolMap["outputSchemaHash"].(string); ok && hashIface != "" {
-										if canonical, ok := toolMap["outputSchemaCanonical"].(map[string]interface{}); ok {
-											if err := s.upsertSchemaEntry(ctx, tx, hashIface, canonical, meta.runtime); err != nil {
-												return fmt.Errorf("upsert output schema for %s: %w", functionName, err)
-											}
-											capCreate = capCreate.SetOutputSchemaHash(hashIface)
-										}
-									}
-									if warningsIface, ok := toolMap["schemaWarnings"]; ok {
-										warnings := []string{}
-										if arr, ok := warningsIface.([]interface{}); ok {
-											for _, w := range arr {
-												if ws, ok := w.(string); ok {
-													warnings = append(warnings, ws)
-												}
-											}
-										} else if arr, ok := warningsIface.([]string); ok {
-											warnings = arr
-										}
-										if len(warnings) > 0 {
-											capCreate = capCreate.SetSchemaWarnings(warnings)
-										}
-									}
-
-									// Add llm_filter if present
-									if llmFilterInterface, ok := toolMap["llm_filter"]; ok {
-										if llmFilter, ok := llmFilterInterface.(map[string]interface{}); ok {
-											capCreate = capCreate.SetLlmFilter(llmFilter)
-										}
-									}
-
-									// Add llm_provider if present (v0.6.1)
-									if llmProviderInterface, ok := toolMap["llm_provider"]; ok {
-										if llmProvider, ok := llmProviderInterface.(map[string]interface{}); ok {
-											capCreate = capCreate.SetLlmProvider(llmProvider)
-										} else if llmProvider, ok := llmProviderInterface.(generated.LLMProvider); ok {
-											// Convert generated.LLMProvider to map for storage
-											providerMap := map[string]interface{}{
-												"capability": llmProvider.Capability,
-											}
-											if llmProvider.Tags != nil {
-												providerMap["tags"] = *llmProvider.Tags
-											}
-											if llmProvider.Version != nil {
-												providerMap["version"] = *llmProvider.Version
-											}
-											if llmProvider.Namespace != nil {
-												providerMap["namespace"] = *llmProvider.Namespace
-											}
-											capCreate = capCreate.SetLlmProvider(providerMap)
-										}
-									}
-
-									// Add kwargs if present
-									if kwargsInterface, ok := toolMap["kwargs"]; ok {
-										if kwargs, ok := kwargsInterface.(map[string]interface{}); ok {
-											capCreate = capCreate.SetKwargs(kwargs)
-										}
-									}
-
-									// Persist dependencies onto the capability row (issue
-									// #971 schema browser). Mirrors the register path; the
-									// handler already converted wire camelCase to the
-									// snake_case keys this column stores.
-									if depsList := coerceDependencies(toolMap["dependencies"]); len(depsList) > 0 {
-										capCreate = capCreate.SetDependencies(depsList)
-									}
-
-									_, err := capCreate.Save(ctx)
-									if err != nil {
-										return fmt.Errorf("failed to create capability %s: %w", functionName, err)
-									}
-								}
-							}
-						}
+					if err := s.syncCapabilities(ctx, tx, req.AgentID, tools, meta.runtime); err != nil {
+						return err
 					}
 				}
 
@@ -2442,16 +2314,6 @@ func (s *EntService) IsStatusChangeHooksEnabled() bool {
 }
 
 // Helper functions for extracting data from maps
-
-// getString safely extracts a string from a map
-func getString(data map[string]interface{}, key string) string {
-	if val, ok := data[key]; ok {
-		if str, ok := val.(string); ok {
-			return str
-		}
-	}
-	return ""
-}
 
 // getStringSlice safely extracts a string slice from a map
 func getStringSlice(data map[string]interface{}, key string) []string {

--- a/src/core/registry/sync_capabilities_schema_test.go
+++ b/src/core/registry/sync_capabilities_schema_test.go
@@ -1,0 +1,134 @@
+package registry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"mcp-mesh/src/core/ent/agent"
+	"mcp-mesh/src/core/ent/capability"
+	"mcp-mesh/src/core/ent/schemaentry"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// TestSyncCapabilitiesSchemaEntry drives the extracted syncCapabilities helper
+// through its issue #547 branch: a tool carrying inputSchemaHash +
+// inputSchemaCanonical must persist the hash on the Capability row and upsert a
+// content-addressed schema_entries row. Covered for both the RegisterAgent and
+// the UpdateHeartbeat write paths (both now share syncCapabilities).
+func TestSyncCapabilitiesSchemaEntry(t *testing.T) {
+	const inputHash = "sha256:deadbeefcafe"
+	canonical := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"city": map[string]interface{}{"type": "string"},
+		},
+	}
+
+	toolWithSchema := func(fn string) map[string]interface{} {
+		return map[string]interface{}{
+			"function_name":        fn,
+			"capability":           "weather_report",
+			"version":              "1.0.0",
+			"description":          "Returns weather",
+			"inputSchemaHash":      inputHash,
+			"inputSchemaCanonical": canonical,
+		}
+	}
+
+	t.Run("RegisterAgentPath", func(t *testing.T) {
+		service := setupTestService(t)
+		ctx := context.Background()
+
+		req := &AgentRegistrationRequest{
+			AgentID: "schema-reg-agent",
+			Metadata: map[string]interface{}{
+				"agent_type": "mcp_agent",
+				"name":       "schema-reg-agent",
+				"version":    "1.0.0",
+				"tools": []interface{}{
+					toolWithSchema("get_weather"),
+				},
+			},
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		if _, err := service.RegisterAgent(req); err != nil {
+			t.Fatalf("RegisterAgent failed: %v", err)
+		}
+
+		assertSchemaPersisted(t, service, ctx, "schema-reg-agent", inputHash)
+	})
+
+	t.Run("HeartbeatPath", func(t *testing.T) {
+		service := setupTestService(t)
+		ctx := context.Background()
+
+		// Register first with no tools so the heartbeat is the path that
+		// ingests the schema-bearing capability.
+		regReq := &AgentRegistrationRequest{
+			AgentID: "schema-hb-agent",
+			Metadata: map[string]interface{}{
+				"agent_type": "mcp_agent",
+				"name":       "schema-hb-agent",
+				"version":    "1.0.0",
+			},
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		if _, err := service.RegisterAgent(regReq); err != nil {
+			t.Fatalf("RegisterAgent failed: %v", err)
+		}
+
+		hbReq := &HeartbeatRequest{
+			AgentID: "schema-hb-agent",
+			Status:  "healthy",
+			Metadata: map[string]interface{}{
+				"version": "1.0.0",
+				"tools": []interface{}{
+					toolWithSchema("get_weather"),
+				},
+			},
+		}
+		resp, err := service.UpdateHeartbeat(hbReq)
+		if err != nil {
+			t.Fatalf("UpdateHeartbeat failed: %v", err)
+		}
+		if resp.Status != "success" {
+			t.Fatalf("Expected heartbeat status success, got %q", resp.Status)
+		}
+
+		assertSchemaPersisted(t, service, ctx, "schema-hb-agent", inputHash)
+	})
+}
+
+func assertSchemaPersisted(t *testing.T, service *EntService, ctx context.Context, agentID, inputHash string) {
+	t.Helper()
+
+	caps, err := service.entDB.Capability.
+		Query().
+		Where(capability.HasAgentWith(agent.IDEQ(agentID))).
+		All(ctx)
+	if err != nil {
+		t.Fatalf("Failed to query capabilities: %v", err)
+	}
+	if len(caps) != 1 {
+		t.Fatalf("Expected 1 capability, got %d", len(caps))
+	}
+	if caps[0].InputSchemaHash == nil {
+		t.Fatalf("Expected InputSchemaHash to be set, got nil")
+	}
+	if *caps[0].InputSchemaHash != inputHash {
+		t.Errorf("Expected InputSchemaHash=%q, got %q", inputHash, *caps[0].InputSchemaHash)
+	}
+
+	exists, err := service.entDB.SchemaEntry.
+		Query().
+		Where(schemaentry.HashEQ(inputHash)).
+		Exist(ctx)
+	if err != nil {
+		t.Fatalf("Failed to query schema_entries: %v", err)
+	}
+	if !exists {
+		t.Errorf("Expected a schema_entries row for hash %q (upsertSchemaEntry side effect), found none", inputHash)
+	}
+}


### PR DESCRIPTION
## Summary
The registry dedup cluster of #1114 ("PR-A") — completes the issue's actionable scope (PR-B #1121, the CLI/lifecycle cleanup, already merged). **Behavior-preserving, proven across runtimes.**

- **Extract `syncCapabilities`** — the ~120-line capability/tool ingestion loop was **duplicated verbatim** between `RegisterAgent` and `UpdateHeartbeat`; it's now a single `func (s *EntService) syncCapabilities(ctx, tx, agentID, tools, runtime) error` called from both. This is exactly where new per-capability fields (#547/#971) had to be edited in two places — the unification removes that recurring footgun. All DB writes (Delete-then-Create of capability rows), per-field setters, the #547 `upsertSchemaEntry` branch, #971 deps, kwargs, llm_provider/filter, and error strings are preserved verbatim.
  - The **only** dropped code is a provably-dead dependency-count loop in `RegisterAgent`: its `totalDeps` accumulator (declared inside the tx closure) was never read — the count persisted via `SetTotalDependencies` comes from a separate `totalDeps := len(indexedResolutions)` downstream; removing the loop forced removing the now-unused declaration, confirming it was dead.
- **Dedup `getString`** → `getStringFromMap(m, key, "")` (4 in-package callers; the separate `tracing`/`cli` `getString` funcs are untouched).
- **New test** `sync_capabilities_schema_test.go` drives the #547 schema-hash path through both register and heartbeat (closes a prior unit-coverage gap).

**Net −138 lines.**

## Review Notes
Independent review: **0 blockers, 0 warnings, 2 INFO** (non-defects):
- The dead loop also carried two `Debug` log lines — incidental; dependency info is still logged on the resolution path.
- The new unit test covers the input-schema #547 path; output-schema/deps/llm_provider/a2a are covered by the green integration suites.
Verified: the two original blocks were identical (only a comment-wording diff); `syncCapabilities` reproduces both field-for-field with a clean closure; call-site args correct; `tools` non-array/absent stays a no-op; dropped count loop confirmed dead; capability clearing identical on both paths; `getString` dedup semantics-preserving with no orphaned callers.

## Test plan
- [x] `go build`/`go vet`/`go test ./registry/... -race` clean
- [x] `src-tests` rebuild 12/12 (registry binary)
- [x] Integration behavior-preserving across runtimes: **uc16 schema (#547) 19/19**, **a2a uc25/uc27/uc31 17/17**, registration/heartbeat/capability-sync/dependency-resolution across py/ts/java all pass. (One pre-existing timing flake — `uc03 tc18_py_dep_index_alignment` — confirmed unrelated: passes 3/3 isolated, TS/Java siblings green, fixed wait windows slip under parallel load.)

## Deliberately deferred (evaluated, not pursued)
The two remaining #1114 findings were assessed and intentionally **not** done — they can be a future task if desired:
- **Full `RegisterAgent`/`UpdateHeartbeat` god-function decomposition** — the post-commit resolution/store sequences differ subtly (first-registration escalation, `LastFullRefresh` semantics), so the risk on the core write path outweighs the readability gain.
- **`Set*` generic applier** — Ent's concrete `AgentCreate`/`AgentUpdateOne` builder types share no `Set*` interface, so generics don't fit cleanly, and the heartbeat copy's non-default guards are intentionally distinct.

Closes #1114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of agent capability and schema persistence mechanisms
  * Enhanced robustness of configuration data extraction with safer defaults

* **Tests**
  * Added comprehensive test coverage for schema entry persistence across agent registration and update operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->