### PR TITLE
feat(ts/llm): configurable provider-managed loop maxIterations (Part of #1116)

### DIFF
--- a/src/runtime/typescript/src/__tests__/llm-max-iterations.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-max-iterations.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Unit tests for the configurable provider-managed agentic-loop cap — issue #1116.
+ *
+ * Two surfaces are covered:
+ *
+ *  1. Provider resolution (`resolveMaxIterations`): precedence of the
+ *     consumer-forwarded `model_params.max_iterations` over the
+ *     `MESH_LLM_MAX_ITERATIONS` env, the default of 10 when neither is set,
+ *     and the sanitization of invalid inputs.
+ *
+ *  2. Consumer forwarding (`MeshDelegatedProvider.complete()`): when the caller
+ *     passes `options.maxIterations`, it surfaces on the wire request as
+ *     `model_params.max_iterations`; when absent, no such key leaks.
+ *
+ * Parity note: the truncation marker stays the PLAIN content string
+ * "Maximum tool call iterations reached" (matching Python `mesh/helpers.py`);
+ * this PR does not introduce a structured marker.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@mcpmesh/core", () => ({
+  generateTraceId: () => "trace-mock",
+  generateSpanId: () => "span-mock",
+  injectTraceContext: (argsJson: string) => argsJson,
+  publishSpan: vi.fn(async () => false),
+  parseSseResponse: (s: string) => s,
+  parseSseResponseToObject: (s: string) => JSON.parse(s),
+}));
+
+vi.mock("../http-pool.js", () => ({
+  getDispatcher: () => undefined,
+}));
+
+import {
+  resolveMaxIterations,
+  envMaxIterations,
+  sanitizeMaxIterations,
+} from "../llm-provider.js";
+import { MeshDelegatedProvider } from "../llm-agent.js";
+import type { LlmMessage } from "../types.js";
+
+// ----------------------------------------------------------------------------
+// resolveMaxIterations — provider-side precedence + sanitization
+// ----------------------------------------------------------------------------
+
+describe("resolveMaxIterations — provider loop cap resolution", () => {
+  const ORIGINAL_ENV = process.env.MESH_LLM_MAX_ITERATIONS;
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.MESH_LLM_MAX_ITERATIONS;
+    } else {
+      process.env.MESH_LLM_MAX_ITERATIONS = ORIGINAL_ENV;
+    }
+  });
+
+  it("model_params override wins over env", () => {
+    process.env.MESH_LLM_MAX_ITERATIONS = "7";
+    expect(resolveMaxIterations(25)).toBe(25);
+  });
+
+  it("falls back to env when the param is absent", () => {
+    process.env.MESH_LLM_MAX_ITERATIONS = "15";
+    expect(resolveMaxIterations(undefined)).toBe(15);
+  });
+
+  it("defaults to 10 when neither param nor env is set", () => {
+    delete process.env.MESH_LLM_MAX_ITERATIONS;
+    expect(resolveMaxIterations(undefined)).toBe(10);
+  });
+
+  it("accepts a numeric string from the env", () => {
+    delete process.env.MESH_LLM_MAX_ITERATIONS;
+    process.env.MESH_LLM_MAX_ITERATIONS = "3";
+    expect(resolveMaxIterations(undefined)).toBe(3);
+  });
+
+  it("floors a fractional value to an integer", () => {
+    delete process.env.MESH_LLM_MAX_ITERATIONS;
+    expect(resolveMaxIterations(4.9)).toBe(4);
+  });
+
+  // #1116 fractional hole: floor-BEFORE-validate. 0.5 floors to 0, which is
+  // not > 0, so it must fall back to the default — NOT return a zero cap that
+  // would disable the loop.
+  it("falls back to 10 for a fractional value that floors to zero (0.5)", () => {
+    delete process.env.MESH_LLM_MAX_ITERATIONS;
+    expect(resolveMaxIterations(0.5)).toBe(10);
+  });
+
+  it("falls back to 10 for a fractional value that floors to zero (0.9)", () => {
+    delete process.env.MESH_LLM_MAX_ITERATIONS;
+    expect(resolveMaxIterations(0.9)).toBe(10);
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -5],
+    ["NaN", NaN],
+    ["non-numeric string", "abc" as unknown as number],
+    ["null", null as unknown as number],
+    ["object", {} as unknown as number],
+  ])("falls back to 10 for an invalid value (%s)", (_label, value) => {
+    delete process.env.MESH_LLM_MAX_ITERATIONS;
+    expect(resolveMaxIterations(value)).toBe(10);
+  });
+
+  it("an invalid env falls back to 10", () => {
+    process.env.MESH_LLM_MAX_ITERATIONS = "not-a-number";
+    expect(resolveMaxIterations(undefined)).toBe(10);
+  });
+
+  // Parity (#1116): the Gemini AI-SDK-managed loop sets
+  // `requestOptions.maxSteps = resolvedMaxIterations`, the SAME value the
+  // manual provider-managed loop uses as its cap. We assert the resolution
+  // the Gemini path consumes here rather than the wired `maxSteps`, since
+  // observing the latter would require a full `vi.mock("ai")` generateText
+  // harness that this file deliberately does not build.
+  it("Gemini maxSteps path consumes the forwarded resolved cap", () => {
+    delete process.env.MESH_LLM_MAX_ITERATIONS;
+    expect(resolveMaxIterations(25)).toBe(25);
+  });
+
+  it("Gemini maxSteps path falls back to 10 when the cap is absent", () => {
+    delete process.env.MESH_LLM_MAX_ITERATIONS;
+    expect(resolveMaxIterations(undefined)).toBe(10);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// envMaxIterations — single source of truth for env parsing
+// ----------------------------------------------------------------------------
+
+describe("envMaxIterations — env parse + validation", () => {
+  const ORIGINAL_ENV = process.env.MESH_LLM_MAX_ITERATIONS;
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.MESH_LLM_MAX_ITERATIONS;
+    } else {
+      process.env.MESH_LLM_MAX_ITERATIONS = ORIGINAL_ENV;
+    }
+  });
+
+  it("returns undefined when the env is unset", () => {
+    delete process.env.MESH_LLM_MAX_ITERATIONS;
+    expect(envMaxIterations()).toBeUndefined();
+  });
+
+  it.each([
+    ["zero", "0", undefined],
+    ["empty string", "", undefined],
+    ["non-numeric", "abc", undefined],
+    ["fractional below one", "0.5", undefined],
+    ["positive integer", "15", 15],
+    ["fractional floors down", "4.9", 4],
+    ["scientific notation (Number semantics)", "1e2", 100],
+  ])("parses %s → %s", (_label, raw, expected) => {
+    process.env.MESH_LLM_MAX_ITERATIONS = raw;
+    expect(envMaxIterations()).toBe(expected);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// sanitizeMaxIterations — single source of truth for cap normalization
+// ----------------------------------------------------------------------------
+
+describe("sanitizeMaxIterations — value normalization", () => {
+  it.each([
+    ["positive integer", 5, 5],
+    ["fractional floors down", 4.9, 4],
+    ["numeric string", "15", 15],
+    ["scientific notation (Number semantics)", "1e2", 100],
+  ])("normalizes a valid value (%s) → %s", (_label, value, expected) => {
+    expect(sanitizeMaxIterations(value)).toBe(expected);
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["zero", 0],
+    ["negative", -3],
+    ["fractional below one", 0.5],
+    ["NaN", NaN],
+    ["non-numeric string", "abc"],
+    ["empty string", ""],
+    ["object", {}],
+  ])("rejects an invalid value (%s) → undefined", (_label, value) => {
+    expect(sanitizeMaxIterations(value)).toBeUndefined();
+  });
+});
+
+// ----------------------------------------------------------------------------
+// MeshDelegatedProvider.complete() — consumer forwards maxIterations
+// ----------------------------------------------------------------------------
+
+const ENDPOINT = "http://provider.local:9001";
+const FN_BUFFERED = "process_chat";
+
+describe("MeshDelegatedProvider.complete() — maxIterations forwarding", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function mockJsonResponse(body: object): Response {
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "content-type" ? "application/json" : null,
+      },
+      text: async () => JSON.stringify(body),
+      json: async () => body,
+    } as unknown as Response;
+  }
+
+  function mcpToolResponse(payload: object) {
+    return {
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        content: [{ type: "text", text: JSON.stringify(payload) }],
+      },
+    };
+  }
+
+  const STUB_COMPLETION = { role: "assistant", content: "ok" };
+
+  it("forwards options.maxIterations as model_params.max_iterations", async () => {
+    let capturedBody: string | undefined;
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      capturedBody = init.body as string;
+      return mockJsonResponse(mcpToolResponse(STUB_COMPLETION));
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = new MeshDelegatedProvider(ENDPOINT, FN_BUFFERED, false);
+    const messages: LlmMessage[] = [{ role: "user", content: "hi" }];
+
+    await provider.complete("anthropic/claude-sonnet-4-5", messages, undefined, {
+      maxIterations: 25,
+    });
+
+    const body = JSON.parse(capturedBody!);
+    const modelParams = body.params.arguments.request.model_params as Record<string, unknown>;
+    expect(modelParams.max_iterations).toBe(25);
+  });
+
+  it("typed maxIterations wins over an escape-hatch modelParams.max_iterations", async () => {
+    let capturedBody: string | undefined;
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      capturedBody = init.body as string;
+      return mockJsonResponse(mcpToolResponse(STUB_COMPLETION));
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = new MeshDelegatedProvider(ENDPOINT, FN_BUFFERED, false);
+    const messages: LlmMessage[] = [{ role: "user", content: "hi" }];
+
+    await provider.complete("anthropic/claude-sonnet-4-5", messages, undefined, {
+      maxIterations: 25,
+      modelParams: { max_iterations: 3 },
+    });
+
+    const body = JSON.parse(capturedBody!);
+    const modelParams = body.params.arguments.request.model_params as Record<string, unknown>;
+    expect(modelParams.max_iterations).toBe(25);
+  });
+
+  it("does not emit max_iterations when maxIterations is absent", async () => {
+    let capturedBody: string | undefined;
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      capturedBody = init.body as string;
+      return mockJsonResponse(mcpToolResponse(STUB_COMPLETION));
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = new MeshDelegatedProvider(ENDPOINT, FN_BUFFERED, false);
+    const messages: LlmMessage[] = [{ role: "user", content: "hi" }];
+
+    await provider.complete("anthropic/claude-sonnet-4-5", messages, undefined, {
+      maxOutputTokens: 256,
+    });
+
+    const body = JSON.parse(capturedBody!);
+    const modelParams = body.params.arguments.request.model_params as Record<string, unknown>;
+    expect(modelParams.max_iterations).toBeUndefined();
+  });
+});

--- a/src/runtime/typescript/src/llm-agent.ts
+++ b/src/runtime/typescript/src/llm-agent.ts
@@ -63,6 +63,7 @@ import {
   type MultiContentResult,
 } from "./proxy.js";
 import { isTimeoutError } from "./timeout-utils.js";
+import { envMaxIterations, sanitizeMaxIterations } from "./llm-provider.js";
 
 /**
  * Configuration for MeshLlmAgent.
@@ -132,6 +133,8 @@ export interface LlmProvider {
       // Issue #1019: escape-hatch for vendor-specific kwargs not exposed by the
       // typed option surface (e.g., thinking_config, output_config, reasoning_effort).
       modelParams?: Record<string, unknown>;
+      // Issue #1116: cap for the provider-managed agentic loop.
+      maxIterations?: number;
     }
   ): Promise<LlmCompletionResponse>;
 }
@@ -171,6 +174,7 @@ export class MeshDelegatedProvider implements LlmProvider {
           stop?: string[];
           outputSchema?: { schema: Record<string, unknown>; name: string };
           modelParams?: Record<string, unknown>;
+          maxIterations?: number;
         }
       | undefined
   ): { request: Record<string, unknown>; args: Record<string, unknown> } {
@@ -200,6 +204,11 @@ export class MeshDelegatedProvider implements LlmProvider {
     // but the provider's agentic loop needs it to decide parallel vs sequential execution.
     if (this.parallelToolCalls) {
       modelParams.parallel_tool_calls = true;
+    }
+    // Issue #1116: forward the provider-managed loop cap. Typed field, so it
+    // takes precedence over any escape-hatch modelParams.max_iterations above.
+    if (options?.maxIterations !== undefined) {
+      modelParams.max_iterations = options.maxIterations;
     }
 
     const request: Record<string, unknown> = {
@@ -234,6 +243,8 @@ export class MeshDelegatedProvider implements LlmProvider {
       // Issue #1019: escape-hatch for vendor-specific kwargs not exposed by the
       // typed option surface (e.g., thinking_config, output_config, reasoning_effort).
       modelParams?: Record<string, unknown>;
+      // Issue #1116: cap for the provider-managed agentic loop.
+      maxIterations?: number;
     }
   ): Promise<LlmCompletionResponse> {
     // Build MeshLlmRequest structure (matches Python claude_provider schema).
@@ -363,6 +374,8 @@ export class MeshDelegatedProvider implements LlmProvider {
       // Issue #1019: escape-hatch for vendor-specific kwargs not exposed by the
       // typed option surface (e.g., thinking_config, output_config, reasoning_effort).
       modelParams?: Record<string, unknown>;
+      // Issue #1116: cap for the provider-managed agentic loop.
+      maxIterations?: number;
     }
   ): AsyncGenerator<string, void, void> {
     // Build MeshLlmRequest body — same shape as complete().
@@ -588,10 +601,9 @@ export class MeshLlmAgent<T = string> {
 
     // Get effective options (runtime options > MESH_LLM_* env > config)
     const maxIterations =
-      context.options?.maxIterations ??
-      (process.env.MESH_LLM_MAX_ITERATIONS
-        ? parseInt(process.env.MESH_LLM_MAX_ITERATIONS, 10)
-        : this.config.maxIterations);
+      sanitizeMaxIterations(context.options?.maxIterations) ??
+      envMaxIterations() ??
+      this.config.maxIterations;
     const maxTokens = context.options?.maxOutputTokens ?? this.config.maxOutputTokens;
     const temperature = context.options?.temperature ?? this.config.temperature;
 
@@ -625,6 +637,8 @@ export class MeshLlmAgent<T = string> {
           outputSchema,
           // Issue #1019: forward caller-supplied escape-hatch kwargs
           modelParams: context.options?.modelParams,
+          // Issue #1116: forward the resolved provider-managed loop cap.
+          maxIterations,
         }
       );
 
@@ -788,6 +802,10 @@ export class MeshLlmAgent<T = string> {
     });
 
     // Effective options (runtime > env > config)
+    const maxIterations =
+      sanitizeMaxIterations(context.options?.maxIterations) ??
+      envMaxIterations() ??
+      this.config.maxIterations;
     const maxTokens = context.options?.maxOutputTokens ?? this.config.maxOutputTokens;
     const temperature = context.options?.temperature ?? this.config.temperature;
 
@@ -817,6 +835,8 @@ export class MeshLlmAgent<T = string> {
         outputSchema,
         // Issue #1019: forward caller-supplied escape-hatch kwargs
         modelParams: context.options?.modelParams,
+        // Issue #1116: forward the resolved provider-managed loop cap.
+        maxIterations,
       },
     );
   }

--- a/src/runtime/typescript/src/llm-provider.ts
+++ b/src/runtime/typescript/src/llm-provider.ts
@@ -193,6 +193,49 @@ export function extractModelName(model: string): string {
   return model;
 }
 
+/**
+ * Coerce an arbitrary value to a positive integer iteration cap, or undefined
+ * when it is unset/invalid (NaN, non-finite, <= 0, or floors to 0). Floors
+ * BEFORE the > 0 check so fractional values in (0,1) are rejected, not zeroed.
+ * Single source of truth for max-iterations normalization.
+ */
+export function sanitizeMaxIterations(value: unknown): number | undefined {
+  const parsed = Math.floor(Number(value));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/**
+ * Parse MESH_LLM_MAX_ITERATIONS into a positive integer, or undefined when
+ * unset/empty/invalid. Single source of truth for env parsing of the cap.
+ */
+export function envMaxIterations(): number | undefined {
+  return sanitizeMaxIterations(process.env.MESH_LLM_MAX_ITERATIONS);
+}
+
+/**
+ * Issue #1116: resolve the provider-managed agentic-loop cap.
+ *
+ * Precedence: consumer-forwarded ``model_params.max_iterations`` →
+ * ``MESH_LLM_MAX_ITERATIONS`` env → default 10. Invalid inputs (NaN, <= 0,
+ * non-finite, non-numeric, fractional <1) fall back to 10. Fractional values
+ * are floored BEFORE the >0 check, so e.g. 0.5 → 0 → default (not a zero cap).
+ * Matches Python parity in ``mesh/helpers.py``.
+ *
+ * Note: a *present* paramValue (even if invalid) never falls through to the
+ * env branch — invalid param → default. The env branch is consulted only when
+ * the param is ABSENT. For TS consumers this means the provider-host env only
+ * applies when the consumer does not forward a cap: run()/stream() always
+ * forward one, so provider-side MESH_LLM_MAX_ITERATIONS primarily affects
+ * non-forwarding / other-language / raw callers.
+ */
+export function resolveMaxIterations(paramValue: unknown): number {
+  const DEFAULT = 10;
+  if (paramValue !== undefined) {
+    return sanitizeMaxIterations(paramValue) ?? DEFAULT;
+  }
+  return envMaxIterations() ?? DEFAULT;
+}
+
 // ============================================================================
 // Vercel AI SDK Integration
 // ============================================================================
@@ -492,6 +535,11 @@ export function llmProvider(config: LlmProviderConfig): {
       debug("🔀 Provider parallel tool calls enabled — tools will execute concurrently via Promise.all()");
     }
 
+    // Resolve provider-managed loop cap. Precedence: model_params.max_iterations
+    // (consumer-forwarded) → MESH_LLM_MAX_ITERATIONS env → default 10.
+    const resolvedMaxIterations = resolveMaxIterations(modelParams.max_iterations);
+    delete modelParams.max_iterations;
+
     // Build OutputSchema object for handler (prompt formatting) - generateObject uses it directly
     const outputSchemaObj = outputSchema ? {
       schema: outputSchema,
@@ -735,8 +783,8 @@ export function llmProvider(config: LlmProviderConfig): {
       if (useMaxSteps) {
         // Gemini: let AI SDK manage the agentic loop via maxSteps.
         // AI SDK preserves thought_signature across turns automatically.
-        requestOptions.maxSteps = 10;
-        debug(`Gemini provider-managed loop via maxSteps=10 (AI SDK preserves thought_signature)`);
+        requestOptions.maxSteps = resolvedMaxIterations;
+        debug(`Gemini provider-managed loop via maxSteps=${resolvedMaxIterations} (AI SDK preserves thought_signature)`);
       }
       // Note: for non-Gemini vendors, maxSteps is NOT set. We manage
       // the agentic loop manually so that providerOptions (including
@@ -864,7 +912,7 @@ export function llmProvider(config: LlmProviderConfig): {
       // (including response_format for structured output) is applied on
       // EVERY LLM call, not just the first one.
       let iteration = 0;
-      const maxIterations = 10;
+      const maxIterations = resolvedMaxIterations;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let currentMessages: any[] = [...convertedMessages];
 

--- a/src/runtime/typescript/src/llm.ts
+++ b/src/runtime/typescript/src/llm.ts
@@ -44,6 +44,7 @@ import type {
   LlmOutputMode,
 } from "./types.js";
 import { MeshLlmAgent, createLlmToolProxy } from "./llm-agent.js";
+import { envMaxIterations } from "./llm-provider.js";
 import { debug } from "./debug.js";
 import { generateTraceId, generateSpanId, publishTraceSpan, matchesPropagateHeader } from "./tracing.js";
 import type { TraceContext } from "./tracing.js";
@@ -443,9 +444,7 @@ export function buildLlmAgentSpecs(): Array<{
       process.env.MESH_LLM_FILTER_MODE || config.filterMode;
 
     // MESH_LLM_MAX_ITERATIONS: Override max iterations
-    const resolvedMaxIterations = process.env.MESH_LLM_MAX_ITERATIONS
-      ? parseInt(process.env.MESH_LLM_MAX_ITERATIONS, 10)
-      : config.maxIterations;
+    const resolvedMaxIterations = envMaxIterations() ?? config.maxIterations;
 
     specs.push({
       functionId: config.functionId,


### PR DESCRIPTION
## Summary
Makes the TypeScript **provider-managed agentic loop** `maxIterations` configurable. It previously hard-coded `10` (and the Gemini AI-SDK loop hard-coded `maxSteps = 10`), silently ignoring any configured value: `@mesh.llm` consumers that set `maxIterations` had it honored only on the *consumer-managed* loop and capped at 10 on the *provider-managed* path. This brings TS to parity with Python (which already honors `MESH_LLM_MAX_ITERATIONS`).

- **`llm-provider.ts`**: new exported `resolveMaxIterations()` — precedence `model_params.max_iterations` (consumer-forwarded) → `MESH_LLM_MAX_ITERATIONS` env → default `10`. Both the manual provider-managed loop and the Gemini `maxSteps` path now use the resolved cap. `max_iterations` is stripped from `modelParams` before the LLM API call so it never leaks to the vendor.
- **`llm-agent.ts`**: `maxIterations` added to the option type surface; the resolved cap is forwarded into `model_params.max_iterations` (as a typed field, taking precedence over the escape-hatch `modelParams`) from both `run()`→`complete()` and `stream()`→`streamComplete()`.
- **Truncation marker unchanged** — kept the plain content string `"Maximum tool call iterations reached"` for cross-runtime parity with Python (`mesh/helpers.py`). No structured marker added (would diverge TS from Python — out of scope). Java has no provider-managed loop, so is unaffected.

## Behavior change (release notes)
The **only** behavior change: a configured `maxIterations != 10` is now honored on the provider-managed loop (both the manual and Gemini variants) instead of being silently capped at 10. Default behavior is preserved everywhere — `run()`/`stream()` resolve to `config.maxIterations` (10) by default, so default requests forward `max_iterations=10` and the provider resolves 10, identical to before.

## Review Notes
Independent review of the first revision raised 3 WARNINGs, all addressed in this PR (re-review: 0 blocker / 0 warning):
- **Unified env parsing** — a single guarded `envMaxIterations()` helper now backs all four `MESH_LLM_MAX_ITERATIONS` read sites (`llm-provider.ts`, `llm-agent.ts` run/stream, `llm.ts`), replacing three unguarded `parseInt` ternaries that diverged in semantics.
- **NaN-poison fix** — an invalid env (e.g. `"abc"`) previously produced `NaN`, making the consumer loop `while (iteration < NaN)` never enter and silently return empty content. It now falls back to the configured default.
- **Floor-before-validate** — fixed a latent hole where a fractional cap in `(0,1)` (e.g. `0.5`) passed the `>0` check then floored to `0`, disabling the loop. Now floors first, so `0.5` → default `10`.
- Docstring clarified that the provider-host env applies only when a consumer does not forward a cap (TS consumers always forward).

## Test plan
- [x] `tsc --noEmit` clean
- [x] vitest: 812 green (+27 new in `__tests__/llm-max-iterations.test.ts` — precedence, sanitization, fractional/0.5, the `envMaxIterations` matrix, consumer forwarding, typed-vs-escape-hatch precedence)
- [x] src-tests 12/12 (TS runtime rebuilt into `tsuite-mesh:local`)
- [x] integration GREEN — uc04_llm_integration 37/37 (manual TS-provider tool loops + Gemini `maxSteps` tc06/tc10/tc37), uc10_toolcalls 54/54, uc03_tool_calling 10/10, uc15_parallel_tool_calls 15/15 (incl. Gemini-TS tc15), uc22_meshjob_ts 24/24

Part of #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable iteration cap for LLM agent loops with environment variable and code-level option support.
  * Flexible precedence handling: code options override environment settings, defaulting to 10 iterations maximum.
  * Centralized resolution logic ensures consistent iteration limits across all providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->