### PR TITLE
feat(helm): single registry Redis endpoint; TLS and auth for external datastores

### DIFF
--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -84,11 +84,15 @@ flowchart TB
 # In mcp-mesh-core values
 mcp-mesh-registry:
   registry:
+    # Single Redis endpoint — session storage and trace streaming share it
+    redis:
+      enabled: true
+      host: "mcp-core-mcp-mesh-redis"
+      port: 6379
     observability:
       distributedTracing:
         enabled: true
-        redisUrl: "redis://mcp-core-mcp-mesh-redis:6379"
-        telemetryEndpoint: "mcp-core-mcp-mesh-tempo:4317"
+      telemetryEndpoint: "mcp-core-mcp-mesh-tempo:4317"
 ```
 
 ## Troubleshooting

--- a/helm/mcp-mesh-core/values.yaml
+++ b/helm/mcp-mesh-core/values.yaml
@@ -97,17 +97,22 @@ mcp-mesh-registry:
       format: "json"
       debug: "true"
 
-    # Redis configuration (optional session storage)
+    # Redis configuration — single source of truth for the registry's Redis
+    # endpoint. Session storage and the distributed-trace stream share the
+    # derived REDIS_URL. For external/managed Redis, the registry subchart
+    # also supports registry.redis.password (or existingSecret) and
+    # registry.redis.tls.enabled (renders rediss://).
     redis:
       enabled: true
       host: "mcp-core-mcp-mesh-redis"
       port: 6379
 
     # Observability configuration - matches k8s examples
+    # (stream/consumer settings only; the Redis endpoint comes from
+    # registry.redis above)
     observability:
       distributedTracing:
         enabled: true
-        redisUrl: "redis://mcp-core-mcp-mesh-redis:6379"
         exporterType: "otlp"
         telemetryProtocol: "grpc"
         batchSize: "100"

--- a/helm/mcp-mesh-registry/README.md
+++ b/helm/mcp-mesh-registry/README.md
@@ -61,10 +61,29 @@ The following table lists the configurable parameters of the MCP Mesh Registry c
 | `registry.database.port`           | External database port                            | `5432`                |
 | `registry.database.name`           | Database name                                     | `"mcp_mesh"`          |
 | `registry.database.username`       | Database username                                 | `""`                  |
-| `registry.database.password`       | Database password                                 | `""`                  |
-| `registry.database.existingSecret` | Existing secret for DB credentials                | `""`                  |
+| `registry.database.password`       | Database password (URL-encoded into the DSN)      | `""`                  |
+| `registry.database.sslmode`        | PostgreSQL SSL mode: `disable`, `require`, `verify-ca`, `verify-full` | `"disable"` |
+| `registry.database.tls.caSecret`   | Secret with CA cert for `verify-ca`/`verify-full` (mounted, added to DSN as `sslrootcert`) | `""` |
+| `registry.database.tls.caKey`      | Key of the CA cert in the secret                  | `"ca.crt"`            |
+| `registry.database.existingSecret` | Existing secret with the DB password (injected via `$(DATABASE_PASSWORD)`; must be URL-safe) | `""` |
 | `registry.logging.level`           | Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL) | `"INFO"`              |
 | `registry.logging.format`          | Log format (json or text)                         | `"json"`              |
+
+### Redis Configuration
+
+`registry.redis.*` is the single source of truth for the registry's Redis
+endpoint: session storage and distributed-trace streaming share the derived
+`REDIS_URL`.
+
+| Parameter                                  | Description                                                              | Default            |
+| ------------------------------------------ | ------------------------------------------------------------------------ | ------------------ |
+| `registry.redis.enabled`                   | Enable Redis (session storage + trace stream)                            | `true`             |
+| `registry.redis.host`                      | Redis host                                                               | See values.yaml    |
+| `registry.redis.port`                      | Redis port                                                               | `6379`             |
+| `registry.redis.password`                  | AUTH password; moves `REDIS_URL` into the chart secret, URL-encoded      | `""`               |
+| `registry.redis.existingSecret`            | Existing secret with the password (injected via `$(REDIS_PASSWORD)`; must be URL-safe) | `""` |
+| `registry.redis.existingSecretPasswordKey` | Key of the password in the existing secret                               | `"redis-password"` |
+| `registry.redis.tls.enabled`               | Use `rediss://` (pair with `serviceTLS.redis.*` for CA/client certs)     | `false`            |
 
 ### Persistence
 
@@ -140,16 +159,67 @@ registry:
     password: supersecret
 ```
 
+### External Managed Datastores (TLS + auth)
+
+```yaml
+registry:
+  database:
+    type: postgres
+    host: mydb.example.com
+    port: 5432
+    name: mcpmesh
+    username: mcp_user
+    password: "s3cret!" # URL-encoded automatically
+    sslmode: verify-full
+    tls:
+      caSecret: pg-ca # secret containing the server CA certificate
+      caKey: ca.crt
+  redis:
+    host: myredis.example.com
+    port: 6380
+    password: "redis-secret" # renders rediss://:<encoded>@host:port into the chart secret
+    tls:
+      enabled: true
+```
+
+With `registry.redis.password` set, `REDIS_URL` is rendered into the chart
+secret instead of the configmap. To source the Redis password from an existing
+secret instead:
+
+```yaml
+registry:
+  redis:
+    host: myredis.example.com
+    existingSecret: my-redis-secret
+    existingSecretPasswordKey: redis-password
+    tls:
+      enabled: true
+```
+
+Note: with `existingSecret`, the password is injected via Kubernetes
+`$(REDIS_PASSWORD)` expansion without URL-encoding, so it must be URL-safe.
+
 ### Using Existing Secret for Database
 
 ```yaml
 registry:
   database:
     type: postgres
+    host: mydb.example.com
+    port: 5432
+    name: mcpmesh
+    username: mcp_user # username comes from values, only the password from the secret
     existingSecret: my-db-secret
-    existingSecretUsernameKey: username
     existingSecretPasswordKey: password
+    sslmode: verify-full # sslmode and tls.* apply in this mode too
+    tls:
+      caSecret: pg-ca
 ```
+
+In this mode `DATABASE_URL` is composed in the pod via Kubernetes
+`$(DATABASE_PASSWORD)` expansion from the existing secret, so the password is
+never templated into a chart-managed resource. It is not URL-encoded either,
+so it must be URL-safe.
 
 ### Enabling TLS
 

--- a/helm/mcp-mesh-registry/README.md
+++ b/helm/mcp-mesh-registry/README.md
@@ -65,7 +65,9 @@ The following table lists the configurable parameters of the MCP Mesh Registry c
 | `registry.database.sslmode`        | PostgreSQL SSL mode: `disable`, `require`, `verify-ca`, `verify-full` | `"disable"` |
 | `registry.database.tls.caSecret`   | Secret with CA cert for `verify-ca`/`verify-full` (mounted, added to DSN as `sslrootcert`) | `""` |
 | `registry.database.tls.caKey`      | Key of the CA cert in the secret                  | `"ca.crt"`            |
-| `registry.database.existingSecret` | Existing secret with the DB password (injected via `$(DATABASE_PASSWORD)`; must be URL-safe) | `""` |
+| `registry.database.existingSecret` | Existing secret with the DB credentials (see modes below)                     | `""` |
+| `registry.database.existingSecretUrlKey` | Key in the existing secret holding a complete `postgres://` DSN, consumed directly (no composition, no URL-safety requirement). Empty = password-only mode | `""` |
+| `registry.database.existingSecretPasswordKey` | Key in the existing secret holding the password (injected via `$(DATABASE_PASSWORD)`; must be URL-safe) | `"password"` |
 | `registry.logging.level`           | Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL) | `"INFO"`              |
 | `registry.logging.format`          | Log format (json or text)                         | `"json"`              |
 
@@ -81,8 +83,9 @@ endpoint: session storage and distributed-trace streaming share the derived
 | `registry.redis.host`                      | Redis host                                                               | See values.yaml    |
 | `registry.redis.port`                      | Redis port                                                               | `6379`             |
 | `registry.redis.password`                  | AUTH password; moves `REDIS_URL` into the chart secret, URL-encoded      | `""`               |
-| `registry.redis.existingSecret`            | Existing secret with the password (injected via `$(REDIS_PASSWORD)`; must be URL-safe) | `""` |
-| `registry.redis.existingSecretPasswordKey` | Key of the password in the existing secret                               | `"redis-password"` |
+| `registry.redis.existingSecret`            | Existing secret with the Redis credentials                                | `""` |
+| `registry.redis.existingSecretUrlKey`      | Key in the existing secret holding a complete `redis://`/`rediss://` URL, consumed directly (no composition, no URL-safety requirement). Empty = password-only mode | `""` |
+| `registry.redis.existingSecretPasswordKey` | Key of the password in the existing secret (injected via `$(REDIS_PASSWORD)`; must be URL-safe) | `"redis-password"` |
 | `registry.redis.tls.enabled`               | Use `rediss://` (pair with `serviceTLS.redis.*` for CA/client certs)     | `false`            |
 
 ### Persistence
@@ -183,8 +186,18 @@ registry:
 ```
 
 With `registry.redis.password` set, `REDIS_URL` is rendered into the chart
-secret instead of the configmap. To source the Redis password from an existing
-secret instead:
+secret instead of the configmap. To source Redis credentials from an existing
+secret instead, prefer a complete URL — it is consumed directly via
+`secretKeyRef`, so the password never needs to be URL-safe:
+
+```yaml
+registry:
+  redis:
+    existingSecret: my-redis-secret
+    existingSecretUrlKey: redis-url # key holding rediss://:<password>@host:port
+```
+
+If the secret only carries the password, fall back to composition:
 
 ```yaml
 registry:
@@ -196,10 +209,28 @@ registry:
       enabled: true
 ```
 
-Note: with `existingSecret`, the password is injected via Kubernetes
+Note: in password-only mode the password is injected via Kubernetes
 `$(REDIS_PASSWORD)` expansion without URL-encoding, so it must be URL-safe.
 
 ### Using Existing Secret for Database
+
+Preferred: store a complete DSN in the secret. It is consumed directly via
+`secretKeyRef` — nothing is composed, so the password never needs to be
+URL-safe. Encode `sslmode` (and `sslrootcert`, if any) in the DSN itself;
+`tls.caSecret` still mounts the CA at `/etc/service-tls/postgres` for the DSN
+to reference.
+
+```yaml
+registry:
+  database:
+    type: postgres
+    host: mydb.example.com # still drives the wait-for-db init container
+    port: 5432
+    existingSecret: my-db-secret
+    existingSecretUrlKey: database-url # key holding postgres://user:pass@host:5432/db?sslmode=verify-full
+```
+
+If the secret only carries the password, fall back to in-pod composition:
 
 ```yaml
 registry:
@@ -216,7 +247,7 @@ registry:
       caSecret: pg-ca
 ```
 
-In this mode `DATABASE_URL` is composed in the pod via Kubernetes
+In password-only mode `DATABASE_URL` is composed in the pod via Kubernetes
 `$(DATABASE_PASSWORD)` expansion from the existing secret, so the password is
 never templated into a chart-managed resource. It is not URL-encoded either,
 so it must be URL-safe.

--- a/helm/mcp-mesh-registry/templates/NOTES.txt
+++ b/helm/mcp-mesh-registry/templates/NOTES.txt
@@ -1,0 +1,9 @@
+MCP Mesh Registry has been deployed!
+
+To check the status:
+  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "mcp-mesh-registry.name" . }}
+
+To access the registry:
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "mcp-mesh-registry.fullname" . }} {{ .Values.registry.port }}:{{ .Values.registry.port }}
+
+Then visit: http://localhost:{{ .Values.registry.port }}/health

--- a/helm/mcp-mesh-registry/templates/NOTES.txt
+++ b/helm/mcp-mesh-registry/templates/NOTES.txt
@@ -4,6 +4,6 @@ To check the status:
   kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "mcp-mesh-registry.name" . }}
 
 To access the registry:
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "mcp-mesh-registry.fullname" . }} {{ .Values.registry.port }}:{{ .Values.registry.port }}
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "mcp-mesh-registry.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
 
-Then visit: http://localhost:{{ .Values.registry.port }}/health
+Then visit: http://localhost:{{ .Values.service.port }}/health

--- a/helm/mcp-mesh-registry/templates/_helpers.tpl
+++ b/helm/mcp-mesh-registry/templates/_helpers.tpl
@@ -101,11 +101,13 @@ deployment composes the DSN via $(DATABASE_PASSWORD) instead).
 {{- end }}
 
 {{/*
-PostgreSQL DSN for the database.existingSecret mode: the password is supplied
-at runtime via Kubernetes $(DATABASE_PASSWORD) expansion (the secretKeyRef env
-must be rendered before this one), so it is never templated. The password is
-not URL-encoded in this mode and must be URL-safe. The username comes from
-registry.database.username.
+PostgreSQL DSN for the database.existingSecret password-only mode (fallback
+when no existingSecretUrlKey is set — with a urlKey the deployment consumes
+the full DSN from the secret directly and nothing is composed): the password
+is supplied at runtime via Kubernetes $(DATABASE_PASSWORD) expansion (the
+secretKeyRef env must be rendered before this one), so it is never templated.
+The password is not URL-encoded in this mode and must be URL-safe. The
+username comes from registry.database.username.
 */}}
 {{- define "mcp-mesh-registry.composedDatabaseURL" -}}
 {{- $db := .Values.registry.database -}}
@@ -124,7 +126,8 @@ Redis scheme: rediss when registry.redis.tls.enabled, redis otherwise.
 Redis URL built from registry.redis.* — the single source of truth for the
 registry's Redis endpoint (session storage and trace stream share REDIS_URL).
 An inline password is URL-encoded. Not used when an existing secret supplies
-the password (the deployment composes the URL via $(REDIS_PASSWORD)).
+the password (the deployment composes the URL via $(REDIS_PASSWORD)) or a
+full URL (consumed directly via existingSecretUrlKey).
 */}}
 {{- define "mcp-mesh-registry.redisURL" -}}
 {{- $redis := .Values.registry.redis -}}

--- a/helm/mcp-mesh-registry/templates/_helpers.tpl
+++ b/helm/mcp-mesh-registry/templates/_helpers.tpl
@@ -63,24 +63,100 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Get the database URL
+Validated PostgreSQL sslmode (default disable). Invoked from the configmap for
+every non-sqlite database — in addition to both DSN builders below — so an
+invalid value fails at template time in all modes.
+*/}}
+{{- define "mcp-mesh-registry.databaseSSLMode" -}}
+{{- $sslmode := .Values.registry.database.sslmode | default "disable" -}}
+{{- if not (has $sslmode (list "disable" "require" "verify-ca" "verify-full")) -}}
+{{- fail (printf "registry.database.sslmode must be one of: disable, require, verify-ca, verify-full (got %q)" $sslmode) -}}
+{{- end -}}
+{{- $sslmode -}}
+{{- end }}
+
+{{/*
+DSN query string: validated sslmode plus sslrootcert when a CA secret is mounted.
+*/}}
+{{- define "mcp-mesh-registry.databaseURLParams" -}}
+{{- $db := .Values.registry.database -}}
+{{- $params := printf "?sslmode=%s" (include "mcp-mesh-registry.databaseSSLMode" .) -}}
+{{- if dig "tls" "caSecret" "" $db -}}
+{{- $params = printf "%s&sslrootcert=/etc/service-tls/postgres/%s" $params (dig "tls" "caKey" "ca.crt" $db) -}}
+{{- end -}}
+{{- $params -}}
+{{- end }}
+
+{{/*
+PostgreSQL DSN with URL-encoded credentials, sslmode, and optional CA cert.
+The DSN is the only SSL-mode consumer: the registry binary reads DATABASE_URL.
+Rendered into the chart Secret. Not used with database.existingSecret (the
+deployment composes the DSN via $(DATABASE_PASSWORD) instead).
 */}}
 {{- define "mcp-mesh-registry.databaseURL" -}}
-{{- if eq .Values.registry.database.type "sqlite" }}
-{{- printf "sqlite:///%s" .Values.registry.database.path }}
-{{- else if eq .Values.registry.database.type "postgres" }}
-{{- if .Values.registry.database.existingSecret }}
-{{- printf "postgres://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@%s:%d/%s" .Values.registry.database.host (.Values.registry.database.port | int) .Values.registry.database.name }}
-{{- else }}
-{{- printf "postgres://%s:%s@%s:%d/%s" .Values.registry.database.username .Values.registry.database.password .Values.registry.database.host (.Values.registry.database.port | int) .Values.registry.database.name }}
+{{- $db := .Values.registry.database -}}
+{{- $user := $db.username | urlquery | replace "+" "%20" -}}
+{{- $pass := $db.password | urlquery | replace "+" "%20" -}}
+{{- printf "postgres://%s:%s@%s:%d/%s%s" $user $pass $db.host ($db.port | int) $db.name (include "mcp-mesh-registry.databaseURLParams" .) -}}
 {{- end }}
-{{- else if eq .Values.registry.database.type "mysql" }}
-{{- if .Values.registry.database.existingSecret }}
-{{- printf "mysql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@%s:%d/%s" .Values.registry.database.host (.Values.registry.database.port | int) .Values.registry.database.name }}
-{{- else }}
-{{- printf "mysql://%s:%s@%s:%d/%s" .Values.registry.database.username .Values.registry.database.password .Values.registry.database.host (.Values.registry.database.port | int) .Values.registry.database.name }}
+
+{{/*
+PostgreSQL DSN for the database.existingSecret mode: the password is supplied
+at runtime via Kubernetes $(DATABASE_PASSWORD) expansion (the secretKeyRef env
+must be rendered before this one), so it is never templated. The password is
+not URL-encoded in this mode and must be URL-safe. The username comes from
+registry.database.username.
+*/}}
+{{- define "mcp-mesh-registry.composedDatabaseURL" -}}
+{{- $db := .Values.registry.database -}}
+{{- $user := $db.username | urlquery | replace "+" "%20" -}}
+{{- printf "postgres://%s:$(DATABASE_PASSWORD)@%s:%d/%s%s" $user $db.host ($db.port | int) $db.name (include "mcp-mesh-registry.databaseURLParams" .) -}}
 {{- end }}
+
+{{/*
+Redis scheme: rediss when registry.redis.tls.enabled, redis otherwise.
+*/}}
+{{- define "mcp-mesh-registry.redisScheme" -}}
+{{- if dig "tls" "enabled" false .Values.registry.redis -}}rediss{{- else -}}redis{{- end -}}
 {{- end }}
+
+{{/*
+Redis URL built from registry.redis.* — the single source of truth for the
+registry's Redis endpoint (session storage and trace stream share REDIS_URL).
+An inline password is URL-encoded. Not used when an existing secret supplies
+the password (the deployment composes the URL via $(REDIS_PASSWORD)).
+*/}}
+{{- define "mcp-mesh-registry.redisURL" -}}
+{{- $redis := .Values.registry.redis -}}
+{{- $auth := "" -}}
+{{- if $redis.password -}}
+{{- $auth = printf ":%s@" ($redis.password | urlquery | replace "+" "%20") -}}
+{{- end -}}
+{{- printf "%s://%s%s:%v" (include "mcp-mesh-registry.redisScheme" .) $auth $redis.host ($redis.port | default 6379) -}}
+{{- end }}
+
+{{/*
+Removed-key guard. distributedTracing.redisUrl was dead config — no template
+ever consumed it — so honoring it now would silently switch endpoints on
+upgrade for values files still carrying it. Fail loudly with migration
+guidance instead. Invoked unconditionally from the configmap.
+*/}}
+{{- define "mcp-mesh-registry.validateNoDeprecatedRedisUrl" -}}
+{{- if dig "observability" "distributedTracing" "redisUrl" "" .Values.registry -}}
+{{- fail "registry.observability.distributedTracing.redisUrl was never consumed and has been removed; configure registry.redis.{host,port,password,tls} instead — the trace stream shares that endpoint" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Whether the chart-managed Secret renders. Shared by secret.yaml and the
+deployment's checksum/secret annotation so the checksum never hashes a
+non-rendered manifest.
+*/}}
+{{- define "mcp-mesh-registry.secretEnabled" -}}
+{{- $redisUrlInSecret := and .Values.registry.redis.enabled .Values.registry.redis.password (not .Values.registry.redis.existingSecret) -}}
+{{- if or (and (ne .Values.registry.database.type "sqlite") (not .Values.registry.database.existingSecret)) (and .Values.registry.security.auth.enabled (not .Values.registry.security.auth.existingSecret)) $redisUrlInSecret -}}
+true
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/helm/mcp-mesh-registry/templates/configmap.yaml
+++ b/helm/mcp-mesh-registry/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "mcp-mesh-registry.validateNoDeprecatedRedisUrl" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,6 +18,9 @@ data:
   {{- if eq .Values.registry.database.type "sqlite" }}
   DATABASE_PATH: {{ .Values.registry.database.path | quote }}
   {{- else }}
+  {{- /* Silent invocation so an invalid sslmode fails in every mode,
+         including database.existingSecret. */}}
+  {{- $_ := include "mcp-mesh-registry.databaseSSLMode" . }}
   DATABASE_HOST: {{ .Values.registry.database.host | quote }}
   DATABASE_PORT: {{ .Values.registry.database.port | quote }}
   DATABASE_NAME: {{ .Values.registry.database.name | quote }}
@@ -83,6 +87,8 @@ data:
 
   # Redis configuration for session/trace storage
   {{- if .Values.registry.redis.enabled }}
-  REDIS_URL: {{ printf "redis://%s:%v" .Values.registry.redis.host (.Values.registry.redis.port | default 6379) | quote }}
+  {{- if and (not .Values.registry.redis.password) (not .Values.registry.redis.existingSecret) }}
+  REDIS_URL: {{ include "mcp-mesh-registry.redisURL" . | quote }}
+  {{- end }}
   MCP_MESH_REDIS_TRACE_PUBLISHING: "true"
   {{- end }}

--- a/helm/mcp-mesh-registry/templates/deployment.yaml
+++ b/helm/mcp-mesh-registry/templates/deployment.yaml
@@ -110,6 +110,16 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             {{- if and (ne .Values.registry.database.type "sqlite") .Values.registry.database.existingSecret }}
+            {{- if and (eq .Values.registry.database.type "postgres") .Values.registry.database.existingSecretUrlKey }}
+            {{- /* Full DSN from the existing secret, consumed directly — no
+                   composition, so the credentials need no URL-safety. The DSN
+                   must carry its own sslmode/sslrootcert params. */}}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.registry.database.existingSecret }}
+                  key: {{ .Values.registry.database.existingSecretUrlKey }}
+            {{- else }}
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -121,6 +131,7 @@ spec:
                    existing secret is not URL-encoded and must be URL-safe. */}}
             - name: DATABASE_URL
               value: {{ include "mcp-mesh-registry.composedDatabaseURL" . | quote }}
+            {{- end }}
             {{- end }}
             {{- else if ne .Values.registry.database.type "sqlite" }}
             - name: DATABASE_PASSWORD
@@ -153,6 +164,15 @@ spec:
             {{- end }}
             {{- if .Values.registry.redis.enabled }}
             {{- if .Values.registry.redis.existingSecret }}
+            {{- if .Values.registry.redis.existingSecretUrlKey }}
+            {{- /* Full URL from the existing secret, consumed directly — no
+                   composition, so the password needs no URL-safety. */}}
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.registry.redis.existingSecret }}
+                  key: {{ .Values.registry.redis.existingSecretUrlKey }}
+            {{- else }}
             {{- /* Password from the existing secret must be URL-safe: it is
                    interpolated into REDIS_URL via $(REDIS_PASSWORD) without
                    URL-encoding. */}}
@@ -163,6 +183,7 @@ spec:
                   key: {{ .Values.registry.redis.existingSecretPasswordKey | default "redis-password" }}
             - name: REDIS_URL
               value: {{ printf "%s://:$(REDIS_PASSWORD)@%s:%v" (include "mcp-mesh-registry.redisScheme" .) .Values.registry.redis.host (.Values.registry.redis.port | default 6379) | quote }}
+            {{- end }}
             {{- else if .Values.registry.redis.password }}
             - name: REDIS_URL
               valueFrom:

--- a/helm/mcp-mesh-registry/templates/deployment.yaml
+++ b/helm/mcp-mesh-registry/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- if not .Values.registry.database.existingSecret }}
+        {{- if include "mcp-mesh-registry.secretEnabled" . }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
         prometheus.io/scrape: "true"
@@ -115,6 +115,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.registry.database.existingSecret }}
                   key: {{ .Values.registry.database.existingSecretPasswordKey }}
+            {{- if eq .Values.registry.database.type "postgres" }}
+            {{- /* Composed via $(DATABASE_PASSWORD) expansion — DATABASE_PASSWORD
+                   must be rendered above this entry. The password from the
+                   existing secret is not URL-encoded and must be URL-safe. */}}
+            - name: DATABASE_URL
+              value: {{ include "mcp-mesh-registry.composedDatabaseURL" . | quote }}
+            {{- end }}
             {{- else if ne .Values.registry.database.type "sqlite" }}
             - name: DATABASE_PASSWORD
               valueFrom:
@@ -142,6 +149,26 @@ spec:
                 secretKeyRef:
                   name: {{ include "mcp-mesh-registry.fullname" . }}-secret
                   key: auth-tokens
+            {{- end }}
+            {{- end }}
+            {{- if .Values.registry.redis.enabled }}
+            {{- if .Values.registry.redis.existingSecret }}
+            {{- /* Password from the existing secret must be URL-safe: it is
+                   interpolated into REDIS_URL via $(REDIS_PASSWORD) without
+                   URL-encoding. */}}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.registry.redis.existingSecret }}
+                  key: {{ .Values.registry.redis.existingSecretPasswordKey | default "redis-password" }}
+            - name: REDIS_URL
+              value: {{ printf "%s://:$(REDIS_PASSWORD)@%s:%v" (include "mcp-mesh-registry.redisScheme" .) .Values.registry.redis.host (.Values.registry.redis.port | default 6379) | quote }}
+            {{- else if .Values.registry.redis.password }}
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-mesh-registry.fullname" . }}-secret
+                  key: redis-url
             {{- end }}
             {{- end }}
             {{- with .Values.env }}
@@ -243,6 +270,11 @@ spec:
               mountPath: /run/spire/agent/sockets
               readOnly: true
             {{- end }}
+            {{- if .Values.registry.database.tls.caSecret }}
+            - name: tls-postgres
+              mountPath: /etc/service-tls/postgres
+              readOnly: true
+            {{- end }}
             {{- if .Values.serviceTLS.redis.secretName }}
             - name: tls-redis
               mountPath: /etc/service-tls/redis
@@ -294,6 +326,12 @@ spec:
           hostPath:
             path: /run/spire/agent/sockets
             type: DirectoryOrCreate
+        {{- end }}
+        {{- if .Values.registry.database.tls.caSecret }}
+        - name: tls-postgres
+          secret:
+            secretName: {{ .Values.registry.database.tls.caSecret }}
+            defaultMode: 0400
         {{- end }}
         {{- if .Values.serviceTLS.redis.secretName }}
         - name: tls-redis

--- a/helm/mcp-mesh-registry/templates/secret.yaml
+++ b/helm/mcp-mesh-registry/templates/secret.yaml
@@ -1,4 +1,5 @@
-{{- if or (and (ne .Values.registry.database.type "sqlite") (not .Values.registry.database.existingSecret)) (and .Values.registry.security.auth.enabled (not .Values.registry.security.auth.existingSecret)) }}
+{{- $redisUrlInSecret := and .Values.registry.redis.enabled .Values.registry.redis.password (not .Values.registry.redis.existingSecret) }}
+{{- if include "mcp-mesh-registry.secretEnabled" . }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,8 +19,11 @@ data:
   database-username: {{ .Values.registry.database.username | b64enc | quote }}
   database-password: {{ .Values.registry.database.password | b64enc | quote }}
   {{- if eq .Values.registry.database.type "postgres" }}
-  database-url: {{ printf "postgres://%s:%s@%s:%d/%s?sslmode=disable" .Values.registry.database.username .Values.registry.database.password .Values.registry.database.host (.Values.registry.database.port | int) .Values.registry.database.name | b64enc | quote }}
+  database-url: {{ include "mcp-mesh-registry.databaseURL" . | b64enc | quote }}
   {{- end }}
+  {{- end }}
+  {{- if $redisUrlInSecret }}
+  redis-url: {{ include "mcp-mesh-registry.redisURL" . | b64enc | quote }}
   {{- end }}
   {{- if and .Values.registry.security.auth.enabled (eq .Values.registry.security.auth.type "token") (not .Values.registry.security.auth.existingSecret) }}
   auth-tokens: {{ .Values.registry.security.auth.tokens | toJson | b64enc | quote }}

--- a/helm/mcp-mesh-registry/values.yaml
+++ b/helm/mcp-mesh-registry/values.yaml
@@ -108,7 +108,19 @@ registry:
     name: "mcpmesh" # Matches working examples
     username: "mcpmesh" # Matches working examples
     password: ""
-    # Use existing secret for database credentials
+    # PostgreSQL SSL mode: disable, require, verify-ca, verify-full
+    sslmode: "disable"
+    # TLS material for verify-ca / verify-full against managed databases
+    tls:
+      # Secret containing the CA certificate used to verify the server.
+      # Mounted at /etc/service-tls/postgres and appended to the DSN as sslrootcert.
+      caSecret: ""
+      caKey: "ca.crt"
+    # Use existing secret for the database password. In this mode DATABASE_URL
+    # is composed in the pod via $(DATABASE_PASSWORD) expansion, so the
+    # password is never templated — but it is not URL-encoded either, so it
+    # must be URL-safe. sslmode and tls.* above apply in this mode too; the
+    # username comes from registry.database.username.
     existingSecret: ""
     # Keys in the secret
     existingSecretUsernameKey: "username"
@@ -190,11 +202,25 @@ registry:
     # Exporter type: console (default), otlp (for Tempo/Jaeger), json
     exporterType: "otlp"
 
-  # Redis configuration for trace streaming (registry reads from mesh:trace stream)
+  # Redis configuration — single source of truth for the registry's Redis
+  # endpoint. One REDIS_URL serves both session storage and the distributed
+  # trace stream (registry reads from mesh:trace).
   redis:
     enabled: true
     host: "mcp-core-mcp-mesh-redis"
     port: 6379
+    # AUTH password. When set, REDIS_URL is rendered into the chart secret
+    # (instead of the configmap) with the password URL-encoded.
+    password: ""
+    # Or take the password from an existing secret. NOTE: in this mode the
+    # password is interpolated into REDIS_URL via $(REDIS_PASSWORD) expansion
+    # without encoding, so it must be URL-safe.
+    existingSecret: ""
+    existingSecretPasswordKey: "redis-password"
+    tls:
+      # Render rediss:// instead of redis://. Pair with serviceTLS.redis.*
+      # below to mount CA / client certificates.
+      enabled: false
 
     # CORS configuration
     cors:

--- a/helm/mcp-mesh-registry/values.yaml
+++ b/helm/mcp-mesh-registry/values.yaml
@@ -116,13 +116,29 @@ registry:
       # Mounted at /etc/service-tls/postgres and appended to the DSN as sslrootcert.
       caSecret: ""
       caKey: "ca.crt"
-    # Use existing secret for the database password. In this mode DATABASE_URL
-    # is composed in the pod via $(DATABASE_PASSWORD) expansion, so the
-    # password is never templated — but it is not URL-encoded either, so it
-    # must be URL-safe. sslmode and tls.* above apply in this mode too; the
-    # username comes from registry.database.username.
+    # Use an existing secret for the database credentials. Two modes:
+    #
+    # 1. Full DSN (preferred, postgres only): set existingSecretUrlKey to the
+    #    key holding a complete postgres:// URL. DATABASE_URL is consumed
+    #    directly via secretKeyRef — no composition, so the password needs no
+    #    URL-safety and sslmode/tls.* above are NOT applied (encode sslmode /
+    #    sslrootcert in the DSN itself; tls.caSecret still mounts the CA at
+    #    /etc/service-tls/postgres for the DSN to reference).
+    #
+    # 2. Password only (fallback): leave existingSecretUrlKey empty and point
+    #    existingSecretPasswordKey at the password. DATABASE_URL is composed
+    #    in the pod via $(DATABASE_PASSWORD) expansion, so the password is
+    #    never templated — but it is not URL-encoded either, so it must be
+    #    URL-safe. sslmode and tls.* apply; the username comes from
+    #    registry.database.username.
+    #
+    # In both modes registry.database.{host,port,name,username} still feed the
+    # configmap and the wait-for-db init container.
     existingSecret: ""
-    # Keys in the secret
+    # Key holding a complete DSN in the existing secret (mode 1). Empty
+    # selects mode 2. The chart's own Secret uses "database-url" for this.
+    existingSecretUrlKey: ""
+    # Keys in the secret (mode 2)
     existingSecretUsernameKey: "username"
     existingSecretPasswordKey: "password"
 
@@ -212,10 +228,19 @@ registry:
     # AUTH password. When set, REDIS_URL is rendered into the chart secret
     # (instead of the configmap) with the password URL-encoded.
     password: ""
-    # Or take the password from an existing secret. NOTE: in this mode the
-    # password is interpolated into REDIS_URL via $(REDIS_PASSWORD) expansion
-    # without encoding, so it must be URL-safe.
+    # Or take credentials from an existing secret. Two modes:
+    # 1. Full URL (preferred): set existingSecretUrlKey to the key holding a
+    #    complete redis:// or rediss:// URL, consumed directly via
+    #    secretKeyRef — no composition, no URL-safety requirement. host/port/
+    #    tls.enabled below are NOT applied to the URL (put the scheme in it);
+    #    serviceTLS.redis.* cert mounts still apply.
+    # 2. Password only (fallback): leave existingSecretUrlKey empty. The
+    #    password is interpolated into REDIS_URL via $(REDIS_PASSWORD)
+    #    expansion without encoding, so it must be URL-safe.
     existingSecret: ""
+    # Key holding a complete Redis URL in the existing secret (mode 1).
+    # Empty selects mode 2. The chart's own Secret uses "redis-url" for this.
+    existingSecretUrlKey: ""
     existingSecretPasswordKey: "redis-password"
     tls:
       # Render rediss:// instead of redis://. Pair with serviceTLS.redis.*


### PR DESCRIPTION
## Summary
Closes #1150 and #1151 — the first of the helm chart-maturity batch.

- **Single Redis endpoint** (#1150): `registry.redis.{host,port,password,existingSecret,tls}` is the one documented source; the trace stream shares it by construction (verified against the registry binary: one `REDIS_URL` feeds both session storage and trace publishing). The old `registry.observability.distributedTracing.redisUrl` turned out to be dead config — no template ever consumed it — so rather than "honoring" a key that never worked (which would silently switch endpoints on upgrade for values files carrying the stale value the old docs instructed), setting it now **fails the render with a migration message**. `distributedTracing.*` keeps only stream settings.
- **External-datastore TLS + auth** (#1151): `registry.database.sslmode` (validated against the four lib/pq modes, firing in every mode) with an optional CA secret mounted and threaded as `sslrootcert`; DSN userinfo URL-encoded (incl. the `+`/`%20` and `%`-single-encoding subtleties); `registry.redis.password`/`existingSecret`/`tls.enabled` render `rediss://` with auth. Secret hygiene: an inline password moves `REDIS_URL` into the chart Secret (the ConfigMap key is fully suppressed, not shadowed); existingSecret paths compose URLs via `$(VAR)` expansion so passwords are never templated.
- **Bonus fix surfaced by review**: `registry.database.existingSecret` mode was non-functional on main — it set only env vars the binary never reads, so the registry silently fell back to ephemeral sqlite. It now composes a real `DATABASE_URL` via `$(DATABASE_PASSWORD)` expansion with sslmode/CA applied.

## Behavior changes — release-note visibility
- Values files setting `distributedTracing.redisUrl` (previously inert) fail at template time with a migration message.
- `registry.database.existingSecret` installs that were silently running sqlite will connect to the configured Postgres after upgrade.

## Review Notes
- Independent review rendered and verified: default-values output is **byte-identical** to main for both charts; no password ever lands in a ConfigMap on canonical paths; `$(VAR)` env ordering correct; checksum gating now shares one helper with the secret's render condition so they cannot diverge; CA mount path matches the DSN exactly.
- All three review warnings addressed (existingSecret DSN composition + all-modes validation, deprecated-key fail, checksum gate).
- Pre-existing dead config flagged for a future cleanup: `database.existingSecretUsernameKey` (never consumed), the non-`enabled` `distributedTracing.*` stream keys, `registry.redis.cors` mis-nesting, and the unused umbrella `registry.environment` map.

Closes #1150
Closes #1151

## Test plan
- [x] `helm lint` all 9 charts (CI parity incl. umbrella dependency update)
- [x] `helm template` default values: byte-identical to main (both charts)
- [x] External-datastore matrix rendered and asserted: sslmode=require/verify-full + CA, special-char passwords URL-encoded, rediss with inline + existingSecret auth, umbrella deep-merge pass-through, deprecated key fails standalone + umbrella
- [ ] Install smoke test on a real cluster with an external Postgres/Redis (manual, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added TLS/SSL support for PostgreSQL and Redis with configurable CA certificates
  * Centralized Redis configuration in Helm values for simplified management

* **Documentation**
  * Enhanced Helm configuration documentation with expanded examples for external managed datastores with TLS and authentication
  * Updated tracing and observability examples to reflect consolidated Redis endpoint configuration
  * Added post-installation guidance showing pod status checks and health endpoint access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->