### PR TITLE
fix(ts): honor GOOGLE_CLOUD_PROJECT/LOCATION for vertex_ai providers

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -467,7 +467,7 @@ tools); only the auth transport and env var names differ.
 | Runtime    | SDK            | Project env var                              | Location env var                             |
 | ---------- | -------------- | -------------------------------------------- | -------------------------------------------- |
 | Python     | LiteLLM        | `VERTEXAI_PROJECT`                           | `VERTEXAI_LOCATION`                          |
-| TypeScript | Vercel AI SDK  | `GOOGLE_VERTEX_PROJECT`                      | `GOOGLE_VERTEX_LOCATION`                     |
+| TypeScript | Vercel AI SDK  | `GOOGLE_CLOUD_PROJECT`                       | `GOOGLE_CLOUD_LOCATION`                      |
 | Java       | Spring AI      | `SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID`<br/>(or set `spring.ai.vertex.ai.gemini.project-id`) | `SPRING_AI_VERTEX_AI_GEMINI_LOCATION`<br/>(or set `spring.ai.vertex.ai.gemini.location`) |
 
 `GOOGLE_APPLICATION_CREDENTIALS` (or `gcloud auth application-default login`)
@@ -521,9 +521,10 @@ agent.addLlmProvider({
 ```
 
 `@ai-sdk/google-vertex` is bundled with `@mcpmesh/sdk` — no extra install.
-Auth uses Google ADC. Both `GOOGLE_VERTEX_PROJECT` and `GOOGLE_VERTEX_LOCATION`
-are required — the SDK throws a `LoadSettingError` on the first call if
-either is unset (no project auto-discovery from ADC, no default location).
+Auth uses Google ADC. Both `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`
+are required — the underlying SDK fails with a `LoadSettingError` on the first
+call if either is unset (no project auto-discovery from ADC, no default
+location).
 Common location values: `us-central1`, `global`.
 
 #### Java — `@MeshLlmProvider` with the Vertex AI starter

--- a/docs/typescript/llm/index.md
+++ b/docs/typescript/llm/index.md
@@ -277,19 +277,21 @@ needed.
 
    ```bash
    gcloud auth application-default login
-   export GOOGLE_VERTEX_PROJECT=my-gcp-project
-   export GOOGLE_VERTEX_LOCATION=us-central1
+   export GOOGLE_CLOUD_PROJECT=my-gcp-project
+   export GOOGLE_CLOUD_LOCATION=us-central1
    ```
 
    **Service account** (CI / prod):
 
    ```bash
    export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
-   export GOOGLE_VERTEX_PROJECT=my-gcp-project
-   export GOOGLE_VERTEX_LOCATION=us-central1
+   export GOOGLE_CLOUD_PROJECT=my-gcp-project
+   export GOOGLE_CLOUD_LOCATION=us-central1
    ```
 
-   `GOOGLE_VERTEX_LOCATION` defaults to `us-central1` if unset.
+   Both vars are required — there is no default location and the project is
+   not auto-discovered from ADC. Common location values: `us-central1`,
+   `global`.
 
 2. Use the `vertex_ai/*` model prefix:
 
@@ -321,8 +323,8 @@ model: "vertex_ai/gemini-2.5-flash";
 export GOOGLE_GENERATIVE_AI_API_KEY=AIza...
 # after:
 gcloud auth application-default login
-export GOOGLE_VERTEX_PROJECT=my-gcp-project
-export GOOGLE_VERTEX_LOCATION=us-central1
+export GOOGLE_CLOUD_PROJECT=my-gcp-project
+export GOOGLE_CLOUD_LOCATION=us-central1
 ```
 
 No other code changes required.

--- a/examples/typescript/vertex-ai-agent/README.md
+++ b/examples/typescript/vertex-ai-agent/README.md
@@ -30,8 +30,8 @@ cd examples/typescript/vertex-ai-agent
 npm install
 
 # Required: project + location for Vercel SDK's @ai-sdk/google-vertex.
-export GOOGLE_VERTEX_PROJECT=my-gcp-project
-export GOOGLE_VERTEX_LOCATION=us-central1
+export GOOGLE_CLOUD_PROJECT=my-gcp-project
+export GOOGLE_CLOUD_LOCATION=us-central1
 
 # Start the registry in another terminal first, then:
 npm start
@@ -65,7 +65,7 @@ model: "gemini/gemini-2.5-flash"   // was: "vertex_ai/gemini-2.5-flash"
 ```
 
 ```bash
-export GOOGLE_GENERATIVE_AI_API_KEY=AIza...   # instead of ADC + GOOGLE_VERTEX_*
+export GOOGLE_GENERATIVE_AI_API_KEY=AIza...   # instead of ADC + GOOGLE_CLOUD_*
 ```
 
 No other code changes required.
@@ -77,7 +77,7 @@ Each runtime follows its own ecosystem's naming convention for Vertex AI:
 | Runtime              | SDK            | Project                | Location               |
 | -------------------- | -------------- | ---------------------- | ---------------------- |
 | Python               | LiteLLM        | `VERTEXAI_PROJECT`     | `VERTEXAI_LOCATION`    |
-| **TypeScript (this)** | **Vercel AI SDK** | `GOOGLE_VERTEX_PROJECT`| `GOOGLE_VERTEX_LOCATION` |
+| **TypeScript (this)** | **Vercel AI SDK** | `GOOGLE_CLOUD_PROJECT` | `GOOGLE_CLOUD_LOCATION`  |
 | Java                 | Spring AI      | `spring.ai.vertex.ai.gemini.project-id` | `spring.ai.vertex.ai.gemini.location` |
 
 `GOOGLE_APPLICATION_CREDENTIALS` (or `gcloud auth application-default login`)

--- a/examples/typescript/vertex-ai-agent/src/index.ts
+++ b/examples/typescript/vertex-ai-agent/src/index.ts
@@ -6,7 +6,7 @@
  *
  * The only differences from a Gemini AI Studio agent are:
  *   - model prefix:   "vertex_ai/<model>"   (vs "gemini/<model>")
- *   - auth env vars:  GOOGLE_VERTEX_PROJECT + GOOGLE_VERTEX_LOCATION + ADC
+ *   - auth env vars:  GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_LOCATION + ADC
  *                     (vs GOOGLE_GENERATIVE_AI_API_KEY)
  *
  * Mesh-side prompt shaping (HINT-mode for tool calls, STRICT-mode for

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -186,14 +186,14 @@ needed. Auth is via Google ADC.
 
 | Scenario                                            | Required env vars                                                                |
 | --------------------------------------------------- | -------------------------------------------------------------------------------- |
-| User ADC (`gcloud auth application-default login`)  | `GOOGLE_VERTEX_PROJECT`, `GOOGLE_VERTEX_LOCATION`                                |
-| Service account JSON                                | `GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json`, `GOOGLE_VERTEX_PROJECT`, `GOOGLE_VERTEX_LOCATION` |
-| Workload Identity (GKE pods)                        | `GOOGLE_VERTEX_PROJECT`, `GOOGLE_VERTEX_LOCATION`                                |
+| User ADC (`gcloud auth application-default login`)  | `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`                                  |
+| Service account JSON                                | `GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION` |
+| Workload Identity (GKE pods)                        | `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`                                  |
 
-Both `GOOGLE_VERTEX_PROJECT` and `GOOGLE_VERTEX_LOCATION` are required by
-`@ai-sdk/google-vertex` — the SDK throws a `LoadSettingError` on the first
-call if either is unset (it does not auto-discover the project from ADC and
-has no default location). Common location values: `us-central1`, `global`.
+Both `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` are required — the
+underlying `@ai-sdk/google-vertex` SDK fails with a `LoadSettingError` on the
+first call if either is unset (it does not auto-discover the project from ADC
+and has no default location). Common location values: `us-central1`, `global`.
 
 #### Java (Spring AI)
 

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -195,7 +195,7 @@ For Vertex AI:
 **Per-language env var names** (each runtime follows its ecosystem's convention):
 
 - **Python (LiteLLM)**: `VERTEXAI_PROJECT`, `VERTEXAI_LOCATION`
-- **TypeScript (Vercel AI SDK)**: `GOOGLE_VERTEX_PROJECT`, `GOOGLE_VERTEX_LOCATION`
+- **TypeScript (Vercel AI SDK)**: `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`
 - **Java (Spring AI)**: `SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID`,
   `SPRING_AI_VERTEX_AI_GEMINI_LOCATION`
 

--- a/src/core/cli/man/content/llm_typescript.md
+++ b/src/core/cli/man/content/llm_typescript.md
@@ -287,19 +287,21 @@ needed.
 
    ```bash
    gcloud auth application-default login
-   export GOOGLE_VERTEX_PROJECT=my-gcp-project
-   export GOOGLE_VERTEX_LOCATION=us-central1
+   export GOOGLE_CLOUD_PROJECT=my-gcp-project
+   export GOOGLE_CLOUD_LOCATION=us-central1
    ```
 
    **Service account** (CI / prod):
 
    ```bash
    export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
-   export GOOGLE_VERTEX_PROJECT=my-gcp-project
-   export GOOGLE_VERTEX_LOCATION=us-central1
+   export GOOGLE_CLOUD_PROJECT=my-gcp-project
+   export GOOGLE_CLOUD_LOCATION=us-central1
    ```
 
-   `GOOGLE_VERTEX_LOCATION` defaults to `us-central1` if unset.
+   Both vars are required — there is no default location and the project is
+   not auto-discovered from ADC. Common location values: `us-central1`,
+   `global`.
 
 2. Use the `vertex_ai/*` model prefix:
 
@@ -331,8 +333,8 @@ model: "vertex_ai/gemini-2.5-flash"
 export GOOGLE_GENERATIVE_AI_API_KEY=AIza...
 # after:
 gcloud auth application-default login
-export GOOGLE_VERTEX_PROJECT=my-gcp-project
-export GOOGLE_VERTEX_LOCATION=us-central1
+export GOOGLE_CLOUD_PROJECT=my-gcp-project
+export GOOGLE_CLOUD_LOCATION=us-central1
 ```
 
 No other code changes required.

--- a/src/runtime/typescript/src/__tests__/llm-provider-vertex-settings.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-provider-vertex-settings.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Vertex AI provider settings resolution — issue #1181.
+ *
+ * The mesh contract (#834) is GOOGLE_CLOUD_PROJECT / GOOGLE_CLOUD_LOCATION
+ * (honored by the Python runtime). @ai-sdk/google-vertex's default `vertex`
+ * instance only reads GOOGLE_VERTEX_PROJECT / GOOGLE_VERTEX_LOCATION at call
+ * time, so identically-configured environments worked on Python and threw
+ * `AI_LoadSettingError` on TS.
+ *
+ * loadProvider("vertex_ai") must now ALWAYS construct the provider via
+ * createVertex() with explicitly resolved settings:
+ *  - mesh-standard names map through,
+ *  - the vendor-specific GOOGLE_VERTEX_* name wins when both are set,
+ *  - settings that resolve to nothing are OMITTED (the SDK surfaces its own
+ *    clear error), and the debug warn mentions BOTH accepted names.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const createVertexMock = vi.fn(
+  (options?: { project?: string; location?: string }) => {
+    // Mimic the real factory: returns a callable provider that resolves models.
+    return (modelId: string) => ({ modelId, options });
+  }
+);
+
+vi.mock("@ai-sdk/google-vertex", () => ({
+  createVertex: (options?: { project?: string; location?: string }) =>
+    createVertexMock(options),
+  // The default instance reads GOOGLE_VERTEX_* env vars at call time and must
+  // never be used by the mesh provider path (#1181 regression guard).
+  vertex: () => {
+    throw new Error("default `vertex` instance must not be used");
+  },
+}));
+
+import { loadProvider, resolveVertexSettings } from "../llm-provider.js";
+
+const ENV_KEYS = [
+  "GOOGLE_VERTEX_PROJECT",
+  "GOOGLE_VERTEX_LOCATION",
+  "GOOGLE_CLOUD_PROJECT",
+  "GOOGLE_CLOUD_LOCATION",
+  "MCP_MESH_DEBUG_MODE",
+  "MCP_MESH_LOG_LEVEL",
+] as const;
+
+describe("vertex_ai provider settings resolution (#1181)", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    createVertexMock.mockClear();
+    // Capture-and-restore: save current values, clear for a clean slate.
+    savedEnv = {};
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("maps mesh-standard GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_LOCATION through to createVertex", async () => {
+    process.env.GOOGLE_CLOUD_PROJECT = "mesh-project";
+    process.env.GOOGLE_CLOUD_LOCATION = "us-central1";
+
+    const provider = await loadProvider("vertex_ai");
+
+    expect(createVertexMock).toHaveBeenCalledTimes(1);
+    expect(createVertexMock).toHaveBeenCalledWith({
+      project: "mesh-project",
+      location: "us-central1",
+    });
+
+    // The swap must be seamless: loadProvider returns the factory's provider,
+    // which resolves model IDs exactly like the previous default instance.
+    expect(typeof provider).toBe("function");
+    const model = provider!("gemini-2.5-flash") as {
+      modelId: string;
+      options?: { project?: string; location?: string };
+    };
+    expect(model.modelId).toBe("gemini-2.5-flash");
+    expect(model.options).toEqual({
+      project: "mesh-project",
+      location: "us-central1",
+    });
+  });
+
+  it("prefers vendor-specific GOOGLE_VERTEX_* when both names are set", async () => {
+    process.env.GOOGLE_VERTEX_PROJECT = "vertex-project";
+    process.env.GOOGLE_VERTEX_LOCATION = "europe-west4";
+    process.env.GOOGLE_CLOUD_PROJECT = "cloud-project";
+    process.env.GOOGLE_CLOUD_LOCATION = "us-central1";
+
+    await loadProvider("vertex_ai");
+
+    expect(createVertexMock).toHaveBeenCalledWith({
+      project: "vertex-project",
+      location: "europe-west4",
+    });
+  });
+
+  it("resolves each setting independently (mixed naming)", async () => {
+    process.env.GOOGLE_VERTEX_PROJECT = "vertex-project";
+    process.env.GOOGLE_CLOUD_LOCATION = "us-east1";
+
+    await loadProvider("vertex_ai");
+
+    expect(createVertexMock).toHaveBeenCalledWith({
+      project: "vertex-project",
+      location: "us-east1",
+    });
+  });
+
+  it("omits unresolved settings and warns mentioning BOTH accepted names", async () => {
+    process.env.MCP_MESH_DEBUG_MODE = "true";
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await loadProvider("vertex_ai");
+
+    // Factory still called (single code path), but without project/location
+    // keys — the SDK throws its own clear LoadSettingError at call time.
+    expect(createVertexMock).toHaveBeenCalledTimes(1);
+    const opts = createVertexMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts).not.toHaveProperty("project");
+    expect(opts).not.toHaveProperty("location");
+
+    const logged = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(logged).toContain("GOOGLE_VERTEX_PROJECT");
+    expect(logged).toContain("GOOGLE_CLOUD_PROJECT");
+    expect(logged).toContain("GOOGLE_VERTEX_LOCATION");
+    expect(logged).toContain("GOOGLE_CLOUD_LOCATION");
+  });
+
+  it("resolveVertexSettings treats empty string as unset (falls through, never blank)", () => {
+    process.env.GOOGLE_VERTEX_PROJECT = "";
+    process.env.GOOGLE_CLOUD_PROJECT = "cloud-project";
+    process.env.GOOGLE_VERTEX_LOCATION = "";
+
+    const settings = resolveVertexSettings();
+
+    // An empty vendor-specific name must not shadow-and-blank the setting: it
+    // falls through to the mesh-standard name, and a setting with no non-empty
+    // source is omitted entirely.
+    expect(settings).toEqual({ project: "cloud-project" });
+    expect(settings).not.toHaveProperty("location");
+  });
+});

--- a/src/runtime/typescript/src/llm-provider.ts
+++ b/src/runtime/typescript/src/llm-provider.ts
@@ -58,10 +58,13 @@ const VENDOR_PROVIDERS: Record<string, string> = {
  * Mapping from vendor name to the export name in the provider module.
  * Most providers export a function with the same name as the vendor,
  * but some (like gemini) use a different name (google).
+ *
+ * Note: vertex_ai is NOT listed here — it bypasses the default-instance
+ * lookup entirely and is constructed via createVertex() in loadProvider()
+ * with explicitly resolved project/location (issue #1181).
  */
 const VENDOR_EXPORTS: Record<string, string> = {
   gemini: "google", // @ai-sdk/google exports 'google', not 'gemini'
-  vertex_ai: "vertex", // @ai-sdk/google-vertex exports 'vertex'
 };
 
 /**
@@ -119,29 +122,60 @@ function normalizeEnvVars(vendor: string): void {
       debug("Set GOOGLE_API_KEY from GOOGLE_GENERATIVE_AI_API_KEY");
     }
   } else if (vendor === "vertex_ai") {
-    // Vercel AI SDK's @ai-sdk/google-vertex reads:
-    //   GOOGLE_VERTEX_PROJECT  - GCP project ID
-    //   GOOGLE_VERTEX_LOCATION - GCP region (e.g., us-central1)
-    //   GOOGLE_APPLICATION_CREDENTIALS - path to service-account JSON (or rely on
-    //                                    gcloud user ADC / GCE/GKE workload identity)
-    // We don't auto-copy from any other env var because the Python (LiteLLM) and
-    // Vercel SDK conventions diverge (VERTEXAI_PROJECT vs GOOGLE_VERTEX_PROJECT) —
-    // each runtime follows its own ecosystem's naming.
-    if (!process.env.GOOGLE_VERTEX_PROJECT) {
+    // Vertex AI settings (issue #1181). The mesh contract (#834) uses
+    // GOOGLE_CLOUD_PROJECT / GOOGLE_CLOUD_LOCATION (honored by the Python
+    // runtime); @ai-sdk/google-vertex natively reads GOOGLE_VERTEX_PROJECT /
+    // GOOGLE_VERTEX_LOCATION. We accept BOTH names per setting (vendor-specific
+    // name wins) and pass the resolved values explicitly to createVertex() in
+    // loadProvider(). Credentials (GOOGLE_APPLICATION_CREDENTIALS, or gcloud
+    // user ADC / GCE/GKE workload identity) are read by google-auth-library
+    // directly and need no mapping.
+    if (!process.env.GOOGLE_VERTEX_PROJECT && !process.env.GOOGLE_CLOUD_PROJECT) {
       debug(
-        "vertex_ai vendor selected but GOOGLE_VERTEX_PROJECT is not set — " +
-        "@ai-sdk/google-vertex will throw a LoadSettingError on the first call " +
-        "(the SDK requires the env var; it does not auto-discover from ADC)"
+        "vertex_ai vendor selected but neither GOOGLE_VERTEX_PROJECT nor " +
+        "GOOGLE_CLOUD_PROJECT is set — @ai-sdk/google-vertex will throw a " +
+        "LoadSettingError on the first call " +
+        "(the SDK requires a project; it does not auto-discover from ADC)"
       );
     }
-    if (!process.env.GOOGLE_VERTEX_LOCATION) {
+    if (!process.env.GOOGLE_VERTEX_LOCATION && !process.env.GOOGLE_CLOUD_LOCATION) {
       debug(
-        "vertex_ai vendor selected but GOOGLE_VERTEX_LOCATION is not set — " +
-        "@ai-sdk/google-vertex will throw a LoadSettingError on the first call " +
+        "vertex_ai vendor selected but neither GOOGLE_VERTEX_LOCATION nor " +
+        "GOOGLE_CLOUD_LOCATION is set — @ai-sdk/google-vertex will throw a " +
+        "LoadSettingError on the first call " +
         "(the SDK has no default location; set e.g. 'us-central1' or 'global')"
       );
     }
   }
+}
+
+/**
+ * Resolve Vertex AI provider settings from the environment (issue #1181).
+ *
+ * Accepts both the @ai-sdk/google-vertex native names (GOOGLE_VERTEX_PROJECT /
+ * GOOGLE_VERTEX_LOCATION) and the mesh-standard names (GOOGLE_CLOUD_PROJECT /
+ * GOOGLE_CLOUD_LOCATION, per #834). The vendor-specific name wins when both
+ * are set; an empty string counts as unset (falls through to the other name).
+ * Settings that resolve to nothing are omitted; createVertex() then falls
+ * back to the SDK's own GOOGLE_VERTEX_* env lookup, which throws a clear
+ * LoadSettingError when the var is absent — but accepts an empty string
+ * (producing a malformed baseURL), since the SDK's loadSetting only rejects
+ * undefined. Omission therefore yields a clean error only when the
+ * GOOGLE_VERTEX_* var is truly unset, not when it is set to "".
+ */
+export function resolveVertexSettings(): { project?: string; location?: string } {
+  const settings: { project?: string; location?: string } = {};
+  const project =
+    process.env.GOOGLE_VERTEX_PROJECT || process.env.GOOGLE_CLOUD_PROJECT;
+  const location =
+    process.env.GOOGLE_VERTEX_LOCATION || process.env.GOOGLE_CLOUD_LOCATION;
+  if (project) {
+    settings.project = project;
+  }
+  if (location) {
+    settings.location = location;
+  }
+  return settings;
 }
 
 /**
@@ -264,6 +298,26 @@ export async function loadProvider(
       string,
       unknown
     >;
+
+    // vertex_ai: always construct via the factory with explicitly resolved
+    // settings instead of the default `vertex` instance, whose env lookups
+    // (GOOGLE_VERTEX_PROJECT/GOOGLE_VERTEX_LOCATION) miss the mesh-standard
+    // GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_LOCATION contract (#834, #1181).
+    if (vendor === "vertex_ai") {
+      const createVertex = providerModule.createVertex as
+        | ((options?: { project?: string; location?: string }) => (modelId: string) => unknown)
+        | undefined;
+      if (typeof createVertex !== "function") {
+        debug(`Provider ${vendor} does not export createVertex`);
+        return null;
+      }
+      const settings = resolveVertexSettings();
+      debug(
+        `Creating Vertex AI provider via createVertex ` +
+          `(project=${settings.project ?? "<unset>"}, location=${settings.location ?? "<unset>"})`
+      );
+      return createVertex(settings);
+    }
 
     // Get the export name (may differ from vendor name, e.g., gemini -> google)
     const exportName = VENDOR_EXPORTS[vendor] ?? vendor;


### PR DESCRIPTION
## Summary
- The TS runtime's `vertex_ai` vendor loaded `@ai-sdk/google-vertex`'s default instance, which resolves only its own `GOOGLE_VERTEX_PROJECT`/`GOOGLE_VERTEX_LOCATION` env names — but the mesh contract (#834, honored by the Python runtime) is the Google-standard `GOOGLE_CLOUD_PROJECT`/`GOOGLE_CLOUD_LOCATION`. Identically configured environments worked on Python and threw `AI_LoadSettingError` at first call on TS. Surfaced by integration test uc04/tc35 — the single failure in a 500+ test run.
- `loadProvider` now constructs the provider via `createVertex()` with explicitly resolved settings: vendor-specific name wins when both are set, empty strings are treated as unset (an empty `GOOGLE_VERTEX_*` can no longer shadow a valid `GOOGLE_CLOUD_*`), and unresolved keys are omitted. `GOOGLE_APPLICATION_CREDENTIALS` is consumed by google-auth-library directly and needs no mapping (verified).
- All TS-facing docs (docs/, hand-maintained man content, example README + header comment) now teach only the canonical `GOOGLE_CLOUD_*` form per the docs convention — the runtime warn naming both forms is the discovery surface for the vendor-specific names. Also corrected a false "defaults to us-central1" claim found during the doc sweep.

## Review Notes
- Independent review: 0 blockers. Verified provider caching is unchanged (factory called exactly once per provider tool), the removed `VENDOR_EXPORTS.vertex_ai` entry has no other consumers, warn conditions and resolution share exact truthiness semantics, and the mock matches the real `createVertex` signature.
- Its one warning (docs teaching only the vendor names) is addressed by the doc sweep above.
- Known pre-existing edge (no regression, documented in code): `GOOGLE_VERTEX_PROJECT=""` with nothing else set falls to the SDK's own env fallback, which accepts empty strings and builds a malformed baseURL.

Closes #1181

## Test plan
- [x] `npm run typecheck:all` + `npm run build` clean; `npx vitest run` — 63 files, 893 tests passing
- [x] New unit tests: GOOGLE_CLOUD_* mapping, vendor-name precedence, mixed resolution, neither-set warn naming all four vars, empty-string fall-through; throwing default-export guard proves the factory path is used
- [ ] uc04/tc35 (`vertex-ai-agent-ts`) on the next `tsuite-mesh:local` build — the integration pin for this contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Vertex AI setup documentation to use standardized `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` environment variables for TypeScript and across all setup scenarios.
  * Both environment variables are now required for Vertex AI authentication.
  * Clarified common location values and improved guidance across multiple setup guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->