### PR TITLE
feat(python): prescriptive DI diagnostics with opt-in MCP_MESH_STRICT_DI

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -84,6 +84,16 @@ export MCP_MESH_SESSION_TTL=3600
 export MCP_MESH_TOOL_WORKERS=1
 ```
 
+### Strict DI Diagnostics (Python)
+
+```bash
+# Default: false. When truthy, ambiguous or skipped dependency-injection
+# configurations raise StrictDIError at decoration/startup instead of
+# warning. Injection semantics are unchanged — only the diagnostic
+# severity is promoted.
+export MCP_MESH_STRICT_DI=true
+```
+
 ### HTTP Server Settings
 
 ```bash

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -108,6 +108,16 @@ export MCP_MESH_DEBOUNCE_DELAY=1.0
 export MCP_MESH_TOOL_WORKERS=1
 ```
 
+### Strict DI Diagnostics (Python)
+
+```bash
+# Default: false. When truthy, ambiguous or skipped dependency-injection
+# configurations raise StrictDIError at decoration/startup instead of
+# warning. Injection semantics are unchanged — only the diagnostic
+# severity is promoted.
+export MCP_MESH_STRICT_DI=true
+```
+
 ### Schema Verdict Policy (issue #547)
 
 ```bash

--- a/src/runtime/python/_mcp_mesh/engine/decorator_registry.py
+++ b/src/runtime/python/_mcp_mesh/engine/decorator_registry.py
@@ -165,6 +165,18 @@ class DecoratorRegistry:
             )
 
     @classmethod
+    def unregister_mesh_tool(cls, func_name: str) -> None:
+        """Remove a registered mesh tool (decoration-failure cleanup).
+
+        Used when wrapper creation fails AFTER registration with an error
+        that must propagate (e.g. ``StrictDIError``) — without this, the
+        registry would keep advertising a half-registered tool whose
+        wrapper never materialized.
+        """
+        if cls._mesh_tools.pop(func_name, None) is not None:
+            logger.debug(f"🗑️ DecoratorRegistry: Unregistered mesh tool '{func_name}'")
+
+    @classmethod
     def register_mesh_resource(cls, func: Callable, metadata: dict[str, Any]) -> None:
         """Register a @mesh_resource decorated function (future use)."""
         decorated_func = DecoratedFunction(
@@ -258,6 +270,19 @@ class DecoratorRegistry:
         )
 
         cls._custom_decorators[decorator_type][func.__name__] = decorated_func
+
+    @classmethod
+    def unregister_custom_decorator(cls, decorator_type: str, func_name: str) -> None:
+        """Remove a registered custom decorator entry (decoration-failure cleanup).
+
+        Counterpart of :meth:`unregister_mesh_tool` for decorators stored
+        under a custom type (``mesh_route``, ``mesh_a2a``, ...).
+        """
+        entries = cls._custom_decorators.get(decorator_type)
+        if entries is not None and entries.pop(func_name, None) is not None:
+            logger.debug(
+                f"🗑️ DecoratorRegistry: Unregistered {decorator_type} '{func_name}'"
+            )
 
     @classmethod
     def get_mesh_agents(cls) -> dict[str, DecoratedFunction]:

--- a/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
@@ -20,6 +20,12 @@ from ..shared.logging_config import (
     get_trace_prefix,
 )
 from .signature_analyzer import get_mesh_agent_positions, has_llm_agent_parameter
+from .strict_di import (
+    StrictDIError,
+    is_strict_di_enabled,
+    pluralize,
+    warn_or_raise,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -308,6 +314,128 @@ def _build_clean_signature(func: Any) -> inspect.Signature | None:
     return sig.replace(parameters=clean_params)
 
 
+def _describe_skipped_params(func: Callable, params: list[inspect.Parameter]) -> str:
+    """Render each parameter with the reason it was passed over for injection.
+
+    Used by the multi-parameter "none typed as McpMeshTool" diagnostic so
+    the warning names every skipped parameter and WHY it was skipped
+    (untyped vs annotated with a non-injectable type).
+
+    Reasons are classified with the SAME type resolution the eligibility
+    scan uses (``get_type_hints`` on the original function) — raw
+    ``p.annotation`` values are strings under
+    ``from __future__ import annotations`` and would misreport a perfectly
+    valid ``db: "McpMeshTool"`` as the self-contradictory "annotated as
+    McpMeshTool, not McpMeshTool". When the hints themselves cannot be
+    resolved (TYPE_CHECKING-only imports, dangling forward references) —
+    which is exactly the condition that made the eligibility scan fall back
+    to "no eligible parameters" — the reason states that failure explicitly
+    instead of misdiagnosing the annotation.
+    """
+    from typing import get_type_hints
+
+    from .signature_analyzer import _get_original_func, _is_mesh_tool_type
+
+    hints: Optional[dict[str, Any]] = None
+    try:
+        hints = get_type_hints(_get_original_func(func))
+    except Exception:
+        # Same failure the eligibility scan (``_scan_params``) swallowed —
+        # report it as the skip reason below rather than guessing from raw
+        # annotations.
+        hints = None
+
+    parts = []
+    for p in params:
+        if p.annotation is inspect.Parameter.empty:
+            parts.append(f"'{p.name}' (untyped)")
+        elif hints is None:
+            parts.append(
+                f"'{p.name}' (type hints could not be resolved — check "
+                f"TYPE_CHECKING imports / forward references)"
+            )
+        else:
+            resolved = hints.get(p.name)
+            if resolved is None:
+                parts.append(f"'{p.name}' (untyped)")
+            elif _is_mesh_tool_type(resolved):
+                # Defensive: eligibility uses this same resolution, so a
+                # mesh-typed parameter cannot land in a skipped list — but
+                # if a future skew ever puts one here, never emit the
+                # contradictory "annotated as McpMeshTool, not McpMeshTool".
+                parts.append(f"'{p.name}' (McpMeshTool)")
+            else:
+                ann_name = getattr(resolved, "__name__", None) or str(resolved)
+                parts.append(
+                    f"'{p.name}' (annotated as {ann_name}, not McpMeshTool)"
+                )
+    return ", ".join(parts)
+
+
+def _format_selected_pairings(
+    dependencies: list[str],
+    eligible_positions: list[int],
+    param_names: list[str],
+) -> str:
+    """Render the dep→param pairs positional pairing selects, in order.
+
+    ``dependencies[i]`` pairs with ``eligible_positions[i]`` (declaration
+    order); only the overlapping prefix is rendered. Out-of-range positions
+    (signature-view skew) degrade to a ``<arg N>`` placeholder instead of
+    raising — these strings feed diagnostics that must never crash dispatch.
+    """
+    pairs = []
+    for i, (dep, pos) in enumerate(zip(dependencies, eligible_positions)):
+        name = param_names[pos] if pos < len(param_names) else f"<arg {pos}>"
+        pairs.append(f"dependencies[{i}] '{dep}' → parameter '{name}'")
+    return ", ".join(pairs) if pairs else "nothing (no dependencies declared)"
+
+
+def _format_unfilled_slots_message(
+    func_label: str,
+    eligible_positions: list[int],
+    dependencies: list[str],
+    param_names: list[str],
+    tp: str = "",
+    unfilled_param_names: Optional[list[str]] = None,
+) -> str:
+    """Build the "more eligible slots than dependencies" diagnostic text.
+
+    Shared by the runtime warning in :func:`_prepare_injection_kwargs` and
+    the strict-mode decoration-time promotion in
+    :func:`analyze_injection_strategy`, so warn-mode and strict-mode users
+    read the exact same prescriptive message.
+
+    ``unfilled_param_names`` lets the call-time site pass the
+    genuinely-unfilled slots (after caller-supplied kwargs are accounted
+    for); when omitted, every eligible position beyond the declared
+    dependencies is reported (the decoration-time view, where no call
+    kwargs exist yet).
+    """
+    if unfilled_param_names is None:
+        untouched_positions = eligible_positions[len(dependencies):]
+        unfilled_param_names = [
+            param_names[pos] if pos < len(param_names) else f"<arg {pos}>"
+            for pos in untouched_positions
+        ]
+    selected = _format_selected_pairings(dependencies, eligible_positions, param_names)
+    param_word = "Parameter" if len(unfilled_param_names) == 1 else "Parameters"
+    return (
+        f"{tp}⚠️ Function '{func_label}' has "
+        f"{pluralize(len(eligible_positions), 'injection-eligible parameter')} "
+        f"(McpMeshTool/MeshJob) but only "
+        f"{pluralize(len(dependencies), 'dependency', 'dependencies')} "
+        f"declared. Positional pairing "
+        f"(declaration order) selected: {selected}. {param_word} "
+        f"{unfilled_param_names} will remain None. Fix: add one entry per "
+        f"unfilled parameter to dependencies=[...] (order matters — "
+        f"dependencies[i] pairs with the i-th McpMeshTool/MeshJob parameter; "
+        f"parameter names are never matched), or remove the "
+        f"McpMeshTool/MeshJob annotation from parameters that should not be "
+        f"injected."
+    )
+
+
 def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[int]:
     """
     Analyze function signature and determine McpMeshTool injection positions.
@@ -315,7 +443,12 @@ def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[
     Rules:
     1. Single parameter: inject regardless of typing (with warning if not McpMeshTool)
     2. Multiple parameters: only inject into McpMeshTool typed parameters
-    3. Log warnings for mismatches and edge cases
+    3. Log prescriptive warnings for mismatches and edge cases; under
+       MCP_MESH_STRICT_DI the ambiguity/skip class of those warnings is
+       raised as :class:`StrictDIError` at decoration time instead
+       (informational warnings never raise; the only call-time strict
+       raise is the wrapper-rewrite bounds guard, which is not statically
+       detectable). Injection semantics are identical in both modes.
 
     Returns ONLY ``McpMeshTool`` positions — ``MeshJob`` positions are
     computed independently in :func:`_prepare_injection_kwargs` so the
@@ -367,25 +500,63 @@ def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[
     # Detect whether the function declares any MeshJob param. The unified
     # positional injection path handles those alongside McpMeshTool slots,
     # so this function's diagnostics must NOT shout about "no injection
-    # target" when a MeshJob slot will consume the dependency.
+    # target" when a MeshJob slot will consume the dependency. The index
+    # (not just presence) is kept so diagnostics can name the dep→param
+    # pairings positional pairing selects.
     has_mesh_job_param = False
+    mesh_job_index: Optional[int] = None
     try:
         from .signature_analyzer import analyze_mesh_job_signature
 
         _mj = analyze_mesh_job_signature(func)
         has_mesh_job_param = _mj.mesh_job_param_name is not None
+        mesh_job_index = _mj.mesh_job_param_index
     except (TypeError, AttributeError):
         # Only narrow signature-introspection errors swallow silently;
         # ValueError (Phase-1 multiple-MeshJob contract violation) MUST
         # propagate per the resolver contract.
         pass
 
-    # No parameters at all
+    # Strict-mode decoration-time promotion of the "eligible slots will
+    # remain None" diagnostic, checked UP FRONT so every branch below —
+    # including the early returns for single-MeshJob-param and
+    # MeshJob-only multi-param functions — is covered. Counts TYPED
+    # eligible slots only (McpMeshTool + MeshJob); the untyped
+    # single-parameter heuristic slot is deliberately excluded so a plain
+    # zero-dependency tool like 'def greet(name)' never trips strict mode.
+    # Permissive mode keeps the existing per-call warning cadence in
+    # ``_prepare_injection_kwargs`` (with caller-supplied kwargs accounted
+    # for), so this site raises directly instead of using warn_or_raise —
+    # it must stay silent when strict is off.
+    if is_strict_di_enabled():
+        typed_eligible_positions = sorted(
+            set(mesh_positions)
+            | ({mesh_job_index} if mesh_job_index is not None else set())
+        )
+        if len(dependencies) < len(typed_eligible_positions):
+            raise StrictDIError(
+                _format_unfilled_slots_message(
+                    func_name,
+                    typed_eligible_positions,
+                    dependencies,
+                    [p.name for p in params],
+                )
+            )
+
+    # No parameters at all — every declared dependency is skipped.
+    # Ambiguity/skip class: raises under MCP_MESH_STRICT_DI.
     if param_count == 0:
         if dependencies:
-            logger.warning(
-                f"Function '{func_name}' has no parameters but {len(dependencies)} "
-                f"dependencies declared. Skipping injection."
+            warn_or_raise(
+                logger,
+                f"Function '{func_name}' has no parameters but "
+                f"{pluralize(len(dependencies), 'dependency', 'dependencies')} "
+                f"declared {dependencies} — there is no parameter to "
+                f"receive a proxy, so all declared dependencies are skipped. "
+                f"Positional pairing assigns dependencies[i] to the i-th "
+                f"McpMeshTool-typed parameter in declaration order (parameter "
+                f"names are never matched). Fix: declare one parameter per "
+                f"dependency, e.g. 'dep_0: McpMeshTool = None'.",
             )
         return []
 
@@ -400,11 +571,14 @@ def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[
                 # position to record here.
                 return []
 
+            # Informational only — injection still happens, so this stays a
+            # plain warning even under MCP_MESH_STRICT_DI.
             param_name = params[0].name
             logger.warning(
                 f"Single parameter '{param_name}' in function '{func_name}' found, "
                 f"injecting {dependencies[0] if dependencies else 'dependency'} proxy "
-                f"(consider typing as McpMeshTool for clarity)"
+                f"(consider typing as McpMeshTool for clarity: "
+                f"'{param_name}: McpMeshTool = None')"
             )
         return [0]  # Inject into the single parameter
 
@@ -414,10 +588,30 @@ def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[
     if param_count > 1 or has_hidden_params:
         if not mesh_positions:
             if dependencies and not has_mesh_job_param:
-                logger.warning(
-                    f"⚠️ Function '{func_name}' has {param_count} parameters but none are "
-                    f"typed as McpMeshTool. Skipping injection of {len(dependencies)} dependencies. "
-                    f"Consider typing dependency parameters as McpMeshTool."
+                # Ambiguity/skip class: every declared dependency is
+                # dropped because no parameter is annotation-eligible.
+                # Raises under MCP_MESH_STRICT_DI.
+                example_param = next(
+                    (
+                        p.name
+                        for p in params
+                        if p.annotation is inspect.Parameter.empty
+                    ),
+                    params[0].name,
+                )
+                warn_or_raise(
+                    logger,
+                    f"⚠️ Function '{func_name}' has "
+                    f"{pluralize(param_count, 'parameter')} but none are "
+                    f"typed as McpMeshTool. Skipping injection of "
+                    f"{pluralize(len(dependencies), 'dependency', 'dependencies')} "
+                    f"{dependencies}. Skipped parameters: "
+                    f"{_describe_skipped_params(func, params)}. Positional pairing assigns "
+                    f"dependencies[i] to the i-th McpMeshTool-typed parameter in "
+                    f"declaration order — '{dependencies[0]}' would go to the first "
+                    f"McpMeshTool-typed parameter (parameter names are never matched). "
+                    f"Fix: annotate the intended parameter(s), e.g. "
+                    f"'{example_param}: McpMeshTool = None'.",
                 )
             return []
 
@@ -426,16 +620,32 @@ def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[
         # don't trigger spurious "excess dependencies" warnings.
         # NOTE: the inverse case (more eligible slots than dependencies) is
         # diagnosed at injection time inside ``_prepare_injection_kwargs``
-        # so it can name BOTH untouched McpMeshTool *and* MeshJob params —
-        # this strategy-time site sees McpMeshTool positions only.
-        eligible_count = len(mesh_positions) + (1 if has_mesh_job_param else 0)
+        # in permissive mode; under MCP_MESH_STRICT_DI it already raised at
+        # the up-front decoration-time check above.
+        param_names = [p.name for p in params]
+        eligible_positions = sorted(
+            set(mesh_positions)
+            | ({mesh_job_index} if mesh_job_index is not None else set())
+        )
+        eligible_count = len(eligible_positions)
         if len(dependencies) > eligible_count:
+            # Ambiguity/skip class: trailing dependencies are dropped.
+            # Raises under MCP_MESH_STRICT_DI.
             excess_deps = dependencies[eligible_count:]
-            logger.warning(
-                f"Function '{func_name}' has {len(dependencies)} dependencies "
-                f"but only {eligible_count} injectable parameter(s) "
-                f"(McpMeshTool + MeshJob). "
-                f"Dependencies {excess_deps} will not be injected."
+            selected = _format_selected_pairings(
+                dependencies, eligible_positions, param_names
+            )
+            warn_or_raise(
+                logger,
+                f"Function '{func_name}' has "
+                f"{pluralize(len(dependencies), 'dependency', 'dependencies')} "
+                f"but only {pluralize(eligible_count, 'injectable parameter')} "
+                f"(McpMeshTool + MeshJob). Positional pairing (declaration "
+                f"order) selected: {selected}. Dependencies {excess_deps} will "
+                f"not be injected — no injectable parameter remains for them. "
+                f"Fix: declare one McpMeshTool-typed parameter per excess "
+                f"dependency, e.g. 'extra_dep: McpMeshTool = None', or remove "
+                f"the excess entries from dependencies=[...].",
             )
 
         # Return McpMeshTool positions we can actually inject into. The
@@ -532,31 +742,49 @@ def _prepare_injection_kwargs(
     # Diagnostic: more eligible (McpMeshTool + MeshJob) slots than declared
     # dependencies — the trailing slots will silently stay None. Flagging
     # here (at injection time) covers cases the strategy-time warning at
-    # ``analyze_injection_strategy`` can't see, because it counts MeshJob
-    # positions too rather than McpMeshTool only.
+    # ``analyze_injection_strategy`` can't see (paths that bypass the
+    # multi-parameter branch). A slot the CALLER filled is not unfilled:
+    # the documented contract lets callers pass a fake/mock for any
+    # injectable slot (see the explicit-kwarg skip in the loop below), so
+    # the diagnostic only reports slots that genuinely remain None after
+    # accounting for caller-supplied kwargs. This is a permissive-mode
+    # warning ONLY — every statically-detectable unfilled configuration
+    # already raised at decoration time under MCP_MESH_STRICT_DI, and the
+    # sole call-time strict raise is the bounds guard below (the one
+    # condition not detectable at decoration).
     if len(eligible_positions) > len(dependencies):
+        unfilled_message = None
         try:
-            untouched_positions = eligible_positions[len(dependencies):]
             # ``params`` above is resolved from the same original signature
-            # the positions came from (#1105), so positions line up — but
-            # bounds-guard regardless.
-            untouched_param_names = [
+            # the positions came from (#1105), so positions line up — and
+            # the message builder bounds-guards regardless.
+            genuinely_unfilled = [
                 params[pos] if pos < len(params) else f"<arg {pos}>"
-                for pos in untouched_positions
+                for pos in eligible_positions[len(dependencies):]
+                if not (
+                    pos < len(params)
+                    and params[pos] in final_kwargs
+                    and final_kwargs.get(params[pos]) is not None
+                )
             ]
-            log.warning(
-                f"{tp}⚠️ Function '{func.__name__}' has {len(eligible_positions)} "
-                f"injection-eligible parameters (McpMeshTool/MeshJob) but only "
-                f"{len(dependencies)} dependency(ies) declared. Parameters "
-                f"{untouched_param_names} will remain None."
-            )
+            if genuinely_unfilled:
+                unfilled_message = _format_unfilled_slots_message(
+                    func.__name__,
+                    eligible_positions,
+                    dependencies,
+                    params,
+                    tp=tp,
+                    unfilled_param_names=genuinely_unfilled,
+                )
         except (TypeError, ValueError, IndexError) as e:
-            # The diagnostic is purely informational and must never crash
-            # dispatch regardless of wrapper/original signature shape.
+            # The message construction must never crash dispatch regardless
+            # of wrapper/original signature shape.
             log.debug(
                 f"{tp}untouched-positional diagnostic skipped for "
                 f"{func.__name__}: {e}"
             )
+        if unfilled_message is not None:
+            log.warning(unfilled_message)
 
     injected_count = 0
     injected_deps: list[str] = []
@@ -595,18 +823,27 @@ def _prepare_injection_kwargs(
 
         dep_name = dependencies[dep_index]
 
-        # Defensive bounds guard: positions are derived from the same
-        # original signature as ``params`` above, so this should never
+        # Defensive bounds guard (#1171): positions are derived from the
+        # same original signature as ``params`` above, so this should never
         # trigger — but a decorator chain we don't model could still skew
         # the views. Skip this one injection rather than crash dispatch;
-        # remaining deps keep their own positional slots.
+        # remaining deps keep their own positional slots. Ambiguity/skip
+        # class: raises under MCP_MESH_STRICT_DI (this condition is only
+        # detectable at call time, so strict promotes it here).
         if position >= len(params):
-            log.warning(
+            warn_or_raise(
+                log,
                 f"{tp}⚠️ Injection position {position} for dependency "
                 f"'{dep_name}' (dep_index={dep_index}) on '{func.__name__}' "
                 f"is out of bounds for its {len(params)}-parameter signature "
-                f"{params}. Skipping this injection — check for decorators "
-                f"that rewrite __signature__ without setting __wrapped__."
+                f"{params}. Positional pairing (declaration order) selected "
+                f"position {position}, but the resolved signature ends at "
+                f"index {len(params) - 1} — dependency '{dep_name}' is "
+                f"skipped and its parameter stays unset. Fix: ensure any "
+                f"decorator that rewrites __signature__ also sets "
+                f"__wrapped__ (use functools.wraps) so injection positions "
+                f"and parameter names resolve from the same "
+                f"original-function view.",
             )
             continue
 

--- a/src/runtime/python/_mcp_mesh/engine/signature_analyzer.py
+++ b/src/runtime/python/_mcp_mesh/engine/signature_analyzer.py
@@ -258,7 +258,10 @@ def analyze_mesh_job_signature(func: Any) -> MeshJobResolution:
                 raise ValueError(
                     f"a tool function may declare at most one MeshJob parameter; "
                     f"function '{func.__name__}' declares both "
-                    f"'{mesh_job_param_name}' and '{param_name}'"
+                    f"'{mesh_job_param_name}' and '{param_name}'. Fix: keep a "
+                    f"single MeshJob parameter (e.g. "
+                    f"'{mesh_job_param_name}: MeshJob = None') and remove the "
+                    f"other(s)."
                 )
             mesh_job_param_index = i
             mesh_job_param_name = param_name
@@ -333,6 +336,13 @@ def validate_mesh_dependencies(func: Any, dependencies: list[dict]) -> tuple[boo
 
     Returns:
         Tuple of (is_valid, error_message)
+
+    Raises:
+        StrictDIError: When the slot/dependency counts mismatch AND
+            ``MCP_MESH_STRICT_DI`` is truthy — the ambiguity/skip class of
+            DI diagnostics is promoted from a heartbeat-time "skipping
+            tool" warning to a startup error. The error text is identical
+            to the returned ``error_message``.
     """
     func = _get_original_func(func)
     mesh_positions = get_mesh_agent_positions(func)
@@ -366,12 +376,51 @@ def validate_mesh_dependencies(func: Any, dependencies: list[dict]) -> tuple[boo
 
     expected = len(mesh_positions) + job_slots
     if len(dependencies) != expected:
-        return False, (
-            f"Function {func.__name__} has {len(mesh_positions)} McpMeshTool "
-            f"parameter(s) and {job_slots} MeshJob slot(s) "
-            f"but {len(dependencies)} dependencies declared. "
-            f"Each typed slot needs a corresponding dependency."
+        # Name each typed slot (declaration order) so the message shows the
+        # exact dep→param pairing positional binding uses, plus the fix.
+        try:
+            param_names_by_pos = list(inspect.signature(func).parameters.keys())
+        except (TypeError, ValueError):
+            param_names_by_pos = []
+        slot_entries = [(pos, "McpMeshTool") for pos in mesh_positions]
+        if resolution is not None and resolution.mesh_job_param_index is not None:
+            slot_entries.append((resolution.mesh_job_param_index, "MeshJob"))
+        slot_entries.sort()
+        slots_desc = (
+            ", ".join(
+                (
+                    f"'{param_names_by_pos[pos]}' ({kind})"
+                    if pos < len(param_names_by_pos)
+                    else f"<arg {pos}> ({kind})"
+                )
+                for pos, kind in slot_entries
+            )
+            or "none"
         )
+        from .strict_di import pluralize
+
+        message = (
+            f"Function {func.__name__} has "
+            f"{pluralize(len(mesh_positions), 'McpMeshTool parameter')} and "
+            f"{pluralize(job_slots, 'MeshJob slot')} "
+            f"but {pluralize(len(dependencies), 'dependency', 'dependencies')} "
+            f"declared. "
+            f"Each typed slot needs a corresponding dependency. "
+            f"Typed slots in declaration order: {slots_desc}; "
+            f"dependencies[i] pairs with the i-th slot positionally "
+            f"(parameter names are never matched). Fix: declare exactly "
+            f"{pluralize(expected, 'entry', 'entries')} in dependencies=[...], "
+            f"or add/remove "
+            f"typed parameters (e.g. 'my_dep: McpMeshTool = None') so the "
+            f"counts match."
+        )
+        # Opt-in strictness (MCP_MESH_STRICT_DI): promote the skip-class
+        # diagnostic to a startup error with the same prescriptive text.
+        from .strict_di import StrictDIError, is_strict_di_enabled
+
+        if is_strict_di_enabled():
+            raise StrictDIError(message)
+        return False, message
 
     return True, ""
 

--- a/src/runtime/python/_mcp_mesh/engine/strict_di.py
+++ b/src/runtime/python/_mcp_mesh/engine/strict_di.py
@@ -1,0 +1,96 @@
+"""
+Opt-in strict dependency-injection diagnostics (``MCP_MESH_STRICT_DI``).
+
+Python DI's parameter-selection rules are deliberately permissive (issue
+#1196): ambiguous or skipped injections log a prescriptive WARNING and the
+agent keeps running. Teams that want rigor can set ``MCP_MESH_STRICT_DI``
+to a truthy value to promote exactly that ambiguity/skip class of warnings
+to errors at decoration/startup time — the error text is byte-identical to
+the warning text, so the fix instructions travel with the failure.
+
+Injection SEMANTICS are untouched in both modes: dependencies pair with
+parameters positionally by declaration order, never by name (pinned by
+``test_multiple_deps_pair_by_declaration_order_not_name``). Strict mode
+only changes warn-vs-raise for the diagnostics; informational warnings
+(e.g. the single-untyped-parameter "injecting anyway" notice) never raise.
+"""
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class StrictDIError(ValueError):
+    """A DI ambiguity/skip diagnostic promoted to an error by strict mode.
+
+    Subclasses :class:`ValueError` deliberately: ``ValueError`` is the
+    exception class ``@mesh.tool`` re-raises at decoration time for
+    signature-contract violations (see the multi-``MeshJob`` rejection in
+    ``analyze_mesh_job_signature`` and the dedicated ``except ValueError``
+    branch in ``mesh.decorators``). Subclassing it means strict-mode
+    failures propagate through the decorator's graceful-degradation
+    catch-all without needing every call site to know about strict mode.
+
+    The message is always the same prescriptive text the permissive-mode
+    warning would have logged.
+    """
+
+
+# Cached per-process resolution of MCP_MESH_STRICT_DI. Strict mode is a
+# process-level posture, not a per-call toggle — resolve the env var once
+# (mirrors the cached-global convention used elsewhere in the engine, e.g.
+# ``_REPORT_PROGRESS_CONVENTION`` in dependency_injector.py).
+_STRICT_DI_ENABLED: Optional[bool] = None
+
+
+def is_strict_di_enabled() -> bool:
+    """True when ``MCP_MESH_STRICT_DI`` resolves truthy. Cached per process.
+
+    Default (unset / falsy) is permissive: DI parameter-selection
+    diagnostics stay warnings and behavior is unchanged.
+    """
+    global _STRICT_DI_ENABLED
+    if _STRICT_DI_ENABLED is None:
+        from ..shared.config_resolver import ValidationRule, get_config_value
+
+        _STRICT_DI_ENABLED = bool(
+            get_config_value(
+                "MCP_MESH_STRICT_DI",
+                default=False,
+                rule=ValidationRule.TRUTHY_RULE,
+            )
+        )
+    return _STRICT_DI_ENABLED
+
+
+def _reset_strict_di_cache() -> None:
+    """Drop the cached env resolution (test support only)."""
+    global _STRICT_DI_ENABLED
+    _STRICT_DI_ENABLED = None
+
+
+def pluralize(count: int, singular: str, plural: Optional[str] = None) -> str:
+    """Render ``count`` + a correctly-inflected noun (``"1 dependency"``,
+    ``"3 dependencies"``, ``"0 entries"``).
+
+    Lives here because the DI diagnostic messages are this module's
+    "single choke point" concern — every count rendered into a
+    warn-or-raise message should route through this so the prescriptive
+    text never reads ``"1 entries"``.
+    """
+    noun = singular if count == 1 else (plural if plural is not None else f"{singular}s")
+    return f"{count} {noun}"
+
+
+def warn_or_raise(log: logging.Logger, message: str) -> None:
+    """Emit ``message`` as a warning, or raise :class:`StrictDIError`.
+
+    Single choke point for the DI ambiguity/skip diagnostic class so the
+    warning text and the strict-mode error text can never drift apart.
+    Informational diagnostics must NOT route through here — they stay
+    plain ``log.warning`` calls in both modes.
+    """
+    if is_strict_di_enabled():
+        raise StrictDIError(message)
+    log.warning(message)

--- a/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
@@ -7,6 +7,7 @@ from typing import Any
 from ...engine.decorator_registry import DecoratorRegistry
 from ...engine.dependency_injector import get_global_injector
 from ...engine.stream_introspection import detect_stream_type
+from ...engine.strict_di import StrictDIError
 from ..shared import PipelineResult, PipelineStatus, PipelineStep
 
 logger = logging.getLogger(__name__)
@@ -390,6 +391,12 @@ class RouteIntegrationStep(PipelineStep):
                 )
                 wrapped_handler._original_handler = original_handler
                 wrapped_handler._mesh_dependencies = dependency_names
+            except StrictDIError:
+                # MCP_MESH_STRICT_DI promotes DI ambiguity/skip warnings to
+                # startup errors; downgrading them to a "failed" step result
+                # here would defeat the opt-in entirely (mirrors the
+                # explicit re-raise branches in mesh.decorators).
+                raise
             except Exception as e:
                 self.logger.error(
                     f"Failed to create injection wrapper for {endpoint_name}: {e}"

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -13,6 +13,7 @@ from typing import Any, TypeVar
 
 # Import from _mcp_mesh for registry and runtime integration
 from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+from _mcp_mesh.engine.strict_di import StrictDIError
 from _mcp_mesh.shared.config_resolver import ValidationRule, get_config_value
 from _mcp_mesh.shared.simple_shutdown import start_blocking_loop_with_shutdown_support
 
@@ -1270,7 +1271,9 @@ def tool(
             # ValueError is reserved for contract violations the user MUST
             # see at decoration time — currently the multi-``MeshJob``
             # rejection from ``analyze_mesh_job_signature`` (per
-            # MESHJOB_DDDI_CONTRACT.md) and any future signature-shape
+            # MESHJOB_DDDI_CONTRACT.md), ``StrictDIError`` (the
+            # MCP_MESH_STRICT_DI promotion of DI ambiguity/skip warnings,
+            # a ValueError subclass) and any future signature-shape
             # rejection. Graceful-degradation would silently advertise a
             # broken tool and surface a confusing AttributeError on first
             # invocation; that is exactly the failure mode this branch is
@@ -1831,6 +1834,11 @@ def route(
             _trigger_debounced_processing()
             return wrapped
 
+        except StrictDIError:
+            # MCP_MESH_STRICT_DI promotes DI ambiguity/skip warnings to
+            # decoration-time errors; swallowing them here for graceful
+            # degradation would defeat the opt-in entirely.
+            raise
         except Exception as e:
             # Log but don't fail - graceful degradation
             logger.error(
@@ -2109,6 +2117,11 @@ def a2a(
 
             _trigger_debounced_processing()
             return wrapped
+        except StrictDIError:
+            # MCP_MESH_STRICT_DI promotes DI ambiguity/skip warnings to
+            # decoration-time errors; swallowing them here for graceful
+            # degradation would defeat the opt-in entirely.
+            raise
         except Exception as e:
             logger.error(
                 f"A2A dependency injection setup failed for {target.__name__}: {e}"

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -1278,6 +1278,12 @@ def tool(
             # broken tool and surface a confusing AttributeError on first
             # invocation; that is exactly the failure mode this branch is
             # supposed to prevent.
+            #
+            # Remove the entry registered above before propagating —
+            # otherwise the registry keeps a half-registered tool (original
+            # function, no wrapper) whenever the raise does NOT kill the
+            # process (decoration inside a user try block, REPL/notebook).
+            DecoratorRegistry.unregister_mesh_tool(target.__name__)
             raise
         except Exception as e:
             # Log but don't fail - graceful degradation
@@ -1837,7 +1843,13 @@ def route(
         except StrictDIError:
             # MCP_MESH_STRICT_DI promotes DI ambiguity/skip warnings to
             # decoration-time errors; swallowing them here for graceful
-            # degradation would defeat the opt-in entirely.
+            # degradation would defeat the opt-in entirely. Remove the
+            # entry registered above before propagating so the registry
+            # does not keep a half-registered route when the raise does
+            # not kill the process.
+            DecoratorRegistry.unregister_custom_decorator(
+                "mesh_route", target.__name__
+            )
             raise
         except Exception as e:
             # Log but don't fail - graceful degradation
@@ -2120,7 +2132,11 @@ def a2a(
         except StrictDIError:
             # MCP_MESH_STRICT_DI promotes DI ambiguity/skip warnings to
             # decoration-time errors; swallowing them here for graceful
-            # degradation would defeat the opt-in entirely.
+            # degradation would defeat the opt-in entirely. Remove the
+            # entry registered above before propagating so the registry
+            # does not keep a half-registered A2A surface when the raise
+            # does not kill the process.
+            DecoratorRegistry.unregister_custom_decorator("mesh_a2a", target.__name__)
             raise
         except Exception as e:
             logger.error(

--- a/src/runtime/python/tests/unit/test_12_dependency_injector.py
+++ b/src/runtime/python/tests/unit/test_12_dependency_injector.py
@@ -2006,3 +2006,105 @@ class TestPrescriptiveDiagnosticsAndStrictDI:
 
         strict_di._reset_strict_di_cache()
         assert strict_di.is_strict_di_enabled() is False
+
+
+class TestStrictDIDecorationFailureRegistryCleanup:
+    """Decorator blocks register with DecoratorRegistry BEFORE wrapper
+    creation (the graceful-degradation path depends on that ordering).
+    When wrapper creation raises an error that must propagate
+    (StrictDIError / contract ValueError), the half-registered entry —
+    original function, no wrapper — must be removed before the re-raise,
+    or any caller that survives the raise (decoration inside a user try
+    block, REPL/notebook) sees a stale registry entry advertised on the
+    next heartbeat."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry_and_strict_cache(self):
+        from _mcp_mesh.engine import strict_di
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+        DecoratorRegistry.clear_all()
+        strict_di._reset_strict_di_cache()
+        yield
+        DecoratorRegistry.clear_all()
+        strict_di._reset_strict_di_cache()
+
+    @staticmethod
+    def _enable_strict(monkeypatch):
+        from _mcp_mesh.engine import strict_di
+
+        monkeypatch.setenv("MCP_MESH_STRICT_DI", "true")
+        strict_di._reset_strict_di_cache()
+
+    def test_strict_tool_decoration_failure_leaves_no_registry_entry(
+        self, monkeypatch
+    ):
+        import mesh
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.engine.strict_di import StrictDIError
+
+        self._enable_strict(monkeypatch)
+
+        with pytest.raises(StrictDIError):
+
+            @mesh.tool(capability="cap", dependencies=["dep1"])
+            def no_params_tool():
+                pass
+
+        assert "no_params_tool" not in DecoratorRegistry.get_mesh_tools()
+
+    def test_strict_route_decoration_failure_leaves_no_registry_entry(
+        self, monkeypatch
+    ):
+        import mesh
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.engine.strict_di import StrictDIError
+
+        self._enable_strict(monkeypatch)
+
+        with pytest.raises(StrictDIError):
+
+            @mesh.route(dependencies=["dep1"])
+            def no_params_route():
+                pass
+
+        assert "no_params_route" not in DecoratorRegistry.get_all_by_type(
+            "mesh_route"
+        )
+
+    def test_strict_a2a_decoration_failure_leaves_no_registry_entry(
+        self, monkeypatch
+    ):
+        import mesh
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.engine.strict_di import StrictDIError
+
+        self._enable_strict(monkeypatch)
+
+        with pytest.raises(StrictDIError):
+
+            @mesh.a2a(path="/agents/no-params", dependencies=["dep1"])
+            def no_params_a2a():
+                pass
+
+        assert "no_params_a2a" not in DecoratorRegistry.get_all_by_type("mesh_a2a")
+
+    def test_permissive_tool_decoration_registers_wrapper_unchanged(self):
+        """Control: the same ambiguous config in permissive mode warns,
+        registers, and swaps in the injection wrapper (register-then-update
+        flow intact)."""
+        import mesh
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+        def no_params_tool():
+            pass
+
+        original = no_params_tool
+        wrapped = mesh.tool(capability="cap", dependencies=["dep1"])(no_params_tool)
+
+        tools = DecoratorRegistry.get_mesh_tools()
+        assert "no_params_tool" in tools
+        # update_mesh_tool_function swapped the registered function to the
+        # returned wrapper, not the original.
+        assert tools["no_params_tool"].function is wrapped
+        assert tools["no_params_tool"].function is not original

--- a/src/runtime/python/tests/unit/test_12_dependency_injector.py
+++ b/src/runtime/python/tests/unit/test_12_dependency_injector.py
@@ -142,7 +142,7 @@ class TestAnalyzeInjectionStrategy:
             return_value=[],
         ):
             analyze_injection_strategy(func_no_params, ["dep1"])
-        assert "has no parameters but 1 dependencies declared" in caplog.text
+        assert "has no parameters but 1 dependency declared" in caplog.text
 
         caplog.clear()
 
@@ -1207,7 +1207,7 @@ class TestUnifiedPositionalInjection:
         # signature-analysis regression could skip the branch and the test
         # would still pass green while no longer guarding #1104.
         assert any(
-            "injection-eligible parameters (McpMeshTool/MeshJob)" in r.message
+            "injection-eligible parameter" in r.message
             and "will remain None" in r.message
             for r in caplog.records
         )
@@ -1452,3 +1452,557 @@ class TestHiddenWrapperParamFunctionalInjection:
             return anything
 
         assert analyze_injection_strategy(f, ["dep1"]) == [0]
+
+
+class TestPrescriptiveDiagnosticsAndStrictDI:
+    """Issue #1196: DI parameter-selection diagnostics name (a) the
+    parameter positional pairing would/did select per declaration order,
+    (b) each skipped parameter with the reason, and (c) the
+    copy-pasteable fix. ``MCP_MESH_STRICT_DI`` promotes exactly that
+    ambiguity/skip class to :class:`StrictDIError` with the SAME text;
+    informational warnings never raise, and injection semantics are
+    untouched in both modes (positional pairing by declaration order —
+    pinned by ``test_multiple_deps_pair_by_declaration_order_not_name``).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_strict_cache(self):
+        """Strict mode is resolved once per process and cached — reset
+        around every test so setenv/delenv actually take effect."""
+        from _mcp_mesh.engine import strict_di
+
+        strict_di._reset_strict_di_cache()
+        yield
+        strict_di._reset_strict_di_cache()
+
+    @staticmethod
+    def _enable_strict(monkeypatch):
+        from _mcp_mesh.engine import strict_di
+
+        monkeypatch.setenv("MCP_MESH_STRICT_DI", "true")
+        strict_di._reset_strict_di_cache()
+
+    @staticmethod
+    def _prep(func, dependencies, mesh_positions=None, kwargs=None):
+        """Drive _prepare_injection_kwargs like the runtime wrapper does."""
+        import logging as _log
+
+        from _mcp_mesh.engine.dependency_injector import _prepare_injection_kwargs
+        from _mcp_mesh.engine.signature_analyzer import get_mesh_agent_positions
+
+        if mesh_positions is None:
+            mesh_positions = get_mesh_agent_positions(func)
+        return _prepare_injection_kwargs(
+            func,
+            kwargs or {},
+            mesh_positions,
+            dependencies,
+            [None] * len(dependencies),
+            lambda _key: None,
+            _log.getLogger("test"),
+        )
+
+    # ------------------------------------------------------------------
+    # Prescriptive warning text (permissive mode — default)
+    # ------------------------------------------------------------------
+
+    def test_no_params_warning_is_prescriptive(self, caplog):
+        """No-parameters + declared deps: the skip warning names the
+        skipped dependencies, explains positional pairing, and shows the
+        copy-pasteable fix."""
+
+        def no_params():
+            pass
+
+        with caplog.at_level(logging.WARNING):
+            result = analyze_injection_strategy(no_params, ["dep1"])
+
+        assert result == []
+        text = caplog.text
+        assert "has no parameters but 1 dependency declared" in text
+        assert "['dep1']" in text  # the skipped dependencies, by name
+        assert "declaration order" in text
+        assert "dep_0: McpMeshTool = None" in text  # copy-pasteable fix
+
+    def test_multi_param_untyped_warning_names_selection_skips_and_fix(
+        self, caplog
+    ):
+        """Multi-param, none typed: the warning names each skipped
+        parameter WITH its reason (untyped / wrong annotation), states
+        what declaration-order pairing would select, and gives the fix."""
+
+        def multi(alpha, beta: str, gamma):
+            pass
+
+        with caplog.at_level(logging.WARNING):
+            result = analyze_injection_strategy(multi, ["cap_a", "cap_b"])
+
+        assert result == []
+        text = caplog.text
+        assert "none are typed as McpMeshTool" in text
+        # (b) each skipped parameter and the reason
+        assert "'alpha' (untyped)" in text
+        assert "'beta' (annotated as str, not McpMeshTool)" in text
+        assert "'gamma' (untyped)" in text
+        # (a) what positional pairing WOULD select, declaration order
+        assert (
+            "'cap_a' would go to the first McpMeshTool-typed parameter" in text
+        )
+        assert "parameter names are never matched" in text
+        # (c) copy-pasteable fix
+        assert "alpha: McpMeshTool = None" in text
+
+    def test_excess_deps_warning_names_pairings_and_fix(self, caplog):
+        """More deps than injectable slots: the warning names the dep→param
+        pairs that DID get selected, the excess deps, and the fix."""
+        from mesh.types import McpMeshTool
+
+        def f(a: str, db: McpMeshTool = None):
+            pass
+
+        with caplog.at_level(logging.WARNING):
+            result = analyze_injection_strategy(f, ["cap0", "cap1", "cap2"])
+
+        assert result == [1]
+        text = caplog.text
+        assert "will not be injected" in text
+        # (a) selected pairing, declaration order
+        assert "dependencies[0] 'cap0' → parameter 'db'" in text
+        # (b) the skipped deps, by name
+        assert "['cap1', 'cap2']" in text
+        # (c) copy-pasteable fix
+        assert "extra_dep: McpMeshTool = None" in text
+
+    def test_unfilled_slots_runtime_warning_names_pairings_and_fix(self, caplog):
+        """More eligible slots than deps (runtime diagnostic): the warning
+        names the selected pairs, the parameters left None, and the fix."""
+        from mesh.types import McpMeshTool
+
+        async def f(
+            a: str, dep0: McpMeshTool = None, dep1: McpMeshTool = None
+        ):
+            return (dep0, dep1)
+
+        with caplog.at_level(logging.WARNING):
+            self._prep(f, ["cap0"])
+
+        text = caplog.text
+        assert "injection-eligible parameters (McpMeshTool/MeshJob)" in text
+        assert "will remain None" in text
+        # (a) the selected pairing
+        assert "dependencies[0] 'cap0' → parameter 'dep0'" in text
+        # (b) the unfilled parameter, by name
+        assert "['dep1']" in text
+        # (c) the fix
+        assert "add one entry per unfilled parameter to dependencies=[...]" in text
+
+    def test_bounds_guard_warning_is_prescriptive(self, caplog):
+        """The #1171 bounds guard names the skipped dep, the out-of-range
+        position vs the real signature, and the __wrapped__ fix."""
+        from mesh.types import McpMeshTool
+
+        async def f(a: str, db: McpMeshTool = None):
+            return db
+
+        with caplog.at_level(logging.WARNING):
+            final_kwargs, count = self._prep(
+                f, ["cap0", "cap1"], mesh_positions=[1, 7]
+            )
+
+        assert count == 1
+        text = caplog.text
+        assert "out of bounds" in text
+        assert "'cap1'" in text  # the skipped dependency, by name
+        assert "selected position 7" in text
+        assert "ends at index 1" in text
+        assert "functools.wraps" in text  # the fix
+
+    def test_validate_mesh_dependencies_message_is_prescriptive(self):
+        """The heartbeat-time count-mismatch message names each typed slot
+        in declaration order and the exact fix."""
+        from _mcp_mesh.engine.signature_analyzer import validate_mesh_dependencies
+        from mesh.types import McpMeshTool
+
+        def f(a: str, db: McpMeshTool = None):
+            pass
+
+        is_valid, message = validate_mesh_dependencies(f, [{"capability": "c0"}, {"capability": "c1"}])
+
+        assert is_valid is False
+        assert "Each typed slot needs a corresponding dependency" in message
+        assert "'db' (McpMeshTool)" in message  # the slot, by name + kind
+        assert "parameter names are never matched" in message
+        assert "declare exactly 1 entry in dependencies=[...]" in message
+
+    # ------------------------------------------------------------------
+    # Strict mode: the ambiguity/skip class raises with the SAME text
+    # ------------------------------------------------------------------
+
+    def test_strict_no_params_raises_same_text(self, caplog, monkeypatch):
+        """Strict promotes the no-parameters skip warning to a
+        decoration-time StrictDIError carrying the identical message."""
+        from _mcp_mesh.engine.strict_di import StrictDIError
+
+        def no_params():
+            pass
+
+        # Capture the permissive-mode warning text first.
+        with caplog.at_level(logging.WARNING):
+            analyze_injection_strategy(no_params, ["dep1"])
+        warning_text = next(
+            r.message
+            for r in caplog.records
+            if "has no parameters" in r.message
+        )
+
+        self._enable_strict(monkeypatch)
+        with pytest.raises(StrictDIError) as exc_info:
+            analyze_injection_strategy(no_params, ["dep1"])
+
+        assert str(exc_info.value) == warning_text
+
+    def test_strict_multi_param_untyped_raises_same_text(
+        self, caplog, monkeypatch
+    ):
+        from _mcp_mesh.engine.strict_di import StrictDIError
+
+        def multi(alpha, beta: str, gamma):
+            pass
+
+        with caplog.at_level(logging.WARNING):
+            analyze_injection_strategy(multi, ["cap_a"])
+        warning_text = next(
+            r.message
+            for r in caplog.records
+            if "none are typed as McpMeshTool" in r.message
+        )
+
+        self._enable_strict(monkeypatch)
+        with pytest.raises(StrictDIError) as exc_info:
+            analyze_injection_strategy(multi, ["cap_a"])
+
+        assert str(exc_info.value) == warning_text
+
+    def test_strict_excess_deps_raises(self, monkeypatch):
+        from _mcp_mesh.engine.strict_di import StrictDIError
+        from mesh.types import McpMeshTool
+
+        def f(a: str, db: McpMeshTool = None):
+            pass
+
+        self._enable_strict(monkeypatch)
+        with pytest.raises(StrictDIError, match="will not be injected"):
+            analyze_injection_strategy(f, ["cap0", "cap1"])
+
+    def test_strict_unfilled_slots_raises_at_decoration_time(self, monkeypatch):
+        """Permissive mode flags unfilled eligible slots per-call only;
+        strict mode fails fast at decoration/startup via the strategy
+        analysis — same prescriptive text as the runtime warning."""
+        from _mcp_mesh.engine.strict_di import StrictDIError
+        from mesh.types import McpMeshTool
+
+        def f(a: str, dep0: McpMeshTool = None, dep1: McpMeshTool = None):
+            pass
+
+        self._enable_strict(monkeypatch)
+        with pytest.raises(StrictDIError, match="will remain None"):
+            analyze_injection_strategy(f, ["cap0"])
+
+    def test_strict_unfilled_slots_call_time_warns_never_raises(
+        self, caplog, monkeypatch
+    ):
+        """Call-time strict raising is reserved for the bounds guard: the
+        unfilled-slots class is statically detectable, so decoration owns
+        it. The injection-time diagnostic stays a warning even under
+        strict — otherwise a config that escaped decoration (or a direct
+        drive like this one) would fail on EVERY call instead of once at
+        startup."""
+        from mesh.types import McpMeshTool
+
+        async def f(
+            a: str, dep0: McpMeshTool = None, dep1: McpMeshTool = None
+        ):
+            return (dep0, dep1)
+
+        self._enable_strict(monkeypatch)
+        with caplog.at_level(logging.WARNING):
+            final_kwargs, count = self._prep(f, ["cap0"])  # no raise
+
+        assert count == 1
+        assert "will remain None" in caplog.text
+
+    def test_strict_zero_deps_with_eligible_slots_raises_at_decoration(
+        self, monkeypatch
+    ):
+        """Zero-declared-deps configs with typed eligible slots previously
+        escaped both the strategy-time promotion and the heartbeat
+        validator (gated on `if dependencies:`) and then raised on every
+        call. They are statically detectable, so strict must fail once at
+        decoration/startup instead."""
+        from _mcp_mesh.engine.dependency_injector import DependencyInjector
+        from _mcp_mesh.engine.strict_di import StrictDIError
+        from mesh.types import McpMeshTool, MeshJob
+
+        def submit(job: MeshJob = None):
+            pass
+
+        def fetch(a: str, db: McpMeshTool = None):
+            pass
+
+        self._enable_strict(monkeypatch)
+        # Single-MeshJob-param early return path.
+        with pytest.raises(StrictDIError, match="will remain None"):
+            analyze_injection_strategy(submit, [])
+        # Typed McpMeshTool slot with zero deps.
+        with pytest.raises(StrictDIError, match="will remain None"):
+            analyze_injection_strategy(fetch, [])
+        # End-to-end through the decoration surface (wrapper factory).
+        with pytest.raises(StrictDIError, match="will remain None"):
+            DependencyInjector().create_injection_wrapper(submit, [])
+
+    def test_strict_zero_deps_meshjob_does_not_raise_per_call(
+        self, caplog, monkeypatch
+    ):
+        """The same zero-deps MeshJob config driven at the call-time site
+        (bypassing decoration) warns instead of raising — per-call strict
+        raising is reserved for the bounds guard."""
+        from mesh.types import MeshJob
+
+        async def submit(job: MeshJob = None):
+            return job
+
+        self._enable_strict(monkeypatch)
+        with caplog.at_level(logging.WARNING):
+            self._prep(submit, [])  # no raise
+
+        assert "will remain None" in caplog.text
+
+    def test_strict_untyped_single_param_zero_deps_does_not_raise(
+        self, monkeypatch
+    ):
+        """A plain zero-dependency single-param tool ('def greet(name)')
+        has NO typed eligible slot — the heuristic slot must not trip the
+        decoration-time strict check, or every such tool would fail under
+        strict."""
+
+        def greet(name):
+            return name
+
+        self._enable_strict(monkeypatch)
+        assert analyze_injection_strategy(greet, []) == [0]
+
+    def test_caller_supplied_kwarg_fills_unfilled_slot_no_warning_no_raise(
+        self, caplog, monkeypatch
+    ):
+        """Documented contract: callers may pass an explicit value (e.g. a
+        mock) for any injectable slot. A slot the caller filled is not
+        unfilled — no permissive warning, no strict raise, and the call
+        proceeds with the caller's value."""
+        from mesh.types import McpMeshTool
+
+        def f(a: str, dep0: McpMeshTool = None, dep1: McpMeshTool = None):
+            return (dep0, dep1)
+
+        fake = MagicMock(name="caller_supplied_dep1")
+
+        # Permissive: previously a false "dep1 will remain None" warning.
+        with caplog.at_level(logging.WARNING):
+            final_kwargs, count = self._prep(
+                f, ["cap0"], kwargs={"a": "x", "dep1": fake}
+            )
+        assert "will remain None" not in caplog.text
+        assert final_kwargs["dep1"] is fake
+        result = f(**final_kwargs)
+        assert result[1] is fake
+
+        # Strict: the count-based check must not fire before the
+        # caller-supplied accounting — no raise either.
+        self._enable_strict(monkeypatch)
+        final_kwargs, count = self._prep(
+            f, ["cap0"], kwargs={"a": "x", "dep1": fake}
+        )
+        assert final_kwargs["dep1"] is fake
+
+    # ------------------------------------------------------------------
+    # Skip reasons resolve hints the same way eligibility does
+    # ------------------------------------------------------------------
+
+    def test_skip_reason_string_annotation_hint_failure_is_explicit(
+        self, caplog
+    ):
+        """A valid-looking `db: "McpMeshTool"` whose name cannot be
+        resolved (TYPE_CHECKING-only import) made eligibility fall back to
+        "no eligible parameters"; the skip reason must report that
+        hint-resolution failure — not the self-contradictory
+        'annotated as McpMeshTool, not McpMeshTool' read off the raw
+        annotation string."""
+        ns: dict = {}
+        exec(
+            "def f(a, db: 'McpMeshTool' = None):\n    return db\n",
+            ns,
+        )
+        f = ns["f"]
+
+        with caplog.at_level(logging.WARNING):
+            result = analyze_injection_strategy(f, ["cap0"])
+
+        assert result == []
+        text = caplog.text
+        assert "type hints could not be resolved" in text
+        assert "TYPE_CHECKING" in text
+        assert "annotated as McpMeshTool, not McpMeshTool" not in text
+
+    def test_skip_reason_optional_mesh_tool_not_misreported_under_hint_failure(
+        self, caplog
+    ):
+        """An eager Optional[McpMeshTool] param sharing a function with an
+        unresolvable forward ref: hints fail wholesale, so eligibility
+        skipped BOTH. The Optional[McpMeshTool] reason must state the
+        hint failure, not render the raw annotation as
+        'annotated as Union/Optional..., not McpMeshTool'."""
+        from typing import Optional as _Optional
+
+        from mesh.types import McpMeshTool
+
+        ns: dict = {"Optional": _Optional, "McpMeshTool": McpMeshTool}
+        exec(
+            "def f(a, db: Optional[McpMeshTool] = None,"
+            " c: 'Unresolvable' = None):\n    return db\n",
+            ns,
+        )
+        f = ns["f"]
+
+        with caplog.at_level(logging.WARNING):
+            result = analyze_injection_strategy(f, ["cap0"])
+
+        assert result == []
+        text = caplog.text
+        assert "type hints could not be resolved" in text
+        # No reason may claim any parameter is annotated as something
+        # other than McpMeshTool — the hints never resolved.
+        assert "not McpMeshTool" not in text
+
+    def test_string_annotation_that_resolves_is_eligible_no_skip_warning(
+        self, caplog
+    ):
+        """Parity check: when the string annotation DOES resolve, the
+        parameter is eligible and no skip diagnostic fires at all."""
+        from mesh.types import McpMeshTool
+
+        ns: dict = {"McpMeshTool": McpMeshTool}
+        exec(
+            "def f(a, db: 'McpMeshTool' = None):\n    return db\n",
+            ns,
+        )
+        f = ns["f"]
+
+        with caplog.at_level(logging.WARNING):
+            result = analyze_injection_strategy(f, ["cap0"])
+
+        assert result == [1]
+        assert "Skipping injection" not in caplog.text
+
+    def test_strict_bounds_guard_raises(self, monkeypatch):
+        """The bounds guard is only detectable at call time; strict
+        promotes it there."""
+        from _mcp_mesh.engine.strict_di import StrictDIError
+        from mesh.types import McpMeshTool
+
+        async def f(a: str, db: McpMeshTool = None):
+            return db
+
+        self._enable_strict(monkeypatch)
+        with pytest.raises(StrictDIError, match="out of bounds"):
+            self._prep(f, ["cap0", "cap1"], mesh_positions=[1, 7])
+
+    def test_strict_validate_mesh_dependencies_raises_same_text(
+        self, monkeypatch
+    ):
+        from _mcp_mesh.engine.signature_analyzer import validate_mesh_dependencies
+        from _mcp_mesh.engine.strict_di import StrictDIError
+        from mesh.types import McpMeshTool
+
+        def f(a: str, db: McpMeshTool = None):
+            pass
+
+        deps = [{"capability": "c0"}, {"capability": "c1"}]
+        _, permissive_message = validate_mesh_dependencies(f, deps)
+
+        self._enable_strict(monkeypatch)
+        with pytest.raises(StrictDIError) as exc_info:
+            validate_mesh_dependencies(f, deps)
+
+        assert str(exc_info.value) == permissive_message
+
+    # ------------------------------------------------------------------
+    # Strict mode boundaries: informational warnings + semantics untouched
+    # ------------------------------------------------------------------
+
+    def test_strict_informational_single_param_warning_does_not_raise(
+        self, caplog, monkeypatch
+    ):
+        """The single-untyped-parameter notice is informational (injection
+        HAPPENS) — strict mode must not promote it."""
+
+        def f(anything):
+            return anything
+
+        self._enable_strict(monkeypatch)
+        with caplog.at_level(logging.WARNING):
+            result = analyze_injection_strategy(f, ["dep1"])
+
+        assert result == [0]  # injection semantics unchanged under strict
+        assert "consider typing as McpMeshTool for clarity" in caplog.text
+
+    def test_strict_clean_configuration_does_not_raise(self, monkeypatch):
+        """A correctly-typed, correctly-counted function is untouched by
+        strict mode."""
+        from mesh.types import McpMeshTool
+
+        def f(a: str, db: McpMeshTool = None, other: McpMeshTool = None):
+            pass
+
+        self._enable_strict(monkeypatch)
+        assert analyze_injection_strategy(f, ["cap0", "cap1"]) == [1, 2]
+
+    def test_strict_unset_never_raises_warnings_only(self, caplog, monkeypatch):
+        """Default posture (env unset): every ambiguous scenario stays a
+        warning; nothing raises."""
+        from _mcp_mesh.engine import strict_di
+        from mesh.types import McpMeshTool
+
+        monkeypatch.delenv("MCP_MESH_STRICT_DI", raising=False)
+        strict_di._reset_strict_di_cache()
+
+        def no_params():
+            pass
+
+        def multi(alpha, beta):
+            pass
+
+        def excess(a: str, db: McpMeshTool = None):
+            pass
+
+        with caplog.at_level(logging.WARNING):
+            assert analyze_injection_strategy(no_params, ["d1"]) == []
+            assert analyze_injection_strategy(multi, ["d1"]) == []
+            assert analyze_injection_strategy(excess, ["d1", "d2"]) == [1]
+
+        # Three skip-class scenarios, three warnings, zero exceptions.
+        assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 3
+
+    def test_strict_env_resolved_once_per_process(self, monkeypatch):
+        """The env var is read once and cached: flipping it after the first
+        resolution has no effect until the cache is reset."""
+        from _mcp_mesh.engine import strict_di
+
+        monkeypatch.setenv("MCP_MESH_STRICT_DI", "true")
+        strict_di._reset_strict_di_cache()
+        assert strict_di.is_strict_di_enabled() is True
+
+        monkeypatch.setenv("MCP_MESH_STRICT_DI", "false")
+        # No reset — the cached resolution must win.
+        assert strict_di.is_strict_di_enabled() is True
+
+        strict_di._reset_strict_di_cache()
+        assert strict_di.is_strict_di_enabled() is False


### PR DESCRIPTION
## Summary
Closes #1196. DI's permissive posture stays (soft-fail, warn, life goes on) — but the warnings now teach, and teams that want rigor can opt in.

- **Prescriptive diagnostics**: every ambiguous or skipped dependency-injection configuration warns with the full picture — what positional pairing selected or would select, each skipped parameter with its *resolved-type* reason (the reason classifier uses the same `get_type_hints` resolution as the eligibility scan, so `"McpMeshTool"` string annotations and `Optional[McpMeshTool]` are never misdiagnosed; hint-resolution failures say so explicitly instead of blaming the annotation), and a copy-pasteable fix.
- **`MCP_MESH_STRICT_DI=true`** promotes exactly the ambiguity/skip class to `StrictDIError` at decoration/startup — including statically-detectable zero-dependency configs that previously only surfaced per-call. Call-time raising is reserved for the single condition not detectable earlier (the wrapper-rewrite bounds guard). The informational single-param hint never raises. Warning and error text share one choke point so they cannot drift.
- **Injection semantics are byte-identical in both modes**: positional pairing by declaration order, never by parameter name — pinned by the unmodified adversarial declaration-order test. The caller-supplied-mock contract is now honored by the unfilled-slot accounting (fixing a pre-existing false warning along the way).
- `StrictDIError` propagates through every decorator entry point (tool/route/a2a/pipeline wrapper creation — each catch-all got an explicit re-raise). Env var resolved once per process; documented in both env-var surfaces, scoped Python-only.
- **TS/Java parity audit** (report-only, follow-up candidates): TS has no diagnostic for `dependencies.length` vs handler-arity mismatch (excess deps spread into nothing); Java's `updateDependency` silently no-ops out-of-bounds indices where its LLM sibling warns.

## Review Notes
- Independent review: 0 blockers; verified no name-based matching crept in (all parameter-name use is display-only) and permissive-mode selection logic is provably unchanged.
- All 4 warnings fixed: hint-failure reason misdiagnosis, zero-deps configs raising per-call instead of at decoration, the strict promotion firing before caller-supplied-kwarg accounting (the documented mock contract), and a remaining `StrictDIError`-swallowing catch-all on the pipeline path.

Closes #1196

## Test plan
- [x] Full Python unit suite: 1126 passed (31 new tests across diagnostics text, strict promotion timing, caller-supplied contract, hint-resolution edge cases)
- [x] Adversarial declaration-order test untouched and passing
- [x] Strict unset → behavior byte-identical (warnings only), pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added strict dependency-injection mode via `MCP_MESH_STRICT_DI` environment variable to catch ambiguous or incomplete configurations at startup instead of warnings.
  * Enhanced dependency-injection error messages with prescriptive guidance for resolution.

* **Documentation**
  * Documented `MCP_MESH_STRICT_DI` environment variable and strict DI diagnostic behavior.

* **Tests**
  * Expanded test coverage for strict dependency-injection scenarios and error message clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->