### PR TITLE
refactor(java): hoist formatSystemPrompt into shared base helper (Closes #1117)

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/AnthropicHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/AnthropicHandler.java
@@ -1,6 +1,5 @@
 package io.mcpmesh.ai.handlers;
 
-import io.mcpmesh.core.MeshCoreBridge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.anthropic.AnthropicChatOptions;
@@ -73,45 +72,7 @@ public class AnthropicHandler implements LlmProviderHandler {
             String basePrompt,
             List<ToolDefinition> tools,
             OutputSchema outputSchema) {
-
-        String outputMode = determineOutputMode(outputSchema);
-        boolean hasTools = tools != null && !tools.isEmpty();
-
-        // Delegate to Rust core
-        String schemaJson = null;
-        String schemaName = null;
-        if (outputSchema != null) {
-            schemaName = outputSchema.name();
-            try {
-                schemaJson = TOOL_CALLBACK_MAPPER.writeValueAsString(outputSchema.schema());
-            } catch (Exception e) {
-                log.warn("Failed to serialize schema for Rust core: {}", e.getMessage());
-            }
-        }
-
-        boolean hasMediaParams = false;
-        if (tools != null) {
-            for (ToolDefinition tool : tools) {
-                if (tool.inputSchema() != null) {
-                    try {
-                        String toolSchemaJson = TOOL_CALLBACK_MAPPER.writeValueAsString(tool.inputSchema());
-                        try {
-                            if (MeshCoreBridge.detectMediaParams(toolSchemaJson)) {
-                                hasMediaParams = true;
-                                break;
-                            }
-                        } catch (UnsatisfiedLinkError e) {
-                            // Native library unavailable (e.g., CI) — safe default
-                        }
-                    } catch (Exception e) {
-                        log.warn("Failed to serialize tool schema for media params detection: {}", e.getMessage());
-                    }
-                }
-            }
-        }
-
-        return MeshCoreBridge.formatSystemPrompt(
-            "anthropic", basePrompt, hasTools, hasMediaParams, schemaJson, schemaName, outputMode);
+        return formatSystemPromptViaCore(basePrompt, tools, outputSchema);
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/GeminiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/GeminiHandler.java
@@ -1,6 +1,5 @@
 package io.mcpmesh.ai.handlers;
 
-import io.mcpmesh.core.MeshCoreBridge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;
@@ -81,45 +80,7 @@ public class GeminiHandler implements LlmProviderHandler {
             String basePrompt,
             List<ToolDefinition> tools,
             OutputSchema outputSchema) {
-
-        String outputMode = determineOutputMode(outputSchema);
-        boolean hasTools = tools != null && !tools.isEmpty();
-
-        // Delegate to Rust core
-        String schemaJson = null;
-        String schemaName = null;
-        if (outputSchema != null) {
-            schemaName = outputSchema.name();
-            try {
-                schemaJson = MAPPER.writeValueAsString(outputSchema.schema());
-            } catch (Exception e) {
-                log.warn("Failed to serialize schema for Rust core: {}", e.getMessage());
-            }
-        }
-
-        boolean hasMediaParams = false;
-        if (tools != null) {
-            for (ToolDefinition tool : tools) {
-                if (tool.inputSchema() != null) {
-                    try {
-                        String toolSchemaJson = MAPPER.writeValueAsString(tool.inputSchema());
-                        try {
-                            if (MeshCoreBridge.detectMediaParams(toolSchemaJson)) {
-                                hasMediaParams = true;
-                                break;
-                            }
-                        } catch (UnsatisfiedLinkError e) {
-                            // Native library unavailable (e.g., CI) — safe default
-                        }
-                    } catch (Exception e) {
-                        log.warn("Failed to serialize tool schema for media params detection: {}", e.getMessage());
-                    }
-                }
-            }
-        }
-
-        return MeshCoreBridge.formatSystemPrompt(
-            "gemini", basePrompt, hasTools, hasMediaParams, schemaJson, schemaName, outputMode);
+        return formatSystemPromptViaCore(basePrompt, tools, outputSchema);
     }
 
     // =========================================================================

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/LlmProviderHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/LlmProviderHandler.java
@@ -143,6 +143,68 @@ public interface LlmProviderHandler {
     }
 
     /**
+     * Shared structured-output system-prompt formatting used by the vendor handlers
+     * (Anthropic, OpenAI, Gemini) that delegate prompt construction to the Rust core.
+     *
+     * <p>Computes the output mode and tool presence, serializes the output schema,
+     * scans tool input schemas for media params via {@link io.mcpmesh.core.MeshCoreBridge},
+     * and delegates to {@code MeshCoreBridge.formatSystemPrompt} using {@link #getVendor()}
+     * as the vendor argument.
+     *
+     * <p>The no-op {@link #formatSystemPrompt} default is intentionally kept separate so
+     * passthrough handlers (e.g. {@code GenericHandler}) return the base prompt unchanged.
+     *
+     * @param basePrompt   The original system prompt
+     * @param tools        Tool schemas (for tool calling instructions)
+     * @param outputSchema Schema for structured output (null = plain text)
+     * @return Formatted system prompt produced by the Rust core
+     */
+    default String formatSystemPromptViaCore(
+        String basePrompt,
+        List<ToolDefinition> tools,
+        OutputSchema outputSchema
+    ) {
+        String outputMode = determineOutputMode(outputSchema);
+        boolean hasTools = tools != null && !tools.isEmpty();
+
+        // Delegate to Rust core
+        String schemaJson = null;
+        String schemaName = null;
+        if (outputSchema != null) {
+            schemaName = outputSchema.name();
+            try {
+                schemaJson = TOOL_CALLBACK_MAPPER.writeValueAsString(outputSchema.schema());
+            } catch (Exception e) {
+                LoggerFactory.getLogger(getClass()).warn("Failed to serialize schema for Rust core: {}", e.getMessage());
+            }
+        }
+
+        boolean hasMediaParams = false;
+        if (tools != null) {
+            for (ToolDefinition tool : tools) {
+                if (tool.inputSchema() != null) {
+                    try {
+                        String toolSchemaJson = TOOL_CALLBACK_MAPPER.writeValueAsString(tool.inputSchema());
+                        try {
+                            if (io.mcpmesh.core.MeshCoreBridge.detectMediaParams(toolSchemaJson)) {
+                                hasMediaParams = true;
+                                break;
+                            }
+                        } catch (UnsatisfiedLinkError e) {
+                            // Native library unavailable (e.g., CI) — safe default
+                        }
+                    } catch (Exception e) {
+                        LoggerFactory.getLogger(getClass()).warn("Failed to serialize tool schema for media params detection: {}", e.getMessage());
+                    }
+                }
+            }
+        }
+
+        return io.mcpmesh.core.MeshCoreBridge.formatSystemPrompt(
+            getVendor(), basePrompt, hasTools, hasMediaParams, schemaJson, schemaName, outputMode);
+    }
+
+    /**
      * Determine the output mode for this vendor.
      *
      * <p>Used primarily by Claude handler to choose between:

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
@@ -1,6 +1,5 @@
 package io.mcpmesh.ai.handlers;
 
-import io.mcpmesh.core.MeshCoreBridge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;
@@ -65,45 +64,7 @@ public class OpenAiHandler implements LlmProviderHandler {
             String basePrompt,
             List<ToolDefinition> tools,
             OutputSchema outputSchema) {
-
-        String outputMode = determineOutputMode(outputSchema);
-        boolean hasTools = tools != null && !tools.isEmpty();
-
-        // Delegate to Rust core
-        String schemaJson = null;
-        String schemaName = null;
-        if (outputSchema != null) {
-            schemaName = outputSchema.name();
-            try {
-                schemaJson = TOOL_CALLBACK_MAPPER.writeValueAsString(outputSchema.schema());
-            } catch (Exception e) {
-                log.warn("Failed to serialize schema for Rust core: {}", e.getMessage());
-            }
-        }
-
-        boolean hasMediaParams = false;
-        if (tools != null) {
-            for (ToolDefinition tool : tools) {
-                if (tool.inputSchema() != null) {
-                    try {
-                        String toolSchemaJson = TOOL_CALLBACK_MAPPER.writeValueAsString(tool.inputSchema());
-                        try {
-                            if (MeshCoreBridge.detectMediaParams(toolSchemaJson)) {
-                                hasMediaParams = true;
-                                break;
-                            }
-                        } catch (UnsatisfiedLinkError e) {
-                            // Native library unavailable (e.g., CI) — safe default
-                        }
-                    } catch (Exception e) {
-                        log.warn("Failed to serialize tool schema for media params detection: {}", e.getMessage());
-                    }
-                }
-            }
-        }
-
-        return MeshCoreBridge.formatSystemPrompt(
-            "openai", basePrompt, hasTools, hasMediaParams, schemaJson, schemaName, outputMode);
+        return formatSystemPromptViaCore(basePrompt, tools, outputSchema);
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary
Hoist the duplicated `formatSystemPrompt` logic shared by the Anthropic/OpenAI/Gemini handlers into a single shared base helper. **The final in-scope sub-part of #1117.** Net −55 lines, behavior-preserving.

- **`LlmProviderHandler.java`** (+62): new shared `default formatSystemPromptViaCore(basePrompt, tools, outputSchema)` — `determineOutputMode` + serialize `outputSchema.schema()` to `schemaJson`/`schemaName` via the base `TOOL_CALLBACK_MAPPER` + the media-detection loop (per-tool `MeshCoreBridge.detectMediaParams`, `UnsatisfiedLinkError` safe-default swallow, break-on-first-match) + `MeshCoreBridge.formatSystemPrompt(getVendor(), …)`. The pre-existing **no-op `formatSystemPrompt` default is left unchanged** so passthrough handlers (`GenericHandler`) keep their behavior.
- **`AnthropicHandler` / `OpenAiHandler` / `GeminiHandler`** (−41 net each): the three near-identical ~45-line overrides reduced to `return formatSystemPromptViaCore(basePrompt, tools, outputSchema);`; removed each file's now-unused `MeshCoreBridge` import.

## Review Notes
- Behavior-equivalence **VERIFIED** by independent review (0 blocker / 0 warning / 2 negligible INFO):
  - `getVendor()` returns exactly the literal each override hardcoded (`"anthropic"`/`"openai"`/`"gemini"`).
  - Gemini's serialization moved from its private `MAPPER` to the shared `TOOL_CALLBACK_MAPPER` — both vanilla `ObjectMapper`, byte-identical JSON. Gemini's `MAPPER` is **retained** (still used by `applyResponseFormat`/`createToolCallback(sForSchema)`).
  - No-op base default unmodified → `GenericHandler` passthrough preserved.
  - Logger identity unchanged (`getClass()` resolves to the concrete handler); log messages, `UnsatisfiedLinkError` swallow, and break-on-first preserved verbatim.
  - `MeshCoreBridge` import removal safe (base uses the fully-qualified name; no residual references in the handlers).

## Deferred (tracked follow-ups)
The remaining audit sub-parts were intentionally scoped out and filed separately:
- **#1136** — message-assembly / `[Previous Response]` prefix hoist (+ optional Gemini tool-callback transform hook). Touches live prompt text → its own careful PR.
- **#1137** — `MeshAutoConfiguration` god-config split (maintainability-only; the two-phase build is already cleanly separated / not fragile).

## Test plan
- [x] `mvn -pl mcp-mesh-spring-ai -am compile` → BUILD SUCCESS
- [x] src-tests 12/12 (Java spring-ai rebuilt into `tsuite-mesh:local`)
- [x] integration GREEN, no flakes — uc04_llm_integration 37/37 (per-vendor Anthropic/OpenAI/Gemini structured output; Java providers tc12/tc13 + cross-runtime tc20/22/24/28/29/30/33), uc08_llm_prompt_templates 9/9 (Java tc14/tc16), uc14_multimedia 31/31 (the `hasMediaParams` detection loop across all vendors incl. Java tc05/tc06/tc31). 77 LLM-provider tests.

Closes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal system prompt formatting logic across AI service integrations by consolidating duplicated code into a shared utility. All existing functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->