### PR TITLE
feat(parity): empty @MeshLlmProvider default tags + expose A2A poll knobs (Part of #1112)

### DIFF
--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlmProvider.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlmProvider.java
@@ -66,9 +66,10 @@ public @interface MeshLlmProvider {
     /**
      * Tags for filtering.
      *
-     * <p>Other agents can prefer specific providers via tags.
+     * <p>Other agents can prefer specific providers via tags. Defaults to
+     * no tags.
      */
-    String[] tags() default {"llm", "provider"};
+    String[] tags() default {};
 
     /**
      * Capability version (semver format).

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AClient.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AClient.java
@@ -97,6 +97,21 @@ public final class A2AClient implements AutoCloseable {
     }
 
     public A2AClient(String url, String skillId, A2ABearer auth, Duration defaultTimeout) {
+        this(url, skillId, auth, defaultTimeout, DEFAULT_POLL_INTERVAL_MS, DEFAULT_POLL_INTERVAL_MAX_MS);
+    }
+
+    /**
+     * Full constructor letting the caller override the poll backoff knobs.
+     *
+     * @param pollIntervalMs    initial backoff (ms) between {@code tasks/get}
+     *                          polls; falls back to {@link #DEFAULT_POLL_INTERVAL_MS}
+     *                          when {@code <= 0}.
+     * @param pollIntervalMaxMs cap (ms) on the exponential poll backoff;
+     *                          falls back to {@link #DEFAULT_POLL_INTERVAL_MAX_MS}
+     *                          when {@code <= 0}.
+     */
+    public A2AClient(String url, String skillId, A2ABearer auth, Duration defaultTimeout,
+                     long pollIntervalMs, long pollIntervalMaxMs) {
         if (url == null || url.isEmpty()) {
             throw new IllegalArgumentException("A2AClient: url must be non-empty");
         }
@@ -115,8 +130,8 @@ public final class A2AClient implements AutoCloseable {
         this.auth = auth;
         this.defaultTimeout = defaultTimeout;
         this.objectMapper = MeshObjectMappers.create();
-        this.pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
-        this.pollIntervalMaxMs = DEFAULT_POLL_INTERVAL_MAX_MS;
+        this.pollIntervalMs = pollIntervalMs > 0 ? pollIntervalMs : DEFAULT_POLL_INTERVAL_MS;
+        this.pollIntervalMaxMs = pollIntervalMaxMs > 0 ? pollIntervalMaxMs : DEFAULT_POLL_INTERVAL_MAX_MS;
         // connectTimeout is the TCP-handshake budget; the per-call
         // request timeout is set on each HttpRequest below using the
         // user-supplied or default deadline.

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AConsumer.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AConsumer.java
@@ -14,8 +14,9 @@ import java.lang.annotation.Target;
  * AND carries the upstream A2A configuration.
  *
  * <p>The Spring starter reads these fields at boot, constructs an
- * {@link A2AClient} per unique {@code (url, skillId, auth, timeout)}
- * tuple, and injects the cached client at the method's
+ * {@link A2AClient} per unique {@code (url, skillId, auth, timeout,
+ * pollIntervalMs, pollIntervalMaxMs)} tuple, and injects the cached
+ * client at the method's
  * {@link A2AClient} parameter slot at invoke time. Mirrors Python's
  * {@code @mesh.a2a_consumer(url=..., a2a_skill_id=..., auth=...)}
  * decorator (issue #913) so Java, Python, and the upcoming TypeScript
@@ -119,4 +120,17 @@ public @interface A2AConsumer {
      * {@link A2AClient}. Default 30. Must be {@code > 0}.
      */
     int timeoutSeconds() default 30;
+
+    /**
+     * Optional: initial backoff (milliseconds) between {@code tasks/get}
+     * polls while a task is non-terminal on the constructed
+     * {@link A2AClient}. Default 500. Must be {@code > 0}.
+     */
+    long pollIntervalMs() default 500;
+
+    /**
+     * Optional: cap (milliseconds) on the exponential poll backoff on the
+     * constructed {@link A2AClient}. Default 2000. Must be {@code > 0}.
+     */
+    long pollIntervalMaxMs() default 2000;
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/A2AConsumerBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/A2AConsumerBeanPostProcessor.java
@@ -27,7 +27,8 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Issue #923: scans Spring beans for {@code @A2AConsumer} methods,
  * constructs an {@link A2AClient} per unique
- * {@code (url, skillId, auth, timeoutSeconds)} tuple, and records a
+ * {@code (url, skillId, auth, timeoutSeconds, pollIntervalMs,
+ * pollIntervalMaxMs)} tuple, and records a
  * per-method binding so {@link MeshToolWrapper} can inject the cached
  * client at the method's {@link A2AClient} parameter slot at invoke
  * time.
@@ -136,6 +137,20 @@ public class A2AConsumerBeanPostProcessor implements BeanPostProcessor, Ordered 
                     + ": timeoutSeconds must be > 0 (got " + timeoutSeconds + ")");
         }
 
+        long pollIntervalMs = annotation.pollIntervalMs();
+        if (pollIntervalMs <= 0) {
+            throw new BeanInitializationException(
+                "@A2AConsumer on " + targetClass.getName() + "#" + method.getName()
+                    + ": pollIntervalMs must be > 0 (got " + pollIntervalMs + ")");
+        }
+
+        long pollIntervalMaxMs = annotation.pollIntervalMaxMs();
+        if (pollIntervalMaxMs <= 0) {
+            throw new BeanInitializationException(
+                "@A2AConsumer on " + targetClass.getName() + "#" + method.getName()
+                    + ": pollIntervalMaxMs must be > 0 (got " + pollIntervalMaxMs + ")");
+        }
+
         // Resolve Spring property placeholders so users can write
         // @A2AConsumer(url = "${weather.a2a.url}") and have the property
         // value (env-overridable) flow into the underlying URL.
@@ -186,12 +201,15 @@ public class A2AConsumerBeanPostProcessor implements BeanPostProcessor, Ordered 
             : hasToken ? AuthSpec.literal(authToken)
             : AuthSpec.none();
 
-        A2AClientKey key = new A2AClientKey(resolvedUrl, skillId, authSpec, timeoutSeconds);
+        A2AClientKey key = new A2AClientKey(
+            resolvedUrl, skillId, authSpec, timeoutSeconds, pollIntervalMs, pollIntervalMaxMs);
         A2AClient client = clientCache.computeIfAbsent(key, k -> {
             A2ABearer bearer = k.auth().toBearer();
-            A2AClient created = new A2AClient(k.url(), k.skillId(), bearer, Duration.ofSeconds(k.timeoutSeconds()));
-            log.info("@A2AConsumer: constructed A2AClient(url={}, skillId={}, auth={}, timeoutSeconds={})",
-                k.url(), k.skillId(), k.auth(), k.timeoutSeconds());
+            A2AClient created = new A2AClient(k.url(), k.skillId(), bearer,
+                Duration.ofSeconds(k.timeoutSeconds()), k.pollIntervalMs(), k.pollIntervalMaxMs());
+            log.info("@A2AConsumer: constructed A2AClient(url={}, skillId={}, auth={}, timeoutSeconds={}, "
+                    + "pollIntervalMs={}, pollIntervalMaxMs={})",
+                k.url(), k.skillId(), k.auth(), k.timeoutSeconds(), k.pollIntervalMs(), k.pollIntervalMaxMs());
             return created;
         });
 
@@ -279,7 +297,8 @@ public class A2AConsumerBeanPostProcessor implements BeanPostProcessor, Ordered 
      * timeoutSeconds)} tuples share the same client instance — the
      * Java HTTP connection pool is amortised across them.
      */
-    public record A2AClientKey(String url, String skillId, AuthSpec auth, int timeoutSeconds) {
+    public record A2AClientKey(String url, String skillId, AuthSpec auth, int timeoutSeconds,
+                               long pollIntervalMs, long pollIntervalMaxMs) {
         public A2AClientKey {
             Objects.requireNonNull(url, "url");
             Objects.requireNonNull(auth, "auth");

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -2031,6 +2031,8 @@ def a2a_consumer(
     version: str = "1.0.0",
     description: str | None = None,
     timeout: float = 30.0,
+    poll_interval: float = 0.5,
+    poll_interval_max: float = 2.0,
     **kwargs: Any,
 ) -> Callable[[T], T]:
     """Bridge an external A2A v1.0 endpoint into a mesh capability (issue #908).
@@ -2074,6 +2076,11 @@ def a2a_consumer(
         timeout: Default timeout (seconds) for ``A2AClient.send`` calls
             issued by this decorator. Per-call ``send(..., timeout=...)``
             overrides the default.
+        poll_interval: Initial backoff (seconds) between ``tasks/get``
+            polls while a task is non-terminal. Must be > 0. Default
+            ``0.5``.
+        poll_interval_max: Cap (seconds) on the exponential poll backoff.
+            Must be > 0. Default ``2.0``.
         **kwargs: Additional metadata stamped onto the underlying
             ``@mesh.tool`` registration (passed through unchanged).
 
@@ -2134,6 +2141,14 @@ def a2a_consumer(
         raise ValueError("@mesh.a2a_consumer: 'description' must be a string or None")
     if not isinstance(timeout, (int, float)) or timeout <= 0:
         raise ValueError("@mesh.a2a_consumer: 'timeout' must be a positive number")
+    if not isinstance(poll_interval, (int, float)) or poll_interval <= 0:
+        raise ValueError(
+            "@mesh.a2a_consumer: 'poll_interval' must be a positive number"
+        )
+    if not isinstance(poll_interval_max, (int, float)) or poll_interval_max <= 0:
+        raise ValueError(
+            "@mesh.a2a_consumer: 'poll_interval_max' must be a positive number"
+        )
 
     final_skill_id = a2a_skill_id if a2a_skill_id else capability
     user_tags = list(tags) if tags is not None else []
@@ -2165,6 +2180,8 @@ def a2a_consumer(
             skill_id=final_skill_id,
             auth=auth,
             timeout_default=float(timeout),
+            poll_interval=float(poll_interval),
+            poll_interval_max=float(poll_interval_max),
         )
 
         # Detect whether the user function declares the ``_a2a`` parameter.


### PR DESCRIPTION
## Summary
Two small cross-runtime parity fixes (Part of #1112).

### Finding 7 — `@MeshLlmProvider` default tags → empty (Java) · behavior change
`@MeshLlmProvider.tags()` default changed from `{"llm","provider"}` to `{}`, matching TS (`tags = []`), Python (`tags = None`), and Java's own `@MeshTool` (`{}`). LLM provider discovery is **capability-based** — a verified blast-radius scan found nothing in the runtimes/tests/examples that requires the default `llm`/`provider` tags for matching (tags are preference filters like `+claude`). The processor reads `annotation.tags()` verbatim with no default-substitution, so the change is self-contained.

### Finding 8 — expose A2A consumer poll-interval knobs (Python + Java) · additive
The knobs already existed in each runtime's `A2AClient` transport; this surfaces them on the consumer decorator/annotation. Defaults equal the prior hardcoded values, so behavior is unchanged; each runtime keeps its idiomatic units (TS already exposed these — untouched).
- **Python** `@a2a_consumer`: `poll_interval=0.5` / `poll_interval_max=2.0` (seconds, matching its `timeout` convention) — `>0` validation, docstring, passthrough to `A2AClient`.
- **Java** `@A2AConsumer`: `pollIntervalMs()=500` / `pollIntervalMaxMs()=2000` (ms). `A2AClient` gains a 6-arg constructor overload; the existing 4-arg delegates to it with the defaults (all prior arities preserved). `A2AConsumerBeanPostProcessor` reads + validates (`>0`) the annotation values and threads them through the `A2AClientKey` cache key into the new constructor — so two `@A2AConsumer` methods with different poll settings get distinct cached clients.

## Review Notes
- **Behavior change (release notes):** Java LLM providers no longer auto-carry the `"llm"`/`"provider"` registration tags by default; set `tags = {...}` explicitly if a consumer was relying on them. (Discovery is capability-based, so this is inert in practice.)
- Independent review: **0 blocker / 0 warning / 2 INFO**. Confirmed: A2AClient backward-compat preserved (all constructor arities chain), `A2AClientKey` is a record so the new poll fields participate in value equality (correct cache keying), defaults unchanged (500ms==0.5s, 2000ms==2.0s), finding-7 default change self-contained, Python passthrough complete (no accepted-but-unused param), new params documented in canonical surfaces only.

## Test plan
- [x] Java SDK + spring-boot-starter `mvn compile` → BUILD SUCCESS; Python `py_compile` OK
- [x] src-tests 12/12 (Java SDK + Python runtime rebuilt into `tsuite-mesh:local`)
- [x] integration GREEN, no flakes:
  - uc04_llm_integration 40/40 — #7: Java providers (`tc12_claude_java`/`tc13_openai_java`) register WITHOUT the default tags and are still discovered/bound by consumers via capability (incl. cross-runtime `tc20/22/24/28/29/30/33` + nested `tc39/40/41`)
  - uc27_a2a_consumer_java 8/8 + uc25_a2a_consumer_python 7/7 — #8: changed poll-wiring paths (dispatch/cancel/failover/consumer-death/SSE) pass with unchanged defaults
  - uc26_a2a_consumer_typescript 7/7 — TS regression sanity (untouched runtime)

Part of #1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
