### PR TITLE
fix(java): MeshHandle drains in-flight native calls before freeing

### DIFF
--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshHandle.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshHandle.java
@@ -7,7 +7,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Handle to a running MCP Mesh agent.
@@ -33,11 +35,28 @@ public class MeshHandle implements Closeable {
     private static final Logger log = LoggerFactory.getLogger(MeshHandle.class);
     private static final ObjectMapper objectMapper = MeshObjectMappers.create();
 
+    /** Bounded wait in {@link #close()} for in-flight native calls to drain. */
+    private static final long CLOSE_DRAIN_TIMEOUT_MS = 5_000;
+
     private final MeshCore core;
     private final Pointer handle;
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    private MeshHandle(MeshCore core, Pointer handle) {
+    /**
+     * Guards the closed-check + native call as one atomic unit (issue #1179).
+     *
+     * <p>Accessors take the read lock around {@code closed.get()} and the
+     * native call, so once {@link #close()} holds the write lock no accessor
+     * can be between the check and the call — closing the check-then-act gap
+     * where a thread passes the {@code closed} check, is preempted for the
+     * entire duration of {@code close()}, and then enters native code with a
+     * freed pointer. (Calls already inside native code when free happens are
+     * separately safe: the Rust side reference-counts the handle.)
+     */
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    // Package-private for tests (MeshHandleTest injects a fake MeshCore).
+    MeshHandle(MeshCore core, Pointer handle) {
         this.core = core;
         this.handle = handle;
     }
@@ -75,10 +94,21 @@ public class MeshHandle implements Closeable {
      * @return true if running, false if shutdown
      */
     public boolean isRunning() {
+        // Lock-free fast path: post-close calls return immediately instead of
+        // queuing behind close()'s write lock. The check under the read lock
+        // below is the authoritative one for the close/accessor race.
         if (closed.get()) {
             return false;
         }
-        return core.mesh_is_running(handle) == 1;
+        lock.readLock().lock();
+        try {
+            if (closed.get()) {
+                return false;
+            }
+            return core.mesh_is_running(handle) == 1;
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     /**
@@ -90,25 +120,39 @@ public class MeshHandle implements Closeable {
      * @return The event, or empty if timeout/shutdown
      */
     public Optional<MeshEvent> nextEvent(long timeoutMs) {
+        // Lock-free fast path: post-close calls return immediately instead of
+        // queuing behind close()'s write lock. The check under the read lock
+        // below is the authoritative one for the close/accessor race.
         if (closed.get()) {
             return Optional.empty();
         }
-
-        Pointer eventPtr = core.mesh_next_event(handle, timeoutMs);
-        if (eventPtr == null) {
-            return Optional.empty();
-        }
-
+        // Holding the read lock for the full (potentially long) native wait
+        // is intentional: close() wakes a parked caller via mesh_shutdown
+        // BEFORE waiting for the lock, and its wait is bounded regardless.
+        lock.readLock().lock();
         try {
-            String eventJson = eventPtr.getString(0);
-            log.debug("Received event: {}", eventJson);
-            MeshEvent event = objectMapper.readValue(eventJson, MeshEvent.class);
-            return Optional.of(event);
-        } catch (Exception e) {
-            log.error("Failed to parse event JSON", e);
-            return Optional.empty();
+            if (closed.get()) {
+                return Optional.empty();
+            }
+
+            Pointer eventPtr = core.mesh_next_event(handle, timeoutMs);
+            if (eventPtr == null) {
+                return Optional.empty();
+            }
+
+            try {
+                String eventJson = eventPtr.getString(0);
+                log.debug("Received event: {}", eventJson);
+                MeshEvent event = objectMapper.readValue(eventJson, MeshEvent.class);
+                return Optional.of(event);
+            } catch (Exception e) {
+                log.error("Failed to parse event JSON", e);
+                return Optional.empty();
+            } finally {
+                core.mesh_free_string(eventPtr);
+            }
         } finally {
-            core.mesh_free_string(eventPtr);
+            lock.readLock().unlock();
         }
     }
 
@@ -119,14 +163,25 @@ public class MeshHandle implements Closeable {
      * @throws MeshException if the status report fails
      */
     public void reportHealth(String status) {
+        // Lock-free fast path: post-close calls fail immediately instead of
+        // queuing behind close()'s write lock. The check under the read lock
+        // below is the authoritative one for the close/accessor race.
         if (closed.get()) {
             throw new MeshException("Handle is closed");
         }
+        lock.readLock().lock();
+        try {
+            if (closed.get()) {
+                throw new MeshException("Handle is closed");
+            }
 
-        int result = core.mesh_report_health(handle, status);
-        if (result != 0) {
-            String error = getLastError(core);
-            throw new MeshException("Failed to report health: " + error);
+            int result = core.mesh_report_health(handle, status);
+            if (result != 0) {
+                String error = getLastError(core);
+                throw new MeshException("Failed to report health: " + error);
+            }
+        } finally {
+            lock.readLock().unlock();
         }
     }
 
@@ -162,18 +217,29 @@ public class MeshHandle implements Closeable {
      * @return true if the update was sent successfully
      */
     public boolean updatePort(int port) {
+        // Lock-free fast path: post-close calls fail immediately instead of
+        // queuing behind close()'s write lock. The check under the read lock
+        // below is the authoritative one for the close/accessor race.
         if (closed.get()) {
             throw new MeshException("Handle is closed");
         }
+        lock.readLock().lock();
+        try {
+            if (closed.get()) {
+                throw new MeshException("Handle is closed");
+            }
 
-        int result = core.mesh_update_port(handle, port);
-        if (result != 0) {
-            String error = getLastError(core);
-            log.warn("Failed to update port to {}: {}", port, error);
-            return false;
+            int result = core.mesh_update_port(handle, port);
+            if (result != 0) {
+                String error = getLastError(core);
+                log.warn("Failed to update port to {}: {}", port, error);
+                return false;
+            }
+            log.info("Port updated to {}", port);
+            return true;
+        } finally {
+            lock.readLock().unlock();
         }
-        log.info("Port updated to {}", port);
-        return true;
     }
 
     /**
@@ -183,9 +249,14 @@ public class MeshHandle implements Closeable {
      * shutdown event.
      */
     public void shutdown() {
-        if (!closed.get()) {
-            log.info("Requesting agent shutdown");
-            core.mesh_shutdown(handle);
+        lock.readLock().lock();
+        try {
+            if (!closed.get()) {
+                log.info("Requesting agent shutdown");
+                core.mesh_shutdown(handle);
+            }
+        } finally {
+            lock.readLock().unlock();
         }
     }
 
@@ -193,14 +264,75 @@ public class MeshHandle implements Closeable {
      * Close the handle and free associated resources.
      *
      * <p>If the agent is still running, this will trigger graceful shutdown
-     * and wait briefly for cleanup.
+     * and wait briefly for cleanup. Waits (bounded) for in-flight native
+     * calls on other threads to drain before freeing the native handle.
+     *
+     * <p>Concurrent close: only one caller performs the shutdown/drain/free
+     * sequence; a losing concurrent caller returns immediately while the
+     * winner may still be draining or freeing. Callers therefore must NOT
+     * treat a returned {@code close()} as "native handle freed".
      */
     @Override
     public void close() {
-        if (closed.compareAndSet(false, true)) {
-            log.info("Closing agent handle");
-            core.mesh_free_handle(handle);
+        if (!closed.compareAndSet(false, true)) {
+            return;
         }
+        log.info("Closing agent handle");
+
+        // Ordering matters here (issue #1179):
+        //
+        // 1. `closed` is flipped first (CAS above), so any accessor that has
+        //    not yet passed its closed-check under the read lock bails out
+        //    before reaching native code.
+        //
+        // 2. mesh_shutdown is called BEFORE waiting for in-flight calls to
+        //    drain. A nextEvent caller can be parked inside native code for
+        //    its full timeout (potentially infinite). mesh_shutdown signals
+        //    the runtime; its run loop emits the shutdown event and exits,
+        //    closing the event channel — which wakes a parked nextEvent
+        //    promptly. Draining first would deadlock against such a caller:
+        //    previously it was mesh_free_handle itself that triggered the
+        //    wake-up, so waiting for the drain before free is chicken-and-egg
+        //    unless shutdown is signalled up front. Calling mesh_shutdown
+        //    without the write lock is safe: this thread is the only one that
+        //    frees (CAS winner) and the free has not happened yet.
+        //
+        // 3. Wait (bounded) for in-flight native calls to drain by acquiring
+        //    the write lock — then RELEASE it before freeing. Acquiring the
+        //    write lock proves the drain is complete: `closed` is already
+        //    true, so any reader that takes the read lock afterwards bails at
+        //    the closed-check before reaching native code — holding the write
+        //    lock across the free adds no safety. It would hurt, though:
+        //    mesh_free_handle can block for seconds on the Rust side
+        //    (shutdown wait + span drain), and holding the lock across it
+        //    would stall every post-close accessor queued on the read lock.
+        //    On timeout (e.g. a nextEvent parked on an infinite timeout with
+        //    a wedged runtime) we warn and free anyway: the Rust side
+        //    reference-counts the handle, so freeing under a call that
+        //    already STARTED is safe — this lock only closes the gap for
+        //    calls that would start after the free.
+        core.mesh_shutdown(handle);
+
+        boolean drained = false;
+        boolean interrupted = false;
+        try {
+            drained = lock.writeLock().tryLock(CLOSE_DRAIN_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            interrupted = true;
+            Thread.currentThread().interrupt(); // restore the interrupt flag for the caller
+        }
+        if (drained) {
+            lock.writeLock().unlock();
+        } else if (interrupted) {
+            log.warn("Interrupted while waiting for in-flight native calls to drain; freeing "
+                + "handle anyway (safe for calls already in native code: the handle is "
+                + "reference-counted)");
+        } else {
+            log.warn("In-flight native calls did not drain within {}ms; freeing handle anyway "
+                + "(safe for calls already in native code: the handle is reference-counted)",
+                CLOSE_DRAIN_TIMEOUT_MS);
+        }
+        core.mesh_free_handle(handle);
     }
 
     private static String getLastError(MeshCore core) {

--- a/src/runtime/java/mcp-mesh-core/src/test/java/io/mcpmesh/core/MeshHandleTest.java
+++ b/src/runtime/java/mcp-mesh-core/src/test/java/io/mcpmesh/core/MeshHandleTest.java
@@ -1,0 +1,401 @@
+package io.mcpmesh.core;
+
+import jnr.ffi.Pointer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Concurrency tests for {@link MeshHandle} close/accessor races (issue #1179).
+ *
+ * <p>These tests use a {@link Proxy}-based fake {@link MeshCore} instead of the
+ * real native library so they run deterministically on every platform and can
+ * observe the exact property under test: no handle-taking native call may
+ * START after {@code mesh_free_handle} has run. (Calls already in flight when
+ * free happens are covered by the Rust side's reference counting — that part
+ * is exercised by the Rust test suite, not here.)
+ *
+ * <p>Limitation: the close-wakes-parked-nextEvent test relies on the fake
+ * mirroring the documented Rust semantics (mesh_shutdown → run loop exits →
+ * event channel closes → parked mesh_next_event returns). The real
+ * end-to-end wake-up path requires the native library plus a running agent
+ * and is not exercised here.
+ */
+class MeshHandleTest {
+
+    /** Native FFI entry points that dereference the agent handle. */
+    private static final Set<String> HANDLE_TAKING = Set.of(
+        "mesh_is_running", "mesh_next_event", "mesh_report_health",
+        "mesh_update_port", "mesh_shutdown", "mesh_free_handle");
+
+    /**
+     * Fake MeshCore that mimics the Rust FFI contract relevant to #1179:
+     * <ul>
+     *   <li>{@code mesh_next_event} parks until woken (or its timeout elapses)</li>
+     *   <li>{@code mesh_shutdown} wakes parked {@code mesh_next_event} callers
+     *       (in the real core: shutdown signal → run loop emits shutdown event
+     *       and exits → event channel closes → parked recv returns)</li>
+     *   <li>{@code mesh_free_handle} marks the handle freed; any handle-taking
+     *       call STARTED afterwards is recorded as a use-after-free</li>
+     * </ul>
+     */
+    private static final class FakeCore implements InvocationHandler {
+        final AtomicBoolean freed = new AtomicBoolean(false);
+        final AtomicInteger freeCount = new AtomicInteger();
+        final AtomicBoolean shutdownSignalled = new AtomicBoolean(false);
+        final AtomicBoolean calledAfterFree = new AtomicBoolean(false);
+        final CountDownLatch nextEventParked = new CountDownLatch(1);
+        final CountDownLatch wake = new CountDownLatch(1);
+        final AtomicLong nextEventReturnedAt = new AtomicLong(-1);
+        final AtomicLong freedAt = new AtomicLong(-1);
+        /** When false, simulates a wedged runtime that never processes shutdown. */
+        volatile boolean shutdownWakesNextEvent = true;
+        /** When true, mesh_free_handle blocks until {@link #freeRelease} —
+         *  simulates the real free taking seconds (Rust shutdown + span drain). */
+        volatile boolean blockFree = false;
+        final CountDownLatch freeStarted = new CountDownLatch(1);
+        final CountDownLatch freeRelease = new CountDownLatch(1);
+
+        MeshCore asCore() {
+            return (MeshCore) Proxy.newProxyInstance(
+                MeshCore.class.getClassLoader(), new Class<?>[]{MeshCore.class}, this);
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            String name = method.getName();
+            // The property under test: no handle-taking call may START after free.
+            if (HANDLE_TAKING.contains(name) && !"mesh_free_handle".equals(name) && freed.get()) {
+                calledAfterFree.set(true);
+            }
+            switch (name) {
+                case "mesh_is_running":
+                    return 1;
+                case "mesh_report_health":
+                case "mesh_update_port":
+                    return 0;
+                case "mesh_shutdown":
+                    shutdownSignalled.set(true);
+                    if (shutdownWakesNextEvent) {
+                        wake.countDown();
+                    }
+                    return null;
+                case "mesh_next_event": {
+                    nextEventParked.countDown();
+                    long timeoutMs = (Long) args[1];
+                    try {
+                        if (timeoutMs < 0) {
+                            wake.await();
+                        } else if (timeoutMs > 0) {
+                            wake.await(timeoutMs, TimeUnit.MILLISECONDS);
+                        }
+                    } finally {
+                        nextEventReturnedAt.set(System.nanoTime());
+                    }
+                    return null; // timeout / shutdown — no event
+                }
+                case "mesh_free_handle":
+                    freedAt.set(System.nanoTime());
+                    freed.set(true);
+                    freeStarted.countDown();
+                    if (blockFree) {
+                        freeRelease.await();
+                    }
+                    freeCount.incrementAndGet();
+                    return null;
+                case "mesh_last_error":
+                case "mesh_free_string":
+                    return null;
+                default:
+                    Class<?> rt = method.getReturnType();
+                    if (rt == int.class) return 0;
+                    if (rt == long.class) return 0L;
+                    if (rt == double.class) return 0.0d;
+                    return null;
+            }
+        }
+    }
+
+    private static MeshHandle newHandle(FakeCore fake) {
+        Pointer dummy = Pointer.wrap(jnr.ffi.Runtime.getSystemRuntime(), 0x1L);
+        return new MeshHandle(fake.asCore(), dummy);
+    }
+
+    @Test
+    @Timeout(60)
+    void concurrentAccessorsRacingCloseNeverCallNativeAfterFree() throws Exception {
+        // Hammer accessors from several threads while close() runs concurrently.
+        // The original check-then-act gap means an accessor could pass the
+        // closed-check, get preempted across the whole of close(), then enter
+        // native code with a freed pointer. Repeat to give the race a chance.
+        final int iterations = 200;
+        final int accessorThreads = 4;
+
+        for (int i = 0; i < iterations; i++) {
+            FakeCore fake = new FakeCore();
+            MeshHandle handle = newHandle(fake);
+
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(accessorThreads);
+            for (int t = 0; t < accessorThreads; t++) {
+                final int id = t;
+                Thread thread = new Thread(() -> {
+                    try {
+                        start.await();
+                        for (int k = 0; k < 50; k++) {
+                            try {
+                                switch ((id + k) % 4) {
+                                    case 0 -> handle.isRunning();
+                                    case 1 -> handle.reportHealthy();
+                                    case 2 -> handle.updatePort(8080);
+                                    default -> handle.nextEvent(0);
+                                }
+                            } catch (MeshException expectedAfterClose) {
+                                // reportHealth/updatePort throw once closed — expected.
+                            }
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+                thread.setDaemon(true);
+                thread.start();
+            }
+
+            start.countDown();
+            handle.close();
+            assertTrue(done.await(30, TimeUnit.SECONDS), "accessor threads did not finish");
+
+            assertFalse(fake.calledAfterFree.get(),
+                "a handle-taking native call started after mesh_free_handle (iteration " + i + ")");
+            assertEquals(1, fake.freeCount.get(), "handle must be freed exactly once");
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void postCloseCallsAreRejectedWithoutTouchingNative() {
+        FakeCore fake = new FakeCore();
+        MeshHandle handle = newHandle(fake);
+
+        handle.close();
+        assertEquals(1, fake.freeCount.get());
+
+        assertFalse(handle.isRunning());
+        assertTrue(handle.nextEvent(0).isEmpty());
+        assertThrows(MeshException.class, () -> handle.reportHealth("healthy"));
+        assertThrows(MeshException.class, () -> handle.updatePort(8080));
+        handle.shutdown(); // no-op after close
+        handle.close();    // idempotent
+
+        assertEquals(1, fake.freeCount.get(), "second close must not free again");
+        assertFalse(fake.calledAfterFree.get(), "post-close calls must not reach native code");
+    }
+
+    @Test
+    @Timeout(30)
+    void closeWakesParkedNextEventAndFreesOnlyAfterItReturns() throws Exception {
+        FakeCore fake = new FakeCore();
+        MeshHandle handle = newHandle(fake);
+
+        Thread parked = new Thread(() -> handle.nextEvent(-1)); // infinite timeout
+        parked.setDaemon(true);
+        parked.start();
+        assertTrue(fake.nextEventParked.await(5, TimeUnit.SECONDS), "nextEvent did not park");
+
+        long closeStart = System.nanoTime();
+        handle.close();
+        long closeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - closeStart);
+
+        parked.join(TimeUnit.SECONDS.toMillis(5));
+        assertFalse(parked.isAlive(), "parked nextEvent caller did not return");
+
+        // close() must signal shutdown FIRST (waking the parked caller), then
+        // drain, then free — well inside the 5s drain budget, not the full
+        // (here: infinite) nextEvent timeout.
+        assertTrue(fake.shutdownSignalled.get(), "close must signal mesh_shutdown before freeing");
+        assertTrue(closeMs < 4000, "close should return promptly once woken, took " + closeMs + "ms");
+        assertTrue(fake.freedAt.get() >= fake.nextEventReturnedAt.get(),
+            "mesh_free_handle ran before the parked mesh_next_event returned");
+        assertFalse(fake.calledAfterFree.get());
+    }
+
+    @Test
+    @Timeout(30)
+    void closeProceedsAfterBoundedWaitWhenNextEventIsStuck() throws Exception {
+        // Wedged-runtime simulation: shutdown never wakes the parked caller.
+        // close() must NOT hang on it — it warns and frees after the bounded
+        // drain wait (safe: the Rust side reference-counts in-flight calls).
+        FakeCore fake = new FakeCore();
+        fake.shutdownWakesNextEvent = false;
+        MeshHandle handle = newHandle(fake);
+
+        Thread parked = new Thread(() -> handle.nextEvent(-1));
+        parked.setDaemon(true);
+        parked.start();
+        assertTrue(fake.nextEventParked.await(5, TimeUnit.SECONDS), "nextEvent did not park");
+
+        long closeStart = System.nanoTime();
+        handle.close();
+        long closeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - closeStart);
+
+        assertEquals(1, fake.freeCount.get(), "close must free despite the stuck call");
+        assertTrue(closeMs >= 4500, "close should wait the full drain budget, took " + closeMs + "ms");
+        assertTrue(closeMs < 15000, "close must be bounded, took " + closeMs + "ms");
+
+        // Release the stuck caller and verify it exits cleanly.
+        fake.wake.countDown();
+        parked.join(TimeUnit.SECONDS.toMillis(5));
+        assertFalse(parked.isAlive(), "stuck nextEvent caller did not exit after wake");
+    }
+
+    @Test
+    @Timeout(30)
+    void postCloseAccessorsReturnFastWhileFreeIsStillInProgress() throws Exception {
+        // close() releases the write lock BEFORE mesh_free_handle, and the
+        // accessors have a lock-free closed fast path — so a slow native free
+        // (real Rust free can block ~4s on shutdown wait + span drain) must
+        // not stall post-close accessors. The fake blocks free on a latch to
+        // pin the closer inside mesh_free_handle while we probe.
+        FakeCore fake = new FakeCore();
+        fake.blockFree = true;
+        MeshHandle handle = newHandle(fake);
+
+        Thread closer = new Thread(handle::close);
+        closer.setDaemon(true);
+        closer.start();
+        assertTrue(fake.freeStarted.await(5, TimeUnit.SECONDS), "close did not reach free");
+        assertTrue(closer.isAlive(), "closer must still be inside mesh_free_handle");
+
+        long start = System.nanoTime();
+        assertFalse(handle.isRunning());
+        assertTrue(handle.nextEvent(0).isEmpty());
+        assertThrows(MeshException.class, () -> handle.reportHealth("healthy"));
+        assertThrows(MeshException.class, () -> handle.updatePort(8080));
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+        assertTrue(closer.isAlive(), "free must still be in progress while accessors ran");
+        assertTrue(elapsedMs < 1000,
+            "post-close accessors blocked behind the in-progress free, took " + elapsedMs + "ms");
+
+        fake.freeRelease.countDown();
+        closer.join(TimeUnit.SECONDS.toMillis(5));
+        assertFalse(closer.isAlive(), "closer did not finish after free was released");
+        assertEquals(1, fake.freeCount.get());
+        assertFalse(fake.calledAfterFree.get(), "post-close accessors must not reach native code");
+    }
+
+    @Test
+    @Timeout(30)
+    void interruptDuringDrainLogsInterruptVariantAndRestoresFlag() throws Exception {
+        // A parked nextEvent holds the read lock (wedged runtime: shutdown
+        // never wakes it), so close()'s drain tryLock blocks. Interrupting the
+        // closing thread must: log the interrupt-specific message (NOT the
+        // "did not drain within Nms" timeout message — the wait lasted ~0ms,
+        // not the full budget), restore the interrupt flag, and still free.
+        FakeCore fake = new FakeCore();
+        fake.shutdownWakesNextEvent = false;
+        MeshHandle handle = newHandle(fake);
+
+        Thread parked = new Thread(() -> handle.nextEvent(-1));
+        parked.setDaemon(true);
+        parked.start();
+        assertTrue(fake.nextEventParked.await(5, TimeUnit.SECONDS), "nextEvent did not park");
+
+        // slf4j-simple writes to System.err dynamically; capture it.
+        java.io.PrintStream originalErr = System.err;
+        java.io.ByteArrayOutputStream errBuf = new java.io.ByteArrayOutputStream();
+        String errOutput;
+        AtomicBoolean interruptFlagRestored = new AtomicBoolean(false);
+        long closeMs;
+        try {
+            System.setErr(new java.io.PrintStream(errBuf, true));
+
+            Thread closer = new Thread(() -> {
+                handle.close();
+                interruptFlagRestored.set(Thread.currentThread().isInterrupted());
+            });
+            closer.setDaemon(true);
+            long closeStart = System.nanoTime();
+            closer.start();
+
+            // Wait until the closer is parked in the drain tryLock, then interrupt.
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+            while (closer.getState() != Thread.State.TIMED_WAITING) {
+                assertTrue(System.nanoTime() < deadline, "closer never reached the drain wait");
+                Thread.onSpinWait();
+            }
+            closer.interrupt();
+
+            closer.join(TimeUnit.SECONDS.toMillis(10));
+            closeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - closeStart);
+            assertFalse(closer.isAlive(), "close did not return after interrupt");
+        } finally {
+            System.setErr(originalErr);
+            errOutput = errBuf.toString();
+        }
+
+        assertTrue(closeMs < 4000,
+            "interrupted close should return well before the 5s drain budget, took " + closeMs + "ms");
+        assertEquals(1, fake.freeCount.get(), "close must still free after interrupt");
+        assertTrue(interruptFlagRestored.get(), "close must restore the interrupt flag");
+        assertTrue(errOutput.contains("Interrupted while waiting for in-flight native calls"),
+            "expected the interrupt-specific log message, got:\n" + errOutput);
+        assertFalse(errOutput.contains("did not drain within"),
+            "interrupted drain must not be mislabelled as a timeout, got:\n" + errOutput);
+
+        // Release the stuck caller and verify it exits cleanly.
+        fake.wake.countDown();
+        parked.join(TimeUnit.SECONDS.toMillis(5));
+        assertFalse(parked.isAlive());
+    }
+
+    @Test
+    @Timeout(30)
+    void closedFlagIsCheckedUnderTheSameLockAsTheNativeCall() throws Exception {
+        // Regression shape of the original TOCTOU: a reader that acquires the
+        // read lock after close() has the write lock must observe closed=true
+        // and bail without a native call. Drive it deterministically: park one
+        // reader in nextEvent, start close() (which will signal shutdown, wake
+        // the reader, then take the write lock and free), then issue a fresh
+        // accessor call that races the free.
+        FakeCore fake = new FakeCore();
+        MeshHandle handle = newHandle(fake);
+
+        Thread parked = new Thread(() -> handle.nextEvent(-1));
+        parked.setDaemon(true);
+        parked.start();
+        assertTrue(fake.nextEventParked.await(5, TimeUnit.SECONDS));
+
+        List<Thread> racers = List.of(
+            new Thread(handle::close),
+            new Thread(() -> {
+                for (int i = 0; i < 1000; i++) {
+                    handle.isRunning();
+                }
+            })
+        );
+        racers.forEach(t -> { t.setDaemon(true); t.start(); });
+        for (Thread t : racers) {
+            t.join(TimeUnit.SECONDS.toMillis(15));
+            assertFalse(t.isAlive());
+        }
+        parked.join(TimeUnit.SECONDS.toMillis(5));
+
+        assertFalse(fake.calledAfterFree.get(), "isRunning reached native code after free");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshRuntime.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshRuntime.java
@@ -30,7 +30,12 @@ public class MeshRuntime implements SmartLifecycle {
     private final ObjectMapper objectMapper;
     private final AtomicBoolean running = new AtomicBoolean(false);
 
-    private MeshHandle handle;
+    // Volatile + local-snapshot access pattern: stop() nulls this field
+    // concurrently with accessors (nextEvent on the event-loop thread, health
+    // reporting, etc.). Each accessor snapshots the field once, so it either
+    // sees null (runtime stopped) or a MeshHandle whose own closed-guard makes
+    // any post-close call safe (issue #1179).
+    private volatile MeshHandle handle;
     private volatile int pendingPort = -1;
 
     public MeshRuntime(AgentSpec agentSpec) {
@@ -90,13 +95,16 @@ public class MeshRuntime implements SmartLifecycle {
     public void stop() {
         if (running.compareAndSet(true, false)) {
             log.info("Stopping MCP Mesh runtime");
-            if (handle != null) {
+            MeshHandle h = handle;
+            // Null the field BEFORE closing so concurrent accessors snapshot
+            // null instead of a handle that is about to be (or being) closed.
+            handle = null;
+            if (h != null) {
                 try {
-                    handle.close();
+                    h.close();
                 } catch (Exception e) {
                     log.warn("Error closing mesh handle", e);
                 }
-                handle = null;
             }
             MeshTlsConfig.cleanupTls();
             log.info("MCP Mesh runtime stopped");
@@ -105,7 +113,8 @@ public class MeshRuntime implements SmartLifecycle {
 
     @Override
     public boolean isRunning() {
-        return running.get() && handle != null && handle.isRunning();
+        MeshHandle h = handle;
+        return running.get() && h != null && h.isRunning();
     }
 
     @Override
@@ -122,10 +131,14 @@ public class MeshRuntime implements SmartLifecycle {
      * @return The next event, or null on timeout
      */
     public MeshEvent nextEvent(long timeoutMs) {
-        if (handle == null || !isRunning()) {
+        // Snapshot once: stop() may null the field at any point. The snapshot
+        // stays safe to call even if stop() closes it concurrently — a closed
+        // MeshHandle returns Optional.empty() from nextEvent.
+        MeshHandle h = handle;
+        if (h == null || !running.get() || !h.isRunning()) {
             return null;
         }
-        return handle.nextEvent(timeoutMs).orElse(null);
+        return h.nextEvent(timeoutMs).orElse(null);
     }
 
     /**
@@ -134,8 +147,9 @@ public class MeshRuntime implements SmartLifecycle {
      * @param status Health status: "healthy", "degraded", or "unhealthy"
      */
     public void reportHealth(String status) {
-        if (handle != null && isRunning()) {
-            handle.reportHealth(status);
+        MeshHandle h = handle;
+        if (h != null && running.get() && h.isRunning()) {
+            h.reportHealth(status);
         }
     }
 
@@ -150,8 +164,9 @@ public class MeshRuntime implements SmartLifecycle {
      * @return true if the update was sent successfully
      */
     public boolean updatePort(int port) {
-        if (handle != null && isRunning()) {
-            return handle.updatePort(port);
+        MeshHandle h = handle;
+        if (h != null && running.get() && h.isRunning()) {
+            return h.updatePort(port);
         }
         // Runtime not started yet — save for application during start()
         log.info("Runtime not yet started. Saving port {} for deferred update", port);
@@ -163,8 +178,9 @@ public class MeshRuntime implements SmartLifecycle {
      * Request graceful shutdown.
      */
     public void shutdown() {
-        if (handle != null) {
-            handle.shutdown();
+        MeshHandle h = handle;
+        if (h != null) {
+            h.shutdown();
         }
     }
 


### PR DESCRIPTION
## Summary
- `MeshHandle.close()` had a check-then-act gap: an accessor past the `closed` check but not yet in native code could enter `mesh_next_event`/`mesh_report_health`/etc. after `mesh_free_handle` ran. Calls already in flight are safe since #1178's Arc counting; this closes the started-after-free window.
- Accessors now hold a read lock around check + native call (with a lock-free `closed` fast-path so post-close calls fail immediately without queuing); `close()` CASes the flag, signals `mesh_shutdown` **first** — which wakes a `nextEvent` parked in native for its full (possibly infinite) timeout, resolving the chicken-and-egg where the wake-up previously came from the free itself — then awaits the write lock bounded at 5s, releases it, and frees outside the lock (the drain is proven at acquisition; holding it across the ~4s Rust free would stall post-close accessors).
- A drain timeout or interrupt warns (distinct messages) and frees anyway — safe under the Rust Arc contract, so a wedged runtime degrades to the pre-fix behavior rather than hanging shutdown.
- `MeshRuntime` snapshots the volatile `handle` once per call instead of racing `stop()`'s null assignment (the issue's companion TOCTOU); `stop()` nulls before closing so the event loop exits without touching the lock.

## Review Notes
- Independent review: 0 blockers. Verified read→write upgrade deadlock is impossible (no code under the read lock can reach `close()`), writer starvation is defused (non-fair RRWL blocks new readers behind a queued writer, and the realistic event-loop caller bails on the nulled runtime handle first), and `mesh_shutdown` is concurrency-safe per the ffi.rs Arc-guard contract.
- Its warning (write lock held across the slow free) and three infos (fast-path, interrupt mislabel, double-close javadoc) are all addressed.
- Tests use a `reflect.Proxy` fake encoding the verified ffi.rs contract (shutdown wakes parked nextEvent; any call *starting* after free is flagged) — deterministic on every platform; the in-flight-safety half of the contract is owned and tested by the Rust suite.

Closes #1179

## Test plan
- [x] mcp-mesh-core: 15 tests (7 new MeshHandleTest: concurrent close race ×200, post-close rejection, close-wakes-parked-nextEvent ordering, wedged-runtime bounded drain, fast accessors during slow free, interrupt-during-drain) — 0 failures; MeshCoreTest ran against the real native lib
- [x] spring-boot-starter full reactor: 417 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
