### PR TITLE
refactor(python/llm): extract shared agentic-loop completion-args + dispatch (Closes #1115)

### DIFF
--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -1275,6 +1275,92 @@ async def _execute_tool_calls_for_iteration(
     return tool_messages, accumulated_images
 
 
+def _build_iteration_completion_args(
+    effective_model: str,
+    current_messages: list,
+    tools: list,
+    litellm_kwargs: dict,
+    model_params: dict,
+    *,
+    stream: bool = False,
+) -> dict[str, Any]:
+    """Build the per-iteration ``completion_args`` dict.
+
+    Shared by the buffered (:func:`_provider_agentic_loop`) and streaming
+    (:func:`_provider_agentic_loop_stream`) agentic loops. Reproduces the
+    base arg set (model/messages/tools + decorator kwargs + model_params)
+    that both paths construct identically. When ``stream`` is True the
+    streaming-only flags (``stream``/``stream_options`` with
+    ``include_usage``) are layered on top, preserving any caller-provided
+    ``stream_options`` exactly as the streaming loop did inline.
+    """
+    completion_args: dict[str, Any] = {
+        "model": effective_model,
+        "messages": current_messages,
+        "tools": tools,
+        **litellm_kwargs,
+    }
+    if model_params:
+        completion_args.update(model_params)
+
+    if stream:
+        existing_stream_opts = completion_args.get("stream_options") or {}
+        completion_args["stream"] = True
+        completion_args["stream_options"] = {
+            **existing_stream_opts,
+            "include_usage": True,
+        }
+
+    return completion_args
+
+
+async def _dispatch_completion(
+    native_handler: Any,
+    completion_args: dict[str, Any],
+    effective_model: str,
+    litellm_module: Any,
+    *,
+    stream: bool,
+    native_exclude_keys: tuple[str, ...],
+) -> Any:
+    """Dispatch one completion call, native-SDK or LiteLLM.
+
+    Routes through the vendor's native SDK adapter when one is installed
+    (issue #834), otherwise falls back to LiteLLM. ``native_exclude_keys``
+    is the set of ``completion_args`` keys NOT forwarded to the native
+    adapter (the native API takes ``model``/``api_key``/``base_url`` as
+    explicit kwargs, and the streaming path additionally excludes
+    ``stream``/``stream_options``). The buffered path uses the buffered
+    native/LiteLLM calls; the streaming path uses the streaming variants.
+
+    Returns the buffered response object (``stream=False``) or the stream
+    async iterator (``stream=True``), matching what each loop inlined.
+    """
+    if native_handler.has_native():
+        _native_args = {
+            k: v
+            for k, v in completion_args.items()
+            if k not in native_exclude_keys
+        }
+        if stream:
+            return await native_handler.complete_stream(
+                _native_args,
+                model=effective_model,
+                api_key=completion_args.get("api_key"),
+                base_url=completion_args.get("base_url"),
+            )
+        return await native_handler.complete(
+            _native_args,
+            model=effective_model,
+            api_key=completion_args.get("api_key"),
+            base_url=completion_args.get("base_url"),
+        )
+
+    if stream:
+        return await litellm_module.acompletion(**completion_args)
+    return await asyncio.to_thread(litellm_module.completion, **completion_args)
+
+
 async def _provider_agentic_loop(
     effective_model: str,
     messages: list,
@@ -1355,14 +1441,13 @@ async def _provider_agentic_loop(
     while iteration < max_iterations:
         iteration += 1
 
-        completion_args: dict[str, Any] = {
-            "model": effective_model,
-            "messages": current_messages,
-            "tools": tools,
-            **litellm_kwargs,
-        }
-        if model_params:
-            completion_args.update(model_params)
+        completion_args = _build_iteration_completion_args(
+            effective_model,
+            current_messages,
+            tools,
+            litellm_kwargs,
+            model_params,
+        )
 
         # Native dispatch (issue #834, PR 1): route through the vendor's
         # native SDK adapter by default when the SDK is installed.
@@ -1387,22 +1472,14 @@ async def _provider_agentic_loop(
             # would be misread as a caller override and trigger a spurious WARN.
             tools = completion_args["tools"]
 
-        if _native_handler.has_native():
-            _native_args = {
-                k: v
-                for k, v in completion_args.items()
-                if k not in ("model", "api_key", "base_url")
-            }
-            response = await _native_handler.complete(
-                _native_args,
-                model=effective_model,
-                api_key=completion_args.get("api_key"),
-                base_url=completion_args.get("base_url"),
-            )
-        else:
-            response = await asyncio.to_thread(
-                litellm.completion, **completion_args
-            )
+        response = await _dispatch_completion(
+            _native_handler,
+            completion_args,
+            effective_model,
+            litellm,
+            stream=False,
+            native_exclude_keys=("model", "api_key", "base_url"),
+        )
         message = response.choices[0].message
 
         # Synthetic-format-tool recognition (native path, structured output).
@@ -1792,6 +1869,11 @@ async def _provider_agentic_loop_stream(
     # the streaming path needs an equivalent path that handles mid-stream
     # tool_use accumulation, abandons the in-flight stream cleanly, and
     # re-issues the corrective call without breaking partial-text yields.
+    # The corrective call should reuse the shared dispatch/args helpers
+    # (:func:`_build_iteration_completion_args` /
+    # :func:`_dispatch_completion`) to build and route the retry request the
+    # same way the main iteration does — see the buffered loop's
+    # ``retry_template`` construction for the keys to strip.
     # Tracking issue: https://github.com/dhyanraj/mcp-mesh/issues/961.
     import litellm
 
@@ -1840,21 +1922,14 @@ async def _provider_agentic_loop_stream(
     while iteration < max_iterations:
         iteration += 1
 
-        completion_args: dict[str, Any] = {
-            "model": effective_model,
-            "messages": current_messages,
-            "tools": tools,
-            **litellm_kwargs,
-        }
-        if model_params:
-            completion_args.update(model_params)
-
-        existing_stream_opts = completion_args.get("stream_options") or {}
-        completion_args["stream"] = True
-        completion_args["stream_options"] = {
-            **existing_stream_opts,
-            "include_usage": True,
-        }
+        completion_args = _build_iteration_completion_args(
+            effective_model,
+            current_messages,
+            tools,
+            litellm_kwargs,
+            model_params,
+            stream=True,
+        )
 
         # Native dispatch (issue #834, PR 1): route through the vendor's
         # native SDK streaming adapter by default when the SDK is installed.
@@ -1876,27 +1951,20 @@ async def _provider_agentic_loop_stream(
             )
             tools = completion_args["tools"]
 
-        if _native_handler.has_native():
-            _native_args = {
-                k: v
-                for k, v in completion_args.items()
-                if k
-                not in (
-                    "model",
-                    "api_key",
-                    "base_url",
-                    "stream",
-                    "stream_options",
-                )
-            }
-            stream_iter = await _native_handler.complete_stream(
-                _native_args,
-                model=effective_model,
-                api_key=completion_args.get("api_key"),
-                base_url=completion_args.get("base_url"),
-            )
-        else:
-            stream_iter = await litellm.acompletion(**completion_args)
+        stream_iter = await _dispatch_completion(
+            _native_handler,
+            completion_args,
+            effective_model,
+            litellm,
+            stream=True,
+            native_exclude_keys=(
+                "model",
+                "api_key",
+                "base_url",
+                "stream",
+                "stream_options",
+            ),
+        )
 
         chunks: list[Any] = []
         saw_tool_call = False


### PR DESCRIPTION
## Summary
The final consolidation cluster of #1115 ("PR-C") — completes the issue (PR-A #1123 + PR-B #1124 merged). **Pure dedup, behavior-preserving on both the buffered and streaming agentic paths.**

Extract two shared helpers from `_provider_agentic_loop` (buffered) and `_provider_agentic_loop_stream` (streaming) in `mesh/helpers.py`:
- **`_build_iteration_completion_args(...)`** — the shared per-iteration `completion_args` dict; the streaming caller passes `stream=True` to layer on `stream=True` + `stream_options={…, "include_usage": True}` (preserving any caller-provided `stream_options`).
- **`_dispatch_completion(…, *, stream, native_exclude_keys)`** — wraps the native-vs-LiteLLM dispatch branch; `native_exclude_keys` parameterizes the per-path key exclusion (streaming additionally drops `stream`/`stream_options`) so each native call is byte-identical to before.

Preserved exactly: native-vs-LiteLLM decision, `vendor == "anthropic"` gating, env flags, usage accumulation, tool-call execution, and the stream `finally`/`aclose()` teardown.

**The #961 streaming synthetic-retry gap is intentionally left as-is** (buffered keeps its corrective retry; streaming still has none) — only the TODO was refined to point at the new helpers. The gap stays tracked under **#961** as a separate behavior fix, not bundled here.

Net +128/−60 (helper defs + docstrings; the win is a single source of truth for the dispatch decision + a shared entry point for the eventual #961 fix).

## Review Notes
Independent review: **0 blockers, 0 warnings, 1 INFO** (positional-vs-keyword call-args style nit). Verified: `completion_args` equivalence (incl. `stream_options` merge not clobbered, `model_params` merge), dispatch equivalence (native/LiteLLM not swapped, per-path exclusions correct), `#961` retry untouched (buffered-only), and `anthropic` gating / usage / `aclose()` teardown intact.

## Test plan
- [x] Agentic-loop unit suite green (67 + 107 related tests)
- [x] `src-tests` 12/12
- [x] Integration behavior-identical **16/16**: `uc18_streaming` 5/5 (streaming path), `uc04` 8/8 (buffered + structured-output incl. multi-turn-tools retry), `uc10` 3/3 (multi-turn tool feedback) — across all 3 vendors + TS/Java consumers

Completes #1115 alongside the merged PR-A (#1123) and PR-B (#1124). The #961 streaming synthetic-retry gap remains its own tracked issue.

Closes #1115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal consistency of AI API call handling by consolidating shared logic across different execution modes, enhancing code maintainability and reducing duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->