### PR TITLE
refactor(ts/proxy): extract buildMcpRequest/wireJobCancel + injectTraceAndHeaders (Part of #1116)

### DIFF
--- a/src/runtime/typescript/src/__tests__/proxy-timeout-guard.test.ts
+++ b/src/runtime/typescript/src/__tests__/proxy-timeout-guard.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit test for the buffered-path effective-timeout guard in callMcpTool.
+ *
+ * PR-B (#1116) item 1 hardening: the streaming path already fell back to a
+ * positive default when the resolved timeout was non-positive; the buffered
+ * path did not. After extracting the shared `buildMcpRequest`, BOTH paths apply
+ * the guard. This test asserts callMcpTool no longer aborts-immediately when a
+ * caller passes a zero/negative timeout (a setTimeout(…, 0) would otherwise fire
+ * on the next tick and abort the in-flight fetch).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { callMcpTool, DEFAULT_CALL_OPTIONS, type CallOptions } from "../proxy.js";
+
+vi.mock("@mcpmesh/core", () => ({
+  generateTraceId: () => "trace-mock",
+  generateSpanId: () => "span-mock",
+  injectTraceContext: (argsJson: string) => argsJson,
+  publishSpan: vi.fn(async () => false),
+  parseSseResponse: (s: string) => s,
+  parseSseResponseToObject: (s: string) => JSON.parse(s),
+  awaitJobCancel: vi.fn(() => new Promise<void>(() => {})),
+  matchesPropagateHeader: () => false,
+}));
+
+vi.mock("../http-pool.js", () => ({
+  getDispatcher: () => undefined,
+}));
+
+const ENDPOINT = "http://producer.local:9000";
+const TOOL = "echo";
+const CAPABILITY = "echoer";
+
+function jsonResponse(result: unknown): Response {
+  const body = JSON.stringify({ jsonrpc: "2.0", id: "x", result });
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => body,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "application/json" : null,
+    },
+  } as unknown as Response;
+}
+
+describe("callMcpTool effective-timeout guard (buffered path)", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("does not abort-immediately when timeout is 0 (falls back to default)", async () => {
+    let aborted = false;
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      const signal = init.signal as AbortSignal | undefined;
+      // Yield a couple of microtasks + a macrotask so any setTimeout(…, 0)
+      // abort would have had a chance to fire before we resolve.
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      if (signal?.aborted) {
+        aborted = true;
+      }
+      return jsonResponse({ content: [{ type: "text", text: "ok" }] });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const options: CallOptions = { ...DEFAULT_CALL_OPTIONS, timeout: 0 };
+    const result = await callMcpTool(ENDPOINT, TOOL, { foo: 1 }, options, CAPABILITY);
+
+    expect(aborted).toBe(false);
+    expect(result).toBe("ok");
+  });
+
+  it("does not abort-immediately when timeout is negative", async () => {
+    let aborted = false;
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      const signal = init.signal as AbortSignal | undefined;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      if (signal?.aborted) {
+        aborted = true;
+      }
+      return jsonResponse({ content: [{ type: "text", text: "ok" }] });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const options: CallOptions = { ...DEFAULT_CALL_OPTIONS, timeout: -100 };
+    const result = await callMcpTool(ENDPOINT, TOOL, { foo: 1 }, options, CAPABILITY);
+
+    expect(aborted).toBe(false);
+    expect(result).toBe("ok");
+  });
+});

--- a/src/runtime/typescript/src/llm-agent.ts
+++ b/src/runtime/typescript/src/llm-agent.ts
@@ -66,7 +66,7 @@ import {
   generateSpanId,
   publishTraceSpan,
   createTraceHeaders,
-  injectTraceContext,
+  injectTraceAndHeaders,
 } from "./tracing.js";
 import { fetchWithTimeout, isTimeoutError } from "./timeout-utils.js";
 import { getDispatcher } from "./http-pool.js";
@@ -215,7 +215,7 @@ export class MeshDelegatedProvider implements LlmProvider {
     }
 
     // Wrap in "request" parameter as expected by Python claude_provider
-    const args: Record<string, unknown> = { request };
+    let args: Record<string, unknown> = { request };
 
     // Set up timeout (default 300s to match Python SDK's stream_timeout)
     const timeoutMs = parseInt(process.env.MESH_PROVIDER_TIMEOUT_MS || "300000", 10);
@@ -225,26 +225,11 @@ export class MeshDelegatedProvider implements LlmProvider {
     const traceSpanId = traceCtx ? generateSpanId() : null;
     const traceStartTime = Date.now() / 1000;
 
-    // Inject trace context and propagated headers into args via Rust core
+    // Inject trace context and propagated headers into args (Rust core,
+    // manual fallback). Returns a NEW merged object; reassign so the
+    // downstream `arguments: args` send picks up the injected fields.
     const delegatedPropHeaders = getCurrentPropagatedHeaders();
-    if (traceCtx && traceSpanId) {
-      try {
-        const argsJson = JSON.stringify(args);
-        const headersJson = Object.keys(delegatedPropHeaders).length > 0 ? JSON.stringify(delegatedPropHeaders) : undefined;
-        const injectedJson = injectTraceContext(argsJson, traceCtx.traceId, traceSpanId, headersJson);
-        const injected = JSON.parse(injectedJson) as Record<string, unknown>;
-        Object.assign(args, injected);
-      } catch {
-        // Fallback to manual injection
-        args._trace_id = traceCtx.traceId;
-        args._parent_span = traceSpanId;
-        if (Object.keys(delegatedPropHeaders).length > 0) {
-          args._mesh_headers = { ...delegatedPropHeaders };
-        }
-      }
-    } else if (Object.keys(delegatedPropHeaders).length > 0) {
-      args._mesh_headers = { ...delegatedPropHeaders };
-    }
+    args = injectTraceAndHeaders(args, traceCtx, traceSpanId, delegatedPropHeaders);
 
     let traceSuccess = true;
     let traceError: string | null = null;
@@ -1167,30 +1152,9 @@ export function createLlmToolProxy(
     let traceError: string | null = null;
     let resultType = "unknown";
 
-    // Build arguments with trace context injection via Rust core
+    // Build arguments with trace context injection (Rust core, manual fallback)
     const toolPropHeaders = getCurrentPropagatedHeaders();
-    let toolArgsWithTrace: Record<string, unknown>;
-    if (traceCtx && traceSpanId) {
-      try {
-        const argsJson = JSON.stringify(args);
-        const headersJson = Object.keys(toolPropHeaders).length > 0 ? JSON.stringify(toolPropHeaders) : undefined;
-        const injectedJson = injectTraceContext(argsJson, traceCtx.traceId, traceSpanId, headersJson);
-        toolArgsWithTrace = JSON.parse(injectedJson);
-      } catch {
-        // Fallback to manual injection
-        toolArgsWithTrace = {
-          ...args,
-          _trace_id: traceCtx.traceId,
-          _parent_span: traceSpanId,
-          ...(Object.keys(toolPropHeaders).length > 0 ? { _mesh_headers: toolPropHeaders } : {}),
-        };
-      }
-    } else {
-      toolArgsWithTrace = {
-        ...args,
-        ...(Object.keys(toolPropHeaders).length > 0 ? { _mesh_headers: toolPropHeaders } : {}),
-      };
-    }
+    const toolArgsWithTrace = injectTraceAndHeaders(args, traceCtx, traceSpanId, toolPropHeaders);
 
     try {
       // Make MCP call to the tool

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -13,7 +13,7 @@ import {
   publishTraceSpan,
   createTraceHeaders,
   matchesPropagateHeader,
-  injectTraceContext,
+  injectTraceAndHeaders,
 } from "./tracing.js";
 import { isTimeoutError } from "./timeout-utils.js";
 import { getDispatcher } from "./http-pool.js";
@@ -224,27 +224,54 @@ export function createProxy(
 }
 
 /**
- * Call an MCP tool via HTTP POST.
- *
- * Uses the MCP HTTP Streamable protocol:
- * POST /mcp with JSON-RPC 2.0 payload.
- * Includes distributed tracing: propagates trace context and publishes spans.
+ * Result of {@link buildMcpRequest}: everything both the buffered and streaming
+ * call paths need to issue the outbound `tools/call` request and publish spans.
  */
-export async function callMcpTool(
+interface BuiltMcpRequest {
+  mcpEndpoint: string;
+  bodyStr: string;
+  requestId: string;
+  requestBytes: number;
+  headers: Record<string, string>;
+  effectiveTimeout: number;
+  traceCtx: TraceContext | null;
+  spanId: string | null;
+  startTime: number;
+}
+
+/**
+ * Build the shared MCP `tools/call` request setup used by both the buffered
+ * (`callMcpTool`) and streaming (`streamMcpTool`) paths.
+ *
+ * Handles endpoint normalization, trace-context capture, merged-header build,
+ * fallback trace injection, payload assembly, effective-timeout resolution and
+ * header assembly. The streaming caller passes `opts.progressToken` so the
+ * payload gets `params._meta.progressToken` (the buffered caller omits it).
+ *
+ * Header insertion order is byte-identical to the pre-extraction code:
+ * customHeaders → Content-Type/Accept → trace headers → mergedHeaders →
+ * conditional X-Mesh-Timeout.
+ *
+ * `defaultTimeout` is the per-path fallback applied when the resolved timeout is
+ * non-positive (DEFAULT_CALL_OPTIONS.timeout for buffered,
+ * DEFAULT_CALL_OPTIONS.streamTimeout for stream).
+ */
+function buildMcpRequest(
   endpoint: string,
   toolName: string,
   args: Record<string, unknown> | undefined,
   options: CallOptions,
-  capability: string,
-  extraHeaders?: Record<string, string>
-): Promise<string | MultiContentResult> {
+  extraHeaders: Record<string, string> | undefined,
+  defaultTimeout: number,
+  opts?: { progressToken?: string },
+): BuiltMcpRequest {
   // Ensure endpoint ends with /mcp
   const mcpEndpoint = endpoint.endsWith("/mcp")
     ? endpoint
     : `${endpoint.replace(/\/$/, "")}/mcp`;
 
-  // Tracing: create span for this outgoing proxy call
-  // Use AsyncLocalStorage to get trace context for the current async execution
+  // Tracing: create span for this outgoing proxy call.
+  // Use AsyncLocalStorage to get trace context for the current async execution.
   const traceCtx = getCurrentTraceContext();
   const spanId = traceCtx ? generateSpanId() : null;
   const startTime = Date.now() / 1000;
@@ -260,30 +287,8 @@ export async function callMcpTool(
     }
   }
 
-  // Build arguments with trace context injection via Rust core
-  let argsWithTrace: Record<string, unknown>;
-  if (traceCtx && spanId) {
-    try {
-      const argsJson = JSON.stringify(args ?? {});
-      const headersJson = Object.keys(mergedHeaders).length > 0 ? JSON.stringify(mergedHeaders) : undefined;
-      const injectedJson = injectTraceContext(argsJson, traceCtx.traceId, spanId, headersJson);
-      argsWithTrace = JSON.parse(injectedJson);
-    } catch {
-      // Fallback to manual injection
-      argsWithTrace = { ...(args ?? {}) };
-      argsWithTrace._trace_id = traceCtx.traceId;
-      argsWithTrace._parent_span = spanId;
-      if (Object.keys(mergedHeaders).length > 0) {
-        argsWithTrace._mesh_headers = mergedHeaders;
-      }
-    }
-  } else {
-    argsWithTrace = { ...(args ?? {}) };
-    // Still inject propagated headers even without trace context
-    if (Object.keys(mergedHeaders).length > 0) {
-      argsWithTrace._mesh_headers = mergedHeaders;
-    }
-  }
+  // Build arguments with trace context injection (Rust core, manual fallback)
+  const argsWithTrace = injectTraceAndHeaders(args ?? {}, traceCtx, spanId, mergedHeaders);
 
   const payload = {
     jsonrpc: "2.0",
@@ -292,6 +297,7 @@ export async function callMcpTool(
     params: {
       name: toolName,
       arguments: argsWithTrace,
+      ...(opts?.progressToken ? { _meta: { progressToken: opts.progressToken } } : {}),
     },
   };
 
@@ -306,63 +312,106 @@ export async function callMcpTool(
       effectiveTimeout = meshTimeoutMs;
     }
   }
+  // A partial caller options object (or a caller passing timeout<=0) could leave
+  // this undefined or non-positive — that would cause setTimeout to fire on the
+  // next tick and abort the call immediately. Fall back to the path default.
+  if (typeof effectiveTimeout !== "number" || effectiveTimeout <= 0) {
+    effectiveTimeout = defaultTimeout;
+  }
 
-  let lastError: Error | null = null;
   const bodyStr = JSON.stringify(payload);
   const requestBytes = Buffer.byteLength(bodyStr, "utf8");
+
+  // Build headers: custom headers first, then protocol-required headers override.
+  // FastMCP stateless HTTP requires BOTH content types in Accept (it returns SSE
+  // for streaming responses; missing application/json yields 406 Not Acceptable).
+  const headers: Record<string, string> = {
+    ...(options.customHeaders ?? {}),
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+  // Propagate trace context (higher priority)
+  if (traceCtx && spanId) {
+    Object.assign(headers, createTraceHeaders(traceCtx.traceId, spanId));
+  }
+  // Inject merged headers (highest priority)
+  for (const [key, value] of Object.entries(mergedHeaders)) {
+    headers[key] = value;
+  }
+  // Set X-Mesh-Timeout for registry proxy (#769). If already propagated, keep it.
+  if (!headers["X-Mesh-Timeout"] && !headers["x-mesh-timeout"]) {
+    const callTimeout = process.env.MCP_MESH_CALL_TIMEOUT || String(Math.floor(options.timeout / 1000));
+    headers["X-Mesh-Timeout"] = callTimeout;
+  }
+
+  return { mcpEndpoint, bodyStr, requestId: payload.id, requestBytes, headers, effectiveTimeout, traceCtx, spanId, startTime };
+}
+
+/**
+ * Wire per-job cancel propagation (#886) onto an outbound AbortController.
+ *
+ * When the handler executing this outbound call is running under a MeshJob
+ * context AND the registry forwards a cancel via POST /jobs/{id}/cancel, fire
+ * the outbound AbortController so in-flight fetch is cancelled instead of
+ * stalling on socket reads. Fire-and-forget — the listener races against fetch
+ * completion / timeout; whichever wins, the others become no-ops
+ * (`controller.abort()` is idempotent and the dangling Promise resolves
+ * immediately once the registry entry is gone).
+ */
+function wireJobCancel(controller: AbortController): void {
+  const jobSnap = currentJob();
+  if (jobSnap?.jobId) {
+    awaitJobCancel(jobSnap.jobId)
+      .then(() => {
+        if (!controller.signal.aborted) {
+          controller.abort();
+        }
+      })
+      .catch(() => {
+        // Defensive: napi rejection here would be unusual (the Rust
+        // implementation only awaits a CancellationToken), but a
+        // runtime shutdown mid-await could surface one. Swallow —
+        // the worst case is that the outbound fetch isn't proactively
+        // aborted, and the existing timeout / fetch-completion path
+        // still applies.
+      });
+  }
+}
+
+/**
+ * Call an MCP tool via HTTP POST.
+ *
+ * Uses the MCP HTTP Streamable protocol:
+ * POST /mcp with JSON-RPC 2.0 payload.
+ * Includes distributed tracing: propagates trace context and publishes spans.
+ */
+export async function callMcpTool(
+  endpoint: string,
+  toolName: string,
+  args: Record<string, unknown> | undefined,
+  options: CallOptions,
+  capability: string,
+  extraHeaders?: Record<string, string>
+): Promise<string | MultiContentResult> {
+  const {
+    mcpEndpoint,
+    bodyStr,
+    requestBytes,
+    headers,
+    effectiveTimeout,
+    traceCtx,
+    spanId,
+    startTime,
+  } = buildMcpRequest(endpoint, toolName, args, options, extraHeaders, DEFAULT_CALL_OPTIONS.timeout);
+
+  let lastError: Error | null = null;
 
   for (let attempt = 0; attempt < options.maxAttempts; attempt++) {
     try {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), effectiveTimeout);
 
-      // Wire per-job cancel propagation (#886). When the handler executing
-      // this outbound call is running under a MeshJob context AND the
-      // registry forwards a cancel via POST /jobs/{id}/cancel, fire the
-      // outbound AbortController so in-flight fetch is cancelled instead
-      // of stalling on socket reads. Fire-and-forget — the listener races
-      // against fetch completion / timeout; whichever wins, the others
-      // become no-ops (`controller.abort()` is idempotent and the dangling
-      // Promise resolves immediately once the registry entry is gone).
-      const jobSnap = currentJob();
-      if (jobSnap?.jobId) {
-        awaitJobCancel(jobSnap.jobId)
-          .then(() => {
-            if (!controller.signal.aborted) {
-              controller.abort();
-            }
-          })
-          .catch(() => {
-            // Defensive: napi rejection here would be unusual (the Rust
-            // implementation only awaits a CancellationToken), but a
-            // runtime shutdown mid-await could surface one. Swallow —
-            // the worst case is that the outbound fetch isn't proactively
-            // aborted, and the existing timeout / fetch-completion path
-            // still applies.
-          });
-      }
-
-      // Build headers: custom headers first, then protocol-required headers override
-      const headers: Record<string, string> = {
-        ...(options.customHeaders ?? {}),
-        "Content-Type": "application/json",
-        Accept: "application/json, text/event-stream",
-      };
-
-      // Propagate trace context (higher priority)
-      if (traceCtx && spanId) {
-        Object.assign(headers, createTraceHeaders(traceCtx.traceId, spanId));
-      }
-      // Inject merged headers (highest priority)
-      for (const [key, value] of Object.entries(mergedHeaders)) {
-        headers[key] = value;
-      }
-
-      // Set X-Mesh-Timeout for registry proxy (#769). If already propagated, keep it.
-      if (!headers["X-Mesh-Timeout"] && !headers["x-mesh-timeout"]) {
-        const callTimeout = process.env.MCP_MESH_CALL_TIMEOUT || String(Math.floor(options.timeout / 1000));
-        headers["X-Mesh-Timeout"] = callTimeout;
-      }
+      wireJobCancel(controller);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const fetchOptions: Record<string, any> = {
@@ -482,128 +531,38 @@ export async function* streamMcpTool(
   capability: string,
   extraHeaders?: Record<string, string>
 ): AsyncGenerator<string, void, void> {
-  // Ensure endpoint ends with /mcp
-  const mcpEndpoint = endpoint.endsWith("/mcp")
-    ? endpoint
-    : `${endpoint.replace(/\/$/, "")}/mcp`;
-
-  // Tracing: create span for this outgoing proxy stream call
-  const traceCtx = getCurrentTraceContext();
-  const spanId = traceCtx ? generateSpanId() : null;
-  const startTime = Date.now() / 1000;
-
-  // Build merged headers: session propagated + per-call (per-call wins, filtered by allowlist)
-  const propagatedHeaders = getCurrentPropagatedHeaders();
-  const mergedHeaders: Record<string, string> = { ...propagatedHeaders };
-  if (extraHeaders) {
-    for (const [key, value] of Object.entries(extraHeaders)) {
-      if (matchesPropagateHeader(key)) {
-        mergedHeaders[key.toLowerCase()] = value;
-      }
-    }
-  }
-
-  // Build arguments with trace context injection via Rust core
-  let argsWithTrace: Record<string, unknown>;
-  if (traceCtx && spanId) {
-    try {
-      const argsJson = JSON.stringify(args ?? {});
-      const headersJson = Object.keys(mergedHeaders).length > 0 ? JSON.stringify(mergedHeaders) : undefined;
-      const injectedJson = injectTraceContext(argsJson, traceCtx.traceId, spanId, headersJson);
-      argsWithTrace = JSON.parse(injectedJson);
-    } catch {
-      argsWithTrace = { ...(args ?? {}) };
-      argsWithTrace._trace_id = traceCtx.traceId;
-      argsWithTrace._parent_span = spanId;
-      if (Object.keys(mergedHeaders).length > 0) {
-        argsWithTrace._mesh_headers = mergedHeaders;
-      }
-    }
-  } else {
-    argsWithTrace = { ...(args ?? {}) };
-    if (Object.keys(mergedHeaders).length > 0) {
-      argsWithTrace._mesh_headers = mergedHeaders;
-    }
-  }
-
-  // Generate progress token to correlate notifications with this call
+  // Generate progress token to correlate notifications with this call.
+  // The request id comes back from buildMcpRequest (it built the payload) so the
+  // final-result matching below stays in sync with the wire id.
   const progressToken = generateProgressToken();
-  const requestId = generateRequestId();
 
-  const payload = {
-    jsonrpc: "2.0",
-    id: requestId,
-    method: "tools/call",
-    params: {
-      name: toolName,
-      arguments: argsWithTrace,
-      _meta: { progressToken },
-    },
-  };
-
-  // Use X-Mesh-Timeout from propagated headers to override client timeout (#769)
-  let effectiveTimeout = options.timeout;
-  const meshTimeoutStr = mergedHeaders["x-mesh-timeout"];
-  if (meshTimeoutStr) {
-    const meshTimeoutMs = parseInt(meshTimeoutStr, 10) * 1000;
-    if (!isNaN(meshTimeoutMs) && meshTimeoutMs > 0) {
-      effectiveTimeout = meshTimeoutMs;
-    }
-  }
-  // Stream timeout defaults are usually generous (300s) but a partial caller
-  // options object could leave this undefined or non-positive — that would
-  // cause setTimeout to fire on next tick and abort the stream immediately.
-  // Fall back to the buffered call default in that case.
-  if (typeof effectiveTimeout !== "number" || effectiveTimeout <= 0) {
-    effectiveTimeout = DEFAULT_CALL_OPTIONS.streamTimeout!;
-  }
-
-  const bodyStr = JSON.stringify(payload);
-  const requestBytes = Buffer.byteLength(bodyStr, "utf8");
+  const {
+    mcpEndpoint,
+    bodyStr,
+    requestId,
+    requestBytes,
+    headers,
+    effectiveTimeout,
+    traceCtx,
+    spanId,
+    startTime,
+  } = buildMcpRequest(
+    endpoint,
+    toolName,
+    args,
+    options,
+    extraHeaders,
+    DEFAULT_CALL_OPTIONS.streamTimeout,
+    { progressToken },
+  );
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), effectiveTimeout);
 
-  // Wire per-job cancel propagation (#886). See callMcpTool above for
-  // rationale; same pattern applied to the streaming path so a cancel
-  // arriving mid-stream aborts the SSE reader instead of waiting for
-  // the next chunk / streamTimeout (default 300s).
-  const jobSnap = currentJob();
-  if (jobSnap?.jobId) {
-    awaitJobCancel(jobSnap.jobId)
-      .then(() => {
-        if (!controller.signal.aborted) {
-          controller.abort();
-        }
-      })
-      .catch(() => {
-        // Defensive: napi rejection here would be unusual (the Rust
-        // implementation only awaits a CancellationToken), but a
-        // runtime shutdown mid-await could surface one. Swallow — the
-        // worst case is that the outbound fetch isn't proactively
-        // aborted, and the existing timeout / fetch-completion path
-        // still applies.
-      });
-  }
-
-  // Build headers — FastMCP stateless HTTP requires BOTH content types in
-  // Accept (it returns SSE for streaming responses; missing application/json
-  // here yields 406 Not Acceptable). Matches the buffered callMcpTool path.
-  const headers: Record<string, string> = {
-    ...(options.customHeaders ?? {}),
-    "Content-Type": "application/json",
-    Accept: "application/json, text/event-stream",
-  };
-  if (traceCtx && spanId) {
-    Object.assign(headers, createTraceHeaders(traceCtx.traceId, spanId));
-  }
-  for (const [key, value] of Object.entries(mergedHeaders)) {
-    headers[key] = value;
-  }
-  if (!headers["X-Mesh-Timeout"] && !headers["x-mesh-timeout"]) {
-    const callTimeout = process.env.MCP_MESH_CALL_TIMEOUT || String(Math.floor(options.timeout / 1000));
-    headers["X-Mesh-Timeout"] = callTimeout;
-  }
+  // Wire per-job cancel propagation (#886) — same pattern as callMcpTool so a
+  // cancel arriving mid-stream aborts the SSE reader instead of waiting for the
+  // next chunk / streamTimeout (default 300s).
+  wireJobCancel(controller);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const fetchOptions: Record<string, any> = {

--- a/src/runtime/typescript/src/tracing.ts
+++ b/src/runtime/typescript/src/tracing.ts
@@ -156,6 +156,48 @@ export function injectTraceContext(
 }
 
 /**
+ * Inject trace context and propagated headers into a JSON-RPC arguments object,
+ * returning a NEW merged object (callers should assign the result).
+ *
+ * Tries the Rust-core ``injectTraceContext`` first; on any throw, falls back to
+ * manual assignment of ``_trace_id`` / ``_parent_span`` / ``_mesh_headers``.
+ * Rust-first then fallback order is preserved.
+ *
+ * When ``traceCtx``/``spanId`` are absent, only ``_mesh_headers`` is injected
+ * (when there are headers to propagate), matching the existing proxy behavior.
+ */
+export function injectTraceAndHeaders(
+  args: Record<string, unknown>,
+  traceCtx: TraceContext | null,
+  spanId: string | null,
+  headers: Record<string, string>,
+): Record<string, unknown> {
+  const hasHeaders = Object.keys(headers).length > 0;
+  if (traceCtx && spanId) {
+    try {
+      const argsJson = JSON.stringify(args);
+      const headersJson = hasHeaders ? JSON.stringify(headers) : undefined;
+      const injectedJson = injectTraceContext(argsJson, traceCtx.traceId, spanId, headersJson);
+      return JSON.parse(injectedJson) as Record<string, unknown>;
+    } catch {
+      // Fallback to manual injection
+      const merged: Record<string, unknown> = { ...args };
+      merged._trace_id = traceCtx.traceId;
+      merged._parent_span = spanId;
+      if (hasHeaders) {
+        merged._mesh_headers = headers;
+      }
+      return merged;
+    }
+  }
+  const merged: Record<string, unknown> = { ...args };
+  if (hasHeaders) {
+    merged._mesh_headers = headers;
+  }
+  return merged;
+}
+
+/**
  * Parse trace context from HTTP headers.
  *
  * Looks for X-Trace-ID and X-Parent-Span headers (matching Python SDK).


### PR DESCRIPTION
## Summary
MCP-request-setup consolidation (items 1+8 of #1116). **Behavior-preserving on the core MCP `tools/call` path** — proven end-to-end across buffered / stream / LLM / job-cancel.

- **`buildMcpRequest` + `wireJobCancel` (`proxy.ts`):** the ~120-line request setup shared by `callMcpTool` (buffered) and `streamMcpTool` (stream) is now one helper returning `{mcpEndpoint, bodyStr, requestBytes, headers, effectiveTimeout, traceCtx, spanId, startTime, requestId}`. The stream caller passes `{progressToken}` (→ `params._meta.progressToken`) and reads `requestId` straight from the result. **Header ordering preserved byte-identical** (customHeaders → Content-Type/Accept → trace headers → mergedHeaders → conditional `X-Mesh-Timeout`).
- **`injectTraceAndHeaders` (`tracing.ts`):** the try-Rust-core-then-manual-fallback trace injection extracted to a helper returning a new merged-args object; used by `buildMcpRequest` + the 2 `llm-agent.ts` sites. The `MeshDelegatedProvider` site is now `let args` so the downstream `arguments: args` send reads the injected value (the old `Object.assign` mutation → reassignment; `{request}` wrapper round-trips).

**One intended behavior delta:** the `effectiveTimeout <= 0` fallback guard (previously stream-only) now applies to BOTH paths, each with its own default (`DEFAULT_CALL_OPTIONS.timeout` / `.streamTimeout`) — a hardening; no real caller passes `timeout<=0`. Covered by a new `proxy-timeout-guard.test.ts`.

**Item 2 intentionally NOT done here** (routing `MeshDelegatedProvider.complete()`/`createLlmToolProxy` through `callMcpTool`) — split into its own behavior PR given the error-type/size-cap/job-cancel deltas.

Net −35 lines.

## Review Notes
Independent review: **0 blockers, 0 warnings, 3 INFO** — addressed/dispositioned:
- requestId re-parse → **fixed** (`buildMcpRequest` now returns `requestId`; redundant `JSON.parse(bodyStr)` removed).
- `_mesh_headers` reference-vs-copy and `X-Mesh-Timeout` from raw `options.timeout` → left as-is (verified harmless / exactly preserves original behavior).
Verified: header ordering byte-identical, timeout-guard correct (no regression for positive timeouts), trace-injection equivalence with all caller reassignments confirmed (traces not dropped), `wireJobCancel` AbortController wiring intact, payload equivalence (buffered omits `_meta`, stream includes `progressToken`).

## Test plan
- [x] `tsc` clean; full **vitest suite green (780 tests, +2 new timeout-guard)** incl. `proxy-stream` (stream correlation)
- [x] `src-tests` 12/12
- [x] Integration behavior-identical **14/14**: `uc10` 5/5 (buffered `callMcpTool`), `uc18` 3/3 (`streamMcpTool` + `progressToken`), `uc04` 3/3 (TS LLM proxy trace sites), `uc22_meshjob_ts` 3/3 (`wireJobCancel` incl. cancel-aborts-outbound-HTTP); header ordering + trace propagation (multi-hop / cross-runtime / polyglot) intact

## Scope / follow-ups (Part of #1116)
- **Item 2** (own PR): route `complete()`/`createLlmToolProxy` through `callMcpTool` — wrap errors back to `LLMAPIError`, neutralize the size cap for LLM responses, keep `maxAttempts=1`, avoid double-span.
- **PR-C**: `buildAgentMessages`/`buildMeshLlmRequest` dedup.
- **PR-D**: `maxIterations` parity (relates to #1112).
- **PR-E** (deferred/optional): `MeshRuntimeBase`.

Part of #1116