### PR TITLE
fix(java): AOP-proxy enrichment, heartbeat schema parity, async budgets and context propagation

### DIFF
--- a/src/runtime/core/include/mcp_mesh_core.h
+++ b/src/runtime/core/include/mcp_mesh_core.h
@@ -1002,6 +1002,34 @@ int32_t mesh_cancel_active_job(const char *job_id);
 // `job_id_ptr` must be a valid C string for the duration of this call.
 int32_t mesh_await_job_cancel(const char *job_id_ptr);
 
+// Read-only probe: has the cancel token for `job_id` fired?
+//
+// `mesh_await_job_cancel` resolves on BOTH explicit cancel and natural
+// job end without telling the caller which one happened. Callers that
+// must distinguish (the Java SDK's outbound-call cancel watcher — a
+// natural-end wake must NOT abort still-healthy in-flight calls) probe
+// this immediately after the await returns:
+//
+// - explicit cancel: the registry entry is still present (teardown
+//   happens later, when the surrounding `run_as_job` scope ends) with
+//   its cancel token fired → returns `1`;
+// - natural end: `unregister_active_job` already removed the entry →
+//   returns `0`;
+// - re-claimed job under the same id: a fresh entry with an un-fired
+//   token → returns `0` (correct — the new attempt was not cancelled).
+//
+// Unlike `mesh_cancel_active_job` this NEVER fires the token, so it is
+// safe to call in races with a re-claim of the same job id.
+//
+// # Returns
+// `1` if an entry is registered for `job_id` and its cancel token has
+// fired, `0` otherwise (not registered, or registered but not
+// cancelled), `-1` on a NULL/invalid `job_id_ptr`.
+//
+// # Safety
+// `job_id_ptr` must be a valid C string for the duration of this call.
+int32_t mesh_job_cancel_fired(const char *job_id_ptr);
+
 // Run a Java-provided callback inside a fresh [`crate::jobs::run_as_job`]
 // scope so the cancel-registry entry under the snapshot's `job_id` is
 // bound for the duration of the callback (allowing

--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -1232,6 +1232,51 @@ pub unsafe extern "C" fn mesh_await_job_cancel(job_id_ptr: *const c_char) -> i32
     0
 }
 
+/// Read-only probe: has the cancel token for `job_id` fired?
+///
+/// `mesh_await_job_cancel` resolves on BOTH explicit cancel and natural
+/// job end without telling the caller which one happened. Callers that
+/// must distinguish (the Java SDK's outbound-call cancel watcher — a
+/// natural-end wake must NOT abort still-healthy in-flight calls) probe
+/// this immediately after the await returns:
+///
+/// - explicit cancel: the registry entry is still present (teardown
+///   happens later, when the surrounding `run_as_job` scope ends) with
+///   its cancel token fired → returns `1`;
+/// - natural end: `unregister_active_job` already removed the entry →
+///   returns `0`;
+/// - re-claimed job under the same id: a fresh entry with an un-fired
+///   token → returns `0` (correct — the new attempt was not cancelled).
+///
+/// Unlike `mesh_cancel_active_job` this NEVER fires the token, so it is
+/// safe to call in races with a re-claim of the same job id.
+///
+/// # Returns
+/// `1` if an entry is registered for `job_id` and its cancel token has
+/// fired, `0` otherwise (not registered, or registered but not
+/// cancelled), `-1` on a NULL/invalid `job_id_ptr`.
+///
+/// # Safety
+/// `job_id_ptr` must be a valid C string for the duration of this call.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_cancel_fired(job_id_ptr: *const c_char) -> i32 {
+    take_last_error();
+    let job_id = match req_cstr(job_id_ptr, "job_id") {
+        Ok(s) => s,
+        Err(()) => return -1,
+    };
+    match cancel_registry::get_state(job_id) {
+        Some((cancel, _ended)) => {
+            if cancel.is_cancelled() {
+                1
+            } else {
+                0
+            }
+        }
+        None => 0,
+    }
+}
+
 // =============================================================================
 // run_as_job — callback-based scope binding
 // =============================================================================
@@ -1471,6 +1516,43 @@ mod tests {
         let rc = unsafe { mesh_await_job_cancel(id_c.as_ptr()) };
         assert_eq!(rc, 0);
         unregisterer.join().expect("unregister thread panicked");
+    }
+
+    /// `mesh_job_cancel_fired` distinguishes the two `mesh_await_job_cancel`
+    /// wake reasons: `1` only when the registry still holds the entry AND
+    /// its cancel token fired; `0` for un-fired entries and for naturally
+    /// unregistered (ended) jobs. Read-only — must NOT fire the token.
+    #[test]
+    fn job_cancel_fired_distinguishes_cancel_from_natural_end() {
+        use tokio_util::sync::CancellationToken;
+
+        let job_id = format!("cancel-fired-probe-{}", uuid::Uuid::new_v4().simple());
+        let id_c = CString::new(job_id.clone()).unwrap();
+
+        // Not registered → 0.
+        assert_eq!(unsafe { mesh_job_cancel_fired(id_c.as_ptr()) }, 0);
+
+        // Registered, not cancelled → 0 (and the probe must not fire it).
+        let token = CancellationToken::new();
+        cancel_registry::register_active_job(&job_id, token.clone());
+        assert_eq!(unsafe { mesh_job_cancel_fired(id_c.as_ptr()) }, 0);
+        assert!(!token.is_cancelled(), "probe must be read-only");
+
+        // Explicit cancel → 1 (entry still present until natural teardown).
+        cancel_registry::cancel_active_job(&job_id);
+        assert_eq!(unsafe { mesh_job_cancel_fired(id_c.as_ptr()) }, 1);
+
+        // Natural teardown (unregister) → back to 0.
+        cancel_registry::unregister_active_job(&job_id);
+        assert_eq!(unsafe { mesh_job_cancel_fired(id_c.as_ptr()) }, 0);
+    }
+
+    /// Null pointer must be rejected with `-1` via the last-error slot,
+    /// same as the other req_cstr-guarded entry points.
+    #[test]
+    fn job_cancel_fired_rejects_null() {
+        let rc = unsafe { mesh_job_cancel_fired(ptr::null()) };
+        assert_eq!(rc, -1);
     }
 
     /// `mesh_run_as_job` must reject malformed JSON cleanly via the

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
@@ -810,6 +810,26 @@ public interface MeshCore {
     int mesh_await_job_cancel(String jobId);
 
     /**
+     * Read-only probe: has the cancel token for {@code jobId} fired?
+     *
+     * <p>{@link #mesh_await_job_cancel} resolves on BOTH explicit cancel and
+     * natural job end without telling the caller which happened. Callers that
+     * must distinguish (the outbound-call cancel watcher in
+     * {@code McpHttpClient} — a natural-end wake must NOT abort still-healthy
+     * in-flight calls) call this immediately after the await returns: on
+     * explicit cancel the registry entry is still present with its token
+     * fired (returns 1); on natural end the entry was already removed
+     * (returns 0). Never fires the token itself, so it is safe to call in
+     * races with a re-claim of the same job id.
+     *
+     * @param jobId the job ID to probe
+     * @return 1 if an entry is registered and its cancel token has fired,
+     *         0 otherwise (not registered, or registered but not cancelled),
+     *         -1 on invalid input (see {@link #mesh_last_error})
+     */
+    int mesh_job_cancel_fired(String jobId);
+
+    /**
      * Callback type for {@link MeshCore#mesh_run_as_job}. The callback is
      * invoked synchronously from the FFI runtime's block_on; its int return
      * value propagates as mesh_run_as_job's return value.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
@@ -361,6 +361,21 @@ public final class JobsRuntimeManager implements SmartLifecycle {
             cf.cancel(true);
             throw new RuntimeException("Async operation timed out after " + timeoutSecs
                 + " seconds (claim-path budget for capability '" + capability + "')");
+        } catch (java.util.concurrent.ExecutionException ee) {
+            // Unwrap to the user exception (mirrors MeshToolWrapper.awaitIfFuture
+            // and the InvocationTargetException handling in invokeViaReflection) —
+            // the @MeshTool(retryOn=...) whitelist matches with cls.isInstance(cause)
+            // in ClaimDispatcher.handleRetryOrFail, so a wrapped ExecutionException
+            // would never match the user's declared exception types.
+            Throwable cause = ee.getCause();
+            if (cause instanceof Exception ex) throw ex;
+            throw new RuntimeException(cause);
+        } catch (InterruptedException ie) {
+            // Restore the interrupt flag — the dispatcher's terminal handler
+            // swallows the exception, so the flag is the only signal the
+            // dispatch thread retains (mirrors MeshToolWrapper.awaitIfFuture).
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Async operation interrupted", ie);
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
@@ -323,7 +323,7 @@ public final class JobsRuntimeManager implements SmartLifecycle {
         try {
             Object result = method.invoke(bean, fullArgs);
             if (result instanceof java.util.concurrent.CompletableFuture<?> cf) {
-                result = cf.get();
+                result = awaitFutureWithJobBudget(cf, meta.capability());
             }
             return result;
         } catch (InvocationTargetException ite) {
@@ -332,6 +332,45 @@ public final class JobsRuntimeManager implements SmartLifecycle {
             throw new RuntimeException(cause);
         }
     }
+
+    /**
+     * Issue #1164 MED-5: claim-path symmetry with the inbound wrapper's
+     * bounded async await. The claim path previously called {@code cf.get()}
+     * with no timeout — a never-completing future would pin a dispatch
+     * thread forever. Bound the await to the job's actual budget
+     * ({@code max_duration} from the claim, surfaced via the
+     * {@link io.mcpmesh.JobContext} snapshot the dispatcher binds around
+     * this handler), falling back to a generous ceiling when the job has no
+     * deadline (jobs are unlimited-by-default per the registry contract, so
+     * the fallback is a leak backstop, not a policy timeout). The timed-out
+     * future is cancelled, which frees the dispatch thread, cancels
+     * dependent stages, and turns a late {@code complete()} into a no-op —
+     * {@code CompletableFuture.cancel} does NOT interrupt the thread
+     * computing the value ({@code mayInterruptIfRunning} has no effect per
+     * its javadoc), so orphaned producer-side work runs to completion in
+     * the background.
+     */
+    static Object awaitFutureWithJobBudget(
+            java.util.concurrent.CompletableFuture<?> cf, String capability) throws Exception {
+        io.mcpmesh.JobContext.Snapshot job = io.mcpmesh.JobContext.current();
+        Long budget = job != null ? job.deadlineSecsRemaining : null;
+        long timeoutSecs = (budget != null && budget > 0) ? budget : NO_DEADLINE_AWAIT_CEILING_SECS;
+        try {
+            return cf.get(timeoutSecs, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (java.util.concurrent.TimeoutException te) {
+            cf.cancel(true);
+            throw new RuntimeException("Async operation timed out after " + timeoutSecs
+                + " seconds (claim-path budget for capability '" + capability + "')");
+        }
+    }
+
+    /**
+     * Await ceiling for claim-dispatched jobs with no {@code max_duration}.
+     * 24h — large enough to never strangle a legitimate long-running job,
+     * small enough that a leaked never-completing future eventually frees
+     * its dispatch thread.
+     */
+    static final long NO_DEADLINE_AWAIT_CEILING_SECS = 86_400L;
 
     /** Best-effort scalar coercion — identical to MeshToolWrapper's fast path. */
     private static Object coerce(Object val, Class<?> target) {
@@ -358,12 +397,18 @@ public final class JobsRuntimeManager implements SmartLifecycle {
     }
 
     private MeshToolWrapper lookupWrapperForMethod(MeshToolRegistry.ToolMetadata meta) {
-        // Wrappers are keyed by funcId == className.methodName
-        String funcId = meta.bean().getClass().getName() + "." + meta.method().getName();
+        // Wrappers are keyed by funcId == targetClassName.methodName.
+        // Unwrap AOP proxies the same way MeshToolBeanPostProcessor does when
+        // constructing the wrapper key, so Spring-proxied beans
+        // (Foo$$SpringCGLIB$$0) hit the primary lookup (issue #1164 MED-1).
+        String funcId = org.springframework.aop.support.AopUtils.getTargetClass(meta.bean()).getName()
+            + "." + meta.method().getName();
         MeshToolWrapper wrapper = wrapperRegistry.getWrapper(funcId);
         if (wrapper == null) {
-            // Fall back via method name (covers CGLIB-proxied beans where
-            // the class name diverges from the user's source class).
+            // Fall back via method name (defensive — covers any residual
+            // key divergence between registration and lookup).
+            log.debug("Wrapper lookup miss for funcId={}; falling back to method-name lookup '{}'",
+                funcId, meta.method().getName());
             wrapper = wrapperRegistry.getWrapperByMethodName(meta.method().getName());
         }
         return wrapper;

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpHttpClient.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpHttpClient.java
@@ -116,9 +116,30 @@ public class McpHttpClient {
     private static final java.util.concurrent.ConcurrentMap<String, JobCancelWatcher>
         ACTIVE_WATCHERS = new java.util.concurrent.ConcurrentHashMap<>();
 
-    private static final class JobCancelWatcher {
-        private final java.util.List<Runnable> subscribers =
-            new java.util.concurrent.CopyOnWriteArrayList<>();
+    // Package-private (not private) so the fire/subscribe race contract is
+    // unit-testable without the native watcher thread (issue #1164 LOW).
+    static final class JobCancelWatcher {
+        /** Guarded by {@code this} — along with {@link #fired}. */
+        private final java.util.List<Runnable> subscribers = new java.util.ArrayList<>();
+        /**
+         * Issue #1164 LOW: set once the cancel token has fired and the
+         * subscriber snapshot was taken. A subscribe() that races with the
+         * firing (previously: CopyOnWriteArrayList iteration snapshot missed
+         * late additions) now runs its runnable immediately instead of never —
+         * otherwise the in-flight call would run to its read timeout despite
+         * the job being cancelled.
+         *
+         * <p>Only a GENUINE cancel sets this. The watcher's await also wakes
+         * on natural job end ({@link #completeNaturally()}); marking that
+         * fired too would make a call subscribing in the wake→remove window
+         * cancel itself even though the job completed normally — flipping the
+         * failure mode from "slow" to "kills a healthy call" (#1164 review).
+         */
+        private boolean fired = false;
+
+        /** Test seam — does NOT spawn the native watcher thread. */
+        JobCancelWatcher() {
+        }
 
         JobCancelWatcher(String jobId) {
             // `self` capture lets us use ConcurrentHashMap.remove(K, V)
@@ -128,17 +149,26 @@ public class McpHttpClient {
             final JobCancelWatcher self = this;
             java.util.concurrent.CompletableFuture.runAsync(() -> {
                 try {
-                    MeshCore.load().mesh_await_job_cancel(jobId);
-                    // Token fired (cancel) OR job unregistered (natural
-                    // end). Either way, run all subscribers; on the
-                    // natural-end path the call.cancel() invocations are
-                    // no-ops because the calls have already completed.
-                    for (Runnable r : subscribers) {
-                        try {
-                            r.run();
-                        } catch (Exception swallow) {
-                            log.debug("Subscriber threw: {}", swallow.toString());
-                        }
+                    MeshCore core = MeshCore.load();
+                    core.mesh_await_job_cancel(jobId);
+                    // The await wakes on BOTH explicit cancel and natural job
+                    // end without saying which. Distinguish via the read-only
+                    // cancel-state probe: on explicit cancel the registry
+                    // entry is still present with its token fired; on natural
+                    // end the entry was already removed. Only a genuine
+                    // cancel may abort subscribers — a natural-end wake must
+                    // leave still-in-flight calls (async work outliving the
+                    // handler) untouched.
+                    //
+                    // Residual race (documented, accepted): a genuine cancel
+                    // whose run_as_job scope tears down before the probe runs
+                    // is classified as natural end — its in-flight calls then
+                    // run to their read timeout (slow, but never cancels
+                    // healthy work).
+                    if (isCancelFired(core, jobId)) {
+                        self.fireSubscribers();
+                    } else {
+                        self.completeNaturally();
                     }
                 } catch (Exception e) {
                     // Swallow Exception — Errors propagate (let the JVM
@@ -151,8 +181,87 @@ public class McpHttpClient {
             }, JOB_CANCEL_WATCHER_EXECUTOR);
         }
 
-        void subscribe(Runnable r) { subscribers.add(r); }
-        void unsubscribe(Runnable r) { subscribers.remove(r); }
+        /**
+         * Probe whether the wake was a genuine cancel. Degrades to "natural
+         * end" when the native library predates {@code mesh_job_cancel_fired}
+         * (custom MESH_NATIVE_LIB_PATH builds): cancelled jobs' in-flight
+         * calls then run to their read timeout instead of aborting — slow,
+         * but never cancels healthy work.
+         */
+        private static boolean isCancelFired(MeshCore core, String jobId) {
+            try {
+                return core.mesh_job_cancel_fired(jobId) == 1;
+            } catch (UnsatisfiedLinkError | Exception t) {
+                // UnsatisfiedLinkError = old native lib without the symbol;
+                // other Errors (OOM/StackOverflow) propagate per the
+                // watcher's convention above.
+                log.debug("mesh_job_cancel_fired probe unavailable for {} ({}); "
+                    + "treating wake as natural end", jobId, t.toString());
+                return false;
+            }
+        }
+
+        /** Mark fired (genuine cancel) and run every current subscriber (each isolated). */
+        void fireSubscribers() {
+            java.util.List<Runnable> snapshot;
+            synchronized (this) {
+                fired = true;
+                snapshot = new java.util.ArrayList<>(subscribers);
+                subscribers.clear();
+            }
+            for (Runnable r : snapshot) {
+                runIsolated(r);
+            }
+        }
+
+        /**
+         * Natural-end wake: the job finished without cancel. Discard the
+         * current subscribers WITHOUT running them — any still-in-flight
+         * outbound calls (async work that outlives the handler) are healthy
+         * and must complete normally. {@link #fired} stays false so a
+         * subscribe racing this wake registers as a no-op on a dead watcher
+         * instead of cancelling itself immediately.
+         */
+        void completeNaturally() {
+            synchronized (this) {
+                subscribers.clear();
+            }
+        }
+
+        /**
+         * Register a cancel runnable. When the token has ALREADY fired, the
+         * runnable runs immediately on the calling thread (it races with the
+         * caller's subsequent {@code call.execute()}, exactly like the normal
+         * fired path).
+         */
+        void subscribe(Runnable r) {
+            boolean runNow;
+            synchronized (this) {
+                if (fired) {
+                    runNow = true;
+                } else {
+                    subscribers.add(r);
+                    runNow = false;
+                }
+            }
+            if (runNow) {
+                runIsolated(r);
+            }
+        }
+
+        void unsubscribe(Runnable r) {
+            synchronized (this) {
+                subscribers.remove(r);
+            }
+        }
+
+        private static void runIsolated(Runnable r) {
+            try {
+                r.run();
+            } catch (Exception swallow) {
+                log.debug("Subscriber threw: {}", swallow.toString());
+            }
+        }
     }
 
     private final OkHttpClient httpClient;
@@ -253,6 +362,35 @@ public class McpHttpClient {
                 watcher.unsubscribe(subscriber);
             }
         }
+    }
+
+    /**
+     * Parse a timeout value (seconds) the same way the inbound
+     * {@link MeshToolWrapper} path does: as a double, rounding (not
+     * truncating) so fractional budgets like {@code "2.5"} survive, with a
+     * floor of 1s. Non-finite, non-positive, or unparseable values fall back
+     * to {@code defaultSecs} with a warning (issue #1164 LOW — previously an
+     * empty {@code catch} silently defaulted).
+     *
+     * @param raw         raw value (may be null/empty)
+     * @param source      human-readable source label for the warning
+     * @param defaultSecs fallback when raw is absent or invalid
+     * @return effective timeout in whole seconds (>= 1)
+     */
+    static int parseTimeoutSecs(String raw, String source, int defaultSecs) {
+        if (raw == null || raw.trim().isEmpty()) {
+            return defaultSecs;
+        }
+        try {
+            double secs = Double.parseDouble(raw.trim());
+            if (Double.isFinite(secs) && secs > 0) {
+                return (int) Math.min(Integer.MAX_VALUE, Math.max(1L, Math.round(secs)));
+            }
+            log.warn("Non-positive {} value '{}' — using default {}s", source, raw, defaultSecs);
+        } catch (NumberFormatException e) {
+            log.warn("Invalid {} value '{}' — using default {}s", source, raw, defaultSecs);
+        }
+        return defaultSecs;
     }
 
     /**
@@ -406,20 +544,19 @@ public class McpHttpClient {
                 requestBuilder.header(entry.getKey(), entry.getValue());
             }
 
-            // Determine effective timeout from X-Mesh-Timeout (propagated) or default (#769)
-            int effectiveTimeoutSecs = 300; // default
+            // Determine effective timeout from X-Mesh-Timeout (propagated) or default (#769).
+            // Issue #1164 LOW: parse as double (the inbound MeshToolWrapper path accepts
+            // fractional budgets like "2.5") and log on parse failure instead of silently
+            // falling back to the 300s default.
+            int effectiveTimeoutSecs;
             String existingTimeout = mergedHeaders.get("x-mesh-timeout");
             if (existingTimeout == null) existingTimeout = mergedHeaders.get("X-Mesh-Timeout");
             if (existingTimeout == null) {
-                String callTimeout = System.getenv("MCP_MESH_CALL_TIMEOUT");
-                if (callTimeout != null && !callTimeout.isEmpty()) {
-                    try { effectiveTimeoutSecs = Integer.parseInt(callTimeout); } catch (NumberFormatException e) {}
-                }
+                effectiveTimeoutSecs = parseTimeoutSecs(
+                    System.getenv("MCP_MESH_CALL_TIMEOUT"), "MCP_MESH_CALL_TIMEOUT env var", 300);
             } else {
-                try { effectiveTimeoutSecs = Integer.parseInt(existingTimeout); } catch (NumberFormatException e) {}
+                effectiveTimeoutSecs = parseTimeoutSecs(existingTimeout, "X-Mesh-Timeout header", 300);
             }
-            // Guard against negative/zero
-            if (effectiveTimeoutSecs <= 0) effectiveTimeoutSecs = 300;
 
             // Set X-Mesh-Timeout on the outgoing request if not already propagated
             if (!mergedHeaders.containsKey("x-mesh-timeout") && !mergedHeaders.containsKey("X-Mesh-Timeout")) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpHttpClient.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpHttpClient.java
@@ -1045,19 +1045,19 @@ public class McpHttpClient {
                 requestBuilder.header(entry.getKey(), entry.getValue());
             }
 
-            // Determine effective timeout — same logic as callTool() (#769)
-            int effectiveTimeoutSecs = 300;
+            // Determine effective timeout — same logic as callTool() (#769).
+            // Issue #1164 LOW (review follow-up): shared parseTimeoutSecs so
+            // fractional budgets parse and invalid values warn instead of
+            // silently defaulting (handles non-positive values too).
+            int effectiveTimeoutSecs;
             String existingTimeout = mergedHeaders.get("x-mesh-timeout");
             if (existingTimeout == null) existingTimeout = mergedHeaders.get("X-Mesh-Timeout");
             if (existingTimeout == null) {
-                String callTimeout = System.getenv("MCP_MESH_CALL_TIMEOUT");
-                if (callTimeout != null && !callTimeout.isEmpty()) {
-                    try { effectiveTimeoutSecs = Integer.parseInt(callTimeout); } catch (NumberFormatException e) {}
-                }
+                effectiveTimeoutSecs = parseTimeoutSecs(
+                    System.getenv("MCP_MESH_CALL_TIMEOUT"), "MCP_MESH_CALL_TIMEOUT env var", 300);
             } else {
-                try { effectiveTimeoutSecs = Integer.parseInt(existingTimeout); } catch (NumberFormatException e) {}
+                effectiveTimeoutSecs = parseTimeoutSecs(existingTimeout, "X-Mesh-Timeout header", 300);
             }
-            if (effectiveTimeoutSecs <= 0) effectiveTimeoutSecs = 300;
 
             if (!mergedHeaders.containsKey("x-mesh-timeout") && !mergedHeaders.containsKey("X-Mesh-Timeout")) {
                 requestBuilder.header("X-Mesh-Timeout", String.valueOf(effectiveTimeoutSecs));

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -1265,7 +1265,8 @@ public class MeshAutoConfiguration {
      * @param llmRegistry  LLM registry with @MeshLlm configs
      * @param objectMapper Jackson ObjectMapper for JSON serialization
      */
-    private void enrichToolsWithLlmProvider(
+    // Package-private static for tests (issue #1164 MED-1) — no instance state used.
+    static void enrichToolsWithLlmProvider(
             List<AgentSpec.ToolSpec> tools,
             MeshToolRegistry toolRegistry,
             MeshLlmRegistry llmRegistry,
@@ -1278,12 +1279,27 @@ public class MeshAutoConfiguration {
                 continue;
             }
 
-            // Build funcId in the format used by MeshLlmRegistry
-            String funcId = meta.bean().getClass().getName() + "." + meta.method().getName();
+            // Build funcId in the format used by MeshLlmRegistry. Use
+            // AopUtils.getTargetClass — the same unwrap MeshLlmBeanPostProcessor
+            // applies at registration time — so Spring-proxied beans
+            // (@Transactional/@Async/@Validated, runtime class Foo$$SpringCGLIB$$0)
+            // still resolve their @MeshLlm config (issue #1164 MED-1).
+            String funcId = org.springframework.aop.support.AopUtils.getTargetClass(meta.bean()).getName()
+                + "." + meta.method().getName();
 
             // Look up @MeshLlm config
             MeshLlmRegistry.LlmConfig llmConfig = llmRegistry.getByFunctionId(funcId);
             if (llmConfig == null) {
+                // Normal for tools without @MeshLlm; a lookup miss for a method
+                // that IS annotated means the registration/lookup keys diverged
+                // again — surface it loudly instead of silently skipping.
+                if (org.springframework.core.annotation.AnnotationUtils
+                        .findAnnotation(meta.method(), io.mcpmesh.MeshLlm.class) != null) {
+                    log.warn("@MeshLlm config lookup miss for tool '{}' (funcId={}): the method is "
+                        + "annotated but no registered config matched — llm_provider enrichment "
+                        + "skipped. Registration/lookup key mismatch; report as a bug.",
+                        toolSpec.getCapability(), funcId);
+                }
                 continue;
             }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -12,6 +12,7 @@ import io.mcpmesh.core.MeshEvent;
 import io.mcpmesh.spring.media.MediaFetchResult;
 import io.mcpmesh.spring.media.MediaResolver;
 import io.mcpmesh.spring.media.MediaStore;
+import io.mcpmesh.spring.tracing.TraceContext;
 import io.mcpmesh.types.McpMeshTool;
 import io.mcpmesh.types.MeshLlmAgent;
 import io.mcpmesh.types.MeshToolCallException;
@@ -219,6 +220,42 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
 
     private void clearInvocationContext() {
         invocationContext.remove();
+    }
+
+    /**
+     * Issue #1164 MED-4: capture the caller thread's per-request context and
+     * restore it inside an async task running on a pool thread.
+     *
+     * <p>{@code CompletableFuture.supplyAsync(this::generate)} previously ran
+     * with empty ThreadLocals on the pool thread: the invocation context
+     * ({@code ${ctx.*}} template variables set by {@link MeshToolWrapper} on
+     * the servlet thread) read null, and {@link TraceContext} was empty — so
+     * outbound calls carried neither trace headers nor propagated headers
+     * (X-Mesh-Job-Id, X-Mesh-Timeout, allowlisted auth).
+     *
+     * <p>The returned supplier layers {@link TraceContext#wrapSupplier} (trace
+     * info + propagated headers, with restore-previous semantics) and a
+     * capture/restore of this proxy's {@code invocationContext} ThreadLocal,
+     * with a finally that clears it so pool threads aren't polluted.
+     */
+    private <T> java.util.function.Supplier<T> withCallerContext(java.util.function.Supplier<T> inner) {
+        Map<String, Object> capturedCtx = invocationContext.get();
+        java.util.function.Supplier<T> traced = TraceContext.wrapSupplier(inner);
+        return () -> {
+            Map<String, Object> previous = invocationContext.get();
+            if (capturedCtx != null) {
+                invocationContext.set(capturedCtx);
+            }
+            try {
+                return traced.get();
+            } finally {
+                if (previous != null) {
+                    invocationContext.set(previous);
+                } else {
+                    invocationContext.remove();
+                }
+            }
+        };
     }
 
     public void updateProvider(String endpoint, String functionName, String provider) {
@@ -512,12 +549,14 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
 
         @Override
         public CompletableFuture<String> generateAsync() {
-            return CompletableFuture.supplyAsync(this::generate);
+            // Issue #1164 MED-4: propagate caller-thread context (trace +
+            // propagated headers + invocation context) onto the pool thread.
+            return CompletableFuture.supplyAsync(withCallerContext(this::generate));
         }
 
         @Override
         public <T> CompletableFuture<T> generateAsync(Class<T> responseType) {
-            return CompletableFuture.supplyAsync(() -> generate(responseType));
+            return CompletableFuture.supplyAsync(withCallerContext(() -> generate(responseType)));
         }
 
         @Override
@@ -682,9 +721,15 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                 }
             }
 
-            // 2. Convert builder messages to LLM format
+            // 2. Convert builder messages to LLM format.
+            // LinkedHashMap instead of Map.of: Message.content() can be null for
+            // assistant turns that only carried tool_calls (Map.of throws NPE on
+            // null values) — mirrors streamGenerate (issue #1164 MED-3).
             for (Message msg : messages) {
-                llmMessages.add(Map.of("role", msg.role(), "content", msg.content()));
+                Map<String, Object> entry = new LinkedHashMap<>(2);
+                entry.put("role", msg.role());
+                entry.put("content", msg.content());
+                llmMessages.add(entry);
             }
 
             // 2.5. Resolve media URIs and attach to the last user message
@@ -755,13 +800,19 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                 log.info("LLM requested {} tool calls", toolCalls.size());
 
                 if (parallelToolCalls && toolCalls.size() > 1) {
-                    // Parallel execution via CompletableFuture
+                    // Parallel execution via CompletableFuture.
+                    // Issue #1164 MED-4: wrap each task with TraceContext so
+                    // parallel tool calls carry trace headers AND propagated
+                    // headers (X-Mesh-Job-Id, X-Mesh-Timeout, allowlisted auth)
+                    // on outbound calls — matching the sequential branch, which
+                    // runs on the caller thread and inherits them implicitly.
                     log.info("Executing {} tool calls in parallel", toolCalls.size());
                     List<CompletableFuture<Map<String, Object>>> futures = new ArrayList<>();
 
                     for (Map<String, Object> toolCall : toolCalls) {
                         ParsedToolCall parsed = parseToolCall(toolCall);
-                        futures.add(CompletableFuture.supplyAsync(() -> buildToolResultMessage(parsed)));
+                        futures.add(CompletableFuture.supplyAsync(
+                            TraceContext.wrapSupplier(() -> buildToolResultMessage(parsed))));
                     }
 
                     // Wait for all tools to complete and add results
@@ -1253,13 +1304,24 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
      * @param message   Human-readable error description
      * @return JSON error string
      */
-    private String buildErrorResponse(String errorType, String toolName, String message) {
-        // Escape quotes in message to ensure valid JSON
-        String safeMessage = message != null ? message.replace("\"", "'").replace("\\", "\\\\") : "Unknown error";
-        return String.format(
-            "{\"error\":{\"type\":\"%s\",\"tool\":\"%s\",\"message\":\"%s\"}}",
-            errorType, toolName, safeMessage
-        );
+    // Package-private static for tests (issue #1164 LOW).
+    static String buildErrorResponse(String errorType, String toolName, String message) {
+        // Issue #1164 LOW: serialize with Jackson — the previous hand-rolled
+        // escaping missed newlines/control chars, producing invalid JSON for
+        // exception messages containing them.
+        Map<String, Object> error = new LinkedHashMap<>();
+        error.put("type", errorType);
+        error.put("tool", toolName);
+        error.put("message", message != null ? message : "Unknown error");
+        Map<String, Object> wrapper = new LinkedHashMap<>();
+        wrapper.put("error", error);
+        try {
+            return objectMapper.writeValueAsString(wrapper);
+        } catch (Exception e) {
+            log.warn("Failed to serialize error response ({} / {}): {}", errorType, toolName, e.getMessage());
+            return "{\"error\":{\"type\":\"serialization_error\",\"tool\":\"unknown\","
+                + "\"message\":\"failed to serialize error response\"}}";
+        }
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshSchemaSupport.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshSchemaSupport.java
@@ -106,6 +106,222 @@ public final class MeshSchemaSupport {
     }
 
     /**
+     * Build the MCP input schema for a {@code @MeshTool} method from its
+     * {@code @Param}-annotated parameters.
+     *
+     * <p>Issue #1164 MED-2: this is the SINGLE source of truth for tool input
+     * schemas — both the MCP-served schema ({@link MeshToolWrapper}) and the
+     * heartbeat catalog ({@link MeshToolRegistry}) call this method, so the
+     * registry-advertised {@code input_schema} / {@code input_schema_hash}
+     * always represents the schema the MCP server actually serves. Previously
+     * the registry hand-rolled a shallow {@code {"type": ...}} per parameter
+     * (POJO → bare {@code {"type":"object"}}, {@code List<Foo>} → bare
+     * {@code {"type":"array"}}), so heartbeat-derived consumers (cross-runtime
+     * schema matching #547, llm_tools definitions) saw an impoverished shape
+     * that diverged from the served one.
+     *
+     * <p>Per-parameter schemas come from the shared victools {@link #generator()}
+     * (full nesting, {@code required}, {@code anyOf} nullability). Each
+     * parameter's {@code $defs} block is hoisted to the root schema so the
+     * composed document's {@code #/$defs/...} pointers stay resolvable; name
+     * collisions between structurally different defs (same simple name,
+     * different package) are disambiguated with a numeric suffix.
+     *
+     * <p>Parameters without {@code @Param} (injectable types: {@code McpMeshTool},
+     * {@code MeshLlmAgent}, {@code MeshJob}, {@code A2AClient}) are excluded by
+     * construction. {@code @MediaParam} contributes {@code x-media-type} and a
+     * media-note description suffix (kept from the legacy registry builder).
+     *
+     * @param method the {@code @MeshTool}-annotated method
+     * @return the composed input schema ({@code type/properties/required/$defs})
+     */
+    public static Map<String, Object> buildToolInputSchema(java.lang.reflect.Method method) {
+        Map<String, Object> schema = new java.util.LinkedHashMap<>();
+        schema.put("type", "object");
+
+        Map<String, Object> properties = new java.util.LinkedHashMap<>();
+        List<String> required = new ArrayList<>();
+        Map<String, Object> rootDefs = new java.util.LinkedHashMap<>();
+
+        java.lang.reflect.Parameter[] params = method.getParameters();
+        java.lang.reflect.Type[] genericTypes = method.getGenericParameterTypes();
+
+        for (int i = 0; i < params.length; i++) {
+            io.mcpmesh.Param paramAnn = params[i].getAnnotation(io.mcpmesh.Param.class);
+            if (paramAnn == null) {
+                continue; // injectable / non-MCP parameter
+            }
+
+            Map<String, Object> propSchema = generateParameterSchema(genericTypes[i]);
+            hoistDefs(propSchema, rootDefs);
+
+            // @Param description WINS over a victools-derived one (Jackson
+            // @JsonClassDescription on the parameter type, etc.) — the
+            // user's per-parameter annotation is the more specific intent,
+            // and the legacy heartbeat builder always used @Param here, so
+            // letting the type-derived text shadow it would silently change
+            // registry-advertised descriptions (#1164 review follow-up).
+            // When @Param carries no description, the derived one is kept.
+            if (!paramAnn.description().isEmpty()) {
+                propSchema.put("description", paramAnn.description());
+            }
+
+            io.mcpmesh.MediaParam mediaParamAnn = params[i].getAnnotation(io.mcpmesh.MediaParam.class);
+            if (mediaParamAnn != null) {
+                propSchema.put("x-media-type", mediaParamAnn.value());
+                String existingDesc = String.valueOf(propSchema.getOrDefault("description", ""));
+                String mediaNote = "(accepts media URI: " + mediaParamAnn.value() + ")";
+                if (!existingDesc.contains(mediaNote)) {
+                    propSchema.put("description", (existingDesc + " " + mediaNote).trim());
+                }
+            }
+
+            properties.put(paramAnn.value(), propSchema);
+            if (paramAnn.required()) {
+                required.add(paramAnn.value());
+            }
+        }
+
+        schema.put("properties", properties);
+        if (!required.isEmpty()) {
+            schema.put("required", required);
+        }
+        if (!rootDefs.isEmpty()) {
+            schema.put("$defs", rootDefs);
+        }
+        return schema;
+    }
+
+    /**
+     * Generate the victools schema for one parameter type as a mutable Map.
+     * Bare {@code "#"} root self-refs (recursive parameter types) are rewritten
+     * to a named {@code $defs} entry first — embedding a bare {@code "#"} into
+     * the composed tool schema would re-point it at the wrong root.
+     * Falls back to {@code {"type":"object"}} on generation failure.
+     */
+    private static Map<String, Object> generateParameterSchema(java.lang.reflect.Type type) {
+        try {
+            JsonNode node = SCHEMA_GENERATOR.generateSchema(type);
+            node = rewriteRootSelfRefs(node, rawClassOf(type));
+            Map<String, Object> map = JSON.convertValue(
+                node, new tools.jackson.core.type.TypeReference<Map<String, Object>>() {});
+            if (map != null) {
+                return map;
+            }
+        } catch (Exception e) {
+            log.warn("Failed to generate JSON Schema for tool parameter type {}: {}", type, e.getMessage());
+        }
+        Map<String, Object> fallback = new java.util.LinkedHashMap<>();
+        fallback.put("type", "object");
+        return fallback;
+    }
+
+    /** Erased class of a reflective Type (for $defs naming); Object.class fallback. */
+    private static Class<?> rawClassOf(java.lang.reflect.Type type) {
+        if (type instanceof Class<?> c) {
+            return c;
+        }
+        if (type instanceof java.lang.reflect.ParameterizedType pt
+                && pt.getRawType() instanceof Class<?> raw) {
+            return raw;
+        }
+        return Object.class;
+    }
+
+    /**
+     * Hoist a property schema's {@code $defs} block into the composed root
+     * schema's defs map, in place. Structurally identical defs are reused;
+     * same-name-different-body collisions get a numeric-suffix rename, with
+     * every {@code #/$defs/<name>} pointer inside the property subtree (and
+     * its own def bodies) rewritten to the disambiguated name.
+     *
+     * <p>Collision detection iterates to a FIXPOINT over post-rename bodies
+     * (#1164 review follow-up): a def whose body only diverges from the root
+     * entry AFTER a nested ref is renamed (e.g. two same-named {@code Wrap}
+     * defs referencing two different same-named {@code Item} defs) must also
+     * be disambiguated. A single pre-rename comparison pass judged such defs
+     * structurally equal, dropped the second one via putIfAbsent, and silently
+     * served the WRONG nested subtree (the renamed {@code Item_2} def was
+     * hoisted but orphaned). Each iteration compares the candidate body with
+     * all renames-so-far applied; every iteration adds at least one rename, so
+     * the loop is bounded by the def count.
+     */
+    @SuppressWarnings("unchecked")
+    private static void hoistDefs(Map<String, Object> propSchema, Map<String, Object> rootDefs) {
+        Object defsObj = propSchema.remove("$defs");
+        if (!(defsObj instanceof Map)) {
+            return;
+        }
+        Map<String, Object> propDefs = (Map<String, Object>) defsObj;
+
+        Map<String, String> renames = new java.util.LinkedHashMap<>();
+        while (true) {
+            Map<String, String> newRenames = new java.util.LinkedHashMap<>();
+            for (Map.Entry<String, Object> e : propDefs.entrySet()) {
+                String name = e.getKey();
+                if (renames.containsKey(name) || !rootDefs.containsKey(name)) {
+                    continue;
+                }
+                // Compare what WOULD be stored: the body with all renames
+                // decided so far applied (on a copy — the in-place rewrite
+                // happens once, below, after the rename set is final).
+                Object candidateBody = deepCopy(e.getValue());
+                if (!renames.isEmpty()) {
+                    renameDefsRefs(candidateBody, renames);
+                }
+                if (!rootDefs.get(name).equals(candidateBody)) {
+                    int suffix = 2;
+                    String candidate = name + "_" + suffix;
+                    while (rootDefs.containsKey(candidate) || propDefs.containsKey(candidate)
+                            || renames.containsValue(candidate)) {
+                        candidate = name + "_" + (++suffix);
+                    }
+                    newRenames.put(name, candidate);
+                    log.debug("$defs name collision on '{}' while composing tool input schema — "
+                        + "disambiguated to '{}'", name, candidate);
+                }
+            }
+            if (newRenames.isEmpty()) {
+                break;
+            }
+            renames.putAll(newRenames);
+        }
+        if (!renames.isEmpty()) {
+            renameDefsRefs(propSchema, renames);
+            for (Object defBody : propDefs.values()) {
+                renameDefsRefs(defBody, renames);
+            }
+        }
+        for (Map.Entry<String, Object> e : propDefs.entrySet()) {
+            String target = renames.getOrDefault(e.getKey(), e.getKey());
+            rootDefs.putIfAbsent(target, e.getValue());
+        }
+    }
+
+    /** Rewrite {@code "#/$defs/<old>"} pointers per the rename map, in place. */
+    @SuppressWarnings("unchecked")
+    private static void renameDefsRefs(Object node, Map<String, String> renames) {
+        if (node instanceof Map<?, ?> m) {
+            Map<String, Object> obj = (Map<String, Object>) m;
+            Object ref = obj.get("$ref");
+            if (ref instanceof String s && s.startsWith("#/$defs/")) {
+                String name = s.substring("#/$defs/".length());
+                String renamed = renames.get(name);
+                if (renamed != null) {
+                    obj.put("$ref", "#/$defs/" + renamed);
+                }
+            }
+            for (Object v : obj.values()) {
+                renameDefsRefs(v, renames);
+            }
+        } else if (node instanceof List<?> l) {
+            for (Object item : l) {
+                renameDefsRefs(item, renames);
+            }
+        }
+    }
+
+    /**
      * Generate a raw JSON Schema for a Java class as a JSON string.
      *
      * @param type the class to introspect
@@ -165,8 +381,21 @@ public final class MeshSchemaSupport {
         }
 
         // Build the body: root content minus $defs, with `#` refs rewritten to
-        // `#/$defs/<TypeName>`.
+        // `#/$defs/<TypeName>`. Issue #1164 LOW: a pre-existing $defs entry with
+        // the same simple name (another package's type) must NOT be shadowed —
+        // its internal refs point at the old body. Disambiguate the new root
+        // def with a numeric suffix instead.
         String defName = type.getSimpleName();
+        if (existingDefs != null && existingDefs.has(defName)) {
+            int suffix = 2;
+            String candidate = defName + "_" + suffix;
+            while (existingDefs.has(candidate)) {
+                candidate = defName + "_" + (++suffix);
+            }
+            log.debug("rewriteRootSelfRefs: $defs already contains '{}' — "
+                + "disambiguating root self-ref def to '{}'", defName, candidate);
+            defName = candidate;
+        }
         ObjectNode body = JSON.createObjectNode();
         Iterator<Map.Entry<String, JsonNode>> fields = rootObj.properties().iterator();
         while (fields.hasNext()) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
@@ -151,20 +151,53 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor, Ordered {
      * (mirroring Java's class-beats-interface resolution), then the
      * interface hierarchies of every class in the chain.
      *
+     * <p>An override that RE-DECLARES {@code @MeshTool} but no {@code @Param}
+     * (#1164 review follow-up) is the same pattern with a twist: the schema
+     * metadata still lives on the ancestor declaration, so registering the
+     * override would boot-fail in {@link MeshToolWrapper} with "must have
+     * {@code @Param} annotation" (or register an empty schema for
+     * injectable-only signatures). The param-annotated ancestor is preferred
+     * as the registration target; the override's {@code @MeshTool} values
+     * still apply because the caller resolves the annotation from the
+     * most-derived declaration before this selection runs.
+     *
      * <p>Generic specializations (the override's parameter types differ from
      * the generic ancestor's erasure) always register the most-derived
      * declaration — the specialized types are what the schema must describe.
      * Annotate {@code @Param} on the specialized override in that case.
      */
     private static Method selectRegistrationTarget(Method specificMethod) {
-        if (specificMethod.isAnnotationPresent(MeshTool.class)
-                || hasAnyParamAnnotation(specificMethod)) {
+        if (hasAnyParamAnnotation(specificMethod)) {
             return specificMethod;
         }
+        // No @Param on the most-derived declaration. When it re-declares
+        // @MeshTool itself, only an ancestor that carries @Param is worth
+        // switching to; when it declares nothing, any ancestor with tool
+        // metadata is the schema source.
+        boolean redeclaresMeshTool = specificMethod.isAnnotationPresent(MeshTool.class);
+        java.util.function.Predicate<Method> carriesMetadata = redeclaresMeshTool
+            ? MeshToolBeanPostProcessor::hasAnyParamAnnotation
+            : m -> m.isAnnotationPresent(MeshTool.class) || hasAnyParamAnnotation(m);
+        Method ancestor = findAncestorDeclaration(specificMethod, carriesMetadata);
+        if (ancestor == null) {
+            return specificMethod;
+        }
+        if (redeclaresMeshTool) {
+            log.warn("@MeshTool re-declared on override {} without @Param annotations — "
+                + "registering ancestor declaration {} as the schema source (the override's "
+                + "@MeshTool values still apply). Annotate @Param on the override to make "
+                + "it the schema source.", specificMethod, ancestor);
+        }
+        return ancestor;
+    }
+
+    /** Same-signature ancestor declaration matching {@code carriesMetadata}, or null. */
+    private static Method findAncestorDeclaration(
+            Method specificMethod, java.util.function.Predicate<Method> carriesMetadata) {
         Class<?> declaring = specificMethod.getDeclaringClass();
         for (Class<?> c = declaring.getSuperclass(); c != null && c != Object.class;
                 c = c.getSuperclass()) {
-            Method ancestor = annotatedDeclaration(c, specificMethod);
+            Method ancestor = matchingDeclaration(c, specificMethod, carriesMetadata);
             if (ancestor != null) {
                 return ancestor;
             }
@@ -172,27 +205,28 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor, Ordered {
         java.util.Set<Class<?>> visited = new java.util.HashSet<>();
         for (Class<?> c = declaring; c != null && c != Object.class; c = c.getSuperclass()) {
             for (Class<?> iface : c.getInterfaces()) {
-                Method ancestor = searchInterfaceHierarchy(iface, specificMethod, visited);
+                Method ancestor = searchInterfaceHierarchy(iface, specificMethod, visited, carriesMetadata);
                 if (ancestor != null) {
                     return ancestor;
                 }
             }
         }
-        return specificMethod;
+        return null;
     }
 
     /** Depth-first walk of one interface and its super-interfaces. */
     private static Method searchInterfaceHierarchy(
-            Class<?> iface, Method specificMethod, java.util.Set<Class<?>> visited) {
+            Class<?> iface, Method specificMethod, java.util.Set<Class<?>> visited,
+            java.util.function.Predicate<Method> carriesMetadata) {
         if (!visited.add(iface)) {
             return null;
         }
-        Method declaration = annotatedDeclaration(iface, specificMethod);
+        Method declaration = matchingDeclaration(iface, specificMethod, carriesMetadata);
         if (declaration != null) {
             return declaration;
         }
         for (Class<?> superIface : iface.getInterfaces()) {
-            Method found = searchInterfaceHierarchy(superIface, specificMethod, visited);
+            Method found = searchInterfaceHierarchy(superIface, specificMethod, visited, carriesMetadata);
             if (found != null) {
                 return found;
             }
@@ -201,16 +235,16 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor, Ordered {
     }
 
     /**
-     * The same-signature declaration on {@code type} when it carries tool
-     * metadata ({@code @MeshTool} or any {@code @Param}); {@code null} when
-     * absent or bare (generic specializations have no same-signature ancestor).
+     * The same-signature declaration on {@code type} when it satisfies
+     * {@code carriesMetadata}; {@code null} when absent or bare (generic
+     * specializations have no same-signature ancestor).
      */
-    private static Method annotatedDeclaration(Class<?> type, Method specificMethod) {
+    private static Method matchingDeclaration(
+            Class<?> type, Method specificMethod, java.util.function.Predicate<Method> carriesMetadata) {
         try {
             Method declaration = type.getDeclaredMethod(
                 specificMethod.getName(), specificMethod.getParameterTypes());
-            if (declaration.isAnnotationPresent(MeshTool.class)
-                    || hasAnyParamAnnotation(declaration)) {
+            if (carriesMetadata.test(declaration)) {
                 return declaration;
             }
         } catch (NoSuchMethodException ignored) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
@@ -8,13 +8,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.MethodIntrospector;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.util.ReflectionUtils;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Bean post-processor that scans beans for {@code @MeshTool} annotations.
@@ -86,33 +87,145 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor, Ordered {
         // Get the target class (unwrap CGLIB proxies)
         Class<?> targetClass = AopUtils.getTargetClass(bean);
 
-        // Check all methods for @MeshTool annotation
-        ReflectionUtils.doWithMethods(targetClass, method -> {
-            MeshTool annotation = AnnotationUtils.findAnnotation(method, MeshTool.class);
-            if (annotation != null) {
-                log.debug("Found @MeshTool on {}.{}", targetClass.getSimpleName(), method.getName());
+        // Select @MeshTool methods, one entry per LOGICAL method. A bare
+        // ReflectionUtils.doWithMethods walk (no MethodFilter) visited an
+        // overridden/inherited @MeshTool method MULTIPLE times — once per
+        // declaring class in the hierarchy, plus generic bridge methods —
+        // and each visit re-registered the same capability, tripping the
+        // duplicate-capability boot error (#1164 review). MethodIntrospector
+        // dedups via getMostSpecificMethod + BridgeMethodResolver: superclass
+        // declarations and bridges collapse onto the single most-derived
+        // user-declared Method, which is also the right invocation target.
+        Map<Method, MeshTool> annotatedMethods = MethodIntrospector.selectMethods(targetClass,
+            (MethodIntrospector.MetadataLookup<MeshTool>) method ->
+                AnnotationUtils.findAnnotation(method, MeshTool.class));
 
-                // Issue #895: retryOn requires task=true (no controller without it,
-                // so release-and-retry has no meaning). The Throwable-subclass
-                // bound is enforced at compile-time by the annotation field
-                // type (Class<? extends Throwable>), so no runtime check needed.
-                Class<? extends Throwable>[] retryOn = annotation.retryOn();
-                if (retryOn.length > 0 && !annotation.task()) {
-                    throw new IllegalStateException(
-                        "@MeshTool(retryOn = ...) on '" + targetClass.getName() +
-                        "#" + method.getName() + "' requires task = true; " +
-                        "remove retryOn or set task = true.");
-                }
+        annotatedMethods.forEach((specificMethod, annotation) -> {
+            Method method = selectRegistrationTarget(specificMethod);
+            log.debug("Found @MeshTool on {}.{} (registering declaration {})",
+                targetClass.getSimpleName(), specificMethod.getName(), method);
 
-                // Register with legacy registry (for agent spec generation)
-                registry.registerTool(bean, method, annotation);
-
-                // Create wrapper for MCP SDK integration
-                createAndRegisterWrapper(bean, targetClass, method, annotation);
+            // Issue #895: retryOn requires task=true (no controller without it,
+            // so release-and-retry has no meaning). The Throwable-subclass
+            // bound is enforced at compile-time by the annotation field
+            // type (Class<? extends Throwable>), so no runtime check needed.
+            Class<? extends Throwable>[] retryOn = annotation.retryOn();
+            if (retryOn.length > 0 && !annotation.task()) {
+                throw new IllegalStateException(
+                    "@MeshTool(retryOn = ...) on '" + targetClass.getName() +
+                    "#" + method.getName() + "' requires task = true; " +
+                    "remove retryOn or set task = true.");
             }
+
+            // Register with legacy registry (for agent spec generation)
+            registry.registerTool(bean, method, annotation);
+
+            // Create wrapper for MCP SDK integration
+            createAndRegisterWrapper(bean, targetClass, method, annotation);
         });
 
         return bean;
+    }
+
+    /**
+     * Choose the {@link Method} object to register for one logical tool.
+     *
+     * <p>Usually the most-derived declaration ({@code specificMethod}, as
+     * selected by {@link MethodIntrospector}). EXCEPT: parameter annotations
+     * are not inherited in Java, so when the override declares neither
+     * {@code @MeshTool} nor any {@code @Param} itself, the metadata lives on
+     * an ancestor declaration with the same signature (the common
+     * "fully-annotated abstract contract, bare subclass implementation"
+     * pattern) — register that ancestor instead. {@code Method.invoke}
+     * dispatches virtually, so the subclass override still runs either way;
+     * what this choice controls is which declaration's {@code @Param} /
+     * schema metadata describes the tool.
+     *
+     * <p>Ancestors include INTERFACES, not just superclasses (#1164 review
+     * follow-up): an annotated default/abstract interface method implemented
+     * bare in a class is the same contract pattern, and
+     * {@link org.springframework.core.annotation.AnnotationUtils#findAnnotation}
+     * already discovers the {@code @MeshTool} through the interface — only
+     * the {@code @Param} metadata lookup was superclass-only, boot-failing
+     * with "must have @Param annotation". Superclasses are searched first
+     * (mirroring Java's class-beats-interface resolution), then the
+     * interface hierarchies of every class in the chain.
+     *
+     * <p>Generic specializations (the override's parameter types differ from
+     * the generic ancestor's erasure) always register the most-derived
+     * declaration — the specialized types are what the schema must describe.
+     * Annotate {@code @Param} on the specialized override in that case.
+     */
+    private static Method selectRegistrationTarget(Method specificMethod) {
+        if (specificMethod.isAnnotationPresent(MeshTool.class)
+                || hasAnyParamAnnotation(specificMethod)) {
+            return specificMethod;
+        }
+        Class<?> declaring = specificMethod.getDeclaringClass();
+        for (Class<?> c = declaring.getSuperclass(); c != null && c != Object.class;
+                c = c.getSuperclass()) {
+            Method ancestor = annotatedDeclaration(c, specificMethod);
+            if (ancestor != null) {
+                return ancestor;
+            }
+        }
+        java.util.Set<Class<?>> visited = new java.util.HashSet<>();
+        for (Class<?> c = declaring; c != null && c != Object.class; c = c.getSuperclass()) {
+            for (Class<?> iface : c.getInterfaces()) {
+                Method ancestor = searchInterfaceHierarchy(iface, specificMethod, visited);
+                if (ancestor != null) {
+                    return ancestor;
+                }
+            }
+        }
+        return specificMethod;
+    }
+
+    /** Depth-first walk of one interface and its super-interfaces. */
+    private static Method searchInterfaceHierarchy(
+            Class<?> iface, Method specificMethod, java.util.Set<Class<?>> visited) {
+        if (!visited.add(iface)) {
+            return null;
+        }
+        Method declaration = annotatedDeclaration(iface, specificMethod);
+        if (declaration != null) {
+            return declaration;
+        }
+        for (Class<?> superIface : iface.getInterfaces()) {
+            Method found = searchInterfaceHierarchy(superIface, specificMethod, visited);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The same-signature declaration on {@code type} when it carries tool
+     * metadata ({@code @MeshTool} or any {@code @Param}); {@code null} when
+     * absent or bare (generic specializations have no same-signature ancestor).
+     */
+    private static Method annotatedDeclaration(Class<?> type, Method specificMethod) {
+        try {
+            Method declaration = type.getDeclaredMethod(
+                specificMethod.getName(), specificMethod.getParameterTypes());
+            if (declaration.isAnnotationPresent(MeshTool.class)
+                    || hasAnyParamAnnotation(declaration)) {
+                return declaration;
+            }
+        } catch (NoSuchMethodException ignored) {
+            // No same-signature declaration on this ancestor.
+        }
+        return null;
+    }
+
+    private static boolean hasAnyParamAnnotation(Method method) {
+        for (java.lang.reflect.Parameter p : method.getParameters()) {
+            if (p.isAnnotationPresent(io.mcpmesh.Param.class)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
@@ -90,9 +90,22 @@ public class MeshToolRegistry {
         if (existing != null) {
             Method existingMethod = existing.method();
             if (existingMethod.equals(method)) {
+                // Deliberately tolerant of a DIFFERENT bean instance here:
+                // prototype-scoped beans and Spring context refresh re-run the
+                // post-processor with NEW instances of the same class —
+                // requiring bean identity would falsely boot-fail those paths.
+                // Last-registered wins; logged at info (not debug) so the
+                // replacement is visible when two live instances genuinely
+                // compete (#1164 review follow-up).
                 tools.put(capability, metadata);
-                log.debug("Mesh tool '{}' re-registered for the same method {} — refreshed bean instance",
-                    capability, method);
+                if (existing.bean() != bean) {
+                    log.info("Mesh tool '{}' re-registered for the same method {} with a new bean "
+                        + "instance — last registration wins (prototype scope / context refresh)",
+                        capability, method);
+                } else {
+                    log.debug("Mesh tool '{}' re-registered for the same method {} — idempotent refresh",
+                        capability, method);
+                }
                 return;
             }
             Method mostDerived = mostDerivedOverride(existingMethod, method);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
@@ -1,8 +1,6 @@
 package io.mcpmesh.spring;
 
-import io.mcpmesh.MediaParam;
 import io.mcpmesh.MeshTool;
-import io.mcpmesh.Param;
 import io.mcpmesh.SchemaMode;
 import io.mcpmesh.Selector;
 import io.mcpmesh.a2a.A2AConsumer;
@@ -10,10 +8,11 @@ import io.mcpmesh.core.AgentSpec;
 import io.mcpmesh.core.MeshCoreBridge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.BridgeMethodResolver;
+import org.springframework.util.ClassUtils;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -71,9 +70,99 @@ public class MeshToolRegistry {
             method
         );
 
-        tools.put(capability, metadata);
+        // Issue #1164 LOW: duplicate capability names previously overwrote
+        // last-wins, silently shadowing one tool with another. Fail fast at
+        // boot with a descriptive error (mirrors the
+        // MeshCapabilityBeanRegistrar.mergeDependency conflict style).
+        // Tolerated as idempotent refreshes instead of conflicts:
+        //   - the SAME method (prototype-scoped bean instantiated more than
+        //     once, context refresh in the same JVM);
+        //   - an OVERRIDE PAIR on the SAME bean instance — one method
+        //     overrides the other in a class hierarchy (incl. generic
+        //     bridges). External scanners may legitimately register both the
+        //     superclass declaration and the subclass override of one logical
+        //     tool; the most-derived declaration wins (#1164 review
+        //     follow-up). The bean-identity guard keeps SIBLING beans honest:
+        //     a BaseCalc bean AND a DerivedCalc bean sharing a capability are
+        //     two tools, not one — without the guard the subclass bean
+        //     silently masked the base bean.
+        ToolMetadata existing = tools.putIfAbsent(capability, metadata);
+        if (existing != null) {
+            Method existingMethod = existing.method();
+            if (existingMethod.equals(method)) {
+                tools.put(capability, metadata);
+                log.debug("Mesh tool '{}' re-registered for the same method {} — refreshed bean instance",
+                    capability, method);
+                return;
+            }
+            Method mostDerived = mostDerivedOverride(existingMethod, method);
+            if (mostDerived != null && existing.bean() == bean) {
+                if (mostDerived.equals(BridgeMethodResolver.findBridgedMethod(method))) {
+                    tools.put(capability, metadata);
+                    log.debug("Mesh tool '{}': {} overrides previously registered {} — most-derived wins",
+                        capability, method, existingMethod);
+                } else {
+                    log.debug("Mesh tool '{}': keeping already-registered override {} over base declaration {}",
+                        capability, existingMethod, method);
+                }
+                return;
+            }
+            String hint = mostDerived != null
+                ? "The methods form an override pair but belong to two different bean "
+                    + "instances — register only one of the beans."
+                : "Capability names must be unique within an agent — rename one of "
+                    + "the tools or remove the duplicate.";
+            throw new IllegalStateException(String.format(
+                "Duplicate @MeshTool capability '%s': already registered by %s.%s, "
+                    + "declared again by %s.%s. %s",
+                capability,
+                existing.method().getDeclaringClass().getName(), existing.method().getName(),
+                method.getDeclaringClass().getName(), method.getName(),
+                hint));
+        }
+
         log.info("Registered mesh tool: {} ({}, task={}, retryOn={})",
             capability, method, annotation.task(), annotation.retryOn().length);
+    }
+
+    /**
+     * Detect whether two distinct {@link Method} objects describe ONE logical
+     * tool — i.e. one overrides the other within a class hierarchy. Returns
+     * the most-derived declaration (bridge-resolved), or {@code null} when
+     * the methods are genuinely distinct (the caller then raises the
+     * duplicate-capability boot error).
+     *
+     * <p>Handles generic overrides: a base declaration like
+     * {@code T handle(T)} resolved against the subclass yields the bridge
+     * {@code handle(Object)}, which {@link BridgeMethodResolver} maps back to
+     * the user-declared {@code handle(String)} override.
+     */
+    private static Method mostDerivedOverride(Method a, Method b) {
+        Method ra = BridgeMethodResolver.findBridgedMethod(a);
+        Method rb = BridgeMethodResolver.findBridgedMethod(b);
+        if (!ra.getName().equals(rb.getName())) {
+            return null;
+        }
+        Class<?> da = ra.getDeclaringClass();
+        Class<?> db = rb.getDeclaringClass();
+        Method derived;
+        Method base;
+        if (da.equals(db)) {
+            return null;
+        } else if (da.isAssignableFrom(db)) {
+            derived = rb;
+            base = ra;
+        } else if (db.isAssignableFrom(da)) {
+            derived = ra;
+            base = rb;
+        } else {
+            return null;
+        }
+        // Same logical method iff resolving the base declaration against the
+        // derived class (then un-bridging) lands on the derived declaration.
+        Method resolved = BridgeMethodResolver.findBridgedMethod(
+            ClassUtils.getMostSpecificMethod(base, derived.getDeclaringClass()));
+        return resolved.equals(derived) ? derived : null;
     }
 
     // Phase B MeshJob substrate: synthetic tool specs registered outside
@@ -399,65 +488,18 @@ public class MeshToolRegistry {
         target.setMatchMode(effectiveMode == SchemaMode.STRICT ? "strict" : "subset");
     }
 
+    /**
+     * Issue #1164 MED-2: delegate to the shared victools-backed builder in
+     * {@link MeshSchemaSupport} — the SAME method {@link MeshToolWrapper} uses
+     * for the MCP-served schema — so the heartbeat-advertised
+     * {@code input_schema} / {@code input_schema_canonical} /
+     * {@code input_schema_hash} can never drift from what the MCP server
+     * actually serves. (The previous hand-rolled builder emitted bare
+     * {@code {"type":"object"}} for POJO params and {@code {"type":"array"}}
+     * for {@code List<Foo>} — no properties, no items, no required.)
+     */
     private Map<String, Object> extractInputSchema(Method method) {
-        Map<String, Object> schema = new LinkedHashMap<>();
-        schema.put("type", "object");
-
-        Map<String, Object> properties = new LinkedHashMap<>();
-        List<String> required = new ArrayList<>();
-
-        for (Parameter param : method.getParameters()) {
-            Param paramAnn = param.getAnnotation(Param.class);
-            if (paramAnn != null) {
-                Map<String, Object> propSchema = new LinkedHashMap<>();
-                propSchema.put("type", getJsonType(param.getType()));
-
-                if (!paramAnn.description().isEmpty()) {
-                    propSchema.put("description", paramAnn.description());
-                }
-
-                MediaParam mediaParamAnn = param.getAnnotation(MediaParam.class);
-                if (mediaParamAnn != null) {
-                    propSchema.put("x-media-type", mediaParamAnn.value());
-                    String existingDesc = (String) propSchema.getOrDefault("description", "");
-                    String mediaNote = "(accepts media URI: " + mediaParamAnn.value() + ")";
-                    if (!existingDesc.contains(mediaNote)) {
-                        propSchema.put("description", (existingDesc + " " + mediaNote).trim());
-                    }
-                }
-
-                properties.put(paramAnn.value(), propSchema);
-
-                if (paramAnn.required()) {
-                    required.add(paramAnn.value());
-                }
-            }
-        }
-
-        schema.put("properties", properties);
-        if (!required.isEmpty()) {
-            schema.put("required", required);
-        }
-
-        return schema;
-    }
-
-    private String getJsonType(Class<?> type) {
-        if (type == String.class) {
-            return "string";
-        } else if (type == int.class || type == Integer.class ||
-                   type == long.class || type == Long.class) {
-            return "integer";
-        } else if (type == double.class || type == Double.class ||
-                   type == float.class || type == Float.class) {
-            return "number";
-        } else if (type == boolean.class || type == Boolean.class) {
-            return "boolean";
-        } else if (type.isArray() || List.class.isAssignableFrom(type)) {
-            return "array";
-        } else {
-            return "object";
-        }
+        return MeshSchemaSupport.buildToolInputSchema(method);
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -1,7 +1,5 @@
 package io.mcpmesh.spring;
 
-import tools.jackson.databind.JsonNode;
-import com.github.victools.jsonschema.generator.SchemaGenerator;
 import tools.jackson.databind.ObjectMapper;
 import io.mcpmesh.JobContext;
 import io.mcpmesh.JobController;
@@ -54,8 +52,28 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 public class MeshToolWrapper implements McpToolHandler {
 
     private static final Logger log = LoggerFactory.getLogger(MeshToolWrapper.class);
-    private static final long ASYNC_TIMEOUT_SECONDS = 30;
-    private static final SchemaGenerator SCHEMA_GENERATOR = MeshSchemaSupport.generator();
+    /**
+     * Default await budget for {@link CompletableFuture}-returning tools when
+     * the inbound request carries no {@code X-Mesh-Timeout} budget. When the
+     * header IS present, its value bounds the await instead (issue #1164 MED-5).
+     */
+    static final long ASYNC_TIMEOUT_SECONDS = 30;
+    /**
+     * CAP on the margin shaved off the propagated {@code X-Mesh-Timeout}
+     * budget when awaiting a {@link CompletableFuture} result. The caller's
+     * socket read timeout typically fires at roughly the same budget; ending
+     * the await slightly earlier lets the structured timeout error (a proper
+     * JSON-RPC error payload) reach the caller instead of racing — and
+     * losing to — the caller's transport-level timeout, which surfaces as an
+     * opaque read-timeout IOException (#1164 review follow-up).
+     *
+     * <p>The actual margin is proportional — {@code min(cap, budget/10)} —
+     * so small budgets keep most of their window: a fixed 2s margin ate 2/3
+     * of a 3s budget. Tiny budgets (under 10s) get little or no margin and
+     * accept the socket-timeout race; that trade beats forfeiting the
+     * useful await time.
+     */
+    static final long ASYNC_AWAIT_MARGIN_SECS = 2;
     /** Issue #895: shared empty {@code retryOn} array — sentinel for "no retry-eligible exceptions". */
     @SuppressWarnings("unchecked")
     private static final Class<? extends Throwable>[] EMPTY_RETRY_ON =
@@ -296,53 +314,18 @@ public class MeshToolWrapper implements McpToolHandler {
 
     /**
      * Generate JSON Schema for MCP, excluding injected parameters.
-     * Uses victools/jsonschema-generator for proper nested type handling.
+     *
+     * <p>Issue #1164 MED-2: delegates to the shared builder in
+     * {@link MeshSchemaSupport#buildToolInputSchema} — the SAME method the
+     * heartbeat catalog ({@link MeshToolRegistry}) uses — so the MCP-served
+     * schema and the registry-advertised schema can never drift. The shared
+     * builder selects exactly the {@code @Param}-annotated parameters, which
+     * is the same set as {@link #analyzeParameters}' {@code mcpParams}
+     * (injectable types are exempt; non-injectable params without
+     * {@code @Param} were already rejected at construction time).
      */
     private Map<String, Object> generateInputSchema() {
-        Map<String, Object> schema = new LinkedHashMap<>();
-        schema.put("type", "object");
-
-        Map<String, Object> properties = new LinkedHashMap<>();
-        List<String> required = new ArrayList<>();
-
-        for (ParamInfo param : mcpParams) {
-            // Use victools to generate schema for the parameter type
-            JsonNode paramSchema = SCHEMA_GENERATOR.generateSchema(param.type());
-            Map<String, Object> propSchema = convertJsonNodeToMap(paramSchema);
-
-            // Add description from @Param annotation if not already present
-            if (!param.description().isEmpty() && !propSchema.containsKey("description")) {
-                propSchema.put("description", param.description());
-            }
-
-            properties.put(param.name(), propSchema);
-
-            if (param.required()) {
-                required.add(param.name());
-            }
-        }
-
-        schema.put("properties", properties);
-        if (!required.isEmpty()) {
-            schema.put("required", required);
-        }
-
-        return schema;
-    }
-
-    /**
-     * Convert Jackson JsonNode to Map for schema representation.
-     */
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> convertJsonNodeToMap(JsonNode node) {
-        try {
-            return objectMapper.convertValue(node, Map.class);
-        } catch (Exception e) {
-            log.warn("Failed to convert JsonNode to Map: {}", e.getMessage());
-            Map<String, Object> fallback = new LinkedHashMap<>();
-            fallback.put("type", "object");
-            return fallback;
-        }
+        return MeshSchemaSupport.buildToolInputSchema(method);
     }
 
     // =========================================================================
@@ -587,8 +570,12 @@ public class MeshToolWrapper implements McpToolHandler {
         // TraceContext.getPropagatedHeaders() with a lowercased key.
         Map<String, String> propagated = TraceContext.getPropagatedHeaders();
         String jobIdHeader = propagated != null ? propagated.get("x-mesh-job-id") : null;
+        // Issue #1164 MED-5: parse the propagated X-Mesh-Timeout budget for
+        // EVERY inbound call (not only job dispatch) so CompletableFuture-
+        // returning tools are awaited against the caller's actual budget
+        // instead of the hard-coded 30s default.
         Long deadlineSecs = null;
-        if (jobIdHeader != null && !jobIdHeader.isEmpty()) {
+        if (propagated != null) {
             String timeoutHeader = propagated.get("x-mesh-timeout");
             if (timeoutHeader != null && !timeoutHeader.isEmpty()) {
                 try {
@@ -652,8 +639,9 @@ public class MeshToolWrapper implements McpToolHandler {
             throw new RuntimeException("Method access denied: " + e.getMessage(), e);
         }
 
-        // Handle async results (CompletableFuture)
-        result = awaitIfFuture(result);
+        // Handle async results (CompletableFuture) — bounded by the inbound
+        // X-Mesh-Timeout budget when present (issue #1164 MED-5).
+        result = awaitIfFuture(result, deadlineSecs);
 
         return result;
     }
@@ -736,16 +724,30 @@ public class MeshToolWrapper implements McpToolHandler {
     }
 
     /**
-     * Await a {@link CompletableFuture} result with the async timeout,
-     * unwrapping execution/interruption failures to match the synchronous
-     * invocation's exception contract. Non-future results pass through.
+     * Await a {@link CompletableFuture} result, unwrapping execution /
+     * interruption failures to match the synchronous invocation's exception
+     * contract. Non-future results pass through.
+     *
+     * <p>Issue #1164 MED-5: the await is bounded by the caller's propagated
+     * {@code X-Mesh-Timeout} budget when present, falling back to
+     * {@link #ASYNC_TIMEOUT_SECONDS} when absent. The timed-out future is
+     * cancelled, which frees this dispatch thread, cancels dependent stages,
+     * and turns a late {@code complete()} into a no-op. Note that
+     * {@link CompletableFuture#cancel} does NOT interrupt whatever thread is
+     * computing the value ({@code mayInterruptIfRunning} has no effect per
+     * its javadoc) — orphaned producer-side work runs to completion in the
+     * background.
+     *
+     * @param budgetSecs await budget in seconds, or null for the default
      */
-    private static Object awaitIfFuture(Object result) throws Exception {
+    static Object awaitIfFuture(Object result, Long budgetSecs) throws Exception {
         if (result instanceof CompletableFuture<?> future) {
+            long timeoutSecs = effectiveAsyncAwaitSecs(budgetSecs);
             try {
-                return future.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                return future.get(timeoutSecs, TimeUnit.SECONDS);
             } catch (TimeoutException e) {
-                throw new RuntimeException("Async operation timed out after " + ASYNC_TIMEOUT_SECONDS + " seconds");
+                future.cancel(true);
+                throw new RuntimeException("Async operation timed out after " + timeoutSecs + " seconds");
             } catch (ExecutionException e) {
                 Throwable cause = e.getCause();
                 if (cause instanceof Exception ex) throw ex;
@@ -756,6 +758,25 @@ public class MeshToolWrapper implements McpToolHandler {
             }
         }
         return result;
+    }
+
+    /**
+     * Effective async-await budget: the propagated {@code X-Mesh-Timeout} /
+     * job deadline when present and positive, otherwise the
+     * {@link #ASYNC_TIMEOUT_SECONDS} default (issue #1164 MED-5).
+     *
+     * <p>A present budget is reduced by a proportional margin —
+     * {@code min(}{@link #ASYNC_AWAIT_MARGIN_SECS}{@code , budget/10)},
+     * floor 1s — so the structured timeout error wins the race against the
+     * caller's socket read timeout without eating most of a small budget;
+     * see the margin constant's javadoc.
+     */
+    static long effectiveAsyncAwaitSecs(Long budgetSecs) {
+        if (budgetSecs == null || budgetSecs <= 0) {
+            return ASYNC_TIMEOUT_SECONDS;
+        }
+        long margin = Math.min(ASYNC_AWAIT_MARGIN_SECS, budgetSecs / 10);
+        return Math.max(1L, budgetSecs - margin);
     }
 
     /**
@@ -820,7 +841,7 @@ public class MeshToolWrapper implements McpToolHandler {
             }
             JobContext.Snapshot snap = new JobContext.Snapshot(jobId, deadlineSecs);
             return runAsJobWithRegistryBinding(jobId, deadlineSecs,
-                () -> JobContext.withJob(snap, () -> invokeNoController(fullArgs)));
+                () -> JobContext.withJob(snap, () -> invokeNoController(fullArgs, deadlineSecs)));
         }
 
         // Construct the producer controller. Free in finally.
@@ -836,7 +857,7 @@ public class MeshToolWrapper implements McpToolHandler {
             JobContext.Snapshot snap = new JobContext.Snapshot(jobId, deadlineSecs);
             try {
                 return runAsJobWithRegistryBinding(jobId, deadlineSecs,
-                    () -> JobContext.withJob(snap, () -> invokeAndAutoComplete(fullArgs, controller)));
+                    () -> JobContext.withJob(snap, () -> invokeAndAutoComplete(fullArgs, controller, deadlineSecs)));
             } catch (Throwable t) {
                 // Defensive: runAsJobWithRegistryBinding can throw BEFORE
                 // invokeAndAutoComplete runs (snapshot serialization or
@@ -947,7 +968,7 @@ public class MeshToolWrapper implements McpToolHandler {
      * stays inside the JobContext snapshot so outbound headers still
      * carry the job id. (PR #891 review.)
      */
-    private Object invokeNoController(Object[] fullArgs) throws Exception {
+    private Object invokeNoController(Object[] fullArgs, Long deadlineSecs) throws Exception {
         Object result;
         try {
             result = method.invoke(bean, fullArgs);
@@ -958,11 +979,11 @@ public class MeshToolWrapper implements McpToolHandler {
         } catch (IllegalAccessException e) {
             throw new RuntimeException("Method access denied: " + e.getMessage(), e);
         }
-        result = awaitIfFuture(result);
+        result = awaitIfFuture(result, deadlineSecs);
         return result;
     }
 
-    private Object invokeAndAutoComplete(Object[] fullArgs, JobController controller) throws Exception {
+    private Object invokeAndAutoComplete(Object[] fullArgs, JobController controller, Long deadlineSecs) throws Exception {
         Object result;
         try {
             result = method.invoke(bean, fullArgs);
@@ -998,11 +1019,19 @@ public class MeshToolWrapper implements McpToolHandler {
         // deciding whether to auto-complete (matches the Python /
         // TypeScript async semantics).
         if (result instanceof CompletableFuture<?> future) {
+            // Issue #1164 MED-5: await against the job's actual budget
+            // (X-Mesh-Timeout / deadline) instead of the hard-coded 30s.
+            // Cancelling the timed-out future frees this dispatch thread,
+            // cancels dependent stages, and makes a late complete() a no-op
+            // — it does NOT interrupt the running work (CompletableFuture
+            // cancel semantics); orphaned work runs to completion.
+            long timeoutSecs = effectiveAsyncAwaitSecs(deadlineSecs);
             try {
-                result = future.get(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                result = future.get(timeoutSecs, TimeUnit.SECONDS);
             } catch (TimeoutException e) {
-                tryFail(controller, "async operation timed out after " + ASYNC_TIMEOUT_SECONDS + "s");
-                throw new RuntimeException("Async operation timed out after " + ASYNC_TIMEOUT_SECONDS + " seconds");
+                future.cancel(true);
+                tryFail(controller, "async operation timed out after " + timeoutSecs + "s");
+                throw new RuntimeException("Async operation timed out after " + timeoutSecs + " seconds");
             } catch (ExecutionException e) {
                 // Issue #895: same retryOn-aware handling as the synchronous
                 // throw path — a CompletableFuture that completes

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpHttpClientTimeoutAndWatcherTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpHttpClientTimeoutAndWatcherTest.java
@@ -1,0 +1,144 @@
+package io.mcpmesh.spring;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1164 LOW coverage for {@link McpHttpClient}:
+ *
+ * <ul>
+ *   <li>Job-cancel watcher subscribe race: a token that fires concurrently
+ *       with a new call's subscribe previously left the cancel runnable
+ *       never-invoked (CopyOnWriteArrayList iteration snapshot) — the call
+ *       ran to its read timeout. subscribe() after a GENUINE cancel must run
+ *       immediately; a natural-end wake must never run subscribers (it would
+ *       cancel healthy in-flight calls — review follow-up).</li>
+ *   <li>X-Mesh-Timeout parse asymmetry: outbound parsed with
+ *       {@code Integer.parseInt} + empty catch while inbound parses double.
+ *       Outbound now parses double (fractional budgets survive) and logs on
+ *       failure.</li>
+ * </ul>
+ */
+@DisplayName("McpHttpClient — timeout parse + cancel-watcher race (issue #1164 LOW)")
+class McpHttpClientTimeoutAndWatcherTest {
+
+    // ── JobCancelWatcher fire/subscribe contract ────────────────────────────
+
+    @Test
+    @DisplayName("subscribe AFTER a genuine cancel fired runs the runnable immediately")
+    void subscribeAfterFireRunsImmediately() {
+        McpHttpClient.JobCancelWatcher watcher = new McpHttpClient.JobCancelWatcher();
+        AtomicInteger ran = new AtomicInteger();
+
+        watcher.fireSubscribers(); // genuine cancel fired before the call subscribed
+
+        watcher.subscribe(ran::incrementAndGet);
+        assertEquals(1, ran.get(),
+            "late subscriber must run immediately — otherwise the in-flight call "
+                + "runs to its read timeout despite the job being cancelled");
+    }
+
+    @Test
+    @DisplayName("natural job end discards subscribers WITHOUT running them")
+    void naturalEndDoesNotRunSubscribers() {
+        McpHttpClient.JobCancelWatcher watcher = new McpHttpClient.JobCancelWatcher();
+        AtomicInteger ran = new AtomicInteger();
+
+        watcher.subscribe(ran::incrementAndGet);
+        watcher.completeNaturally(); // job finished without cancel
+
+        assertEquals(0, ran.get(),
+            "a natural-end wake must not abort still-in-flight outbound calls — "
+                + "they belong to async work that legitimately outlives the handler");
+    }
+
+    @Test
+    @DisplayName("subscribe AFTER a natural-end wake is a no-op (healthy late call proceeds)")
+    void subscribeAfterNaturalEndDoesNotRun() {
+        McpHttpClient.JobCancelWatcher watcher = new McpHttpClient.JobCancelWatcher();
+        AtomicInteger ran = new AtomicInteger();
+
+        watcher.completeNaturally();
+
+        watcher.subscribe(ran::incrementAndGet);
+        assertEquals(0, ran.get(),
+            "a call subscribing in the natural-end wake → watcher-removal window must "
+                + "NOT be cancelled — the job completed normally (#1164 review: the "
+                + "failure mode must never flip from 'slow' to 'kills a healthy call')");
+    }
+
+    @Test
+    @DisplayName("subscribe BEFORE fire runs on fire (and only once)")
+    void subscribeBeforeFireRunsOnFire() {
+        McpHttpClient.JobCancelWatcher watcher = new McpHttpClient.JobCancelWatcher();
+        AtomicInteger ran = new AtomicInteger();
+
+        watcher.subscribe(ran::incrementAndGet);
+        assertEquals(0, ran.get(), "must not run before the token fires");
+
+        watcher.fireSubscribers();
+        assertEquals(1, ran.get(), "must run exactly once on fire");
+    }
+
+    @Test
+    @DisplayName("unsubscribed runnable does not run on fire")
+    void unsubscribePreventsRun() {
+        McpHttpClient.JobCancelWatcher watcher = new McpHttpClient.JobCancelWatcher();
+        AtomicInteger ran = new AtomicInteger();
+
+        Runnable r = ran::incrementAndGet;
+        watcher.subscribe(r);
+        watcher.unsubscribe(r);
+
+        watcher.fireSubscribers();
+        assertEquals(0, ran.get());
+    }
+
+    @Test
+    @DisplayName("a throwing subscriber does not prevent the others from running")
+    void throwingSubscriberIsIsolated() {
+        McpHttpClient.JobCancelWatcher watcher = new McpHttpClient.JobCancelWatcher();
+        AtomicInteger ran = new AtomicInteger();
+
+        watcher.subscribe(() -> { throw new IllegalStateException("boom"); });
+        watcher.subscribe(ran::incrementAndGet);
+
+        watcher.fireSubscribers();
+        assertEquals(1, ran.get());
+    }
+
+    // ── X-Mesh-Timeout / MCP_MESH_CALL_TIMEOUT parsing ──────────────────────
+
+    @Test
+    @DisplayName("integer timeout values parse as before")
+    void integerTimeoutParses() {
+        assertEquals(120, McpHttpClient.parseTimeoutSecs("120", "test", 300));
+        assertEquals(1, McpHttpClient.parseTimeoutSecs("1", "test", 300));
+    }
+
+    @Test
+    @DisplayName("fractional timeout values parse (like the inbound double-parse path)")
+    void fractionalTimeoutParses() {
+        // Round, don't truncate — matches MeshToolWrapper's inbound semantics.
+        assertEquals(3, McpHttpClient.parseTimeoutSecs("2.5", "test", 300));
+        // Sub-second budgets clamp to the 1s floor instead of collapsing to 0.
+        assertEquals(1, McpHttpClient.parseTimeoutSecs("0.4", "test", 300));
+    }
+
+    @Test
+    @DisplayName("absent / invalid / non-positive values fall back to the default")
+    void invalidTimeoutFallsBack() {
+        assertEquals(300, McpHttpClient.parseTimeoutSecs(null, "test", 300));
+        assertEquals(300, McpHttpClient.parseTimeoutSecs("", "test", 300));
+        assertEquals(300, McpHttpClient.parseTimeoutSecs("  ", "test", 300));
+        assertEquals(300, McpHttpClient.parseTimeoutSecs("abc", "test", 300));
+        assertEquals(300, McpHttpClient.parseTimeoutSecs("-1", "test", 300));
+        assertEquals(300, McpHttpClient.parseTimeoutSecs("0", "test", 300));
+        assertEquals(300, McpHttpClient.parseTimeoutSecs("NaN", "test", 300));
+        assertEquals(300, McpHttpClient.parseTimeoutSecs("Infinity", "test", 300));
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyAsyncContextTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyAsyncContextTest.java
@@ -1,0 +1,308 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.core.MeshEvent;
+import io.mcpmesh.core.MeshObjectMappers;
+import io.mcpmesh.spring.tracing.TraceContext;
+import io.mcpmesh.spring.tracing.TraceInfo;
+import io.mcpmesh.types.MeshLlmAgent;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1164 MED-3 + MED-4 coverage for {@link MeshLlmAgentProxy}.
+ *
+ * <ul>
+ *   <li>MED-3: buffered {@code generate()} must not NPE on a null-content
+ *       message (tool-call-only assistant turns from persisted history).</li>
+ *   <li>MED-4: {@code generateAsync()} and the parallel tool-call branch run
+ *       on pool threads — caller-thread ThreadLocals (trace context,
+ *       propagated headers, invocation context for {@code ${ctx.*}} template
+ *       vars) must be captured and restored, otherwise outbound calls lose
+ *       trace + propagated headers and template vars vanish.</li>
+ * </ul>
+ *
+ * <p>Wiring mirrors {@link MeshLlmAgentProxyModelParamsTest}: a real
+ * {@link McpHttpClient} pointed at a {@link MockWebServer}.
+ */
+@DisplayName("MeshLlmAgentProxy — async context propagation + null-content history (issue #1164)")
+class MeshLlmAgentProxyAsyncContextTest {
+
+    private MockWebServer server;
+    private McpHttpClient client;
+    private ObjectMapper mapper;
+    private MeshLlmAgentProxy proxy;
+
+    @BeforeAll
+    static void initTlsConfig() throws Exception {
+        // Pre-seed MeshTlsConfig.cached so tests don't hit native FFI
+        Constructor<MeshTlsConfig> ctor = MeshTlsConfig.class.getDeclaredConstructor(
+            boolean.class, String.class, String.class, String.class, String.class);
+        ctor.setAccessible(true);
+        MeshTlsConfig disabled = ctor.newInstance(false, "off", null, null, null);
+
+        Field cachedField = MeshTlsConfig.class.getDeclaredField("cached");
+        cachedField.setAccessible(true);
+        cachedField.set(null, disabled);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        mapper = MeshObjectMappers.create();
+        client = new McpHttpClient(mapper);
+
+        proxy = new MeshLlmAgentProxy("test.asynccontext");
+        proxy.configure(client, null, null, null, "", "ctx", 1, false);
+        proxy.updateProvider(
+            server.url("/").toString().replaceAll("/$", ""),
+            "process_chat",
+            "mesh-delegated"
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        TraceContext.clear();
+        TraceContext.clearPropagatedHeaders();
+        if (client != null) client.close();
+        server.shutdown();
+    }
+
+    // ── Mock helpers (same MCP tools/call shape as ModelParamsTest) ────────
+
+    private MockResponse stubLlmResponse(String reply) {
+        Map<String, Object> innerPayload = Map.of("role", "assistant", "content", reply);
+        return envelope(innerPayload);
+    }
+
+    private MockResponse stubToolCallsResponse(List<Map<String, Object>> toolCalls) {
+        Map<String, Object> innerPayload = Map.of(
+            "role", "assistant",
+            "content", "",
+            "tool_calls", toolCalls
+        );
+        return envelope(innerPayload);
+    }
+
+    private MockResponse envelope(Map<String, Object> innerPayload) {
+        try {
+            String innerJson = mapper.writeValueAsString(innerPayload);
+            Map<String, Object> env = Map.of(
+                "jsonrpc", "2.0",
+                "id", System.currentTimeMillis(),
+                "result", Map.of(
+                    "content", List.of(Map.of("type", "text", "text", innerJson))
+                )
+            );
+            return new MockResponse()
+                .setBody(mapper.writeValueAsString(env))
+                .setHeader("Content-Type", "application/json");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Map<String, Object> toolCall(String id, String name) {
+        return Map.of(
+            "id", id,
+            "type", "function",
+            "function", Map.of("name", name, "arguments", Map.of())
+        );
+    }
+
+    private MeshEvent.LlmToolInfo llmToolInfo(String name, String endpoint) throws Exception {
+        Map<String, Object> json = new LinkedHashMap<>();
+        json.put("function_name", name);
+        json.put("capability", name);
+        json.put("description", "test tool " + name);
+        json.put("endpoint", endpoint);
+        json.put("agent_id", "agent-1");
+        json.put("input_schema", "{\"type\":\"object\",\"properties\":{}}");
+        return mapper.readValue(mapper.writeValueAsString(json), MeshEvent.LlmToolInfo.class);
+    }
+
+    private JsonNode requestMessages(RecordedRequest req) throws Exception {
+        JsonNode root = mapper.readTree(req.getBody().readUtf8());
+        return root.get("params").get("arguments").get("request").get("messages");
+    }
+
+    // ── MED-3: null-content history ────────────────────────────────────────
+
+    @Test
+    @DisplayName("MED-3: history with a null-content assistant turn does not NPE")
+    void nullContentAssistantTurnDoesNotNpe() throws Exception {
+        server.enqueue(stubLlmResponse("ok"));
+
+        // Tool-call-only assistant turns persisted from history carry content=null.
+        String result = proxy.request()
+            .user("question")
+            .message(new MeshLlmAgent.Message("assistant", null))
+            .generate();
+
+        assertEquals("ok", result);
+
+        RecordedRequest req = server.takeRequest(2, TimeUnit.SECONDS);
+        assertNotNull(req);
+        JsonNode messages = requestMessages(req);
+        boolean sawNullContentAssistant = false;
+        for (JsonNode m : messages) {
+            if ("assistant".equals(m.path("role").asText()) && m.get("content").isNull()) {
+                sawNullContentAssistant = true;
+            }
+        }
+        assertTrue(sawNullContentAssistant,
+            "null-content assistant turn must reach the wire as content:null. Got: " + messages);
+    }
+
+    // ── MED-4: generateAsync context propagation ───────────────────────────
+
+    @Test
+    @DisplayName("MED-4: generateAsync propagates trace, propagated headers, and ${ctx} template vars")
+    void generateAsyncPropagatesCallerContext() throws Exception {
+        // System prompt template reads an invocation-context variable.
+        proxy.configure(client, null, null, null, "Hello ${name}!", "ctx", 1, false);
+
+        TraceContext.set(TraceInfo.forPropagation("aaaabbbbccccdddd", "span00001111"));
+        TraceContext.setPropagatedHeaders(Map.of("x-mesh-timeout", "42"));
+        proxy.setInvocationContext(Map.of("name", "Bob"));
+
+        server.enqueue(stubLlmResponse("ok"));
+
+        String result = proxy.request().user("hi").generateAsync().get(10, TimeUnit.SECONDS);
+        assertEquals("ok", result);
+
+        RecordedRequest req = server.takeRequest(2, TimeUnit.SECONDS);
+        assertNotNull(req);
+
+        // Trace headers must survive the pool-thread hop.
+        assertEquals("aaaabbbbccccdddd", req.getHeader("X-Trace-ID"),
+            "trace header must be present on the outbound LLM call made from the async pool thread");
+        // Propagated header (x-mesh-timeout is always allowlisted).
+        assertEquals("42", req.getHeader("x-mesh-timeout"),
+            "propagated headers must be forwarded from the async pool thread");
+
+        // ${ctx} template var must render (invocation context restored on pool thread).
+        JsonNode messages = requestMessages(req);
+        assertEquals("system", messages.get(0).path("role").asText());
+        assertTrue(messages.get(0).path("content").asText().contains("Hello Bob!"),
+            "invocation-context template var must render in the async path. Got: " + messages);
+    }
+
+    @Test
+    @DisplayName("MED-4: pool thread is not polluted — invocation context cleared after async task")
+    void asyncTaskClearsPoolThreadContext() throws Exception {
+        proxy.configure(client, null, null, null, "Hi ${name}!", "ctx", 1, false);
+        proxy.setInvocationContext(Map.of("name", "Eve"));
+
+        server.enqueue(stubLlmResponse("first"));
+        assertEquals("first", proxy.request().user("a").generateAsync().get(10, TimeUnit.SECONDS));
+        server.takeRequest(2, TimeUnit.SECONDS);
+
+        // Clear the CALLER thread's context, then issue a second async call:
+        // the template must fail to resolve ${name} (renderer falls back to
+        // the raw template) rather than reusing 'Eve' leaked into a pool
+        // thread by the first call.
+        proxy.setInvocationContext(null);
+        server.enqueue(stubLlmResponse("second"));
+        assertEquals("second", proxy.request().user("b").generateAsync().get(10, TimeUnit.SECONDS));
+        RecordedRequest req2 = server.takeRequest(2, TimeUnit.SECONDS);
+        assertNotNull(req2);
+        JsonNode messages = requestMessages(req2);
+        String systemContent = messages.get(0).path("content").asText();
+        assertFalse(systemContent.contains("Eve"),
+            "pool thread must not leak a previous call's invocation context. Got: " + systemContent);
+    }
+
+    // ── MED-4: parallel tool-call branch ───────────────────────────────────
+
+    @Test
+    @DisplayName("MED-4: parallel tool calls carry trace + propagated headers on outbound requests")
+    void parallelToolCallsPropagateContext() throws Exception {
+        String endpoint = server.url("/").toString().replaceAll("/$", "");
+        // parallelToolCalls=true, two iterations, real proxy factory so tool
+        // calls go over HTTP to the mock server.
+        proxy.configure(client, new McpMeshToolProxyFactory(client), null, null, "", "ctx", 2, true);
+        proxy.updateTools(List.of(
+            llmToolInfo("tool_a", endpoint),
+            llmToolInfo("tool_b", endpoint)
+        ));
+
+        TraceContext.set(TraceInfo.forPropagation("ffff0000ffff0000", null));
+        TraceContext.setPropagatedHeaders(Map.of("x-mesh-timeout", "55"));
+
+        // Iteration 1: LLM requests two tool calls → executed in parallel.
+        server.enqueue(stubToolCallsResponse(List.of(
+            toolCall("c1", "tool_a"),
+            toolCall("c2", "tool_b")
+        )));
+        // The two parallel tool invocations (order nondeterministic).
+        server.enqueue(stubLlmResponse("a-result"));
+        server.enqueue(stubLlmResponse("b-result"));
+        // Iteration 2: final content.
+        server.enqueue(stubLlmResponse("done"));
+
+        String result = proxy.request().user("go").generate();
+        assertEquals("done", result);
+
+        List<RecordedRequest> toolRequests = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            RecordedRequest req = server.takeRequest(5, TimeUnit.SECONDS);
+            assertNotNull(req, "expected 4 outbound requests, missing #" + (i + 1));
+            JsonNode body = mapper.readTree(req.getBody().readUtf8());
+            String name = body.get("params").get("name").asText();
+            if ("tool_a".equals(name) || "tool_b".equals(name)) {
+                toolRequests.add(req);
+            }
+        }
+        assertEquals(2, toolRequests.size(), "both parallel tool calls must reach the wire");
+
+        for (RecordedRequest toolReq : toolRequests) {
+            assertEquals("ffff0000ffff0000", toolReq.getHeader("X-Trace-ID"),
+                "parallel tool execution must carry trace headers (pool thread context)");
+            assertEquals("55", toolReq.getHeader("x-mesh-timeout"),
+                "parallel tool execution must forward propagated headers");
+        }
+    }
+
+    // ── LOW: buildErrorResponse must emit valid JSON for control chars ─────
+
+    @Test
+    @DisplayName("LOW: error response with newlines/control chars is valid JSON")
+    void buildErrorResponseControlCharsValidJson() throws Exception {
+        String message = "line1\nline2\ttabbed \"quoted\" back\\slash bell\u0001 end";
+        String json = MeshLlmAgentProxy.buildErrorResponse("tool_call_failed", "my_tool", message);
+
+        JsonNode node = mapper.readTree(json); // must parse — previously invalid
+        assertEquals("tool_call_failed", node.get("error").get("type").asText());
+        assertEquals("my_tool", node.get("error").get("tool").asText());
+        assertEquals(message, node.get("error").get("message").asText(),
+            "message must round-trip exactly through serialization");
+    }
+
+    @Test
+    @DisplayName("LOW: null message falls back to 'Unknown error'")
+    void buildErrorResponseNullMessage() throws Exception {
+        String json = MeshLlmAgentProxy.buildErrorResponse("unexpected_error", "t", null);
+        JsonNode node = mapper.readTree(json);
+        assertEquals("Unknown error", node.get("error").get("message").asText());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyAsyncContextTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyAsyncContextTest.java
@@ -8,6 +8,7 @@ import io.mcpmesh.types.MeshLlmAgent;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +51,9 @@ class MeshLlmAgentProxyAsyncContextTest {
     private ObjectMapper mapper;
     private MeshLlmAgentProxy proxy;
 
+    /** Original MeshTlsConfig.cached value, restored in {@link #restoreTlsConfig()}. */
+    private static Object originalTlsConfig;
+
     @BeforeAll
     static void initTlsConfig() throws Exception {
         // Pre-seed MeshTlsConfig.cached so tests don't hit native FFI
@@ -60,7 +64,17 @@ class MeshLlmAgentProxyAsyncContextTest {
 
         Field cachedField = MeshTlsConfig.class.getDeclaredField("cached");
         cachedField.setAccessible(true);
+        originalTlsConfig = cachedField.get(null);
         cachedField.set(null, disabled);
+    }
+
+    @AfterAll
+    static void restoreTlsConfig() throws Exception {
+        // The cached field is process-wide static state — restore it so later
+        // test classes in the same JVM see whatever was there before.
+        Field cachedField = MeshTlsConfig.class.getDeclaredField("cached");
+        cachedField.setAccessible(true);
+        cachedField.set(null, originalTlsConfig);
     }
 
     @BeforeEach

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmEnrichmentAopProxyTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmEnrichmentAopProxyTest.java
@@ -1,0 +1,104 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshLlm;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.core.MeshObjectMappers;
+import io.mcpmesh.types.MeshLlmAgent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.AopUtils;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1164 MED-1: {@code @MeshLlm} provider enrichment must resolve for
+ * AOP-proxied beans.
+ *
+ * <p>{@link MeshLlmRegistry#register} keys configs by
+ * {@code AopUtils.getTargetClass(bean).getName()} (the post-processor unwraps
+ * CGLIB proxies), but {@code enrichToolsWithLlmProvider} previously built its
+ * lookup key from {@code meta.bean().getClass().getName()} — for a Spring-
+ * proxied bean ({@code @Transactional}/{@code @Async}/{@code @Validated}) the
+ * runtime class is {@code Foo$$SpringCGLIB$$0}, the lookup returned null, and
+ * the {@code llm_provider} selector silently never reached the heartbeat.
+ */
+@DisplayName("enrichToolsWithLlmProvider — AOP-proxied bean key unwrap (issue #1164 MED-1)")
+class MeshLlmEnrichmentAopProxyTest {
+
+    public static class ChatAgent {
+        @MeshTool(capability = "chat", description = "chat tool")
+        @MeshLlm(providerSelector = @Selector(capability = "llm", tags = {"+claude"}))
+        public String chat(@Param("question") String question, MeshLlmAgent llm) {
+            return "ok";
+        }
+    }
+
+    @Test
+    @DisplayName("CGLIB-proxied @MeshLlm bean resolves its provider selector")
+    void cglibProxiedMeshLlmBeanGetsLlmProviderEnrichment() throws Exception {
+        // Build a REAL CGLIB proxy — the same shape @Transactional/@Async/
+        // @Validated produce at runtime (class name contains $$).
+        ProxyFactory pf = new ProxyFactory(new ChatAgent());
+        pf.setProxyTargetClass(true);
+        Object proxiedBean = pf.getProxy();
+        assertNotEquals(ChatAgent.class, proxiedBean.getClass(),
+            "Proxy runtime class must differ from the user class for this test to be meaningful");
+        assertEquals(ChatAgent.class, AopUtils.getTargetClass(proxiedBean),
+            "AopUtils must unwrap the proxy back to the user class");
+
+        Method method = ChatAgent.class.getMethod("chat", String.class, MeshLlmAgent.class);
+
+        // Registration mirrors the post-processors: MeshLlmRegistry keys by
+        // the unwrapped target class; MeshToolRegistry stores the (proxied)
+        // bean instance.
+        MeshLlmRegistry llmRegistry = new MeshLlmRegistry();
+        llmRegistry.register(ChatAgent.class, method, method.getAnnotation(MeshLlm.class));
+
+        MeshToolRegistry toolRegistry = new MeshToolRegistry();
+        toolRegistry.registerTool(proxiedBean, method, method.getAnnotation(MeshTool.class));
+
+        List<AgentSpec.ToolSpec> tools = toolRegistry.getToolSpecs();
+        MeshAutoConfiguration.enrichToolsWithLlmProvider(
+            tools, toolRegistry, llmRegistry, MeshObjectMappers.create());
+
+        AgentSpec.ToolSpec spec = tools.stream()
+            .filter(t -> "chat".equals(t.getCapability()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("chat tool spec missing"));
+
+        assertNotNull(spec.getLlmProvider(),
+            "llmProvider must be set on the tool spec even when the bean is AOP-proxied "
+                + "(registration key uses AopUtils.getTargetClass; lookup must match)");
+        assertTrue(spec.getLlmProvider().contains("\"capability\":\"llm\""),
+            "llmProvider JSON must carry the selector capability. Got: " + spec.getLlmProvider());
+        assertTrue(spec.getLlmProvider().contains("+claude"),
+            "llmProvider JSON must carry the selector tags. Got: " + spec.getLlmProvider());
+    }
+
+    @Test
+    @DisplayName("unproxied bean still resolves (regression guard)")
+    void plainBeanStillResolves() throws Exception {
+        ChatAgent bean = new ChatAgent();
+        Method method = ChatAgent.class.getMethod("chat", String.class, MeshLlmAgent.class);
+
+        MeshLlmRegistry llmRegistry = new MeshLlmRegistry();
+        llmRegistry.register(ChatAgent.class, method, method.getAnnotation(MeshLlm.class));
+
+        MeshToolRegistry toolRegistry = new MeshToolRegistry();
+        toolRegistry.registerTool(bean, method, method.getAnnotation(MeshTool.class));
+
+        List<AgentSpec.ToolSpec> tools = toolRegistry.getToolSpecs();
+        MeshAutoConfiguration.enrichToolsWithLlmProvider(
+            tools, toolRegistry, llmRegistry, MeshObjectMappers.create());
+
+        assertNotNull(tools.get(0).getLlmProvider(),
+            "llmProvider must be set for a plain (unproxied) bean");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshSchemaSupportSelfRefCollisionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshSchemaSupportSelfRefCollisionTest.java
@@ -1,0 +1,85 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.core.MeshObjectMappers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1164 LOW: {@code rewriteRootSelfRefs} keyed the new root def by the
+ * type's simple name, shadowing a pre-existing same-simple-name {@code $defs}
+ * entry from another package — whose internal refs then silently resolved to
+ * the WRONG body. The collision must be disambiguated, the root refs rewritten
+ * to the disambiguated name, and the pre-existing def preserved untouched.
+ */
+@DisplayName("MeshSchemaSupport.rewriteRootSelfRefs — $defs name collision (issue #1164 LOW)")
+class MeshSchemaSupportSelfRefCollisionTest {
+
+    /** Simple name intentionally collides with the crafted $defs entry below. */
+    public record TreeNode(String value) {}
+
+    private static final ObjectMapper MAPPER = MeshObjectMappers.create();
+
+    @Test
+    @DisplayName("pre-existing same-simple-name def is preserved; root def disambiguated")
+    void collisionIsDisambiguated() throws Exception {
+        // Simulates a victools output where the root type self-references ("#")
+        // AND a nested type from another package already produced a $defs entry
+        // named "TreeNode".
+        JsonNode root = MAPPER.readTree("""
+            {
+              "type": "object",
+              "properties": {
+                "self": { "$ref": "#" },
+                "other": { "$ref": "#/$defs/TreeNode" }
+              },
+              "$defs": {
+                "TreeNode": { "type": "string", "description": "the OTHER package's TreeNode" }
+              }
+            }
+            """);
+
+        JsonNode out = MeshSchemaSupport.rewriteRootSelfRefs(root, TreeNode.class);
+
+        // Root must point at the DISAMBIGUATED def, not shadow the existing one.
+        assertEquals("#/$defs/TreeNode_2", out.path("$ref").asString(""),
+            "root ref must use the disambiguated name. Got: " + out);
+
+        JsonNode defs = out.get("$defs");
+        assertNotNull(defs);
+
+        // Pre-existing def preserved byte-for-byte.
+        JsonNode existing = defs.get("TreeNode");
+        assertNotNull(existing, "pre-existing TreeNode def must survive. Got: " + defs);
+        assertEquals("string", existing.path("type").asString(""),
+            "pre-existing def body must be untouched. Got: " + existing);
+
+        // New def carries the root body with `#` refs rewritten to the new name.
+        JsonNode renamed = defs.get("TreeNode_2");
+        assertNotNull(renamed, "disambiguated def must exist. Got: " + defs);
+        assertEquals("#/$defs/TreeNode_2",
+            renamed.path("properties").path("self").path("$ref").asString(""),
+            "self refs must point at the disambiguated def. Got: " + renamed);
+        // Refs into the OLD def keep pointing at the preserved entry.
+        assertEquals("#/$defs/TreeNode",
+            renamed.path("properties").path("other").path("$ref").asString(""),
+            "refs to the pre-existing def must remain intact. Got: " + renamed);
+    }
+
+    @Test
+    @DisplayName("no collision → behavior unchanged (named after the simple name)")
+    void noCollisionUsesSimpleName() throws Exception {
+        JsonNode root = MAPPER.readTree("""
+            {
+              "type": "object",
+              "properties": { "self": { "$ref": "#" } }
+            }
+            """);
+        JsonNode out = MeshSchemaSupport.rewriteRootSelfRefs(root, TreeNode.class);
+        assertEquals("#/$defs/TreeNode", out.path("$ref").asString(""));
+        assertNotNull(out.get("$defs").get("TreeNode"));
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolInheritanceScanTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolInheritanceScanTest.java
@@ -65,6 +65,18 @@ class MeshToolInheritanceScanTest {
         }
     }
 
+    /**
+     * Override that re-declares {@code @MeshTool} but NOT {@code @Param}
+     * (#1164 review follow-up) — the param metadata stays on the base.
+     */
+    public static class DerivedNoParamCalc extends BaseCalc {
+        @Override
+        @MeshTool(capability = "calc", description = "derived calc no param")
+        public String calc(String x) {
+            return "derivedNoParam:" + x;
+        }
+    }
+
     /** Fully-annotated interface contract (default method); bare impl class. */
     public interface PricerContract {
         @MeshTool(capability = "price", description = "prices a sku")
@@ -175,6 +187,37 @@ class MeshToolInheritanceScanTest {
             "the most-derived @MeshTool declaration must win");
         assertEquals(DerivedCalc.class, meta.method().getDeclaringClass());
         assertEquals("derived:7", meta.method().invoke(meta.bean(), "7"));
+    }
+
+    @Test
+    @DisplayName("override re-declares @MeshTool without @Param → boots, ancestor @Param schema kept, override values win")
+    void redeclaredMeshToolWithoutParamKeepsAncestorSchema() throws Exception {
+        // Previously the override's bare declaration was registered (it
+        // declares @MeshTool), dropping the base @Param metadata — the
+        // wrapper then boot-failed with "must have @Param annotation".
+        MeshToolRegistry registry = new MeshToolRegistry();
+        DerivedNoParamCalc bean = new DerivedNoParamCalc();
+
+        assertDoesNotThrow(() -> processor(registry).postProcessAfterInitialization(bean, "calc"),
+            "re-declared @MeshTool without @Param must fall back to the param-annotated ancestor");
+
+        assertEquals(1, registry.getAllTools().size());
+        MeshToolRegistry.ToolMetadata meta = registry.getTool("calc");
+        assertNotNull(meta);
+        // The override's @MeshTool values still apply (annotation resolved
+        // from the most-derived declaration)...
+        assertEquals("derived calc no param", meta.description(),
+            "the override's @MeshTool values must win");
+        // ...but the param-annotated ancestor is the schema source.
+        assertEquals(BaseCalc.class, meta.method().getDeclaringClass(),
+            "the param-annotated ancestor declaration must be the registration target");
+        Map<String, Object> schema = meta.inputSchema();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> props = (Map<String, Object>) schema.get("properties");
+        assertTrue(props.containsKey("x"),
+            "@Param metadata from the base declaration must be preserved. Got: " + props);
+        // Method.invoke dispatches virtually — the override still runs.
+        assertEquals("derivedNoParam:9", meta.method().invoke(meta.bean(), "9"));
     }
 
     @Test

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolInheritanceScanTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolInheritanceScanTest.java
@@ -1,0 +1,301 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1164 review follow-up (BLOCKER): the duplicate-capability boot error
+ * must not fire for ONE logical tool seen through an inheritance hierarchy.
+ *
+ * <p>The previous scan ({@code ReflectionUtils.doWithMethods} with no
+ * {@code MethodFilter}) visited an overridden/inherited {@code @MeshTool}
+ * method once per declaring class (plus generic bridge methods), and each
+ * visit re-registered the same capability — tripping the new fail-fast
+ * {@code IllegalStateException} at boot for code that previously worked.
+ * Both layers are covered here:
+ *
+ * <ul>
+ *   <li>{@link MeshToolBeanPostProcessor} dedups to one registration per
+ *       logical method (MethodIntrospector + BridgeMethodResolver);</li>
+ *   <li>{@link MeshToolRegistry#registerTool} tolerates an override PAIR on
+ *       the SAME bean instance (most-derived declaration wins) while still
+ *       hard-failing for genuinely distinct methods claiming the same
+ *       capability — including sibling beans of a base/derived pair.</li>
+ * </ul>
+ */
+@DisplayName("@MeshTool inheritance — scan dedup + registry override tolerance (issue #1164 review)")
+class MeshToolInheritanceScanTest {
+
+    // ── Fixtures ────────────────────────────────────────────────────────────
+
+    /** Fully-annotated abstract contract; bare subclass implementation. */
+    public abstract static class AbstractGreeter {
+        @MeshTool(capability = "greet", description = "greets someone")
+        public abstract String greet(@Param("name") String name);
+    }
+
+    public static class GreeterImpl extends AbstractGreeter {
+        @Override
+        public String greet(String name) {
+            return "hello " + name;
+        }
+    }
+
+    /** Concrete base method overridden (and re-annotated) in the subclass. */
+    public static class BaseCalc {
+        @MeshTool(capability = "calc", description = "base calc")
+        public String calc(@Param("x") String x) {
+            return "base:" + x;
+        }
+    }
+
+    public static class DerivedCalc extends BaseCalc {
+        @Override
+        @MeshTool(capability = "calc", description = "derived calc")
+        public String calc(@Param("x") String x) {
+            return "derived:" + x;
+        }
+    }
+
+    /** Fully-annotated interface contract (default method); bare impl class. */
+    public interface PricerContract {
+        @MeshTool(capability = "price", description = "prices a sku")
+        default String price(@Param("sku") String sku) {
+            return "default:" + sku;
+        }
+    }
+
+    public static class PricerImpl implements PricerContract {
+        @Override
+        public String price(String sku) {
+            return "impl:" + sku;
+        }
+    }
+
+    /** Generic base whose specialization produces a compiler bridge method. */
+    public abstract static class GenericEcho<T> {
+        @MeshTool(capability = "echo", description = "echoes")
+        public abstract String echo(@Param("v") T v);
+    }
+
+    public static class StringEcho extends GenericEcho<String> {
+        @Override
+        public String echo(@Param("v") String v) {
+            return "echo:" + v;
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static Method declaredMethod(Class<?> cls, String name) {
+        for (Method m : cls.getDeclaredMethods()) {
+            if (m.getName().equals(name) && !m.isBridge() && !m.isSynthetic()) {
+                return m;
+            }
+        }
+        throw new AssertionError("no method " + name + " on " + cls);
+    }
+
+    private static MeshToolBeanPostProcessor processor(MeshToolRegistry registry) {
+        return new MeshToolBeanPostProcessor(
+            registry,
+            new MeshToolWrapperRegistry(new McpMeshToolProxyFactory()),
+            JsonMapper.builder().build());
+    }
+
+    // ── Post-processor scan: one registration per logical tool ─────────────
+
+    @Test
+    @DisplayName("abstract @MeshTool contract implemented in subclass → boots, one tool, invokes the override")
+    void abstractContractRegistersOnceAndInvokesOverride() throws Exception {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        GreeterImpl bean = new GreeterImpl();
+
+        assertDoesNotThrow(() -> processor(registry).postProcessAfterInitialization(bean, "greeter"),
+            "inherited @MeshTool must not trip the duplicate-capability boot error");
+
+        assertEquals(1, registry.getAllTools().size(), "exactly one logical tool");
+        MeshToolRegistry.ToolMetadata meta = registry.getTool("greet");
+        assertNotNull(meta);
+        // Method.invoke dispatches virtually — the subclass override runs.
+        assertEquals("hello mesh", meta.method().invoke(meta.bean(), "mesh"));
+        // The abstract declaration carries the @Param annotations (parameter
+        // annotations are NOT inherited) — they must survive into the schema.
+        Map<String, Object> schema = meta.inputSchema();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> props = (Map<String, Object>) schema.get("properties");
+        assertTrue(props.containsKey("name"),
+            "@Param metadata from the abstract declaration must be preserved. Got: " + props);
+    }
+
+    @Test
+    @DisplayName("interface @MeshTool default-method contract implemented bare → boots, one tool, invokes the impl")
+    void interfaceContractRegistersOnceAndInvokesImpl() throws Exception {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        PricerImpl bean = new PricerImpl();
+
+        assertDoesNotThrow(() -> processor(registry).postProcessAfterInitialization(bean, "pricer"),
+            "interface-declared @MeshTool contract must register like the abstract-class form");
+
+        assertEquals(1, registry.getAllTools().size(), "exactly one logical tool");
+        MeshToolRegistry.ToolMetadata meta = registry.getTool("price");
+        assertNotNull(meta);
+        // Method.invoke dispatches virtually — the impl runs, not the default body.
+        assertEquals("impl:abc", meta.method().invoke(meta.bean(), "abc"));
+        // The interface declaration carries the @Param annotations (parameter
+        // annotations are NOT inherited) — they must survive into the schema.
+        Map<String, Object> schema = meta.inputSchema();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> props = (Map<String, Object>) schema.get("properties");
+        assertTrue(props.containsKey("sku"),
+            "@Param metadata from the interface declaration must be preserved. Got: " + props);
+    }
+
+    @Test
+    @DisplayName("concrete base overridden in subclass → boots, most-derived declaration wins")
+    void concreteOverrideRegistersOnceMostDerivedWins() throws Exception {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        DerivedCalc bean = new DerivedCalc();
+
+        assertDoesNotThrow(() -> processor(registry).postProcessAfterInitialization(bean, "calc"),
+            "an override pair is ONE logical tool, not a duplicate");
+
+        assertEquals(1, registry.getAllTools().size());
+        MeshToolRegistry.ToolMetadata meta = registry.getTool("calc");
+        assertNotNull(meta);
+        assertEquals("derived calc", meta.description(),
+            "the most-derived @MeshTool declaration must win");
+        assertEquals(DerivedCalc.class, meta.method().getDeclaringClass());
+        assertEquals("derived:7", meta.method().invoke(meta.bean(), "7"));
+    }
+
+    @Test
+    @DisplayName("generic base producing a bridge method → boots, one tool, specialized signature registered")
+    void genericBridgeRegistersOnce() throws Exception {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        StringEcho bean = new StringEcho();
+
+        assertDoesNotThrow(() -> processor(registry).postProcessAfterInitialization(bean, "echo"),
+            "bridge + generic super declaration must collapse onto one logical tool");
+
+        assertEquals(1, registry.getAllTools().size());
+        MeshToolRegistry.ToolMetadata meta = registry.getTool("echo");
+        assertNotNull(meta);
+        assertFalse(meta.method().isBridge(), "the bridge must never be the registered method");
+        assertEquals(String.class, meta.method().getParameterTypes()[0],
+            "the specialized override (not the erased generic declaration) must be registered");
+        assertEquals("echo:hi", meta.method().invoke(meta.bean(), "hi"));
+    }
+
+    // ── Registry carve-out: override pairs tolerated, true duplicates fail ──
+
+    @Test
+    @DisplayName("registry tolerates base-then-derived registration; most-derived wins")
+    void registryToleratesBaseThenDerived() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        Method base = declaredMethod(BaseCalc.class, "calc");
+        Method derived = declaredMethod(DerivedCalc.class, "calc");
+        DerivedCalc bean = new DerivedCalc();
+
+        registry.registerTool(bean, base, base.getAnnotation(MeshTool.class));
+        assertDoesNotThrow(() ->
+            registry.registerTool(bean, derived, derived.getAnnotation(MeshTool.class)));
+
+        assertEquals(derived, registry.getTool("calc").method(),
+            "most-derived declaration must replace the base one");
+    }
+
+    @Test
+    @DisplayName("registry tolerates derived-then-base registration; most-derived kept")
+    void registryToleratesDerivedThenBase() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        Method base = declaredMethod(BaseCalc.class, "calc");
+        Method derived = declaredMethod(DerivedCalc.class, "calc");
+        DerivedCalc bean = new DerivedCalc();
+
+        registry.registerTool(bean, derived, derived.getAnnotation(MeshTool.class));
+        assertDoesNotThrow(() ->
+            registry.registerTool(bean, base, base.getAnnotation(MeshTool.class)));
+
+        assertEquals(derived, registry.getTool("calc").method(),
+            "the already-registered most-derived declaration must be kept");
+    }
+
+    @Test
+    @DisplayName("registry tolerates a generic-override pair (bridge-resolved)")
+    void registryToleratesGenericOverridePair() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        Method base = declaredMethod(GenericEcho.class, "echo");
+        Method derived = declaredMethod(StringEcho.class, "echo");
+        StringEcho bean = new StringEcho();
+
+        registry.registerTool(bean, base, base.getAnnotation(MeshTool.class));
+        assertDoesNotThrow(() ->
+            registry.registerTool(bean, derived, base.getAnnotation(MeshTool.class)),
+            "generic specialization is the same logical method after bridge resolution");
+
+        assertEquals(derived, registry.getTool("echo").method());
+    }
+
+    @Test
+    @DisplayName("SIBLING beans — base bean + derived bean sharing a capability → boot error naming both")
+    void siblingBeansFailFastInsteadOfMasking() {
+        // The override-pair tolerance is scoped to ONE bean instance seen
+        // through two declarations. TWO beans (a BaseCalc bean AND a
+        // DerivedCalc bean) are two tools — previously the subclass bean
+        // silently masked the base bean.
+        MeshToolRegistry registry = new MeshToolRegistry();
+        Method base = declaredMethod(BaseCalc.class, "calc");
+        Method derived = declaredMethod(DerivedCalc.class, "calc");
+
+        registry.registerTool(new BaseCalc(), base, base.getAnnotation(MeshTool.class));
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () ->
+            registry.registerTool(new DerivedCalc(), derived, derived.getAnnotation(MeshTool.class)));
+
+        assertTrue(ex.getMessage().contains("calc"),
+            "error must name the colliding capability. Got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(BaseCalc.class.getName())
+                && ex.getMessage().contains(DerivedCalc.class.getName()),
+            "error must name both declaration sites. Got: " + ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("SIBLING beans — derived-then-base ordering fails fast too")
+    void siblingBeansFailFastDerivedFirst() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        Method base = declaredMethod(BaseCalc.class, "calc");
+        Method derived = declaredMethod(DerivedCalc.class, "calc");
+
+        registry.registerTool(new DerivedCalc(), derived, derived.getAnnotation(MeshTool.class));
+        assertThrows(IllegalStateException.class, () ->
+            registry.registerTool(new BaseCalc(), base, base.getAnnotation(MeshTool.class)),
+            "the keep-existing-override branch must not hide a second bean either");
+    }
+
+    @Test
+    @DisplayName("genuinely distinct methods claiming one capability still fail fast")
+    void unrelatedDuplicateStillFails() {
+        // Same-named capability from two UNRELATED classes — the override
+        // carve-out must not soften the real conflict (existing contract,
+        // see MeshToolRegistryDuplicateCapabilityTest for the full matrix).
+        MeshToolRegistry registry = new MeshToolRegistry();
+        Method one = declaredMethod(
+            MeshToolRegistryDuplicateCapabilityTest.AgentOne.class, "lookupV1");
+        Method two = declaredMethod(
+            MeshToolRegistryDuplicateCapabilityTest.AgentTwo.class, "lookupV2");
+
+        registry.registerTool(new MeshToolRegistryDuplicateCapabilityTest.AgentOne(),
+            one, one.getAnnotation(MeshTool.class));
+        assertThrows(IllegalStateException.class, () ->
+            registry.registerTool(new MeshToolRegistryDuplicateCapabilityTest.AgentTwo(),
+                two, two.getAnnotation(MeshTool.class)));
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolInputSchemaParityTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolInputSchemaParityTest.java
@@ -1,0 +1,328 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.core.AgentSpec;
+import jakarta.validation.constraints.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1164 MED-2: the registry-advertised input schema must be IDENTICAL to
+ * the MCP-served schema.
+ *
+ * <p>Previously {@link MeshToolRegistry} hand-rolled {@code {"type": ...}} per
+ * parameter — a POJO/record param became a bare {@code {"type":"object"}} with
+ * no properties and {@code List<Foo>} a bare {@code {"type":"array"}} with no
+ * items — while {@link MeshToolWrapper} served the rich victools schema.
+ * Everything heartbeat-derived (input_schema_canonical / input_schema_hash for
+ * #547 cross-runtime matching, llm_tools definitions delivered to consuming
+ * LLM agents) used the impoverished shape. Both sites now call
+ * {@link MeshSchemaSupport#buildToolInputSchema}.
+ */
+@DisplayName("Tool input schema parity — wrapper vs heartbeat (issue #1164 MED-2)")
+class MeshToolInputSchemaParityTest {
+
+    public record Order(@NotNull String sku, @NotNull Integer qty) {}
+
+    public static class OrderAgent {
+        @MeshTool(capability = "process_order", description = "Process an order")
+        public String process(
+                @Param(value = "order", description = "the order") Order order,
+                @Param("tags") List<String> tags,
+                @Param("note") String note) {
+            return "ok";
+        }
+    }
+
+    private static Method method(Class<?> cls, String name) {
+        for (Method m : cls.getDeclaredMethods()) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+        throw new AssertionError("no method " + name + " on " + cls);
+    }
+
+    /** Resolve a property schema, following a root-level {@code #/$defs/...} ref if present. */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> resolveProperty(Map<String, Object> schema, String propName) {
+        Map<String, Object> props = (Map<String, Object>) schema.get("properties");
+        assertNotNull(props, "schema must have properties. Got: " + schema);
+        Map<String, Object> prop = (Map<String, Object>) props.get(propName);
+        assertNotNull(prop, "property '" + propName + "' missing. Got: " + props.keySet());
+        Object ref = prop.get("$ref");
+        if (ref instanceof String s && s.startsWith("#/$defs/")) {
+            Map<String, Object> defs = (Map<String, Object>) schema.get("$defs");
+            assertNotNull(defs, "$ref present but no root $defs. Got: " + schema);
+            Map<String, Object> resolved = (Map<String, Object>) defs.get(s.substring("#/$defs/".length()));
+            assertNotNull(resolved, "dangling ref " + s + ". $defs keys: " + defs.keySet());
+            return resolved;
+        }
+        return prop;
+    }
+
+    @Test
+    @DisplayName("wrapper-served schema and heartbeat metadata schema are the same generator output")
+    void wrapperAndHeartbeatSchemasAreIdentical() {
+        OrderAgent bean = new OrderAgent();
+        Method m = method(OrderAgent.class, "process");
+
+        MeshToolWrapper wrapper = new MeshToolWrapper(
+            "OrderAgent.process", "process_order", "Process an order",
+            bean, m, List.of(), JsonMapper.builder().build());
+
+        MeshToolRegistry registry = new MeshToolRegistry();
+        registry.registerTool(bean, m, m.getAnnotation(MeshTool.class));
+
+        assertEquals(wrapper.getInputSchema(), registry.getTool("process_order").inputSchema(),
+            "heartbeat metadata schema must be byte-for-byte the wrapper-served schema");
+    }
+
+    @Test
+    @DisplayName("structured param (record) advertises nested properties + required, not bare {type:object}")
+    @SuppressWarnings("unchecked")
+    void structuredParamSchemaIsRich() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        Method m = method(OrderAgent.class, "process");
+        registry.registerTool(new OrderAgent(), m, m.getAnnotation(MeshTool.class));
+
+        Map<String, Object> schema = registry.getTool("process_order").inputSchema();
+
+        Map<String, Object> order = resolveProperty(schema, "order");
+        Map<String, Object> orderProps = (Map<String, Object>) order.get("properties");
+        assertNotNull(orderProps,
+            "record param must carry nested properties — bare {type:object} is the bug. Got: " + order);
+        assertTrue(orderProps.containsKey("sku"), "Order.sku missing. Got: " + orderProps.keySet());
+        assertTrue(orderProps.containsKey("qty"), "Order.qty missing. Got: " + orderProps.keySet());
+        List<String> orderRequired = (List<String>) order.get("required");
+        assertNotNull(orderRequired, "record fields must be marked required. Got: " + order);
+        assertTrue(orderRequired.contains("sku") && orderRequired.contains("qty"),
+            "sku+qty required. Got: " + orderRequired);
+
+        Map<String, Object> tags = resolveProperty(schema, "tags");
+        assertEquals("array", tags.get("type"));
+        assertNotNull(tags.get("items"),
+            "List<String> param must carry items — bare {type:array} is the bug. Got: " + tags);
+
+        // Top-level required: all three @Param(required=true by default)
+        List<String> required = (List<String>) schema.get("required");
+        assertNotNull(required);
+        assertTrue(required.containsAll(List.of("order", "tags", "note")),
+            "all params required. Got: " + required);
+
+        // @Param description survives the rich generator path.
+        Map<String, Object> props = (Map<String, Object>) schema.get("properties");
+        Map<String, Object> orderProp = (Map<String, Object>) props.get("order");
+        // description sits on the property node (possibly alongside a $ref)
+        assertEquals("the order", orderProp.get("description"),
+            "@Param description must be preserved. Got: " + orderProp);
+    }
+
+    @Test
+    @DisplayName("heartbeat ToolSpec carries the rich schema through canonicalization")
+    void heartbeatToolSpecCarriesRichCanonicalSchema() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        Method m = method(OrderAgent.class, "process");
+        registry.registerTool(new OrderAgent(), m, m.getAnnotation(MeshTool.class));
+
+        List<AgentSpec.ToolSpec> specs;
+        try {
+            specs = registry.getToolSpecs();
+        } catch (UnsatisfiedLinkError e) {
+            org.junit.jupiter.api.Assumptions.assumeTrue(false,
+                "Rust core native library not available: " + e.getMessage());
+            return;
+        }
+        AgentSpec.ToolSpec spec = specs.get(0);
+
+        assertTrue(spec.getInputSchema().contains("\"sku\""),
+            "advertised input_schema must contain the nested record field. Got: " + spec.getInputSchema());
+        assertNotNull(spec.getInputSchemaCanonical(),
+            "canonicalization must handle the richer schema ($defs, required) without choking");
+        assertTrue(spec.getInputSchemaCanonical().contains("sku"),
+            "canonical schema must retain nested fields. Got: " + spec.getInputSchemaCanonical());
+        assertNotNull(spec.getInputSchemaHash(), "input_schema_hash must be present");
+        assertTrue(spec.getInputSchemaHash().startsWith("sha256:"),
+            "hash format. Got: " + spec.getInputSchemaHash());
+    }
+
+    // ── $defs hoisting + collision disambiguation ─────────────────────────
+
+    public static class PkgA {
+        public record Item(@NotNull String sku) {}
+        public record Wrap(@NotNull Item item) {}
+    }
+
+    public static class PkgB {
+        public record Item(@NotNull Integer qty) {}
+        public record Wrap(@NotNull Item item) {}
+    }
+
+    public static class CollisionAgent {
+        @MeshTool(capability = "collide", description = "two same-simple-name defs")
+        public String collide(@Param("a") PkgA.Wrap a, @Param("b") PkgB.Wrap b) {
+            return "ok";
+        }
+    }
+
+    @Test
+    @DisplayName("same-simple-name $defs from different params are disambiguated, refs rewritten")
+    @SuppressWarnings("unchecked")
+    void defsNameCollisionAcrossParamsIsDisambiguated() {
+        Method m = method(CollisionAgent.class, "collide");
+        Map<String, Object> schema = MeshSchemaSupport.buildToolInputSchema(m);
+
+        Map<String, Object> defs = (Map<String, Object>) schema.get("$defs");
+        assertNotNull(defs, "param $defs must be hoisted to the root schema. Got: " + schema);
+        assertTrue(defs.containsKey("Item"), "first Item def kept. Got: " + defs.keySet());
+        assertTrue(defs.containsKey("Item_2"),
+            "structurally different same-name def must be disambiguated. Got: " + defs.keySet());
+
+        Map<String, Object> itemA = (Map<String, Object>) defs.get("Item");
+        Map<String, Object> itemB = (Map<String, Object>) defs.get("Item_2");
+        assertTrue(((Map<String, Object>) itemA.get("properties")).containsKey("sku"),
+            "Item must be PkgA's body. Got: " + itemA);
+        assertTrue(((Map<String, Object>) itemB.get("properties")).containsKey("qty"),
+            "Item_2 must be PkgB's body. Got: " + itemB);
+
+        // The second param's subtree must point at the disambiguated def.
+        String schemaJson = schema.toString();
+        assertTrue(schemaJson.contains("#/$defs/Item_2"),
+            "refs in the renamed param's subtree must be rewritten. Got: " + schemaJson);
+    }
+
+    public static class CascadeAgent {
+        @MeshTool(capability = "cascade", description = "two-level same-name defs")
+        public String cascade(@Param("a") List<PkgA.Wrap> a, @Param("b") List<PkgB.Wrap> b) {
+            return "ok";
+        }
+    }
+
+    /**
+     * Issue #1164 review follow-up: the rename cascade. With {@code List}
+     * params BOTH {@code Wrap} and {@code Item} land in {@code $defs} (the
+     * wrapper is no longer inlined in the property node). The two {@code Wrap}
+     * bodies are byte-identical BEFORE renaming (both ref {@code #/$defs/Item})
+     * and only diverge AFTER the nested {@code Item} rename — a single
+     * pre-rename comparison judged them equal, dropped PkgB's {@code Wrap},
+     * and silently served PkgA's {@code Item} for param {@code b}.
+     */
+    @Test
+    @DisplayName("two-level same-name def cascade: param B's subtree resolves to PkgB's Item")
+    @SuppressWarnings("unchecked")
+    void twoLevelDefCascadeResolvesCorrectSubtree() {
+        Method m = method(CascadeAgent.class, "cascade");
+        Map<String, Object> schema = MeshSchemaSupport.buildToolInputSchema(m);
+        Map<String, Object> defs = (Map<String, Object>) schema.get("$defs");
+        assertNotNull(defs, "list params must hoist Wrap+Item defs. Got: " + schema);
+
+        // Walk param b: items.$ref → Wrap def → properties.item.$ref → Item def.
+        Map<String, Object> itemA = followItemDef(schema, defs, "a");
+        Map<String, Object> itemB = followItemDef(schema, defs, "b");
+
+        assertTrue(((Map<String, Object>) itemA.get("properties")).containsKey("sku"),
+            "param a must resolve to PkgA's Item (sku). Got: " + itemA);
+        assertTrue(((Map<String, Object>) itemB.get("properties")).containsKey("qty"),
+            "param b must resolve to PkgB's Item (qty) through the FINAL $defs — "
+                + "serving PkgA's Item here is the cascade bug. Got: " + itemB);
+
+        // No orphaned def: every hoisted def must be reachable by some $ref.
+        for (String defName : defs.keySet()) {
+            assertTrue(schema.toString().contains("#/$defs/" + defName),
+                "def '" + defName + "' must be referenced somewhere — an orphaned def "
+                    + "means the rename was applied without keeping its referrer. $defs: "
+                    + defs.keySet());
+        }
+    }
+
+    /** Resolve {@code properties.<param>.items.$ref → Wrap.properties.item.$ref → Item}. */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> followItemDef(
+            Map<String, Object> schema, Map<String, Object> defs, String param) {
+        Map<String, Object> props = (Map<String, Object>) schema.get("properties");
+        Map<String, Object> listProp = (Map<String, Object>) props.get(param);
+        Map<String, Object> items = (Map<String, Object>) listProp.get("items");
+        assertNotNull(items, "List param must carry items. Got: " + listProp);
+        Map<String, Object> wrap = resolveRef(items, defs);
+        Map<String, Object> wrapProps = (Map<String, Object>) wrap.get("properties");
+        assertNotNull(wrapProps, "Wrap def must have properties. Got: " + wrap);
+        return resolveRef((Map<String, Object>) wrapProps.get("item"), defs);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> resolveRef(Map<String, Object> node, Map<String, Object> defs) {
+        Object ref = node.get("$ref");
+        if (ref instanceof String s && s.startsWith("#/$defs/")) {
+            Map<String, Object> resolved = (Map<String, Object>) defs.get(s.substring("#/$defs/".length()));
+            assertNotNull(resolved, "dangling ref " + s + ". $defs keys: " + defs.keySet());
+            return resolved;
+        }
+        return node;
+    }
+
+    // ── @Param description precedence ───────────────────────────────────────
+
+    @com.fasterxml.jackson.annotation.JsonClassDescription("type-derived description")
+    public record DescribedPayload(@NotNull String field) {}
+
+    public static class DescAgent {
+        @MeshTool(capability = "desc_both", description = "t")
+        public String both(
+                @Param(value = "p", description = "param-level description") DescribedPayload p) {
+            return "ok";
+        }
+
+        @MeshTool(capability = "desc_derived_only", description = "t")
+        public String derivedOnly(@Param("p") DescribedPayload p) {
+            return "ok";
+        }
+    }
+
+    @Test
+    @DisplayName("@Param description wins over the victools/type-derived one; derived kept when @Param is silent")
+    @SuppressWarnings("unchecked")
+    void paramDescriptionWinsOverDerived() {
+        Map<String, Object> both = MeshSchemaSupport.buildToolInputSchema(
+            method(DescAgent.class, "both"));
+        Map<String, Object> bothProp = (Map<String, Object>)
+            ((Map<String, Object>) both.get("properties")).get("p");
+        assertEquals("param-level description", bothProp.get("description"),
+            "@Param description must beat the type-derived one on the composed schema "
+                + "(the legacy heartbeat builder always used @Param here). Got: " + bothProp);
+
+        Map<String, Object> derived = MeshSchemaSupport.buildToolInputSchema(
+            method(DescAgent.class, "derivedOnly"));
+        Map<String, Object> derivedProp = (Map<String, Object>)
+            ((Map<String, Object>) derived.get("properties")).get("p");
+        assertEquals("type-derived description", derivedProp.get("description"),
+            "with no @Param description, the type-derived one must be kept. Got: " + derivedProp);
+    }
+
+    @Test
+    @DisplayName("identical defs across params are reused (no spurious suffixes)")
+    @SuppressWarnings("unchecked")
+    void identicalDefsAreReusedNotDuplicated() throws Exception {
+        // Two params of the SAME wrapper type → identical Item defs → single entry.
+        class Holder {
+            @SuppressWarnings("unused")
+            public String twice(@Param("a") PkgA.Wrap a, @Param("b") PkgA.Wrap b) {
+                return "ok";
+            }
+        }
+        Method m = method(Holder.class, "twice");
+        Map<String, Object> schema = MeshSchemaSupport.buildToolInputSchema(m);
+        Map<String, Object> defs = (Map<String, Object>) schema.get("$defs");
+        assertNotNull(defs);
+        assertTrue(defs.containsKey("Item"));
+        assertFalse(defs.containsKey("Item_2"),
+            "structurally identical defs must be reused, not renamed. Got: " + defs.keySet());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolRegistryDuplicateCapabilityTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolRegistryDuplicateCapabilityTest.java
@@ -1,0 +1,75 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1164 LOW: duplicate {@code @MeshTool} capability names must fail fast
+ * at boot instead of silently last-wins overwriting — one of the two tools
+ * would otherwise never be served while still appearing registered.
+ */
+@DisplayName("MeshToolRegistry — duplicate capability fail-fast (issue #1164 LOW)")
+class MeshToolRegistryDuplicateCapabilityTest {
+
+    public static class AgentOne {
+        @MeshTool(capability = "lookup", description = "first")
+        public String lookupV1(@Param("q") String q) {
+            return "v1";
+        }
+    }
+
+    public static class AgentTwo {
+        @MeshTool(capability = "lookup", description = "second")
+        public String lookupV2(@Param("q") String q) {
+            return "v2";
+        }
+    }
+
+    private static Method method(Class<?> cls, String name) {
+        for (Method m : cls.getDeclaredMethods()) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+        throw new AssertionError("no method " + name + " on " + cls);
+    }
+
+    @Test
+    @DisplayName("two different methods claiming the same capability → descriptive boot error")
+    void duplicateCapabilityThrowsDescriptiveError() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        Method m1 = method(AgentOne.class, "lookupV1");
+        Method m2 = method(AgentTwo.class, "lookupV2");
+
+        registry.registerTool(new AgentOne(), m1, m1.getAnnotation(MeshTool.class));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> registry.registerTool(new AgentTwo(), m2, m2.getAnnotation(MeshTool.class)));
+
+        assertTrue(ex.getMessage().contains("lookup"),
+            "error must name the colliding capability. Got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("lookupV1") && ex.getMessage().contains("lookupV2"),
+            "error must name both declaration sites. Got: " + ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("re-registering the SAME method is an idempotent refresh (prototype beans, context refresh)")
+    void sameMethodReRegistrationIsTolerated() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        Method m1 = method(AgentOne.class, "lookupV1");
+
+        registry.registerTool(new AgentOne(), m1, m1.getAnnotation(MeshTool.class));
+        AgentOne refreshed = new AgentOne();
+        assertDoesNotThrow(() ->
+            registry.registerTool(refreshed, m1, m1.getAnnotation(MeshTool.class)));
+
+        assertSame(refreshed, registry.getTool("lookup").bean(),
+            "re-registration must refresh the bean instance");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperAsyncTimeoutTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperAsyncTimeoutTest.java
@@ -1,0 +1,179 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.JobContext;
+import io.mcpmesh.Param;
+import io.mcpmesh.spring.tracing.TraceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1164 MED-5: async tool timeout symmetry.
+ *
+ * <p>Previously the inbound path hard-coded a 30s {@code future.get} while the
+ * claim path awaited unbounded, and the timed-out future was never cancelled.
+ * Now both paths award the job's actual budget (propagated
+ * {@code X-Mesh-Timeout} / claim {@code max_duration}), fall back to a sane
+ * default only when absent, and cancel the future on timeout (freeing the
+ * dispatch thread and making a late {@code complete()} a no-op — NOT
+ * interrupting the running work; {@code CompletableFuture.cancel}'s
+ * {@code mayInterruptIfRunning} has no effect per its javadoc).
+ *
+ * <p>The inbound await additionally shaves a proportional margin —
+ * {@code min(}{@link MeshToolWrapper#ASYNC_AWAIT_MARGIN_SECS}{@code ,
+ * budget/10)}, floor 1s — off a present budget so the structured timeout
+ * error reaches the caller before the caller's socket read timeout fires,
+ * without a fixed margin eating most of a small budget (a 3s budget keeps
+ * 3s, accepting the socket race, instead of collapsing to 1s).
+ */
+@DisplayName("Async tool await budget — inbound + claim path (issue #1164 MED-5)")
+class MeshToolWrapperAsyncTimeoutTest {
+
+    public static class AsyncAgent {
+        volatile CompletableFuture<String> lastFuture;
+
+        public CompletableFuture<String> neverDone(@Param("x") String x) {
+            lastFuture = new CompletableFuture<>();
+            return lastFuture;
+        }
+
+        public CompletableFuture<String> quick(@Param("x") String x) {
+            return CompletableFuture.completedFuture("done:" + x);
+        }
+    }
+
+    private static Method method(String name) {
+        for (Method m : AsyncAgent.class.getDeclaredMethods()) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+        throw new AssertionError("no method " + name);
+    }
+
+    private static MeshToolWrapper wrapper(AsyncAgent bean, String methodName) {
+        return new MeshToolWrapper(
+            "AsyncAgent." + methodName, methodName, "test",
+            bean, method(methodName), List.of(), JsonMapper.builder().build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        TraceContext.clear();
+        TraceContext.clearPropagatedHeaders();
+    }
+
+    // ── Budget selection (unit) ─────────────────────────────────────────────
+
+    @Test
+    @DisplayName("budget > 30s wins over the 30s default (minus margin); absent/invalid budget falls back")
+    void effectiveBudgetSelection() {
+        // X-Mesh-Timeout=120 must bound the await near 120s — NOT fail at 30s.
+        // The margin (min(cap, budget/10)) keeps the structured timeout error
+        // ahead of the caller's socket read timeout, which would otherwise
+        // fire at the same instant.
+        assertEquals(120L - MeshToolWrapper.ASYNC_AWAIT_MARGIN_SECS,
+            MeshToolWrapper.effectiveAsyncAwaitSecs(120L));
+        // Mid-range budgets: proportional margin below the cap.
+        assertEquals(18L, MeshToolWrapper.effectiveAsyncAwaitSecs(20L));
+        assertEquals(9L, MeshToolWrapper.effectiveAsyncAwaitSecs(10L));
+        // Small budgets (< 10s) keep their whole window — a fixed 2s margin
+        // previously ate 2/3 of a 3s budget; accepting the socket-timeout
+        // race is the better trade at this scale.
+        assertEquals(3L, MeshToolWrapper.effectiveAsyncAwaitSecs(3L));
+        assertEquals(2L, MeshToolWrapper.effectiveAsyncAwaitSecs(2L));
+        assertEquals(1L, MeshToolWrapper.effectiveAsyncAwaitSecs(1L));
+        // Absent header → the 30s default (no margin: nothing to race against).
+        assertEquals(MeshToolWrapper.ASYNC_TIMEOUT_SECONDS, MeshToolWrapper.effectiveAsyncAwaitSecs(null));
+        // Defensive: non-positive budgets fall back too.
+        assertEquals(MeshToolWrapper.ASYNC_TIMEOUT_SECONDS, MeshToolWrapper.effectiveAsyncAwaitSecs(0L));
+        assertEquals(MeshToolWrapper.ASYNC_TIMEOUT_SECONDS, MeshToolWrapper.effectiveAsyncAwaitSecs(-5L));
+    }
+
+    // ── Inbound path behavior ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("inbound X-Mesh-Timeout bounds the await; timed-out future is cancelled")
+    void inboundTimeoutBoundsAwaitAndCancelsFuture() {
+        AsyncAgent bean = new AsyncAgent();
+        MeshToolWrapper w = wrapper(bean, "neverDone");
+
+        // 1s budget propagated from the caller.
+        TraceContext.setPropagatedHeaders(Map.of("x-mesh-timeout", "1"));
+
+        long start = System.nanoTime();
+        RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> w.invoke(Map.of("x", "v")));
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(ex.getMessage().contains("timed out after 1 seconds"),
+            "failure message must carry the actual budget used. Got: " + ex.getMessage());
+        assertTrue(elapsedMs < 15_000,
+            "await must be bounded by the 1s header budget, not the 30s default (took " + elapsedMs + "ms)");
+        assertNotNull(bean.lastFuture);
+        assertTrue(bean.lastFuture.isCancelled(),
+            "timed-out future must be cancelled so dependent stages abort and a late complete() is a no-op");
+    }
+
+    @Test
+    @DisplayName("budget larger than the default lets a quick future complete normally")
+    void largeBudgetCompletesNormally() throws Exception {
+        AsyncAgent bean = new AsyncAgent();
+        MeshToolWrapper w = wrapper(bean, "quick");
+
+        TraceContext.setPropagatedHeaders(Map.of("x-mesh-timeout", "120"));
+        assertEquals("done:v", w.invoke(Map.of("x", "v")));
+    }
+
+    @Test
+    @DisplayName("absent header → default budget still awaits and returns")
+    void absentHeaderUsesDefaultAndCompletes() throws Exception {
+        AsyncAgent bean = new AsyncAgent();
+        MeshToolWrapper w = wrapper(bean, "quick");
+        assertEquals("done:v", w.invoke(Map.of("x", "v")));
+    }
+
+    @Test
+    @DisplayName("awaitIfFuture timeout cancels and reports the budget")
+    void awaitIfFutureCancelsOnTimeout() {
+        CompletableFuture<String> cf = new CompletableFuture<>();
+        RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> MeshToolWrapper.awaitIfFuture(cf, 1L));
+        assertTrue(ex.getMessage().contains("1 seconds"), "Got: " + ex.getMessage());
+        assertTrue(cf.isCancelled());
+    }
+
+    // ── Claim path behavior ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("claim path awaits with the job's max_duration budget and cancels on timeout")
+    void claimPathUsesJobDeadlineAndCancels() throws Exception {
+        CompletableFuture<Object> cf = new CompletableFuture<>();
+        RuntimeException ex = assertThrows(RuntimeException.class, () ->
+            JobContext.withJob("job-1", 1L, () ->
+                JobsRuntimeManager.awaitFutureWithJobBudget(cf, "report_gen")));
+        assertTrue(ex.getMessage().contains("timed out after 1 seconds"),
+            "failure message must carry the actual budget. Got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("report_gen"),
+            "failure message must name the capability. Got: " + ex.getMessage());
+        assertTrue(cf.isCancelled(), "timed-out claim-path future must be cancelled");
+    }
+
+    @Test
+    @DisplayName("claim path without a deadline uses the 24h ceiling (no longer fully unbounded)")
+    void claimPathNoDeadlineHasCeiling() throws Exception {
+        assertEquals(86_400L, JobsRuntimeManager.NO_DEADLINE_AWAIT_CEILING_SECS,
+            "no-deadline ceiling is a leak backstop, not a policy timeout");
+        // Completed future returns immediately regardless.
+        CompletableFuture<Object> cf = CompletableFuture.completedFuture("v");
+        assertEquals("v", JobsRuntimeManager.awaitFutureWithJobBudget(cf, "cap"));
+    }
+}


### PR DESCRIPTION
## Summary
Closes the Java consolidated audit (#1164).

- **AOP-proxied `@MeshLlm` beans**: enrichment and `JobsRuntimeManager` lookups now unwrap proxies via `AopUtils.getTargetClass` (matching what the post-processors register), so `@Transactional`/`@Async`/`@Validated` beans no longer silently lose their `llm_provider` binding; a warn fires if an `@MeshLlm` lookup ever misses again.
- **Heartbeat schema parity**: the registry catalog and the MCP server now build tool input schemas through one shared `MeshSchemaSupport.buildToolInputSchema` (victools) — structured params publish full `properties`/`required`/`$defs` instead of bare `{"type":"object"}` stubs, so `input_schema_hash` represents the served schema (#547 cross-runtime matching) and `llm_tools` consumers see real parameter shapes. Per-param `$defs` are hoisted to the composed root with fixpoint collision disambiguation (also fixes previously-dangling `#/$defs/...` refs in the served schema; root-level `$defs` matches the Python/pydantic shape).
- **Async tool budgets**: inbound `CompletableFuture` tools await the propagated `X-Mesh-Timeout` budget (proportional safety margin so the structured timeout error beats the caller's socket timeout) instead of a hard-coded 30s; the claim path awaits the job's `max_duration` with a 24h backstop instead of `cf.get()` unbounded; futures are cancelled on timeout (freeing the dispatch thread and making late `complete()` a no-op — documented that orphaned work runs to completion, since `CompletableFuture.cancel` does not interrupt).
- **Async context propagation**: `generateAsync()` and parallel tool calls carry `TraceContext` + the invocation-context ThreadLocal to pool threads — `${ctx.*}` template vars and propagated headers (`X-Mesh-Job-Id`, `X-Mesh-Timeout`, allowlisted auth) now survive async/parallel paths.
- **Job-cancel watcher**: subscribe-after-fire race closed with a fired flag, and a new read-only Rust FFI probe (`mesh_job_cancel_fired`) distinguishes genuine cancels from natural job end — natural-end fires discard subscribers instead of cancelling healthy in-flight calls; older native libs degrade to the safe (slow, never-kills) direction.
- **Lows**: null-content assistant turns no longer NPE in buffered `generate()` (LinkedHashMap, mirroring streaming); fractional `X-Mesh-Timeout` parsing with logging; duplicate `@MeshTool` capability is a descriptive boot-time error (override-aware: inheritance/bridge/interface-contract patterns register exactly once via `MethodIntrospector`, sibling-bean conflicts fail fast); error responses serialized with Jackson (control chars no longer produce invalid JSON); `$defs` simple-name collisions disambiguated.

## Behavior changes — release-note visibility
- `input_schema_hash`/`input_schema_canonical` change for every Java tool with structured/collection params on next deploy (the point of the fix); integration suites snapshotting heartbeat hashes need a refresh.
- The MCP-served schema now includes `x-media-type` annotations (previously heartbeat-only) and `@Param` descriptions take precedence over type-derived descriptions on both surfaces.
- Duplicate-capability registration is now a boot error instead of silent last-wins.

## Review Notes
- Three review rounds. Round 1 found a blocker — the duplicate-capability check false-positived on inherited/overridden `@MeshTool` methods (Spring scans visit subclass + superclass `Method`s separately), which would have broken inheritance-based agents at boot — fixed with `MethodIntrospector`-based scanning and override-aware tolerance. Round 2 (focused) confirmed the blocker fix and surfaced the interface-contract asymmetry and a sibling-bean masking case; both closed in round 3 along with a `$defs` rename-cascade bug one nesting level deep (fixpoint iteration, with the reviewer's exact two-level case as a test).
- Includes a small Rust core addition: the read-only `mesh_job_cancel_fired` FFI export (+ regenerated header, jnr binding) with Rust-side tests.

Closes #1164

## Test plan
- [x] `mvn -pl mcp-mesh-spring-boot-starter -am test` — 416 tests, 0 failures; full reactor BUILD SUCCESS (incl. Spring AI 135)
- [x] `cargo test --features ffi jobs_ffi` — 25 passed
- [x] New suites: AOP-proxy enrichment (real CGLIB), schema parity (wrapper≡heartbeat byte-equality, canonical/hash through the Rust normalizer, two-level `$defs` collision), inheritance/interface/bridge registration, async budgets + cancellation, async context propagation, watcher cancel-vs-natural-end
- [ ] Integration suites on the next `tsuite-mesh:local` build (expect heartbeat-hash refresh for Java structured-param tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added job cancellation status checking to distinguish explicit cancellation from natural completion.
  * Enhanced async timeout handling with configurable per-request budgets and proper margin enforcement.
  * Improved tool input schema generation with collision detection for inherited/generic types.

* **Bug Fixes**
  * Fixed race condition in job cancellation watcher for in-flight HTTP requests.
  * Fixed context propagation (trace headers, timeouts) across thread pool boundaries in async operations.
  * Enhanced duplicate tool capability detection with clear error messages naming conflicting methods.
  * Improved tool discovery for inheritance hierarchies, interfaces, and AOP-proxied beans.

* **Tests**
  * Added comprehensive coverage for cancellation, timeout, schema, inheritance, and context propagation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->