### PR TITLE
feat(helm): pass Pod Security Standards 'restricted' across all charts

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Check Pod Security Standards compliance
         run: |
-          pip install pyyaml
+          pip install pyyaml==6.0.3
           python3 scripts/check_helm_pss.py
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -53,6 +53,16 @@ jobs:
             fi
           done
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check Pod Security Standards compliance
+        run: |
+          pip install pyyaml
+          python3 scripts/check_helm_pss.py
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/helm/mcp-mesh-agent/README.md
+++ b/helm/mcp-mesh-agent/README.md
@@ -110,6 +110,8 @@ helm uninstall my-agent -n mcp-mesh
 | `resources.requests.cpu`    | CPU request                            | `100m`                     |
 | `resources.requests.memory` | Memory request                         | `256Mi`                    |
 
+> **Upgrade note:** `podSecurityContext` (runAsNonRoot, uid/gid 999, fsGroup 999, RuntimeDefault seccomp) is now always applied — it was previously gated behind the removed `podSecurityPolicy.enabled` flag and never rendered. It covers user-supplied `initContainers` (an init container that must run as root needs its own `securityContext`, which overrides the pod level), and `fsGroup: 999` changes group ownership of mounted volumes, including PVCs from `extraVolumes`.
+
 ### Agent Code Configuration
 
 | Parameter                 | Description                               | Default        |

--- a/helm/mcp-mesh-agent/templates/deployment.yaml
+++ b/helm/mcp-mesh-agent/templates/deployment.yaml
@@ -43,10 +43,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "mcp-mesh-agent.serviceAccountName" . }}
-      {{- if .Values.podSecurityPolicy.enabled }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- end }}
       {{- if .Values.runtimeClassName }}
       runtimeClassName: {{ .Values.runtimeClassName }}
       {{- end }}
@@ -243,6 +241,8 @@ spec:
             defaultMode: 0400
         {{- end }}
         {{- if .Values.mesh.tls.spire.enabled }}
+        {{- /* hostPath volume: SPIRE mode is incompatible with the Pod
+               Security Standards "restricted" profile. */}}
         - name: spire-agent-socket
           hostPath:
             path: /run/spire/agent/sockets

--- a/helm/mcp-mesh-agent/values.yaml
+++ b/helm/mcp-mesh-agent/values.yaml
@@ -54,18 +54,36 @@ serviceAccount:
 
 podAnnotations: {}
 
+# Pod security context (hardened for Pod Security Standards "restricted").
+# Upgrade note: this block is now ALWAYS applied — it was previously gated
+# behind the (removed) podSecurityPolicy.enabled flag and never rendered.
+# It covers every container in the pod, including user-supplied
+# initContainers: an init container that must run as root (e.g. a chown
+# image) now fails runAsNonRoot admission — give it its own securityContext
+# (per-container settings override the pod level). fsGroup: 999 also changes
+# group ownership of mounted volumes, including PVCs from extraVolumes.
 podSecurityContext:
   runAsNonRoot: true
-  runAsUser: 999 # mcp-mesh user in the container
+  runAsUser: 999 # mcp-mesh user in the runtime images
+  runAsGroup: 999
   fsGroup: 999
+  seccompProfile:
+    type: RuntimeDefault
 
+# Container security context
 securityContext:
+  allowPrivilegeEscalation: false
   capabilities:
     drop:
       - ALL
-  readOnlyRootFilesystem: false # Agents may need writable filesystem
+  # false: agents run arbitrary user code — Python writes __pycache__ under
+  # /app, runtimes use /tmp, and some agents install dependencies at startup.
+  # Set true (plus emptyDir mounts for the paths your agent writes) if your
+  # agent image tolerates a read-only root filesystem.
+  readOnlyRootFilesystem: false
   runAsNonRoot: true
-  runAsUser: 999 # mcp-mesh user in the container
+  runAsUser: 999 # mcp-mesh user in the runtime images
+  runAsGroup: 999
 
 service:
   type: ClusterIP
@@ -409,9 +427,8 @@ topologySpreadConstraints: []
 # Priority class name
 priorityClassName: ""
 
-# Security policies
-podSecurityPolicy:
-  enabled: false
+# Note: podSecurityPolicy.enabled was removed (PSP left Kubernetes in 1.25);
+# podSecurityContext above is now always applied. A leftover key is ignored.
 
 # Runtime class name (for container runtime selection)
 runtimeClassName: ""

--- a/helm/mcp-mesh-grafana/templates/configmap.yaml
+++ b/helm/mcp-mesh-grafana/templates/configmap.yaml
@@ -27,9 +27,14 @@ data:
 
     [paths]
     data = /var/lib/grafana
-    logs = /var/log/grafana
     plugins = /var/lib/grafana/plugins
     provisioning = /etc/grafana/provisioning
+
+    {{- /* Console-only logging: the root filesystem is read-only
+           (securityContext), so the file target under /var/log/grafana
+           would fail. */}}
+    [log]
+    mode = console
 
     [analytics]
     reporting_enabled = false

--- a/helm/mcp-mesh-grafana/templates/deployment.yaml
+++ b/helm/mcp-mesh-grafana/templates/deployment.yaml
@@ -1,4 +1,14 @@
 {{- if .Values.grafana.enabled }}
+{{- /* Migration guard: grafana.securityContext used to be the POD security
+       context (it carried fsGroup). It is now the CONTAINER security context
+       and pod-level settings live under grafana.podSecurityContext — an old
+       override here would put fsGroup in the container context, where the
+       API server drops it (losing PVC write access). */}}
+{{- range $field := list "fsGroup" "fsGroupChangePolicy" "supplementalGroups" "sysctls" }}
+{{- if hasKey ($.Values.grafana.securityContext | default dict) $field }}
+{{- fail (printf "grafana.securityContext.%s: grafana.securityContext is now the container security context; pod-level fields (fsGroup, runAsUser, ...) moved to grafana.podSecurityContext. Move your override there." $field) }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -16,11 +26,13 @@ spec:
         {{- include "mcp-mesh-grafana.selectorLabels" . | nindent 8 }}
     spec:
       securityContext:
-        {{- toYaml .Values.grafana.securityContext | nindent 8 }}
+        {{- toYaml .Values.grafana.podSecurityContext | nindent 8 }}
       containers:
       - name: grafana
         image: "{{ .Values.grafana.image.repository }}:{{ .Values.grafana.image.tag }}"
         imagePullPolicy: {{ .Values.grafana.image.pullPolicy }}
+        securityContext:
+          {{- toYaml .Values.grafana.securityContext | nindent 10 }}
         ports:
         - name: http
           containerPort: 3000
@@ -71,10 +83,13 @@ spec:
           mountPath: /var/lib/grafana/dashboards
           readOnly: true
         {{- end }}
-        {{- if .Values.grafana.persistence.enabled }}
+        {{- /* /var/lib/grafana and /tmp must be writable (data, sqlite db,
+               plugin install) — always volumes since the root filesystem is
+               read-only. */}}
         - name: storage
           mountPath: /var/lib/grafana
-        {{- end }}
+        - name: tmp
+          mountPath: /tmp
         livenessProbe:
           httpGet:
             path: /api/health
@@ -108,9 +123,13 @@ spec:
         configMap:
           name: {{ include "mcp-mesh-grafana.fullname" . }}-dashboard
       {{- end }}
-      {{- if .Values.grafana.persistence.enabled }}
       - name: storage
+        {{- if .Values.grafana.persistence.enabled }}
         persistentVolumeClaim:
           claimName: {{ include "mcp-mesh-grafana.fullname" . }}-pvc
-      {{- end }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+      - name: tmp
+        emptyDir: {}
 {{- end }}

--- a/helm/mcp-mesh-grafana/templates/deployment.yaml
+++ b/helm/mcp-mesh-grafana/templates/deployment.yaml
@@ -6,7 +6,7 @@
        API server drops it (losing PVC write access). */}}
 {{- range $field := list "fsGroup" "fsGroupChangePolicy" "supplementalGroups" "sysctls" }}
 {{- if hasKey ($.Values.grafana.securityContext | default dict) $field }}
-{{- fail (printf "grafana.securityContext.%s: grafana.securityContext is now the container security context; pod-level fields (fsGroup, runAsUser, ...) moved to grafana.podSecurityContext. Move your override there." $field) }}
+{{- fail (printf "grafana.securityContext.%s: grafana.securityContext is now the container security context; pod-only fields (fsGroup, fsGroupChangePolicy, supplementalGroups, sysctls) are invalid there and belong in grafana.podSecurityContext. Move your override there." $field) }}
 {{- end }}
 {{- end }}
 apiVersion: apps/v1

--- a/helm/mcp-mesh-grafana/values.yaml
+++ b/helm/mcp-mesh-grafana/values.yaml
@@ -63,8 +63,28 @@ grafana:
     configMaps:
       - mcp-mesh-dashboards
 
-  # Security context
+  # Pod security context (hardened for Pod Security Standards "restricted").
+  # Renamed: this key was previously called securityContext (which is now the
+  # container security context below) — templating fails with a migration
+  # message if an old-shaped override still carries pod-level fields there.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 472 # grafana user in the grafana/grafana image
+    runAsGroup: 472
+    fsGroup: 472
+    seccompProfile:
+      type: RuntimeDefault
+
+  # Container security context. readOnlyRootFilesystem works because every
+  # path Grafana writes is a volume: /var/lib/grafana (data, sqlite db,
+  # GF_INSTALL_PLUGINS target — PVC or emptyDir) and /tmp (emptyDir, plugin
+  # download scratch); logs go to console (see grafana.ini in the configmap).
   securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 472
-    fsGroup: 472
+    runAsGroup: 472

--- a/helm/mcp-mesh-postgres/templates/statefulset.yaml
+++ b/helm/mcp-mesh-postgres/templates/statefulset.yaml
@@ -94,8 +94,19 @@ spec:
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data
+            {{- /* Writable paths required with readOnlyRootFilesystem: the
+                   unix socket / pid dir and scratch space. */}}
+            - name: postgres-run
+              mountPath: /var/run/postgresql
+            - name: postgres-tmp
+              mountPath: /tmp
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+      volumes:
+        - name: postgres-run
+          emptyDir: {}
+        - name: postgres-tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/mcp-mesh-postgres/values.yaml
+++ b/helm/mcp-mesh-postgres/values.yaml
@@ -26,11 +26,6 @@ postgres:
   # PostgreSQL configuration
   postgresqlDataDir: "/var/lib/postgresql/data/pgdata"
 
-  # Security configuration
-  runAsUser: 999
-  runAsGroup: 999
-  fsGroup: 999
-
 image:
   repository: postgres
   tag: "15"
@@ -78,19 +73,36 @@ startupProbe:
   timeoutSeconds: 5
   failureThreshold: 30
 
-# Pod security context
+# Container security context (hardened for Pod Security Standards "restricted").
+# readOnlyRootFilesystem works because every path postgres writes is a volume:
+# the data directory (PVC) and /var/run/postgresql + /tmp (emptyDir, see the
+# statefulset).
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
       - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
   runAsUser: 999
   runAsGroup: 999
 
-# Pod security context
+# Pod security context. Runs the official postgres image as its in-image
+# postgres user (uid 999) — no root and no chown initContainer needed:
+# fsGroup makes the PVC mount group-writable, the entrypoint skips its
+# root-only chown path when started non-root, and initdb creates the pgdata
+# subdirectory (postgres.postgresqlDataDir) itself with the right ownership.
 podSecurityContext:
-  runAsNonRoot: false
+  runAsNonRoot: true
+  runAsUser: 999
+  runAsGroup: 999
   fsGroup: 999
+  # Skip the recursive chown/chmod of the data volume when its root already
+  # has the right ownership — on a large database the recursive walk on every
+  # pod start is expensive.
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
 
 # Node selector
 nodeSelector: {}

--- a/helm/mcp-mesh-redis/values.yaml
+++ b/helm/mcp-mesh-redis/values.yaml
@@ -5,10 +5,6 @@ redis:
   maxmemory: "256mb"
   maxmemoryPolicy: "allkeys-lru"
 
-  # Security
-  runAsUser: 999
-  runAsGroup: 999
-
 image:
   repository: redis
   tag: "7-alpine"
@@ -53,12 +49,16 @@ readinessProbe:
   timeoutSeconds: 3
   failureThreshold: 3
 
-# Pod security context
+# Container security context (hardened for Pod Security Standards
+# "restricted"). readOnlyRootFilesystem works because redis only writes /data,
+# which is always a volume (PVC or emptyDir).
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
       - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
   runAsUser: 999
   runAsGroup: 999
 
@@ -67,6 +67,9 @@ podSecurityContext:
   runAsNonRoot: true
   runAsUser: 999
   runAsGroup: 999
+  fsGroup: 999
+  seccompProfile:
+    type: RuntimeDefault
 
 # Node selector
 nodeSelector: {}

--- a/helm/mcp-mesh-registry/templates/deployment.yaml
+++ b/helm/mcp-mesh-registry/templates/deployment.yaml
@@ -58,6 +58,15 @@ spec:
         # Wait for database (if using external DB)
         - name: wait-for-db
           image: busybox:1.35
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 999
           command: ["sh", "-c"]
           args:
             - |
@@ -278,6 +287,17 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            {{- /* Writable scratch space — required with
+                   readOnlyRootFilesystem. */}}
+            - name: tmp
+              mountPath: /tmp
+            {{- if or .Values.persistence.enabled (eq .Values.registry.database.type "sqlite") }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
+            {{- end }}
             {{- if .Values.registry.security.tls.enabled }}
             - name: tls-certs
               mountPath: /etc/tls
@@ -332,6 +352,17 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- if or .Values.persistence.enabled (eq .Values.registry.database.type "sqlite") }}
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (printf "%s-data" (include "mcp-mesh-registry.fullname" .)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
         {{- if .Values.registry.security.tls.enabled }}
         - name: tls-certs
           secret:
@@ -345,6 +376,8 @@ spec:
             defaultMode: 0400
         {{- end }}
         {{- if .Values.registry.security.trust.spire.enabled }}
+        {{- /* hostPath volume: SPIRE mode is incompatible with the Pod
+               Security Standards "restricted" profile. */}}
         - name: spire-agent-socket
           hostPath:
             path: /run/spire/agent/sockets
@@ -377,4 +410,3 @@ spec:
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-# No persistent storage needed - registry is stateless and uses external database

--- a/helm/mcp-mesh-registry/values.yaml
+++ b/helm/mcp-mesh-registry/values.yaml
@@ -27,18 +27,32 @@ serviceAccount:
 
 podAnnotations: {}
 
+# Pod security context (hardened for Pod Security Standards "restricted";
+# seccompProfile here also covers the wait-for-db init container)
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 999
+  runAsGroup: 999
   fsGroup: 999
+  seccompProfile:
+    type: RuntimeDefault
 
+# Container security context. readOnlyRootFilesystem works because the
+# registry is a static Go binary that only writes its database: /tmp is
+# emptyDir-mounted and /data is a volume in sqlite mode (PVC when
+# persistence.enabled, emptyDir otherwise). If you point an opt-in feature at
+# a path on the root filesystem (e.g. registry.security.trust.dir with the
+# localca/filestore backend and no caSecret), mount it via extraVolumes or
+# relax this setting.
 securityContext:
+  allowPrivilegeEscalation: false
   capabilities:
     drop:
       - ALL
-  readOnlyRootFilesystem: false # Registry may need to write temp files
+  readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 999
+  runAsGroup: 999
 
 service:
   type: ClusterIP

--- a/helm/mcp-mesh-registry/values.yaml
+++ b/helm/mcp-mesh-registry/values.yaml
@@ -28,7 +28,11 @@ serviceAccount:
 podAnnotations: {}
 
 # Pod security context (hardened for Pod Security Standards "restricted";
-# seccompProfile here also covers the wait-for-db init container)
+# seccompProfile here also covers the wait-for-db init container).
+# Note: uid 999 intentionally differs from the mcpmesh/registry image's
+# built-in mcp-mesh user (1001). Any non-root uid works here: the root
+# filesystem is read-only and every writable path is a volume (/tmp emptyDir,
+# /data PVC/emptyDir) made group-writable via fsGroup.
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 999

--- a/helm/mcp-mesh-tempo/templates/deployment.yaml
+++ b/helm/mcp-mesh-tempo/templates/deployment.yaml
@@ -1,4 +1,14 @@
 {{- if .Values.tempo.enabled }}
+{{- /* Migration guard: tempo.securityContext used to be the POD security
+       context (it carried fsGroup). It is now the CONTAINER security context
+       and pod-level settings live under tempo.podSecurityContext — an old
+       override here would put fsGroup in the container context, where the
+       API server drops it (losing PVC write access). */}}
+{{- range $field := list "fsGroup" "fsGroupChangePolicy" "supplementalGroups" "sysctls" }}
+{{- if hasKey ($.Values.tempo.securityContext | default dict) $field }}
+{{- fail (printf "tempo.securityContext.%s: tempo.securityContext is now the container security context; pod-level fields (fsGroup, runAsUser, ...) moved to tempo.podSecurityContext. Move your override there." $field) }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -16,11 +26,13 @@ spec:
         {{- include "mcp-mesh-tempo.selectorLabels" . | nindent 8 }}
     spec:
       securityContext:
-        {{- toYaml .Values.tempo.securityContext | nindent 8 }}
+        {{- toYaml .Values.tempo.podSecurityContext | nindent 8 }}
       containers:
       - name: tempo
         image: "{{ .Values.tempo.image.repository }}:{{ .Values.tempo.image.tag }}"
         imagePullPolicy: {{ .Values.tempo.image.pullPolicy }}
+        securityContext:
+          {{- toYaml .Values.tempo.securityContext | nindent 10 }}
         args:
           - -config.file=/etc/tempo.yaml
         ports:
@@ -41,10 +53,12 @@ spec:
           mountPath: /etc/tempo.yaml
           subPath: tempo.yaml
           readOnly: true
-        {{- if .Values.tempo.persistence.enabled }}
+        {{- /* /var/tempo (wal/blocks) and /tmp must be writable — always
+               volumes since the root filesystem is read-only. */}}
         - name: storage
           mountPath: /var/tempo
-        {{- end }}
+        - name: tmp
+          mountPath: /tmp
         livenessProbe:
           httpGet:
             path: /ready
@@ -67,9 +81,13 @@ spec:
       - name: config
         configMap:
           name: {{ include "mcp-mesh-tempo.fullname" . }}-config
-      {{- if .Values.tempo.persistence.enabled }}
       - name: storage
+        {{- if .Values.tempo.persistence.enabled }}
         persistentVolumeClaim:
           claimName: {{ include "mcp-mesh-tempo.fullname" . }}-pvc
-      {{- end }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+      - name: tmp
+        emptyDir: {}
 {{- end }}

--- a/helm/mcp-mesh-tempo/templates/deployment.yaml
+++ b/helm/mcp-mesh-tempo/templates/deployment.yaml
@@ -6,7 +6,7 @@
        API server drops it (losing PVC write access). */}}
 {{- range $field := list "fsGroup" "fsGroupChangePolicy" "supplementalGroups" "sysctls" }}
 {{- if hasKey ($.Values.tempo.securityContext | default dict) $field }}
-{{- fail (printf "tempo.securityContext.%s: tempo.securityContext is now the container security context; pod-level fields (fsGroup, runAsUser, ...) moved to tempo.podSecurityContext. Move your override there." $field) }}
+{{- fail (printf "tempo.securityContext.%s: tempo.securityContext is now the container security context; pod-only fields (fsGroup, fsGroupChangePolicy, supplementalGroups, sysctls) are invalid there and belong in tempo.podSecurityContext. Move your override there." $field) }}
 {{- end }}
 {{- end }}
 apiVersion: apps/v1

--- a/helm/mcp-mesh-tempo/values.yaml
+++ b/helm/mcp-mesh-tempo/values.yaml
@@ -47,8 +47,27 @@ tempo:
     retention: "1h"
     blockDuration: "5m"
 
-  # Security context
-  securityContext:
+  # Pod security context (hardened for Pod Security Standards "restricted").
+  # Renamed: this key was previously called securityContext (which is now the
+  # container security context below) — templating fails with a migration
+  # message if an old-shaped override still carries pod-level fields there.
+  podSecurityContext:
     runAsNonRoot: true
     runAsUser: 10001
+    runAsGroup: 10001
     fsGroup: 10001
+    seccompProfile:
+      type: RuntimeDefault
+
+  # Container security context. readOnlyRootFilesystem works because tempo
+  # only writes under /var/tempo (wal/blocks — PVC or emptyDir) and /tmp
+  # (emptyDir).
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 10001
+    runAsGroup: 10001

--- a/helm/mcp-mesh-ui/templates/deployment.yaml
+++ b/helm/mcp-mesh-ui/templates/deployment.yaml
@@ -40,15 +40,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        fsGroup: 1000
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            readOnlyRootFilesystem: true
+            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.service.targetPort }}

--- a/helm/mcp-mesh-ui/values.yaml
+++ b/helm/mcp-mesh-ui/values.yaml
@@ -9,6 +9,27 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Pod security context (hardened for Pod Security Standards "restricted")
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000 # mcp-mesh user in the mcpmesh/ui image
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container security context. readOnlyRootFilesystem works because meshui is
+# a static Go binary whose only writable path, /tmp, is emptyDir-mounted.
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+
 service:
   type: ClusterIP
   port: 3080

--- a/packaging/docker/cli.Dockerfile
+++ b/packaging/docker/cli.Dockerfile
@@ -7,15 +7,17 @@ ARG TARGETPLATFORM
 ARG VERSION
 
 # Install system dependencies
+# hadolint ignore=DL3008,DL3015
 RUN apt-get update && apt-get install -y \
     curl \
     wget \
     git \
     && rm -rf /var/lib/apt/lists/* \
-    && groupadd -r mcp-mesh \
-    && useradd -r -g mcp-mesh mcp-mesh
+    && groupadd -r -g 999 mcp-mesh \
+    && useradd -r -u 999 -g mcp-mesh mcp-mesh
 
 # Install both meshctl and registry using install.sh script
+# hadolint ignore=DL4006
 RUN if [ -z "$VERSION" ]; then echo "VERSION build arg is required" && exit 1; fi && \
     echo "Installing meshctl and registry ${VERSION} using install.sh..." && \
     curl -sSL "https://raw.githubusercontent.com/dhyansraj/mcp-mesh/main/install.sh" | bash -s -- --all --version ${VERSION} --install-dir /usr/local/bin
@@ -23,7 +25,7 @@ RUN if [ -z "$VERSION" ]; then echo "VERSION build arg is required" && exit 1; f
 # Install mcp-mesh package from PyPI (remove 'v' prefix if present)
 RUN VERSION_NO_V="${VERSION#v}" && \
     echo "Installing mcp-mesh==${VERSION_NO_V} from PyPI" && \
-    pip install --no-cache-dir mcp-mesh==${VERSION_NO_V}
+    pip install --no-cache-dir "mcp-mesh==${VERSION_NO_V}"
 
 # Create workspace
 RUN mkdir -p /workspace && chown mcp-mesh:mcp-mesh /workspace

--- a/packaging/docker/java-runtime.Dockerfile
+++ b/packaging/docker/java-runtime.Dockerfile
@@ -5,16 +5,21 @@ FROM --platform=$TARGETPLATFORM eclipse-temurin:17-jdk-jammy
 
 ARG VERSION
 
-# Install runtime dependencies
+# Install runtime dependencies. uid/gid pinned to 999: the helm
+# mcp-mesh-agent chart forces runAsUser/runAsGroup/fsGroup 999, which must
+# match this user so files chowned to mcp-mesh in-image stay writable.
+# hadolint ignore=DL3008,DL3015
 RUN apt-get update && apt-get install -y \
     curl \
     wget \
     maven \
     && rm -rf /var/lib/apt/lists/* \
-    && groupadd -r mcp-mesh \
-    && useradd -r -g mcp-mesh mcp-mesh
+    && groupadd -r -g 999 mcp-mesh \
+    && useradd -r -u 999 -g mcp-mesh mcp-mesh
 
-# Pre-cache SDK dependencies from Maven Central
+# Pre-cache SDK dependencies from Maven Central (cd is scoped to this RUN;
+# the directory is removed at the end, so WORKDIR would be wrong here)
+# hadolint ignore=DL3003
 RUN if [ -z "$VERSION" ]; then echo "VERSION build arg is required" && exit 1; fi && \
     echo "Pre-caching io.mcp-mesh SDK ${VERSION} from Maven Central" && \
     mkdir -p /tmp/warmup && \

--- a/packaging/docker/python-runtime.Dockerfile
+++ b/packaging/docker/python-runtime.Dockerfile
@@ -5,13 +5,16 @@ FROM --platform=$TARGETPLATFORM python:3.11-slim
 
 ARG VERSION
 
-# Install runtime dependencies
+# Install runtime dependencies. uid/gid pinned to 999: the helm
+# mcp-mesh-agent chart forces runAsUser/runAsGroup/fsGroup 999, which must
+# match this user so files chowned to mcp-mesh in-image stay writable.
+# hadolint ignore=DL3008,DL3015
 RUN apt-get update && apt-get install -y \
     curl \
     wget \
     && rm -rf /var/lib/apt/lists/* \
-    && groupadd -r mcp-mesh \
-    && useradd -r -g mcp-mesh mcp-mesh
+    && groupadd -r -g 999 mcp-mesh \
+    && useradd -r -u 999 -g mcp-mesh mcp-mesh
 
 # Install mcp-mesh package from PyPI
 RUN if [ -z "$VERSION" ]; then echo "VERSION build arg is required" && exit 1; fi && \

--- a/packaging/docker/typescript-runtime.Dockerfile
+++ b/packaging/docker/typescript-runtime.Dockerfile
@@ -5,13 +5,16 @@ FROM --platform=$TARGETPLATFORM node:22-slim
 
 ARG VERSION
 
-# Install runtime dependencies
+# Install runtime dependencies. uid/gid pinned to 999: the helm
+# mcp-mesh-agent chart forces runAsUser/runAsGroup/fsGroup 999, which must
+# match this user so files chowned to mcp-mesh in-image stay writable.
+# hadolint ignore=DL3008,DL3015
 RUN apt-get update && apt-get install -y \
     curl \
     wget \
     && rm -rf /var/lib/apt/lists/* \
-    && groupadd -r mcp-mesh \
-    && useradd -r -g mcp-mesh mcp-mesh
+    && groupadd -r -g 999 mcp-mesh \
+    && useradd -r -u 999 -g mcp-mesh mcp-mesh
 
 # Create app directory
 RUN mkdir -p /app && chown mcp-mesh:mcp-mesh /app

--- a/scripts/check_helm_pss.py
+++ b/scripts/check_helm_pss.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Assert every pod spec rendered by the helm/ charts satisfies the
+Pod Security Standards "restricted" profile with default values.
+
+For each chart that renders workloads, runs `helm template` and checks every
+container (init containers included):
+
+  - seccompProfile.type RuntimeDefault/Localhost (pod- or container-level)
+  - runAsNonRoot: true (pod- or container-level)
+  - allowPrivilegeEscalation: false (container-level)
+  - capabilities.drop contains ALL (container-level)
+
+Also rejects restricted-profile spec violations: hostNetwork/hostPID/hostIPC,
+privileged containers, and disallowed volume types (hostPath, etc.).
+
+Usage: python3 scripts/check_helm_pss.py  (run from the repo root)
+Exit code 0 = all checks pass.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HELM_DIR = REPO_ROOT / "helm"
+
+# chart dir -> extra helm template args (cover optional pods). Charts are
+# auto-discovered (every helm/*/Chart.yaml); this map only adds args.
+EXTRA_ARGS = {
+    # umbrella: render the optional UI pod too
+    "mcp-mesh-core": ["--set", "ui.enabled=true"],
+}
+
+
+def discover_charts() -> list[str]:
+    return sorted(d.name for d in HELM_DIR.iterdir()
+                  if (d / "Chart.yaml").is_file())
+
+WORKLOAD_KINDS = {"Deployment", "StatefulSet", "DaemonSet", "Job", "ReplicaSet"}
+
+ALLOWED_VOLUME_TYPES = {
+    "configMap", "csi", "downwardAPI", "emptyDir", "ephemeral",
+    "persistentVolumeClaim", "projected", "secret",
+}
+
+
+def build_dependencies(chart: str) -> None:
+    """(Re)package charts/*.tgz for charts with dependencies, so the check
+    templates the current local subcharts instead of stale archives (and
+    works on fresh clones with no charts/ dir at all)."""
+    chart_dir = HELM_DIR / chart
+    with open(chart_dir / "Chart.yaml") as f:
+        meta = yaml.safe_load(f)
+    if not meta.get("dependencies"):
+        return
+    for cmd in (["helm", "dependency", "build", str(chart_dir)],
+                ["helm", "dependency", "update", str(chart_dir)]):
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode == 0:
+            return
+    print(f"FAIL {chart}: helm dependency build/update failed:\n{result.stderr}")
+    sys.exit(1)
+
+
+def render(chart: str, extra_args: list[str]) -> str:
+    cmd = ["helm", "template", "pss-check", str(HELM_DIR / chart), *extra_args]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"FAIL {chart}: helm template failed:\n{result.stderr}")
+        sys.exit(1)
+    return result.stdout
+
+
+def pod_spec_of(doc: dict):
+    kind = doc.get("kind")
+    if kind == "Pod":
+        return doc.get("spec"), doc["metadata"].get("name", "?")
+    if kind in WORKLOAD_KINDS:
+        spec = doc.get("spec", {}).get("template", {}).get("spec")
+        return spec, doc["metadata"].get("name", "?")
+    if kind == "CronJob":
+        spec = (doc.get("spec", {}).get("jobTemplate", {})
+                .get("spec", {}).get("template", {}).get("spec"))
+        return spec, doc["metadata"].get("name", "?")
+    return None, None
+
+
+def check_pod(chart: str, name: str, spec: dict) -> list[str]:
+    errors = []
+    pod_sc = spec.get("securityContext") or {}
+
+    for field in ("hostNetwork", "hostPID", "hostIPC"):
+        if spec.get(field):
+            errors.append(f"{field} is set")
+
+    for vol in spec.get("volumes") or []:
+        types = set(vol.keys()) - {"name"}
+        bad = types - ALLOWED_VOLUME_TYPES
+        if bad:
+            errors.append(f"volume {vol.get('name')}: disallowed type(s) {sorted(bad)}")
+
+    containers = (spec.get("containers") or []) + (spec.get("initContainers") or []) \
+        + (spec.get("ephemeralContainers") or [])
+    for c in containers:
+        cname = c.get("name", "?")
+        sc = c.get("securityContext") or {}
+
+        if sc.get("privileged"):
+            errors.append(f"{cname}: privileged")
+
+        seccomp = (sc.get("seccompProfile") or pod_sc.get("seccompProfile") or {}).get("type")
+        if seccomp not in ("RuntimeDefault", "Localhost"):
+            errors.append(f"{cname}: seccompProfile.type missing/invalid (got {seccomp!r})")
+
+        run_as_non_root = sc.get("runAsNonRoot", pod_sc.get("runAsNonRoot"))
+        if run_as_non_root is not True:
+            errors.append(f"{cname}: runAsNonRoot != true (got {run_as_non_root!r})")
+
+        run_as_user = sc.get("runAsUser", pod_sc.get("runAsUser"))
+        if run_as_user == 0:
+            errors.append(f"{cname}: runAsUser is 0")
+
+        if sc.get("allowPrivilegeEscalation") is not False:
+            errors.append(f"{cname}: allowPrivilegeEscalation != false")
+
+        drops = (sc.get("capabilities") or {}).get("drop") or []
+        if "ALL" not in drops:
+            errors.append(f"{cname}: capabilities.drop missing ALL")
+        adds = set((sc.get("capabilities") or {}).get("add") or [])
+        if adds - {"NET_BIND_SERVICE"}:
+            errors.append(f"{cname}: capabilities.add {sorted(adds)} not allowed")
+
+    return [f"{name}/{e}" for e in errors]
+
+
+def main() -> int:
+    failures = 0
+    for chart in discover_charts():
+        build_dependencies(chart)
+        rendered = render(chart, EXTRA_ARGS.get(chart, []))
+        pods = 0
+        errors = []
+        for doc in yaml.safe_load_all(rendered):
+            if not isinstance(doc, dict):
+                continue
+            spec, name = pod_spec_of(doc)
+            if spec is None:
+                continue
+            pods += 1
+            errors.extend(check_pod(chart, name, spec))
+        if errors:
+            failures += 1
+            print(f"FAIL {chart} ({pods} pod spec(s)):")
+            for e in errors:
+                print(f"  - {e}")
+        else:
+            print(f"OK   {chart} ({pods} pod spec(s))")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_helm_pss.py
+++ b/scripts/check_helm_pss.py
@@ -39,6 +39,7 @@ def discover_charts() -> list[str]:
                   if (d / "Chart.yaml").is_file())
 
 WORKLOAD_KINDS = {"Deployment", "StatefulSet", "DaemonSet", "Job", "ReplicaSet"}
+POD_BEARING_KINDS = WORKLOAD_KINDS | {"Pod", "CronJob"}
 
 ALLOWED_VOLUME_TYPES = {
     "configMap", "csi", "downwardAPI", "emptyDir", "ephemeral",
@@ -145,8 +146,13 @@ def main() -> int:
         for doc in yaml.safe_load_all(rendered):
             if not isinstance(doc, dict):
                 continue
+            if doc.get("kind") not in POD_BEARING_KINDS:
+                continue
             spec, name = pod_spec_of(doc)
             if spec is None:
+                errors.append(
+                    f"{doc.get('kind')}/{name or '?'}: "
+                    "recognized workload kind but no pod spec found")
                 continue
             pods += 1
             errors.extend(check_pod(chart, name, spec))


### PR DESCRIPTION
## Summary
Closes #1153 — helm batch 4 of 5. Every chart passes Pod Security Standards `restricted` by default, validated against a live enforcing namespace.

- **One securityContext shape across all 7 pod-rendering charts**: pod-level `runAsNonRoot` + numeric uid/gid/fsGroup + `RuntimeDefault` seccomp (covering init containers), container-level `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]`, all values-overridable.
- **Postgres runs non-root** (uid 999, fsGroup-only — no chown initContainer, which would itself violate restricted): the official entrypoint skips its root-only path when started non-root and `initdb` owns the pgdata subdir; `fsGroupChangePolicy: OnRootMismatch` avoids recursive chowns on large DBs.
- **readOnlyRootFilesystem everywhere it's feasible** (registry, ui, redis, grafana, tempo, postgres) with emptyDirs for genuine writable paths; the agent stays `false` with an explicit rationale (arbitrary user code: `__pycache__`, startup installs). Each verdict is evidence-based, not guessed.
- **Real bugs fixed along the way**: the agent's pod securityContext was gated behind the PSP flag (removed in k8s 1.25) and *never rendered*; registry sqlite mode had no volume at all (`/data` unwritable) — it now gets a PVC-or-emptyDir; grafana logs to console (file target would violate rofs, nothing consumed the files).
- **Enforced going forward**: new `scripts/check_helm_pss.py` (auto-discovers charts, handles umbrella deps, asserts the full restricted profile per container incl. init/ephemeral containers) wired into the helm-release workflow next to lint.
- **Loud migrations**: grafana/tempo's `securityContext`→`podSecurityContext` rename has a template-time `fail` when old-shaped overrides carry pod-only fields (silently dropping a user's `fsGroup` is a PVC-access-loss path); agent upgrade note covers user initContainers and extraVolume re-ownership.

## Validation — the real acceptance test
- Namespace labeled `pod-security.kubernetes.io/enforce=restricted` on a live k3s cluster: server-side dry-run of every chart → zero PodSecurity warnings, with negative controls (a bare pod and the pre-fix postgres chart both rejected/warned, proving enforcement was active).
- Full umbrella install (ui enabled) into the restricted namespace: 6/6 pods Running with real readiness; rofs verified in-pod (`touch /x` → Read-only file system).
- `scripts/check_helm_pss.py` clean on all 9 charts; `helm lint` 9/9.

## Review Notes
- Independent review: 0 blockers; all 4 warnings fixed (rename guard, agent upgrade notes, CI wiring, script dependency-build) plus the infos (fsGroupChangePolicy, grafana paths cleanup, SPIRE-hostPath incompatibility comments, chart auto-discovery).
- Verified non-issues: postgres PVC ownership on upgrade (the old chart already ran the container as uid 999 — no #1187-style break), removed values keys were dead code, no docs referenced the renamed keys.
- Known boundary (commented in the charts): SPIRE mode's hostPath volumes are inherently incompatible with restricted.

Closes #1153

## Test plan
- [x] Live restricted-namespace dry-run (all charts) + full install reaching Running
- [x] `scripts/check_helm_pss.py` + `helm lint` all 9 (both now CI-enforced)
- [x] Rename guards fire on old-shaped values, pass on defaults
- [ ] GKE Autopilot/EKS spot-check (manual, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Pod Security Standards compliance validation in the CI/CD pipeline

* **Security & Infrastructure**
  * Enhanced security across all deployments with read-only root filesystems and restricted Linux capabilities
  * Enforced non-root user execution with seccomp profile isolation
  * Removed deprecated Pod Security Policy support

* **Documentation**
  * Updated upgrade documentation with pod security context configuration changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->