### PR TITLE
fix(java): named @MeshRoute agents report agent_type=api

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -926,6 +926,43 @@ public class MeshAutoConfiguration {
         // was registered. Producer flag is set inside applyA2ASurfaces above.
         spec.setA2aConsumer(!a2aConsumerBeanPostProcessor.bindings().isEmpty());
 
+        // Flip agent_type to "api" for a NAMED route-only agent. The unnamed
+        // path already gets agent_type="api" from buildConsumerAgentSpec, but a
+        // named @MeshAgent that only exposes @MeshRoute surfaces (no real
+        // @MeshTool capabilities) takes buildBaseAgentSpec and would otherwise
+        // stay at the AgentSpec default "mcp_agent" — mislabeling it as an MCP
+        // agent in the dashboard. This mirrors Python, whose API pipeline
+        // decides agent_type="api" independently of whether a name was set.
+        //
+        // Guard: only flip when still the default "mcp_agent" so an A2A agent
+        // (already flipped to "a2a" above) or any explicit type is preserved.
+        // Do NOT rely on the a2a flip having succeeded: applyA2ASurfaces sets
+        // "a2a" inside a try block that swallows a serialization exception and
+        // leaves agent_type at "mcp_agent". So make a2a precedence explicit by
+        // checking the SAME signal applyA2ASurfaces keys on (hasSurfaces()) —
+        // an A2A producer is never mislabeled "api" even if that serialize threw.
+        // Reuse the same signals the consumer-only path relies on:
+        //   - routes: MeshRouteRegistry.hasRoutes()
+        //   - a2a surfaces: MeshA2ARegistry.hasSurfaces()
+        //   - "no real tools": no ToolSpec whose function name is a genuine user
+        //     @MeshTool. Framework job-control tools and synthetic dependency
+        //     surfaces all carry the "__mesh_" prefix, so a user tool is any
+        //     spec whose functionName does not start with that prefix.
+        if ("mcp_agent".equals(spec.getAgentType())) {
+            MeshRouteRegistry routeRegistry = routeRegistryProvider.getIfAvailable();
+            boolean hasRoutes = routeRegistry != null && routeRegistry.hasRoutes();
+            MeshA2ARegistry a2aRegistry = a2aRegistryProvider.getIfAvailable();
+            boolean hasA2aSurfaces = a2aRegistry != null && a2aRegistry.hasSurfaces();
+            boolean hasRealTools = spec.getTools().stream()
+                .map(AgentSpec.ToolSpec::getFunctionName)
+                .anyMatch(name -> name != null && !name.startsWith("__mesh_"));
+            if (hasRoutes && !hasRealTools && !hasA2aSurfaces) {
+                spec.setAgentType("api");
+                log.info("@MeshRoute (route-only, named): agent_type=api "
+                    + "(no @MeshTool capabilities — matches unnamed consumer path)");
+            }
+        }
+
         log.info("Agent spec finalized for '{}' with {} tool(s)",
             spec.getName(), spec.getTools().size());
     }


### PR DESCRIPTION
## Summary
A **named** Java `@MeshRoute` (API) agent registered with `agent_type="mcp_agent"` instead of `"api"`, so the meshui dashboard labeled it "MCP Agent". Unnamed route agents were unaffected (they already report `api`).

**Root cause:** the Java SDK only set `agent_type="api"` in its consumer-only builder (`buildConsumerAgentSpec`), gated on the agent having no name (`MeshAutoConfiguration.java:752`). A named route-only agent takes the named path (`buildBaseAgentSpec`), which never assigns `agent_type` → keeps the `AgentSpec` default `"mcp_agent"`. The registry is pass-through (`ent_handlers.go:416`) and the UI maps lowercase `"api"`→"API" (`src/ui/lib/api.ts:176`), so the field just never got set. Python decides `agent_type="api"` from its API pipeline independent of naming (`rust_api_heartbeat.py:167`) — which is why Python worked and Java was missed.

**Fix:** in `finalizeAgentSpec`, after the existing `@MeshA2A`→`"a2a"` flip, add an `"api"` flip mirroring that pattern. Guard fires only when the spec is still `"mcp_agent"`, has `@MeshRoute` routes (`MeshRouteRegistry.hasRoutes()`), exposes no real user `@MeshTool` (no non-`__mesh_`-prefixed function names), **and** has no A2A surfaces (`MeshA2ARegistry.hasSurfaces()`). Named and unnamed route agents now behave identically.

## Review Notes
- Independent review: 0 blockers. One WARNING (A2A could be mislabeled `api` if `applyA2ASurfaces`'s swallowed serialization exception left the type at `mcp_agent`) — **addressed** by adding the explicit `!hasA2aSurfaces` guard (the same `hasSurfaces()` signal `applyA2ASurfaces` early-returns on), so the flip no longer depends on the a2a flip having succeeded.
- A2A agents stay `"a2a"`; MCP-tool agents stay `"mcp_agent"`; unnamed route agents already `"api"` (guard skips them).

## Verification (live)
Built the Java SDK 2.4.0, ran a named route-only agent (`MCP_MESH_AGENT_NAME=route-api-test`, `examples/java/header-api`) against a local registry:
- Before fix: `/agents` → `"agent_type": "mcp_agent"`
- After fix (md5-confirmed the rebuilt jar bundled the updated starter): `/agents` → `"agent_type": "api"`

Closes #1156

## Test plan
- [ ] Named Java `@MeshRoute`-only agent shows "API" in the dashboard.
- [ ] A2A Java agent still shows "A2A"; Java `@MeshTool` agent still shows "MCP Agent".
- [ ] Unnamed route agent unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent type classification to correctly label route-only agents as API-type agents instead of retaining the default classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->