### PR TITLE
fix(python): LLM agent concurrency, parse-error unification, dispatcher drain, fallback unregister

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/claim_dispatcher.py
+++ b/src/runtime/python/_mcp_mesh/engine/claim_dispatcher.py
@@ -70,6 +70,25 @@ _MAX_CONCURRENT_DISPATCHES = 4
 # operator dashboards without spamming on a single transient blip.
 _CONSECUTIVE_FAILURES_ERROR_THRESHOLD = 5
 
+# Bounded wait for in-flight dispatch tasks during ``stop()``. Mirrors the
+# TypeScript ``ClaimDispatcher.stop(timeoutMs = 30_000)`` drain default
+# (``src/runtime/typescript/src/claim-dispatcher.ts``): long enough that a
+# typical job's terminal complete/fail flush finishes, short enough that a
+# runaway handler doesn't block shutdown forever.
+_STOP_DRAIN_TIMEOUT_SECS = 30.0
+
+# Bounded wait for cancelled stragglers AFTER the drain window. A handler
+# that swallows CancelledError (broad retry loops, shielded awaits) would
+# make an unbounded await hang ``stop()`` forever; past this window the
+# tasks are logged and abandoned.
+_STOP_CANCEL_WAIT_SECS = 5.0
+
+# Extra headroom on top of the shared drain budget in ``stop_dispatchers``:
+# covers the per-dispatcher poll-loop stop (<=5s), straggler-cancel wait
+# (<=_STOP_CANCEL_WAIT_SECS) and HTTP client close, which all happen
+# outside the drain window itself.
+_STOP_BUDGET_GRACE_SECS = 10.0
+
 
 class PythonClaimDispatcher:
     """Background task that claims pending jobs for a single capability
@@ -108,6 +127,12 @@ class PythonClaimDispatcher:
         self._dispatch_sem = asyncio.Semaphore(_MAX_CONCURRENT_DISPATCHES)
         # Consecutive failure tracker for log-level escalation (W1).
         self._consecutive_failures = 0
+        # Strong refs to in-flight dispatch tasks (issue #1162 LOW-5):
+        # asyncio only keeps a weak reference to tasks, so a long-running
+        # handler task with no other referent can be GC'd mid-flight. The
+        # set also lets stop() drain in-flight dispatches so their
+        # best-effort terminal fail() reports aren't killed with the loop.
+        self._dispatch_tasks: set[asyncio.Task] = set()
 
     async def _claim_once(self) -> list[dict]:
         """Single ``POST /jobs/claim`` call. Returns the list of claimed
@@ -332,7 +357,7 @@ class PythonClaimDispatcher:
                             job.get("id"),
                         )
                         if first:
-                            asyncio.create_task(self._dispatch_with_permit(job))
+                            self._spawn_dispatch(job)
                             permit_held = False  # ownership transferred
                             first = False
                         else:
@@ -341,7 +366,7 @@ class PythonClaimDispatcher:
                             # don't dispatch more concurrently than
                             # ``_MAX_CONCURRENT_DISPATCHES`` allows.
                             await self._dispatch_sem.acquire()
-                            asyncio.create_task(self._dispatch_with_permit(job))
+                            self._spawn_dispatch(job)
                     backoff = _POLL_BASE_SECS  # reset on success
                     continue
 
@@ -367,6 +392,16 @@ class PythonClaimDispatcher:
             self.instance_id,
         )
 
+    def _spawn_dispatch(self, claimed: dict) -> None:
+        """Spawn a dispatch task and retain a strong reference to it.
+
+        The done-callback discard keeps the set bounded to genuinely
+        in-flight tasks; ``stop()`` drains whatever remains.
+        """
+        task = asyncio.create_task(self._dispatch_with_permit(claimed))
+        self._dispatch_tasks.add(task)
+        task.add_done_callback(self._dispatch_tasks.discard)
+
     async def _dispatch_with_permit(self, claimed: dict) -> None:
         """Run ``_dispatch`` and guarantee the semaphore permit is released.
 
@@ -388,8 +423,26 @@ class PythonClaimDispatcher:
             self._run_loop(), name=f"mesh-claim-{self.capability}"
         )
 
-    async def stop(self) -> None:
-        """Signal the loop to exit and await it."""
+    async def stop(self, drain_timeout: float = _STOP_DRAIN_TIMEOUT_SECS) -> None:
+        """Signal the loop to exit, await it, then drain in-flight dispatches.
+
+        Drain order (mirrors the TypeScript ``ClaimDispatcher.stop()``):
+
+        1. stop the poll loop — no new claims/dispatches after this;
+        2. await in-flight dispatch tasks, bounded by ``drain_timeout``,
+           so handlers finish their terminal ``complete``/``fail`` reports
+           instead of dying with the loop;
+        3. cancel stragglers that outlive the window and await the
+           cancellations, bounded by ``_STOP_CANCEL_WAIT_SECS`` (permit
+           release is guaranteed by ``_dispatch_with_permit``'s
+           ``finally``; a handler that swallows CancelledError is logged
+           and abandoned rather than hanging stop() forever);
+        4. close the dispatcher-owned HTTP client.
+
+        Args:
+            drain_timeout: Bounded wait (seconds) for in-flight handlers.
+                ``<= 0`` skips the drain and cancels immediately (tests).
+        """
         self._stop.set()
         if self._task is not None:
             try:
@@ -401,6 +454,41 @@ class PythonClaimDispatcher:
                     self.capability,
                 )
                 self._task.cancel()
+
+        # Drain in-flight dispatch tasks (issue #1162 LOW-5). The poll loop
+        # is down so the set can only shrink from here.
+        pending = {t for t in self._dispatch_tasks if not t.done()}
+        if pending:
+            if drain_timeout > 0:
+                _done, pending = await asyncio.wait(pending, timeout=drain_timeout)
+            if pending:
+                logger.warning(
+                    "claim_dispatcher: stop() drain timed out for capability=%s "
+                    "with %d dispatch task(s) still in flight; cancelling",
+                    self.capability,
+                    len(pending),
+                )
+                for task in pending:
+                    task.cancel()
+                # Bounded: a handler that swallows CancelledError would
+                # otherwise hang stop() forever (post-#1162 review). The
+                # tasks only ever end cancelled or clean (_dispatch
+                # swallows handler exceptions), so abandoning here leaks
+                # no unretrieved exceptions.
+                _done, abandoned = await asyncio.wait(
+                    pending, timeout=_STOP_CANCEL_WAIT_SECS
+                )
+                if abandoned:
+                    logger.warning(
+                        "claim_dispatcher: %d dispatch task(s) for "
+                        "capability=%s did not exit within %.1fs of "
+                        "cancellation (handler may be swallowing "
+                        "CancelledError); abandoning",
+                        len(abandoned),
+                        self.capability,
+                        _STOP_CANCEL_WAIT_SECS,
+                    )
+
         # Close the dispatcher-owned HTTP client so connection pools
         # don't leak across agent restarts in long-lived test harnesses.
         client = self._http_client
@@ -413,6 +501,66 @@ class PythonClaimDispatcher:
                     "claim_dispatcher: http client close raised (%s); ignoring",
                     e,
                 )
+
+
+async def stop_dispatchers(
+    dispatchers: list,
+    drain_timeout: float = _STOP_DRAIN_TIMEOUT_SECS,
+    grace: float = _STOP_BUDGET_GRACE_SECS,
+) -> None:
+    """Stop multiple dispatchers concurrently under ONE shared drain budget.
+
+    Every dispatcher drains against the SAME ``drain_timeout`` window —
+    the ``stop()`` calls run in parallel via ``asyncio.gather`` — so N
+    dispatchers with in-flight jobs cost roughly one drain window of wall
+    time, not N stacked windows. Sequential 30s drains would starve
+    whatever the caller sequences after this (registry unregister, Rust
+    core shutdown) past a typical SIGTERM grace period (K8s default 30s),
+    getting the process SIGKILLed before cleanup runs.
+
+    The whole phase is additionally hard-capped at ``drain_timeout +
+    grace``: past that, the remaining ``stop()`` calls are cancelled and
+    abandoned with a warning. Never raises (short of outer cancellation)
+    — a wedged dispatcher must not prevent the registry cleanup that
+    callers run after this.
+
+    Args:
+        dispatchers: Dispatchers to stop (objects exposing
+            ``stop(drain_timeout=...)``).
+        drain_timeout: Shared in-flight-handler drain window, passed to
+            every ``stop()`` call.
+        grace: Headroom on top of ``drain_timeout`` for per-dispatcher
+            bookkeeping (poll-loop stop, straggler cancel, client close)
+            before the phase is abandoned wholesale.
+    """
+    if not dispatchers:
+        return
+
+    async def _stop_one(d: Any) -> None:
+        try:
+            await d.stop(drain_timeout=drain_timeout)
+        except Exception as e:
+            logger.warning(
+                "claim_dispatcher: error stopping dispatcher for "
+                "capability=%s: %s",
+                getattr(d, "capability", "?"),
+                e,
+            )
+
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(*(_stop_one(d) for d in dispatchers)),
+            timeout=drain_timeout + grace,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "claim_dispatcher: shutdown of %d dispatcher(s) exceeded the "
+            "shared budget (%.1fs drain + %.1fs grace); abandoning "
+            "remaining drains so shutdown can proceed to registry cleanup",
+            len(dispatchers),
+            drain_timeout,
+            grace,
+        )
 
 
 def discover_task_handlers(

--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
@@ -188,7 +188,6 @@ class MeshLlmAgent:
         self.output_type = output_type
         self.system_prompt = config.system_prompt  # Public attribute for tests
         self.output_mode = config.output_mode  # Output mode override (strict/hint/text)
-        self._iteration_count = 0
         self._default_model_params = (
             default_model_params or {}
         )  # Decorator-level defaults
@@ -876,7 +875,13 @@ class MeshLlmAgent:
             # Replace context entirely
             result = await llm("What is the answer?", context={"only": "this"}, context_mode="replace")
         """
-        self._iteration_count = 0
+        # Issue #1162 MED-2: the iteration counter MUST be call-local. In
+        # non-template mode a single cached MeshLlmAgent instance is shared
+        # across concurrent invocations of the same @mesh.llm tool; an
+        # instance-level counter lets one call's reset/increments corrupt
+        # another's mid-loop state (defeating the max_iterations runaway
+        # defense, or tripping MaxIterationsError early).
+        iteration_count = 0
 
         # Issue #311: Track timing and token usage for _mesh_meta
         start_time = time.perf_counter()
@@ -892,10 +897,10 @@ class MeshLlmAgent:
         from _mcp_mesh.tracing.context import set_llm_metadata
 
         # Agentic loop
-        while self._iteration_count < self.max_iterations:
-            self._iteration_count += 1
+        while iteration_count < self.max_iterations:
+            iteration_count += 1
             logger.debug(
-                f"🔄 Iteration {self._iteration_count}/{self.max_iterations}..."
+                f"🔄 Iteration {iteration_count}/{self.max_iterations}..."
             )
 
             try:
@@ -1034,8 +1039,10 @@ class MeshLlmAgent:
 
                 # No tool calls - this is the final response
                 logger.debug("✅ Final response received from LLM")
+                # content can legally be None (e.g. max-token cutoffs); the
+                # f-string evaluates regardless of log level, so guard the slice.
                 logger.debug(
-                    f"📥 Raw LLM response: {assistant_message.content[:500]}..."
+                    f"📥 Raw LLM response: {(assistant_message.content or '')[:500]}..."
                 )
 
                 # Parse the response
@@ -1066,7 +1073,7 @@ class MeshLlmAgent:
             f"❌ Max iterations ({self.max_iterations}) exceeded without final response"
         )
         raise MaxIterationsError(
-            iteration_count=self._iteration_count,
+            iteration_count=iteration_count,
             max_allowed=self.max_iterations,
         )
 
@@ -1200,7 +1207,7 @@ class MeshLlmAgent:
 
         return resolved
 
-    def _parse_response(self, content: str) -> Any:
+    def _parse_response(self, content: Optional[str]) -> Any:
         """
         Parse LLM response into output type.
 
@@ -1208,7 +1215,8 @@ class MeshLlmAgent:
         For Pydantic models, delegates to ResponseParser.
 
         Args:
-            content: Response content from LLM
+            content: Response content from LLM (may be None — a legal
+                OpenAI-shape final message, e.g. on max-token cutoffs)
 
         Returns:
             Raw string (if output_type is str) or parsed Pydantic model instance
@@ -1216,6 +1224,21 @@ class MeshLlmAgent:
         Raises:
             ResponseParseError: If response doesn't match output_type schema or invalid JSON
         """
+        # content=None is a legal final-message shape (e.g. max-token
+        # cutoffs). For str output, normalize to "". For structured output,
+        # raise a proper parse error instead of letting None propagate into
+        # the parser as a TypeError (issue #1162).
+        if content is None:
+            if self.output_type is str:
+                return ""
+            raise ResponseParseError(
+                raw_content="",
+                expected_schema=getattr(
+                    self.output_type, "__name__", str(self.output_type)
+                ),
+                validation_errors="model returned empty content (content=None)",
+            )
+
         # For str return type, return content directly without parsing
         if self.output_type is str:
             return content

--- a/src/runtime/python/_mcp_mesh/engine/response_parser.py
+++ b/src/runtime/python/_mcp_mesh/engine/response_parser.py
@@ -13,15 +13,16 @@ from typing import Any, TypeVar, Union
 import mcp_mesh_core
 from pydantic import BaseModel, ValidationError
 
+# Issue #1162 LOW-4: the parser raises the single rich ResponseParseError
+# from llm_errors (raw_content / expected_schema / validation_errors attrs).
+# Re-exported here for back-compat — callers importing
+# `_mcp_mesh.engine.response_parser.ResponseParseError` get the same class
+# that `except llm_errors.ResponseParseError` catches.
+from .llm_errors import ResponseParseError
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
-
-
-class ResponseParseError(Exception):
-    """Raised when response parsing or validation fails."""
-
-    pass
 
 
 class ResponseParser:
@@ -80,7 +81,11 @@ class ResponseParser:
             raise
         except Exception as e:
             logger.error(f"❌ Unexpected error parsing response: {e}")
-            raise ResponseParseError(f"Unexpected parsing error: {e}")
+            raise ResponseParseError(
+                raw_content=str(content),
+                expected_schema=output_type.__name__,
+                validation_errors=f"Unexpected parsing error: {e}",
+            ) from e
 
     @staticmethod
     def _extract_json_from_mixed_content(content: str) -> str:
@@ -148,7 +153,11 @@ class ResponseParser:
                 return response_data
             except ValidationError:
                 # If wrapping doesn't work, raise the original JSON error
-                raise ResponseParseError(f"Invalid JSON response: {e}")
+                raise ResponseParseError(
+                    raw_content=content,
+                    expected_schema=output_type.__name__,
+                    validation_errors=f"Invalid JSON response: {e}",
+                ) from e
 
     @staticmethod
     def _is_list_annotation(annotation: Any) -> bool:
@@ -241,7 +250,12 @@ class ResponseParser:
                     response_data = {list_field_name: response_data}
                 else:
                     raise ResponseParseError(
-                        f"Response is a list but {output_type.__name__} has no list field to wrap into"
+                        raw_content=str(response_data),
+                        expected_schema=output_type.__name__,
+                        validation_errors=(
+                            f"Response is a list but {output_type.__name__} "
+                            f"has no list field to wrap into"
+                        ),
                     )
 
             # Defensive unwrap for LLM-side envelope hallucinations.
@@ -300,4 +314,8 @@ class ResponseParser:
                 f"Received data: {json.dumps(response_data, indent=2)}\n"
                 f"Validation errors: {e}"
             )
-            raise ResponseParseError(f"Response validation failed: {e}")
+            raise ResponseParseError(
+                raw_content=json.dumps(response_data, default=str),
+                expected_schema=output_type.__name__,
+                validation_errors=str(e),
+            ) from e

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
@@ -754,16 +754,35 @@ async def _handle_dependency_change(
         logger.info(f"Registered dependency: {dep_key}")
         return
 
-    # Fallback: capability-based matching (backward compatibility)
+    # Fallback: capability-based matching (backward compatibility — only
+    # reachable when the Rust core event lacks requesting_function/dep_index,
+    # i.e. older Rust cores).
     if not available:
-        # Dependency became unavailable - unregister it
-        if hasattr(injector, "_dependencies"):
-            keys_to_remove = [
-                key for key in injector._dependencies.keys() if capability in key
-            ]
-            for dep_key in keys_to_remove:
-                await injector.unregister_dependency(dep_key)
-                logger.info(f"Unregistered dependency: {dep_key}")
+        # Dependency became unavailable - unregister it. Map the capability
+        # to exact (func_id, dep_index) pairs via DecoratorRegistry metadata,
+        # mirroring the registration fallback below. The previous substring
+        # match against injector keys ("capability in key") was normally a
+        # no-op (keys are "{module}.{qualname}:dep_{N}", which never contain
+        # the capability) and over-matched when the capability happened to
+        # be a substring of an unrelated tool's qualname (issue #1162 LOW-6).
+        for tool_name, decorated_func in mesh_tools.items():
+            tool_metadata = decorated_func.metadata or {}
+            dependencies = tool_metadata.get("dependencies", [])
+            for idx, dep_info in enumerate(dependencies):
+                if dep_info.get("capability") == capability:
+                    func = decorated_func.function
+                    func_id = f"{func.__module__}.{func.__qualname__}"
+                    dep_key = f"{func_id}:dep_{idx}"
+                    # Only unregister (and log) slots that are actually
+                    # registered — a declared-but-never-resolved slot is a
+                    # no-op and logging "Unregistered" for it is misleading.
+                    if injector.get_dependency(dep_key) is None:
+                        logger.debug(
+                            f"Skipping unregister for {dep_key}: not registered"
+                        )
+                        continue
+                    await injector.unregister_dependency(dep_key)
+                    logger.info(f"Unregistered dependency: {dep_key}")
         return
 
     # Dependency is available - create proxy and register
@@ -1010,16 +1029,25 @@ def _start_claim_dispatchers_on_heartbeat_loop(context: dict[str, Any]) -> list:
 
 
 async def _stop_claim_dispatchers(dispatchers: list) -> None:
-    """Best-effort shutdown of claim dispatchers started by the heartbeat loop."""
-    for d in dispatchers:
-        try:
-            await d.stop()
-        except Exception as e:
-            logger.warning(
-                "heartbeat: error stopping claim dispatcher for capability=%s: %s",
-                getattr(d, "capability", "?"),
-                e,
-            )
+    """Best-effort shutdown of claim dispatchers started by the heartbeat loop.
+
+    All dispatchers stop concurrently under ONE shared drain budget (see
+    :func:`_mcp_mesh.engine.claim_dispatcher.stop_dispatchers`) so the
+    Rust core shutdown (registry unregister) sequenced after this in
+    ``rust_heartbeat_task``'s ``finally`` block isn't starved by N
+    stacked 30s drains past the SIGTERM grace period. Never raises
+    (short of outer cancellation).
+    """
+    if not dispatchers:
+        return
+    try:
+        from ...engine.claim_dispatcher import stop_dispatchers
+
+        await stop_dispatchers(dispatchers)
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning("heartbeat: error stopping claim dispatchers: %s", e)
 
 
 async def rust_heartbeat_task(heartbeat_config: dict[str, Any]) -> None:

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/lifespan_factory.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/lifespan_factory.py
@@ -341,16 +341,25 @@ def _start_claim_dispatchers(app: Any) -> list:
 
 
 async def _stop_claim_dispatchers(dispatchers: list) -> None:
-    """Best-effort shutdown of claim dispatchers started by the lifespan."""
-    for d in dispatchers:
-        try:
-            await d.stop()
-        except Exception as e:
-            logger.warning(
-                "lifespan: error stopping claim dispatcher for capability=%s: %s",
-                getattr(d, "capability", "?"),
-                e,
-            )
+    """Best-effort shutdown of claim dispatchers started by the lifespan.
+
+    All dispatchers stop concurrently under ONE shared drain budget (see
+    :func:`_mcp_mesh.engine.claim_dispatcher.stop_dispatchers`) so the
+    registry cleanup sequenced after this in the lifespan ``finally``
+    block isn't starved by N stacked 30s drains past the SIGTERM grace
+    period. Never raises (short of outer cancellation): a drain failure
+    or timeout in one dispatcher must not prevent registry cleanup.
+    """
+    if not dispatchers:
+        return
+    try:
+        from ...engine.claim_dispatcher import stop_dispatchers
+
+        await stop_dispatchers(dispatchers)
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning("lifespan: error stopping claim dispatchers: %s", e)
 
 
 async def _perform_registry_cleanup(

--- a/src/runtime/python/tests/unit/test_claim_dispatcher_stop_drain.py
+++ b/src/runtime/python/tests/unit/test_claim_dispatcher_stop_drain.py
@@ -1,0 +1,203 @@
+"""Issue #1162 LOW-5: claim dispatcher must retain and drain dispatch tasks.
+
+Before the fix, ``asyncio.create_task(self._dispatch_with_permit(job))``
+results were not retained (weak-ref GC hazard for long handlers) and
+``stop()`` awaited only the poll loop — in-flight dispatch tasks died with
+the loop without their best-effort terminal ``fail()`` report.
+
+Now tasks are tracked in a strong-ref set and ``stop()`` drains them with a
+bounded timeout (default mirrors the TypeScript ``ClaimDispatcher.stop``
+30s drain), cancelling stragglers. Permit accounting must stay balanced
+through both completion and cancellation.
+"""
+
+import asyncio
+import time
+from unittest import mock
+
+import pytest
+from _mcp_mesh.engine import claim_dispatcher as claim_dispatcher_module
+from _mcp_mesh.engine.claim_dispatcher import (
+    _MAX_CONCURRENT_DISPATCHES,
+    PythonClaimDispatcher,
+)
+
+
+def _make_dispatcher(handler) -> PythonClaimDispatcher:
+    return PythonClaimDispatcher(
+        capability="test_cap",
+        instance_id="test-instance",
+        registry_url="http://registry:8000",
+        handler=handler,
+    )
+
+
+def _single_job_claimer(dispatcher: PythonClaimDispatcher, job_id: str = "job-1"):
+    """Patch _claim_once to yield exactly one job, then no work."""
+    jobs = [[{"id": job_id, "submitted_payload": {}}]]
+
+    async def fake_claim_once():
+        return jobs.pop(0) if jobs else []
+
+    dispatcher._claim_once = fake_claim_once
+
+
+class TestStopDrainsInflightDispatch:
+    @pytest.mark.asyncio
+    async def test_stop_waits_for_slow_handler_to_complete(self):
+        started = asyncio.Event()
+        completed: list[bool] = []
+
+        async def handler(**kwargs):
+            started.set()
+            await asyncio.sleep(0.2)
+            completed.append(True)
+
+        dispatcher = _make_dispatcher(handler)
+        _single_job_claimer(dispatcher)
+
+        dispatcher.start()
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+
+        await dispatcher.stop(drain_timeout=5.0)
+
+        assert completed == [True]
+        assert not dispatcher._dispatch_tasks
+        # Permit accounting balanced after a drained completion.
+        assert dispatcher._dispatch_sem._value == _MAX_CONCURRENT_DISPATCHES
+
+    @pytest.mark.asyncio
+    async def test_stop_drain_lets_terminal_fail_report_fire(self):
+        """A handler that raises reports fail() to the registry; stop()
+        must not kill the dispatch task before that report fires."""
+        started = asyncio.Event()
+        fail_reports: list[tuple[str, str]] = []
+
+        class _FakeController:
+            def __init__(self, job_id, instance_id, registry_url):
+                self.job_id = job_id
+
+            async def fail(self, error):
+                # Yield once so the report itself needs the drain window.
+                await asyncio.sleep(0.05)
+                fail_reports.append((self.job_id, error))
+
+        async def handler(**kwargs):
+            started.set()
+            await asyncio.sleep(0.1)
+            raise RuntimeError("boom")
+
+        dispatcher = _make_dispatcher(handler)
+        _single_job_claimer(dispatcher, job_id="job-fail")
+
+        with mock.patch("mcp_mesh_core.JobController", _FakeController, create=True):
+            dispatcher.start()
+            await asyncio.wait_for(started.wait(), timeout=2.0)
+            await dispatcher.stop(drain_timeout=5.0)
+
+        assert fail_reports == [("job-fail", "boom")]
+        assert dispatcher._dispatch_sem._value == _MAX_CONCURRENT_DISPATCHES
+
+    @pytest.mark.asyncio
+    async def test_stragglers_past_drain_timeout_are_cancelled(self):
+        started = asyncio.Event()
+        completed: list[bool] = []
+        cancelled = asyncio.Event()
+
+        async def handler(**kwargs):
+            started.set()
+            try:
+                await asyncio.sleep(30)
+                completed.append(True)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        dispatcher = _make_dispatcher(handler)
+        _single_job_claimer(dispatcher)
+
+        dispatcher.start()
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+
+        await dispatcher.stop(drain_timeout=0.05)
+
+        assert cancelled.is_set()
+        assert completed == []
+        assert not dispatcher._dispatch_tasks
+        # Cancellation must hit _dispatch_with_permit's finally and
+        # release the permit — accounting stays balanced.
+        assert dispatcher._dispatch_sem._value == _MAX_CONCURRENT_DISPATCHES
+
+    @pytest.mark.asyncio
+    async def test_handler_swallowing_cancellation_is_abandoned_bounded(
+        self, monkeypatch, caplog
+    ):
+        """Post-cancel wait is bounded: a handler that swallows
+        CancelledError must not hang stop() forever — the task is logged
+        and abandoned after _STOP_CANCEL_WAIT_SECS."""
+        monkeypatch.setattr(
+            claim_dispatcher_module, "_STOP_CANCEL_WAIT_SECS", 0.2
+        )
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+        swallowed = asyncio.Event()
+
+        async def handler(**kwargs):
+            started.set()
+            while True:
+                try:
+                    await release.wait()
+                    return
+                except asyncio.CancelledError:
+                    # Misbehaving handler: swallow the cancellation and
+                    # keep waiting (retry-loop / shielded-await pattern).
+                    swallowed.set()
+
+        dispatcher = _make_dispatcher(handler)
+        _single_job_claimer(dispatcher)
+
+        dispatcher.start()
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+        abandoned_task = next(iter(dispatcher._dispatch_tasks))
+
+        t0 = time.monotonic()
+        with caplog.at_level("WARNING"):
+            await dispatcher.stop(drain_timeout=0.05)
+        elapsed = time.monotonic() - t0
+
+        assert swallowed.is_set()
+        assert elapsed < 2.0  # bounded, not hung on the swallowed cancel
+        assert any(
+            "abandoning" in rec.getMessage()
+            for rec in caplog.records
+            if rec.levelname == "WARNING"
+        )
+
+        # Clean up the abandoned task so it doesn't leak past the test.
+        release.set()
+        await asyncio.wait_for(abandoned_task, timeout=2.0)
+
+    @pytest.mark.asyncio
+    async def test_dispatch_tasks_strongly_referenced_while_inflight(self):
+        """The task set holds a strong reference for the lifetime of the
+        dispatch (asyncio itself only keeps weak refs) and self-cleans on
+        completion via the done callback."""
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def handler(**kwargs):
+            started.set()
+            await release.wait()
+
+        dispatcher = _make_dispatcher(handler)
+        _single_job_claimer(dispatcher)
+
+        dispatcher.start()
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+
+        assert len(dispatcher._dispatch_tasks) == 1
+
+        release.set()
+        await dispatcher.stop(drain_timeout=5.0)
+        assert not dispatcher._dispatch_tasks

--- a/src/runtime/python/tests/unit/test_dep_fallback_unregister.py
+++ b/src/runtime/python/tests/unit/test_dep_fallback_unregister.py
@@ -1,0 +1,153 @@
+"""Issue #1162 LOW-6: legacy capability-based unregister must not substring-match.
+
+The fallback path in ``_handle_dependency_change`` (only reachable with older
+Rust cores whose events lack ``requesting_function``/``dep_index``) used to
+remove every injector key where ``capability in key``. Keys are shaped
+``{module}.{qualname}:dep_{N}`` so that was normally a no-op — and
+over-matched when the capability happened to be a substring of an unrelated
+tool's qualname (capability ``"date"`` vs a tool named ``get_date``).
+
+Now the fallback maps capability → exact (func_id, dep_index) pairs via
+DecoratorRegistry metadata, mirroring the registration fallback.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+from _mcp_mesh.pipeline.mcp_heartbeat import rust_heartbeat
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    DecoratorRegistry.clear_all()
+    yield
+    DecoratorRegistry.clear_all()
+
+
+def _func_id(func) -> str:
+    return f"{func.__module__}.{func.__qualname__}"
+
+
+async def _fallback_unregister(capability: str, injector) -> None:
+    """Drive the fallback path: no requesting_function / dep_index."""
+    with patch(
+        "_mcp_mesh.engine.dependency_injector.get_global_injector",
+        return_value=injector,
+    ):
+        await rust_heartbeat._handle_dependency_change(
+            capability=capability,
+            endpoint=None,
+            function_name=None,
+            agent_id=None,
+            available=False,
+            context={},
+            requesting_function=None,
+            dep_index=None,
+            producer_kwargs=None,
+        )
+
+
+def _make_injector(dep_keys: list[str]) -> MagicMock:
+    injector = MagicMock()
+    injector.unregister_dependency = AsyncMock()
+    # Present so the OLD substring-matching code path would have had
+    # something to over-match against. The fixed code consults membership
+    # via get_dependency() before unregistering, so wire it to the dict.
+    injector._dependencies = {key: object() for key in dep_keys}
+    injector.get_dependency = lambda name: injector._dependencies.get(name)
+    return injector
+
+
+class TestFallbackUnregister:
+    @pytest.mark.asyncio
+    async def test_capability_substring_of_qualname_does_not_over_match(self):
+        """capability="date" must NOT remove deps of a tool whose qualname
+        contains "date" (get_date) — only deps declared on capability="date"."""
+
+        async def report_tool(prompt: str, date=None):
+            return date
+
+        DecoratorRegistry.register_mesh_tool(
+            report_tool,
+            {"capability": "report", "dependencies": [{"capability": "date"}]},
+        )
+
+        async def get_date(prompt: str, other=None):
+            return other
+
+        DecoratorRegistry.register_mesh_tool(
+            get_date,
+            {"capability": "get_date", "dependencies": [{"capability": "other_cap"}]},
+        )
+
+        consumer_key = f"{_func_id(report_tool)}:dep_0"
+        unrelated_key = f"{_func_id(get_date)}:dep_0"
+        # Sanity: the unrelated key contains the capability as a substring —
+        # the exact shape the old code over-matched on.
+        assert "date" in unrelated_key
+
+        injector = _make_injector([consumer_key, unrelated_key])
+        await _fallback_unregister("date", injector)
+
+        injector.unregister_dependency.assert_awaited_once_with(consumer_key)
+
+    @pytest.mark.asyncio
+    async def test_correct_func_id_and_dep_index_removed_on_metadata_match(self):
+        """Multi-dependency consumer: only the dep slot whose declared
+        capability matches is unregistered, at the right index."""
+
+        async def consumer(prompt: str, time_svc=None, date_svc=None):
+            return date_svc
+
+        DecoratorRegistry.register_mesh_tool(
+            consumer,
+            {
+                "capability": "consumer_tool",
+                "dependencies": [{"capability": "time"}, {"capability": "date"}],
+            },
+        )
+
+        injector = _make_injector(
+            [f"{_func_id(consumer)}:dep_0", f"{_func_id(consumer)}:dep_1"]
+        )
+        await _fallback_unregister("date", injector)
+
+        injector.unregister_dependency.assert_awaited_once_with(
+            f"{_func_id(consumer)}:dep_1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_matching_capability_unregisters_nothing(self):
+        async def consumer(prompt: str, dep=None):
+            return dep
+
+        DecoratorRegistry.register_mesh_tool(
+            consumer,
+            {"capability": "consumer_tool", "dependencies": [{"capability": "time"}]},
+        )
+
+        injector = _make_injector([f"{_func_id(consumer)}:dep_0"])
+        await _fallback_unregister("date", injector)
+
+        injector.unregister_dependency.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_declared_but_unregistered_slot_is_skipped(self):
+        """A slot whose declared capability matches but that was never
+        registered (dependency never resolved) must not be unregistered —
+        and must not produce a misleading 'Unregistered dependency' log."""
+
+        async def consumer(prompt: str, date_svc=None):
+            return date_svc
+
+        DecoratorRegistry.register_mesh_tool(
+            consumer,
+            {"capability": "consumer_tool", "dependencies": [{"capability": "date"}]},
+        )
+
+        # Injector has NO registered deps — the slot is declared only.
+        injector = _make_injector([])
+        await _fallback_unregister("date", injector)
+
+        injector.unregister_dependency.assert_not_awaited()

--- a/src/runtime/python/tests/unit/test_mesh_llm_agent_iteration_isolation.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_agent_iteration_isolation.py
@@ -1,0 +1,110 @@
+"""Issue #1162 MED-2: iteration count must be call-local, not instance state.
+
+In non-template mode a single cached ``MeshLlmAgent`` instance is injected
+into every invocation of a ``@mesh.llm`` tool, so two concurrent ``__call__``s
+share the same object. Before the fix, ``__call__`` reset and incremented
+``self._iteration_count`` — one call's reset zeroed the other's mid-loop
+counter (loop could exceed ``max_iterations``, the runaway-LLM-spend defense)
+or combined increments tripped ``MaxIterationsError`` prematurely.
+
+These tests run two concurrent calls against ONE agent instance with a slow
+async provider stub that counts model invocations and force-yields so the
+calls genuinely interleave.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from _mcp_mesh.engine.llm_config import LLMConfig
+from _mcp_mesh.engine.llm_errors import MaxIterationsError
+from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+
+
+def _make_agent(provider_proxy, max_iterations: int) -> MeshLlmAgent:
+    tool_proxy = MagicMock()
+    tool_proxy.call_tool = AsyncMock(return_value="ok")
+    return MeshLlmAgent(
+        config=LLMConfig(
+            provider={"capability": "llm", "tags": ["claude"]},
+            model=None,
+            max_iterations=max_iterations,
+            system_prompt="Test prompt",
+        ),
+        filtered_tools=[],
+        output_type=str,
+        tool_proxies={"noop_tool": tool_proxy},
+        provider_proxy=provider_proxy,
+        vendor="anthropic",
+    )
+
+
+def _tool_call_message(call_id: str) -> dict:
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": "noop_tool", "arguments": "{}"},
+            }
+        ],
+    }
+
+
+class TestConcurrentCallIterationIsolation:
+    @pytest.mark.asyncio
+    async def test_concurrent_calls_each_respect_own_max_iterations(self):
+        """Two interleaved calls that never reach a final response must EACH
+        run exactly max_iterations model invocations, then raise
+        MaxIterationsError reporting their own count — no cross-talk."""
+        max_iterations = 3
+        invocations = 0
+
+        async def provider(request):
+            nonlocal invocations
+            invocations += 1
+            # Force a yield so the two concurrent loops interleave.
+            await asyncio.sleep(0.001)
+            return _tool_call_message(f"call_{invocations}")
+
+        agent = _make_agent(provider, max_iterations)
+
+        results = await asyncio.gather(
+            agent("call A"), agent("call B"), return_exceptions=True
+        )
+
+        # Both calls must hit the iteration ceiling — independently.
+        assert all(isinstance(r, MaxIterationsError) for r in results), results
+        for r in results:
+            assert r.iteration_count == max_iterations
+            assert r.max_allowed == max_iterations
+
+        # Exactly max_iterations model invocations per call. A shared
+        # instance-level counter would exit both loops after a COMBINED
+        # max_iterations increments (premature) or let one loop run past
+        # the ceiling after the other call's reset.
+        assert invocations == 2 * max_iterations
+
+    @pytest.mark.asyncio
+    async def test_concurrent_calls_do_not_trip_max_iterations_prematurely(self):
+        """Two concurrent calls that each legitimately need 2 iterations
+        (tool call, then final answer) must BOTH succeed with
+        max_iterations=2 — combined increments on a shared counter would
+        raise MaxIterationsError before either call finished."""
+
+        async def provider(request):
+            await asyncio.sleep(0.001)
+            messages = request["messages"]
+            has_tool_result = any(m.get("role") == "tool" for m in messages)
+            if not has_tool_result:
+                return _tool_call_message("call_1")
+            return {"role": "assistant", "content": "done"}
+
+        agent = _make_agent(provider, max_iterations=2)
+
+        result_a, result_b = await asyncio.gather(agent("call A"), agent("call B"))
+
+        assert result_a == "done"
+        assert result_b == "done"

--- a/src/runtime/python/tests/unit/test_mesh_llm_content_none_and_parse_error.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_content_none_and_parse_error.py
@@ -1,0 +1,108 @@
+"""Issue #1162 findings 3 and 4.
+
+Finding 3 (LOW/MED): a final assistant message with ``content: null`` is a
+legal OpenAI-shape response (e.g. max-token cutoffs). It must not raise
+TypeError from the debug-log slice or from the parser:
+
+* ``output_type=str`` → the call returns ``""``;
+* Pydantic output → the rich ``ResponseParseError`` is raised with a clear
+  "empty content" message.
+
+Finding 4 (LOW): there used to be TWO ``ResponseParseError`` classes — a rich
+one in ``llm_errors`` (raw_content / expected_schema / validation_errors)
+that was imported and caught, and a bare one in ``response_parser`` that was
+actually raised. ``except llm_errors.ResponseParseError`` silently missed
+real parse failures. Now there is exactly one class: the parser raises the
+rich one and ``response_parser.ResponseParseError`` is a back-compat alias.
+"""
+
+import pytest
+from _mcp_mesh.engine import llm_errors, response_parser
+from _mcp_mesh.engine.llm_config import LLMConfig
+from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+from _mcp_mesh.engine.response_parser import ResponseParser
+from pydantic import BaseModel
+
+
+class StrictModel(BaseModel):
+    count: int
+    name: str
+
+
+def _make_agent(provider_proxy, output_type) -> MeshLlmAgent:
+    return MeshLlmAgent(
+        config=LLMConfig(
+            provider={"capability": "llm", "tags": ["claude"]},
+            model=None,
+            max_iterations=3,
+            system_prompt="Test prompt",
+        ),
+        filtered_tools=[],
+        output_type=output_type,
+        provider_proxy=provider_proxy,
+        vendor="anthropic",
+    )
+
+
+async def _none_content_provider(request):
+    return {"role": "assistant", "content": None}
+
+
+class TestContentNoneFinalResponse:
+    @pytest.mark.asyncio
+    async def test_str_output_returns_empty_string(self):
+        agent = _make_agent(_none_content_provider, str)
+        result = await agent("hello")
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_pydantic_output_raises_rich_parse_error(self):
+        agent = _make_agent(_none_content_provider, StrictModel)
+        with pytest.raises(llm_errors.ResponseParseError) as exc_info:
+            await agent("hello")
+        err = exc_info.value
+        assert err.expected_schema == "StrictModel"
+        assert "empty content" in (err.validation_errors or "")
+
+    def test_parse_response_none_str_output(self):
+        agent = _make_agent(_none_content_provider, str)
+        assert agent._parse_response(None) == ""
+
+    def test_parse_response_none_pydantic_output(self):
+        agent = _make_agent(_none_content_provider, StrictModel)
+        with pytest.raises(llm_errors.ResponseParseError):
+            agent._parse_response(None)
+
+
+class TestResponseParseErrorUnification:
+    def test_single_class_aliased_for_back_compat(self):
+        """The bare class in response_parser is gone; the import path still
+        works and resolves to the rich llm_errors class."""
+        assert response_parser.ResponseParseError is llm_errors.ResponseParseError
+
+    def test_invalid_json_raises_llm_errors_class_with_attrs(self):
+        raw = "definitely not json"
+        with pytest.raises(llm_errors.ResponseParseError) as exc_info:
+            ResponseParser.parse(raw, StrictModel)
+        err = exc_info.value
+        assert err.raw_content == raw
+        assert err.expected_schema == "StrictModel"
+        assert "Invalid JSON response" in err.validation_errors
+
+    def test_validation_failure_raises_llm_errors_class_with_attrs(self):
+        with pytest.raises(llm_errors.ResponseParseError) as exc_info:
+            ResponseParser.parse('{"count": "nope", "name": "x"}', StrictModel)
+        err = exc_info.value
+        assert err.expected_schema == "StrictModel"
+        assert err.validation_errors  # Pydantic error details populated
+        assert "count" in err.raw_content
+
+    def test_except_clause_on_llm_errors_class_catches_parser_raise(self):
+        """Regression for the original bug: callers catching the llm_errors
+        class must actually catch what the parser raises."""
+        caught = None
+        try:
+            ResponseParser.parse("definitely not json", StrictModel)
+        except llm_errors.ResponseParseError as e:
+            caught = e
+        assert caught is not None

--- a/src/runtime/python/tests/unit/test_stop_dispatchers_shared_budget.py
+++ b/src/runtime/python/tests/unit/test_stop_dispatchers_shared_budget.py
@@ -1,0 +1,187 @@
+"""Post-#1162 review: dispatcher shutdown must not starve registry cleanup.
+
+``_stop_claim_dispatchers`` (both the lifespan-factory and the
+rust-heartbeat copies) used to await each dispatcher's ``stop()``
+sequentially. With the 30s drain default, N dispatchers with in-flight
+jobs cost N x 30s+ of wall time before the registry unregister that runs
+after them — past a typical SIGTERM grace period (K8s default 30s), the
+process is SIGKILLed before cleanup.
+
+Now both delegate to :func:`_mcp_mesh.engine.claim_dispatcher.stop_dispatchers`:
+
+* all ``stop()`` calls run concurrently via ``asyncio.gather`` against
+  ONE shared drain budget (one window of wall time, not N stacked);
+* the whole phase is hard-capped at ``drain_timeout + grace`` — past
+  that the remaining drains are cancelled and abandoned;
+* a drain failure or timeout in one dispatcher can never prevent the
+  registry cleanup sequenced after the call from running.
+"""
+
+import asyncio
+import time
+
+import pytest
+from _mcp_mesh.engine import claim_dispatcher as claim_dispatcher_module
+from _mcp_mesh.engine.claim_dispatcher import stop_dispatchers
+from _mcp_mesh.pipeline.mcp_heartbeat import rust_heartbeat
+from _mcp_mesh.pipeline.mcp_startup import lifespan_factory
+
+
+class _FakeDispatcher:
+    """Minimal stand-in exposing the ``stop(drain_timeout=...)`` surface."""
+
+    def __init__(
+        self,
+        capability: str,
+        stop_duration: float = 0.0,
+        hang: bool = False,
+        fail: bool = False,
+    ) -> None:
+        self.capability = capability
+        self.stop_duration = stop_duration
+        self.hang = hang
+        self.fail = fail
+        self.stop_started_at: float | None = None
+        self.stop_finished = False
+        self.received_drain_timeout: float | None = None
+
+    async def stop(self, drain_timeout: float = 30.0) -> None:
+        self.stop_started_at = time.monotonic()
+        self.received_drain_timeout = drain_timeout
+        if self.fail:
+            raise RuntimeError(f"stop failed for {self.capability}")
+        if self.hang:
+            await asyncio.Event().wait()  # never completes
+        if self.stop_duration:
+            await asyncio.sleep(self.stop_duration)
+        self.stop_finished = True
+
+
+class TestStopDispatchersSharedBudget:
+    @pytest.mark.asyncio
+    async def test_two_slow_dispatchers_drain_concurrently_not_stacked(self):
+        """2 dispatchers each needing ~0.4s must finish in ~one window
+        (concurrent), not ~0.8s+ (sequential)."""
+        d1 = _FakeDispatcher("cap-a", stop_duration=0.4)
+        d2 = _FakeDispatcher("cap-b", stop_duration=0.4)
+
+        t0 = time.monotonic()
+        await stop_dispatchers([d1, d2], drain_timeout=2.0, grace=1.0)
+        elapsed = time.monotonic() - t0
+
+        assert d1.stop_finished and d2.stop_finished
+        # Concurrent: ~0.4s wall. Sequential would be >= 0.8s.
+        assert elapsed < 0.75, f"stops appear sequential: {elapsed:.2f}s"
+        # Both started inside the same window (overlap, not back-to-back).
+        assert abs(d1.stop_started_at - d2.stop_started_at) < 0.1
+
+    @pytest.mark.asyncio
+    async def test_every_dispatcher_gets_the_shared_drain_window(self):
+        """Each stop() receives the SAME shared drain_timeout — the budget
+        is not split per dispatcher."""
+        dispatchers = [_FakeDispatcher(f"cap-{i}") for i in range(3)]
+        await stop_dispatchers(dispatchers, drain_timeout=7.0, grace=1.0)
+        assert [d.received_drain_timeout for d in dispatchers] == [7.0] * 3
+
+    @pytest.mark.asyncio
+    async def test_hanging_drain_is_abandoned_and_code_after_still_runs(
+        self, caplog
+    ):
+        """A drain that never completes must not block past the hard cap;
+        registry-cleanup-style code sequenced after the call still runs."""
+        hanging = _FakeDispatcher("cap-stuck", hang=True)
+        healthy = _FakeDispatcher("cap-ok", stop_duration=0.05)
+
+        cleanup_ran = False
+        t0 = time.monotonic()
+        with caplog.at_level("WARNING"):
+            await stop_dispatchers(
+                [hanging, healthy], drain_timeout=0.1, grace=0.1
+            )
+        # Mirrors the lifespan finally block: cleanup is the next statement.
+        cleanup_ran = True
+        elapsed = time.monotonic() - t0
+
+        assert cleanup_ran
+        assert healthy.stop_finished
+        assert not hanging.stop_finished
+        assert elapsed < 1.0, f"hard cap did not engage: {elapsed:.2f}s"
+        assert any(
+            "exceeded the shared budget" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_one_failing_stop_does_not_block_the_others_or_raise(self):
+        failing = _FakeDispatcher("cap-bad", fail=True)
+        healthy = _FakeDispatcher("cap-ok", stop_duration=0.05)
+
+        # Must not raise — and the healthy dispatcher still drains.
+        await stop_dispatchers([failing, healthy], drain_timeout=1.0, grace=0.5)
+        assert healthy.stop_finished
+
+    @pytest.mark.asyncio
+    async def test_empty_list_is_a_noop(self):
+        await stop_dispatchers([], drain_timeout=0.0, grace=0.0)
+
+
+@pytest.mark.parametrize(
+    "wrapper",
+    [
+        lifespan_factory._stop_claim_dispatchers,
+        rust_heartbeat._stop_claim_dispatchers,
+    ],
+    ids=["lifespan_factory", "rust_heartbeat"],
+)
+class TestStopClaimDispatcherWrappers:
+    """Both shutdown call sites delegate to the shared-budget helper and
+    never let a dispatcher failure escape to skip registry cleanup."""
+
+    @pytest.mark.asyncio
+    async def test_wrapper_stops_concurrently(self, wrapper):
+        d1 = _FakeDispatcher("cap-a", stop_duration=0.3)
+        d2 = _FakeDispatcher("cap-b", stop_duration=0.3)
+
+        t0 = time.monotonic()
+        await wrapper([d1, d2])
+        elapsed = time.monotonic() - t0
+
+        assert d1.stop_finished and d2.stop_finished
+        assert elapsed < 0.55, f"wrapper stops appear sequential: {elapsed:.2f}s"
+
+    @pytest.mark.asyncio
+    async def test_wrapper_swallows_helper_failure(self, wrapper, monkeypatch):
+        async def exploding_stop_dispatchers(dispatchers, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(
+            claim_dispatcher_module,
+            "stop_dispatchers",
+            exploding_stop_dispatchers,
+        )
+        # Must not raise — cleanup after the call site depends on it.
+        await wrapper([_FakeDispatcher("cap-a")])
+
+    @pytest.mark.asyncio
+    async def test_wrapper_survives_hanging_drain_within_budget(
+        self, wrapper, monkeypatch
+    ):
+        """End-to-end through the wrapper: with a tightened budget, a
+        hanging dispatcher is abandoned and the call returns so the
+        cleanup sequenced after it can run."""
+        real = claim_dispatcher_module.stop_dispatchers
+
+        async def fast_budget(dispatchers, drain_timeout=0.05, grace=0.1):
+            await real(dispatchers, drain_timeout=drain_timeout, grace=grace)
+
+        monkeypatch.setattr(
+            claim_dispatcher_module, "stop_dispatchers", fast_budget
+        )
+
+        hanging = _FakeDispatcher("cap-stuck", hang=True)
+        t0 = time.monotonic()
+        await wrapper([hanging])
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 1.0
+        assert not hanging.stop_finished


### PR DESCRIPTION
## Summary
Remaining findings from the Python runtime audit (#1162); MED-1 shipped separately in #1171.

- **LLM iteration cap under concurrency**: `MeshLlmAgent.__call__` used instance state for its loop counter while a single cached instance serves every invocation of a `@mesh.llm` tool — concurrent calls reset each other's counter, defeating `max_iterations` (the runaway-spend bound) or tripping `MaxIterationsError` early. The count is now call-local; nothing reads the old mirror, so it's gone entirely.
- **`content: null` final messages**: no more `TypeError` from the debug-log slice (f-strings evaluate regardless of log level); `_parse_response(None)` returns `""` for str output and raises `ResponseParseError` for structured output.
- **One `ResponseParseError`**: the bare class in `response_parser.py` is deleted; all raise sites use the rich `llm_errors` class with `raw_content`/`expected_schema`/`validation_errors` populated and `from e` chaining — so `except llm_errors.ResponseParseError` now actually catches parse failures. The old import path still works as an alias; the bare class was never publicly exported.
- **Claim dispatcher drain**: dispatch tasks are tracked in a strong-ref set (asyncio weak-ref GC hazard); `stop()` drains in-flight handlers with a 30s bound (TS parity), cancels stragglers, and bounds the post-cancel wait so a handler swallowing `CancelledError` can't hang shutdown. Shutdown now stops all dispatchers concurrently under one shared budget via a new `stop_dispatchers` helper (both the lifespan and heartbeat paths had sequential loops — N×30s would have outlived a default K8s SIGTERM grace before registry cleanup ran), and a drain timeout can never skip registry cleanup.
- **Legacy fallback unregister**: the capability-based path matches exact `{module}.{qualname}:dep_{N}` keys via the DecoratorRegistry walk (same as the registration fallback) instead of substring matching, which could remove unrelated deps when a capability was a substring of a qualname.

## Review Notes
- Independent review: 0 blockers. It verified the exception-contract blast radius exhaustively (two catch sites, both correct post-change), drain ordering (poll loop provably stopped before the snapshot; permits balanced through cancellation), and byte-identical key construction in the fallback walk.
- Its warning (sequential drains starving shutdown) is fixed by the shared-budget concurrent stop above.
- **Follow-up found during the fix**: the TypeScript runtime has the same sequential per-dispatcher 30s drain ahead of registry unregister (`agent.ts` shutdown loop) — issue to follow.

Closes #1162

## Test plan
- [x] Full Python unit suite: 1083 passed
- [x] New tests validated against pre-fix source (11 failures pre-fix, including the wedged drain-less stop)
- [x] Concurrency isolation (2 concurrent calls each respect max_iterations), shared-budget stop (2 slow dispatchers < 1 window, cleanup runs after hung drain), drain/cancel/permit accounting, fallback unregister precision
- [ ] Integration suites on the next `tsuite-mesh:local` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed concurrent invocation handling in LLM agent iteration tracking to prevent cross-call interference
  * Improved response parsing error messages with richer error details including schema information
  * Enhanced dependency cleanup to prevent unintended removals due to substring matching

* **Refactor**
  * Dispatcher shutdown now supports configurable drain timeout for in-flight tasks with improved task tracking
  * Centralized dispatcher shutdown under a shared drain budget for concurrent and resource-efficient cleanup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->