### PR TITLE
fix(registry): enforce MeshJob lease expiry with delta-driven renewal

### DIFF
--- a/src/core/registry/ent_handlers_jobs.go
+++ b/src/core/registry/ent_handlers_jobs.go
@@ -29,9 +29,10 @@ import (
 
 // cancelForwardTimeout is the wall-clock cap on the registry → owner
 // HTTP forward in CancelJob. Short on purpose: if the owner doesn't ack
-// quickly we proceed to mark the row cancelled regardless. The
-// heartbeat/lease + sweep loop guarantees correctness even when the
-// forward is dropped.
+// quickly we proceed to mark the row cancelled regardless. The row is
+// already terminal at that point, so a dropped forward only means the
+// owner keeps executing until its next /jobs/batch delta is rejected
+// as already_terminal — registry-side state stays correct either way.
 const cancelForwardTimeout = 5 * time.Second
 
 // cancelEventGraceDefault is the wall-clock pause between posting the
@@ -311,6 +312,10 @@ func (h *EntBusinessLogicHandlers) GetJob(c *gin.Context, jobId string) {
 // Accepts a coalesced batch of per-job deltas from a single producer
 // instance. Each delta is applied independently — partial success is the
 // spec; rejections are surfaced per-id with a stable reason code.
+//
+// Every accepted non-terminal delta extends the job's lease (see
+// ApplyJobDeltas), so this endpoint doubles as the producer's heartbeat
+// against the expired-lease sweep.
 func (h *EntBusinessLogicHandlers) SubmitJobBatch(c *gin.Context) {
 	var req generated.JobBatchRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -391,6 +396,14 @@ func (h *EntBusinessLogicHandlers) SubmitJobBatch(c *gin.Context) {
 // Single-claim per round-trip (see Resolved Decisions). Race-free across
 // concurrent claimers via guarded UPDATE inside the service layer; "no
 // work available" is a 200 with claimed=[] (not an error).
+//
+// Honesty note on re-claims after a lease reclaim: claiming a job whose
+// previous lease expired does NOT fence out the previous execution. If the
+// same instance re-claims (the only possibility in a single-replica
+// deployment), deltas from the original still-running handler pass the
+// owner check and are accepted alongside the new execution's. State stays
+// consistent — the first terminal delta wins — but the handler may run
+// twice concurrently. See ReclaimExpiredLeaseJobs.
 func (h *EntBusinessLogicHandlers) ClaimJobs(c *gin.Context) {
 	var req generated.ClaimJobsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -531,7 +544,8 @@ func (h *EntBusinessLogicHandlers) ReleaseJob(c *gin.Context, jobId string) {
 // Three scenarios per the design:
 //   - Owned (alive): registry forwards cancel to the owner replica's HTTP
 //     endpoint, then marks the row cancelled regardless of forward outcome
-//     (best-effort forward; lease/sweep guarantees eventual correctness).
+//     (best-effort forward; the row is terminal regardless, so registry
+//     state is correct even when the forward is dropped).
 //   - Unowned (orphan / pre-claim): registry directly marks cancelled.
 //   - Already terminal: 409 Conflict.
 //
@@ -635,8 +649,10 @@ func (h *EntBusinessLogicHandlers) CancelJob(c *gin.Context, jobId string) {
 	}
 
 	// Best-effort owner notification. Errors are logged but never affect
-	// the response — the registry row is the source of truth, and the
-	// owner's lease will time out even if the forward never lands.
+	// the response — the registry row is the source of truth (already
+	// terminal=cancelled), so a missed forward only means the owner keeps
+	// working until its next /jobs/batch delta is rejected as
+	// already_terminal.
 	resp := generated.CancelJobResponse{
 		Status:                generated.JobStatus(string(updated.Status)),
 		ForwardedToInstanceId: prevOwner,
@@ -649,8 +665,9 @@ func (h *EntBusinessLogicHandlers) CancelJob(c *gin.Context, jobId string) {
 
 // forwardCancelToOwner POSTs the cancel to the owner agent's HTTP endpoint
 // best-effort. Any failure (agent unknown, unreachable, non-2xx) is logged
-// and swallowed: the registry row already shows status=cancelled, and the
-// owner's lease will expire if the message is missed.
+// and swallowed: the registry row already shows status=cancelled, and a
+// missed forward only delays the owner noticing via its next rejected
+// /jobs/batch delta.
 //
 // Scheme handling: when the agent registered an entity_id (i.e. presented
 // a TLS client cert at registration time) we dial https with the registry's

--- a/src/core/registry/ent_handlers_jobs_extended_test.go
+++ b/src/core/registry/ent_handlers_jobs_extended_test.go
@@ -217,6 +217,105 @@ func TestSubmitJobBatch_RejectsAlreadyTerminal(t *testing.T) {
 	assert.Equal(t, JobDeltaRejectionAlreadyTerminal, br.Rejected[0].Reason)
 }
 
+// TestSubmitJobBatch_AcceptedDeltaExtendsLease pins the lease-extension
+// contract on the batch endpoint: every accepted non-terminal delta moves
+// lease_expires_at forward to now + the job's lease window (max_duration
+// when set, else the 300s claim default), while rejected and terminal
+// deltas leave the lease alone.
+func TestSubmitJobBatch_AcceptedDeltaExtendsLease(t *testing.T) {
+	srv, service, cleanup := newJobsEndpointTestEnvWithService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	owner := "producer-a"
+	jobDefault := seedJob(t, service, "job-lease-default", "render", &owner)
+	jobCustom := seedJob(t, service, "job-lease-custom", "render", &owner, withMaxDuration(600))
+
+	// Seed near-expiry leases so "moved forward" is unambiguous.
+	soon := time.Now().UTC().Add(10 * time.Second)
+	for _, id := range []string{jobDefault.ID, jobCustom.ID} {
+		_, err := service.entDB.Job.UpdateOneID(id).SetLeaseExpiresAt(soon).Save(ctx)
+		require.NoError(t, err)
+	}
+
+	progress := float32(0.5)
+	body, _ := json.Marshal(generated.JobBatchRequest{
+		InstanceId: owner,
+		Deltas: []generated.JobDelta{
+			{Id: jobDefault.ID, Progress: &progress},
+			{Id: jobCustom.ID, Progress: &progress},
+		},
+	})
+	resp, err := http.Post(srv.URL+"/jobs/batch", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var br generated.JobBatchResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&br))
+	require.Equal(t, 2, br.Accepted)
+	require.Empty(t, br.Rejected)
+
+	// Default window: extension lands ~300s out — comfortably past the
+	// seeded near-expiry lease (loose lower bound to avoid flakes).
+	d, err := service.GetJob(ctx, jobDefault.ID)
+	require.NoError(t, err)
+	require.NotNil(t, d.LeaseExpiresAt, "accepted delta must extend the lease")
+	assert.True(t, d.LeaseExpiresAt.After(soon.Add(4*time.Minute)),
+		"default-window lease should be ~300s out, got %v (seeded %v)", d.LeaseExpiresAt, soon)
+
+	// max_duration window: extension must use the job's 600s window, not
+	// the 300s default — same derivation as the claim-time lease.
+	cJob, err := service.GetJob(ctx, jobCustom.ID)
+	require.NoError(t, err)
+	require.NotNil(t, cJob.LeaseExpiresAt)
+	assert.True(t, cJob.LeaseExpiresAt.After(soon.Add(8*time.Minute)),
+		"max_duration lease should be ~600s out, got %v (seeded %v)", cJob.LeaseExpiresAt, soon)
+	assert.True(t, cJob.LeaseExpiresAt.After(*d.LeaseExpiresAt),
+		"max_duration window must beat the default window")
+
+	// Rejected (not_owner) delta must NOT touch the lease.
+	leaseBefore := *d.LeaseExpiresAt
+	body2, _ := json.Marshal(generated.JobBatchRequest{
+		InstanceId: "producer-b",
+		Deltas:     []generated.JobDelta{{Id: jobDefault.ID, Progress: &progress}},
+	})
+	resp2, err := http.Post(srv.URL+"/jobs/batch", "application/json", bytes.NewReader(body2))
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	var br2 generated.JobBatchResponse
+	require.NoError(t, json.NewDecoder(resp2.Body).Decode(&br2))
+	require.Equal(t, 0, br2.Accepted)
+
+	d2, err := service.GetJob(ctx, jobDefault.ID)
+	require.NoError(t, err)
+	require.NotNil(t, d2.LeaseExpiresAt)
+	assert.Equal(t, leaseBefore.Unix(), d2.LeaseExpiresAt.Unix(),
+		"rejected delta must not extend the lease")
+
+	// Terminal delta is accepted but skips the extension — the sweep
+	// never reclaims terminal rows, so the lease is dead weight.
+	customLeaseBefore := *cJob.LeaseExpiresAt
+	completed := generated.JobStatus("completed")
+	body3, _ := json.Marshal(generated.JobBatchRequest{
+		InstanceId: owner,
+		Deltas:     []generated.JobDelta{{Id: jobCustom.ID, Status: &completed}},
+	})
+	resp3, err := http.Post(srv.URL+"/jobs/batch", "application/json", bytes.NewReader(body3))
+	require.NoError(t, err)
+	defer resp3.Body.Close()
+	var br3 generated.JobBatchResponse
+	require.NoError(t, json.NewDecoder(resp3.Body).Decode(&br3))
+	require.Equal(t, 1, br3.Accepted)
+
+	c3, err := service.GetJob(ctx, jobCustom.ID)
+	require.NoError(t, err)
+	assert.Equal(t, job.StatusCompleted, c3.Status)
+	require.NotNil(t, c3.LeaseExpiresAt)
+	assert.Equal(t, customLeaseBefore.Unix(), c3.LeaseExpiresAt.Unix(),
+		"terminal delta must not extend the lease")
+}
+
 func TestSubmitJobBatch_ValidationErrors(t *testing.T) {
 	srv, _, cleanup := newJobsEndpointTestEnvWithService(t)
 	defer cleanup()

--- a/src/core/registry/ent_service_jobs.go
+++ b/src/core/registry/ent_service_jobs.go
@@ -20,6 +20,7 @@ import (
 	"mcp-mesh/src/core/ent/capability"
 	"mcp-mesh/src/core/ent/job"
 	"mcp-mesh/src/core/ent/jobevent"
+	"mcp-mesh/src/core/ent/predicate"
 	"mcp-mesh/src/core/registry/generated"
 )
 
@@ -41,6 +42,18 @@ const defaultClaimLeaseSeconds = 300
 // most one row is claimed per round-trip — long contention loops would
 // indicate a runaway and should fail fast rather than spin.
 const claimMaxAttempts = 8
+
+// leaseWindowFor returns the lease window for a job: `max_duration` when
+// set and positive, else the 300s claim default. Shared by ClaimNextJob
+// (initial lease at claim time) and ApplyJobDeltas (extension on each
+// accepted delta) so the two derivations cannot drift.
+func leaseWindowFor(j *ent.Job) time.Duration {
+	secs := defaultClaimLeaseSeconds
+	if j.MaxDuration != nil && *j.MaxDuration > 0 {
+		secs = *j.MaxDuration
+	}
+	return time.Duration(secs) * time.Second
+}
 
 // CreateJob persists a new job row. Caller is responsible for generating
 // the ID (UUID) and applying defaults; this method does the mechanical
@@ -260,9 +273,21 @@ const (
 // spec (see MESHJOB_DESIGN.org > "Producer-side flow" Tick step). Returns
 // the number of accepted deltas plus a per-delta rejection list.
 //
-// Lease semantics: any accepted delta refreshes `last_heartbeat_at` (the
-// batch itself counts as a lease extension), matching the design's
-// "POST /jobs/batch → progress + heartbeat (lease extension)" comment.
+// Lease semantics: any accepted non-terminal delta refreshes
+// `last_heartbeat_at` AND extends `lease_expires_at` to now + the job's
+// lease window (max_duration when set, else the 300s claim default — see
+// leaseWindowFor), implementing the design's "POST /jobs/batch → progress
+// + heartbeat (lease extension)" comment. A handler that keeps posting
+// deltas is therefore never reclaimed by the expired-lease sweep, no
+// matter how long it runs. Terminal deltas skip the extension (the sweep
+// ignores terminal rows). Rejected deltas (not_owner / already_terminal /
+// invalid_status / not_found) never touch the lease.
+//
+// NOTE: the SDKs do NOT auto-heartbeat while a handler runs — the
+// runtime's batching tick only flushes deltas the handler actually posted
+// (see src/runtime/core/src/jobs.rs flush_once, which early-returns on an
+// empty queue). A handler that stays silent past its lease window relies
+// entirely on max_duration being sized to its real runtime.
 func (s *EntService) ApplyJobDeltas(ctx context.Context, instanceID string, deltas []JobDeltaInput) (int, []JobDeltaRejection, error) {
 	if instanceID == "" {
 		return 0, nil, fmt.Errorf("ApplyJobDeltas: instance_id is required")
@@ -305,7 +330,26 @@ func (s *EntService) ApplyJobDeltas(ctx context.Context, instanceID string, delt
 			newStatus = &st
 		}
 
-		upd := s.entDB.Job.UpdateOneID(d.ID).SetLastHeartbeatAt(now)
+		// Guarded write: the owner/terminal checks above ran on an
+		// unguarded read, so re-assert both in the UPDATE's WHERE clause.
+		// If the row changed in between (sweep reclaim cleared the owner,
+		// a peer re-claimed, or a concurrent cancel made it terminal) the
+		// predicate fails with Affected=0 and the delta is rejected —
+		// crucially, without extending a lease this instance no longer
+		// holds.
+		upd := s.entDB.Job.Update().
+			Where(
+				job.IDEQ(d.ID),
+				job.OwnerInstanceIDEQ(instanceID),
+				job.StatusNotIn(job.StatusCompleted, job.StatusFailed, job.StatusCancelled),
+			).
+			SetLastHeartbeatAt(now)
+		if newStatus == nil || !isTerminalStatus(*newStatus) {
+			// The accepted delta doubles as a lease extension (see the
+			// doc comment). Terminal transitions skip it — the sweep
+			// never reclaims terminal rows, so the lease is dead weight.
+			upd = upd.SetLeaseExpiresAt(now.Add(leaseWindowFor(j)))
+		}
 		if d.Progress != nil {
 			upd = upd.SetProgress(*d.Progress)
 		}
@@ -325,8 +369,33 @@ func (s *EntService) ApplyJobDeltas(ctx context.Context, instanceID string, delt
 			}
 		}
 
-		if _, err := upd.Save(ctx); err != nil {
+		affected, err := upd.Save(ctx)
+		if err != nil {
 			return accepted, rejections, fmt.Errorf("update job %s: %w", d.ID, err)
+		}
+		if affected == 0 {
+			// Lost a race between the read and the guarded write. Re-read
+			// once to classify: still ours but now terminal → terminal
+			// rejection; row deleted in between → not_found; anything
+			// else → not_owner.
+			reason := JobDeltaRejectionNotOwner
+			cur, rerr := s.entDB.Job.Query().Where(job.IDEQ(d.ID)).Only(ctx)
+			switch {
+			case rerr == nil:
+				if cur.OwnerInstanceID != nil && *cur.OwnerInstanceID == instanceID &&
+					isTerminalStatus(cur.Status) {
+					reason = JobDeltaRejectionAlreadyTerminal
+				}
+			case ent.IsNotFound(rerr):
+				reason = JobDeltaRejectionNotFound
+			default:
+				// Transient error on the classifying re-read — keep the
+				// conservative not_owner rejection rather than failing the
+				// whole batch, but surface the error.
+				s.logger.Warning("ApplyJobDeltas: classify re-read for job %s failed, rejecting as %s: %v", d.ID, reason, rerr)
+			}
+			rejections = append(rejections, JobDeltaRejection{ID: d.ID, Reason: reason})
+			continue
 		}
 		accepted++
 	}
@@ -401,11 +470,7 @@ func (s *EntService) ClaimNextJob(ctx context.Context, capability, instanceID st
 			return nil, nil
 		}
 
-		leaseSeconds := defaultClaimLeaseSeconds
-		if candidate.MaxDuration != nil && *candidate.MaxDuration > 0 {
-			leaseSeconds = *candidate.MaxDuration
-		}
-		leaseExpires := now.Add(time.Duration(leaseSeconds) * time.Second)
+		leaseExpires := now.Add(leaseWindowFor(candidate))
 
 		// Guarded update: only succeed if owner is still NULL. Concurrent
 		// claimers race here; exactly one wins, the rest see Affected=0.
@@ -829,6 +894,120 @@ func (s *EntService) ResetOrphanedJobs(ctx context.Context) (reset, exhausted in
 			return reset, exhausted, fmt.Errorf("reset orphan job %s: %w", j.ID, uerr)
 		}
 		reset++
+	}
+	return reset, exhausted, nil
+}
+
+// ReclaimExpiredLeaseJobs handles the lease-expiry phase of the registry
+// sweep. It catches the failure mode the orphan reroute can't: an owner
+// whose agent row keeps heartbeating (status=healthy) but whose handler is
+// wedged and never completes the job. Without this phase such a job would
+// stay status=working forever.
+//
+// What keeps a healthy job's lease alive: every accepted non-terminal
+// /jobs/batch delta extends lease_expires_at by the job's lease window
+// (see ApplyJobDeltas / leaseWindowFor), so a handler posting progress is
+// never reclaimed regardless of runtime. The SDKs do NOT auto-heartbeat
+// during handler execution, however — the runtime batching tick only
+// flushes deltas the handler actually posted. Producers whose handlers can
+// run silently (no progress posts) past the 300s default MUST set
+// max_duration sized to the real runtime; otherwise this phase reclaims
+// the still-running job, and its eventual completion delta is rejected
+// not_owner.
+//
+// For every working job whose lease_expires_at has passed, the job is
+// either:
+//
+//   - reset to claimable (owner=NULL, lease cleared, last_heartbeat_at
+//     cleared) when attempt_count <= max_retries — identical field-reset
+//     semantics to ResetOrphanedJobs so expired-lease and orphan reroutes
+//     behave the same. attempt_count is NOT incremented here; the claim
+//     itself counts as the attempt (see ClaimNextJob's AddAttemptCount(1)).
+//
+//   - marked failed (status=failed, error="lease expired: no completion
+//     within lease window") when attempt_count > max_retries — mirrors the
+//     orphan-sweep budget-exhaustion path.
+//
+// Jobs with a NULL lease_expires_at (legacy rows / unclaimed jobs) are
+// never touched — the candidate predicate requires a non-NULL, expired
+// lease.
+//
+// Race-safety vs. a legitimate in-flight completion: candidates are
+// scanned outside any transaction, then each row is mutated via a guarded
+// UPDATE (same discipline as ClaimNextJob) conditional on the row still
+// being status=working with the SAME expired lease we observed. If the
+// owner completed/failed the job in between (status changed), released it
+// (lease cleared), or it was re-claimed with a fresh lease, the guard
+// predicate fails, Affected=0, and we skip the row without counting it.
+//
+// What this phase does NOT provide: execution fencing. After a reclaim the
+// original handler may still be running. When the job is re-claimed — in a
+// single-replica deployment necessarily by the SAME owner_instance_id —
+// deltas from BOTH the original and the new execution pass the owner check
+// and are accepted interleaved. Registry state stays consistent (the first
+// terminal delta wins; later ones are rejected already_terminal) but the
+// handler itself runs twice concurrently, which matters for non-idempotent
+// work. Reclaim is a liveness mechanism, not a mutual-exclusion one.
+func (s *EntService) ReclaimExpiredLeaseJobs(ctx context.Context) (reset, exhausted int, err error) {
+	now := time.Now().UTC()
+
+	candidates, err := s.entDB.Client.Job.Query().
+		Where(
+			job.StatusEQ(job.StatusWorking),
+			job.LeaseExpiresAtNotNil(),
+			job.LeaseExpiresAtLT(now),
+		).
+		All(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("query expired-lease candidates: %w", err)
+	}
+	if len(candidates) == 0 {
+		return 0, 0, nil
+	}
+
+	for _, j := range candidates {
+		if j.LeaseExpiresAt == nil {
+			continue // defensive; predicate already excludes NULL leases
+		}
+
+		// Guard predicate shared by both branches: the row must still be
+		// working AND still carry the exact expired lease we observed.
+		guard := []predicate.Job{
+			job.IDEQ(j.ID),
+			job.StatusEQ(job.StatusWorking),
+			job.LeaseExpiresAtEQ(*j.LeaseExpiresAt),
+		}
+
+		if j.AttemptCount > j.MaxRetries {
+			affected, uerr := s.entDB.Client.Job.Update().
+				Where(guard...).
+				SetStatus(job.StatusFailed).
+				SetError("lease expired: no completion within lease window").
+				ClearLeaseExpiresAt().
+				ClearOwnerInstanceID().
+				SetLastHeartbeatAt(now).
+				Save(ctx)
+			if uerr != nil {
+				return reset, exhausted, fmt.Errorf("mark lease-expired job %s failed: %w", j.ID, uerr)
+			}
+			if affected > 0 {
+				exhausted++
+			}
+			continue
+		}
+
+		affected, uerr := s.entDB.Client.Job.Update().
+			Where(guard...).
+			ClearOwnerInstanceID().
+			ClearLeaseExpiresAt().
+			ClearLastHeartbeatAt().
+			Save(ctx)
+		if uerr != nil {
+			return reset, exhausted, fmt.Errorf("reset lease-expired job %s: %w", j.ID, uerr)
+		}
+		if affected > 0 {
+			reset++
+		}
 	}
 	return reset, exhausted, nil
 }

--- a/src/core/registry/sweep.go
+++ b/src/core/registry/sweep.go
@@ -240,6 +240,8 @@ type sweepResult struct {
 	schemasPurged    int
 	jobsReset        int // orphan jobs returned to the pool for re-claim
 	jobsExhausted    int // orphan jobs that ran out of retries (status=failed)
+	jobsLeaseReset   int // expired-lease jobs returned to the pool for re-claim
+	jobsLeaseFailed  int // expired-lease jobs that ran out of retries (status=failed)
 	jobsDeadlined    int // total_deadline-exceeded jobs (status=failed)
 	jobEventsPurged  int // JobEvent rows GC'd for terminal jobs past retention
 }
@@ -260,12 +262,14 @@ func (s *SweepJob) tick(ctx context.Context) {
 
 	if s.logger != nil {
 		anyWork := res.agentsPurged > 0 || res.eventsPurged > 0 || res.schemasPurged > 0 ||
-			res.jobsReset > 0 || res.jobsExhausted > 0 || res.jobsDeadlined > 0 ||
+			res.jobsReset > 0 || res.jobsExhausted > 0 ||
+			res.jobsLeaseReset > 0 || res.jobsLeaseFailed > 0 || res.jobsDeadlined > 0 ||
 			res.jobEventsPurged > 0
 		if anyWork {
-			s.logger.Info("sweep: purged %d agents, %d events, %d orphan schemas; jobs: %d reset, %d exhausted, %d deadlined, %d job_events purged (took %s)",
+			s.logger.Info("sweep: purged %d agents, %d events, %d orphan schemas; jobs: %d reset, %d exhausted, %d lease-reset, %d lease-failed, %d deadlined, %d job_events purged (took %s)",
 				res.agentsPurged, res.eventsPurged, res.schemasPurged,
-				res.jobsReset, res.jobsExhausted, res.jobsDeadlined, res.jobEventsPurged, took)
+				res.jobsReset, res.jobsExhausted, res.jobsLeaseReset, res.jobsLeaseFailed,
+				res.jobsDeadlined, res.jobEventsPurged, took)
 		} else {
 			s.logger.Debug("sweep: nothing to purge (took %s)", took)
 		}
@@ -280,9 +284,12 @@ func (s *SweepJob) tick(ctx context.Context) {
 //  1. Stale-agent purge (existing #837 behaviour).
 //  2. Orphan-job reroute — runs after agent purge so jobs whose owner was
 //     just deleted in step 1 are picked up in the same tick.
-//  3. Total-deadline expiry — independent of agent liveness.
-//  4. Event cap enforcement.
-//  5. Orphan schema_entry purge.
+//  3. Expired-lease reclaim — runs after the orphan reroute (which clears
+//     the lease on the rows it resets) so only leases held by a still-live
+//     owner are considered.
+//  4. Total-deadline expiry — independent of agent liveness.
+//  5. Event cap enforcement.
+//  6. Orphan schema_entry purge.
 func (s *SweepJob) runOnce(ctx context.Context) (sweepResult, error) {
 	var res sweepResult
 	now := s.clock()
@@ -311,6 +318,22 @@ func (s *SweepJob) runOnce(ctx context.Context) (sweepResult, error) {
 		res.jobsExhausted = exhausted
 		if err != nil {
 			return res, fmt.Errorf("reset orphaned jobs: %w", err)
+		}
+
+		// Expired-lease reclaim — catches the case the orphan reroute
+		// can't: an owner whose agent row keeps heartbeating (healthy)
+		// but whose handler is wedged and never completes the job.
+		// Accepted /jobs/batch deltas extend the lease, so only jobs
+		// with no accepted delta inside the lease window are reclaimed
+		// — producers must post progress within the window or size
+		// max_duration to the handler's real runtime (the SDKs do not
+		// auto-heartbeat during execution). NULL leases (legacy /
+		// unclaimed rows) are never touched.
+		leaseReset, leaseFailed, err := s.service.ReclaimExpiredLeaseJobs(ctx)
+		res.jobsLeaseReset = leaseReset
+		res.jobsLeaseFailed = leaseFailed
+		if err != nil {
+			return res, fmt.Errorf("reclaim expired-lease jobs: %w", err)
 		}
 
 		// total_deadline expiry is opt-in (column is NULL by default per

--- a/src/core/registry/sweep_jobs_test.go
+++ b/src/core/registry/sweep_jobs_test.go
@@ -1,9 +1,9 @@
 package registry
 
 // Tests for the job-related sweep extensions wired in alongside the #837
-// stale-agent sweep machinery: orphan-job reroute and total_deadline
-// expiry. Reuses newSweepTestEnv from sweep_test.go for the same
-// in-memory Ent + mock-clock setup.
+// stale-agent sweep machinery: orphan-job reroute, expired-lease reclaim,
+// and total_deadline expiry. Reuses newSweepTestEnv from sweep_test.go
+// for the same in-memory Ent + mock-clock setup.
 
 import (
 	"context"
@@ -279,6 +279,366 @@ func TestSweep_ResetOrphanedJobs_ReleasesUnknownOwnerPinnedJob(t *testing.T) {
 	}
 	if got.OwnerInstanceID != nil {
 		t.Errorf("expected owner cleared, got %v", *got.OwnerInstanceID)
+	}
+}
+
+// TestSweep_ReclaimExpiredLeaseJobs_ResetsRetryable verifies that a
+// working job whose CURRENT lease has genuinely expired — no accepted
+// delta inside the lease window (any accepted delta would have extended
+// the lease via ApplyJobDeltas), owner agent still healthy and
+// heartbeating (so the orphan reroute does NOT act) — is reset to
+// claimable with the exact same field semantics as the orphan reset:
+// owner cleared, lease cleared, last_heartbeat_at cleared, attempt_count
+// untouched.
+//
+// Lease times are seeded relative to real time.Now() because
+// ReclaimExpiredLeaseJobs (like ExpireDeadlinedJobs) compares against
+// time.Now().UTC() internally, not the injected sweep clock.
+func TestSweep_ReclaimExpiredLeaseJobs_ResetsRetryable(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Healthy, recently-updated owner — neither purgeStaleAgents nor the
+	// orphan reroute will touch this job; only the lease phase can.
+	seedAgent(t, client, "wedged-owner", agent.StatusHealthy, now)
+	owner := "wedged-owner"
+	j := seedJobRow(t, client, "job-lease-retry", "render", &owner, job.StatusWorking, 1, 3, now.Add(-10*time.Minute))
+
+	// Expired lease, UTC-pinned to match the production comparison path.
+	// last_heartbeat_at is OLDER than the lease — the only state an
+	// expired lease can legitimately coexist with, since every accepted
+	// delta now refreshes heartbeat AND lease together. A silent wedged
+	// handler produces exactly this row.
+	if _, err := client.Job.UpdateOneID(j.ID).
+		SetLeaseExpiresAt(time.Now().UTC().Add(-5 * time.Minute)).
+		SetLastHeartbeatAt(time.Now().UTC().Add(-10 * time.Minute)).
+		Save(ctx); err != nil {
+		t.Fatalf("seed lease: %v", err)
+	}
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsReset != 0 || res.jobsExhausted != 0 {
+		t.Fatalf("setup: expected orphan phase to skip live owner, got reset=%d exhausted=%d", res.jobsReset, res.jobsExhausted)
+	}
+	if res.jobsLeaseReset != 1 {
+		t.Errorf("expected 1 lease-expired job reset, got %d", res.jobsLeaseReset)
+	}
+	if res.jobsLeaseFailed != 0 {
+		t.Errorf("expected 0 lease-expired jobs failed, got %d", res.jobsLeaseFailed)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusWorking {
+		t.Errorf("expected status=working (claimable) after lease reclaim, got %s", got.Status)
+	}
+	if got.OwnerInstanceID != nil {
+		t.Errorf("expected owner cleared, got %v", *got.OwnerInstanceID)
+	}
+	if got.LeaseExpiresAt != nil {
+		t.Errorf("expected lease cleared, got %v", got.LeaseExpiresAt)
+	}
+	if got.LastHeartbeatAt != nil {
+		t.Errorf("expected last_heartbeat_at cleared, got %v", got.LastHeartbeatAt)
+	}
+	// attempt_count must NOT be incremented here — claim path increments
+	// when the next replica picks the job up. Mirrors the orphan reset.
+	if got.AttemptCount != 1 {
+		t.Errorf("expected attempt_count unchanged at 1 (claim increments, not lease reclaim), got %d", got.AttemptCount)
+	}
+}
+
+// TestSweep_ReclaimExpiredLeaseJobs_MarksExhausted verifies that an
+// expired-lease job whose attempt_count has exceeded max_retries is
+// moved to status=failed with the lease-expired error rather than being
+// recycled.
+func TestSweep_ReclaimExpiredLeaseJobs_MarksExhausted(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "wedged-owner-2", agent.StatusHealthy, now)
+	owner := "wedged-owner-2"
+	// attempt_count=4, max_retries=3 → strictly exceeded → exhausted.
+	j := seedJobRow(t, client, "job-lease-exhausted", "render", &owner, job.StatusWorking, 4, 3, now.Add(-10*time.Minute))
+
+	if _, err := client.Job.UpdateOneID(j.ID).
+		SetLeaseExpiresAt(time.Now().UTC().Add(-5 * time.Minute)).
+		Save(ctx); err != nil {
+		t.Fatalf("seed lease: %v", err)
+	}
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsLeaseReset != 0 {
+		t.Errorf("expected 0 lease-expired jobs reset, got %d", res.jobsLeaseReset)
+	}
+	if res.jobsLeaseFailed != 1 {
+		t.Errorf("expected 1 lease-expired job failed, got %d", res.jobsLeaseFailed)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusFailed {
+		t.Errorf("expected status=failed, got %s", got.Status)
+	}
+	if got.Error == nil || *got.Error != "lease expired: no completion within lease window" {
+		t.Errorf("expected error 'lease expired: no completion within lease window', got %v", got.Error)
+	}
+	if got.OwnerInstanceID != nil {
+		t.Errorf("expected owner cleared on exhausted, got %v", *got.OwnerInstanceID)
+	}
+	if got.LeaseExpiresAt != nil {
+		t.Errorf("expected lease cleared on exhausted, got %v", got.LeaseExpiresAt)
+	}
+}
+
+// TestSweep_ReclaimExpiredLeaseJobs_UnexpiredLeaseUntouched verifies
+// that a working job whose lease is still in the future is NOT touched
+// by the lease phase — healthy in-flight jobs see no behavior change.
+func TestSweep_ReclaimExpiredLeaseJobs_UnexpiredLeaseUntouched(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "inflight-owner", agent.StatusHealthy, now)
+	owner := "inflight-owner"
+	j := seedJobRow(t, client, "job-lease-live", "render", &owner, job.StatusWorking, 1, 3, now.Add(-1*time.Minute))
+
+	if _, err := client.Job.UpdateOneID(j.ID).
+		SetLeaseExpiresAt(time.Now().UTC().Add(10 * time.Minute)).
+		Save(ctx); err != nil {
+		t.Fatalf("seed lease: %v", err)
+	}
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsLeaseReset != 0 || res.jobsLeaseFailed != 0 {
+		t.Errorf("expected no lease action for unexpired lease, got reset=%d failed=%d", res.jobsLeaseReset, res.jobsLeaseFailed)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusWorking {
+		t.Errorf("expected status=working preserved, got %s", got.Status)
+	}
+	if got.OwnerInstanceID == nil || *got.OwnerInstanceID != owner {
+		t.Errorf("expected owner preserved, got %v", got.OwnerInstanceID)
+	}
+	if got.LeaseExpiresAt == nil {
+		t.Errorf("expected lease preserved, got nil")
+	}
+}
+
+// TestSweep_ReclaimExpiredLeaseJobs_NullLeaseUntouched verifies that a
+// working job with a NULL lease_expires_at (legacy rows, or rows pinned
+// at create time that were never claimed) is never touched by the lease
+// phase.
+func TestSweep_ReclaimExpiredLeaseJobs_NullLeaseUntouched(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "null-lease-owner", agent.StatusHealthy, now)
+	owner := "null-lease-owner"
+	// No lease set at all — seedJobRow leaves lease_expires_at NULL.
+	j := seedJobRow(t, client, "job-lease-null", "render", &owner, job.StatusWorking, 1, 3, now.Add(-10*time.Minute))
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsLeaseReset != 0 || res.jobsLeaseFailed != 0 {
+		t.Errorf("expected no lease action for NULL lease, got reset=%d failed=%d", res.jobsLeaseReset, res.jobsLeaseFailed)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusWorking {
+		t.Errorf("expected status=working preserved, got %s", got.Status)
+	}
+	if got.OwnerInstanceID == nil || *got.OwnerInstanceID != owner {
+		t.Errorf("expected owner preserved, got %v", got.OwnerInstanceID)
+	}
+}
+
+// TestSweep_ReclaimExpiredLeaseJobs_DeltaExtendedLeaseUntouched verifies
+// the lease-extension contract end to end: a job whose claim-time lease
+// has lapsed but whose owner posted an accepted /jobs/batch delta is NOT
+// reclaimed — ApplyJobDeltas extended lease_expires_at, so the sweep sees
+// a fresh lease and skips the row. Without the extension this job would
+// be reclaimed mid-execution and its eventual completion rejected
+// not_owner.
+func TestSweep_ReclaimExpiredLeaseJobs_DeltaExtendedLeaseUntouched(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, service, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "chatty-owner", agent.StatusHealthy, now)
+	owner := "chatty-owner"
+	j := seedJobRow(t, client, "job-lease-extended", "render", &owner, job.StatusWorking, 1, 3, now.Add(-10*time.Minute))
+
+	// Claim-time lease already lapsed — without the delta below the sweep
+	// would reclaim this row.
+	staleLease := time.Now().UTC().Add(-5 * time.Minute)
+	if _, err := client.Job.UpdateOneID(j.ID).
+		SetLeaseExpiresAt(staleLease).
+		Save(ctx); err != nil {
+		t.Fatalf("seed lease: %v", err)
+	}
+
+	// Owner posts a progress delta: the accepted delta must extend the
+	// lease (now + 300s default window — the job has no max_duration).
+	progress := 0.5
+	accepted, rejected, err := service.ApplyJobDeltas(ctx, owner, []JobDeltaInput{{ID: j.ID, Progress: &progress}})
+	if err != nil {
+		t.Fatalf("ApplyJobDeltas: %v", err)
+	}
+	if accepted != 1 || len(rejected) != 0 {
+		t.Fatalf("expected delta accepted, got accepted=%d rejected=%v", accepted, rejected)
+	}
+
+	mid, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job after delta: %v", err)
+	}
+	if mid.LeaseExpiresAt == nil {
+		t.Fatalf("expected lease extended by accepted delta, got nil")
+	}
+	if !mid.LeaseExpiresAt.After(time.Now().UTC()) {
+		t.Fatalf("expected lease extended into the future, got %v", mid.LeaseExpiresAt)
+	}
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsLeaseReset != 0 || res.jobsLeaseFailed != 0 {
+		t.Errorf("expected no lease action for delta-extended lease, got reset=%d failed=%d", res.jobsLeaseReset, res.jobsLeaseFailed)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusWorking {
+		t.Errorf("expected status=working preserved, got %s", got.Status)
+	}
+	if got.OwnerInstanceID == nil || *got.OwnerInstanceID != owner {
+		t.Errorf("expected owner preserved after extension, got %v", got.OwnerInstanceID)
+	}
+	if got.LeaseExpiresAt == nil {
+		t.Errorf("expected extended lease preserved, got nil")
+	}
+}
+
+// TestSweep_ReclaimExpiredLeaseJobs_InputRequiredResumeExtendsLease covers
+// the input_required round trip: a job pauses in input_required longer
+// than its lease window (the paused row is never touched — the lease
+// phase only targets status=working), then resumes via an accepted
+// status=working delta. The resume delta must extend the stale claim-time
+// lease so the freshly resumed job is not instantly reclaimed on the next
+// sweep tick.
+func TestSweep_ReclaimExpiredLeaseJobs_InputRequiredResumeExtendsLease(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, service, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "paused-owner", agent.StatusHealthy, now)
+	owner := "paused-owner"
+	j := seedJobRow(t, client, "job-input-required", "render", &owner, job.StatusInputRequired, 1, 3, now.Add(-30*time.Minute))
+
+	// Claim-time lease that lapsed while the job sat in input_required.
+	if _, err := client.Job.UpdateOneID(j.ID).
+		SetLeaseExpiresAt(time.Now().UTC().Add(-20 * time.Minute)).
+		Save(ctx); err != nil {
+		t.Fatalf("seed lease: %v", err)
+	}
+
+	// Tick 1: the paused job must NOT be reclaimed despite the expired
+	// lease — input_required is not status=working.
+	res1, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce (paused): %v", err)
+	}
+	if res1.jobsLeaseReset != 0 || res1.jobsLeaseFailed != 0 {
+		t.Fatalf("expected paused job untouched, got reset=%d failed=%d", res1.jobsLeaseReset, res1.jobsLeaseFailed)
+	}
+
+	// Resume: owner posts status=working. The accepted delta must extend
+	// the long-expired lease in the same write.
+	st := string(job.StatusWorking)
+	accepted, rejected, err := service.ApplyJobDeltas(ctx, owner, []JobDeltaInput{{ID: j.ID, Status: &st}})
+	if err != nil {
+		t.Fatalf("ApplyJobDeltas (resume): %v", err)
+	}
+	if accepted != 1 || len(rejected) != 0 {
+		t.Fatalf("expected resume delta accepted, got accepted=%d rejected=%v", accepted, rejected)
+	}
+
+	mid, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job after resume: %v", err)
+	}
+	if mid.Status != job.StatusWorking {
+		t.Fatalf("expected status=working after resume, got %s", mid.Status)
+	}
+	if mid.LeaseExpiresAt == nil || !mid.LeaseExpiresAt.After(time.Now().UTC()) {
+		t.Fatalf("expected resume delta to extend lease into the future, got %v", mid.LeaseExpiresAt)
+	}
+
+	// Tick 2: the resumed job carries a fresh lease — must be untouched.
+	res2, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce (resumed): %v", err)
+	}
+	if res2.jobsLeaseReset != 0 || res2.jobsLeaseFailed != 0 {
+		t.Errorf("expected resumed job untouched, got reset=%d failed=%d", res2.jobsLeaseReset, res2.jobsLeaseFailed)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusWorking {
+		t.Errorf("expected status=working preserved, got %s", got.Status)
+	}
+	if got.OwnerInstanceID == nil || *got.OwnerInstanceID != owner {
+		t.Errorf("expected owner preserved through resume, got %v", got.OwnerInstanceID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `lease_expires_at` was written at claim time but never read or renewed: a job whose owner kept heartbeating while its handler wedged stayed in `working` forever, and the "batch counts as lease extension" contract documented in `ApplyJobDeltas` was never implemented.
- New `ReclaimExpiredLeaseJobs` sweep phase: expired-lease `working` jobs are reset to claimable while attempts remain, else failed with `lease expired: no completion within lease window`. Field-reset semantics mirror `ResetOrphanedJobs` exactly.
- Implemented the documented lease extension: every accepted non-terminal delta in `ApplyJobDeltas` extends the lease by the claim window, via a shared `leaseWindowFor` helper used by both `ClaimNextJob` and the extension so the derivations cannot drift. This also covers the `input_required` → `working` resume path.
- Hardened the delta-accept path with a guarded owner/non-terminal UPDATE (was an unguarded pre-read), so a delta racing a reclaim cannot extend a lease the instance no longer holds; `Affected=0` is classified via re-read into `not_owner` / `already_terminal` / `not_found`.
- Corrected comments that asserted lease-timeout behavior before it existed, and documented honestly that reclaim is a liveness mechanism, not mutual exclusion (same-instance re-claim can briefly run two executions; first terminal delta wins).

## Race safety
Sweep reclaim requires `status=working AND lease_expires_at = <observed expired value>`; delta accept requires `owner = instance AND status non-terminal`. Either interleaving resolves correctly: a winning delta moves the lease so the sweep's EQ guard fails; a winning reclaim clears the owner so the delta is rejected without extending a lost lease.

## Behavior change — release-note visibility
Producers must post progress within the lease window or size `max_duration` accordingly. Runtimes do not auto-heartbeat (verified: the Rust core's batching tick only flushes handler-posted deltas), so a silent handler running past its lease window (default 300s with no `max_duration`) is now reclaimed and re-executed where it previously ran unbounded. A possible follow-up is an SDK-side idle keepalive.

## Review Notes
- Two independent review rounds. Round 1 found a blocker — enforcement without renewal would have reclaimed healthy long-running jobs — which drove the lease-extension half of this PR. Round 2: 0 blockers; its warning (swallowed re-read error, `not_found` misclassified as `not_owner`) is fixed.
- Remaining infos (terminal-status set duplicated in three places; `input_required` jobs with a dead owner are only rescued by `total_deadline` — pre-existing gap) left for follow-up.

Closes #1159

## Test plan
- [x] `go test ./src/core/registry/...` green; `go vet` clean
- [x] New tests: expired-lease reset/exhausted branches, unexpired + NULL lease untouched, delta-extended lease untouched, lease extension on accept (default + max_duration windows, no-op on reject/terminal), input_required round-trip
- [ ] Integration suites on the next `tsuite-mesh:local` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job leases now properly extend when batch submissions are accepted
  * Fixed job lease expiration detection to reclaim expired jobs and reset retryable ones
  * Improved handling of concurrent job execution scenarios with better state transition guards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->