### PR TITLE
refactor(ts/llm): route complete()/createLlmToolProxy through callMcpTool (Part of #1116)

### DIFF
--- a/src/runtime/typescript/src/__tests__/llm-mesh-error-mapping.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-mesh-error-mapping.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for #1116 item-2 regression fixes: routing TS LLM calls through
+ * the shared callMcpTool must preserve the behavior the hand-rolled paths had.
+ *
+ * Covered:
+ *  - Fix 1: MeshDelegatedProvider.complete() maps a timeout to LLMAPIError(408).
+ *           callMcpTool re-throws the AbortError as a plain Error ("MCP call
+ *           timed out after <N>ms"), so complete() now matches on the message.
+ *  - Fix 2: callMcpTool surfaces a tool-level isError result by throwing, so
+ *           complete() re-wraps it into LLMAPIError and createLlmToolProxy into
+ *           ToolExecutionError instead of returning the error text as success.
+ *  - Fix 3: createLlmToolProxy returns null (not "") when the tool returns no
+ *           content.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MeshDelegatedProvider, createLlmToolProxy } from "../llm-agent.js";
+import { LLMAPIError, ToolExecutionError } from "../errors.js";
+
+vi.mock("@mcpmesh/core", () => ({
+  generateTraceId: () => "trace-mock",
+  generateSpanId: () => "span-mock",
+  injectTraceContext: (argsJson: string) => argsJson,
+  publishSpan: vi.fn(async () => false),
+  parseSseResponse: (s: string) => s,
+  parseSseResponseToObject: (s: string) => JSON.parse(s),
+  awaitJobCancel: vi.fn(() => new Promise<void>(() => {})),
+  matchesPropagateHeader: () => false,
+}));
+
+vi.mock("../http-pool.js", () => ({
+  getDispatcher: () => undefined,
+}));
+
+const ENDPOINT = "http://provider.local:9000";
+const FUNCTION = "mesh_complete";
+
+function jsonResponse(result: unknown): Response {
+  const body = JSON.stringify({ jsonrpc: "2.0", id: "x", result });
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => body,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "application/json" : null,
+    },
+  } as unknown as Response;
+}
+
+describe("MeshDelegatedProvider.complete() error mapping (#1116 item-2)", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    delete process.env.MESH_PROVIDER_TIMEOUT_MS;
+  });
+
+  it("Fix 1: maps a timeout to LLMAPIError with status 408", async () => {
+    process.env.MESH_PROVIDER_TIMEOUT_MS = "10";
+    // fetch hangs until aborted; reject with AbortError when the signal fires.
+    const fetchMock = vi.fn((_url: string, init: RequestInit) => {
+      const signal = init.signal as AbortSignal;
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = new MeshDelegatedProvider(ENDPOINT, FUNCTION);
+    const err = await provider
+      .complete("mesh-delegated", [{ role: "user", content: "hi" }])
+      .then(() => null)
+      .catch((e) => e);
+
+    expect(err).toBeInstanceOf(LLMAPIError);
+    expect((err as LLMAPIError).statusCode).toBe(408);
+    expect((err as LLMAPIError).message).toMatch(/timed out/i);
+  });
+
+  it("Fix 2: maps a tool-level isError result to LLMAPIError(0)", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        isError: true,
+        content: [{ type: "text", text: "provider blew up" }],
+      })
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = new MeshDelegatedProvider(ENDPOINT, FUNCTION);
+    const err = await provider
+      .complete("mesh-delegated", [{ role: "user", content: "hi" }])
+      .then(() => null)
+      .catch((e) => e);
+
+    expect(err).toBeInstanceOf(LLMAPIError);
+    expect((err as LLMAPIError).statusCode).toBe(0);
+    expect((err as LLMAPIError).message).toContain("provider blew up");
+  });
+});
+
+describe("createLlmToolProxy error/empty mapping (#1116 item-2)", () => {
+  let originalFetch: typeof fetch;
+
+  const toolInfo = {
+    functionName: "do_thing",
+    capability: "doer",
+    endpoint: ENDPOINT,
+    agentId: "agent-1",
+  };
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("Fix 2: maps a tool-level isError result to ToolExecutionError", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        isError: true,
+        content: [{ type: "text", text: "tool failed" }],
+      })
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const proxy = createLlmToolProxy(toolInfo);
+    const err = await proxy({}).then(() => null).catch((e) => e);
+
+    expect(err).toBeInstanceOf(ToolExecutionError);
+    expect((err as Error).message).toContain("tool failed");
+  });
+
+  it("Fix 3: returns null when the tool returns no content", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ content: [] }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const proxy = createLlmToolProxy(toolInfo);
+    const result = await proxy({});
+
+    expect(result).toBeNull();
+  });
+
+  it("returns parsed JSON for non-empty content", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ content: [{ type: "text", text: '{"ok":true}' }] })
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const proxy = createLlmToolProxy(toolInfo);
+    const result = await proxy({});
+
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/src/runtime/typescript/src/llm-agent.ts
+++ b/src/runtime/typescript/src/llm-agent.ts
@@ -54,22 +54,15 @@ import {
   LLMAPIError,
   ToolExecutionError,
 } from "./errors.js";
-import { parseSSEResponse } from "./sse.js";
 import { resolveMediaInputs } from "./media/index.js";
 import {
-  getCurrentTraceContext,
-  getCurrentPropagatedHeaders,
+  callMcpTool,
   streamMcpTool,
   DEFAULT_CALL_OPTIONS,
+  type CallOptions,
+  type MultiContentResult,
 } from "./proxy.js";
-import {
-  generateSpanId,
-  publishTraceSpan,
-  createTraceHeaders,
-  injectTraceAndHeaders,
-} from "./tracing.js";
-import { fetchWithTimeout, isTimeoutError } from "./timeout-utils.js";
-import { getDispatcher } from "./http-pool.js";
+import { isTimeoutError } from "./timeout-utils.js";
 
 /**
  * Configuration for MeshLlmAgent.
@@ -244,163 +237,104 @@ export class MeshDelegatedProvider implements LlmProvider {
     }
   ): Promise<LlmCompletionResponse> {
     // Build MeshLlmRequest structure (matches Python claude_provider schema).
-    let { args } = this.buildMeshLlmRequest(model, messages, tools, options);
+    // The {request} wrapper stays; callMcpTool injects trace context internally.
+    const { args } = this.buildMeshLlmRequest(model, messages, tools, options);
 
     // Set up timeout (default 300s to match Python SDK's stream_timeout)
     const timeoutMs = parseInt(process.env.MESH_PROVIDER_TIMEOUT_MS || "300000", 10);
 
-    // Tracing: propagate context to downstream provider
-    const traceCtx = getCurrentTraceContext();
-    const traceSpanId = traceCtx ? generateSpanId() : null;
-    const traceStartTime = Date.now() / 1000;
+    // Route through the shared callMcpTool (trace injection, span publish,
+    // dispatcher pooling, job-cancel wiring all handled internally). LLM calls
+    // are expensive / non-idempotent so disable retries; LLM responses can
+    // exceed the default 10 MiB cap so raise it to effectively unbounded.
+    const callOptions: CallOptions = {
+      ...DEFAULT_CALL_OPTIONS,
+      timeout: timeoutMs,
+      maxAttempts: 1,
+      maxResponseSize: Number.MAX_SAFE_INTEGER,
+    };
 
-    // Inject trace context and propagated headers into args (Rust core,
-    // manual fallback). Returns a NEW merged object; reassign so the
-    // downstream `arguments: args` send picks up the injected fields.
-    const delegatedPropHeaders = getCurrentPropagatedHeaders();
-    args = injectTraceAndHeaders(args, traceCtx, traceSpanId, delegatedPropHeaders);
-
-    let traceSuccess = true;
-    let traceError: string | null = null;
-
+    // Call the mesh provider via MCP. callMcpTool throws a plain Error on
+    // failure — re-wrap into LLMAPIError to preserve the public error type.
+    let content: string | MultiContentResult;
     try {
-      // Call the mesh provider via MCP
-      let response: Response;
-      try {
-        response = await fetchWithTimeout(`${this.endpoint}/mcp`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "Accept": "application/json, text/event-stream",
-            ...(traceCtx && traceSpanId ? createTraceHeaders(traceCtx.traceId, traceSpanId) : {}),
-            ...getCurrentPropagatedHeaders(),
-          },
-          body: JSON.stringify({
-            jsonrpc: "2.0",
-            id: Date.now(),
-            method: "tools/call",
-            params: {
-              name: this.functionName,
-              arguments: args,
-            },
-          }),
-          timeout: timeoutMs,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          dispatcher: getDispatcher(`${this.endpoint}/mcp`) as any,
-        });
-      } catch (error) {
-        if (isTimeoutError(error)) {
-          throw new LLMAPIError(408, `Request timed out after ${timeoutMs}ms`, `mesh:${this.endpoint}`);
-        }
-        throw new LLMAPIError(0, `Fetch failed: ${error instanceof Error ? error.message : String(error)}`, `mesh:${this.endpoint}`);
-      }
-
-      if (!response.ok) {
-        const error = await response.text();
-        throw new LLMAPIError(response.status, error, `mesh:${this.endpoint}`);
-      }
-
-      // Handle SSE response from FastMCP stateless HTTP stream
-      const responseText = await response.text();
-
-      const result = parseSSEResponse<{
-        error?: { message: string };
-        result?: { content?: Array<{ type: string; text: string }> };
-      }>(responseText);
-
-      if (result.error) {
-        throw new Error(`Mesh provider RPC error: ${result.error.message}`);
-      }
-
-      // Parse the MCP result content
-      const content = result.result?.content?.[0];
-      if (!content || content.type !== "text") {
-        throw new Error("Invalid response from mesh provider");
-      }
-
-      // Check for MCP tool execution error (isError flag in result)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if ((result.result as any)?.isError) {
-        throw new Error(`Mesh provider tool error: ${content.text}`);
-      }
-
-      // Parse the LLM provider response
-      // Format: { role, content, tool_calls?, _mesh_usage? }
-      const meshResponse = JSON.parse(content.text) as {
-        role: string;
-        content: string;
-        tool_calls?: Array<{
-          id: string;
-          type: "function";
-          function: { name: string; arguments: string };
-        }>;
-        _mesh_usage?: { prompt_tokens: number; completion_tokens: number };
-      };
-
-      // Validate role - LLM responses should always be "assistant"
-      let validatedRole: "assistant" = "assistant";
-      if (meshResponse.role !== "assistant") {
-        console.warn(
-          `[mesh.llm] Unexpected role "${meshResponse.role}" from mesh provider, defaulting to "assistant"`
-        );
-      }
-
-      // Convert to OpenAI format expected by MeshLlmAgent
-      const openAiResponse: LlmCompletionResponse = {
-        id: `mesh-${Date.now()}`,
-        object: "chat.completion",
-        created: Math.floor(Date.now() / 1000),
-        model: "mesh-delegated",
-        choices: [
-          {
-            index: 0,
-            message: {
-              role: validatedRole,
-              content: meshResponse.content,
-              tool_calls: meshResponse.tool_calls,
-            },
-            finish_reason: meshResponse.tool_calls ? "tool_calls" : "stop",
-          },
-        ],
-        usage: meshResponse._mesh_usage
-          ? {
-              prompt_tokens: meshResponse._mesh_usage.prompt_tokens,
-              completion_tokens: meshResponse._mesh_usage.completion_tokens,
-              total_tokens:
-                meshResponse._mesh_usage.prompt_tokens +
-                meshResponse._mesh_usage.completion_tokens,
-            }
-          : undefined,
-      };
-
-      return openAiResponse;
+      content = await callMcpTool(
+        this.endpoint,
+        this.functionName,
+        args,
+        callOptions,
+        "mesh-llm",
+      );
     } catch (err) {
-      traceSuccess = false;
-      traceError = err instanceof Error ? err.message : String(err);
-      throw err;
-    } finally {
-      if (traceCtx && traceSpanId) {
-        const traceEndTime = Date.now() / 1000;
-        const traceDurationMs = (traceEndTime - traceStartTime) * 1000;
-        publishTraceSpan({
-          traceId: traceCtx.traceId,
-          spanId: traceSpanId,
-          parentSpan: traceCtx.parentSpanId,
-          functionName: "proxy_call_wrapper",
-          startTime: traceStartTime,
-          endTime: traceEndTime,
-          durationMs: traceDurationMs,
-          success: traceSuccess,
-          error: traceError,
-          resultType: traceSuccess ? "object" : "error",
-          argsCount: 0,
-          kwargsCount: 0,
-          dependencies: [this.endpoint],
-          injectedDependencies: 0,
-          meshPositions: [],
-        }).catch(() => {});
+      const message = err instanceof Error ? err.message : String(err);
+      // callMcpTool catches the AbortError and re-throws a plain Error whose
+      // message is "MCP call timed out after <N>ms", so isTimeoutError (name ===
+      // "AbortError") no longer matches here — also detect the message.
+      const isTimeout =
+        isTimeoutError(err) ||
+        (err instanceof Error && /timed out/i.test(err.message));
+      if (isTimeout) {
+        throw new LLMAPIError(408, message, `mesh:${this.endpoint}`);
       }
+      throw new LLMAPIError(0, message, `mesh:${this.endpoint}`);
     }
+
+    // The mesh provider returns a single text content item whose text is the
+    // LLM provider response JSON. callMcpTool joins/extracts it to a string.
+    if (typeof content !== "string") {
+      throw new Error("Invalid response from mesh provider");
+    }
+
+    // Parse the LLM provider response
+    // Format: { role, content, tool_calls?, _mesh_usage? }
+    const meshResponse = JSON.parse(content) as {
+      role: string;
+      content: string;
+      tool_calls?: Array<{
+        id: string;
+        type: "function";
+        function: { name: string; arguments: string };
+      }>;
+      _mesh_usage?: { prompt_tokens: number; completion_tokens: number };
+    };
+
+    // Validate role - LLM responses should always be "assistant"
+    let validatedRole: "assistant" = "assistant";
+    if (meshResponse.role !== "assistant") {
+      console.warn(
+        `[mesh.llm] Unexpected role "${meshResponse.role}" from mesh provider, defaulting to "assistant"`
+      );
+    }
+
+    // Convert to OpenAI format expected by MeshLlmAgent
+    const openAiResponse: LlmCompletionResponse = {
+      id: `mesh-${Date.now()}`,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: "mesh-delegated",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: validatedRole,
+            content: meshResponse.content,
+            tool_calls: meshResponse.tool_calls,
+          },
+          finish_reason: meshResponse.tool_calls ? "tool_calls" : "stop",
+        },
+      ],
+      usage: meshResponse._mesh_usage
+        ? {
+            prompt_tokens: meshResponse._mesh_usage.prompt_tokens,
+            completion_tokens: meshResponse._mesh_usage.completion_tokens,
+            total_tokens:
+              meshResponse._mesh_usage.prompt_tokens +
+              meshResponse._mesh_usage.completion_tokens,
+          }
+        : undefined,
+    };
+
+    return openAiResponse;
   }
 
   /**
@@ -1122,124 +1056,49 @@ export function createLlmToolProxy(
     // Set up timeout (default 30s for tool calls)
     const timeoutMs = parseInt(process.env.MESH_TOOL_TIMEOUT_MS || "30000", 10);
 
-    // Tracing: propagate context to downstream tool
-    const traceCtx = getCurrentTraceContext();
-    const traceSpanId = traceCtx ? generateSpanId() : null;
-    const traceStartTime = Date.now() / 1000;
+    // Route through the shared callMcpTool (trace injection, span publish,
+    // dispatcher pooling, job-cancel wiring all handled internally). Tools may
+    // be non-idempotent so disable retries; LLM tool results can exceed the
+    // default 10 MiB cap so raise it to effectively unbounded.
+    const callOptions: CallOptions = {
+      ...DEFAULT_CALL_OPTIONS,
+      timeout: timeoutMs,
+      maxAttempts: 1,
+      maxResponseSize: Number.MAX_SAFE_INTEGER,
+    };
 
-    let traceSuccess = true;
-    let traceError: string | null = null;
-    let resultType = "unknown";
-
-    // Build arguments with trace context injection (Rust core, manual fallback)
-    const toolPropHeaders = getCurrentPropagatedHeaders();
-    const toolArgsWithTrace = injectTraceAndHeaders(args, traceCtx, traceSpanId, toolPropHeaders);
-
+    let result: string | MultiContentResult;
     try {
-      // Make MCP call to the tool
-      let response: Response;
-      try {
-        response = await fetchWithTimeout(`${toolInfo.endpoint}/mcp`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "Accept": "application/json, text/event-stream",
-            ...(traceCtx && traceSpanId ? createTraceHeaders(traceCtx.traceId, traceSpanId) : {}),
-            ...toolPropHeaders,
-          },
-          body: JSON.stringify({
-            jsonrpc: "2.0",
-            id: Date.now(),
-            method: "tools/call",
-            params: {
-              name: toolInfo.functionName,
-              arguments: toolArgsWithTrace,
-            },
-          }),
-          timeout: timeoutMs,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          dispatcher: getDispatcher(`${toolInfo.endpoint}/mcp`) as any,
-        });
-      } catch (error) {
-        if (isTimeoutError(error)) {
-          throw new ToolExecutionError(
-            toolInfo.functionName,
-            new Error(`Tool call timed out after ${timeoutMs}ms (endpoint: ${toolInfo.endpoint})`)
-          );
-        }
-        throw new ToolExecutionError(
-          toolInfo.functionName,
-          error instanceof Error ? error : new Error(String(error))
-        );
-      }
+      result = await callMcpTool(
+        toolInfo.endpoint,
+        toolInfo.functionName,
+        args,
+        callOptions,
+        "mesh-tool",
+      );
+    } catch (error) {
+      // callMcpTool throws a plain Error on failure — re-wrap into the
+      // ToolExecutionError shape the agentic loop expects.
+      throw new ToolExecutionError(
+        toolInfo.functionName,
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
 
-      if (!response.ok) {
-        const errorBody = await response.text();
-        throw new ToolExecutionError(
-          toolInfo.functionName,
-          new Error(`Tool call failed: ${response.status} ${errorBody}`)
-        );
-      }
-
-      // Handle SSE response from FastMCP stateless HTTP stream
-      const responseText = await response.text();
-
-      const result = parseSSEResponse<{
-        error?: { message: string };
-        result?: { content?: Array<{ type: string; text?: string }> };
-      }>(responseText);
-
-      if (result.error) {
-        throw new Error(`Tool error: ${result.error.message}`);
-      }
-
-      // Parse result content
-      const content = result.result?.content?.[0];
-      if (!content) {
-        resultType = "null";
-        return null;
-      }
-
-      if (content.type === "text" && content.text) {
-        // Try to parse as JSON
-        try {
-          const parsed = JSON.parse(content.text);
-          resultType = typeof parsed;
-          return parsed;
-        } catch {
-          resultType = "string";
-          return content.text;
-        }
-      }
-
-      resultType = typeof content;
-      return content;
-    } catch (err) {
-      traceSuccess = false;
-      traceError = err instanceof Error ? err.message : String(err);
-      throw err;
-    } finally {
-      if (traceCtx && traceSpanId) {
-        const traceEndTime = Date.now() / 1000;
-        const traceDurationMs = (traceEndTime - traceStartTime) * 1000;
-        publishTraceSpan({
-          traceId: traceCtx.traceId,
-          spanId: traceSpanId,
-          parentSpan: traceCtx.parentSpanId,
-          functionName: "proxy_call_wrapper",
-          startTime: traceStartTime,
-          endTime: traceEndTime,
-          durationMs: traceDurationMs,
-          success: traceSuccess,
-          error: traceError,
-          resultType: traceSuccess ? resultType : "error",
-          argsCount: 0,
-          kwargsCount: 0,
-          dependencies: [toolInfo.endpoint],
-          injectedDependencies: 0,
-          meshPositions: [],
-        }).catch(() => {});
-      }
+    // Multi-content results are returned as structured objects as-is.
+    if (typeof result === "object") {
+      return result;
+    }
+    // Empty content signals "tool returned nothing" — preserve the null result
+    // the hand-rolled path produced rather than an empty string.
+    if (result === "") {
+      return null;
+    }
+    // Parse JSON if possible, otherwise return the raw string.
+    try {
+      return JSON.parse(result);
+    } catch {
+      return result;
     }
   };
 

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -472,6 +472,18 @@ export async function callMcpTool(
         throw new Error(`MCP error: ${errorMsg}`);
       }
 
+      // Surface tool-level errors. An MCP CallToolResult with isError === true
+      // carries the failure message in its content; the JSON-RPC envelope above
+      // is success in that case. Throw so callers (LLM provider, tool proxy)
+      // re-wrap it instead of returning the error text as a successful result.
+      const innerResult = result.result;
+      if (innerResult && typeof innerResult === "object" && (innerResult as Record<string, unknown>).isError === true) {
+        const toolErr = extractContent(innerResult);
+        const toolErrMsg = typeof toolErr === "string" ? toolErr : JSON.stringify(toolErr);
+        publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, toolErrMsg, "error", requestBytes, responseBytes);
+        throw new Error(`MCP tool error: ${toolErrMsg}`);
+      }
+
       // Extract content from result
       const content = extractContent(result.result);
       // Publish success span


### PR DESCRIPTION
## Summary
Item 2 of #1116 — retire the two hand-rolled buffered MCP `tools/call` paths in `llm-agent.ts` (`MeshDelegatedProvider.complete()` — the mesh-delegated LLM call — and `createLlmToolProxy` — the LLM tool proxy) by routing them through the shared `callMcpTool`, deleting ~150 net lines of duplicated `fetchWithTimeout` + manual SSE parse + manual trace-span plumbing.

Behavior deltas handled to keep the paths equivalent:
- **Content extraction:** `complete()` `JSON.parse`s `callMcpTool`'s extracted string into `LlmCompletionResponse` (validated against real provider responses + structured output).
- **Error contract preserved:** failures still throw `LLMAPIError` (complete) / `ToolExecutionError` (tool proxy), wrapped from `callMcpTool`'s plain `Error`. **Timeout → 408** restored by matching `callMcpTool`'s `"MCP call timed out"` message (it flattens the `AbortError`, so `isTimeoutError` alone no longer matched).
- **Tool-level `isError`:** added to the **shared `callMcpTool`** (proxy.ts) — an MCP result with `isError: true` now throws instead of being silently returned as success content. Restores a guard `complete()` had, and closes the same latent gap for *all* proxy callers.
- **`null`-on-empty:** `createLlmToolProxy` returns `null` (not `""`) for empty tool content, matching prior behavior.
- `maxAttempts:1` (no retry on non-idempotent LLM/tool calls) + `maxResponseSize:Number.MAX_SAFE_INTEGER` (no size-cap regression for large LLM responses).
- **Span parity:** removed both manual `proxy_call_wrapper` spans; `callMcpTool` publishes exactly one.

## ⚠️ Intended behavior change (release notes)
Both paths now wire `awaitJobCancel` via `callMcpTool` — **provider/tool calls under a MeshJob now cancel mid-flight** (they didn't before). Also, MCP tool-level `isError` results now surface as errors across all `callMcpTool` callers (previously swallowed as content).

## Review Notes
Independent review (after fixes): **0 blockers, 0 warnings, 3 INFO** — the prior round's 1 BLOCKER (dead timeout→408) + 2 WARNINGs (lost `isError`, `null`→`""`) are all resolved and covered by 5 new regression tests (`llm-mesh-error-mapping.test.ts`). INFOs: timeout message-match has no cleaner discriminator (callMcpTool flattens AbortError); `isError === true` matches the MCP spec; a single non-text tool result now returns a `MultiContentResult` wrapper (consistency improvement).

## Test plan
- [x] `tsc` clean; full **vitest suite green (785 tests, +5 error-mapping regression tests)**
- [x] `src-tests` 12/12
- [x] Integration green (initial 17/17, **re-validated after fixes**): `uc02_tools` 27/27 (shared `isError` guard doesn't over-trip normal calls), `uc04` 37/37 (LLM + structured), `uc10` toolcalls (the 2 reds were a pre-existing Python-side LLM confidence-scale flake — green on isolated re-run, unrelated to TS), `uc22_meshjob_ts` 24/24 (normal + cancel), `uc06_observability` (span parity)

## Scope / follow-ups (Part of #1116)
- **PR-D**: `maxIterations` parity (relates to #1112).
- **PR-E** (deferred/optional): `MeshRuntimeBase`.

Part of #1116