### PR TITLE
refactor(java): extract buildToolResultMessage in executeAgenticLoop (Part of #1117)

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -709,15 +709,7 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
 
                     for (Map<String, Object> toolCall : toolCalls) {
                         ParsedToolCall parsed = parseToolCall(toolCall);
-                        futures.add(CompletableFuture.supplyAsync(() -> {
-                            log.debug("Executing tool: {} with args: {}", parsed.toolName(), parsed.toolArgs());
-                            String toolResult = executeToolCall(parsed.toolName(), parsed.toolArgs());
-                            return Map.<String, Object>of(
-                                "role", "tool",
-                                "tool_call_id", parsed.toolId(),
-                                "content", toolResult
-                            );
-                        }));
+                        futures.add(CompletableFuture.supplyAsync(() -> buildToolResultMessage(parsed)));
                     }
 
                     // Wait for all tools to complete and add results
@@ -729,19 +721,23 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                     // Sequential execution (default)
                     for (Map<String, Object> toolCall : toolCalls) {
                         ParsedToolCall parsed = parseToolCall(toolCall);
-                        log.debug("Executing tool: {} with args: {}", parsed.toolName(), parsed.toolArgs());
-                        String toolResult = executeToolCall(parsed.toolName(), parsed.toolArgs());
-                        llmMessages.add(Map.of(
-                            "role", "tool",
-                            "tool_call_id", parsed.toolId(),
-                            "content", toolResult
-                        ));
+                        llmMessages.add(buildToolResultMessage(parsed));
                     }
                 }
             }
 
             log.warn("Max iterations ({}) reached for LLM agent {}", maxIterations, functionId);
             return extractLastAssistantContent(llmMessages);
+        }
+
+        private Map<String, Object> buildToolResultMessage(ParsedToolCall parsed) {
+            log.debug("Executing tool: {} with args: {}", parsed.toolName(), parsed.toolArgs());
+            String toolResult = executeToolCall(parsed.toolName(), parsed.toolArgs());
+            return Map.of(
+                "role", "tool",
+                "tool_call_id", parsed.toolId(),
+                "content", toolResult
+            );
         }
 
         private String renderSystemPrompt() {


### PR DESCRIPTION
## Summary
Behavior-preserving dedup in `MeshLlmAgentProxy.executeAgenticLoop` (Part of #1117). Net −4 lines.

The parallel and sequential tool-execution branches shared an identical per-tool block after `parseToolCall`: `log.debug("Executing tool…")` + `executeToolCall(…)` + building the `{role:"tool", tool_call_id, content}` message map. Extracted into one private helper `buildToolResultMessage(ParsedToolCall parsed)` returning `Map<String,Object>` (the declared return type also removes the parallel site's previously-needed `Map.<String,Object>of(…)` type witness).

- **Parallel branch:** `parseToolCall` still runs on the **calling thread** (unchanged, before `supplyAsync`) so parse-exception propagation and lambda-capture semantics are identical; the lambda body becomes `() -> buildToolResultMessage(parsed)`. The pre-loop `log.info("Executing N tool calls in parallel")` and the `CompletableFuture.allOf(…).join()` + per-future `llmMessages.add(future.join())` are unchanged.
- **Sequential branch:** `parseToolCall` then `llmMessages.add(buildToolResultMessage(parsed))`.

The intentional parallel-vs-sequential log-level difference is preserved (parallel keeps its info-level overview; both keep the per-tool `debug`). No map key/order/value change; no change to `extractToolCalls`/`extractContent`/the assistant-message append/max-iterations handling.

## Review Notes
- Independent review: **0 blocker / 0 warning / 1 INFO**. Behavior-preserving **VERIFIED**, with the critical parse-exception/thread semantics for the parallel path explicitly confirmed unchanged (`parseToolCall` stays on the calling thread → a parse failure still throws synchronously, not as a deferred `CompletionException` at `join()`).

## Test plan
- [x] `mvn -pl mcp-mesh-spring-boot-starter -am compile` → BUILD SUCCESS
- [x] src-tests 12/12 (Java SDK rebuilt into `tsuite-mesh:local`)
- [x] integration GREEN, no flakes — uc04_llm_integration 37/37 (Java sequential loop: `tc15_java_llm_agentic_loop`, `tc12/tc13` Java providers, Java-consumer cross-runtime), uc15_parallel_tool_calls 15/15 (the changed `supplyAsync→buildToolResultMessage` path: `tc05/tc08/tc09/tc17/tc18` — incl. `tc09_parallel_error_handling_java` confirming per-future error semantics and `tc08` timing confirming concurrency), uc08_llm_prompt_templates 9/9 (`tc14/tc16` Java)

Part of #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal agentic tool execution logic by centralizing shared message construction, reducing code duplication and improving maintainability without affecting public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->