### PR TITLE
fix(java): serialize dependency tags as JSON array in route/A2A/dependsOn paths

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -1,6 +1,7 @@
 package io.mcpmesh.spring;
 
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import io.mcpmesh.core.MeshObjectMappers;
 import io.mcpmesh.MeshAgent;
 import io.mcpmesh.Selector;
@@ -1017,6 +1018,7 @@ public class MeshAutoConfiguration {
         // doesn't need a registry-resolved dependency to call its own tool.
         Set<String> seenCapabilities = collectKnownCapabilities(tools, true);
         List<AgentSpec.DependencySpec> deps = new ArrayList<>();
+        var jsonMapper = JsonMapper.builder().build();
         // Issue #547 Phase 4: cluster-wide strict knob promotes WARN→BLOCK on
         // the consumer side too. Same source-of-truth as MeshRouteRegistry.
         boolean clusterStrict = io.mcpmesh.spring.MeshSchemaSupport.clusterStrictEnabled();
@@ -1043,7 +1045,16 @@ public class MeshAutoConfiguration {
                 AgentSpec.DependencySpec agentDep = new AgentSpec.DependencySpec();
                 agentDep.setCapability(capability);
                 if (dep.tags().length > 0) {
-                    agentDep.setTags(String.join(",", dep.tags()));
+                    // Issue #1158: tags is contractually a JSON-array string
+                    // (the Rust core JSON-parses it; a comma-joined string
+                    // silently degrades to "no tag constraint").
+                    try {
+                        agentDep.setTags(jsonMapper.writeValueAsString(dep.tags()));
+                    } catch (Exception e) {
+                        log.warn("Failed to serialize tags for dependency '{}' — registering with no tag constraint: {}",
+                            capability, e.getMessage());
+                        agentDep.setTags("[]");
+                    }
                 }
                 if (dep.version() != null && !dep.version().isEmpty()) {
                     agentDep.setVersion(dep.version());

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
@@ -202,6 +202,8 @@ public class MeshToolRegistry {
                 try {
                     depSpec.setTags(jsonMapper.writeValueAsString(dep.tags()));
                 } catch (Exception e) {
+                    log.warn("Failed to serialize tags for dependency '{}' — registering with no tag constraint: {}",
+                        dep.capability(), e.getMessage());
                     depSpec.setTags("[]");
                 }
                 depSpec.setVersion(dep.version());

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ARegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ARegistry.java
@@ -4,6 +4,7 @@ import io.mcpmesh.core.AgentSpec;
 import io.mcpmesh.spring.MeshSchemaSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -142,6 +143,7 @@ public class MeshA2ARegistry {
     public List<AgentSpec.DependencySpec> getUniqueDependencySpecs() {
         Set<String> seenCapabilities = new HashSet<>();
         List<AgentSpec.DependencySpec> specs = new ArrayList<>();
+        var jsonMapper = JsonMapper.builder().build();
         // Issue #547 Phase 4: cluster-wide strict knob promotes WARN→BLOCK.
         boolean clusterStrict = MeshSchemaSupport.clusterStrictEnabled();
         for (SurfaceMetadata surface : getAllSurfaces()) {
@@ -150,7 +152,16 @@ public class MeshA2ARegistry {
                     AgentSpec.DependencySpec agentDep = new AgentSpec.DependencySpec();
                     agentDep.setCapability(dep.getCapability());
                     if (dep.hasTags()) {
-                        agentDep.setTags(String.join(",", dep.getTags()));
+                        // Issue #1158: tags is contractually a JSON-array string
+                        // (the Rust core JSON-parses it; a comma-joined string
+                        // silently degrades to "no tag constraint").
+                        try {
+                            agentDep.setTags(jsonMapper.writeValueAsString(dep.getTags()));
+                        } catch (Exception e) {
+                            log.warn("Failed to serialize tags for dependency '{}' — registering with no tag constraint: {}",
+                                dep.getCapability(), e.getMessage());
+                            agentDep.setTags("[]");
+                        }
                     }
                     if (dep.hasVersion()) {
                         agentDep.setVersion(dep.getVersion());

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
@@ -6,6 +6,7 @@ import io.mcpmesh.core.MeshCoreBridge;
 import io.mcpmesh.spring.MeshSchemaSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -114,6 +115,7 @@ public class MeshRouteRegistry {
     public List<AgentSpec.DependencySpec> getUniqueDependencySpecs() {
         Set<String> seenCapabilities = new HashSet<>();
         List<AgentSpec.DependencySpec> specs = new ArrayList<>();
+        var jsonMapper = JsonMapper.builder().build();
         // Issue #547 Phase 4: cluster-wide strict knob promotes WARN→BLOCK.
         boolean clusterStrict = MeshSchemaSupport.clusterStrictEnabled();
 
@@ -123,7 +125,16 @@ public class MeshRouteRegistry {
                     AgentSpec.DependencySpec agentDep = new AgentSpec.DependencySpec();
                     agentDep.setCapability(dep.getCapability());
                     if (dep.hasTags()) {
-                        agentDep.setTags(String.join(",", dep.getTags()));
+                        // Issue #1158: tags is contractually a JSON-array string
+                        // (the Rust core JSON-parses it; a comma-joined string
+                        // silently degrades to "no tag constraint").
+                        try {
+                            agentDep.setTags(jsonMapper.writeValueAsString(dep.getTags()));
+                        } catch (Exception e) {
+                            log.warn("Failed to serialize tags for dependency '{}' — registering with no tag constraint: {}",
+                                dep.getCapability(), e.getMessage());
+                            agentDep.setTags("[]");
+                        }
                     }
                     if (dep.hasVersion()) {
                         agentDep.setVersion(dep.getVersion());

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDependsOnIntegrationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDependsOnIntegrationTest.java
@@ -458,6 +458,20 @@ class MeshDependsOnIntegrationTest {
                 assertThat(hasSynthetic)
                     .as("synthetic __mesh_depends_on_deps tool must be present")
                     .isTrue();
+
+                // Issue #1158: a tag-less dependency must keep the JSON-array
+                // default — an empty string would fail the Rust core's JSON
+                // parse and degrade to "no tag constraint".
+                AgentSpec.DependencySpec dep = spec.getTools().stream()
+                    .filter(t -> "__mesh_depends_on_deps".equals(t.getCapability()))
+                    .flatMap(t -> t.getDependencies().stream())
+                    .filter(d -> "test_cap".equals(d.getCapability()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError(
+                        "test_cap dependency missing from __mesh_depends_on_deps tool"));
+                assertThat(dep.getTags())
+                    .as("empty tags must serialise as the JSON-array default '[]'")
+                    .isEqualTo("[]");
             });
     }
 
@@ -636,11 +650,13 @@ class MeshDependsOnIntegrationTest {
                     .isEqualTo("subset");
                 // Nit1: tags/version on the annotation must propagate into the
                 // synthetic dependency spec — same serialisation as the
-                // @MeshRoute / @MeshA2A paths (comma-joined tag list, version
-                // string copied through verbatim).
+                // @MeshRoute / @MeshA2A paths (JSON-array string, version
+                // string copied through verbatim). Issue #1158: the Rust core
+                // JSON-parses this field; comma-joined strings silently
+                // degrade to "no tag constraint".
                 assertThat(dep.getTags())
-                    .as("tags from @MeshDependency must serialise as comma-joined string")
-                    .isEqualTo("v2,beta");
+                    .as("tags from @MeshDependency must serialise as a JSON-array string")
+                    .isEqualTo("[\"v2\",\"beta\"]");
                 assertThat(dep.getVersion())
                     .as("version constraint must propagate verbatim")
                     .isEqualTo(">=1.0");


### PR DESCRIPTION
## Summary
- Serialize dependency tags as a JSON-array string in the three Java registration paths that comma-joined them: `MeshRouteRegistry`, `MeshA2ARegistry`, and the `@MeshDependsOn` path in `MeshAutoConfiguration` — mirroring the existing `MeshToolRegistry` pattern.
- The Rust core JSON-parses `DependencySpec.tags` and degrades to `[]` (no constraint) on parse failure, so the comma-joined form silently dropped all tag constraints (`+tag` smart selection, tag isolation) for these dependency sources.
- Updated `MeshDependsOnIntegrationTest` to assert the JSON-array form (it previously codified the broken format) and added a regression assertion that tag-less dependencies keep the `"[]"` default.
- Added a `log.warn` to all four tag-serialization fallback paths (including the pre-existing one in `MeshToolRegistry`) so a serialization failure can no longer silently register a dependency with no tag constraint.

## Review Notes
- Independent review: 0 blockers. Its one warning (silent `"[]"` fallback) is addressed by the warn logs; remaining infos (per-call `JsonMapper` construction, duplicated try/catch block across 4 sites) follow existing precedent and are left for a future cleanup.
- Reviewer verified the JSON-array contract against the Python (`json.dumps`) and TypeScript (`JSON.stringify`) runtimes, and that no comma-join sites remain in the Java runtime.
- Follow-up candidate (out of scope): same silent-fallback shape on the tool's own tags in the LLM-provider path at `MeshToolRegistry.java:~324`.

Closes #1158

## Test plan
- [x] `mvn -pl mcp-mesh-spring-boot-starter -am test` — 371 tests, 0 failures
- [x] `MeshDependsOnIntegrationTest` asserts `["v2","beta"]` JSON form and `"[]"` default for tag-less deps
- [ ] Integration suites (`tests/integration`) on the next `tsuite-mesh:local` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected dependency tag serialization format to proper JSON-array standard across runtime configurations.
  * Enhanced error handling and logging for tag serialization failures.

* **Tests**
  * Updated integration tests to validate corrected tag serialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->