### PR TITLE
refactor(python/llm): consolidate native-dispatch + HINT into BaseProviderHandler (Part of #1115)

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/base_provider_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/base_provider_handler.py
@@ -10,7 +10,7 @@ import logging
 import os
 import threading
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import mcp_mesh_core
 from pydantic import BaseModel
@@ -101,6 +101,72 @@ def _reset_legacy_hint_timeout_dedupe() -> None:
     global _legacy_hint_timeout_deprecation_logged
     with _legacy_hint_timeout_lock:
         _legacy_hint_timeout_deprecation_logged = False
+
+
+# ============================================================================
+# Shared native-dispatch status logging (issue #834)
+# ============================================================================
+#
+# Each handler module owns a module-level ``_DISPATCH_STATUS_LOGGED`` latch and
+# a thin ``_log_dispatch_status_once()`` wrapper that delegates here, passing
+# its own logger + vendor labels. The state and the logger stay per-module so:
+#   - tests can flip ``<module>._DISPATCH_STATUS_LOGGED`` to re-observe the log,
+#   - the DEBUG record is emitted under the handler module's logger name
+#     (``...claude_handler`` / ``...openai_handler`` / ``...gemini_handler``),
+#   - the latch dedupes independently per vendor (Claude logging once does not
+#     suppress OpenAI's log).
+# The rendered message text is byte-identical to the original per-vendor logs.
+
+
+def render_dispatch_status_log(
+    module_logger: logging.Logger,
+    *,
+    vendor_label: str,
+    sdk_display: str,
+    install_extra: str,
+    native_module: Any,
+    version_probe: Callable[[], str],
+) -> None:
+    """Emit the once-per-process native-dispatch status DEBUG log.
+
+    ``module_logger`` is the calling handler module's logger so the record is
+    attributed to that module. ``vendor_label`` is the display name ("Claude"/
+    "OpenAI"/"Gemini"); ``sdk_display`` is the SDK name as it appears in the log
+    ("anthropic"/"openai"/"google-genai"); ``install_extra`` is the pip extra
+    ("anthropic"/"openai"/"gemini"); ``native_module`` exposes ``is_available()``;
+    ``version_probe`` is a zero-arg callable returning the SDK version string.
+
+    The caller is responsible for the once-per-process latch — this function
+    always renders.
+    """
+    env_value = os.getenv("MCP_MESH_NATIVE_LLM", "").strip().lower()
+
+    if env_value in ("0", "false", "no", "off"):
+        module_logger.debug(
+            "%s native dispatch: disabled "
+            "(MCP_MESH_NATIVE_LLM=%s explicitly set; using LiteLLM)",
+            vendor_label,
+            env_value,
+        )
+        return
+
+    if native_module.is_available():
+        version = version_probe()
+        module_logger.debug(
+            "%s native dispatch: enabled (%s SDK %s)",
+            vendor_label,
+            sdk_display,
+            version,
+        )
+    else:
+        module_logger.debug(
+            "%s native dispatch: disabled "
+            "(%s SDK not installed; install mcp-mesh[%s] to enable)",
+            vendor_label,
+            sdk_display,
+            install_extra,
+        )
+
 
 # ============================================================================
 # Shared Media Detection
@@ -404,26 +470,202 @@ class BaseProviderHandler(ABC):
 
         return "{\n" + "\n".join(parts) + "\n}"
 
+    def _build_hint_text(self, sanitized_schema: dict[str, Any]) -> str:
+        """Build the ``OUTPUT FORMAT:`` HINT block for ``apply_structured_output``.
+
+        Returned text starts with leading blank lines so it can be appended
+        directly to existing system message content. Callers that synthesize
+        a fresh system message should ``.strip()`` the result.
+
+        Shared verbatim by Claude and Gemini HINT modes — the rendered text is
+        byte-identical for both vendors.
+        """
+        hint_text = "\n\nOUTPUT FORMAT:\n"
+        hint_text += (
+            "Your FINAL response must be ONLY valid JSON (no markdown, "
+            "no code blocks) with this exact structure:\n"
+        )
+        properties = sanitized_schema.get("properties", {})
+        hint_text += self.build_json_example(properties) + "\n\n"
+        hint_text += (
+            "Return ONLY the JSON object with actual values. Do not "
+            "include the schema definition, markdown formatting, or "
+            "code blocks."
+        )
+        return hint_text
+
+    def apply_prose_hint(
+        self,
+        model_params: dict[str, Any],
+        sanitized_schema: dict[str, Any],
+        output_type_name: Optional[str],
+        *,
+        support_content_blocks: bool,
+        logger: Optional[logging.Logger] = None,
+    ) -> dict[str, Any]:
+        """Inject the OUTPUT FORMAT HINT block into the first system message.
+
+        Shared HINT-mode mechanics for the prompt-injection vendors (Claude,
+        Gemini): append the hint to the first system message (synthesizing one
+        if none exists), stamp the ``_mesh_hint_*`` sentinels read by the
+        agentic loop, and pop ``response_format`` (defense-in-depth — the HINT
+        path must never set it).
+
+        ``support_content_blocks``:
+            True  — tolerate a content-block list on the system message
+                    (post-prompt-cache, Claude): a string concatenates; a list
+                    gets a NEW text block appended; an unknown shape is coerced
+                    to string with a DEBUG log.
+            False — string-only concatenation (Gemini): ``content + hint_text``.
+
+        ``logger``:
+            Optional per-vendor module logger so the HINT-injection DEBUG
+            records are attributed to the calling handler's module
+            (``...claude_handler`` / ``...gemini_handler``) rather than this
+            base module. Defaults to the base module logger when not supplied.
+
+        Vendor-specific side effects (e.g. Gemini's ``set_pending_output_schema``)
+        and the per-vendor INFO log stay at the call site — this method only
+        performs the shared inject/synthesize/stamp/pop work.
+        """
+        log = logger if logger is not None else globals()["logger"]
+        messages = model_params.get("messages", [])
+        hint_text = self._build_hint_text(sanitized_schema)
+        hint_block_inserted = False
+        for msg in messages:
+            if msg.get("role") == "system":
+                base_content = msg.get("content", "")
+                if support_content_blocks:
+                    # Tolerate string OR content-block list (post-prompt-cache).
+                    # A string concatenates; a list gets a NEW text block
+                    # appended so the original blocks' cache_control is preserved.
+                    if isinstance(base_content, str):
+                        msg["content"] = base_content + hint_text
+                    elif isinstance(base_content, list):
+                        msg["content"] = list(base_content) + [
+                            {"type": "text", "text": hint_text}
+                        ]
+                    else:
+                        # Unknown content shape — defensive coerce to string so
+                        # the model still sees the schema. Log so the unexpected
+                        # shape surfaces in debugging.
+                        log.debug(
+                            "%s HINT injection: unexpected system content "
+                            "type %s; coercing to string",
+                            self._native_label(),
+                            type(base_content).__name__,
+                        )
+                        msg["content"] = str(base_content) + hint_text
+                else:
+                    msg["content"] = base_content + hint_text
+                hint_block_inserted = True
+                break
+
+        if not hint_block_inserted:
+            # No system message found — synthesize one containing just the
+            # HINT block. Without this, the _mesh_hint_* flags below would
+            # still be set but the model would never see the schema, every
+            # response would fail validation, and the fallback timeout would
+            # fire on every request.
+            messages.insert(0, {"role": "system", "content": hint_text.strip()})
+            log.debug(
+                "%s HINT mode for '%s': no system message found, "
+                "synthesized one with HINT block",
+                self._native_label(),
+                output_type_name or "Response",
+            )
+            # Keep model_params["messages"] in sync — messages may be a
+            # fresh list reference if the caller passed an empty/missing list.
+            model_params["messages"] = messages
+
+        # Internal flags read by the agentic loop. Prefixed with "_mesh_" so
+        # the loop strips them before calling LiteLLM (these are NOT API params).
+        fallback_timeout = resolve_hint_fallback_timeout()
+        model_params["_mesh_hint_mode"] = True
+        model_params["_mesh_hint_schema"] = sanitized_schema
+        model_params["_mesh_hint_fallback_timeout"] = fallback_timeout
+        model_params["_mesh_hint_output_type_name"] = output_type_name or "Response"
+
+        # Defense-in-depth: never set response_format on the HINT path.
+        model_params.pop("response_format", None)
+
+        return model_params
+
     # ------------------------------------------------------------------
     # Native SDK dispatch (issue #834)
     # ------------------------------------------------------------------
-    # Each subclass that ships a native vendor SDK adapter overrides
-    # ``has_native()`` to gate the dispatch on the relevant SDK actually
-    # being importable. Native dispatch is enabled by default; the
-    # ``MCP_MESH_NATIVE_LLM=0`` env flag is the explicit opt-out.
-    # The default implementation here returns False so the buffered /
-    # streaming call sites in mesh.helpers transparently keep using
-    # LiteLLM for vendors that have not migrated yet.
+    # Native dispatch is driven by ``_native_module()``: a subclass that ships
+    # a native vendor SDK adapter overrides it (plus ``_native_label()``) to
+    # return the imported native module. The base
+    # ``has_native()`` / ``complete()`` / ``complete_stream()`` then operate
+    # against that module's uniform surface (``is_available()``,
+    # ``is_fallback_logged()``, ``log_fallback_once()``, ``complete()``,
+    # ``complete_stream()``). The base default returns ``None`` so the buffered /
+    # streaming call sites in mesh.helpers transparently keep using LiteLLM for
+    # vendors that have not migrated yet.
+    #
+    # Native dispatch is enabled by default; the ``MCP_MESH_NATIVE_LLM=0`` env
+    # flag (also false/no/off) is the explicit opt-out and wins over SDK
+    # availability.
+
+    def _native_module(self):
+        """Return the imported native-SDK adapter module, or None.
+
+        Base default: None — ``has_native()`` stays False and the native
+        ``complete*`` paths raise NotImplementedError. Subclasses that ship a
+        native adapter override this with a one-line lazy import (so the SDK is
+        not imported at module load).
+        """
+        return None
+
+    def _native_label(self) -> str:
+        """Display label for the vendor in the dispatch-status DEBUG log.
+
+        Subclasses override (e.g. "Claude" / "OpenAI" / "Gemini").
+        """
+        return self.vendor
+
+    def _log_dispatch_status(self) -> None:
+        """Emit the once-per-process native-dispatch status DEBUG log.
+
+        Subclasses with a native adapter override this to delegate to their
+        module-level once-latch (so tests can re-arm it and the record is
+        attributed to the handler module's logger). Base default: no-op.
+        """
+        return
 
     def has_native(self) -> bool:
         """Return True if this handler can dispatch via a native vendor SDK.
 
-        Default: False. Override in subclasses that ship a native adapter.
-        Subclass implementations honor ``MCP_MESH_NATIVE_LLM=0`` as an
-        explicit opt-out and return False when the relevant SDK is not
-        importable.
+        Driven by ``_native_module()``: returns False when the subclass has not
+        migrated (module is None). For migrated handlers, honors
+        ``MCP_MESH_NATIVE_LLM`` in {0,false,no,off} as an explicit opt-out that
+        wins over SDK availability, and returns False (with a one-time fallback
+        log) when the SDK is not importable.
         """
-        return False
+        native = self._native_module()
+        if native is None:
+            return False
+
+        # Emit the one-time dispatch-status DEBUG log. Lazy here (vs. at
+        # module/handler init) so it fires when the first dispatch decision
+        # is actually made — the most useful signal for ``--debug`` runs.
+        self._log_dispatch_status()
+
+        flag = os.environ.get("MCP_MESH_NATIVE_LLM", "").strip().lower()
+        # Explicit opt-out wins over SDK availability.
+        if flag in ("0", "false", "no", "off"):
+            return False
+
+        if not native.is_available():
+            # Skip the log call entirely once it has already fired — the
+            # function dedupes internally, but on the no-native hot path
+            # avoiding the call frame altogether is cheaper still.
+            if not native.is_fallback_logged():
+                native.log_fallback_once()
+            return False
+
+        return True
 
     async def complete(
         self,
@@ -434,12 +676,21 @@ class BaseProviderHandler(ABC):
     ) -> Any:
         """Run a buffered completion via the vendor's native SDK.
 
-        Default: NotImplementedError. Subclasses with ``has_native() == True``
-        MUST override this to return a litellm-shaped response object (see
-        ``_mcp_mesh.engine.mesh_llm_agent._MockResponse`` for the shape).
+        Dispatches to ``_native_module().complete(...)``. Subclasses with a
+        native adapter (``_native_module()`` not None) inherit this directly;
+        the base raises NotImplementedError when no native module is wired so
+        the default contract is preserved.
         """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement native complete()"
+        native = self._native_module()
+        if native is None:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} does not implement native complete()"
+            )
+        return await native.complete(
+            request_params,
+            model=model,
+            api_key=kwargs.get("api_key"),
+            base_url=kwargs.get("base_url"),
         )
 
     async def complete_stream(
@@ -451,14 +702,23 @@ class BaseProviderHandler(ABC):
     ):
         """Stream a completion via the vendor's native SDK.
 
-        Default: NotImplementedError. Subclasses with ``has_native() == True``
-        MUST override this to return an async iterator yielding chunks
-        matching the litellm streaming shape consumed by
-        ``mesh.helpers._provider_agentic_loop_stream`` and the legacy
-        no-tools branch of ``llm_provider``'s stream tool.
+        ``async def`` but ``return``s (without awaiting) the async generator
+        from ``_native_module().complete_stream(...)``. Callers ``await`` this
+        handler call (which resolves the coroutine to the AG), then
+        ``async for chunk in stream_iter:`` to consume. Subclasses with a
+        native adapter inherit this directly; the base raises
+        NotImplementedError when no native module is wired.
         """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement native complete_stream()"
+        native = self._native_module()
+        if native is None:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} does not implement native complete_stream()"
+            )
+        return native.complete_stream(
+            request_params,
+            model=model,
+            api_key=kwargs.get("api_key"),
+            base_url=kwargs.get("base_url"),
         )
 
     def __repr__(self) -> str:

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/claude_handler.py
@@ -41,7 +41,7 @@ from .base_provider_handler import (
     BaseProviderHandler,
     has_media_params,
     make_schema_strict,
-    resolve_hint_fallback_timeout,
+    render_dispatch_status_log,
     sanitize_schema_for_structured_output,
 )
 
@@ -68,6 +68,42 @@ from .._structured_output_helpers import (  # noqa: F401
     schema_to_synthetic_tool,
 )
 
+# Single source of truth for every ``_mesh_*`` structured-output sentinel that
+# the three Claude modes (HINT / synthetic-tool / output_config) may stamp on
+# ``model_params``. Each mode clears ALL sentinels EXCEPT its own before
+# stamping — this cross-mode defense-in-depth prevents a stale sentinel from a
+# prior code path leaking into another mode and confusing the agentic loop's
+# recognition logic. Centralizing the list keeps the clear-scopes in lockstep.
+_HINT_SENTINELS = (
+    "_mesh_hint_mode",
+    "_mesh_hint_schema",
+    "_mesh_hint_fallback_timeout",
+    "_mesh_hint_output_type_name",
+)
+_SYNTHETIC_SENTINELS = (
+    "_mesh_synthetic_format_tool_name",
+    "_mesh_synthetic_format_tool",
+    "_mesh_synthetic_format_output_type_name",
+)
+_OUTPUT_CONFIG_SENTINELS = (
+    "_mesh_output_config_mode",
+    "_mesh_output_config_schema",
+    "_mesh_output_config_output_type_name",
+)
+def _clear_structured_output_sentinels(
+    model_params: dict[str, Any], *keys: str
+) -> None:
+    """Pop the given structured-output sentinels from ``model_params``.
+
+    Call sites pass the sentinel tuples (``_HINT_SENTINELS`` /
+    ``_SYNTHETIC_SENTINELS`` / ``_OUTPUT_CONFIG_SENTINELS``) so the exact
+    cross-mode clear-scope each mode had before centralization is preserved —
+    the only change is that the key lists now have a single source of truth.
+    """
+    for key in keys:
+        model_params.pop(key, None)
+
+
 # One-time guard so the dispatch-status DEBUG log fires exactly once per
 # process. Mirrors ``_logged_fallback_once`` in anthropic_native. The
 # registry caches a singleton handler per vendor
@@ -90,45 +126,41 @@ def is_dispatch_status_logged() -> bool:
     return _DISPATCH_STATUS_LOGGED
 
 
+def _anthropic_sdk_version() -> str:
+    """Probe the installed anthropic SDK version for the dispatch-status log."""
+    try:
+        import anthropic
+        return getattr(anthropic, "__version__", "<unknown>")
+    except Exception:
+        return "<import-failed>"
+
+
 def _log_dispatch_status_once() -> None:
     """Log the resolved native-dispatch status once per process at DEBUG level.
 
     Designed so users running with ``meshctl ... --debug`` can confirm whether
     a Claude provider agent is using the native anthropic SDK or falling back
     to LiteLLM. Fires on first call only; subsequent invocations are no-ops.
+
+    The rendered text is delegated to the shared base helper but the latch +
+    logger stay module-local so the DEBUG record is attributed to this module
+    and tests can re-arm the once-guard.
     """
     global _DISPATCH_STATUS_LOGGED
     if _DISPATCH_STATUS_LOGGED:
         return
     _DISPATCH_STATUS_LOGGED = True
 
-    env_value = os.getenv("MCP_MESH_NATIVE_LLM", "").strip().lower()
-
-    if env_value in ("0", "false", "no", "off"):
-        logger.debug(
-            "Claude native dispatch: disabled "
-            "(MCP_MESH_NATIVE_LLM=%s explicitly set; using LiteLLM)",
-            env_value,
-        )
-        return
-
     from _mcp_mesh.engine.native_clients import anthropic_native
 
-    if anthropic_native.is_available():
-        try:
-            import anthropic
-            version = getattr(anthropic, "__version__", "<unknown>")
-        except Exception:
-            version = "<import-failed>"
-        logger.debug(
-            "Claude native dispatch: enabled (anthropic SDK %s)",
-            version,
-        )
-    else:
-        logger.debug(
-            "Claude native dispatch: disabled "
-            "(anthropic SDK not installed; install mcp-mesh[anthropic] to enable)"
-        )
+    render_dispatch_status_log(
+        logger,
+        vendor_label="Claude",
+        sdk_display="anthropic",
+        install_extra="anthropic",
+        native_module=anthropic_native,
+        version_probe=_anthropic_sdk_version,
+    )
 
 
 class ClaudeHandler(BaseProviderHandler):
@@ -353,27 +385,6 @@ class ClaudeHandler(BaseProviderHandler):
             determined_mode,
         )
 
-    def _build_hint_text(self, sanitized_schema: dict[str, Any]) -> str:
-        """Build the ``OUTPUT FORMAT:`` HINT block for ``apply_structured_output``.
-
-        Returned text starts with leading blank lines so it can be appended
-        directly to existing system message content. Callers that synthesize
-        a fresh system message should ``.strip()`` the result.
-        """
-        hint_text = "\n\nOUTPUT FORMAT:\n"
-        hint_text += (
-            "Your FINAL response must be ONLY valid JSON (no markdown, "
-            "no code blocks) with this exact structure:\n"
-        )
-        properties = sanitized_schema.get("properties", {})
-        hint_text += self.build_json_example(properties) + "\n\n"
-        hint_text += (
-            "Return ONLY the JSON object with actual values. Do not "
-            "include the schema definition, markdown formatting, or "
-            "code blocks."
-        )
-        return hint_text
-
     def apply_structured_output(
         self,
         output_schema: dict[str, Any],
@@ -504,69 +515,22 @@ class ClaudeHandler(BaseProviderHandler):
         # Inject HINT instructions into the first system message.
         # Mesh delegation always involves tools, and Claude's response_format
         # path silently hangs on certain content+tools combos (issue #820),
-        # so we cannot use it here.
-        messages = model_params.get("messages", [])
-        hint_block_inserted = False
-        for msg in messages:
-            if msg.get("role") == "system":
-                base_content = msg.get("content", "")
-                hint_text = self._build_hint_text(sanitized_schema)
-                # Tolerate string OR content-block list (post-prompt-cache).
-                # Mirrors the synthetic-tool injection site below: a string
-                # concatenates; a list gets a NEW text block appended so the
-                # original blocks' cache_control is preserved.
-                if isinstance(base_content, str):
-                    msg["content"] = base_content + hint_text
-                elif isinstance(base_content, list):
-                    msg["content"] = list(base_content) + [
-                        {"type": "text", "text": hint_text}
-                    ]
-                else:
-                    # Unknown content shape — defensive coerce to string so
-                    # the model still sees the schema. Log so the unexpected
-                    # shape surfaces in debugging.
-                    logger.debug(
-                        "Claude HINT injection: unexpected system content "
-                        "type %s; coercing to string",
-                        type(base_content).__name__,
-                    )
-                    msg["content"] = str(base_content) + hint_text
-                hint_block_inserted = True
-                break
-
-        if not hint_block_inserted:
-            # No system message found — synthesize one containing just the
-            # HINT block. Without this, the _mesh_hint_* flags below would
-            # still be set but the model would never see the schema, every
-            # response would fail validation, and the 30s fallback timeout
-            # would fire on every request.
-            hint_text = self._build_hint_text(sanitized_schema)
-            messages.insert(0, {"role": "system", "content": hint_text.strip()})
-            logger.debug(
-                "Claude HINT mode for '%s': no system message found, "
-                "synthesized one with HINT block",
-                output_type_name or "Response",
-            )
-            # Keep model_params["messages"] in sync — messages may be a
-            # fresh list reference if the caller passed an empty/missing list.
-            model_params["messages"] = messages
-
-        # Internal flags read by _provider_agentic_loop. Prefixed with
-        # "_mesh_" so the loop strips them before calling LiteLLM (these
-        # are NOT API params).
-        # Fallback timeout: 30s was too tight for complex nested schemas
-        # (e.g. list[NestedModel] where Claude generates multi-day itineraries).
-        # Configurable via MCP_MESH_HINT_FALLBACK_TIMEOUT (seconds); the
-        # legacy MCP_MESH_CLAUDE_HINT_FALLBACK_TIMEOUT remains as a
-        # back-compat alias with a deprecation warning.
-        fallback_timeout = resolve_hint_fallback_timeout()
-        model_params["_mesh_hint_mode"] = True
-        model_params["_mesh_hint_schema"] = sanitized_schema
-        model_params["_mesh_hint_fallback_timeout"] = fallback_timeout
-        model_params["_mesh_hint_output_type_name"] = output_type_name or "Response"
-
-        # Explicitly DO NOT set response_format — that's the bug we're avoiding.
-        model_params.pop("response_format", None)
+        # so we cannot use it here. The shared base helper performs the
+        # inject/synthesize/stamp work and pops response_format; Claude uses
+        # ``support_content_blocks=True`` so the system message's post-prompt-
+        # cache content-block list shape is tolerated (a NEW text block is
+        # appended, preserving the original blocks' cache_control).
+        # Fallback timeout (stamped by the helper): configurable via
+        # MCP_MESH_HINT_FALLBACK_TIMEOUT (seconds); the legacy
+        # MCP_MESH_CLAUDE_HINT_FALLBACK_TIMEOUT remains as a back-compat alias
+        # with a deprecation warning.
+        self.apply_prose_hint(
+            model_params,
+            sanitized_schema,
+            output_type_name,
+            support_content_blocks=True,
+            logger=logger,
+        )
 
         logger.info(
             "Claude HINT mode for '%s' (mesh delegation, schema in prompt; "
@@ -678,13 +642,7 @@ class ClaudeHandler(BaseProviderHandler):
         # leak through (defense-in-depth; both response_format and HINT flags
         # would confuse the loop).
         model_params.pop("response_format", None)
-        for hint_key in (
-            "_mesh_hint_mode",
-            "_mesh_hint_schema",
-            "_mesh_hint_fallback_timeout",
-            "_mesh_hint_output_type_name",
-        ):
-            model_params.pop(hint_key, None)
+        _clear_structured_output_sentinels(model_params, *_HINT_SENTINELS)
 
         logger.info(
             "Claude native synthetic-tool mode for '%s' (mesh delegation; "
@@ -751,16 +709,9 @@ class ClaudeHandler(BaseProviderHandler):
         # Defense-in-depth: ``output_config`` mode is mutually exclusive with
         # HINT and synthetic-tool modes. Clear any leftover sentinels from a
         # prior code path so the loop's recognition logic stays deterministic.
-        for stale_key in (
-            "_mesh_hint_mode",
-            "_mesh_hint_schema",
-            "_mesh_hint_fallback_timeout",
-            "_mesh_hint_output_type_name",
-            "_mesh_synthetic_format_tool_name",
-            "_mesh_synthetic_format_tool",
-            "_mesh_synthetic_format_output_type_name",
-        ):
-            model_params.pop(stale_key, None)
+        _clear_structured_output_sentinels(
+            model_params, *_HINT_SENTINELS, *_SYNTHETIC_SENTINELS
+        )
 
         logger.info(
             "Claude native output_config mode for '%s' (mesh delegation; "
@@ -794,72 +745,23 @@ class ClaudeHandler(BaseProviderHandler):
     # False and the call sites in mesh.helpers fall back to LiteLLM with
     # a one-time INFO log nudging the user toward
     # ``pip install mcp-mesh[anthropic]``.
+    #
+    # ``has_native()`` / ``complete()`` / ``complete_stream()`` are inherited
+    # from BaseProviderHandler, driven by the one-line ``_native_module()`` hook
+    # below (plus label/version for the dispatch-status log).
 
-    def has_native(self) -> bool:
-        """Native dispatch is enabled by default when the anthropic SDK is
-        importable. Set ``MCP_MESH_NATIVE_LLM=0`` (or ``false``/``no``/``off``)
-        to disable and force the LiteLLM fallback path. Setting the flag to
-        ``1``/``true``/``yes``/``on`` is accepted as an explicit-enable
-        (same behavior as the default).
-        """
-        # Emit the one-time dispatch-status DEBUG log. Lazy here (vs. at
-        # module/handler init) so it fires when the first dispatch decision
-        # is actually made — the most useful signal for ``--debug`` runs.
-        # Skip the call entirely once the log has fired — the function
-        # dedupes internally, but avoiding the call frame on the hot path
-        # is cheaper still.
+    def _native_module(self):
+        # Lazy import inside the method so module import does not fail when the
+        # SDK is absent; this mirrors what the call sites do.
+        from _mcp_mesh.engine.native_clients import anthropic_native
+
+        return anthropic_native
+
+    def _native_label(self) -> str:
+        return "Claude"
+
+    def _log_dispatch_status(self) -> None:
+        # Skip the call entirely once the log has fired — the function dedupes
+        # internally, but avoiding the call frame on the hot path is cheaper.
         if not is_dispatch_status_logged():
             _log_dispatch_status_once()
-
-        flag = os.environ.get("MCP_MESH_NATIVE_LLM", "").strip().lower()
-        # Explicit opt-out wins over SDK availability.
-        if flag in ("0", "false", "no", "off"):
-            return False
-
-        # Lazy import inside the function so module import does not fail
-        # when the SDK is absent; this mirrors what the call sites do.
-        from _mcp_mesh.engine.native_clients import anthropic_native
-
-        if not anthropic_native.is_available():
-            # Skip the log call entirely once it has already fired — the
-            # function dedupes internally, but on the no-native hot path
-            # avoiding the call frame altogether is cheaper still.
-            if not anthropic_native.is_fallback_logged():
-                anthropic_native.log_fallback_once()
-            return False
-
-        return True
-
-    async def complete(
-        self,
-        request_params: dict[str, Any],
-        *,
-        model: str,
-        **kwargs: Any,
-    ) -> Any:
-        """Dispatch a buffered completion to the native Anthropic SDK adapter."""
-        from _mcp_mesh.engine.native_clients import anthropic_native
-
-        return await anthropic_native.complete(
-            request_params,
-            model=model,
-            api_key=kwargs.get("api_key"),
-            base_url=kwargs.get("base_url"),
-        )
-
-    async def complete_stream(
-        self,
-        request_params: dict[str, Any],
-        *,
-        model: str,
-        **kwargs: Any,
-    ):
-        """Dispatch a streaming completion to the native Anthropic SDK adapter."""
-        from _mcp_mesh.engine.native_clients import anthropic_native
-
-        return anthropic_native.complete_stream(
-            request_params,
-            model=model,
-            api_key=kwargs.get("api_key"),
-            base_url=kwargs.get("base_url"),
-        )

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/gemini_handler.py
@@ -38,7 +38,7 @@ from .base_provider_handler import (
     BaseProviderHandler,
     has_media_params,
     make_schema_strict,
-    resolve_hint_fallback_timeout,
+    render_dispatch_status_log,
     sanitize_schema_for_structured_output,
 )
 
@@ -99,6 +99,15 @@ def is_dispatch_status_logged() -> bool:
     return _DISPATCH_STATUS_LOGGED
 
 
+def _gemini_sdk_version() -> str:
+    """Probe the installed google-genai SDK version for the dispatch-status log."""
+    try:
+        import google.genai as genai
+        return getattr(genai, "__version__", "<unknown>")
+    except Exception:
+        return "<import-failed>"
+
+
 def _log_dispatch_status_once() -> None:
     """Log the resolved native-dispatch status once per process at DEBUG level.
 
@@ -106,39 +115,26 @@ def _log_dispatch_status_once() -> None:
     a Gemini provider agent is using the native google-genai SDK or falling
     back to LiteLLM. Fires on first call only; subsequent invocations are
     no-ops.
+
+    The rendered text is delegated to the shared base helper but the latch +
+    logger stay module-local so the DEBUG record is attributed to this module
+    and tests can re-arm the once-guard.
     """
     global _DISPATCH_STATUS_LOGGED
     if _DISPATCH_STATUS_LOGGED:
         return
     _DISPATCH_STATUS_LOGGED = True
 
-    env_value = os.getenv("MCP_MESH_NATIVE_LLM", "").strip().lower()
-
-    if env_value in ("0", "false", "no", "off"):
-        logger.debug(
-            "Gemini native dispatch: disabled "
-            "(MCP_MESH_NATIVE_LLM=%s explicitly set; using LiteLLM)",
-            env_value,
-        )
-        return
-
     from _mcp_mesh.engine.native_clients import gemini_native
 
-    if gemini_native.is_available():
-        try:
-            import google.genai as genai
-            version = getattr(genai, "__version__", "<unknown>")
-        except Exception:
-            version = "<import-failed>"
-        logger.debug(
-            "Gemini native dispatch: enabled (google-genai SDK %s)",
-            version,
-        )
-    else:
-        logger.debug(
-            "Gemini native dispatch: disabled "
-            "(google-genai SDK not installed; install mcp-mesh[gemini] to enable)"
-        )
+    render_dispatch_status_log(
+        logger,
+        vendor_label="Gemini",
+        sdk_display="google-genai",
+        install_extra="gemini",
+        native_module=gemini_native,
+        version_probe=_gemini_sdk_version,
+    )
 
 
 class GeminiHandler(BaseProviderHandler):
@@ -395,19 +391,6 @@ class GeminiHandler(BaseProviderHandler):
             "large_context": True,
         }
 
-    def _build_hint_text(self, sanitized_schema: dict[str, Any]) -> str:
-        """Build the OUTPUT FORMAT hint block appended to the system message."""
-        properties = sanitized_schema.get("properties", {})
-        return (
-            "\n\nOUTPUT FORMAT:\n"
-            "Your FINAL response must be ONLY valid JSON (no markdown, "
-            "no code blocks) with this exact structure:\n"
-            + self.build_json_example(properties)
-            + "\n\n"
-            "Return ONLY the JSON object with actual values. Do not include "
-            "the schema definition, markdown formatting, or code blocks."
-        )
-
     def apply_structured_output(
         self,
         output_schema: dict[str, Any],
@@ -492,44 +475,28 @@ class GeminiHandler(BaseProviderHandler):
             return model_params
 
         # Store for format_system_prompt (per-async-context to avoid races
-        # across concurrent requests sharing this singleton handler).
+        # across concurrent requests sharing this singleton handler). This
+        # Gemini-only side effect feeds the ``format_system_prompt`` ContextVar
+        # path and MUST stay at the call site (not in the shared base helper).
         set_pending_output_schema(sanitized_schema, output_type_name)
 
         # Inject HINT instructions into the first system message; synthesize
-        # one if none exists. Without this, the _mesh_hint_* flags below
-        # would be set but the model would never see the schema, every
-        # response would fail validation, and the fallback timeout would
-        # fire on every request.
-        messages = model_params.get("messages", [])
-        hint_text = self._build_hint_text(sanitized_schema)
-        hint_block_inserted = False
-        for msg in messages:
-            if msg.get("role") == "system":
-                base_content = msg.get("content", "")
-                msg["content"] = base_content + hint_text
-                hint_block_inserted = True
-                break
-
-        if not hint_block_inserted:
-            messages.insert(0, {"role": "system", "content": hint_text.strip()})
-            logger.debug(
-                "Gemini HINT mode for '%s': no system message found, "
-                "synthesized one with HINT block",
-                output_type_name or "Response",
-            )
-            model_params["messages"] = messages
-
-        fallback_timeout = resolve_hint_fallback_timeout()
-
-        model_params["_mesh_hint_mode"] = True
-        model_params["_mesh_hint_schema"] = sanitized_schema
-        model_params["_mesh_hint_fallback_timeout"] = fallback_timeout
-        model_params["_mesh_hint_output_type_name"] = output_type_name or "Response"
-
-        # Defense-in-depth: never set response_format on the HINT path
-        # (would re-trigger the Gemini 3 + response_format + tools infinite
-        # tool-loop bug).
-        model_params.pop("response_format", None)
+        # one if none exists. Without this, the _mesh_hint_* flags would be set
+        # but the model would never see the schema, every response would fail
+        # validation, and the fallback timeout would fire on every request.
+        # ``support_content_blocks=False`` keeps Gemini's string-only concat
+        # (no post-prompt-cache content-block list shape, unlike Claude).
+        # The shared base helper also stamps the _mesh_hint_* sentinels and
+        # pops response_format (defense-in-depth — never set it on the HINT
+        # path; would re-trigger the Gemini 3 + response_format + tools
+        # infinite tool-loop bug).
+        self.apply_prose_hint(
+            model_params,
+            sanitized_schema,
+            output_type_name,
+            support_content_blocks=False,
+            logger=logger,
+        )
 
         logger.info(
             "Gemini HINT mode for '%s' (mesh delegation, schema in prompt; "
@@ -552,81 +519,23 @@ class GeminiHandler(BaseProviderHandler):
     # response_format vs HINT (the existing Gemini API infinite-tool-loop
     # workaround for ``response_format + tools``). The native adapter
     # forwards whatever the handler hands it — no behavioral change.
+    #
+    # ``has_native()`` / ``complete()`` / ``complete_stream()`` are inherited
+    # from BaseProviderHandler, driven by the one-line ``_native_module()`` hook
+    # below (plus label/version for the dispatch-status log).
 
-    def has_native(self) -> bool:
-        """Native dispatch is enabled by default when the google-genai SDK is
-        importable. Set ``MCP_MESH_NATIVE_LLM=0`` (or ``false``/``no``/``off``)
-        to disable and force the LiteLLM fallback path. Setting the flag to
-        ``1``/``true``/``yes``/``on`` is accepted as an explicit-enable
-        (same behavior as the default).
-        """
-        # Emit the one-time dispatch-status DEBUG log. Lazy here (vs. at
-        # module/handler init) so it fires when the first dispatch decision
-        # is actually made — the most useful signal for ``--debug`` runs.
-        # Skip the call entirely once the log has fired — the function
-        # dedupes internally, but avoiding the call frame on the hot path
-        # is cheaper still.
+    def _native_module(self):
+        # Lazy import inside the method so module import does not fail when the
+        # SDK is absent; this mirrors what the call sites do.
+        from _mcp_mesh.engine.native_clients import gemini_native
+
+        return gemini_native
+
+    def _native_label(self) -> str:
+        return "Gemini"
+
+    def _log_dispatch_status(self) -> None:
+        # Skip the call entirely once the log has fired — the function dedupes
+        # internally, but avoiding the call frame on the hot path is cheaper.
         if not is_dispatch_status_logged():
             _log_dispatch_status_once()
-
-        flag = os.environ.get("MCP_MESH_NATIVE_LLM", "").strip().lower()
-        # Explicit opt-out wins over SDK availability.
-        if flag in ("0", "false", "no", "off"):
-            return False
-
-        # Lazy import inside the function so module import does not fail
-        # when the SDK is absent; this mirrors what the call sites do.
-        from _mcp_mesh.engine.native_clients import gemini_native
-
-        if not gemini_native.is_available():
-            # Skip the log call entirely once it has already fired — the
-            # function dedupes internally, but on the no-native hot path
-            # avoiding the call frame altogether is cheaper still.
-            if not gemini_native.is_fallback_logged():
-                gemini_native.log_fallback_once()
-            return False
-
-        return True
-
-    async def complete(
-        self,
-        request_params: dict[str, Any],
-        *,
-        model: str,
-        **kwargs: Any,
-    ) -> Any:
-        """Dispatch a buffered completion to the native Gemini SDK adapter."""
-        from _mcp_mesh.engine.native_clients import gemini_native
-
-        return await gemini_native.complete(
-            request_params,
-            model=model,
-            api_key=kwargs.get("api_key"),
-            base_url=kwargs.get("base_url"),
-        )
-
-    async def complete_stream(
-        self,
-        request_params: dict[str, Any],
-        *,
-        model: str,
-        **kwargs: Any,
-    ):
-        """Streaming completion via the native Gemini SDK.
-
-        Note: this method is ``async def`` but ``return``s (without
-        awaiting) the async generator from
-        ``gemini_native.complete_stream``. Callers ``await`` the handler
-        call (which resolves the coroutine to the AG), then
-        ``async for chunk in stream_iter:`` to consume. Mirrors the
-        dispatch contract used in mesh/helpers.py and matches the
-        ClaudeHandler / OpenAIHandler patterns.
-        """
-        from _mcp_mesh.engine.native_clients import gemini_native
-
-        return gemini_native.complete_stream(
-            request_params,
-            model=model,
-            api_key=kwargs.get("api_key"),
-            base_url=kwargs.get("base_url"),
-        )

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/openai_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/openai_handler.py
@@ -7,7 +7,6 @@ using OpenAI's native structured output capabilities.
 
 import json
 import logging
-import os
 from typing import Any, Optional
 
 import mcp_mesh_core
@@ -16,6 +15,7 @@ from pydantic import BaseModel
 from .base_provider_handler import (
     BaseProviderHandler,
     has_media_params,
+    render_dispatch_status_log,
 )
 
 logger = logging.getLogger(__name__)
@@ -43,45 +43,41 @@ def is_dispatch_status_logged() -> bool:
     return _DISPATCH_STATUS_LOGGED
 
 
+def _openai_sdk_version() -> str:
+    """Probe the installed openai SDK version for the dispatch-status log."""
+    try:
+        import openai
+        return getattr(openai, "__version__", "<unknown>")
+    except Exception:
+        return "<import-failed>"
+
+
 def _log_dispatch_status_once() -> None:
     """Log the resolved native-dispatch status once per process at DEBUG level.
 
     Designed so users running with ``meshctl ... --debug`` can confirm whether
     an OpenAI provider agent is using the native openai SDK or falling back
     to LiteLLM. Fires on first call only; subsequent invocations are no-ops.
+
+    The rendered text is delegated to the shared base helper but the latch +
+    logger stay module-local so the DEBUG record is attributed to this module
+    and tests can re-arm the once-guard.
     """
     global _DISPATCH_STATUS_LOGGED
     if _DISPATCH_STATUS_LOGGED:
         return
     _DISPATCH_STATUS_LOGGED = True
 
-    env_value = os.getenv("MCP_MESH_NATIVE_LLM", "").strip().lower()
-
-    if env_value in ("0", "false", "no", "off"):
-        logger.debug(
-            "OpenAI native dispatch: disabled "
-            "(MCP_MESH_NATIVE_LLM=%s explicitly set; using LiteLLM)",
-            env_value,
-        )
-        return
-
     from _mcp_mesh.engine.native_clients import openai_native
 
-    if openai_native.is_available():
-        try:
-            import openai
-            version = getattr(openai, "__version__", "<unknown>")
-        except Exception:
-            version = "<import-failed>"
-        logger.debug(
-            "OpenAI native dispatch: enabled (openai SDK %s)",
-            version,
-        )
-    else:
-        logger.debug(
-            "OpenAI native dispatch: disabled "
-            "(openai SDK not installed; install mcp-mesh[openai] to enable)"
-        )
+    render_dispatch_status_log(
+        logger,
+        vendor_label="OpenAI",
+        sdk_display="openai",
+        install_extra="openai",
+        native_module=openai_native,
+        version_probe=_openai_sdk_version,
+    )
 
 
 class OpenAIHandler(BaseProviderHandler):
@@ -249,81 +245,23 @@ class OpenAIHandler(BaseProviderHandler):
     # the missing-SDK branch should never trigger — kept for symmetry with
     # the Anthropic handler and to guard against custom installs that
     # strip the SDK.
+    #
+    # ``has_native()`` / ``complete()`` / ``complete_stream()`` are inherited
+    # from BaseProviderHandler, driven by the one-line ``_native_module()`` hook
+    # below (plus label/version for the dispatch-status log).
 
-    def has_native(self) -> bool:
-        """Native dispatch is enabled by default when the openai SDK is
-        importable. Set ``MCP_MESH_NATIVE_LLM=0`` (or ``false``/``no``/``off``)
-        to disable and force the LiteLLM fallback path. Setting the flag to
-        ``1``/``true``/``yes``/``on`` is accepted as an explicit-enable
-        (same behavior as the default).
-        """
-        # Emit the one-time dispatch-status DEBUG log. Lazy here (vs. at
-        # module/handler init) so it fires when the first dispatch decision
-        # is actually made — the most useful signal for ``--debug`` runs.
-        # Skip the call entirely once the log has fired — the function
-        # dedupes internally, but avoiding the call frame on the hot path
-        # is cheaper still.
+    def _native_module(self):
+        # Lazy import inside the method so module import does not fail when the
+        # SDK is absent; this mirrors what the call sites do.
+        from _mcp_mesh.engine.native_clients import openai_native
+
+        return openai_native
+
+    def _native_label(self) -> str:
+        return "OpenAI"
+
+    def _log_dispatch_status(self) -> None:
+        # Skip the call entirely once the log has fired — the function dedupes
+        # internally, but avoiding the call frame on the hot path is cheaper.
         if not is_dispatch_status_logged():
             _log_dispatch_status_once()
-
-        flag = os.environ.get("MCP_MESH_NATIVE_LLM", "").strip().lower()
-        # Explicit opt-out wins over SDK availability.
-        if flag in ("0", "false", "no", "off"):
-            return False
-
-        # Lazy import inside the function so module import does not fail
-        # when the SDK is absent; this mirrors what the call sites do.
-        from _mcp_mesh.engine.native_clients import openai_native
-
-        if not openai_native.is_available():
-            # Skip the log call entirely once it has already fired — the
-            # function dedupes internally, but on the no-native hot path
-            # avoiding the call frame altogether is cheaper still.
-            if not openai_native.is_fallback_logged():
-                openai_native.log_fallback_once()
-            return False
-
-        return True
-
-    async def complete(
-        self,
-        request_params: dict[str, Any],
-        *,
-        model: str,
-        **kwargs: Any,
-    ) -> Any:
-        """Dispatch a buffered completion to the native OpenAI SDK adapter."""
-        from _mcp_mesh.engine.native_clients import openai_native
-
-        return await openai_native.complete(
-            request_params,
-            model=model,
-            api_key=kwargs.get("api_key"),
-            base_url=kwargs.get("base_url"),
-        )
-
-    async def complete_stream(
-        self,
-        request_params: dict[str, Any],
-        *,
-        model: str,
-        **kwargs: Any,
-    ):
-        """Streaming completion via the native OpenAI SDK.
-
-        Note: this method is ``async def`` but ``return``s (without
-        awaiting) the async generator from
-        ``openai_native.complete_stream``. Callers ``await`` the handler
-        call (which resolves the coroutine to the AG), then
-        ``async for chunk in stream_iter:`` to consume. Mirrors the
-        dispatch contract used in mesh/helpers.py and matches the
-        ClaudeHandler pattern.
-        """
-        from _mcp_mesh.engine.native_clients import openai_native
-
-        return openai_native.complete_stream(
-            request_params,
-            model=model,
-            api_key=kwargs.get("api_key"),
-            base_url=kwargs.get("base_url"),
-        )


### PR DESCRIPTION
## Summary
The provider-handler base-class consolidation cluster of #1115 ("PR-B"). Behavior-sensitive but proven behavior-identical.

- **Native-dispatch → base:** lift `has_native()`/`complete()`/`complete_stream()` + the once-per-process dispatch-status DEBUG latch into `BaseProviderHandler` via a `_native_module()` hook (each handler is now a one-line override). Preserved exactly: `MCP_MESH_NATIVE_LLM` opt-out precedence, lazy SDK import, `is_fallback_logged()` hot-path skip, **per-vendor latch independence**, and the DEBUG message text (parameterized template → byte-identical per vendor).
- **HINT → base:** lift `_build_hint_text` (byte-identical between Claude & Gemini) and `apply_prose_hint(..., support_content_blocks)` to the base (Claude content-block list vs Gemini string concat). Gemini's `set_pending_output_schema` side effect stays in the Gemini caller; per-vendor INFO logs stay at call sites.
- **Sentinels:** Claude `apply_structured_output` HINT branch calls the base `apply_prose_hint`; structured-output sentinel key lists centralized into named tuples + `_clear_structured_output_sentinels`, **preserving each mode's exact original clear set** (not "all-except-own", which would have changed behavior).

Net ~even (+475/−459; the dedup moved into the base).

## Review Notes
Independent review: **0 blockers, 1 WARNING + 3 INFO — all addressed in this commit**:
- WARNING: the two HINT-injection DEBUG logs were emitting under the base logger; **fixed** by threading the per-vendor logger into `apply_prose_hint` (restores `…claude_handler`/`…gemini_handler` attribution, matching the dispatch-status log).
- INFO: removed dead `import os` (openai_handler), removed the vestigial `_sdk_version()` hook (base + 3 subclasses; the module-level probes are kept), annotated `version_probe: Callable[[], str]`.
Verified behavior-preserving: native-dispatch env-opt-out/lazy-import/hot-path-skip, per-vendor latch + byte-identical DEBUG text, byte-identical HINT text, Gemini side effect placement, sentinel clear-scope unchanged.

## Test plan
- [x] 255 provider/hint/structured-output unit tests pass (DEBUG + HINT strings verified byte-identical); re-validated after the review fixes
- [x] `src-tests` 12/12
- [x] Integration behavior-identical: **uc04 8/8** (native dispatch per vendor + output_config/synthetic-tool/HINT), **uc08 3/3** (mesh-delegation HINT path, all vendors), **uc10 3/3** (agentic + synthetic-tool) — 14/14 across 3 vendors × 3 structured modes + agentic + HINT

## Scope / follow-ups (Part of #1115)
- **PR-C**: agentic-loop per-iteration `completion_args` + dispatch-branch dedup (safe part).
- The **#961 streaming synthetic-retry gap** stays tracked under #961 (separate behavior fix, not bundled).

Part of #1115