### PR TITLE
fix(rust): sticky shutdown, pooled trace publisher, generation-tagged cancel registry, FFI hygiene

### DIFF
--- a/src/runtime/core/Cargo.lock
+++ b/src/runtime/core/Cargo.lock
@@ -167,6 +167,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,9 +1597,12 @@ version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "014cc767fefab6a3e798ca45112bccad9c6e0e218fbd49720042716c73cfef44"
 dependencies = [
+ "arc-swap",
+ "backon",
  "bytes",
  "cfg-if",
  "combine",
+ "futures-channel",
  "futures-util",
  "itoa",
  "num-bigint",

--- a/src/runtime/core/Cargo.toml
+++ b/src/runtime/core/Cargo.toml
@@ -2,6 +2,11 @@
 name = "mcp-mesh-core"
 version = "2.4.0"
 edition = "2021"
+# MSRV. CI builds with moving stable (dtolnay/rust-toolchain@stable);
+# this floor documents the newest stdlib API the crate relies on
+# (u64::is_multiple_of, stabilized in 1.87) so older toolchains fail
+# with a clear error instead of a confusing method-not-found.
+rust-version = "1.87"
 description = "Rust core runtime for MCP Mesh agents"
 license = "MIT"
 authors = ["MCP Mesh Team"]
@@ -52,8 +57,12 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2"
 uuid = { version = "1", features = ["v4"] }
 
-# Redis for distributed tracing
-redis = { version = "0.32.7", features = ["tokio-comp"] }
+# Redis for distributed tracing. `connection-manager` provides the
+# crate's blessed reconnecting wrapper (`aio::ConnectionManager`): one
+# multiplexed connection created at init, cloned per publish, with
+# automatic background reconnect when a command fails — instead of a
+# fresh TCP dial + handshake per span (issue #1166 MED-3).
+redis = { version = "0.32.7", features = ["tokio-comp", "connection-manager"] }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/runtime/core/include/mcp_mesh_core.h
+++ b/src/runtime/core/include/mcp_mesh_core.h
@@ -89,13 +89,17 @@ struct MeshAgentHandle *mesh_start_agent(const char *spec_json);
 //
 // # Safety
 // * `handle` must be a valid handle from `mesh_start_agent`
-void mesh_shutdown(struct MeshAgentHandle *handle);
+void mesh_shutdown(const struct MeshAgentHandle *handle);
 
 // Free agent handle and associated resources.
 //
 // If the agent is still running, this will trigger graceful shutdown
 // and wait briefly (up to 2 seconds) for the agent to unregister from
 // the registry before dropping resources.
+//
+// Also drains queued trace spans (up to 2 seconds, equivalent to
+// `mesh_flush_spans(2000)`) so spans published during the agent's final
+// moments are not lost.
 //
 // # Safety
 // * `handle` must be a valid handle from `mesh_start_agent` or NULL
@@ -104,7 +108,16 @@ void mesh_free_handle(struct MeshAgentHandle *handle);
 
 // Get next event from agent runtime.
 //
-// Blocks until event available or timeout.
+// Blocks until event available or timeout. The timeout covers the FULL
+// wait, including acquisition of the internal receiver lock — a
+// `timeout_ms = 0` (non-blocking) or finite-timeout call returns within
+// its budget even while another thread is parked in an infinite
+// `mesh_next_event` wait on the same handle.
+//
+// Each event is delivered to exactly ONE caller: the receiver is a
+// shared single-consumer queue, not a broadcast. With multiple
+// concurrent callers, an event goes to whichever caller dequeues it
+// first.
 //
 // # Arguments
 // * `handle` - Agent handle
@@ -116,7 +129,7 @@ void mesh_free_handle(struct MeshAgentHandle *handle);
 // # Safety
 // * `handle` must be a valid handle from `mesh_start_agent`
 // * The returned string must be freed with `mesh_free_string`
-char *mesh_next_event(struct MeshAgentHandle *handle, int64_t timeout_ms);
+char *mesh_next_event(const struct MeshAgentHandle *handle, int64_t timeout_ms);
 
 // Check if agent is still running.
 //
@@ -142,7 +155,7 @@ int32_t mesh_is_running(const struct MeshAgentHandle *handle);
 // # Safety
 // * `handle` must be a valid handle from `mesh_start_agent`
 // * `status` must be a valid null-terminated C string
-int32_t mesh_report_health(struct MeshAgentHandle *handle, const char *status);
+int32_t mesh_report_health(const struct MeshAgentHandle *handle, const char *status);
 
 // Update the HTTP port after auto-detection.
 //
@@ -159,7 +172,7 @@ int32_t mesh_report_health(struct MeshAgentHandle *handle, const char *status);
 //
 // # Safety
 // * `handle` must be a valid handle from `mesh_start_agent`
-int32_t mesh_update_port(struct MeshAgentHandle *handle, int32_t port);
+int32_t mesh_update_port(const struct MeshAgentHandle *handle, int32_t port);
 
 // Get last error message.
 //
@@ -296,18 +309,40 @@ int32_t mesh_is_trace_publisher_available(void);
 
 // Publish a trace span to Redis.
 //
-// Non-blocking (from the caller's perspective) - returns after queuing the span.
-// Silently handles failures to never break agent operations.
+// Non-blocking (from the caller's perspective) - returns after queuing the span
+// onto a bounded in-process queue drained by the tracing runtime, which
+// performs the actual Redis XADD asynchronously. Silently handles failures
+// to never break agent operations; on queue overflow the span is dropped
+// (counted, logged periodically).
 //
 // # Arguments
 // * `span_json` - JSON string containing span data (all values should be strings)
 //
 // # Returns
-// 1 on success (queued), 0 on failure
+// 1 on success (queued), 0 on failure (not initialized, invalid input,
+// or queue full)
 //
 // # Safety
 // * `span_json` must be a valid null-terminated C string
 int32_t mesh_publish_span(const char *span_json);
+
+// Flush queued trace spans.
+//
+// Blocks until every span queued via `mesh_publish_span` before this
+// call has been published to Redis (or dropped on a publish error), or
+// until `timeout_ms` elapses. `mesh_free_handle` calls this
+// automatically with a 2-second budget so an agent's final spans are not
+// lost at teardown; embedders that need a different budget (or that
+// publish spans after freeing the handle) can call it directly.
+//
+// # Arguments
+// * `timeout_ms` - Maximum time to wait in milliseconds; negative values
+//   are treated as 0
+//
+// # Returns
+// 1 if the queue fully drained (or the publisher was never initialized),
+// 0 on timeout
+int32_t mesh_flush_spans(int64_t timeout_ms);
 
 // Extract JSON from LLM response text.
 //

--- a/src/runtime/core/include/mcp_mesh_core.h
+++ b/src/runtime/core/include/mcp_mesh_core.h
@@ -61,6 +61,16 @@ typedef struct JobProxyHandle JobProxyHandle;
 // This struct holds all resources needed to interact with the agent runtime.
 // It must be freed with `mesh_free_handle` when no longer needed.
 //
+// Lifetime: the raw pointer handed to C is `Arc`-managed
+// (`Arc::into_raw` in `mesh_start_agent`). Every accessor takes a
+// temporary strong reference for the duration of the call (see
+// `handle_guard`), and `mesh_free_handle` releases the creation
+// reference — so freeing while another thread is still inside
+// `mesh_next_event` / `mesh_report_health` / etc. defers the actual
+// drop until the last in-flight call returns instead of yanking the
+// memory out from under it (use-after-free under the "safe from any
+// thread" contract).
+//
 // Note: This struct is intentionally NOT `#[repr(C)]` to keep its internals
 // opaque to C consumers. The FFI functions work with raw pointers.
 typedef struct MeshAgentHandle MeshAgentHandle;
@@ -101,9 +111,23 @@ void mesh_shutdown(const struct MeshAgentHandle *handle);
 // `mesh_flush_spans(2000)`) so spans published during the agent's final
 // moments are not lost.
 //
+// Safe to call while other threads are still inside `mesh_*` accessors
+// on the same handle (including a `mesh_next_event` parked on an
+// infinite timeout): the handle is reference-counted, so this releases
+// the creation reference and the underlying resources are dropped when
+// the last in-flight call returns. A parked infinite `mesh_next_event`
+// unparks on its own — the graceful shutdown triggered here makes the
+// runtime emit the shutdown event and then exit, closing the event
+// channel, so the parked caller observes the shutdown event (or channel
+// close → NULL) and returns. Only if the runtime is wedged and never
+// processes the shutdown signal does a parked infinite wait keep the
+// resources alive (a leak, not a crash).
+//
 // # Safety
 // * `handle` must be a valid handle from `mesh_start_agent` or NULL
-// * After this call, `handle` is invalid and must not be used
+// * After this call, `handle` is invalid and must not be passed to any
+//   `mesh_*` function (calls already in flight are safe; new calls are
+//   not)
 void mesh_free_handle(struct MeshAgentHandle *handle);
 
 // Get next event from agent runtime.

--- a/src/runtime/core/src/cancel_registry.rs
+++ b/src/runtime/core/src/cancel_registry.rs
@@ -490,18 +490,25 @@ mod tests {
 
     #[test]
     fn active_job_count_reflects_registrations() {
-        // Don't make absolute assertions about the count (other tests run
-        // in parallel) — just check delta within this test's lifetime.
-        let baseline = active_job_count();
+        // The registry is process-global and other tests register/
+        // unregister concurrently, so NO baseline comparison is safe: a
+        // `count >= baseline + 2` snapshot races concurrent unregisters
+        // (the baseline may include jobs that vanish before our assert).
+        // The only race-free assertion is the lower bound guaranteed by
+        // our own live registrations.
         let id1 = unique_id("count-1");
         let id2 = unique_id("count-2");
 
         let gen1 = register_active_job(&id1, CancellationToken::new());
         let gen2 = register_active_job(&id2, CancellationToken::new());
-        assert!(active_job_count() >= baseline + 2);
+        // Our two jobs are registered right now, so the global map holds
+        // at least 2 entries regardless of what parallel tests do.
+        assert!(active_job_count() >= 2);
 
         unregister_active_job(&id1, gen1);
         unregister_active_job(&id2, gen2);
+        assert!(get_state(&id1).is_none(), "id1 must be gone after unregister");
+        assert!(get_state(&id2).is_none(), "id2 must be gone after unregister");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/src/runtime/core/src/cancel_registry.rs
+++ b/src/runtime/core/src/cancel_registry.rs
@@ -14,53 +14,107 @@
 //! Both paths converge on [`crate::jobs::run_as_job`], which performs the
 //! register/run/unregister dance in a panic-safe manner.
 //!
+//! # Registration model (issue #1166 MED-4)
+//!
+//! Multiple registrations for the same `job_id` can legitimately overlap:
+//!
+//! * **Same logical scope, registered twice** — `with_job_async_py`
+//!   registers synchronously (to close the asyncio-scheduling race), then
+//!   `run_as_job` registers again when the future is first polled.
+//! * **Two live scopes** — a claimed job whose handler loops back into
+//!   the same process with `X-Mesh-Job-Id` (nested inbound dispatch), or
+//!   a re-claim of a job whose previous overlong attempt is still
+//!   unwinding after lease expiry.
+//!
+//! A naive insert/remove-by-id map loses tokens in both cases: an
+//! overwrite drops the displaced entry's `ended` token unfired (waiters
+//! that snapshotted it never wake on natural end), and remove-by-id lets
+//! the first scope to exit delete the second's registration (its `ended`
+//! fires while the job still runs, and a later cancel finds nothing —
+//! the cancel is silently lost).
+//!
+//! Instead, each `job_id` maps to a **stack of registration frames**, each
+//! carrying a unique generation:
+//!
+//! * [`register_active_job`] pushes a frame and returns its generation.
+//!   Nothing is displaced and nothing fires — an outer scope's `ended`
+//!   stays armed while an inner scope is live.
+//! * [`unregister_active_job`] removes ONLY the caller's own frame (by
+//!   generation) and fires that frame's `ended`, regardless of stack
+//!   position. If an inner frame exits first the outer frame becomes the
+//!   active one again; if the outer exits first (zombie attempt after a
+//!   re-claim) the inner frame is untouched.
+//! * [`cancel_active_job`] / [`get_state`] operate on the TOP frame —
+//!   the most recent registration is the live attempt the registry would
+//!   forward a cancel to.
+//!
 //! # Concurrency model
-//! Backed by a `std::sync::Mutex<HashMap<String, JobCancelState>>` held
+//! Backed by a `std::sync::Mutex<HashMap<String, Vec<Frame>>>` held
 //! behind a `OnceLock` (matches `tracing_publish.rs`, `tls.rs`, etc.).
 //! Critical sections are short — clone-and-drop — so contention is not a
 //! concern at the scale of in-flight jobs per process.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 
 use tokio_util::sync::CancellationToken;
 
-/// Per-job state held by the cancel registry. The two tokens are
-/// distinct: `cancel` is fired by user-initiated cancel (the existing
-/// behaviour); `ended` is fired by the registry itself when
-/// `unregister_active_job` runs, so awaiters that need to clean up
-/// when the job finishes naturally (without cancel) can do so.
-pub struct JobCancelState {
-    pub cancel: CancellationToken,
-    pub ended: CancellationToken,
+/// Per-registration state held by the cancel registry. The two tokens
+/// are distinct: `cancel` is fired by user-initiated cancel (the
+/// existing behaviour); `ended` is fired by the registry itself when the
+/// owning scope's [`unregister_active_job`] runs, so awaiters that need
+/// to clean up when the job finishes naturally (without cancel) can do
+/// so.
+struct Frame {
+    /// Unique registration identity. [`unregister_active_job`] removes
+    /// only the frame whose generation matches — a different scope that
+    /// registered later under the same `job_id` is never disturbed.
+    generation: u64,
+    cancel: CancellationToken,
+    ended: CancellationToken,
 }
 
-/// Process-wide map of active job ID → per-job cancel state.
-static REGISTRY: OnceLock<Mutex<HashMap<String, JobCancelState>>> = OnceLock::new();
+/// Process-wide map of active job ID → stack of registration frames
+/// (last element = most recent registration = the live attempt).
+static REGISTRY: OnceLock<Mutex<HashMap<String, Vec<Frame>>>> = OnceLock::new();
 
-fn registry() -> &'static Mutex<HashMap<String, JobCancelState>> {
+/// Monotonic generation source for registration identities.
+static NEXT_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+fn registry() -> &'static Mutex<HashMap<String, Vec<Frame>>> {
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Insert (or replace) the cancel token for the given job ID.
+/// Register the cancel token for the given job ID and return the
+/// registration's generation. The caller MUST pass the returned
+/// generation back to [`unregister_active_job`] when its scope ends —
+/// that is what scopes the teardown to this registration only.
 ///
-/// If a prior entry exists (e.g. previous attempt was never unregistered),
-/// it is silently overwritten — the latest registration wins. The old
-/// token is dropped, which does NOT fire it (cancellation requires an
-/// explicit `.cancel()` call). The companion `ended` token is freshly
-/// constructed inside the registry for each registration; it fires only
-/// on `unregister_active_job` so awaiters can wake up when a job ends
-/// naturally (without explicit cancel).
-pub fn register_active_job(job_id: &str, token: CancellationToken) {
-    let state = JobCancelState {
+/// If a prior registration exists for the same `job_id` (same-scope
+/// double registration via `with_job_async_py` + `run_as_job`, a nested
+/// inbound dispatch carrying the same `X-Mesh-Job-Id`, or a re-claim
+/// racing a zombie attempt), it is kept underneath the new frame: its
+/// `ended` token stays armed (it fires when ITS scope unregisters), and
+/// [`cancel_active_job`] / [`get_state`] switch to the new top frame.
+///
+/// The companion `ended` token is freshly constructed inside the
+/// registry for each registration; it fires only when this
+/// registration's [`unregister_active_job`] runs.
+pub fn register_active_job(job_id: &str, token: CancellationToken) -> u64 {
+    let generation = NEXT_GENERATION.fetch_add(1, Ordering::Relaxed);
+    let frame = Frame {
+        generation,
         cancel: token,
         ended: CancellationToken::new(),
     };
     let mut map = registry().lock().expect("cancel_registry mutex poisoned");
-    map.insert(job_id.to_string(), state);
+    map.entry(job_id.to_string()).or_default().push(frame);
+    generation
 }
 
-/// Fire the cancel token for the given job ID, if one is registered.
+/// Fire the cancel token of the most recent registration for the given
+/// job ID, if any.
 ///
 /// Returns `true` if a token was found and fired, `false` if the job is
 /// not currently active in this process. Idempotent — repeated calls on
@@ -68,12 +122,14 @@ pub fn register_active_job(job_id: &str, token: CancellationToken) {
 /// first call returns `true` (subsequent calls still return `true` while
 /// the entry exists; once unregistered, returns `false`).
 ///
-/// This does NOT fire the `ended` token — `ended` is reserved for
+/// This does NOT fire any `ended` token — `ended` is reserved for
 /// natural lifecycle teardown via [`unregister_active_job`].
 pub fn cancel_active_job(job_id: &str) -> bool {
     let token = {
         let map = registry().lock().expect("cancel_registry mutex poisoned");
-        map.get(job_id).map(|s| s.cancel.clone())
+        map.get(job_id)
+            .and_then(|stack| stack.last())
+            .map(|f| f.cancel.clone())
     };
     match token {
         Some(t) => {
@@ -84,18 +140,31 @@ pub fn cancel_active_job(job_id: &str) -> bool {
     }
 }
 
-/// Remove the registry entry for the given job ID. Safe to call even if
-/// no entry exists. The associated `cancel` token is NOT cancelled by
-/// this call — callers that want both behaviors should call
-/// [`cancel_active_job`] first. The `ended` token IS fired before the
-/// entry is removed, so awaiters tracking natural job termination wake
-/// up promptly (used by the napi `await_job_cancel` path so per-call
-/// listeners don't leak when a job finishes without explicit cancel).
-pub fn unregister_active_job(job_id: &str) {
+/// Remove the registration identified by (`job_id`, `generation`). Safe
+/// to call even if the registration no longer exists. The associated
+/// `cancel` token is NOT cancelled by this call — callers that want both
+/// behaviors should call [`cancel_active_job`] first. The registration's
+/// `ended` token IS fired after removal, so awaiters tracking natural
+/// job termination wake up promptly (used by the `await_job_cancel`
+/// paths in all three bindings so per-call listeners don't leak when a
+/// job finishes without explicit cancel).
+///
+/// Only the caller's own frame is removed: a different registration for
+/// the same `job_id` (nested scope, re-claimed attempt) keeps its tokens
+/// — this is what prevents the "first scope to exit deletes the second's
+/// registration" cancel loss (issue #1166 MED-4).
+pub fn unregister_active_job(job_id: &str, generation: u64) {
     let ended = {
         let mut map = registry().lock().expect("cancel_registry mutex poisoned");
-        let ended = map.get(job_id).map(|s| s.ended.clone());
-        map.remove(job_id);
+        let mut ended = None;
+        if let Some(stack) = map.get_mut(job_id) {
+            if let Some(pos) = stack.iter().position(|f| f.generation == generation) {
+                ended = Some(stack.remove(pos).ended);
+            }
+            if stack.is_empty() {
+                map.remove(job_id);
+            }
+        }
         ended
     };
     if let Some(t) = ended {
@@ -103,32 +172,39 @@ pub fn unregister_active_job(job_id: &str) {
     }
 }
 
-/// Number of active job entries currently registered. For diagnostics
-/// (tests, /health endpoints, dashboards). Cheap snapshot — does not
-/// hold the lock across other work.
+/// Number of job IDs with at least one active registration. For
+/// diagnostics (tests, /health endpoints, dashboards). Cheap snapshot —
+/// does not hold the lock across other work.
 pub fn active_job_count() -> usize {
-    registry().lock().expect("cancel_registry mutex poisoned").len()
+    registry()
+        .lock()
+        .expect("cancel_registry mutex poisoned")
+        .len()
 }
 
-/// Snapshot both per-job tokens (cancel, ended) without firing either.
-/// Used by the napi `await_job_cancel` accessor so callers in non-Rust
-/// runtimes can race their outbound work against EITHER the in-flight
-/// job's cancel signal OR its natural-termination signal — without this,
-/// an `awaitJobCancel(...)` future on a job that finishes normally would
-/// hang forever (its sole resolve path would be explicit cancel) and
-/// leak one Rust task + one JS Promise per outbound call. Returns `None`
-/// if the job is not currently registered (already terminal / never
-/// claimed) — callers should treat `None` as "no cancellation possible
-/// from here" and resolve immediately.
+/// Snapshot both tokens (cancel, ended) of the most recent registration
+/// for `job_id`, without firing either. Used by the `await_job_cancel`
+/// accessors so callers in non-Rust runtimes can race their outbound
+/// work against EITHER the in-flight job's cancel signal OR its
+/// natural-termination signal — without this, an `awaitJobCancel(...)`
+/// future on a job that finishes normally would hang forever (its sole
+/// resolve path would be explicit cancel) and leak one Rust task + one
+/// JS Promise per outbound call. Returns `None` if the job is not
+/// currently registered (already terminal / never claimed) — callers
+/// should treat `None` as "no cancellation possible from here" and
+/// resolve immediately.
 pub fn get_state(job_id: &str) -> Option<(CancellationToken, CancellationToken)> {
     let map = registry().lock().expect("cancel_registry mutex poisoned");
-    map.get(job_id).map(|s| (s.cancel.clone(), s.ended.clone()))
+    map.get(job_id)
+        .and_then(|stack| stack.last())
+        .map(|f| (f.cancel.clone(), f.ended.clone()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::Arc;
+    use std::time::Duration;
     use tokio::sync::Barrier;
 
     /// Generate a unique job ID prefix per test so tests can run in
@@ -145,7 +221,7 @@ mod tests {
     fn register_then_cancel_fires_token() {
         let id = unique_id("a");
         let token = CancellationToken::new();
-        register_active_job(&id, token.clone());
+        let generation = register_active_job(&id, token.clone());
 
         assert!(!token.is_cancelled());
         let fired = cancel_active_job(&id);
@@ -153,7 +229,8 @@ mod tests {
         assert!(token.is_cancelled(), "token should be fired");
 
         // Cleanup so this test doesn't leak entries.
-        unregister_active_job(&id);
+        unregister_active_job(&id, generation);
+        assert!(get_state(&id).is_none());
     }
 
     #[test]
@@ -167,33 +244,191 @@ mod tests {
     fn unregister_then_cancel_returns_false() {
         let id = unique_id("ephemeral");
         let token = CancellationToken::new();
-        register_active_job(&id, token.clone());
-        unregister_active_job(&id);
+        let generation = register_active_job(&id, token.clone());
+        unregister_active_job(&id, generation);
         assert!(!cancel_active_job(&id));
         assert!(!token.is_cancelled(), "token should remain un-fired");
     }
 
     #[test]
-    fn re_registration_overwrites_prior_token() {
+    fn unregister_with_stale_generation_is_noop() {
+        let id = unique_id("stale-gen");
+        let token = CancellationToken::new();
+        let generation = register_active_job(&id, token.clone());
+        // A generation that never belonged to this job must not disturb it.
+        unregister_active_job(&id, generation + 1_000_000);
+        assert!(get_state(&id).is_some(), "live registration must survive");
+        assert!(cancel_active_job(&id));
+        unregister_active_job(&id, generation);
+    }
+
+    /// MED-4 (b): with two live registrations for one job_id (nested
+    /// inbound dispatch / zombie attempt + re-claim), the first scope to
+    /// exit must remove ONLY its own frame — the second registration
+    /// stays live and a subsequent cancel reaches it.
+    #[test]
+    fn unregister_by_generation_does_not_remove_successor() {
+        let id = unique_id("two-scopes");
+        let first = CancellationToken::new();
+        let second = CancellationToken::new();
+        let gen1 = register_active_job(&id, first.clone());
+        let gen2 = register_active_job(&id, second.clone());
+
+        // First (outer) scope exits first.
+        unregister_active_job(&id, gen1);
+
+        // The second registration is still live — cancel reaches it.
+        assert!(
+            cancel_active_job(&id),
+            "cancel after the outer scope exited must reach the live scope"
+        );
+        assert!(second.is_cancelled());
+        assert!(!first.is_cancelled());
+
+        unregister_active_job(&id, gen2);
+        assert!(!cancel_active_job(&id));
+    }
+
+    /// Re-registration stacks: cancel targets the most recent (top)
+    /// registration; the older one is preserved underneath and becomes
+    /// active again when the newer scope unregisters.
+    #[test]
+    fn re_registration_stacks_and_cancel_targets_top() {
         let id = unique_id("overwrite");
         let first = CancellationToken::new();
         let second = CancellationToken::new();
-        register_active_job(&id, first.clone());
-        register_active_job(&id, second.clone());
+        let gen1 = register_active_job(&id, first.clone());
+        let gen2 = register_active_job(&id, second.clone());
 
         let fired = cancel_active_job(&id);
         assert!(fired);
-        assert!(second.is_cancelled());
+        assert!(second.is_cancelled(), "cancel must hit the top frame");
         assert!(!first.is_cancelled(), "first token should NOT be fired");
 
-        unregister_active_job(&id);
+        // Inner scope exits: the first registration is active again.
+        unregister_active_job(&id, gen2);
+        assert!(cancel_active_job(&id));
+        assert!(first.is_cancelled(), "restored frame must receive cancel");
+
+        unregister_active_job(&id, gen1);
+        assert!(get_state(&id).is_none());
+    }
+
+    /// MED-4 (a): every registration's `ended` token fires when ITS
+    /// scope unregisters — a waiter that snapshotted the older frame
+    /// before a re-registration still wakes on natural end (previously
+    /// the overwrite dropped that token unfired and the waiter hung
+    /// forever).
+    #[test]
+    fn each_frame_ended_fires_at_its_own_unregister() {
+        let id = unique_id("ended-per-frame");
+        let gen1 = register_active_job(&id, CancellationToken::new());
+        let (_c1, ended1) = get_state(&id).expect("first frame visible");
+
+        let gen2 = register_active_job(&id, CancellationToken::new());
+        let (_c2, ended2) = get_state(&id).expect("second frame visible");
+
+        // Registering a second scope must NOT wake the first scope's
+        // waiters — that scope is still live (nested dispatch case).
+        assert!(!ended1.is_cancelled());
+        assert!(!ended2.is_cancelled());
+
+        unregister_active_job(&id, gen2);
+        assert!(ended2.is_cancelled(), "inner ended fires at inner exit");
+        assert!(!ended1.is_cancelled(), "outer scope is still live");
+
+        unregister_active_job(&id, gen1);
+        assert!(ended1.is_cancelled(), "outer ended fires at outer exit");
+    }
+
+    /// The `with_job_async_py` double-register window (Rust-level
+    /// equivalent): the same cancel token is registered twice for the
+    /// same logical scope (outer synchronous registration + inner
+    /// `run_as_job` registration). A watcher that snapshots state at any
+    /// point must (1) see a live entry, (2) be cancellable through the
+    /// shared token, and (3) wake on natural end when the scopes tear
+    /// down (LIFO).
+    #[tokio::test]
+    async fn same_scope_double_register_keeps_waiters_wakeable() {
+        let id = unique_id("same-scope");
+        let token = CancellationToken::new();
+
+        // Outer registration (with_job_async_py, synchronous).
+        let outer = register_active_job(&id, token.clone());
+        let (cancel_snap_outer, ended_snap_outer) =
+            get_state(&id).expect("entry visible after outer register");
+
+        // Inner registration when run_as_job's future is polled — a
+        // clone of the SAME token.
+        let inner = register_active_job(&id, token.clone());
+        let (cancel_snap_inner, ended_snap_inner) =
+            get_state(&id).expect("entry visible after inner register");
+
+        // A watcher racing cancel-vs-ended on either snapshot.
+        let watcher = |cancel: CancellationToken, ended: CancellationToken| async move {
+            tokio::select! {
+                _ = cancel.cancelled() => "cancel",
+                _ = ended.cancelled() => "ended",
+            }
+        };
+        let w_outer = tokio::spawn(watcher(cancel_snap_outer.clone(), ended_snap_outer));
+        let w_inner = tokio::spawn(watcher(cancel_snap_inner.clone(), ended_snap_inner));
+
+        // Cancel through the registry reaches the shared token, so both
+        // snapshots observe it.
+        assert!(!cancel_snap_outer.is_cancelled());
+        assert!(!cancel_snap_inner.is_cancelled());
+
+        // Natural end: scopes unwind LIFO (run_as_job guard, then the
+        // outer guard). Both watchers must wake.
+        unregister_active_job(&id, inner);
+        unregister_active_job(&id, outer);
+
+        let outcome_inner = tokio::time::timeout(Duration::from_secs(2), w_inner)
+            .await
+            .expect("inner watcher must wake on natural end")
+            .unwrap();
+        let outcome_outer = tokio::time::timeout(Duration::from_secs(2), w_outer)
+            .await
+            .expect("outer watcher must wake on natural end")
+            .unwrap();
+        assert_eq!(outcome_inner, "ended");
+        assert_eq!(outcome_outer, "ended");
+
+        assert!(get_state(&id).is_none(), "registry must be clean");
+    }
+
+    /// Cancel after a re-claim reaches the live (new) scope, never the
+    /// finished one — and `mesh_job_cancel_fired` semantics survive:
+    /// after natural end + re-claim, the fresh frame's token is un-fired.
+    #[test]
+    fn cancel_after_reclaim_reaches_live_scope() {
+        let id = unique_id("reclaim");
+        let first_attempt = CancellationToken::new();
+        let gen1 = register_active_job(&id, first_attempt.clone());
+        // First attempt ends naturally.
+        unregister_active_job(&id, gen1);
+
+        // Re-claimed in the same process under the same job_id.
+        let second_attempt = CancellationToken::new();
+        let gen2 = register_active_job(&id, second_attempt.clone());
+
+        // The fresh registration must not look cancelled.
+        let (cancel, _ended) = get_state(&id).expect("re-claimed entry visible");
+        assert!(!cancel.is_cancelled());
+
+        assert!(cancel_active_job(&id));
+        assert!(second_attempt.is_cancelled());
+        assert!(!first_attempt.is_cancelled());
+
+        unregister_active_job(&id, gen2);
     }
 
     #[test]
     fn get_state_returns_clones_for_registered_job() {
         let id = unique_id("get-state");
         let token = CancellationToken::new();
-        register_active_job(&id, token.clone());
+        let generation = register_active_job(&id, token.clone());
 
         let (cancel, ended) = get_state(&id).expect("state should be present");
         // Cancel snapshot is a clone of the token the caller registered —
@@ -205,7 +440,7 @@ mod tests {
         assert!(token.is_cancelled(), "original token should also fire");
         assert!(!ended.is_cancelled(), "ended must remain un-fired");
 
-        unregister_active_job(&id);
+        unregister_active_job(&id, generation);
     }
 
     #[test]
@@ -217,19 +452,19 @@ mod tests {
     #[test]
     fn get_state_after_unregister_returns_none() {
         let id = unique_id("get-state-ephemeral");
-        register_active_job(&id, CancellationToken::new());
+        let generation = register_active_job(&id, CancellationToken::new());
         assert!(get_state(&id).is_some());
-        unregister_active_job(&id);
+        unregister_active_job(&id, generation);
         assert!(get_state(&id).is_none());
     }
 
     #[test]
     fn get_ended_token_fires_on_unregister() {
         let id = unique_id("ended-on-unregister");
-        register_active_job(&id, CancellationToken::new());
+        let generation = register_active_job(&id, CancellationToken::new());
         let (_cancel, ended) = get_state(&id).expect("state should be present");
         assert!(!ended.is_cancelled());
-        unregister_active_job(&id);
+        unregister_active_job(&id, generation);
         assert!(
             ended.is_cancelled(),
             "ended token must fire when job is unregistered (natural end)"
@@ -239,7 +474,7 @@ mod tests {
     #[test]
     fn get_cancel_token_isolated_from_ended() {
         let id = unique_id("cancel-isolated-from-ended");
-        register_active_job(&id, CancellationToken::new());
+        let generation = register_active_job(&id, CancellationToken::new());
         let (cancel, ended) = get_state(&id).expect("state should be present");
 
         // Firing cancel must NOT fire ended — they are distinct tokens.
@@ -250,7 +485,7 @@ mod tests {
             "ended must remain un-fired when only cancel is fired"
         );
 
-        unregister_active_job(&id);
+        unregister_active_job(&id, generation);
     }
 
     #[test]
@@ -261,12 +496,12 @@ mod tests {
         let id1 = unique_id("count-1");
         let id2 = unique_id("count-2");
 
-        register_active_job(&id1, CancellationToken::new());
-        register_active_job(&id2, CancellationToken::new());
+        let gen1 = register_active_job(&id1, CancellationToken::new());
+        let gen2 = register_active_job(&id2, CancellationToken::new());
         assert!(active_job_count() >= baseline + 2);
 
-        unregister_active_job(&id1);
-        unregister_active_job(&id2);
+        unregister_active_job(&id1, gen1);
+        unregister_active_job(&id2, gen2);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -287,7 +522,7 @@ mod tests {
                     i
                 );
                 let token = CancellationToken::new();
-                register_active_job(&id, token.clone());
+                let generation = register_active_job(&id, token.clone());
 
                 // Wait for everyone to register before any of us cancels.
                 b.wait().await;
@@ -295,7 +530,7 @@ mod tests {
                 let fired = cancel_active_job(&id);
                 assert!(fired, "task {} expected its token to be present", i);
                 assert!(token.is_cancelled());
-                unregister_active_job(&id);
+                unregister_active_job(&id, generation);
                 assert!(!cancel_active_job(&id));
             }));
         }

--- a/src/runtime/core/src/ffi.rs
+++ b/src/runtime/core/src/ffi.rs
@@ -12,11 +12,11 @@
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::ptr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, error, info, warn};
 
 use crate::config::is_tracing_enabled;
@@ -49,8 +49,14 @@ pub(crate) fn take_last_error() -> Option<String> {
 /// Note: This struct is intentionally NOT `#[repr(C)]` to keep its internals
 /// opaque to C consumers. The FFI functions work with raw pointers.
 pub struct MeshAgentHandle {
-    /// Channel to receive events from the runtime
-    event_rx: mpsc::Receiver<MeshEvent>,
+    /// Channel to receive events from the runtime. Behind a tokio Mutex
+    /// (like the Python/napi handles) so `mesh_next_event` can take
+    /// `*const` like every other accessor — the previous `&mut *handle`
+    /// could overlap with concurrent `&*handle` borrows from
+    /// `mesh_report_health` / `mesh_shutdown` / `mesh_is_running` under
+    /// the "safe from any thread" contract, which is formal aliasing UB
+    /// (issue #1166 LOW).
+    event_rx: Mutex<mpsc::Receiver<MeshEvent>>,
     /// Channel to signal shutdown to the runtime
     shutdown_tx: mpsc::Sender<()>,
     /// Channel to send commands to the runtime (e.g., update tools)
@@ -170,7 +176,7 @@ pub unsafe extern "C" fn mesh_start_agent(spec_json: *const c_char) -> *mut Mesh
 
     // Create the handle
     let handle = Box::new(MeshAgentHandle {
-        event_rx,
+        event_rx: Mutex::new(event_rx),
         shutdown_tx,
         command_tx,
         runtime,
@@ -192,7 +198,7 @@ pub unsafe extern "C" fn mesh_start_agent(spec_json: *const c_char) -> *mut Mesh
 /// # Safety
 /// * `handle` must be a valid handle from `mesh_start_agent`
 #[no_mangle]
-pub unsafe extern "C" fn mesh_shutdown(handle: *mut MeshAgentHandle) {
+pub unsafe extern "C" fn mesh_shutdown(handle: *const MeshAgentHandle) {
     if handle.is_null() {
         return;
     }
@@ -216,6 +222,10 @@ pub unsafe extern "C" fn mesh_shutdown(handle: *mut MeshAgentHandle) {
 /// and wait briefly (up to 2 seconds) for the agent to unregister from
 /// the registry before dropping resources.
 ///
+/// Also drains queued trace spans (up to 2 seconds, equivalent to
+/// `mesh_flush_spans(2000)`) so spans published during the agent's final
+/// moments are not lost.
+///
 /// # Safety
 /// * `handle` must be a valid handle from `mesh_start_agent` or NULL
 /// * After this call, `handle` is invalid and must not be used
@@ -230,17 +240,53 @@ pub unsafe extern "C" fn mesh_free_handle(handle: *mut MeshAgentHandle) {
     // Take ownership
     let handle = Box::from_raw(handle);
 
-    // If still running, trigger graceful shutdown and wait briefly
+    // If still running, trigger graceful shutdown and wait (bounded) for
+    // the runtime to finish unregistering before dropping it.
     if handle.is_running() {
         warn!("FFI: Agent still running during free, triggering graceful shutdown");
 
         // Send shutdown signal
         let _ = handle.shutdown_tx.try_send(());
 
-        // Wait briefly for graceful termination (up to 2 seconds)
-        handle.runtime.block_on(async {
-            tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait up to 2 seconds for the shutdown event. The runtime's run
+        // loop sends the registry DELETE (unregister) BEFORE emitting the
+        // shutdown event, so observing the event means the unregister
+        // attempt completed — dropping the tokio runtime earlier would
+        // abort the in-flight DELETE and leave a stale registry entry
+        // until the heartbeat timeout (issue #1166 LOW).
+        let waited = handle.runtime.block_on(async {
+            tokio::time::timeout(Duration::from_secs(2), async {
+                let mut rx = handle.event_rx.lock().await;
+                loop {
+                    match rx.recv().await {
+                        Some(event)
+                            if event.event_type == crate::events::EventType::Shutdown =>
+                        {
+                            break;
+                        }
+                        // Drain unrelated events queued before shutdown.
+                        Some(_) => continue,
+                        // Channel closed: the runtime task is already gone.
+                        None => break,
+                    }
+                }
+            })
+            .await
         });
+        if waited.is_err() {
+            warn!("FFI: graceful shutdown did not complete within 2s; dropping runtime");
+        }
+    }
+
+    // Drain queued trace spans (bounded). The span queue is process-global
+    // and outlives this handle, but for the common one-agent-per-process
+    // embedder this is the last mesh_* call before exit — without a drain
+    // here, spans queued via mesh_publish_span during the agent's final
+    // moments (often the diagnostically critical ones) would be silently
+    // lost when the process exits. No-op if the publisher was never
+    // initialized. Embedders can also call mesh_flush_spans directly.
+    if !flush_span_queue(Duration::from_secs(2)) {
+        warn!("FFI: trace span queue did not drain within 2s; some spans may be lost");
     }
 
     // Mark as stopped
@@ -256,7 +302,16 @@ pub unsafe extern "C" fn mesh_free_handle(handle: *mut MeshAgentHandle) {
 
 /// Get next event from agent runtime.
 ///
-/// Blocks until event available or timeout.
+/// Blocks until event available or timeout. The timeout covers the FULL
+/// wait, including acquisition of the internal receiver lock — a
+/// `timeout_ms = 0` (non-blocking) or finite-timeout call returns within
+/// its budget even while another thread is parked in an infinite
+/// `mesh_next_event` wait on the same handle.
+///
+/// Each event is delivered to exactly ONE caller: the receiver is a
+/// shared single-consumer queue, not a broadcast. With multiple
+/// concurrent callers, an event goes to whichever caller dequeues it
+/// first.
 ///
 /// # Arguments
 /// * `handle` - Agent handle
@@ -270,7 +325,7 @@ pub unsafe extern "C" fn mesh_free_handle(handle: *mut MeshAgentHandle) {
 /// * The returned string must be freed with `mesh_free_string`
 #[no_mangle]
 pub unsafe extern "C" fn mesh_next_event(
-    handle: *mut MeshAgentHandle,
+    handle: *const MeshAgentHandle,
     timeout_ms: i64,
 ) -> *mut c_char {
     if handle.is_null() {
@@ -278,32 +333,48 @@ pub unsafe extern "C" fn mesh_next_event(
         return ptr::null_mut();
     }
 
-    let handle = &mut *handle;
+    let handle = &*handle;
 
     if !handle.is_running() {
         return ptr::null_mut();
     }
 
-    // Receive event with timeout
-    let event = handle.runtime.block_on(async {
-        if timeout_ms < 0 {
-            // Infinite wait
-            handle.event_rx.recv().await
-        } else if timeout_ms == 0 {
-            // Non-blocking
-            match handle.event_rx.try_recv() {
-                Ok(event) => Some(event),
-                Err(_) => None,
-            }
-        } else {
-            // Timeout
-            let duration = Duration::from_millis(timeout_ms as u64);
-            tokio::time::timeout(duration, handle.event_rx.recv())
-                .await
-                .ok()
-                .flatten()
+    // Receive event with timeout. The receiver lives behind a tokio Mutex
+    // so this function can share the handle (`&*handle`) with concurrent
+    // accessors instead of taking `&mut` (aliasing UB under the
+    // "safe from any thread" contract).
+    //
+    // The lock acquisition MUST sit inside the timeout: another caller may
+    // hold the receiver in an infinite recv(), and wrapping only recv()
+    // would turn a bounded call into an unbounded one (it would park on
+    // `.lock()` first).
+    let event = if timeout_ms == 0 {
+        // Non-blocking: if the receiver is held by another caller, no
+        // event is available to *this* caller right now — report
+        // timeout instead of waiting for the lock.
+        match handle.event_rx.try_lock() {
+            Ok(mut event_rx) => event_rx.try_recv().ok(),
+            Err(_) => None,
         }
-    });
+    } else if timeout_ms < 0 {
+        // Infinite wait
+        handle.runtime.block_on(async {
+            let mut event_rx = handle.event_rx.lock().await;
+            event_rx.recv().await
+        })
+    } else {
+        // Bounded wait covering lock + recv
+        let duration = Duration::from_millis(timeout_ms as u64);
+        handle.runtime.block_on(async {
+            tokio::time::timeout(duration, async {
+                let mut event_rx = handle.event_rx.lock().await;
+                event_rx.recv().await
+            })
+            .await
+            .ok()
+            .flatten()
+        })
+    };
 
     match event {
         Some(event) => {
@@ -376,7 +447,7 @@ pub unsafe extern "C" fn mesh_is_running(handle: *const MeshAgentHandle) -> i32 
 /// * `status` must be a valid null-terminated C string
 #[no_mangle]
 pub unsafe extern "C" fn mesh_report_health(
-    handle: *mut MeshAgentHandle,
+    handle: *const MeshAgentHandle,
     status: *const c_char,
 ) -> i32 {
     if handle.is_null() {
@@ -439,7 +510,7 @@ pub unsafe extern "C" fn mesh_report_health(
 /// * `handle` must be a valid handle from `mesh_start_agent`
 #[no_mangle]
 pub unsafe extern "C" fn mesh_update_port(
-    handle: *mut MeshAgentHandle,
+    handle: *const MeshAgentHandle,
     port: i32,
 ) -> i32 {
     if handle.is_null() {
@@ -791,6 +862,84 @@ pub extern "C" fn mesh_is_tracing_enabled() -> i32 {
     if is_tracing_enabled() { 1 } else { 0 }
 }
 
+/// Bounded queue between `mesh_publish_span` (caller thread) and the
+/// tracing runtime's drain task. Sized for bursts; on overflow spans are
+/// dropped with a counter (tracing must never block or break agent
+/// operations).
+const SPAN_QUEUE_CAPACITY: usize = 1024;
+
+/// Message on the span queue: a span to publish, or a flush marker whose
+/// ack fires once every message enqueued before it has been processed
+/// (the drain task consumes the queue in FIFO order).
+enum SpanQueueMsg {
+    Span(std::collections::HashMap<String, String>),
+    Flush(tokio::sync::oneshot::Sender<()>),
+}
+
+/// Sender side of the span queue. Initialized by
+/// `mesh_init_trace_publisher` on success; `None` (unset) means the
+/// publisher was never initialized and `mesh_publish_span` returns 0.
+static SPAN_QUEUE: std::sync::OnceLock<mpsc::Sender<SpanQueueMsg>> = std::sync::OnceLock::new();
+
+/// Spans dropped because the queue was full. Logged periodically from
+/// the enqueue path.
+static DROPPED_SPANS: AtomicU64 = AtomicU64::new(0);
+
+/// Initialize the span queue and spawn its drain task on the tracing
+/// runtime. Idempotent — subsequent calls return the existing sender.
+fn ensure_span_queue() -> &'static mpsc::Sender<SpanQueueMsg> {
+    SPAN_QUEUE.get_or_init(|| {
+        let (tx, mut rx) = mpsc::channel::<SpanQueueMsg>(SPAN_QUEUE_CAPACITY);
+        get_tracing_runtime().spawn(async move {
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    SpanQueueMsg::Span(span) => {
+                        // Failures are already logged (debug) inside
+                        // publish_span; never break the drain loop on a
+                        // bad span.
+                        let _ = tracing_publish::publish_span(span).await;
+                    }
+                    SpanQueueMsg::Flush(ack) => {
+                        // FIFO: everything enqueued before this marker has
+                        // been processed — wake the flusher (receiver may
+                        // have given up on timeout; ignore send errors).
+                        let _ = ack.send(());
+                    }
+                }
+            }
+        });
+        tx
+    })
+}
+
+/// Drain the span queue: block until every span enqueued via
+/// `mesh_publish_span` before this call has been handed to Redis (or
+/// failed), or until `timeout` elapses.
+///
+/// Returns true if the queue fully drained (or was never armed — nothing
+/// queued means nothing to lose), false on timeout.
+fn flush_span_queue(timeout: Duration) -> bool {
+    let Some(queue) = SPAN_QUEUE.get() else {
+        // Publisher never initialized: the queue doesn't exist, so no
+        // span can be pending. Don't arm it just to flush nothing.
+        return true;
+    };
+
+    let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+    get_tracing_runtime().block_on(async {
+        tokio::time::timeout(timeout, async {
+            if queue.send(SpanQueueMsg::Flush(ack_tx)).await.is_err() {
+                // Drain task gone (runtime tearing down) — nothing more
+                // can be flushed; treat as drained-as-far-as-possible.
+                return;
+            }
+            let _ = ack_rx.await;
+        })
+        .await
+        .is_ok()
+    })
+}
+
 /// Initialize the trace publisher.
 ///
 /// Must be called before `mesh_publish_span`. Connects to Redis.
@@ -805,6 +954,8 @@ pub extern "C" fn mesh_init_trace_publisher() -> i32 {
     });
 
     if result {
+        // Arm the non-blocking publish path (queue + drain task).
+        let _ = ensure_span_queue();
         info!("FFI: Trace publisher initialized successfully");
         1
     } else {
@@ -829,14 +980,18 @@ pub extern "C" fn mesh_is_trace_publisher_available() -> i32 {
 
 /// Publish a trace span to Redis.
 ///
-/// Non-blocking (from the caller's perspective) - returns after queuing the span.
-/// Silently handles failures to never break agent operations.
+/// Non-blocking (from the caller's perspective) - returns after queuing the span
+/// onto a bounded in-process queue drained by the tracing runtime, which
+/// performs the actual Redis XADD asynchronously. Silently handles failures
+/// to never break agent operations; on queue overflow the span is dropped
+/// (counted, logged periodically).
 ///
 /// # Arguments
 /// * `span_json` - JSON string containing span data (all values should be strings)
 ///
 /// # Returns
-/// 1 on success (queued), 0 on failure
+/// 1 on success (queued), 0 on failure (not initialized, invalid input,
+/// or queue full)
 ///
 /// # Safety
 /// * `span_json` must be a valid null-terminated C string
@@ -864,17 +1019,60 @@ pub unsafe extern "C" fn mesh_publish_span(span_json: *const c_char) -> i32 {
         }
     };
 
-    // Publish to Redis
-    let rt = get_tracing_runtime();
-    let result = rt.block_on(async {
-        tracing_publish::publish_span(span_data).await
-    });
+    // Enqueue for the tracing runtime's drain task. The queue only exists
+    // after a successful mesh_init_trace_publisher — without it there's
+    // nothing to publish to, so fail fast (matches the previous behavior
+    // of publish_span returning false when uninitialized).
+    let Some(queue) = SPAN_QUEUE.get() else {
+        debug!("FFI: mesh_publish_span called before mesh_init_trace_publisher");
+        return 0;
+    };
 
-    if result {
-        debug!("FFI: Trace span published successfully");
+    match queue.try_send(SpanQueueMsg::Span(span_data)) {
+        Ok(()) => 1,
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            let dropped = DROPPED_SPANS.fetch_add(1, Ordering::Relaxed) + 1;
+            // Log periodically rather than per drop — overflow happens in
+            // bursts and per-span logging would amplify the load.
+            // (`u64::is_multiple_of` needs Rust >= 1.87 — see
+            // `rust-version` in Cargo.toml.)
+            if dropped == 1 || dropped.is_multiple_of(100) {
+                warn!(
+                    "FFI: trace span queue full; dropped {} spans so far",
+                    dropped
+                );
+            }
+            0
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            debug!("FFI: trace span queue closed");
+            0
+        }
+    }
+}
+
+/// Flush queued trace spans.
+///
+/// Blocks until every span queued via `mesh_publish_span` before this
+/// call has been published to Redis (or dropped on a publish error), or
+/// until `timeout_ms` elapses. `mesh_free_handle` calls this
+/// automatically with a 2-second budget so an agent's final spans are not
+/// lost at teardown; embedders that need a different budget (or that
+/// publish spans after freeing the handle) can call it directly.
+///
+/// # Arguments
+/// * `timeout_ms` - Maximum time to wait in milliseconds; negative values
+///   are treated as 0
+///
+/// # Returns
+/// 1 if the queue fully drained (or the publisher was never initialized),
+/// 0 on timeout
+#[no_mangle]
+pub extern "C" fn mesh_flush_spans(timeout_ms: i64) -> i32 {
+    let timeout = Duration::from_millis(timeout_ms.max(0) as u64);
+    if flush_span_queue(timeout) {
         1
     } else {
-        debug!("FFI: Failed to publish trace span");
         0
     }
 }
@@ -2419,6 +2617,144 @@ mod tests {
             // Should return 0 for invalid JSON
             assert_eq!(mesh_publish_span(invalid.as_ptr()), 0);
         }
+    }
+
+    /// Issue #1166 MED-3 + span-drain follow-up: ONE lifecycle test for
+    /// the process-global span queue. SPAN_QUEUE / TRACING_RUNTIME / the
+    /// tracing_publish PUBLISHER singleton are all process-wide, and a
+    /// OnceLock'd queue can never be unarmed again — so every assertion
+    /// that touches the queue lives in this single test fn (splitting
+    /// them up would create order-dependent tests). No other test in this
+    /// crate depends on the queue being UNarmed: the other
+    /// mesh_publish_span tests fail on null/invalid JSON before reaching
+    /// the queue.
+    ///
+    /// Covers:
+    /// * `mesh_publish_span` enqueues and returns 1 immediately — the
+    ///   Redis XADD happens on the tracing runtime's drain task;
+    /// * `mesh_flush_spans` blocks until previously queued spans reached
+    ///   the (fake) Redis server;
+    /// * `mesh_free_handle` drains the queue, so spans published right
+    ///   before teardown are not lost.
+    ///
+    /// NB: mutates process env (REDIS_URL, tracing flag); the suite runs
+    /// with --test-threads=1 like the other env-mutating tests.
+    #[test]
+    fn test_mesh_span_queue_lifecycle_publish_flush_free() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        // Fake RESP server that records every byte it reads and answers
+        // each command with "+PONG" (parses as the reply to everything
+        // this test triggers: PING, CLIENT SETINFO, XADD-as-String — see
+        // the sibling test in tracing_publish.rs for the pipelining
+        // details).
+        let server_rt = tokio::runtime::Runtime::new().unwrap();
+        let received: Arc<std::sync::Mutex<Vec<u8>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let received_srv = received.clone();
+        let addr = server_rt.block_on(async {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind fake redis");
+            let addr = listener.local_addr().unwrap();
+            tokio::spawn(async move {
+                loop {
+                    let Ok((mut sock, _)) = listener.accept().await else {
+                        break;
+                    };
+                    let received = received_srv.clone();
+                    tokio::spawn(async move {
+                        let mut buf = [0u8; 8192];
+                        loop {
+                            match sock.read(&mut buf).await {
+                                Ok(0) | Err(_) => break,
+                                Ok(n) => {
+                                    received.lock().unwrap().extend_from_slice(&buf[..n]);
+                                    let req = String::from_utf8_lossy(&buf[..n]);
+                                    let ncmds = req
+                                        .split("\r\n")
+                                        .filter(|line| line.starts_with('*'))
+                                        .count()
+                                        .max(1);
+                                    let resp = "+PONG\r\n".repeat(ncmds);
+                                    if sock.write_all(resp.as_bytes()).await.is_err() {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    });
+                }
+            });
+            addr
+        });
+
+        // publish_span awaits the XADD reply before completing, and the
+        // flush ack fires only after all prior queue entries completed —
+        // so once a flush returns, the server has read every span.
+        let count_xadds = || {
+            let buf = received.lock().unwrap();
+            String::from_utf8_lossy(&buf).matches("XADD").count()
+        };
+
+        std::env::set_var("MCP_MESH_DISTRIBUTED_TRACING_ENABLED", "true");
+        std::env::set_var("REDIS_URL", format!("redis://{}", addr));
+
+        assert_eq!(
+            mesh_init_trace_publisher(),
+            1,
+            "init must succeed against the fake server"
+        );
+
+        // Non-blocking enqueue path: valid spans are accepted (1) right
+        // away; Redis I/O happens on the drain task.
+        for i in 0..3 {
+            let span =
+                CString::new(format!(r#"{{"span_id":"s{}","name":"test"}}"#, i)).unwrap();
+            assert_eq!(
+                unsafe { mesh_publish_span(span.as_ptr()) },
+                1,
+                "span {} must be queued without blocking",
+                i
+            );
+        }
+
+        assert_eq!(mesh_flush_spans(5_000), 1, "flush must drain within budget");
+        assert_eq!(count_xadds(), 3, "server must have all pre-flush spans");
+
+        // Spans queued just before teardown must survive mesh_free_handle
+        // (the final spans of an agent's life are exactly what an
+        // embedder loses without the teardown drain).
+        for i in 3..5 {
+            let span =
+                CString::new(format!(r#"{{"span_id":"s{}","name":"test"}}"#, i)).unwrap();
+            assert_eq!(unsafe { mesh_publish_span(span.as_ptr()) }, 1);
+        }
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let (_event_tx, event_rx) = mpsc::channel::<MeshEvent>(4);
+        let (shutdown_tx, _shutdown_rx) = mpsc::channel(1);
+        let (command_tx, _command_rx) = mpsc::channel(1);
+        let handle = Box::new(MeshAgentHandle {
+            event_rx: Mutex::new(event_rx),
+            shutdown_tx,
+            command_tx,
+            runtime,
+            // Already stopped: free skips the graceful-shutdown wait and
+            // exercises exactly the teardown drain.
+            is_running: AtomicBool::new(false),
+            agent_id: None,
+            shared_state: Arc::new(tokio::sync::RwLock::new(HandleState::default())),
+        });
+        unsafe { mesh_free_handle(Box::into_raw(handle)) };
+        assert_eq!(
+            count_xadds(),
+            5,
+            "mesh_free_handle must drain spans queued before teardown"
+        );
+
+        std::env::remove_var("MCP_MESH_DISTRIBUTED_TRACING_ENABLED");
+        std::env::remove_var("REDIS_URL");
     }
 
     #[test]

--- a/src/runtime/core/src/ffi.rs
+++ b/src/runtime/core/src/ffi.rs
@@ -46,6 +46,16 @@ pub(crate) fn take_last_error() -> Option<String> {
 /// This struct holds all resources needed to interact with the agent runtime.
 /// It must be freed with `mesh_free_handle` when no longer needed.
 ///
+/// Lifetime: the raw pointer handed to C is `Arc`-managed
+/// (`Arc::into_raw` in `mesh_start_agent`). Every accessor takes a
+/// temporary strong reference for the duration of the call (see
+/// `handle_guard`), and `mesh_free_handle` releases the creation
+/// reference — so freeing while another thread is still inside
+/// `mesh_next_event` / `mesh_report_health` / etc. defers the actual
+/// drop until the last in-flight call returns instead of yanking the
+/// memory out from under it (use-after-free under the "safe from any
+/// thread" contract).
+///
 /// Note: This struct is intentionally NOT `#[repr(C)]` to keep its internals
 /// opaque to C consumers. The FFI functions work with raw pointers.
 pub struct MeshAgentHandle {
@@ -81,6 +91,23 @@ impl MeshAgentHandle {
     pub fn mark_stopped(&self) {
         self.is_running.store(false, Ordering::SeqCst);
     }
+}
+
+/// Take a temporary strong reference to the handle for the duration of
+/// one FFI call.
+///
+/// The returned `Arc` keeps the handle (and its tokio runtime) alive even
+/// if `mesh_free_handle` runs concurrently on another thread — the memory
+/// is released only when the last in-flight call drops its guard.
+///
+/// # Safety
+/// `ptr` must be a non-null pointer obtained from `mesh_start_agent` that
+/// has not yet been passed to `mesh_free_handle`. (Calls that *start*
+/// after free are still undefined behavior — the contract is unchanged;
+/// this guard only protects calls already in flight when free happens.)
+unsafe fn handle_guard(ptr: *const MeshAgentHandle) -> Arc<MeshAgentHandle> {
+    Arc::increment_strong_count(ptr);
+    Arc::from_raw(ptr)
 }
 
 /// Library version string.
@@ -174,8 +201,10 @@ pub unsafe extern "C" fn mesh_start_agent(spec_json: *const c_char) -> *mut Mesh
         agent_runtime.run().await;
     });
 
-    // Create the handle
-    let handle = Box::new(MeshAgentHandle {
+    // Create the handle. Arc-managed (not Box) so concurrent in-flight
+    // accessors each hold a strong reference via `handle_guard` and
+    // `mesh_free_handle` cannot free the memory out from under them.
+    let handle = Arc::new(MeshAgentHandle {
         event_rx: Mutex::new(event_rx),
         shutdown_tx,
         command_tx,
@@ -187,7 +216,7 @@ pub unsafe extern "C" fn mesh_start_agent(spec_json: *const c_char) -> *mut Mesh
 
     info!("FFI: Agent '{}' started successfully", spec.name);
 
-    Box::into_raw(handle)
+    Arc::into_raw(handle) as *mut MeshAgentHandle
 }
 
 /// Request graceful shutdown of agent.
@@ -203,7 +232,7 @@ pub unsafe extern "C" fn mesh_shutdown(handle: *const MeshAgentHandle) {
         return;
     }
 
-    let handle = &*handle;
+    let handle = handle_guard(handle);
 
     if !handle.is_running() {
         debug!("FFI: Agent already shut down");
@@ -226,9 +255,23 @@ pub unsafe extern "C" fn mesh_shutdown(handle: *const MeshAgentHandle) {
 /// `mesh_flush_spans(2000)`) so spans published during the agent's final
 /// moments are not lost.
 ///
+/// Safe to call while other threads are still inside `mesh_*` accessors
+/// on the same handle (including a `mesh_next_event` parked on an
+/// infinite timeout): the handle is reference-counted, so this releases
+/// the creation reference and the underlying resources are dropped when
+/// the last in-flight call returns. A parked infinite `mesh_next_event`
+/// unparks on its own — the graceful shutdown triggered here makes the
+/// runtime emit the shutdown event and then exit, closing the event
+/// channel, so the parked caller observes the shutdown event (or channel
+/// close → NULL) and returns. Only if the runtime is wedged and never
+/// processes the shutdown signal does a parked infinite wait keep the
+/// resources alive (a leak, not a crash).
+///
 /// # Safety
 /// * `handle` must be a valid handle from `mesh_start_agent` or NULL
-/// * After this call, `handle` is invalid and must not be used
+/// * After this call, `handle` is invalid and must not be passed to any
+///   `mesh_*` function (calls already in flight are safe; new calls are
+///   not)
 #[no_mangle]
 pub unsafe extern "C" fn mesh_free_handle(handle: *mut MeshAgentHandle) {
     if handle.is_null() {
@@ -237,8 +280,10 @@ pub unsafe extern "C" fn mesh_free_handle(handle: *mut MeshAgentHandle) {
 
     info!("FFI: Freeing agent handle");
 
-    // Take ownership
-    let handle = Box::from_raw(handle);
+    // Take back the creation reference from mesh_start_agent. In-flight
+    // accessors hold their own strong counts (handle_guard), so dropping
+    // this one frees the memory only when no call is mid-execution.
+    let handle = Arc::from_raw(handle as *const MeshAgentHandle);
 
     // If still running, trigger graceful shutdown and wait (bounded) for
     // the runtime to finish unregistering before dropping it.
@@ -292,7 +337,8 @@ pub unsafe extern "C" fn mesh_free_handle(handle: *mut MeshAgentHandle) {
     // Mark as stopped
     handle.mark_stopped();
 
-    // The runtime and channels will be dropped automatically
+    // Release the creation reference. The runtime and channels drop here
+    // if no accessor is in flight, otherwise when the last guard drops.
     drop(handle);
 }
 
@@ -333,7 +379,7 @@ pub unsafe extern "C" fn mesh_next_event(
         return ptr::null_mut();
     }
 
-    let handle = &*handle;
+    let handle = handle_guard(handle);
 
     if !handle.is_running() {
         return ptr::null_mut();
@@ -421,7 +467,7 @@ pub unsafe extern "C" fn mesh_is_running(handle: *const MeshAgentHandle) -> i32 
         return 0;
     }
 
-    let handle = &*handle;
+    let handle = handle_guard(handle);
     if handle.is_running() {
         1
     } else {
@@ -482,7 +528,7 @@ pub unsafe extern "C" fn mesh_report_health(
     };
 
     // Update health status in shared state
-    let handle = &*handle;
+    let handle = handle_guard(handle);
     handle.runtime.block_on(async {
         let mut state = handle.shared_state.write().await;
         state.health_status = health_status;
@@ -523,7 +569,7 @@ pub unsafe extern "C" fn mesh_update_port(
         return -1;
     }
 
-    let handle = &*handle;
+    let handle = handle_guard(handle);
 
     match handle.command_tx.try_send(crate::runtime::RuntimeCommand::UpdatePort(port as u16)) {
         Ok(_) => {
@@ -2735,7 +2781,9 @@ mod tests {
         let (_event_tx, event_rx) = mpsc::channel::<MeshEvent>(4);
         let (shutdown_tx, _shutdown_rx) = mpsc::channel(1);
         let (command_tx, _command_rx) = mpsc::channel(1);
-        let handle = Box::new(MeshAgentHandle {
+        // Arc (not Box): mesh_free_handle reclaims via Arc::from_raw,
+        // matching what mesh_start_agent hands out.
+        let handle = Arc::new(MeshAgentHandle {
             event_rx: Mutex::new(event_rx),
             shutdown_tx,
             command_tx,
@@ -2746,7 +2794,7 @@ mod tests {
             agent_id: None,
             shared_state: Arc::new(tokio::sync::RwLock::new(HandleState::default())),
         });
-        unsafe { mesh_free_handle(Box::into_raw(handle)) };
+        unsafe { mesh_free_handle(Arc::into_raw(handle) as *mut MeshAgentHandle) };
         assert_eq!(
             count_xadds(),
             5,
@@ -2755,6 +2803,58 @@ mod tests {
 
         std::env::remove_var("MCP_MESH_DISTRIBUTED_TRACING_ENABLED");
         std::env::remove_var("REDIS_URL");
+    }
+
+    /// Freeing the handle while another thread sits parked in an
+    /// infinite-timeout `mesh_next_event` must not crash (the
+    /// use-after-free this would have been with a Box-owned handle), and
+    /// the parked caller must unpark cleanly once the event channel
+    /// closes. With a wedged runtime (no shutdown event ever emitted —
+    /// the test holds the event sender), free's bounded 2s wait times
+    /// out, free returns, and the parked caller returns NULL when the
+    /// sender finally drops.
+    #[test]
+    fn test_free_handle_while_next_event_parked() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let (event_tx, event_rx) = mpsc::channel::<MeshEvent>(4);
+        let (shutdown_tx, _shutdown_rx) = mpsc::channel(1);
+        let (command_tx, _command_rx) = mpsc::channel(1);
+        let handle = Arc::new(MeshAgentHandle {
+            event_rx: Mutex::new(event_rx),
+            shutdown_tx,
+            command_tx,
+            runtime,
+            is_running: AtomicBool::new(true),
+            agent_id: None,
+            shared_state: Arc::new(tokio::sync::RwLock::new(HandleState::default())),
+        });
+        let ptr = Arc::into_raw(handle) as *mut MeshAgentHandle;
+
+        // Park a caller in an infinite wait. Its handle_guard keeps the
+        // handle alive across the concurrent free below.
+        let ptr_addr = ptr as usize;
+        let parked = std::thread::spawn(move || {
+            let result =
+                unsafe { mesh_next_event(ptr_addr as *const MeshAgentHandle, -1) };
+            result.is_null()
+        });
+
+        // Give the thread time to actually park inside recv().
+        std::thread::sleep(Duration::from_millis(200));
+        assert!(!parked.is_finished(), "caller must be parked before free");
+
+        // Free while parked. The graceful-shutdown wait can't get the
+        // receiver lock (the parked caller holds it) and no shutdown
+        // event ever arrives, so this returns after its 2s budget —
+        // dropping the creation reference but NOT the memory.
+        unsafe { mesh_free_handle(ptr) };
+
+        // The parked caller is still alive and still parked; dropping the
+        // last sender closes the channel and unparks it with None → NULL.
+        assert!(!parked.is_finished(), "parked caller must survive free");
+        drop(event_tx);
+        let got_null = parked.join().expect("parked mesh_next_event must not crash");
+        assert!(got_null, "parked caller must observe channel close as NULL");
     }
 
     #[test]

--- a/src/runtime/core/src/handle.rs
+++ b/src/runtime/core/src/handle.rs
@@ -199,6 +199,38 @@ impl AgentHandle {
         state.shutdown_requested
     }
 
+    /// Get current dependency endpoints (async version).
+    ///
+    /// Use this — not the `*_internal` variant — when calling from an
+    /// async context (e.g. napi-rs async methods): `blocking_read()`
+    /// panics when invoked within an async execution context. Mirrors
+    /// the `shutdown_async` / `update_tools_async` pattern.
+    pub async fn get_dependencies_async(&self) -> HashMap<String, String> {
+        let state = self.state.read().await;
+        state.dependencies.clone()
+    }
+
+    /// Get current agent health status (async version).
+    /// See [`Self::get_dependencies_async`] for when to use this.
+    pub async fn get_status_async(&self) -> HealthStatus {
+        let state = self.state.read().await;
+        state.health_status
+    }
+
+    /// Get the agent ID assigned by the registry (async version).
+    /// See [`Self::get_dependencies_async`] for when to use this.
+    pub async fn get_agent_id_async(&self) -> Option<String> {
+        let state = self.state.read().await;
+        state.agent_id.clone()
+    }
+
+    /// Check if shutdown has been requested (async version).
+    /// See [`Self::get_dependencies_async`] for when to use this.
+    pub async fn is_shutdown_requested_async(&self) -> bool {
+        let state = self.state.read().await;
+        state.shutdown_requested
+    }
+
     /// Request graceful shutdown of the agent runtime.
     pub fn shutdown_internal(&self) {
         // Set shutdown flag
@@ -333,6 +365,45 @@ mod tests {
             .unwrap();
 
         drop(event_tx);
+    }
+
+    /// Issue #1166 MED-2: the async accessors must be callable from
+    /// within a tokio runtime. The `*_internal` variants use
+    /// `blocking_read()`, which panics in an async execution context —
+    /// these `.await`-based variants are what async bindings (napi)
+    /// must call.
+    #[tokio::test]
+    async fn test_async_accessors_work_in_async_context() {
+        let (_event_tx, event_rx) = mpsc::channel(10);
+        let (shutdown_tx, _shutdown_rx) = mpsc::channel(1);
+        let (command_tx, _command_rx) = mpsc::channel(10);
+        let state = Arc::new(RwLock::new(HandleState::default()));
+
+        let handle = AgentHandle::new(event_rx, state.clone(), shutdown_tx, command_tx);
+
+        {
+            let mut s = state.write().await;
+            s.agent_id = Some("async-agent".to_string());
+            s.dependencies
+                .insert("date-service".to_string(), "http://localhost:9001".to_string());
+            s.health_status = HealthStatus::Degraded;
+        }
+
+        assert_eq!(
+            handle.get_agent_id_async().await,
+            Some("async-agent".to_string())
+        );
+        let deps = handle.get_dependencies_async().await;
+        assert_eq!(deps.len(), 1);
+        assert_eq!(
+            deps.get("date-service").map(String::as_str),
+            Some("http://localhost:9001")
+        );
+        assert_eq!(handle.get_status_async().await, HealthStatus::Degraded);
+        assert!(!handle.is_shutdown_requested_async().await);
+
+        handle.shutdown_async().await;
+        assert!(handle.is_shutdown_requested_async().await);
     }
 
     #[test]

--- a/src/runtime/core/src/heartbeat.rs
+++ b/src/runtime/core/src/heartbeat.rs
@@ -187,7 +187,7 @@ impl HeartbeatStateMachine {
                 // Registry doesn't know us, need to re-register
                 warn!("Agent unknown to registry, re-registering");
                 self.registered = false;
-                self.state = HeartbeatState::Unregistered;
+                self.transition(HeartbeatState::Unregistered);
                 HeartbeatAction::SendFull
             }
             FastHeartbeatStatus::RegistryError | FastHeartbeatStatus::NetworkError => {
@@ -199,7 +199,7 @@ impl HeartbeatStateMachine {
                 );
 
                 if self.consecutive_failures >= self.config.missed_threshold {
-                    self.state = HeartbeatState::Reconnecting;
+                    self.transition(HeartbeatState::Reconnecting);
                     self.retry_attempt = 0;
                 }
 
@@ -217,11 +217,11 @@ impl HeartbeatStateMachine {
         self.registered = true;
         self.heartbeat_count += 1;
 
-        self.state = match self.health_status {
+        self.transition(match self.health_status {
             HealthStatus::Healthy => HeartbeatState::Healthy,
             HealthStatus::Degraded => HeartbeatState::Degraded,
             HealthStatus::Unhealthy => HeartbeatState::Degraded,
-        };
+        });
     }
 
     /// Process a full heartbeat failure.
@@ -231,8 +231,28 @@ impl HeartbeatStateMachine {
         self.retry_attempt += 1;
 
         if self.consecutive_failures >= self.config.missed_threshold {
-            self.state = HeartbeatState::Reconnecting;
+            self.transition(HeartbeatState::Reconnecting);
         }
+    }
+
+    /// Transition to a new state, preserving `ShuttingDown`.
+    ///
+    /// `ShuttingDown` is sticky: once `shutdown()` runs, no heartbeat
+    /// outcome may overwrite it. Without this, a full heartbeat that
+    /// succeeds after a shutdown request (e.g. the Retry arm's
+    /// post-backoff heartbeat in `AgentRuntime::run`) would flip the
+    /// state back to Healthy/Degraded — and since the one-shot shutdown
+    /// signal was already consumed from the capacity-1 channel, the
+    /// agent would re-register and run forever (issue #1166).
+    fn transition(&mut self, new_state: HeartbeatState) {
+        if self.state == HeartbeatState::ShuttingDown {
+            debug!(
+                "Ignoring heartbeat state transition to {:?} during shutdown",
+                new_state
+            );
+            return;
+        }
+        self.state = new_state;
     }
 
     /// Request shutdown.
@@ -450,6 +470,55 @@ mod tests {
         let mut sm = HeartbeatStateMachine::new(HeartbeatConfig::default());
         sm.shutdown();
 
+        assert!(sm.is_shutting_down());
+        assert_eq!(sm.next_action(), HeartbeatAction::None);
+    }
+
+    /// Issue #1166 MED-1: a full-heartbeat success landing after a
+    /// shutdown request must NOT overwrite ShuttingDown with Healthy.
+    #[test]
+    fn test_shutdown_preserved_across_full_heartbeat_success() {
+        let mut sm = HeartbeatStateMachine::new(HeartbeatConfig::default());
+        sm.on_full_heartbeat_success();
+        sm.shutdown();
+
+        sm.on_full_heartbeat_success();
+        assert!(sm.is_shutting_down(), "success must not clear ShuttingDown");
+        assert_eq!(sm.next_action(), HeartbeatAction::None);
+    }
+
+    /// ShuttingDown is sticky across failures too — Reconnecting must
+    /// not replace it (would re-enter the Retry arm forever).
+    #[test]
+    fn test_shutdown_preserved_across_full_heartbeat_failure() {
+        let config = HeartbeatConfig {
+            missed_threshold: 1,
+            ..Default::default()
+        };
+        let mut sm = HeartbeatStateMachine::new(config);
+        sm.shutdown();
+
+        sm.on_full_heartbeat_failure("boom");
+        assert!(sm.is_shutting_down(), "failure must not clear ShuttingDown");
+        assert_eq!(sm.next_action(), HeartbeatAction::None);
+    }
+
+    /// Fast-heartbeat outcomes (AgentUnknown -> Unregistered, errors ->
+    /// Reconnecting) must also preserve ShuttingDown.
+    #[test]
+    fn test_shutdown_preserved_across_fast_heartbeat_results() {
+        let config = HeartbeatConfig {
+            missed_threshold: 1,
+            ..Default::default()
+        };
+        let mut sm = HeartbeatStateMachine::new(config);
+        sm.on_full_heartbeat_success();
+        sm.shutdown();
+
+        let _ = sm.on_fast_heartbeat_result(fhb(FastHeartbeatStatus::AgentUnknown));
+        assert!(sm.is_shutting_down());
+
+        let _ = sm.on_fast_heartbeat_result(fhb(FastHeartbeatStatus::NetworkError));
         assert!(sm.is_shutting_down());
         assert_eq!(sm.next_action(), HeartbeatAction::None);
     }

--- a/src/runtime/core/src/jobs.rs
+++ b/src/runtime/core/src/jobs.rs
@@ -8,7 +8,7 @@
 //! v1"). TODO(phase 2/3): SQLite backing for crash-survival across replica
 //! restarts.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::future::Future;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
@@ -77,16 +77,15 @@ pub struct JobCancelled;
 /// collapse to the latest; terminal deltas are kept as-is and replace any
 /// pending progress for that job.
 ///
-/// `terminal` tracks job ids that have already been flushed via
-/// `flush_terminal` so any racing `update_progress` for the same job is
-/// dropped on the floor. This preserves the "no progress after terminal"
-/// invariant even when the mutex is briefly released between the queue
-/// drain and the backend submit (see `JobController::flush_terminal`):
-/// without this guard a concurrent `update_progress` could re-enqueue a
-/// progress delta AFTER the terminal had already left the queue, and the
-/// next batching-tick flush would push that progress to the registry —
-/// where it would either silently overwrite the terminal status or get
-/// rejected as a not_owner / illegal-transition delta.
+/// The "no progress after terminal" sentinel does NOT live here: it is a
+/// per-[`JobController`] flag (`JobController::terminal`) checked under
+/// this queue's mutex. Keeping it per-controller (instead of a
+/// process-lived `HashSet<String>` inside the queue) matters on the
+/// claim-worker path, where ONE queue is shared across every
+/// `JobController` the worker constructs — a queue-resident set would
+/// retain one string per completed job for the life of the process
+/// (issue #1166 LOW), and would also wrongly block progress from a NEW
+/// controller that re-claims a previously completed `job_id`.
 ///
 /// Public so the FFI layer (and language SDKs that wrap the producer-side
 /// pipeline directly) can construct one. Fields are private so callers can't
@@ -95,48 +94,20 @@ pub struct JobCancelled;
 #[derive(Default)]
 pub struct CoalescingQueue {
     pending: HashMap<String, JobDelta>,
-    /// Job ids that have already had a terminal delta dispatched. Any
-    /// further `enqueue` for these ids is silently dropped. The set is
-    /// process-lived (deliberate): once a job is terminal, it should
-    /// stay terminal for the rest of this controller's lifetime — the
-    /// JobController is single-use anyway (constructed per inbound
-    /// dispatch in `job_dispatch.maybe_dispatch_as_job`).
-    terminal: HashSet<String>,
 }
 
 impl CoalescingQueue {
     fn enqueue(&mut self, delta: JobDelta) {
-        let id = delta.id.clone();
-        if self.terminal.contains(&id) {
-            // Late progress after a terminal flush — drop it. Logged at
-            // debug because this is the *expected* path when an
-            // application thread fires one last update_progress while
-            // the controller is already shutting down; only operators
-            // tracing missing progress events care.
-            debug!(
-                "CoalescingQueue: dropping post-terminal delta for job {}",
-                id
-            );
-            return;
-        }
         // Terminal deltas always replace anything pending for that id;
         // progress-only deltas also replace prior pending progress for the
-        // same id (coalesce). Same insert behavior either way.
-        self.pending.insert(id, delta);
+        // same id (coalesce). Same insert behavior either way. The
+        // post-terminal drop guard lives in `JobController::update_progress`
+        // (checked under this queue's lock).
+        self.pending.insert(delta.id.clone(), delta);
     }
 
     fn drain(&mut self) -> Vec<JobDelta> {
         std::mem::take(&mut self.pending).into_values().collect()
-    }
-
-    /// Mark `job_id` as having been terminally flushed. Subsequent
-    /// `enqueue` calls for the same id are silently dropped. Idempotent.
-    fn mark_terminal(&mut self, job_id: &str) {
-        self.terminal.insert(job_id.to_string());
-        // Defensive: also evict any pending non-terminal entry for this
-        // id. Callers (`JobController::flush_terminal`) already remove
-        // explicitly, but doing it here keeps the invariant local.
-        self.pending.remove(job_id);
     }
 
     fn len(&self) -> usize {
@@ -277,6 +248,14 @@ pub struct JobController {
     instance_id: String,
     backend: Arc<dyn TaskBackend>,
     queue: Arc<Mutex<CoalescingQueue>>,
+    /// Set once `complete` / `fail` / `release_lease` has dispatched a
+    /// terminal for this controller's job. Shared across `Clone`s of the
+    /// same instance. Checked (under the queue mutex) by
+    /// `update_progress` so a racing late progress delta can't land in
+    /// the queue after the terminal left it — per-controller rather than
+    /// queue-resident so the shared claim-worker queue doesn't accumulate
+    /// one entry per completed job forever (issue #1166 LOW).
+    terminal: Arc<std::sync::atomic::AtomicBool>,
     /// Last event seq returned by `recv_event` on this controller (or any
     /// of its `Clone`s). `0` means no events consumed yet — the next
     /// `recv_event` will return the first event in the job's event log.
@@ -307,6 +286,7 @@ impl JobController {
             instance_id: instance_id.into(),
             backend,
             queue,
+            terminal: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             last_seen_seq: Arc::new(AtomicI64::new(0)),
             recv_event_lock: Arc::new(Mutex::new(())),
         }
@@ -322,6 +302,24 @@ impl JobController {
     pub async fn update_progress(&self, progress: f32, message: Option<String>) {
         let delta = JobDelta::progress(self.job_id.clone(), progress, message);
         let mut q = self.queue.lock().await;
+        // Check the terminal sentinel UNDER the queue lock: flush_terminal
+        // sets it (and evicts pending) while holding the same lock, so a
+        // racing late progress delta can never land in the queue after the
+        // terminal left it (would push stale progress to the registry on
+        // the next batching tick — silently overwriting the terminal status
+        // or getting rejected as not_owner / illegal-transition).
+        if self.terminal.load(Ordering::SeqCst) {
+            // Late progress after a terminal flush — drop it. Logged at
+            // debug because this is the *expected* path when an
+            // application thread fires one last update_progress while
+            // the controller is already shutting down; only operators
+            // tracing missing progress events care.
+            debug!(
+                "JobController: dropping post-terminal progress delta for job {}",
+                self.job_id
+            );
+            return;
+        }
         q.enqueue(delta);
     }
 
@@ -341,15 +339,14 @@ impl JobController {
     }
 
     async fn flush_terminal(&self, mut delta: JobDelta) -> Result<(), JobError> {
-        // Mark the job terminal in the queue BEFORE dropping the lock —
-        // this both removes any pending non-terminal delta (the terminal
-        // supersedes it) and slams the door on any racing
-        // `update_progress` that lands while the backend submit is in
-        // flight. Without the sentinel, a concurrent progress update
+        // Set the per-controller terminal sentinel and evict the pending
+        // entry BEFORE dropping the lock — this slams the door on any
+        // racing `update_progress` that lands while the backend submit is
+        // in flight. Without the sentinel, a concurrent progress update
         // after we'd released the lock would land in the queue and the
         // next batching-tick flush would push stale progress AFTER a
-        // terminal status was already on the wire (see CoalescingQueue
-        // docs for the invariant).
+        // terminal status was already on the wire. (`update_progress`
+        // checks the sentinel under this same lock.)
         //
         // BEFORE we drop the pending entry, harvest its `progress_message`
         // and `progress` (if any) and fold them into the terminal delta —
@@ -369,7 +366,8 @@ impl JobController {
                     delta.progress = pending.progress;
                 }
             }
-            q.mark_terminal(&self.job_id);
+            self.terminal.store(true, Ordering::SeqCst);
+            q.pending.remove(&self.job_id);
         }
         self.backend
             .submit_batch(&self.instance_id, vec![delta])
@@ -381,9 +379,12 @@ impl JobController {
     /// controller. Exposed so per-language SDKs can tell whether a
     /// returning user function still needs an auto-`complete` (the
     /// "if the user forgot, finish the job for them" path).
+    ///
+    /// Per-controller (shared across `Clone`s) — a NEW controller for the
+    /// same `job_id` (e.g. a re-claim) starts non-terminal. Kept `async`
+    /// for binding-surface stability even though the read is lock-free.
     pub async fn is_terminal(&self) -> bool {
-        let q = self.queue.lock().await;
-        q.terminal.contains(&self.job_id)
+        self.terminal.load(Ordering::SeqCst)
     }
 
     /// Whether the cancel token bound to this controller's job in the
@@ -438,10 +439,12 @@ impl JobController {
         // Mark terminal locally first to mirror the flush_terminal pattern
         // (#880): prevents any racing update_progress from re-enqueuing a
         // delta that would land at the registry after we've released
-        // ownership.
+        // ownership. Sentinel set + pending eviction under the queue lock,
+        // same as flush_terminal.
         {
             let mut q = self.queue.lock().await;
-            q.mark_terminal(&self.job_id);
+            self.terminal.store(true, Ordering::SeqCst);
+            q.pending.remove(&self.job_id);
         }
         let resp = self
             .backend
@@ -943,14 +946,18 @@ where
 
 /// Drop guard that unregisters the job from [`crate::cancel_registry`]
 /// when scope exits — including the panic-unwind path. Pairs with the
-/// `register_active_job` call at the top of [`run_as_job`].
+/// `register_active_job` call at the top of [`run_as_job`]. Carries the
+/// registration generation so only THIS scope's registration is torn
+/// down — a different registration for the same `job_id` (nested
+/// dispatch, re-claimed attempt) is never disturbed (issue #1166 MED-4).
 struct CancelRegistryGuard {
     job_id: String,
+    generation: u64,
 }
 
 impl Drop for CancelRegistryGuard {
     fn drop(&mut self) {
-        cancel_registry::unregister_active_job(&self.job_id);
+        cancel_registry::unregister_active_job(&self.job_id, self.generation);
     }
 }
 
@@ -971,9 +978,10 @@ pub async fn run_as_job<F, T>(ctx: JobContext, body: F) -> T
 where
     F: Future<Output = T>,
 {
-    cancel_registry::register_active_job(&ctx.job_id, ctx.cancel_token.clone());
+    let generation = cancel_registry::register_active_job(&ctx.job_id, ctx.cancel_token.clone());
     let _guard = CancelRegistryGuard {
         job_id: ctx.job_id.clone(),
+        generation,
     };
     job_context::with_job(ctx, body).await
 }
@@ -1684,6 +1692,68 @@ mod tests {
         let (_, deltas) = backend.last_batch().unwrap();
         assert_eq!(deltas.len(), 1);
         assert!(deltas[0].is_terminal());
+    }
+
+    /// Issue #1166 LOW: the terminal sentinel is per-controller, not
+    /// queue-resident. On the claim-worker path one queue is shared
+    /// across all controllers — a queue-lived `HashSet<job_id>` would
+    /// (a) retain one string per completed job forever and (b) wrongly
+    /// block progress from a NEW controller that re-claims a previously
+    /// completed job_id. A fresh controller for the same job_id on the
+    /// same shared queue must be able to enqueue progress.
+    #[tokio::test]
+    async fn terminal_guard_is_per_controller_not_shared_queue() {
+        let backend = MockBackend::new();
+        let queue = new_coalescing_queue();
+        let resp = backend
+            .create_job(CreateJobRequest {
+                capability: "cap".into(),
+                submitted_payload: serde_json::json!({}),
+                submitted_by: "inst-1".into(),
+                max_retries: None,
+                max_duration: None,
+                total_deadline: None,
+                owner_instance_id: None,
+            })
+            .await
+            .unwrap();
+
+        let first_attempt = JobController::new(
+            resp.id.clone(),
+            "inst-1".to_string(),
+            backend.clone() as Arc<dyn TaskBackend>,
+            queue.clone(),
+        );
+        first_attempt
+            .complete(serde_json::json!({"done": true}))
+            .await
+            .unwrap();
+        assert!(first_attempt.is_terminal().await);
+
+        // Same job_id re-claimed: a NEW controller on the SAME queue.
+        let second_attempt = JobController::new(
+            resp.id.clone(),
+            "inst-1".to_string(),
+            backend.clone() as Arc<dyn TaskBackend>,
+            queue.clone(),
+        );
+        assert!(
+            !second_attempt.is_terminal().await,
+            "fresh controller must start non-terminal"
+        );
+        second_attempt.update_progress(0.5, Some("retry".into())).await;
+        {
+            let q = queue.lock().await;
+            assert_eq!(
+                q.len(),
+                1,
+                "fresh controller's progress must reach the shared queue"
+            );
+        }
+
+        // The first controller's clone still drops late progress.
+        let clone_of_first = first_attempt.clone();
+        assert!(clone_of_first.is_terminal().await);
     }
 
     #[tokio::test]

--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -1504,12 +1504,12 @@ mod tests {
             "await-cancel-natural-{}",
             uuid::Uuid::new_v4().simple()
         );
-        cancel_registry::register_active_job(&job_id, CancellationToken::new());
+        let generation = cancel_registry::register_active_job(&job_id, CancellationToken::new());
 
         let job_id_for_thread = job_id.clone();
         let unregisterer = thread::spawn(move || {
             thread::sleep(Duration::from_millis(50));
-            cancel_registry::unregister_active_job(&job_id_for_thread);
+            cancel_registry::unregister_active_job(&job_id_for_thread, generation);
         });
 
         let id_c = CString::new(job_id).unwrap();
@@ -1534,7 +1534,7 @@ mod tests {
 
         // Registered, not cancelled → 0 (and the probe must not fire it).
         let token = CancellationToken::new();
-        cancel_registry::register_active_job(&job_id, token.clone());
+        let generation = cancel_registry::register_active_job(&job_id, token.clone());
         assert_eq!(unsafe { mesh_job_cancel_fired(id_c.as_ptr()) }, 0);
         assert!(!token.is_cancelled(), "probe must be read-only");
 
@@ -1543,8 +1543,16 @@ mod tests {
         assert_eq!(unsafe { mesh_job_cancel_fired(id_c.as_ptr()) }, 1);
 
         // Natural teardown (unregister) → back to 0.
-        cancel_registry::unregister_active_job(&job_id);
+        cancel_registry::unregister_active_job(&job_id, generation);
         assert_eq!(unsafe { mesh_job_cancel_fired(id_c.as_ptr()) }, 0);
+
+        // Re-claim under the same id: a fresh registration must NOT look
+        // cancelled (issue #1166 MED-4 — stacked registrations keep
+        // per-frame tokens; a new frame starts un-fired).
+        let retoken = CancellationToken::new();
+        let regen = cancel_registry::register_active_job(&job_id, retoken);
+        assert_eq!(unsafe { mesh_job_cancel_fired(id_c.as_ptr()) }, 0);
+        cancel_registry::unregister_active_job(&job_id, regen);
     }
 
     /// Null pointer must be rejected with `-1` via the last-error slot,

--- a/src/runtime/core/src/jobs_py.rs
+++ b/src/runtime/core/src/jobs_py.rs
@@ -631,20 +631,23 @@ pub fn with_job_async_py<'py>(
     // that as a real cancel and abort the user task immediately. By
     // registering here — synchronously, before any asyncio scheduling
     // happens — the watcher always observes a live entry.
-    cancel_registry::register_active_job(&job_id, ctx.cancel_token.clone());
+    let generation = cancel_registry::register_active_job(&job_id, ctx.cancel_token.clone());
     // Panic-safe RAII: cleanup runs whether the body completes normally,
     // returns Err, or panics. Mirrors `CancelRegistryGuard` in
-    // `jobs.rs::run_as_job`.
+    // `jobs.rs::run_as_job`. Carries the registration generation so only
+    // THIS registration is torn down (issue #1166 MED-4).
     struct CleanupGuard {
         job_id: String,
+        generation: u64,
     }
     impl Drop for CleanupGuard {
         fn drop(&mut self) {
-            cancel_registry::unregister_active_job(&self.job_id);
+            cancel_registry::unregister_active_job(&self.job_id, self.generation);
         }
     }
     let guard = CleanupGuard {
         job_id: job_id.clone(),
+        generation,
     };
 
     // Convert the Python awaitable to a Rust future. Per pyo3-async-runtimes
@@ -666,21 +669,22 @@ pub fn with_job_async_py<'py>(
         // future's lifetime (not this synchronous function's stack frame).
         let _guard = guard;
         // `run_as_job` binds the task-local JobContext for Rust-side
-        // futures inside the body. It will also re-register the cancel
-        // token (idempotent — `register_active_job` overwrites existing
-        // entries with the same `job_id` + same `cancel_token` clone, so
-        // semantics are unchanged) and install its own drop guard. The
-        // outer guard above is what closes the race window between this
-        // function returning and the body being polled.
+        // futures inside the body. It also registers a SECOND cancel-
+        // registry frame for the same job_id (a clone of the same
+        // `cancel_token`, so cancels propagate through either frame) and
+        // installs its own drop guard. The outer registration above is
+        // what closes the race window between this function returning and
+        // the body being polled.
         //
-        // Duplicate-registration note: the outer `register_active_job`
-        // above creates a `JobCancelState` whose `ended` notify token is
-        // silently dropped when `run_as_job`'s inner registration
-        // overwrites the entry. This is safe because the `cancel_token`
-        // is a clone sharing state, so cancels still propagate; only the
-        // `ended` token instance is replaced, and any awaiter that grabbed
-        // the inner entry's `ended` token is still notified when this
-        // outer drop guard fires (via the registry entry being removed).
+        // Duplicate-registration note (issue #1166 MED-4): the registry
+        // stacks registrations per job_id — the inner `run_as_job` frame
+        // sits on top of the outer one; nothing is displaced and no
+        // `ended` token is dropped unfired. Each frame's `ended` fires at
+        // its own unregister: the inner frame's when `run_as_job`'s guard
+        // drops (body finished), the outer frame's microseconds later
+        // when the guard above drops. A Python `await_job_cancel(job_id)`
+        // watcher that snapshotted EITHER frame therefore wakes on
+        // natural end.
         run_as_job(ctx, async move {
             // Awaiting `fut` yields a `PyResult<Py<PyAny>>` — propagate
             // both the success value and any Python exception verbatim.

--- a/src/runtime/core/src/lib.rs
+++ b/src/runtime/core/src/lib.rs
@@ -137,9 +137,15 @@ pub fn init_logging() {
 #[cfg(feature = "python")]
 #[pyfunction]
 #[pyo3(signature = (spec))]
-fn start_agent_py(_py: Python<'_>, spec: AgentSpec) -> PyResult<AgentHandle> {
+fn start_agent_py(py: Python<'_>, spec: AgentSpec) -> PyResult<AgentHandle> {
     init_logging();
-    start_agent_internal(spec).map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))
+    // Detach from the interpreter: construction is synchronous and
+    // `AgentRuntime::new` can perform real network I/O (TLS resolution
+    // against Vault/SPIRE when no config was pre-cached by prepare_tls).
+    // Running it attached would freeze every other Python thread for the
+    // duration of those calls.
+    py.detach(|| start_agent_internal(spec))
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))
 }
 
 /// Internal agent start function (language-agnostic).
@@ -157,51 +163,43 @@ pub fn start_agent_internal(spec: AgentSpec) -> Result<AgentHandle, String> {
         ..Default::default()
     };
 
-    // We need to spawn a tokio runtime in a background thread
-    // because Python's asyncio and tokio don't mix well in the same thread
-    let (event_rx, shared_state, shutdown_tx, command_tx) = {
-        // Create channels that will be used by both the spawned thread and the handle
-        let (event_tx, event_rx) = tokio::sync::mpsc::channel(config.event_buffer_size);
-        let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel(1);
-        let (command_tx, command_rx) = tokio::sync::mpsc::channel::<runtime::RuntimeCommand>(10);
-        let shared_state = Arc::new(RwLock::new(HandleState::default()));
+    // Create channels that will be used by both the spawned thread and the handle
+    let (event_tx, event_rx) = tokio::sync::mpsc::channel(config.event_buffer_size);
+    let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel(1);
+    let (command_tx, command_rx) = tokio::sync::mpsc::channel::<runtime::RuntimeCommand>(10);
+    let shared_state = Arc::new(RwLock::new(HandleState::default()));
 
-        let spec_clone = spec.clone();
-        let config_clone = config.clone();
-        let event_tx_clone = event_tx;
-        let shared_state_clone = shared_state.clone();
+    // Construct the runtime SYNCHRONOUSLY so initialization errors (TLS
+    // resolution, registry-client construction) propagate to the caller
+    // as a Python/JS exception instead of being logged inside the spawned
+    // thread while a healthy-looking handle is returned (issue #1166 LOW
+    // — mirrors the C-ABI `mesh_start_agent` fix).
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| format!("Failed to create tokio runtime: {}", e))?;
+    let agent_runtime = rt
+        .block_on(runtime::AgentRuntime::new(
+            spec,
+            config,
+            event_tx,
+            shared_state.clone(),
+            shutdown_rx,
+            command_rx,
+        ))
+        .map_err(|e| format!("Failed to create agent runtime: {}", e))?;
 
-        // Spawn background thread with tokio runtime
-        thread::spawn(move || {
-            // Initialize Python in this thread to allow PyO3 object creation
-            #[cfg(feature = "python")]
-            {
-                // Ensure Python is attached to this thread for PyO3 operations
-                pyo3::Python::attach(|_| {});
-            }
+    // Run the heartbeat loop on a background thread with its own tokio
+    // runtime because Python's asyncio and tokio don't mix well in the
+    // same thread.
+    thread::spawn(move || {
+        // Initialize Python in this thread to allow PyO3 object creation
+        #[cfg(feature = "python")]
+        {
+            // Ensure Python is attached to this thread for PyO3 operations
+            pyo3::Python::attach(|_| {});
+        }
 
-            let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
-            rt.block_on(async {
-                match runtime::AgentRuntime::new(
-                    spec_clone,
-                    config_clone,
-                    event_tx_clone,
-                    shared_state_clone,
-                    shutdown_rx,
-                    command_rx,
-                ).await {
-                    Ok(agent_runtime) => {
-                        agent_runtime.run().await;
-                    }
-                    Err(e) => {
-                        tracing::error!("Failed to create agent runtime: {}", e);
-                    }
-                }
-            });
-        });
-
-        (event_rx, shared_state, shutdown_tx, command_tx)
-    };
+        rt.block_on(agent_runtime.run());
+    });
 
     // Create the handle
     let handle = AgentHandle::new(event_rx, shared_state, shutdown_tx, command_tx);
@@ -462,13 +460,19 @@ fn call_tool_py(
     let args = args_json.map(|s| s.to_string());
     let headers = headers_json.map(|s| s.to_string());
 
-    pyo3_async_runtimes::tokio::get_runtime().block_on(py.allow_threads(|| async {
-        mcp_client::call_tool(
-            &endpoint, &tool_name,
-            args.as_deref(), headers.as_deref(),
-            timeout_ms, max_retries,
-        ).await.map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))
-    }))
+    // Detach around the ENTIRE block_on: the previous
+    // `block_on(py.allow_threads(|| async ...))` shape only released the
+    // GIL while constructing the future, then ran the HTTP call with the
+    // GIL held — blocking every Python thread for up to timeout_ms.
+    py.detach(|| {
+        pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+            mcp_client::call_tool(
+                &endpoint, &tool_name,
+                args.as_deref(), headers.as_deref(),
+                timeout_ms, max_retries,
+            ).await.map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))
+        })
+    })
 }
 
 // =============================================================================

--- a/src/runtime/core/src/lib.rs
+++ b/src/runtime/core/src/lib.rs
@@ -97,16 +97,29 @@ pub mod napi;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 
+// Imports below are gated to the binding features that use them
+// (start_agent_internal for python|typescript, the pymodule for python)
+// so feature combos without bindings (e.g. ffi-only) build warning-free.
+#[cfg(any(feature = "python", feature = "typescript"))]
 use std::sync::Arc;
+#[cfg(any(feature = "python", feature = "typescript"))]
 use std::thread;
+#[cfg(any(feature = "python", feature = "typescript"))]
 use tokio::sync::RwLock;
+#[cfg(any(feature = "python", feature = "typescript"))]
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
+#[cfg(feature = "python")]
 use events::{EventType, HealthStatus, LlmToolInfo, MeshEvent};
+#[cfg(any(feature = "python", feature = "typescript"))]
 use handle::{AgentHandle, HandleState};
+#[cfg(any(feature = "python", feature = "typescript"))]
 use runtime::RuntimeConfig;
-use spec::{AgentSpec, DependencySpec, LlmAgentSpec, ToolSpec};
+#[cfg(any(feature = "python", feature = "typescript"))]
+use spec::AgentSpec;
+#[cfg(feature = "python")]
+use spec::{DependencySpec, LlmAgentSpec, ToolSpec};
 
 /// Initialize logging with tracing.
 ///
@@ -150,8 +163,25 @@ fn start_agent_py(py: Python<'_>, spec: AgentSpec) -> PyResult<AgentHandle> {
 
 /// Internal agent start function (language-agnostic).
 ///
-/// This is the core implementation used by both Python bindings and FFI.
-pub fn start_agent_internal(spec: AgentSpec) -> Result<AgentHandle, String> {
+/// This is the core implementation shared by the Python (pyo3) and
+/// TypeScript (napi) bindings, which both call it from synchronous,
+/// non-async contexts. The C ABI (`mesh_start_agent`) has its own
+/// equivalent in `ffi.rs`.
+///
+/// Must NOT be called from inside a tokio runtime: it creates its own
+/// runtime and `block_on`s it, which would panic in an async context —
+/// guarded below so callers get an `Err` instead of a panic.
+#[cfg(any(feature = "python", feature = "typescript"))]
+pub(crate) fn start_agent_internal(spec: AgentSpec) -> Result<AgentHandle, String> {
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return Err(
+            "start_agent_internal called from within a tokio runtime; it creates its own \
+             runtime and blocks on it, which is not allowed in an async context — call it \
+             from a non-async thread"
+                .to_string(),
+        );
+    }
+
     info!("Starting agent '{}' with Rust core", spec.name);
 
     // Create runtime config from spec

--- a/src/runtime/core/src/napi.rs
+++ b/src/runtime/core/src/napi.rs
@@ -377,31 +377,36 @@ impl JsAgentHandle {
     /// Get current dependency endpoints.
     ///
     /// Returns an object mapping capability names to endpoint URLs.
+    ///
+    /// NB: these accessors run inside napi's tokio runtime, so they must
+    /// use the `*_async` handle variants — the `*_internal` ones call
+    /// `blocking_read()`, which panics in an async execution context
+    /// (issue #1166 MED-2).
     #[napi]
     pub async fn get_dependencies(&self) -> Result<HashMap<String, String>> {
         let handle = self.inner.lock().await;
-        Ok(handle.get_dependencies_internal())
+        Ok(handle.get_dependencies_async().await)
     }
 
     /// Get current agent health status.
     #[napi]
     pub async fn get_status(&self) -> Result<String> {
         let handle = self.inner.lock().await;
-        Ok(handle.get_status_internal().as_api_str().to_string())
+        Ok(handle.get_status_async().await.as_api_str().to_string())
     }
 
     /// Get the agent ID assigned by the registry.
     #[napi]
     pub async fn get_agent_id(&self) -> Result<Option<String>> {
         let handle = self.inner.lock().await;
-        Ok(handle.get_agent_id_internal())
+        Ok(handle.get_agent_id_async().await)
     }
 
     /// Check if shutdown has been requested.
     #[napi]
     pub async fn is_shutdown_requested(&self) -> Result<bool> {
         let handle = self.inner.lock().await;
-        Ok(handle.is_shutdown_requested_internal())
+        Ok(handle.is_shutdown_requested_async().await)
     }
 
     /// Request graceful shutdown of the agent runtime.
@@ -473,6 +478,15 @@ impl JsAgentHandle {
 /// - Periodic heartbeats
 /// - Topology change detection
 /// - Event streaming
+///
+/// NOTE: construction is synchronous and runs on the calling JS thread
+/// (normally the Node main thread). TLS resolution inside
+/// `AgentRuntime::new` short-circuits to the config cached by
+/// `prepare_tls` — the TS SDK calls `prepareTls()` before `startAgent()`
+/// in all three boot paths (agent.ts, api-runtime.ts, express.ts), so no
+/// Vault/SPIRE network I/O happens here. If a future caller skips
+/// `prepare_tls` while a network credential provider is configured,
+/// `TlsConfig::resolve` would block this thread on that I/O.
 #[napi]
 pub fn start_agent(spec: JsAgentSpec) -> Result<JsAgentHandle> {
     crate::init_logging();

--- a/src/runtime/core/src/runtime.rs
+++ b/src/runtime/core/src/runtime.rs
@@ -259,6 +259,17 @@ impl AgentRuntime {
                             }
                         }
                     }
+                    // A shutdown that arrived during the backoff consumed
+                    // the one-shot signal from the capacity-1 channel — the
+                    // next iteration's try_recv would find nothing. Skip the
+                    // heartbeat so the loop-top is_shutting_down() check runs
+                    // the normal shutdown path (unregister + shutdown event)
+                    // instead of re-registering (issue #1166 MED-1). The
+                    // Wait arm doesn't need this: it does no state-mutating
+                    // work after its select.
+                    if self.state_machine.is_shutting_down() {
+                        continue;
+                    }
                     // After backoff, try full registration
                     self.send_full_heartbeat().await;
                 }
@@ -609,16 +620,32 @@ impl AgentRuntime {
             }
         }
 
-        // Update local topology and emit events (no lock needed)
+        // Update local topology and emit events (no lock needed).
+        //
+        // Send each event BEFORE recording the change in the topology map.
+        // If the send fails (channel dropped/full receiver gone), leaving
+        // the topology unchanged means the diff gate re-detects the change
+        // on the next heartbeat and re-emits (self-healing) — recording it
+        // anyway would permanently suppress re-emission (a lost
+        // DEPENDENCY_AVAILABLE would leave the consumer proxy unbound
+        // forever). Mirrors `process_llm_providers_changes`.
         for (key, value) in removed {
-            let _ = self
+            if let Err(e) = self
                 .event_tx
                 .send(MeshEvent::dependency_unavailable(
                     value.capability.clone(),
                     key.requesting_function.clone(),
                     key.dep_index,
                 ))
-                .await;
+                .await
+            {
+                warn!(
+                    "Failed to emit DEPENDENCY_UNAVAILABLE for '{}' at {}:{}: {}; \
+                     will retry on next heartbeat",
+                    value.capability, key.requesting_function, key.dep_index, e
+                );
+                continue;
+            }
             self.topology.dependencies.remove(&key);
         }
 
@@ -644,7 +671,14 @@ impl AgentRuntime {
                     value.kwargs.clone(),
                 )
             };
-            let _ = self.event_tx.send(event).await;
+            if let Err(e) = self.event_tx.send(event).await {
+                warn!(
+                    "Failed to emit dependency event for '{}' at {}:{}: {}; \
+                     will retry on next heartbeat",
+                    value.capability, key.requesting_function, key.dep_index, e
+                );
+                continue;
+            }
 
             self.topology.dependencies.insert(key, value);
         }
@@ -706,14 +740,25 @@ impl AgentRuntime {
                     tool_infos.len()
                 );
 
-                // Emit event
-                let _ = self
+                // Send the event BEFORE recording it in topology — same
+                // self-healing pattern as `process_llm_providers_changes`
+                // and `process_dependency_changes`: a failed send leaves
+                // the diff gate primed to re-emit on the next heartbeat.
+                if let Err(e) = self
                     .event_tx
                     .send(MeshEvent::llm_tools_updated(
                         function_id.clone(),
                         tool_infos.clone(),
                     ))
-                    .await;
+                    .await
+                {
+                    warn!(
+                        "Failed to emit LLM_TOOLS_UPDATED for function '{}': {}; \
+                         will retry on next heartbeat",
+                        function_id, e
+                    );
+                    continue;
+                }
 
                 self.topology
                     .llm_tools
@@ -816,5 +861,123 @@ mod tests {
         let config = RuntimeConfig::default();
         assert_eq!(config.event_buffer_size, 100);
         assert_eq!(config.heartbeat.interval, Duration::from_secs(5));
+    }
+
+    /// Issue #1166 MED-1 regression: a shutdown that arrives during the
+    /// Retry arm's backoff must terminate the runtime — even when the
+    /// registry recovers at exactly that heartbeat. Before the fix, the
+    /// Retry arm consumed the one-shot shutdown signal, then sent the
+    /// heartbeat anyway; the success overwrote ShuttingDown with Healthy
+    /// and the agent re-registered and ran forever.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_during_retry_backoff_is_not_swallowed() {
+        use crate::events::EventType;
+        use crate::spec::AgentSpec;
+
+        let mut server = mockito::Server::new_async().await;
+
+        // First full heartbeat fails -> with missed_threshold=1 the state
+        // machine enters Reconnecting and the run loop hits the Retry arm.
+        let fail = server
+            .mock("POST", "/heartbeat")
+            .with_status(500)
+            .expect(1)
+            .create_async()
+            .await;
+        // Registry "recovers": any subsequent heartbeat would succeed.
+        // It must never be hit — the shutdown arrives during the backoff.
+        let recover = server
+            .mock("POST", "/heartbeat")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"status":"success","message":"ok","agent_id":"shutdown-retry-agent"}"#)
+            .create_async()
+            .await;
+        // Graceful unregister during shutdown.
+        let unregister = server
+            .mock("DELETE", "/agents/shutdown-retry-agent")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let spec = AgentSpec::new(
+            "shutdown-retry-agent".to_string(),
+            server.url(),
+            "1.0.0".to_string(),
+            "".to_string(),
+            8080,
+            "localhost".to_string(),
+            "default".to_string(),
+            None,
+            None,
+            None,
+            None,
+            1, // heartbeat_interval (secs)
+            None,
+        );
+        let config = RuntimeConfig {
+            heartbeat: HeartbeatConfig {
+                interval: Duration::from_secs(1),
+                max_retries: 5,
+                // After one failure retry_attempt=1 -> capped at
+                // max_backoff=2s, equal jitter floors at 1s. The shutdown
+                // below lands ~300ms in, well inside the backoff window.
+                base_backoff: Duration::from_secs(2),
+                max_backoff: Duration::from_secs(2),
+                missed_threshold: 1,
+            },
+            event_buffer_size: 100,
+        };
+
+        let (event_tx, mut event_rx) = mpsc::channel(100);
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let (_command_tx, command_rx) = mpsc::channel(10);
+        let shared_state = Arc::new(RwLock::new(HandleState::default()));
+
+        let runtime = AgentRuntime::new(
+            spec,
+            config,
+            event_tx,
+            shared_state,
+            shutdown_rx,
+            command_rx,
+        )
+        .await
+        .expect("runtime construction should succeed");
+
+        let join = tokio::spawn(runtime.run());
+
+        // Let the first heartbeat fail and the Retry backoff begin, then
+        // request shutdown mid-backoff.
+        sleep(Duration::from_millis(300)).await;
+        shutdown_tx.send(()).await.expect("shutdown signal");
+
+        // The runtime must exit promptly (backoff floor is 1s; allow 5s).
+        tokio::time::timeout(Duration::from_secs(5), join)
+            .await
+            .expect("runtime did not exit after shutdown during retry backoff")
+            .expect("runtime task panicked");
+
+        // Collect emitted events: must include shutdown, must NOT include
+        // a (re-)registration.
+        let mut saw_shutdown = false;
+        while let Ok(event) = event_rx.try_recv() {
+            assert_ne!(
+                event.event_type,
+                EventType::AgentRegistered,
+                "agent must not re-register after shutdown was requested"
+            );
+            if event.event_type == EventType::Shutdown {
+                saw_shutdown = true;
+            }
+        }
+        assert!(saw_shutdown, "shutdown event must be emitted to the caller");
+
+        fail.assert_async().await;
+        assert!(
+            !recover.matched_async().await,
+            "no heartbeat may be sent after shutdown arrived during backoff"
+        );
+        unregister.assert_async().await;
     }
 }

--- a/src/runtime/core/src/tracing_publish.rs
+++ b/src/runtime/core/src/tracing_publish.rs
@@ -5,8 +5,9 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use redis::aio::{ConnectionManager, ConnectionManagerConfig};
 use redis::AsyncCommands;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
@@ -21,8 +22,16 @@ const TRACE_STREAM_NAME: &str = "mesh:trace";
 
 /// Global trace publisher state.
 struct TracePublisherState {
-    /// Redis client (lazily initialized).
-    client: Option<redis::Client>,
+    /// Reconnecting multiplexed connection, created once at init and
+    /// cheaply cloned per publish (issue #1166 MED-3 — previously every
+    /// span paid a fresh TCP dial + handshake via
+    /// `get_multiplexed_async_connection`). `ConnectionManager` is the
+    /// redis crate's reconnect convention: when a command fails because
+    /// the underlying connection died, the manager triggers a background
+    /// reconnect and subsequent commands succeed once Redis is back — so
+    /// a transient outage drops spans (acceptable for tracing) without
+    /// failing forever.
+    conn: Option<ConnectionManager>,
     /// Whether tracing is enabled.
     enabled: bool,
     /// Whether Redis is available.
@@ -34,7 +43,7 @@ struct TracePublisherState {
 impl Default for TracePublisherState {
     fn default() -> Self {
         Self {
-            client: None,
+            conn: None,
             enabled: false,
             available: false,
             redis_url: String::new(),
@@ -74,18 +83,33 @@ pub async fn init_trace_publisher() -> bool {
     // Get Redis URL
     state.redis_url = get_redis_url();
 
-    // Initialize Redis client
+    // Initialize the reconnecting connection once; publishes clone it.
+    //
+    // Bound the initial connect: ConnectionManager's DEFAULTS retry the
+    // first connection 6 times with exponential backoff and no connect
+    // timeout, which turns a down Redis into a multi-second agent-startup
+    // stall inside init (the previous per-span code failed fast). Two
+    // retries with a 500ms per-attempt connect timeout keeps the worst
+    // case around ~2s.
+    //
+    // The response timeout bounds every subsequent command too (the XADD
+    // on the drain task): without it, a black-holed Redis (accepts
+    // connections, never replies) would stall publishes forever — the
+    // manager only triggers a reconnect when a command actually errors.
     match redis::Client::open(state.redis_url.as_str()) {
         Ok(client) => {
-            // Test connection
-            match client.get_multiplexed_async_connection().await {
+            let cm_config = ConnectionManagerConfig::new()
+                .set_number_of_retries(2)
+                .set_connection_timeout(Duration::from_millis(500))
+                .set_response_timeout(Duration::from_secs(2));
+            match ConnectionManager::new_with_config(client, cm_config).await {
                 Ok(mut conn) => {
                     // Ping to verify
                     let result: Result<String, _> = redis::cmd("PING").query_async(&mut conn).await;
                     match result {
                         Ok(_) => {
                             debug!("Redis connection established for tracing");
-                            state.client = Some(client);
+                            state.conn = Some(conn);
                             state.available = true;
                             true
                         }
@@ -122,16 +146,21 @@ pub async fn init_trace_publisher() -> bool {
 /// # Returns
 /// true if published successfully, false otherwise.
 pub async fn publish_span(span_data: HashMap<String, String>) -> bool {
-    let publisher = get_publisher();
-    let state = publisher.read().await;
+    // Clone the shared connection under a short read lock, then publish
+    // without holding the lock. `ConnectionManager` clones share the same
+    // underlying multiplexed connection — no per-span TCP dial.
+    let mut conn = {
+        let publisher = get_publisher();
+        let state = publisher.read().await;
 
-    if !state.enabled || !state.available {
-        return false;
-    }
+        if !state.enabled || !state.available {
+            return false;
+        }
 
-    let client = match &state.client {
-        Some(c) => c,
-        None => return false,
+        match &state.conn {
+            Some(c) => c.clone(),
+            None => return false,
+        }
     };
 
     // Add timestamp if missing
@@ -151,25 +180,19 @@ pub async fn publish_span(span_data: HashMap<String, String>) -> bool {
         .collect();
 
     // Publish to stream
-    match client.get_multiplexed_async_connection().await {
-        Ok(mut conn) => {
-            let result: Result<String, redis::RedisError> = conn
-                .xadd(TRACE_STREAM_NAME, "*", &items)
-                .await;
-            match result {
-                Ok(_msg_id) => {
-                    debug!("Published trace span to Redis stream");
-                    true
-                }
-                Err(e) => {
-                    // Non-blocking - never fail agent operations
-                    debug!("Failed to publish trace span: {}", e);
-                    false
-                }
-            }
+    let result: Result<String, redis::RedisError> = conn
+        .xadd(TRACE_STREAM_NAME, "*", &items)
+        .await;
+    match result {
+        Ok(_msg_id) => {
+            debug!("Published trace span to Redis stream");
+            true
         }
         Err(e) => {
-            debug!("Failed to get Redis connection: {}", e);
+            // Non-blocking - never fail agent operations. The manager
+            // reconnects in the background; subsequent publishes succeed
+            // once Redis is reachable again (this span is dropped).
+            debug!("Failed to publish trace span: {}", e);
             false
         }
     }
@@ -186,30 +209,37 @@ pub async fn is_trace_publisher_available() -> bool {
 // Python bindings
 // =============================================================================
 
+// NB on shape: these detach from the Python interpreter around the
+// ENTIRE block_on. The previous `block_on(py.allow_threads(|| async ...))`
+// only released the GIL while *constructing* the future — block_on then
+// ran the Redis I/O with the GIL held, stalling every Python thread for
+// the duration of the network call.
+
 #[cfg(feature = "python")]
 #[pyfunction]
 pub fn init_trace_publisher_py(py: Python<'_>) -> PyResult<bool> {
-    // Run async function in tokio runtime
-    pyo3_async_runtimes::tokio::get_runtime().block_on(py.allow_threads(|| async {
-        Ok(init_trace_publisher().await)
-    }))
+    py.detach(|| {
+        pyo3_async_runtimes::tokio::get_runtime()
+            .block_on(async { Ok(init_trace_publisher().await) })
+    })
 }
 
 #[cfg(feature = "python")]
 #[pyfunction]
 pub fn publish_span_py(py: Python<'_>, span_data: HashMap<String, String>) -> PyResult<bool> {
-    // Run async function in tokio runtime
-    pyo3_async_runtimes::tokio::get_runtime().block_on(py.allow_threads(|| async {
-        Ok(publish_span(span_data).await)
-    }))
+    py.detach(|| {
+        pyo3_async_runtimes::tokio::get_runtime()
+            .block_on(async { Ok(publish_span(span_data).await) })
+    })
 }
 
 #[cfg(feature = "python")]
 #[pyfunction]
 pub fn is_trace_publisher_available_py(py: Python<'_>) -> PyResult<bool> {
-    pyo3_async_runtimes::tokio::get_runtime().block_on(py.allow_threads(|| async {
-        Ok(is_trace_publisher_available().await)
-    }))
+    py.detach(|| {
+        pyo3_async_runtimes::tokio::get_runtime()
+            .block_on(async { Ok(is_trace_publisher_available().await) })
+    })
 }
 
 // =============================================================================
@@ -219,9 +249,98 @@ pub fn is_trace_publisher_available_py(py: Python<'_>) -> PyResult<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     #[test]
     fn test_trace_stream_name() {
         assert_eq!(TRACE_STREAM_NAME, "mesh:trace");
+    }
+
+    /// Issue #1166 MED-3: the publisher must establish ONE connection at
+    /// init and reuse it across publishes — not dial Redis per span.
+    /// Uses a minimal fake RESP server that counts accepted TCP
+    /// connections and answers PING/XADD.
+    ///
+    /// NB: mutates process env (REDIS_URL, tracing flag) and the global
+    /// publisher singleton; the test suite runs with --test-threads=1 in
+    /// CI, matching the other env-mutating tests in this crate.
+    #[tokio::test]
+    async fn publisher_reuses_connection_across_publishes() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fake redis");
+        let addr = listener.local_addr().unwrap();
+        let conn_count = Arc::new(AtomicUsize::new(0));
+        let conn_count_srv = conn_count.clone();
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                conn_count_srv.fetch_add(1, Ordering::SeqCst);
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 8192];
+                    loop {
+                        match sock.read(&mut buf).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => {
+                                let req = String::from_utf8_lossy(&buf[..n]);
+                                // RESP requests are arrays — one line
+                                // starting with '*' per command. The
+                                // client pipelines connection-setup
+                                // commands (CLIENT SETINFO x2) in a
+                                // single chunk, so reply once PER
+                                // command or the connect handshake
+                                // hangs waiting for missing replies.
+                                // "+PONG" parses fine as the reply to
+                                // every command this test triggers
+                                // (PING, CLIENT SETINFO, XADD-as-String).
+                                let ncmds = req
+                                    .split("\r\n")
+                                    .filter(|line| line.starts_with('*'))
+                                    .count()
+                                    .max(1);
+                                let resp = "+PONG\r\n".repeat(ncmds);
+                                if sock.write_all(resp.as_bytes()).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        std::env::set_var("MCP_MESH_DISTRIBUTED_TRACING_ENABLED", "true");
+        std::env::set_var("REDIS_URL", format!("redis://{}", addr));
+
+        // Bound every await so a handshake regression fails the test
+        // instead of hanging the (single-threaded) suite.
+        let budget = std::time::Duration::from_secs(10);
+        let inited = tokio::time::timeout(budget, init_trace_publisher())
+            .await
+            .expect("init timed out against the fake server");
+        assert!(inited, "init must succeed against the fake server");
+        assert!(is_trace_publisher_available().await);
+
+        for i in 0..3 {
+            let span: HashMap<String, String> =
+                HashMap::from([("span".to_string(), format!("s{}", i))]);
+            let published = tokio::time::timeout(budget, publish_span(span))
+                .await
+                .unwrap_or_else(|_| panic!("publish {} timed out", i));
+            assert!(published, "publish {} must succeed", i);
+        }
+
+        assert_eq!(
+            conn_count.load(Ordering::SeqCst),
+            1,
+            "all publishes must reuse the single init-time connection"
+        );
+
+        std::env::remove_var("MCP_MESH_DISTRIBUTED_TRACING_ENABLED");
+        std::env::remove_var("REDIS_URL");
     }
 }


### PR DESCRIPTION
## Summary
Closes the Rust shared-core audit (#1166) — the last of the June-9 cross-runtime audit issues.

- **Shutdown can no longer be swallowed during reconnect backoff**: `ShuttingDown` is sticky in the heartbeat state machine (all transitions route through a guard) and the `Retry` arm re-checks it after its select — previously a shutdown signal arriving mid-backoff was consumed from the one-shot channel and then overwritten by a successful heartbeat, leaving the agent re-registered and running forever. Regression-tested end-to-end with a mock registry.
- **napi async accessors** (`getDependencies`/`getStatus`/`getAgentId`/`isShutdownRequested`) use awaitable read locks — the `blocking_read` variants are documented to panic in async context. PyO3/C-ABI blocking call sites verified legal.
- **Trace publisher**: one `ConnectionManager` (bounded init: 2 retries / 500ms connect / 2s response timeout — Redis-down agents fail tracing init in ~2s instead of stalling startup, and a black-holed Redis errors instead of wedging the drain task) cloned per publish, replacing a TCP dial + handshake per span. The C-ABI `mesh_publish_span` now honors its documented non-blocking contract via a bounded(1024) channel with drop counters; `mesh_flush_spans` exported and called from `mesh_free_handle`, so final spans drain on clean shutdown.
- **Cancel registry redesigned as a stack of generation-tagged frames per job_id**: registration returns a generation; unregister removes only its own frame and fires that frame's `ended` token. Fixes waiter wake-loss on re-registration (the `with_job_async_py` double-register window) and cross-scope deletion when one job_id has two live scopes (re-entrant dispatch) — a later cancel now reaches the surviving scope. `mesh_job_cancel_fired` (#1175, Java contract) verified across all states including re-claim and nesting.
- **FFI hygiene**: `mesh_next_event` takes `*const` with a Mutex'd receiver (removes formal `&mut` aliasing UB under the "any thread" contract); its timeout now covers lock acquisition (a 0ms call can't park behind an infinite waiter) and the header documents single-consumer delivery. `mesh_free_handle` waits its documented 2s for the unregister-then-Shutdown event instead of a fixed 100ms.
- **Smaller**: per-controller terminal guard replaces the shared claim-worker queue's unbounded per-job HashSet (slow leak on long-running agents); dependency/`llm_tools` events use send-before-record like the providers path (a lost event re-emits next heartbeat instead of being diff-gate-suppressed forever); `start_agent` constructs the runtime synchronously and surfaces init errors to the Python/JS caller (C-ABI parity) — with the construction properly GIL-detached on Python, and four pre-existing pyo3 paths fixed that ran Redis/HTTP I/O with the GIL held (`allow_threads` wrapped future construction, not execution).

## Review Notes
- Independent review: 0 blockers, 4 warnings — all fixed (timeout-vs-lock contract, span drain on shutdown, init retry stall, GIL-held TLS fetch). The frame-stack semantics were verified under adversarial interleavings: out-of-order scope exits, panic unwind paths (both drop guards carry generations), token sharing in the Python double-register, no lock-across-await.
- Residual (pre-existing, documented): nested inbound dispatch with distinct cancel tokens delivers a cancel to the inner scope only; a zombie controller's late progress after a re-claim is backstopped by registry-side ownership validation.
- ABI: `*mut`→`*const` is ABI-neutral for JNR/ctypes; `mesh_flush_spans` is additive; `rust-version = "1.87"` now declared (uses `is_multiple_of`).

Closes #1166

## Test plan
- [x] `cargo test --no-default-features` (433) and `--features ffi` (458) — all passing, single-threaded per CI convention
- [x] `cargo check` for `typescript`, `python,simd`, `ffi,spire,simd` feature sets; clippy strictly fewer lints than baseline
- [x] New tests: shutdown-during-backoff e2e, async accessors in tokio context, connection reuse against a fake RESP server, span flush lifecycle, frame-stack interleavings (stale generation, successor preservation, re-claim cancel, double-register wake)
- [ ] Integration suites on the next `tsuite-mesh:local` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shutdown signal handling during retry backoff to prevent delayed exits
  * Improved shutdown state preservation to prevent overwriting by subsequent heartbeat outcomes
  * Enhanced event emission error handling for topology changes

* **Performance Improvements**
  * Optimized Python and Node.js bindings to reduce runtime lock contention
  * Improved thread-safe concurrent handle operations for multi-threaded environments
  * Enhanced connection reuse for tracing infrastructure

* **Stability Improvements**
  * Strengthened job cancellation handling for overlapping registrations
  * Improved trace span draining on shutdown to prevent data loss
  * Better error propagation for agent initialization failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->