### PR TITLE
refactor(java): dedup synthetic-deps builders + dependency-event handlers (Part of #1117)

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -72,8 +72,22 @@ public class MeshAutoConfiguration {
 
     private static final Logger log = LoggerFactory.getLogger(MeshAutoConfiguration.class);
 
+    private static final String A2A_DEPS_TOOL = "__mesh_a2a_deps";
+    private static final String DEPENDS_ON_DEPS_TOOL = "__mesh_depends_on_deps";
+    private static final String ROUTE_DEPS_TOOL = "__mesh_route_deps";
+
     @Autowired
     private ApplicationContext applicationContext;
+
+    private static AgentSpec.ToolSpec syntheticDepsTool(
+            String name, String description, List<AgentSpec.DependencySpec> deps) {
+        AgentSpec.ToolSpec tool = new AgentSpec.ToolSpec();
+        tool.setFunctionName(name);
+        tool.setCapability(name);
+        tool.setDescription(description);
+        tool.setDependencies(deps);
+        return tool;
+    }
 
     @Bean
     @ConditionalOnMissingBean
@@ -934,12 +948,8 @@ public class MeshAutoConfiguration {
         if (deps.isEmpty()) {
             return;
         }
-        AgentSpec.ToolSpec syntheticTool = new AgentSpec.ToolSpec();
-        syntheticTool.setFunctionName("__mesh_a2a_deps");
-        syntheticTool.setCapability("__mesh_a2a_deps");
-        syntheticTool.setDescription("Synthetic tool for @MeshA2A dependency resolution");
-        syntheticTool.setDependencies(deps);
-        tools.add(syntheticTool);
+        tools.add(syntheticDepsTool(A2A_DEPS_TOOL,
+            "Synthetic tool for @MeshA2A dependency resolution", deps));
         log.info("Added {} @MeshA2A dependencies to agent registration", deps.size());
     }
 
@@ -1019,12 +1029,8 @@ public class MeshAutoConfiguration {
             return;
         }
 
-        AgentSpec.ToolSpec syntheticTool = new AgentSpec.ToolSpec();
-        syntheticTool.setFunctionName("__mesh_depends_on_deps");
-        syntheticTool.setCapability("__mesh_depends_on_deps");
-        syntheticTool.setDescription("Synthetic tool for @MeshDependsOn dependency resolution");
-        syntheticTool.setDependencies(deps);
-        tools.add(syntheticTool);
+        tools.add(syntheticDepsTool(DEPENDS_ON_DEPS_TOOL,
+            "Synthetic tool for @MeshDependsOn dependency resolution", deps));
         log.info("Added {} @MeshDependsOn dependencies to agent registration", deps.size());
     }
 
@@ -1193,13 +1199,8 @@ public class MeshAutoConfiguration {
         }
 
         // Create synthetic tool for route dependencies
-        AgentSpec.ToolSpec routeDepsTool = new AgentSpec.ToolSpec();
-        routeDepsTool.setFunctionName("__mesh_route_deps");
-        routeDepsTool.setCapability("__mesh_route_deps");
-        routeDepsTool.setDescription("Synthetic tool for @MeshRoute dependency resolution");
-        routeDepsTool.setDependencies(routeDeps);
-
-        tools.add(routeDepsTool);
+        tools.add(syntheticDepsTool(ROUTE_DEPS_TOOL,
+            "Synthetic tool for @MeshRoute dependency resolution", routeDeps));
 
         log.info("Added {} @MeshRoute dependencies to agent registration", routeDeps.size());
     }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
@@ -168,16 +168,21 @@ public class MeshEventProcessor implements SmartLifecycle {
         log.info("Agent registered with mesh: {}", event.getAgentId());
     }
 
-    private void handleDependencyAvailable(MeshEvent event) {
-        log.info("Dependency available: {} at {} (requestingFunction={}, depIndex={})",
-            event.getCapability(), event.getEndpoint(),
-            event.getRequestingFunction(), event.getDepIndex());
+    private void updateWrapperDep(MeshEvent event, boolean available) {
+        if (available) {
+            log.info("Dependency available: {} at {} (requestingFunction={}, depIndex={})",
+                event.getCapability(), event.getEndpoint(),
+                event.getRequestingFunction(), event.getDepIndex());
+        } else {
+            log.info("Dependency unavailable: {} (requestingFunction={}, depIndex={})",
+                event.getCapability(), event.getRequestingFunction(), event.getDepIndex());
+        }
 
         // Update legacy injector
         injector.updateToolDependency(
             event.getCapability(),
-            event.getEndpoint(),
-            event.getFunctionName()
+            available ? event.getEndpoint() : null,
+            available ? event.getFunctionName() : null
         );
 
         // Update wrapper registry with composite key
@@ -186,33 +191,24 @@ public class MeshEventProcessor implements SmartLifecycle {
                 event.getRequestingFunction(),
                 event.getDepIndex()
             );
-            wrapperRegistry.updateDependency(
-                compositeKey,
-                event.getEndpoint(),
-                event.getFunctionName()
-            );
+            if (available) {
+                wrapperRegistry.updateDependency(
+                    compositeKey,
+                    event.getEndpoint(),
+                    event.getFunctionName()
+                );
+            } else {
+                wrapperRegistry.markDependencyUnavailable(compositeKey);
+            }
         }
     }
 
+    private void handleDependencyAvailable(MeshEvent event) {
+        updateWrapperDep(event, true);
+    }
+
     private void handleDependencyUnavailable(MeshEvent event) {
-        log.info("Dependency unavailable: {} (requestingFunction={}, depIndex={})",
-            event.getCapability(), event.getRequestingFunction(), event.getDepIndex());
-
-        // Update legacy injector
-        injector.updateToolDependency(
-            event.getCapability(),
-            null,
-            null
-        );
-
-        // Mark wrapper dependency as unavailable
-        if (event.getRequestingFunction() != null && event.getDepIndex() != null) {
-            String compositeKey = MeshToolWrapperRegistry.buildDependencyKey(
-                event.getRequestingFunction(),
-                event.getDepIndex()
-            );
-            wrapperRegistry.markDependencyUnavailable(compositeKey);
-        }
+        updateWrapperDep(event, false);
     }
 
     private void handleLlmToolsUpdated(MeshEvent event) {


### PR DESCRIPTION
## Summary
Two LOW-risk, **behavior-preserving** dedups in the Java Spring-Boot starter (Part of #1117). Pure mechanical extraction — every log line, argument, and branch reproduces the originals exactly.

- **`MeshAutoConfiguration.java`** (Finding 3): the three near-identical synthetic dependency-tool builders — `@MeshA2A` → `__mesh_a2a_deps`, `@MeshDependsOn` → `__mesh_depends_on_deps`, `@MeshRoute` → `__mesh_route_deps` — collapse into one private static `syntheticDepsTool(name, description, deps)` helper, and the repeated `__mesh_*_deps` magic strings become named constants (`A2A_DEPS_TOOL` / `DEPENDS_ON_DEPS_TOOL` / `ROUTE_DEPS_TOOL`). Per-site `log.info` lines and descriptions are unchanged.
- **`MeshEventProcessor.java`** (Finding 6): `handleDependencyAvailable` / `handleDependencyUnavailable` shared an un-factored dual-update (legacy injector + composite-key wrapper registry). Unified into `updateWrapperDep(event, available)`; the two handlers become one-line delegators. Both log lines, the `injector.updateToolDependency` call, the `requestingFunction != null && depIndex != null` guard, and `updateDependency` vs `markDependencyUnavailable` are verbatim — the only difference (endpoint/fn vs `null`) is driven by the boolean.

## Review Notes
Independent review: **0 blocker / 0 warning / 1 cosmetic INFO**; zero-behavior-change **VERIFIED** (constants byte-identical to the literals; every call site passes the correct constant + unchanged description + correct deps var; both event paths reproduce the originals exactly).

## Test plan
- [x] `mvn -pl mcp-mesh-spring-boot-starter -am compile` → BUILD SUCCESS
- [x] src-tests 12/12 (Java SDK rebuilt into `tsuite-mesh:local`)
- [x] integration 43/43 — uc30_spring_constructor_inject_java 2/2 (@MeshRoute + @MeshA2A registration), uc27_a2a_consumer_java 8/8 (dispatch/failover/consumer-death — exercises the dependency-event path), uc28_a2a_producer_java 6/6, uc23_meshjob_java 27/27 (cross-runtime Java dependency injection)

Part of #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
