### PR TITLE
fix(java/llm): nested response-model schema via victools + $ref inliner (Part of #1112)

### DIFF
--- a/examples/java/llm-mesh-agent/src/main/java/com/example/analyst/AnalystAgentApplication.java
+++ b/examples/java/llm-mesh-agent/src/main/java/com/example/analyst/AnalystAgentApplication.java
@@ -168,6 +168,82 @@ public class AnalystAgentApplication {
     }
 
     /**
+     * Generate a NESTED structured report using LLM with mesh delegation.
+     *
+     * <p>Unlike {@link #analyze}, whose {@link AnalysisResult} is flat
+     * (primitives + {@code List<String>}), this endpoint returns a deeply
+     * nested {@link StructuredReport}: a record-of-record ({@link ReportMeta}),
+     * a {@code List} of nested records ({@link Finding}), an enum
+     * ({@link Sentiment}), and a nullable field. This exercises the
+     * victools schema generator + {@code MeshSchemaSupport.inlineRefs}
+     * flattening path against real vendor structured-output APIs.
+     *
+     * <p>No tools are needed; the LLM is asked for a small fixed-shape report
+     * so assertions can be structural.
+     *
+     * @param topic Topic to produce a structured report about
+     * @param llm   Injected LLM agent proxy (delegates to mesh provider)
+     * @return Nested structured report
+     */
+    @MeshLlm(
+        providerSelector = @Selector(capability = "llm"),
+        maxIterations = 1,
+        systemPrompt = "You are a report generator. Produce a concise structured report "
+            + "with a summary, metadata (author and overall sentiment), and a short "
+            + "list of findings (each with a title, a detail, and a severity 1-5).",
+        maxTokens = 2048,
+        temperature = 0.3
+    )
+    @MeshTool(
+        capability = "structuredReport",
+        description = "Generate a nested structured report using mesh LLM",
+        tags = {"report", "llm", "java", "structured"}
+    )
+    public StructuredReport structuredReport(
+        @Param(value = "topic", description = "Topic for the report") String topic,
+        MeshLlmAgent llm
+    ) {
+        log.info("Generating structured report for topic: {}", topic);
+
+        if (llm == null || !llm.isAvailable()) {
+            log.warn("LLM provider not available, returning fallback report");
+            return fallbackReport();
+        }
+
+        try {
+            StructuredReport result = llm.request()
+                .user("Produce a structured report about: " + topic
+                    + ". Include a one-sentence summary, metadata with an author name and an "
+                    + "overall sentiment (POSITIVE, NEUTRAL, or NEGATIVE), and 2 to 3 findings, "
+                    + "each with a title, a detail, and a severity from 1 to 5.")
+                .maxTokens(2048)
+                .temperature(0.3)
+                .generate(StructuredReport.class);
+
+            var meta = llm.request().lastMeta();
+            if (meta != null) {
+                log.info("Report generation completed: {} iterations, {}ms latency",
+                    meta.iterations(), meta.latencyMs());
+            }
+
+            return result;
+
+        } catch (Exception e) {
+            log.error("Report generation failed: {}", e.getMessage(), e);
+            return fallbackReport();
+        }
+    }
+
+    private StructuredReport fallbackReport() {
+        return new StructuredReport(
+            "Report unavailable - LLM provider not connected",
+            new ReportMeta("system", Sentiment.NEUTRAL),
+            List.of(new Finding("LLM unavailable", "Please check mesh connectivity", 5)),
+            null
+        );
+    }
+
+    /**
      * Simple chat endpoint using mesh LLM with fluent builder.
      *
      * <p>Demonstrates the fluent builder for simple text generation.
@@ -343,5 +419,57 @@ public class AnalystAgentApplication {
         String response,
         String timestamp,
         String source
+    ) {}
+
+    /**
+     * Overall sentiment of a structured report.
+     *
+     * <p>An enum field forces victools to emit an {@code enum} constraint in
+     * the generated schema, which {@code MeshSchemaSupport.inlineRefs} must
+     * preserve through ref-flattening.
+     */
+    public enum Sentiment {
+        POSITIVE,
+        NEUTRAL,
+        NEGATIVE
+    }
+
+    /**
+     * A single finding within a structured report (a nested record).
+     */
+    public record Finding(
+        String title,
+        String detail,
+        int severity
+    ) {}
+
+    /**
+     * Report metadata (a record nested inside {@link StructuredReport}).
+     *
+     * <p>Exercises the record-of-record path: victools emits this as a
+     * {@code $ref}/{@code $defs} entry that {@code inlineRefs} must flatten.
+     */
+    public record ReportMeta(
+        String author,
+        Sentiment sentiment
+    ) {}
+
+    /**
+     * Deeply NESTED structured report record.
+     *
+     * <p>Exercises the constructs that {@code MeshSchemaSupport.inlineRefs}
+     * flattens, end-to-end against real vendor structured-output APIs:
+     * <ul>
+     *   <li>{@code meta} - a nested record ({@link ReportMeta}) containing an enum</li>
+     *   <li>{@code findings} - a {@code List} of nested records ({@link Finding})</li>
+     *   <li>{@code reviewer} - a nullable/optional field (victools should emit
+     *       {@code anyOf:[{...},{type:null}]} for a non-primitive nullable)</li>
+     * </ul>
+     */
+    public record StructuredReport(
+        String summary,
+        ReportMeta meta,
+        List<Finding> findings,
+        String reviewer
     ) {}
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -1,6 +1,8 @@
 package io.mcpmesh.spring;
 
 import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import io.mcpmesh.MeshLlmDefaults;
 import io.mcpmesh.core.MeshObjectMappers;
@@ -898,109 +900,27 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
         /**
          * Build JSON schema from the response type class.
          *
-         * <p>This generates a JSON Schema object that can be passed to LLM providers
-         * via model_params.output_schema. The provider handler converts this to
-         * vendor-specific structured output format (e.g., response_format for OpenAI/Gemini).
-         *
-         * <p>Uses reflection to inspect record components or class fields.
+         * <p>Routes through the shared victools generator ({@link MeshSchemaSupport#generator()})
+         * — the same generator used for tool input schemas — so the response-model
+         * schema sent to LLM providers via {@code model_params.output_schema} is
+         * richly nested (full {@code properties}/{@code items}/{@code anyOf} expansion),
+         * not the shallow hand-rolled shape. The victools output carries
+         * {@code $defs}/{@code $ref}; {@link MeshSchemaSupport#inlineRefs(Map)}
+         * inlines them so every vendor — including Anthropic hint mode — receives a
+         * self-contained schema.
          *
          * @param type the response type class
          * @return JSON schema as a Map, or null if schema cannot be built
          */
         private Map<String, Object> buildJsonSchema(Class<?> type) {
-            Map<String, Object> schema = new LinkedHashMap<>();
-            schema.put("type", "object");
-
-            Map<String, Object> properties = new LinkedHashMap<>();
-            List<String> required = new ArrayList<>();
-
-            // Handle records - use getGenericType() to preserve parameterized types
-            if (type.isRecord()) {
-                var components = type.getRecordComponents();
-                for (var comp : components) {
-                    properties.put(comp.getName(), getJsonSchemaType(comp.getGenericType()));
-                    required.add(comp.getName());
-                }
-            } else {
-                // Handle regular classes - use declared fields with generic types
-                var fields = type.getDeclaredFields();
-                for (var field : fields) {
-                    if (java.lang.reflect.Modifier.isStatic(field.getModifiers())) continue;
-                    properties.put(field.getName(), getJsonSchemaType(field.getGenericType()));
-                    required.add(field.getName());
-                }
-            }
-
-            schema.put("properties", properties);
-            schema.put("required", required);
-            return schema;
-        }
-
-        /**
-         * Get JSON schema type for a given Java type.
-         *
-         * <p>Handles both raw classes and parameterized types (e.g., List&lt;String&gt;).
-         * For collections, extracts the element type from the generic parameter.
-         *
-         * @param type the Java type (Class or ParameterizedType)
-         * @return JSON schema type object
-         */
-        private Map<String, Object> getJsonSchemaType(java.lang.reflect.Type type) {
-            Map<String, Object> schemaType = new LinkedHashMap<>();
-
-            // Handle parameterized types (e.g., List<String>, Map<String, Object>)
-            if (type instanceof java.lang.reflect.ParameterizedType pt) {
-                Class<?> rawType = (Class<?>) pt.getRawType();
-
-                if (java.util.Collection.class.isAssignableFrom(rawType)) {
-                    schemaType.put("type", "array");
-                    // Get the element type from the generic parameter
-                    java.lang.reflect.Type[] typeArgs = pt.getActualTypeArguments();
-                    if (typeArgs.length > 0) {
-                        schemaType.put("items", getJsonSchemaType(typeArgs[0]));
-                    } else {
-                        schemaType.put("items", Map.of("type", "object"));
-                    }
-                    return schemaType;
-                } else if (java.util.Map.class.isAssignableFrom(rawType)) {
-                    schemaType.put("type", "object");
-                    return schemaType;
-                }
-                // Fall through to handle rawType as a regular class
-                type = rawType;
-            }
-
-            // Handle raw class types
-            if (type instanceof Class<?> clazz) {
-                if (clazz == String.class) {
-                    schemaType.put("type", "string");
-                } else if (clazz == int.class || clazz == Integer.class ||
-                           clazz == long.class || clazz == Long.class) {
-                    schemaType.put("type", "integer");
-                } else if (clazz == double.class || clazz == Double.class ||
-                           clazz == float.class || clazz == Float.class) {
-                    schemaType.put("type", "number");
-                } else if (clazz == boolean.class || clazz == Boolean.class) {
-                    schemaType.put("type", "boolean");
-                } else if (clazz.isArray()) {
-                    schemaType.put("type", "array");
-                    Class<?> componentType = clazz.getComponentType();
-                    schemaType.put("items", getJsonSchemaType(componentType));
-                } else if (java.util.Collection.class.isAssignableFrom(clazz)) {
-                    // Raw collection without type parameter - default to object
-                    schemaType.put("type", "array");
-                    schemaType.put("items", Map.of("type", "object"));
-                } else if (java.util.Map.class.isAssignableFrom(clazz)) {
-                    schemaType.put("type", "object");
-                } else {
-                    schemaType.put("type", "object");
-                }
-            } else {
-                // Unknown type - default to object
-                schemaType.put("type", "object");
-            }
-
-            return schemaType;
+            JsonNode node = MeshSchemaSupport.generator().generateSchema(type);
+            // Rewrite victools' bare "#" root self-reference into "#/$defs/<TypeName>"
+            // (mirrors the tool-schema path) so inlineRefs' cycle guard can collapse
+            // it to a bounded placeholder instead of leaving a non-self-contained "#".
+            node = MeshSchemaSupport.rewriteRootSelfRefs(node, type);
+            Map<String, Object> schema =
+                objectMapper.convertValue(node, new TypeReference<Map<String, Object>>() {});
+            return MeshSchemaSupport.inlineRefs(schema);
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshSchemaSupport.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshSchemaSupport.java
@@ -382,6 +382,172 @@ public final class MeshSchemaSupport {
     }
 
     /**
+     * Inline every {@code $ref} in a victools-generated schema, returning a
+     * self-contained schema with the root {@code $defs}/{@code definitions} removed.
+     *
+     * <p>The shared {@link #generator()} emits {@code DEFINITIONS_FOR_ALL_OBJECTS}
+     * + {@code NULLABLE_ALWAYS_AS_ANYOF}, i.e. {@code $defs} + {@code $ref} +
+     * {@code anyOf}. Some LLM providers (notably Anthropic hint mode) need a
+     * fully self-contained schema with no {@code $ref} indirection, so this
+     * resolves and inlines each reference in place.
+     *
+     * <p>Behaviour:
+     * <ul>
+     *   <li>Resolves {@code "#/$defs/<Name>"} and {@code "#/definitions/<Name>"}
+     *       pointers against the root {@code $defs}/{@code definitions} map.</li>
+     *   <li>Recurses through {@code properties}, {@code items} (object or array),
+     *       {@code additionalProperties} (when a schema object) and the
+     *       {@code anyOf}/{@code oneOf}/{@code allOf} arrays.</li>
+     *   <li>Deep-copies each resolved definition per inline site, so multiple
+     *       references to the same def never share mutable state.</li>
+     *   <li>Guards cycles: a {@code $ref} that targets a name already on the
+     *       expansion stack collapses to a bounded {@code {"type":"object"}}
+     *       placeholder instead of recursing forever.</li>
+     *   <li>A {@code $ref} node with sibling keys (e.g.
+     *       {@code {"$ref":"...","description":"..."}}) inlines the resolved
+     *       definition, then overlays the sibling keys (excluding {@code $ref}).</li>
+     *   <li>Preserves all other keys verbatim and drops the root
+     *       {@code $defs}/{@code definitions}.</li>
+     * </ul>
+     *
+     * <p>Pure Java; null-safe. {@code null} in returns {@code null} out.
+     *
+     * @param schema victools schema as a Map (possibly null)
+     * @return a self-contained schema Map with refs inlined, or {@code null}
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> inlineRefs(Map<String, Object> schema) {
+        if (schema == null) {
+            return null;
+        }
+        Map<String, Object> defs = new java.util.LinkedHashMap<>();
+        Object dollarDefs = schema.get("$defs");
+        if (dollarDefs instanceof Map<?, ?> m) {
+            defs.putAll((Map<String, Object>) m);
+        }
+        Object plainDefs = schema.get("definitions");
+        if (plainDefs instanceof Map<?, ?> m) {
+            defs.putAll((Map<String, Object>) m);
+        }
+
+        Map<String, Object> result =
+            (Map<String, Object>) inlineNode(schema, defs, new java.util.LinkedHashSet<>());
+        result.remove("$defs");
+        result.remove("definitions");
+        return result;
+    }
+
+    /**
+     * Recursively inline refs within a single JSON-schema node.
+     *
+     * @param node    the node to process (any JSON value)
+     * @param defs    flattened root definition map ($defs + definitions)
+     * @param stack   names currently being expanded (cycle guard)
+     * @return a new, ref-free node (deep copies on inline)
+     */
+    @SuppressWarnings("unchecked")
+    private static Object inlineNode(Object node, Map<String, Object> defs, java.util.Set<String> stack) {
+        if (node instanceof Map<?, ?> mapNode) {
+            Map<String, Object> obj = (Map<String, Object>) mapNode;
+            Object refVal = obj.get("$ref");
+            if (refVal instanceof String ref) {
+                String name = refDefName(ref);
+                if (name != null) {
+                    boolean cycle = stack.contains(name);
+                    boolean dangling = !defs.containsKey(name);
+                    if (cycle || dangling) {
+                        // Cycle (self/recursive type) or dangling ref: emit a
+                        // bounded placeholder so inlining always terminates.
+                        // Recursive response models are rare; termination wins
+                        // over preserving unbounded nesting depth here.
+                        // A dangling ref is a real defect (the def map is missing
+                        // the target) — warn loudly; an expected cycle stays silent.
+                        if (dangling && !cycle) {
+                            log.warn("inlineRefs: unresolved $ref '{}' (no matching def) "
+                                + "— emitting bounded {{\"type\":\"object\"}} placeholder", ref);
+                        }
+                        Map<String, Object> placeholder = new java.util.LinkedHashMap<>();
+                        placeholder.put("type", "object");
+                        // Overlay any sibling keys (description, etc.).
+                        for (Map.Entry<String, Object> e : obj.entrySet()) {
+                            if (!"$ref".equals(e.getKey())) {
+                                placeholder.put(e.getKey(), deepCopy(e.getValue()));
+                            }
+                        }
+                        return placeholder;
+                    }
+                    stack.add(name);
+                    Object resolved = inlineNode(defs.get(name), defs, stack);
+                    stack.remove(name);
+                    // Overlay sibling keys (excluding $ref) on top of the def.
+                    // `resolved`/`merged` is always a freshly-built tree from
+                    // inlineNode (never a shared def), so the in-place put is safe.
+                    if (resolved instanceof Map) {
+                        Map<String, Object> merged = (Map<String, Object>) resolved;
+                        for (Map.Entry<String, Object> e : obj.entrySet()) {
+                            if (!"$ref".equals(e.getKey())) {
+                                merged.put(e.getKey(), deepCopy(e.getValue()));
+                            }
+                        }
+                        return merged;
+                    }
+                    return resolved;
+                }
+                // Unrecognized ref form — fall through and copy verbatim.
+            }
+
+            Map<String, Object> out = new java.util.LinkedHashMap<>();
+            for (Map.Entry<String, Object> e : obj.entrySet()) {
+                out.put(e.getKey(), inlineNode(e.getValue(), defs, stack));
+            }
+            return out;
+        }
+        if (node instanceof List<?> listNode) {
+            List<Object> out = new ArrayList<>(listNode.size());
+            for (Object item : listNode) {
+                out.add(inlineNode(item, defs, stack));
+            }
+            return out;
+        }
+        // Scalars are immutable — return as-is.
+        return node;
+    }
+
+    /** Extract {@code <Name>} from {@code "#/$defs/<Name>"} or {@code "#/definitions/<Name>"}. */
+    private static String refDefName(String ref) {
+        if (ref == null) {
+            return null;
+        }
+        if (ref.startsWith("#/$defs/")) {
+            return ref.substring("#/$defs/".length());
+        }
+        if (ref.startsWith("#/definitions/")) {
+            return ref.substring("#/definitions/".length());
+        }
+        return null;
+    }
+
+    /** Deep-copy a JSON-shaped value (Map/List/scalar) so inline sites never share state. */
+    @SuppressWarnings("unchecked")
+    private static Object deepCopy(Object node) {
+        if (node instanceof Map<?, ?> m) {
+            Map<String, Object> out = new java.util.LinkedHashMap<>();
+            for (Map.Entry<String, Object> e : ((Map<String, Object>) m).entrySet()) {
+                out.put(e.getKey(), deepCopy(e.getValue()));
+            }
+            return out;
+        }
+        if (node instanceof List<?> l) {
+            List<Object> out = new ArrayList<>(l.size());
+            for (Object item : l) {
+                out.add(deepCopy(item));
+            }
+            return out;
+        }
+        return node;
+    }
+
+    /**
      * Merge a list of warnings into the target list, ignoring null/empty inputs.
      *
      * @param accumulator the list to merge into

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshSchemaSupportTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshSchemaSupportTest.java
@@ -5,14 +5,19 @@ import jakarta.validation.constraints.NotNull;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -142,5 +147,377 @@ class MeshSchemaSupportTest {
                 + "Raw JSON: " + rawJson
                 + "\nCanonical: " + result.canonicalJson()
         );
+    }
+
+    // =========================================================================
+    // inlineRefs — issue #1112 finding 5 (Approach B)
+    // =========================================================================
+
+    /** Recursively assert no $ref / $defs / definitions key appears anywhere. */
+    @SuppressWarnings("unchecked")
+    private static void assertNoRefsOrDefs(Object node) {
+        if (node instanceof Map<?, ?> m) {
+            for (Map.Entry<String, Object> e : ((Map<String, Object>) m).entrySet()) {
+                assertFalse("$ref".equals(e.getKey()), "Unexpected $ref at: " + m);
+                assertFalse("$defs".equals(e.getKey()), "Unexpected $defs at: " + m);
+                assertFalse("definitions".equals(e.getKey()), "Unexpected definitions at: " + m);
+                assertNoRefsOrDefs(e.getValue());
+            }
+        } else if (node instanceof List<?> l) {
+            for (Object item : l) {
+                assertNoRefsOrDefs(item);
+            }
+        }
+    }
+
+    private static Map<String, Object> map(Object... kv) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            m.put((String) kv[i], kv[i + 1]);
+        }
+        return m;
+    }
+
+    private static List<Object> list(Object... items) {
+        List<Object> l = new ArrayList<>();
+        for (Object o : items) {
+            l.add(o);
+        }
+        return l;
+    }
+
+    @Test
+    @DisplayName("inlineRefs(null) returns null")
+    void inlineRefsNullSafe() {
+        assertNull(MeshSchemaSupport.inlineRefs(null));
+    }
+
+    @Test
+    @DisplayName("flat schema with no refs is unchanged except $defs dropped")
+    @SuppressWarnings("unchecked")
+    void inlineRefsFlatSchema() {
+        Map<String, Object> schema = map(
+            "type", "object",
+            "properties", map(
+                "name", map("type", "string"),
+                "age", map("type", "integer")
+            ),
+            "required", list("name", "age"),
+            "$defs", map("Unused", map("type", "string"))
+        );
+        Map<String, Object> out = MeshSchemaSupport.inlineRefs(schema);
+
+        assertEquals("object", out.get("type"));
+        assertFalse(out.containsKey("$defs"), "Root $defs should be dropped");
+        Map<String, Object> props = (Map<String, Object>) out.get("properties");
+        assertEquals("string", ((Map<String, Object>) props.get("name")).get("type"));
+        assertEquals("integer", ((Map<String, Object>) props.get("age")).get("type"));
+        assertEquals(list("name", "age"), out.get("required"));
+    }
+
+    @Test
+    @DisplayName("single nested object $ref is inlined; no $ref/$defs remain")
+    @SuppressWarnings("unchecked")
+    void inlineRefsSingleNested() {
+        Map<String, Object> schema = map(
+            "type", "object",
+            "properties", map(
+                "address", map("$ref", "#/$defs/Address")
+            ),
+            "$defs", map(
+                "Address", map(
+                    "type", "object",
+                    "properties", map(
+                        "city", map("type", "string"),
+                        "zip", map("type", "string")
+                    )
+                )
+            )
+        );
+        Map<String, Object> out = MeshSchemaSupport.inlineRefs(schema);
+        assertNoRefsOrDefs(out);
+
+        Map<String, Object> address =
+            (Map<String, Object>) ((Map<String, Object>) out.get("properties")).get("address");
+        assertEquals("object", address.get("type"));
+        Map<String, Object> addrProps = (Map<String, Object>) address.get("properties");
+        assertEquals("string", ((Map<String, Object>) addrProps.get("city")).get("type"));
+        assertEquals("string", ((Map<String, Object>) addrProps.get("zip")).get("type"));
+    }
+
+    @Test
+    @DisplayName("List<Record> -> items.{$ref} is inlined")
+    @SuppressWarnings("unchecked")
+    void inlineRefsArrayItemsRef() {
+        Map<String, Object> schema = map(
+            "type", "object",
+            "properties", map(
+                "lines", map(
+                    "type", "array",
+                    "items", map("$ref", "#/$defs/LineItem")
+                )
+            ),
+            "$defs", map(
+                "LineItem", map(
+                    "type", "object",
+                    "properties", map("sku", map("type", "string"))
+                )
+            )
+        );
+        Map<String, Object> out = MeshSchemaSupport.inlineRefs(schema);
+        assertNoRefsOrDefs(out);
+
+        Map<String, Object> lines =
+            (Map<String, Object>) ((Map<String, Object>) out.get("properties")).get("lines");
+        Map<String, Object> items = (Map<String, Object>) lines.get("items");
+        assertEquals("object", items.get("type"));
+        Map<String, Object> itemProps = (Map<String, Object>) items.get("properties");
+        assertEquals("string", ((Map<String, Object>) itemProps.get("sku")).get("type"));
+    }
+
+    @Test
+    @DisplayName("same def referenced twice -> independent deep copies")
+    @SuppressWarnings("unchecked")
+    void inlineRefsDeepCopyIndependence() {
+        Map<String, Object> schema = map(
+            "type", "object",
+            "properties", map(
+                "from", map("$ref", "#/$defs/Point"),
+                "to", map("$ref", "#/$defs/Point")
+            ),
+            "$defs", map(
+                "Point", map(
+                    "type", "object",
+                    "properties", map("x", map("type", "integer"))
+                )
+            )
+        );
+        Map<String, Object> out = MeshSchemaSupport.inlineRefs(schema);
+        assertNoRefsOrDefs(out);
+
+        Map<String, Object> props = (Map<String, Object>) out.get("properties");
+        Map<String, Object> from = (Map<String, Object>) props.get("from");
+        Map<String, Object> to = (Map<String, Object>) props.get("to");
+
+        // Mutate one inlined copy; the other must be untouched (deep copy).
+        ((Map<String, Object>) from.get("properties")).put("y", map("type", "integer"));
+        assertTrue(((Map<String, Object>) from.get("properties")).containsKey("y"));
+        assertFalse(((Map<String, Object>) to.get("properties")).containsKey("y"),
+            "Second inline site must be an independent deep copy");
+    }
+
+    @Test
+    @DisplayName("nullable anyOf:[{$ref},{type:null}] inlines the $ref inside anyOf")
+    @SuppressWarnings("unchecked")
+    void inlineRefsAnyOf() {
+        Map<String, Object> schema = map(
+            "type", "object",
+            "properties", map(
+                "maybe", map("anyOf", list(
+                    map("$ref", "#/$defs/Inner"),
+                    map("type", "null")
+                ))
+            ),
+            "$defs", map(
+                "Inner", map(
+                    "type", "object",
+                    "properties", map("v", map("type", "string"))
+                )
+            )
+        );
+        Map<String, Object> out = MeshSchemaSupport.inlineRefs(schema);
+        assertNoRefsOrDefs(out);
+
+        Map<String, Object> maybe =
+            (Map<String, Object>) ((Map<String, Object>) out.get("properties")).get("maybe");
+        List<Object> anyOf = (List<Object>) maybe.get("anyOf");
+        Map<String, Object> first = (Map<String, Object>) anyOf.get(0);
+        assertEquals("object", first.get("type"));
+        assertTrue(((Map<String, Object>) first.get("properties")).containsKey("v"));
+        assertEquals("null", ((Map<String, Object>) anyOf.get(1)).get("type"));
+    }
+
+    @Test
+    @DisplayName("$ref with sibling description -> inlined def + description overlaid")
+    @SuppressWarnings("unchecked")
+    void inlineRefsSiblingKeysOverlaid() {
+        Map<String, Object> schema = map(
+            "type", "object",
+            "properties", map(
+                "addr", map(
+                    "$ref", "#/$defs/Address",
+                    "description", "home address"
+                )
+            ),
+            "$defs", map(
+                "Address", map(
+                    "type", "object",
+                    "properties", map("city", map("type", "string"))
+                )
+            )
+        );
+        Map<String, Object> out = MeshSchemaSupport.inlineRefs(schema);
+        assertNoRefsOrDefs(out);
+
+        Map<String, Object> addr =
+            (Map<String, Object>) ((Map<String, Object>) out.get("properties")).get("addr");
+        assertEquals("object", addr.get("type"));
+        assertEquals("home address", addr.get("description"));
+        assertTrue(((Map<String, Object>) addr.get("properties")).containsKey("city"));
+    }
+
+    @Test
+    @DisplayName("recursive type terminates with bounded {type:object} placeholder")
+    @SuppressWarnings("unchecked")
+    void inlineRefsCycleGuard() {
+        // Node -> { value: string, child: Node }
+        Map<String, Object> schema = map(
+            "$ref", "#/$defs/Node",
+            "$defs", map(
+                "Node", map(
+                    "type", "object",
+                    "properties", map(
+                        "value", map("type", "string"),
+                        "child", map("$ref", "#/$defs/Node")
+                    )
+                )
+            )
+        );
+        // Must not StackOverflow.
+        Map<String, Object> out = MeshSchemaSupport.inlineRefs(schema);
+        assertNoRefsOrDefs(out);
+
+        assertEquals("object", out.get("type"));
+        Map<String, Object> props = (Map<String, Object>) out.get("properties");
+        assertEquals("string", ((Map<String, Object>) props.get("value")).get("type"));
+        Map<String, Object> child = (Map<String, Object>) props.get("child");
+        // The recursive ref collapses to a bounded placeholder.
+        assertEquals("object", child.get("type"));
+        assertFalse(child.containsKey("properties"),
+            "Cycle placeholder should be bounded (no further expansion)");
+    }
+
+    @Test
+    @DisplayName("enum field preserved through inlining")
+    @SuppressWarnings("unchecked")
+    void inlineRefsPreservesEnum() {
+        Map<String, Object> schema = map(
+            "type", "object",
+            "properties", map(
+                "status", map("$ref", "#/$defs/Status")
+            ),
+            "$defs", map(
+                "Status", map(
+                    "type", "string",
+                    "enum", list("OPEN", "CLOSED")
+                )
+            )
+        );
+        Map<String, Object> out = MeshSchemaSupport.inlineRefs(schema);
+        assertNoRefsOrDefs(out);
+
+        Map<String, Object> status =
+            (Map<String, Object>) ((Map<String, Object>) out.get("properties")).get("status");
+        assertEquals("string", status.get("type"));
+        assertEquals(list("OPEN", "CLOSED"), status.get("enum"));
+    }
+
+    @Test
+    @DisplayName("resolves #/definitions/<Name> pointers too")
+    @SuppressWarnings("unchecked")
+    void inlineRefsDefinitionsPointer() {
+        Map<String, Object> schema = map(
+            "type", "object",
+            "properties", map(
+                "addr", map("$ref", "#/definitions/Address")
+            ),
+            "definitions", map(
+                "Address", map(
+                    "type", "object",
+                    "properties", map("city", map("type", "string"))
+                )
+            )
+        );
+        Map<String, Object> out = MeshSchemaSupport.inlineRefs(schema);
+        assertNoRefsOrDefs(out);
+        assertFalse(out.containsKey("definitions"), "Root definitions should be dropped");
+
+        Map<String, Object> addr =
+            (Map<String, Object>) ((Map<String, Object>) out.get("properties")).get("addr");
+        assertTrue(((Map<String, Object>) addr.get("properties")).containsKey("city"));
+    }
+
+    // End-to-end: real victools generator output through inlineRefs.
+    public record Address(@NotNull String street, @NotNull String city) {}
+    public record Company(@NotNull String name, @NotNull Address headquarters) {}
+    public record OrgChart(@NotNull Company company, @NotNull List<Address> sites) {}
+
+    @Test
+    @DisplayName("E2E: real generator output through inlineRefs has no $ref/$defs, nested props present")
+    @SuppressWarnings("unchecked")
+    void inlineRefsEndToEndWithRealGenerator() {
+        JsonNode node = MeshSchemaSupport.generator().generateSchema(OrgChart.class);
+        ObjectMapper mapper = io.mcpmesh.core.MeshObjectMappers.create();
+        Map<String, Object> schema =
+            mapper.convertValue(node, new TypeReference<Map<String, Object>>() {});
+
+        Map<String, Object> out = MeshSchemaSupport.inlineRefs(schema);
+        assertNoRefsOrDefs(out);
+
+        // Deeply-nested field: OrgChart.company.headquarters.{street,city}
+        Map<String, Object> rootProps = (Map<String, Object>) out.get("properties");
+        assertNotNull(rootProps, "Root properties present. Got: " + out);
+        Map<String, Object> company = (Map<String, Object>) rootProps.get("company");
+        Map<String, Object> companyProps = (Map<String, Object>) company.get("properties");
+        Map<String, Object> hq = (Map<String, Object>) companyProps.get("headquarters");
+        Map<String, Object> hqProps = (Map<String, Object>) hq.get("properties");
+        assertTrue(hqProps.containsKey("street"),
+            "Nested Address.street should be inlined. Got: " + out);
+        assertTrue(hqProps.containsKey("city"),
+            "Nested Address.city should be inlined. Got: " + out);
+
+        // Array of records: sites.items.properties present too.
+        Map<String, Object> sites = (Map<String, Object>) rootProps.get("sites");
+        Map<String, Object> siteItems = (Map<String, Object>) sites.get("items");
+        assertTrue(((Map<String, Object>) siteItems.get("properties")).containsKey("street"),
+            "Array item Address.street should be inlined. Got: " + out);
+    }
+
+    @Test
+    @DisplayName("E2E: self-referencing root model (buildJsonSchema path) terminates, no $ref remains")
+    @SuppressWarnings("unchecked")
+    void inlineRefsSelfReferencingRootModel() {
+        // Mirror MeshLlmAgentProxy.buildJsonSchema exactly: generateSchema ->
+        // rewriteRootSelfRefs -> convertValue -> inlineRefs. victools emits the
+        // self-referencing root as a bare "#" ref; without the rewrite that "#"
+        // would survive inlineRefs verbatim (not self-contained).
+        JsonNode node = MeshSchemaSupport.generator().generateSchema(TreeNode.class);
+        node = MeshSchemaSupport.rewriteRootSelfRefs(node, TreeNode.class);
+        ObjectMapper mapper = io.mcpmesh.core.MeshObjectMappers.create();
+        Map<String, Object> schema =
+            mapper.convertValue(node, new TypeReference<Map<String, Object>>() {});
+
+        // (a) Must terminate (no StackOverflow on the recursive root).
+        Map<String, Object> out = MeshSchemaSupport.inlineRefs(schema);
+
+        // (b) NO $ref of ANY form remains (including a bare "#").
+        assertNoRefsOrDefs(out);
+
+        // Top-level properties present (root content was inlined, not left as a ref).
+        assertEquals("object", out.get("type"));
+        Map<String, Object> props = (Map<String, Object>) out.get("properties");
+        assertNotNull(props, "Root properties present. Got: " + out);
+        assertTrue(props.containsKey("value"), "value field present. Got: " + out);
+        assertTrue(props.containsKey("children"), "children field present. Got: " + out);
+
+        // (c) The recursion is cut by a bounded {"type":"object"} placeholder where
+        // children -> items would otherwise recurse into TreeNode again.
+        Map<String, Object> children = (Map<String, Object>) props.get("children");
+        assertEquals("array", children.get("type"));
+        Map<String, Object> items = (Map<String, Object>) children.get("items");
+        assertEquals("object", items.get("type"),
+            "Recursive child should collapse to bounded placeholder. Got: " + out);
+        assertFalse(items.containsKey("properties"),
+            "Cycle placeholder should be bounded (no further expansion). Got: " + out);
     }
 }

--- a/tests/integration/suites/uc04_llm_integration/tc39_java_nested_structured_output_claude_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc39_java_nested_structured_output_claude_py/test.yaml
@@ -1,0 +1,178 @@
+# Test Case: Java NESTED Structured Output -> Py Claude Provider
+# Validates #1112 finding 5: the Java response-model schema now routes through
+# the victools generator + MeshSchemaSupport.inlineRefs, producing a richly-nested
+# output_schema. Every existing Java response model in uc04 is FLAT; this exercises
+# the nested-schema path against a real vendor (Claude) structured-output API.
+#
+# Scenario:
+#   - Start Python claude-provider (provides 'llm' capability)
+#   - Start java-analyst-agent (defines NESTED StructuredReport record)
+#   - Call the analyst's structuredReport tool
+#   - Verify Claude ACCEPTED the nested schema and returned a parseable nested object
+#
+# Response-model shape (com.example.analyst.AnalystAgentApplication):
+#   enum Sentiment { POSITIVE, NEUTRAL, NEGATIVE }
+#   record Finding(String title, String detail, int severity)
+#   record ReportMeta(String author, Sentiment sentiment)        // record-of-record + enum
+#   record StructuredReport(String summary, ReportMeta meta,
+#                           List<Finding> findings, String reviewer)  // nullable reviewer
+
+name: "Java NESTED Structured Output - Java Consumer -> Py Claude"
+description: "Verify Java analyst returns a parseable NESTED StructuredReport via Python Claude (validates victools/inlineRefs nested schema, #1112 finding 5)"
+tags:
+  - llm
+  - claude
+  - structured-output
+  - nested-schema
+  - cross-runtime
+  - java
+  - python
+timeout: 420
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+  - routine: global.setup_for_java_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  - name: "Copy Python Claude provider to workspace"
+    handler: shell
+    command: "cp -r /uc-artifacts/claude-provider /workspace/"
+    capture: copy_provider
+
+  - name: "Copy analyst to workspace"
+    handler: shell
+    command: "cp -r /uc-artifacts/java-analyst-agent /workspace/"
+    capture: copy_analyst
+
+  - name: "Create env file for provider"
+    handler: secrets
+    target: /workspace/.env
+
+  - name: "Create env file for analyst"
+    handler: secrets
+    target: /workspace/java-analyst-agent/.env
+
+  - name: "Install Maven dependencies for analyst agent"
+    handler: maven-install
+    path: /workspace/java-analyst-agent
+    timeout: 600
+
+  - name: "Start Python Claude provider"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start claude-provider/main.py --env-file .env -d"
+    capture: start_provider
+
+  - name: "Wait for provider to register"
+    handler: wait
+    seconds: 10
+
+  - name: "Verify provider is running"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: provider_list
+
+  - name: "Start analyst agent"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl start /workspace/java-analyst-agent --env-file /workspace/java-analyst-agent/.env -d
+    capture: start_analyst
+
+  - name: "Wait for analyst"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for analyst agent..."
+      for i in $(seq 1 45); do
+        AGENTS=$(meshctl list 2>/dev/null || echo "")
+        if echo "$AGENTS" | grep -q "analyst"; then
+          echo "Analyst registered after $((i*2))s"
+          exit 0
+        fi
+        if [ $((i % 10)) -eq 0 ]; then
+          echo "Still waiting... ($((i*2))s)"
+          echo "$AGENTS"
+        fi
+        sleep 2
+      done
+      echo "WARNING: Analyst not registered within 90s"
+      meshctl list 2>/dev/null || true
+      meshctl logs analyst 2>/dev/null | tail -20 || true
+      exit 1
+    capture: wait_analyst
+    timeout: 120
+
+  - name: "Wait for dependency resolution"
+    handler: wait
+    seconds: 8
+
+  - name: "Verify all agents"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: list_all
+
+  - name: "List all tools"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list --tools"
+    capture: list_tools
+
+  - name: "Call structuredReport (nested schema)"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call structuredReport ''{"topic": "the reliability of distributed systems"}'''
+    capture: call_report
+    timeout: 120
+
+assertions:
+  # Registration
+  - expr: "${captured.provider_list} contains 'claude-provider'"
+    message: "Python Claude provider should be registered"
+  - expr: "${captured.list_all} contains 'claude-provider'"
+    message: "Claude provider should be registered"
+  - expr: "${captured.list_all} contains 'analyst'"
+    message: "Analyst should be registered"
+  - expr: "${captured.list_tools} contains 'structuredReport'"
+    message: "structuredReport tool should be available"
+
+  # No MCP error envelope / provider schema rejection
+  - expr: "${captured.call_report} not contains '\"isError\":true'"
+    message: "Call must not return an MCP error envelope (provider must accept the nested schema)"
+
+  # Nested structure populated: meta (record-of-record) with author + enum sentiment
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .meta | type} == 'object'"
+    message: "meta should be a nested object (record-of-record)"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .meta.author} != ''"
+    message: "meta.author should be populated"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | [.meta.sentiment] | inside([\"POSITIVE\",\"NEUTRAL\",\"NEGATIVE\"])} == 'true'"
+    message: "meta.sentiment should be one of the Sentiment enum values"
+
+  # findings: non-empty array of nested records, first element has title/detail/severity
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings | type} == 'array'"
+    message: "findings should be an array"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings | length} > 0"
+    message: "findings should be non-empty"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings[0].title} != ''"
+    message: "first finding should have a title"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings[0].detail} != ''"
+    message: "first finding should have a detail"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings[0].severity | type} == 'number'"
+    message: "first finding should have a numeric severity"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop 2>/dev/null || true
+      pkill -f "spring-boot:run" 2>/dev/null || true
+      pkill -f "java.*analyst" 2>/dev/null || true
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc04_llm_integration/tc40_java_nested_structured_output_openai_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc40_java_nested_structured_output_openai_py/test.yaml
@@ -1,0 +1,172 @@
+# Test Case: Java NESTED Structured Output -> Py OpenAI Provider
+# Validates #1112 finding 5: the Java response-model schema now routes through
+# the victools generator + MeshSchemaSupport.inlineRefs, producing a richly-nested
+# output_schema. Every existing Java response model in uc04 is FLAT; this exercises
+# the nested-schema path against a real vendor (OpenAI) structured-output API.
+#
+# Response-model shape (com.example.analyst.AnalystAgentApplication):
+#   enum Sentiment { POSITIVE, NEUTRAL, NEGATIVE }
+#   record Finding(String title, String detail, int severity)
+#   record ReportMeta(String author, Sentiment sentiment)        // record-of-record + enum
+#   record StructuredReport(String summary, ReportMeta meta,
+#                           List<Finding> findings, String reviewer)  // nullable reviewer
+
+name: "Java NESTED Structured Output - Java Consumer -> Py OpenAI"
+description: "Verify Java analyst returns a parseable NESTED StructuredReport via Python OpenAI (validates victools/inlineRefs nested schema, #1112 finding 5)"
+tags:
+  - llm
+  - openai
+  - structured-output
+  - nested-schema
+  - cross-runtime
+  - java
+  - python
+timeout: 420
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+  - routine: global.setup_for_java_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  - name: "Copy Python OpenAI provider to workspace"
+    handler: shell
+    command: "cp -r /uc-artifacts/openai-provider /workspace/"
+    capture: copy_provider
+
+  - name: "Copy analyst to workspace"
+    handler: shell
+    command: "cp -r /uc-artifacts/java-analyst-agent /workspace/"
+    capture: copy_analyst
+
+  - name: "Create env file for provider"
+    handler: secrets
+    target: /workspace/.env
+
+  - name: "Create env file for analyst"
+    handler: secrets
+    target: /workspace/java-analyst-agent/.env
+
+  - name: "Install Maven dependencies for analyst agent"
+    handler: maven-install
+    path: /workspace/java-analyst-agent
+    timeout: 600
+
+  - name: "Start Python OpenAI provider"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start openai-provider/main.py --env-file .env -d"
+    capture: start_provider
+
+  - name: "Wait for provider to register"
+    handler: wait
+    seconds: 10
+
+  - name: "Verify provider is running"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: provider_list
+
+  - name: "Start analyst agent"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl start /workspace/java-analyst-agent --env-file /workspace/java-analyst-agent/.env -d
+    capture: start_analyst
+
+  - name: "Wait for analyst"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for analyst agent..."
+      for i in $(seq 1 45); do
+        AGENTS=$(meshctl list 2>/dev/null || echo "")
+        if echo "$AGENTS" | grep -q "analyst"; then
+          echo "Analyst registered after $((i*2))s"
+          exit 0
+        fi
+        if [ $((i % 10)) -eq 0 ]; then
+          echo "Still waiting... ($((i*2))s)"
+          echo "$AGENTS"
+        fi
+        sleep 2
+      done
+      echo "WARNING: Analyst not registered within 90s"
+      meshctl list 2>/dev/null || true
+      meshctl logs analyst 2>/dev/null | tail -20 || true
+      exit 1
+    capture: wait_analyst
+    timeout: 120
+
+  - name: "Wait for dependency resolution"
+    handler: wait
+    seconds: 8
+
+  - name: "Verify all agents"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: list_all
+
+  - name: "List all tools"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list --tools"
+    capture: list_tools
+
+  - name: "Call structuredReport (nested schema)"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call structuredReport ''{"topic": "the reliability of distributed systems"}'''
+    capture: call_report
+    timeout: 120
+
+assertions:
+  # Registration
+  - expr: "${captured.provider_list} contains 'openai-provider'"
+    message: "Python OpenAI provider should be registered"
+  - expr: "${captured.list_all} contains 'openai-provider'"
+    message: "OpenAI provider should be registered"
+  - expr: "${captured.list_all} contains 'analyst'"
+    message: "Analyst should be registered"
+  - expr: "${captured.list_tools} contains 'structuredReport'"
+    message: "structuredReport tool should be available"
+
+  # No MCP error envelope / provider schema rejection
+  - expr: "${captured.call_report} not contains '\"isError\":true'"
+    message: "Call must not return an MCP error envelope (provider must accept the nested schema)"
+
+  # Nested structure populated: meta (record-of-record) with author + enum sentiment
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .meta | type} == 'object'"
+    message: "meta should be a nested object (record-of-record)"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .meta.author} != ''"
+    message: "meta.author should be populated"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | [.meta.sentiment] | inside([\"POSITIVE\",\"NEUTRAL\",\"NEGATIVE\"])} == 'true'"
+    message: "meta.sentiment should be one of the Sentiment enum values"
+
+  # findings: non-empty array of nested records, first element has title/detail/severity
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings | type} == 'array'"
+    message: "findings should be an array"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings | length} > 0"
+    message: "findings should be non-empty"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings[0].title} != ''"
+    message: "first finding should have a title"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings[0].detail} != ''"
+    message: "first finding should have a detail"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings[0].severity | type} == 'number'"
+    message: "first finding should have a numeric severity"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop 2>/dev/null || true
+      pkill -f "spring-boot:run" 2>/dev/null || true
+      pkill -f "java.*analyst" 2>/dev/null || true
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc04_llm_integration/tc41_java_nested_structured_output_gemini_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc41_java_nested_structured_output_gemini_py/test.yaml
@@ -1,0 +1,172 @@
+# Test Case: Java NESTED Structured Output -> Py Gemini Provider
+# Validates #1112 finding 5: the Java response-model schema now routes through
+# the victools generator + MeshSchemaSupport.inlineRefs, producing a richly-nested
+# output_schema. Every existing Java response model in uc04 is FLAT; this exercises
+# the nested-schema path against a real vendor (Gemini) structured-output API.
+#
+# Response-model shape (com.example.analyst.AnalystAgentApplication):
+#   enum Sentiment { POSITIVE, NEUTRAL, NEGATIVE }
+#   record Finding(String title, String detail, int severity)
+#   record ReportMeta(String author, Sentiment sentiment)        // record-of-record + enum
+#   record StructuredReport(String summary, ReportMeta meta,
+#                           List<Finding> findings, String reviewer)  // nullable reviewer
+
+name: "Java NESTED Structured Output - Java Consumer -> Py Gemini"
+description: "Verify Java analyst returns a parseable NESTED StructuredReport via Python Gemini (validates victools/inlineRefs nested schema, #1112 finding 5)"
+tags:
+  - llm
+  - gemini
+  - structured-output
+  - nested-schema
+  - cross-runtime
+  - java
+  - python
+timeout: 420
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+  - routine: global.setup_for_java_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+
+test:
+  - name: "Copy Python Gemini provider to workspace"
+    handler: shell
+    command: "cp -r /uc-artifacts/gemini-provider /workspace/"
+    capture: copy_provider
+
+  - name: "Copy analyst to workspace"
+    handler: shell
+    command: "cp -r /uc-artifacts/java-analyst-agent /workspace/"
+    capture: copy_analyst
+
+  - name: "Create env file for provider"
+    handler: secrets
+    target: /workspace/.env
+
+  - name: "Create env file for analyst"
+    handler: secrets
+    target: /workspace/java-analyst-agent/.env
+
+  - name: "Install Maven dependencies for analyst agent"
+    handler: maven-install
+    path: /workspace/java-analyst-agent
+    timeout: 600
+
+  - name: "Start Python Gemini provider"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start gemini-provider/main.py --env-file .env -d"
+    capture: start_provider
+
+  - name: "Wait for provider to register"
+    handler: wait
+    seconds: 15
+
+  - name: "Verify provider is running"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: provider_list
+
+  - name: "Start analyst agent"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl start /workspace/java-analyst-agent --env-file /workspace/java-analyst-agent/.env -d
+    capture: start_analyst
+
+  - name: "Wait for analyst"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for analyst agent..."
+      for i in $(seq 1 45); do
+        AGENTS=$(meshctl list 2>/dev/null || echo "")
+        if echo "$AGENTS" | grep -q "analyst"; then
+          echo "Analyst registered after $((i*2))s"
+          exit 0
+        fi
+        if [ $((i % 10)) -eq 0 ]; then
+          echo "Still waiting... ($((i*2))s)"
+          echo "$AGENTS"
+        fi
+        sleep 2
+      done
+      echo "WARNING: Analyst not registered within 90s"
+      meshctl list 2>/dev/null || true
+      meshctl logs analyst 2>/dev/null | tail -20 || true
+      exit 1
+    capture: wait_analyst
+    timeout: 120
+
+  - name: "Wait for dependency resolution"
+    handler: wait
+    seconds: 8
+
+  - name: "Verify all agents"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: list_all
+
+  - name: "List all tools"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list --tools"
+    capture: list_tools
+
+  - name: "Call structuredReport (nested schema)"
+    handler: shell
+    workdir: /workspace
+    command: 'meshctl call structuredReport ''{"topic": "the reliability of distributed systems"}'''
+    capture: call_report
+    timeout: 120
+
+assertions:
+  # Registration
+  - expr: "${captured.provider_list} contains 'gemini-provider'"
+    message: "Python Gemini provider should be registered"
+  - expr: "${captured.list_all} contains 'gemini-provider'"
+    message: "Gemini provider should be registered"
+  - expr: "${captured.list_all} contains 'analyst'"
+    message: "Analyst should be registered"
+  - expr: "${captured.list_tools} contains 'structuredReport'"
+    message: "structuredReport tool should be available"
+
+  # No MCP error envelope / provider schema rejection
+  - expr: "${captured.call_report} not contains '\"isError\":true'"
+    message: "Call must not return an MCP error envelope (provider must accept the nested schema)"
+
+  # Nested structure populated: meta (record-of-record) with author + enum sentiment
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .meta | type} == 'object'"
+    message: "meta should be a nested object (record-of-record)"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .meta.author} != ''"
+    message: "meta.author should be populated"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | [.meta.sentiment] | inside([\"POSITIVE\",\"NEUTRAL\",\"NEGATIVE\"])} == 'true'"
+    message: "meta.sentiment should be one of the Sentiment enum values"
+
+  # findings: non-empty array of nested records, first element has title/detail/severity
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings | type} == 'array'"
+    message: "findings should be an array"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings | length} > 0"
+    message: "findings should be non-empty"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings[0].title} != ''"
+    message: "first finding should have a title"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings[0].detail} != ''"
+    message: "first finding should have a detail"
+  - expr: "${jq:captured.call_report:.content[0].text | fromjson | .findings[0].severity | type} == 'number'"
+    message: "first finding should have a numeric severity"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop 2>/dev/null || true
+      pkill -f "spring-boot:run" 2>/dev/null || true
+      pkill -f "java.*analyst" 2>/dev/null || true
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary
Route the Java `@mesh.llm` response-model JSON-schema through the shared **victools** generator + a new **`$ref` inliner**, replacing a hand-rolled reflective generator that emitted bare `{"type":"object"}` (no `properties`) for any nested record/POJO and ignored enums — **lossy for nested structured output**, and inconsistent with `@MeshTool` params (which already use victools). Part of #1112.

- **`MeshLlmAgentProxy.buildJsonSchema`** — now: `MeshSchemaSupport.generator().generateSchema(type)` → `rewriteRootSelfRefs(node, type)` (mirrors the tool-schema path; converts victools' bare `$ref:"#"` root self-ref → `#/$defs/<Name>`) → convert to `Map` → `MeshSchemaSupport.inlineRefs(...)`. Deleted the dead `getJsonSchemaType` helper (net −112 lines here).
- **`MeshSchemaSupport.inlineRefs(Map)`** (new) — resolves `#/$defs/*` and `#/definitions/*` refs recursively through `properties`/`items`/`additionalProperties`/`anyOf`/`oneOf`/`allOf`; deep-copies each resolved def (multiply-referenced defs get independent trees); overlays `$ref` sibling keys; drops root `$defs`/`definitions`; **cycle-guarded** (a `$ref` to a name on the expansion stack collapses to a bounded `{"type":"object"}` placeholder → always terminates). Dangling/unknown refs also collapse to the placeholder **and log a warning**. Produces a self-contained schema that works for Anthropic hint mode (reads `properties` directly) as well as OpenAI strict / Gemini `responseSchema`.
- **+12 `MeshSchemaSupportTest` unit tests** — flat no-op, single nested `$ref`, `List<record>` items, multiply-referenced deep-copy independence, nullable `anyOf` inlining, `$ref`+sibling overlay, recursive cycle guard, enum preserved, an E2E generator→inlineRefs test, and a **self-referencing-root** test mirroring the production pipeline.
- **Example (additive):** nested response model `StructuredReport(summary, ReportMeta meta, List<Finding> findings, String reviewer)` — nested record `ReportMeta(author, Sentiment)` w/ enum, record-list `Finding`, nullable `reviewer` (forces victools `anyOf:[...,{type:null}]`) — + a `structuredReport` `@mesh.llm` function. Existing `AnalysisResult`/`analyze`/`chat` untouched.
- **New uc04 `tc39`/`tc40`/`tc41`** — Java nested structured output → Claude/OpenAI/Gemini.

## Behavior change (release notes)
The `output_schema` Java sends to LLM providers changes from the hand-rolled flat shape to a victools-derived, `$ref`-inlined **nested** shape. For flat models it's an equivalent/richer shape (regression-validated); for nested models it's the fix (previously lossy). No API/signature change.

## Review Notes
Independent review (re-reviewed after fixes): **0 blocker / 0 warning**. `inlineRefs` confirmed **termination-safe** (balanced cycle-guard push/pop) and **deep-copy-correct** (independent trees per ref site; downstream `makeStrict`/`sanitize` can't bleed across sites). Two first-round WARNINGs fixed: (1) root self-ref now handled via the reused `rewriteRootSelfRefs` (identity pass for non-self-ref roots → existing models unaffected); (2) dangling refs now `log.warn` instead of silently becoming accept-anything.

## Test plan
- [x] JUnit 16/16 (`MeshSchemaSupportTest`) + module compile clean
- [x] src-tests 12/12 (Java rebuilt into `tsuite-mesh:local`)
- [x] **Regression** — uc04_llm_integration 37/37, uc16_schema_filtering 3/3, uc16_schema_registry 16/16, uc08_llm_prompt_templates 9/9 (all existing flat Java structured-output across vendors)
- [x] **Nested (the fix)** — tc39 Claude 13/13, tc40 OpenAI 13/13, tc41 Gemini 13/13: **all three vendors accept the nested victools+inlineRefs schema** (incl. nullable `anyOf` — OpenAI strict→null, Gemini→value, Claude hint→value) and return parseable nested objects. The "not a free swap" vendor-rejection risk was verified absent, not assumed.

Part of #1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new structured report generation capability that produces nested, validated outputs including sentiment analysis, detailed findings, and metadata.
  * Enhanced schema handling to support complex nested structures across multiple LLM providers (Claude, OpenAI, Gemini).

* **Tests**
  * Added comprehensive integration tests validating nested structured output across multiple LLM provider configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->