### PR TITLE
feat(helm): global image registry override and registry HA scheduling knobs

### DIFF
--- a/helm/mcp-mesh-agent/templates/_helpers.tpl
+++ b/helm/mcp-mesh-agent/templates/_helpers.tpl
@@ -187,3 +187,44 @@ via $(REDIS_PASSWORD) expansion, so the password must be URL-safe.
 {{- $g := include "mcp-mesh-agent.globalRedis" . | fromJson -}}
 {{- printf "%s://:$(REDIS_PASSWORD)@%s:%d" (include "mcp-mesh-agent.redisScheme" .) ($g.host | default "mcp-core-mcp-mesh-redis") (coalesce $g.port 6379 | int) -}}
 {{- end }}
+
+{{/*
+Render the image reference as [registry/]repository:tag. The registry prefix
+resolves as image.registry > global.imageRegistry > "" (implicit Docker Hub).
+The repository path is preserved — mirror images to the same paths in a
+private registry.
+*/}}
+{{- define "mcp-mesh-agent.image" -}}
+{{- $img := .Values.image -}}
+{{- $registry := $img.registry | default (dig "imageRegistry" "" (.Values.global | default dict)) | trimSuffix "/" -}}
+{{- $tag := $img.tag | default .Chart.AppVersion -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $img.repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $img.repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+imagePullSecrets for the pod spec: global.imagePullSecrets merged with the
+chart's own imagePullSecrets, deduplicated by name. Entries may be maps
+({name: ...}, the Kubernetes shape) or bare strings. Renders nothing when
+both lists are empty.
+*/}}
+{{- define "mcp-mesh-agent.imagePullSecrets" -}}
+{{- $names := list -}}
+{{- $global := dig "imagePullSecrets" (list) (.Values.global | default dict) -}}
+{{- range concat ($global | default list) ((.Values.imagePullSecrets) | default list) -}}
+{{- $name := . -}}
+{{- if kindIs "map" . -}}{{- $name = get . "name" -}}{{- end -}}
+{{- if and $name (not (has $name $names)) -}}
+{{- $names = append $names $name -}}
+{{- end -}}
+{{- end -}}
+{{- if $names -}}
+imagePullSecrets:
+{{- range $names }}
+  - name: {{ . }}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/helm/mcp-mesh-agent/templates/deployment.yaml
+++ b/helm/mcp-mesh-agent/templates/deployment.yaml
@@ -38,9 +38,8 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+      {{- with include "mcp-mesh-agent.imagePullSecrets" . }}
+      {{- . | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "mcp-mesh-agent.serviceAccountName" . }}
       securityContext:
@@ -71,7 +70,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "mcp-mesh-agent.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.agent.http.enabled }}
           ports:

--- a/helm/mcp-mesh-agent/values.yaml
+++ b/helm/mcp-mesh-agent/values.yaml
@@ -31,6 +31,11 @@ global:
 replicaCount: 1
 
 image:
+  # Registry prefix for the image. Resolution: this value >
+  # global.imageRegistry > "" (Docker Hub). The repository path is preserved
+  # (registry: my.registry.internal pulls
+  # my.registry.internal/mcpmesh/python-runtime).
+  registry: ""
   # Default: Python base runtime image (has no agent code)
   # Available runtimes: mcpmesh/python-runtime, mcpmesh/typescript-runtime, mcpmesh/java-runtime
   # Override with your built agent image: --set image.repository=your-registry/my-agent
@@ -39,6 +44,10 @@ image:
   # Minor version tag tracks latest patch (0.8 → 0.8.x)
   tag: "2.4"
 
+# Pull secrets for this chart's pods, merged with global.imagePullSecrets
+# (deduplicated by name). Standard shape:
+#   imagePullSecrets:
+#     - name: my-registry-credentials
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/helm/mcp-mesh-core/README.md
+++ b/helm/mcp-mesh-core/README.md
@@ -225,6 +225,80 @@ mcp-mesh-registry:
             pathType: Prefix
 ```
 
+### Air-gapped / private registry installs
+
+`global.imageRegistry` repoints every image in the stack — the registry, UI,
+PostgreSQL, Redis, Grafana, Tempo, and the registry's wait-for-db busybox
+init container — to a private registry. `global.imagePullSecrets` adds pull
+secrets to every pod spec (merged with each chart's own `imagePullSecrets`,
+deduplicated by name):
+
+```yaml
+# values.yaml
+global:
+  imageRegistry: my.registry.internal
+  imagePullSecrets:
+    - name: my-registry-credentials
+```
+
+Repository paths are preserved, so mirror each image to the same path:
+
+| Source image          | Pulled as                                  |
+| --------------------- | ------------------------------------------ |
+| `mcpmesh/registry`    | `my.registry.internal/mcpmesh/registry`    |
+| `mcpmesh/ui`          | `my.registry.internal/mcpmesh/ui`          |
+| `postgres`            | `my.registry.internal/postgres`            |
+| `redis`               | `my.registry.internal/redis`               |
+| `grafana/grafana`     | `my.registry.internal/grafana/grafana`     |
+| `grafana/tempo`       | `my.registry.internal/grafana/tempo`       |
+| `busybox`             | `my.registry.internal/busybox`             |
+
+Docker Hub library images (`postgres`, `redis`, `busybox`) keep their
+single-segment name — mirror them to that same path; the charts do not
+rewrite repository paths. Per-component overrides win over the global (e.g.
+`mcp-mesh-registry.image.registry`). The standalone `mcp-mesh-agent` chart
+honors the same `global.imageRegistry` / `global.imagePullSecrets` values
+when passed to each agent release.
+
+### Registry high availability
+
+The registry is stateless when backed by PostgreSQL (the default), so it can
+run multi-replica:
+
+```yaml
+# values.yaml
+mcp-mesh-registry:
+  replicaCount: 3
+```
+
+That is the only required change. At more than one replica the chart
+automatically adds:
+
+- **Soft topology spread** across zones and nodes (`ScheduleAnyway`,
+  `maxSkew: 1`) — a no-op on single-node clusters, replica spreading
+  wherever real topology exists. Replace with explicit
+  `mcp-mesh-registry.topologySpreadConstraints` (or disable via
+  `mcp-mesh-registry.defaultTopologySpread.enabled: false`) for hard
+  requirements.
+- **A PodDisruptionBudget** (`minAvailable: 1`) so node drains keep at least
+  one registry running. It never renders at a single replica, where it would
+  block drains.
+
+For load-based scaling, enable the HPA instead of a fixed count:
+
+```yaml
+mcp-mesh-registry:
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 80
+```
+
+Multi-replica and autoscaling require an external database — with
+`registry.database.type=sqlite` the template fails, since sqlite is a
+single-writer local file.
+
 ## Architecture
 
 The core infrastructure follows this deployment pattern:
@@ -309,6 +383,8 @@ Note: This will delete all data in PostgreSQL. Back up data before uninstalling.
 | Key                | Type   | Default      | Description                          |
 | ------------------ | ------ | ------------ | ------------------------------------ |
 | `global.namespace` | string | `"mcp-mesh"` | Namespace for all components         |
+| `global.imageRegistry` | string | `""` | Registry prefix applied to every image (repository paths preserved — see "Air-gapped / private registry installs"); per-component `image.registry` overrides win |
+| `global.imagePullSecrets` | list | `[]` | Pull secrets (`- name: ...`) added to every pod spec, merged with each chart's own `imagePullSecrets` and deduplicated by name |
 | `global.postgres.*` | object | bundled postgres | PostgreSQL endpoint/credentials inherited by all consumers (`host`, `port`, `name`, `username`, `password`, `sslmode`, `existingSecret`, `existingSecretUrlKey`, `existingSecretPasswordKey`, `tls.caSecret`, `tls.caKey`) |
 | `global.postgres.generatedSecret` | bool | `true` | Auto-generate the password into `<release>-mcp-mesh-postgres-credentials` when no `password`/`existingSecret` is set (provisioning and all consumers share it) |
 | `global.postgres.generatedSecretName` | string | `""` | Override the generated Secret's name (needed only with name/fullname overrides on the postgres subchart) |

--- a/helm/mcp-mesh-core/values.yaml
+++ b/helm/mcp-mesh-core/values.yaml
@@ -11,6 +11,21 @@ global:
   # Example: helm install my-core ... → set coreReleaseName: "my-core"
   coreReleaseName: "mcp-core"
 
+  # Private/air-gapped registry prefix applied to EVERY image in the stack:
+  # the registry, UI, postgres, redis, grafana, tempo, and the registry's
+  # wait-for-db busybox init container. Repository paths are preserved —
+  # with imageRegistry: my.registry.internal the charts pull
+  # my.registry.internal/mcpmesh/registry, my.registry.internal/postgres,
+  # my.registry.internal/grafana/grafana, my.registry.internal/busybox, ... —
+  # so mirror each image to the same path in your registry. Per-component
+  # overrides win (e.g. mcp-mesh-registry.image.registry).
+  imageRegistry: ""
+  # Pull secrets added to every pod spec, merged with each chart's own
+  # imagePullSecrets (deduplicated by name). Standard shape:
+  #   imagePullSecrets:
+  #     - name: my-registry-credentials
+  imagePullSecrets: []
+
   # Datastore endpoints, declared ONCE and inherited by every consumer:
   # the registry (DATABASE_URL/REDIS_URL), the UI (when enabled), and the
   # bundled postgres provisioning. The defaults below point at the bundled
@@ -314,9 +329,11 @@ commonAnnotations: {}
 networkPolicies:
   enabled: false
 
-# Pod disruption budgets (disabled by default)
-podDisruptionBudgets:
-  enabled: false
+# Pod disruption budgets are configured per subchart (this umbrella-level
+# flag was never consumed and has been removed). The registry PDB defaults
+# on and engages automatically at mcp-mesh-registry.replicaCount > 1 — see
+# mcp-mesh-registry.podDisruptionBudget. HA scheduling lives there too
+# (topologySpreadConstraints / defaultTopologySpread / autoscaling).
 
 # Service monitors for Prometheus (disabled by default)
 serviceMonitors:

--- a/helm/mcp-mesh-grafana/templates/_helpers.tpl
+++ b/helm/mcp-mesh-grafana/templates/_helpers.tpl
@@ -49,3 +49,44 @@ Selector labels
 app.kubernetes.io/name: {{ include "mcp-mesh-grafana.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Render the image reference as [registry/]repository:tag. The registry prefix
+resolves as grafana.image.registry > global.imageRegistry > "" (implicit Docker Hub).
+The repository path is preserved — mirror images to the same paths in a
+private registry.
+*/}}
+{{- define "mcp-mesh-grafana.image" -}}
+{{- $img := .Values.grafana.image -}}
+{{- $registry := $img.registry | default (dig "imageRegistry" "" (.Values.global | default dict)) | trimSuffix "/" -}}
+{{- $tag := $img.tag -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $img.repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $img.repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+imagePullSecrets for the pod spec: global.imagePullSecrets merged with the
+chart's own imagePullSecrets, deduplicated by name. Entries may be maps
+({name: ...}, the Kubernetes shape) or bare strings. Renders nothing when
+both lists are empty.
+*/}}
+{{- define "mcp-mesh-grafana.imagePullSecrets" -}}
+{{- $names := list -}}
+{{- $global := dig "imagePullSecrets" (list) (.Values.global | default dict) -}}
+{{- range concat ($global | default list) ((.Values.grafana.imagePullSecrets) | default list) -}}
+{{- $name := . -}}
+{{- if kindIs "map" . -}}{{- $name = get . "name" -}}{{- end -}}
+{{- if and $name (not (has $name $names)) -}}
+{{- $names = append $names $name -}}
+{{- end -}}
+{{- end -}}
+{{- if $names -}}
+imagePullSecrets:
+{{- range $names }}
+  - name: {{ . }}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/helm/mcp-mesh-grafana/templates/_helpers.tpl
+++ b/helm/mcp-mesh-grafana/templates/_helpers.tpl
@@ -55,11 +55,17 @@ Render the image reference as [registry/]repository:tag. The registry prefix
 resolves as grafana.image.registry > global.imageRegistry > "" (implicit Docker Hub).
 The repository path is preserved — mirror images to the same paths in a
 private registry.
+The tag is upstream-versioned (no .Chart.AppVersion fallback — that tracks a
+different versioning line), so an empty tag can only come from an explicit
+override; fail loudly at template time instead of rendering an invalid ref.
 */}}
 {{- define "mcp-mesh-grafana.image" -}}
 {{- $img := .Values.grafana.image -}}
 {{- $registry := $img.registry | default (dig "imageRegistry" "" (.Values.global | default dict)) | trimSuffix "/" -}}
 {{- $tag := $img.tag -}}
+{{- if not $tag -}}
+{{- fail "grafana.image.tag must not be empty; set the upstream image tag explicitly" -}}
+{{- end -}}
 {{- if $registry -}}
 {{- printf "%s/%s:%s" $registry $img.repository $tag -}}
 {{- else -}}

--- a/helm/mcp-mesh-grafana/templates/deployment.yaml
+++ b/helm/mcp-mesh-grafana/templates/deployment.yaml
@@ -25,11 +25,14 @@ spec:
       labels:
         {{- include "mcp-mesh-grafana.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with include "mcp-mesh-grafana.imagePullSecrets" . }}
+      {{- . | nindent 6 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.grafana.podSecurityContext | nindent 8 }}
       containers:
       - name: grafana
-        image: "{{ .Values.grafana.image.repository }}:{{ .Values.grafana.image.tag }}"
+        image: "{{ include "mcp-mesh-grafana.image" . }}"
         imagePullPolicy: {{ .Values.grafana.image.pullPolicy }}
         securityContext:
           {{- toYaml .Values.grafana.securityContext | nindent 10 }}

--- a/helm/mcp-mesh-grafana/values.yaml
+++ b/helm/mcp-mesh-grafana/values.yaml
@@ -1,9 +1,20 @@
 grafana:
   enabled: true
   image:
+    # Registry prefix for the image. Resolution: this value >
+    # global.imageRegistry > "" (Docker Hub). The repository path is
+    # preserved (registry: my.registry.internal pulls
+    # my.registry.internal/grafana/grafana).
+    registry: ""
     repository: grafana/grafana
     tag: "12.3.1"
     pullPolicy: IfNotPresent
+
+  # Pull secrets for this chart's pods, merged with global.imagePullSecrets
+  # (deduplicated by name). Standard shape:
+  #   imagePullSecrets:
+  #     - name: my-registry-credentials
+  imagePullSecrets: []
 
   resources:
     requests:

--- a/helm/mcp-mesh-postgres/templates/_helpers.tpl
+++ b/helm/mcp-mesh-postgres/templates/_helpers.tpl
@@ -145,11 +145,17 @@ Render the image reference as [registry/]repository:tag. The registry prefix
 resolves as image.registry > global.imageRegistry > "" (implicit Docker Hub).
 The repository path is preserved — mirror images to the same paths in a
 private registry.
+The tag is upstream-versioned (no .Chart.AppVersion fallback — that tracks a
+different versioning line), so an empty tag can only come from an explicit
+override; fail loudly at template time instead of rendering an invalid ref.
 */}}
 {{- define "mcp-mesh-postgres.image" -}}
 {{- $img := .Values.image -}}
 {{- $registry := $img.registry | default (dig "imageRegistry" "" (.Values.global | default dict)) | trimSuffix "/" -}}
 {{- $tag := $img.tag -}}
+{{- if not $tag -}}
+{{- fail "image.tag must not be empty; set the upstream image tag explicitly" -}}
+{{- end -}}
 {{- if $registry -}}
 {{- printf "%s/%s:%s" $registry $img.repository $tag -}}
 {{- else -}}

--- a/helm/mcp-mesh-postgres/templates/_helpers.tpl
+++ b/helm/mcp-mesh-postgres/templates/_helpers.tpl
@@ -139,3 +139,44 @@ combination. Invoked unconditionally from the statefulset.
 {{- fail (printf "nameOverride/fullnameOverride on the bundled PostgreSQL chart renames the auto-generated credentials Secret to %q, but consumers derive the default name from the release name and would reference a Secret that does not exist. Set global.postgres.generatedSecretName=%q so every chart follows the override" (include "mcp-mesh-postgres.credentialsSecretName" .) (include "mcp-mesh-postgres.credentialsSecretName" .)) -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Render the image reference as [registry/]repository:tag. The registry prefix
+resolves as image.registry > global.imageRegistry > "" (implicit Docker Hub).
+The repository path is preserved — mirror images to the same paths in a
+private registry.
+*/}}
+{{- define "mcp-mesh-postgres.image" -}}
+{{- $img := .Values.image -}}
+{{- $registry := $img.registry | default (dig "imageRegistry" "" (.Values.global | default dict)) | trimSuffix "/" -}}
+{{- $tag := $img.tag -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $img.repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $img.repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+imagePullSecrets for the pod spec: global.imagePullSecrets merged with the
+chart's own imagePullSecrets, deduplicated by name. Entries may be maps
+({name: ...}, the Kubernetes shape) or bare strings. Renders nothing when
+both lists are empty.
+*/}}
+{{- define "mcp-mesh-postgres.imagePullSecrets" -}}
+{{- $names := list -}}
+{{- $global := dig "imagePullSecrets" (list) (.Values.global | default dict) -}}
+{{- range concat ($global | default list) ((.Values.imagePullSecrets) | default list) -}}
+{{- $name := . -}}
+{{- if kindIs "map" . -}}{{- $name = get . "name" -}}{{- end -}}
+{{- if and $name (not (has $name $names)) -}}
+{{- $names = append $names $name -}}
+{{- end -}}
+{{- end -}}
+{{- if $names -}}
+imagePullSecrets:
+{{- range $names }}
+  - name: {{ . }}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/helm/mcp-mesh-postgres/templates/statefulset.yaml
+++ b/helm/mcp-mesh-postgres/templates/statefulset.yaml
@@ -24,11 +24,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with include "mcp-mesh-postgres.imagePullSecrets" . }}
+      {{- . | nindent 6 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: postgres
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ include "mcp-mesh-postgres.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: postgres

--- a/helm/mcp-mesh-postgres/values.yaml
+++ b/helm/mcp-mesh-postgres/values.yaml
@@ -27,9 +27,20 @@ postgres:
   postgresqlDataDir: "/var/lib/postgresql/data/pgdata"
 
 image:
+  # Registry prefix for the image. Resolution: this value >
+  # global.imageRegistry > "" (Docker Hub). The repository path is preserved:
+  # registry: my.registry.internal pulls my.registry.internal/postgres —
+  # mirror Docker Hub library images to the same single-segment path.
+  registry: ""
   repository: postgres
   tag: "15"
   pullPolicy: IfNotPresent
+
+# Pull secrets for this chart's pods, merged with global.imagePullSecrets
+# (deduplicated by name). Standard shape:
+#   imagePullSecrets:
+#     - name: my-registry-credentials
+imagePullSecrets: []
 
 # Service configuration
 service:

--- a/helm/mcp-mesh-redis/templates/_helpers.tpl
+++ b/helm/mcp-mesh-redis/templates/_helpers.tpl
@@ -73,11 +73,17 @@ Render the image reference as [registry/]repository:tag. The registry prefix
 resolves as image.registry > global.imageRegistry > "" (implicit Docker Hub).
 The repository path is preserved — mirror images to the same paths in a
 private registry.
+The tag is upstream-versioned (no .Chart.AppVersion fallback — that tracks a
+different versioning line), so an empty tag can only come from an explicit
+override; fail loudly at template time instead of rendering an invalid ref.
 */}}
 {{- define "mcp-mesh-redis.image" -}}
 {{- $img := .Values.image -}}
 {{- $registry := $img.registry | default (dig "imageRegistry" "" (.Values.global | default dict)) | trimSuffix "/" -}}
 {{- $tag := $img.tag -}}
+{{- if not $tag -}}
+{{- fail "image.tag must not be empty; set the upstream image tag explicitly" -}}
+{{- end -}}
 {{- if $registry -}}
 {{- printf "%s/%s:%s" $registry $img.repository $tag -}}
 {{- else -}}

--- a/helm/mcp-mesh-redis/templates/_helpers.tpl
+++ b/helm/mcp-mesh-redis/templates/_helpers.tpl
@@ -67,3 +67,44 @@ deployment.
 {{- fail "global.redis.password / global.redis.existingSecret cannot be combined with the bundled Redis chart: it runs without AUTH, so the credential every consumer connects with can never work. Disable the bundled subchart (redis.enabled=false) and point global.redis at an external Redis, or drop the global.redis credentials" -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Render the image reference as [registry/]repository:tag. The registry prefix
+resolves as image.registry > global.imageRegistry > "" (implicit Docker Hub).
+The repository path is preserved — mirror images to the same paths in a
+private registry.
+*/}}
+{{- define "mcp-mesh-redis.image" -}}
+{{- $img := .Values.image -}}
+{{- $registry := $img.registry | default (dig "imageRegistry" "" (.Values.global | default dict)) | trimSuffix "/" -}}
+{{- $tag := $img.tag -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $img.repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $img.repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+imagePullSecrets for the pod spec: global.imagePullSecrets merged with the
+chart's own imagePullSecrets, deduplicated by name. Entries may be maps
+({name: ...}, the Kubernetes shape) or bare strings. Renders nothing when
+both lists are empty.
+*/}}
+{{- define "mcp-mesh-redis.imagePullSecrets" -}}
+{{- $names := list -}}
+{{- $global := dig "imagePullSecrets" (list) (.Values.global | default dict) -}}
+{{- range concat ($global | default list) ((.Values.imagePullSecrets) | default list) -}}
+{{- $name := . -}}
+{{- if kindIs "map" . -}}{{- $name = get . "name" -}}{{- end -}}
+{{- if and $name (not (has $name $names)) -}}
+{{- $names = append $names $name -}}
+{{- end -}}
+{{- end -}}
+{{- if $names -}}
+imagePullSecrets:
+{{- range $names }}
+  - name: {{ . }}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/helm/mcp-mesh-redis/templates/deployment.yaml
+++ b/helm/mcp-mesh-redis/templates/deployment.yaml
@@ -23,11 +23,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with include "mcp-mesh-redis.imagePullSecrets" . }}
+      {{- . | nindent 6 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: redis
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ include "mcp-mesh-redis.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: redis

--- a/helm/mcp-mesh-redis/values.yaml
+++ b/helm/mcp-mesh-redis/values.yaml
@@ -6,9 +6,20 @@ redis:
   maxmemoryPolicy: "allkeys-lru"
 
 image:
+  # Registry prefix for the image. Resolution: this value >
+  # global.imageRegistry > "" (Docker Hub). The repository path is preserved:
+  # registry: my.registry.internal pulls my.registry.internal/redis —
+  # mirror Docker Hub library images to the same single-segment path.
+  registry: ""
   repository: redis
   tag: "7-alpine"
   pullPolicy: IfNotPresent
+
+# Pull secrets for this chart's pods, merged with global.imagePullSecrets
+# (deduplicated by name). Standard shape:
+#   imagePullSecrets:
+#     - name: my-registry-credentials
+imagePullSecrets: []
 
 # Service configuration
 service:

--- a/helm/mcp-mesh-registry/README.md
+++ b/helm/mcp-mesh-registry/README.md
@@ -30,15 +30,25 @@ The following table lists the configurable parameters of the MCP Mesh Registry c
 
 ### General Configuration
 
-| Parameter          | Description                            | Default             |
-| ------------------ | -------------------------------------- | ------------------- |
-| `replicaCount`     | Number of registry replicas            | `1`                 |
-| `image.repository` | Registry image repository              | `mcp-mesh-registry` |
-| `image.pullPolicy` | Image pull policy                      | `IfNotPresent`      |
-| `image.tag`        | Image tag (overrides chart appVersion) | `""`                |
-| `imagePullSecrets` | Docker registry secret names           | `[]`                |
-| `nameOverride`     | Override chart name                    | `""`                |
-| `fullnameOverride` | Override full name                     | `""`                |
+| Parameter                  | Description                                                                | Default             |
+| -------------------------- | -------------------------------------------------------------------------- | ------------------- |
+| `replicaCount`             | Number of registry replicas (> 1 requires an external database)            | `1`                 |
+| `image.registry`           | Image registry prefix (overrides `global.imageRegistry`)                   | `""`                |
+| `image.repository`         | Registry image repository                                                   | `mcpmesh/registry`  |
+| `image.pullPolicy`         | Image pull policy                                                           | `IfNotPresent`      |
+| `image.tag`                | Image tag (overrides chart appVersion)                                      | `"2.4"`             |
+| `waitForDbImage.registry`  | wait-for-db init image registry prefix (overrides `global.imageRegistry`)  | `""`                |
+| `waitForDbImage.repository` | wait-for-db init image repository                                           | `busybox`           |
+| `waitForDbImage.tag`       | wait-for-db init image tag                                                  | `"1.35"`            |
+| `imagePullSecrets`         | Pull secrets, merged with `global.imagePullSecrets` (deduplicated by name) | `[]`                |
+| `nameOverride`             | Override chart name                                                         | `""`                |
+| `fullnameOverride`         | Override full name                                                          | `""`                |
+
+`global.imageRegistry` prefixes every image in the chart (the registry image
+and the wait-for-db init container) while preserving repository paths — with
+`global.imageRegistry=my.registry.internal` the chart pulls
+`my.registry.internal/mcpmesh/registry` and `my.registry.internal/busybox`.
+Mirror images to the same paths in a private registry.
 
 ### Service Configuration
 
@@ -154,6 +164,25 @@ here; an explicit value always wins.
 | `autoscaling.maxReplicas`                       | Maximum replicas          | `10`    |
 | `autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization    | `80`    |
 | `autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization | `80`    |
+
+The registry is stateless when backed by an external database, so the HPA is
+safe to enable. Autoscaling (and `replicaCount > 1`) with
+`registry.database.type=sqlite` fails at template time: sqlite is a
+single-writer local file and cannot be shared across replicas.
+
+### HA Scheduling
+
+| Parameter                       | Description                                                                                                        | Default |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------- |
+| `defaultTopologySpread.enabled` | Soft zone + node spread (`ScheduleAnyway`) applied automatically when more than one replica is possible             | `true`  |
+| `topologySpreadConstraints`     | Explicit constraints; replace the built-in soft defaults entirely                                                   | `[]`    |
+| `podDisruptionBudget.enabled`   | PDB; engages only when more than one replica is guaranteed (`replicaCount > 1` or `autoscaling.minReplicas > 1`)    | `true`  |
+| `podDisruptionBudget.minAvailable` | Minimum available pods during voluntary disruptions                                                              | `1`     |
+
+At `replicaCount: 1` (the default) neither the spread constraints nor the PDB
+render — a `minAvailable` PDB on a single-replica deployment would block node
+drains. Hard placement requirements (`DoNotSchedule`, pod anti-affinity) stay
+opt-in via `topologySpreadConstraints` / `affinity`.
 
 ### Monitoring
 

--- a/helm/mcp-mesh-registry/templates/_helpers.tpl
+++ b/helm/mcp-mesh-registry/templates/_helpers.tpl
@@ -261,6 +261,92 @@ true
 {{- end }}
 
 {{/*
+Render an image reference as [registry/]repository:tag from an image block.
+The registry prefix resolves as <block>.registry > global.imageRegistry > ""
+(implicit Docker Hub). Repository paths are preserved: with
+global.imageRegistry=my.registry.internal this renders
+my.registry.internal/mcpmesh/registry and (for the init container)
+my.registry.internal/busybox — mirror images to the same paths.
+Call with (dict "image" <imageBlock> "root" $).
+*/}}
+{{- define "mcp-mesh-registry.imageRef" -}}
+{{- $img := .image -}}
+{{- $registry := $img.registry | default (dig "imageRegistry" "" (.root.Values.global | default dict)) | trimSuffix "/" -}}
+{{- $tag := $img.tag | default .root.Chart.AppVersion -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $img.repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $img.repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+imagePullSecrets for the pod spec: global.imagePullSecrets merged with the
+chart's own imagePullSecrets, deduplicated by name. Entries may be maps
+({name: ...}, the Kubernetes shape) or bare strings. Renders nothing when
+both lists are empty.
+*/}}
+{{- define "mcp-mesh-registry.imagePullSecrets" -}}
+{{- $names := list -}}
+{{- $global := dig "imagePullSecrets" (list) (.Values.global | default dict) -}}
+{{- range concat ($global | default list) (.Values.imagePullSecrets | default list) -}}
+{{- $name := . -}}
+{{- if kindIs "map" . -}}{{- $name = get . "name" -}}{{- end -}}
+{{- if and $name (not (has $name $names)) -}}
+{{- $names = append $names $name -}}
+{{- end -}}
+{{- end -}}
+{{- if $names -}}
+imagePullSecrets:
+{{- range $names }}
+  - name: {{ . }}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Multi-replica safety guard: sqlite is a single-writer local file — each
+replica would either get its own divergent database (emptyDir) or fight
+over one ReadWriteOnce volume. Fail at template time instead of deploying
+a broken topology. Invoked unconditionally from the deployment.
+*/}}
+{{- define "mcp-mesh-registry.validateMultiReplica" -}}
+{{- if eq .Values.registry.database.type "sqlite" -}}
+{{- if .Values.autoscaling.enabled -}}
+{{- fail "autoscaling.enabled requires an external database: sqlite is a single-writer local file and cannot be shared across replicas. Set registry.database.type=postgres, or disable autoscaling." -}}
+{{- end -}}
+{{- if gt (int .Values.replicaCount) 1 -}}
+{{- fail "replicaCount > 1 requires an external database: sqlite is a single-writer local file and cannot be shared across replicas. Set registry.database.type=postgres, or keep replicaCount=1." -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Whether more than one registry replica is possible: replicaCount > 1, or the
+HPA owns the replica count and can scale beyond one. Gates the default
+topology spread constraints.
+*/}}
+{{- define "mcp-mesh-registry.multiReplica" -}}
+{{- if .Values.autoscaling.enabled -}}
+{{- if gt (int .Values.autoscaling.maxReplicas) 1 -}}true{{- end -}}
+{{- else if gt (int .Values.replicaCount) 1 -}}true{{- end -}}
+{{- end }}
+
+{{/*
+Whether the PodDisruptionBudget renders. Enabled by default, but it only
+engages when the registry is guaranteed more than one replica
+(replicaCount > 1, or autoscaling.minReplicas > 1 with the HPA enabled):
+a minAvailable PDB on a single-replica deployment blocks node drains.
+*/}}
+{{- define "mcp-mesh-registry.pdbEnabled" -}}
+{{- if .Values.podDisruptionBudget.enabled -}}
+{{- if .Values.autoscaling.enabled -}}
+{{- if gt (int .Values.autoscaling.minReplicas) 1 -}}true{{- end -}}
+{{- else if gt (int .Values.replicaCount) 1 -}}true{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Get persistence volume claim name
 */}}
 {{- define "mcp-mesh-registry.pvcName" -}}

--- a/helm/mcp-mesh-registry/templates/deployment.yaml
+++ b/helm/mcp-mesh-registry/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "mcp-mesh-registry.validateMultiReplica" . -}}
 {{- $db := include "mcp-mesh-registry.databaseSettings" . | fromJson -}}
 {{- $redis := include "mcp-mesh-registry.redisSettings" . | fromJson -}}
 apiVersion: apps/v1
@@ -46,9 +47,8 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+      {{- with include "mcp-mesh-registry.imagePullSecrets" . }}
+      {{- . | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "mcp-mesh-registry.serviceAccountName" . }}
       securityContext:
@@ -57,7 +57,7 @@ spec:
       initContainers:
         # Wait for database (if using external DB)
         - name: wait-for-db
-          image: busybox:1.35
+          image: "{{ include "mcp-mesh-registry.imageRef" (dict "image" .Values.waitForDbImage "root" $) }}"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -87,7 +87,7 @@ spec:
         - name: registry
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "mcp-mesh-registry.imageRef" (dict "image" .Values.image "root" $) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -346,6 +346,27 @@ spec:
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      {{- else if and .Values.defaultTopologySpread.enabled (include "mcp-mesh-registry.multiReplica" .) }}
+      {{- /* Soft zone + node spread for multi-replica HA: ScheduleAnyway is
+             a no-op on single-node / single-zone clusters but keeps replicas
+             apart wherever real topology exists. */}}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "mcp-mesh-registry.selectorLabels" . | nindent 14 }}
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "mcp-mesh-registry.selectorLabels" . | nindent 14 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/helm/mcp-mesh-registry/templates/poddisruptionbudget.yaml
+++ b/helm/mcp-mesh-registry/templates/poddisruptionbudget.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.podDisruptionBudget.enabled }}
+{{- /* Renders only when more than one replica is guaranteed (see the
+       pdbEnabled helper) — a minAvailable PDB on a single-replica
+       deployment blocks node drains. */ -}}
+{{- if include "mcp-mesh-registry.pdbEnabled" . }}
 {{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: policy/v1
 {{- else -}}

--- a/helm/mcp-mesh-registry/values.yaml
+++ b/helm/mcp-mesh-registry/values.yaml
@@ -7,11 +7,29 @@ replicaCount: 1
 workloadType: "Deployment" # Registry is stateless
 
 image:
+  # Registry prefix for the image. Resolution: this value >
+  # global.imageRegistry > "" (Docker Hub). The repository path is preserved:
+  # registry: my.registry.internal pulls my.registry.internal/mcpmesh/registry
+  # — mirror images to the same paths.
+  registry: ""
   repository: mcpmesh/registry
   pullPolicy: IfNotPresent
   # Minor version tag tracks latest patch (0.8 → 0.8.x)
   tag: "2.4"
 
+# Image for the wait-for-db init container (rendered for non-sqlite databases;
+# disable the init container via registry.database.waitForDatabase: false).
+# The registry prefix resolves like image.registry above — with
+# global.imageRegistry set, this pulls <registry>/busybox:1.35.
+waitForDbImage:
+  registry: ""
+  repository: busybox
+  tag: "1.35"
+
+# Pull secrets for this chart's pods, merged with global.imagePullSecrets
+# (deduplicated by name). Standard shape:
+#   imagePullSecrets:
+#     - name: my-registry-credentials
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -103,6 +121,26 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Explicit topology spread constraints. When set, they replace the built-in
+# soft defaults below entirely.
+topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       app.kubernetes.io/name: mcp-mesh-registry
+
+# Built-in soft spread for HA: when no explicit topologySpreadConstraints are
+# set and more than one replica is possible (replicaCount > 1, or autoscaling
+# enabled with maxReplicas > 1), the registry pods get soft (ScheduleAnyway,
+# maxSkew 1) spread across zones and nodes. ScheduleAnyway is a no-op on
+# single-node / single-zone clusters, so this is safe to leave on. Hard
+# requirements (DoNotSchedule, pod anti-affinity) stay opt-in via
+# topologySpreadConstraints / affinity above.
+defaultTopologySpread:
+  enabled: true
 
 # Registry-specific configuration
 registry:
@@ -358,9 +396,12 @@ readinessProbe:
   timeoutSeconds: 3
   failureThreshold: 3
 
-# Pod disruption budget
+# Pod disruption budget. Enabled by default, but it only engages when the
+# registry is guaranteed more than one replica (replicaCount > 1, or
+# autoscaling.minReplicas > 1 with the HPA enabled) — a minAvailable PDB on
+# a single-replica deployment would block node drains.
 podDisruptionBudget:
-  enabled: false
+  enabled: true
   minAvailable: 1
   # maxUnavailable: 1
 

--- a/helm/mcp-mesh-tempo/templates/_helpers.tpl
+++ b/helm/mcp-mesh-tempo/templates/_helpers.tpl
@@ -49,3 +49,44 @@ Selector labels
 app.kubernetes.io/name: {{ include "mcp-mesh-tempo.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Render the image reference as [registry/]repository:tag. The registry prefix
+resolves as tempo.image.registry > global.imageRegistry > "" (implicit Docker Hub).
+The repository path is preserved — mirror images to the same paths in a
+private registry.
+*/}}
+{{- define "mcp-mesh-tempo.image" -}}
+{{- $img := .Values.tempo.image -}}
+{{- $registry := $img.registry | default (dig "imageRegistry" "" (.Values.global | default dict)) | trimSuffix "/" -}}
+{{- $tag := $img.tag -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $img.repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $img.repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+imagePullSecrets for the pod spec: global.imagePullSecrets merged with the
+chart's own imagePullSecrets, deduplicated by name. Entries may be maps
+({name: ...}, the Kubernetes shape) or bare strings. Renders nothing when
+both lists are empty.
+*/}}
+{{- define "mcp-mesh-tempo.imagePullSecrets" -}}
+{{- $names := list -}}
+{{- $global := dig "imagePullSecrets" (list) (.Values.global | default dict) -}}
+{{- range concat ($global | default list) ((.Values.tempo.imagePullSecrets) | default list) -}}
+{{- $name := . -}}
+{{- if kindIs "map" . -}}{{- $name = get . "name" -}}{{- end -}}
+{{- if and $name (not (has $name $names)) -}}
+{{- $names = append $names $name -}}
+{{- end -}}
+{{- end -}}
+{{- if $names -}}
+imagePullSecrets:
+{{- range $names }}
+  - name: {{ . }}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/helm/mcp-mesh-tempo/templates/_helpers.tpl
+++ b/helm/mcp-mesh-tempo/templates/_helpers.tpl
@@ -55,11 +55,17 @@ Render the image reference as [registry/]repository:tag. The registry prefix
 resolves as tempo.image.registry > global.imageRegistry > "" (implicit Docker Hub).
 The repository path is preserved — mirror images to the same paths in a
 private registry.
+The tag is upstream-versioned (no .Chart.AppVersion fallback — that tracks a
+different versioning line), so an empty tag can only come from an explicit
+override; fail loudly at template time instead of rendering an invalid ref.
 */}}
 {{- define "mcp-mesh-tempo.image" -}}
 {{- $img := .Values.tempo.image -}}
 {{- $registry := $img.registry | default (dig "imageRegistry" "" (.Values.global | default dict)) | trimSuffix "/" -}}
 {{- $tag := $img.tag -}}
+{{- if not $tag -}}
+{{- fail "tempo.image.tag must not be empty; set the upstream image tag explicitly" -}}
+{{- end -}}
 {{- if $registry -}}
 {{- printf "%s/%s:%s" $registry $img.repository $tag -}}
 {{- else -}}

--- a/helm/mcp-mesh-tempo/templates/deployment.yaml
+++ b/helm/mcp-mesh-tempo/templates/deployment.yaml
@@ -25,11 +25,14 @@ spec:
       labels:
         {{- include "mcp-mesh-tempo.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with include "mcp-mesh-tempo.imagePullSecrets" . }}
+      {{- . | nindent 6 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.tempo.podSecurityContext | nindent 8 }}
       containers:
       - name: tempo
-        image: "{{ .Values.tempo.image.repository }}:{{ .Values.tempo.image.tag }}"
+        image: "{{ include "mcp-mesh-tempo.image" . }}"
         imagePullPolicy: {{ .Values.tempo.image.pullPolicy }}
         securityContext:
           {{- toYaml .Values.tempo.securityContext | nindent 10 }}

--- a/helm/mcp-mesh-tempo/values.yaml
+++ b/helm/mcp-mesh-tempo/values.yaml
@@ -1,9 +1,20 @@
 tempo:
   enabled: true
   image:
+    # Registry prefix for the image. Resolution: this value >
+    # global.imageRegistry > "" (Docker Hub). The repository path is
+    # preserved (registry: my.registry.internal pulls
+    # my.registry.internal/grafana/tempo).
+    registry: ""
     repository: grafana/tempo
     tag: "2.9.0"
     pullPolicy: IfNotPresent
+
+  # Pull secrets for this chart's pods, merged with global.imagePullSecrets
+  # (deduplicated by name). Standard shape:
+  #   imagePullSecrets:
+  #     - name: my-registry-credentials
+  imagePullSecrets: []
 
   resources:
     requests:

--- a/helm/mcp-mesh-ui/templates/_helpers.tpl
+++ b/helm/mcp-mesh-ui/templates/_helpers.tpl
@@ -213,3 +213,44 @@ existing secrets.
 true
 {{- end -}}
 {{- end }}
+
+{{/*
+Render the image reference as [registry/]repository:tag. The registry prefix
+resolves as image.registry > global.imageRegistry > "" (implicit Docker Hub).
+The repository path is preserved — mirror images to the same paths in a
+private registry.
+*/}}
+{{- define "mcp-mesh-ui.image" -}}
+{{- $img := .Values.image -}}
+{{- $registry := $img.registry | default (dig "imageRegistry" "" (.Values.global | default dict)) | trimSuffix "/" -}}
+{{- $tag := $img.tag | default .Chart.AppVersion -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $img.repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $img.repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+imagePullSecrets for the pod spec: global.imagePullSecrets merged with the
+chart's own imagePullSecrets, deduplicated by name. Entries may be maps
+({name: ...}, the Kubernetes shape) or bare strings. Renders nothing when
+both lists are empty.
+*/}}
+{{- define "mcp-mesh-ui.imagePullSecrets" -}}
+{{- $names := list -}}
+{{- $global := dig "imagePullSecrets" (list) (.Values.global | default dict) -}}
+{{- range concat ($global | default list) ((.Values.imagePullSecrets) | default list) -}}
+{{- $name := . -}}
+{{- if kindIs "map" . -}}{{- $name = get . "name" -}}{{- end -}}
+{{- if and $name (not (has $name $names)) -}}
+{{- $names = append $names $name -}}
+{{- end -}}
+{{- end -}}
+{{- if $names -}}
+imagePullSecrets:
+{{- range $names }}
+  - name: {{ . }}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/helm/mcp-mesh-ui/templates/deployment.yaml
+++ b/helm/mcp-mesh-ui/templates/deployment.yaml
@@ -35,15 +35,14 @@ spec:
       labels:
         {{- include "mcp-mesh-ui.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+      {{- with include "mcp-mesh-ui.imagePullSecrets" . }}
+      {{- . | nindent 6 }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "mcp-mesh-ui.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/helm/mcp-mesh-ui/values.yaml
+++ b/helm/mcp-mesh-ui/values.yaml
@@ -1,10 +1,18 @@
 replicaCount: 1
 
 image:
+  # Registry prefix for the image. Resolution: this value >
+  # global.imageRegistry > "" (Docker Hub). The repository path is preserved
+  # (registry: my.registry.internal pulls my.registry.internal/mcpmesh/ui).
+  registry: ""
   repository: mcpmesh/ui
   pullPolicy: IfNotPresent
   tag: "2.4"
 
+# Pull secrets for this chart's pods, merged with global.imagePullSecrets
+# (deduplicated by name). Standard shape:
+#   imagePullSecrets:
+#     - name: my-registry-credentials
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Summary
Closes #1155 — the final PR of the helm chart-maturity batch (#1150–#1155).

- **Air-gapped/enterprise image config in one place**: per-chart image helpers render `[registry/]repository:tag` with component override > `global.imageRegistry` > Docker Hub precedence across all 8 image references — including the previously *hardcoded* busybox wait-for-db init image, now values-driven. Mirrored repository paths are preserved (`postgres:15` → `my.registry.internal/postgres:15`); the README documents the mirroring contract. Trailing-slash registry values are normalized (`trimSuffix`) instead of rendering invalid `//` refs that would only fail at pull time.
- **`global.imagePullSecrets`** merges with per-chart lists into every pod spec (order-stable, deduped, accepts both `{name:}` and bare-string entries).
- **Registry HA knobs**: soft zone/hostname topology spread defaults ON but renders only when more than one replica is possible (`ScheduleAnyway` + the gate make it a provable no-op at defaults); the PDB default flips to enabled but is render-gated on *guaranteed* multi-replica (`replicaCount > 1`, or HPA `minReplicas > 1` — gating on min, not max, avoids the blocked-drain footgun when HPA can scale down to 1); explicit constraint lists fully replace the defaults; HPA was already present (off by default).
- **sqlite guard**: HPA or `replicaCount > 1` with `registry.database.type=sqlite` fails at template time with an actionable message (single-writer local file).
- The umbrella's `podDisruptionBudgets` flag was dead config (zero template references on main, verified) — removed with a pointer comment.

## Behavior notes — release-note visibility
- Existing `replicaCount > 1` registry deployments gain a PDB on upgrade (intended).
- Already-broken sqlite+multi-replica topologies now fail at template time instead of corrupting silently.

## Review Notes
- Independent review rendered the full matrix: image-helper edge cases (per-component override, trailing slash, empty-tag/appVersion fallbacks, digest non-support documented as pre-existing), pull-secret dedupe + byte-identity of the empty case, the complete PDB/spread gating truth table, spread/PDB label selectors verified against actual pod labels, sqlite-guard fire/no-fire incl. through the umbrella, and removed-flag upgrade safety.
- 0 blockers; the one warning (trailing slash) and both cosmetic infos fixed.
- Follow-up candidates noted: agent chart's PDB is ungated (default off, no footgun at defaults); umbrella `networkPolicies`/`serviceMonitors` flags look unconsumed like the removed PDB flag — adding both to the #1186 dead-config cleanup.

Closes #1155

## Test plan
- [x] `helm lint` all 9 + `scripts/check_helm_pss.py` (CI-enforced) clean
- [x] Defaults byte-identical across all 9 charts
- [x] Image sweep: every rendered `image:` line carries the global prefix (umbrella + agent standalone); component override wins; trailing slash normalized
- [x] HA matrix: PDB/spread/HPA gating truth table, selectors match pod labels, sqlite guards
- [ ] Air-gapped install against a real mirror registry (manual, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for private and air-gapped registry deployments with configurable image registry prefix and pull secrets
  * Added image pull secrets merging and deduplication across global and per-chart configurations
  * Enhanced registry chart with high availability features: multi-replica validation, topology spread constraints, and pod disruption budget support

* **Documentation**
  * Updated documentation with comprehensive guidance for air-gapped registry installations and multi-replica registry deployments with external database requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->