### PR TITLE
chore: remove dead config across core and helm; guard removed keys with shipped-default tolerance

### DIFF
--- a/cmd/mcp-mesh-registry/main.go
+++ b/cmd/mcp-mesh-registry/main.go
@@ -50,7 +50,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  MCP_MESH_DEBUG_MODE      - Enable debug mode (true/false, 1/0, yes/no) - forces DEBUG level\n")
 		fmt.Fprintf(os.Stderr, "  HEALTH_CHECK_INTERVAL    - Health check interval in seconds (default: 10)\n")
 		fmt.Fprintf(os.Stderr, "  DEFAULT_TIMEOUT_THRESHOLD - Agent heartbeat timeout in seconds (default: 20)\n")
-		fmt.Fprintf(os.Stderr, "  CACHE_TTL                - Response cache TTL in seconds (default: 30)\n")
 		fmt.Fprintf(os.Stderr, "  MCP_MESH_DISTRIBUTED_TRACING_ENABLED - Enable distributed tracing (true/false, default: false)\n")
 		fmt.Fprintf(os.Stderr, "  REDIS_URL                - Redis URL for distributed tracing (default: redis://localhost:6379)\n")
 		fmt.Fprintf(os.Stderr, "\nThe registry service provides:\n")
@@ -114,11 +113,9 @@ func main() {
 
 	// Create registry service
 	registryConfig := &registry.RegistryConfig{
-		CacheTTL:                 cfg.CacheTTL,
 		DefaultTimeoutThreshold:  cfg.DefaultTimeoutThreshold,
 		DefaultEvictionThreshold: cfg.DefaultEvictionThreshold,
 		HealthCheckInterval:      cfg.HealthCheckInterval,
-		EnableResponseCache:      cfg.EnableResponseCache,
 		TracingEnabled:           strings.ToLower(os.Getenv("MCP_MESH_DISTRIBUTED_TRACING_ENABLED")) == "true",
 		TlsMode:                 getEnvDefault("MCP_MESH_TLS_MODE", "off"),
 		TrustBackend:             os.Getenv("MCP_MESH_TRUST_BACKEND"),

--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -68,8 +68,6 @@ flowchart TB
 | `REDIS_URL`                            | `redis://localhost:6379`       | Redis for trace events                   |
 | `TELEMETRY_ENDPOINT`                   | -                              | Tempo OTLP endpoint                      |
 | `TRACE_EXPORTER_TYPE`                  | `otlp`                         | Export format: `otlp`, `console`, `json` |
-| `STREAM_NAME`                          | `mesh:trace`                   | Redis stream name                        |
-| `CONSUMER_GROUP`                       | `mcp-mesh-registry-processors` | Consumer group                           |
 
 **Agents (trace publishers):**
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -232,16 +232,6 @@ export MCP_MESH_RETENTION=1h
 - Hardcoded internal constants: sweep interval = 5m, event hard cap =
   100,000 rows.
 
-### Cache and Performance
-
-```bash
-# Response cache TTL (seconds)
-export CACHE_TTL=30
-
-# Enable response caching
-export ENABLE_RESPONSE_CACHE=true
-```
-
 ### Logging and Debug
 
 ```bash
@@ -404,16 +394,6 @@ export MCP_MESH_TELEMETRY_ENABLED=true
 ```bash
 # Comma-separated header prefixes to propagate across agent calls
 export MCP_MESH_PROPAGATE_HEADERS=x-request-id,x-trace,x-correlation
-```
-
-### Stream Consumer
-
-```bash
-# Redis stream name for trace events
-export STREAM_NAME=mesh:trace
-
-# Consumer group name
-export CONSUMER_GROUP=mcp-mesh-registry-processors
 ```
 
 ## UI Server
@@ -720,7 +700,6 @@ HOST=localhost
 PORT=8000
 DEFAULT_TIMEOUT_THRESHOLD=10  # Fast detection for development
 HEALTH_CHECK_INTERVAL=5       # Quick scans for development
-ENABLE_RESPONSE_CACHE=false   # Disable cache for testing
 ```
 
 #### Production Registry
@@ -733,8 +712,6 @@ HOST=0.0.0.0
 PORT=8000
 DEFAULT_TIMEOUT_THRESHOLD=20  # Balanced for production
 HEALTH_CHECK_INTERVAL=10      # Regular monitoring
-ENABLE_RESPONSE_CACHE=true
-CACHE_TTL=30
 DATABASE_URL=postgresql://user:pass@db:5432/mcp_mesh
 ```
 
@@ -745,8 +722,6 @@ DATABASE_URL=postgresql://user:pass@db:5432/mcp_mesh
 MCP_MESH_LOG_LEVEL=WARNING
 DEFAULT_TIMEOUT_THRESHOLD=5   # Ultra-fast detection
 HEALTH_CHECK_INTERVAL=2       # Very frequent monitoring
-CACHE_TTL=60                  # Longer cache for performance
-ENABLE_RESPONSE_CACHE=true
 ```
 
 ### Agent Development Environment

--- a/examples/k8s/tls/helm-values-tls.yaml
+++ b/examples/k8s/tls/helm-values-tls.yaml
@@ -21,9 +21,6 @@
 # Registry values (consumed by mcp-mesh-core chart)
 # =============================================================================
 registry:
-  # Agent chart: switch registry URL from http to https
-  url: "https://mcp-core-mcp-mesh-registry:8000"
-
   # Core chart: registry server TLS configuration
   security:
     tls:

--- a/examples/tutorial/trip-planner/day-09/helm/values-core.yaml
+++ b/examples/tutorial/trip-planner/day-09/helm/values-core.yaml
@@ -8,7 +8,6 @@
 
 global:
   namespace: trip-planner
-  coreReleaseName: "mcp-core"
 
 # All components enabled
 postgres:

--- a/examples/tutorial/trip-planner/day-10/helm/values-core.yaml
+++ b/examples/tutorial/trip-planner/day-10/helm/values-core.yaml
@@ -8,7 +8,6 @@
 
 global:
   namespace: trip-planner
-  coreReleaseName: "mcp-core"
 
 # All components enabled
 postgres:

--- a/examples/tutorial/trip-planner/final_product/k8s/helm/values-core.yaml
+++ b/examples/tutorial/trip-planner/final_product/k8s/helm/values-core.yaml
@@ -7,7 +7,6 @@
 
 global:
   namespace: trip-planner
-  coreReleaseName: "mcp-core"
 
 # All components enabled
 postgres:
@@ -62,18 +61,14 @@ mcp-mesh-registry:
 
   registry:
     # SPIRE-based TLS for registry
-    environment:
-      MCP_MESH_TLS_MODE: "auto"
-      MCP_MESH_TLS_PROVIDER: "spire"
-      MCP_MESH_SPIRE_SOCKET: "/run/spire/agent/sockets/agent.sock"
-      MCP_MESH_TRUST_BACKEND: "spire"
-      ENABLE_RESPONSE_CACHE: "true"
-      ENABLE_CORS: "true"
-      ENABLE_METRICS: "true"
-      ENABLE_PROMETHEUS: "true"
-      ENABLE_EVENTS: "true"
-      ACCESS_LOG: "true"
-      CACHE_TTL: "30"
+    security:
+      tls:
+        mode: "auto"
+      trust:
+        backend: "spire"
+        spire:
+          enabled: true
+          socketPath: "/run/spire/agent/sockets/agent.sock"
 
   # Mount SPIRE agent socket into registry pod
   extraVolumes:

--- a/helm/mcp-mesh-agent/docs/agent-code-methods.md
+++ b/helm/mcp-mesh-agent/docs/agent-code-methods.md
@@ -24,7 +24,8 @@ agent:
 ```bash
 helm install my-agent ./helm/mcp-mesh-agent \
   --set agent.script=/app/agents/hello_world.py \
-  --set registry.url=http://mcp-mesh-registry:8080
+  --set registry.host=mcp-mesh-registry \
+  --set registry.port="8080"
 ```
 
 ### Pros
@@ -68,7 +69,8 @@ kubectl create configmap my-agent-code --from-file=agent.py=./my-agent.py
 helm install my-agent ./helm/mcp-mesh-agent \
   --set agentCode.enabled=true \
   --set agentCode.configMapName=my-agent-code \
-  --set registry.url=http://mcp-mesh-registry:8080
+  --set registry.host=mcp-mesh-registry \
+  --set registry.port="8080"
 ```
 
 ### Pros
@@ -109,7 +111,8 @@ agentCode:
 helm install my-agent ./helm/mcp-mesh-agent \
   --set agentCode.enabled=true \
   --set agentCode.scriptPath=scripts/my-agent.py \
-  --set registry.url=http://mcp-mesh-registry:8080
+  --set registry.host=mcp-mesh-registry \
+  --set registry.port="8080"
 ```
 
 ### Pros

--- a/helm/mcp-mesh-agent/examples/auto-configmap-values.yaml
+++ b/helm/mcp-mesh-agent/examples/auto-configmap-values.yaml
@@ -21,11 +21,11 @@ agentCode:
   # configMapName: ""  # Auto-generated: {release-name}-code
   mountPath: "/app"
 
-# Registry connection
+# Registry connection (host empty defaults to
+# "<global.coreReleaseName>-mcp-mesh-registry")
 registry:
-  host: "mcp-core-mcp-mesh-registry"
+  host: ""
   port: "8000"
-  url: "http://mcp-core-mcp-mesh-registry:8000"
 
 # Container image
 image:

--- a/helm/mcp-mesh-agent/templates/_helpers.tpl
+++ b/helm/mcp-mesh-agent/templates/_helpers.tpl
@@ -116,6 +116,47 @@ Detect if using Python runtime (checks agent.runtime first, then image name)
 {{- end }}
 
 {{/*
+Core release-name prefix for the default core service hostnames
+(<prefix>-mcp-mesh-{registry,redis,tempo}). global.coreReleaseName matches
+the release name the mcp-mesh-core umbrella was installed under — agents
+are separate releases, so .Release.Name cannot derive it. Explicit
+hostnames (registry.host, global.redis.host, telemetryEndpoint) always win.
+*/}}
+{{- define "mcp-mesh-agent.corePrefix" -}}
+{{- coalesce (dig "coreReleaseName" "" (.Values.global | default dict)) "mcp-core" -}}
+{{- end }}
+
+{{/*
+Removed-key guard. agent.environment was dead config — no template ever
+consumed it — so a values file carrying it would silently no-op while the
+user expects the variables to be injected. Fail loudly with migration
+guidance instead. Invoked unconditionally from the configmap.
+
+Carve-out: the v2.4.0 chart SHIPPED a 5-entry agent.environment map as a
+default (see `git show v2.4.0:helm/mcp-mesh-agent/values.yaml`). A values
+file copied from it carries those entries without any user intent, so
+entries exactly matching the old shipped defaults are tolerated; only a
+divergent value or an extra entry — user intent that would silently
+no-op — fails.
+*/}}
+{{- define "mcp-mesh-agent.validateNoRemovedKeys" -}}
+{{/* Old shipped defaults, verbatim from the v2.4.0 chart values.yaml. */}}
+{{- $oldEnvironmentDefaults := dict
+      "MCP_MESH_DISTRIBUTED_TRACING_ENABLED" "true"
+      "REDIS_URL" "redis://mcp-core-mcp-mesh-redis:6379"
+      "TELEMETRY_ENDPOINT" "mcp-core-mcp-mesh-tempo:4317"
+      "MCP_MESH_TRACING_ENABLED" "true"
+      "MCP_MESH_METRICS_ENABLED" "true" -}}
+{{- range $key, $val := (dig "environment" (dict) (.Values.agent | default dict)) | default dict -}}
+{{- if not (hasKey $oldEnvironmentDefaults $key) -}}
+{{- fail (printf "agent.environment was never consumed and has been removed (entry %s is not in the old shipped defaults, so it would silently no-op); add environment variables via the top-level env list (name/value entries) instead. REDIS_URL is derived from global.redis / agent.observability.distributedTracing.redisUrl" $key) -}}
+{{- else if ne (toString $val) (get $oldEnvironmentDefaults $key) -}}
+{{- fail (printf "agent.environment was never consumed and has been removed (%s=%q diverges from the old shipped default %q, so it would silently no-op); add environment variables via the top-level env list (name/value entries) instead. REDIS_URL is derived from global.redis / agent.observability.distributedTracing.redisUrl" $key (toString $val) (get $oldEnvironmentDefaults $key)) -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Shared Redis settings (global.redis) as JSON — the same shape the
 mcp-mesh-core umbrella shares with its datastore consumers. This chart is
 standalone (not an umbrella subchart), so set the same global.redis values
@@ -175,7 +216,7 @@ carry the credential. Not used in the existing-secret modes.
 {{- if $g.password -}}
 {{- $auth = printf ":%s@" ($g.password | urlquery | replace "+" "%20") -}}
 {{- end -}}
-{{- printf "%s://%s%s:%d" (include "mcp-mesh-agent.redisScheme" .) $auth (coalesce $g.host "mcp-core-mcp-mesh-redis") (coalesce $g.port 6379 | int) -}}
+{{- printf "%s://%s%s:%d" (include "mcp-mesh-agent.redisScheme" .) $auth (coalesce $g.host (printf "%s-mcp-mesh-redis" (include "mcp-mesh-agent.corePrefix" .))) (coalesce $g.port 6379 | int) -}}
 {{- end -}}
 {{- end }}
 
@@ -185,7 +226,7 @@ via $(REDIS_PASSWORD) expansion, so the password must be URL-safe.
 */}}
 {{- define "mcp-mesh-agent.composedRedisURL" -}}
 {{- $g := include "mcp-mesh-agent.globalRedis" . | fromJson -}}
-{{- printf "%s://:$(REDIS_PASSWORD)@%s:%d" (include "mcp-mesh-agent.redisScheme" .) ($g.host | default "mcp-core-mcp-mesh-redis") (coalesce $g.port 6379 | int) -}}
+{{- printf "%s://:$(REDIS_PASSWORD)@%s:%d" (include "mcp-mesh-agent.redisScheme" .) ($g.host | default (printf "%s-mcp-mesh-redis" (include "mcp-mesh-agent.corePrefix" .))) (coalesce $g.port 6379 | int) -}}
 {{- end }}
 
 {{/*

--- a/helm/mcp-mesh-agent/templates/configmap.yaml
+++ b/helm/mcp-mesh-agent/templates/configmap.yaml
@@ -1,3 +1,5 @@
+{{- include "mcp-mesh-agent.validateNoRemovedKeys" . -}}
+{{- $corePrefix := include "mcp-mesh-agent.corePrefix" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,14 +15,15 @@ metadata:
   {{- end }}
 data:
   # Registry connection (configurable for federated networks) - matches working examples
-  REGISTRY_HOST: {{ .Values.registry.host | default "mcp-mesh-registry" | quote }}
+  {{- $registryHost := .Values.registry.host | default (printf "%s-mcp-mesh-registry" $corePrefix) }}
+  REGISTRY_HOST: {{ $registryHost | quote }}
   REGISTRY_PORT: {{ .Values.registry.port | default "8000" | quote }}
 
   # Complete registry URL (primary variable used by runtime)
   {{- if and .Values.mesh.tls.mode (ne .Values.mesh.tls.mode "off") }}
-  MCP_MESH_REGISTRY_URL: {{ printf "https://%s:%s" (.Values.registry.host | default "mcp-mesh-registry") (.Values.registry.port | default "8000" | toString) | quote }}
+  MCP_MESH_REGISTRY_URL: {{ printf "https://%s:%s" $registryHost (.Values.registry.port | default "8000" | toString) | quote }}
   {{- else }}
-  MCP_MESH_REGISTRY_URL: {{ printf "http://%s:%s" (.Values.registry.host | default "mcp-mesh-registry") (.Values.registry.port | default "8000" | toString) | quote }}
+  MCP_MESH_REGISTRY_URL: {{ printf "http://%s:%s" $registryHost (.Values.registry.port | default "8000" | toString) | quote }}
   {{- end }}
 
   # Service DNS for agent endpoint advertisement
@@ -59,7 +62,7 @@ data:
 
   # Observability configuration - matches Docker setup
   MCP_MESH_DISTRIBUTED_TRACING_ENABLED: {{ .Values.agent.observability.distributedTracing.enabled | default true | quote }}
-  TELEMETRY_ENDPOINT: {{ .Values.agent.observability.telemetryEndpoint | default "mcp-core-mcp-mesh-tempo:4317" | quote }}
+  TELEMETRY_ENDPOINT: {{ .Values.agent.observability.telemetryEndpoint | default (printf "%s-mcp-mesh-tempo:4317" $corePrefix) | quote }}
   MCP_MESH_TRACING_ENABLED: {{ .Values.agent.observability.tracing.enabled | default true | quote }}
   MCP_MESH_METRICS_ENABLED: {{ .Values.agent.observability.metrics.enabled | default true | quote }}
 

--- a/helm/mcp-mesh-agent/values.yaml
+++ b/helm/mcp-mesh-agent/values.yaml
@@ -4,9 +4,12 @@
 
 # Global configuration
 global:
-  # Release name used when installing mcp-mesh-core
+  # Release name used when installing mcp-mesh-core. Prefixes the default
+  # core service hostnames: <coreReleaseName>-mcp-mesh-{registry,redis,tempo}.
   # Override this if you installed mcp-mesh-core with a different release name
   # Example: helm install my-core mcp-mesh-core ... → set coreReleaseName: "my-core"
+  # Explicit hostnames (registry.host, global.redis.host,
+  # agent.observability.telemetryEndpoint) always win over the prefix.
   coreReleaseName: "mcp-core"
   # Shared Redis endpoint for trace publishing — same shape as the
   # mcp-mesh-core umbrella's global.redis, so the umbrella's datastore values
@@ -137,13 +140,12 @@ tolerations: []
 
 affinity: {}
 
-# Registry configuration
-# Hostnames use global.coreReleaseName prefix (default: "mcp-core")
-# Override these if you installed mcp-mesh-core with a different release name
+# Registry connection. host left empty defaults to
+# "<global.coreReleaseName>-mcp-mesh-registry" (default:
+# "mcp-core-mcp-mesh-registry"); an explicit host always wins.
 registry:
-  host: "mcp-core-mcp-mesh-registry"
+  host: ""
   port: "8000"
-  url: "http://mcp-core-mcp-mesh-registry:8000"
 
 # Mesh configuration
 mesh:
@@ -245,16 +247,18 @@ agent:
       origins: ["*"]
 
   # Observability configuration
-  # Hostnames use global.coreReleaseName prefix (default: "mcp-core")
+  # Default hostnames use the global.coreReleaseName prefix (default: "mcp-core")
   observability:
     distributedTracing:
       enabled: true
       # Full Redis URL for trace publishing. Empty inherits global.redis.*
       # (see the global block above); an explicit value here always wins.
       # When neither is set, the chart default applies:
-      #   redis://mcp-core-mcp-mesh-redis:6379
+      #   redis://<global.coreReleaseName>-mcp-mesh-redis:6379
       redisUrl: ""
-    telemetryEndpoint: "mcp-core-mcp-mesh-tempo:4317"
+    # OTLP endpoint for trace export. Empty defaults to
+    # "<global.coreReleaseName>-mcp-mesh-tempo:4317".
+    telemetryEndpoint: ""
     tracing:
       enabled: true
     metrics:

--- a/helm/mcp-mesh-core/README.md
+++ b/helm/mcp-mesh-core/README.md
@@ -310,12 +310,13 @@ The core infrastructure follows this deployment pattern:
 
 ## Monitoring
 
-Enable monitoring with:
+Enable a Prometheus ServiceMonitor on the registry subchart:
 
 ```yaml
 # values.yaml
-serviceMonitors:
-  enabled: true
+mcp-mesh-registry:
+  serviceMonitor:
+    enabled: true
 ```
 
 ## Security

--- a/helm/mcp-mesh-core/templates/_helpers.tpl
+++ b/helm/mcp-mesh-core/templates/_helpers.tpl
@@ -32,3 +32,25 @@ truth: "<fullname>-secret" in helm/mcp-mesh-grafana/templates/secret.yaml
 {{- printf "%s-secret" (printf "%s-mcp-mesh-grafana" .Release.Name | trunc 63 | trimSuffix "-") -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Removed-key guards. These umbrella-level keys were dead config — no template
+ever consumed them — so a values file still carrying one would silently
+no-op while the user expects effect (a no-op network policy in particular).
+Fail loudly with migration guidance instead. Invoked unconditionally from
+namespace.yaml. global.coreReleaseName only fails on a non-default value:
+the default "mcp-core" was shipped in values.yaml and is carried harmlessly
+by copied values files.
+*/}}
+{{- define "mcp-mesh-core.validateNoRemovedKeys" -}}
+{{- if dig "enabled" false (.Values.networkPolicies | default dict) -}}
+{{- fail "networkPolicies.enabled was never consumed and has been removed; enable the per-chart policy instead: mcp-mesh-registry.networkPolicy.enabled (and networkPolicy.enabled on each agent release)" -}}
+{{- end -}}
+{{- if dig "enabled" false (.Values.serviceMonitors | default dict) -}}
+{{- fail "serviceMonitors.enabled was never consumed and has been removed; enable the per-chart monitor instead: mcp-mesh-registry.serviceMonitor.enabled (or podMonitor.enabled)" -}}
+{{- end -}}
+{{- $coreReleaseName := dig "coreReleaseName" "" (.Values.global | default dict) -}}
+{{- if and $coreReleaseName (ne $coreReleaseName "mcp-core") -}}
+{{- fail "global.coreReleaseName was documentation-only here and has been removed; with a non-default release name, set global.postgres.host, global.redis.host, and the *-mcp-mesh-tempo endpoints to \"<release>-mcp-mesh-<component>\" explicitly (agent releases still use global.coreReleaseName on the mcp-mesh-agent chart)" -}}
+{{- end -}}
+{{- end }}

--- a/helm/mcp-mesh-core/templates/namespace.yaml
+++ b/helm/mcp-mesh-core/templates/namespace.yaml
@@ -1,3 +1,4 @@
+{{- include "mcp-mesh-core.validateNoRemovedKeys" . -}}
 {{- if .Values.namespaceCreate }}
 apiVersion: v1
 kind: Namespace

--- a/helm/mcp-mesh-core/values.yaml
+++ b/helm/mcp-mesh-core/values.yaml
@@ -6,10 +6,6 @@ global:
   # Namespace for all components (used by namespaceCreate).
   # Usually matches the -n flag: helm install ... -n my-namespace --set global.namespace=my-namespace
   namespace: mcp-mesh
-  # Release name for mcp-mesh-core (used to construct service hostnames)
-  # Override this if you install mcp-mesh-core with a different release name
-  # Example: helm install my-core ... → set coreReleaseName: "my-core"
-  coreReleaseName: "mcp-core"
 
   # Private/air-gapped registry prefix applied to EVERY image in the stack:
   # the registry, UI, postgres, redis, grafana, tempo, and the registry's
@@ -87,7 +83,10 @@ global:
 
 # Service hostname convention:
 # All internal service hostnames use short names (e.g., "mcp-core-mcp-mesh-redis")
-# which resolve within the same namespace via Kubernetes DNS.
+# which resolve within the same namespace via Kubernetes DNS. The defaults
+# above assume the release name "mcp-core"; with a different release name,
+# override global.postgres.host, global.redis.host, and the
+# *-mcp-mesh-tempo endpoints to "<release>-mcp-mesh-<component>".
 # For cross-namespace access, override with FQDNs:
 #   --set mcp-mesh-registry.registry.redis.host=mcp-core-mcp-mesh-redis.other-ns.svc.cluster.local
 
@@ -172,41 +171,13 @@ mcp-mesh-registry:
     redis:
       enabled: true
 
-    # Observability configuration - matches k8s examples
-    # (stream/consumer settings only; the Redis endpoint comes from
-    # registry.redis above)
+    # Observability configuration (the Redis endpoint for the trace stream
+    # comes from registry.redis above; stream tuning is set via the env
+    # list: TRACE_BATCH_SIZE, TRACE_TIMEOUT, TELEMETRY_PROTOCOL, ...)
     observability:
       distributedTracing:
         enabled: true
-        exporterType: "otlp"
-        telemetryProtocol: "grpc"
-        batchSize: "100"
-        timeout: "5m"
-        prettyOutput: "false"
-        enableStats: "true"
-        streamName: "mesh:trace"
-        consumerGroup: "mcp-mesh-registry-processors"
       telemetryEndpoint: "mcp-core-mcp-mesh-tempo:4317"
-
-    # Additional environment variables for tracing (matches k8s examples)
-    environment:
-      MCP_MESH_DISTRIBUTED_TRACING_ENABLED: "true"
-      TRACE_EXPORTER_TYPE: "otlp"
-      TELEMETRY_PROTOCOL: "grpc"
-      TRACE_BATCH_SIZE: "100"
-      TRACE_TIMEOUT: "5m"
-      TRACE_PRETTY_OUTPUT: "false"
-      TRACE_ENABLE_STATS: "true"
-      STREAM_NAME: "mesh:trace"
-      CONSUMER_GROUP: "mcp-mesh-registry-processors"
-      MCP_MESH_TRACE_DEBUG: "true"
-      ENABLE_RESPONSE_CACHE: "true"
-      ENABLE_CORS: "true"
-      ENABLE_METRICS: "true"
-      ENABLE_PROMETHEUS: "true"
-      ENABLE_EVENTS: "true"
-      ACCESS_LOG: "true"
-      CACHE_TTL: "30"
 
     # Health check configuration
     healthCheck:
@@ -325,16 +296,14 @@ commonLabels:
 # Common annotations for all resources
 commonAnnotations: {}
 
-# Network policies (disabled by default)
-networkPolicies:
-  enabled: false
-
-# Pod disruption budgets are configured per subchart (this umbrella-level
-# flag was never consumed and has been removed). The registry PDB defaults
-# on and engages automatically at mcp-mesh-registry.replicaCount > 1 — see
-# mcp-mesh-registry.podDisruptionBudget. HA scheduling lives there too
-# (topologySpreadConstraints / defaultTopologySpread / autoscaling).
-
-# Service monitors for Prometheus (disabled by default)
-serviceMonitors:
-  enabled: false
+# Network policies, service monitors, and pod disruption budgets are
+# configured per subchart (the umbrella-level networkPolicies /
+# serviceMonitors / podDisruptionBudgets flags were never consumed and have
+# been removed):
+# - mcp-mesh-registry.networkPolicy.enabled (and networkPolicy.enabled on
+#   each agent release)
+# - mcp-mesh-registry.serviceMonitor.enabled / podMonitor.enabled
+# - mcp-mesh-registry.podDisruptionBudget — defaults on and engages
+#   automatically at mcp-mesh-registry.replicaCount > 1. HA scheduling
+#   lives there too (topologySpreadConstraints / defaultTopologySpread /
+#   autoscaling).

--- a/helm/mcp-mesh-registry/templates/_helpers.tpl
+++ b/helm/mcp-mesh-registry/templates/_helpers.tpl
@@ -235,14 +235,75 @@ $(REDIS_PASSWORD)) or a full URL (consumed directly via existingSecretUrlKey).
 {{- end }}
 
 {{/*
-Removed-key guard. distributedTracing.redisUrl was dead config — no template
-ever consumed it — so honoring it now would silently switch endpoints on
-upgrade for values files still carrying it. Fail loudly with migration
-guidance instead. Invoked unconditionally from the configmap.
+Removed-key guards. These keys were dead config — no template ever consumed
+them — so a values file carrying one would silently no-op while the user
+expects effect. Fail loudly with migration guidance instead. Invoked
+unconditionally from the configmap.
+
+Carve-out: the v2.4.0 mcp-mesh-core umbrella SHIPPED these keys as defaults
+(nine distributedTracing.* keys including redisUrl, and a 17-entry
+registry.environment map — see `git show v2.4.0:helm/mcp-mesh-core/values.yaml`).
+A values file copied from it carries them without any user intent, so a key
+whose value exactly matches the old shipped default is tolerated; only a
+DIVERGING value — user intent that would silently no-op — fails.
+- distributedTracing.redisUrl: removed in favor of the shared registry.redis
+  endpoint (honoring a divergent value now would silently switch endpoints
+  on upgrade; the old default matches the derived default endpoint).
+- distributedTracing.* stream keys (streamName, consumerGroup, batchSize,
+  ...): never rendered into env; the binary reads TRACE_* env vars, settable
+  via the env list.
+- registry.environment: never rendered; use the top-level env list.
 */}}
-{{- define "mcp-mesh-registry.validateNoDeprecatedRedisUrl" -}}
-{{- if dig "observability" "distributedTracing" "redisUrl" "" .Values.registry -}}
-{{- fail "registry.observability.distributedTracing.redisUrl was never consumed and has been removed; configure registry.redis.{host,port,password,tls} instead — the trace stream shares that endpoint" -}}
+{{- define "mcp-mesh-registry.validateNoRemovedKeys" -}}
+{{/* Old shipped defaults, verbatim from the v2.4.0 umbrella values.yaml. */}}
+{{- $oldTracingDefaults := dict
+      "redisUrl" "redis://mcp-core-mcp-mesh-redis:6379"
+      "exporterType" "otlp"
+      "telemetryProtocol" "grpc"
+      "batchSize" "100"
+      "timeout" "5m"
+      "prettyOutput" "false"
+      "enableStats" "true"
+      "streamName" "mesh:trace"
+      "consumerGroup" "mcp-mesh-registry-processors" -}}
+{{- range $key, $val := (dig "observability" "distributedTracing" (dict) .Values.registry) | default dict -}}
+{{- if eq $key "enabled" -}}
+{{- else if not (hasKey $oldTracingDefaults $key) -}}
+{{- fail (printf "registry.observability.distributedTracing.%s was never consumed and has been removed; only 'enabled' lives under distributedTracing (telemetryEndpoint and exporterType sit directly under registry.observability). Stream tuning is set via the top-level env list: TRACE_BATCH_SIZE, TRACE_TIMEOUT, TRACE_PRETTY_OUTPUT, TRACE_ENABLE_STATS, TELEMETRY_PROTOCOL" $key) -}}
+{{- else if ne (toString $val) (get $oldTracingDefaults $key) -}}
+{{- if eq $key "redisUrl" -}}
+{{- fail (printf "registry.observability.distributedTracing.redisUrl was never consumed and has been removed (set to %q, diverging from the old shipped default, so it would silently no-op); configure registry.redis.{host,port,password,tls} instead — the trace stream shares that endpoint" (toString $val)) -}}
+{{- else -}}
+{{- fail (printf "registry.observability.distributedTracing.%s was never consumed and has been removed (set to %q, diverging from the old shipped default %q, so it would silently no-op). Stream tuning is set via the top-level env list: TRACE_BATCH_SIZE, TRACE_TIMEOUT, TRACE_PRETTY_OUTPUT, TRACE_ENABLE_STATS, TELEMETRY_PROTOCOL" $key (toString $val) (get $oldTracingDefaults $key)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{/* Old shipped 17-entry registry.environment, verbatim from the v2.4.0
+     umbrella values.yaml. */}}
+{{- $oldEnvironmentDefaults := dict
+      "MCP_MESH_DISTRIBUTED_TRACING_ENABLED" "true"
+      "TRACE_EXPORTER_TYPE" "otlp"
+      "TELEMETRY_PROTOCOL" "grpc"
+      "TRACE_BATCH_SIZE" "100"
+      "TRACE_TIMEOUT" "5m"
+      "TRACE_PRETTY_OUTPUT" "false"
+      "TRACE_ENABLE_STATS" "true"
+      "STREAM_NAME" "mesh:trace"
+      "CONSUMER_GROUP" "mcp-mesh-registry-processors"
+      "MCP_MESH_TRACE_DEBUG" "true"
+      "ENABLE_RESPONSE_CACHE" "true"
+      "ENABLE_CORS" "true"
+      "ENABLE_METRICS" "true"
+      "ENABLE_PROMETHEUS" "true"
+      "ENABLE_EVENTS" "true"
+      "ACCESS_LOG" "true"
+      "CACHE_TTL" "30" -}}
+{{- range $key, $val := (dig "environment" (dict) .Values.registry) | default dict -}}
+{{- if not (hasKey $oldEnvironmentDefaults $key) -}}
+{{- fail (printf "registry.environment was never consumed and has been removed (entry %s is not in the old shipped defaults, so it would silently no-op); add environment variables via the top-level env list (name/value entries) instead. Registry TLS/trust settings belong under registry.security" $key) -}}
+{{- else if ne (toString $val) (get $oldEnvironmentDefaults $key) -}}
+{{- fail (printf "registry.environment was never consumed and has been removed (%s=%q diverges from the old shipped default %q, so it would silently no-op); add environment variables via the top-level env list (name/value entries) instead" $key (toString $val) (get $oldEnvironmentDefaults $key)) -}}
+{{- end -}}
 {{- end -}}
 {{- end }}
 
@@ -267,12 +328,19 @@ The registry prefix resolves as <block>.registry > global.imageRegistry > ""
 global.imageRegistry=my.registry.internal this renders
 my.registry.internal/mcpmesh/registry and (for the init container)
 my.registry.internal/busybox — mirror images to the same paths.
-Call with (dict "image" <imageBlock> "root" $).
+Call with (dict "image" <imageBlock> "root" $) plus an optional
+"defaultTag" used when <imageBlock>.tag is empty. Only the chart's own
+image may fall back to Chart.AppVersion — that version is meaningless for
+third-party images like the busybox init container, so without a
+defaultTag an empty tag fails the render instead.
 */}}
 {{- define "mcp-mesh-registry.imageRef" -}}
 {{- $img := .image -}}
 {{- $registry := $img.registry | default (dig "imageRegistry" "" (.root.Values.global | default dict)) | trimSuffix "/" -}}
-{{- $tag := $img.tag | default .root.Chart.AppVersion -}}
+{{- $tag := $img.tag | default (.defaultTag | default "") -}}
+{{- if not $tag -}}
+{{- fail (printf "image tag for %s must not be empty" $img.repository) -}}
+{{- end -}}
 {{- if $registry -}}
 {{- printf "%s/%s:%s" $registry $img.repository $tag -}}
 {{- else -}}

--- a/helm/mcp-mesh-registry/templates/configmap.yaml
+++ b/helm/mcp-mesh-registry/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- include "mcp-mesh-registry.validateNoDeprecatedRedisUrl" . -}}
+{{- include "mcp-mesh-registry.validateNoRemovedKeys" . -}}
 {{- $db := include "mcp-mesh-registry.databaseSettings" . | fromJson -}}
 {{- $redis := include "mcp-mesh-registry.redisSettings" . | fromJson -}}
 apiVersion: v1

--- a/helm/mcp-mesh-registry/templates/deployment.yaml
+++ b/helm/mcp-mesh-registry/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
         - name: registry
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ include "mcp-mesh-registry.imageRef" (dict "image" .Values.image "root" $) }}"
+          image: "{{ include "mcp-mesh-registry.imageRef" (dict "image" .Values.image "root" $ "defaultTag" $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/helm/mcp-mesh-registry/values.yaml
+++ b/helm/mcp-mesh-registry/values.yaml
@@ -197,8 +197,7 @@ registry:
     # Key holding a complete DSN in the existing secret (mode 1). Empty
     # selects mode 2. The chart's own Secret uses "database-url" for this.
     existingSecretUrlKey: ""
-    # Keys in the secret (mode 2)
-    existingSecretUsernameKey: "username"
+    # Key holding the password in the secret (mode 2)
     existingSecretPasswordKey: "" # default: password
 
   # Logging configuration (matches K8s examples)
@@ -306,21 +305,6 @@ registry:
     # inherits global.redis.tls.enabled when not set here). Pair with
     # serviceTLS.redis.* below to mount CA / client certificates.
     tls: {}
-
-    # CORS configuration
-    cors:
-      enabled: true
-      allowedOrigins:
-        - "*"
-      allowedMethods:
-        - "GET"
-        - "POST"
-        - "PUT"
-        - "DELETE"
-        - "OPTIONS"
-      allowedHeaders:
-        - "*"
-      allowCredentials: true
 
 # Per-service TLS configuration for external service connections
 # Each service connection can use its own CA, client cert, and key

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -473,10 +473,6 @@ export DEFAULT_EVICTION_THRESHOLD=60  # Evict stale agents (seconds)
 # rows). Event rows are governed by a separate hardcoded 100k row cap.
 export MCP_MESH_RETENTION=1h
 
-# Caching
-export CACHE_TTL=30
-export ENABLE_RESPONSE_CACHE=true
-
 # CORS
 export ENABLE_CORS=true
 export ALLOWED_ORIGINS="*"

--- a/src/core/cli/man/content/registry.md
+++ b/src/core/cli/man/content/registry.md
@@ -59,10 +59,6 @@ export DEFAULT_TIMEOUT_THRESHOLD=20  # Mark unhealthy after (seconds)
 export HEALTH_CHECK_INTERVAL=10      # Scan frequency (seconds)
 export DEFAULT_EVICTION_THRESHOLD=60 # Remove stale agents (seconds)
 
-# Caching
-export CACHE_TTL=30
-export ENABLE_RESPONSE_CACHE=true
-
 # Logging
 export MCP_MESH_LOG_LEVEL=INFO
 export MCP_MESH_DEBUG_MODE=false

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -23,10 +23,6 @@ type Config struct {
 	RegistryName        string `env:"REGISTRY_NAME" envDefault:"mcp-mesh-registry"`
 	HealthCheckInterval int    `env:"HEALTH_CHECK_INTERVAL" envDefault:"10"`
 
-	// Cache configuration
-	CacheTTL            int  `env:"CACHE_TTL" envDefault:"30"` // seconds
-	EnableResponseCache bool `env:"ENABLE_RESPONSE_CACHE" envDefault:"true"`
-
 	// Health monitoring configuration (optimized for 5-second HEAD heartbeats)
 	DefaultTimeoutThreshold  int `env:"DEFAULT_TIMEOUT_THRESHOLD" envDefault:"20"`   // seconds (4 missed heartbeats)
 	DefaultEvictionThreshold int `env:"DEFAULT_EVICTION_THRESHOLD" envDefault:"60"`  // seconds (reduced from 120)
@@ -56,8 +52,6 @@ func LoadFromEnv() *Config {
 		Port:                     getEnvInt("PORT", 8000),
 		RegistryName:             getEnvString("REGISTRY_NAME", "mcp-mesh-registry"),
 		HealthCheckInterval:      getEnvInt("HEALTH_CHECK_INTERVAL", 10),
-		CacheTTL:                 getEnvInt("CACHE_TTL", 30),
-		EnableResponseCache:      getEnvBool("ENABLE_RESPONSE_CACHE", true),
 		DefaultTimeoutThreshold:  getEnvInt("DEFAULT_TIMEOUT_THRESHOLD", 20),
 		DefaultEvictionThreshold: getEnvInt("DEFAULT_EVICTION_THRESHOLD", 60),
 		EnableCORS:               getEnvBool("ENABLE_CORS", true),
@@ -98,10 +92,6 @@ func (c *Config) Validate() error {
 
 	if c.HealthCheckInterval < 1 {
 		return fmt.Errorf("health check interval must be positive: %d", c.HealthCheckInterval)
-	}
-
-	if c.CacheTTL < 0 {
-		return fmt.Errorf("cache TTL must be non-negative: %d", c.CacheTTL)
 	}
 
 	// Validate log level (case insensitive)

--- a/src/core/registry/ent_service.go
+++ b/src/core/registry/ent_service.go
@@ -51,12 +51,10 @@ type Dependency struct {
 
 // RegistryConfig holds registry-specific configuration
 type RegistryConfig struct {
-	CacheTTL                 int
 	DefaultTimeoutThreshold  int
 	DefaultEvictionThreshold int
 	HealthCheckInterval      int
 	StartupCleanupThreshold  int // Threshold in seconds for marking stale agents on startup (default: 30)
-	EnableResponseCache      bool
 	TracingEnabled           bool   // Enable distributed tracing
 	TlsMode                  string // "off", "auto", "strict" — from MCP_MESH_TLS_MODE
 	TrustBackend             string // comma-separated backend names — from MCP_MESH_TRUST_BACKEND
@@ -247,12 +245,10 @@ type EntService struct {
 func NewEntService(entDB *database.EntDatabase, config *RegistryConfig, logger *logger.Logger) *EntService {
 	if config == nil {
 		config = &RegistryConfig{
-			CacheTTL:                 30,
 			DefaultTimeoutThreshold:  60,
 			DefaultEvictionThreshold: 120,
 			HealthCheckInterval:      30, // Health check every 30 seconds
 			StartupCleanupThreshold:  30, // Mark agents as stale if no heartbeat for 30s on startup
-			EnableResponseCache:      true,
 		}
 	}
 

--- a/src/core/registry/test_utils.go
+++ b/src/core/registry/test_utils.go
@@ -91,10 +91,8 @@ func setupTestService(t *testing.T) *EntService {
 
 	// Create test config with very long timeout for test stability
 	testRegistryConfig := &RegistryConfig{
-		CacheTTL:                 30,
 		DefaultTimeoutThreshold:  3600, // 1 hour - very long for tests
 		DefaultEvictionThreshold: 7200, // 2 hours
-		EnableResponseCache:      false,
 	}
 
 	// Create and return EntService

--- a/src/core/registry/types_clean.go
+++ b/src/core/registry/types_clean.go
@@ -5,10 +5,8 @@ type Config struct {
 	Port                     int
 	Debug                    bool
 	DatabaseURL              string
-	CacheTTL                 int
 	DefaultTimeoutThreshold  int
 	DefaultEvictionThreshold int
-	EnableResponseCache      bool
 	HealthCheckInterval      int
 	StartupCleanupThreshold  int // Threshold in seconds for marking stale agents on startup
 }
@@ -16,11 +14,9 @@ type Config struct {
 // DefaultServiceConfig returns default service configuration
 func DefaultServiceConfig() *RegistryConfig {
 	return &RegistryConfig{
-		CacheTTL:                 30,
 		DefaultTimeoutThreshold:  60,
 		DefaultEvictionThreshold: 120,
 		StartupCleanupThreshold:  30, // Mark agents as stale if no heartbeat for 30s on startup
-		EnableResponseCache:      false, // NO CACHE - Multiple registry instances
 	}
 }
 


### PR DESCRIPTION
## Summary
Closes #1186 — the dead-config inventory accumulated across the June audits and helm batch, all items re-verified against current code before touching.

- **Go**: `CACHE_TTL`/`ENABLE_RESPONSE_CACHE` removed end-to-end (fields, parsing, validation, pass-throughs, `--help` line) — inert since the ResponseCache deletion in #1177. Root `openapitools.json` deleted (gitignore entry retained as protection, since the codegen config can still regenerate it).
- **Helm plain removals** (keys that silently no-op'd, defaults matched binary behavior): registry `existingSecretUsernameKey`, mis-nested `registry.redis.cors`, agent `registry.url` (plus three doc examples teaching it).
- **Helm guarded removals** — template-time `fail` with migration messages, with **shipped-default tolerance**: the guards embed the exact v2.4.0 shipped default values (source-cited) and fail only on *divergence* — a values file copied from the old shipped defaults renders clean, while a user-set value that silently no-op'd fails loudly naming the key, the set value, and the old default. Covers the `distributedTracing.*` stream keys, `registry.environment`/`agent.environment` maps, umbrella `networkPolicies`/`serviceMonitors` flags (the real per-chart singular flags are pointed to), and umbrella `coreReleaseName` ≠ default.
- **`global.coreReleaseName` wired instead of removed** (agent chart): default registry/redis/tempo hostnames now compute from it — doc-only config made real, three lines.
- **Registry `imageRef`**: the busybox init image no longer inherits the appVersion tag fallback (empty init tag fails instead of rendering `busybox:<mesh-version>`).
- **Straggler sweep**: env-var docs, man pages, tutorial values (including the final_product SPIRE block that set `registry.environment` keys which *never worked* — replaced with the consumed `registry.security.*` keys, render-verified), TLS example.

## Review Notes
- Two review rounds. Round 1's blocker — guards firing on values files copied from old shipped umbrella defaults — drove the shipped-default-tolerance design. Round 2's fix went further than the review asked: the reviewer's "never shipped" premises for `redisUrl` and `agent.environment` were checked against the actual **v2.4.0 tag** (not post-release main) and found wrong — both shipped as defaults and get the same carve-out.
- Verified: zero remaining repo references to removed keys; old shipped v2.4.0 values render clean verbatim; single-key divergence fails naming exactly that key; defaults byte-identical everywhere; `go build`/`go test -race` clean; helm lint 9/9 + PSS checker.
- Follow-up filed separately: the TLS example documents a `registry:` values nesting the umbrella silently ignores.

Closes #1186

## Test plan
- [x] `go build ./...` + `go test ./src/core/... -race -count=1`
- [x] helm lint 9/9 + `scripts/check_helm_pss.py`; defaults byte-identical
- [x] Guard matrix: v2.4.0 shipped values verbatim (clean), per-key divergence (fails, correct message), all in-repo values files render

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed response caching functionality from registry
  * Simplified Helm registry connection configuration to use separate host and port values instead of full URLs
  * Updated service discovery and release name handling

* **Documentation**
  * Updated environment variable reference guides
  * Updated Helm deployment examples and monitoring documentation
  * Removed deprecated cache and streaming configuration references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->