### PR TITLE
fix(examples): umbrella nesting for registry TLS values; rename to the consumed secretName key

### DIFF
--- a/examples/k8s/tls/README.md
+++ b/examples/k8s/tls/README.md
@@ -44,6 +44,11 @@ kubectl apply -f selfsigned-cluster-issuer.yaml \
 # Wait for certificates to be ready
 kubectl get certificates -n mcp-mesh -w
 
+# The root CA Certificate labels its secret mcp-mesh.io/trust=entity-ca via
+# secretTemplate so the registry's k8s-secrets trust backend discovers it.
+# Verify the label is present:
+kubectl get secret mcp-mesh-ca-secret -n mcp-mesh --show-labels
+
 # Install MCP Mesh core with TLS enabled
 helm install mcp-core helm/mcp-mesh-core -n mcp-mesh \
   -f helm-values-tls.yaml
@@ -114,6 +119,15 @@ kubectl apply -f vault-issuer.yaml \
 
 # Wait for certificates
 kubectl get certificates -n mcp-mesh -w
+
+# No Certificate creates the CA trust secret in this flow, so create it from
+# the Vault root CA and label it for the registry's k8s-secrets trust backend
+# (helm-values-tls.yaml references mcp-mesh-ca-secret and selects on this label):
+vault read -field=certificate pki/cert/ca > vault-ca.crt
+kubectl create secret generic mcp-mesh-ca-secret -n mcp-mesh \
+  --from-file=ca.crt=vault-ca.crt
+kubectl label secret mcp-mesh-ca-secret -n mcp-mesh \
+  mcp-mesh.io/trust=entity-ca
 
 # Install with TLS values
 helm install mcp-core helm/mcp-mesh-core -n mcp-mesh \

--- a/examples/k8s/tls/helm-values-tls.yaml
+++ b/examples/k8s/tls/helm-values-tls.yaml
@@ -13,44 +13,53 @@
 #
 # Secret mapping (cert-manager Certificate -> K8s Secret -> Helm value):
 #
-#   mcp-mesh-root-ca          -> mcp-mesh-ca-secret      -> caSecret
-#   mcp-mesh-registry-cert    -> mcp-mesh-registry-tls   -> registry.security.tls.existingSecret
+#   mcp-mesh-root-ca          -> mcp-mesh-ca-secret      -> trust.caSecret / mesh.tls.caSecret
+#   mcp-mesh-registry-cert    -> mcp-mesh-registry-tls   -> tls.secretName
 #   mcp-mesh-agent-cert       -> mcp-mesh-agent-tls      -> mesh.tls.certSecret
 
 # =============================================================================
-# Registry values (consumed by mcp-mesh-core chart)
+# Registry values (consumed by the mcp-mesh-core umbrella chart)
+#
+# mcp-mesh-core is an umbrella chart: the registry runs in the
+# mcp-mesh-registry subchart, so its values MUST be nested under the
+# dependency name "mcp-mesh-registry". A top-level "registry:" key on the
+# umbrella only carries the enablement flag (registry.enabled) — anything
+# else under it is silently ignored.
 # =============================================================================
-registry:
-  # Core chart: registry server TLS configuration
-  security:
-    tls:
-      enabled: true
-      # "strict" requires valid TLS for all connections.
-      # Use "auto" to accept both TLS and plaintext during migration.
-      mode: "strict"
+mcp-mesh-registry:
+  registry:
+    security:
+      tls:
+        enabled: true
+        # "strict" requires valid TLS for all connections.
+        # Use "auto" to accept both TLS and plaintext during migration.
+        mode: "strict"
 
-      # cert-manager stores certs in standard tls.crt / tls.key fields.
-      # Secret: mcp-mesh-registry-tls (from Certificate "mcp-mesh-registry-cert")
-      existingSecret: "mcp-mesh-registry-tls"
-      certKey: "tls.crt"
-      keyKey: "tls.key"
+        # K8s TLS secret mounted at /etc/tls in the registry pod.
+        # cert-manager stores certs in standard tls.crt / tls.key fields.
+        # Secret: mcp-mesh-registry-tls (from Certificate "mcp-mesh-registry-cert")
+        secretName: "mcp-mesh-registry-tls"
+        certKey: "tls.crt"
+        keyKey: "tls.key"
 
-    trust:
-      # k8s-secrets backend reads CA certs from labeled Secrets.
-      # cert-manager populates ca.crt in the CA secret automatically.
-      backend: "k8s-secrets"
+      trust:
+        # k8s-secrets backend reads CA certs from labeled Secrets.
+        # cert-manager populates ca.crt in the CA secret automatically.
+        backend: "k8s-secrets"
 
-      # Direct CA secret reference for file-based trust.
-      # Secret: mcp-mesh-ca-secret (from Certificate "mcp-mesh-root-ca")
-      caSecret: "mcp-mesh-ca-secret"
+        # Direct CA secret reference for file-based trust.
+        # Secret: mcp-mesh-ca-secret (from Certificate "mcp-mesh-root-ca")
+        caSecret: "mcp-mesh-ca-secret"
 
-      k8sSecrets:
-        namespace: "mcp-mesh"
-        # Label selector to discover CA secrets.
-        # Add this label to mcp-mesh-ca-secret:
-        #   kubectl label secret mcp-mesh-ca-secret -n mcp-mesh \
-        #     mcp-mesh.io/trust=entity-ca
-        labelSelector: "mcp-mesh.io/trust=entity-ca"
+        k8sSecrets:
+          namespace: "mcp-mesh"
+          # Label selector to discover CA secrets. The self-signed root CA
+          # Certificate applies this label via secretTemplate (see
+          # selfsigned-root-ca.yaml); for the Vault flow, label the secret
+          # manually:
+          #   kubectl label secret mcp-mesh-ca-secret -n mcp-mesh \
+          #     mcp-mesh.io/trust=entity-ca
+          labelSelector: "mcp-mesh.io/trust=entity-ca"
 
 # =============================================================================
 # Agent mesh TLS values (consumed by mcp-mesh-agent chart)

--- a/examples/k8s/tls/selfsigned-root-ca.yaml
+++ b/examples/k8s/tls/selfsigned-root-ca.yaml
@@ -15,6 +15,12 @@ spec:
     organizations:
       - mcp-mesh
   secretName: mcp-mesh-ca-secret
+  # Label the CA secret so the registry's k8s-secrets trust backend
+  # (labelSelector mcp-mesh.io/trust=entity-ca in helm-values-tls.yaml)
+  # discovers it. secretTemplate requires cert-manager >= v1.7.
+  secretTemplate:
+    labels:
+      mcp-mesh.io/trust: entity-ca
   privateKey:
     algorithm: ECDSA
     size: 256

--- a/helm/mcp-mesh-registry/README.md
+++ b/helm/mcp-mesh-registry/README.md
@@ -130,11 +130,9 @@ here; an explicit value always wins.
 | Parameter                               | Description                      | Default   |
 | --------------------------------------- | -------------------------------- | --------- |
 | `registry.security.tls.enabled`         | Enable TLS                       | `false`   |
-| `registry.security.tls.existingSecret`  | Existing TLS secret              | `""`      |
+| `registry.security.tls.secretName`      | Existing TLS secret              | `""`      |
 | `registry.security.auth.enabled`        | Enable authentication            | `false`   |
 | `registry.security.auth.type`           | Auth type (token, basic, oauth2) | `"token"` |
-| `registry.security.cors.enabled`        | Enable CORS                      | `true`    |
-| `registry.security.cors.allowedOrigins` | Allowed origins                  | `["*"]`   |
 
 ### Ingress
 
@@ -304,7 +302,7 @@ registry:
   security:
     tls:
       enabled: true
-      existingSecret: my-tls-secret
+      secretName: my-tls-secret
 ```
 
 ### Production Configuration

--- a/helm/mcp-mesh-registry/templates/_helpers.tpl
+++ b/helm/mcp-mesh-registry/templates/_helpers.tpl
@@ -253,6 +253,12 @@ DIVERGING value — user intent that would silently no-op — fails.
   ...): never rendered into env; the binary reads TRACE_* env vars, settable
   via the env list.
 - registry.environment: never rendered; use the top-level env list.
+- security.tls.existingSecret: the README documented this name but every
+  template reads security.tls.secretName; a carried value would mount an
+  empty secret name. Renamed — fail naming the consumed key.
+- security.tls.certFile/keyFile: never consumed; the cert and key paths are
+  fixed (/etc/tls/<certKey|keyKey>). Shipped as "" in the old values.yaml,
+  so empty is tolerated; only a non-empty value fails.
 */}}
 {{- define "mcp-mesh-registry.validateNoRemovedKeys" -}}
 {{/* Old shipped defaults, verbatim from the v2.4.0 umbrella values.yaml. */}}
@@ -303,6 +309,15 @@ DIVERGING value — user intent that would silently no-op — fails.
 {{- fail (printf "registry.environment was never consumed and has been removed (entry %s is not in the old shipped defaults, so it would silently no-op); add environment variables via the top-level env list (name/value entries) instead. Registry TLS/trust settings belong under registry.security" $key) -}}
 {{- else if ne (toString $val) (get $oldEnvironmentDefaults $key) -}}
 {{- fail (printf "registry.environment was never consumed and has been removed (%s=%q diverges from the old shipped default %q, so it would silently no-op); add environment variables via the top-level env list (name/value entries) instead" $key (toString $val) (get $oldEnvironmentDefaults $key)) -}}
+{{- end -}}
+{{- end -}}
+{{- $tls := (dig "security" "tls" (dict) .Values.registry) | default dict -}}
+{{- if get $tls "existingSecret" -}}
+{{- fail (printf "registry.security.tls.existingSecret was never consumed and has been renamed; the templates read registry.security.tls.secretName — set secretName: %q instead (mounted read-only at /etc/tls)" (toString (get $tls "existingSecret"))) -}}
+{{- end -}}
+{{- range $key := list "certFile" "keyFile" -}}
+{{- if get $tls $key -}}
+{{- fail (printf "registry.security.tls.%s was never consumed and has been removed (set to %q, so it would silently no-op); the cert and key are mounted from registry.security.tls.secretName at /etc/tls/<certKey|keyKey>" $key (toString (get $tls $key))) -}}
 {{- end -}}
 {{- end -}}
 {{- end }}

--- a/helm/mcp-mesh-registry/values.yaml
+++ b/helm/mcp-mesh-registry/values.yaml
@@ -229,10 +229,9 @@ registry:
       enabled: false
       # TLS mode: off, auto, strict
       mode: "off"
-      certFile: ""
-      keyFile: ""
-      # Use existing TLS secret
-      existingSecret: ""
+      # Existing K8s TLS secret (e.g. from a cert-manager Certificate),
+      # mounted read-only at /etc/tls. Required when enabled.
+      secretName: ""
       certKey: "tls.crt"
       keyKey: "tls.key"
 


### PR DESCRIPTION
## Summary
Closes #1191 — and the two latent bugs that fell out of fixing it.

- **The TLS example's registry block was silently ignored**: it nested under a top-level `registry:` key, but the umbrella reads only `registry.enabled` there (no subchart alias) — the documented install rendered `MCP_MESH_TLS_MODE: "off"`. Re-nested under `mcp-mesh-registry:` with a comment documenting the trap; render-verified the full TLS surface now appears (strict mode, cert/key paths, both secret mounts, trust-reader RBAC).
- **`security.tls.existingSecret` was documentation fiction**: every template has read `security.tls.secretName` since the chart's first commit, so the re-nested example would have mounted an empty `secretName:`. Values/README renamed to the consumed key; dead `certFile`/`keyFile` removed; a `validateNoRemovedKeys` guard (the #1190 convention) fails loudly on non-empty `existingSecret` naming the replacement — the README actively taught the key, so real values files plausibly carry it.
- **The example's trust-backend flow now actually works end-to-end**: activating the registry block made `trust.backend: k8s-secrets` live, but its required `mcp-mesh.io/trust=entity-ca` label existed only as a comment. The root-CA Certificate now applies it via `secretTemplate.labels`, and the Vault flow gains an export-create-label step — which also fixes a pre-existing breakage where that flow never created the `mcp-mesh-ca-secret` it referenced.

## Review Notes
- Independent review rendered the example against both charts, verified secret-name consistency across the values file, both README flows, and all six Certificate manifests, and confirmed the registry chart's default render is byte-identical.
- Its blocker (a second `existingSecret` occurrence in the same README) and both warnings (the missing guard; the trust-label gap) are fixed.
- Sweep confirmed the tutorial values files and `docs/deployment.md` use correct nesting for their respective targets; zero TLS-`existingSecret` references remain repo-wide.

Closes #1191

## Test plan
- [x] Umbrella + agent renders with the fixed example: full TLS env/volumes (evidence in review)
- [x] Guard fires on `existingSecret` (standalone + umbrella pass-through), silent on defaults/empty
- [x] `helm lint` registry + core; registry defaults byte-identical
- [ ] Live cert-manager walkthrough of the example README (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
