### PR TITLE
fix(go): guarded health transitions, lifecycle-backed kills, locked process state, streaming proxy

### DIFF
--- a/src/core/cli/logs.go
+++ b/src/core/cli/logs.go
@@ -256,6 +256,18 @@ func readLogTailOnly(file *os.File, tailLines int) error {
 }
 
 func followLog(file *os.File, logPath string, tailLines int, sinceTime, untilTime *time.Time) error {
+	return followLogTo(os.Stdout, file, logPath, tailLines, sinceTime, untilTime, nil)
+}
+
+// followLogTo implements `logs -f` with tail -F semantics: when the watched
+// file is rotated away (RotateLogs renames it and a fresh file is created at
+// the same path), the follower drains what's left of the old file, reopens
+// logPath, and continues streaming from the new file instead of blocking
+// forever on the renamed inode.
+//
+// out receives the streamed lines; done (optional, may be nil) stops the
+// follower — both exist so tests can drive the loop deterministically.
+func followLogTo(out io.Writer, file *os.File, logPath string, tailLines int, sinceTime, untilTime *time.Time, done <-chan struct{}) error {
 	// First, print existing content (respecting tail)
 	if tailLines != 0 {
 		if err := readLog(file, tailLines, sinceTime, untilTime); err != nil {
@@ -279,49 +291,116 @@ func followLog(file *os.File, logPath string, tailLines int, sinceTime, untilTim
 		return fmt.Errorf("failed to watch log file: %w", err)
 	}
 
-	reader := bufio.NewReader(file)
+	// currentFile tracks the file we're streaming from; it diverges from the
+	// caller-owned `file` after a rotation. Close our reopened handle on exit
+	// (the caller's defer covers the original).
+	currentFile := file
+	defer func() {
+		if currentFile != file {
+			currentFile.Close()
+		}
+	}()
+
+	reader := bufio.NewReader(currentFile)
 
 	// Track last known timestamp for continuation lines
 	var lastKnownTime *time.Time
 
+	// emitNewLines drains complete lines from reader, applying time filters.
+	emitNewLines := func() {
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				break
+			}
+			line = strings.TrimSuffix(line, "\n")
+
+			// Apply time filters
+			if sinceTime != nil || untilTime != nil {
+				lineTime := parseLogTimestamp(line)
+				if lineTime != nil {
+					lastKnownTime = lineTime
+				}
+				effectiveTime := lineTime
+				if effectiveTime == nil {
+					effectiveTime = lastKnownTime
+				}
+				if effectiveTime != nil {
+					if sinceTime != nil && effectiveTime.Before(*sinceTime) {
+						continue
+					}
+					if untilTime != nil && effectiveTime.After(*untilTime) {
+						continue
+					}
+				}
+			}
+
+			fmt.Fprintln(out, line)
+		}
+	}
+
+	// reopenAfterRotation waits for a new file to appear at logPath (tail -F
+	// semantics: wait indefinitely, the agent may take a while to restart),
+	// then swaps the reader over to it and re-arms the watch.
+	reopenAfterRotation := func() error {
+		// Drain anything still buffered/readable from the rotated-away file.
+		emitNewLines()
+
+		var newFile *os.File
+		for {
+			f, err := os.Open(logPath)
+			if err == nil {
+				newFile = f
+				break
+			}
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to reopen log after rotation: %w", err)
+			}
+			select {
+			case <-done:
+				return nil
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+
+		if currentFile != file {
+			currentFile.Close()
+		}
+		currentFile = newFile
+		reader = bufio.NewReader(currentFile)
+
+		// Re-arm the watch on the new inode. Remove is best-effort — the old
+		// watch may already be gone along with the renamed file.
+		_ = watcher.Remove(logPath)
+		if err := watcher.Add(logPath); err != nil {
+			return fmt.Errorf("failed to re-watch log file after rotation: %w", err)
+		}
+
+		// Emit anything already written to the fresh file before the watch
+		// was re-armed.
+		emitNewLines()
+		return nil
+	}
+
 	// Watch for changes
 	for {
 		select {
+		case <-done:
+			return nil
 		case event, ok := <-watcher.Events:
 			if !ok {
 				return nil
 			}
-			if event.Op&fsnotify.Write == fsnotify.Write {
-				// Read new content
-				for {
-					line, err := reader.ReadString('\n')
-					if err != nil {
-						break
-					}
-					line = strings.TrimSuffix(line, "\n")
-
-					// Apply time filters
-					if sinceTime != nil || untilTime != nil {
-						lineTime := parseLogTimestamp(line)
-						if lineTime != nil {
-							lastKnownTime = lineTime
-						}
-						effectiveTime := lineTime
-						if effectiveTime == nil {
-							effectiveTime = lastKnownTime
-						}
-						if effectiveTime != nil {
-							if sinceTime != nil && effectiveTime.Before(*sinceTime) {
-								continue
-							}
-							if untilTime != nil && effectiveTime.After(*untilTime) {
-								continue
-							}
-						}
-					}
-
-					fmt.Println(line)
+			if event.Op&(fsnotify.Rename|fsnotify.Remove) != 0 {
+				// Log rotation: RotateLogs renames the file and a new one is
+				// created at the same path. Follow the path, not the inode.
+				if err := reopenAfterRotation(); err != nil {
+					return err
 				}
+				continue
+			}
+			if event.Op&fsnotify.Write == fsnotify.Write {
+				emitNewLines()
 			}
 		case err, ok := <-watcher.Errors:
 			if !ok {

--- a/src/core/cli/logs_follow_test.go
+++ b/src/core/cli/logs_follow_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncBuffer is a goroutine-safe bytes.Buffer for capturing follower output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// TestFollowLogSurvivesRotation verifies tail -F semantics: `logs -f` must
+// keep streaming after RotateLogs renames the file and a fresh one is created
+// at the same path. Pre-fix, followLog only handled fsnotify.Write and
+// blocked forever on the renamed inode.
+//
+// Writes are nudged in a poll loop rather than written once: fsnotify watch
+// arming races with the test's first write, and a lost first write would be
+// a test-harness flake, not the regression under test. The nudges cannot mask
+// a real rotation bug — with the old code the watch stays on the renamed
+// inode, so no amount of writes to the NEW file produces events.
+func TestFollowLogSurvivesRotation(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "agent.log")
+	if err := os.WriteFile(logPath, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := os.Open(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	out := &syncBuffer{}
+	done := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- followLogTo(out, file, logPath, 0, nil, nil, done)
+	}()
+
+	appendLine := func(line string) {
+		f, err := os.OpenFile(logPath, os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			t.Fatalf("append to %s: %v", logPath, err)
+		}
+		if _, err := f.WriteString(line + "\n"); err != nil {
+			t.Fatalf("write line: %v", err)
+		}
+		f.Close()
+	}
+
+	waitContains := func(needle string, nudge func()) bool {
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) {
+			if strings.Contains(out.String(), needle) {
+				return true
+			}
+			if nudge != nil {
+				nudge()
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		return strings.Contains(out.String(), needle)
+	}
+
+	// First half: confirm the follower is streaming pre-rotation.
+	if !waitContains("first-half", func() { appendLine("first-half") }) {
+		close(done)
+		t.Fatal("follower never streamed pre-rotation content")
+	}
+
+	// Rotate: rename away + create a fresh file at the same path (this is
+	// what RotateLogs + CreateLogFile do on agent restart).
+	if err := os.Rename(logPath, logPath+".1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(logPath, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second half: the follower must pick up the NEW file.
+	if !waitContains("second-half", func() { appendLine("second-half") }) {
+		close(done)
+		t.Fatal("follower did not stream content from the new file after rotation")
+	}
+
+	close(done)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("followLogTo returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("follower did not stop after done was closed")
+	}
+}

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -419,6 +419,8 @@ export MCP_MESH_PROXY_TIMEOUT=60
 export MCP_MESH_CALL_TIMEOUT=300
 ```
 
+Streamed responses (e.g., SSE) routed through the registry proxy are bounded by the same call timeout — the proxy ends the exchange when it elapses, even mid-stream. Send a larger `X-Mesh-Timeout` header (or raise `MCP_MESH_PROXY_TIMEOUT`) for long-lived streams.
+
 ## MeshJob event channel
 
 Tunables for the MeshJob event injection + stream subscription surface

--- a/src/core/cli/process_manager.go
+++ b/src/core/cli/process_manager.go
@@ -183,10 +183,33 @@ func (pm *ProcessManager) UntrackProcess(name string) bool {
 	return false
 }
 
-// GetProcess returns information about a managed process
+// clone returns a deep copy of the ProcessInfo so callers can't mutate (or
+// race on) the manager's shared state through the returned pointer. The
+// Process handle is intentionally shared: *os.Process is safe for concurrent
+// Signal/Kill calls and cloning it is not meaningful.
+func (info *ProcessInfo) clone() *ProcessInfo {
+	c := *info
+	if info.Environment != nil {
+		c.Environment = make(map[string]string, len(info.Environment))
+		for k, v := range info.Environment {
+			c.Environment[k] = v
+		}
+	}
+	if info.Metadata != nil {
+		c.Metadata = make(map[string]interface{}, len(info.Metadata))
+		for k, v := range info.Metadata {
+			c.Metadata[k] = v
+		}
+	}
+	return &c
+}
+
+// GetProcess returns a deep copy of a managed process's info. The write lock
+// is required (not RLock) because updateProcessStatus mutates the shared
+// struct (Status/LastSeen/HealthCheck/Process).
 func (pm *ProcessManager) GetProcess(name string) (*ProcessInfo, bool) {
-	pm.mutex.RLock()
-	defer pm.mutex.RUnlock()
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
 
 	info, exists := pm.processes[name]
 	if !exists {
@@ -196,19 +219,20 @@ func (pm *ProcessManager) GetProcess(name string) (*ProcessInfo, bool) {
 	// Update process status
 	pm.updateProcessStatus(info)
 
-	return info, true
+	return info.clone(), true
 }
 
-// GetAllProcesses returns all managed processes
+// GetAllProcesses returns deep copies of all managed processes. The write
+// lock is required (not RLock) because updateProcessStatus mutates the shared
+// structs; the copies mean concurrent callers never alias manager state.
 func (pm *ProcessManager) GetAllProcesses() map[string]*ProcessInfo {
-	pm.mutex.RLock()
-	defer pm.mutex.RUnlock()
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
 
-	// Create a copy to avoid race conditions
-	result := make(map[string]*ProcessInfo)
+	result := make(map[string]*ProcessInfo, len(pm.processes))
 	for name, info := range pm.processes {
 		pm.updateProcessStatus(info)
-		result[name] = info
+		result[name] = info.clone()
 	}
 
 	return result
@@ -236,7 +260,8 @@ func (pm *ProcessManager) cleanupDeadProcesses() []string {
 	return removed
 }
 
-// updateProcessStatus updates the status of a process
+// updateProcessStatus updates the status of a process.
+// Caller must hold pm.mutex (write lock) — this mutates the shared struct.
 func (pm *ProcessManager) updateProcessStatus(info *ProcessInfo) {
 	if info.Process == nil {
 		// Try to find process by PID if we don't have a handle

--- a/src/core/cli/process_manager_test.go
+++ b/src/core/cli/process_manager_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestProcessManager builds a ProcessManager directly (bypassing the
+// global singleton and config loading) with a temp state file.
+func newTestProcessManager(t *testing.T) *ProcessManager {
+	t.Helper()
+	return &ProcessManager{
+		processes:    make(map[string]*ProcessInfo),
+		logger:       NewCLILogger("TEST"),
+		stateFile:    filepath.Join(t.TempDir(), "processes.json"),
+		shutdownChan: make(chan struct{}),
+	}
+}
+
+func seedManagedProcess(pm *ProcessManager, name string, pid int) {
+	pm.processes[name] = &ProcessInfo{
+		PID:         pid,
+		Name:        name,
+		Command:     "test-cmd",
+		StartTime:   time.Now(),
+		Status:      "running",
+		HealthCheck: "unknown",
+		LastSeen:    time.Now(),
+		ServiceType: "agent",
+		Type:        "agent",
+		Environment: map[string]string{"MCP_MESH_TEST": "1"},
+		Metadata:    map[string]interface{}{"k": "v"},
+	}
+}
+
+// TestProcessManagerGettersReturnIsolatedCopies verifies MED-3: mutations on
+// the structs returned by GetProcess / GetAllProcesses must not leak into the
+// manager's shared state.
+func TestProcessManagerGettersReturnIsolatedCopies(t *testing.T) {
+	pm := newTestProcessManager(t)
+	seedManagedProcess(pm, "agent-a", os.Getpid())
+
+	got, ok := pm.GetProcess("agent-a")
+	if !ok {
+		t.Fatal("GetProcess: agent-a not found")
+	}
+	got.Status = "mutated"
+	got.HealthCheck = "mutated"
+	got.Environment["MCP_MESH_TEST"] = "mutated"
+	got.Metadata["k"] = "mutated"
+
+	all := pm.GetAllProcesses()
+	allCopy, ok := all["agent-a"]
+	if !ok {
+		t.Fatal("GetAllProcesses: agent-a not found")
+	}
+	allCopy.Status = "also-mutated"
+	allCopy.Environment["MCP_MESH_TEST"] = "also-mutated"
+
+	// Re-read: the manager's state must be unaffected by either mutation.
+	fresh, ok := pm.GetProcess("agent-a")
+	if !ok {
+		t.Fatal("GetProcess (re-read): agent-a not found")
+	}
+	if fresh.Status == "mutated" || fresh.Status == "also-mutated" {
+		t.Errorf("manager state Status leaked caller mutation: %q", fresh.Status)
+	}
+	if fresh.HealthCheck == "mutated" {
+		t.Errorf("manager state HealthCheck leaked caller mutation: %q", fresh.HealthCheck)
+	}
+	if fresh.Environment["MCP_MESH_TEST"] != "1" {
+		t.Errorf("manager state Environment leaked caller mutation: %q", fresh.Environment["MCP_MESH_TEST"])
+	}
+	if fresh.Metadata["k"] != "v" {
+		t.Errorf("manager state Metadata leaked caller mutation: %v", fresh.Metadata["k"])
+	}
+}
+
+// TestProcessManagerConcurrentGetters exercises concurrent GetAllProcesses +
+// GetProcess callers (the signal_handler.go pattern) under the race detector.
+// Pre-MED-3, GetAllProcesses mutated shared structs under RLock and returned
+// aliased pointers — `go test -race` flagged exactly this interleave.
+func TestProcessManagerConcurrentGetters(t *testing.T) {
+	pm := newTestProcessManager(t)
+	for i := 0; i < 5; i++ {
+		// Mix of live (our own PID) and dead PIDs so updateProcessStatus
+		// takes both branches.
+		pid := os.Getpid()
+		if i%2 == 1 {
+			pid = 0x7ffffff - i // certainly not a live PID
+		}
+		seedManagedProcess(pm, fmt.Sprintf("agent-%d", i), pid)
+	}
+
+	const goroutines = 8
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if i%2 == 0 {
+					all := pm.GetAllProcesses()
+					// Mutate the returned copies — must be race-free and
+					// must not affect the manager.
+					for _, info := range all {
+						info.Status = "scribbled"
+						info.LastSeen = time.Time{}
+					}
+				} else {
+					if info, ok := pm.GetProcess(fmt.Sprintf("agent-%d", g%5)); ok {
+						info.HealthCheck = "scribbled"
+					}
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// Manager state must never contain the scribbles.
+	for name, info := range pm.GetAllProcesses() {
+		if info.Status == "scribbled" || info.HealthCheck == "scribbled" {
+			t.Errorf("manager state for %s contains caller scribbles (status=%q health=%q)", name, info.Status, info.HealthCheck)
+		}
+	}
+}

--- a/src/core/cli/start_execution.go
+++ b/src/core/cli/start_execution.go
@@ -233,6 +233,11 @@ func buildAgentEnvironment(cmd *cobra.Command, registryURL string, config *CLICo
 // .group files and register registry/UI deps).
 func startAgentsWithEnv(agentPaths []string, env []string, cmd *cobra.Command, config *CLIConfig, locallyStartedRegistryPID int, groupID lifecycle.GroupID) error {
 	var agentCmds []*exec.Cmd
+	// agentCmdNames parallels agentCmds: the declared agent name resolved via
+	// extractAgentName (same resolution the detach path uses), so foreground
+	// PID files / process records carry the registered name instead of a
+	// filename-derived guess (#920/#1109 family).
+	var agentCmdNames []string
 	var watchers []*AgentWatcher
 	workingDir, _ := cmd.Flags().GetString("working-dir")
 	user, _ := cmd.Flags().GetString("user")
@@ -401,6 +406,7 @@ func startAgentsWithEnv(agentPaths []string, env []string, cmd *cobra.Command, c
 		} else {
 			// For foreground mode, we'll start the process later
 			agentCmds = append(agentCmds, agentCmd)
+			agentCmdNames = append(agentCmdNames, extractAgentName(absPath))
 		}
 	}
 
@@ -414,7 +420,7 @@ func startAgentsWithEnv(agentPaths []string, env []string, cmd *cobra.Command, c
 
 	// If running in foreground, start agents and wait
 	if len(agentCmds) > 0 || len(watchers) > 0 {
-		return runAgentsInForeground(agentCmds, watchers, cmd, config, locallyStartedRegistryPID, groupID, uiEnabled)
+		return runAgentsInForeground(agentCmds, agentCmdNames, watchers, cmd, config, locallyStartedRegistryPID, groupID, uiEnabled)
 	}
 
 	return nil
@@ -445,7 +451,7 @@ func registerInvocationDeps(group lifecycle.GroupID, agents []string, uiEnabled,
 	}
 }
 
-func runAgentsInForeground(agentCmds []*exec.Cmd, watchers []*AgentWatcher, cmd *cobra.Command, config *CLIConfig, locallyStartedRegistryPID int, groupID lifecycle.GroupID, uiEnabled bool) error {
+func runAgentsInForeground(agentCmds []*exec.Cmd, agentCmdNames []string, watchers []*AgentWatcher, cmd *cobra.Command, config *CLIConfig, locallyStartedRegistryPID int, groupID lifecycle.GroupID, uiEnabled bool) error {
 	// Setup signal handling
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
@@ -478,13 +484,13 @@ func runAgentsInForeground(agentCmds []*exec.Cmd, watchers []*AgentWatcher, cmd 
 			return fmt.Errorf("failed to start agent: %w", err)
 		}
 
+		// Use the declared agent name resolved at command-build time (same
+		// extractAgentName resolution as the detach path) so stop/logs find
+		// the agent under its registered name. Index fallback only guards a
+		// caller passing mismatched slices.
 		agentName := fmt.Sprintf("agent-%d", i)
-		for _, arg := range agentCmd.Args {
-			if strings.HasSuffix(arg, ".py") {
-				agentName = filepath.Base(arg)
-				agentName = strings.TrimSuffix(agentName, ".py")
-				break
-			}
+		if i < len(agentCmdNames) && agentCmdNames[i] != "" {
+			agentName = agentCmdNames[i]
 		}
 		trackedNames = append(trackedNames, agentName)
 		localAgentPIDsMu.Lock()

--- a/src/core/cli/utils.go
+++ b/src/core/cli/utils.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"mcp-mesh/src/core/cli/lifecycle"
 	"mcp-mesh/src/core/tlsutil"
 )
 
@@ -177,14 +178,56 @@ type PythonProcessFile struct {
 	LastUpdated   string                 `json:"last_updated"`
 }
 
-// GetRunningProcesses returns information about running MCP Mesh processes
-func GetRunningProcesses() ([]ProcessInfo, error) {
+// processesFilePath returns the path to ~/.mcp-mesh/processes.json.
+func processesFilePath() (string, error) {
 	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".mcp-mesh", "processes.json"), nil
+}
+
+// withProcessesLock serializes read-modify-write cycles on processes.json via
+// a dedicated flock (processes.json.lock). The lock is advisory but every
+// writer in this codebase goes through it, which covers both intra-process
+// concurrency (reaper goroutines + parallel shutdown kills) and cross-process
+// concurrency (multiple meshctl invocations).
+//
+// A dedicated lock file is used instead of the global lifecycle.lock to keep
+// processes.json in its own lock domain: lifecycle.lock serializes deps
+// register/unregister cycles, and sharing it would couple process-list updates
+// to that traffic — and would invite a same-goroutine flock re-acquisition
+// (flock is not reentrant) if a future caller ever touched processes.json
+// while already holding the lifecycle lock. No such call chain exists today;
+// this is isolation, not a fix for a current deadlock.
+func withProcessesLock(fn func() error) error {
+	processFile, err := processesFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(processFile), 0755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(processFile+".lock", os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return err
+	}
+	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return fn()
+}
+
+// readProcessesLocked reads and parses processes.json WITHOUT filtering dead
+// PIDs. Caller must hold the processes lock.
+func readProcessesLocked() ([]ProcessInfo, error) {
+	processFile, err := processesFilePath()
 	if err != nil {
 		return nil, err
 	}
-
-	processFile := filepath.Join(homeDir, ".mcp-mesh", "processes.json")
+	homeDir := filepath.Dir(filepath.Dir(processFile))
 
 	// One-time migration from legacy path (~/.mcp_mesh/ -> ~/.mcp-mesh/)
 	if _, err := os.Stat(processFile); os.IsNotExist(err) {
@@ -202,7 +245,7 @@ func GetRunningProcesses() ([]ProcessInfo, error) {
 	data, err := os.ReadFile(processFile)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return []ProcessInfo{}, nil
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -210,89 +253,152 @@ func GetRunningProcesses() ([]ProcessInfo, error) {
 	// Try to parse as Go format first (simple array)
 	var processes []ProcessInfo
 	if err := json.Unmarshal(data, &processes); err == nil {
+		return processes, nil
+	}
+
+	// Try to parse as Python format (complex structure)
+	var pythonFile PythonProcessFile
+	if err := json.Unmarshal(data, &pythonFile); err == nil {
+		// Return empty list when using Python format — the Python processes
+		// are managed differently and we don't want to interfere.
+		return nil, nil
+	}
+
+	// Both formats failed — the file is corrupt (e.g., a torn write from a
+	// pre-atomic-rename version). Quarantine the corrupt content for
+	// post-mortem (overwriting any previous quarantine) and reset the file to
+	// an empty list, so the warning fires exactly once instead of on every
+	// subsequent read.
+	corruptPath := processFile + ".corrupt"
+	if renameErr := os.Rename(processFile, corruptPath); renameErr == nil {
+		_ = saveProcessesLocked([]ProcessInfo{})
+		fmt.Fprintf(os.Stderr, "Warning: %s is not valid JSON; quarantined to %s and reset to an empty list\n", processFile, corruptPath)
+	} else {
+		fmt.Fprintf(os.Stderr, "Warning: %s is not valid JSON; treating process list as empty (quarantine failed: %v)\n", processFile, renameErr)
+	}
+	return nil, nil
+}
+
+// saveProcessesLocked writes processes.json atomically (temp file + rename) so
+// readers never observe a torn write. Caller must hold the processes lock.
+func saveProcessesLocked(processes []ProcessInfo) error {
+	processFile, err := processesFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(processFile), 0755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(processes, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(processFile), ".processes-*.json")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	// CreateTemp creates 0600; match the historical 0644 mode before rename.
+	if err := os.Chmod(tmpPath, 0644); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, processFile); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+// GetRunningProcesses returns information about running MCP Mesh processes.
+// Dead PIDs are filtered out and the pruned list is persisted back.
+func GetRunningProcesses() ([]ProcessInfo, error) {
+	var alive []ProcessInfo
+	err := withProcessesLock(func() error {
+		processes, err := readProcessesLocked()
+		if err != nil {
+			return err
+		}
+
 		// Filter out dead processes
-		var alive []ProcessInfo
 		for _, proc := range processes {
 			if IsProcessAlive(proc.PID) {
 				alive = append(alive, proc)
 			}
 		}
 
-		// Save the filtered list back
+		// Save the filtered list back (best-effort — the read result is
+		// still valid even if the prune fails to persist).
 		if len(alive) != len(processes) {
-			SaveRunningProcesses(alive)
+			_ = saveProcessesLocked(alive)
 		}
-
-		return alive, nil
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-
-	// Try to parse as Python format (complex structure)
-	var pythonFile PythonProcessFile
-	if err := json.Unmarshal(data, &pythonFile); err == nil {
-		// For now, return empty list when using Python format
-		// The Python processes are managed differently and we don't want to interfere
-		return []ProcessInfo{}, nil
+	if alive == nil {
+		alive = []ProcessInfo{}
 	}
-
-	// If both formats fail, return empty list
-	return []ProcessInfo{}, nil
+	return alive, nil
 }
 
 // SaveRunningProcesses saves the list of running processes
 func SaveRunningProcesses(processes []ProcessInfo) error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
-	mcpDir := filepath.Join(homeDir, ".mcp-mesh")
-	if err := os.MkdirAll(mcpDir, 0755); err != nil {
-		return err
-	}
-
-	processFile := filepath.Join(mcpDir, "processes.json")
-	data, err := json.MarshalIndent(processes, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	return os.WriteFile(processFile, data, 0644)
+	return withProcessesLock(func() error {
+		return saveProcessesLocked(processes)
+	})
 }
 
 // AddRunningProcess adds a process to the running processes list
 func AddRunningProcess(proc ProcessInfo) error {
-	processes, err := GetRunningProcesses()
-	if err != nil {
-		return err
-	}
-
-	// Remove any existing entry with the same PID
-	var filtered []ProcessInfo
-	for _, p := range processes {
-		if p.PID != proc.PID {
-			filtered = append(filtered, p)
+	return withProcessesLock(func() error {
+		processes, err := readProcessesLocked()
+		if err != nil {
+			return err
 		}
-	}
 
-	filtered = append(filtered, proc)
-	return SaveRunningProcesses(filtered)
+		// Remove any existing entry with the same PID
+		var filtered []ProcessInfo
+		for _, p := range processes {
+			if p.PID != proc.PID {
+				filtered = append(filtered, p)
+			}
+		}
+
+		filtered = append(filtered, proc)
+		return saveProcessesLocked(filtered)
+	})
 }
 
 // RemoveRunningProcess removes a process from the running processes list
 func RemoveRunningProcess(pid int) error {
-	processes, err := GetRunningProcesses()
-	if err != nil {
-		return err
-	}
-
-	var filtered []ProcessInfo
-	for _, p := range processes {
-		if p.PID != pid {
-			filtered = append(filtered, p)
+	return withProcessesLock(func() error {
+		processes, err := readProcessesLocked()
+		if err != nil {
+			return err
 		}
-	}
 
-	return SaveRunningProcesses(filtered)
+		var filtered []ProcessInfo
+		for _, p := range processes {
+			if p.PID != pid {
+				filtered = append(filtered, p)
+			}
+		}
+
+		return saveProcessesLocked(filtered)
+	})
 }
 
 // IsProcessAlive checks if a process is still running.
@@ -319,45 +425,26 @@ func IsProcessAlive(pid int) bool {
 	return !isProcessZombie(pid)
 }
 
-// KillProcess attempts to gracefully kill a process
+// KillProcess attempts to gracefully kill a process: SIGTERM first, then a
+// verified SIGKILL if the process doesn't exit within timeout.
+//
+// Delegates to lifecycle.KillPIDVerify so this legacy entry point inherits the
+// hardened kill semantics used by `meshctl stop`:
+//   - signals the whole process group (negative PID) with single-PID fallback,
+//     so children spawned by the agent die too (bug class #1033);
+//   - honors the caller's FULL timeout for the graceful phase (previously the
+//     timeout was silently capped at 5s, ignoring --shutdown-timeout);
+//   - verifies death after SIGKILL (zombie-aware poll) instead of
+//     fire-and-forget, returning an error if the process refuses to die.
 func KillProcess(pid int, timeout time.Duration) error {
 	if !IsProcessAlive(pid) {
 		return nil // Already dead
 	}
 
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return err
+	if !lifecycle.KillPIDVerify(pid, timeout) {
+		return fmt.Errorf("process %d still alive after SIGKILL", pid)
 	}
-
-	// Try graceful shutdown first (SIGINT for Python processes)
-	if err := process.Signal(os.Interrupt); err != nil {
-		// If SIGINT fails, try SIGTERM
-		if err := process.Signal(syscall.SIGTERM); err != nil {
-			return err
-		}
-	}
-
-	// For FastAPI agents, use shorter timeout and more frequent checks
-	// Most FastAPI agents terminate within 1-2 seconds
-	effectiveTimeout := timeout
-	if effectiveTimeout > 5*time.Second {
-		effectiveTimeout = 5 * time.Second // Cap at 5 seconds for responsive agents
-	}
-
-	// Wait for graceful shutdown with more frequent checks
-	deadline := time.Now().Add(effectiveTimeout)
-	checkInterval := 50 * time.Millisecond // Check every 50ms instead of 100ms
-
-	for time.Now().Before(deadline) {
-		if !IsProcessAlive(pid) {
-			return nil // Process terminated gracefully
-		}
-		time.Sleep(checkInterval)
-	}
-
-	// Force kill if graceful shutdown failed
-	return process.Signal(syscall.SIGKILL)
+	return nil
 }
 
 // StartPythonAgent starts a Python agent process

--- a/src/core/cli/utils_kill_test.go
+++ b/src/core/cli/utils_kill_test.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// pollProcessDead polls IsProcessAlive until the PID is dead (zombies count
+// as dead) or the deadline passes. Returns true iff confirmed dead.
+func pollProcessDead(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !IsProcessAlive(pid) {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return !IsProcessAlive(pid)
+}
+
+// TestKillProcessAlreadyDead verifies the fast path: a dead PID returns nil
+// immediately without signaling.
+func TestKillProcessAlreadyDead(t *testing.T) {
+	// Spawn and fully reap a short-lived process so the PID is dead.
+	cmd := exec.Command("true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run true: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	start := time.Now()
+	if err := KillProcess(pid, 5*time.Second); err != nil {
+		t.Errorf("KillProcess on dead PID: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("KillProcess on dead PID took %v, expected immediate return", elapsed)
+	}
+}
+
+// TestKillProcessKillsProcessGroup verifies KillProcess signals the whole
+// process group (bug class #1033): a child that spawned a grandchild in the
+// same pgid must take the grandchild down with it.
+func TestKillProcessKillsProcessGroup(t *testing.T) {
+	t.Parallel()
+
+	gpidFile := filepath.Join(t.TempDir(), "gpid")
+	// bash backgrounds a long sleep (the grandchild, same pgid), records its
+	// PID, then blocks in wait.
+	cmd := exec.Command("bash", "-c", fmt.Sprintf("sleep 300 & echo $! > %q; wait", gpidFile))
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn bash: %v", err)
+	}
+	childPID := cmd.Process.Pid
+
+	// Reap from a goroutine and synchronize on it after the kill so the
+	// child's zombie is gone before we assert death (#1176 reap race).
+	waitDone := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(waitDone)
+	}()
+	t.Cleanup(func() { _ = syscall.Kill(-childPID, syscall.SIGKILL) })
+
+	// Wait for the grandchild PID to be recorded.
+	var gpid int
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(gpidFile); err == nil {
+			if v, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil && v > 0 {
+				gpid = v
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if gpid == 0 {
+		t.Fatal("grandchild PID was never recorded")
+	}
+	if !IsProcessAlive(gpid) {
+		t.Fatalf("grandchild %d should be alive before kill", gpid)
+	}
+
+	if err := KillProcess(childPID, 3*time.Second); err != nil {
+		t.Fatalf("KillProcess: %v", err)
+	}
+
+	// Synchronize the child's reap, then assert both child and grandchild died.
+	select {
+	case <-waitDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("child was not reaped after KillProcess")
+	}
+	if IsProcessAlive(childPID) {
+		t.Errorf("child %d still alive after KillProcess", childPID)
+	}
+	// Grandchild is reparented to init after the child dies; poll until init
+	// reaps it (zombie counts as dead via IsProcessAlive's zombie filter).
+	if !pollProcessDead(gpid, 3*time.Second) {
+		t.Errorf("grandchild %d still alive after KillProcess — process group was not signaled", gpid)
+	}
+}
+
+// TestKillProcessHonorsTimeoutBeyondFiveSeconds guards against the legacy 5s
+// hard cap: a process whose graceful shutdown takes ~6s must be allowed to
+// finish when the caller passes a 9s timeout (e.g., --shutdown-timeout 9),
+// instead of being SIGKILLed at the 5s mark.
+//
+// The trap handler sleeps 6s and then writes a marker file before exiting; a
+// SIGKILL at 5s would prevent the marker from ever appearing.
+func TestKillProcessHonorsTimeoutBeyondFiveSeconds(t *testing.T) {
+	t.Parallel()
+
+	marker := filepath.Join(t.TempDir(), "graceful-exit")
+	script := fmt.Sprintf("trap 'sleep 6; touch %q; exit 0' TERM; while :; do sleep 0.2; done", marker)
+	cmd := exec.Command("bash", "-c", script)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn bash: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	waitDone := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(waitDone)
+	}()
+	t.Cleanup(func() { _ = syscall.Kill(-pid, syscall.SIGKILL) })
+
+	// Give bash a moment to install the trap.
+	time.Sleep(200 * time.Millisecond)
+
+	start := time.Now()
+	if err := KillProcess(pid, 9*time.Second); err != nil {
+		t.Fatalf("KillProcess: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	select {
+	case <-waitDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("process was not reaped after KillProcess")
+	}
+
+	if elapsed < 5500*time.Millisecond {
+		t.Errorf("KillProcess returned after %v — graceful phase appears capped below the caller's timeout", elapsed)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("graceful-exit marker missing (%v) — process was SIGKILLed before its ~6s graceful shutdown finished", err)
+	}
+}

--- a/src/core/cli/utils_processes_test.go
+++ b/src/core/cli/utils_processes_test.go
@@ -1,0 +1,247 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// readRawProcessesFile reads and parses processes.json directly, WITHOUT the
+// liveness filtering GetRunningProcesses applies — the test PIDs are fake.
+func readRawProcessesFile(t *testing.T) []ProcessInfo {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("home dir: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".mcp-mesh", "processes.json"))
+	if err != nil {
+		t.Fatalf("read processes.json: %v", err)
+	}
+	var procs []ProcessInfo
+	if err := json.Unmarshal(data, &procs); err != nil {
+		t.Fatalf("processes.json is not valid JSON (torn write?): %v", err)
+	}
+	return procs
+}
+
+// TestConcurrentProcessFileUpdates verifies MED-4: concurrent Add/Remove
+// read-modify-write cycles on processes.json must not lose updates (each
+// cycle is serialized by the flock) and must never produce a torn write
+// (atomic temp+rename).
+func TestConcurrentProcessFileUpdates(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const n = 40
+	basePID := 1_000_000 // fake PIDs; never touched by liveness checks here
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			proc := ProcessInfo{
+				PID:  basePID + i,
+				Name: fmt.Sprintf("agent-%d", i),
+				Type: "agent",
+			}
+			if err := AddRunningProcess(proc); err != nil {
+				t.Errorf("AddRunningProcess(%d): %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	procs := readRawProcessesFile(t)
+	if len(procs) != n {
+		t.Fatalf("after %d concurrent adds, file has %d entries — updates were lost", n, len(procs))
+	}
+	seen := make(map[int]bool, len(procs))
+	for _, p := range procs {
+		seen[p.PID] = true
+	}
+	for i := 0; i < n; i++ {
+		if !seen[basePID+i] {
+			t.Errorf("entry for PID %d missing after concurrent adds", basePID+i)
+		}
+	}
+
+	// Concurrent removes of the first half (parallel-shutdown-kill pattern).
+	for i := 0; i < n/2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if err := RemoveRunningProcess(basePID + i); err != nil {
+				t.Errorf("RemoveRunningProcess(%d): %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	procs = readRawProcessesFile(t)
+	if len(procs) != n/2 {
+		t.Fatalf("after %d concurrent removes, file has %d entries, want %d", n/2, len(procs), n/2)
+	}
+	for _, p := range procs {
+		if p.PID < basePID+n/2 {
+			t.Errorf("PID %d should have been removed", p.PID)
+		}
+	}
+}
+
+// TestGetRunningProcessesWarnsOnCorruptFile verifies that a torn/corrupt
+// processes.json falls back to an empty list WITH a warning on stderr instead
+// of silently pretending nothing was ever tracked.
+func TestGetRunningProcessesWarnsOnCorruptFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	mcpDir := filepath.Join(home, ".mcp-mesh")
+	if err := os.MkdirAll(mcpDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mcpDir, "processes.json"), []byte("{\"truncated\": [1, 2"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture stderr around the call.
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+
+	procs, gerr := GetRunningProcesses()
+
+	w.Close()
+	os.Stderr = oldStderr
+	captured, _ := io.ReadAll(r)
+	r.Close()
+
+	if gerr != nil {
+		t.Fatalf("GetRunningProcesses on corrupt file: %v", gerr)
+	}
+	if len(procs) != 0 {
+		t.Errorf("expected empty list for corrupt file, got %d entries", len(procs))
+	}
+	if !strings.Contains(string(captured), "not valid JSON") {
+		t.Errorf("expected parse-failure warning on stderr, got: %q", string(captured))
+	}
+}
+
+// TestCorruptProcessFileSelfHealsOnce verifies that a corrupt processes.json
+// is quarantined to processes.json.corrupt (overwriting any previous
+// quarantine) and reset to an empty list on the first read, so the warning
+// fires exactly once and subsequent reads are silent.
+func TestCorruptProcessFileSelfHealsOnce(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	mcpDir := filepath.Join(home, ".mcp-mesh")
+	if err := os.MkdirAll(mcpDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	processFile := filepath.Join(mcpDir, "processes.json")
+	corruptFile := processFile + ".corrupt"
+
+	corruptContent := []byte("{\"truncated\": [1, 2")
+	if err := os.WriteFile(processFile, corruptContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+	// A stale quarantine from a previous incident must be overwritten.
+	if err := os.WriteFile(corruptFile, []byte("old quarantine"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	captureStderr := func(fn func()) string {
+		t.Helper()
+		oldStderr := os.Stderr
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		os.Stderr = w
+		fn()
+		w.Close()
+		os.Stderr = oldStderr
+		captured, _ := io.ReadAll(r)
+		r.Close()
+		return string(captured)
+	}
+
+	// First read: warns, quarantines, heals.
+	first := captureStderr(func() {
+		procs, err := GetRunningProcesses()
+		if err != nil {
+			t.Errorf("first GetRunningProcesses: %v", err)
+		}
+		if len(procs) != 0 {
+			t.Errorf("expected empty list for corrupt file, got %d entries", len(procs))
+		}
+	})
+	if !strings.Contains(first, "not valid JSON") {
+		t.Errorf("expected parse-failure warning on first read, got: %q", first)
+	}
+
+	quarantined, err := os.ReadFile(corruptFile)
+	if err != nil {
+		t.Fatalf("read quarantine file: %v", err)
+	}
+	if string(quarantined) != string(corruptContent) {
+		t.Errorf("quarantine file content = %q, want original corrupt content %q", quarantined, corruptContent)
+	}
+
+	healed, err := os.ReadFile(processFile)
+	if err != nil {
+		t.Fatalf("read healed processes.json: %v", err)
+	}
+	var procs []ProcessInfo
+	if err := json.Unmarshal(healed, &procs); err != nil {
+		t.Errorf("healed processes.json is not valid JSON: %v (content: %q)", err, healed)
+	}
+	if len(procs) != 0 {
+		t.Errorf("healed processes.json should be an empty list, got %d entries", len(procs))
+	}
+
+	// Second read: silent.
+	second := captureStderr(func() {
+		procs, err := GetRunningProcesses()
+		if err != nil {
+			t.Errorf("second GetRunningProcesses: %v", err)
+		}
+		if len(procs) != 0 {
+			t.Errorf("expected empty list on second read, got %d entries", len(procs))
+		}
+	})
+	if second != "" {
+		t.Errorf("expected no warning on second read, got: %q", second)
+	}
+}
+
+// TestAddRunningProcessReplacesSamePID preserves the historical dedupe
+// behavior: re-adding a PID replaces the existing entry instead of
+// duplicating it.
+func TestAddRunningProcessReplacesSamePID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := AddRunningProcess(ProcessInfo{PID: 1_000_001, Name: "old-name", Type: "agent"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddRunningProcess(ProcessInfo{PID: 1_000_001, Name: "new-name", Type: "agent"}); err != nil {
+		t.Fatal(err)
+	}
+
+	procs := readRawProcessesFile(t)
+	if len(procs) != 1 {
+		t.Fatalf("expected 1 entry after re-add of same PID, got %d", len(procs))
+	}
+	if procs[0].Name != "new-name" {
+		t.Errorf("expected re-add to replace entry, got name %q", procs[0].Name)
+	}
+}

--- a/src/core/database/ent_database.go
+++ b/src/core/database/ent_database.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"path/filepath"
@@ -257,7 +258,9 @@ func (db *EntDatabase) Transaction(ctx context.Context, fn func(*ent.Tx) error) 
 
 	if err := fn(tx); err != nil {
 		if rerr := tx.Rollback(); rerr != nil {
-			return fmt.Errorf("rolling back transaction: %w", rerr)
+			// Preserve the original error — it explains WHY we rolled back —
+			// alongside the rollback failure.
+			return errors.Join(err, fmt.Errorf("rolling back transaction: %w", rerr))
 		}
 		return err
 	}
@@ -291,7 +294,9 @@ func (db *EntDatabase) TransactionWithOptions(ctx context.Context, opts *sql.TxO
 
 	if err := fn(tx); err != nil {
 		if rerr := tx.Rollback(); rerr != nil {
-			return fmt.Errorf("rolling back transaction: %w", rerr)
+			// Preserve the original error — it explains WHY we rolled back —
+			// alongside the rollback failure.
+			return errors.Join(err, fmt.Errorf("rolling back transaction: %w", rerr))
 		}
 		return err
 	}

--- a/src/core/registry/ent_handlers.go
+++ b/src/core/registry/ent_handlers.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"mcp-mesh/src/core/ent"
 	"mcp-mesh/src/core/ent/agent"
 	"mcp-mesh/src/core/registry/generated"
 )
@@ -871,16 +871,18 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 			proxyTimeout = time.Duration(secs) * time.Second
 		}
 	}
+	// http.Client is cheap to build per request; the expensive part (the
+	// Transport with its connection pool + TLS material) is shared. Plain
+	// HTTP rides http.DefaultTransport's pool; HTTPS uses the cached mTLS
+	// transport below. Client.Timeout covers the full exchange including the
+	// streamed body, preserving the X-Mesh-Timeout cap.
 	client := &http.Client{
 		Timeout: proxyTimeout,
 	}
 
 	// Configure TLS transport for HTTPS targets (mTLS proxy support).
-	// Hostname verification is intentionally skipped because --tls-auto
-	// generates certs with SANs for 127.0.0.1/::1 only, while agents in
-	// K8s bind to pod IPs.  We still verify the peer cert chain against
-	// our mesh CA so only certs issued by the same CA are accepted.
-	// Target legitimacy is already enforced by isRegisteredAgentEndpoint().
+	// The transport is built once and cached; it is rebuilt automatically if
+	// the CA/cert/key files change on disk (mtime/size check per request).
 	if scheme == "https" {
 		// Require the full mTLS bundle for HTTPS proxy calls.
 		caPath := os.Getenv("MCP_MESH_TLS_CA")
@@ -895,9 +897,9 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 			return
 		}
 
-		caCert, err := os.ReadFile(caPath)
+		transport, err := getProxyTLSTransport(caPath, certPath, keyPath)
 		if err != nil {
-			log.Printf("ERROR: failed to read CA cert %s: %v", caPath, err)
+			log.Printf("ERROR: %v", err)
 			// Sanitize response: full detail (paths, OS errors) stays in server log only (#794).
 			c.JSON(http.StatusInternalServerError, generated.ErrorResponse{
 				Error:     "Proxy TLS misconfiguration",
@@ -905,48 +907,7 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 			})
 			return
 		}
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(caCert) {
-			log.Printf("ERROR: failed to parse CA cert from %s (empty or malformed PEM)", caPath)
-			// Sanitize response: full detail stays in server log only (#794).
-			c.JSON(http.StatusInternalServerError, generated.ErrorResponse{
-				Error:     "Proxy TLS misconfiguration",
-				Timestamp: time.Now().UTC(),
-			})
-			return
-		}
-
-		clientCert, err := tls.LoadX509KeyPair(certPath, keyPath)
-		if err != nil {
-			log.Printf("ERROR: failed to load client cert/key (%s, %s): %v", certPath, keyPath, err)
-			// Sanitize response: full detail (paths, OS errors) stays in server log only (#794).
-			c.JSON(http.StatusInternalServerError, generated.ErrorResponse{
-				Error:     "Proxy TLS misconfiguration",
-				Timestamp: time.Now().UTC(),
-			})
-			return
-		}
-
-		// Skip hostname check but verify the cert chain against our CA.
-		tlsConfig := &tls.Config{
-			InsecureSkipVerify: true,
-			Certificates:      []tls.Certificate{clientCert},
-			VerifyConnection: func(cs tls.ConnectionState) error {
-				if len(cs.PeerCertificates) == 0 {
-					return fmt.Errorf("no peer certificates presented")
-				}
-				opts := x509.VerifyOptions{
-					Roots:         caCertPool,
-					Intermediates: x509.NewCertPool(),
-				}
-				for _, cert := range cs.PeerCertificates[1:] {
-					opts.Intermediates.AddCert(cert)
-				}
-				_, err := cs.PeerCertificates[0].Verify(opts)
-				return err
-			},
-		}
-		client.Transport = &http.Transport{TLSClientConfig: tlsConfig}
+		client.Transport = transport
 	}
 
 	resp, err := client.Do(proxyReq)
@@ -959,25 +920,152 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 	}
 	defer resp.Body.Close()
 
-	// Read response body
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		c.JSON(http.StatusBadGateway, generated.ErrorResponse{
-			Error:     fmt.Sprintf("Failed to read response from agent: %v", err),
-			Timestamp: time.Now().UTC(),
-		})
-		return
-	}
-
-	// Copy response headers
+	// Copy response headers (Add, not Set, to preserve multi-value headers).
 	for key, values := range resp.Header {
 		for _, value := range values {
-			c.Header(key, value)
+			c.Writer.Header().Add(key, value)
 		}
 	}
+	c.Status(resp.StatusCode)
 
-	// Return the response with the same status code
-	c.Data(resp.StatusCode, resp.Header.Get("Content-Type"), body)
+	// Stream the body instead of buffering it whole: large tool results don't
+	// balloon registry memory, and SSE responses reach the client as they are
+	// produced. Flush after every chunk so streamed (SSE) responses aren't
+	// held back by the response writer's buffer; gin's ResponseWriter
+	// implements http.Flusher.
+	buf := make([]byte, 32*1024)
+	for {
+		n, rerr := resp.Body.Read(buf)
+		if n > 0 {
+			if _, werr := c.Writer.Write(buf[:n]); werr != nil {
+				// Client went away — nothing useful left to do.
+				return
+			}
+			c.Writer.Flush()
+		}
+		if rerr != nil {
+			if rerr != io.EOF {
+				log.Printf("WARNING: proxy stream from %s ended early: %v", targetURL, rerr)
+			}
+			return
+		}
+	}
+}
+
+// proxyTLSCacheEntry holds the cached mTLS transport for the proxy along with
+// the on-disk identity (path + mtime + size) of the material it was built
+// from, so cert rotation is picked up without restarting the registry.
+type proxyTLSCacheEntry struct {
+	transport *http.Transport
+	caPath    string
+	certPath  string
+	keyPath   string
+	caStamp   fileStamp
+	certStamp fileStamp
+	keyStamp  fileStamp
+}
+
+type fileStamp struct {
+	modTime time.Time
+	size    int64
+}
+
+var (
+	proxyTLSCacheMu sync.Mutex
+	proxyTLSCache   *proxyTLSCacheEntry
+)
+
+func stampFile(path string) (fileStamp, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return fileStamp{}, err
+	}
+	return fileStamp{modTime: fi.ModTime(), size: fi.Size()}, nil
+}
+
+// getProxyTLSTransport returns the shared mTLS transport for /proxy/* HTTPS
+// calls, building it on first use and rebuilding it if any of the CA, cert,
+// or key files change (path or content stamp). The per-request cost is three
+// os.Stat calls instead of reading + parsing the full PEM material.
+//
+// Hostname verification is intentionally skipped because --tls-auto generates
+// certs with SANs for 127.0.0.1/::1 only, while agents in K8s bind to pod
+// IPs. We still verify the peer cert chain against our mesh CA so only certs
+// issued by the same CA are accepted. Target legitimacy is already enforced
+// by isRegisteredAgentEndpoint().
+func getProxyTLSTransport(caPath, certPath, keyPath string) (*http.Transport, error) {
+	caStamp, err := stampFile(caPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat CA cert %s: %w", caPath, err)
+	}
+	certStamp, err := stampFile(certPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat client cert %s: %w", certPath, err)
+	}
+	keyStamp, err := stampFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat client key %s: %w", keyPath, err)
+	}
+
+	proxyTLSCacheMu.Lock()
+	defer proxyTLSCacheMu.Unlock()
+
+	if e := proxyTLSCache; e != nil &&
+		e.caPath == caPath && e.certPath == certPath && e.keyPath == keyPath &&
+		e.caStamp == caStamp && e.certStamp == certStamp && e.keyStamp == keyStamp {
+		return e.transport, nil
+	}
+
+	caCert, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA cert %s: %w", caPath, err)
+	}
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to parse CA cert from %s (empty or malformed PEM)", caPath)
+	}
+
+	clientCert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client cert/key (%s, %s): %w", certPath, keyPath, err)
+	}
+
+	// Skip hostname check but verify the cert chain against our CA.
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		Certificates:       []tls.Certificate{clientCert},
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			if len(cs.PeerCertificates) == 0 {
+				return fmt.Errorf("no peer certificates presented")
+			}
+			opts := x509.VerifyOptions{
+				Roots:         caCertPool,
+				Intermediates: x509.NewCertPool(),
+			}
+			for _, cert := range cs.PeerCertificates[1:] {
+				opts.Intermediates.AddCert(cert)
+			}
+			_, err := cs.PeerCertificates[0].Verify(opts)
+			return err
+		},
+	}
+
+	// Close idle connections of the transport we're replacing so a rotation
+	// doesn't leave stale TLS sessions pooled forever.
+	if proxyTLSCache != nil && proxyTLSCache.transport != nil {
+		proxyTLSCache.transport.CloseIdleConnections()
+	}
+
+	proxyTLSCache = &proxyTLSCacheEntry{
+		transport: &http.Transport{TLSClientConfig: tlsConfig},
+		caPath:    caPath,
+		certPath:  certPath,
+		keyPath:   keyPath,
+		caStamp:   caStamp,
+		certStamp: certStamp,
+		keyStamp:  keyStamp,
+	}
+	return proxyTLSCache.transport, nil
 }
 
 // isRegisteredAgentEndpoint checks if the given host:port is a registered agent.
@@ -993,39 +1081,60 @@ func (h *EntBusinessLogicHandlers) isRegisteredAgentEndpoint(ctx context.Context
 	}
 
 	host := parts[0]
+	portInt, err := strconv.Atoi(parts[1])
+	if err != nil || portInt <= 0 {
+		return false, "", "", nil // Invalid port
+	}
 
-	// Query all agents and check if any matches this endpoint
-	params := &AgentQueryParams{}
-	resp, err := h.entService.ListAgents(params)
+	// Narrow query instead of loading ALL agents with four eager edges per
+	// proxy call: only agents on the requested port whose HTTP host, ID, or
+	// name matches the requested host can possibly satisfy the checks below.
+	candidates, err := h.entService.entDB.Client.Agent.
+		Query().
+		Where(
+			agent.HTTPPortEQ(portInt),
+			agent.HTTPHostNEQ(""),
+			agent.Or(
+				agent.HTTPHostEQ(host),
+				agent.IDEQ(host),
+				agent.NameEQ(host),
+			),
+		).
+		All(ctx)
 	if err != nil {
 		return false, "", "", err
 	}
 
-	port := parts[1]
+	// Prefer the direct host:port match, mirroring the historical behavior of
+	// "exact endpoint match wins over ID/Name fallback".
+	//
+	// Scheme derivation matches ListAgents: https when the agent registered
+	// with a TLS entity identity, http otherwise.
+	schemeFor := func(a *ent.Agent) string {
+		if a.EntityID != nil && *a.EntityID != "" {
+			return "https"
+		}
+		return "http"
+	}
+	for _, a := range candidates {
+		if a.HTTPHost == host {
+			return true, schemeFor(a), fmt.Sprintf("%s:%d", a.HTTPHost, a.HTTPPort), nil
+		}
+	}
 
-	for _, agent := range resp.Agents {
-		// Parse the registered endpoint URL for accurate host:port matching
-		if agent.Endpoint != "" {
-			parsedEP, err := url.Parse(agent.Endpoint)
-			if err == nil {
-				// Direct host:port match against parsed endpoint
-				if parsedEP.Host == hostPort {
-					return true, parsedEP.Scheme, parsedEP.Host, nil
-				}
-				// Match by agent ID (primary: callers use full agent IDs like "fortuna-abc12345").
-				// Also match by agent Name as a fallback for future base-name proxying
-				// (e.g., /proxy/fortuna:8080 -> any replica named "fortuna") and to stay
-				// backward-compatible with old SDK versions that sent Name == ID.
-				//
-				// Matching by Name as a fallback is intentional — it routes to an
-				// arbitrary replica when multiple share a base name. The registry
-				// proxy is a dev/test convenience and replica targeting is not a
-				// dev concern; to target a specific replica, port-forward to it
-				// directly.
-				if (agent.Id == host || agent.Name == host) && parsedEP.Port() == port {
-					return true, parsedEP.Scheme, parsedEP.Host, nil
-				}
-			}
+	// Match by agent ID (primary: callers use full agent IDs like "fortuna-abc12345").
+	// Also match by agent Name as a fallback for future base-name proxying
+	// (e.g., /proxy/fortuna:8080 -> any replica named "fortuna") and to stay
+	// backward-compatible with old SDK versions that sent Name == ID.
+	//
+	// Matching by Name as a fallback is intentional — it routes to an
+	// arbitrary replica when multiple share a base name. The registry
+	// proxy is a dev/test convenience and replica targeting is not a
+	// dev concern; to target a specific replica, port-forward to it
+	// directly.
+	for _, a := range candidates {
+		if a.ID == host || a.Name == host {
+			return true, schemeFor(a), fmt.Sprintf("%s:%d", a.HTTPHost, a.HTTPPort), nil
 		}
 	}
 

--- a/src/core/registry/ent_service.go
+++ b/src/core/registry/ent_service.go
@@ -66,18 +66,6 @@ type RegistryConfig struct {
 	AdminPort                int    // admin API port — from MCP_MESH_ADMIN_PORT (0 = disabled)
 }
 
-// ResponseCache provides caching functionality matching Python implementation
-type ResponseCache struct {
-	cache   map[string]CacheEntry
-	ttl     time.Duration
-	enabled bool
-}
-
-type CacheEntry struct {
-	Data      interface{}
-	Timestamp time.Time
-}
-
 // AgentRegistrationRequest matches Python RegisterAgentRequest exactly
 type AgentRegistrationRequest struct {
 	AgentID   string                 `json:"agent_id" binding:"required"`
@@ -249,7 +237,6 @@ type HeartbeatResponse struct {
 type EntService struct {
 	entDB       *database.EntDatabase
 	config      *RegistryConfig
-	cache       *ResponseCache
 	validator   *AgentRegistrationValidator
 	logger      *logger.Logger
 	hookManager *AgentStatusChangeHookManager
@@ -269,12 +256,6 @@ func NewEntService(entDB *database.EntDatabase, config *RegistryConfig, logger *
 		}
 	}
 
-	cache := &ResponseCache{
-		cache:   make(map[string]CacheEntry),
-		ttl:     time.Duration(config.CacheTTL) * time.Second,
-		enabled: config.EnableResponseCache,
-	}
-
 	// Initialize status change hook manager
 	hookManager := NewAgentStatusChangeHookManager(logger, true) // Enable hooks by default
 
@@ -285,7 +266,6 @@ func NewEntService(entDB *database.EntDatabase, config *RegistryConfig, logger *
 	service := &EntService{
 		entDB:       entDB,
 		config:      config,
-		cache:       cache,
 		validator:   NewAgentRegistrationValidator(),
 		logger:      logger,
 		hookManager: hookManager,
@@ -993,6 +973,16 @@ func (s *EntService) StoreDependencyResolutions(
 // All three need to be flipped together when an agent goes offline so that
 // consumer-side state stays consistent before the FK-driven SetNull leaves
 // the rows dangling with status=available.
+//
+// Called from unregisterAgentAttempt (graceful shutdown) and from the health
+// monitor's unhealthy transition (after its optimistic update wins). The sweep
+// job performs its own equivalent flip inside the purge transaction. The
+// reverse transition needs no special handling here: when a provider comes
+// back, its register/heartbeat creates a "register"/status-change registry
+// event, consumers' HEAD heartbeats detect the topology change and trigger a
+// full POST heartbeat, and StoreDependencyResolutions /
+// StoreLLMToolResolutions / StoreLLMProviderResolutions delete-and-recreate
+// the consumer's rows with status=available.
 func (s *EntService) UpdateDependencyStatusOnAgentOffline(ctx context.Context, agentID string) error {
 	if _, err := s.entDB.DependencyResolution.Update().
 		Where(dependencyresolution.ProviderAgentIDEQ(agentID)).
@@ -1847,8 +1837,7 @@ func (s *EntService) Health() map[string]interface{} {
 			}
 			return "sqlite"
 		}(),
-		"cache_enabled": s.cache.enabled,
-		"stats":         stats,
+		"stats": stats,
 	}
 }
 
@@ -2119,6 +2108,15 @@ func (s *EntService) unregisterAgentAttempt(ctx context.Context, agentID string)
 	err = tx.Commit()
 	if err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	// Flip all resolution rows that point at this provider to unavailable so
+	// consumer-side state stays consistent immediately rather than waiting for
+	// the sweep job's purge (up to retention window later). Best-effort: the
+	// unregister itself already committed; a failure here is logged and the
+	// sweep will eventually fix the rows.
+	if err := s.UpdateDependencyStatusOnAgentOffline(ctx, agentID); err != nil {
+		s.logger.Warning("Failed to mark resolutions unavailable for unregistered agent %s: %v", agentID, err)
 	}
 
 	s.logger.Info("Created unregister event and marked agent %s as unhealthy (graceful shutdown)", agentID)

--- a/src/core/registry/health_monitor.go
+++ b/src/core/registry/health_monitor.go
@@ -110,22 +110,66 @@ func (h *AgentHealthMonitor) checkUnhealthyAgents() {
 	// Update each agent while preserving their original updated_at timestamp.
 	// Individual updates needed because Ent's UpdateDefault(time.Now) would
 	// auto-bump updated_at in a batch update, making agents appear recently seen.
-	var agentsUpdated int
+	var agentsUpdated, racesLost int
 	for _, a := range agentsToUpdate {
-		_, err := h.entService.entDB.Client.Agent.
-			Update().
-			Where(agent.IDEQ(a.ID)).
-			SetStatus(agent.StatusUnhealthy).
-			SetUpdatedAt(a.UpdatedAt).
-			Save(ctx)
+		won, err := h.markAgentUnhealthyIfUnchanged(ctx, a)
 		if err != nil {
 			h.logger.Error("Failed to mark agent %s as unhealthy: %v", a.ID, err)
 			continue
 		}
+		if !won {
+			// Race lost: a concurrent heartbeat updated the row between our
+			// query and this update. The agent is alive — leave it alone.
+			racesLost++
+			continue
+		}
 		agentsUpdated++
+
+		// Flip all resolution rows that point at this now-offline provider to
+		// unavailable so consumer-side state stays consistent (see
+		// UpdateDependencyStatusOnAgentOffline). Only the race-winner gets
+		// here, so a concurrently-heartbeating agent never has its rows
+		// flipped. Best-effort: a failure here is logged, not fatal — the
+		// sweep job's purge will eventually fix the rows.
+		if err := h.entService.UpdateDependencyStatusOnAgentOffline(ctx, a.ID); err != nil {
+			h.logger.Warning("Failed to mark resolutions unavailable for unhealthy agent %s: %v", a.ID, err)
+		}
 	}
 
-	h.logger.Info("Health monitor: marked %d agents as unhealthy", agentsUpdated)
+	if racesLost > 0 {
+		h.logger.Info("Health monitor: marked %d agents as unhealthy (%d skipped due to concurrent heartbeat)", agentsUpdated, racesLost)
+	} else {
+		h.logger.Info("Health monitor: marked %d agents as unhealthy", agentsUpdated)
+	}
+}
+
+// markAgentUnhealthyIfUnchanged flips a single agent to unhealthy using an
+// optimistic conditional update (same pattern as markAgentStaleAttempt): the
+// WHERE clause re-checks that the row still has the status and updated_at we
+// observed when we queried it. A concurrent heartbeat between the staleness
+// query and this update changes updated_at (and possibly status), so the
+// update affects 0 rows and we report the race as lost instead of overwriting
+// the heartbeat and rolling the timestamp back.
+//
+// The original updated_at is deliberately preserved on success: that field is
+// the agent's last-heartbeat timestamp from the sweep job's perspective
+// (purgeStaleAgents filters on UpdatedAtLT(now-retention)); bumping it would
+// make a long-silent agent survive sweeps it should not.
+func (h *AgentHealthMonitor) markAgentUnhealthyIfUnchanged(ctx context.Context, a *ent.Agent) (bool, error) {
+	affected, err := h.entService.entDB.Client.Agent.
+		Update().
+		Where(
+			agent.IDEQ(a.ID),
+			agent.UpdatedAtEQ(a.UpdatedAt),
+			agent.StatusEQ(a.Status),
+		).
+		SetStatus(agent.StatusUnhealthy).
+		SetUpdatedAt(a.UpdatedAt).
+		Save(ctx)
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
 }
 
 // IsRunning returns whether the health monitor is currently running

--- a/src/core/registry/health_monitor_test.go
+++ b/src/core/registry/health_monitor_test.go
@@ -1,0 +1,337 @@
+package registry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"mcp-mesh/src/core/config"
+	"mcp-mesh/src/core/database"
+	"mcp-mesh/src/core/ent"
+	"mcp-mesh/src/core/ent/agent"
+	"mcp-mesh/src/core/ent/dependencyresolution"
+	"mcp-mesh/src/core/ent/enttest"
+	"mcp-mesh/src/core/ent/llmproviderresolution"
+	"mcp-mesh/src/core/ent/llmtoolresolution"
+	"mcp-mesh/src/core/logger"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// newHealthMonitorTestEnv constructs an in-memory Ent client + EntService +
+// health monitor with the given heartbeat timeout. Status change hooks are
+// disabled (like the sweep tests) so direct Ent status updates don't create
+// extra registry events.
+func newHealthMonitorTestEnv(t *testing.T, heartbeatTimeout time.Duration) (*ent.Client, *EntService, *AgentHealthMonitor, func()) {
+	t.Helper()
+
+	client := enttest.Open(t, "sqlite3", "file:healthmon_"+t.Name()+"?mode=memory&cache=shared&_fk=1")
+	testLogger := logger.New(&config.Config{LogLevel: "ERROR"})
+	entDB := &database.EntDatabase{Client: client}
+	service := NewEntService(entDB, nil, testLogger)
+	service.DisableStatusChangeHooks()
+
+	monitor := NewAgentHealthMonitor(service, testLogger, heartbeatTimeout, time.Minute)
+
+	cleanup := func() {
+		client.Close()
+	}
+	return client, service, monitor, cleanup
+}
+
+// seedProviderResolutions inserts one row per resolution table, all pointing
+// consumer -> provider with status=available.
+func seedProviderResolutions(t *testing.T, client *ent.Client, consumerID, providerID string) {
+	t.Helper()
+	ctx := context.Background()
+
+	_, err := client.DependencyResolution.Create().
+		SetConsumerAgentID(consumerID).
+		SetConsumerFunctionName("do_thing").
+		SetCapabilityRequired("widget").
+		SetProviderAgentID(providerID).
+		SetProviderFunctionName("widget_impl").
+		SetEndpoint("http://provider:8080").
+		SetStatus(dependencyresolution.StatusAvailable).
+		SetResolvedAt(time.Now().UTC()).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("seed dep resolution: %v", err)
+	}
+
+	_, err = client.LLMToolResolution.Create().
+		SetConsumerAgentID(consumerID).
+		SetConsumerFunctionName("ask_llm").
+		SetProviderAgentID(providerID).
+		SetProviderFunctionName("time_tool").
+		SetProviderCapability("time_service").
+		SetEndpoint("http://provider:8080").
+		SetStatus(llmtoolresolution.StatusAvailable).
+		SetResolvedAt(time.Now().UTC()).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("seed llm tool resolution: %v", err)
+	}
+
+	_, err = client.LLMProviderResolution.Create().
+		SetConsumerAgentID(consumerID).
+		SetConsumerFunctionName("ask_llm").
+		SetRequiredCapability("llm").
+		SetProviderAgentID(providerID).
+		SetProviderFunctionName("llm").
+		SetEndpoint("http://provider:8080").
+		SetStatus(llmproviderresolution.StatusAvailable).
+		SetResolvedAt(time.Now().UTC()).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("seed llm provider resolution: %v", err)
+	}
+}
+
+// assertProviderResolutionStatuses asserts the status of the seeded rows in
+// all three resolution tables for the given consumer.
+func assertProviderResolutionStatuses(t *testing.T, client *ent.Client, consumerID string, wantAvailable bool) {
+	t.Helper()
+	ctx := context.Background()
+
+	depRows, err := client.DependencyResolution.Query().
+		Where(dependencyresolution.ConsumerAgentIDEQ(consumerID)).
+		All(ctx)
+	if err != nil || len(depRows) != 1 {
+		t.Fatalf("query dep resolutions: err=%v len=%d", err, len(depRows))
+	}
+	toolRows, err := client.LLMToolResolution.Query().
+		Where(llmtoolresolution.ConsumerAgentIDEQ(consumerID)).
+		All(ctx)
+	if err != nil || len(toolRows) != 1 {
+		t.Fatalf("query llm tool resolutions: err=%v len=%d", err, len(toolRows))
+	}
+	provRows, err := client.LLMProviderResolution.Query().
+		Where(llmproviderresolution.ConsumerAgentIDEQ(consumerID)).
+		All(ctx)
+	if err != nil || len(provRows) != 1 {
+		t.Fatalf("query llm provider resolutions: err=%v len=%d", err, len(provRows))
+	}
+
+	if wantAvailable {
+		if depRows[0].Status != dependencyresolution.StatusAvailable {
+			t.Errorf("dep resolution status = %s, want available", depRows[0].Status)
+		}
+		if toolRows[0].Status != llmtoolresolution.StatusAvailable {
+			t.Errorf("llm tool resolution status = %s, want available", toolRows[0].Status)
+		}
+		if provRows[0].Status != llmproviderresolution.StatusAvailable {
+			t.Errorf("llm provider resolution status = %s, want available", provRows[0].Status)
+		}
+	} else {
+		if depRows[0].Status != dependencyresolution.StatusUnavailable {
+			t.Errorf("dep resolution status = %s, want unavailable", depRows[0].Status)
+		}
+		if toolRows[0].Status != llmtoolresolution.StatusUnavailable {
+			t.Errorf("llm tool resolution status = %s, want unavailable", toolRows[0].Status)
+		}
+		if provRows[0].Status != llmproviderresolution.StatusUnavailable {
+			t.Errorf("llm provider resolution status = %s, want unavailable", provRows[0].Status)
+		}
+	}
+}
+
+// TestHealthMonitorMarksStaleAgentUnhealthy verifies the happy path: a stale
+// agent is flipped to unhealthy with its updated_at PRESERVED (not bumped),
+// and all three resolution tables pointing at it are flipped to unavailable
+// (MED-5 wiring).
+func TestHealthMonitorMarksStaleAgentUnhealthy(t *testing.T) {
+	client, _, monitor, cleanup := newHealthMonitorTestEnv(t, time.Minute)
+	defer cleanup()
+	ctx := context.Background()
+
+	staleTime := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Millisecond)
+	seedAgent(t, client, "provider", agent.StatusHealthy, staleTime)
+	seedAgent(t, client, "consumer", agent.StatusHealthy, time.Now().UTC())
+	seedProviderResolutions(t, client, "consumer", "provider")
+
+	monitor.checkUnhealthyAgents()
+
+	got, err := client.Agent.Get(ctx, "provider")
+	if err != nil {
+		t.Fatalf("reload provider: %v", err)
+	}
+	if got.Status != agent.StatusUnhealthy {
+		t.Errorf("provider status = %s, want unhealthy", got.Status)
+	}
+	if !got.UpdatedAt.Equal(staleTime) {
+		t.Errorf("provider updated_at = %v, want preserved %v", got.UpdatedAt, staleTime)
+	}
+
+	// Consumer (fresh heartbeat) must be untouched.
+	gotConsumer, err := client.Agent.Get(ctx, "consumer")
+	if err != nil {
+		t.Fatalf("reload consumer: %v", err)
+	}
+	if gotConsumer.Status != agent.StatusHealthy {
+		t.Errorf("consumer status = %s, want healthy", gotConsumer.Status)
+	}
+
+	// All three resolution tables flipped to unavailable.
+	assertProviderResolutionStatuses(t, client, "consumer", false)
+}
+
+// TestHealthMonitorSkipsConcurrentHeartbeat simulates the MED-1 interleave:
+// the monitor queries a stale snapshot, a heartbeat lands on the row, and the
+// monitor's guarded update must affect 0 rows — leaving the agent healthy
+// with its CURRENT (heartbeat) timestamp instead of overwriting it unhealthy
+// with a rolled-back timestamp.
+func TestHealthMonitorSkipsConcurrentHeartbeat(t *testing.T) {
+	client, _, monitor, cleanup := newHealthMonitorTestEnv(t, time.Minute)
+	defer cleanup()
+	ctx := context.Background()
+
+	staleTime := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Millisecond)
+	seedAgent(t, client, "racer", agent.StatusHealthy, staleTime)
+	seedAgent(t, client, "consumer", agent.StatusHealthy, time.Now().UTC())
+	seedProviderResolutions(t, client, "consumer", "racer")
+
+	// Step 1: the monitor's staleness query loads a snapshot.
+	snapshot, err := client.Agent.Get(ctx, "racer")
+	if err != nil {
+		t.Fatalf("load snapshot: %v", err)
+	}
+
+	// Step 2: a heartbeat lands between query and update.
+	heartbeatTime := time.Now().UTC().Truncate(time.Millisecond)
+	if _, err := client.Agent.UpdateOneID("racer").
+		SetStatus(agent.StatusHealthy).
+		SetUpdatedAt(heartbeatTime).
+		Save(ctx); err != nil {
+		t.Fatalf("simulate heartbeat: %v", err)
+	}
+
+	// Step 3: the monitor's guarded update runs with the stale snapshot and
+	// must lose the race (0 rows affected, no error).
+	won, err := monitor.markAgentUnhealthyIfUnchanged(ctx, snapshot)
+	if err != nil {
+		t.Fatalf("markAgentUnhealthyIfUnchanged: %v", err)
+	}
+	if won {
+		t.Error("guarded update must lose the race against a concurrent heartbeat")
+	}
+
+	got, err := client.Agent.Get(ctx, "racer")
+	if err != nil {
+		t.Fatalf("reload agent: %v", err)
+	}
+	if got.Status != agent.StatusHealthy {
+		t.Errorf("agent status = %s, want healthy (heartbeat must win)", got.Status)
+	}
+	if !got.UpdatedAt.Equal(heartbeatTime) {
+		t.Errorf("agent updated_at = %v, want heartbeat time %v (must NOT be rolled back to %v)",
+			got.UpdatedAt, heartbeatTime, staleTime)
+	}
+
+	// Race-lost path must NOT flip resolution rows either.
+	assertProviderResolutionStatuses(t, client, "consumer", true)
+}
+
+// TestHealthMonitorFullPassSkipsConcurrentHeartbeat exercises the same race
+// through checkUnhealthyAgents itself: the agent heartbeats after seeding but
+// the monitor query then no longer sees it as stale — and a stale OTHER agent
+// in the same pass is still flipped. Guards against the per-agent failure
+// affecting the whole batch.
+func TestHealthMonitorFullPassSkipsConcurrentHeartbeat(t *testing.T) {
+	client, _, monitor, cleanup := newHealthMonitorTestEnv(t, time.Minute)
+	defer cleanup()
+	ctx := context.Background()
+
+	staleTime := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Millisecond)
+	seedAgent(t, client, "stale-a", agent.StatusHealthy, staleTime)
+	seedAgent(t, client, "fresh-b", agent.StatusHealthy, time.Now().UTC())
+
+	monitor.checkUnhealthyAgents()
+
+	gotA, _ := client.Agent.Get(ctx, "stale-a")
+	if gotA.Status != agent.StatusUnhealthy {
+		t.Errorf("stale-a status = %s, want unhealthy", gotA.Status)
+	}
+	gotB, _ := client.Agent.Get(ctx, "fresh-b")
+	if gotB.Status != agent.StatusHealthy {
+		t.Errorf("fresh-b status = %s, want healthy", gotB.Status)
+	}
+}
+
+// TestUnregisterAgentFlipsResolutions verifies the MED-5 wiring on the
+// graceful-shutdown path: UnregisterAgent marks the agent unhealthy AND flips
+// all three resolution tables pointing at it to unavailable.
+func TestUnregisterAgentFlipsResolutions(t *testing.T) {
+	client, service, _, cleanup := newHealthMonitorTestEnv(t, time.Minute)
+	defer cleanup()
+	ctx := context.Background()
+
+	seedAgent(t, client, "provider", agent.StatusHealthy, time.Now().UTC())
+	seedAgent(t, client, "consumer", agent.StatusHealthy, time.Now().UTC())
+	seedProviderResolutions(t, client, "consumer", "provider")
+
+	if err := service.UnregisterAgent(ctx, "provider"); err != nil {
+		t.Fatalf("UnregisterAgent: %v", err)
+	}
+
+	got, err := client.Agent.Get(ctx, "provider")
+	if err != nil {
+		t.Fatalf("reload provider: %v", err)
+	}
+	if got.Status != agent.StatusUnhealthy {
+		t.Errorf("provider status = %s, want unhealthy", got.Status)
+	}
+
+	assertProviderResolutionStatuses(t, client, "consumer", false)
+}
+
+// TestReturningProviderRestoresResolutions documents the reverse transition:
+// when the provider comes back, the consumer's next FULL heartbeat re-resolves
+// and StoreDependencyResolutions recreates the row with status=available.
+// (HEAD heartbeats detect the provider's "register" event as a topology
+// change, which is what triggers that full refresh in production.)
+func TestReturningProviderRestoresResolutions(t *testing.T) {
+	client, service, _, cleanup := newHealthMonitorTestEnv(t, time.Minute)
+	defer cleanup()
+	ctx := context.Background()
+
+	seedAgent(t, client, "provider", agent.StatusHealthy, time.Now().UTC())
+	seedAgent(t, client, "consumer", agent.StatusHealthy, time.Now().UTC())
+	seedProviderResolutions(t, client, "consumer", "provider")
+
+	// Provider goes away gracefully — rows flip to unavailable.
+	if err := service.UnregisterAgent(ctx, "provider"); err != nil {
+		t.Fatalf("UnregisterAgent: %v", err)
+	}
+	assertProviderResolutionStatuses(t, client, "consumer", false)
+
+	// Provider returns; consumer's full-heartbeat persistence path runs.
+	resolutions := []IndexedResolution{
+		{
+			FunctionName: "do_thing",
+			DepIndex:     0,
+			Spec:         DependencySpec{Capability: "widget"},
+			Resolution: &DependencyResolution{
+				AgentID:      "provider",
+				FunctionName: "widget_impl",
+				Endpoint:     "http://provider:8080",
+				Capability:   "widget",
+				Status:       "available",
+			},
+			Status: "available",
+		},
+	}
+	if err := service.StoreDependencyResolutions(ctx, "consumer", resolutions); err != nil {
+		t.Fatalf("StoreDependencyResolutions: %v", err)
+	}
+
+	depRows, err := client.DependencyResolution.Query().
+		Where(dependencyresolution.ConsumerAgentIDEQ("consumer")).
+		All(ctx)
+	if err != nil || len(depRows) != 1 {
+		t.Fatalf("query dep resolutions: err=%v len=%d", err, len(depRows))
+	}
+	if depRows[0].Status != dependencyresolution.StatusAvailable {
+		t.Errorf("dep resolution status = %s, want available after provider returns", depRows[0].Status)
+	}
+}


### PR DESCRIPTION
## Summary
Closes the Go core consolidated audit (#1165).

- **Health monitor races**: unhealthy transitions now use optimistic conditional updates (`UpdatedAtEQ` + `StatusEQ`, the `markAgentStaleAttempt` pattern) — a concurrent heartbeat wins instead of being overwritten unhealthy with a rolled-back timestamp, which could previously feed the sweep purge a live agent.
- **Offline resolution flips**: the previously-dead `UpdateDependencyStatusOnAgentOffline` is wired into graceful unregister (post-commit, best-effort) and the monitor's race-winning transition — `dependency_resolution`/`llm_*_resolution` rows flip to `unavailable` immediately instead of waiting up to `MCP_MESH_RETENTION` (1h) for the purge. Returning providers restore through the existing topology-change → full-heartbeat re-resolution path (verified and pinned by test).
- **`KillProcess` delegates to `lifecycle.KillPIDVerify`**: caller's full timeout honored (the silent 5s cap is gone), process-group signaling (the #1033 orphan class), zombie-aware polling, verified SIGKILL. First signal is now SIGTERM (was SIGINT) — not observable for mesh runtimes, which register identical handlers for both.
- **Process state**: `ProcessManager` getters deep-copy under the write lock (was: mutation under `RLock` + aliased pointers — a textbook `-race` finding); `processes.json` read-modify-write runs under a dedicated flock with temp-file + atomic rename; corrupt files quarantine to `.corrupt` and self-heal once instead of warning forever.
- **Registry `/proxy/*`**: streams bodies with per-chunk flush (SSE through the proxy now works), caches the TLS transport keyed on cert file mtime/size, and validates targets with a narrow indexed Ent query instead of loading every agent with four eager edges per call.
- **Smaller**: `meshctl logs -f` survives log rotation (tail -F semantics); foreground agents get declared-name lifecycle files via `extractAgentName` (the #920/#1109 divergence family, fixed for detach but not foreground); transaction helpers `errors.Join` rollback errors instead of masking the root cause; the dead mutex-less `ResponseCache` is deleted.

## Behavior changes — release-note visibility
- Resolution rows flip to `unavailable` immediately on provider unregister/unhealthy (previously up to 1h stale).
- The registry proxy now streams; streamed exchanges are bounded by `X-Mesh-Timeout` / the 60s default — documented in the environment man page. Previously long streams were buffered then failed entirely, so this is strictly better, but the cap is newly user-visible.
- A mid-stream upstream failure now yields a truncated body on an already-sent 200 (transport-level truncation is detectable) instead of a buffered 502 — inherent to streaming, accepted deliberately.

## Review Notes
- Independent review: 0 blockers, 3 warnings — all addressed (false lock-rationale comment rewritten, corrupt-file self-heal added, streaming timeout documented in the man page). 
- Review verified the narrow proxy query is semantically identical to the old all-agents scan (no false negatives; match preference is now deterministic), the guarded update is safe against Ent auto-bump (schema has no `UpdateDefault`), and the flock split has no re-acquisition path.
- Follow-up candidates surfaced: `CACHE_TTL`/`ENABLE_RESPONSE_CACHE` env vars are now config-only dead weight; `ProcessInfo.clone()` is one-level deep (nested `Metadata` values stay aliased).

Closes #1165

## Test plan
- [x] `go test ./src/core/... -race -count=1` — all packages ok; `go build ./...` clean
- [x] New tests: health-monitor race interleave, kill timeout/group semantics (reap-synchronized per #1176), ProcessManager `-race` concurrency, processes.json concurrent RMW + corrupt-file quarantine, logs rotation follow
- [ ] Integration suites on the next `tsuite-mesh:local` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added log rotation support to `logs -f`, now seamlessly continues tailing after log files are rotated or renamed.

* **Bug Fixes**
  * Fixed process tracking concurrency issues and corruption handling in process state files.
  * Improved proxy response streaming and timeout handling for long-lived connections.
  * Corrected agent identity tracking consistency across startup modes.

* **Documentation**
  * Clarified timeout behavior for streamed responses through the proxy.

* **Tests**
  * Added comprehensive test coverage for log rotation, process management, and health monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->