### PR TITLE
fix(ts): surface MCP tool errors on SSE and streaming transports

### DIFF
--- a/src/runtime/typescript/src/__tests__/proxy-stream.test.ts
+++ b/src/runtime/typescript/src/__tests__/proxy-stream.test.ts
@@ -206,6 +206,35 @@ describe("streamMcpTool", () => {
     await expect(collect()).rejects.toThrow(/tool blew up/);
   });
 
+  it("throws when the final result carries a tool-level error (isError: true)", async () => {
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string);
+      return makeMockResponse([
+        sseEvent({
+          jsonrpc: "2.0",
+          method: "notifications/progress",
+          params: { progressToken: body.params._meta.progressToken, progress: 1, message: "partial" },
+        }),
+        sseEvent({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { isError: true, content: [{ type: "text", text: "tool exploded mid-stream" }] },
+        }),
+      ]);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const collect = async () => {
+      const out: string[] = [];
+      for await (const chunk of streamMcpTool(ENDPOINT, TOOL, undefined, DEFAULT_CALL_OPTIONS, CAPABILITY)) {
+        out.push(chunk);
+      }
+      return out;
+    };
+
+    await expect(collect()).rejects.toThrow("MCP tool error: tool exploded mid-stream");
+  });
+
   it("throws on non-2xx HTTP response", async () => {
     const fetchMock = vi.fn(async () => {
       return {

--- a/src/runtime/typescript/src/__tests__/proxy-tool-error.test.ts
+++ b/src/runtime/typescript/src/__tests__/proxy-tool-error.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Unit tests for transport-symmetric tool-error surfacing in callMcpTool (#1161).
+ *
+ * FastMCP streamable-HTTP commonly answers ``tools/call`` with
+ * ``text/event-stream``, so SSE is the hot path for TS→TS agent calls. A
+ * producer tool that throws returns a CallToolResult with ``isError: true``;
+ * BOTH the JSON and SSE response paths must throw the same
+ * ``MCP tool error: …`` shape instead of returning the error text as a
+ * successful result (which would poison LLM tool-execution loops and record
+ * success spans).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { callMcpTool, DEFAULT_CALL_OPTIONS, runWithTraceContext } from "../proxy.js";
+import { publishTraceSpan } from "../tracing.js";
+
+vi.mock("@mcpmesh/core", () => ({
+  generateTraceId: () => "trace-mock",
+  generateSpanId: () => "span-mock",
+  injectTraceContext: (argsJson: string) => argsJson,
+  publishSpan: vi.fn(async () => false),
+  parseSseResponse: (s: string) => s,
+  parseSseResponseToObject: (s: string) => JSON.parse(s),
+  awaitJobCancel: vi.fn(() => new Promise<void>(() => {})),
+  matchesPropagateHeader: () => false,
+}));
+
+// Spy on publishTraceSpan so span-accounting tests can count emitted spans.
+// The real implementation gates on initTracing() module state, which unit
+// tests can't reach; everything else in tracing.js stays real.
+vi.mock("../tracing.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../tracing.js")>();
+  return {
+    ...actual,
+    publishTraceSpan: vi.fn(async () => true),
+  };
+});
+
+vi.mock("../http-pool.js", () => ({
+  getDispatcher: () => undefined,
+}));
+
+const ENDPOINT = "http://producer.local:9000";
+const TOOL = "explode";
+const CAPABILITY = "exploder";
+
+function jsonResponse(envelope: object): Response {
+  const body = JSON.stringify({ jsonrpc: "2.0", id: "x", ...envelope });
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => body,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "application/json" : null,
+    },
+  } as unknown as Response;
+}
+
+/** Build a Response whose body is a ReadableStream emitting SSE event blocks. */
+function sseResponse(envelopes: object[]): Response {
+  const encoder = new TextEncoder();
+  const blocks = envelopes.map(
+    (e) => `event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: "x", ...e })}\n\n`
+  );
+  let i = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < blocks.length) {
+        controller.enqueue(encoder.encode(blocks[i]));
+        i += 1;
+      } else {
+        controller.close();
+      }
+    },
+  });
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    body: stream,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "text/event-stream" : null,
+    },
+  } as unknown as Response;
+}
+
+/**
+ * Build a Response whose SSE body errors mid-read with the given error —
+ * models a job-cancel or timeout firing `controller.abort()` while the
+ * body is being consumed.
+ */
+function sseAbortingResponse(err: unknown): Response {
+  const encoder = new TextEncoder();
+  let pulled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (!pulled) {
+        pulled = true;
+        controller.enqueue(encoder.encode("event: message\n"));
+      } else {
+        controller.error(err);
+      }
+    },
+  });
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    body: stream,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "text/event-stream" : null,
+    },
+  } as unknown as Response;
+}
+
+function mockFetch(makeResponse: () => Response): void {
+  // Fresh Response per call so retries don't reuse a consumed SSE body.
+  const fetchMock = vi.fn(async () => makeResponse());
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+}
+
+const TOOL_ERROR_RESULT = {
+  isError: true,
+  content: [{ type: "text", text: "boom: division by zero" }],
+};
+
+describe("callMcpTool tool-level error surfacing (isError)", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("rejects on SSE response with isError: true (same shape as JSON path)", async () => {
+    mockFetch(() => sseResponse([{ result: TOOL_ERROR_RESULT }]));
+
+    await expect(
+      callMcpTool(ENDPOINT, TOOL, { a: 1 }, DEFAULT_CALL_OPTIONS, CAPABILITY)
+    ).rejects.toThrow("MCP tool error: boom: division by zero");
+  });
+
+  it("rejects on JSON response with isError: true (regression guard)", async () => {
+    mockFetch(() => jsonResponse({ result: TOOL_ERROR_RESULT }));
+
+    await expect(
+      callMcpTool(ENDPOINT, TOOL, { a: 1 }, DEFAULT_CALL_OPTIONS, CAPABILITY)
+    ).rejects.toThrow("MCP tool error: boom: division by zero");
+  });
+
+  it("rejects on SSE response carrying a JSON-RPC protocol error", async () => {
+    mockFetch(() =>
+      sseResponse([{ error: { code: -32603, message: "internal failure" } }])
+    );
+
+    await expect(
+      callMcpTool(ENDPOINT, TOOL, { a: 1 }, DEFAULT_CALL_OPTIONS, CAPABILITY)
+    ).rejects.toThrow("MCP error: internal failure");
+  });
+
+  it("resolves a legitimately falsy SSE result identically to the JSON path", async () => {
+    // JSON-RPC permits any `result` value, including falsy ones; a truthiness
+    // check would silently drop them. Verify SSE and JSON agree.
+    mockFetch(() => sseResponse([{ result: 0 }]));
+    const sseValue = await callMcpTool(
+      ENDPOINT, TOOL, { a: 1 }, DEFAULT_CALL_OPTIONS, CAPABILITY
+    );
+
+    mockFetch(() => jsonResponse({ result: 0 }));
+    const jsonValue = await callMcpTool(
+      ENDPOINT, TOOL, { a: 1 }, DEFAULT_CALL_OPTIONS, CAPABILITY
+    );
+
+    expect(sseValue).toBe(jsonValue);
+    expect(sseValue).toBe("0");
+  });
+
+  it("resolves an empty-content SSE result as empty string", async () => {
+    mockFetch(() => sseResponse([{ result: { content: [] } }]));
+
+    const value = await callMcpTool(
+      ENDPOINT, TOOL, { a: 1 }, DEFAULT_CALL_OPTIONS, CAPABILITY
+    );
+    expect(value).toBe("");
+  });
+
+  it("still resolves successful SSE results (sanity)", async () => {
+    mockFetch(() =>
+      sseResponse([{ result: { content: [{ type: "text", text: "fine" }] } }])
+    );
+
+    const value = await callMcpTool(
+      ENDPOINT, TOOL, { a: 1 }, DEFAULT_CALL_OPTIONS, CAPABILITY
+    );
+    expect(value).toBe("fine");
+  });
+});
+
+describe("callMcpTool abort mid-SSE-read span accounting", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    vi.mocked(publishTraceSpan).mockClear();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("publishes exactly one error span (the outer timeout one) when the body read aborts", async () => {
+    // An abort (timeout or job-cancel) surfaces from reader.read() as an
+    // AbortError. The SSE catch must NOT publish a span for it — the outer
+    // catch owns abort accounting; both publishing would emit two spans
+    // with the same spanId, the second mislabeled "timeout".
+    const abortErr = new DOMException("This operation was aborted", "AbortError");
+    mockFetch(() => sseAbortingResponse(abortErr));
+
+    await expect(
+      runWithTraceContext({ traceId: "trace-abort", parentSpanId: null }, () =>
+        callMcpTool(ENDPOINT, TOOL, { a: 1 }, DEFAULT_CALL_OPTIONS, CAPABILITY)
+      )
+    ).rejects.toThrow(`MCP call timed out after ${DEFAULT_CALL_OPTIONS.timeout}ms`);
+
+    expect(publishTraceSpan).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(publishTraceSpan).mock.calls[0][0]).toMatchObject({
+      success: false,
+      error: "timeout",
+    });
+  });
+
+  it("still publishes the SSE-reader error span for genuine tool errors", async () => {
+    // Counterpart guard: the abort fix must not stop non-abort SSE-reader
+    // errors from publishing their error span. The first published span
+    // carries the precise tool-error message, and nothing is mislabeled
+    // "timeout". (A generic post-loop span on exhausted retries is
+    // pre-existing JSON-path behavior, deliberately not asserted on.)
+    mockFetch(() => sseResponse([{ result: TOOL_ERROR_RESULT }]));
+
+    await expect(
+      runWithTraceContext({ traceId: "trace-toolerr", parentSpanId: null }, () =>
+        callMcpTool(ENDPOINT, TOOL, { a: 1 }, DEFAULT_CALL_OPTIONS, CAPABILITY)
+      )
+    ).rejects.toThrow("MCP tool error: boom: division by zero");
+
+    const calls = vi.mocked(publishTraceSpan).mock.calls;
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    expect(calls[0][0]).toMatchObject({
+      success: false,
+      error: "MCP tool error: boom: division by zero",
+    });
+    expect(calls.some((c) => c[0].error === "timeout")).toBe(false);
+  });
+});

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -449,9 +449,24 @@ export async function callMcpTool(
 
       // Handle SSE streaming response
       if (contentType.includes("text/event-stream")) {
-        const sseResult = await readSSEResponseToContent(response);
         // Estimate response size from content-length header (exact size not available for SSE)
         const sseResponseBytes = contentLength > 0 ? contentLength : undefined;
+        let sseResult: string | MultiContentResult;
+        try {
+          sseResult = await readSSEResponseToContent(response);
+        } catch (sseErr) {
+          // Mirror the JSON path below: JSON-RPC errors and tool-level errors
+          // (CallToolResult.isError) thrown by the SSE reader record an error
+          // span instead of a success span. Aborts (timeout or job-cancel
+          // firing mid-read) are deliberately NOT published here — the outer
+          // catch owns abort/timeout accounting, and publishing in both
+          // places would emit two spans with the same spanId.
+          if (!isTimeoutError(sseErr)) {
+            const sseErrMsg = sseErr instanceof Error ? sseErr.message : String(sseErr);
+            publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, sseErrMsg, "error", requestBytes, sseResponseBytes);
+          }
+          throw sseErr;
+        }
         // Publish success span
         publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, true, null, typeof sseResult, requestBytes, sseResponseBytes);
         return sseResult;
@@ -476,10 +491,8 @@ export async function callMcpTool(
       // carries the failure message in its content; the JSON-RPC envelope above
       // is success in that case. Throw so callers (LLM provider, tool proxy)
       // re-wrap it instead of returning the error text as a successful result.
-      const innerResult = result.result;
-      if (innerResult && typeof innerResult === "object" && (innerResult as Record<string, unknown>).isError === true) {
-        const toolErr = extractContent(innerResult);
-        const toolErrMsg = typeof toolErr === "string" ? toolErr : JSON.stringify(toolErr);
+      const toolErrMsg = toolErrorMessage(result.result);
+      if (toolErrMsg !== null) {
         publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, toolErrMsg, "error", requestBytes, responseBytes);
         throw new Error(`MCP tool error: ${toolErrMsg}`);
       }
@@ -498,7 +511,9 @@ export async function callMcpTool(
         throw new Error(`MCP call timed out after ${effectiveTimeout}ms`);
       }
 
-      // Retry on network errors
+      // Retry everything else (network, HTTP, protocol, and tool-level
+      // errors) until attempts are exhausted; only the abort/timeout case
+      // above is non-retryable.
       if (attempt < options.maxAttempts - 1) {
         await sleep(options.retryDelay * Math.pow(options.retryBackoff, attempt));
         continue;
@@ -661,6 +676,13 @@ export async function* streamMcpTool(
           const em = msg.error.message ?? JSON.stringify(msg.error);
           throw new Error(`MCP error: ${em}`);
         }
+        // Surface tool-level errors on the final result (mirrors callMcpTool):
+        // a producer tool that throws mid-stream ends with isError === true
+        // and must not look like a clean end-of-stream.
+        const streamToolErrMsg = toolErrorMessage(msg.result);
+        if (streamToolErrMsg !== null) {
+          throw new Error(`MCP tool error: ${streamToolErrMsg}`);
+        }
         // result arrived — done; do NOT yield the buffered final result
         break;
       }
@@ -813,6 +835,21 @@ async function* iterateSSEEvents(
 }
 
 /**
+ * Extract the failure message from an MCP CallToolResult with
+ * ``isError === true``, or return null when the result is not a tool-level
+ * error. Shared by callMcpTool's JSON and SSE paths (and streamMcpTool's
+ * final-result handling) so every transport surfaces tool errors with the
+ * exact same `MCP tool error: …` shape — they can't drift apart.
+ */
+function toolErrorMessage(innerResult: unknown): string | null {
+  if (innerResult && typeof innerResult === "object" && (innerResult as Record<string, unknown>).isError === true) {
+    const toolErr = extractContent(innerResult);
+    return typeof toolErr === "string" ? toolErr : JSON.stringify(toolErr);
+  }
+  return null;
+}
+
+/**
  * Read an SSE response from the MCP HTTP Streamable transport down to its
  * final content (the JSON-RPC `result`).
  *
@@ -844,21 +881,32 @@ async function readSSEResponseToContent(response: Response): Promise<string | Mu
         const data = line.slice(6);
         if (data === "[DONE]") continue;
 
+        let event: unknown;
         try {
-          const event = JSON.parse(data);
-
-          // Handle JSON-RPC response
-          const jsonRpcEvent = event as { result?: unknown; error?: { message?: string } };
-          if (jsonRpcEvent.result) {
-            result = extractContent(jsonRpcEvent.result);
-          } else if (jsonRpcEvent.error) {
-            throw new Error(
-              `MCP error: ${jsonRpcEvent.error.message ?? JSON.stringify(jsonRpcEvent.error)}`
-            );
-          }
-        } catch (e) {
+          event = JSON.parse(data);
+        } catch {
           // Ignore parse errors for non-JSON data events
-          if (!(e instanceof SyntaxError)) throw e;
+          continue;
+        }
+
+        // Handle JSON-RPC response — mirror callMcpTool's JSON path exactly so
+        // callers can't distinguish transports: protocol-level error first,
+        // then tool-level isError, then content extraction.
+        const jsonRpcEvent = event as { result?: unknown; error?: { message?: string } };
+        if (jsonRpcEvent.error) {
+          throw new Error(
+            `MCP error: ${jsonRpcEvent.error.message ?? JSON.stringify(jsonRpcEvent.error)}`
+          );
+        }
+        // Key-presence (not truthiness) so legitimately falsy results
+        // (null, "", 0) are extracted just like the JSON path does. Events
+        // without a `result` key (e.g. notifications) are skipped.
+        if (event && typeof event === "object" && "result" in event) {
+          const toolErrMsg = toolErrorMessage(jsonRpcEvent.result);
+          if (toolErrMsg !== null) {
+            throw new Error(`MCP tool error: ${toolErrMsg}`);
+          }
+          result = extractContent(jsonRpcEvent.result);
         }
       }
     }


### PR DESCRIPTION
## Summary
- The SSE branch of `callMcpTool` extracted CallToolResult content without checking `isError`, while the JSON branch checked and threw — so on the hot path for TS→TS agent calls (FastMCP streamable-HTTP answers `tools/call` with `text/event-stream`), producer tool failures arrived at consumers as successful string results: swallowed errors, error text fed to LLM loops as valid data, success spans recorded.
- Both transports and `streamMcpTool`'s final result (same hole, found by survey: a producer throwing mid-stream looked like a clean end-of-stream) now route through a shared `toolErrorMessage` helper, so the `MCP tool error: …` shape cannot drift between paths.
- The SSE reader now checks JSON-RPC protocol errors before result extraction (parity with JSON-branch ordering), and `if (jsonRpcEvent.result)` truthiness is replaced with `"result" in event` key presence so legitimately falsy results (`0`, `null`, `""`) survive like they do on the JSON path.
- SSE-path failures publish error spans like the JSON branch, with abort/timeout accounting owned solely by the outer handler (no double-publish on job-cancel mid-read).

## Review Notes
- Independent review: 0 blockers. Verified JSON/SSE parity pairwise, confirmed `streamMcpTool` consumers already handled mid-stream throws (the protocol-error branch threw before this change), and confirmed retry semantics are exact parity — internal LLM tool loops pin `maxAttempts: 1` because tools may be non-idempotent.
- Its one newly-introduced warning (abort mid-SSE-read double-publishing spans, second mislabeled "timeout") is fixed; a regression test asserts exactly one span on that path.
- Pre-existing follow-up candidates surfaced by review, untouched here: per-attempt + post-loop aggregate error spans share one spanId on exhausted retries; JSON response with an absent `result` key stringifies to `"undefined"`; SSE reader doesn't correlate JSON-RPC response ids.

Closes #1161

## Test plan
- [x] `npm run typecheck:all` + `npm run build` clean
- [x] `npx vitest run` — 58 files, 859 tests passing
- [x] New tests: SSE/JSON `isError` parity (exact message), SSE protocol error, falsy-result parity (`0` → `"0"` both transports), empty content, mid-stream `isError` on streaming path, abort-mid-read span accounting
- [ ] Integration suites on the next `tsuite-mesh:local` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
