### PR TITLE
fix(ts): retain resolved deps on registry_disconnected (Part of #1131)

### DIFF
--- a/src/runtime/typescript/src/__tests__/registry-disconnect-retains-deps.spec.ts
+++ b/src/runtime/typescript/src/__tests__/registry-disconnect-retains-deps.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression test for #1131 — TS data-plane resilience on a registry blip.
+ *
+ * The registry is the CONTROL plane. Once a dependency is resolved, its
+ * endpoint is a DATA-plane address: a direct agent→agent connection that
+ * stays valid even while the registry is unreachable. The Rust core never
+ * resets topology on a registry disconnect, and its reconnect diff gate
+ * re-emits only CHANGED dependencies — so any dep cleared on disconnect
+ * would NEVER be re-emitted, permanently severing a still-valid connection.
+ *
+ * The correct, cross-runtime-consistent behavior (MeshAgent, Python ×3,
+ * Java) is therefore to RETAIN resolved dependencies through a
+ * `registry_disconnected` event and log only.
+ *
+ * Previously `ApiRuntime` and `MeshExpress` called
+ * `registry.clearAllDependencies()` in their `registry_disconnected`
+ * handlers. This test drives each runtime's real (private) `runEventLoop`
+ * against a stub `this` that exposes a scripted core handle emitting
+ * `registry_disconnected` followed by `shutdown`, and asserts a
+ * pre-resolved dependency survives.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { MockInstance } from "vitest";
+
+import { ApiRuntime } from "../api-runtime.js";
+import { MeshExpress } from "../express.js";
+import { RouteRegistry } from "../route.js";
+import type { McpMeshTool } from "../types.js";
+
+/**
+ * Build a stub core handle whose `nextEvent()` replays the given event
+ * sequence once, then parks forever. The runtimes' event loops exit on the
+ * `shutdown` event, so each sequence must end with one.
+ */
+function stubHandle(events: Array<{ eventType: string; reason?: string }>) {
+  let i = 0;
+  return {
+    nextEvent: async () => {
+      if (i < events.length) return events[i++] as never;
+      // Never resolve once the scripted events are exhausted.
+      return new Promise<never>(() => {});
+    },
+  };
+}
+
+const DISCONNECT_THEN_SHUTDOWN = [
+  { eventType: "registry_disconnected", reason: "connection reset" },
+  { eventType: "shutdown" },
+];
+
+describe("registry_disconnected retains resolved dependencies (#1131)", () => {
+  let warnSpy: MockInstance;
+
+  beforeEach(() => {
+    RouteRegistry.reset();
+    // Silence the expected warn/log from the disconnect/shutdown handlers.
+    // Keep the warn spy so we can assert the disconnect path actually ran —
+    // a path-executed guard that fails if the `registry_disconnected` case is
+    // ever skipped/removed (closes the vacuous-pass hole).
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function seedResolvedDep(): { routeId: string; proxy: McpMeshTool } {
+    const registry = RouteRegistry.getInstance();
+    const routeId = registry.registerRoute("GET", "/test", ["calculator"]);
+    const proxy = (() => Promise.resolve("ok")) as unknown as McpMeshTool;
+    registry.setDependency(routeId, 0, proxy);
+    // Sanity: dep is resolved before the disconnect.
+    expect(registry.getDependency(routeId, 0)).toBe(proxy);
+    return { routeId, proxy };
+  }
+
+  it("ApiRuntime keeps the resolved dep after registry_disconnected", async () => {
+    const { routeId, proxy } = seedResolvedDep();
+
+    // Drive the REAL private event loop against a stub `this`. The loop only
+    // reads `this.handle` and the RouteRegistry singleton, so we don't need
+    // to construct the singleton (which would bind the napi runtime).
+    const stubThis = { handle: stubHandle(DISCONNECT_THEN_SHUTDOWN) };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const runEventLoop = (ApiRuntime.prototype as any).runEventLoop;
+    await runEventLoop.call(stubThis);
+
+    // Path-executed guard: the disconnect handler must have run (negative
+    // control). If `registry_disconnected` is ever skipped/removed, the dep
+    // could survive for an unrelated reason — this assertion fails loudly.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("API runtime disconnected"),
+    );
+
+    const registry = RouteRegistry.getInstance();
+    expect(registry.getDependency(routeId, 0)).toBe(proxy);
+  });
+
+  it("MeshExpress keeps the resolved dep after registry_disconnected", async () => {
+    const { routeId, proxy } = seedResolvedDep();
+
+    const stubThis = { handle: stubHandle(DISCONNECT_THEN_SHUTDOWN) };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const runEventLoop = (MeshExpress.prototype as any).runEventLoop;
+    await runEventLoop.call(stubThis);
+
+    // Path-executed guard: the disconnect handler must have run (negative
+    // control). If `registry_disconnected` is ever skipped/removed, the dep
+    // could survive for an unrelated reason — this assertion fails loudly.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Disconnected from registry"),
+    );
+
+    const registry = RouteRegistry.getInstance();
+    expect(registry.getDependency(routeId, 0)).toBe(proxy);
+  });
+});

--- a/src/runtime/typescript/src/api-runtime.ts
+++ b/src/runtime/typescript/src/api-runtime.ts
@@ -340,8 +340,15 @@ class ApiRuntime {
             break;
 
           case "registry_disconnected":
+            // #1131: Log only — RETAIN resolved dependencies on a registry
+            // (control-plane) blip. Already-resolved dependency endpoints are
+            // data-plane: direct agent→agent connections that stay valid while
+            // the registry is unreachable. Clearing them here would permanently
+            // sever those connections, since the Rust core never resets topology
+            // and its diff gate re-emits only CHANGED deps on reconnect (so the
+            // unchanged, still-valid ones would never come back). Matches the
+            // cross-runtime reference behavior (MeshAgent, Python, Java).
             console.warn(`API runtime disconnected: ${event.reason}`);
-            registry.clearAllDependencies();
             break;
 
           case "shutdown":

--- a/src/runtime/typescript/src/express.ts
+++ b/src/runtime/typescript/src/express.ts
@@ -378,8 +378,15 @@ export class MeshExpress {
             break;
 
           case "registry_disconnected":
+            // #1131: Log only — RETAIN resolved dependencies on a registry
+            // (control-plane) blip. Already-resolved dependency endpoints are
+            // data-plane: direct agent→agent connections that stay valid while
+            // the registry is unreachable. Clearing them here would permanently
+            // sever those connections, since the Rust core never resets topology
+            // and its diff gate re-emits only CHANGED deps on reconnect (so the
+            // unchanged, still-valid ones would never come back). Matches the
+            // cross-runtime reference behavior (MeshAgent, Python, Java).
             console.warn(`Disconnected from registry: ${event.reason}`);
-            registry.clearAllDependencies();
             break;
 
           case "shutdown":


### PR DESCRIPTION
## Summary
Stop clearing resolved dependencies on `registry_disconnected` in the TS `ApiRuntime` and `MeshExpress` — they now **RETAIN** (log-only), matching `MeshAgent`, Python (×3 heartbeats), and Java. **Part of #1131** (resolves its critical behavior divergence; the `MeshRuntimeBase` structural extraction is deferred to a separate focused PR — #1131 stays open to track it).

Clearing resolved deps on a **registry** outage violates the mesh resilience model: the registry is **control-plane**; already-resolved dependency endpoints are **data-plane** (direct agent→agent) and stay valid through a blip. Worse — the Rust core **never resets its topology** on disconnect and the reconnect refresh is **diff-gated** (re-emits only *changed* deps), so a cleared dep would **never be restored on reconnect** → permanently severed connections until an unrelated topology change.

- `api-runtime.ts` + `express.ts`: removed the `registry.clearAllDependencies()` call from the `registry_disconnected` case (log-only now), with a rationale comment.
- The `clearAllDependencies()` **method** is kept (legitimate reset/test utility); only the two disconnect call sites were removed. No other disconnect-triggered caller exists.
- New regression test drives the real `runEventLoop` through `registry_disconnected → shutdown` and asserts the dep survives **and** that the disconnect path actually executed (a `console.warn` path-executed guard, so it can't pass vacuously).

## Review Notes
- Independent review: **0 blocker / 0 warning** (after hardening) / 2 INFO. Production change confirmed minimal + correct — `clearAllDependencies()` is only `Map.clear()` (no proxy/socket/connection close → no resource leak); retaining is safe (`dependency_unavailable`/`dependency_changed` still prune/update normally). The regression test genuinely fails on the pre-fix code (not a tautology); the review's fragility WARNING was addressed by adding the warn-spy path-executed guard, with **both failure modes verified** (retain assertion fails if clearing is restored; warn assertion fails if the disconnect case is removed).
- **Latent today** — the Rust core does not yet emit `registry_disconnected`, so there is **zero runtime-observable change**; this removes a dead-code-path landmine and locks in the resilient behavior before any emitter is wired.
- Context: the clearing dates to PR #396 (~5 months old) — pre-existing, not introduced by any recent PR. A cross-runtime audit also found #1131 under-counted the clearing sites (it named ApiRuntime vs MeshAgent but missed `MeshExpress`); this PR fixes both.

## Test plan
- [x] `tsc --noEmit` clean
- [x] vitest 845 green (+2 new, hardened with a path-executed guard)
- [x] No integration run needed — `registry_disconnected` is not emitted by the core today (no runtime-observable change); the vitest regression test exercises the handler path directly.

Part of #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where resolved dependencies were being unnecessarily cleared when the registry disconnected. These dependencies are now retained during disconnection, improving service resilience and preventing unnecessary service interruptions.

* **Tests**
  * Added a regression test to verify that resolved dependencies are properly retained when the registry disconnects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->