### PR TITLE
refactor(ts/llm): cache output schema + dedup context-merge/strict-format/SSE (Part of #1116)

### DIFF
--- a/src/runtime/typescript/src/llm-agent.ts
+++ b/src/runtime/typescript/src/llm-agent.ts
@@ -484,10 +484,35 @@ export class MeshLlmAgent<T = string> {
   private _meta: LlmMeta | null = null;
   private _systemPromptOverride: string | null = null;
   private _parallelLogEmitted = false;
+  // Cached output schema derived from the immutable returnSchema (Issue #459).
+  // Computed once: `null` means "not yet computed", an object holds the result
+  // (which may itself be `undefined` when conversion failed).
+  private _outputSchema: { schema: Record<string, unknown>; name: string } | undefined | null = null;
+  private _outputSchemaSection: string | null = null;
 
   constructor(config: MeshLlmAgentConfig) {
     this.config = config;
     this.responseParser = new ResponseParser(config.returnSchema as ZodType<T> | undefined);
+  }
+
+  /**
+   * Build (once) the provider output schema from the immutable returnSchema.
+   * Returns `undefined` when there is no schema or conversion failed.
+   */
+  private getOutputSchema(): { schema: Record<string, unknown>; name: string } | undefined {
+    if (this._outputSchema !== null) return this._outputSchema;
+    let result: { schema: Record<string, unknown>; name: string } | undefined;
+    if (this.config.returnSchema) {
+      try {
+        const jsonSchema = zodToJsonSchema(this.config.returnSchema) as Record<string, unknown>;
+        const schemaName = (jsonSchema.title as string) ?? "Response";
+        result = { schema: jsonSchema, name: schemaName };
+      } catch {
+        // If schema conversion fails, skip
+      }
+    }
+    this._outputSchema = result;
+    return result;
   }
 
   /**
@@ -629,18 +654,8 @@ export class MeshLlmAgent<T = string> {
       this.config.model ??
       this.getDefaultModel();
 
-    // Build output schema for provider (Issue #459) - computed once before loop
-    let outputSchema: { schema: Record<string, unknown>; name: string } | undefined;
-    if (this.config.returnSchema) {
-      try {
-        const jsonSchema = zodToJsonSchema(this.config.returnSchema) as Record<string, unknown>;
-        // Extract schema name from title or use generic name
-        const schemaName = (jsonSchema.title as string) ?? "Response";
-        outputSchema = { schema: jsonSchema, name: schemaName };
-      } catch {
-        // If schema conversion fails, skip
-      }
-    }
+    // Build output schema for provider (Issue #459) - computed once, cached
+    const outputSchema = this.getOutputSchema();
 
     // Agentic loop
     let iteration = 0;
@@ -884,16 +899,7 @@ export class MeshLlmAgent<T = string> {
       this.config.model ??
       this.getDefaultModel();
 
-    let outputSchema: { schema: Record<string, unknown>; name: string } | undefined;
-    if (this.config.returnSchema) {
-      try {
-        const jsonSchema = zodToJsonSchema(this.config.returnSchema) as Record<string, unknown>;
-        const schemaName = (jsonSchema.title as string) ?? "Response";
-        outputSchema = { schema: jsonSchema, name: schemaName };
-      } catch {
-        // skip
-      }
-    }
+    const outputSchema = this.getOutputSchema();
 
     const provider = new MeshDelegatedProvider(
       context.meshProvider.endpoint,
@@ -929,8 +935,9 @@ export class MeshLlmAgent<T = string> {
   } {
     const agent = this;
 
-    const callable = async (message: LlmMessageInput, options?: LlmCallOptions): Promise<T> => {
-      // Handle context mode
+    // Shared "context merge vs replace" semantics used by both the buffered
+    // callable and the stream method below.
+    const mergeRunContext = (options?: LlmCallOptions): AgentRunContext => {
       const contextMode: LlmContextMode = options?.contextMode ?? "merge";
       let mergedTemplateContext: Record<string, unknown>;
 
@@ -945,14 +952,15 @@ export class MeshLlmAgent<T = string> {
         mergedTemplateContext = context.templateContext ?? {};
       }
 
-      // Merge options
-      const mergedContext: AgentRunContext = {
+      return {
         ...context,
         options: options ? { ...context.options, ...options } : context.options,
         templateContext: mergedTemplateContext,
       };
+    };
 
-      return agent.run(message, mergedContext);
+    const callable = async (message: LlmMessageInput, options?: LlmCallOptions): Promise<T> => {
+      return agent.run(message, mergeRunContext(options));
     };
 
     // Attach meta property
@@ -975,21 +983,7 @@ export class MeshLlmAgent<T = string> {
     // "context merge vs replace" behavior as the buffered call.
     Object.defineProperty(callable, "stream", {
       value: (message: LlmMessageInput, options?: LlmCallOptions): AsyncIterable<string> => {
-        const contextMode: LlmContextMode = options?.contextMode ?? "merge";
-        let mergedTemplateContext: Record<string, unknown>;
-        if (contextMode === "replace" && options?.context) {
-          mergedTemplateContext = options.context;
-        } else if (options?.context) {
-          mergedTemplateContext = { ...context.templateContext, ...options.context };
-        } else {
-          mergedTemplateContext = context.templateContext ?? {};
-        }
-        const mergedContext: AgentRunContext = {
-          ...context,
-          options: options ? { ...context.options, ...options } : context.options,
-          templateContext: mergedTemplateContext,
-        };
-        return agent.stream(message, mergedContext);
+        return agent.stream(message, mergeRunContext(options));
       },
     });
 
@@ -1085,17 +1079,17 @@ export class MeshLlmAgent<T = string> {
    * Guides the LLM to produce structured output matching the schema.
    */
   private buildOutputSchemaSection(): string {
-    if (!this.config.returnSchema) return "";
+    if (this._outputSchemaSection !== null) return this._outputSchemaSection;
 
-    try {
-      const jsonSchema = zodToJsonSchema(this.config.returnSchema);
-      const schemaStr = JSON.stringify(jsonSchema, null, 2);
-
-      return `\n\n## Output Format\n\nYour response MUST be valid JSON matching this schema:\n\n\`\`\`json\n${schemaStr}\n\`\`\`\n\nRespond ONLY with the JSON object, no additional text.`;
-    } catch {
-      // If schema conversion fails, skip injection
+    const cached = this.getOutputSchema();
+    if (!cached) {
+      this._outputSchemaSection = "";
       return "";
     }
+
+    const schemaStr = JSON.stringify(cached.schema, null, 2);
+    this._outputSchemaSection = `\n\n## Output Format\n\nYour response MUST be valid JSON matching this schema:\n\n\`\`\`json\n${schemaStr}\n\`\`\`\n\nRespond ONLY with the JSON object, no additional text.`;
+    return this._outputSchemaSection;
   }
 
   /**

--- a/src/runtime/typescript/src/provider-handlers/gemini-handler.ts
+++ b/src/runtime/typescript/src/provider-handlers/gemini-handler.ts
@@ -17,12 +17,10 @@
  * - https://ai.google.dev/gemini-api/docs
  */
 
-import { createDebug } from "../debug.js";
 import type { LlmMessage } from "../types.js";
 import { formatSystemPrompt as coreFormatSystemPrompt } from "@mcpmesh/core";
 import {
-  makeSchemaStrict,
-  sanitizeSchemaForStructuredOutput,
+  applyStrictResponseFormat,
   hasMediaParams,
   defaultDetermineOutputMode,
   prepareRequestBaseline,
@@ -34,8 +32,6 @@ import {
   type OutputMode,
 } from "./provider-handler.js";
 import { ProviderHandlerRegistry } from "./provider-handler-registry.js";
-
-const debug = createDebug("gemini-handler");
 
 /**
  * Provider handler for Google Gemini models.
@@ -95,19 +91,7 @@ export class GeminiHandler implements ProviderHandler {
     // Hint mode relies on prompt instructions instead
     if (determinedMode === "strict") {
       // Vercel AI SDK translates this to Gemini's native format
-      const sanitizedSchema = sanitizeSchemaForStructuredOutput(outputSchema.schema);
-      const strictSchema = makeSchemaStrict(sanitizedSchema, { addAllRequired: true });
-
-      request.responseFormat = {
-        type: "json_schema",
-        jsonSchema: {
-          name: outputSchema.name,
-          schema: strictSchema,
-          strict: true, // Enforce schema compliance
-        },
-      };
-
-      debug(`Using response_format with strict schema: ${outputSchema.name}`);
+      applyStrictResponseFormat(request, outputSchema);
     }
 
     return request;

--- a/src/runtime/typescript/src/provider-handlers/openai-handler.ts
+++ b/src/runtime/typescript/src/provider-handlers/openai-handler.ts
@@ -8,12 +8,10 @@
  * src/runtime/python/_mcp_mesh/engine/provider_handlers/openai_handler.py
  */
 
-import { createDebug } from "../debug.js";
 import type { LlmMessage } from "../types.js";
 import { formatSystemPrompt as coreFormatSystemPrompt } from "@mcpmesh/core";
 import {
-  makeSchemaStrict,
-  sanitizeSchemaForStructuredOutput,
+  applyStrictResponseFormat,
   hasMediaParams,
   defaultDetermineOutputMode,
   prepareRequestBaseline,
@@ -25,8 +23,6 @@ import {
   type OutputMode,
 } from "./provider-handler.js";
 import { ProviderHandlerRegistry } from "./provider-handler-registry.js";
-
-const debug = createDebug("openai-handler");
 
 /**
  * Provider handler for OpenAI models.
@@ -94,21 +90,8 @@ export class OpenAIHandler implements ProviderHandler {
     if (determinedMode === "strict") {
       // Transform schema for OpenAI strict mode
       // OpenAI requires additionalProperties: false and all properties in required
-      const sanitizedSchema = sanitizeSchemaForStructuredOutput(outputSchema.schema);
-      const strictSchema = makeSchemaStrict(sanitizedSchema, { addAllRequired: true });
-
-      // OpenAI structured output format
       // See: https://platform.openai.com/docs/guides/structured-outputs
-      request.responseFormat = {
-        type: "json_schema",
-        jsonSchema: {
-          name: outputSchema.name,
-          schema: strictSchema,
-          strict: true, // Enforce schema compliance
-        },
-      };
-
-      debug(`Using response_format with strict schema: ${outputSchema.name}`);
+      applyStrictResponseFormat(request, outputSchema);
     }
 
     return request;

--- a/src/runtime/typescript/src/provider-handlers/provider-handler.ts
+++ b/src/runtime/typescript/src/provider-handlers/provider-handler.ts
@@ -309,6 +309,36 @@ export function makeSchemaStrict(
 }
 
 /**
+ * Apply a strict `responseFormat` to a prepared request from an output schema.
+ *
+ * Shared by the OpenAI and Gemini handlers' "strict" branch: sanitize the
+ * schema, make it strict (additionalProperties: false + all-required), and
+ * assign the vendor `json_schema` response format. The Vercel AI SDK
+ * translates this to each vendor's native structured-output format.
+ *
+ * NOTE: GenericHandler deliberately does NOT use this — it passes raw schemas
+ * through without strict transformation.
+ */
+export function applyStrictResponseFormat(
+  request: PreparedRequest,
+  outputSchema: OutputSchema
+): void {
+  const sanitizedSchema = sanitizeSchemaForStructuredOutput(outputSchema.schema);
+  const strictSchema = makeSchemaStrict(sanitizedSchema, { addAllRequired: true });
+
+  request.responseFormat = {
+    type: "json_schema",
+    jsonSchema: {
+      name: outputSchema.name,
+      schema: strictSchema,
+      strict: true, // Enforce schema compliance
+    },
+  };
+
+  debug(`Using response_format with strict schema: ${outputSchema.name}`);
+}
+
+/**
  * Check if any tool schema contains media parameters (x-media-type).
  * Delegates to Rust core.
  *

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -400,7 +400,7 @@ export async function callMcpTool(
 
       // Handle SSE streaming response
       if (contentType.includes("text/event-stream")) {
-        const sseResult = await parseSSEResponse(response);
+        const sseResult = await readSSEResponseToContent(response);
         // Estimate response size from content-length header (exact size not available for SSE)
         const sseResponseBytes = contentLength > 0 ? contentLength : undefined;
         // Publish success span
@@ -649,80 +649,49 @@ export async function* streamMcpTool(
     }
 
     reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    let streamDone = false;
 
-    while (!streamDone) {
-      const { done, value } = await reader.read();
-      if (done) break;
+    for await (const data of iterateSSEEvents(reader)) {
+      // Parse the JSON-RPC message
+      let msg: {
+        jsonrpc?: string;
+        id?: string | number;
+        method?: string;
+        params?: { progressToken?: string | number; message?: string; data?: string };
+        result?: unknown;
+        error?: { message?: string; code?: number };
+      };
+      try {
+        msg = JSON.parse(data);
+      } catch {
+        // Ignore non-JSON data events (defensive)
+        continue;
+      }
 
-      // Normalize CRLF to LF so the same parser handles either line ending
-      buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, "\n");
-
-      // SSE events are separated by blank lines (\n\n)
-      let sep: number;
-      while ((sep = buffer.indexOf("\n\n")) !== -1) {
-        const rawEvent = buffer.slice(0, sep);
-        buffer = buffer.slice(sep + 2);
-
-        // Collect data: lines from this event (per spec, multi-line data joined by \n)
-        const dataLines: string[] = [];
-        for (const line of rawEvent.split("\n")) {
-          if (line.startsWith("data: ")) {
-            dataLines.push(line.slice(6));
-          } else if (line.startsWith("data:")) {
-            // Allow "data:" with no space (defensive)
-            dataLines.push(line.slice(5));
+      // Progress notification: yield message if it matches our token
+      if (msg.method === "notifications/progress" && msg.params) {
+        if (msg.params.progressToken === progressToken) {
+          // FastMCP sends ``message``; some implementations may send ``data``
+          const chunk =
+            typeof msg.params.message === "string"
+              ? msg.params.message
+              : typeof msg.params.data === "string"
+                ? msg.params.data
+                : null;
+          if (chunk !== null) {
+            yield chunk;
           }
         }
-        if (dataLines.length === 0) continue;
-        const data = dataLines.join("\n");
-        if (!data) continue;
+        continue;
+      }
 
-        // Parse the JSON-RPC message
-        let msg: {
-          jsonrpc?: string;
-          id?: string | number;
-          method?: string;
-          params?: { progressToken?: string | number; message?: string; data?: string };
-          result?: unknown;
-          error?: { message?: string; code?: number };
-        };
-        try {
-          msg = JSON.parse(data);
-        } catch {
-          // Ignore non-JSON data events (defensive)
-          continue;
+      // Final response for our request: end the stream
+      if (msg.id !== undefined && msg.id === requestId) {
+        if (msg.error) {
+          const em = msg.error.message ?? JSON.stringify(msg.error);
+          throw new Error(`MCP error: ${em}`);
         }
-
-        // Progress notification: yield message if it matches our token
-        if (msg.method === "notifications/progress" && msg.params) {
-          if (msg.params.progressToken === progressToken) {
-            // FastMCP sends ``message``; some implementations may send ``data``
-            const chunk =
-              typeof msg.params.message === "string"
-                ? msg.params.message
-                : typeof msg.params.data === "string"
-                  ? msg.params.data
-                  : null;
-            if (chunk !== null) {
-              yield chunk;
-            }
-          }
-          continue;
-        }
-
-        // Final response for our request: end the stream
-        if (msg.id !== undefined && msg.id === requestId) {
-          if (msg.error) {
-            const em = msg.error.message ?? JSON.stringify(msg.error);
-            throw new Error(`MCP error: ${em}`);
-          }
-          // result arrived — done; do NOT yield the buffered final result
-          streamDone = true;
-          break;
-        }
+        // result arrived — done; do NOT yield the buffered final result
+        break;
       }
     }
   } catch (err) {
@@ -828,9 +797,58 @@ function publishProxySpan(
 }
 
 /**
- * Parse SSE response from MCP HTTP Streamable transport.
+ * Split an SSE byte stream into raw `data:` payload strings.
+ *
+ * Reads from the given reader, normalizes CRLF→LF, separates events on blank
+ * lines (`\n\n`), and joins each event's `data:` lines per the SSE spec.
+ * Empty/data-less events are skipped. Yields one string per event so callers
+ * can JSON-parse and dispatch without re-implementing the framing.
  */
-async function parseSSEResponse(response: Response): Promise<string | MultiContentResult> {
+async function* iterateSSEEvents(
+  reader: ReadableStreamDefaultReader<Uint8Array>
+): AsyncGenerator<string> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    // Normalize CRLF to LF so the same parser handles either line ending
+    buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, "\n");
+
+    // SSE events are separated by blank lines (\n\n)
+    let sep: number;
+    while ((sep = buffer.indexOf("\n\n")) !== -1) {
+      const rawEvent = buffer.slice(0, sep);
+      buffer = buffer.slice(sep + 2);
+
+      // Collect data: lines from this event (per spec, multi-line data joined by \n)
+      const dataLines: string[] = [];
+      for (const line of rawEvent.split("\n")) {
+        if (line.startsWith("data: ")) {
+          dataLines.push(line.slice(6));
+        } else if (line.startsWith("data:")) {
+          // Allow "data:" with no space (defensive)
+          dataLines.push(line.slice(5));
+        }
+      }
+      if (dataLines.length === 0) continue;
+      const data = dataLines.join("\n");
+      if (!data) continue;
+      yield data;
+    }
+  }
+}
+
+/**
+ * Read an SSE response from the MCP HTTP Streamable transport down to its
+ * final content (the JSON-RPC `result`).
+ *
+ * Distinct from `sse.ts`'s `parseSSEResponse` (string→object, Rust-core-backed):
+ * this consumes a whole `Response` body and returns the extracted content.
+ */
+async function readSSEResponseToContent(response: Response): Promise<string | MultiContentResult> {
   const reader = response.body?.getReader();
   if (!reader) {
     throw new Error("No response body");


### PR DESCRIPTION
## Summary
The low-risk consolidation cluster of #1116 ("PR-A") — pure dedup/perf/readability, **no behavior change**.

- **Output-schema caching** (`llm-agent.ts`): `zodToJsonSchema` was recomputed at 3 sites (run, stream, `buildOutputSchemaSection`); now computed once via a lazy `getOutputSchema()` (private `_outputSchema`/`_outputSchemaSection`). `returnSchema` is immutable post-construction, and the cached object is never mutated downstream (sanitize/makeStrict round-trip through JSON).
- **`mergeRunContext` closure** (`llm-agent.ts`): the run-vs-stream context-merge in `createCallable` is now one closure called from both the buffered callable and the stream method.
- **`applyStrictResponseFormat` helper** (`provider-handlers/provider-handler.ts`): the byte-identical strict-`responseFormat` block from the OpenAI & Gemini handlers, extracted to a shared helper (alongside `makeSchemaStrict`/`sanitize`); now-unused imports removed. **GenericHandler left untouched** (deliberate raw passthrough).
- **SSE rename/extraction** (`proxy.ts`): renamed the local `parseSSEResponse` → `readSSEResponseToContent` (disambiguating it from the Rust-core-backed `sse.ts:parseSSEResponse`) and factored the inline streaming event-framing into an `iterateSSEEvents` async generator. No SSE semantics merged.

Net ~even (+168/−159).

## Review Notes
Independent review: **0 blockers, 0 warnings, 2 INFO** (a tri-state-cache clarifying-comment nit; a doc-comment reference — `sse.ts:parseSSEResponse` is untouched, so accurate). Verified: cached schema not mutated downstream, tri-state + failure path correct, `mergeRunContext` no stale-capture, `applyStrictResponseFormat` faithful with GenericHandler untouched, `iterateSSEEvents` framing exact (no off-by-one, reader cleanup preserved on break). One benign cosmetic: the strict-block debug channel moves from `openai-handler`/`gemini-handler` to `provider-handler` (debug-only).

## Test plan
- [x] `tsc` build clean; full **vitest suite green (778 tests / 49 files)** incl. proxy-stream / sse-stream / openai-handler / generic-handler (GenericHandler untouched confirmed)
- [x] `src-tests` 12/12
- [x] Smoke integration **9/9**: `uc18_streaming` 3/3 (`tc04_ts_consumer_streaming` exercises the `iterateSSEEvents` refactor on a real 5-chunk stream) + `uc04` 3/3 (`tc31` TS OpenAI structured output via `applyStrictResponseFormat`, OpenAI/Gemini provider paths)

## Scope / follow-ups (Part of #1116)
- **PR-B**: MCP-request consolidation (`buildMcpRequest`/`wireJobCancel`; route `MeshDelegatedProvider.complete`/`createLlmToolProxy` through `callMcpTool`; trace-injection fallback helper) — behavior-sensitive.
- **PR-C**: LLM-agent `buildAgentMessages`/`buildMeshLlmRequest` dedup.
- **PR-D**: the `maxIterations` parity behavior fix (provider loop hardcodes 10 / doesn't forward the configured value — relates to #1112) — isolated behavior PR.
- **PR-E** (deferred/optional): `MeshRuntimeBase` (`ApiRuntime`/`MeshAgent` event-loop dedup — high structural risk; real `registry_disconnected` divergence).

Part of #1116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized schema caching to eliminate repeated conversions during agent inference operations
  * Consolidated structured output format handling across AI providers for improved consistency
  * Enhanced MCP tool streaming with refactored response parsing for more robust event handling
  * Unified runtime context merging logic to ensure consistent execution semantics across callable invocations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->