### PR TITLE
refactor(python/llm): dedup native-client helpers, mesh-usage, signature scans (Part of #1115)

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/native_clients/_native_client_helpers.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/_native_client_helpers.py
@@ -13,7 +13,7 @@ otherwise — no module-level state here.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Callable
 
 
 def warn_unsupported_kwarg_once(
@@ -125,3 +125,90 @@ def resolve_request_timeout(
             return None
 
     return chosen
+
+
+def make_is_available(
+    import_name: str,
+) -> tuple[Callable[[], bool], Callable[[], None]]:
+    """Build the ``(is_available, reset)`` pair for a native adapter.
+
+    Each adapter has a structurally-identical ``is_available()`` that probes
+    whether its vendor SDK is importable, caching the result after the first
+    probe — SDK presence does not change at runtime and the
+    import-then-immediately-discard pattern was needless overhead on the
+    dispatch-decision hot path.
+
+    The cache lives in a closure cell here (one per adapter), so each
+    adapter's pair is independent. ``reset`` is a test hook — the adapters
+    expose it module-level as ``_reset_is_available_cache``.
+
+    ``import_name`` is the importable module path. ``__import__`` is used
+    (not ``importlib.import_module``) so the probe issues exactly the same
+    ``__import__(import_name)`` a bare ``import`` statement would — the
+    adapters' tests patch ``builtins.__import__`` and count those calls,
+    and ``importlib.import_module`` would skip the call entirely when the
+    module is already cached in ``sys.modules``.
+    """
+    cache: dict[str, bool] = {}
+
+    def is_available() -> bool:
+        cached = cache.get("value")
+        if cached is not None:
+            return cached
+        try:
+            __import__(import_name)
+        except ImportError:
+            cache["value"] = False
+            return False
+        cache["value"] = True
+        return True
+
+    def reset() -> None:
+        """For tests — reset the cached availability probe. NOT for production."""
+        cache.pop("value", None)
+
+    return is_available, reset
+
+
+def make_fallback_logger(
+    extra_label: str,
+    logger: logging.Logger,
+    *,
+    module_globals: dict[str, Any],
+    flag_name: str = "_logged_fallback_once",
+) -> tuple[Callable[[], None], Callable[[], bool], Callable[[], None]]:
+    """Build the ``(log_fallback_once, is_fallback_logged, reset)`` trio.
+
+    Each adapter emits a one-time INFO nudge ("Install `mcp-mesh[<extra>]`
+    ...") when native dispatch was attempted but the vendor SDK is not
+    importable. The trio dedupes that to once per process.
+
+    State is the module-level ``flag_name`` attribute (default
+    ``_logged_fallback_once``) read/written through ``module_globals`` — the
+    adapters' tests ``monkeypatch.setattr(module, "_logged_fallback_once",
+    ...)`` and expect ``is_fallback_logged()`` to reflect it, which only
+    works if the flag stays a real module attribute (a closure cell would
+    not be visible to the monkeypatch). Pass ``globals()`` from the adapter.
+
+    ``extra_label`` is the pip extra ("anthropic" / "openai" / "gemini")
+    interpolated into the install hint.
+    """
+
+    def log_fallback_once() -> None:
+        if module_globals.get(flag_name):
+            return
+        module_globals[flag_name] = True
+        logger.info(
+            "Install `mcp-mesh[%s]` for native SDK with full feature "
+            "support — falling back to LiteLLM",
+            extra_label,
+        )
+
+    def is_fallback_logged() -> bool:
+        return bool(module_globals.get(flag_name))
+
+    def reset() -> None:
+        """For tests — clear the one-time fallback-log flag. NOT for production."""
+        module_globals[flag_name] = False
+
+    return log_fallback_once, is_fallback_logged, reset

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
@@ -45,6 +45,8 @@ from .._structured_output_helpers import (
     schema_to_synthetic_tool,
 )
 from ._native_client_helpers import (
+    make_fallback_logger,
+    make_is_available,
     reset_unsupported_kwargs_dedupe,
     resolve_request_timeout,
     warn_unsupported_kwarg_once,
@@ -321,32 +323,11 @@ class _StreamFunctionDelta:
 # ---------------------------------------------------------------------------
 
 
-_IS_AVAILABLE_CACHE: bool | None = None
-
-
-def is_available() -> bool:
-    """True if the ``anthropic`` SDK is importable in this process.
-
-    Result is cached after the first probe — the SDK presence does not
-    change at runtime, and the import-then-immediately-discard pattern was
-    showing up as needless overhead on the dispatch-decision hot path.
-    """
-    global _IS_AVAILABLE_CACHE
-    if _IS_AVAILABLE_CACHE is not None:
-        return _IS_AVAILABLE_CACHE
-    try:
-        import anthropic  # noqa: F401
-    except ImportError:
-        _IS_AVAILABLE_CACHE = False
-        return False
-    _IS_AVAILABLE_CACHE = True
-    return True
-
-
-def _reset_is_available_cache() -> None:
-    """For tests — reset the cached availability probe. NOT for production."""
-    global _IS_AVAILABLE_CACHE
-    _IS_AVAILABLE_CACHE = None
+# is_available() probes whether the ``anthropic`` SDK is importable,
+# caching the result after the first probe (SDK presence is fixed for the
+# process). Built from the shared factory so all three adapters share one
+# implementation; the cache lives in the factory's closure.
+is_available, _reset_is_available_cache = make_is_available("anthropic")
 
 
 def supports_model(model: str) -> bool:
@@ -1315,34 +1296,19 @@ async def complete_stream(
 # Fallback-logging helpers
 # ---------------------------------------------------------------------------
 
+# One-time LiteLLM-fallback notice ("Install `mcp-mesh[anthropic]` ...")
+# emitted from the dispatch sites in helpers.py / claude_handler.py when
+# native dispatch was attempted (the default) but the ``anthropic`` SDK is
+# not importable. ``is_fallback_logged()`` lets callers (notably
+# ``ClaudeHandler.has_native``) skip the call entirely after the first miss.
+#
+# State is the module-level ``_logged_fallback_once`` flag read/written
+# through this module's globals by the factory closures (tests monkeypatch
+# the flag as a module attribute).
 _logged_fallback_once = False
-
-
-def log_fallback_once() -> None:
-    """Emit the LiteLLM-fallback notice exactly once per process.
-
-    Called from the dispatch sites in helpers.py / claude_handler.py when
-    native dispatch was attempted (the default) but the ``anthropic`` SDK
-    is not importable.
-    """
-    global _logged_fallback_once
-    if _logged_fallback_once:
-        return
-    _logged_fallback_once = True
-    logger.info(
-        "Install `mcp-mesh[anthropic]` for native SDK with full feature "
-        "support — falling back to LiteLLM"
-    )
-
-
-def is_fallback_logged() -> bool:
-    """True once :func:`log_fallback_once` has emitted its notice.
-
-    Lets callers (notably ``ClaudeHandler.has_native``) skip the call entirely
-    on the hot path after the first miss — avoids one function-frame per
-    request once we've already published the install nudge.
-    """
-    return _logged_fallback_once
+log_fallback_once, is_fallback_logged, _reset_fallback_logged = make_fallback_logger(
+    "anthropic", logger, module_globals=globals()
+)
 
 
 # Module-level dedupe set for the unsupported-kwarg WARN. WARN once per

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
@@ -58,6 +58,8 @@ from typing import Any
 import httpx
 
 from ._native_client_helpers import (
+    make_fallback_logger,
+    make_is_available,
     reset_unsupported_kwargs_dedupe,
     resolve_request_timeout,
     warn_unsupported_kwarg_once,
@@ -366,33 +368,12 @@ class _StreamToolCallDelta:
 # ---------------------------------------------------------------------------
 
 
-_IS_AVAILABLE_CACHE: bool | None = None
-
-
-def is_available() -> bool:
-    """True if the ``google.genai`` SDK is importable in this process.
-
-    Result is cached after the first probe — the SDK presence does not
-    change at runtime, and the import-then-immediately-discard pattern
-    showed up as needless overhead on the dispatch-decision hot path in
-    PR 1 (anthropic_native) so the same caching is applied here.
-    """
-    global _IS_AVAILABLE_CACHE
-    if _IS_AVAILABLE_CACHE is not None:
-        return _IS_AVAILABLE_CACHE
-    try:
-        import google.genai  # noqa: F401
-    except ImportError:
-        _IS_AVAILABLE_CACHE = False
-        return False
-    _IS_AVAILABLE_CACHE = True
-    return True
-
-
-def _reset_is_available_cache() -> None:
-    """For tests — reset the cached availability probe. NOT for production."""
-    global _IS_AVAILABLE_CACHE
-    _IS_AVAILABLE_CACHE = None
+# is_available() probes whether the ``google.genai`` SDK is importable,
+# caching the result after the first probe (SDK presence is fixed for the
+# process). Built from the shared factory so all three adapters share one
+# implementation; the cache lives in the factory's closure. The dotted
+# ``google.genai`` is passed through to the factory's ``__import__`` probe.
+is_available, _reset_is_available_cache = make_is_available("google.genai")
 
 
 def supports_model(model: str) -> bool:
@@ -1796,37 +1777,21 @@ async def complete_stream(
 # Fallback-logging helpers
 # ---------------------------------------------------------------------------
 
+# One-time LiteLLM-fallback notice ("Install `mcp-mesh[gemini]` ...")
+# emitted from ``GeminiHandler.has_native()`` when native dispatch was
+# attempted (the default) but the ``google.genai`` SDK is not importable.
+# In normal installs the SDK is a base dep so this branch should never
+# fire — kept for symmetry with the Anthropic / OpenAI paths and to guard
+# against custom installs that strip the SDK. ``is_fallback_logged()`` lets
+# callers skip the call entirely after the first miss.
+#
+# State is the module-level ``_logged_fallback_once`` flag read/written
+# through this module's globals by the factory closures (tests monkeypatch
+# the flag as a module attribute).
 _logged_fallback_once = False
-
-
-def log_fallback_once() -> None:
-    """Emit the LiteLLM-fallback notice exactly once per process.
-
-    Called from ``GeminiHandler.has_native()`` when native dispatch was
-    attempted (the default) but the ``google.genai`` SDK is not importable.
-    In normal installs the SDK is a base dep so this branch should never
-    fire — kept for symmetry with the Anthropic / OpenAI paths and to guard
-    against custom installs that strip the SDK.
-    """
-    global _logged_fallback_once
-    if _logged_fallback_once:
-        return
-    _logged_fallback_once = True
-    logger.info(
-        "Install `mcp-mesh[gemini]` for native SDK with full feature "
-        "support — falling back to LiteLLM"
-    )
-
-
-def is_fallback_logged() -> bool:
-    """True once :func:`log_fallback_once` has emitted its notice.
-
-    Lets callers (notably ``GeminiHandler.has_native``) skip the call
-    entirely on the hot path after the first miss — avoids one
-    function-frame per request once we've already published the install
-    nudge.
-    """
-    return _logged_fallback_once
+log_fallback_once, is_fallback_logged, _reset_fallback_logged = make_fallback_logger(
+    "gemini", logger, module_globals=globals()
+)
 
 
 # Module-level dedupe set for the unsupported-kwarg WARN. WARN once per

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -41,6 +41,8 @@ from typing import Any
 import httpx
 
 from ._native_client_helpers import (
+    make_fallback_logger,
+    make_is_available,
     reset_unsupported_kwargs_dedupe,
     resolve_request_timeout,
     warn_unsupported_kwarg_once,
@@ -318,33 +320,11 @@ class _StreamToolCallDelta:
 # ---------------------------------------------------------------------------
 
 
-_IS_AVAILABLE_CACHE: bool | None = None
-
-
-def is_available() -> bool:
-    """True if the ``openai`` SDK is importable in this process.
-
-    Result is cached after the first probe — the SDK presence does not
-    change at runtime, and the import-then-immediately-discard pattern
-    showed up as needless overhead on the dispatch-decision hot path in
-    PR 1 (anthropic_native) so the same caching is applied here.
-    """
-    global _IS_AVAILABLE_CACHE
-    if _IS_AVAILABLE_CACHE is not None:
-        return _IS_AVAILABLE_CACHE
-    try:
-        import openai  # noqa: F401
-    except ImportError:
-        _IS_AVAILABLE_CACHE = False
-        return False
-    _IS_AVAILABLE_CACHE = True
-    return True
-
-
-def _reset_is_available_cache() -> None:
-    """For tests — reset the cached availability probe. NOT for production."""
-    global _IS_AVAILABLE_CACHE
-    _IS_AVAILABLE_CACHE = None
+# is_available() probes whether the ``openai`` SDK is importable, caching
+# the result after the first probe (SDK presence is fixed for the process).
+# Built from the shared factory so all three adapters share one
+# implementation; the cache lives in the factory's closure.
+is_available, _reset_is_available_cache = make_is_available("openai")
 
 
 def supports_model(model: str) -> bool:
@@ -798,36 +778,21 @@ async def complete_stream(
 # Fallback-logging helpers
 # ---------------------------------------------------------------------------
 
+# One-time LiteLLM-fallback notice ("Install `mcp-mesh[openai]` ...")
+# emitted from ``OpenAIHandler.has_native()`` when native dispatch was
+# attempted (the default) but the ``openai`` SDK is not importable. In
+# normal installs the SDK is a base dep so this branch should never fire —
+# kept for symmetry with the Anthropic path and to guard against custom
+# installs that strip the SDK. ``is_fallback_logged()`` lets callers skip
+# the call entirely after the first miss.
+#
+# State is the module-level ``_logged_fallback_once`` flag read/written
+# through this module's globals by the factory closures (tests monkeypatch
+# the flag as a module attribute).
 _logged_fallback_once = False
-
-
-def log_fallback_once() -> None:
-    """Emit the LiteLLM-fallback notice exactly once per process.
-
-    Called from the dispatch sites in ``OpenAIHandler.has_native()`` when
-    native dispatch was attempted (the default) but the ``openai`` SDK is
-    not importable. In normal installs the SDK is a base dep so this
-    branch should never fire — kept for symmetry with the Anthropic path
-    and to guard against custom installs that strip the SDK.
-    """
-    global _logged_fallback_once
-    if _logged_fallback_once:
-        return
-    _logged_fallback_once = True
-    logger.info(
-        "Install `mcp-mesh[openai]` for native SDK with full feature "
-        "support — falling back to LiteLLM"
-    )
-
-
-def is_fallback_logged() -> bool:
-    """True once :func:`log_fallback_once` has emitted its notice.
-
-    Lets callers (notably ``OpenAIHandler.has_native``) skip the call entirely
-    on the hot path after the first miss — avoids one function-frame per
-    request once we've already published the install nudge.
-    """
-    return _logged_fallback_once
+log_fallback_once, is_fallback_logged, _reset_fallback_logged = make_fallback_logger(
+    "openai", logger, module_globals=globals()
+)
 
 
 # Module-level dedupe set for the unsupported-kwarg WARN. WARN once per

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
@@ -69,9 +69,12 @@ from .._structured_output_helpers import (  # noqa: F401
 )
 
 # One-time guard so the dispatch-status DEBUG log fires exactly once per
-# process. Mirrors ``_logged_fallback_once`` in anthropic_native — we
-# deliberately keep the state at module level (not on the handler instance)
-# because mesh constructs a fresh handler per request in some paths.
+# process. Mirrors ``_logged_fallback_once`` in anthropic_native. The
+# registry caches a singleton handler per vendor
+# (``ProviderHandlerRegistry._instances``), so an instance-level flag would
+# already dedupe across requests — we keep the state at module level so the
+# dedupe survives even if the singleton is ever rebuilt, and to match the
+# native-client modules' module-level fallback flag.
 _DISPATCH_STATUS_LOGGED = False
 
 

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
@@ -78,9 +78,12 @@ RESPONSE_JSON_SCHEMA_MARKER = "_mesh_gemini_response_json_schema"
 
 
 # One-time guard so the dispatch-status DEBUG log fires exactly once per
-# process. Mirrors ``_logged_fallback_once`` in gemini_native — we
-# deliberately keep the state at module level (not on the handler instance)
-# because mesh constructs a fresh handler per request in some paths.
+# process. Mirrors ``_logged_fallback_once`` in gemini_native. The
+# registry caches a singleton handler per vendor
+# (``ProviderHandlerRegistry._instances``), so an instance-level flag would
+# already dedupe across requests — we keep the state at module level so the
+# dedupe survives even if the singleton is ever rebuilt, and to match the
+# native-client modules' module-level fallback flag.
 _DISPATCH_STATUS_LOGGED = False
 
 

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/openai_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/openai_handler.py
@@ -22,9 +22,12 @@ logger = logging.getLogger(__name__)
 
 
 # One-time guard so the dispatch-status DEBUG log fires exactly once per
-# process. Mirrors ``_logged_fallback_once`` in openai_native — we
-# deliberately keep the state at module level (not on the handler instance)
-# because mesh constructs a fresh handler per request in some paths.
+# process. Mirrors ``_logged_fallback_once`` in openai_native. The
+# registry caches a singleton handler per vendor
+# (``ProviderHandlerRegistry._instances``), so an instance-level flag would
+# already dedupe across requests — we keep the state at module level so the
+# dedupe survives even if the singleton is ever rebuilt, and to match the
+# native-client modules' module-level fallback flag.
 _DISPATCH_STATUS_LOGGED = False
 
 

--- a/src/runtime/python/_mcp_mesh/engine/signature_analyzer.py
+++ b/src/runtime/python/_mcp_mesh/engine/signature_analyzer.py
@@ -5,7 +5,7 @@ Function signature analysis for MCP Mesh dependency injection.
 import inspect
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Optional, get_type_hints
+from typing import Any, Callable, Optional, get_type_hints
 
 from mesh.types import McpMeshTool, MeshJob, MeshLlmAgent
 
@@ -116,6 +116,45 @@ def _is_mesh_job_type(param_type: Any) -> bool:
                 return True
 
     return False
+
+
+def _scan_params(
+    func: Any,
+    predicate: Callable[[Any], bool],
+    *,
+    want: str = "positions",
+) -> list:
+    """Scan a function's typed parameters and collect the ones matching
+    ``predicate``.
+
+    Shared body of the four public ``get_*_positions`` / ``get_*_parameter_names``
+    helpers — same unwrap-and-introspect loop, differing only in the
+    classifier predicate and whether positions (0-indexed) or names are
+    returned (``want="positions"`` or ``want="names"``).
+
+    The broad ``except Exception`` is intentional: any introspection failure
+    (unresolvable forward refs, missing imports, weird callables) is logged
+    at WARNing and yields an empty list so registration can proceed — the
+    function is still invokable as a plain tool, the typed slots just won't
+    bind. Do NOT narrow this.
+    """
+    try:
+        func = _get_original_func(func)
+        type_hints = get_type_hints(func)
+        sig = inspect.signature(func)
+
+        result: list = []
+        for i, param_name in enumerate(sig.parameters.keys()):
+            if param_name not in type_hints:
+                continue
+            if predicate(type_hints[param_name]):
+                result.append(i if want == "positions" else param_name)
+        return result
+
+    except Exception as e:
+        # If we can't analyze the signature, return empty list
+        logger.warning(f"Failed to analyze signature for {func}: {e}")
+        return []
 
 
 @dataclass(frozen=True)
@@ -251,29 +290,7 @@ def get_mesh_agent_positions(func: Any) -> list[int]:
 
         get_mesh_agent_positions(greet) → [1, 2]
     """
-    try:
-        func = _get_original_func(func)
-        # Get type hints for the function
-        type_hints = get_type_hints(func)
-
-        # Get parameter names in order
-        sig = inspect.signature(func)
-        param_names = list(sig.parameters.keys())
-
-        # Find positions of McpMeshTool parameters
-        mesh_positions = []
-        for i, param_name in enumerate(param_names):
-            if param_name in type_hints:
-                param_type = type_hints[param_name]
-                if _is_mesh_tool_type(param_type):
-                    mesh_positions.append(i)
-
-        return mesh_positions
-
-    except Exception as e:
-        # If we can't analyze the signature, return empty list
-        logger.warning(f"Failed to analyze signature for {func}: {e}")
-        return []
+    return _scan_params(func, _is_mesh_tool_type, want="positions")
 
 
 def get_mesh_agent_parameter_names(func: Any) -> list[str]:
@@ -286,23 +303,7 @@ def get_mesh_agent_parameter_names(func: Any) -> list[str]:
     Returns:
         List of parameter names that are McpMeshTool types
     """
-    try:
-        func = _get_original_func(func)
-        type_hints = get_type_hints(func)
-        sig = inspect.signature(func)
-
-        mesh_param_names = []
-        for param_name, param in sig.parameters.items():
-            if param_name in type_hints:
-                param_type = type_hints[param_name]
-                if _is_mesh_tool_type(param_type):
-                    mesh_param_names.append(param_name)
-
-        return mesh_param_names
-
-    except Exception as e:
-        logger.warning(f"Failed to analyze signature for {func}: {e}")
-        return []
+    return _scan_params(func, _is_mesh_tool_type, want="names")
 
 
 def validate_mesh_dependencies(func: Any, dependencies: list[dict]) -> tuple[bool, str]:
@@ -391,30 +392,7 @@ def get_llm_agent_positions(func: Any) -> list[int]:
 
         get_llm_agent_positions(chat) → [1]
     """
-    try:
-        func = _get_original_func(func)
-        # Get type hints for the function
-        type_hints = get_type_hints(func)
-
-        # Get parameter names in order
-        sig = inspect.signature(func)
-        param_names = list(sig.parameters.keys())
-
-        # Find positions of MeshLlmAgent parameters
-        llm_positions = []
-        for i, param_name in enumerate(param_names):
-            if param_name in type_hints:
-                param_type = type_hints[param_name]
-
-                if _is_mesh_llm_type(param_type):
-                    llm_positions.append(i)
-
-        return llm_positions
-
-    except Exception as e:
-        # If we can't analyze the signature, return empty list
-        logger.warning(f"Failed to analyze signature for {func}: {e}")
-        return []
+    return _scan_params(func, _is_mesh_llm_type, want="positions")
 
 
 def has_llm_agent_parameter(func: Any) -> bool:
@@ -440,22 +418,7 @@ def get_llm_agent_parameter_names(func: Any) -> list[str]:
     Returns:
         List of parameter names that are MeshLlmAgent types
     """
-    try:
-        func = _get_original_func(func)
-        type_hints = get_type_hints(func)
-        sig = inspect.signature(func)
-
-        llm_param_names = []
-        for param_name, param in sig.parameters.items():
-            if param_name in type_hints:
-                param_type = type_hints[param_name]
-                if _is_mesh_llm_type(param_type):
-                    llm_param_names.append(param_name)
-
-        return llm_param_names
-    except Exception as e:
-        logger.warning(f"Failed to analyze signature for {func}: {e}")
-        return []
+    return _scan_params(func, _is_mesh_llm_type, want="names")
 
 
 def get_context_parameter_name(

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -936,6 +936,37 @@ async def _maybe_retry_synthetic_on_validation_failure(
     return retry_args_str, retry_usage_dict
 
 
+def _build_mesh_usage(usage: Any, model: Any) -> dict:
+    """Extract ``{prompt_tokens, completion_tokens, model}`` from a LiteLLM
+    ``response.usage`` object.
+
+    The ``getattr(..., 0) or 0`` guards coerce both a missing attribute and a
+    ``None`` value to ``0``. Callers keep their own
+    ``if hasattr(response, "usage") and response.usage:`` guard and pass
+    ``response.usage`` here — this helper does not re-check it.
+    """
+    return {
+        "prompt_tokens": getattr(usage, "prompt_tokens", 0) or 0,
+        "completion_tokens": getattr(usage, "completion_tokens", 0) or 0,
+        "model": model,
+    }
+
+
+def _merge_mesh_usage(a: dict, b: dict) -> dict:
+    """Additively fold the prompt/completion token counts of ``b`` into ``a``
+    and return ``a``.
+
+    Used to accumulate a corrective retry call's tokens into the cumulative
+    ``_mesh_usage`` block so observability captures both calls. Only the
+    token counts are folded; ``a``'s ``model`` is left untouched.
+    """
+    a["prompt_tokens"] = a.get("prompt_tokens", 0) + b.get("prompt_tokens", 0)
+    a["completion_tokens"] = a.get("completion_tokens", 0) + b.get(
+        "completion_tokens", 0
+    )
+    return a
+
+
 def _extract_text_from_message_content(content: Any) -> str:
     """Normalize a LiteLLM message ``content`` field to a plain string.
 
@@ -1451,12 +1482,9 @@ async def _provider_agentic_loop(
                     "content": synthetic_args,
                 }
                 if hasattr(response, "usage") and response.usage:
-                    usage = response.usage
-                    message_dict["_mesh_usage"] = {
-                        "prompt_tokens": getattr(usage, "prompt_tokens", 0) or 0,
-                        "completion_tokens": getattr(usage, "completion_tokens", 0) or 0,
-                        "model": effective_model,
-                    }
+                    message_dict["_mesh_usage"] = _build_mesh_usage(
+                        response.usage, effective_model
+                    )
                 # Fold retry usage into the cumulative block so observability
                 # captures the corrective call's tokens.
                 if retry_usage:
@@ -1466,15 +1494,7 @@ async def _provider_agentic_loop(
                             "completion_tokens": 0,
                             "model": effective_model,
                         }
-                    bucket = message_dict["_mesh_usage"]
-                    bucket["prompt_tokens"] = (
-                        bucket.get("prompt_tokens", 0)
-                        + retry_usage.get("prompt_tokens", 0)
-                    )
-                    bucket["completion_tokens"] = (
-                        bucket.get("completion_tokens", 0)
-                        + retry_usage.get("completion_tokens", 0)
-                    )
+                    _merge_mesh_usage(message_dict["_mesh_usage"], retry_usage)
                 return message_dict
 
         if hasattr(message, "tool_calls") and message.tool_calls:
@@ -1571,13 +1591,9 @@ async def _provider_agentic_loop(
                     "content": final_content if final_content else "",
                 }
                 if hasattr(response, "usage") and response.usage:
-                    usage = response.usage
-                    message_dict["_mesh_usage"] = {
-                        "prompt_tokens": getattr(usage, "prompt_tokens", 0) or 0,
-                        "completion_tokens": getattr(usage, "completion_tokens", 0)
-                        or 0,
-                        "model": effective_model,
-                    }
+                    message_dict["_mesh_usage"] = _build_mesh_usage(
+                        response.usage, effective_model
+                    )
 
                 if loop_logger:
                     loop_logger.info(
@@ -1663,12 +1679,9 @@ async def _provider_agentic_loop(
             }
 
             if hasattr(response, "usage") and response.usage:
-                usage = response.usage
-                message_dict["_mesh_usage"] = {
-                    "prompt_tokens": getattr(usage, "prompt_tokens", 0) or 0,
-                    "completion_tokens": getattr(usage, "completion_tokens", 0) or 0,
-                    "model": effective_model,
-                }
+                message_dict["_mesh_usage"] = _build_mesh_usage(
+                    response.usage, effective_model
+                )
 
             if loop_logger:
                 loop_logger.info(
@@ -2688,12 +2701,9 @@ def llm_provider(
                         "content": synthetic_args,
                     }
                     if hasattr(response, "usage") and response.usage:
-                        usage = response.usage
-                        message_dict["_mesh_usage"] = {
-                            "prompt_tokens": getattr(usage, "prompt_tokens", 0) or 0,
-                            "completion_tokens": getattr(usage, "completion_tokens", 0) or 0,
-                            "model": effective_model,
-                        }
+                        message_dict["_mesh_usage"] = _build_mesh_usage(
+                            response.usage, effective_model
+                        )
                     return message_dict
 
                 # Handle content - it can be a string or list of content blocks
@@ -2822,13 +2832,9 @@ def llm_provider(
 
                 # Issue #311: Include usage metadata for cost tracking
                 if hasattr(response, "usage") and response.usage:
-                    usage = response.usage
-                    message_dict["_mesh_usage"] = {
-                        "prompt_tokens": getattr(usage, "prompt_tokens", 0) or 0,
-                        "completion_tokens": getattr(usage, "completion_tokens", 0)
-                        or 0,
-                        "model": effective_model,
-                    }
+                    message_dict["_mesh_usage"] = _build_mesh_usage(
+                        response.usage, effective_model
+                    )
 
                 logger.info(
                     f"LLM provider {func.__name__} processed request "


### PR DESCRIPTION
## Summary
The low-risk consolidation cluster of #1115 ("PR-A") — pure dedup/docs with **no LLM-path behavior change**.

- **Native clients:** extract the duplicated `is_available()` (cache + reset) and fallback-logging (`log_fallback_once`/`is_fallback_logged` + flag) from `anthropic_native.py` / `openai_native.py` / `gemini_native.py` into shared closure factories `make_is_available` / `make_fallback_logger` in the existing `_native_client_helpers.py`; each module rebinds at module scope. Test-hook names preserved; uses `__import__` (not `importlib.import_module`) so the `builtins.__import__`-patching caching tests stay valid; fallback log messages byte-identical (incl. the `mcp-mesh[<extra>]` hint).
- **`helpers.py`:** `_build_mesh_usage` + `_merge_mesh_usage` replace 5 copy-pasted token-usage extraction blocks + a hand-rolled cumulative fold.
- **`signature_analyzer.py`:** `_scan_params(func, predicate, want=...)` — the 4 near-identical signature-scan functions become one-line delegates (broad `except → warning → []` preserved).
- **Docs:** corrected the stale "fresh handler per request" comments in the 3 handlers to the accurate registry-singleton / module-level dedupe-latch rationale.

**Net ~−39 lines.**

## Review Notes
Independent review: **0 blockers, 0 warnings, 2 INFO** (non-defects):
- `_scan_params`' `want` is stringly-typed (internal helper, 2 fixed call sites).
- A 6th usage block (`_maybe_retry_synthetic…`) correctly left un-migrated (different shape — no `model` key).
Verified behavior-preserving: `is_available` caching/reset + dotted-`google.genai` import equivalence with independent per-factory cache cells; per-module fallback flag (no shared state) with monkeypatch visibility intact; `_build_mesh_usage` shape + `getattr(...,0) or 0` guards; `_scan_params` predicates (incl. deprecated `McpMeshAgent` match), return shapes, and `except` fallback.

## Test plan
- [x] Full Python unit suite green (native_clients / provider_handlers / signature_analyzer / dependency_injector / agentic-loop / usage tests)
- [x] `src-tests` rebuild 12/12
- [x] Smoke integration: `uc04` native big-3 3/3 (claude/openai/gemini live calls); per-vendor provider logs confirm `<vendor> native dispatch: enabled (SDK X)` with **no LiteLLM fall-through** — the `is_available` gate refactor is behavior-preserving.

## Scope / follow-ups (Part of #1115)
- **PR-B** (behavior-sensitive): provider-handler base-class consolidation — native-dispatch `_native_module()` hook, lift `_build_hint_text`/`apply_prose_hint` to the base, `apply_structured_output` HINT-branch dedup + sentinel-clear centralization.
- **PR-C**: agentic-loop per-iteration `completion_args` + dispatch-branch dedup (safe part).
- The **#961 streaming synthetic-retry gap** (buffered has the corrective retry, streaming doesn't) is a behavior fix that stays tracked under **#961** — intentionally NOT bundled into this consolidation.

Part of #1115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal helper functions for native adapter availability detection and fallback logging across multiple adapters, reducing code duplication.
  * Improved signature parameter introspection by introducing shared helper logic for dependency injection analysis.
  * Enhanced mesh usage token tracking with reusable utility functions.

* **Bug Fixes**
  * Fixed native synthetic-tool token usage accumulation in the buffered provider's agentic loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->