### PR TITLE
fix(ts): event-loop resilience, full signal shutdown with shared drain budget, ESM https, google vendor

### DIFF
--- a/src/runtime/typescript/src/__tests__/agent-single-instance.spec.ts
+++ b/src/runtime/typescript/src/__tests__/agent-single-instance.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression tests for #1163 LOW-6 — a second MeshAgent constructed in
+ * the same synchronous chunk as another used to silently overwrite the
+ * module-level pending-auto-start slot: `scheduleAutoStart` only ever
+ * ran once per tick, so the first agent never started and nobody
+ * noticed.
+ *
+ * Fixed behavior:
+ *   - constructing a second agent in the same synchronous chunk (i.e.
+ *     while the first is still pending its auto-start tick — in real
+ *     Node the nextTick drains before any microtask continuation, so
+ *     the guard window covers the whole danger zone) throws a clear
+ *     "one MeshAgent per process" error;
+ *   - sequential constructions across async boundaries (e.g. one agent
+ *     per test in a harness) remain allowed: the guard auto-releases on
+ *     the first microtask.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { MeshAgent } from "../agent.js";
+
+function makeFastMCPStub() {
+  return {
+    addTool: vi.fn(),
+    start: vi.fn(),
+    getApp: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+let autoStartSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+beforeEach(() => {
+  autoStartSpy = vi
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .spyOn(MeshAgent.prototype as any, "_autoStart")
+    .mockImplementation(async () => {
+      /* no-op */
+    });
+});
+
+afterEach(() => {
+  if (autoStartSpy) {
+    autoStartSpy.mockRestore();
+    autoStartSpy = null;
+  }
+});
+
+describe("one MeshAgent per process (#1163 LOW-6)", () => {
+  it("throws when a second agent is constructed in the same synchronous chunk", () => {
+    const first = new MeshAgent(makeFastMCPStub(), {
+      name: "first-agent",
+      httpPort: 0,
+    });
+    expect(first).toBeDefined();
+
+    expect(
+      () =>
+        new MeshAgent(makeFastMCPStub(), {
+          name: "second-agent",
+          httpPort: 0,
+        }),
+    ).toThrow(/Only one MeshAgent may be constructed per process/);
+    expect(
+      () =>
+        new MeshAgent(makeFastMCPStub(), {
+          name: "second-agent",
+          httpPort: 0,
+        }),
+    ).toThrow(/'first-agent' is already pending auto-start/);
+  });
+
+  it("allows constructing a new agent after the guard releases", async () => {
+    const first = new MeshAgent(makeFastMCPStub(), {
+      name: "first-agent",
+      httpPort: 0,
+    });
+    expect(first).toBeDefined();
+
+    // Cross the async boundary: the construction guard releases on the
+    // first microtask (and in real Node the auto-start tick has already
+    // consumed the pending slot by then).
+    await Promise.resolve();
+
+    expect(
+      () =>
+        new MeshAgent(makeFastMCPStub(), {
+          name: "later-agent",
+          httpPort: 0,
+        }),
+    ).not.toThrow();
+  });
+});

--- a/src/runtime/typescript/src/__tests__/agent-single-instance.spec.ts
+++ b/src/runtime/typescript/src/__tests__/agent-single-instance.spec.ts
@@ -38,7 +38,12 @@ beforeEach(() => {
     });
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Drain the next-tick queue BEFORE restoring the spy: the constructor
+  // schedules the auto-start callback via process.nextTick, and vitest
+  // runs afterEach before that tick fires for sync test bodies. Restoring
+  // first would let the REAL _autoStart run against the FastMCP stub.
+  await new Promise(process.nextTick);
   if (autoStartSpy) {
     autoStartSpy.mockRestore();
     autoStartSpy = null;

--- a/src/runtime/typescript/src/__tests__/event-loop-resilience.spec.ts
+++ b/src/runtime/typescript/src/__tests__/event-loop-resilience.spec.ts
@@ -1,0 +1,371 @@
+/**
+ * Regression tests for #1163 MED-1 — the mesh event loop must outlive
+ * individual failures.
+ *
+ * Previously all three event loops (MeshAgent, ApiRuntime, MeshExpress)
+ * wrapped the entire `nextEvent()` + switch in one try/catch whose catch
+ * did `console.error(...); break;` — a single throw (transient napi
+ * rejection from nextEvent(), malformed event hitting a non-null
+ * assertion inside a handler) killed dependency-event processing for the
+ * process lifetime while the agent kept serving: frozen topology.
+ *
+ * The fixed loops:
+ *   - isolate each event: a handler throw is logged and the loop keeps
+ *     consuming events;
+ *   - retry `nextEvent()` rejections with a bounded exponential backoff
+ *     (100ms doubling, capped at 5s, reset on success);
+ *   - exit only on the "shutdown" event or a torn-down handle.
+ *
+ * Pattern mirrors registry-disconnect-retains-deps.spec.ts: drive the
+ * REAL private `runEventLoop` against a stub `this`.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { MeshAgent } from "../agent.js";
+import { ApiRuntime } from "../api-runtime.js";
+import { MeshExpress } from "../express.js";
+import { RouteRegistry } from "../route.js";
+import { MAX_CONSECUTIVE_NEXT_EVENT_FAILURES } from "../config.js";
+
+/** Replays the given event sequence once, then parks forever. */
+function stubHandle(events: Array<Record<string, unknown>>) {
+  let i = 0;
+  return {
+    nextEvent: async () => {
+      if (i < events.length) return events[i++] as never;
+      return new Promise<never>(() => {});
+    },
+  };
+}
+
+function depEvent(capability: string): Record<string, unknown> {
+  return {
+    eventType: "dependency_available",
+    capability,
+    endpoint: "http://peer:9000",
+    functionName: "fn",
+    agentId: "peer-1",
+    requestingFunction: "tool",
+    depIndex: 0,
+  };
+}
+
+const THROW_THEN_PROCESS_THEN_SHUTDOWN = [
+  depEvent("first"), // handler throws on this one
+  depEvent("second"), // must still be processed
+  { eventType: "shutdown" },
+];
+
+describe("event loop survives a throwing event handler (#1163 MED-1)", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    RouteRegistry.reset();
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function throwingThenRecordingHandler() {
+    return vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("malformed event boom");
+      })
+      .mockImplementation(() => {
+        /* subsequent events processed fine */
+      });
+  }
+
+  it("MeshAgent keeps processing events after a handler throw", async () => {
+    const handler = throwingThenRecordingHandler();
+    const stubThis = {
+      handle: stubHandle(THROW_THEN_PROCESS_THEN_SHUTDOWN),
+      handleDependencyAvailable: handler,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const runEventLoop = (MeshAgent.prototype as any).runEventLoop;
+    await runEventLoop.call(stubThis);
+
+    // Both dependency events reached the handler; the throw on the first
+    // one was logged and did NOT kill the loop, and shutdown still exits.
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("error handling event 'dependency_available'"),
+      expect.any(Error),
+    );
+  });
+
+  it("ApiRuntime keeps processing events after a handler throw", async () => {
+    const handler = throwingThenRecordingHandler();
+    const stubThis = {
+      handle: stubHandle(THROW_THEN_PROCESS_THEN_SHUTDOWN),
+      handleDependencyAvailable: handler,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const runEventLoop = (ApiRuntime.prototype as any).runEventLoop;
+    await runEventLoop.call(stubThis);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("error handling event 'dependency_available'"),
+      expect.any(Error),
+    );
+  });
+
+  it("MeshExpress keeps processing events after a handler throw", async () => {
+    const handler = throwingThenRecordingHandler();
+    const stubThis = {
+      handle: stubHandle(THROW_THEN_PROCESS_THEN_SHUTDOWN),
+      handleDependencyAvailable: handler,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const runEventLoop = (MeshExpress.prototype as any).runEventLoop;
+    await runEventLoop.call(stubThis);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("error handling event 'dependency_available'"),
+      expect.any(Error),
+    );
+  });
+});
+
+describe("event loop retries nextEvent() rejections with bounded backoff (#1163 MED-1)", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    RouteRegistry.reset();
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  /**
+   * Extract the backoff delays from the loop's "retrying in Xms" log
+   * lines. Deliberately NOT a setTimeout spy: a spy on the (fake)
+   * global setTimeout survives `vi.restoreAllMocks()` re-runs in later
+   * tests' afterEach hooks and re-installs the stale fake clock,
+   * hanging unrelated real-timer tests.
+   */
+  function loggedBackoffs(): number[] {
+    return errorSpy.mock.calls
+      .map((c) => /retrying in (\d+)ms/.exec(String(c[0]))?.[1])
+      .filter((m): m is string => m !== undefined)
+      .map(Number);
+  }
+
+  it("MeshAgent survives repeated nextEvent failures and still exits on shutdown", async () => {
+    vi.useFakeTimers();
+    const failures = 8;
+    let attempts = 0;
+    const stubThis = {
+      handle: {
+        nextEvent: async () => {
+          if (attempts < failures) {
+            attempts++;
+            throw new Error(`transient napi failure ${attempts}`);
+          }
+          return { eventType: "shutdown" };
+        },
+      },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const runEventLoop = (MeshAgent.prototype as any).runEventLoop;
+    const loop: Promise<void> = runEventLoop.call(stubThis);
+
+    // Each rejection schedules one backoff sleep; advancing by the cap
+    // flushes whichever delay is pending.
+    for (let i = 0; i < failures + 1; i++) {
+      await vi.advanceTimersByTimeAsync(5000);
+    }
+    await loop; // resolves — the loop survived and exited on shutdown
+
+    expect(attempts).toBe(failures);
+    // Backoff delays: exponential from 100ms, hard-capped at 5000ms.
+    expect(loggedBackoffs()).toEqual([100, 200, 400, 800, 1600, 3200, 5000, 5000]);
+  });
+
+  it("MeshAgent resets the backoff after a successful nextEvent", async () => {
+    vi.useFakeTimers();
+    // fail, fail, succeed (benign event), fail, shutdown
+    const script: Array<"fail" | Record<string, unknown>> = [
+      "fail",
+      "fail",
+      { eventType: "registry_connected" },
+      "fail",
+      { eventType: "shutdown" },
+    ];
+    let i = 0;
+    const stubThis = {
+      handle: {
+        nextEvent: async () => {
+          const step = script[i++];
+          if (step === "fail") throw new Error("transient");
+          return step;
+        },
+      },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const runEventLoop = (MeshAgent.prototype as any).runEventLoop;
+    const loop: Promise<void> = runEventLoop.call(stubThis);
+
+    for (let n = 0; n < script.length; n++) {
+      await vi.advanceTimersByTimeAsync(5000);
+    }
+    await loop;
+
+    // 100, 200 (two consecutive failures), then reset to 100 after the
+    // successful event.
+    expect(loggedBackoffs()).toEqual([100, 200, 100]);
+  });
+
+  it("ApiRuntime survives a nextEvent rejection and still exits on shutdown", async () => {
+    let attempts = 0;
+    const stubThis = {
+      handle: {
+        nextEvent: async () => {
+          if (attempts === 0) {
+            attempts++;
+            throw new Error("transient");
+          }
+          return { eventType: "shutdown" };
+        },
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const runEventLoop = (ApiRuntime.prototype as any).runEventLoop;
+    await runEventLoop.call(stubThis); // real timers: single 100ms backoff
+    expect(attempts).toBe(1);
+  });
+
+  it("MeshExpress survives a nextEvent rejection and still exits on shutdown", async () => {
+    let attempts = 0;
+    const stubThis = {
+      handle: {
+        nextEvent: async () => {
+          if (attempts === 0) {
+            attempts++;
+            throw new Error("transient");
+          }
+          return { eventType: "shutdown" };
+        },
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const runEventLoop = (MeshExpress.prototype as any).runEventLoop;
+    await runEventLoop.call(stubThis);
+    expect(attempts).toBe(1);
+  });
+});
+
+describe("event loop terminates at the consecutive-failure ceiling instead of retrying forever", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    RouteRegistry.reset();
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  /**
+   * Drive a permanently-failing nextEvent() against the given class's
+   * REAL private runEventLoop. Returns the number of nextEvent()
+   * attempts before the loop gave up (the loop resolving at all IS the
+   * regression assertion — before the ceiling it retried forever, and
+   * its ref'd backoff timer kept the process alive).
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function runUntilCeiling(proto: any): Promise<number> {
+    vi.useFakeTimers();
+    let attempts = 0;
+    const stubThis = {
+      handle: {
+        nextEvent: async () => {
+          attempts++;
+          throw new Error("permanent napi failure");
+        },
+      },
+    };
+    const loop: Promise<void> = proto.runEventLoop.call(stubThis);
+    // Failures 1..N-1 each schedule one backoff sleep (≤ the 5s cap);
+    // the Nth failure terminates without sleeping. Each advance
+    // flushes at most one pending sleep.
+    for (let i = 0; i < MAX_CONSECUTIVE_NEXT_EVENT_FAILURES; i++) {
+      await vi.advanceTimersByTimeAsync(5000);
+    }
+    await loop;
+    return attempts;
+  }
+
+  function expectTerminationLogged() {
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `terminating after ${MAX_CONSECUTIVE_NEXT_EVENT_FAILURES} consecutive nextEvent() failures`,
+      ),
+      expect.any(Error),
+    );
+  }
+
+  it("MeshAgent stops retrying after the documented failure count", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const attempts = await runUntilCeiling(MeshAgent.prototype as any);
+    expect(attempts).toBe(MAX_CONSECUTIVE_NEXT_EVENT_FAILURES);
+    expectTerminationLogged();
+  });
+
+  it("ApiRuntime stops retrying after the documented failure count", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const attempts = await runUntilCeiling(ApiRuntime.prototype as any);
+    expect(attempts).toBe(MAX_CONSECUTIVE_NEXT_EVENT_FAILURES);
+    expectTerminationLogged();
+  });
+
+  it("MeshExpress stops retrying after the documented failure count", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const attempts = await runUntilCeiling(MeshExpress.prototype as any);
+    expect(attempts).toBe(MAX_CONSECUTIVE_NEXT_EVENT_FAILURES);
+    expectTerminationLogged();
+  });
+
+  it("a failing loop exits promptly once shutdown() is requested (well before the ceiling)", async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    const stubThis = {
+      shutdownRequested: false,
+      handle: {
+        nextEvent: async () => {
+          attempts++;
+          throw new Error("still broken");
+        },
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const runEventLoop = (MeshAgent.prototype as any).runEventLoop;
+    const loop: Promise<void> = runEventLoop.call(stubThis);
+
+    await vi.advanceTimersByTimeAsync(100); // flush the first backoff
+    stubThis.shutdownRequested = true; // shutdown() sets this flag
+    await vi.advanceTimersByTimeAsync(5000); // flush the pending backoff
+
+    await loop; // exits via the failure-branch shutdown check
+    expect(attempts).toBeLessThan(MAX_CONSECUTIVE_NEXT_EVENT_FAILURES);
+  });
+});

--- a/src/runtime/typescript/src/__tests__/provider-handler-registry.test.ts
+++ b/src/runtime/typescript/src/__tests__/provider-handler-registry.test.ts
@@ -8,10 +8,10 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { ProviderHandler, VendorCapabilities, OutputMode, PreparedRequest } from "../provider-handlers/provider-handler.js";
 import { ProviderHandlerRegistry } from "../provider-handlers/provider-handler-registry.js";
 import { ClaudeHandler } from "../provider-handlers/claude-handler.js";
+import { GeminiHandler } from "../provider-handlers/gemini-handler.js";
 
 // Import handlers to register them (side effect registration)
 import "../provider-handlers/openai-handler.js";
-import "../provider-handlers/gemini-handler.js";
 import "../provider-handlers/generic-handler.js";
 
 describe("ProviderHandlerRegistry", () => {
@@ -46,6 +46,24 @@ describe("ProviderHandlerRegistry", () => {
       expect(handler.constructor.name).toBe("GeminiHandler");
     });
 
+    it("should return GeminiHandler for google vendor (#1163 MED-4)", () => {
+      // "google" is a first-class model prefix (VENDOR_PROVIDERS,
+      // llm-provider guards, media/resolver) and must map to the Gemini
+      // handler, not fall through to GenericHandler.
+      const handler = ProviderHandlerRegistry.getHandler("google");
+
+      expect(handler).toBeDefined();
+      expect(handler).toBeInstanceOf(GeminiHandler);
+      expect(handler.vendor).toBe("google");
+    });
+
+    it("should return GeminiHandler for vertex_ai vendor", () => {
+      const handler = ProviderHandlerRegistry.getHandler("vertex_ai");
+
+      expect(handler).toBeDefined();
+      expect(handler).toBeInstanceOf(GeminiHandler);
+    });
+
     it("should return GenericHandler for unknown vendor", () => {
       const handler = ProviderHandlerRegistry.getHandler("unknown");
 
@@ -72,6 +90,16 @@ describe("ProviderHandlerRegistry", () => {
 
       expect(handler).toBeDefined();
       expect(handler.constructor.name).toBe("GenericHandler");
+    });
+
+    it("should pass the requested vendor into the fallback GenericHandler (#1163 MED-4)", () => {
+      // The fallback used to be constructed with no args, hard-wiring
+      // vendor "unknown" — losing vendor-aware prompt shaping for
+      // unregistered-but-known vendors.
+      const handler = ProviderHandlerRegistry.getHandler("cohere");
+
+      expect(handler.constructor.name).toBe("GenericHandler");
+      expect(handler.vendor).toBe("cohere");
     });
 
     it("should normalize vendor name to lowercase", () => {

--- a/src/runtime/typescript/src/__tests__/proxy-timer-leak.test.ts
+++ b/src/runtime/typescript/src/__tests__/proxy-timer-leak.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression tests for #1163 LOW-5 — callMcpTool's abort timer.
+ *
+ * Previously `clearTimeout(timeoutId)` ran only after `fetch` RESOLVED:
+ *   (a) on fetch rejection the timer stayed armed until effectiveTimeout
+ *       elapsed — one leaked timer per retry attempt;
+ *   (b) because the timer cleared as soon as headers arrived, the body
+ *       read (response.text() / SSE) was unbounded by the call timeout.
+ *
+ * The fix clears the timer in a per-attempt `finally`, keeping the
+ * controller armed until the body is fully consumed — so an
+ * over-deadline body read aborts and surfaces through the existing
+ * isTimeoutError path ("MCP call timed out after Xms").
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { callMcpTool, DEFAULT_CALL_OPTIONS, type CallOptions } from "../proxy.js";
+
+vi.mock("@mcpmesh/core", () => ({
+  generateTraceId: () => "trace-mock",
+  generateSpanId: () => "span-mock",
+  injectTraceContext: (argsJson: string) => argsJson,
+  publishSpan: vi.fn(async () => false),
+  parseSseResponse: (s: string) => s,
+  parseSseResponseToObject: (s: string) => JSON.parse(s),
+  awaitJobCancel: vi.fn(() => new Promise<void>(() => {})),
+  matchesPropagateHeader: () => false,
+}));
+
+vi.mock("../http-pool.js", () => ({
+  getDispatcher: () => undefined,
+}));
+
+const ENDPOINT = "http://producer.local:9000";
+const TOOL = "echo";
+const CAPABILITY = "echoer";
+
+function abortError(): Error {
+  const err = new Error("This operation was aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+describe("callMcpTool abort-timer lifecycle (#1163 LOW-5)", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("clears the abort timer when fetch rejects (no leaked timer per attempt)", async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn(async () => {
+      throw new TypeError("fetch failed: connection refused");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const options: CallOptions = {
+      ...DEFAULT_CALL_OPTIONS,
+      timeout: 30_000,
+      maxAttempts: 1,
+    };
+
+    await expect(
+      callMcpTool(ENDPOINT, TOOL, { foo: 1 }, options, CAPABILITY),
+    ).rejects.toThrow(/connection refused/);
+
+    // Before the fix the 30s abort timer stayed armed after the
+    // rejection; with the per-attempt finally it is cleared.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("aborts an over-deadline body read and surfaces it as the timeout path", async () => {
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      const signal = init.signal as AbortSignal | undefined;
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: {
+          get: (name: string) =>
+            name.toLowerCase() === "content-type" ? "application/json" : null,
+        },
+        // Body read never resolves on its own — only rejects when the
+        // call-timeout abort fires (mirrors a stalled producer socket).
+        text: () =>
+          new Promise<string>((_resolve, reject) => {
+            if (signal?.aborted) {
+              reject(abortError());
+              return;
+            }
+            signal?.addEventListener("abort", () => reject(abortError()));
+          }),
+      } as unknown as Response;
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const options: CallOptions = {
+      ...DEFAULT_CALL_OPTIONS,
+      timeout: 50,
+      maxAttempts: 1,
+    };
+
+    // Must reject with the timeout message (isTimeoutError path), not
+    // hang forever waiting on the body.
+    await expect(
+      callMcpTool(ENDPOINT, TOOL, { foo: 1 }, options, CAPABILITY),
+    ).rejects.toThrow(/MCP call timed out after 50ms/);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // timeout is non-retryable
+  });
+});

--- a/src/runtime/typescript/src/__tests__/stop-dispatchers.spec.ts
+++ b/src/runtime/typescript/src/__tests__/stop-dispatchers.spec.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for #1173 — concurrent claim-dispatcher shutdown under one
+ * shared drain budget, and #1163 MED-2 — `MeshAgent.shutdown()` reaching
+ * the registry unregister (`handle.shutdown()`) regardless of drain
+ * outcome.
+ *
+ * Mirrors the Python fix in PR #1172
+ * (`_mcp_mesh/engine/claim_dispatcher.py::stop_dispatchers`):
+ *   - N dispatchers drain CONCURRENTLY against the SAME window (one
+ *     drain window of wall time, not N stacked 30s windows);
+ *   - the whole phase is hard-capped at drain + grace, after which the
+ *     remaining drains are abandoned with a warning;
+ *   - never rejects — a wedged dispatcher must not prevent the registry
+ *     cleanup callers sequence afterwards.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { stopDispatchers, type ClaimDispatcher } from "../claim-dispatcher.js";
+import { MeshAgent } from "../agent.js";
+import { ApiRuntime } from "../api-runtime.js";
+import { MeshExpress } from "../express.js";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Build a stub dispatcher whose stop() runs the given impl. */
+function fakeDispatcher(
+  capability: string,
+  stopImpl: (timeoutMs?: number) => Promise<void>,
+): ClaimDispatcher {
+  return {
+    capability,
+    stop: vi.fn(stopImpl),
+  } as unknown as ClaimDispatcher;
+}
+
+describe("stopDispatchers (#1173)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("stops dispatchers concurrently — wall time is one drain window, not N", async () => {
+    const d1 = fakeDispatcher("cap-a", () => sleep(200));
+    const d2 = fakeDispatcher("cap-b", () => sleep(200));
+    const d3 = fakeDispatcher("cap-c", () => sleep(200));
+
+    const t0 = Date.now();
+    await stopDispatchers([d1, d2, d3], 2000, 2000);
+    const elapsed = Date.now() - t0;
+
+    // Sequential would be >= 600ms; concurrent is ~200ms. The 500ms
+    // bound leaves ~300ms of CI scheduling-jitter headroom while still
+    // failing a sequential drain.
+    expect(elapsed).toBeLessThan(500);
+    expect(d1.stop).toHaveBeenCalledWith(2000);
+    expect(d2.stop).toHaveBeenCalledWith(2000);
+    expect(d3.stop).toHaveBeenCalledWith(2000);
+  });
+
+  it("passes the SHARED drain window to every dispatcher", async () => {
+    const ds = [
+      fakeDispatcher("cap-a", async () => {}),
+      fakeDispatcher("cap-b", async () => {}),
+      fakeDispatcher("cap-c", async () => {}),
+    ];
+    await stopDispatchers(ds, 250, 100);
+    for (const d of ds) {
+      expect(d.stop).toHaveBeenCalledWith(250);
+    }
+  });
+
+  it("abandons a hanging drain at the hard cap (drain + grace) with a warning", async () => {
+    const hanging = fakeDispatcher("cap-stuck", () => new Promise(() => {}));
+
+    const t0 = Date.now();
+    await stopDispatchers([hanging], 50, 50);
+    const elapsed = Date.now() - t0;
+
+    // Returned at ~100ms (50 drain + 50 grace), not hung forever.
+    expect(elapsed).toBeGreaterThanOrEqual(90);
+    expect(elapsed).toBeLessThan(1000);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("exceeded the shared budget"),
+    );
+  });
+
+  it("a rejecting stop() does not skip its peers and does not reject", async () => {
+    const bad = fakeDispatcher("cap-bad", async () => {
+      throw new Error("stop blew up");
+    });
+    const good = fakeDispatcher("cap-good", () => sleep(20));
+
+    await expect(stopDispatchers([bad, good], 500, 100)).resolves.toBeUndefined();
+    expect(good.stop).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("error stopping dispatcher capability=cap-bad"),
+      expect.any(Error),
+    );
+  });
+
+  it("is a no-op for an empty dispatcher list", async () => {
+    await expect(stopDispatchers([], 50, 50)).resolves.toBeUndefined();
+  });
+});
+
+describe("MeshAgent.shutdown() — unregister runs regardless of drain outcome (#1163 MED-2 / #1173)", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Drive the REAL `shutdown()` against a stub `this` (same pattern as
+   * the event-loop specs) so we don't have to bind a full agent to the
+   * napi runtime. Only the fields shutdown() reads are provided.
+   */
+  function stubAgentThis(dispatchers: ClaimDispatcher[]) {
+    return {
+      _claimDispatchers: dispatchers,
+      _a2aClients: new Map(),
+      httpsProxy: undefined,
+      handle: { shutdown: vi.fn(async () => {}) },
+    };
+  }
+
+  it("calls handle.shutdown() even when a dispatcher drain hangs", async () => {
+    const hanging = fakeDispatcher("cap-stuck", () => new Promise(() => {}));
+    const stubThis = stubAgentThis([hanging]);
+    const handle = stubThis.handle; // shutdown() nulls this.handle
+
+    const shutdown = MeshAgent.prototype.shutdown;
+    await shutdown.call(stubThis as unknown as MeshAgent, {
+      drainTimeoutMs: 30,
+      drainGraceMs: 30,
+    });
+
+    expect(handle.shutdown).toHaveBeenCalledTimes(1);
+    // Handle nulled + dispatcher list cleared after a successful unregister.
+    expect((stubThis as { handle: unknown }).handle).toBeNull();
+    expect(stubThis._claimDispatchers).toEqual([]);
+  });
+
+  it("calls handle.shutdown() even when a dispatcher stop() throws", async () => {
+    const bad = fakeDispatcher("cap-bad", async () => {
+      throw new Error("drain blew up");
+    });
+    const stubThis = stubAgentThis([bad]);
+    const handle = stubThis.handle;
+
+    const shutdown = MeshAgent.prototype.shutdown;
+    await shutdown.call(stubThis as unknown as MeshAgent, {
+      drainTimeoutMs: 30,
+      drainGraceMs: 30,
+    });
+
+    expect(handle.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("drains slow dispatchers concurrently within one budget", async () => {
+    const d1 = fakeDispatcher("cap-a", () => sleep(200));
+    const d2 = fakeDispatcher("cap-b", () => sleep(200));
+    const d3 = fakeDispatcher("cap-c", () => sleep(200));
+    const stubThis = stubAgentThis([d1, d2, d3]);
+    const handle = stubThis.handle;
+
+    const shutdown = MeshAgent.prototype.shutdown;
+    const t0 = Date.now();
+    await shutdown.call(stubThis as unknown as MeshAgent, {
+      drainTimeoutMs: 2000,
+      drainGraceMs: 2000,
+    });
+    const elapsed = Date.now() - t0;
+
+    // Sequential would be >= 600ms; concurrent is ~200ms. 500ms bound
+    // leaves ~300ms of CI scheduling-jitter headroom.
+    expect(elapsed).toBeLessThan(500);
+    expect(handle.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("shutdown() is idempotent — repeat calls return the SAME promise and never re-run the teardown", async () => {
+    const d = fakeDispatcher("cap-a", () => sleep(50));
+    const stubThis = stubAgentThis([d]);
+    const handle = stubThis.handle;
+
+    const shutdown = MeshAgent.prototype.shutdown;
+    const p1 = shutdown.call(stubThis as unknown as MeshAgent, {
+      drainTimeoutMs: 1000,
+      drainGraceMs: 1000,
+    });
+    // Re-entrant call while the first teardown is mid-drain — the
+    // user-code-shutdown() + signal-during-drain race. Must NOT start
+    // a second concurrent teardown (double dispatcher stop, double
+    // napi handle.shutdown()).
+    const p2 = shutdown.call(stubThis as unknown as MeshAgent, {
+      drainTimeoutMs: 1000,
+      drainGraceMs: 1000,
+    });
+    expect(p2).toBe(p1);
+
+    await p1;
+
+    // A call AFTER completion also returns the memoized promise.
+    const p3 = shutdown.call(stubThis as unknown as MeshAgent);
+    expect(p3).toBe(p1);
+    await p3;
+
+    expect(d.stop).toHaveBeenCalledTimes(1);
+    expect(handle.shutdown).toHaveBeenCalledTimes(1);
+    // shutdown() itself flags the shutdown so the event loop's failure
+    // branch can exit promptly.
+    expect(
+      (stubThis as { shutdownRequested?: boolean }).shutdownRequested,
+    ).toBe(true);
+  });
+});
+
+describe("shutdown() idempotency — ApiRuntime / MeshExpress (same memoized-promise pattern)", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("ApiRuntime.shutdown() memoizes — one napi handle.shutdown() across repeat calls", async () => {
+    const stubThis = {
+      handle: { shutdown: vi.fn(async () => {}) },
+      shutdownPromise: null,
+      shutdownRequested: false,
+    };
+    const handle = stubThis.handle; // shutdown() nulls this.handle
+
+    const shutdown = ApiRuntime.prototype.shutdown;
+    const p1 = shutdown.call(stubThis as unknown as ApiRuntime);
+    const p2 = shutdown.call(stubThis as unknown as ApiRuntime);
+    expect(p2).toBe(p1);
+    await p1;
+    expect(shutdown.call(stubThis as unknown as ApiRuntime)).toBe(p1);
+
+    expect(handle.shutdown).toHaveBeenCalledTimes(1);
+    expect(stubThis.shutdownRequested).toBe(true);
+  });
+
+  it("MeshExpress.shutdown() memoizes — one napi handle.shutdown() across repeat calls", async () => {
+    const stubThis = {
+      handle: { shutdown: vi.fn(async () => {}) },
+      server: null,
+      shutdownPromise: null,
+      shutdownRequested: false,
+    };
+    const handle = stubThis.handle;
+
+    const shutdown = MeshExpress.prototype.shutdown;
+    const p1 = shutdown.call(stubThis as unknown as MeshExpress);
+    const p2 = shutdown.call(stubThis as unknown as MeshExpress);
+    expect(p2).toBe(p1);
+    await p1;
+    expect(shutdown.call(stubThis as unknown as MeshExpress)).toBe(p1);
+
+    expect(handle.shutdown).toHaveBeenCalledTimes(1);
+    expect(stubThis.shutdownRequested).toBe(true);
+  });
+});

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -31,7 +31,13 @@ import type {
   NormalizedDependency,
   LlmProviderConfig,
 } from "./types.js";
-import { resolveConfig, generateAgentIdSuffix, findAvailablePort } from "./config.js";
+import {
+  resolveConfig,
+  generateAgentIdSuffix,
+  findAvailablePort,
+  MAX_CONSECUTIVE_NEXT_EVENT_FAILURES,
+  NEXT_EVENT_BACKOFF_CAP_MS,
+} from "./config.js";
 import { enrichSchemaWithMediaTypes } from "./media-param.js";
 import { createProxy, normalizeDependency, runWithTraceContext, runWithPropagatedHeaders, PROXY_DISPATCH_META } from "./proxy.js";
 import {
@@ -41,7 +47,11 @@ import {
   spliceJobController,
 } from "./inbound-job-dispatch.js";
 import { MeshJobSubmitter } from "./mesh-job-submitter.js";
-import { ClaimDispatcher, type ClaimHandler } from "./claim-dispatcher.js";
+import {
+  ClaimDispatcher,
+  stopDispatchers,
+  type ClaimHandler,
+} from "./claim-dispatcher.js";
 import { registerJobHelperTools, type HelperToolMeta } from "./jobs-helper-tools.js";
 import { registerCancelRoute } from "./jobs-cancel-route.js";
 import {
@@ -120,9 +130,22 @@ export function __getWorkerToolMap(): Map<string, (...args: unknown[]) => unknow
   return _workerToolMap;
 }
 
-// Internal: pending agent for auto-start
+// Internal: pending agent for auto-start. The slot holds at most one
+// agent awaiting its auto-start tick; it is consumed (cleared) when the
+// scheduled nextTick fires.
 let pendingAgent: MeshAgent | null = null;
 let autoStartScheduled = false;
+
+// Issue #1163 LOW-6 guard: name of the agent constructed in the CURRENT
+// synchronous chunk. Two constructions in one chunk meant the second
+// silently overwrote `pendingAgent` before the auto-start tick fired —
+// the first agent never started and nobody noticed. The constructor now
+// throws while this guard is set. The guard auto-releases on the first
+// microtask: in real Node the auto-start nextTick drains BEFORE any
+// microtask continuation, so the guard window fully covers the
+// pre-consumption danger zone, while sequential constructions across
+// async boundaries (e.g. one agent per test in a harness) stay allowed.
+let constructionGuardName: string | null = null;
 
 // Schedule auto-start after module loading completes
 function scheduleAutoStart(): void {
@@ -130,8 +153,14 @@ function scheduleAutoStart(): void {
   autoStartScheduled = true;
 
   process.nextTick(() => {
-    if (pendingAgent) {
-      pendingAgent._autoStart().catch((err) => {
+    // Consume the slot and re-arm the scheduler BEFORE starting, so a
+    // later (post-start) construction gets its own auto-start tick
+    // instead of being silently dropped.
+    const agent = pendingAgent;
+    pendingAgent = null;
+    autoStartScheduled = false;
+    if (agent) {
+      agent._autoStart().catch((err) => {
         console.error("MCP Mesh auto-start failed:", err);
         process.exit(1);
       });
@@ -149,6 +178,14 @@ function scheduleAutoStart(): void {
  * - Dependency injection for tool functions
  */
 export class MeshAgent {
+  /**
+   * Hard cap on the signal-path shutdown sequence. Must exceed the
+   * dispatcher drain hard-cap (30s drain + 10s grace, see
+   * `stopDispatchers`) so a clean drain isn't cut short; the extra 5s
+   * covers pool/A2A teardown and the registry unregister.
+   */
+  private static readonly SIGNAL_SHUTDOWN_TIMEOUT_MS = 45_000;
+
   private server: FastMCP;
   private config: ResolvedAgentConfig;
   private agentId: string;
@@ -164,6 +201,14 @@ export class MeshAgent {
   private started = false;
   private tracingEnabled = false;
   private shutdownRequested = false;
+  /**
+   * Memoized in-flight (or completed) teardown. `shutdown()` is
+   * idempotent: the first caller creates this promise and every later
+   * caller — user code, the signal handler, a second signal — awaits
+   * the SAME teardown instead of racing a concurrent one (double
+   * dispatcher drain, double napi `handle.shutdown()`).
+   */
+  private shutdownPromise: Promise<void> | null = null;
 
   /**
    * Resolved dependencies: composite key -> proxy
@@ -256,7 +301,24 @@ export class MeshAgent {
     // Generate unique agent ID with suffix (e.g., "calculator-a1b2c3d4")
     this.agentId = `${this.config.name}-${generateAgentIdSuffix()}`;
 
-    // Register as pending agent for auto-start
+    // Register as pending agent for auto-start. Throw if another agent
+    // was already constructed in this synchronous chunk — the previous
+    // behavior overwrote the slot and the earlier agent silently never
+    // started (issue #1163 LOW-6). Only one MeshAgent per process is
+    // supported (it owns the FastMCP HTTP server, registry heartbeat,
+    // and process-wide signal handlers).
+    if (constructionGuardName !== null) {
+      throw new Error(
+        `Only one MeshAgent may be constructed per process: agent ` +
+          `'${constructionGuardName}' is already pending auto-start. ` +
+          `Register all tools on a single MeshAgent instead of constructing ` +
+          `'${this.config.name}' as a second agent.`,
+      );
+    }
+    constructionGuardName = this.config.name;
+    queueMicrotask(() => {
+      constructionGuardName = null;
+    });
     pendingAgent = this;
     scheduleAutoStart();
   }
@@ -1253,38 +1315,57 @@ export class MeshAgent {
    * Install signal handlers for graceful shutdown.
    * Ensures agent unregisters from registry on SIGINT/SIGTERM.
    *
-   * Calls handle.shutdown() directly to trigger Rust core unregistration.
-   * This causes nextEvent() to return with a "shutdown" event, breaking
-   * the event loop cleanly. The shutdown is async but we don't await it
-   * in the signal handler - the event loop handles the exit.
+   * Runs the FULL `shutdown()` sequence (issue #1163 MED-2): claim
+   * dispatchers drain their in-flight jobs (concurrently, under one
+   * shared budget — see `stopDispatchers`), A2A clients / HTTP pool /
+   * tool-worker pool close, and `handle.shutdown()` unregisters from
+   * the registry (which also resolves the event loop's `nextEvent()`
+   * with a "shutdown" event, ending it cleanly).
+   *
+   * The whole sequence is bounded by a force-exit timer so a hang in
+   * any cleanup step cannot wedge the process past its SIGTERM grace.
    */
   private installSignalHandlers(): void {
+    // Dedupe repeated signals locally. This must NOT key off
+    // `shutdownRequested` (set by shutdown() itself): a signal arriving
+    // while a user-initiated shutdown() is draining must still arm the
+    // force-exit timer and exit the process when that same (memoized)
+    // shutdown completes.
+    let signalHandled = false;
     const shutdownHandler = (signal: string) => {
-      if (this.shutdownRequested) return;
-      this.shutdownRequested = true;
+      if (signalHandled) return;
+      signalHandled = true;
 
       console.log(
         `\nReceived ${signal}, shutting down agent ${this.agentId}...`
       );
 
-      // Close HTTPS proxy if it exists
-      if (this.httpsProxy) {
-        this.httpsProxy.close();
-      }
+      // Bounded overall shutdown: the dispatcher drain phase is already
+      // hard-capped (30s drain + 10s grace shared across dispatchers);
+      // this timer covers everything else (pool/A2A close, registry
+      // unregister) so a hang anywhere cannot block exit forever.
+      //
+      // Deliberately ref'd (no unref): both completion paths below
+      // clearTimeout and process.exit synchronously, so the timer never
+      // delays a successful exit — but it must keep a wedged shutdown's
+      // otherwise-empty event loop alive long enough to emit the loud
+      // exit(1) diagnostic instead of silently exiting 0.
+      const forceExitTimer = setTimeout(() => {
+        console.error(
+          `Shutdown did not complete within ${MeshAgent.SIGNAL_SHUTDOWN_TIMEOUT_MS}ms; forcing exit`
+        );
+        process.exit(1);
+      }, MeshAgent.SIGNAL_SHUTDOWN_TIMEOUT_MS);
 
-      // Call shutdown directly - this triggers Rust core to unregister
-      // and send a shutdown event that breaks the event loop
-      if (this.handle) {
-        this.handle.shutdown().then(() => {
-          console.log(`Agent ${this.agentId} unregistered from registry`);
-          process.exit(0);
-        }).catch((err) => {
-          console.error("Error during shutdown:", err);
-          process.exit(1);
-        });
-      } else {
+      this.shutdown().then(() => {
+        clearTimeout(forceExitTimer);
+        console.log(`Agent ${this.agentId} shut down cleanly`);
         process.exit(0);
-      }
+      }).catch((err) => {
+        clearTimeout(forceExitTimer);
+        console.error("Error during shutdown:", err);
+        process.exit(1);
+      });
     };
 
     process.on("SIGINT", () => shutdownHandler("SIGINT"));
@@ -1504,14 +1585,69 @@ export class MeshAgent {
 
   /**
    * Run the event loop to handle mesh events.
+   *
+   * Resilience (issue #1163 MED-1): the loop must outlive individual
+   * failures. A throw from an event handler (e.g. a malformed event
+   * hitting a non-null assertion) is logged and the loop continues; a
+   * `nextEvent()` rejection (e.g. a transient napi failure) backs off
+   * exponentially (capped) and retries. Only the "shutdown" event — or
+   * the handle being torn down — exits the loop. Previously a single
+   * throw broke the loop permanently, freezing dependency-topology
+   * updates for the process lifetime while the agent kept serving.
    */
   private async runEventLoop(): Promise<void> {
     if (!this.handle) return;
 
-    while (true) {
-      try {
-        const event = await this.handle.nextEvent();
+    let consecutiveNextEventFailures = 0;
 
+    while (true) {
+      // Handle is nulled by shutdown(); exit cleanly instead of
+      // spinning on a dead reference.
+      if (!this.handle) {
+        console.log("Event loop: handle closed, exiting");
+        return;
+      }
+
+      let event: Awaited<ReturnType<JsAgentHandle["nextEvent"]>>;
+      try {
+        event = await this.handle.nextEvent();
+        consecutiveNextEventFailures = 0;
+      } catch (err) {
+        // Explicit shutdown() racing a failing nextEvent(): exit
+        // promptly instead of burning more backoff cycles.
+        if (!this.handle || this.shutdownRequested) {
+          console.log("Event loop: shutdown requested, exiting");
+          return;
+        }
+        consecutiveNextEventFailures++;
+        // Ceiling (~60s of continuous failure — see the constant's doc
+        // in config.ts): a permanently broken handle must not retry
+        // forever, keeping the process alive via the backoff timer.
+        if (
+          consecutiveNextEventFailures >= MAX_CONSECUTIVE_NEXT_EVENT_FAILURES
+        ) {
+          console.error(
+            `Event loop: terminating after ${consecutiveNextEventFailures} ` +
+              `consecutive nextEvent() failures; dependency topology is ` +
+              `frozen for the remainder of the process:`,
+            err
+          );
+          return;
+        }
+        const backoffMs = Math.min(
+          100 * 2 ** (consecutiveNextEventFailures - 1),
+          NEXT_EVENT_BACKOFF_CAP_MS
+        );
+        console.error(
+          `Event loop: nextEvent() failed (consecutive=${consecutiveNextEventFailures}), ` +
+            `retrying in ${backoffMs}ms:`,
+          err
+        );
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+        continue;
+      }
+
+      try {
         switch (event.eventType) {
           case "agent_registered":
             console.log(`Agent registered with ID: ${event.agentId}`);
@@ -1608,8 +1744,13 @@ export class MeshAgent {
             break;
         }
       } catch (err) {
-        console.error("Event loop error:", err);
-        break;
+        // Per-event isolation: a bad event (or a bug in one handler)
+        // must not kill dependency-event processing for the process
+        // lifetime. Log and keep consuming events.
+        console.error(
+          `Event loop: error handling event '${event.eventType}':`,
+          err
+        );
       }
     }
   }
@@ -1763,49 +1904,75 @@ export class MeshAgent {
 
   /**
    * Shutdown the agent gracefully.
+   *
+   * Idempotent and re-entrant: the first call runs the teardown; every
+   * later call (user code, the signal handler, a double signal) returns
+   * the SAME promise — later calls' `opts` are ignored. The memo is
+   * never cleared: shutdown is terminal, and re-running a half-torn-down
+   * cleanup after a failure would be worse than surfacing the original
+   * rejection to every caller.
    */
-  async shutdown(): Promise<void> {
-    // Phase 1 MeshJob substrate: stop claim dispatchers first so
-    // they don't pull a fresh job mid-shutdown.
-    for (const d of this._claimDispatchers) {
+  shutdown(opts?: {
+    /** Shared in-flight-handler drain window for claim dispatchers. */
+    drainTimeoutMs?: number;
+    /** Headroom on top of the drain window before drains are abandoned. */
+    drainGraceMs?: number;
+  }): Promise<void> {
+    if (this.shutdownPromise) return this.shutdownPromise;
+    this.shutdownRequested = true;
+    this.shutdownPromise = (async () => {
+      // Phase 1 MeshJob substrate: stop claim dispatchers first so they
+      // don't pull a fresh job mid-shutdown. Issue #1173: all dispatchers
+      // drain CONCURRENTLY under one shared, hard-capped budget — never
+      // N×30s sequential — and a hanging drain is abandoned with a
+      // warning so the registry unregister below always runs.
+      await stopDispatchers(
+        this._claimDispatchers,
+        opts?.drainTimeoutMs,
+        opts?.drainGraceMs,
+      );
+      this._claimDispatchers = [];
+      // Issue #917: mark all cached A2AClients closed so any in-flight
+      // user code raises cleanly instead of reusing a torn-down instance.
+      // Close in parallel so one slow client doesn't block the others —
+      // the undici Agent pool is shared via closeHttpPool() below.
+      const closePromises = Array.from(this._a2aClients.values()).map(
+        (client) =>
+          client.close().catch((err) => {
+            console.warn("[mesh-a2a] Error closing A2AClient:", err);
+            return null;
+          }),
+      );
+      await Promise.allSettled(closePromises);
+      this._a2aClients.clear();
       try {
-        await d.stop();
+        await closeHttpPool();
       } catch (err) {
-        console.warn(`[mesh-jobs] error stopping claim dispatcher:`, err);
+        console.warn("Error closing HTTP pool:", err);
       }
-    }
-    this._claimDispatchers = [];
-    // Issue #917: mark all cached A2AClients closed so any in-flight
-    // user code raises cleanly instead of reusing a torn-down instance.
-    // Close in parallel so one slow client doesn't block the others —
-    // the undici Agent pool is shared via closeHttpPool() below.
-    const closePromises = Array.from(this._a2aClients.values()).map((client) =>
-      client.close().catch((err) => {
-        console.warn("[mesh-a2a] Error closing A2AClient:", err);
-        return null;
-      }),
-    );
-    await Promise.allSettled(closePromises);
-    this._a2aClients.clear();
-    try {
-      await closeHttpPool();
-    } catch (err) {
-      console.warn("Error closing HTTP pool:", err);
-    }
-    try {
-      await closePool();
-    } catch (err) {
-      console.warn("Error closing tool worker pool:", err);
-    }
-    if (this.httpsProxy) {
-      this.httpsProxy.close();
-      this.httpsProxy = undefined;
-    }
-    if (this.handle) {
-      await this.handle.shutdown();
-      this.handle = null;
-    }
-    cleanupTls();
+      try {
+        await closePool();
+      } catch (err) {
+        console.warn("Error closing tool worker pool:", err);
+      }
+      if (this.httpsProxy) {
+        try {
+          this.httpsProxy.close();
+        } catch (err) {
+          console.warn("Error closing HTTPS proxy:", err);
+        }
+        this.httpsProxy = undefined;
+      }
+      // Registry unregister runs regardless of how the cleanup steps above
+      // fared — every prior step is guarded so a drain/close failure can't
+      // leave a stale registration behind.
+      if (this.handle) {
+        await this.handle.shutdown();
+        this.handle = null;
+      }
+      cleanupTls();
+    })();
+    return this.shutdownPromise;
   }
 }
 

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -209,6 +209,18 @@ export class MeshAgent {
    * dispatcher drain, double napi `handle.shutdown()`).
    */
   private shutdownPromise: Promise<void> | null = null;
+  /**
+   * This agent's own SIGINT/SIGTERM handler references, kept so
+   * shutdown() can `process.off` them. Without removal, sequential
+   * MeshAgent instances in one process (legal across async chunk
+   * boundaries) accumulate stale handlers whose memoized — already
+   * resolved — shutdown() would `process.exit(0)` immediately on the
+   * next signal, cutting short the LIVE agent's drain.
+   */
+  private signalHandlers: {
+    sigint: () => void;
+    sigterm: () => void;
+  } | null = null;
 
   /**
    * Resolved dependencies: composite key -> proxy
@@ -1368,8 +1380,13 @@ export class MeshAgent {
       });
     };
 
-    process.on("SIGINT", () => shutdownHandler("SIGINT"));
-    process.on("SIGTERM", () => shutdownHandler("SIGTERM"));
+    // Keep named references so shutdown() can remove exactly these
+    // listeners (anonymous arrows can't be process.off'd).
+    const sigint = () => shutdownHandler("SIGINT");
+    const sigterm = () => shutdownHandler("SIGTERM");
+    this.signalHandlers = { sigint, sigterm };
+    process.on("SIGINT", sigint);
+    process.on("SIGTERM", sigterm);
   }
 
   /**
@@ -1956,12 +1973,17 @@ export class MeshAgent {
         console.warn("Error closing tool worker pool:", err);
       }
       if (this.httpsProxy) {
-        try {
-          this.httpsProxy.close();
-        } catch (err) {
-          console.warn("Error closing HTTPS proxy:", err);
-        }
+        // Await the close callback so the TLS listener's port is
+        // actually released by the time shutdown() resolves (mirrors
+        // MeshExpress.shutdown()'s server.close handling).
+        const proxy = this.httpsProxy;
         this.httpsProxy = undefined;
+        await new Promise<void>((resolve) => {
+          proxy.close((err) => {
+            if (err) console.warn("Error closing HTTPS proxy:", err);
+            resolve();
+          });
+        });
       }
       // Registry unregister runs regardless of how the cleanup steps above
       // fared — every prior step is guarded so a drain/close failure can't
@@ -1971,6 +1993,16 @@ export class MeshAgent {
         this.handle = null;
       }
       cleanupTls();
+      // Remove this agent's own signal listeners LAST: during the drain
+      // above a signal must still reach the handler (it arms the
+      // force-exit timer and exits when this memoized teardown settles).
+      // Leaving them installed would let a LATER agent's signal hit this
+      // already-resolved shutdown() and process.exit(0) prematurely.
+      if (this.signalHandlers) {
+        process.off("SIGINT", this.signalHandlers.sigint);
+        process.off("SIGTERM", this.signalHandlers.sigterm);
+        this.signalHandlers = null;
+      }
     })();
     return this.shutdownPromise;
   }

--- a/src/runtime/typescript/src/api-runtime.ts
+++ b/src/runtime/typescript/src/api-runtime.ts
@@ -117,6 +117,16 @@ class ApiRuntime {
    */
   private shutdownPromise: Promise<void> | null = null;
   /**
+   * This runtime's own SIGINT/SIGTERM handler references, kept so
+   * shutdown() can `process.off` them — otherwise sequential runtimes
+   * in one process accumulate stale handlers whose memoized (already
+   * resolved) shutdown() would `process.exit(0)` on the next signal.
+   */
+  private signalHandlers: {
+    sigint: () => void;
+    sigterm: () => void;
+  } | null = null;
+  /**
    * PR #938 W2: race-flag for `pushSurfacesUpdate()` calls that arrive
    * AFTER `start()` has been scheduled but BEFORE `this.handle` is set.
    * `start()` does async work (TLS prep, tracing init) between
@@ -547,8 +557,13 @@ class ApiRuntime {
       });
     };
 
-    process.on("SIGINT", () => shutdownHandler("SIGINT"));
-    process.on("SIGTERM", () => shutdownHandler("SIGTERM"));
+    // Keep named references so shutdown() can remove exactly these
+    // listeners (anonymous arrows can't be process.off'd).
+    const sigint = () => shutdownHandler("SIGINT");
+    const sigterm = () => shutdownHandler("SIGTERM");
+    this.signalHandlers = { sigint, sigterm };
+    process.on("SIGINT", sigint);
+    process.on("SIGTERM", sigterm);
   }
 
   /**
@@ -569,6 +584,16 @@ class ApiRuntime {
         this.handle = null;
       }
       cleanupTls();
+      // Remove this runtime's own signal listeners LAST: during the
+      // teardown above a signal must still reach the handler (it arms
+      // the force-exit timer). Leaving them installed would let a later
+      // runtime's signal hit this already-resolved shutdown() and
+      // process.exit(0) prematurely.
+      if (this.signalHandlers) {
+        process.off("SIGINT", this.signalHandlers.sigint);
+        process.off("SIGTERM", this.signalHandlers.sigterm);
+        this.signalHandlers = null;
+      }
     })();
     return this.shutdownPromise;
   }

--- a/src/runtime/typescript/src/api-runtime.ts
+++ b/src/runtime/typescript/src/api-runtime.ts
@@ -41,6 +41,10 @@ import {
   type JsDependencySpec,
 } from "@mcpmesh/core";
 
+import {
+  MAX_CONSECUTIVE_NEXT_EVENT_FAILURES,
+  NEXT_EVENT_BACKOFF_CAP_MS,
+} from "./config.js";
 import { RouteRegistry, type RouteMetadata } from "./route.js";
 import { createProxy } from "./proxy.js";
 import { initTracing, type AgentMetadata } from "./tracing.js";
@@ -104,6 +108,14 @@ class ApiRuntime {
   private starting = false;
   private scheduledStart = false;
   private shutdownRequested = false;
+  /**
+   * Memoized in-flight (or completed) teardown. `shutdown()` is
+   * idempotent: the first caller creates this promise and every later
+   * caller — user code, the signal handler, a second signal — awaits
+   * the SAME teardown instead of racing a concurrent napi
+   * `handle.shutdown()`.
+   */
+  private shutdownPromise: Promise<void> | null = null;
   /**
    * PR #938 W2: race-flag for `pushSurfacesUpdate()` calls that arrive
    * AFTER `start()` has been scheduled but BEFORE `this.handle` is set.
@@ -288,22 +300,67 @@ class ApiRuntime {
 
   /**
    * Run the event loop to handle mesh events.
+   *
+   * Resilience (issue #1163 MED-1): the loop must outlive individual
+   * failures. A throw from an event handler (e.g. a malformed event
+   * hitting a non-null assertion) is logged and the loop continues; a
+   * `nextEvent()` rejection (e.g. a transient napi failure) backs off
+   * exponentially (capped) and retries. Only the "shutdown" event — or
+   * the handle being torn down — exits the loop.
    */
   private async runEventLoop(): Promise<void> {
     if (!this.handle) return;
 
     const registry = RouteRegistry.getInstance();
+    let consecutiveNextEventFailures = 0;
 
     while (true) {
+      // Check if handle was nulled during shutdown
+      if (!this.handle) {
+        console.log("API runtime event loop: handle nulled, exiting");
+        return;
+      }
+
+      let event: Awaited<ReturnType<JsAgentHandle["nextEvent"]>>;
       try {
-        // Check if handle was nulled during shutdown
-        if (!this.handle) {
-          console.log("API runtime event loop: handle nulled, exiting");
+        event = await this.handle.nextEvent();
+        consecutiveNextEventFailures = 0;
+      } catch (err) {
+        // Explicit shutdown() racing a failing nextEvent(): exit
+        // promptly instead of burning more backoff cycles.
+        if (!this.handle || this.shutdownRequested) {
+          console.log("API runtime event loop: shutdown requested, exiting");
           return;
         }
+        consecutiveNextEventFailures++;
+        // Ceiling (~60s of continuous failure — see the constant's doc
+        // in config.ts): a permanently broken handle must not retry
+        // forever, keeping the process alive via the backoff timer.
+        if (
+          consecutiveNextEventFailures >= MAX_CONSECUTIVE_NEXT_EVENT_FAILURES
+        ) {
+          console.error(
+            `API runtime event loop: terminating after ${consecutiveNextEventFailures} ` +
+              `consecutive nextEvent() failures; dependency topology is ` +
+              `frozen for the remainder of the process:`,
+            err
+          );
+          return;
+        }
+        const backoffMs = Math.min(
+          100 * 2 ** (consecutiveNextEventFailures - 1),
+          NEXT_EVENT_BACKOFF_CAP_MS
+        );
+        console.error(
+          `API runtime event loop: nextEvent() failed ` +
+            `(consecutive=${consecutiveNextEventFailures}), retrying in ${backoffMs}ms:`,
+          err
+        );
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+        continue;
+      }
 
-        const event = await this.handle.nextEvent();
-
+      try {
         switch (event.eventType) {
           case "agent_registered":
             console.log(`API service registered: ${event.agentId}`);
@@ -359,8 +416,13 @@ class ApiRuntime {
             break;
         }
       } catch (err) {
-        console.error("API runtime event loop error:", err);
-        break;
+        // Per-event isolation: a bad event (or a bug in one handler)
+        // must not kill dependency-event processing for the process
+        // lifetime. Log and keep consuming events.
+        console.error(
+          `API runtime event loop: error handling event '${event.eventType}':`,
+          err
+        );
       }
     }
   }
@@ -442,30 +504,47 @@ class ApiRuntime {
   /**
    * Install signal handlers for graceful shutdown.
    *
-   * Calls handle.shutdown() directly to trigger Rust core unregistration.
-   * This causes nextEvent() to return with a "shutdown" event, breaking
-   * the event loop cleanly.
+   * Runs the full `shutdown()` sequence (issue #1163 MED-2) — registry
+   * unregister via `handle.shutdown()` (which also resolves the event
+   * loop's `nextEvent()` with a "shutdown" event) plus TLS cleanup —
+   * bounded by a force-exit timer so a hang cannot wedge the process
+   * past its SIGTERM grace.
    */
   private installSignalHandlers(): void {
+    const SIGNAL_SHUTDOWN_TIMEOUT_MS = 10_000;
+    // Dedupe repeated signals locally. This must NOT key off
+    // `shutdownRequested` (set by shutdown() itself): a signal arriving
+    // while a user-initiated shutdown() is in flight must still arm the
+    // force-exit timer and exit the process when that same (memoized)
+    // shutdown completes.
+    let signalHandled = false;
     const shutdownHandler = (signal: string) => {
-      if (this.shutdownRequested) return;
-      this.shutdownRequested = true;
+      if (signalHandled) return;
+      signalHandled = true;
 
       console.log(`\nReceived ${signal}, shutting down ${this.serviceId}...`);
 
-      // Call shutdown directly - this triggers Rust core to unregister
-      // and send a shutdown event that breaks the event loop
-      if (this.handle) {
-        this.handle.shutdown().then(() => {
-          console.log(`API runtime ${this.serviceId} unregistered from registry`);
-          process.exit(0);
-        }).catch((err) => {
-          console.error("Error during API runtime shutdown:", err);
-          process.exit(1);
-        });
-      } else {
+      // Deliberately ref'd (no unref): both completion paths below
+      // clearTimeout and process.exit synchronously, so the timer never
+      // delays a successful exit — but it must keep a wedged shutdown's
+      // otherwise-empty event loop alive long enough to emit the loud
+      // exit(1) diagnostic instead of silently exiting 0.
+      const forceExitTimer = setTimeout(() => {
+        console.error(
+          `API runtime shutdown did not complete within ${SIGNAL_SHUTDOWN_TIMEOUT_MS}ms; forcing exit`
+        );
+        process.exit(1);
+      }, SIGNAL_SHUTDOWN_TIMEOUT_MS);
+
+      this.shutdown().then(() => {
+        clearTimeout(forceExitTimer);
+        console.log(`API runtime ${this.serviceId} shut down cleanly`);
         process.exit(0);
-      }
+      }).catch((err) => {
+        clearTimeout(forceExitTimer);
+        console.error("Error during API runtime shutdown:", err);
+        process.exit(1);
+      });
     };
 
     process.on("SIGINT", () => shutdownHandler("SIGINT"));
@@ -474,13 +553,24 @@ class ApiRuntime {
 
   /**
    * Shutdown the API runtime gracefully.
+   *
+   * Idempotent and re-entrant: the first call runs the teardown; every
+   * later call (user code, the signal handler, a double signal) returns
+   * the SAME promise. The memo is never cleared: shutdown is terminal,
+   * and re-running a half-torn-down cleanup after a failure would be
+   * worse than surfacing the original rejection to every caller.
    */
-  async shutdown(): Promise<void> {
-    if (this.handle) {
-      await this.handle.shutdown();
-      this.handle = null;
-    }
-    cleanupTls();
+  shutdown(): Promise<void> {
+    if (this.shutdownPromise) return this.shutdownPromise;
+    this.shutdownRequested = true;
+    this.shutdownPromise = (async () => {
+      if (this.handle) {
+        await this.handle.shutdown();
+        this.handle = null;
+      }
+      cleanupTls();
+    })();
+    return this.shutdownPromise;
   }
 
   /**

--- a/src/runtime/typescript/src/claim-dispatcher.ts
+++ b/src/runtime/typescript/src/claim-dispatcher.ts
@@ -44,6 +44,15 @@ const _POLL_BASE_MS = 500;
 const _POLL_MAX_MS = 5000;
 const _MAX_CONCURRENT_DISPATCHES = 4;
 const _CONSECUTIVE_FAILURES_ERROR_THRESHOLD = 5;
+/** Default per-dispatcher in-flight-handler drain window (see stop()). */
+const _STOP_DRAIN_TIMEOUT_MS = 30_000;
+/**
+ * Headroom on top of the shared drain budget in `stopDispatchers` for
+ * per-dispatcher bookkeeping (poll-loop stop, keep-alive pool close)
+ * before the whole phase is abandoned. Mirrors Python's
+ * `_STOP_BUDGET_GRACE_SECS` in `_mcp_mesh/engine/claim_dispatcher.py`.
+ */
+const _STOP_BUDGET_GRACE_MS = 10_000;
 
 /**
  * Handler signature: the user's `task=true` execute function as
@@ -162,7 +171,7 @@ export class ClaimDispatcher {
    *   forever. Caller is free to override (e.g. tests pass `0` for an
    *   immediate close).
    */
-  async stop(timeoutMs: number = 30_000): Promise<void> {
+  async stop(timeoutMs: number = _STOP_DRAIN_TIMEOUT_MS): Promise<void> {
     this._stopped = true;
     // Wake any waiters so the loop can observe the stop signal.
     while (this._permitWaiters.length) this._permitWaiters.shift()!();
@@ -546,5 +555,65 @@ export class ClaimDispatcher {
       const handle = setTimeout(wake, ms);
       this._sleepWaiters.push(wake);
     });
+  }
+}
+
+/**
+ * Stop multiple dispatchers concurrently under ONE shared drain budget
+ * (issue #1173 — mirrors Python's `stop_dispatchers` in
+ * `_mcp_mesh/engine/claim_dispatcher.py`).
+ *
+ * Every dispatcher drains against the SAME `drainTimeoutMs` window — the
+ * `stop()` calls run in parallel — so N dispatchers with in-flight jobs
+ * cost roughly one drain window of wall time, not N stacked windows.
+ * Sequential 30s drains would starve whatever the caller sequences after
+ * this (registry unregister via `handle.shutdown()`, pool teardown) past
+ * a typical SIGTERM grace period (K8s default 30s), getting the process
+ * SIGKILLed before unregister runs.
+ *
+ * The whole phase is additionally hard-capped at `drainTimeoutMs +
+ * graceMs`: past that, the remaining `stop()` calls are abandoned with a
+ * warning. Never rejects — a wedged dispatcher must not prevent the
+ * registry cleanup that callers run after this.
+ *
+ * @param dispatchers - Dispatchers to stop.
+ * @param drainTimeoutMs - Shared in-flight-handler drain window, passed
+ *   to every `stop()` call. Defaults to 30s.
+ * @param graceMs - Headroom on top of `drainTimeoutMs` for per-dispatcher
+ *   bookkeeping before the phase is abandoned wholesale. Defaults to 10s.
+ */
+export async function stopDispatchers(
+  dispatchers: ClaimDispatcher[],
+  drainTimeoutMs: number = _STOP_DRAIN_TIMEOUT_MS,
+  graceMs: number = _STOP_BUDGET_GRACE_MS,
+): Promise<void> {
+  if (dispatchers.length === 0) return;
+
+  // ClaimDispatcher.stop() is documented never-throws, but guard anyway —
+  // one failing stop must not reject the gather and skip its peers.
+  const stops = dispatchers.map((d) =>
+    d.stop(drainTimeoutMs).catch((err) => {
+      console.warn(
+        `[mesh-claim] error stopping dispatcher capability=${d.capability}:`,
+        err,
+      );
+    }),
+  );
+
+  let budgetTimer: ReturnType<typeof setTimeout> | null = null;
+  const budget = new Promise<"timeout">((resolve) => {
+    budgetTimer = setTimeout(() => resolve("timeout"), drainTimeoutMs + graceMs);
+  });
+  try {
+    const outcome = await Promise.race([Promise.allSettled(stops), budget]);
+    if (outcome === "timeout") {
+      console.warn(
+        `[mesh-claim] shutdown of ${dispatchers.length} dispatcher(s) exceeded ` +
+          `the shared budget (${drainTimeoutMs}ms drain + ${graceMs}ms grace); ` +
+          `abandoning remaining drains so shutdown can proceed to registry cleanup`,
+      );
+    }
+  } finally {
+    if (budgetTimer) clearTimeout(budgetTimer);
   }
 }

--- a/src/runtime/typescript/src/config.ts
+++ b/src/runtime/typescript/src/config.ts
@@ -17,6 +17,24 @@ import {
 } from "@mcpmesh/core";
 
 /**
+ * Hard cap on the exponential backoff between `nextEvent()` retries in
+ * the mesh event loops (MeshAgent, ApiRuntime, MeshExpress).
+ */
+export const NEXT_EVENT_BACKOFF_CAP_MS = 5_000;
+
+/**
+ * Consecutive `nextEvent()` failure ceiling for the mesh event loops.
+ *
+ * The backoff ramps 100ms → 3.2s over the first 6 failures (~6.3s of
+ * sleep), then sits at the 5s cap; terminating on failure #18 means
+ * 11 more sleeps at the cap (~55s), so the loop tolerates roughly
+ * 60 seconds of CONTINUOUS failure before giving up. A permanently
+ * broken handle must not retry forever — the ref'd backoff timers
+ * would keep an otherwise-finished process alive indefinitely.
+ */
+export const MAX_CONSECUTIVE_NEXT_EVENT_FAILURES = 18;
+
+/**
  * Find an available port by binding to port 0 and getting the OS-assigned port.
  * This is used when port=0 is specified to auto-assign a port.
  */

--- a/src/runtime/typescript/src/express.ts
+++ b/src/runtime/typescript/src/express.ts
@@ -52,7 +52,13 @@ import {
 } from "@mcpmesh/core";
 
 import type { AgentConfig, ResolvedAgentConfig } from "./types.js";
-import { resolveConfig, generateAgentIdSuffix, findAvailablePort } from "./config.js";
+import {
+  resolveConfig,
+  generateAgentIdSuffix,
+  findAvailablePort,
+  MAX_CONSECUTIVE_NEXT_EVENT_FAILURES,
+  NEXT_EVENT_BACKOFF_CAP_MS,
+} from "./config.js";
 import { createProxy } from "./proxy.js";
 import { RouteRegistry, type RouteMetadata } from "./route.js";
 import { initTracing, type AgentMetadata } from "./tracing.js";
@@ -140,6 +146,14 @@ export class MeshExpress {
   private server: Server | null = null;
   private started = false;
   private shutdownRequested = false;
+  /**
+   * Memoized in-flight (or completed) teardown. `shutdown()` is
+   * idempotent: the first caller creates this promise and every later
+   * caller — user code, the signal handler, a second signal — awaits
+   * the SAME teardown instead of racing a concurrent napi
+   * `handle.shutdown()` / `server.close()`.
+   */
+  private shutdownPromise: Promise<void> | null = null;
 
   constructor(app: Application, config: MeshExpressConfig) {
     this.app = app;
@@ -228,16 +242,22 @@ export class MeshExpress {
 
   /**
    * Start the Express HTTP server.
+   *
+   * Issue #1163 MED-3: uses `await import("node:https")` — `require()`
+   * is not defined in an ESM package ("type": "module"), so the TLS
+   * path previously threw a ReferenceError at startup. Mirrors the
+   * MCP-agent path in agent.ts.
    */
-  private startServer(): Promise<void> {
+  private async startServer(): Promise<void> {
+    const bindHost = process.env.HOST ?? "0.0.0.0";
+
+    // Use HTTPS when TLS is enabled
+    const tlsOpts = getTlsOptions();
+    const https = tlsOpts ? await import("node:https") : null;
+
     return new Promise((resolve, reject) => {
       try {
-        const bindHost = process.env.HOST ?? "0.0.0.0";
-
-        // Use HTTPS when TLS is enabled
-        const tlsOpts = getTlsOptions();
-        if (tlsOpts) {
-          const https = require("node:https");
+        if (tlsOpts && https) {
           const serverOpts = {
             ...tlsOpts,
             requestCert: true,
@@ -321,16 +341,68 @@ export class MeshExpress {
 
   /**
    * Run the event loop to handle mesh events.
+   *
+   * Resilience (issue #1163 MED-1): the loop must outlive individual
+   * failures. A throw from an event handler (e.g. a malformed event
+   * hitting a non-null assertion) is logged and the loop continues; a
+   * `nextEvent()` rejection (e.g. a transient napi failure) backs off
+   * exponentially (capped) and retries. Only the "shutdown" event — or
+   * the handle being torn down — exits the loop.
    */
   private async runEventLoop(): Promise<void> {
     if (!this.handle) return;
 
     const registry = RouteRegistry.getInstance();
+    let consecutiveNextEventFailures = 0;
 
     while (true) {
-      try {
-        const event = await this.handle.nextEvent();
+      // Handle is nulled by shutdown(); exit cleanly instead of
+      // spinning on a dead reference.
+      if (!this.handle) {
+        console.log("Event loop: handle closed, exiting");
+        return;
+      }
 
+      let event: Awaited<ReturnType<JsAgentHandle["nextEvent"]>>;
+      try {
+        event = await this.handle.nextEvent();
+        consecutiveNextEventFailures = 0;
+      } catch (err) {
+        // Explicit shutdown() racing a failing nextEvent(): exit
+        // promptly instead of burning more backoff cycles.
+        if (!this.handle || this.shutdownRequested) {
+          console.log("Event loop: shutdown requested, exiting");
+          return;
+        }
+        consecutiveNextEventFailures++;
+        // Ceiling (~60s of continuous failure — see the constant's doc
+        // in config.ts): a permanently broken handle must not retry
+        // forever, keeping the process alive via the backoff timer.
+        if (
+          consecutiveNextEventFailures >= MAX_CONSECUTIVE_NEXT_EVENT_FAILURES
+        ) {
+          console.error(
+            `Event loop: terminating after ${consecutiveNextEventFailures} ` +
+              `consecutive nextEvent() failures; dependency topology is ` +
+              `frozen for the remainder of the process:`,
+            err
+          );
+          return;
+        }
+        const backoffMs = Math.min(
+          100 * 2 ** (consecutiveNextEventFailures - 1),
+          NEXT_EVENT_BACKOFF_CAP_MS
+        );
+        console.error(
+          `Event loop: nextEvent() failed (consecutive=${consecutiveNextEventFailures}), ` +
+            `retrying in ${backoffMs}ms:`,
+          err
+        );
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+        continue;
+      }
+
+      try {
         switch (event.eventType) {
           case "agent_registered":
             console.log(`Service registered with ID: ${event.agentId}`);
@@ -397,8 +469,13 @@ export class MeshExpress {
             break;
         }
       } catch (err) {
-        console.error("Event loop error:", err);
-        break;
+        // Per-event isolation: a bad event (or a bug in one handler)
+        // must not kill dependency-event processing for the process
+        // lifetime. Log and keep consuming events.
+        console.error(
+          `Event loop: error handling event '${event.eventType}':`,
+          err
+        );
       }
     }
   }
@@ -489,18 +566,44 @@ export class MeshExpress {
    * the event loop cleanly.
    */
   private installSignalHandlers(): void {
+    const SIGNAL_SHUTDOWN_TIMEOUT_MS = 10_000;
+    // Dedupe repeated signals locally. This must NOT key off
+    // `shutdownRequested` (set by shutdown() itself): a signal arriving
+    // while a user-initiated shutdown() is in flight must still arm the
+    // force-exit timer and exit the process when that same (memoized)
+    // shutdown completes.
+    let signalHandled = false;
     const shutdownHandler = (signal: string) => {
-      if (this.shutdownRequested) return;
-      this.shutdownRequested = true;
+      if (signalHandled) return;
+      signalHandled = true;
 
       console.log(
         `\nReceived ${signal}, shutting down service ${this.serviceId}...`
       );
 
+      // Bounded overall shutdown (issue #1163 MED-2 consistency): a
+      // hang anywhere in the cleanup sequence (e.g. server.close()
+      // waiting on open connections) cannot wedge the process past its
+      // SIGTERM grace.
+      //
+      // Deliberately ref'd (no unref): both completion paths below
+      // clearTimeout and process.exit synchronously, so the timer never
+      // delays a successful exit — but it must keep a wedged shutdown's
+      // otherwise-empty event loop alive long enough to emit the loud
+      // exit(1) diagnostic instead of silently exiting 0.
+      const forceExitTimer = setTimeout(() => {
+        console.error(
+          `Shutdown did not complete within ${SIGNAL_SHUTDOWN_TIMEOUT_MS}ms; forcing exit`
+        );
+        process.exit(1);
+      }, SIGNAL_SHUTDOWN_TIMEOUT_MS);
+
       this.shutdown().then(() => {
+        clearTimeout(forceExitTimer);
         console.log(`Service ${this.serviceId} shut down cleanly`);
         process.exit(0);
       }).catch((err) => {
+        clearTimeout(forceExitTimer);
         console.error("Error during shutdown:", err);
         process.exit(1);
       });
@@ -547,20 +650,31 @@ export class MeshExpress {
 
   /**
    * Shutdown the service gracefully.
+   *
+   * Idempotent and re-entrant: the first call runs the teardown; every
+   * later call (user code, the signal handler, a double signal) returns
+   * the SAME promise. The memo is never cleared: shutdown is terminal,
+   * and re-running a half-torn-down cleanup after a failure would be
+   * worse than surfacing the original rejection to every caller.
    */
-  async shutdown(): Promise<void> {
-    if (this.handle) {
-      await this.handle.shutdown();
-      this.handle = null;
-    }
+  shutdown(): Promise<void> {
+    if (this.shutdownPromise) return this.shutdownPromise;
+    this.shutdownRequested = true;
+    this.shutdownPromise = (async () => {
+      if (this.handle) {
+        await this.handle.shutdown();
+        this.handle = null;
+      }
 
-    if (this.server) {
-      await new Promise<void>((resolve) => {
-        this.server!.close(() => resolve());
-      });
-      this.server = null;
-    }
-    cleanupTls();
+      if (this.server) {
+        await new Promise<void>((resolve) => {
+          this.server!.close(() => resolve());
+        });
+        this.server = null;
+      }
+      cleanupTls();
+    })();
+    return this.shutdownPromise;
   }
 }
 

--- a/src/runtime/typescript/src/express.ts
+++ b/src/runtime/typescript/src/express.ts
@@ -154,6 +154,16 @@ export class MeshExpress {
    * `handle.shutdown()` / `server.close()`.
    */
   private shutdownPromise: Promise<void> | null = null;
+  /**
+   * This instance's own SIGINT/SIGTERM handler references, kept so
+   * shutdown() can `process.off` them — otherwise sequential instances
+   * in one process accumulate stale handlers whose memoized (already
+   * resolved) shutdown() would `process.exit(0)` on the next signal.
+   */
+  private signalHandlers: {
+    sigint: () => void;
+    sigterm: () => void;
+  } | null = null;
 
   constructor(app: Application, config: MeshExpressConfig) {
     this.app = app;
@@ -609,8 +619,13 @@ export class MeshExpress {
       });
     };
 
-    process.on("SIGINT", () => shutdownHandler("SIGINT"));
-    process.on("SIGTERM", () => shutdownHandler("SIGTERM"));
+    // Keep named references so shutdown() can remove exactly these
+    // listeners (anonymous arrows can't be process.off'd).
+    const sigint = () => shutdownHandler("SIGINT");
+    const sigterm = () => shutdownHandler("SIGTERM");
+    this.signalHandlers = { sigint, sigterm };
+    process.on("SIGINT", sigint);
+    process.on("SIGTERM", sigterm);
   }
 
   /**
@@ -673,6 +688,16 @@ export class MeshExpress {
         this.server = null;
       }
       cleanupTls();
+      // Remove this instance's own signal listeners LAST: during the
+      // teardown above a signal must still reach the handler (it arms
+      // the force-exit timer). Leaving them installed would let a later
+      // instance's signal hit this already-resolved shutdown() and
+      // process.exit(0) prematurely.
+      if (this.signalHandlers) {
+        process.off("SIGINT", this.signalHandlers.sigint);
+        process.off("SIGTERM", this.signalHandlers.sigterm);
+        this.signalHandlers = null;
+      }
     })();
     return this.shutdownPromise;
   }

--- a/src/runtime/typescript/src/index.ts
+++ b/src/runtime/typescript/src/index.ts
@@ -352,6 +352,7 @@ export {
 } from "./inbound-job-dispatch.js";
 export {
   ClaimDispatcher,
+  stopDispatchers,
   type ClaimHandler,
 } from "./claim-dispatcher.js";
 export { registerJobHelperTools } from "./jobs-helper-tools.js";

--- a/src/runtime/typescript/src/provider-handlers/gemini-handler.ts
+++ b/src/runtime/typescript/src/provider-handlers/gemini-handler.ts
@@ -166,3 +166,10 @@ ProviderHandlerRegistry.register("gemini", GeminiHandler);
 // only the auth/transport differs (IAM via @ai-sdk/google-vertex vs API key via
 // @ai-sdk/google). Mirrors Python's GeminiHandler registry alias.
 ProviderHandlerRegistry.register("vertex_ai", GeminiHandler);
+
+// Also register under "google" (issue #1163 MED-4) — "google" is a first-class
+// model prefix throughout the runtime (VENDOR_PROVIDERS, the useMaxSteps /
+// skipResponseFormat guards in llm-provider.ts, media/resolver.ts) and is the
+// handler's own `vendor` field. Without this alias, getHandler("google") fell
+// through to the GenericHandler and lost Gemini-specific prompt shaping.
+ProviderHandlerRegistry.register("google", GeminiHandler);

--- a/src/runtime/typescript/src/provider-handlers/provider-handler-registry.ts
+++ b/src/runtime/typescript/src/provider-handlers/provider-handler-registry.ts
@@ -21,6 +21,18 @@ const debug = createDebug("provider-handler-registry");
  */
 export type ProviderHandlerConstructor = new () => ProviderHandler;
 
+/**
+ * Constructor type for the fallback handler (issue #1163 MED-4): the
+ * registry passes the requested vendor through so an unregistered vendor
+ * still gets vendor-aware prompt shaping (the Rust core's
+ * formatSystemPrompt branches on the vendor string). A plain
+ * `new () => ProviderHandler` is assignable here, so existing fallback
+ * classes keep working.
+ */
+export type FallbackHandlerConstructor = new (
+  vendor?: string
+) => ProviderHandler;
+
 // ============================================================================
 // Registry Singleton
 // ============================================================================
@@ -57,7 +69,7 @@ export class ProviderHandlerRegistry {
   private static instances: Map<string, ProviderHandler> = new Map();
 
   /** Fallback handler class (set by generic-handler.ts) */
-  private static fallbackHandlerClass: ProviderHandlerConstructor | null = null;
+  private static fallbackHandlerClass: FallbackHandlerConstructor | null = null;
 
   /**
    * Register a custom provider handler.
@@ -94,7 +106,7 @@ export class ProviderHandlerRegistry {
    *
    * @param handlerClass - Fallback handler class
    */
-  static setFallbackHandler(handlerClass: ProviderHandlerConstructor): void {
+  static setFallbackHandler(handlerClass: FallbackHandlerConstructor): void {
     this.fallbackHandlerClass = handlerClass;
     debug(`Set fallback handler: ${handlerClass.name}`);
   }
@@ -157,7 +169,10 @@ export class ProviderHandlerRegistry {
         debug(`Using GenericHandler for unknown vendor`);
       }
 
-      handler = new this.fallbackHandlerClass();
+      // Pass the requested vendor through (issue #1163 MED-4) so the
+      // fallback handler's prompt shaping is vendor-aware instead of
+      // hard-wired to "unknown".
+      handler = new this.fallbackHandlerClass(normalizedVendor);
     }
 
     // Cache the instance

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -407,10 +407,17 @@ export async function callMcpTool(
   let lastError: Error | null = null;
 
   for (let attempt = 0; attempt < options.maxAttempts; attempt++) {
+    // Abort timer covers the WHOLE attempt — connect, headers, AND body
+    // read — and is cleared in `finally` (issue #1163 LOW-5). Previously
+    // it was cleared right after `fetch` resolved, so (a) a fetch
+    // rejection leaked one armed timer per retry for the rest of the
+    // timeout window, and (b) the body read (response.text() / SSE) was
+    // unbounded by the call timeout. Keeping the controller armed until
+    // the body is consumed makes an over-deadline body read abort and
+    // surface through the existing isTimeoutError path below.
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), effectiveTimeout);
     try {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), effectiveTimeout);
-
       wireJobCancel(controller);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -428,8 +435,6 @@ export async function callMcpTool(
       }
 
       const response = await fetch(mcpEndpoint, fetchOptions as RequestInit);
-
-      clearTimeout(timeoutId);
 
       if (!response.ok) {
         throw new Error(
@@ -518,6 +523,8 @@ export async function callMcpTool(
         await sleep(options.retryDelay * Math.pow(options.retryBackoff, attempt));
         continue;
       }
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 


### PR DESCRIPTION
## Summary
Closes the TypeScript consolidated audit (#1163) and the shutdown-sequencing finding (#1173).

- **Event-loop resilience**: the mesh event loops in `MeshAgent`, `ApiRuntime`, and `MeshExpress` previously did `console.error; break` on the first error — one transient napi rejection or malformed event froze dependency topology for the process lifetime while the agent kept serving. Now: per-event try/catch (log and continue), bounded exponential backoff on `nextEvent()` failures (100ms→5s cap), and a terminal ceiling of 18 consecutive failures (~60s of continuous failure) with a loud "topology is frozen" message instead of an infinite retry keeping a dead process alive.
- **Signals run full shutdown** (#1163) **under one shared drain budget** (#1173): SIGINT/SIGTERM previously skipped `shutdown()` entirely — claimed MeshJobs died mid-flight and sat in `working` until lease expiry; A2A clients, HTTP pool, and tool-worker pool never closed. The signal handlers now run full `shutdown()` with a ref'd force-exit timer (loud exit 1 if wedged). `shutdown()` drains all claim dispatchers concurrently via a new `stopDispatchers` helper — one shared 30s budget hard-capped with 10s grace (Python #1172 parity) instead of sequential 30s-per-dispatcher — and registry unregister runs regardless of drain outcome. `shutdown()` is memoized (terminal, single in-flight promise), so signal + user-code overlap cannot double-run teardown or issue concurrent napi `handle.shutdown()` calls.
- **ESM TLS startup**: `MeshExpress.startServer()` used `require("node:https")` in this `"type": "module"` package — `ReferenceError` at startup for TLS configs. Now `await import("node:https")`, matching the MCP-agent path.
- **Vendor `google`**: registered to `GeminiHandler` (was silently falling back to `GenericHandler` with vendor `unknown`, losing strict response_format and Gemini prompt shaping for `google/gemini-…` models); the fallback handler now receives the requested vendor.
- **`callMcpTool` timer hygiene**: abort timer cleared in `finally` (previously leaked one armed timer per failed retry attempt) and the deadline now stays armed through the body read.
- **Second `MeshAgent` construction throws** (same synchronous chunk) instead of silently never starting; later constructions get their own auto-start tick.

## Behavior changes — release-note visibility
- The call timeout on `callMcpTool` is now an end-to-end deadline including the body read; previously it effectively covered only time-to-headers, so a slow tool over streamable-HTTP (headers immediate, result event when done) could run unbounded. This matches the documented meaning and Python's read-timeout behavior for slow tools; the divergent edge is a steadily-streaming body exceeding the timeout in total. Tools needing longer than the 30s default should pass an explicit timeout / `X-Mesh-Timeout`.
- Event-loop errors no longer kill topology processing on first failure (strictly better); permanent failure now terminates the loop after ~60s with a clear diagnostic.

## Review Notes
- Independent review: 0 blockers, 4 warnings — three fixed (shutdown idempotency, retry ceiling, ref'd force timer), the fourth is the body-read deadline change above, kept deliberately per the reviewer's own analysis.
- Verified by review: no double-span from aborts mid-SSE-read (the #1170 accounting holds), `stopDispatchers` is faithful to the Python semantics with the inherent JS divergence (abandons rather than cancels; abandoned drains hold only dispatcher-owned resources), single-instance guard is vitest-leak-free.
- Known leftovers (deliberate): the resilient-loop block is consistent-but-copied across the three runtimes (divergent switch bodies); worst-case full drain (40s) still exceeds a default 30s K8s grace — same trade-off as the Python runtime, tune `terminationGracePeriodSeconds` or pass a smaller `drainTimeoutMs` for tight environments.

Closes #1163
Closes #1173

## Test plan
- [x] `npm run typecheck:all` + `npm run build` clean
- [x] `npx vitest run` — 62 files, 888 tests passing
- [x] New suites: event-loop resilience (throw-continuity, backoff sequence, 18-failure ceiling, prompt shutdown mid-backoff), stopDispatchers (concurrency, shared window, hard-cap abandonment, unregister-after-hung-drain, shutdown memoization ×3 runtimes), proxy timer leak + body-read deadline, single-instance guard, google vendor registration
- [ ] Integration suites on the next `tsuite-mesh:local` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event loop resilience with exponential backoff retry on consecutive failures
  * Fixed timer leak in MCP call timeout handling during fetch rejection
  * Prevented multiple runtime agent instances from being constructed in the same process
  * Improved Google provider routing to use dedicated handler

* **New Features**
  * Added idempotent, concurrent shutdown with dispatcher draining across all runtimes

* **Tests**
  * Added comprehensive regression test suites covering process safety, event-loop resilience, timer lifecycle, and concurrent shutdown behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->