### PR TITLE
feat(helm): global.postgres/global.redis declared once, inherited everywhere

### DIFF
--- a/helm/mcp-mesh-agent/templates/_helpers.tpl
+++ b/helm/mcp-mesh-agent/templates/_helpers.tpl
@@ -114,3 +114,76 @@ Detect if using Python runtime (checks agent.runtime first, then image name)
 {{- else if and (not .Values.agent.runtime) (contains "python" .Values.image.repository) }}true
 {{- end }}
 {{- end }}
+
+{{/*
+Shared Redis settings (global.redis) as JSON — the same shape the
+mcp-mesh-core umbrella shares with its datastore consumers. This chart is
+standalone (not an umbrella subchart), so set the same global.redis values
+on each agent release (e.g. reuse the umbrella's datastore values file).
+Precedence: explicit agent.observability.distributedTracing.redisUrl >
+global.redis.* > chart default.
+*/}}
+{{- define "mcp-mesh-agent.globalRedis" -}}
+{{- dig "redis" (dict) (.Values.global | default dict) | default dict | toJson -}}
+{{- end }}
+
+{{/*
+Redis scheme: rediss when global.redis.tls.enabled, redis otherwise.
+*/}}
+{{- define "mcp-mesh-agent.redisScheme" -}}
+{{- $g := include "mcp-mesh-agent.globalRedis" . | fromJson -}}
+{{- if dig "tls" "enabled" false $g -}}rediss{{- else -}}redis{{- end -}}
+{{- end }}
+
+{{/*
+Where REDIS_URL is sourced from:
+  - "configmap": plain URL in the chart configmap (no credential involved —
+    explicit redisUrl, composed global host without password, or the default)
+  - "secret": inline global.redis.password — the URL carries a credential, so
+    it renders into the chart Secret and is consumed via secretKeyRef
+  - "existing-url" / "existing-password": global.redis.existingSecret modes,
+    consumed via secretKeyRef in the deployment
+*/}}
+{{- define "mcp-mesh-agent.redisURLSource" -}}
+{{- $explicit := dig "observability" "distributedTracing" "redisUrl" "" .Values.agent -}}
+{{- $g := include "mcp-mesh-agent.globalRedis" . | fromJson -}}
+{{- if $explicit -}}
+configmap
+{{- else if $g.existingSecret -}}
+{{- if $g.existingSecretUrlKey -}}existing-url{{- else -}}existing-password{{- end -}}
+{{- else if $g.password -}}
+secret
+{{- else -}}
+configmap
+{{- end -}}
+{{- end }}
+
+{{/*
+Effective REDIS_URL (trace publishing). An inline global password is
+URL-encoded and applies over the coalesced default host (registry
+semantics), so a password without a host still renders a credentialed URL —
+redisURLSource classifies that combination as "secret" and the Secret must
+carry the credential. Not used in the existing-secret modes.
+*/}}
+{{- define "mcp-mesh-agent.redisURL" -}}
+{{- $explicit := dig "observability" "distributedTracing" "redisUrl" "" .Values.agent -}}
+{{- if $explicit -}}
+{{- $explicit -}}
+{{- else -}}
+{{- $g := include "mcp-mesh-agent.globalRedis" . | fromJson -}}
+{{- $auth := "" -}}
+{{- if $g.password -}}
+{{- $auth = printf ":%s@" ($g.password | urlquery | replace "+" "%20") -}}
+{{- end -}}
+{{- printf "%s://%s%s:%d" (include "mcp-mesh-agent.redisScheme" .) $auth (coalesce $g.host "mcp-core-mcp-mesh-redis") (coalesce $g.port 6379 | int) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+REDIS_URL for the global.redis.existingSecret password-only mode: composed
+via $(REDIS_PASSWORD) expansion, so the password must be URL-safe.
+*/}}
+{{- define "mcp-mesh-agent.composedRedisURL" -}}
+{{- $g := include "mcp-mesh-agent.globalRedis" . | fromJson -}}
+{{- printf "%s://:$(REDIS_PASSWORD)@%s:%d" (include "mcp-mesh-agent.redisScheme" .) ($g.host | default "mcp-core-mcp-mesh-redis") (coalesce $g.port 6379 | int) -}}
+{{- end }}

--- a/helm/mcp-mesh-agent/templates/configmap.yaml
+++ b/helm/mcp-mesh-agent/templates/configmap.yaml
@@ -90,5 +90,10 @@ data:
   {{- end }}
 
   # Redis configuration for session/trace storage
-  REDIS_URL: {{ .Values.agent.observability.distributedTracing.redisUrl | default "redis://mcp-core-mcp-mesh-redis:6379" | quote }}
+  {{- /* When the URL carries a credential (global.redis password /
+         existingSecret), it is sourced from a Secret in the deployment
+         instead of this configmap. */}}
+  {{- if eq (include "mcp-mesh-agent.redisURLSource" .) "configmap" }}
+  REDIS_URL: {{ include "mcp-mesh-agent.redisURL" . | quote }}
+  {{- end }}
   MCP_MESH_REDIS_TRACE_PUBLISHING: "true"

--- a/helm/mcp-mesh-agent/templates/deployment.yaml
+++ b/helm/mcp-mesh-agent/templates/deployment.yaml
@@ -1,4 +1,6 @@
 {{- /* Render deployment — always enabled when image.repository is set */ -}}
+{{- $redisSource := include "mcp-mesh-agent.redisURLSource" . -}}
+{{- $gredis := include "mcp-mesh-agent.globalRedis" . | fromJson -}}
 {{- if .Values.image.repository -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -24,7 +26,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- if .Values.secrets }}
+        {{- if or .Values.secrets (eq $redisSource "secret") }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}
@@ -140,6 +142,34 @@ spec:
             # Python environment variables
             - name: PYTHONUNBUFFERED
               value: "1"
+            {{- end }}
+            {{- if eq $redisSource "secret" }}
+            {{- /* Inline global.redis.password: the composed URL carries the
+                   credential, so it lives in the chart Secret. */}}
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-mesh-agent.fullname" . }}-secret
+                  key: redis-url
+            {{- else if eq $redisSource "existing-url" }}
+            {{- /* Full URL from the existing secret, consumed directly — no
+                   composition, so the password needs no URL-safety. */}}
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $gredis.existingSecret }}
+                  key: {{ $gredis.existingSecretUrlKey }}
+            {{- else if eq $redisSource "existing-password" }}
+            {{- /* Password from the existing secret must be URL-safe: it is
+                   interpolated into REDIS_URL via $(REDIS_PASSWORD) without
+                   URL-encoding. */}}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $gredis.existingSecret }}
+                  key: {{ $gredis.existingSecretPasswordKey | default "redis-password" }}
+            - name: REDIS_URL
+              value: {{ include "mcp-mesh-agent.composedRedisURL" . | quote }}
             {{- end }}
             {{- if .Values.mesh.tls.vault.tokenSecret }}
             - name: VAULT_TOKEN

--- a/helm/mcp-mesh-agent/templates/secret.yaml
+++ b/helm/mcp-mesh-agent/templates/secret.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.secrets (not .Values.existingSecret) }}
+{{- $redisUrlInSecret := eq (include "mcp-mesh-agent.redisURLSource" .) "secret" }}
+{{- if or (and .Values.secrets (not .Values.existingSecret)) $redisUrlInSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,7 +15,12 @@ metadata:
   {{- end }}
 type: Opaque
 data:
+  {{- if not .Values.existingSecret }}
   {{- range $key, $value := .Values.secrets }}
   {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if $redisUrlInSecret }}
+  redis-url: {{ include "mcp-mesh-agent.redisURL" . | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/helm/mcp-mesh-agent/values.yaml
+++ b/helm/mcp-mesh-agent/values.yaml
@@ -8,6 +8,22 @@ global:
   # Override this if you installed mcp-mesh-core with a different release name
   # Example: helm install my-core mcp-mesh-core ... → set coreReleaseName: "my-core"
   coreReleaseName: "mcp-core"
+  # Shared Redis endpoint for trace publishing — same shape as the
+  # mcp-mesh-core umbrella's global.redis, so the umbrella's datastore values
+  # file can be reused for agent releases (this chart is standalone, not an
+  # umbrella subchart, so helm does not propagate the umbrella's globals
+  # automatically). Used when agent.observability.distributedTracing.redisUrl
+  # is unset. With password/existingSecret set, REDIS_URL is sourced from a
+  # Secret instead of the chart configmap.
+  # redis:
+  #   host: "my-redis.example.com"
+  #   port: 6379
+  #   password: ""
+  #   existingSecret: ""
+  #   existingSecretUrlKey: ""       # key holding a full redis:// URL
+  #   existingSecretPasswordKey: ""  # default: redis-password
+  #   tls:
+  #     enabled: true                # renders rediss://
 
 replicaCount: 1
 
@@ -203,7 +219,11 @@ agent:
   observability:
     distributedTracing:
       enabled: true
-      redisUrl: "redis://mcp-core-mcp-mesh-redis:6379"
+      # Full Redis URL for trace publishing. Empty inherits global.redis.*
+      # (see the global block above); an explicit value here always wins.
+      # When neither is set, the chart default applies:
+      #   redis://mcp-core-mcp-mesh-redis:6379
+      redisUrl: ""
     telemetryEndpoint: "mcp-core-mcp-mesh-tempo:4317"
     tracing:
       enabled: true

--- a/helm/mcp-mesh-agent/values.yaml
+++ b/helm/mcp-mesh-agent/values.yaml
@@ -21,7 +21,10 @@ global:
   #   password: ""
   #   existingSecret: ""
   #   existingSecretUrlKey: ""       # key holding a full redis:// URL
-  #   existingSecretPasswordKey: ""  # default: redis-password
+  #   existingSecretPasswordKey: ""  # default: redis-password (must be
+  #                                  # URL-safe: interpolated into REDIS_URL
+  #                                  # via $(REDIS_PASSWORD) without encoding;
+  #                                  # prefer existingSecretUrlKey otherwise)
   #   tls:
   #     enabled: true                # renders rediss://
 
@@ -229,14 +232,6 @@ agent:
       enabled: true
     metrics:
       enabled: true
-
-  # Additional environment variables for tracing (matches k8s examples)
-  environment:
-    MCP_MESH_DISTRIBUTED_TRACING_ENABLED: "true"
-    REDIS_URL: "redis://mcp-core-mcp-mesh-redis:6379"
-    TELEMETRY_ENDPOINT: "mcp-core-mcp-mesh-tempo:4317"
-    MCP_MESH_TRACING_ENABLED: "true"
-    MCP_MESH_METRICS_ENABLED: "true"
 # Duplicate registry and mesh sections removed - see lines 85-97 for the main definitions
 
 # ConfigMap for agent code

--- a/helm/mcp-mesh-core/README.md
+++ b/helm/mcp-mesh-core/README.md
@@ -93,7 +93,14 @@ mcp-mesh-postgres:
 
 To use a managed PostgreSQL/Redis (RDS, Cloud SQL, ElastiCache, ...), disable
 the bundled subcharts and point `global.*` at the managed endpoints — every
-consumer inherits them, no per-subchart overrides needed:
+consumer inherits them, no per-subchart overrides needed.
+
+Disabling the bundled subcharts (`postgres.enabled: false`,
+`redis.enabled: false`) is required, not optional: leaving them enabled
+alongside external credentials fails at template time, because the bundled
+Redis runs without AUTH and the bundled PostgreSQL provisions with the inline
+password — `global.redis.password` / `global.redis.existingSecret` /
+`global.postgres.existingSecret` could never work against them.
 
 ```yaml
 # values.yaml

--- a/helm/mcp-mesh-core/README.md
+++ b/helm/mcp-mesh-core/README.md
@@ -68,19 +68,68 @@ tempo:
 
 ### Database Configuration
 
+Datastore endpoints and credentials are declared once under `global.*` and
+inherited by every consumer: the registry, the UI (when enabled), and the
+bundled PostgreSQL provisioning. Per-subchart values (e.g.
+`mcp-mesh-registry.registry.database.host`) override the global for that
+component only.
+
 ```yaml
 # values.yaml
-mcp-mesh-postgres:
+global:
   postgres:
-    database: "mcpmesh"
+    name: "mcpmesh"
     username: "mcpmesh"
-    password: "mcpmesh123" # Change in production
+    password: "change-me" # Change in production
 
+mcp-mesh-postgres:
   persistence:
     enabled: true
     size: 20Gi
     storageClass: "fast-ssd"
 ```
+
+### External managed datastores
+
+To use a managed PostgreSQL/Redis (RDS, Cloud SQL, ElastiCache, ...), disable
+the bundled subcharts and point `global.*` at the managed endpoints — every
+consumer inherits them, no per-subchart overrides needed:
+
+```yaml
+# values.yaml
+postgres:
+  enabled: false
+redis:
+  enabled: false
+
+global:
+  postgres:
+    host: "mydb.abc123.us-east-1.rds.amazonaws.com"
+    port: 5432
+    name: "mcpmesh"
+    username: "mcpmesh"
+    sslmode: "require"
+    # Credential from an existing secret: either a key holding a full
+    # postgres:// DSN (existingSecretUrlKey) or just the password
+    existingSecret: "pg-credentials"
+    existingSecretPasswordKey: "password"
+  redis:
+    host: "myredis.abc123.cache.amazonaws.com"
+    port: 6379
+    tls:
+      enabled: true # rediss://
+    existingSecret: "redis-credentials"
+    existingSecretPasswordKey: "redis-password"
+```
+
+```bash
+helm install mcp-core ./mcp-mesh-core -n mcp-mesh -f values.yaml
+```
+
+The separate `mcp-mesh-agent` chart is standalone (not an umbrella subchart),
+so Helm does not propagate these globals to it automatically — pass the same
+`global.redis` values (e.g. the same values file) to each agent release to
+point its trace publishing at the managed Redis.
 
 ### Registry Configuration
 
@@ -88,14 +137,6 @@ mcp-mesh-postgres:
 # values.yaml
 mcp-mesh-registry:
   registry:
-    database:
-      type: "postgres"
-      host: "mcp-mesh-core-mcp-mesh-postgres"
-      port: 5432
-      name: "mcpmesh"
-      username: "mcpmesh"
-      password: "mcpmesh123"
-
     logging:
       level: "DEBUG"
       format: "json"
@@ -162,6 +203,8 @@ Note: This will delete all data in PostgreSQL. Back up data before uninstalling.
 | Key                | Type   | Default      | Description                          |
 | ------------------ | ------ | ------------ | ------------------------------------ |
 | `global.namespace` | string | `"mcp-mesh"` | Namespace for all components         |
+| `global.postgres.*` | object | bundled postgres | PostgreSQL endpoint/credentials inherited by all consumers (`host`, `port`, `name`, `username`, `password`, `sslmode`, `existingSecret`, `existingSecretUrlKey`, `existingSecretPasswordKey`, `tls.caSecret`, `tls.caKey`) |
+| `global.redis.*`   | object | bundled redis | Redis endpoint/credentials inherited by all consumers (`host`, `port`, `password`, `existingSecret`, `existingSecretUrlKey`, `existingSecretPasswordKey`, `tls.enabled`) |
 | `postgres.enabled` | bool   | `true`       | Enable PostgreSQL deployment         |
 | `redis.enabled`    | bool   | `true`       | Enable Redis deployment              |
 | `registry.enabled` | bool   | `true`       | Enable Registry deployment           |

--- a/helm/mcp-mesh-core/templates/NOTES.txt
+++ b/helm/mcp-mesh-core/templates/NOTES.txt
@@ -22,4 +22,15 @@ Then visit: http://localhost:8000/health
 To deploy MCP agents, use the mcp-mesh-agent chart:
   helm install my-agent ../mcp-mesh-agent --set agent.script=my_script.py
 
+{{- /* Mirrors the mcp-mesh-postgres password resolution: subchart override >
+       global.postgres.password > built-in default. No warning when the
+       credential comes from an existing secret (password unused). */}}
+{{- $pgSub := dig "postgres" (dict) (index .Values "mcp-mesh-postgres" | default dict) }}
+{{- $gpg := dig "postgres" (dict) (.Values.global | default dict) | default dict }}
+{{- if and (not $gpg.existingSecret) (eq (coalesce $pgSub.password $gpg.password "mcpmesh123") "mcpmesh123") }}
+
+WARNING: PostgreSQL is using the built-in development password.
+Set global.postgres.password for production.
+{{- end }}
+
 For more information, visit: https://github.com/dhyansraj/mcp-mesh

--- a/helm/mcp-mesh-core/values.yaml
+++ b/helm/mcp-mesh-core/values.yaml
@@ -11,6 +11,46 @@ global:
   # Example: helm install my-core ... → set coreReleaseName: "my-core"
   coreReleaseName: "mcp-core"
 
+  # Datastore endpoints, declared ONCE and inherited by every consumer:
+  # the registry (DATABASE_URL/REDIS_URL), the UI (when enabled), and the
+  # bundled postgres provisioning. The defaults below point at the bundled
+  # subcharts. For a managed/external datastore, disable the bundled subchart
+  # (postgres.enabled / redis.enabled) and override these — see the
+  # "External managed datastores" recipe in the README. Per-subchart values
+  # (e.g. mcp-mesh-registry.registry.database.host) still win when set.
+  postgres:
+    host: "mcp-core-mcp-mesh-postgres"
+    port: 5432
+    name: "mcpmesh"
+    username: "mcpmesh"
+    password: "mcpmesh123"
+    # PostgreSQL SSL mode for managed endpoints: disable (default), require,
+    # verify-ca, verify-full
+    # sslmode: "require"
+    # CA certificate for verify-ca / verify-full (mounted into each consumer
+    # and appended to the DSN as sslrootcert)
+    # tls:
+    #   caSecret: ""
+    #   caKey: "ca.crt"
+    # Credentials from an existing secret instead of the inline password:
+    # either a full postgres:// DSN (urlKey mode) or just the password
+    # existingSecret: ""
+    # existingSecretUrlKey: ""       # key holding a complete DSN
+    # existingSecretPasswordKey: ""  # default: password (must be URL-safe)
+  redis:
+    host: "mcp-core-mcp-mesh-redis"
+    port: 6379
+    # AUTH password for managed endpoints (URL-encoded into REDIS_URL, which
+    # then renders into each consumer's secret instead of its configmap)
+    # password: ""
+    # Or credentials from an existing secret: a full redis://(s) URL (urlKey
+    # mode) or just the password
+    # existingSecret: ""
+    # existingSecretUrlKey: ""       # key holding a complete URL
+    # existingSecretPasswordKey: ""  # default: redis-password (URL-safe)
+    # tls:
+    #   enabled: true                # renders rediss://
+
 # Service hostname convention:
 # All internal service hostnames use short names (e.g., "mcp-core-mcp-mesh-redis")
 # which resolve within the same namespace via Kubernetes DNS.
@@ -38,12 +78,8 @@ ui:
   enabled: false
 
 # PostgreSQL configuration
+# (database name / credentials are inherited from global.postgres above)
 mcp-mesh-postgres:
-  postgres:
-    database: "mcpmesh"
-    username: "mcpmesh"
-    password: "mcpmesh123"
-
   persistence:
     enabled: true
     size: 10Gi
@@ -80,15 +116,12 @@ mcp-mesh-registry:
     repository: mcpmesh/registry
     tag: "2.4" # Minor version tracks latest patch
   registry:
-    # Database configuration (connects to PostgreSQL)
-    # Note: Hostnames use global.coreReleaseName prefix (default: "mcp-core")
+    # Database configuration (connects to PostgreSQL). The endpoint and
+    # credentials are inherited from global.postgres above; set
+    # registry.database.{host,port,name,username,password,...} here only to
+    # override them for the registry alone.
     database:
       type: "postgres"
-      host: "mcp-core-mcp-mesh-postgres"
-      port: 5432
-      name: "mcpmesh"
-      username: "mcpmesh"
-      password: "mcpmesh123"
       waitForDatabase: true # Wait for database to be ready before starting registry
 
     # Logging configuration (matches K8s examples)
@@ -99,13 +132,11 @@ mcp-mesh-registry:
 
     # Redis configuration — single source of truth for the registry's Redis
     # endpoint. Session storage and the distributed-trace stream share the
-    # derived REDIS_URL. For external/managed Redis, the registry subchart
-    # also supports registry.redis.password (or existingSecret) and
-    # registry.redis.tls.enabled (renders rediss://).
+    # derived REDIS_URL. The endpoint is inherited from global.redis above;
+    # set registry.redis.{host,port,password,existingSecret,tls,...} here
+    # only to override it for the registry alone.
     redis:
       enabled: true
-      host: "mcp-core-mcp-mesh-redis"
-      port: 6379
 
     # Observability configuration - matches k8s examples
     # (stream/consumer settings only; the Redis endpoint comes from
@@ -234,14 +265,13 @@ mcp-mesh-tempo:
         cpu: "500m"
 
 # UI Server configuration
+# (DATABASE_URL / REDIS_URL are composed from global.postgres / global.redis
+# above; set ui.database.url / ui.redis.url here only to override them for
+# the UI alone — e.g. a read-only database credential)
 mcp-mesh-ui:
   ui:
     registryURL: "http://mcp-core-mcp-mesh-registry:8000"
     basePath: "/ops/dashboard"  # default; override with custom image for different path
-    database:
-      url: "postgresql://mcp_mesh_readonly:changeme@mcp-core-mcp-mesh-postgres:5432/mcpmesh?sslmode=disable"
-    redis:
-      url: "redis://mcp-core-mcp-mesh-redis:6379"
     tempo:
       url: "http://mcp-core-mcp-mesh-tempo:3200"
       telemetryEndpoint: "mcp-core-mcp-mesh-tempo:4317"

--- a/helm/mcp-mesh-postgres/templates/NOTES.txt
+++ b/helm/mcp-mesh-postgres/templates/NOTES.txt
@@ -1,0 +1,6 @@
+{{- /* Mirrors the mcp-mesh-postgres.password helper resolution. */ -}}
+{{- $g := dig "postgres" (dict) (.Values.global | default dict) | default dict }}
+{{- if eq (coalesce .Values.postgres.password $g.password "mcpmesh123") "mcpmesh123" }}
+WARNING: PostgreSQL is provisioned with the built-in development password.
+Set postgres.password (or global.postgres.password) for production.
+{{- end }}

--- a/helm/mcp-mesh-postgres/templates/_helpers.tpl
+++ b/helm/mcp-mesh-postgres/templates/_helpers.tpl
@@ -50,3 +50,40 @@ Selector labels
 app.kubernetes.io/name: {{ include "mcp-mesh-postgres.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Provisioned database / credentials. Precedence per field: explicit
+postgres.* > global.postgres.* (the mcp-mesh-core umbrella shares one
+global.postgres block, so the bundled database is provisioned with the same
+credentials every consumer connects with) > chart default.
+*/}}
+{{- define "mcp-mesh-postgres.database" -}}
+{{- $g := dig "postgres" (dict) (.Values.global | default dict) | default dict -}}
+{{- coalesce .Values.postgres.database $g.name "mcpmesh" -}}
+{{- end }}
+
+{{- define "mcp-mesh-postgres.username" -}}
+{{- $g := dig "postgres" (dict) (.Values.global | default dict) | default dict -}}
+{{- coalesce .Values.postgres.username $g.username "mcpmesh" -}}
+{{- end }}
+
+{{- define "mcp-mesh-postgres.password" -}}
+{{- $g := dig "postgres" (dict) (.Values.global | default dict) | default dict -}}
+{{- coalesce .Values.postgres.password $g.password "mcpmesh123" -}}
+{{- end }}
+
+{{/*
+Reject global.postgres.existingSecret while this bundled chart renders:
+provisioning can only use the inline/default password (there is no secret
+plumbing here), while every consumer would read its credential from the
+external secret — a silent runtime auth failure. This chart only renders
+when it is enabled (postgres.enabled in the mcp-mesh-core umbrella), so the
+guard fires exactly on the broken combination. Invoked unconditionally from
+the statefulset.
+*/}}
+{{- define "mcp-mesh-postgres.validateCredentialSource" -}}
+{{- $g := dig "postgres" (dict) (.Values.global | default dict) | default dict -}}
+{{- if $g.existingSecret -}}
+{{- fail "global.postgres.existingSecret cannot be combined with the bundled PostgreSQL chart: provisioning would use the inline/default password while consumers read credentials from the external secret. Disable the bundled subchart (postgres.enabled=false) to use an external database, or drop global.postgres.existingSecret and use inline global.postgres credentials" -}}
+{{- end -}}
+{{- end }}

--- a/helm/mcp-mesh-postgres/templates/statefulset.yaml
+++ b/helm/mcp-mesh-postgres/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- include "mcp-mesh-postgres.validateCredentialSource" . -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -35,11 +36,11 @@ spec:
               protocol: TCP
           env:
             - name: POSTGRES_DB
-              value: {{ .Values.postgres.database | quote }}
+              value: {{ include "mcp-mesh-postgres.database" . | quote }}
             - name: POSTGRES_USER
-              value: {{ .Values.postgres.username | quote }}
+              value: {{ include "mcp-mesh-postgres.username" . | quote }}
             - name: POSTGRES_PASSWORD
-              value: {{ .Values.postgres.password | quote }}
+              value: {{ include "mcp-mesh-postgres.password" . | quote }}
             - name: PGDATA
               value: {{ .Values.postgres.postgresqlDataDir | quote }}
             {{- with .Values.extraEnvVars }}
@@ -50,7 +51,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - exec pg_isready -U "{{ .Values.postgres.username }}" -d "{{ .Values.postgres.database }}" -h 127.0.0.1 -p 5432
+                - exec pg_isready -U "{{ include "mcp-mesh-postgres.username" . }}" -d "{{ include "mcp-mesh-postgres.database" . }}" -h 127.0.0.1 -p 5432
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -60,7 +61,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - exec pg_isready -U "{{ .Values.postgres.username }}" -d "{{ .Values.postgres.database }}" -h 127.0.0.1 -p 5432
+                - exec pg_isready -U "{{ include "mcp-mesh-postgres.username" . }}" -d "{{ include "mcp-mesh-postgres.database" . }}" -h 127.0.0.1 -p 5432
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -70,7 +71,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - exec pg_isready -U "{{ .Values.postgres.username }}" -d "{{ .Values.postgres.database }}" -h 127.0.0.1 -p 5432
+                - exec pg_isready -U "{{ include "mcp-mesh-postgres.username" . }}" -d "{{ include "mcp-mesh-postgres.database" . }}" -h 127.0.0.1 -p 5432
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}

--- a/helm/mcp-mesh-postgres/values.yaml
+++ b/helm/mcp-mesh-postgres/values.yaml
@@ -1,9 +1,12 @@
 # PostgreSQL configuration for MCP Mesh
 postgres:
-  # Database configuration
-  database: "mcpmesh"
-  username: "mcpmesh"
-  password: "mcpmesh123"
+  # Database / credentials provisioned at first start. Each field inherits
+  # global.postgres.{name,username,password} when left empty here (so the
+  # mcp-mesh-core umbrella provisions the bundled database with the same
+  # credentials every consumer connects with); explicit values win.
+  database: "" # default: mcpmesh (inherits global.postgres.name)
+  username: "" # default: mcpmesh (inherits global.postgres.username)
+  password: "" # default: mcpmesh123 (inherits global.postgres.password)
 
   # PostgreSQL configuration
   postgresqlDataDir: "/var/lib/postgresql/data/pgdata"

--- a/helm/mcp-mesh-redis/templates/_helpers.tpl
+++ b/helm/mcp-mesh-redis/templates/_helpers.tpl
@@ -50,3 +50,20 @@ Selector labels
 app.kubernetes.io/name: {{ include "mcp-mesh-redis.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Reject global.redis credentials while this bundled chart renders: this chart
+starts redis-server without AUTH (no requirepass plumbing), so a
+global.redis.password / global.redis.existingSecret credential renders into
+every consumer's REDIS_URL but the bundled server would reject (or ignore)
+it — a silent runtime auth failure. This chart only renders when it is
+enabled (redis.enabled in the mcp-mesh-core umbrella), so the guard fires
+exactly on the broken combination. Invoked unconditionally from the
+deployment.
+*/}}
+{{- define "mcp-mesh-redis.validateCredentialSource" -}}
+{{- $g := dig "redis" (dict) (.Values.global | default dict) | default dict -}}
+{{- if or $g.password $g.existingSecret -}}
+{{- fail "global.redis.password / global.redis.existingSecret cannot be combined with the bundled Redis chart: it runs without AUTH, so the credential every consumer connects with can never work. Disable the bundled subchart (redis.enabled=false) and point global.redis at an external Redis, or drop the global.redis credentials" -}}
+{{- end -}}
+{{- end }}

--- a/helm/mcp-mesh-redis/templates/deployment.yaml
+++ b/helm/mcp-mesh-redis/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "mcp-mesh-redis.validateCredentialSource" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/mcp-mesh-registry/README.md
+++ b/helm/mcp-mesh-registry/README.md
@@ -51,6 +51,10 @@ The following table lists the configurable parameters of the MCP Mesh Registry c
 
 ### Registry Configuration
 
+Each `registry.database.*` connection field inherits `global.postgres.*` when
+left unset (the `mcp-mesh-core` umbrella shares one `global.postgres` block
+with every datastore consumer); an explicit value here always wins.
+
 | Parameter                          | Description                                       | Default               |
 | ---------------------------------- | ------------------------------------------------- | --------------------- |
 | `registry.host`                    | Registry host address                             | `"0.0.0.0"`           |
@@ -75,7 +79,8 @@ The following table lists the configurable parameters of the MCP Mesh Registry c
 
 `registry.redis.*` is the single source of truth for the registry's Redis
 endpoint: session storage and distributed-trace streaming share the derived
-`REDIS_URL`.
+`REDIS_URL`. Each connection field inherits `global.redis.*` when left unset
+here; an explicit value always wins.
 
 | Parameter                                  | Description                                                              | Default            |
 | ------------------------------------------ | ------------------------------------------------------------------------ | ------------------ |

--- a/helm/mcp-mesh-registry/templates/_helpers.tpl
+++ b/helm/mcp-mesh-registry/templates/_helpers.tpl
@@ -63,14 +63,70 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Effective PostgreSQL connection settings as JSON. Per-field precedence:
+explicit registry.database.* > global.postgres.* (shared once by the
+mcp-mesh-core umbrella with every datastore consumer) > chart default.
+The chart defaults live here — values.yaml ships the inheritable fields
+empty so an unset field can fall through to the global. tls.* is flattened
+to tlsCaSecret/tlsCaKey for the consumers.
+*/}}
+{{- define "mcp-mesh-registry.databaseSettings" -}}
+{{- $db := .Values.registry.database -}}
+{{- $g := dig "postgres" (dict) (.Values.global | default dict) | default dict -}}
+{{- $dbTls := $db.tls | default dict -}}
+{{- $gTls := $g.tls | default dict -}}
+{{- dict
+      "host" (coalesce $db.host $g.host "mcp-mesh-postgres")
+      "port" (coalesce $db.port $g.port 5432 | int)
+      "name" (coalesce $db.name $g.name "mcpmesh")
+      "username" (coalesce $db.username $g.username "mcpmesh")
+      "password" (or $db.password $g.password "")
+      "sslmode" (coalesce $db.sslmode $g.sslmode "disable")
+      "existingSecret" (or $db.existingSecret $g.existingSecret "")
+      "existingSecretUrlKey" (or $db.existingSecretUrlKey $g.existingSecretUrlKey "")
+      "existingSecretPasswordKey" (coalesce $db.existingSecretPasswordKey $g.existingSecretPasswordKey "password")
+      "tlsCaSecret" (or $dbTls.caSecret $gTls.caSecret "")
+      "tlsCaKey" (coalesce $dbTls.caKey $gTls.caKey "ca.crt")
+    | toJson -}}
+{{- end }}
+
+{{/*
+Effective Redis connection settings as JSON. Per-field precedence: explicit
+registry.redis.* > global.redis.* > chart default (same scheme as
+databaseSettings above). tls.enabled is a boolean, so presence — not
+truthiness — decides which layer wins (hasKey), flattened to tlsEnabled.
+*/}}
+{{- define "mcp-mesh-registry.redisSettings" -}}
+{{- $redis := .Values.registry.redis -}}
+{{- $g := dig "redis" (dict) (.Values.global | default dict) | default dict -}}
+{{- $rTls := $redis.tls | default dict -}}
+{{- $gTls := $g.tls | default dict -}}
+{{- $tlsEnabled := false -}}
+{{- if hasKey $rTls "enabled" -}}
+{{- $tlsEnabled = $rTls.enabled -}}
+{{- else if hasKey $gTls "enabled" -}}
+{{- $tlsEnabled = $gTls.enabled -}}
+{{- end -}}
+{{- dict
+      "host" (coalesce $redis.host $g.host "mcp-core-mcp-mesh-redis")
+      "port" (coalesce $redis.port $g.port 6379 | int)
+      "password" (or $redis.password $g.password "")
+      "existingSecret" (or $redis.existingSecret $g.existingSecret "")
+      "existingSecretUrlKey" (or $redis.existingSecretUrlKey $g.existingSecretUrlKey "")
+      "existingSecretPasswordKey" (coalesce $redis.existingSecretPasswordKey $g.existingSecretPasswordKey "redis-password")
+      "tlsEnabled" $tlsEnabled
+    | toJson -}}
+{{- end }}
+
+{{/*
 Validated PostgreSQL sslmode (default disable). Invoked from the configmap for
 every non-sqlite database — in addition to both DSN builders below — so an
 invalid value fails at template time in all modes.
 */}}
 {{- define "mcp-mesh-registry.databaseSSLMode" -}}
-{{- $sslmode := .Values.registry.database.sslmode | default "disable" -}}
+{{- $sslmode := (include "mcp-mesh-registry.databaseSettings" . | fromJson).sslmode -}}
 {{- if not (has $sslmode (list "disable" "require" "verify-ca" "verify-full")) -}}
-{{- fail (printf "registry.database.sslmode must be one of: disable, require, verify-ca, verify-full (got %q)" $sslmode) -}}
+{{- fail (printf "registry.database.sslmode / global.postgres.sslmode must be one of: disable, require, verify-ca, verify-full (got %q)" $sslmode) -}}
 {{- end -}}
 {{- $sslmode -}}
 {{- end }}
@@ -79,10 +135,10 @@ invalid value fails at template time in all modes.
 DSN query string: validated sslmode plus sslrootcert when a CA secret is mounted.
 */}}
 {{- define "mcp-mesh-registry.databaseURLParams" -}}
-{{- $db := .Values.registry.database -}}
+{{- $db := include "mcp-mesh-registry.databaseSettings" . | fromJson -}}
 {{- $params := printf "?sslmode=%s" (include "mcp-mesh-registry.databaseSSLMode" .) -}}
-{{- if dig "tls" "caSecret" "" $db -}}
-{{- $params = printf "%s&sslrootcert=/etc/service-tls/postgres/%s" $params (dig "tls" "caKey" "ca.crt" $db) -}}
+{{- if $db.tlsCaSecret -}}
+{{- $params = printf "%s&sslrootcert=/etc/service-tls/postgres/%s" $params $db.tlsCaKey -}}
 {{- end -}}
 {{- $params -}}
 {{- end }}
@@ -94,7 +150,7 @@ Rendered into the chart Secret. Not used with database.existingSecret (the
 deployment composes the DSN via $(DATABASE_PASSWORD) instead).
 */}}
 {{- define "mcp-mesh-registry.databaseURL" -}}
-{{- $db := .Values.registry.database -}}
+{{- $db := include "mcp-mesh-registry.databaseSettings" . | fromJson -}}
 {{- $user := $db.username | urlquery | replace "+" "%20" -}}
 {{- $pass := $db.password | urlquery | replace "+" "%20" -}}
 {{- printf "postgres://%s:%s@%s:%d/%s%s" $user $pass $db.host ($db.port | int) $db.name (include "mcp-mesh-registry.databaseURLParams" .) -}}
@@ -107,35 +163,36 @@ the full DSN from the secret directly and nothing is composed): the password
 is supplied at runtime via Kubernetes $(DATABASE_PASSWORD) expansion (the
 secretKeyRef env must be rendered before this one), so it is never templated.
 The password is not URL-encoded in this mode and must be URL-safe. The
-username comes from registry.database.username.
+username comes from registry.database.username (or global.postgres.username).
 */}}
 {{- define "mcp-mesh-registry.composedDatabaseURL" -}}
-{{- $db := .Values.registry.database -}}
+{{- $db := include "mcp-mesh-registry.databaseSettings" . | fromJson -}}
 {{- $user := $db.username | urlquery | replace "+" "%20" -}}
 {{- printf "postgres://%s:$(DATABASE_PASSWORD)@%s:%d/%s%s" $user $db.host ($db.port | int) $db.name (include "mcp-mesh-registry.databaseURLParams" .) -}}
 {{- end }}
 
 {{/*
-Redis scheme: rediss when registry.redis.tls.enabled, redis otherwise.
+Redis scheme: rediss when registry.redis.tls.enabled (or the inherited
+global.redis.tls.enabled), redis otherwise.
 */}}
 {{- define "mcp-mesh-registry.redisScheme" -}}
-{{- if dig "tls" "enabled" false .Values.registry.redis -}}rediss{{- else -}}redis{{- end -}}
+{{- if (include "mcp-mesh-registry.redisSettings" . | fromJson).tlsEnabled -}}rediss{{- else -}}redis{{- end -}}
 {{- end }}
 
 {{/*
-Redis URL built from registry.redis.* — the single source of truth for the
-registry's Redis endpoint (session storage and trace stream share REDIS_URL).
-An inline password is URL-encoded. Not used when an existing secret supplies
-the password (the deployment composes the URL via $(REDIS_PASSWORD)) or a
-full URL (consumed directly via existingSecretUrlKey).
+Redis URL built from the effective redis settings — the single source of
+truth for the registry's Redis endpoint (session storage and trace stream
+share REDIS_URL). An inline password is URL-encoded. Not used when an
+existing secret supplies the password (the deployment composes the URL via
+$(REDIS_PASSWORD)) or a full URL (consumed directly via existingSecretUrlKey).
 */}}
 {{- define "mcp-mesh-registry.redisURL" -}}
-{{- $redis := .Values.registry.redis -}}
+{{- $redis := include "mcp-mesh-registry.redisSettings" . | fromJson -}}
 {{- $auth := "" -}}
 {{- if $redis.password -}}
 {{- $auth = printf ":%s@" ($redis.password | urlquery | replace "+" "%20") -}}
 {{- end -}}
-{{- printf "%s://%s%s:%v" (include "mcp-mesh-registry.redisScheme" .) $auth $redis.host ($redis.port | default 6379) -}}
+{{- printf "%s://%s%s:%d" (include "mcp-mesh-registry.redisScheme" .) $auth $redis.host ($redis.port | int) -}}
 {{- end }}
 
 {{/*
@@ -156,8 +213,10 @@ deployment's checksum/secret annotation so the checksum never hashes a
 non-rendered manifest.
 */}}
 {{- define "mcp-mesh-registry.secretEnabled" -}}
-{{- $redisUrlInSecret := and .Values.registry.redis.enabled .Values.registry.redis.password (not .Values.registry.redis.existingSecret) -}}
-{{- if or (and (ne .Values.registry.database.type "sqlite") (not .Values.registry.database.existingSecret)) (and .Values.registry.security.auth.enabled (not .Values.registry.security.auth.existingSecret)) $redisUrlInSecret -}}
+{{- $db := include "mcp-mesh-registry.databaseSettings" . | fromJson -}}
+{{- $redis := include "mcp-mesh-registry.redisSettings" . | fromJson -}}
+{{- $redisUrlInSecret := and .Values.registry.redis.enabled $redis.password (not $redis.existingSecret) -}}
+{{- if or (and (ne .Values.registry.database.type "sqlite") (not $db.existingSecret)) (and .Values.registry.security.auth.enabled (not .Values.registry.security.auth.existingSecret)) $redisUrlInSecret -}}
 true
 {{- end -}}
 {{- end }}

--- a/helm/mcp-mesh-registry/templates/configmap.yaml
+++ b/helm/mcp-mesh-registry/templates/configmap.yaml
@@ -1,4 +1,6 @@
 {{- include "mcp-mesh-registry.validateNoDeprecatedRedisUrl" . -}}
+{{- $db := include "mcp-mesh-registry.databaseSettings" . | fromJson -}}
+{{- $redis := include "mcp-mesh-registry.redisSettings" . | fromJson -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -21,10 +23,10 @@ data:
   {{- /* Silent invocation so an invalid sslmode fails in every mode,
          including database.existingSecret. */}}
   {{- $_ := include "mcp-mesh-registry.databaseSSLMode" . }}
-  DATABASE_HOST: {{ .Values.registry.database.host | quote }}
-  DATABASE_PORT: {{ .Values.registry.database.port | quote }}
-  DATABASE_NAME: {{ .Values.registry.database.name | quote }}
-  DATABASE_USERNAME: {{ .Values.registry.database.username | quote }}
+  DATABASE_HOST: {{ $db.host | quote }}
+  DATABASE_PORT: {{ $db.port | int | quote }}
+  DATABASE_NAME: {{ $db.name | quote }}
+  DATABASE_USERNAME: {{ $db.username | quote }}
   {{- end }}
 
   # Registry server configuration - matches working K8s examples
@@ -87,7 +89,7 @@ data:
 
   # Redis configuration for session/trace storage
   {{- if .Values.registry.redis.enabled }}
-  {{- if and (not .Values.registry.redis.password) (not .Values.registry.redis.existingSecret) }}
+  {{- if and (not $redis.password) (not $redis.existingSecret) }}
   REDIS_URL: {{ include "mcp-mesh-registry.redisURL" . | quote }}
   {{- end }}
   MCP_MESH_REDIS_TRACE_PUBLISHING: "true"

--- a/helm/mcp-mesh-registry/templates/deployment.yaml
+++ b/helm/mcp-mesh-registry/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $db := include "mcp-mesh-registry.databaseSettings" . | fromJson -}}
+{{- $redis := include "mcp-mesh-registry.redisSettings" . | fromJson -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -59,8 +61,8 @@ spec:
           command: ["sh", "-c"]
           args:
             - |
-              echo "Waiting for database at {{ .Values.registry.database.host }}:{{ .Values.registry.database.port }}..."
-              until nc -z {{ .Values.registry.database.host }} {{ .Values.registry.database.port }}; do
+              echo "Waiting for database at {{ $db.host }}:{{ $db.port | int }}..."
+              until nc -z {{ $db.host }} {{ $db.port | int }}; do
                 echo "Database not ready, waiting..."
                 sleep 2
               done
@@ -109,22 +111,22 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            {{- if and (ne .Values.registry.database.type "sqlite") .Values.registry.database.existingSecret }}
-            {{- if and (eq .Values.registry.database.type "postgres") .Values.registry.database.existingSecretUrlKey }}
+            {{- if and (ne .Values.registry.database.type "sqlite") $db.existingSecret }}
+            {{- if and (eq .Values.registry.database.type "postgres") $db.existingSecretUrlKey }}
             {{- /* Full DSN from the existing secret, consumed directly — no
                    composition, so the credentials need no URL-safety. The DSN
                    must carry its own sslmode/sslrootcert params. */}}
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.registry.database.existingSecret }}
-                  key: {{ .Values.registry.database.existingSecretUrlKey }}
+                  name: {{ $db.existingSecret }}
+                  key: {{ $db.existingSecretUrlKey }}
             {{- else }}
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.registry.database.existingSecret }}
-                  key: {{ .Values.registry.database.existingSecretPasswordKey }}
+                  name: {{ $db.existingSecret }}
+                  key: {{ $db.existingSecretPasswordKey }}
             {{- if eq .Values.registry.database.type "postgres" }}
             {{- /* Composed via $(DATABASE_PASSWORD) expansion — DATABASE_PASSWORD
                    must be rendered above this entry. The password from the
@@ -163,15 +165,15 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Values.registry.redis.enabled }}
-            {{- if .Values.registry.redis.existingSecret }}
-            {{- if .Values.registry.redis.existingSecretUrlKey }}
+            {{- if $redis.existingSecret }}
+            {{- if $redis.existingSecretUrlKey }}
             {{- /* Full URL from the existing secret, consumed directly — no
                    composition, so the password needs no URL-safety. */}}
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.registry.redis.existingSecret }}
-                  key: {{ .Values.registry.redis.existingSecretUrlKey }}
+                  name: {{ $redis.existingSecret }}
+                  key: {{ $redis.existingSecretUrlKey }}
             {{- else }}
             {{- /* Password from the existing secret must be URL-safe: it is
                    interpolated into REDIS_URL via $(REDIS_PASSWORD) without
@@ -179,12 +181,12 @@ spec:
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.registry.redis.existingSecret }}
-                  key: {{ .Values.registry.redis.existingSecretPasswordKey | default "redis-password" }}
+                  name: {{ $redis.existingSecret }}
+                  key: {{ $redis.existingSecretPasswordKey }}
             - name: REDIS_URL
-              value: {{ printf "%s://:$(REDIS_PASSWORD)@%s:%v" (include "mcp-mesh-registry.redisScheme" .) .Values.registry.redis.host (.Values.registry.redis.port | default 6379) | quote }}
+              value: {{ printf "%s://:$(REDIS_PASSWORD)@%s:%d" (include "mcp-mesh-registry.redisScheme" .) $redis.host ($redis.port | int) | quote }}
             {{- end }}
-            {{- else if .Values.registry.redis.password }}
+            {{- else if $redis.password }}
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:
@@ -291,7 +293,7 @@ spec:
               mountPath: /run/spire/agent/sockets
               readOnly: true
             {{- end }}
-            {{- if .Values.registry.database.tls.caSecret }}
+            {{- if $db.tlsCaSecret }}
             - name: tls-postgres
               mountPath: /etc/service-tls/postgres
               readOnly: true
@@ -348,10 +350,10 @@ spec:
             path: /run/spire/agent/sockets
             type: DirectoryOrCreate
         {{- end }}
-        {{- if .Values.registry.database.tls.caSecret }}
+        {{- if $db.tlsCaSecret }}
         - name: tls-postgres
           secret:
-            secretName: {{ .Values.registry.database.tls.caSecret }}
+            secretName: {{ $db.tlsCaSecret }}
             defaultMode: 0400
         {{- end }}
         {{- if .Values.serviceTLS.redis.secretName }}

--- a/helm/mcp-mesh-registry/templates/secret.yaml
+++ b/helm/mcp-mesh-registry/templates/secret.yaml
@@ -1,4 +1,6 @@
-{{- $redisUrlInSecret := and .Values.registry.redis.enabled .Values.registry.redis.password (not .Values.registry.redis.existingSecret) }}
+{{- $db := include "mcp-mesh-registry.databaseSettings" . | fromJson }}
+{{- $redis := include "mcp-mesh-registry.redisSettings" . | fromJson }}
+{{- $redisUrlInSecret := and .Values.registry.redis.enabled $redis.password (not $redis.existingSecret) }}
 {{- if include "mcp-mesh-registry.secretEnabled" . }}
 apiVersion: v1
 kind: Secret
@@ -15,9 +17,9 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- if and (ne .Values.registry.database.type "sqlite") (not .Values.registry.database.existingSecret) }}
-  database-username: {{ .Values.registry.database.username | b64enc | quote }}
-  database-password: {{ .Values.registry.database.password | b64enc | quote }}
+  {{- if and (ne .Values.registry.database.type "sqlite") (not $db.existingSecret) }}
+  database-username: {{ $db.username | b64enc | quote }}
+  database-password: {{ $db.password | b64enc | quote }}
   {{- if eq .Values.registry.database.type "postgres" }}
   database-url: {{ include "mcp-mesh-registry.databaseURL" . | b64enc | quote }}
   {{- end }}

--- a/helm/mcp-mesh-registry/values.yaml
+++ b/helm/mcp-mesh-registry/values.yaml
@@ -96,26 +96,29 @@ registry:
   # Port for the registry service (matches working examples)
   port: 8000
 
-  # Database configuration
+  # Database configuration. Each connection field below inherits
+  # global.postgres.* when left empty here (the mcp-mesh-core umbrella shares
+  # one global.postgres block with every datastore consumer); explicit values
+  # here always win. Chart defaults apply when neither layer sets a field.
   database:
     # Database path (for SQLite)
     path: "/data/registry.db"
     # Database type (sqlite, postgres, mysql)
     type: "postgres" # Default to postgres like working examples
     # For external databases (postgres/mysql)
-    host: "mcp-mesh-postgres" # Matches working examples
-    port: 5432
-    name: "mcpmesh" # Matches working examples
-    username: "mcpmesh" # Matches working examples
+    host: "" # default: mcp-mesh-postgres
+    port: null # default: 5432
+    name: "" # default: mcpmesh
+    username: "" # default: mcpmesh
     password: ""
     # PostgreSQL SSL mode: disable, require, verify-ca, verify-full
-    sslmode: "disable"
+    sslmode: "" # default: disable
     # TLS material for verify-ca / verify-full against managed databases
     tls:
       # Secret containing the CA certificate used to verify the server.
       # Mounted at /etc/service-tls/postgres and appended to the DSN as sslrootcert.
       caSecret: ""
-      caKey: "ca.crt"
+      caKey: "" # default: ca.crt
     # Use an existing secret for the database credentials. Two modes:
     #
     # 1. Full DSN (preferred, postgres only): set existingSecretUrlKey to the
@@ -140,7 +143,7 @@ registry:
     existingSecretUrlKey: ""
     # Keys in the secret (mode 2)
     existingSecretUsernameKey: "username"
-    existingSecretPasswordKey: "password"
+    existingSecretPasswordKey: "" # default: password
 
   # Logging configuration (matches K8s examples)
   logging:
@@ -220,11 +223,12 @@ registry:
 
   # Redis configuration — single source of truth for the registry's Redis
   # endpoint. One REDIS_URL serves both session storage and the distributed
-  # trace stream (registry reads from mesh:trace).
+  # trace stream (registry reads from mesh:trace). Each connection field
+  # inherits global.redis.* when left empty here; explicit values win.
   redis:
     enabled: true
-    host: "mcp-core-mcp-mesh-redis"
-    port: 6379
+    host: "" # default: mcp-core-mcp-mesh-redis
+    port: null # default: 6379
     # AUTH password. When set, REDIS_URL is rendered into the chart secret
     # (instead of the configmap) with the password URL-encoded.
     password: ""
@@ -241,11 +245,11 @@ registry:
     # Key holding a complete Redis URL in the existing secret (mode 1).
     # Empty selects mode 2. The chart's own Secret uses "redis-url" for this.
     existingSecretUrlKey: ""
-    existingSecretPasswordKey: "redis-password"
-    tls:
-      # Render rediss:// instead of redis://. Pair with serviceTLS.redis.*
-      # below to mount CA / client certificates.
-      enabled: false
+    existingSecretPasswordKey: "" # default: redis-password
+    # tls.enabled: true renders rediss:// instead of redis:// (default false;
+    # inherits global.redis.tls.enabled when not set here). Pair with
+    # serviceTLS.redis.* below to mount CA / client certificates.
+    tls: {}
 
     # CORS configuration
     cors:

--- a/helm/mcp-mesh-ui/templates/NOTES.txt
+++ b/helm/mcp-mesh-ui/templates/NOTES.txt
@@ -1,0 +1,9 @@
+{{- /* Mirrors the mcp-mesh-ui.databaseURL fallback condition: the legacy
+       read-only DSN renders only when nothing else supplies the database
+       connection. */ -}}
+{{- $g := include "mcp-mesh-ui.globalPostgres" . | fromJson }}
+{{- if and (not .Values.ui.database.url) (not $g.existingSecret) (not (or $g.host $g.port $g.name $g.username $g.password)) }}
+WARNING: DATABASE_URL is using the built-in development fallback
+(read-only user "mcp_mesh_readonly" with a placeholder password).
+Set ui.database.url or global.postgres.* for production.
+{{- end }}

--- a/helm/mcp-mesh-ui/templates/_helpers.tpl
+++ b/helm/mcp-mesh-ui/templates/_helpers.tpl
@@ -38,3 +38,143 @@ Selector labels
 app.kubernetes.io/name: {{ include "mcp-mesh-ui.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Shared datastore settings (global.postgres / global.redis) as JSON — the
+mcp-mesh-core umbrella shares one block with every datastore consumer. The
+UI consumes full URLs, so the globals are composed into a DSN/URL here,
+mirroring the mcp-mesh-registry chart's composition. Precedence: explicit
+ui.database.url / ui.redis.url > global.* > chart default.
+*/}}
+{{- define "mcp-mesh-ui.globalPostgres" -}}
+{{- dig "postgres" (dict) (.Values.global | default dict) | default dict | toJson -}}
+{{- end }}
+
+{{- define "mcp-mesh-ui.globalRedis" -}}
+{{- dig "redis" (dict) (.Values.global | default dict) | default dict | toJson -}}
+{{- end }}
+
+{{/*
+Existing-secret name for the database credentials: set only when no explicit
+ui.database.url overrides the global layer. Non-empty means DATABASE_URL is
+consumed via secretKeyRef (urlKey mode) or composed via $(DATABASE_PASSWORD)
+(password mode) instead of being rendered into the chart Secret.
+*/}}
+{{- define "mcp-mesh-ui.databaseExistingSecret" -}}
+{{- $g := include "mcp-mesh-ui.globalPostgres" . | fromJson -}}
+{{- if not .Values.ui.database.url -}}{{- $g.existingSecret | default "" -}}{{- end -}}
+{{- end }}
+
+{{- define "mcp-mesh-ui.redisExistingSecret" -}}
+{{- $g := include "mcp-mesh-ui.globalRedis" . | fromJson -}}
+{{- if not .Values.ui.redis.url -}}{{- $g.existingSecret | default "" -}}{{- end -}}
+{{- end }}
+
+{{/*
+Validated PostgreSQL sslmode from global.postgres (default disable).
+*/}}
+{{- define "mcp-mesh-ui.databaseSSLMode" -}}
+{{- $g := include "mcp-mesh-ui.globalPostgres" . | fromJson -}}
+{{- $sslmode := $g.sslmode | default "disable" -}}
+{{- if not (has $sslmode (list "disable" "require" "verify-ca" "verify-full")) -}}
+{{- fail (printf "global.postgres.sslmode must be one of: disable, require, verify-ca, verify-full (got %q)" $sslmode) -}}
+{{- end -}}
+{{- $sslmode -}}
+{{- end }}
+
+{{/*
+DSN query string: validated sslmode plus sslrootcert when global.postgres
+supplies a CA secret (mounted at /etc/service-tls/postgres).
+*/}}
+{{- define "mcp-mesh-ui.databaseURLParams" -}}
+{{- $g := include "mcp-mesh-ui.globalPostgres" . | fromJson -}}
+{{- $gTls := $g.tls | default dict -}}
+{{- $params := printf "?sslmode=%s" (include "mcp-mesh-ui.databaseSSLMode" .) -}}
+{{- if $gTls.caSecret -}}
+{{- $params = printf "%s&sslrootcert=/etc/service-tls/postgres/%s" $params ($gTls.caKey | default "ca.crt") -}}
+{{- end -}}
+{{- $params -}}
+{{- end }}
+
+{{/*
+Effective DATABASE_URL for the chart Secret. Not used when an existing
+secret supplies the credential (see databaseExistingSecret above).
+Registry semantics: any global connection part (host, port, name, username,
+password) composes a DSN with the remaining parts coalesced to their
+defaults — a password without a host still applies over the default host.
+The legacy readonly fallback renders only when no global part is set at all.
+*/}}
+{{- define "mcp-mesh-ui.databaseURL" -}}
+{{- if .Values.ui.database.url -}}
+{{- .Values.ui.database.url -}}
+{{- else -}}
+{{- $g := include "mcp-mesh-ui.globalPostgres" . | fromJson -}}
+{{- if or $g.host $g.port $g.name $g.username $g.password -}}
+{{- $user := ($g.username | default "mcpmesh") | urlquery | replace "+" "%20" -}}
+{{- $pass := ($g.password | default "") | urlquery | replace "+" "%20" -}}
+{{- printf "postgresql://%s:%s@%s:%d/%s%s" $user $pass (coalesce $g.host "mcp-mesh-postgres") (coalesce $g.port 5432 | int) ($g.name | default "mcpmesh") (include "mcp-mesh-ui.databaseURLParams" .) -}}
+{{- else -}}
+{{- "postgresql://mcp_mesh_readonly:changeme@mcp-mesh-postgres:5432/mcp_mesh_registry?sslmode=disable" -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+DATABASE_URL for the global.postgres.existingSecret password-only mode: the
+password is supplied at runtime via $(DATABASE_PASSWORD) expansion (the
+secretKeyRef env must be rendered before this one). It is not URL-encoded
+in this mode and must be URL-safe.
+*/}}
+{{- define "mcp-mesh-ui.composedDatabaseURL" -}}
+{{- $g := include "mcp-mesh-ui.globalPostgres" . | fromJson -}}
+{{- $user := ($g.username | default "mcpmesh") | urlquery | replace "+" "%20" -}}
+{{- printf "postgresql://%s:$(DATABASE_PASSWORD)@%s:%d/%s%s" $user ($g.host | default "mcp-mesh-postgres") (coalesce $g.port 5432 | int) ($g.name | default "mcpmesh") (include "mcp-mesh-ui.databaseURLParams" .) -}}
+{{- end }}
+
+{{/*
+Redis scheme: rediss when global.redis.tls.enabled, redis otherwise.
+*/}}
+{{- define "mcp-mesh-ui.redisScheme" -}}
+{{- $g := include "mcp-mesh-ui.globalRedis" . | fromJson -}}
+{{- if dig "tls" "enabled" false $g -}}rediss{{- else -}}redis{{- end -}}
+{{- end }}
+
+{{/*
+Effective REDIS_URL for the chart Secret. An inline global password is
+URL-encoded and applies over the coalesced default host (registry
+semantics), so a password without a host still renders a credentialed URL.
+Not used when an existing secret supplies the credential.
+*/}}
+{{- define "mcp-mesh-ui.redisURL" -}}
+{{- if .Values.ui.redis.url -}}
+{{- .Values.ui.redis.url -}}
+{{- else -}}
+{{- $g := include "mcp-mesh-ui.globalRedis" . | fromJson -}}
+{{- $auth := "" -}}
+{{- if $g.password -}}
+{{- $auth = printf ":%s@" ($g.password | urlquery | replace "+" "%20") -}}
+{{- end -}}
+{{- printf "%s://%s%s:%d" (include "mcp-mesh-ui.redisScheme" .) $auth (coalesce $g.host "mcp-mesh-redis") (coalesce $g.port 6379 | int) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+REDIS_URL for the global.redis.existingSecret password-only mode: composed
+via $(REDIS_PASSWORD) expansion, so the password must be URL-safe.
+*/}}
+{{- define "mcp-mesh-ui.composedRedisURL" -}}
+{{- $g := include "mcp-mesh-ui.globalRedis" . | fromJson -}}
+{{- printf "%s://:$(REDIS_PASSWORD)@%s:%d" (include "mcp-mesh-ui.redisScheme" .) ($g.host | default "mcp-mesh-redis") (coalesce $g.port 6379 | int) -}}
+{{- end }}
+
+{{/*
+Whether the chart-managed Secret renders. Shared by secret.yaml and the
+deployment's checksum/secret annotation and envFrom secretRef, so neither
+references a non-rendered manifest. False only when BOTH URLs come from
+existing secrets.
+*/}}
+{{- define "mcp-mesh-ui.secretEnabled" -}}
+{{- if or (not (include "mcp-mesh-ui.databaseExistingSecret" .)) (not (include "mcp-mesh-ui.redisExistingSecret" .)) -}}
+true
+{{- end -}}
+{{- end }}

--- a/helm/mcp-mesh-ui/templates/deployment.yaml
+++ b/helm/mcp-mesh-ui/templates/deployment.yaml
@@ -1,3 +1,8 @@
+{{- $gpg := include "mcp-mesh-ui.globalPostgres" . | fromJson -}}
+{{- $gredis := include "mcp-mesh-ui.globalRedis" . | fromJson -}}
+{{- $dbExisting := include "mcp-mesh-ui.databaseExistingSecret" . -}}
+{{- $redisExisting := include "mcp-mesh-ui.redisExistingSecret" . -}}
+{{- $pgCaSecret := ($gpg.tls | default dict).caSecret | default "" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,7 +19,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if include "mcp-mesh-ui.secretEnabled" . }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
       labels:
         {{- include "mcp-mesh-ui.selectorLabels" . | nindent 8 }}
     spec:
@@ -37,6 +44,48 @@ spec:
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           env:
+            {{- if $dbExisting }}
+            {{- if $gpg.existingSecretUrlKey }}
+            {{- /* Full DSN from the existing secret, consumed directly — no
+                   composition, so the credentials need no URL-safety. The DSN
+                   must carry its own sslmode/sslrootcert params. */}}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $dbExisting }}
+                  key: {{ $gpg.existingSecretUrlKey }}
+            {{- else }}
+            {{- /* Composed via $(DATABASE_PASSWORD) expansion — DATABASE_PASSWORD
+                   must be rendered above this entry. */}}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $dbExisting }}
+                  key: {{ $gpg.existingSecretPasswordKey | default "password" }}
+            - name: DATABASE_URL
+              value: {{ include "mcp-mesh-ui.composedDatabaseURL" . | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if $redisExisting }}
+            {{- if $gredis.existingSecretUrlKey }}
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $redisExisting }}
+                  key: {{ $gredis.existingSecretUrlKey }}
+            {{- else }}
+            {{- /* Password from the existing secret must be URL-safe: it is
+                   interpolated into REDIS_URL via $(REDIS_PASSWORD) without
+                   URL-encoding. */}}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $redisExisting }}
+                  key: {{ $gredis.existingSecretPasswordKey | default "redis-password" }}
+            - name: REDIS_URL
+              value: {{ include "mcp-mesh-ui.composedRedisURL" . | quote }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.ui.tls.registry.secretName }}
             - name: MCP_MESH_REGISTRY_TLS_CA
               value: /etc/service-tls/registry/{{ .Values.ui.tls.registry.caKey }}
@@ -104,8 +153,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "mcp-mesh-ui.fullname" . }}-config
+            {{- if include "mcp-mesh-ui.secretEnabled" . }}
             - secretRef:
                 name: {{ include "mcp-mesh-ui.fullname" . }}-secret
+            {{- end }}
           livenessProbe:
             httpGet:
               path: {{ .Values.ui.basePath }}/api/ui-health
@@ -121,6 +172,11 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if $pgCaSecret }}
+            - name: tls-postgres
+              mountPath: /etc/service-tls/postgres
+              readOnly: true
+            {{- end }}
             {{- if .Values.ui.tls.registry.secretName }}
             - name: tls-registry
               mountPath: /etc/service-tls/registry
@@ -146,6 +202,12 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if $pgCaSecret }}
+        - name: tls-postgres
+          secret:
+            secretName: {{ $pgCaSecret }}
+            defaultMode: 0440
+        {{- end }}
         {{- if .Values.ui.tls.registry.secretName }}
         - name: tls-registry
           secret:

--- a/helm/mcp-mesh-ui/templates/secret.yaml
+++ b/helm/mcp-mesh-ui/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if include "mcp-mesh-ui.secretEnabled" . -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,5 +8,10 @@ metadata:
     {{- include "mcp-mesh-ui.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  DATABASE_URL: {{ .Values.ui.database.url | quote }}
-  REDIS_URL: {{ .Values.ui.redis.url | quote }}
+  {{- if not (include "mcp-mesh-ui.databaseExistingSecret" .) }}
+  DATABASE_URL: {{ include "mcp-mesh-ui.databaseURL" . | quote }}
+  {{- end }}
+  {{- if not (include "mcp-mesh-ui.redisExistingSecret" .) }}
+  REDIS_URL: {{ include "mcp-mesh-ui.redisURL" . | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/mcp-mesh-ui/values.yaml
+++ b/helm/mcp-mesh-ui/values.yaml
@@ -27,12 +27,21 @@ ui:
   #   proxy_pass http://ui-service:3080;  (NOT http://ui-service:3080/)
   basePath: "/ops/dashboard"
   database:
-    # Override with a read-only database credential for production
-    url: "postgresql://mcp_mesh_readonly:changeme@mcp-mesh-postgres:5432/mcp_mesh_registry?sslmode=disable"
+    # Full PostgreSQL DSN. When empty, the URL is composed from
+    # global.postgres.* (the mcp-mesh-core umbrella shares one block with
+    # every datastore consumer — host/port/name/username/password/sslmode,
+    # existingSecret modes included); an explicit value here always wins.
+    # When neither is set, the chart default applies:
+    #   postgresql://mcp_mesh_readonly:changeme@mcp-mesh-postgres:5432/mcp_mesh_registry?sslmode=disable
+    # Override with a read-only database credential for production.
+    url: ""
   tracing:
     enabled: true
   redis:
-    url: "redis://mcp-mesh-redis:6379"
+    # Full Redis URL. When empty, composed from global.redis.* (rediss:// when
+    # global.redis.tls.enabled); an explicit value here always wins. When
+    # neither is set, the chart default applies: redis://mcp-mesh-redis:6379
+    url: ""
   tempo:
     url: "http://mcp-mesh-tempo:3200"
     telemetryEndpoint: "mcp-mesh-tempo:4317"


### PR DESCRIPTION
## Summary
Closes #1152 — helm batch 2 of 5, building on the per-consumer shapes from #1184.

- **Declare external datastores once**: `global.postgres.*` and `global.redis.*` inherited by the registry, UI, agent chart, and bundled postgres provisioning, with per-field precedence explicit > global > chart default (coalesce helpers; `hasKey` for booleans so an explicit `false` beats a global `true`). Per-consumer fields now ship empty with historical defaults moved into helpers — default rendering is byte-identical across all 9 charts (review-verified against main).
- **UI**: composes its URLs from global parts (explicit `ui.*.url` wins entirely), gains the postgres CA mount that global `verify-ca/-full` requires, and supports global existingSecret modes via secretKeyRefs with the chart Secret suppressed when unused.
- **Agent (standalone chart)**: honors `global.redis.*` set on its own release — the umbrella values file can be reused verbatim; its explicit `redisUrl` keeps top precedence. Inline passwords move `REDIS_URL` into the chart Secret.
- **Template-time guards for impossible combos** (from review): `global.postgres.existingSecret` with the bundled postgres enabled, and `global.redis.{password,existingSecret}` with the bundled redis enabled (it has no AUTH support), both fail the render with instructions — previously these were silent runtime auth failures.
- **Consistent password-only semantics**: a global password now applies over the coalesced default host identically in registry, UI, and agent (the agent previously stored a credential-less URL in its Secret in that mode).
- Umbrella README documents the single managed-datastore recipe.

## Behavior change — release-note visibility
- Umbrella installs with `ui.enabled=true`: the UI's `DATABASE_URL` now derives from global credentials instead of the `mcp_mesh_readonly:changeme` default — review confirmed that role was never provisioned by any chart, so the old default could not connect. The readonly-role recommendation stays documented as a per-component override.
- The two new guards reject previously-renderable (but never-working) value combinations at template time.

## Review Notes
- Independent review rendered all matrices: byte-identity (umbrella + 4 standalones), per-field partial overrides, all 6 tls-boolean combos, credential consistency across provisioning/registry/UI, agent standalone precedence, and the fromJson number/int trap (avoided via `| int` at every port consumer). 0 blockers; all 3 warnings addressed (the two guards + password-only alignment).
- Pre-existing dead config flagged for the cleanup follow-up: `registry.database.existingSecretUsernameKey`, the agent chart's unused `agent.environment` block (with duplicate REDIS_URL), and the documentation-only `global.coreReleaseName`.

Closes #1152

## Test plan
- [x] `helm lint` all 9 charts; umbrella dependency rebuild (CI parity)
- [x] Default renders byte-identical to main for every chart
- [x] Matrices: global-only repoint (registry + UI + agent evidence lines in review), override-wins, global existingSecret url-key + password-key modes, guard fire/no-fire combos, sqlite + invalid-sslmode regressions
- [ ] Managed-datastore install smoke test on a real cluster (manual, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced shared global datastore configuration for PostgreSQL and Redis across all components, enabling centralized management of database and cache endpoints.
  * Added support for external PostgreSQL and Redis instances with configurable TLS/SSL encryption.
  * Implemented flexible credential sourcing through existing Kubernetes secrets with multiple authentication modes.

* **Documentation**
  * Updated configuration guides detailing datastore inheritance patterns and external service integration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->