### PR TITLE
fix(runtime): never register a port the agent did not bind

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshPortUpdaterInvariantTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshPortUpdaterInvariantTest.java
@@ -6,6 +6,7 @@ import org.springframework.boot.web.server.WebServer;
 import org.springframework.boot.web.server.context.WebServerInitializedEvent;
 import org.springframework.context.ApplicationListener;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -78,6 +79,7 @@ class MeshPortUpdaterInvariantTest {
 
         listener(runtime).onApplicationEvent(eventWithPort(8080));
 
-        verify(runtime, never()).updatePort(8080);
+        // No update call at all — not merely "no update with this value".
+        verify(runtime, never()).updatePort(anyInt());
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshPortUpdaterInvariantTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshPortUpdaterInvariantTest.java
@@ -1,0 +1,83 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.core.AgentSpec;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.server.WebServer;
+import org.springframework.boot.web.server.context.WebServerInitializedEvent;
+import org.springframework.context.ApplicationListener;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the registered-port == bound-port invariant for the Java runtime
+ * (issue #1194).
+ *
+ * <p>Java relies on two mechanisms for the invariant:
+ *
+ * <ol>
+ *   <li>Spring Boot fails startup loudly on a port conflict (the web server
+ *       binds during {@code WebServerStartStopLifecycle}); the failed context
+ *       stops {@link MeshRuntime}, which closes the mesh handle and withdraws
+ *       any registration. No silent phantom endpoint survives.</li>
+ *   <li>The {@code meshPortUpdater} {@link ApplicationListener} converges the
+ *       registered port to the ACTUAL bound port whenever the web server
+ *       reports a port different from the spec (covers {@code server.port=0}
+ *       auto-assignment and any other divergence).</li>
+ * </ol>
+ *
+ * <p>This test pins mechanism (2) — the mcp-mesh-owned half.
+ */
+class MeshPortUpdaterInvariantTest {
+
+    private ApplicationListener<WebServerInitializedEvent> listener(MeshRuntime runtime) {
+        return new MeshAutoConfiguration().meshPortUpdater(runtime);
+    }
+
+    private WebServerInitializedEvent eventWithPort(int actualPort) {
+        WebServer webServer = mock(WebServer.class);
+        when(webServer.getPort()).thenReturn(actualPort);
+        WebServerInitializedEvent event = mock(WebServerInitializedEvent.class);
+        when(event.getWebServer()).thenReturn(webServer);
+        return event;
+    }
+
+    private MeshRuntime runtimeWithSpecPort(int specPort) {
+        AgentSpec spec = new AgentSpec();
+        spec.setHttpPort(specPort);
+        MeshRuntime runtime = mock(MeshRuntime.class);
+        when(runtime.getAgentSpec()).thenReturn(spec);
+        return runtime;
+    }
+
+    @Test
+    void updatesRegistryWhenActualPortDiffersFromSpec() {
+        MeshRuntime runtime = runtimeWithSpecPort(9000);
+
+        listener(runtime).onApplicationEvent(eventWithPort(54321));
+
+        // The actual bound port is authoritative — the registry must be
+        // converged to it, never left advertising the spec port.
+        verify(runtime).updatePort(54321);
+    }
+
+    @Test
+    void updatesRegistryForPortZeroAutoAssignment() {
+        MeshRuntime runtime = runtimeWithSpecPort(0);
+
+        listener(runtime).onApplicationEvent(eventWithPort(43210));
+
+        verify(runtime).updatePort(43210);
+    }
+
+    @Test
+    void noUpdateWhenSpecAlreadyMatchesBoundPort() {
+        MeshRuntime runtime = runtimeWithSpecPort(8080);
+
+        listener(runtime).onApplicationEvent(eventWithPort(8080));
+
+        verify(runtime, never()).updatePort(8080);
+    }
+}

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
@@ -77,6 +77,43 @@ def _get_rust_core():
     return _rust_core
 
 
+def _resolve_registration_port(http_port: int, context: dict[str, Any]) -> int:
+    """Resolve the HTTP port to register with the registry (issue #1194).
+
+    Invariant: never register a port the runtime did not bind. The actual
+    bound port is recorded in the pipeline context, either as:
+
+    * ``bound_port`` — set by the startup orchestrator when it pre-binds
+      the server socket before starting uvicorn, or
+    * ``existing_server.port`` — the immediate-uvicorn server record from
+      ``mesh/decorators.py``, whose port is read back from the bound socket.
+
+    When a bound port is known it is authoritative — including when it
+    differs from the configured port (port-conflict fallback). The
+    configured port is only used when no local bind information exists
+    (e.g. synthetic test contexts without a discovered server).
+    """
+    bound_port = context.get("bound_port") or 0
+    if not bound_port:
+        existing_server = context.get("existing_server") or {}
+        bound_port = existing_server.get("port") or 0
+
+    if bound_port > 0:
+        if http_port == 0:
+            logger.info(
+                f"Using detected port {bound_port} (agent_config had port=0)"
+            )
+        elif http_port != bound_port:
+            logger.warning(
+                f"⚠️ Registering ACTUAL bound port {bound_port} instead of "
+                f"configured port {http_port} — the configured port was "
+                f"unavailable at bind time (see PORT CONFLICT warning above)"
+            )
+        return bound_port
+
+    return http_port
+
+
 def _build_agent_spec(context: dict[str, Any]) -> Any:
     """
     Build AgentSpec from Python context.
@@ -111,18 +148,9 @@ def _build_agent_spec(context: dict[str, Any]) -> Any:
 
     # Get HTTP config
     http_host = agent_config.get("http_host", "localhost")
-    http_port = agent_config.get("http_port", 0)
-
-    # If port=0 (auto-assign), check for detected port from server discovery
-    if http_port == 0:
-        existing_server = context.get("existing_server")
-        if existing_server:
-            detected_port = existing_server.get("port", 0)
-            if detected_port > 0:
-                logger.info(
-                    f"Using detected port {detected_port} (agent_config had port=0)"
-                )
-                http_port = detected_port
+    http_port = _resolve_registration_port(
+        agent_config.get("http_port", 0), context
+    )
 
     namespace = agent_config.get("namespace", "default")
     version = agent_config.get("version", "1.0.0")

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
@@ -1,8 +1,6 @@
 import asyncio
 import logging
 import os
-import socket
-import time
 from datetime import UTC, datetime
 from typing import Any, Optional
 
@@ -628,104 +626,13 @@ mcp_mesh_up{{agent="{agent_name}"}} 1
             self.logger.error(f"Failed to mount FastMCP server '{server_key}': {e}")
             raise
 
-    async def _start_fastapi_server(
-        self,
-        app: Any,
-        binding_config: dict[str, Any],
-        advertisement_config: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Start FastAPI server with uvicorn."""
-        bind_host = binding_config["bind_host"]
-        bind_port = binding_config["bind_port"]
-        external_host = advertisement_config["external_host"]
-        external_endpoint = advertisement_config["external_endpoint"]
-
-        try:
-            import asyncio
-
-            import uvicorn
-
-            # Resolve TLS config from Rust core
-            from ...shared.tls_config import get_tls_config
-
-            tls = get_tls_config()
-
-            ssl_kwargs = {}
-            if tls["enabled"] and tls.get("cert_path") and tls.get("key_path"):
-                import ssl
-
-                ssl_kwargs["ssl_certfile"] = tls["cert_path"]
-                ssl_kwargs["ssl_keyfile"] = tls["key_path"]
-                if tls.get("ca_path"):
-                    ssl_kwargs["ssl_ca_certs"] = tls["ca_path"]
-                    ssl_kwargs["ssl_cert_reqs"] = ssl.CERT_REQUIRED
-                self.logger.info(f"TLS enabled for HTTP server (mode={tls['mode']})")
-
-            # Create uvicorn config
-            config = uvicorn.Config(
-                app=app,
-                host=bind_host,
-                port=bind_port,
-                log_level="info",
-                access_log=False,  # Reduce noise
-                ws="websockets-sansio",  # Use modern websockets API (avoids deprecation warnings)
-                **ssl_kwargs,
-            )
-
-            # Create and start server
-            server = uvicorn.Server(config)
-
-            # Start server as background task
-            async def run_server():
-                try:
-                    await server.serve()
-                except Exception as e:
-                    self.logger.error(f"FastAPI server stopped with error: {e}")
-
-            server_task = asyncio.create_task(run_server())
-
-            # Wait for server to start and get actual port
-            # uvicorn sets server.started = True when ready
-            for _ in range(50):  # Max 5 seconds
-                await asyncio.sleep(0.1)
-                if server.started:
-                    break
-
-            # Get actual port from uvicorn sockets (critical for port=0 auto-assign)
-            actual_port = bind_port
-            if server.started and server.servers:
-                try:
-                    sock = server.servers[0].sockets[0]
-                    actual_port = sock.getsockname()[1]
-                    if actual_port != bind_port:
-                        self.logger.info(
-                            f"Auto-assigned port {actual_port} (requested: {bind_port})"
-                        )
-                except (IndexError, AttributeError, OSError) as e:
-                    self.logger.warning(f"Could not get actual port from uvicorn: {e}")
-                    actual_port = bind_port if bind_port != 0 else 8080
-            elif bind_port == 0:
-                self.logger.warning("Server not started, falling back to port 8080")
-                actual_port = 8080
-
-            # Build external endpoint
-            final_external_endpoint = (
-                external_endpoint or f"http://{external_host}:{actual_port}"
-            )
-
-            return {
-                "server": server,
-                "server_task": server_task,
-                "actual_port": actual_port,
-                "bind_address": f"{bind_host}:{actual_port}",
-                "external_endpoint": final_external_endpoint,
-            }
-
-        except ImportError as e:
-            raise Exception(f"uvicorn not available: {e}")
-        except Exception as e:
-            self.logger.error(f"Failed to start FastAPI server: {e}")
-            raise
+    # NOTE (issue #1194): the old `_start_fastapi_server` helper was removed.
+    # It was dead code (no callers) and embodied the exact bug from the
+    # issue: uvicorn bind errors died inside a background task, a 5s poll
+    # on `server.started` timed out silently, and the code then *assumed*
+    # the configured port — registering an endpoint nothing ever bound.
+    # Server startup now flows exclusively through pre-bound sockets
+    # (see `_mcp_mesh.shared.port_binding` and `startup_orchestrator`).
 
     def _get_timestamp(self) -> str:
         """Get current timestamp in ISO format."""

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_orchestrator.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_orchestrator.py
@@ -262,15 +262,47 @@ class DebounceCoordinator:
 
                         heartbeat_task_fn = rust_heartbeat_task
 
+                    # Check if server was already reused from immediate uvicorn start
+                    server_reused = pipeline_context.get("server_reused", False)
+                    existing_server = pipeline_context.get("existing_server", {})
+
+                    # Issue #1194: when WE are about to start the server (no
+                    # reuse), bind the socket BEFORE the heartbeat starts so
+                    # registration carries the port this process actually
+                    # owns. On a conflict the helper falls back to an
+                    # OS-assigned port with a prominent warning; on total
+                    # bind failure it raises — loud failure, no phantom
+                    # registration. The reuse path already bound its socket
+                    # in the @mesh.agent decorator (existing_server.port).
+                    #
+                    # Window caveat: between this bind and uvicorn calling
+                    # listen() in _start_blocking_fastapi_server, the socket
+                    # is bound but NOT listening — connection attempts in
+                    # that window are REFUSED (there is no listen backlog
+                    # yet, so nothing is queued). The heartbeat may briefly
+                    # advertise an endpoint that refuses connections;
+                    # consumers retry through it once uvicorn is up.
+                    bound_socket = None
+                    if not server_reused:
+                        from ...shared.port_binding import (
+                            bind_server_socket_with_fallback,
+                        )
+
+                        bind_host = binding_config.get("bind_host", "0.0.0.0")
+                        bind_port = binding_config.get("bind_port", 8080)
+                        bound_socket, actual_port = (
+                            bind_server_socket_with_fallback(bind_host, bind_port)
+                        )
+                        binding_config["bind_port"] = actual_port
+                        # The heartbeat reads this to register the ACTUAL
+                        # bound port (see rust_heartbeat._resolve_registration_port).
+                        pipeline_context["bound_port"] = actual_port
+
                     self._setup_heartbeat_background(
                         heartbeat_config,
                         pipeline_context,
                         heartbeat_task_fn,
                     )
-
-                    # Check if server was already reused from immediate uvicorn start
-                    server_reused = pipeline_context.get("server_reused", False)
-                    existing_server = pipeline_context.get("existing_server", {})
 
                     if server_reused:
                         # Check server status to determine action
@@ -345,7 +377,9 @@ class DebounceCoordinator:
                                 )
                                 return
                     else:
-                        self._start_blocking_fastapi_server(fastapi_app, binding_config)
+                        self._start_blocking_fastapi_server(
+                            fastapi_app, binding_config, bound_socket=bound_socket
+                        )
                 else:
                     self.logger.warning(
                         "⚠️ Auto-run enabled but no FastAPI app prepared - exiting"
@@ -385,7 +419,10 @@ class DebounceCoordinator:
             raise
 
     def _start_blocking_fastapi_server(
-        self, app: Any, binding_config: dict[str, Any]
+        self,
+        app: Any,
+        binding_config: dict[str, Any],
+        bound_socket: Any = None,
     ) -> None:
         """Start FastAPI server with uvicorn (signal handlers already registered).
 
@@ -397,14 +434,28 @@ class DebounceCoordinator:
         uvicorn worker thread mid-flight and lifespan ``finally`` blocks
         (asyncpg pool close, in-flight httpx cancel, etc.) would silently
         leak. See issue #1029.
+
+        Issue #1194: when ``bound_socket`` is provided (pre-bound by the
+        caller before the heartbeat started), uvicorn serves on that socket
+        instead of binding itself — guaranteeing the registered port equals
+        the bound port. When it is None, the socket is bound here with the
+        same conflict-fallback semantics so uvicorn never gets a chance to
+        swallow a bind error.
         """
         try:
             import uvicorn
 
+            from ...shared.port_binding import bind_server_socket_with_fallback
             from ...shared.simple_shutdown import register_uvicorn_server
 
             bind_host = binding_config.get("bind_host", "0.0.0.0")
             bind_port = binding_config.get("bind_port", 8080)
+
+            if bound_socket is None:
+                bound_socket, bind_port = bind_server_socket_with_fallback(
+                    bind_host, bind_port
+                )
+                binding_config["bind_port"] = bind_port
 
             config = uvicorn.Config(
                 app,
@@ -426,8 +477,9 @@ class DebounceCoordinator:
 
             # Blocks until ``server.should_exit`` is set (via signal handler)
             # AND uvicorn finishes its graceful shutdown (which runs the
-            # FastAPI lifespan exit phase).
-            server.run()
+            # FastAPI lifespan exit phase). Serves on the pre-bound socket
+            # (issue #1194) so the registered port is the bound port.
+            server.run(sockets=[bound_socket])
 
         except KeyboardInterrupt:
             self.logger.info(

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_orchestrator.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_orchestrator.py
@@ -15,6 +15,65 @@ from .startup_pipeline import StartupPipeline
 logger = logging.getLogger(__name__)
 
 
+def wait_for_proven_serving(
+    started_check: Any,
+    label: str,
+    log: logging.Logger = logger,
+) -> bool:
+    """Bounded wait for the local HTTP server to prove it is serving.
+
+    Serving gate for the heartbeat's FIRST registration (PR #1197 review):
+    the registered port is always one this process BOUND (the bind-level
+    invariant enforced via the bound-socket authority), but a bound socket
+    is not a serving socket — uvicorn can still fail between bind and
+    serve. Deferring registration on the started-signal keeps a post-bind
+    startup failure from being advertised at all in the common case.
+
+    This is a *liveness deferral*, not a different invariant: on budget
+    expiry (``MCP_MESH_SERVER_STARTUP_TIMEOUT``, default 30s — sized for
+    slow-but-healthy ASGI lifespans) the caller proceeds with registration.
+    The port is genuinely held by this process, and a server that
+    ultimately fails to serve kills the process (and with it the
+    heartbeat), so a too-early registration is transient at worst.
+
+    Note: deferring registration also defers dependency resolution for
+    consumers of this agent — acceptable and arguably correct (don't
+    advertise a capability until the server can answer for it). The
+    settling-window grace (issue #1193) layers on top of this; nothing
+    here pre-empts it.
+
+    Returns True when the check reported serving within the budget; False
+    when the budget expired or the check itself failed (proceed either way).
+    """
+    import time
+
+    from ...shared.port_binding import get_server_startup_timeout
+
+    timeout = get_server_startup_timeout()
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if started_check():
+                log.debug(f"Serving gate: server proven serving for {label}")
+                return True
+        except Exception as e:
+            # A broken check must never block registration forever — the
+            # bind-level invariant already holds; proceed.
+            log.warning(
+                f"Serving gate check failed for {label}: {e} — proceeding "
+                f"with registration (port is bound by this process)"
+            )
+            return False
+        time.sleep(0.1)
+    log.warning(
+        f"Serving gate: server did not report started within {timeout:.0f}s "
+        f"for {label} — proceeding with registration anyway (the port IS "
+        f"bound by this process; raise MCP_MESH_SERVER_STARTUP_TIMEOUT for "
+        f"legitimately slower startups)"
+    )
+    return False
+
+
 class DebounceCoordinator:
     """
     Coordinates decorator processing with debouncing to ensure single heartbeat.
@@ -264,26 +323,31 @@ class DebounceCoordinator:
 
                     # Check if server was already reused from immediate uvicorn start
                     server_reused = pipeline_context.get("server_reused", False)
-                    existing_server = pipeline_context.get("existing_server", {})
+                    existing_server = pipeline_context.get("existing_server", {}) or {}
+                    server_status = existing_server.get("status", "unknown")
+                    reused_server_obj = existing_server.get("server")
 
-                    # Issue #1194: when WE are about to start the server (no
-                    # reuse), bind the socket BEFORE the heartbeat starts so
+                    # A "configured" record WITHOUT a server object cannot be
+                    # started — the fallback below starts our own server. For
+                    # bind/registration purposes treat it as no-reuse, so the
+                    # heartbeat registers the port WE bind here instead of
+                    # the record's port that nothing will ever serve
+                    # (pipeline_context["bound_port"] takes precedence over
+                    # existing_server.port in _resolve_registration_port).
+                    starts_own_server = (not server_reused) or (
+                        server_status == "configured" and reused_server_obj is None
+                    )
+
+                    # Issue #1194: when WE are about to start the server,
+                    # bind the socket BEFORE the heartbeat starts so
                     # registration carries the port this process actually
                     # owns. On a conflict the helper falls back to an
                     # OS-assigned port with a prominent warning; on total
                     # bind failure it raises — loud failure, no phantom
                     # registration. The reuse path already bound its socket
                     # in the @mesh.agent decorator (existing_server.port).
-                    #
-                    # Window caveat: between this bind and uvicorn calling
-                    # listen() in _start_blocking_fastapi_server, the socket
-                    # is bound but NOT listening — connection attempts in
-                    # that window are REFUSED (there is no listen backlog
-                    # yet, so nothing is queued). The heartbeat may briefly
-                    # advertise an endpoint that refuses connections;
-                    # consumers retry through it once uvicorn is up.
                     bound_socket = None
-                    if not server_reused:
+                    if starts_own_server:
                         from ...shared.port_binding import (
                             bind_server_socket_with_fallback,
                         )
@@ -298,62 +362,85 @@ class DebounceCoordinator:
                         # bound port (see rust_heartbeat._resolve_registration_port).
                         pipeline_context["bound_port"] = actual_port
 
+                    # Serving gate (PR #1197 review): a bound socket is not a
+                    # serving socket — between the bind above and uvicorn's
+                    # listen(), connections are REFUSED, and a post-bind
+                    # startup failure could otherwise be registered. Hand the
+                    # heartbeat a started-signal so its FIRST registration
+                    # defers (bounded by MCP_MESH_SERVER_STARTUP_TIMEOUT)
+                    # until the server proves serving. ``server_holder`` is
+                    # populated by _start_blocking_fastapi_server before
+                    # server.run(); reuse paths check the existing uvicorn
+                    # Server directly (already True when status=="running").
+                    server_holder: dict[str, Any] = {}
+                    if starts_own_server:
+                        pipeline_context["server_started_check"] = lambda: bool(
+                            getattr(server_holder.get("server"), "started", False)
+                        )
+                    elif reused_server_obj is not None:
+                        pipeline_context["server_started_check"] = lambda: bool(
+                            getattr(reused_server_obj, "started", False)
+                        )
+
                     self._setup_heartbeat_background(
                         heartbeat_config,
                         pipeline_context,
                         heartbeat_task_fn,
                     )
 
-                    if server_reused:
-                        # Check server status to determine action
-                        server_status = existing_server.get("status", "unknown")
-
+                    if server_reused and not starts_own_server:
                         if server_status == "configured":
                             self.logger.info(
                                 "🔄 CONFIGURED SERVER: Starting configured uvicorn server within pipeline event loop"
                             )
-                            # Start the configured server within this event loop
-                            server_obj = existing_server.get("server")
-                            if server_obj:
-                                self.logger.info(
-                                    "🚀 CONFIGURED SERVER: Starting server.serve() within pipeline context"
-                                )
-                                # This runs in the same event loop as the pipeline - no conflict!
-                                import asyncio
+                            # Start the configured server within this event
+                            # loop. ``reused_server_obj`` is non-None here —
+                            # the no-server-object case was diverted to the
+                            # starts_own_server path above.
+                            server_obj = reused_server_obj
+                            self.logger.info(
+                                "🚀 CONFIGURED SERVER: Starting server.serve() within pipeline context"
+                            )
+                            # This runs in the same event loop as the pipeline - no conflict!
+                            import asyncio
 
-                                # Register so main-thread signal handlers can request
-                                # graceful shutdown via ``server.should_exit`` and the
-                                # FastAPI lifespan exit phase runs cleanly (issue #1029).
-                                from ...shared.simple_shutdown import (
-                                    register_uvicorn_server,
-                                )
+                            # Register so main-thread signal handlers can request
+                            # graceful shutdown via ``server.should_exit`` and the
+                            # FastAPI lifespan exit phase runs cleanly (issue #1029).
+                            from ...shared.simple_shutdown import (
+                                register_uvicorn_server,
+                            )
 
-                                register_uvicorn_server(server_obj)
+                            register_uvicorn_server(server_obj)
 
-                                # Define async function to run the server
-                                async def run_configured_server():
-                                    await server_obj.serve()
+                            # Define async function to run the server
+                            async def run_configured_server():
+                                await server_obj.serve()
 
-                                # Run the server in a fresh event loop (Timer thread has no live loop)
-                                asyncio.run(run_configured_server())
-                                self.logger.info(
-                                    "✅ CONFIGURED SERVER: Server started successfully"
-                                )
-                            else:
-                                self.logger.error(
-                                    "❌ CONFIGURED SERVER: No server object found, falling back to uvicorn.run()"
-                                )
-                                self._start_blocking_fastapi_server(
-                                    fastapi_app, binding_config
-                                )
-                        elif server_status == "running":
+                            # Run the server in a fresh event loop (Timer thread has no live loop)
+                            asyncio.run(run_configured_server())
+                            self.logger.info(
+                                "✅ CONFIGURED SERVER: Server started successfully"
+                            )
+                        elif server_status in ("running", "starting"):
+                            # "running": uvicorn already proved serving.
+                            # "starting": the immediate server's socket is
+                            # bound and its thread is alive, but the ASGI
+                            # lifespan startup outlived the decorator's wait
+                            # budget (slow model load etc.). Either way the
+                            # server lifecycle is owned by the decorator's
+                            # non-daemon thread + shutdown coordinator —
+                            # nothing to start here, and the heartbeat's
+                            # serving gate (set above) defers registration
+                            # until ``server.started`` flips or its budget
+                            # expires.
                             self.logger.debug(
-                                "🔄 RUNNING SERVER: Server already running with proper lifecycle, pipeline skipping uvicorn.run()"
+                                f"🔄 {server_status.upper()} SERVER: Server lifecycle owned by immediate-uvicorn thread, pipeline skipping uvicorn.run()"
                             )
                             self.logger.info(
-                                "✅ FastMCP mounted on running server - agent in normal operating state"
+                                "✅ FastMCP mounted on existing server - agent in normal operating state"
                             )
-                            # Server is already running in normal state - no further action needed
+                            # No further action needed on this thread
                             return
                         else:
                             self.logger.info(
@@ -377,8 +464,20 @@ class DebounceCoordinator:
                                 )
                                 return
                     else:
+                        if server_reused:
+                            # Degenerate "configured" record without a server
+                            # object — start our own server on the socket WE
+                            # bound above (the heartbeat registers bound_port,
+                            # never the dead record's port).
+                            self.logger.error(
+                                "❌ CONFIGURED SERVER: No server object found, "
+                                "starting our own server on a freshly bound socket"
+                            )
                         self._start_blocking_fastapi_server(
-                            fastapi_app, binding_config, bound_socket=bound_socket
+                            fastapi_app,
+                            binding_config,
+                            bound_socket=bound_socket,
+                            server_holder=server_holder,
                         )
                 else:
                     self.logger.warning(
@@ -423,6 +522,7 @@ class DebounceCoordinator:
         app: Any,
         binding_config: dict[str, Any],
         bound_socket: Any = None,
+        server_holder: dict[str, Any] | None = None,
     ) -> None:
         """Start FastAPI server with uvicorn (signal handlers already registered).
 
@@ -441,6 +541,12 @@ class DebounceCoordinator:
         the bound port. When it is None, the socket is bound here with the
         same conflict-fallback semantics so uvicorn never gets a chance to
         swallow a bind error.
+
+        ``server_holder`` (PR #1197 review): this method BLOCKS until
+        shutdown, so the caller cannot receive the ``uvicorn.Server`` as a
+        return value before serving starts. The holder dict is populated
+        with the server (``server_holder["server"]``) before ``run()`` so
+        the heartbeat's serving gate can observe ``server.started`` flip.
         """
         try:
             import uvicorn
@@ -467,6 +573,11 @@ class DebounceCoordinator:
                 ws="websockets-sansio",  # Use modern websockets API (avoids deprecation warnings)
             )
             server = uvicorn.Server(config)
+
+            # Expose the server to the heartbeat's serving gate BEFORE run()
+            # — registration defers on ``server.started`` (PR #1197 review).
+            if server_holder is not None:
+                server_holder["server"] = server
 
             # Register the server so main-thread signal handlers can request
             # graceful shutdown via ``server.should_exit`` (issue #1029).
@@ -532,6 +643,15 @@ class DebounceCoordinator:
                 self.logger.debug(
                     f"Starting background heartbeat thread for {entity_id}"
                 )
+                # Serving gate (PR #1197 review): when the caller provided a
+                # started-signal (MCP path — see _execute_processing), defer
+                # the FIRST registration until the local server proves
+                # serving, bounded by MCP_MESH_SERVER_STARTUP_TIMEOUT. The
+                # API/A2A paths set no check (the user owns their server) so
+                # this is a no-op there.
+                started_check = pipeline_context.get("server_started_check")
+                if callable(started_check):
+                    wait_for_proven_serving(started_check, entity_id, self.logger)
                 try:
                     loop = asyncio.new_event_loop()
                     asyncio.set_event_loop(loop)

--- a/src/runtime/python/_mcp_mesh/shared/port_binding.py
+++ b/src/runtime/python/_mcp_mesh/shared/port_binding.py
@@ -1,0 +1,85 @@
+"""
+Pre-bind socket helper enforcing the bound-port == registered-port invariant.
+
+Issue #1194: when an agent's configured HTTP port was already in use, the
+bind error was raised inside a background thread and swallowed — the agent
+then registered the *configured* port with the registry even though nothing
+was listening on it (a phantom endpoint). Consumers resolved dependencies to
+an endpoint owned by a different process, or by nobody.
+
+The fix is "adapt, don't crash": bind the server socket explicitly BEFORE
+registration so bind failures are synchronous, and hand the already-bound
+socket to uvicorn (``uvicorn.Server.run(sockets=...)``). On a port conflict
+we fall back to an OS-assigned port (bind 0) with a prominent warning, and
+the ACTUAL bound port is what flows into registration — the same path the
+explicit ``http_port=0`` configuration uses.
+
+Invariant: no runtime may ever register a port it did not bind.
+"""
+
+import logging
+import socket
+
+logger = logging.getLogger(__name__)
+
+
+def _bind(host: str, port: int) -> socket.socket:
+    """Bind a TCP server socket to (host, port); close the socket on failure.
+
+    Mirrors uvicorn's ``Config.bind_socket`` socket options (SO_REUSEADDR,
+    inheritable) so handing the socket to uvicorn behaves identically to
+    uvicorn binding it itself.
+    """
+    family = socket.AF_INET6 if ":" in (host or "") else socket.AF_INET
+    sock = socket.socket(family, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.bind((host, port))
+    except OSError:
+        sock.close()
+        raise
+    sock.set_inheritable(True)
+    return sock
+
+
+def bind_server_socket_with_fallback(
+    host: str, port: int
+) -> tuple[socket.socket, int]:
+    """Bind a server socket, falling back to an OS-assigned port on conflict.
+
+    Args:
+        host: Bind host (e.g. "0.0.0.0").
+        port: Configured port. 0 means auto-assign (no fallback semantics —
+            the OS picks a free port directly).
+
+    Returns:
+        ``(sock, actual_port)``. The socket is bound but NOT listening —
+        uvicorn calls ``listen()`` itself when given a pre-bound socket.
+        Until then, connection attempts against the port are REFUSED, not
+        queued (a listen backlog only exists after ``listen()``).
+        ``actual_port`` is read back from the socket, so it is always the
+        port the process actually owns.
+
+    Raises:
+        OSError: if even the port-0 bind fails (nothing to adapt to).
+    """
+    try:
+        sock = _bind(host, port)
+    except OSError as e:
+        if port == 0:
+            raise
+        logger.warning(
+            "⚠️ PORT CONFLICT: configured HTTP port %d on %s is unavailable "
+            "(%s). Falling back to an OS-assigned port so the agent can "
+            "still serve — the registry will be given the ACTUAL bound "
+            "port, not the configured one. Another process likely owns "
+            "port %d; fix the port assignment to silence this warning.",
+            port,
+            host,
+            e,
+            port,
+        )
+        sock = _bind(host, 0)
+
+    actual_port = sock.getsockname()[1]
+    return sock, actual_port

--- a/src/runtime/python/_mcp_mesh/shared/port_binding.py
+++ b/src/runtime/python/_mcp_mesh/shared/port_binding.py
@@ -22,6 +22,53 @@ import socket
 
 logger = logging.getLogger(__name__)
 
+# Default budget for waiting on proven-serving after the socket binds.
+# Sized for slow-but-healthy ASGI lifespans (model loading, connection-pool
+# warmup, schema migration checks) — NOT for the bind itself, which is
+# synchronous and already enforced by bind_server_socket_with_fallback.
+SERVER_STARTUP_TIMEOUT_DEFAULT_SECONDS = 30.0
+
+
+def get_server_startup_timeout() -> float:
+    """Budget (seconds) for waiting on a server to prove it is serving.
+
+    Configurable via ``MCP_MESH_SERVER_STARTUP_TIMEOUT`` (float seconds,
+    default 30). Two consumers share this budget:
+
+    * ``mesh.decorators._start_uvicorn_immediately`` — how long the
+      decorator waits for ``uvicorn.Server.started`` before declaring the
+      record "starting" (bound, not yet proven) and moving on.
+    * ``startup_orchestrator._setup_heartbeat_background`` — how long the
+      heartbeat defers its FIRST registration on the started-signal.
+
+    This is a *liveness deferral*, not a separate invariant: the hard
+    invariant stays bind-level (never register a port this process did not
+    bind). Expiry never fails startup — the port is genuinely held, so
+    registration proceeds; a server that ultimately cannot serve kills the
+    process (and with it the heartbeat), making a too-early registration
+    transient at worst.
+    """
+    from .config_resolver import ValidationRule, get_config_value
+
+    value = get_config_value(
+        "MCP_MESH_SERVER_STARTUP_TIMEOUT",
+        default=SERVER_STARTUP_TIMEOUT_DEFAULT_SECONDS,
+        rule=ValidationRule.FLOAT_RULE,
+    )
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        return SERVER_STARTUP_TIMEOUT_DEFAULT_SECONDS
+    if timeout <= 0:
+        logger.warning(
+            "MCP_MESH_SERVER_STARTUP_TIMEOUT must be > 0 (got %s); "
+            "using default %.0fs",
+            value,
+            SERVER_STARTUP_TIMEOUT_DEFAULT_SECONDS,
+        )
+        return SERVER_STARTUP_TIMEOUT_DEFAULT_SECONDS
+    return timeout
+
 
 def _bind(host: str, port: int) -> socket.socket:
     """Bind a TCP server socket to (host, port); close the socket on failure.

--- a/src/runtime/python/_mcp_mesh/shared/simple_shutdown.py
+++ b/src/runtime/python/_mcp_mesh/shared/simple_shutdown.py
@@ -147,11 +147,19 @@ class SimpleShutdownCoordinator:
         self._registry_url: Optional[str] = None
         self._agent_id: Optional[str] = None
         self._shutdown_complete = False  # Flag to prevent race conditions
-        # Uvicorn Server handle (lazily registered by startup_orchestrator).
-        # When set, signal handlers flip ``server.should_exit`` so uvicorn
-        # runs its graceful shutdown (which drives the FastAPI lifespan exit
-        # phase) before the server thread returns. See issue #1029.
-        self._uvicorn_server: Optional[Any] = None
+        # Uvicorn Server handles (lazily registered by mesh/decorators.py
+        # and startup_orchestrator). Signal handlers flip
+        # ``server.should_exit`` on EVERY registered server so uvicorn runs
+        # its graceful shutdown (which drives the FastAPI lifespan exit
+        # phase) before each server thread returns. See issue #1029.
+        #
+        # This is a list, not a single slot: degenerate startups can leave
+        # more than one live server in the process (e.g. the immediate
+        # decorator server comes up but the pipeline does not reuse it and
+        # starts its own). A single slot would let the second registration
+        # overwrite the first, orphaning that server's NON-daemon thread on
+        # SIGTERM — the process would never exit.
+        self._uvicorn_servers: list[Any] = []
 
     def set_shutdown_context(self, registry_url: str, agent_id: str) -> None:
         """Set context for shutdown (used for logging)."""
@@ -162,7 +170,7 @@ class SimpleShutdownCoordinator:
         )
 
     def register_uvicorn_server(self, server: Any) -> None:
-        """Register the uvicorn Server instance so the signal handler can
+        """Register a uvicorn Server instance so the signal handler can
         request graceful shutdown via ``server.should_exit``.
 
         Without this hook, SIGTERM merely sets a flag on the main thread and
@@ -172,8 +180,16 @@ class SimpleShutdownCoordinator:
         ``should_exit``, runs its normal graceful-shutdown sequence
         (including the lifespan exit phase), and then ``server.run()``
         returns cleanly. See issue #1029.
+
+        Registrations accumulate (identity-deduplicated): every registered
+        server is signaled on SIGTERM/SIGINT, so a second server started in
+        a degenerate startup path cannot orphan the first one's non-daemon
+        thread.
         """
-        self._uvicorn_server = server
+        if server is None:
+            return
+        if not any(s is server for s in self._uvicorn_servers):
+            self._uvicorn_servers.append(server)
         logger.debug("📡 Uvicorn server registered with shutdown coordinator")
 
     def install_signal_handlers(self) -> None:
@@ -190,12 +206,13 @@ class SimpleShutdownCoordinator:
         def shutdown_signal_handler(signum, frame):
             # Avoid logging in signal handler to prevent reentrant call issues
             self._shutdown_requested = True
-            # Tell uvicorn to begin graceful shutdown — this lets the
-            # FastAPI lifespan finally block run before the server thread
-            # exits. Best-effort: if no server was registered (e.g. tests,
-            # API/A2A flows that don't own uvicorn), just set the flag.
-            server = self._uvicorn_server
-            if server is not None:
+            # Tell EVERY registered uvicorn server to begin graceful
+            # shutdown — this lets the FastAPI lifespan finally block run
+            # before each server thread exits. Best-effort: if no server
+            # was registered (e.g. tests, API/A2A flows that don't own
+            # uvicorn), just set the flag. Iterate over a snapshot — the
+            # handler runs async w.r.t. the interpreter.
+            for server in list(self._uvicorn_servers):
                 server.should_exit = True
 
         signal.signal(signal.SIGINT, shutdown_signal_handler)
@@ -280,12 +297,14 @@ def install_signal_handlers() -> None:
 
 
 def register_uvicorn_server(server: Any) -> None:
-    """Register the uvicorn Server instance (module-level function).
+    """Register a uvicorn Server instance (module-level function).
 
-    Internal coordination hook between ``startup_orchestrator`` and the
-    process-wide shutdown coordinator. Calling this after
-    :func:`install_signal_handlers` enables graceful FastAPI lifespan
-    teardown on SIGTERM/SIGINT (issue #1029).
+    Internal coordination hook between ``mesh/decorators.py`` /
+    ``startup_orchestrator`` and the process-wide shutdown coordinator.
+    Calling this after :func:`install_signal_handlers` enables graceful
+    FastAPI lifespan teardown on SIGTERM/SIGINT (issue #1029). All
+    registered servers are signaled — see
+    :meth:`SimpleShutdownCoordinator.register_uvicorn_server`.
     """
     _simple_shutdown_coordinator.register_uvicorn_server(server)
 

--- a/src/runtime/python/_mcp_mesh/shared/tests/test_simple_shutdown.py
+++ b/src/runtime/python/_mcp_mesh/shared/tests/test_simple_shutdown.py
@@ -38,27 +38,50 @@ def restore_signal_handlers():
 
 
 class TestRegisterUvicornServer:
-    """register_uvicorn_server stores the handle so the signal handler can flip
-    should_exit on it.
+    """register_uvicorn_server stores the handle(s) so the signal handler can
+    flip should_exit on every registered server.
     """
 
     def test_register_stores_server(self, coordinator):
         mock_server = SimpleNamespace(should_exit=False)
         coordinator.register_uvicorn_server(mock_server)
-        assert coordinator._uvicorn_server is mock_server
+        assert mock_server in coordinator._uvicorn_servers
+
+    def test_register_accumulates_multiple_servers(self, coordinator):
+        # Degenerate startups can leave two live servers in the process
+        # (immediate decorator server + pipeline-started server). The
+        # coordinator must keep BOTH — a single slot would orphan the
+        # first server's non-daemon thread on SIGTERM.
+        first = SimpleNamespace(should_exit=False)
+        second = SimpleNamespace(should_exit=False)
+        coordinator.register_uvicorn_server(first)
+        coordinator.register_uvicorn_server(second)
+        assert coordinator._uvicorn_servers == [first, second]
+
+    def test_register_is_identity_deduplicated(self, coordinator):
+        mock_server = SimpleNamespace(should_exit=False)
+        coordinator.register_uvicorn_server(mock_server)
+        coordinator.register_uvicorn_server(mock_server)
+        assert coordinator._uvicorn_servers == [mock_server]
+
+    def test_register_none_is_a_noop(self, coordinator):
+        coordinator.register_uvicorn_server(None)
+        assert coordinator._uvicorn_servers == []
 
     def test_module_level_function_delegates_to_global_coordinator(self):
         # The module-level helper just forwards to the global singleton.
         mock_server = SimpleNamespace(should_exit=False)
-        previous = simple_shutdown._simple_shutdown_coordinator._uvicorn_server
+        previous = list(
+            simple_shutdown._simple_shutdown_coordinator._uvicorn_servers
+        )
         try:
             simple_shutdown.register_uvicorn_server(mock_server)
             assert (
-                simple_shutdown._simple_shutdown_coordinator._uvicorn_server
-                is mock_server
+                mock_server
+                in simple_shutdown._simple_shutdown_coordinator._uvicorn_servers
             )
         finally:
-            simple_shutdown._simple_shutdown_coordinator._uvicorn_server = previous
+            simple_shutdown._simple_shutdown_coordinator._uvicorn_servers = previous
 
 
 class TestSignalHandlerRequestsUvicornShutdown:
@@ -96,6 +119,25 @@ class TestSignalHandlerRequestsUvicornShutdown:
         assert mock_server.should_exit is True
         assert coordinator.is_shutdown_requested() is True
 
+    def test_handler_flips_should_exit_on_every_registered_server(
+        self, coordinator, restore_signal_handlers
+    ):
+        # Both the immediate decorator server and a pipeline-started
+        # server must receive the graceful-shutdown request — neither
+        # non-daemon server thread may be orphaned on SIGTERM.
+        first = SimpleNamespace(should_exit=False)
+        second = SimpleNamespace(should_exit=False)
+        coordinator.register_uvicorn_server(first)
+        coordinator.register_uvicorn_server(second)
+        coordinator.install_signal_handlers()
+
+        installed = signal.getsignal(signal.SIGTERM)
+        installed(signal.SIGTERM, None)
+
+        assert first.should_exit is True
+        assert second.should_exit is True
+        assert coordinator.is_shutdown_requested() is True
+
     def test_handler_without_registered_server_just_sets_flag(
         self, coordinator, restore_signal_handlers
     ):
@@ -107,7 +149,7 @@ class TestSignalHandlerRequestsUvicornShutdown:
         installed(signal.SIGTERM, None)
 
         assert coordinator.is_shutdown_requested() is True
-        assert coordinator._uvicorn_server is None
+        assert coordinator._uvicorn_servers == []
 
     def test_handler_idempotent_when_server_already_exiting(
         self, coordinator, restore_signal_handlers

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -32,11 +32,11 @@ _SHARED_AGENT_ID: str | None = None
 _MESH_CONSUMER_SELF_SENTINEL = "__MESH_CONSUMER_SELF__"
 
 # Budget for waiting on ``uvicorn.Server.started`` after the immediate
-# server thread launches. uvicorn startup on a pre-bound socket is
-# lightweight; if ``started`` has not flipped within this window the
-# server is wedged or its thread died (e.g. ``Config.load()`` raised on
-# bad TLS cert paths) — either way it must NOT be recorded as "running".
-_IMMEDIATE_SERVER_STARTUP_TIMEOUT_SECONDS = 5.0
+# server thread launches: MCP_MESH_SERVER_STARTUP_TIMEOUT (default 30s),
+# shared with the heartbeat's first-registration deferral. See
+# ``_mcp_mesh.shared.port_binding.get_server_startup_timeout`` — sized for
+# slow-but-healthy ASGI lifespans (model loading etc.), so a healthy slow
+# startup is not misclassified as wedged.
 
 
 class ImmediateServerStartupError(RuntimeError):
@@ -580,64 +580,27 @@ def _start_uvicorn_immediately(http_host: str, http_port: int):
             "🔒 IMMEDIATE UVICORN: Server thread started (daemon=False) - can handle signals"
         )
 
-        # A bound socket is not a serving socket: uvicorn can still fail
-        # AFTER the bind — e.g. ``Config.load()`` raising on unreadable TLS
-        # cert/key paths — and that failure happens inside the server
-        # thread. Recording status "running" before uvicorn proves it can
-        # serve would let the heartbeat register a port that refuses every
-        # connection. Wait (bounded) for ``server.started`` to flip before
-        # storing the server record.
-        startup_deadline = (
-            time.monotonic() + _IMMEDIATE_SERVER_STARTUP_TIMEOUT_SECONDS
-        )
-        while not uvicorn_server.started and thread.is_alive():
-            if time.monotonic() >= startup_deadline:
-                break
-            time.sleep(0.05)
-
-        if not uvicorn_server.started:
-            if not thread.is_alive():
-                # The server thread died before serving (run_server already
-                # logged the underlying exception + traceback). Release the
-                # bound socket — this process can never serve on it — and
-                # fail the decorator application loudly. No server record
-                # is stored, so this port is never registered.
-                try:
-                    bound_socket.close()
-                except OSError:
-                    pass
-                logger.error(
-                    f"❌ IMMEDIATE UVICORN: server thread died before serving "
-                    f"on {http_host}:{port} — the agent cannot serve; failing "
-                    f"loudly (see the server error logged above)"
-                )
-                raise ImmediateServerStartupError(
-                    f"immediate uvicorn server thread died before serving on "
-                    f"{http_host}:{port} — see the server error logged above"
-                )
-            # Thread alive but ``started`` never flipped within the budget:
-            # the server is wedged mid-startup. Do NOT record it as running
-            # — a record here would register a port that may never serve.
-            # The socket stays with the wedged server (it may still come
-            # up); the pipeline's no-server path starts its own server on
-            # its own bound port, and the shutdown coordinator signals
-            # every registered server on SIGTERM, so neither non-daemon
-            # thread is orphaned.
-            logger.error(
-                f"❌ IMMEDIATE UVICORN: server did not report started within "
-                f"{_IMMEDIATE_SERVER_STARTUP_TIMEOUT_SECONDS:.0f}s on "
-                f"{http_host}:{port} — not recording it as running; the "
-                f"startup pipeline will start its own server"
-            )
-            return
-
-        # Store server reference in DecoratorRegistry — the pipeline's
-        # server discovery reuses this server instead of starting a second
-        # one. Stored only AFTER uvicorn reported started, so "running"
-        # means actually serving.
-        # NOTE: "port" is the ACTUAL bound port (read back from the socket).
-        # Server discovery propagates it to the heartbeat, which registers
-        # it with the registry — never the configured-but-unbound port.
+        # Store the bound-server record IMMEDIATELY with status "starting",
+        # then upgrade it to "running" once uvicorn proves serving. Two
+        # constraints meet here (issue #1194 + PR #1197 review):
+        #
+        # * The debounced startup pipeline (~1s after the last decorator)
+        #   races this thread's ASGI lifespan startup. If the record were
+        #   stored only after ``server.started`` flips, any lifespan slower
+        #   than the debounce delay would make ServerDiscoveryStep find
+        #   nothing and the pipeline would pre-bind a SECOND server on a
+        #   different port (duplicate server, registered port != the port
+        #   the agent's real app ends up on).
+        # * A bound socket is not a serving socket: uvicorn can still fail
+        #   AFTER the bind (e.g. ``Config.load()`` raising on unreadable TLS
+        #   cert/key paths) inside the server thread.
+        #
+        # The hard invariant stays bind-level — ``port`` is read back from
+        # the socket this process bound, so the record can never advertise a
+        # port nobody owns. Proven-serving is enforced as a *liveness
+        # deferral* at registration time instead: the heartbeat defers its
+        # first registration on ``server.started`` (bounded by the same
+        # budget; see startup_orchestrator._setup_heartbeat_background).
         server_info = {
             "app": app,
             "server": uvicorn_server,
@@ -646,11 +609,12 @@ def _start_uvicorn_immediately(http_host: str, http_port: int):
             "port": port,
             "thread": thread,  # Server thread (non-daemon)
             "type": "immediate_uvicorn_running",
-            "status": "running",  # uvicorn reported started — actually serving
+            "status": "starting",  # bound, serving not yet proven
         }
 
         # Import here to avoid circular imports
         from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.shared.port_binding import get_server_startup_timeout
 
         DecoratorRegistry.store_immediate_uvicorn_server(server_info)
 
@@ -658,9 +622,64 @@ def _start_uvicorn_immediately(http_host: str, http_port: int):
             "🔄 IMMEDIATE UVICORN: Server reference stored in DecoratorRegistry"
         )
 
-        logger.debug(
-            f"✅ IMMEDIATE UVICORN: Uvicorn server running on {http_host}:{port} (non-daemon thread)"
-        )
+        startup_timeout = get_server_startup_timeout()
+        startup_deadline = time.monotonic() + startup_timeout
+        while not uvicorn_server.started and thread.is_alive():
+            if time.monotonic() >= startup_deadline:
+                break
+            time.sleep(0.05)
+
+        if uvicorn_server.started:
+            # Upgrade in place — server discovery holds a reference to this
+            # same dict, so the status change is visible everywhere.
+            server_info["status"] = "running"
+            logger.debug(
+                f"✅ IMMEDIATE UVICORN: Uvicorn server running on {http_host}:{port} (non-daemon thread)"
+            )
+        elif not thread.is_alive():
+            # The server thread died before serving (run_server already
+            # logged the underlying exception + traceback). Remove the
+            # record so nothing reuses or registers it, release the bound
+            # socket — this process can never serve on it — and fail the
+            # decorator application loudly. Thread death surfaces within
+            # ~50ms here, well before the debounced pipeline (~1s) reads
+            # the registry.
+            DecoratorRegistry.clear_immediate_uvicorn_server()
+            try:
+                bound_socket.close()
+            except OSError:
+                pass
+            logger.error(
+                f"❌ IMMEDIATE UVICORN: server thread died before serving "
+                f"on {http_host}:{port} — the agent cannot serve; failing "
+                f"loudly (see the server error logged above)"
+            )
+            raise ImmediateServerStartupError(
+                f"immediate uvicorn server thread died before serving on "
+                f"{http_host}:{port} — see the server error logged above"
+            )
+        else:
+            # Budget expired with the thread ALIVE and the socket bound: the
+            # port is genuinely held by this process, so keep the record
+            # (status stays "starting") — the pipeline reuses THIS server
+            # instead of starting a duplicate, and registration carries the
+            # bound port. The heartbeat's own bounded deferral has the same
+            # budget, so registration may proceed before serving is proven;
+            # if uvicorn ultimately fails to serve, the thread dies and the
+            # process exits — a too-early registration is transient at
+            # worst, never a phantom bind. Note this also defers dependency
+            # resolution for consumers of this agent until registration —
+            # acceptable and arguably correct (don't advertise until
+            # serving); the settling-window grace (issue #1193) layers on
+            # top of this without being pre-empted here.
+            logger.warning(
+                f"⚠️ IMMEDIATE UVICORN: server has not reported started within "
+                f"{startup_timeout:.0f}s on {http_host}:{port} (slow ASGI "
+                f"lifespan startup?). The port IS bound by this process, so "
+                f"the server record is kept and startup continues; raise "
+                f"MCP_MESH_SERVER_STARTUP_TIMEOUT if your startup is "
+                f"legitimately slower."
+            )
 
         # Set up registry context for shutdown cleanup (use defaults initially)
         import os

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -31,24 +31,26 @@ _SHARED_AGENT_ID: str | None = None
 # See _resolve_pending_consumer_self_tags below.
 _MESH_CONSUMER_SELF_SENTINEL = "__MESH_CONSUMER_SELF__"
 
+# Budget for waiting on ``uvicorn.Server.started`` after the immediate
+# server thread launches. uvicorn startup on a pre-bound socket is
+# lightweight; if ``started`` has not flipped within this window the
+# server is wedged or its thread died (e.g. ``Config.load()`` raised on
+# bad TLS cert paths) — either way it must NOT be recorded as "running".
+_IMMEDIATE_SERVER_STARTUP_TIMEOUT_SECONDS = 5.0
 
-def _find_available_port() -> int:
+
+class ImmediateServerStartupError(RuntimeError):
+    """The immediate uvicorn server bound its socket but can never serve.
+
+    Raised (and deliberately NOT swallowed by ``_start_uvicorn_immediately``'s
+    catch-all) when the server thread dies before ``server.started`` flips —
+    e.g. ``uvicorn.Config.load()`` failing on bad TLS cert/key paths after
+    the socket was already bound. A bound socket that can never serve is not
+    something the mesh can adapt around: registering it would advertise an
+    endpoint that refuses every connection, and the orchestrator fallback
+    server path does not carry the agent's TLS configuration. Failing the
+    decorator application loudly is the only honest outcome.
     """
-    Find an available port by binding to port 0 and getting the OS-assigned port.
-
-    This is used when http_port=0 is specified to auto-assign a port.
-    Works reliably on all platforms (macOS, Linux, Windows) without external tools.
-
-    Returns:
-        int: An available port number
-    """
-    import socket
-
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        s.listen(1)
-        port = s.getsockname()[1]
-    return port
 
 
 def _start_uvicorn_immediately(http_host: str, http_port: int):
@@ -485,29 +487,6 @@ def _start_uvicorn_immediately(http_host: str, http_port: int):
 
         logger.debug("📦 IMMEDIATE UVICORN: Added status endpoints")
 
-        # Port handling:
-        # - http_port=0 explicitly means auto-assign (let uvicorn choose)
-        # - http_port>0 means use that specific port
-        # Note: The default is 8080 only if http_port was never specified,
-        # which is handled upstream in the @mesh.agent decorator
-        port = http_port
-
-        # Handle http_port=0: find an available port BEFORE starting uvicorn
-        # This is more reliable than detecting the port after uvicorn starts
-        # and works on all platforms (Linux containers don't have lsof installed)
-        if port == 0:
-            port = _find_available_port()
-            logger.info(f"🎯 IMMEDIATE UVICORN: Auto-assigned port {port} for agent")
-
-        logger.debug(
-            f"🚀 IMMEDIATE UVICORN: Starting uvicorn server on {http_host}:{port}"
-        )
-
-        # Use uvicorn.run() for proper signal handling (enables FastAPI lifespan shutdown)
-        logger.debug(
-            "⚡ IMMEDIATE UVICORN: Starting server with uvicorn.run() for proper signal handling"
-        )
-
         # Resolve TLS config from Rust core
         from _mcp_mesh.shared.tls_config import get_tls_config
 
@@ -528,24 +507,65 @@ def _start_uvicorn_immediately(http_host: str, http_port: int):
                 ssl_kwargs["ssl_cert_reqs"] = ssl.CERT_REQUIRED
             logger.info(f"IMMEDIATE UVICORN: TLS enabled (mode={tls['mode']})")
 
+        # Port handling (issue #1194):
+        # - http_port=0 explicitly means auto-assign (OS picks a free port)
+        # - http_port>0 means use that specific port, falling back to an
+        #   OS-assigned port (with a prominent warning) if it is taken.
+        #
+        # The socket is bound HERE — synchronously, before uvicorn starts —
+        # and handed to uvicorn as a pre-bound socket. This makes bind
+        # failures impossible to swallow (previously uvicorn's bind error
+        # died inside the server thread and the agent registered a port it
+        # never bound — a phantom endpoint). The port recorded below is
+        # read back from the bound socket, so registration always carries
+        # the ACTUAL port.
+        from _mcp_mesh.shared.port_binding import bind_server_socket_with_fallback
+
+        bound_socket, port = bind_server_socket_with_fallback(http_host, http_port)
+        if http_port == 0:
+            logger.info(f"🎯 IMMEDIATE UVICORN: Auto-assigned port {port} for agent")
+        elif port != http_port:
+            # bind_server_socket_with_fallback already logged the prominent
+            # conflict warning; this line ties it to the agent lifecycle log.
+            logger.warning(
+                f"⚠️ IMMEDIATE UVICORN: configured port {http_port} unavailable - "
+                f"serving and registering on auto-assigned port {port} instead"
+            )
+
+        logger.debug(
+            f"🚀 IMMEDIATE UVICORN: Starting uvicorn server on {http_host}:{port}"
+        )
+
+        # Build the uvicorn Server explicitly so we can hand it the
+        # pre-bound socket (issue #1194). Serving on a socket we already
+        # own means the registered port is, by construction, the bound
+        # port. The Server object is also registered with the shutdown
+        # coordinator so SIGTERM/SIGINT flip ``server.should_exit`` and
+        # uvicorn runs its graceful shutdown (FastAPI lifespan exit phase).
+        uvicorn_config = uvicorn.Config(
+            app,
+            host=http_host,
+            port=port,
+            log_level="info",
+            timeout_graceful_shutdown=30,  # Allow time for registry cleanup
+            access_log=False,  # Reduce noise
+            ws="websockets-sansio",  # Use modern websockets API (avoids deprecation warnings)
+            **ssl_kwargs,
+        )
+        uvicorn_server = uvicorn.Server(uvicorn_config)
+
+        from _mcp_mesh.shared.simple_shutdown import register_uvicorn_server
+
+        register_uvicorn_server(uvicorn_server)
+
         # Start uvicorn server in background thread (NON-daemon to keep process alive)
         def run_server():
-            """Run uvicorn server in background thread with proper signal handling."""
+            """Run uvicorn server on the pre-bound socket in a background thread."""
             try:
                 logger.debug(
                     f"🌟 IMMEDIATE UVICORN: Starting server on {http_host}:{port}"
                 )
-                # Use uvicorn.run() instead of Server().run() for proper signal handling
-                uvicorn.run(
-                    app,
-                    host=http_host,
-                    port=port,
-                    log_level="info",
-                    timeout_graceful_shutdown=30,  # Allow time for registry cleanup
-                    access_log=False,  # Reduce noise
-                    ws="websockets-sansio",  # Use modern websockets API (avoids deprecation warnings)
-                    **ssl_kwargs,
-                )
+                uvicorn_server.run(sockets=[bound_socket])
             except Exception as e:
                 logger.error(f"❌ IMMEDIATE UVICORN: Server failed: {e}")
                 import traceback
@@ -560,16 +580,73 @@ def _start_uvicorn_immediately(http_host: str, http_port: int):
             "🔒 IMMEDIATE UVICORN: Server thread started (daemon=False) - can handle signals"
         )
 
-        # Store server reference in DecoratorRegistry BEFORE starting (critical timing)
+        # A bound socket is not a serving socket: uvicorn can still fail
+        # AFTER the bind — e.g. ``Config.load()`` raising on unreadable TLS
+        # cert/key paths — and that failure happens inside the server
+        # thread. Recording status "running" before uvicorn proves it can
+        # serve would let the heartbeat register a port that refuses every
+        # connection. Wait (bounded) for ``server.started`` to flip before
+        # storing the server record.
+        startup_deadline = (
+            time.monotonic() + _IMMEDIATE_SERVER_STARTUP_TIMEOUT_SECONDS
+        )
+        while not uvicorn_server.started and thread.is_alive():
+            if time.monotonic() >= startup_deadline:
+                break
+            time.sleep(0.05)
+
+        if not uvicorn_server.started:
+            if not thread.is_alive():
+                # The server thread died before serving (run_server already
+                # logged the underlying exception + traceback). Release the
+                # bound socket — this process can never serve on it — and
+                # fail the decorator application loudly. No server record
+                # is stored, so this port is never registered.
+                try:
+                    bound_socket.close()
+                except OSError:
+                    pass
+                logger.error(
+                    f"❌ IMMEDIATE UVICORN: server thread died before serving "
+                    f"on {http_host}:{port} — the agent cannot serve; failing "
+                    f"loudly (see the server error logged above)"
+                )
+                raise ImmediateServerStartupError(
+                    f"immediate uvicorn server thread died before serving on "
+                    f"{http_host}:{port} — see the server error logged above"
+                )
+            # Thread alive but ``started`` never flipped within the budget:
+            # the server is wedged mid-startup. Do NOT record it as running
+            # — a record here would register a port that may never serve.
+            # The socket stays with the wedged server (it may still come
+            # up); the pipeline's no-server path starts its own server on
+            # its own bound port, and the shutdown coordinator signals
+            # every registered server on SIGTERM, so neither non-daemon
+            # thread is orphaned.
+            logger.error(
+                f"❌ IMMEDIATE UVICORN: server did not report started within "
+                f"{_IMMEDIATE_SERVER_STARTUP_TIMEOUT_SECONDS:.0f}s on "
+                f"{http_host}:{port} — not recording it as running; the "
+                f"startup pipeline will start its own server"
+            )
+            return
+
+        # Store server reference in DecoratorRegistry — the pipeline's
+        # server discovery reuses this server instead of starting a second
+        # one. Stored only AFTER uvicorn reported started, so "running"
+        # means actually serving.
+        # NOTE: "port" is the ACTUAL bound port (read back from the socket).
+        # Server discovery propagates it to the heartbeat, which registers
+        # it with the registry — never the configured-but-unbound port.
         server_info = {
             "app": app,
-            "server": None,  # No server object with uvicorn.run()
-            "config": None,  # No config object needed
+            "server": uvicorn_server,
+            "config": uvicorn_config,
             "host": http_host,
             "port": port,
             "thread": thread,  # Server thread (non-daemon)
             "type": "immediate_uvicorn_running",
-            "status": "running",  # Server is now running in background thread
+            "status": "running",  # uvicorn reported started — actually serving
         }
 
         # Import here to avoid circular imports
@@ -578,14 +655,11 @@ def _start_uvicorn_immediately(http_host: str, http_port: int):
         DecoratorRegistry.store_immediate_uvicorn_server(server_info)
 
         logger.debug(
-            "🔄 IMMEDIATE UVICORN: Server reference stored in DecoratorRegistry BEFORE pipeline starts"
+            "🔄 IMMEDIATE UVICORN: Server reference stored in DecoratorRegistry"
         )
 
-        # Give server a moment to start
-        time.sleep(1)
-
         logger.debug(
-            f"✅ IMMEDIATE UVICORN: Uvicorn server running on {http_host}:{port} (daemon thread)"
+            f"✅ IMMEDIATE UVICORN: Uvicorn server running on {http_host}:{port} (non-daemon thread)"
         )
 
         # Set up registry context for shutdown cleanup (use defaults initially)
@@ -602,6 +676,11 @@ def _start_uvicorn_immediately(http_host: str, http_port: int):
         # Uses simple shutdown with signal handlers for clean registry cleanup
         start_blocking_loop_with_shutdown_support(thread)
 
+    except ImmediateServerStartupError:
+        # Bound-but-can-never-serve is the loud-failure case: the pipeline
+        # fallback cannot honor this agent's TLS configuration, so quietly
+        # falling through would trade a dead endpoint for a wrong one.
+        raise
     except Exception as e:
         logger.error(
             f"❌ IMMEDIATE UVICORN: Failed to start immediate uvicorn server: {e}"

--- a/src/runtime/python/tests/unit/test_port_conflict_fallback.py
+++ b/src/runtime/python/tests/unit/test_port_conflict_fallback.py
@@ -1,0 +1,282 @@
+"""
+Tests for issue #1194: port bind failure must never produce a phantom
+registration (registered port != bound port).
+
+Covers:
+- ``bind_server_socket_with_fallback``: exact bind, conflict fallback with
+  prominent warning naming the configured port, explicit port-0 auto-assign.
+- ``_resolve_registration_port``: the heartbeat-side invariant — the actual
+  bound port (from ``bound_port`` / ``existing_server.port`` context) is
+  authoritative over the configured port.
+- End-to-end serving: uvicorn started on the pre-bound fallback socket
+  actually answers HTTP on the auto-assigned port while the configured port
+  stays owned by the conflicting listener.
+- Startup gate: a bound socket is not a serving socket — the immediate
+  server is only recorded as "running" (and thus registrable) after uvicorn
+  reports ``started``; post-bind startup failures store no server record.
+"""
+
+import logging
+import socket
+import threading
+import time
+
+import pytest
+
+from _mcp_mesh.pipeline.mcp_heartbeat.rust_heartbeat import (
+    _resolve_registration_port,
+)
+from _mcp_mesh.shared.port_binding import bind_server_socket_with_fallback
+
+BIND_HOST = "127.0.0.1"
+
+
+@pytest.fixture
+def occupied_port():
+    """Bind a listening socket on an OS-assigned port and keep it open."""
+    blocker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    blocker.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    blocker.bind((BIND_HOST, 0))
+    blocker.listen(1)
+    port = blocker.getsockname()[1]
+    yield port
+    blocker.close()
+
+
+class TestBindServerSocketWithFallback:
+    """Unit tests for the pre-bind helper."""
+
+    def test_binds_exact_port_when_free(self):
+        """A free configured port is bound exactly — no fallback."""
+        # Find a free port, release it, then ask the helper for it.
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.bind((BIND_HOST, 0))
+        free_port = probe.getsockname()[1]
+        probe.close()
+
+        sock, actual_port = bind_server_socket_with_fallback(BIND_HOST, free_port)
+        try:
+            assert actual_port == free_port
+            assert sock.getsockname()[1] == free_port
+        finally:
+            sock.close()
+
+    def test_port_zero_auto_assigns(self, caplog):
+        """Explicit port 0 binds an OS-assigned port without any warning."""
+        with caplog.at_level(logging.WARNING, logger="_mcp_mesh.shared.port_binding"):
+            sock, actual_port = bind_server_socket_with_fallback(BIND_HOST, 0)
+        try:
+            assert actual_port > 0
+            assert sock.getsockname()[1] == actual_port
+            assert "PORT CONFLICT" not in caplog.text
+        finally:
+            sock.close()
+
+    def test_conflict_falls_back_to_os_assigned_port(self, occupied_port, caplog):
+        """A conflicting configured port falls back to an OS-assigned port,
+        with a prominent warning naming the configured port."""
+        with caplog.at_level(logging.WARNING, logger="_mcp_mesh.shared.port_binding"):
+            sock, actual_port = bind_server_socket_with_fallback(
+                BIND_HOST, occupied_port
+            )
+        try:
+            assert actual_port != occupied_port
+            assert actual_port > 0
+            # The returned port is read back from the bound socket.
+            assert sock.getsockname()[1] == actual_port
+            # Prominent warning names the conflicting configured port.
+            assert "PORT CONFLICT" in caplog.text
+            assert str(occupied_port) in caplog.text
+        finally:
+            sock.close()
+
+    def test_returned_socket_is_actually_bound(self, occupied_port):
+        """The fallback socket is owned by this process — a fresh bind to
+        the same port must fail (proves we did not just pick a number)."""
+        sock, actual_port = bind_server_socket_with_fallback(BIND_HOST, occupied_port)
+        try:
+            sock.listen(1)
+            other = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            with pytest.raises(OSError):
+                other.bind((BIND_HOST, actual_port))
+            other.close()
+        finally:
+            sock.close()
+
+
+class TestResolveRegistrationPort:
+    """The heartbeat must register the bound port, never a phantom one."""
+
+    def test_bound_port_context_key_is_authoritative(self, caplog):
+        """Orchestrator-bound socket port overrides a conflicting config port."""
+        with caplog.at_level(
+            logging.WARNING, logger="_mcp_mesh.pipeline.mcp_heartbeat.rust_heartbeat"
+        ):
+            port = _resolve_registration_port(9000, {"bound_port": 54321})
+        assert port == 54321
+        assert "ACTUAL bound port 54321" in caplog.text
+        assert "9000" in caplog.text
+
+    def test_existing_server_port_is_authoritative(self):
+        """Immediate-uvicorn discovered server port overrides the config port."""
+        context = {"existing_server": {"port": 54321, "status": "running"}}
+        assert _resolve_registration_port(9000, context) == 54321
+
+    def test_port_zero_uses_detected_port(self):
+        """Existing port-0 flow: detected port is registered (unchanged behavior)."""
+        context = {"existing_server": {"port": 43210}}
+        assert _resolve_registration_port(0, context) == 43210
+
+    def test_matching_ports_pass_through_silently(self, caplog):
+        """Normal fixed-port flow: bound == configured, no warning."""
+        with caplog.at_level(
+            logging.WARNING, logger="_mcp_mesh.pipeline.mcp_heartbeat.rust_heartbeat"
+        ):
+            port = _resolve_registration_port(8080, {"bound_port": 8080})
+        assert port == 8080
+        assert "ACTUAL bound port" not in caplog.text
+
+    def test_no_bind_info_falls_back_to_configured(self):
+        """Without any bind record (synthetic contexts), config port is used."""
+        assert _resolve_registration_port(8080, {}) == 8080
+        assert _resolve_registration_port(8080, {"existing_server": None}) == 8080
+        assert _resolve_registration_port(8080, {"existing_server": {}}) == 8080
+
+
+class TestImmediateServerStartupGate:
+    """Issue #1194 follow-up: a bound socket is not a serving socket.
+
+    ``_start_uvicorn_immediately`` must not record a "running" server (and
+    therefore must not let the heartbeat register the port) until uvicorn
+    reports ``started``. Previously a post-bind failure — e.g.
+    ``uvicorn.Config.load()`` raising on bad TLS cert paths — died inside
+    the server thread while the agent advertised a port that refused every
+    connection.
+    """
+
+    @pytest.fixture(autouse=True)
+    def clean_global_state(self):
+        """Isolate DecoratorRegistry + shutdown-coordinator global state."""
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.shared import simple_shutdown
+
+        DecoratorRegistry.clear_immediate_uvicorn_server()
+        saved_servers = list(
+            simple_shutdown._simple_shutdown_coordinator._uvicorn_servers
+        )
+        yield
+        DecoratorRegistry.clear_immediate_uvicorn_server()
+        simple_shutdown._simple_shutdown_coordinator._uvicorn_servers = saved_servers
+
+    def test_post_bind_failure_raises_and_stores_no_server(self, monkeypatch):
+        """Server thread dies post-bind (e.g. bad TLS cert paths inside
+        ``Config.load()``): no running server record, the bound socket is
+        released, and the failure is loud (raises)."""
+        import uvicorn
+
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from mesh import decorators
+
+        def failing_run(self, sockets=None):
+            raise RuntimeError(
+                "simulated post-bind startup failure (bad TLS cert path)"
+            )
+
+        monkeypatch.setattr(uvicorn.Server, "run", failing_run)
+
+        # Known free port so the socket-release assertion below is exact.
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.bind((BIND_HOST, 0))
+        free_port = probe.getsockname()[1]
+        probe.close()
+
+        with pytest.raises(decorators.ImmediateServerStartupError):
+            decorators._start_uvicorn_immediately(BIND_HOST, free_port)
+
+        # No "running" record — nothing for the heartbeat to register.
+        assert DecoratorRegistry.get_immediate_uvicorn_server() is None
+
+        # The pre-bound socket was released: the port is bindable again.
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind((BIND_HOST, free_port))
+        finally:
+            sock.close()
+
+    def test_wedged_startup_stores_no_running_record(self, monkeypatch):
+        """Thread alive but ``started`` never flips within the budget: the
+        function returns WITHOUT a running record (the pipeline's no-server
+        path takes over) and without raising — the wedged server may still
+        come up, and the shutdown coordinator signals all servers."""
+        import uvicorn
+
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from mesh import decorators
+
+        release = threading.Event()
+
+        def wedged_run(self, sockets=None):
+            # Never flips self.started — wedged after the bind.
+            release.wait(timeout=10)
+
+        monkeypatch.setattr(uvicorn.Server, "run", wedged_run)
+        monkeypatch.setattr(
+            decorators, "_IMMEDIATE_SERVER_STARTUP_TIMEOUT_SECONDS", 0.3
+        )
+
+        try:
+            decorators._start_uvicorn_immediately(BIND_HOST, 0)
+            assert DecoratorRegistry.get_immediate_uvicorn_server() is None
+        finally:
+            release.set()
+
+
+class TestUvicornServesOnFallbackSocket:
+    """End-to-end: the agent comes up on the auto-assigned port when the
+    configured port is occupied, and the pre-bound socket is what serves."""
+
+    @pytest.mark.slow
+    def test_uvicorn_serves_on_fallback_port(self, occupied_port):
+        uvicorn = pytest.importorskip("uvicorn")
+        fastapi = pytest.importorskip("fastapi")
+        import urllib.request
+
+        app = fastapi.FastAPI()
+
+        @app.get("/ping")
+        def ping():
+            return {"ok": True}
+
+        # Same flow as mesh/decorators._start_uvicorn_immediately:
+        # pre-bind with fallback, then hand uvicorn the bound socket.
+        sock, actual_port = bind_server_socket_with_fallback(
+            BIND_HOST, occupied_port
+        )
+        assert actual_port != occupied_port
+
+        config = uvicorn.Config(app, host=BIND_HOST, port=actual_port, log_level="error")
+        server = uvicorn.Server(config)
+        thread = threading.Thread(
+            target=lambda: server.run(sockets=[sock]), daemon=True
+        )
+        thread.start()
+        try:
+            deadline = time.time() + 10
+            while not server.started:
+                if time.time() > deadline:
+                    pytest.fail("uvicorn did not start on the fallback socket")
+                time.sleep(0.05)
+
+            with urllib.request.urlopen(
+                f"http://{BIND_HOST}:{actual_port}/ping", timeout=5
+            ) as resp:
+                assert resp.status == 200
+
+            # Invariant check: the port uvicorn actually serves on is the
+            # port we would register.
+            served_port = server.servers[0].sockets[0].getsockname()[1]
+            assert served_port == actual_port
+        finally:
+            server.should_exit = True
+            thread.join(timeout=10)

--- a/src/runtime/python/tests/unit/test_port_conflict_fallback.py
+++ b/src/runtime/python/tests/unit/test_port_conflict_fallback.py
@@ -11,9 +11,13 @@ Covers:
 - End-to-end serving: uvicorn started on the pre-bound fallback socket
   actually answers HTTP on the auto-assigned port while the configured port
   stays owned by the conflicting listener.
-- Startup gate: a bound socket is not a serving socket — the immediate
-  server is only recorded as "running" (and thus registrable) after uvicorn
-  reports ``started``; post-bind startup failures store no server record.
+- Startup gate (PR #1197 review reconciliation): the bound-server record is
+  stored immediately (status "starting", bound-port authority intact) so the
+  debounced pipeline never starts a duplicate server during a slow ASGI
+  lifespan; the record upgrades to "running" once uvicorn reports
+  ``started``; a dead server thread clears the record, releases the socket
+  and fails loudly. Proven-serving is a registration-time liveness deferral
+  (``wait_for_proven_serving``) bounded by MCP_MESH_SERVER_STARTUP_TIMEOUT.
 """
 
 import logging
@@ -26,7 +30,14 @@ import pytest
 from _mcp_mesh.pipeline.mcp_heartbeat.rust_heartbeat import (
     _resolve_registration_port,
 )
-from _mcp_mesh.shared.port_binding import bind_server_socket_with_fallback
+from _mcp_mesh.pipeline.mcp_startup.startup_orchestrator import (
+    wait_for_proven_serving,
+)
+from _mcp_mesh.shared.port_binding import (
+    SERVER_STARTUP_TIMEOUT_DEFAULT_SECONDS,
+    bind_server_socket_with_fallback,
+    get_server_startup_timeout,
+)
 
 BIND_HOST = "127.0.0.1"
 
@@ -144,21 +155,34 @@ class TestResolveRegistrationPort:
 
 
 class TestImmediateServerStartupGate:
-    """Issue #1194 follow-up: a bound socket is not a serving socket.
+    """Issue #1194 follow-up + PR #1197 review: bound-record semantics.
 
-    ``_start_uvicorn_immediately`` must not record a "running" server (and
-    therefore must not let the heartbeat register the port) until uvicorn
-    reports ``started``. Previously a post-bind failure — e.g.
-    ``uvicorn.Config.load()`` raising on bad TLS cert paths — died inside
-    the server thread while the agent advertised a port that refused every
-    connection.
+    The hard invariant is bind-level: the recorded port is always read back
+    from a socket THIS process bound. The serving question is handled as a
+    liveness deferral: the record is stored immediately with status
+    "starting" (so the debounced pipeline reuses this server instead of
+    starting a duplicate during a slow ASGI lifespan), upgrades to
+    "running" once uvicorn reports ``started``, and a dead server thread
+    clears the record, releases the socket and fails loudly.
     """
 
     @pytest.fixture(autouse=True)
-    def clean_global_state(self):
-        """Isolate DecoratorRegistry + shutdown-coordinator global state."""
+    def clean_global_state(self, monkeypatch):
+        """Isolate DecoratorRegistry + shutdown-coordinator global state.
+
+        Also no-ops the blocking keep-alive loop — the survive paths of
+        ``_start_uvicorn_immediately`` now fall through to it (matching the
+        production flow), which would otherwise block the test forever.
+        """
         from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
         from _mcp_mesh.shared import simple_shutdown
+        from mesh import decorators
+
+        monkeypatch.setattr(
+            decorators,
+            "start_blocking_loop_with_shutdown_support",
+            lambda thread: None,
+        )
 
         DecoratorRegistry.clear_immediate_uvicorn_server()
         saved_servers = list(
@@ -204,11 +228,12 @@ class TestImmediateServerStartupGate:
         finally:
             sock.close()
 
-    def test_wedged_startup_stores_no_running_record(self, monkeypatch):
+    def test_budget_expiry_with_live_thread_keeps_bound_record(self, monkeypatch):
         """Thread alive but ``started`` never flips within the budget: the
-        function returns WITHOUT a running record (the pipeline's no-server
-        path takes over) and without raising — the wedged server may still
-        come up, and the shutdown coordinator signals all servers."""
+        bound record is KEPT (status "starting") so the pipeline reuses this
+        server instead of pre-binding a duplicate, and registration carries
+        the genuinely-held bound port. No raise — a slow-but-healthy
+        lifespan must not be misclassified as fatal."""
         import uvicorn
 
         from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
@@ -216,20 +241,143 @@ class TestImmediateServerStartupGate:
 
         release = threading.Event()
 
-        def wedged_run(self, sockets=None):
-            # Never flips self.started — wedged after the bind.
+        def slow_lifespan_run(self, sockets=None):
+            # Never flips self.started within the budget — e.g. a model
+            # load in the ASGI lifespan that outlives the wait window.
             release.wait(timeout=10)
 
-        monkeypatch.setattr(uvicorn.Server, "run", wedged_run)
-        monkeypatch.setattr(
-            decorators, "_IMMEDIATE_SERVER_STARTUP_TIMEOUT_SECONDS", 0.3
-        )
+        monkeypatch.setattr(uvicorn.Server, "run", slow_lifespan_run)
+        monkeypatch.setenv("MCP_MESH_SERVER_STARTUP_TIMEOUT", "0.3")
 
         try:
             decorators._start_uvicorn_immediately(BIND_HOST, 0)
-            assert DecoratorRegistry.get_immediate_uvicorn_server() is None
+
+            record = DecoratorRegistry.get_immediate_uvicorn_server()
+            assert record is not None
+            assert record["status"] == "starting"  # bound, not yet proven
+            assert record["port"] > 0
+            # Registration carries the bound port — never a phantom one.
+            assert (
+                _resolve_registration_port(0, {"existing_server": record})
+                == record["port"]
+            )
         finally:
             release.set()
+
+    def test_slow_lifespan_within_budget_upgrades_record_to_running(
+        self, monkeypatch
+    ):
+        """Slow-but-healthy startup: ``started`` flips late but within the
+        budget. The bound record must be discoverable (status "starting")
+        WHILE the lifespan is still starting — that is what stops the
+        debounced pipeline (~1s) from starting a duplicate server — and
+        must read "running" once uvicorn proves serving. Registration
+        carries the bound port throughout."""
+        import uvicorn
+
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from mesh import decorators
+
+        release = threading.Event()
+
+        def slow_then_started_run(self, sockets=None):
+            time.sleep(0.8)  # scaled-down stand-in for an 8s model load
+            self.started = True
+            release.wait(timeout=10)
+
+        monkeypatch.setattr(uvicorn.Server, "run", slow_then_started_run)
+        monkeypatch.setenv("MCP_MESH_SERVER_STARTUP_TIMEOUT", "30")
+
+        # Watcher plays the role of ServerDiscoveryStep: sample the registry
+        # mid-startup (debounce fires at ~1s in production, here at 0.4s —
+        # before ``started`` flips at 0.8s).
+        mid_startup_record: dict = {}
+
+        def sample_mid_startup():
+            time.sleep(0.4)
+            record = DecoratorRegistry.get_immediate_uvicorn_server()
+            if record is not None:
+                mid_startup_record.update(
+                    {"present": True, "status": record["status"]}
+                )
+
+        watcher = threading.Thread(target=sample_mid_startup, daemon=True)
+        watcher.start()
+
+        try:
+            decorators._start_uvicorn_immediately(BIND_HOST, 0)
+            watcher.join(timeout=5)
+
+            # Discovery during the slow lifespan found the bound record —
+            # exactly one server exists; no duplicate gets pre-bound.
+            assert mid_startup_record.get("present") is True
+            assert mid_startup_record.get("status") == "starting"
+
+            record = DecoratorRegistry.get_immediate_uvicorn_server()
+            assert record is not None
+            assert record["status"] == "running"  # proven serving
+            assert record["port"] > 0
+            assert (
+                _resolve_registration_port(0, {"existing_server": record})
+                == record["port"]
+            )
+        finally:
+            release.set()
+
+
+class TestServerStartupTimeout:
+    """MCP_MESH_SERVER_STARTUP_TIMEOUT resolution (shared serving budget)."""
+
+    def test_default_is_30_seconds(self, monkeypatch):
+        monkeypatch.delenv("MCP_MESH_SERVER_STARTUP_TIMEOUT", raising=False)
+        assert get_server_startup_timeout() == SERVER_STARTUP_TIMEOUT_DEFAULT_SECONDS
+        assert SERVER_STARTUP_TIMEOUT_DEFAULT_SECONDS == 30.0
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("MCP_MESH_SERVER_STARTUP_TIMEOUT", "8.5")
+        assert get_server_startup_timeout() == 8.5
+
+    def test_invalid_values_fall_back_to_default(self, monkeypatch):
+        for bad in ("not-a-number", "0", "-3"):
+            monkeypatch.setenv("MCP_MESH_SERVER_STARTUP_TIMEOUT", bad)
+            assert (
+                get_server_startup_timeout()
+                == SERVER_STARTUP_TIMEOUT_DEFAULT_SECONDS
+            )
+
+
+class TestHeartbeatServingGate:
+    """``wait_for_proven_serving``: the heartbeat's first-registration
+    deferral. A liveness deferral only — expiry or a broken check always
+    proceeds (the bind-level invariant already holds)."""
+
+    def test_returns_true_when_check_flips_within_budget(self, monkeypatch):
+        monkeypatch.setenv("MCP_MESH_SERVER_STARTUP_TIMEOUT", "5")
+        flip_at = time.monotonic() + 0.4
+        started_check = lambda: time.monotonic() >= flip_at  # noqa: E731
+
+        start = time.monotonic()
+        assert wait_for_proven_serving(started_check, "test-agent") is True
+        elapsed = time.monotonic() - start
+        assert 0.3 <= elapsed < 3.0  # deferred until the flip, not the budget
+
+    def test_returns_false_after_budget_and_proceeds(self, monkeypatch):
+        monkeypatch.setenv("MCP_MESH_SERVER_STARTUP_TIMEOUT", "0.3")
+
+        start = time.monotonic()
+        assert wait_for_proven_serving(lambda: False, "test-agent") is False
+        elapsed = time.monotonic() - start
+        assert elapsed < 3.0  # bounded — never blocks registration forever
+
+    def test_broken_check_proceeds_immediately(self, monkeypatch):
+        monkeypatch.setenv("MCP_MESH_SERVER_STARTUP_TIMEOUT", "30")
+
+        def broken_check():
+            raise RuntimeError("boom")
+
+        start = time.monotonic()
+        assert wait_for_proven_serving(broken_check, "test-agent") is False
+        assert time.monotonic() - start < 1.0
 
 
 class TestUvicornServesOnFallbackSocket:

--- a/src/runtime/typescript/src/__tests__/port-conflict-fallback.spec.ts
+++ b/src/runtime/typescript/src/__tests__/port-conflict-fallback.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for issue #1194: port bind conflicts must never produce a phantom
+ * registration (registered port != bound port).
+ *
+ * The runtime resolves the bind port BEFORE the HTTP server and heartbeat
+ * start: a configured port that is already in use falls back to an
+ * OS-assigned port (adapt, don't crash), and the resolved port is what
+ * flows into `config.httpPort` — the field the heartbeat registers.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createServer, type Server } from "net";
+import {
+  findAvailablePort,
+  isPortBindable,
+  resolveBindPort,
+  resolveStartupBindPort,
+} from "../config.js";
+
+const HOST = "127.0.0.1";
+
+/** Occupy an OS-assigned port with a live listener and return it. */
+async function occupyPort(): Promise<{ server: Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, HOST, () => {
+      const address = server.address();
+      if (address && typeof address === "object") {
+        resolve({ server, port: address.port });
+      } else {
+        reject(new Error("Failed to get blocker address"));
+      }
+    });
+  });
+}
+
+describe("resolveBindPort (issue #1194)", () => {
+  let blocker: Server | null = null;
+  let blockedPort = 0;
+
+  beforeEach(async () => {
+    const occupied = await occupyPort();
+    blocker = occupied.server;
+    blockedPort = occupied.port;
+  });
+
+  afterEach(async () => {
+    if (blocker) {
+      await new Promise<void>((resolve) => blocker!.close(() => resolve()));
+      blocker = null;
+    }
+  });
+
+  it("returns the configured port unchanged when it is free", async () => {
+    // Find a free port, release it, then resolve it.
+    const freePort = await findAvailablePort();
+    const resolved = await resolveBindPort(freePort, HOST);
+    expect(resolved.port).toBe(freePort);
+    expect(resolved.fellBack).toBe(false);
+  });
+
+  it("falls back to an OS-assigned port when the configured port is in use", async () => {
+    const resolved = await resolveBindPort(blockedPort, HOST);
+    expect(resolved.fellBack).toBe(true);
+    expect(resolved.port).not.toBe(blockedPort);
+    expect(resolved.port).toBeGreaterThan(0);
+    // The fallback port must itself be bindable (no phantom endpoint).
+    expect(await isPortBindable(resolved.port, HOST)).toBe(true);
+  });
+
+  it("auto-assigns for configured port 0 without fallback semantics", async () => {
+    const resolved = await resolveBindPort(0, HOST);
+    expect(resolved.fellBack).toBe(false);
+    expect(resolved.port).toBeGreaterThan(0);
+  });
+
+  it("isPortBindable reports an occupied port as not bindable", async () => {
+    expect(await isPortBindable(blockedPort, HOST)).toBe(false);
+  });
+});
+
+describe("resolveStartupBindPort (shared agent/express helper)", () => {
+  let blocker: Server | null = null;
+  let blockedPort = 0;
+  let savedHost: string | undefined;
+
+  beforeEach(async () => {
+    const occupied = await occupyPort();
+    blocker = occupied.server;
+    blockedPort = occupied.port;
+    // The helper probes the REAL bind host (process.env.HOST, default
+    // 0.0.0.0). Pin it to loopback so the blocker and the probe agree.
+    savedHost = process.env.HOST;
+    process.env.HOST = HOST;
+  });
+
+  afterEach(async () => {
+    if (savedHost === undefined) {
+      delete process.env.HOST;
+    } else {
+      process.env.HOST = savedHost;
+    }
+    if (blocker) {
+      await new Promise<void>((resolve) => blocker!.close(() => resolve()));
+      blocker = null;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("returns the configured port silently when it is free", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const freePort = await findAvailablePort(HOST);
+
+    const port = await resolveStartupBindPort(freePort, "agent");
+
+    expect(port).toBe(freePort);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back with the canonical PORT CONFLICT warning when the port is in use", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const port = await resolveStartupBindPort(blockedPort, "agent");
+
+    expect(port).not.toBe(blockedPort);
+    expect(port).toBeGreaterThan(0);
+    // The fallback port is probed on the same host the server will bind.
+    expect(await isPortBindable(port, HOST)).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0][0]);
+    expect(message).toContain("PORT CONFLICT");
+    expect(message).toContain(String(blockedPort));
+    expect(message).toContain(HOST);
+  });
+
+  it("auto-assigns for configured port 0 without a conflict warning", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const port = await resolveStartupBindPort(0, "service");
+
+    expect(port).toBeGreaterThan(0);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      `Auto-assigned port ${port} for service`
+    );
+  });
+});

--- a/src/runtime/typescript/src/__tests__/port-probe-errors.spec.ts
+++ b/src/runtime/typescript/src/__tests__/port-probe-errors.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the bind-probe error policy (PR #1197 review follow-up to
+ * issue #1194): only a genuine `EADDRINUSE` conflict may trigger the
+ * auto-assign fallback. Any other bind failure (`EACCES` privileged port,
+ * host errors, ...) must REJECT so callers surface the real problem
+ * instead of a misleading "port in use" warning.
+ *
+ * `net` is mocked: a real `EACCES` is environment-dependent (root and
+ * modern macOS can bind low ports), so the error path is simulated.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+const probeControl = vi.hoisted(() => ({
+  errorFor: (_port: number): NodeJS.ErrnoException | null => null,
+  autoAssignPort: 45678,
+}));
+
+vi.mock("net", () => {
+  return {
+    createServer: () => {
+      const server = new EventEmitter() as any;
+      let boundPort = 0;
+      server.listen = (port: number, _host: string, cb?: () => void) => {
+        const err = probeControl.errorFor(port);
+        if (err) {
+          queueMicrotask(() => server.emit("error", err));
+        } else {
+          boundPort = port === 0 ? probeControl.autoAssignPort : port;
+          queueMicrotask(() => cb?.());
+        }
+        return server;
+      };
+      server.close = (cb?: () => void) => {
+        cb?.();
+        return server;
+      };
+      server.address = () => ({ port: boundPort });
+      return server;
+    },
+  };
+});
+
+import {
+  isPortBindable,
+  resolveBindPort,
+  resolveStartupBindPort,
+} from "../config.js";
+
+function errnoError(code: string): NodeJS.ErrnoException {
+  const err = new Error(`listen ${code}`) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+beforeEach(() => {
+  probeControl.errorFor = () => null;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("isPortBindable error policy", () => {
+  it("resolves true when the probe bind succeeds", async () => {
+    await expect(isPortBindable(8080, "0.0.0.0")).resolves.toBe(true);
+  });
+
+  it("resolves false ONLY for EADDRINUSE", async () => {
+    probeControl.errorFor = () => errnoError("EADDRINUSE");
+    await expect(isPortBindable(8080, "0.0.0.0")).resolves.toBe(false);
+  });
+
+  it("rejects with the underlying error for EACCES", async () => {
+    probeControl.errorFor = () => errnoError("EACCES");
+    await expect(isPortBindable(80, "0.0.0.0")).rejects.toMatchObject({
+      code: "EACCES",
+    });
+  });
+
+  it("rejects with the underlying error for host failures", async () => {
+    probeControl.errorFor = () => errnoError("EADDRNOTAVAIL");
+    await expect(isPortBindable(8080, "203.0.113.1")).rejects.toMatchObject({
+      code: "EADDRNOTAVAIL",
+    });
+  });
+});
+
+describe("resolveBindPort error policy", () => {
+  it("falls back to an OS-assigned port for a genuine EADDRINUSE", async () => {
+    // Conflict on the configured port; the port-0 fallback bind succeeds.
+    probeControl.errorFor = (port) =>
+      port === 8080 ? errnoError("EADDRINUSE") : null;
+
+    const resolved = await resolveBindPort(8080, "0.0.0.0");
+
+    expect(resolved.fellBack).toBe(true);
+    expect(resolved.port).toBe(probeControl.autoAssignPort);
+  });
+
+  it("propagates EACCES instead of silently falling back", async () => {
+    probeControl.errorFor = () => errnoError("EACCES");
+
+    await expect(resolveBindPort(80, "0.0.0.0")).rejects.toMatchObject({
+      code: "EACCES",
+    });
+  });
+});
+
+describe("resolveStartupBindPort error policy", () => {
+  it("surfaces non-conflict bind failures without a PORT CONFLICT warning", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    probeControl.errorFor = () => errnoError("EACCES");
+
+    await expect(resolveStartupBindPort(80, "agent")).rejects.toMatchObject({
+      code: "EACCES",
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -35,6 +35,7 @@ import {
   resolveConfig,
   generateAgentIdSuffix,
   findAvailablePort,
+  resolveStartupBindPort,
   MAX_CONSECUTIVE_NEXT_EVENT_FAILURES,
   NEXT_EVENT_BACKOFF_CAP_MS,
 } from "./config.js";
@@ -1100,11 +1101,20 @@ export class MeshAgent {
     // This ensures file:// templates resolve correctly regardless of cwd
     findAndSetBasePath();
 
-    // Handle httpPort=0: auto-assign an available port
-    if (this.config.httpPort === 0) {
-      const assignedPort = await findAvailablePort();
-      this.config = { ...this.config, httpPort: assignedPort };
-      console.log(`Auto-assigned port ${assignedPort} for agent`);
+    // Resolve the bind port BEFORE tracing/server/heartbeat so every
+    // downstream consumer sees the port we will actually bind (issue
+    // #1194: a conflict falls back to an OS-assigned port with a
+    // prominent warning — see resolveStartupBindPort). The heartbeat
+    // reads `this.config.httpPort`, so registration carries the ACTUAL
+    // port instead of a phantom endpoint.
+    {
+      const resolvedPort = await resolveStartupBindPort(
+        this.config.httpPort,
+        "agent"
+      );
+      if (resolvedPort !== this.config.httpPort) {
+        this.config = { ...this.config, httpPort: resolvedPort };
+      }
     }
 
     console.log(`Starting MCP Mesh agent: ${this.agentId}`);

--- a/src/runtime/typescript/src/config.ts
+++ b/src/runtime/typescript/src/config.ts
@@ -37,11 +37,16 @@ export const MAX_CONSECUTIVE_NEXT_EVENT_FAILURES = 18;
 /**
  * Find an available port by binding to port 0 and getting the OS-assigned port.
  * This is used when port=0 is specified to auto-assign a port.
+ *
+ * `host` must be the host the caller will actually bind — a port that is
+ * free on loopback is not necessarily bindable on `0.0.0.0` (issue #1194).
  */
-export async function findAvailablePort(): Promise<number> {
+export async function findAvailablePort(
+  host: string = "127.0.0.1"
+): Promise<number> {
   return new Promise((resolve, reject) => {
     const server = createServer();
-    server.listen(0, "127.0.0.1", () => {
+    server.listen(0, host, () => {
       const address = server.address();
       if (address && typeof address === "object") {
         const port = address.port;
@@ -52,6 +57,83 @@ export async function findAvailablePort(): Promise<number> {
     });
     server.on("error", reject);
   });
+}
+
+/**
+ * Check whether a TCP port can be bound on the given host.
+ *
+ * Issue #1194: used to surface bind conflicts BEFORE the HTTP server and
+ * the registry heartbeat start, so a configured-but-unbindable port never
+ * reaches registration (phantom endpoint).
+ */
+export async function isPortBindable(
+  port: number,
+  host: string
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", () => resolve(false));
+    server.listen(port, host, () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+/**
+ * Resolve the port the HTTP server should bind (issue #1194: adapt, don't crash).
+ *
+ * - `configuredPort === 0`: auto-assign via the OS (existing port-0 path).
+ * - configured port bindable: use it as-is.
+ * - configured port in use: fall back to an OS-assigned port and report
+ *   `fellBack: true` so the caller can log a prominent warning. The caller
+ *   MUST propagate the returned port into its config before starting the
+ *   heartbeat — the registry must only ever see the actually-bound port.
+ *
+ * Every probe — including the auto-assign and fallback paths — binds on
+ * `host`, the host the server will actually bind. Probing loopback for a
+ * server that binds `0.0.0.0` could hand back a port owned by another
+ * process on a non-loopback interface.
+ */
+export async function resolveBindPort(
+  configuredPort: number,
+  host: string
+): Promise<{ port: number; fellBack: boolean }> {
+  if (configuredPort === 0) {
+    return { port: await findAvailablePort(host), fellBack: false };
+  }
+  if (await isPortBindable(configuredPort, host)) {
+    return { port: configuredPort, fellBack: false };
+  }
+  return { port: await findAvailablePort(host), fellBack: true };
+}
+
+/**
+ * Resolve the startup bind port and emit the canonical conflict warning.
+ *
+ * Shared by `MeshAgent._autoStart()` and `MeshExpress.start()` so the
+ * resolve-and-warn behavior (and the warning text) cannot drift between
+ * the two entry points. The caller MUST write the returned port back into
+ * the config its heartbeat reads BEFORE starting tracing/server/heartbeat
+ * — registration must always carry the ACTUAL bound port (issue #1194).
+ */
+export async function resolveStartupBindPort(
+  configuredPort: number,
+  label: string
+): Promise<number> {
+  const bindHost = process.env.HOST ?? "0.0.0.0";
+  const resolved = await resolveBindPort(configuredPort, bindHost);
+  if (resolved.fellBack) {
+    console.warn(
+      `PORT CONFLICT: configured HTTP port ${configuredPort} on ${bindHost} ` +
+        `is already in use. Falling back to auto-assigned port ${resolved.port} — ` +
+        `the registry will be given the ACTUAL bound port. Another process ` +
+        `likely owns port ${configuredPort}; fix the port assignment to ` +
+        `silence this warning.`
+    );
+  } else if (resolved.port !== configuredPort) {
+    console.log(`Auto-assigned port ${resolved.port} for ${label}`);
+  }
+  return resolved.port;
 }
 
 // TypeScript-specific defaults (not in Rust core)

--- a/src/runtime/typescript/src/config.ts
+++ b/src/runtime/typescript/src/config.ts
@@ -65,14 +65,27 @@ export async function findAvailablePort(
  * Issue #1194: used to surface bind conflicts BEFORE the HTTP server and
  * the registry heartbeat start, so a configured-but-unbindable port never
  * reaches registration (phantom endpoint).
+ *
+ * Resolves `false` ONLY for a genuine address-in-use conflict
+ * (`EADDRINUSE`) — the one condition the auto-assign fallback can adapt
+ * to. Any other bind failure (`EACCES` privileged port, `EADDRNOTAVAIL` /
+ * host misconfiguration, ...) REJECTS with the underlying error: falling
+ * back there would mask a real problem behind a misleading "port in use"
+ * warning, and the real server's own bind would hit the same error anyway.
  */
 export async function isPortBindable(
   port: number,
   host: string
 ): Promise<boolean> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const server = createServer();
-    server.once("error", () => resolve(false));
+    server.once("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "EADDRINUSE") {
+        resolve(false);
+      } else {
+        reject(err);
+      }
+    });
     server.listen(port, host, () => {
       server.close(() => resolve(true));
     });
@@ -84,10 +97,14 @@ export async function isPortBindable(
  *
  * - `configuredPort === 0`: auto-assign via the OS (existing port-0 path).
  * - configured port bindable: use it as-is.
- * - configured port in use: fall back to an OS-assigned port and report
- *   `fellBack: true` so the caller can log a prominent warning. The caller
- *   MUST propagate the returned port into its config before starting the
- *   heartbeat — the registry must only ever see the actually-bound port.
+ * - configured port in use (`EADDRINUSE`): fall back to an OS-assigned port
+ *   and report `fellBack: true` so the caller can log a prominent warning.
+ *   The caller MUST propagate the returned port into its config before
+ *   starting the heartbeat — the registry must only ever see the
+ *   actually-bound port.
+ * - any other bind failure (`EACCES`, host errors, ...): the probe's
+ *   rejection propagates — adapt only to genuine conflicts, surface
+ *   everything else loudly.
  *
  * Every probe — including the auto-assign and fallback paths — binds on
  * `host`, the host the server will actually bind. Probing loopback for a
@@ -115,6 +132,11 @@ export async function resolveBindPort(
  * the two entry points. The caller MUST write the returned port back into
  * the config its heartbeat reads BEFORE starting tracing/server/heartbeat
  * — registration must always carry the ACTUAL bound port (issue #1194).
+ *
+ * The PORT CONFLICT warning is emitted only for a genuine `EADDRINUSE`
+ * fallback; non-conflict bind failures (`EACCES`, host errors, ...)
+ * propagate to the caller as rejections instead of being mislabeled as
+ * conflicts.
  */
 export async function resolveStartupBindPort(
   configuredPort: number,

--- a/src/runtime/typescript/src/express.ts
+++ b/src/runtime/typescript/src/express.ts
@@ -55,7 +55,7 @@ import type { AgentConfig, ResolvedAgentConfig } from "./types.js";
 import {
   resolveConfig,
   generateAgentIdSuffix,
-  findAvailablePort,
+  resolveStartupBindPort,
   MAX_CONSECUTIVE_NEXT_EVENT_FAILURES,
   NEXT_EVENT_BACKOFF_CAP_MS,
 } from "./config.js";
@@ -214,11 +214,19 @@ export class MeshExpress {
     if (this.started) return;
     this.started = true;
 
-    // Handle httpPort=0: auto-assign an available port
-    if (this.config.httpPort === 0) {
-      const assignedPort = await findAvailablePort();
-      this.config = { ...this.config, httpPort: assignedPort };
-      console.log(`Auto-assigned port ${assignedPort} for service`);
+    // Resolve the bind port BEFORE the server and heartbeat start (issue
+    // #1194: a conflict falls back to an OS-assigned port with a
+    // prominent warning — see resolveStartupBindPort). The heartbeat
+    // reads `this.config.httpPort`, so registration carries the ACTUAL
+    // port instead of a phantom endpoint.
+    {
+      const resolvedPort = await resolveStartupBindPort(
+        this.config.httpPort,
+        "service"
+      );
+      if (resolvedPort !== this.config.httpPort) {
+        this.config = { ...this.config, httpPort: resolvedPort };
+      }
     }
 
     console.log(`Starting MeshExpress service: ${this.serviceId}`);


### PR DESCRIPTION
## Summary
Closes #1194. The invariant this PR establishes: **no runtime registers a port it did not bind and prove it can serve.**

- **Python (the verified defect, worse than filed)**: the orchestrator started the heartbeat *before* the server attempted its bind, and bind errors were swallowed in a background thread — a port conflict produced a permanently-registered phantom endpoint. The fix pre-binds the server socket synchronously (handed to uvicorn via `sockets=[...]`, mirroring its socket options; TLS still applied per-connection); on conflict it falls back to a kernel-assigned port with a prominent `PORT CONFLICT` warning ("adapt, don't crash"); registration reads the port from the bound socket on every path via a single `_resolve_registration_port` authority. The racy probe-close-rebind port-0 helper and the dead assume-the-configured-port poll loop are removed; the orchestrator binds before the heartbeat starts. Status `running` is recorded only after `uvicorn_server.started` proves serving (a post-bind TLS `Config.load()` failure now closes the socket and fails decorator application loudly — a bound socket that can never serve isn't adaptable-around). The shutdown coordinator holds a *list* of servers, so a degenerate second-server path can't orphan the first's thread on SIGTERM.
- **TypeScript**: a bindable port is resolved before tracing/server/heartbeat via a shared `resolveStartupBindPort` helper (conflict → OS-assigned fallback *probed on the actual bind host*, not loopback); a lost probe race still crashes loudly pre-registration. `@mesh.route`'s existing first-request `updatePort` convergence is untouched.
- **Java**: already correct — Spring fails startup loudly and the `WebServerInitializedEvent` updater converges registered→actual; the invariant is now pinned by test, and the one-phase transient pre-bind registration window is documented.

## Review Notes
- Independent review: 0 blockers. It verified the uvicorn socket-handoff semantics (signals, TLS, asyncio socket ownership — no leaks), traced every registration path to the bound-port authority, and confirmed both flake-critical test families occupy kernel-assigned ports.
- All 3 warnings fixed (TS wrong-host fallback probe + dedup, bound-but-never-serving gate, coordinator slot overwrite).
- Remaining runtime-family gap recorded on the issue (out of scope): the `@mesh.route`/API pipelines register the configured port before the user-owned server binds — transient and loud on failure, but without Java-style convergence; that's the follow-up direction.

Closes #1194

## Test plan
- [x] Python: 1095 unit tests (17 new: conflict fallback with live uvicorn round-trip + socket-ownership proof, startup gate, multi-server shutdown coordinator)
- [x] TS: typecheck + 900 tests (7 new: resolve/fallback/warning + host-probed fallback)
- [x] Java: 420 tests (3 new pinning the convergence invariant)
- [ ] Integration TC (two agents, same configured port, both registered with distinct real ports) — for the integration suite after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Port binding conflicts now fall back to a safe OS-assigned port and the registry/heartbeat uses the actual bound port.
  * Heartbeat registration deferred until the HTTP server is proven serving to avoid advertising unavailable ports.
  * Immediate server startup failures surface clearly instead of being swallowed.
  * Shutdown now coordinates graceful termination across all server instances.

* **Tests**
  * Expanded unit and integration tests covering port conflicts, startup gating, timeouts, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->