### PR TITLE
fix(ts): replace removed maxSteps with stopWhen(stepCountIs) on AI SDK v6

### DIFF
--- a/src/runtime/typescript/src/__tests__/llm-max-iterations.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-max-iterations.test.ts
@@ -111,18 +111,20 @@ describe("resolveMaxIterations — provider loop cap resolution", () => {
     expect(resolveMaxIterations(undefined)).toBe(10);
   });
 
-  // Parity (#1116): the Gemini AI-SDK-managed loop sets
-  // `requestOptions.maxSteps = resolvedMaxIterations`, the SAME value the
-  // manual provider-managed loop uses as its cap. We assert the resolution
-  // the Gemini path consumes here rather than the wired `maxSteps`, since
-  // observing the latter would require a full `vi.mock("ai")` generateText
-  // harness that this file deliberately does not build.
-  it("Gemini maxSteps path consumes the forwarded resolved cap", () => {
+  // Parity (#1116/#1160): the Gemini AI-SDK-managed loop wires
+  // `stopWhen: stepCountIs(resolvedMaxIterations)` — AI SDK v6 removed
+  // `maxSteps`, whose default-stepCountIs(1) replacement caused the empty
+  // assistant message regression (#1160). The actual generateText option
+  // wiring is asserted in llm-provider-stopwhen.test.ts, and the multi-step
+  // loop behavior (tool call → follow-up text) in
+  // llm-provider-multistep.test.ts. Here we only assert the resolution the
+  // Gemini path consumes.
+  it("Gemini stopWhen path consumes the forwarded resolved cap", () => {
     delete process.env.MESH_LLM_MAX_ITERATIONS;
     expect(resolveMaxIterations(25)).toBe(25);
   });
 
-  it("Gemini maxSteps path falls back to 10 when the cap is absent", () => {
+  it("Gemini stopWhen path falls back to 10 when the cap is absent", () => {
     delete process.env.MESH_LLM_MAX_ITERATIONS;
     expect(resolveMaxIterations(undefined)).toBe(10);
   });

--- a/src/runtime/typescript/src/__tests__/llm-provider-multistep.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-provider-multistep.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Gemini SDK-managed multi-step loop — end-to-end regression test for #1160.
+ *
+ * Uses the REAL `ai` module (generateText + stopWhen + tool execution) with a
+ * `MockLanguageModelV3` (from `ai/test`) injected via a mocked
+ * `@ai-sdk/google` provider. The model emits a tool call on step 1 and text
+ * on step 2.
+ *
+ * With the broken `maxSteps` wiring (removed in AI SDK v6), generateText
+ * defaulted to `stopWhen: stepCountIs(1)`: the loop stopped right after the
+ * tool-call step, `result.text` was empty, and since the tools carried
+ * `_mesh_endpoint` the provider also stripped tool_calls — consumers received
+ * an empty assistant message. With `stopWhen: stepCountIs(n)` the loop does
+ * the follow-up generation and the final text is non-empty.
+ *
+ * Tool execution goes through the provider's execute functions →
+ * `callMcpTool`, which is mocked here to return a canned tool result.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Per-step model results, controllable per test. vi.hoisted so the
+// vi.mock("@ai-sdk/google") factory can reference it.
+const modelHarness = vi.hoisted(() => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  results: [] as any[],
+  calls: 0,
+}));
+
+const callMcpToolMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@ai-sdk/google", async () => {
+  const { MockLanguageModelV3 } = await import("ai/test");
+  return {
+    google: (modelId: string) =>
+      new MockLanguageModelV3({
+        modelId,
+        // Function form (not the array form: MockLanguageModelV3 indexes the
+        // array AFTER pushing the call, skipping element 0).
+        doGenerate: async () => {
+          const result = modelHarness.results[modelHarness.calls];
+          modelHarness.calls++;
+          if (!result) {
+            throw new Error(`MockLanguageModelV3: no scripted result for step ${modelHarness.calls}`);
+          }
+          return result;
+        },
+      }),
+  };
+});
+
+// Replace only callMcpTool — keep runWithTraceContext etc. real.
+vi.mock("../proxy.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../proxy.js")>();
+  return { ...actual, callMcpTool: callMcpToolMock };
+});
+
+// Keep tracing inert (publishTraceSpan is best-effort fire-and-forget).
+vi.mock("../tracing.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../tracing.js")>();
+  return { ...actual, publishTraceSpan: vi.fn(async () => false) };
+});
+
+import { llmProvider } from "../llm-provider.js";
+
+const TOOL_CALL_STEP = {
+  content: [
+    {
+      type: "tool-call",
+      toolCallId: "call-1",
+      toolName: "get_weather",
+      input: JSON.stringify({ city: "Paris" }),
+    },
+  ],
+  finishReason: "tool-calls",
+  usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+  warnings: [],
+};
+
+const TEXT_STEP = {
+  content: [{ type: "text", text: "It is sunny in Paris." }],
+  finishReason: "stop",
+  usage: { inputTokens: 20, outputTokens: 8, totalTokens: 28 },
+  warnings: [],
+};
+
+function meshToolRequest(modelParams: Record<string, unknown>) {
+  return {
+    request: {
+      messages: [{ role: "user", content: "What's the weather in Paris?" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "get_weather",
+            description: "Get the current weather for a city",
+            parameters: {
+              type: "object",
+              properties: { city: { type: "string" } },
+              required: ["city"],
+            },
+            _mesh_endpoint: "http://weather-agent.local:9100",
+          },
+        },
+      ],
+      model_params: { ...modelParams },
+    },
+  };
+}
+
+describe("Gemini multi-step loop with real generateText (#1160)", () => {
+  beforeEach(() => {
+    modelHarness.results = [TOOL_CALL_STEP, TEXT_STEP];
+    modelHarness.calls = 0;
+    callMcpToolMock.mockReset();
+    callMcpToolMock.mockResolvedValue(
+      JSON.stringify({ temperature_c: 21, condition: "sunny" })
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("executes the tool on step 1 and returns the follow-up text from step 2", async () => {
+    const tool = llmProvider({ model: "gemini/gemini-2.5-flash", capability: "llm" });
+    const raw = await tool.execute(meshToolRequest({ max_iterations: 3 }) as never);
+    const response = JSON.parse(raw) as Record<string, unknown>;
+
+    // The model was called twice: tool-call step + follow-up generation.
+    expect(modelHarness.calls).toBe(2);
+
+    // The tool was executed provider-side via its _mesh_endpoint.
+    expect(callMcpToolMock).toHaveBeenCalledTimes(1);
+    const [endpoint, toolName, toolArgs] = callMcpToolMock.mock.calls[0];
+    expect(endpoint).toBe("http://weather-agent.local:9100");
+    expect(toolName).toBe("get_weather");
+    expect(toolArgs).toEqual({ city: "Paris" });
+
+    // #1160: the assistant message must carry the step-2 text, not be empty.
+    expect(response.content).toBe("It is sunny in Paris.");
+
+    // Tools were executed provider-side — no tool_calls leak to the consumer.
+    expect(response.tool_calls).toBeUndefined();
+  });
+
+  it("honors the forwarded cap: max_iterations=1 stops after the tool-call step", async () => {
+    const tool = llmProvider({ model: "gemini/gemini-2.5-flash", capability: "llm" });
+    const raw = await tool.execute(meshToolRequest({ max_iterations: 1 }) as never);
+    const response = JSON.parse(raw) as Record<string, unknown>;
+
+    // stopWhen=stepCountIs(1): the tool still executes within step 1, but no
+    // follow-up generation happens — proving the cap actually drives the loop.
+    expect(modelHarness.calls).toBe(1);
+    expect(callMcpToolMock).toHaveBeenCalledTimes(1);
+    expect(response.content).toBe("");
+    expect(response.tool_calls).toBeUndefined();
+  });
+});

--- a/src/runtime/typescript/src/__tests__/llm-provider-output-mode.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-provider-output-mode.test.ts
@@ -28,6 +28,7 @@ vi.mock("ai", () => ({
   generateObject: (opts: unknown) => generateObjectMock(opts),
   jsonSchema: (schema: Record<string, unknown>) => schema,
   tool: (config: unknown) => config,
+  stepCountIs: (n: number) => ({ steps }: { steps: unknown[] }) => steps.length === n,
 }));
 
 // Keep tracing inert/deterministic (publishTraceSpan is best-effort anyway).

--- a/src/runtime/typescript/src/__tests__/llm-provider-stopwhen.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-provider-stopwhen.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Gemini SDK-managed agentic loop wiring — issue #1160.
+ *
+ * AI SDK v6 removed `maxSteps` from generateText; loop control is now
+ * `stopWhen` with a default of `stepCountIs(1)`. The provider previously set
+ * `requestOptions.maxSteps`, which landed in the `...settings` rest and was
+ * silently ignored — Gemini executed the tool-call step but never did the
+ * follow-up generation, returning an empty assistant message.
+ *
+ * These tests mock `generateText` (keeping the REAL `stepCountIs`/`tool`/
+ * `jsonSchema` via importOriginal) and assert the options object that reaches
+ * the AI SDK:
+ *
+ *  - Gemini + `_mesh_endpoint` tools: `stopWhen` is set to the result of
+ *    `stepCountIs(resolvedMaxIterations)`. `stepCountIs(n)` returns a
+ *    predicate `({ steps }) => steps.length === n`, so we assert the
+ *    predicate's behavior at the boundary (true at n steps, false at n-1).
+ *  - The removed `maxSteps` key is NOT present (regression guard).
+ *  - Non-Gemini vendors (manual provider-managed loop) do NOT set `stopWhen`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const generateTextMock = vi.fn();
+const generateObjectMock = vi.fn();
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return {
+    ...actual,
+    generateText: (opts: unknown) => generateTextMock(opts),
+    generateObject: (opts: unknown) => generateObjectMock(opts),
+  };
+});
+
+// Keep tracing inert/deterministic (publishTraceSpan is best-effort anyway).
+vi.mock("../tracing.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../tracing.js")>();
+  return {
+    ...actual,
+    generateTraceId: () => "trace-mock",
+    generateSpanId: () => "span-mock",
+    publishTraceSpan: vi.fn(async () => false),
+    matchesPropagateHeader: () => false,
+  };
+});
+
+import { llmProvider } from "../llm-provider.js";
+
+type StopWhenPredicate = (options: { steps: unknown[] }) => boolean | PromiseLike<boolean>;
+
+function meshToolRequest(modelParams: Record<string, unknown>) {
+  return {
+    request: {
+      messages: [{ role: "user", content: "What's the weather in Paris?" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "get_weather",
+            description: "Get the current weather for a city",
+            parameters: {
+              type: "object",
+              properties: { city: { type: "string" } },
+              required: ["city"],
+            },
+            // Mesh-enriched endpoint → provider-managed tool execution
+            _mesh_endpoint: "http://weather-agent.local:9100",
+          },
+        },
+      ],
+      model_params: { ...modelParams },
+    },
+  };
+}
+
+async function stepsAtCount(stopWhen: StopWhenPredicate, count: number): Promise<boolean> {
+  return await stopWhen({ steps: new Array(count).fill({}) });
+}
+
+describe("Gemini SDK-managed loop wires stopWhen (#1160)", () => {
+  beforeEach(() => {
+    generateTextMock.mockReset();
+    generateObjectMock.mockReset();
+    generateTextMock.mockResolvedValue({
+      text: "It is sunny in Paris.",
+      toolCalls: [],
+      usage: { inputTokens: 1, outputTokens: 1 },
+      finishReason: "stop",
+    });
+    // Model creation must not depend on real credentials at request time
+    // (generateText is mocked), but keep keys set for construction safety.
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY = "test-key";
+    process.env.ANTHROPIC_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    vi.restoreAllMocks();
+  });
+
+  it("sets stopWhen=stepCountIs(max_iterations) and never the removed maxSteps", async () => {
+    const tool = llmProvider({ model: "gemini/gemini-2.5-flash", capability: "llm" });
+    await tool.execute(meshToolRequest({ max_iterations: 25 }) as never);
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    const opts = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+
+    // AI SDK v6 removed maxSteps — it must not be passed at all.
+    expect("maxSteps" in opts).toBe(false);
+
+    // stopWhen must be the stepCountIs(25) predicate: stops exactly when the
+    // step count reaches the resolved cap.
+    const stopWhen = opts.stopWhen as StopWhenPredicate;
+    expect(typeof stopWhen).toBe("function");
+    expect(await stepsAtCount(stopWhen, 25)).toBe(true);
+    expect(await stepsAtCount(stopWhen, 24)).toBe(false);
+    expect(await stepsAtCount(stopWhen, 1)).toBe(false);
+  });
+
+  it("defaults stopWhen to stepCountIs(10) when no cap is forwarded", async () => {
+    delete process.env.MESH_LLM_MAX_ITERATIONS;
+    const tool = llmProvider({ model: "gemini/gemini-2.5-flash", capability: "llm" });
+    await tool.execute(meshToolRequest({}) as never);
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    const opts = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect("maxSteps" in opts).toBe(false);
+
+    const stopWhen = opts.stopWhen as StopWhenPredicate;
+    expect(typeof stopWhen).toBe("function");
+    expect(await stepsAtCount(stopWhen, 10)).toBe(true);
+    expect(await stepsAtCount(stopWhen, 9)).toBe(false);
+  });
+
+  it("non-Gemini vendors keep the manual loop: no stopWhen, no maxSteps", async () => {
+    const tool = llmProvider({ model: "anthropic/claude-sonnet-4-5", capability: "llm" });
+    await tool.execute(meshToolRequest({ max_iterations: 25 }) as never);
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    const opts = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts.stopWhen).toBeUndefined();
+    expect("maxSteps" in opts).toBe(false);
+  });
+});

--- a/src/runtime/typescript/src/__tests__/llm-provider-system-synthesis.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-provider-system-synthesis.test.ts
@@ -27,6 +27,7 @@ vi.mock("ai", () => ({
   generateObject: (opts: unknown) => generateObjectMock(opts),
   jsonSchema: (schema: Record<string, unknown>) => schema,
   tool: (config: unknown) => config,
+  stepCountIs: (n: number) => ({ steps }: { steps: unknown[] }) => steps.length === n,
 }));
 
 vi.mock("../tracing.js", () => ({

--- a/src/runtime/typescript/src/llm-provider.ts
+++ b/src/runtime/typescript/src/llm-provider.ts
@@ -678,6 +678,7 @@ export function llmProvider(config: LlmProviderConfig): {
           parameters?: Record<string, unknown>;
         }
       >;
+      stopWhen?: (options: { steps: unknown[] }) => boolean | PromiseLike<boolean>;
       maxOutputTokens?: number;
       temperature?: number;
       topP?: number;
@@ -699,9 +700,10 @@ export function llmProvider(config: LlmProviderConfig): {
 
     // Convert tools to Vercel AI SDK format using the tool() helper
     // Import jsonSchema and tool from ai package for proper schema handling
-    const { jsonSchema, tool: aiTool } = aiModule as {
+    const { jsonSchema, tool: aiTool, stepCountIs } = aiModule as {
       jsonSchema: (schema: Record<string, unknown>) => unknown;
       tool: (config: { description?: string; inputSchema: unknown; execute?: (args: unknown) => Promise<unknown> }) => unknown;
+      stepCountIs: (stepCount: number) => (options: { steps: unknown[] }) => boolean | PromiseLike<boolean>;
     };
 
     // Extract _mesh_endpoint from tool schemas for provider-side execution.
@@ -719,14 +721,17 @@ export function llmProvider(config: LlmProviderConfig): {
       }
     }
     const hasToolEndpoints = Object.keys(toolEndpoints).length > 0;
-    // Gemini: use AI SDK's maxSteps with execute functions instead of manual loop.
-    // The manual loop drops Gemini's thought_signature from assistant messages,
-    // causing 400 errors in multi-turn tool conversations. AI SDK preserves it.
+    // Gemini: use the AI SDK's built-in agentic loop (stopWhen + execute
+    // functions) instead of the manual loop. The manual loop drops Gemini's
+    // thought_signature from assistant messages, causing 400 errors in
+    // multi-turn tool conversations. AI SDK preserves it.
     // Claude/OpenAI keep the manual loop (they need response_format on every call).
     // vertex_ai is the same Gemini model on the wire, so it gets the same treatment.
+    // Note: `useMaxSteps` is a historical name — AI SDK v6 removed `maxSteps`;
+    // this flag now drives `stopWhen: stepCountIs(n)` (the v6 loop control).
     const useMaxSteps = hasToolEndpoints && (vendor === "gemini" || vendor === "google" || vendor === "vertex_ai");
     if (hasToolEndpoints) {
-      debug(`Provider-managed loop: ${Object.keys(toolEndpoints).length} tools with endpoints${useMaxSteps ? " (Gemini maxSteps mode)" : ""}`);
+      debug(`Provider-managed loop: ${Object.keys(toolEndpoints).length} tools with endpoints${useMaxSteps ? " (Gemini SDK-managed stopWhen mode)" : ""}`);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -752,7 +757,7 @@ export function llmProvider(config: LlmProviderConfig): {
         const toolName = tool.function.name;
 
         if (useMaxSteps) {
-          // Gemini: use execute functions + maxSteps (AI SDK preserves thought_signature)
+          // Gemini: use execute functions + stopWhen (AI SDK preserves thought_signature)
           const toolEndpoint = toolEndpoints[toolName];
           vercelTools[toolName] = aiTool({
             description: tool.function.description ?? "",
@@ -782,7 +787,7 @@ export function llmProvider(config: LlmProviderConfig): {
               }
             },
           });
-          debug(`Tool '${toolName}' vercelTool created (with execute for Gemini maxSteps)`);
+          debug(`Tool '${toolName}' vercelTool created (with execute for Gemini SDK-managed loop)`);
         } else {
           // Claude/OpenAI or no endpoints: schema only (manual loop or consumer handles)
           vercelTools[toolName] = aiTool({
@@ -819,7 +824,7 @@ export function llmProvider(config: LlmProviderConfig): {
       model: unknown;
       messages: any; // VercelCoreMessage[] - Vercel AI SDK validates at runtime
       tools?: Record<string, any>;
-      maxSteps?: number;
+      stopWhen?: (options: { steps: unknown[] }) => boolean | PromiseLike<boolean>;
       maxOutputTokens?: number;
       temperature?: number;
       topP?: number;
@@ -833,12 +838,15 @@ export function llmProvider(config: LlmProviderConfig): {
     if (vercelTools && Object.keys(vercelTools).length > 0) {
       requestOptions.tools = vercelTools;
       if (useMaxSteps) {
-        // Gemini: let AI SDK manage the agentic loop via maxSteps.
+        // Gemini: let AI SDK manage the agentic loop via stopWhen.
+        // AI SDK v6 removed `maxSteps`; without stopWhen the default is
+        // stepCountIs(1), which would stop right after the tool-call step
+        // and return an empty assistant message (#1160).
         // AI SDK preserves thought_signature across turns automatically.
-        requestOptions.maxSteps = resolvedMaxIterations;
-        debug(`Gemini provider-managed loop via maxSteps=${resolvedMaxIterations} (AI SDK preserves thought_signature)`);
+        requestOptions.stopWhen = stepCountIs(resolvedMaxIterations);
+        debug(`Gemini provider-managed loop via stopWhen=stepCountIs(${resolvedMaxIterations}) (AI SDK preserves thought_signature)`);
       }
-      // Note: for non-Gemini vendors, maxSteps is NOT set. We manage
+      // Note: for non-Gemini vendors, stopWhen is NOT set. We manage
       // the agentic loop manually so that providerOptions (including
       // response_format) is applied on every LLM call, not just the first.
     }
@@ -960,9 +968,9 @@ export function llmProvider(config: LlmProviderConfig): {
       resultUsage = objectResult.usage;
     } else if (hasToolEndpoints && !useMaxSteps) {
       // Provider-managed agentic loop: execute tools internally.
-      // Unlike AI SDK's maxSteps, this manual loop ensures providerOptions
-      // (including response_format for structured output) is applied on
-      // EVERY LLM call, not just the first one.
+      // Unlike the AI SDK's stopWhen-managed loop, this manual loop ensures
+      // providerOptions (including response_format for structured output) is
+      // applied on EVERY LLM call, not just the first one.
       let iteration = 0;
       const maxIterations = resolvedMaxIterations;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -976,7 +984,7 @@ export function llmProvider(config: LlmProviderConfig): {
           ...requestOptions,
           messages: currentMessages,
         };
-        // Do NOT set maxSteps — we manage the loop manually
+        // Do NOT set stopWhen — we manage the loop manually
 
         const result = await generateText(iterRequest);
 
@@ -1166,7 +1174,7 @@ export function llmProvider(config: LlmProviderConfig): {
       }
     } else {
       // generateText path covers:
-      // 1. Gemini maxSteps: AI SDK manages the tool loop (execute functions + maxSteps)
+      // 1. Gemini SDK-managed loop: AI SDK runs the tool loop (execute functions + stopWhen)
       // 2. No tool endpoints: consumer-managed tools or plain text
       const result = await generateText(requestOptions);
 
@@ -1185,8 +1193,8 @@ export function llmProvider(config: LlmProviderConfig): {
       };
 
       // Include tool_calls for consumer-managed execution only.
-      // When hasToolEndpoints is true (Gemini maxSteps), tools were already
-      // executed by AI SDK via execute functions — don't return tool_calls.
+      // When hasToolEndpoints is true (Gemini SDK-managed loop), tools were
+      // already executed by AI SDK via execute functions — don't return tool_calls.
       if (!hasToolEndpoints && result.toolCalls && result.toolCalls.length > 0) {
         response.tool_calls = convertToolCalls(result.toolCalls);
       }


### PR DESCRIPTION
## Summary
- `ai@6` removed `maxSteps`; `generateText` defaults to `stopWhen: stepCountIs(1)`, so the assignment at `llm-provider.ts:836` landed in the `...settings` rest and was silently ignored. Gemini/google/vertex_ai providers with mesh-delegated tools executed the tool-call step but never produced the follow-up generation — and since `_mesh_endpoint` tools strip `tool_calls` from the response, consumers received an empty assistant message. The consumer-forwarded `max_iterations` cap (#1116) was inert on this path.
- Wire `resolvedMaxIterations` through `stopWhen: stepCountIs(n)`, destructured from the dynamically imported `ai` module following the file's existing `jsonSchema`/`tool` pattern. Types and all stale `maxSteps` comments updated; the internal `useMaxSteps` flag keeps its name with a comment noting it now drives `stopWhen`.
- New `llm-provider-stopwhen.test.ts`: asserts the captured `generateText` options carry a working `stepCountIs(n)` predicate (boundary behavior tested), that `maxSteps` is absent (regression guard), and that non-Gemini vendors (manual loop) set neither.
- New `llm-provider-multistep.test.ts`: runs the REAL `generateText` loop against a scripted `MockLanguageModelV3` (tool call on step 1, text on step 2) — asserts the tool executes at the `_mesh_endpoint`, the final content is non-empty (the #1160 symptom), and `max_iterations: 1` caps the loop at one model call. The old test only asserted the resolved option value, which is why this regression was invisible.

## Review Notes
- Independent review: 0 blockers, 0 warnings. It verified against the installed `ai@6.0.37` source that the loop is do-while (condition checked after each step), so `stepCountIs(n)` gives at most n model calls — the exact old `maxSteps: n` semantic; no off-by-one. It also confirmed no other loop surface exists (`streamText` unused; Gemini+tools can't route into `generateObject`).
- Minor cosmetic notes (predicate type repeated 3×, `useMaxSteps` naming debt) left as is.

Closes #1160

## Test plan
- [x] `npm run typecheck` (express4 + express5) and `npm run build` clean
- [x] `npx vitest run` — 57 files, 850 tests, all passing
- [ ] Integration suites (uc04/uc10/uc15 Gemini paths) on the next `tsuite-mesh:local` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
