### PR TITLE
fix(python): positional injection reads the original-function view consistently

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
@@ -328,11 +328,41 @@ def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[
     Returns:
         List of McpMeshTool parameter positions to inject into
     """
-    sig = inspect.signature(func)
+    # Consistent view (#1162 MED-1): ``mesh_positions`` (and the MeshJob
+    # analysis below) index the ORIGINAL function's parameter space —
+    # ``get_mesh_agent_positions`` peels back to it via
+    # ``_get_original_func`` (follows ``__wrapped__``). The param count
+    # MUST come from that SAME view: positions and the param list they
+    # index have to move together. Decorators like ``@mesh.a2a_consumer``
+    # rewrite the wrapper's ``__signature__`` to hide framework-bound
+    # params (e.g. ``_a2a``), so ``inspect.signature(func)`` can be
+    # SHORTER than the position space. Pre-fix, mixing the two views
+    # injected into the WRONG slot — ``(_a2a, db: McpMeshTool, y)``:
+    # original-space position 1 indexed the wrapper param list
+    # ``['db', 'y']`` and landed the proxy in ``y`` — or raised
+    # IndexError outright (``(_a2a, job: MeshJob)``: position 1 against
+    # a 1-param wrapper view).
+    from .signature_analyzer import _get_original_func
+
+    try:
+        sig = inspect.signature(_get_original_func(func))
+    except (TypeError, ValueError):
+        sig = inspect.signature(func)
     params = list(sig.parameters.values())
     param_count = len(params)
     mesh_positions = get_mesh_agent_positions(func)
     func_name = f"{func.__module__}.{func.__qualname__}"
+
+    # Detect ``__signature__``-hidden params structurally (count comparison
+    # only — dependency binding stays strictly positional, never by name).
+    # A wrapper that advertises FEWER params than the original is hiding a
+    # framework-bound slot (e.g. the a2a_consumer ``_a2a`` client); the
+    # untyped single-parameter heuristic must not target such a slot.
+    try:
+        visible_count = len(inspect.signature(func).parameters)
+    except (TypeError, ValueError):
+        visible_count = param_count
+    has_hidden_params = visible_count < param_count
 
     # Detect whether the function declares any MeshJob param. The unified
     # positional injection path handles those alongside McpMeshTool slots,
@@ -359,8 +389,10 @@ def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[
             )
         return []
 
-    # Single parameter rule: inject regardless of typing
-    if param_count == 1:
+    # Single parameter rule: inject regardless of typing. Only applies when
+    # no params are hidden — a hidden single param is framework-bound by the
+    # hiding decorator itself, never an injection target.
+    if param_count == 1 and not has_hidden_params:
         if not mesh_positions:
             if has_mesh_job_param:
                 # The single parameter is a MeshJob — the unified injection
@@ -376,10 +408,12 @@ def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[
             )
         return [0]  # Inject into the single parameter
 
-    # Multiple parameters rule: only inject into McpMeshTool typed parameters
-    if param_count > 1:
+    # Multiple parameters rule: only inject into McpMeshTool typed
+    # parameters. Functions with hidden params route here too (even at
+    # param_count == 1) so the typed-only rule governs them.
+    if param_count > 1 or has_hidden_params:
         if not mesh_positions:
-            if not has_mesh_job_param:
+            if dependencies and not has_mesh_job_param:
                 logger.warning(
                     f"⚠️ Function '{func_name}' has {param_count} parameters but none are "
                     f"typed as McpMeshTool. Skipping injection of {len(dependencies)} dependencies. "
@@ -453,8 +487,26 @@ def _prepare_injection_kwargs(
     log.debug(f"{tp}🔧 Tool '{func.__name__}' called with kwargs={arg_keys}")
     log.debug(f"{tp}🔧 Tool '{func.__name__}' args: {format_log_value(kwargs)}")
 
-    # Build final kwargs with injected dependencies
-    sig = inspect.signature(func)
+    # Build final kwargs with injected dependencies.
+    #
+    # Consistent view (#1162 MED-1): every position used below —
+    # ``mesh_positions`` (from :func:`get_mesh_agent_positions`) and the
+    # MeshJob index (from :func:`analyze_mesh_job_signature`) — indexes the
+    # ORIGINAL function's parameter space (both follow ``__wrapped__`` via
+    # ``_get_original_func``). The param-name list MUST come from that SAME
+    # view: decorators like ``@mesh.a2a_consumer`` rewrite the wrapper's
+    # ``__signature__`` to hide framework-bound params (e.g. ``_a2a``), so
+    # ``inspect.signature(func)`` can be SHORTER — indexing it with an
+    # original-derived position raised IndexError or silently injected into
+    # the WRONG parameter. The resulting kwargs are keyed by ORIGINAL param
+    # names, which is correct because hiding wrappers (a2a_consumer bridge,
+    # @mesh.llm wrappers) forward ``**kwargs`` verbatim to the original.
+    from .signature_analyzer import _get_original_func
+
+    try:
+        sig = inspect.signature(_get_original_func(func))
+    except (TypeError, ValueError):
+        sig = inspect.signature(func)
     params = list(sig.parameters.keys())
     final_kwargs = kwargs.copy()
 
@@ -485,20 +537,11 @@ def _prepare_injection_kwargs(
     if len(eligible_positions) > len(dependencies):
         try:
             untouched_positions = eligible_positions[len(dependencies):]
-            # Positions are derived from the resolved/original signature
-            # (via ``analyze_mesh_job_signature``, which follows the
-            # ``__wrapped__``/``_mesh_original_func`` chain), which may have
-            # MORE params than the wrapper ``sig`` when a decorator (e.g.
-            # @mesh.a2a_consumer) rewrites ``__signature__`` to hide an
-            # injected param. Name the slots from that SAME original signature
-            # so positions line up — and bounds-guard regardless.
-            from .signature_analyzer import _get_original_func
-
-            diag_params = list(
-                inspect.signature(_get_original_func(func)).parameters.values()
-            )
+            # ``params`` above is resolved from the same original signature
+            # the positions came from (#1105), so positions line up — but
+            # bounds-guard regardless.
             untouched_param_names = [
-                diag_params[pos].name if pos < len(diag_params) else f"<arg {pos}>"
+                params[pos] if pos < len(params) else f"<arg {pos}>"
                 for pos in untouched_positions
             ]
             log.warning(
@@ -551,6 +594,22 @@ def _prepare_injection_kwargs(
             break
 
         dep_name = dependencies[dep_index]
+
+        # Defensive bounds guard: positions are derived from the same
+        # original signature as ``params`` above, so this should never
+        # trigger — but a decorator chain we don't model could still skew
+        # the views. Skip this one injection rather than crash dispatch;
+        # remaining deps keep their own positional slots.
+        if position >= len(params):
+            log.warning(
+                f"{tp}⚠️ Injection position {position} for dependency "
+                f"'{dep_name}' (dep_index={dep_index}) on '{func.__name__}' "
+                f"is out of bounds for its {len(params)}-parameter signature "
+                f"{params}. Skipping this injection — check for decorators "
+                f"that rewrite __signature__ without setting __wrapped__."
+            )
+            continue
+
         param_name = params[position]
 
         # Skip if user explicitly passed a value — preserves the

--- a/src/runtime/python/tests/unit/test_12_dependency_injector.py
+++ b/src/runtime/python/tests/unit/test_12_dependency_injector.py
@@ -1211,3 +1211,244 @@ class TestUnifiedPositionalInjection:
             and "will remain None" in r.message
             for r in caplog.records
         )
+
+
+class TestHiddenWrapperParamFunctionalInjection:
+    """Regression for #1162 MED-1 (functional sibling of #1104/#1105).
+
+    Decorators like ``@mesh.a2a_consumer`` rewrite the wrapper's
+    ``__signature__`` to hide a framework-bound param (``_a2a``) while
+    ``__wrapped__`` still points at the original function. Injection
+    positions are derived from the ORIGINAL signature, so the param-name
+    list they index must come from that SAME view — pre-fix, the
+    functional path indexed the SHORTER wrapper signature, raising
+    IndexError or injecting the proxy into the WRONG parameter.
+
+    Mesh deps bind strictly by POSITION (deliberate design); these tests
+    assert the positions resolve against a consistent view, never that
+    names are matched.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _registry_url(self, monkeypatch):
+        # MeshJob slots need MCP_MESH_REGISTRY_URL to construct a
+        # MeshJobSubmitter.
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://registry.local:8000")
+
+    # Sentinel standing in for the A2AClient the bridge binds itself.
+    _CLIENT = object()
+
+    @classmethod
+    def _make_bridge(cls, original):
+        """Mimic the @mesh.a2a_consumer bridge: forward **kwargs to the
+        original, bind ``_a2a`` when the caller didn't, and hide ``_a2a``
+        from the advertised signature (decorators.py:2221-2226)."""
+        from functools import wraps as _wraps
+
+        @_wraps(original)
+        async def bridge(*args, **call_kwargs):
+            if "_a2a" not in call_kwargs:
+                call_kwargs["_a2a"] = cls._CLIENT
+            return await original(*args, **call_kwargs)
+
+        user_sig = inspect.signature(original)
+        cleaned = [p for n, p in user_sig.parameters.items() if n != "_a2a"]
+        bridge.__signature__ = user_sig.replace(parameters=cleaned)
+        return bridge
+
+    @pytest.mark.asyncio
+    async def test_a2a_consumer_dependency_injects_into_db(self):
+        """`(_a2a, db)` with dependencies=['db_cap']: the proxy must land
+        in ``db`` (original position 1), the bridge must still bind its
+        own client into ``_a2a``, and dispatch must not raise."""
+        from mesh.types import McpMeshTool
+
+        async def original(_a2a=None, db: McpMeshTool = None):
+            return (_a2a, db)
+
+        bridge = self._make_bridge(original)
+        injector = DependencyInjector()
+        wrapper = injector.create_injection_wrapper(bridge, ["db_cap"])
+
+        proxy = MagicMock(name="db_proxy")
+        wrapper._mesh_update_dependency(0, proxy)
+
+        a2a, db = await wrapper()
+
+        assert db is proxy
+        # The hidden slot stays bridge-bound — the proxy must NOT have
+        # displaced the client at position 0.
+        assert a2a is self._CLIENT
+
+    @pytest.mark.asyncio
+    async def test_a2a_consumer_proxy_lands_in_db_not_y(self):
+        """`(_a2a, db, y)`: pre-fix the wrapper-view list ['db', 'y']
+        indexed with original position 1 put the proxy into ``y`` and left
+        ``db`` None. The proxy must land in ``db``; ``y`` keeps the
+        caller's value."""
+        from mesh.types import McpMeshTool
+
+        async def original(_a2a=None, db: McpMeshTool = None, y: str = ""):
+            return (_a2a, db, y)
+
+        bridge = self._make_bridge(original)
+        injector = DependencyInjector()
+        wrapper = injector.create_injection_wrapper(bridge, ["db_cap"])
+
+        proxy = MagicMock(name="db_proxy")
+        wrapper._mesh_update_dependency(0, proxy)
+
+        a2a, db, y = await wrapper(y="hello")
+
+        assert db is proxy
+        assert y == "hello"
+        assert a2a is self._CLIENT
+
+    @pytest.mark.asyncio
+    async def test_multiple_deps_pair_by_declaration_order_not_name(self):
+        """DESIGN PIN: deps pair with params by declaration order
+        (position), NEVER by name — name-matching must fail this test.
+
+        The params are named ADVERSARIALLY: the FIRST McpMeshTool param
+        is named ``cap_b`` and the SECOND is named ``cap_a``, while
+        ``dependencies=["cap_a", "cap_b"]``. Declaration-order pairing
+        puts the cap_a proxy in the first typed slot (param ``cap_b``)
+        and the cap_b proxy in the second (param ``cap_a``). Any future
+        dependency-name<->parameter-name matcher produces the exact
+        OPPOSITE pairing and must fail here loudly.
+        """
+        from mesh.types import McpMeshTool
+
+        async def original(
+            _a2a=None, cap_b: McpMeshTool = None, cap_a: McpMeshTool = None
+        ):
+            # Slots returned in DECLARATION order: (hidden, first, second).
+            return (_a2a, cap_b, cap_a)
+
+        bridge = self._make_bridge(original)
+        injector = DependencyInjector()
+        wrapper = injector.create_injection_wrapper(bridge, ["cap_a", "cap_b"])
+
+        proxy_a = MagicMock(name="cap_a_proxy")
+        proxy_b = MagicMock(name="cap_b_proxy")
+        wrapper._mesh_update_dependency(0, proxy_a)  # dependency "cap_a"
+        wrapper._mesh_update_dependency(1, proxy_b)  # dependency "cap_b"
+
+        a2a, first_slot, second_slot = await wrapper()
+
+        # deps pair with params by declaration order (position), NEVER by
+        # name — name-matching must fail this test: it would route
+        # proxy_a into the param NAMED ``cap_a`` (the second slot).
+        assert first_slot is proxy_a  # param named cap_b ← dep[0] "cap_a"
+        assert second_slot is proxy_b  # param named cap_a ← dep[1] "cap_b"
+        assert a2a is self._CLIENT
+
+    @pytest.mark.asyncio
+    async def test_a2a_consumer_meshjob_dep_no_indexerror(self):
+        """`(_a2a, job: MeshJob)` with one dependency: the MeshJob position
+        (1, original view) exceeded the 1-param wrapper view pre-fix →
+        IndexError on every invocation. Must inject a MeshJobSubmitter."""
+        from mesh import MeshJob
+        from _mcp_mesh.engine.mesh_job_submitter import MeshJobSubmitter
+
+        async def original(_a2a=None, job: MeshJob = None):
+            return (_a2a, job)
+
+        bridge = self._make_bridge(original)
+        injector = DependencyInjector()
+        wrapper = injector.create_injection_wrapper(bridge, ["jobs.run"])
+
+        a2a, job = await wrapper()
+
+        assert isinstance(job, MeshJobSubmitter)
+        assert job.capability == "jobs.run"
+        assert a2a is self._CLIENT
+
+    def test_strategy_counts_original_view_for_hidden_param_wrapper(self):
+        """analyze_injection_strategy on the bridge must classify by the
+        ORIGINAL signature: `(_a2a, db)` is two params, McpMeshTool at
+        original position 1 — not 'single param, position 0'."""
+        from mesh.types import McpMeshTool
+
+        async def original(_a2a=None, db: McpMeshTool = None):
+            return (_a2a, db)
+
+        bridge = self._make_bridge(original)
+
+        assert analyze_injection_strategy(bridge, ["db_cap"]) == [1]
+
+    def test_strategy_hidden_single_param_stays_silent(self, caplog):
+        """`(_a2a)`-only with zero deps: the single-param 'inject
+        regardless of typing' heuristic must NOT fire for a hidden,
+        framework-bound slot — no injection target, no warning (matches
+        pre-fix behavior the __signature__ hiding was added for)."""
+
+        async def original(_a2a=None):
+            return _a2a
+
+        bridge = self._make_bridge(original)
+
+        with caplog.at_level(logging.WARNING):
+            result = analyze_injection_strategy(bridge, [])
+
+        assert result == []
+        assert not caplog.records
+
+    def test_bounds_guard_skips_out_of_range_position(self, caplog):
+        """Defensive guard: a position beyond the resolved param list must
+        log a warning and skip that one injection — no crash, and other
+        deps still inject into their own positional slots."""
+        import logging as _log
+        from mesh.types import McpMeshTool
+        from _mcp_mesh.engine.dependency_injector import _prepare_injection_kwargs
+
+        async def f(a: str, db: McpMeshTool = None):
+            return db
+
+        proxy0 = MagicMock(name="proxy0")
+        with caplog.at_level(logging.WARNING):
+            final_kwargs, count = _prepare_injection_kwargs(
+                f,
+                {},
+                [1, 7],  # position 7 is synthetic skew — out of bounds
+                ["cap0", "cap1"],
+                [proxy0, MagicMock(name="proxy1")],
+                lambda _key: None,
+                _log.getLogger("test"),
+            )
+
+        assert final_kwargs["db"] is proxy0
+        assert count == 1
+        assert any(
+            "out of bounds" in r.message and "'cap1'" in r.message
+            for r in caplog.records
+        )
+
+    def test_plain_mesh_tool_positional_injection_unchanged(self):
+        """Common-path guard: a plain function (no __signature__ rewrite)
+        injects exactly as before — wrapper and original views are the
+        same view."""
+        from mesh.types import McpMeshTool
+
+        def f(a: str, db: McpMeshTool = None):
+            return (a, db)
+
+        injector = DependencyInjector()
+        wrapper = injector.create_injection_wrapper(f, ["db_cap"])
+
+        proxy = MagicMock(name="db_proxy")
+        wrapper._mesh_update_dependency(0, proxy)
+
+        a, db = wrapper("x")
+
+        assert a == "x"
+        assert db is proxy
+
+    def test_plain_single_param_heuristic_unchanged(self):
+        """The untyped single-parameter heuristic still applies to plain
+        functions (no hidden params): position 0 is selected."""
+
+        def f(anything):
+            return anything
+
+        assert analyze_injection_strategy(f, ["dep1"]) == [0]


### PR DESCRIPTION
## Summary
- `_prepare_injection_kwargs` indexed the wrapper's `__signature__`-overridden parameter list with positions computed from the original function (via `_get_original_func`), so decorators that hide params through `__signature__` rewrite — `@mesh.a2a_consumer` and the `@mesh.llm` fallback wrapper — hit `IndexError` on every invocation (`(_a2a, job: MeshJob)` + dep) or silently injected the proxy into the wrong parameter (`(_a2a, db: McpMeshTool, y)` → proxy landed in `y`).
- Fix is the consistent-view approach: resolve the parameter list from `inspect.signature(_get_original_func(func))` — the same source the positions come from, the exact move #1105 made for the diagnostic — plus a bounds guard that warns (with position, dep, function, and param-list context) and skips one injection instead of crashing. Same fix in `analyze_injection_strategy`, which is a required companion: moving only the prepare side would have injected into the hidden `_a2a` slot and displaced the bridge's client.
- **Design contract preserved and now pinned by test**: dependencies pair with parameters by declaration order (position), never by name. The new test names parameters adversarially (`cap_b` first, `cap_a` second, with `dependencies=["cap_a","cap_b"]`) so any future name-based matcher fails it loudly.

## Behavior change (intended)
A hidden-wrapper consumer with a single **untyped** user param (`@mesh.a2a_consumer` over `(_a2a, data)` + dep) previously received the proxy via the single-param heuristic — but only because the position and name lookups shared the same wrong view. Post-fix, the typed-only rule governs: no injection, with a warning explaining the param needs a `McpMeshTool` annotation. Confirmed with the maintainer: injection eligibility requires the type annotation; pairing stays positional.

## Review Notes
- Independent review: 0 blockers. It reconstructed the full pre/post decision table, verified the common path is unchanged (`inspect.signature` follows `__wrapped__` by default, so the views only diverge when `__signature__` is explicitly set — exactly the broken case), and confirmed all wrappers forward `**kwargs` verbatim so original-name keys are correct.
- Hot-path note for a future cleanup: the original-view signature could be precomputed at decoration time like `mesh_positions` already is.
- Surfaced during the work (cosmetic, untouched): the a2a bridge's `__signature__` override still exposes `McpMeshTool` params to FastMCP's tool schema.

Part of #1162 (MED-1 only; remaining findings follow in a separate PR)

## Test plan
- [x] Full Python unit suite: 1053 passed
- [x] New tests validated against the pre-fix source: the IndexError and wrong-param cases fail exactly as expected pre-fix
- [x] Declaration-order pinning test (adversarial param naming), bounds-guard test, plain-`@mesh.tool` common-path guards
- [ ] Integration suites on the next `tsuite-mesh:local` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved dependency injection failures when decorators hide framework parameters. Added bounds validation to prevent crashes during parameter positioning.

* **Tests**
  * Added comprehensive test coverage for decorator scenarios with hidden parameters to prevent future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->