### PR TITLE
feat(runtime): settling-window dependency grace across Python, TypeScript, and Java

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -94,6 +94,33 @@ export MCP_MESH_TOOL_WORKERS=1
 export MCP_MESH_STRICT_DI=true
 ```
 
+### Dependency Settling Window (all runtimes)
+
+```bash
+# Float seconds, default: 20. 0 disables the grace entirely.
+#
+# During agent startup, declared dependencies resolve asynchronously (first
+# full heartbeat cycle). A call that arrives while a declared dependency is
+# still unresolved waits — bounded by the remaining window — for that
+# dependency's resolution event before proceeding. Event-driven: resolution
+# at 800ms unblocks at 800ms; the value is a ceiling, never a sleep.
+# The window starts when the agent's first dependency is declared during
+# startup (not at process start or module import).
+#
+# Once the agent settles (all declared dependencies resolved at least once,
+# OR the window expires), the latch is permanent: calls never wait again and
+# unresolved dependencies inject None/null exactly as before.
+#
+# Scope: dependency-injection call paths only (@mesh.tool, @mesh.route).
+# Startup-hook usage, module-scope captured deps, and @mesh.llm
+# provider/filter assembly are not covered.
+#
+# Tuning: lower it (e.g. 2–5) in integration tests that intentionally
+# exercise unresolved-dependency behavior, so degraded-path assertions
+# don't sit out the full default window.
+export MCP_MESH_SETTLE_TIMEOUT=20
+```
+
 ### HTTP Server Settings
 
 ```bash

--- a/docs/typescript/examples.md
+++ b/docs/typescript/examples.md
@@ -230,6 +230,8 @@ expect(mockCalculator).toHaveBeenCalledWith({ expression: "6*7" });
 expect(result).toBe("42");
 ```
 
+Call `setMockDependency` AFTER the tools are registered — it targets the registered tool's dependency slot. Mocks are not sticky: a later real `dependency_available` event overwrites them, by design for the no-registry unit-test context this API is meant for.
+
 ## Available MCP Methods
 
 | Method           | Description                  |

--- a/examples/simple/llm_with_deps_agent.py
+++ b/examples/simple/llm_with_deps_agent.py
@@ -52,10 +52,18 @@ class AnalysisResponse(BaseModel):
 )
 async def smart_analyze(
     query: str,
-    time_service: mesh.McpMeshTool = None
+    time_service: mesh.McpMeshTool = None,
+    info: mesh.McpMeshTool = None,
+    llm: mesh.MeshLlmAgent = None,
 ) -> AnalysisResponse:
 
-    timestamp = await time_service()
+    # Get timestamp from dependency
+    timestamp = "unknown"
+    if time_service:
+        try:
+            timestamp = str(await time_service())
+        except Exception:
+            pass
 
     # Get system info from dependency
     system_info = "unknown"

--- a/src/core/cli/man/content/dependency-injection.md
+++ b/src/core/cli/man/content/dependency-injection.md
@@ -177,7 +177,7 @@ def smart_tool(ctx: Context, llm: mesh.MeshLlmAgent = None):
 
 ## Graceful Degradation
 
-Dependencies may be unavailable. Always handle `None`:
+Dependencies may be unavailable. During agent startup, calls on a declared-but-unresolved dependency first wait — bounded by the settle window (`MCP_MESH_SETTLE_TIMEOUT`, default 20s; the window starts when the agent's first dependency is declared) — for the resolution to land before degrading; once the agent settles, unresolved dependencies inject `None` immediately. Always handle `None`:
 
 ```python
 async def my_tool(helper: mesh.McpMeshTool = None):

--- a/src/core/cli/man/content/dependency-injection_java.md
+++ b/src/core/cli/man/content/dependency-injection_java.md
@@ -295,7 +295,7 @@ record Employee(int id, String name, String department) {}
 
 ## Graceful Degradation
 
-Dependencies may be unavailable if the providing agent is down or not yet started. Always handle `null` and check availability:
+Dependencies may be unavailable if the providing agent is down or not yet started. During agent startup, calls on a declared-but-unresolved dependency first wait — bounded by the settle window (`MCP_MESH_SETTLE_TIMEOUT`, default 20s; the window starts when the agent's first dependency is declared) — for the resolution to land before degrading; once the agent settles, unresolved dependencies inject `null`/unavailable proxies immediately. Always handle `null` and check availability:
 
 ```java
 @MeshTool(capability = "agent_status",

--- a/src/core/cli/man/content/dependency-injection_typescript.md
+++ b/src/core/cli/man/content/dependency-injection_typescript.md
@@ -184,7 +184,7 @@ agent.addTool({
 
 ## Graceful Degradation
 
-Dependencies may be unavailable. Always handle `null`:
+Dependencies may be unavailable. During agent startup, calls on a declared-but-unresolved dependency first wait — bounded by the settle window (`MCP_MESH_SETTLE_TIMEOUT`, default 20s; the window starts when the agent's first dependency is declared) — for the resolution to land before degrading; once the agent settles, unresolved dependencies inject `null` immediately. Always handle `null`:
 
 ```typescript
 agent.addTool({

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -118,6 +118,33 @@ export MCP_MESH_TOOL_WORKERS=1
 export MCP_MESH_STRICT_DI=true
 ```
 
+### Dependency Settling Window (all runtimes)
+
+```bash
+# Float seconds, default: 20. 0 disables the grace entirely.
+#
+# During agent startup, declared dependencies resolve asynchronously (first
+# full heartbeat cycle). A call that arrives while a declared dependency is
+# still unresolved waits — bounded by the remaining window — for that
+# dependency's resolution event before proceeding. Event-driven: resolution
+# at 800ms unblocks at 800ms; the value is a ceiling, never a sleep.
+# The window starts when the agent's first dependency is declared during
+# startup (not at process start or module import).
+#
+# Once the agent settles (all declared dependencies resolved at least once,
+# OR the window expires), the latch is permanent: calls never wait again and
+# unresolved dependencies inject None/null exactly as before.
+#
+# Scope: dependency-injection call paths only (@mesh.tool, @mesh.route).
+# Startup-hook usage, module-scope captured deps, and @mesh.llm
+# provider/filter assembly are not covered.
+#
+# Tuning: lower it (e.g. 2–5) in integration tests that intentionally
+# exercise unresolved-dependency behavior, so degraded-path assertions
+# don't sit out the full default window.
+export MCP_MESH_SETTLE_TIMEOUT=20
+```
+
 ### Schema Verdict Policy (issue #547)
 
 ```bash

--- a/src/core/cli/man/content/testing_typescript.md
+++ b/src/core/cli/man/content/testing_typescript.md
@@ -222,6 +222,8 @@ expect(mockCalculator).toHaveBeenCalledWith({ expression: "6*7" });
 expect(result).toBe("42");
 ```
 
+Call `setMockDependency` AFTER the tools are registered — it targets the registered tool's dependency slot. Mocks are not sticky: a later real `dependency_available` event overwrites them, by design for the no-registry unit-test context this API is meant for.
+
 ## Available MCP Methods
 
 | Method           | Description                  |

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshDependencyInjector.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshDependencyInjector.java
@@ -52,6 +52,16 @@ public class MeshDependencyInjector {
         if (endpoint != null) {
             log.info("Dependency available: {} at {}", capability, endpoint);
             proxy.updateEndpoint(endpoint, functionName);
+            // Settling-window grace (#1193): this is the ROUTE funnel —
+            // @MeshRoute requests wait on capability keys because every
+            // route resolves through THIS injector's SHARED per-capability
+            // proxy, which the updateEndpoint above makes live before the
+            // countdown — a woken route request re-reads a live proxy
+            // regardless of which consumer's event fired. Tool wrappers do
+            // NOT use this key: their waits are per-consumer-slot
+            // composites counted down inside MeshToolWrapper
+            // .updateDependency (after that wrapper's slot is written).
+            MeshSettleState.getInstance().markResolved(capability);
         } else {
             log.info("Dependency unavailable: {}", capability);
             proxy.markUnavailable();

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
@@ -178,14 +178,16 @@ public class MeshEventProcessor implements SmartLifecycle {
                 event.getCapability(), event.getRequestingFunction(), event.getDepIndex());
         }
 
-        // Update legacy injector
-        injector.updateToolDependency(
-            event.getCapability(),
-            available ? event.getEndpoint() : null,
-            available ? event.getFunctionName() : null
-        );
-
-        // Update wrapper registry with composite key
+        // Update wrapper registry with composite key.
+        //
+        // Settling-window grace (#1193): the wrapper update counts down
+        // the per-consumer-slot settle latch (funcId:dep_N) INSIDE
+        // MeshToolWrapper.updateDependency, strictly after the wrapper's
+        // injectedDeps slot is written — a woken tool call re-reads a
+        // populated slot. It runs before the legacy injector update below,
+        // whose capability-keyed countdown serves the @MeshRoute path
+        // (shared per-capability proxy, updated there before its own
+        // countdown).
         if (event.getRequestingFunction() != null && event.getDepIndex() != null) {
             String compositeKey = MeshToolWrapperRegistry.buildDependencyKey(
                 event.getRequestingFunction(),
@@ -201,6 +203,14 @@ public class MeshEventProcessor implements SmartLifecycle {
                 wrapperRegistry.markDependencyUnavailable(compositeKey);
             }
         }
+
+        // Update legacy injector (also wakes @MeshRoute settle waiters on
+        // availability — capability-keyed; see MeshDependencyInjector)
+        injector.updateToolDependency(
+            event.getCapability(),
+            available ? event.getEndpoint() : null,
+            available ? event.getFunctionName() : null
+        );
     }
 
     private void handleDependencyAvailable(MeshEvent event) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshSettleState.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshSettleState.java
@@ -1,0 +1,266 @@
+package io.mcpmesh.spring;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Settling-window dependency grace (issue #1193).
+ *
+ * <p>Dependency injection resolves asynchronously: declared dependencies
+ * become available when the first full heartbeat cycle completes and
+ * {@code dependency_available} events land. A tool call (or {@code @MeshRoute}
+ * request) that fires during that settling window would otherwise see a
+ * declared-but-unresolved dependency as {@code null} / unavailable even
+ * though resolution typically lands moments later.
+ *
+ * <p>Process-wide settle state:
+ * <ul>
+ *   <li>The agent is <b>unsettled</b> from process start until EITHER every
+ *       declared dependency capability has resolved at least once OR the
+ *       settle window (wall clock from start,
+ *       {@code MCP_MESH_SETTLE_TIMEOUT} seconds, default 20) expires.</li>
+ *   <li>While unsettled, invocation paths block — bounded by the REMAINING
+ *       settle budget — on a per-key {@link CountDownLatch} that the
+ *       existing dependency-update handling counts down the moment a real
+ *       endpoint lands. Resolution at 800ms unblocks at 800ms; the budget is
+ *       a ceiling only, never a sleep. Blocking is safe: both the MCP tool
+ *       dispatch and Spring MVC route handling run on dedicated request
+ *       threads (Tomcat/Spring pool), never an event loop.</li>
+ *   <li>Once settled — either way — the latch is permanent: calls never
+ *       touch the wait primitives again and fail-fast behavior is
+ *       byte-identical to the pre-grace behavior (unresolved deps inject
+ *       {@code null} / unavailable proxies exactly as before).</li>
+ * </ul>
+ *
+ * <p>Key spaces (two, by consumer type):
+ * <ul>
+ *   <li><b>Tool wrappers</b> use per-consumer-slot composite keys
+ *       ({@code funcId:dep_N}, mirroring the Python/TypeScript composite
+ *       keys), counted down by {@link MeshToolWrapper#updateDependency}
+ *       AFTER that wrapper's array slot is written. Capability-level
+ *       keying was wrong here: with tools A and B both depending on the
+ *       same capability, A's resolution event would wake B's waiter
+ *       before B's slot was written — B proceeded with {@code null}.</li>
+ *   <li><b>{@code @MeshRoute} requests</b> use capability keys, counted
+ *       down by {@link MeshDependencyInjector#updateToolDependency}. That
+ *       keying is safe for routes because every route resolves through
+ *       the injector's SHARED per-capability proxy, which is updated
+ *       ({@code updateEndpoint}) immediately before the countdown — a
+ *       woken route request re-reads a live proxy regardless of which
+ *       consumer's event fired.</li>
+ * </ul>
+ *
+ * <p>Scope (deliberate): the grace covers the dependency-injection
+ * invocation paths only — {@link MeshToolWrapper} argument building and the
+ * {@code @MeshRoute} interceptor. Startup-hook dependency usage and
+ * {@code @MeshLlm} provider/filter assembly (registration-time, with its own
+ * update mechanism) are NOT covered.
+ *
+ * <p>This is environmental, not a declaration mistake: strict-DI style
+ * diagnostics never interact with the settle window in any way.
+ */
+public final class MeshSettleState {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshSettleState.class);
+
+    /** Default settle window in seconds. */
+    public static final double SETTLE_TIMEOUT_DEFAULT_SECONDS = 20.0;
+
+    /**
+     * Process-wide (JVM-static) instance. Static on purpose: the settle
+     * window is a process-level posture and the consumers (wrapper
+     * registry, event processor, route interceptor) live in the Spring
+     * context while resolution events arrive from the Rust core's event
+     * loop. NOTE: being static, the state PERSISTS across Spring context
+     * refreshes in the same JVM (e.g. test suites rebuilding the
+     * application context) — acceptable because the window is bounded by
+     * expiry: a refreshed context inherits at most the remainder of the
+     * original window, never a fresh or unbounded one. Tests reset via
+     * {@link #resetForTests()}.
+     */
+    private static volatile MeshSettleState instance = new MeshSettleState();
+
+    /** Get the process-wide settle state. */
+    public static MeshSettleState getInstance() {
+        return instance;
+    }
+
+    /**
+     * Replace the settle state with a DISABLED one (timeout=0) — test
+     * support only. Default-disabled so a test class that exercised the
+     * grace never leaks a live window into subsequent test classes in the
+     * same JVM; suites that test the grace arm an explicit window via
+     * {@link #resetForTests(double)} per test. Installed suite-wide before
+     * EVERY test class by the auto-registered
+     * {@code MeshSettleDisabledExtension} (test sources), so the opt-out
+     * never depends on test-class ordering.
+     */
+    static void resetForTests() {
+        instance = new MeshSettleState(0.0);
+    }
+
+    /** Replace the settle state with an explicit window (test support only). */
+    static void resetForTests(double timeoutSeconds) {
+        instance = new MeshSettleState(timeoutSeconds);
+    }
+
+    /**
+     * Window anchor: set when the static instance is created on first
+     * class load — i.e. the window anchors at first CLASS TOUCH, not at
+     * the first dependency declaration as in Python/TypeScript; that is
+     * acceptable because in practice the class is first touched during
+     * startup wrapper/route wiring, moments before the first declaration,
+     * so the two anchors coincide.
+     */
+    private final long startNanos = System.nanoTime();
+    /** Read once per process (per instance) — process-level posture. */
+    private final double timeoutSeconds;
+    private final Set<String> declared = ConcurrentHashMap.newKeySet();
+    private final Set<String> resolved = ConcurrentHashMap.newKeySet();
+    private final Map<String, CountDownLatch> latches = new ConcurrentHashMap<>();
+    /** Capabilities whose first wait was already logged at INFO. */
+    private final Set<String> loggedWaits = ConcurrentHashMap.newKeySet();
+    private volatile boolean settled;
+    /**
+     * Diagnostic counter: number of actual bounded waits performed. Used by
+     * tests to prove the settled steady-state path never touches the wait
+     * primitives.
+     */
+    private volatile int waitCount;
+
+    private MeshSettleState() {
+        this(readTimeoutSeconds(System.getenv("MCP_MESH_SETTLE_TIMEOUT")));
+    }
+
+    private MeshSettleState(double timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    static double readTimeoutSeconds(String raw) {
+        if (raw == null || raw.trim().isEmpty()) {
+            return SETTLE_TIMEOUT_DEFAULT_SECONDS;
+        }
+        try {
+            double parsed = Double.parseDouble(raw.trim());
+            if (!Double.isFinite(parsed) || parsed < 0) {
+                log.warn("MCP_MESH_SETTLE_TIMEOUT must be >= 0 (got '{}'); using default {}s",
+                    raw, (long) SETTLE_TIMEOUT_DEFAULT_SECONDS);
+                return SETTLE_TIMEOUT_DEFAULT_SECONDS;
+            }
+            return parsed;
+        } catch (NumberFormatException e) {
+            log.warn("MCP_MESH_SETTLE_TIMEOUT is not a number (got '{}'); using default {}s",
+                raw, (long) SETTLE_TIMEOUT_DEFAULT_SECONDS);
+            return SETTLE_TIMEOUT_DEFAULT_SECONDS;
+        }
+    }
+
+    /**
+     * Record a declared dependency key (registration time).
+     *
+     * <p>Tool wrappers declare per-consumer-slot composite keys
+     * ({@code funcId:dep_N}); routes declare capability keys — see the
+     * class javadoc's key-spaces section.
+     */
+    public void registerDeclared(String depKey) {
+        if (depKey == null || depKey.isEmpty()) {
+            return;
+        }
+        declared.add(depKey);
+    }
+
+    /**
+     * Record a resolution and wake any waiter on this key.
+     *
+     * <p>"Resolved at least once" semantics: a later unavailability does NOT
+     * un-resolve the key — the settle window only measures initial
+     * topology convergence. The agent-settled latch flips on per-key
+     * resolution: every declared key (per-slot for tools, per-capability
+     * for routes) must resolve before the agent settles eagerly.
+     */
+    public void markResolved(String depKey) {
+        if (depKey == null || depKey.isEmpty()) {
+            return;
+        }
+        resolved.add(depKey);
+        latches.computeIfAbsent(depKey, c -> new CountDownLatch(1)).countDown();
+        if (!settled && !declared.isEmpty() && resolved.containsAll(declared)) {
+            // Eager latch: the LAST declared dependency just resolved.
+            settled = true;
+        }
+    }
+
+    /** Permanent latch check; flips on window expiry or timeout=0. */
+    public boolean isSettled() {
+        if (settled) {
+            return true;
+        }
+        if (timeoutSeconds <= 0 || elapsedSeconds() >= timeoutSeconds) {
+            settled = true;
+            return true;
+        }
+        return false;
+    }
+
+    /** Remaining settle budget in milliseconds (>= 0). */
+    public long remainingMillis() {
+        double remaining = (timeoutSeconds - elapsedSeconds()) * 1000.0;
+        return remaining > 0 ? (long) remaining : 0L;
+    }
+
+    public boolean isResolved(String depKey) {
+        return resolved.contains(depKey);
+    }
+
+    int getWaitCount() {
+        return waitCount;
+    }
+
+    private double elapsedSeconds() {
+        return (System.nanoTime() - startNanos) / 1_000_000_000.0;
+    }
+
+    /**
+     * Block the current (request) thread until {@code depKey} resolves
+     * or the remaining settle budget elapses. Event-driven: the per-key
+     * latch is counted down by the existing dependency-update handling,
+     * so resolution unblocks immediately — never a fixed sleep.
+     *
+     * <p>On timeout the caller simply proceeds — the unresolved dep injects
+     * {@code null} / unavailable exactly as today; the existing
+     * unresolved-dep warning paths cover the diagnostic.
+     *
+     * @param depKey     wait key — per-slot composite key for tools,
+     *                   capability for routes (see class javadoc)
+     * @param capability human-readable capability name for the log lines
+     */
+    public void awaitDependency(String depKey, String capability) {
+        long remainingMs = remainingMillis();
+        if (remainingMs <= 0 || resolved.contains(depKey)) {
+            return;
+        }
+        CountDownLatch latch = latches.computeIfAbsent(depKey, c -> new CountDownLatch(1));
+        if (latch.getCount() == 0) {
+            return;
+        }
+        if (loggedWaits.add(capability)) {
+            log.info("waiting up to {}s for dependency '{}' to settle",
+                String.format("%.1f", remainingMs / 1000.0), capability);
+        } else {
+            log.debug("waiting up to {}s for dependency '{}' to settle",
+                String.format("%.1f", remainingMs / 1000.0), capability);
+        }
+        waitCount++;
+        try {
+            latch.await(remainingMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -111,6 +111,21 @@ public class MeshToolWrapper implements McpToolHandler {
     // Dependency names for error messages
     private final List<String> dependencyNames;
 
+    // Positional pairing between the DECLARED dependency list and this
+    // method's injectable slots (issue #1193 fix round). Declared
+    // dependencies pair positionally with injectable parameters
+    // (McpMeshTool + MeshJob) in parameter order — the same contract as
+    // Python/TypeScript. The two index spaces differ whenever a MeshJob
+    // dependency is declared: e.g. dependencies = ["job_cap", "db_cap"]
+    // with params (MeshJob job, McpMeshTool db) has db_cap at DECLARED
+    // index 1 but McpMeshTool SLOT ordinal 0. Registry events carry the
+    // declared index; injectedDeps/meshToolReturnTypes are slot-ordinal
+    // arrays — these tables translate between the two.
+    /** Declared dep index → McpMeshTool slot ordinal; -1 = no proxy slot (MeshJob-backed or excess). */
+    private final int[] depIndexToSlot;
+    /** McpMeshTool slot ordinal → declared dep index; -1 = no declared dependency backs the slot. */
+    private final int[] slotToDepIndex;
+
     // Consumer-side: MeshJobSubmitter to inject when MeshJob slot is present
     // and this method depends on a task=true capability. Set by the runtime
     // wiring (MeshAutoConfiguration / MeshEventProcessor) once the registry
@@ -226,6 +241,32 @@ public class MeshToolWrapper implements McpToolHandler {
         this.injectedDeps = new AtomicReferenceArray<>(meshToolPositions.size());
         this.injectedLlmAgents = new AtomicReferenceArray<>(llmAgentPositions.size());
 
+        // Build the declared-index ↔ slot-ordinal translation (see field
+        // javadoc). Eligible positions = McpMeshTool + MeshJob parameter
+        // positions in parameter order; dependencies[k] pairs with the
+        // k-th eligible position.
+        this.depIndexToSlot = new int[this.dependencyNames.size()];
+        this.slotToDepIndex = new int[meshToolPositions.size()];
+        Arrays.fill(this.depIndexToSlot, -1);
+        Arrays.fill(this.slotToDepIndex, -1);
+        List<Integer> eligiblePositions = new ArrayList<>(meshToolPositions);
+        if (meshJobParamIndex != null) {
+            eligiblePositions.add(meshJobParamIndex);
+            Collections.sort(eligiblePositions);
+        }
+        for (int k = 0; k < eligiblePositions.size() && k < this.dependencyNames.size(); k++) {
+            int paramPos = eligiblePositions.get(k);
+            if (meshJobParamIndex != null && paramPos == meshJobParamIndex) {
+                // MeshJob-backed dependency: the submitter is wired
+                // locally (JobsRuntimeManager), never by a proxy event —
+                // no slot, no settle key.
+                continue;
+            }
+            int slot = meshToolPositions.indexOf(paramPos);
+            this.depIndexToSlot[k] = slot;
+            this.slotToDepIndex[slot] = k;
+        }
+
         // Generate input schema (excluding injected params)
         this.inputSchema = generateInputSchema();
 
@@ -333,18 +374,43 @@ public class MeshToolWrapper implements McpToolHandler {
     // =========================================================================
 
     /**
-     * Update a McpMeshTool dependency at the given index.
+     * Update a McpMeshTool dependency at the given DECLARED index.
      * Called by MeshToolWrapperRegistry when heartbeat resolves a dependency.
+     *
+     * <p>The declared index is translated to the McpMeshTool slot ordinal
+     * (they differ when a MeshJob dependency is declared — see
+     * {@link #depIndexToSlot}). Updates for MeshJob-backed or excess
+     * declared indices are ignored: a job dependency's resolution event
+     * must never land a proxy in (or evict) another parameter's slot.
+     *
+     * <p>Settling-window grace (#1193): a non-null available proxy counts
+     * down the per-consumer-slot settle latch ({@code funcId:dep_N}) AFTER
+     * the array slot is written, so a settling call woken by the latch
+     * re-reads a populated slot. Per-slot keying means only THIS wrapper's
+     * waiters wake — another tool sharing the capability keeps waiting for
+     * its own slot's event.
      *
      * @param depIndex The dependency index (0-based, in declaration order)
      * @param proxy    The resolved proxy (or null if unavailable)
      */
     @SuppressWarnings("rawtypes")
     public void updateDependency(int depIndex, McpMeshTool proxy) {
-        if (depIndex >= 0 && depIndex < injectedDeps.length()) {
-            injectedDeps.set(depIndex, proxy);
-            log.debug("Updated dependency {} at index {} for {}",
-                proxy != null ? proxy.getCapability() : "null", depIndex, funcId);
+        if (depIndex < 0 || depIndex >= depIndexToSlot.length) {
+            return;
+        }
+        int slot = depIndexToSlot[depIndex];
+        if (slot < 0) {
+            log.debug("Ignoring dependency update at declared index {} for {} — "
+                + "no McpMeshTool slot (MeshJob-backed or excess dependency)",
+                depIndex, funcId);
+            return;
+        }
+        injectedDeps.set(slot, proxy);
+        log.debug("Updated dependency {} at declared index {} (slot {}) for {}",
+            proxy != null ? proxy.getCapability() : "null", depIndex, slot, funcId);
+        if (proxy != null && proxy.isAvailable()) {
+            MeshSettleState.getInstance().markResolved(
+                MeshToolWrapperRegistry.buildDependencyKey(funcId, depIndex));
         }
     }
 
@@ -680,14 +746,39 @@ public class MeshToolWrapper implements McpToolHandler {
         }
 
         // Fill McpMeshTool dependencies (null if unavailable for graceful degradation)
+        MeshSettleState settleState = MeshSettleState.getInstance();
         for (int i = 0; i < meshToolPositions.size(); i++) {
             int paramPos = meshToolPositions.get(i);
             McpMeshTool proxy = injectedDeps.get(i);
+            // Declared dependency index backing this slot — NOT i: the two
+            // index spaces skew when a MeshJob dependency is declared
+            // (e.g. ["job_cap", "db_cap"] puts db_cap at declared index 1
+            // but slot ordinal 0). -1 = slot has no declared dependency.
+            int depIdx = slotToDepIndex[i];
+
+            // Settling-window grace (#1193): while the agent is still
+            // settling, block — bounded by the remaining settle budget — on
+            // THIS consumer slot's latch (composite funcId:dep_N key,
+            // counted down by updateDependency AFTER it writes the slot),
+            // then re-read the slot. A proxy may exist but be unavailable
+            // (endpoint not yet landed), so the wait is keyed on
+            // AVAILABILITY, not just null-ness. No-op (single latch check)
+            // once settled — fail-fast behavior is unchanged. Blocking is
+            // fine here: tool dispatch runs on Spring's request pool,
+            // never an event loop.
+            if ((proxy == null || !proxy.isAvailable())
+                    && depIdx >= 0
+                    && !settleState.isSettled()) {
+                settleState.awaitDependency(
+                    MeshToolWrapperRegistry.buildDependencyKey(funcId, depIdx),
+                    dependencyNames.get(depIdx));
+                proxy = injectedDeps.get(i);
+            }
 
             // Allow null for graceful degradation - tool method can check:
             //   if (dep != null && dep.isAvailable()) { ... } else { fallback }
             if (proxy == null) {
-                String depName = i < dependencyNames.size() ? dependencyNames.get(i) : "unknown";
+                String depName = depIdx >= 0 ? dependencyNames.get(depIdx) : "unknown";
                 log.debug("Dependency {} not available for {}, passing null for graceful degradation",
                     depName, funcId);
             }
@@ -1301,19 +1392,44 @@ public class MeshToolWrapper implements McpToolHandler {
     }
 
     /**
-     * Get the expected return type for a dependency at the given index.
+     * Get the expected return type for a dependency at the given DECLARED index.
      *
      * <p>This is extracted from the generic type parameter of McpMeshTool&lt;T&gt;.
      * For example, for {@code McpMeshTool<Integer>}, this returns {@code Integer.class}.
      *
-     * @param depIndex The dependency index
+     * <p>The declared index is translated to the McpMeshTool slot ordinal
+     * (the spaces skew when a MeshJob dependency is declared — see
+     * {@link #depIndexToSlot}).
+     *
+     * @param depIndex The dependency index (0-based, in declaration order)
      * @return The return type, or null if not specified or index out of bounds
      */
     public Type getDependencyReturnType(int depIndex) {
-        if (depIndex >= 0 && depIndex < meshToolReturnTypes.size()) {
-            return meshToolReturnTypes.get(depIndex);
+        if (depIndex >= 0 && depIndex < depIndexToSlot.length) {
+            int slot = depIndexToSlot[depIndex];
+            if (slot >= 0 && slot < meshToolReturnTypes.size()) {
+                return meshToolReturnTypes.get(slot);
+            }
         }
         return null;
+    }
+
+    /**
+     * Declared dependency indices backed by McpMeshTool slots — the
+     * indices whose composite keys ({@code funcId:dep_N}) participate in
+     * the settling-window grace (#1193). MeshJob-backed dependencies are
+     * excluded (the submitter is constructed locally, no resolution event
+     * will ever arrive for the slot), as are excess dependencies with no
+     * parameter to land in.
+     */
+    List<Integer> getSettleDepIndices() {
+        List<Integer> indices = new ArrayList<>();
+        for (int depIndex = 0; depIndex < depIndexToSlot.length; depIndex++) {
+            if (depIndexToSlot[depIndex] >= 0) {
+                indices.add(depIndex);
+            }
+        }
+        return indices;
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapperRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapperRegistry.java
@@ -77,6 +77,19 @@ public class MeshToolWrapperRegistry {
         handlersByCapability.put(capability, wrapper);
         handlersByMethodName.put(methodName, wrapper);
 
+        // Settling-window grace (#1193): declare this tool's dependency
+        // slots with the process-wide settle state so the agent-level
+        // "all declared deps resolved" latch can flip eagerly. Keys are
+        // per-consumer-slot composites (funcId:dep_N) — capability-level
+        // keying would let one consumer's resolution wake another
+        // consumer's waiter before that consumer's slot is written.
+        // MeshJob-backed dependencies are excluded (submitter is wired
+        // locally; no resolution event ever lands for the slot).
+        MeshSettleState settleState = MeshSettleState.getInstance();
+        for (int depIndex : wrapper.getSettleDepIndices()) {
+            settleState.registerDeclared(buildDependencyKey(funcId, depIndex));
+        }
+
         log.info("Registered wrapper: {} (capability: {}, deps: {}, llm: {})",
             funcId, capability, wrapper.getDependencyCount(), wrapper.getLlmAgentCount());
     }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteHandlerInterceptor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteHandlerInterceptor.java
@@ -116,9 +116,28 @@ public class MeshRouteHandlerInterceptor implements HandlerInterceptor {
         Map<String, McpMeshTool> resolvedDeps = new LinkedHashMap<>();
         boolean allResolved = true;
 
+        io.mcpmesh.spring.MeshSettleState settleState =
+            io.mcpmesh.spring.MeshSettleState.getInstance();
         for (MeshRouteRegistry.DependencySpec dep : metadata.getDependencies()) {
             try {
                 McpMeshTool tool = resolveDependency(dep);
+                // Settling-window grace (#1193): while the agent is still
+                // settling, block — bounded by the remaining settle budget —
+                // on the per-capability latch, then re-resolve. CAPABILITY
+                // keying is deliberate (unlike the tool wrappers' per-slot
+                // composite keys): routes resolve through the injector's
+                // SHARED per-capability proxy, which updateToolDependency
+                // makes live BEFORE counting this latch down — a woken
+                // request re-reads a live proxy regardless of which
+                // consumer's event fired, so there is no wrong-consumer
+                // hazard here. Java route proxies typically
+                // exist-but-unavailable rather than null, so the wait is
+                // keyed on AVAILABILITY. No-op (single latch check) once
+                // settled. Blocking is fine on the servlet request thread.
+                if ((tool == null || !tool.isAvailable()) && !settleState.isSettled()) {
+                    settleState.awaitDependency(dep.getCapability(), dep.getCapability());
+                    tool = resolveDependency(dep);
+                }
                 if (tool != null && tool.isAvailable()) {
                     resolvedDeps.put(dep.getCapability(), tool);
                     // Also store by parameter name for @MeshInject

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
@@ -52,6 +52,19 @@ public class MeshRouteRegistry {
         routesByPath.put(routeId, metadata);
         routesByHandler.put(metadata.getHandlerMethodId(), metadata);
 
+        // Settling-window grace (#1193): declare this route's dependency
+        // capabilities with the process-wide settle state so the
+        // agent-level "all declared deps resolved" latch can flip eagerly.
+        // Capability keying is correct for routes (unlike tool wrappers'
+        // per-slot composite keys): every route resolves through the
+        // injector's shared per-capability proxy, updated before its
+        // countdown — see MeshRouteHandlerInterceptor.
+        io.mcpmesh.spring.MeshSettleState settleState =
+            io.mcpmesh.spring.MeshSettleState.getInstance();
+        for (DependencySpec dep : metadata.getDependencies()) {
+            settleState.registerDeclared(dep.getCapability());
+        }
+
         log.info("Registered @MeshRoute: {} {} with {} dependencies",
             httpMethod, path, metadata.getDependencies().size());
     }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshSettleDisabledExtension.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshSettleDisabledExtension.java
@@ -1,0 +1,29 @@
+package io.mcpmesh.spring;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Suite-wide settling-window opt-out (issue #1193) — the Java analogue of
+ * the Python {@code tests/unit} conftest fixture and the TypeScript
+ * suite-level {@code MCP_MESH_SETTLE_TIMEOUT=0}.
+ *
+ * <p>Auto-registered for EVERY test class via
+ * {@code META-INF/services/org.junit.jupiter.api.extension.Extension} plus
+ * {@code junit.jupiter.extensions.autodetection.enabled} in
+ * {@code junit-platform.properties}, so the opt-out never depends on test
+ * class execution order: {@link MeshSettleState} is JVM-static and its
+ * default instance reads the environment (default 20s window) at first
+ * class touch — without this, whichever test class happened to touch it
+ * first would inherit a live window. Installing a DISABLED (timeout=0)
+ * state in {@code beforeAll} of every class makes the suite posture
+ * deterministic; {@link MeshSettleStateTest} arms explicit windows per
+ * test via {@code resetForTests(double)} on top of this baseline.
+ */
+public final class MeshSettleDisabledExtension implements BeforeAllCallback {
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        MeshSettleState.resetForTests();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshSettleDisabledExtensionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshSettleDisabledExtensionTest.java
@@ -1,0 +1,31 @@
+package io.mcpmesh.spring;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the suite-wide settle opt-out (issue #1193): the auto-registered
+ * {@link MeshSettleDisabledExtension} must have installed a DISABLED
+ * (timeout=0) settle state before this class's tests run — WITHOUT this
+ * class arming anything itself. Run in isolation this is a hard proof the
+ * autodetection wiring (junit-platform.properties + META-INF/services)
+ * engages: the default JVM-static instance reads the environment (20s
+ * window) at class load and would NOT be settled here.
+ */
+class MeshSettleDisabledExtensionTest {
+
+    @Test
+    void everyTestClassStartsWithADisabledSettleWindow() {
+        MeshSettleState state = MeshSettleState.getInstance();
+        assertTrue(state.isSettled(),
+            "auto-registered extension must install a disabled (timeout=0) window before each class");
+        state.registerDeclared("never_resolved_cap");
+        long start = System.nanoTime();
+        state.awaitDependency("never_resolved_cap", "never_resolved_cap");
+        assertTrue((System.nanoTime() - start) / 1_000_000 < 50,
+            "disabled window must never wait");
+        assertEquals(0, state.getWaitCount());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshSettleStateTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshSettleStateTest.java
@@ -1,0 +1,419 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.Param;
+import io.mcpmesh.types.McpMeshTool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Settling-window dependency grace tests (issue #1193).
+ *
+ * <p>Cross-runtime contract (mirrors the Python
+ * {@code test_settle_window.py} and TypeScript
+ * {@code settle-window.spec.ts} suites):
+ * <ul>
+ *   <li>(a) a call firing while a declared dep is unresolved blocks —
+ *       bounded by the remaining settle budget — and proceeds EARLY when
+ *       the resolution lands (event-driven, never a sleep);</li>
+ *   <li>(b) on timeout the call proceeds with {@code null} exactly as
+ *       today (defensive user code untouched);</li>
+ *   <li>(c)/(d) the settled latch is permanent (window expiry OR all
+ *       declared deps resolved) — subsequent calls never wait;</li>
+ *   <li>(e) {@code MCP_MESH_SETTLE_TIMEOUT=0} disables the grace
+ *       entirely;</li>
+ *   <li>(h) the settled steady-state call path never touches the wait
+ *       primitives (waitCount stays 0).</li>
+ * </ul>
+ *
+ * <p>Fix-round additions: per-consumer-slot keying (a shared capability
+ * must not wake the wrong consumer), MeshJob declared-index/slot-ordinal
+ * skew, and default-disabled {@link MeshSettleState#resetForTests()}.
+ */
+class MeshSettleStateTest {
+
+    @AfterEach
+    void resetSettleState() {
+        // Installs a DISABLED (timeout=0) state so subsequent test classes
+        // in this JVM never inherit a live window.
+        MeshSettleState.resetForTests();
+    }
+
+    // ---- env knob parsing ---------------------------------------------------
+
+    @Test
+    void timeoutKnob_defaultsTo20Seconds() {
+        assertEquals(20.0, MeshSettleState.readTimeoutSeconds(null));
+        assertEquals(20.0, MeshSettleState.readTimeoutSeconds(""));
+        assertEquals(20.0, MeshSettleState.SETTLE_TIMEOUT_DEFAULT_SECONDS);
+    }
+
+    @Test
+    void timeoutKnob_parsesFloatSeconds() {
+        assertEquals(3.5, MeshSettleState.readTimeoutSeconds("3.5"));
+        assertEquals(0.0, MeshSettleState.readTimeoutSeconds("0"));
+    }
+
+    @Test
+    void timeoutKnob_fallsBackOnInvalidValues() {
+        assertEquals(20.0, MeshSettleState.readTimeoutSeconds("-5"));
+        assertEquals(20.0, MeshSettleState.readTimeoutSeconds("abc"));
+        assertEquals(20.0, MeshSettleState.readTimeoutSeconds("NaN"));
+    }
+
+    @Test
+    void resetForTests_installsDisabledStateByDefault() {
+        MeshSettleState.resetForTests();
+        MeshSettleState state = MeshSettleState.getInstance();
+        state.registerDeclared("some_cap");
+        // timeout=0 → permanently settled, zero waits possible.
+        assertTrue(state.isSettled(),
+            "default test reset must install a disabled (timeout=0) window");
+        long start = System.nanoTime();
+        state.awaitDependency("some_cap", "some_cap");
+        assertTrue((System.nanoTime() - start) / 1_000_000 < 50);
+        assertEquals(0, state.getWaitCount());
+    }
+
+    // ---- state-level behavior -----------------------------------------------
+
+    @Test
+    void awaitDependency_unblocksEarlyWhenResolutionArrivesMidWait() throws Exception {
+        MeshSettleState.resetForTests(10.0);
+        MeshSettleState state = MeshSettleState.getInstance();
+        state.registerDeclared("db_cap");
+
+        Thread resolver = new Thread(() -> {
+            try {
+                Thread.sleep(150);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            state.markResolved("db_cap");
+        });
+        resolver.start();
+
+        long start = System.nanoTime();
+        state.awaitDependency("db_cap", "db_cap");
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+        resolver.join(2000);
+
+        // Unblocked by the resolution event, not the 10s budget ceiling.
+        assertTrue(elapsedMs < 5000, "expected early unblock, waited " + elapsedMs + "ms");
+        assertTrue(elapsedMs >= 100, "expected an actual wait, got " + elapsedMs + "ms");
+        assertTrue(state.isSettled(), "single declared dep resolved -> eager latch");
+        assertEquals(1, state.getWaitCount());
+    }
+
+    @Test
+    void settledByWindowExpiry_latchIsPermanent() throws Exception {
+        MeshSettleState.resetForTests(0.05);
+        MeshSettleState state = MeshSettleState.getInstance();
+        state.registerDeclared("db_cap");
+        Thread.sleep(80);
+
+        assertTrue(state.isSettled());
+        long start = System.nanoTime();
+        state.awaitDependency("db_cap", "db_cap"); // remaining budget is 0 -> no wait
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+        assertTrue(elapsedMs < 50, "settled agent must not wait, waited " + elapsedMs + "ms");
+        assertEquals(0, state.getWaitCount());
+    }
+
+    @Test
+    void settledByAllResolved_neverWaits() {
+        MeshSettleState.resetForTests(10.0);
+        MeshSettleState state = MeshSettleState.getInstance();
+        state.registerDeclared("cap_a");
+        state.registerDeclared("cap_b");
+
+        state.markResolved("cap_a");
+        assertFalse(state.isSettled(), "cap_b still unresolved");
+        state.markResolved("cap_b");
+        assertTrue(state.isSettled(), "all declared resolved -> eager latch");
+
+        long start = System.nanoTime();
+        state.awaitDependency("cap_a", "cap_a");
+        assertTrue((System.nanoTime() - start) / 1_000_000 < 50);
+        assertEquals(0, state.getWaitCount());
+    }
+
+    @Test
+    void zeroTimeout_disablesGraceEntirely() {
+        MeshSettleState.resetForTests(0.0);
+        MeshSettleState state = MeshSettleState.getInstance();
+        state.registerDeclared("db_cap");
+
+        assertTrue(state.isSettled());
+        long start = System.nanoTime();
+        state.awaitDependency("db_cap", "db_cap");
+        assertTrue((System.nanoTime() - start) / 1_000_000 < 50);
+        assertEquals(0, state.getWaitCount());
+    }
+
+    @Test
+    void resolvedAtLeastOnce_isSticky() {
+        MeshSettleState.resetForTests(10.0);
+        MeshSettleState state = MeshSettleState.getInstance();
+        state.registerDeclared("db_cap");
+        state.markResolved("db_cap");
+
+        // Settle measures INITIAL convergence; later unavailability does not
+        // re-open the window (there is no unmark API by design).
+        assertTrue(state.isSettled());
+        assertTrue(state.isResolved("db_cap"));
+    }
+
+    // ---- MeshToolWrapper integration -----------------------------------------
+
+    @SuppressWarnings("unused")
+    static class Tool {
+        public String lookup(@Param("q") String q, McpMeshTool<String> db) {
+            // Defensive user idiom — must keep working unchanged.
+            return (db != null && db.isAvailable()) ? "resolved" : "degraded";
+        }
+
+        public String lookupB(@Param("q") String q, McpMeshTool<String> db) {
+            return (db != null && db.isAvailable()) ? "resolved" : "degraded";
+        }
+
+        // MeshJob-consuming shape: the job dependency is declared FIRST,
+        // so db_cap sits at DECLARED index 1 but McpMeshTool slot 0.
+        public String lookupWithJob(MeshJob job, McpMeshTool<String> db, @Param("q") String q) {
+            return (db != null && db.isAvailable()) ? "resolved" : "degraded";
+        }
+    }
+
+    private static Method find(Class<?> cls, String name) {
+        for (Method m : cls.getDeclaredMethods()) {
+            if (m.getName().equals(name)) return m;
+        }
+        throw new AssertionError("not found: " + name);
+    }
+
+    private static MeshToolWrapper newWrapper() {
+        return newWrapper("Tool.lookup", "lookup", List.of("db_cap"));
+    }
+
+    private static MeshToolWrapper newWrapper(String funcId, String method, List<String> deps) {
+        return new MeshToolWrapper(
+            funcId,
+            method,
+            "test",
+            new Tool(),
+            find(Tool.class, method),
+            deps,
+            JsonMapper.builder().build());
+    }
+
+    private static McpMeshToolProxy availableProxy() {
+        McpMeshToolProxy proxy = new McpMeshToolProxy("db_cap", new McpHttpClient());
+        proxy.updateEndpoint("http://localhost:1", "remote_fn");
+        return proxy;
+    }
+
+    @Test
+    void wrapperInvoke_proceedsEarlyWithRealProxyWhenResolutionArrivesMidWait() throws Exception {
+        MeshSettleState.resetForTests(10.0);
+        MeshSettleState state = MeshSettleState.getInstance();
+        // Per-consumer-slot composite key (funcId:dep_N) — what the
+        // registry declares for tool wrappers.
+        state.registerDeclared("Tool.lookup:dep_0");
+        MeshToolWrapper wrapper = newWrapper();
+
+        // updateDependency writes the slot, THEN counts the latch down
+        // internally — the woken call re-reads a populated slot.
+        Thread resolver = new Thread(() -> {
+            try {
+                Thread.sleep(150);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            wrapper.updateDependency(0, availableProxy());
+        });
+        resolver.start();
+
+        long start = System.nanoTime();
+        Object result = wrapper.invoke(Map.of("q", "x"));
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+        resolver.join(2000);
+
+        assertEquals("resolved", result, "woken call must re-read the REAL proxy");
+        assertTrue(elapsedMs < 5000, "unblocked by event, not budget; waited " + elapsedMs + "ms");
+        assertTrue(state.getWaitCount() >= 1);
+        assertTrue(state.isSettled(), "slot resolution flips the per-slot declared key");
+    }
+
+    @Test
+    void wrapperInvoke_timesOutToTodayBehaviorWithNullDep() throws Exception {
+        MeshSettleState.resetForTests(0.3);
+        MeshSettleState.getInstance().registerDeclared("Tool.lookup:dep_0");
+        MeshToolWrapper wrapper = newWrapper();
+
+        long start = System.nanoTime();
+        Object result = wrapper.invoke(Map.of("q", "x"));
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertEquals("degraded", result, "defensive user code runs with null dep");
+        assertTrue(elapsedMs >= 200, "expected a wait toward the budget, got " + elapsedMs + "ms");
+    }
+
+    @Test
+    void wrapperInvoke_waitsOnAvailabilityNotJustNull() throws Exception {
+        // Java proxies may exist-but-unavailable rather than null — the
+        // wait must trigger for an unavailable proxy too (an unavailable
+        // proxy also does NOT count the slot as resolved).
+        MeshSettleState.resetForTests(10.0);
+        MeshSettleState state = MeshSettleState.getInstance();
+        state.registerDeclared("Tool.lookup:dep_0");
+        MeshToolWrapper wrapper = newWrapper();
+
+        // Pre-inject an EXISTING but unavailable proxy.
+        McpMeshToolProxy unavailable = new McpMeshToolProxy("db_cap", new McpHttpClient());
+        wrapper.updateDependency(0, unavailable);
+        assertFalse(state.isResolved("Tool.lookup:dep_0"),
+            "unavailable proxy must not mark the slot resolved");
+
+        Thread resolver = new Thread(() -> {
+            try {
+                Thread.sleep(150);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            wrapper.updateDependency(0, availableProxy());
+        });
+        resolver.start();
+
+        Object result = wrapper.invoke(Map.of("q", "x"));
+        resolver.join(2000);
+
+        assertEquals("resolved", result);
+        assertTrue(state.getWaitCount() >= 1, "unavailable proxy must trigger the wait");
+    }
+
+    @Test
+    void steadyState_settledCallPathNeverTouchesWaitPrimitives() throws Exception {
+        MeshSettleState.resetForTests(10.0);
+        MeshSettleState state = MeshSettleState.getInstance();
+        state.registerDeclared("Tool.lookup:dep_0");
+        MeshToolWrapper wrapper = newWrapper();
+
+        wrapper.updateDependency(0, availableProxy());
+        assertTrue(state.isSettled());
+
+        for (int i = 0; i < 3; i++) {
+            long start = System.nanoTime();
+            assertEquals("resolved", wrapper.invoke(Map.of("q", "x")));
+            assertTrue((System.nanoTime() - start) / 1_000_000 < 100);
+        }
+        assertEquals(0, state.getWaitCount(),
+            "settled steady-state must never touch the wait primitives");
+    }
+
+    @Test
+    void perSlotKeying_sharedCapabilityDoesNotWakeTheWrongConsumer() throws Exception {
+        // Tools A and B both depend on "db_cap". Under capability-level
+        // keying, A's resolution event woke B's waiter before B's slot was
+        // written — B proceeded with null. Per-slot composite keys mean
+        // B's waiter only wakes when B's OWN slot resolves.
+        MeshSettleState.resetForTests(10.0);
+        MeshSettleState state = MeshSettleState.getInstance();
+        state.registerDeclared("Tool.lookup:dep_0");
+        state.registerDeclared("Tool.lookupB:dep_0");
+        MeshToolWrapper wrapperA = newWrapper("Tool.lookup", "lookup", List.of("db_cap"));
+        MeshToolWrapper wrapperB = newWrapper("Tool.lookupB", "lookupB", List.of("db_cap"));
+
+        Thread resolver = new Thread(() -> {
+            try {
+                Thread.sleep(150);
+                wrapperA.updateDependency(0, availableProxy()); // A first
+                Thread.sleep(250);
+                wrapperB.updateDependency(0, availableProxy()); // B later
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        resolver.start();
+
+        long start = System.nanoTime();
+        Object resultB = wrapperB.invoke(Map.of("q", "x"));
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+        resolver.join(3000);
+
+        // The old capability-keyed latch woke B at ~150ms with a null slot
+        // → "degraded". Per-slot keying keeps B waiting for ITS event.
+        assertEquals("resolved", resultB,
+            "B must wake on its OWN slot's resolution, not A's");
+        assertTrue(elapsedMs >= 300, "B waited past A's event; got " + elapsedMs + "ms");
+        assertTrue(elapsedMs < 5000, "B unblocked by its event, not the budget");
+        assertTrue(state.isSettled(), "both per-slot keys resolved -> eager latch");
+    }
+
+    @Test
+    void meshJobFirstDependencyList_waitsOnTheRightCapabilityAndSettles() throws Exception {
+        // dependencies = ["job_cap", "db_cap"] with params
+        // (MeshJob, McpMeshTool, @Param): db_cap is DECLARED index 1 but
+        // McpMeshTool SLOT 0. The wait must key on dep_1 (db_cap), the
+        // job slot must be excluded from the declared settle set, and the
+        // declared-index update must land in slot 0.
+        MeshSettleState.resetForTests(10.0);
+        MeshSettleState state = MeshSettleState.getInstance();
+        MeshToolWrapper wrapper = newWrapper(
+            "Tool.lookupWithJob", "lookupWithJob", List.of("job_cap", "db_cap"));
+
+        // Registry-level declaration: only the db-backed slot, keyed by
+        // DECLARED index (dep_1) — job_cap contributes no settle key.
+        MeshToolWrapperRegistry registry =
+            new MeshToolWrapperRegistry(new McpMeshToolProxyFactory(new McpHttpClient()));
+        registry.registerWrapper(wrapper);
+        assertEquals(List.of(1), wrapper.getSettleDepIndices(),
+            "only the McpMeshTool-backed declared index participates in settle");
+
+        // Resolve db_cap through the registry funnel with its DECLARED
+        // index, exactly as the event processor does.
+        Thread resolver = new Thread(() -> {
+            try {
+                Thread.sleep(150);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            registry.updateDependency(
+                "Tool.lookupWithJob:dep_1", "http://localhost:1", "remote_fn");
+        });
+        resolver.start();
+
+        long start = System.nanoTime();
+        Object result = wrapper.invoke(Map.of("q", "x"));
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+        resolver.join(2000);
+
+        assertEquals("resolved", result,
+            "declared-index update must land in the McpMeshTool slot");
+        assertTrue(elapsedMs < 5000, "no full-window burn; waited " + elapsedMs + "ms");
+        assertTrue(elapsedMs >= 100, "an actual wait happened; got " + elapsedMs + "ms");
+        assertTrue(state.isSettled(),
+            "db resolution settles the agent — job_cap is not a declared settle key");
+    }
+
+    @Test
+    void meshJobDependencyEvent_neverCorruptsTheProxySlot() {
+        // A resolution event for the JOB capability (declared index 0)
+        // must not write into — or evict — the McpMeshTool slot.
+        MeshSettleState.resetForTests(10.0);
+        MeshToolWrapper wrapper = newWrapper(
+            "Tool.lookupWithJob", "lookupWithJob", List.of("job_cap", "db_cap"));
+
+        wrapper.updateDependency(1, availableProxy()); // db lands in slot 0
+        wrapper.updateDependency(0, null);             // job event: ignored
+
+        assertTrue(wrapper.areDependenciesAvailable(),
+            "job-index update must not evict the db proxy from slot 0");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+io.mcpmesh.spring.MeshSettleDisabledExtension

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/resources/junit-platform.properties
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+# Settling-window grace (#1193): auto-register MeshSettleDisabledExtension
+# so EVERY test class starts with a DISABLED (timeout=0) settle window,
+# independent of class execution order. The include filter scopes
+# autodetection to our extension only.
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.extensions.autodetection.include=io.mcpmesh.spring.MeshSettleDisabledExtension

--- a/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
@@ -19,6 +19,12 @@ from ..shared.logging_config import (
     format_result_summary,
     get_trace_prefix,
 )
+from .settle import (
+    collect_pending_settle_deps,
+    get_settle_state,
+    wait_for_settle_async,
+    wait_for_settle_sync,
+)
 from .signature_analyzer import get_mesh_agent_positions, has_llm_agent_parameter
 from .strict_di import (
     StrictDIError,
@@ -158,6 +164,8 @@ def _make_stream_wrapper(
     dependencies: list[str],
     get_dependency_fn: Callable[[str], Any | None],
     log: logging.Logger,
+    settle_keys: Optional[list] = None,
+    settle_params: Optional[list] = None,
 ) -> Callable:
     """Build a wrapper that drives an async-iterator tool over MCP progress.
 
@@ -183,6 +191,21 @@ def _make_stream_wrapper(
         # FastMCP injects its Context under our internal name; pop it so
         # it never leaks into the user function's kwargs.
         progress_ctx = kwargs.pop(_MESH_PROGRESS_CTX_PARAM, None)
+
+        # Settling-window grace (#1193): bounded wait for declared-but-
+        # unresolved deps while the agent is still settling. No-op (single
+        # latch check) once settled. Caller-supplied slots (mock contract)
+        # are skipped via the kwargs consult.
+        pending_settle = collect_pending_settle_deps(
+            settle_keys,
+            dependencies,
+            stream_wrapper._mesh_injected_deps,
+            get_dependency_fn,
+            kwargs,
+            settle_params,
+        )
+        if pending_settle:
+            await wait_for_settle_async(pending_settle, log)
 
         final_kwargs, injected_count = _prepare_injection_kwargs(
             func,
@@ -1239,16 +1262,55 @@ class DependencyInjector:
         # never runs, the MeshJob auto-injection block never fires, and
         # consumer-side jobs silently lose their submitter (#bug 1).
         has_mesh_job_param = False
+        mesh_job_index: Optional[int] = None
         try:
             from .signature_analyzer import analyze_mesh_job_signature
 
             _mj = analyze_mesh_job_signature(func)
             has_mesh_job_param = _mj.mesh_job_param_name is not None
+            mesh_job_index = _mj.mesh_job_param_index
         except (TypeError, AttributeError):
             # Narrow catch: only swallow signature-introspection errors.
             # ValueError (multi-MeshJob contract violation per the Phase-1
             # resolver) MUST propagate so the wrapper fails fast.
             pass
+
+        # Settling-window grace (#1193): composite keys for the proxy slots
+        # this wrapper will inject, index-aligned with ``dependencies``.
+        # ``None`` marks slots the grace does not cover: MeshJob submitter
+        # slots (constructed locally, no resolution event) and excess
+        # dependencies with no parameter to land in. ``settle_params``
+        # carries the parameter NAME behind each slot so the call-time
+        # pending collection can skip caller-supplied slots (the documented
+        # mock contract). The declared set is registered with the
+        # process-wide settle state so the agent-level "all declared deps
+        # resolved" latch can flip eagerly — the FIRST registration anchors
+        # the settle window.
+        from .signature_analyzer import _get_original_func
+
+        settle_eligible = sorted(
+            set(mesh_positions)
+            | ({mesh_job_index} if mesh_job_index is not None else set())
+        )
+        try:
+            _settle_param_names = list(
+                inspect.signature(_get_original_func(func)).parameters.keys()
+            )
+        except (TypeError, ValueError):
+            _settle_param_names = []
+        settle_keys: list[Optional[str]] = [None] * len(dependencies)
+        settle_params: list[Optional[str]] = [None] * len(dependencies)
+        for _i, _pos in enumerate(settle_eligible):
+            if _i >= len(dependencies):
+                break
+            if _pos != mesh_job_index:
+                settle_keys[_i] = f"{func_id}:dep_{_i}"
+                if _pos < len(_settle_param_names):
+                    settle_params[_i] = _settle_param_names[_pos]
+        _settle_state = get_settle_state()
+        for _key in settle_keys:
+            if _key is not None:
+                _settle_state.register_declared(_key)
 
         # If no mesh positions to inject AND no MeshJob slot, fall back to
         # the minimal tracking wrapper. With a MeshJob slot we route to the
@@ -1265,6 +1327,8 @@ class DependencyInjector:
                     dependencies,
                     self.get_dependency,
                     wrapper_logger,
+                    settle_keys=settle_keys,
+                    settle_params=settle_params,
                 )
             elif inspect.iscoroutinefunction(func):
 
@@ -1344,11 +1408,30 @@ class DependencyInjector:
                 dependencies,
                 self.get_dependency,
                 wrapper_logger,
+                settle_keys=settle_keys,
+                settle_params=settle_params,
             )
         elif need_async_wrapper:
 
             @functools.wraps(func)
             async def dependency_wrapper(*args, **kwargs):
+                # Settling-window grace (#1193): bounded wait for declared-
+                # but-unresolved deps while the agent is still settling.
+                # No-op (single latch check) once settled. The wait is a
+                # loop-native asyncio.Event await (set by the resolution
+                # funnel via call_soon_threadsafe) — no executor, the loop
+                # stays free. Caller-supplied slots (mock contract) skip.
+                pending_settle = collect_pending_settle_deps(
+                    settle_keys,
+                    dependencies,
+                    dependency_wrapper._mesh_injected_deps,
+                    self.get_dependency,
+                    kwargs,
+                    settle_params,
+                )
+                if pending_settle:
+                    await wait_for_settle_async(pending_settle, wrapper_logger)
+
                 final_kwargs, injected_count = _prepare_injection_kwargs(
                     func,
                     kwargs,
@@ -1387,6 +1470,25 @@ class DependencyInjector:
 
             @functools.wraps(func)
             def dependency_wrapper(*args, **kwargs):
+                # Settling-window grace (#1193): sync tools are dispatched
+                # by FastMCP onto anyio.to_thread worker threads (see
+                # fastmcp.utilities.async_utils.call_sync_fn_in_threadpool),
+                # so a blocking threading.Event wait here never stalls an
+                # event loop (wait_for_settle_sync additionally probes for
+                # a running loop and skips if one is found). No-op (single
+                # latch check) once settled. Caller-supplied slots (mock
+                # contract) skip via the kwargs consult.
+                pending_settle = collect_pending_settle_deps(
+                    settle_keys,
+                    dependencies,
+                    dependency_wrapper._mesh_injected_deps,
+                    self.get_dependency,
+                    kwargs,
+                    settle_params,
+                )
+                if pending_settle:
+                    wait_for_settle_sync(pending_settle, wrapper_logger)
+
                 final_kwargs, injected_count = _prepare_injection_kwargs(
                     func,
                     kwargs,
@@ -1428,6 +1530,16 @@ class DependencyInjector:
             """Called when a dependency changes (index-based for duplicate capability support)."""
             if dep_index < len(dependency_wrapper._mesh_injected_deps):
                 dependency_wrapper._mesh_injected_deps[dep_index] = instance
+                if instance is not None:
+                    # Settling-window grace (#1193): this closure is the
+                    # single funnel for resolution across every path (MCP
+                    # register_dependency, API/A2A heartbeat direct calls)
+                    # — wake any settling call waiting on this dependency
+                    # AFTER the array slot is set so the woken call re-reads
+                    # a real proxy.
+                    get_settle_state().mark_resolved(
+                        f"{func_id}:dep_{dep_index}"
+                    )
                 if instance is None:
                     wrapper_logger.debug(
                         f"Removed dependency at index {dep_index} from {func_id}"
@@ -1449,6 +1561,12 @@ class DependencyInjector:
         dependency_wrapper._mesh_dependencies = dependencies
         dependency_wrapper._mesh_positions = mesh_positions
         dependency_wrapper._mesh_original_func = func
+        # Settling-window grace (#1193): exposed so secondary invocation
+        # paths built on this wrapper's arrays (e.g. the SSE route endpoint
+        # in route_integration) can apply the same bounded wait — including
+        # the caller-supplied (mock contract) skip via settle_params.
+        dependency_wrapper._mesh_settle_keys = settle_keys
+        dependency_wrapper._mesh_settle_params = settle_params
 
         # Register this wrapper for dependency updates
         logger.debug(

--- a/src/runtime/python/_mcp_mesh/engine/settle.py
+++ b/src/runtime/python/_mcp_mesh/engine/settle.py
@@ -1,0 +1,417 @@
+"""
+Settling-window dependency grace (issue #1193).
+
+Dependency injection resolves asynchronously: declared dependencies become
+available when the first full heartbeat cycle completes and
+``dependency_available`` events land. A call that fires during that settling
+window would otherwise see a declared-but-unresolved dependency as ``None``
+even though resolution typically lands moments later.
+
+This module provides a process-wide settle state:
+
+* The settle window is ANCHORED at the first dependency declaration (the
+  first :meth:`SettleState.register_declared` call during startup wiring) —
+  not at module import — so slow imports or pre-decoration work never eat
+  into the grace budget. The agent is **unsettled** from that anchor until
+  EITHER every declared dependency has resolved at least once OR the window
+  (``MCP_MESH_SETTLE_TIMEOUT`` seconds, default 20) expires.
+* While unsettled, the DI wrappers wait — bounded by the REMAINING settle
+  budget — for the dependency to resolve; the existing
+  ``_mesh_update_dependency`` funnel wakes waiters the moment the
+  dependency resolves. Resolution at 800ms unblocks at 800ms; the budget is
+  a ceiling only, never a sleep.
+* Once settled — either way — the latch is permanent: calls never touch the
+  wait primitives again and fail-fast behavior is byte-identical to the
+  pre-grace behavior (unresolved deps inject ``None`` exactly as before).
+
+Wait primitives (two, by execution context):
+
+* Sync tool wrappers (dispatched by FastMCP onto ``anyio.to_thread`` worker
+  threads) block on a per-dependency :class:`threading.Event` — resolution
+  events arrive on arbitrary threads/loops (MCP heartbeat loop, API/A2A
+  heartbeat tasks), and a loop-bound primitive could not be safely set
+  across loops. A defensive running-loop probe skips the blocking wait if a
+  sync wrapper is ever invoked ON an event loop (blocking there would stall
+  the loop that delivers the very resolution events the wait needs).
+* Async wrappers await a loop-native :class:`asyncio.Event` mirror that the
+  resolution funnel sets via ``loop.call_soon_threadsafe`` — zero executor
+  usage, so graced calls never consume the shared default-executor capacity
+  the sync-HTTP proxy fallback and media paths rely on, and shutdown
+  mid-wait never delays process exit (the awaits are loop-bound and
+  cancellable; no daemon-thread games needed).
+
+Caller-supplied slots never wait: the documented mock contract lets callers
+pass a fake/proxy for any injectable parameter explicitly — the pending
+collection consults the call kwargs and skips those slots entirely.
+
+Scope (deliberate): the grace covers the dependency-injection wrappers only
+— ``@mesh.tool`` / ``@mesh.route`` call paths. Lifespan/startup-hook
+dependency usage, module-scope captured deps, and ``@mesh.llm``
+provider/filter assembly (registration-time, with its own update mechanism)
+are NOT covered.
+
+This is environmental, not a declaration mistake: ``MCP_MESH_STRICT_DI``
+never interacts with the settle window in any way.
+"""
+
+import asyncio
+import logging
+import threading
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+SETTLE_TIMEOUT_DEFAULT_SECONDS = 20.0
+
+# Cached per-process resolution of MCP_MESH_SETTLE_TIMEOUT (mirrors the
+# cached-global convention of ``is_strict_di_enabled``). The settle window
+# is a process-level posture, not a per-call toggle.
+_SETTLE_TIMEOUT: Optional[float] = None
+
+
+def get_settle_timeout() -> float:
+    """Settle window in seconds. ``0`` disables the grace entirely.
+
+    Configurable via ``MCP_MESH_SETTLE_TIMEOUT`` (float seconds, default
+    20). Read once per process and cached. Negative or unparseable values
+    fall back to the default with a warning.
+    """
+    global _SETTLE_TIMEOUT
+    if _SETTLE_TIMEOUT is None:
+        from ..shared.config_resolver import ValidationRule, get_config_value
+
+        value = get_config_value(
+            "MCP_MESH_SETTLE_TIMEOUT",
+            default=SETTLE_TIMEOUT_DEFAULT_SECONDS,
+            rule=ValidationRule.FLOAT_RULE,
+        )
+        try:
+            timeout = float(value)
+        except (TypeError, ValueError):
+            timeout = SETTLE_TIMEOUT_DEFAULT_SECONDS
+        if timeout < 0:
+            logger.warning(
+                "MCP_MESH_SETTLE_TIMEOUT must be >= 0 (got %s); "
+                "using default %.0fs",
+                value,
+                SETTLE_TIMEOUT_DEFAULT_SECONDS,
+            )
+            timeout = SETTLE_TIMEOUT_DEFAULT_SECONDS
+        _SETTLE_TIMEOUT = timeout
+    return _SETTLE_TIMEOUT
+
+
+class SettleState:
+    """Process-wide settle latch + per-dependency resolution wakeups.
+
+    Dependencies are tracked at the AGENT level as the union of declared
+    dependency keys across all decorated functions (composite
+    ``"<func_id>:dep_<N>"`` keys — the same keys the resolution paths
+    already use). The latch flips eagerly when the last declared key
+    resolves, or lazily when :meth:`is_settled` observes window expiry.
+
+    The window is anchored at the FIRST :meth:`register_declared` call
+    (startup wiring time), not at construction/import time.
+    """
+
+    def __init__(self) -> None:
+        # Anchored lazily by the first register_declared call.
+        self._start: Optional[float] = None
+        self._lock = threading.Lock()
+        self._declared: set[str] = set()
+        self._resolved: set[str] = set()
+        self._events: dict[str, threading.Event] = {}
+        # Loop-native mirrors for async waiters: dep_key -> [(loop, event)].
+        # Set via loop.call_soon_threadsafe from the resolution funnel so
+        # async waits never touch a thread pool (see module docstring).
+        self._async_waiters: dict[
+            str, list[tuple[asyncio.AbstractEventLoop, asyncio.Event]]
+        ] = {}
+        self._settled = False
+        # Capabilities whose first wait was already logged at INFO —
+        # subsequent waits on the same capability log at DEBUG.
+        self._logged_waits: set[str] = set()
+        # Diagnostic counter: number of actual bounded waits performed.
+        # Used by tests to prove the settled steady-state path never
+        # touches the wait primitives.
+        self.wait_count = 0
+
+    def register_declared(self, dep_key: str) -> None:
+        """Record a declared dependency key (decoration/wiring time).
+
+        The FIRST declaration anchors the settle window — the window
+        measures topology convergence from the moment the agent starts
+        declaring dependencies, not from module import.
+        """
+        with self._lock:
+            if self._start is None:
+                self._start = time.monotonic()
+            self._declared.add(dep_key)
+
+    def mark_resolved(self, dep_key: str) -> None:
+        """Record a resolution and wake any waiter on this key.
+
+        Called from the existing dependency-update funnel whenever a real
+        proxy lands. "Resolved at least once" semantics: a later
+        unavailability does NOT un-resolve the key — the settle window only
+        measures initial topology convergence.
+        """
+        with self._lock:
+            self._resolved.add(dep_key)
+            event = self._events.get(dep_key)
+            if event is None:
+                event = threading.Event()
+                self._events[dep_key] = event
+            # Snapshot under the lock so a concurrent wait_for_async
+            # registration can never be missed (it re-checks _resolved
+            # under the same lock before registering).
+            async_waiters = list(self._async_waiters.get(dep_key, ()))
+            if self._declared and self._declared <= self._resolved:
+                # Eager latch: the LAST declared dependency just resolved.
+                self._settled = True
+        event.set()
+        for loop, async_event in async_waiters:
+            try:
+                loop.call_soon_threadsafe(async_event.set)
+            except RuntimeError:
+                # The waiter's loop already closed (shutdown mid-wait) —
+                # nothing left to wake.
+                pass
+
+    def is_settled(self) -> bool:
+        """Permanent latch check; flips on window expiry or timeout=0."""
+        if self._settled:
+            return True
+        timeout = get_settle_timeout()
+        if timeout <= 0:
+            self._settled = True
+            return True
+        if self._start is None:
+            # Window not yet anchored — no dependency has been declared,
+            # so nothing can be pending. Report settled WITHOUT latching:
+            # the window must still open when the first declaration lands.
+            return True
+        if (time.monotonic() - self._start) >= timeout:
+            self._settled = True
+            return True
+        return False
+
+    def remaining(self) -> float:
+        """Remaining settle budget in seconds (>= 0)."""
+        if self._start is None:
+            return 0.0
+        return max(0.0, get_settle_timeout() - (time.monotonic() - self._start))
+
+    def _event_for(self, dep_key: str) -> threading.Event:
+        with self._lock:
+            event = self._events.get(dep_key)
+            if event is None:
+                event = threading.Event()
+                self._events[dep_key] = event
+            return event
+
+    def _log_wait(
+        self, capability: str, remaining: float, log: logging.Logger
+    ) -> None:
+        """One INFO line per capability per process; later waits DEBUG."""
+        if capability not in self._logged_waits:
+            self._logged_waits.add(capability)
+            log.info(
+                "waiting up to %.1fs for dependency '%s' to settle",
+                remaining,
+                capability,
+            )
+        else:
+            log.debug(
+                "waiting up to %.1fs for dependency '%s' to settle",
+                remaining,
+                capability,
+            )
+
+    def wait_for(
+        self, dep_key: str, capability: str, log: logging.Logger
+    ) -> None:
+        """Block (current thread) until ``dep_key`` resolves or the budget ends.
+
+        MUST only be called off the event loop — sync tool wrappers run on
+        FastMCP's ``anyio.to_thread`` worker threads, and
+        :func:`wait_for_settle_sync` probes for a running loop before
+        dispatching here. Async wrappers use :meth:`wait_for_async`.
+        """
+        remaining = self.remaining()
+        if remaining <= 0:
+            return
+        event = self._event_for(dep_key)
+        if event.is_set():
+            return
+        self._log_wait(capability, remaining, log)
+        self.wait_count += 1
+        # On timeout we simply proceed — the unresolved dep injects None
+        # exactly as today, and the existing unresolved-dep warning path
+        # covers the diagnostic (no double-logging here).
+        event.wait(remaining)
+
+    async def wait_for_async(
+        self, dep_key: str, capability: str, log: logging.Logger
+    ) -> None:
+        """Await ``dep_key``'s resolution on the CURRENT loop, budget-bounded.
+
+        Loop-native: registers an :class:`asyncio.Event` mirror that
+        :meth:`mark_resolved` sets via ``loop.call_soon_threadsafe`` from
+        whatever thread the resolution funnel runs on. No executor is ever
+        touched, the await is cancellable, and shutdown mid-wait cannot
+        delay process exit by the window.
+        """
+        remaining = self.remaining()
+        if remaining <= 0:
+            return
+        loop = asyncio.get_running_loop()
+        async_event = asyncio.Event()
+        with self._lock:
+            if dep_key in self._resolved:
+                return
+            self._async_waiters.setdefault(dep_key, []).append(
+                (loop, async_event)
+            )
+        self._log_wait(capability, remaining, log)
+        self.wait_count += 1
+        try:
+            # On timeout we simply proceed — same None-injection contract
+            # as the sync path.
+            await asyncio.wait_for(async_event.wait(), remaining)
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            with self._lock:
+                waiters = self._async_waiters.get(dep_key)
+                if waiters is not None:
+                    try:
+                        waiters.remove((loop, async_event))
+                    except ValueError:
+                        pass
+                    if not waiters:
+                        self._async_waiters.pop(dep_key, None)
+
+
+_settle_state = SettleState()
+
+
+def get_settle_state() -> SettleState:
+    """Get the process-wide settle state."""
+    return _settle_state
+
+
+def _reset_settle_state_for_tests() -> None:
+    """Replace the settle state and drop the cached timeout (test support)."""
+    global _settle_state, _SETTLE_TIMEOUT
+    _settle_state = SettleState()
+    _SETTLE_TIMEOUT = None
+
+
+def _capability_of(dep: object) -> str:
+    """Best-effort capability name from a dependency declaration entry."""
+    if isinstance(dep, dict):
+        return str(dep.get("capability", dep))
+    return str(dep)
+
+
+def collect_pending_settle_deps(
+    settle_keys: Optional[list],
+    dependencies: list,
+    injected_deps_array: list,
+    get_dependency_fn,
+    call_kwargs: Optional[dict] = None,
+    settle_params: Optional[list] = None,
+) -> list[tuple[str, str]]:
+    """Declared-but-unresolved deps the wrapper is about to inject.
+
+    Returns ``[(dep_key, capability), ...]`` — empty when the agent is
+    settled (the steady-state fast path: a single latch check, no wait
+    primitives touched), when no settle keys exist, or when everything the
+    wrapper would inject already has a proxy.
+
+    ``settle_keys`` is index-aligned with ``dependencies``; ``None``
+    entries mark slots the settle grace does not cover (MeshJob submitter
+    slots, excess dependencies with no parameter to land in).
+
+    ``settle_params`` (index-aligned parameter names) + ``call_kwargs``
+    implement the caller-supplied skip: a slot the caller explicitly
+    filled — the documented mock contract that lets tests pass a fake for
+    any injectable parameter — is never waited on (the injection path
+    will keep the caller's value untouched anyway).
+    """
+    if not settle_keys:
+        return []
+    state = get_settle_state()
+    if state.is_settled():
+        return []
+    pending: list[tuple[str, str]] = []
+    for dep_index, dep_key in enumerate(settle_keys):
+        if dep_key is None:
+            continue
+        if (
+            call_kwargs
+            and settle_params is not None
+            and dep_index < len(settle_params)
+            and settle_params[dep_index] is not None
+            and call_kwargs.get(settle_params[dep_index]) is not None
+        ):
+            # Caller-supplied slot (documented mock contract) — the
+            # injection path preserves the caller's value, so there is
+            # nothing to wait for.
+            continue
+        resolved = None
+        if dep_index < len(injected_deps_array):
+            resolved = injected_deps_array[dep_index]
+        if resolved is None:
+            resolved = get_dependency_fn(dep_key)
+        if resolved is None:
+            pending.append((dep_key, _capability_of(dependencies[dep_index])))
+    return pending
+
+
+def wait_for_settle_sync(
+    pending: list[tuple[str, str]], log: logging.Logger
+) -> None:
+    """Blocking settle wait for sync wrappers (worker-thread dispatch).
+
+    Waits each pending dependency in turn; the per-wait budget is the
+    REMAINING window, so the total wait is bounded by the settle window
+    regardless of how many deps are pending.
+
+    Defensive guard: if this is ever invoked ON a running event loop
+    (a dispatch path we don't model calling the sync wrapper inline), the
+    wait is SKIPPED — blocking that loop would stall the very machinery
+    that delivers the resolution events, turning the grace into a
+    guaranteed dead wait. Skipping degrades to today's None-injection.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        log.debug(
+            "settle wait skipped: sync wrapper invoked on a running event "
+            "loop — blocking here would stall the loop that delivers the "
+            "resolution events; proceeding without the grace"
+        )
+        return
+    state = get_settle_state()
+    for dep_key, capability in pending:
+        state.wait_for(dep_key, capability, log)
+
+
+async def wait_for_settle_async(
+    pending: list[tuple[str, str]], log: logging.Logger
+) -> None:
+    """Settle wait for async wrappers — never blocks the event loop.
+
+    Awaits loop-native :class:`asyncio.Event` mirrors set by the
+    resolution funnel via ``call_soon_threadsafe`` — no thread pool, no
+    executor pressure, cancellable, and shutdown-friendly (see
+    :meth:`SettleState.wait_for_async`).
+    """
+    state = get_settle_state()
+    for dep_key, capability in pending:
+        await state.wait_for_async(dep_key, capability, log)

--- a/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
@@ -61,6 +61,10 @@ def _build_sse_endpoint(wrapped_handler: Any, user_func: Any) -> Any:
     from fastapi.responses import StreamingResponse
 
     from ...engine.dependency_injector import _prepare_injection_kwargs
+    from ...engine.settle import (
+        collect_pending_settle_deps,
+        wait_for_settle_async,
+    )
 
     injector = get_global_injector()
     mesh_positions = list(getattr(wrapped_handler, "_mesh_positions", []) or [])
@@ -68,10 +72,27 @@ def _build_sse_endpoint(wrapped_handler: Any, user_func: Any) -> Any:
     injected_deps = getattr(
         wrapped_handler, "_mesh_injected_deps", [None] * len(dependencies)
     )
+    settle_keys = getattr(wrapped_handler, "_mesh_settle_keys", None)
+    settle_params = getattr(wrapped_handler, "_mesh_settle_params", None)
 
     @functools.wraps(user_func)
     async def sse_endpoint(*args, **kwargs):
         if mesh_positions:
+            # Settling-window grace (#1193): same bounded wait the inner
+            # DI wrapper applies — this endpoint bypasses that wrapper and
+            # reads the dependency arrays directly. Caller-supplied slots
+            # (mock contract) are skipped via the kwargs consult.
+            pending_settle = collect_pending_settle_deps(
+                settle_keys,
+                dependencies,
+                injected_deps,
+                injector.get_dependency,
+                kwargs,
+                settle_params,
+            )
+            if pending_settle:
+                await wait_for_settle_async(pending_settle, logger)
+
             final_kwargs, _ = _prepare_injection_kwargs(
                 user_func,
                 kwargs,

--- a/src/runtime/python/tests/unit/conftest.py
+++ b/src/runtime/python/tests/unit/conftest.py
@@ -1,0 +1,43 @@
+"""
+Unit-suite settle-window opt-out (issue #1193 fix round).
+
+The settling-window grace makes calls on declared-but-unresolved
+dependencies wait up to MCP_MESH_SETTLE_TIMEOUT (default 20s). Dozens of
+unit tests in this directory deliberately invoke DI wrappers with
+unresolved dependencies to assert the degraded (None-injection) behavior —
+without an opt-out each such call would sit out the window (e.g.
+``test_wrapper_execution_missing_dependency`` went from milliseconds to
+~20s and the whole suite from ~17s to ~59s).
+
+This mirrors the TypeScript treatment in ``route.test.ts``: disable the
+grace for the suite via the documented ``MCP_MESH_SETTLE_TIMEOUT=0`` tuning
+case and reset the process-wide state so nothing cached survives.
+
+``test_settle_window.py`` is the exception — it tests the grace itself and
+manages its own state (per-test env override + state reset via its autouse
+``fresh_settle_state`` fixture), so the session-level ``0`` here is simply
+its baseline to override.
+"""
+
+import os
+
+import pytest
+
+from _mcp_mesh.engine import settle
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _disable_settle_window_for_unit_suite():
+    """Disable the settling-window grace for the whole unit session."""
+    saved = os.environ.get("MCP_MESH_SETTLE_TIMEOUT")
+    os.environ["MCP_MESH_SETTLE_TIMEOUT"] = "0"
+    # Drop any state created during collection-time imports (decoration-time
+    # register_declared calls land on the import-time instance) and the
+    # cached timeout, so the "0" above is actually read.
+    settle._reset_settle_state_for_tests()
+    yield
+    if saved is None:
+        os.environ.pop("MCP_MESH_SETTLE_TIMEOUT", None)
+    else:
+        os.environ["MCP_MESH_SETTLE_TIMEOUT"] = saved
+    settle._reset_settle_state_for_tests()

--- a/src/runtime/python/tests/unit/test_settle_window.py
+++ b/src/runtime/python/tests/unit/test_settle_window.py
@@ -1,0 +1,438 @@
+"""
+Unit tests for the settling-window dependency grace (issue #1193).
+
+Covers the cross-runtime contract for Python:
+
+* a call that fires while a declared dependency is still unresolved waits —
+  bounded by the remaining settle budget — and proceeds EARLY the moment the
+  resolution event lands (event-driven, never a sleep);
+* on timeout the call proceeds with ``None`` exactly as today (defensive
+  ``if dep:`` user code untouched);
+* the settled latch is permanent (window expiry or all-declared-resolved)
+  and the steady-state call path never touches the wait primitives;
+* ``MCP_MESH_SETTLE_TIMEOUT=0`` disables the grace entirely;
+* sync tools (dispatched on worker threads, mirroring FastMCP's
+  ``anyio.to_thread`` dispatch) block safely while the event loop stays free;
+* a sync wrapper invoked ON a running loop skips the wait entirely (the
+  blocking wait would stall the loop that delivers resolution events);
+* async waits are loop-native (``asyncio.Event`` mirrors set via
+  ``call_soon_threadsafe``) — zero executor usage;
+* the window is anchored at the FIRST dependency declaration, not import;
+* caller-supplied slots (the documented mock contract) never wait;
+* ``MCP_MESH_STRICT_DI`` never interacts with the settle window.
+"""
+
+import asyncio
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import mesh
+import pytest
+
+from _mcp_mesh.engine import settle
+from _mcp_mesh.engine.dependency_injector import DependencyInjector
+from _mcp_mesh.engine.settle import (
+    SETTLE_TIMEOUT_DEFAULT_SECONDS,
+    get_settle_state,
+    get_settle_timeout,
+)
+from _mcp_mesh.engine.strict_di import _reset_strict_di_cache
+
+
+@pytest.fixture(autouse=True)
+def fresh_settle_state(monkeypatch):
+    """Isolate every test: fresh settle state + uncached timeout knob."""
+    monkeypatch.delenv("MCP_MESH_SETTLE_TIMEOUT", raising=False)
+    settle._reset_settle_state_for_tests()
+    yield
+    settle._reset_settle_state_for_tests()
+
+
+def _set_budget(monkeypatch, value: str) -> None:
+    """Set the settle budget and re-anchor the settle state on it."""
+    monkeypatch.setenv("MCP_MESH_SETTLE_TIMEOUT", value)
+    settle._reset_settle_state_for_tests()
+
+
+def _make_async_wrapper(injector, dep_name="db_cap"):
+    async def tool(db: mesh.McpMeshTool = None):
+        # Defensive user idiom — must keep working unchanged.
+        if db is None:
+            return "degraded"
+        return db
+
+    return injector.create_injection_wrapper(tool, [dep_name])
+
+
+class TestSettleTimeoutKnob:
+    def test_default_is_20_seconds(self):
+        assert get_settle_timeout() == SETTLE_TIMEOUT_DEFAULT_SECONDS == 20.0
+
+    def test_env_override_float(self, monkeypatch):
+        _set_budget(monkeypatch, "3.5")
+        assert get_settle_timeout() == 3.5
+
+    def test_cached_per_process(self, monkeypatch):
+        _set_budget(monkeypatch, "3.5")
+        assert get_settle_timeout() == 3.5
+        # Changing the env after the first read has no effect (cached).
+        monkeypatch.setenv("MCP_MESH_SETTLE_TIMEOUT", "99")
+        assert get_settle_timeout() == 3.5
+
+    def test_negative_falls_back_to_default(self, monkeypatch):
+        _set_budget(monkeypatch, "-5")
+        assert get_settle_timeout() == SETTLE_TIMEOUT_DEFAULT_SECONDS
+
+
+class TestSettleWait:
+    @pytest.mark.asyncio
+    async def test_resolution_mid_wait_unblocks_early(self, monkeypatch):
+        """(a) Event arriving mid-wait → call proceeds early with the proxy."""
+        _set_budget(monkeypatch, "10")
+        injector = DependencyInjector()
+        wrapper = _make_async_wrapper(injector)
+        proxy = MagicMock(name="proxy")
+
+        async def resolve_later():
+            await asyncio.sleep(0.2)
+            wrapper._mesh_update_dependency(0, proxy)
+
+        resolver = asyncio.create_task(resolve_later())
+        start = time.monotonic()
+        result = await wrapper()
+        elapsed = time.monotonic() - start
+        await resolver
+
+        assert result is proxy
+        # Unblocked by the event, not the 10s budget ceiling.
+        assert elapsed < 5.0
+        assert get_settle_state().wait_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_proceeds_with_none(self, monkeypatch):
+        """(b) No event → call proceeds at budget with None; defensive
+        user code runs (today-behavior on expiry)."""
+        _set_budget(monkeypatch, "0.3")
+        injector = DependencyInjector()
+        wrapper = _make_async_wrapper(injector)
+
+        start = time.monotonic()
+        result = await wrapper()
+        elapsed = time.monotonic() - start
+
+        assert result == "degraded"
+        assert elapsed >= 0.2  # actually waited toward the budget
+
+    @pytest.mark.asyncio
+    async def test_settled_by_window_expiry_never_waits_again(
+        self, monkeypatch
+    ):
+        """(c) Window expired → latch is permanent; calls never wait."""
+        _set_budget(monkeypatch, "0.1")
+        injector = DependencyInjector()
+        wrapper = _make_async_wrapper(injector)
+        await asyncio.sleep(0.15)
+
+        for _ in range(2):
+            start = time.monotonic()
+            result = await wrapper()
+            elapsed = time.monotonic() - start
+            assert result == "degraded"
+            assert elapsed < 0.05
+
+        state = get_settle_state()
+        assert state.is_settled()
+        assert state.wait_count == 0
+
+    @pytest.mark.asyncio
+    async def test_settled_by_all_resolved_never_waits(self, monkeypatch):
+        """(d) All declared deps resolved → eager latch; calls never wait."""
+        _set_budget(monkeypatch, "10")
+        injector = DependencyInjector()
+        wrapper = _make_async_wrapper(injector)
+        proxy = MagicMock(name="proxy")
+        wrapper._mesh_update_dependency(0, proxy)
+
+        state = get_settle_state()
+        assert state.is_settled()
+
+        start = time.monotonic()
+        result = await wrapper()
+        elapsed = time.monotonic() - start
+
+        assert result is proxy
+        assert elapsed < 0.05
+        assert state.wait_count == 0
+
+    @pytest.mark.asyncio
+    async def test_agent_level_union_across_functions(self, monkeypatch):
+        """The latch tracks the UNION of declared deps across functions:
+        resolving one function's dep does not settle the agent, and only
+        the call whose dep is unresolved waits."""
+        _set_budget(monkeypatch, "0.3")
+        injector = DependencyInjector()
+        wrapper_a = _make_async_wrapper(injector, "cap_a")
+
+        async def other_tool(svc: mesh.McpMeshTool = None):
+            return "ok" if svc is None else svc
+
+        wrapper_b = injector.create_injection_wrapper(other_tool, ["cap_b"])
+
+        proxy = MagicMock(name="proxy_a")
+        wrapper_a._mesh_update_dependency(0, proxy)
+
+        state = get_settle_state()
+        assert not state.is_settled()  # cap_b still unresolved
+
+        # wrapper_a's dep is resolved — no wait even though unsettled.
+        start = time.monotonic()
+        assert await wrapper_a() is proxy
+        assert time.monotonic() - start < 0.05
+
+        # wrapper_b's dep is unresolved — it waits toward the budget.
+        start = time.monotonic()
+        assert await wrapper_b() == "ok"
+        assert time.monotonic() - start >= 0.2
+
+    @pytest.mark.asyncio
+    async def test_zero_timeout_disables_grace(self, monkeypatch):
+        """(e) MCP_MESH_SETTLE_TIMEOUT=0 → no waits anywhere."""
+        _set_budget(monkeypatch, "0")
+        injector = DependencyInjector()
+        wrapper = _make_async_wrapper(injector)
+
+        start = time.monotonic()
+        result = await wrapper()
+        elapsed = time.monotonic() - start
+
+        assert result == "degraded"
+        assert elapsed < 0.05
+        state = get_settle_state()
+        assert state.is_settled()
+        assert state.wait_count == 0
+
+    @pytest.mark.asyncio
+    async def test_sync_tool_blocking_wait_keeps_loop_free(self, monkeypatch):
+        """(f) Sync tool on its worker thread: the blocking threading.Event
+        wait works AND the event loop stays unblocked meanwhile (proven by
+        a concurrent health-style ticker)."""
+        _set_budget(monkeypatch, "5")
+        injector = DependencyInjector()
+
+        def sync_tool(db: mesh.McpMeshTool = None):
+            return db if db is not None else "degraded"
+
+        wrapper = injector.create_injection_wrapper(sync_tool, ["db_cap"])
+        proxy = MagicMock(name="proxy")
+
+        ticks = 0
+
+        async def health_ticker():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.05)
+                ticks += 1
+
+        ticker = asyncio.create_task(health_ticker())
+
+        async def resolve_later():
+            await asyncio.sleep(0.4)
+            wrapper._mesh_update_dependency(0, proxy)
+
+        resolver = asyncio.create_task(resolve_later())
+        # Mirror FastMCP's dispatch: sync tools run via anyio.to_thread.
+        result = await asyncio.to_thread(wrapper)
+        await resolver
+        ticker.cancel()
+
+        assert result is proxy
+        # The loop processed ticker iterations DURING the blocking wait —
+        # the wait blocked only the worker thread, never the loop.
+        assert ticks >= 3
+
+    @pytest.mark.asyncio
+    async def test_strict_di_does_not_interact(self, monkeypatch):
+        """(g) Strict DI enabled + settle timeout → warning path only, no
+        raise. The settle window is environmental, not a declaration
+        mistake."""
+        monkeypatch.setenv("MCP_MESH_STRICT_DI", "true")
+        _reset_strict_di_cache()
+        try:
+            _set_budget(monkeypatch, "0.2")
+            injector = DependencyInjector()
+            wrapper = _make_async_wrapper(injector)
+
+            result = await wrapper()  # must NOT raise StrictDIError
+            assert result == "degraded"
+        finally:
+            monkeypatch.delenv("MCP_MESH_STRICT_DI", raising=False)
+            _reset_strict_di_cache()
+
+    @pytest.mark.asyncio
+    async def test_steady_state_never_touches_wait_primitives(
+        self, monkeypatch
+    ):
+        """(h) Once settled, the call path performs only the latch check —
+        the per-dependency event primitives are never touched."""
+        _set_budget(monkeypatch, "10")
+        injector = DependencyInjector()
+        wrapper = _make_async_wrapper(injector)
+        wrapper._mesh_update_dependency(0, MagicMock(name="proxy"))
+
+        state = get_settle_state()
+        assert state.is_settled()
+        baseline_wait_count = state.wait_count
+
+        with patch.object(
+            state, "_event_for", wraps=state._event_for
+        ) as event_spy, patch.object(
+            state, "wait_for", wraps=state.wait_for
+        ) as wait_spy:
+            for _ in range(3):
+                await wrapper()
+
+        event_spy.assert_not_called()
+        wait_spy.assert_not_called()
+        assert state.wait_count == baseline_wait_count
+
+    @pytest.mark.asyncio
+    async def test_caller_supplied_dep_never_waits(self, monkeypatch):
+        """A slot the caller explicitly filled (documented mock contract,
+        e.g. ``wrapper(db=mock)``) is skipped by the pending collection —
+        no wait even though the agent is unsettled and the dep unresolved."""
+        _set_budget(monkeypatch, "5")
+        injector = DependencyInjector()
+        wrapper = _make_async_wrapper(injector)
+        mock_dep = MagicMock(name="caller_supplied_mock")
+
+        state = get_settle_state()
+        assert not state.is_settled()
+
+        start = time.monotonic()
+        result = await wrapper(db=mock_dep)
+        elapsed = time.monotonic() - start
+
+        assert result is mock_dep  # injection preserved the caller's value
+        assert elapsed < 0.1
+        assert state.wait_count == 0
+
+    @pytest.mark.asyncio
+    async def test_window_anchored_at_first_declaration(self, monkeypatch):
+        """The settle window starts at the FIRST register_declared call
+        (startup wiring), not at module import / state construction —
+        pre-declaration idle time never eats the grace budget."""
+        _set_budget(monkeypatch, "0.3")
+        # Idle past the would-be window BEFORE any dependency declaration.
+        await asyncio.sleep(0.4)
+
+        injector = DependencyInjector()
+        wrapper = _make_async_wrapper(injector)
+        state = get_settle_state()
+        # With an import-time anchor this would already be (incorrectly)
+        # settled; the declaration-time anchor keeps the window open.
+        assert not state.is_settled()
+
+        start = time.monotonic()
+        result = await wrapper()
+        elapsed = time.monotonic() - start
+
+        assert result == "degraded"
+        assert elapsed >= 0.2  # waited toward the freshly-anchored budget
+
+    @pytest.mark.asyncio
+    async def test_sync_wrapper_on_running_loop_skips_wait(self, monkeypatch):
+        """Defensive guard: a sync wrapper invoked ON a running event loop
+        must skip the blocking wait — blocking would stall the loop that
+        delivers the resolution events (a guaranteed dead wait)."""
+        _set_budget(monkeypatch, "5")
+        injector = DependencyInjector()
+
+        def sync_tool(db: mesh.McpMeshTool = None):
+            return db if db is not None else "degraded"
+
+        wrapper = injector.create_injection_wrapper(sync_tool, ["db_cap"])
+        assert not get_settle_state().is_settled()
+
+        start = time.monotonic()
+        result = wrapper()  # inline on the loop, NOT via to_thread
+        elapsed = time.monotonic() - start
+
+        assert result == "degraded"
+        assert elapsed < 0.5
+        assert get_settle_state().wait_count == 0
+
+    @pytest.mark.asyncio
+    async def test_async_wait_is_loop_native_and_thread_woken(
+        self, monkeypatch
+    ):
+        """Async graced waits use loop-native asyncio.Event mirrors set via
+        call_soon_threadsafe — no executor is touched, and a resolution
+        arriving on a FOREIGN thread (the real heartbeat shape) wakes the
+        waiter early."""
+        _set_budget(monkeypatch, "10")
+        injector = DependencyInjector()
+        wrapper = _make_async_wrapper(injector)
+        proxy = MagicMock(name="proxy")
+
+        # Resolution fires from a plain thread, not the event loop.
+        timer = threading.Timer(
+            0.2, lambda: wrapper._mesh_update_dependency(0, proxy)
+        )
+        timer.start()
+
+        with patch.object(
+            asyncio,
+            "to_thread",
+            side_effect=AssertionError(
+                "settle wait must not consume executor capacity"
+            ),
+        ):
+            start = time.monotonic()
+            result = await wrapper()
+            elapsed = time.monotonic() - start
+        timer.join()
+
+        assert result is proxy
+        assert elapsed < 5.0  # woken by the cross-thread event, not budget
+        assert get_settle_state().wait_count >= 1
+
+    def test_first_wait_logs_info_then_debug(self, monkeypatch, caplog):
+        """One INFO line per dependency per process; later waits DEBUG.
+
+        Subsequent waits on the same dependency only occur while it is
+        still unresolved (i.e. concurrent calls), so the second waiter
+        runs on the main thread while a timer resolves the dependency.
+        """
+        import logging
+        import threading
+
+        _set_budget(monkeypatch, "5")
+        state = get_settle_state()
+        state.register_declared("f:dep_0")
+
+        log = logging.getLogger("test.settle.logging")
+        with caplog.at_level(logging.DEBUG, logger="test.settle.logging"):
+            first = threading.Thread(
+                target=lambda: state.wait_for("f:dep_0", "db_cap", log)
+            )
+            first.start()
+            # Wait until the first waiter has logged its INFO line.
+            deadline = time.monotonic() + 2
+            while (
+                not any("db_cap" in r.getMessage() for r in caplog.records)
+                and time.monotonic() < deadline
+            ):
+                time.sleep(0.01)
+
+            # Second concurrent waiter (main thread) — resolution arrives
+            # via timer so the blocking wait ends promptly.
+            threading.Timer(0.15, lambda: state.mark_resolved("f:dep_0")).start()
+            state.wait_for("f:dep_0", "db_cap", log)
+            first.join(timeout=2)
+
+        records = [r for r in caplog.records if "db_cap" in r.getMessage()]
+        assert len(records) == 2
+        assert records[0].levelno == logging.INFO
+        assert records[1].levelno == logging.DEBUG
+        assert "waiting up to" in records[0].getMessage()

--- a/src/runtime/typescript/src/__tests__/route.test.ts
+++ b/src/runtime/typescript/src/__tests__/route.test.ts
@@ -4,10 +4,30 @@
  * Tests mesh.route() Express middleware and RouteRegistry.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
 import type { Request, Response, NextFunction } from "express";
 import { route, routeWithConfig, RouteRegistry } from "../route.js";
+import { resetSettleStateForTests } from "../settle.js";
 import type { McpMeshTool } from "../types.js";
+
+// These tests deliberately invoke route middleware with unresolved
+// dependencies to assert the degraded (null-injection) behavior. Disable
+// the settling-window grace (#1193) so they don't sit out the default 20s
+// window — the documented MCP_MESH_SETTLE_TIMEOUT=0 tuning case. The grace
+// itself is covered by settle-window.spec.ts.
+const savedSettleTimeout = process.env.MCP_MESH_SETTLE_TIMEOUT;
+beforeEach(() => {
+  process.env.MCP_MESH_SETTLE_TIMEOUT = "0";
+  resetSettleStateForTests();
+});
+afterAll(() => {
+  if (savedSettleTimeout === undefined) {
+    delete process.env.MCP_MESH_SETTLE_TIMEOUT;
+  } else {
+    process.env.MCP_MESH_SETTLE_TIMEOUT = savedSettleTimeout;
+  }
+  resetSettleStateForTests();
+});
 
 // Mock createProxy from proxy.ts
 vi.mock("../proxy.js", () => ({

--- a/src/runtime/typescript/src/__tests__/settle-window.spec.ts
+++ b/src/runtime/typescript/src/__tests__/settle-window.spec.ts
@@ -1,0 +1,400 @@
+/**
+ * Settling-window dependency grace tests (issue #1193).
+ *
+ * Cross-runtime contract (mirrors the Python/Java suites):
+ *
+ *  (a) a call firing while a declared dep is unresolved waits — bounded by
+ *      the remaining settle budget — and proceeds EARLY when the
+ *      `dependency_available` event lands (event-driven, never a sleep);
+ *  (b) on timeout the call proceeds with `null` exactly as today
+ *      (defensive user code untouched);
+ *  (c)/(d) the settled latch is permanent (window expiry OR all declared
+ *      deps resolved) — subsequent calls never wait;
+ *  (e) `MCP_MESH_SETTLE_TIMEOUT=0` disables the grace entirely;
+ *  (h) the settled steady-state call path never touches the wait
+ *      primitives.
+ *
+ * Route coverage: RouteRegistry declaration/resolution/rename keep the
+ * settle state's keys aligned with remapped route IDs.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { z } from "zod";
+import { MeshAgent } from "../agent.js";
+import { RouteRegistry } from "../route.js";
+import {
+  SETTLE_TIMEOUT_DEFAULT_SECONDS,
+  getSettleState,
+  getSettleTimeoutSeconds,
+  resetSettleStateForTests,
+} from "../settle.js";
+
+function makeFastMCPStub() {
+  return {
+    addTool: vi.fn(),
+    start: vi.fn(),
+    getApp: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+let autoStartSpy: ReturnType<typeof vi.spyOn> | null = null;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  autoStartSpy = vi
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .spyOn(MeshAgent.prototype as any, "_autoStart")
+    .mockImplementation(async () => {
+      /* no-op */
+    });
+  savedEnv.MCP_MESH_SETTLE_TIMEOUT = process.env.MCP_MESH_SETTLE_TIMEOUT;
+  savedEnv.MCP_MESH_TOOL_ISOLATION = process.env.MCP_MESH_TOOL_ISOLATION;
+  // Run tool bodies inline — worker isolation is orthogonal to the settle
+  // grace (the wait happens before the isolation branch either way).
+  process.env.MCP_MESH_TOOL_ISOLATION = "false";
+  delete process.env.MCP_MESH_SETTLE_TIMEOUT;
+  resetSettleStateForTests();
+  RouteRegistry.reset();
+});
+
+afterEach(() => {
+  if (autoStartSpy) {
+    autoStartSpy.mockRestore();
+    autoStartSpy = null;
+  }
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetSettleStateForTests();
+  RouteRegistry.reset();
+});
+
+function setBudget(seconds: string): void {
+  process.env.MCP_MESH_SETTLE_TIMEOUT = seconds;
+  resetSettleStateForTests();
+}
+
+/**
+ * Register a one-dep tool and return its FastMCP-registered execute fn.
+ * The tool's user function follows the defensive `if (dep)` idiom.
+ */
+function registerTool(toolName = "settle_tool", capability = "db_cap") {
+  const fastmcp = makeFastMCPStub();
+  const agent = new MeshAgent(fastmcp, { name: "settle-agent", httpPort: 0 });
+  agent.addTool({
+    name: toolName,
+    parameters: z.object({}),
+    dependencies: [{ capability }],
+    execute: async (_args: unknown, dep: unknown) =>
+      dep ? "resolved" : "degraded",
+  });
+  const execute = fastmcp.addTool.mock.calls[0][0].execute as (
+    args: unknown,
+  ) => Promise<string>;
+  return { agent, execute };
+}
+
+function resolveDep(
+  agent: MeshAgent,
+  toolName: string,
+  capability: string,
+  depIndex = 0,
+): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (agent as any).handleDependencyAvailable(
+    capability,
+    "http://localhost:19999",
+    "remote_fn",
+    "provider-agent",
+    toolName,
+    depIndex,
+  );
+}
+
+describe("settle timeout knob", () => {
+  it("defaults to 20 seconds", () => {
+    expect(getSettleTimeoutSeconds()).toBe(SETTLE_TIMEOUT_DEFAULT_SECONDS);
+    expect(SETTLE_TIMEOUT_DEFAULT_SECONDS).toBe(20);
+  });
+
+  it("honors a float env override and caches it per process", () => {
+    setBudget("3.5");
+    expect(getSettleTimeoutSeconds()).toBe(3.5);
+    process.env.MCP_MESH_SETTLE_TIMEOUT = "99";
+    expect(getSettleTimeoutSeconds()).toBe(3.5); // cached
+  });
+
+  it("falls back to the default on negative values", () => {
+    setBudget("-5");
+    expect(getSettleTimeoutSeconds()).toBe(SETTLE_TIMEOUT_DEFAULT_SECONDS);
+  });
+});
+
+describe("MCP tool execute wrapper", () => {
+  it("(a) proceeds early with the real proxy when resolution arrives mid-wait", async () => {
+    setBudget("10");
+    const { agent, execute } = registerTool();
+
+    setTimeout(() => resolveDep(agent, "settle_tool", "db_cap"), 200);
+
+    const start = Date.now();
+    const result = await execute({});
+    const elapsedMs = Date.now() - start;
+
+    expect(result).toBe("resolved");
+    // Unblocked by the event, not the 10s budget ceiling.
+    expect(elapsedMs).toBeLessThan(5000);
+    expect(getSettleState().waitCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("(b) proceeds with null at budget expiry — defensive user code runs", async () => {
+    setBudget("0.3");
+    const { execute } = registerTool();
+
+    const start = Date.now();
+    const result = await execute({});
+    const elapsedMs = Date.now() - start;
+
+    expect(result).toBe("degraded");
+    expect(elapsedMs).toBeGreaterThanOrEqual(200); // actually waited
+  });
+
+  it("(c) settled by window expiry → latch is permanent, no more waits", async () => {
+    setBudget("0.1");
+    const { execute } = registerTool();
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    for (let i = 0; i < 2; i++) {
+      const start = Date.now();
+      expect(await execute({})).toBe("degraded");
+      expect(Date.now() - start).toBeLessThan(50);
+    }
+    const state = getSettleState();
+    expect(state.isSettled()).toBe(true);
+    expect(state.waitCount).toBe(0);
+  });
+
+  it("(d) settled by all-declared-resolved → eager latch, no waits", async () => {
+    setBudget("10");
+    const { agent, execute } = registerTool();
+    resolveDep(agent, "settle_tool", "db_cap");
+
+    const state = getSettleState();
+    expect(state.isSettled()).toBe(true);
+
+    const start = Date.now();
+    expect(await execute({})).toBe("resolved");
+    expect(Date.now() - start).toBeLessThan(50);
+    expect(state.waitCount).toBe(0);
+  });
+
+  it("tracks the agent-level union: one unresolved dep keeps the agent unsettled", async () => {
+    setBudget("0.3");
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, { name: "settle-agent", httpPort: 0 });
+    agent.addTool({
+      name: "tool_a",
+      parameters: z.object({}),
+      dependencies: [{ capability: "cap_a" }],
+      execute: async (_args: unknown, dep: unknown) => (dep ? "a-resolved" : "a-degraded"),
+    });
+    agent.addTool({
+      name: "tool_b",
+      parameters: z.object({}),
+      dependencies: [{ capability: "cap_b" }],
+      execute: async (_args: unknown, dep: unknown) => (dep ? "b-resolved" : "b-degraded"),
+    });
+    const executeA = fastmcp.addTool.mock.calls[0][0].execute;
+    const executeB = fastmcp.addTool.mock.calls[1][0].execute;
+
+    resolveDep(agent, "tool_a", "cap_a");
+    const state = getSettleState();
+    expect(state.isSettled()).toBe(false); // cap_b still unresolved
+
+    // tool_a's dep is resolved — no wait even though unsettled.
+    let start = Date.now();
+    expect(await executeA({})).toBe("a-resolved");
+    expect(Date.now() - start).toBeLessThan(50);
+
+    // tool_b's dep is unresolved — it waits toward the budget.
+    start = Date.now();
+    expect(await executeB({})).toBe("b-degraded");
+    expect(Date.now() - start).toBeGreaterThanOrEqual(200);
+  });
+
+  it("anchors the settle window at first dependency declaration, not process start", async () => {
+    setBudget("0.3");
+    // Idle past the would-be window BEFORE any dependency declaration —
+    // with an import/reset-time anchor this would (incorrectly) expire it.
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    const { execute } = registerTool();
+    expect(getSettleState().isSettled()).toBe(false);
+
+    const start = Date.now();
+    expect(await execute({})).toBe("degraded");
+    // Waited toward the freshly-anchored budget.
+    expect(Date.now() - start).toBeGreaterThanOrEqual(200);
+  });
+
+  it("a caller-supplied mock dependency never waits (documented mock contract)", async () => {
+    setBudget("5");
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, { name: "settle-agent", httpPort: 0 });
+    agent.addTool({
+      name: "tool_a",
+      parameters: z.object({}),
+      dependencies: [{ capability: "cap_a" }],
+      execute: async (_args: unknown, dep: unknown) =>
+        dep ? "a-resolved" : "a-degraded",
+    });
+    agent.addTool({
+      name: "tool_b",
+      parameters: z.object({}),
+      dependencies: [{ capability: "cap_b" }],
+      execute: async (_args: unknown, dep: unknown) =>
+        dep ? "b-resolved" : "b-degraded",
+    });
+    const executeA = fastmcp.addTool.mock.calls[0][0].execute;
+
+    // Caller supplies cap_a explicitly; cap_b stays unresolved so the
+    // agent is still UNSETTLED — proving the per-slot skip, not the latch.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    agent.setMockDependency("cap_a", (async () => "mock") as any);
+    const state = getSettleState();
+    expect(state.isSettled()).toBe(false);
+
+    const start = Date.now();
+    expect(await executeA({})).toBe("a-resolved"); // mock injected
+    expect(Date.now() - start).toBeLessThan(50);
+    expect(state.waitCount).toBe(0);
+  });
+
+  it("(e) MCP_MESH_SETTLE_TIMEOUT=0 disables the grace entirely", async () => {
+    setBudget("0");
+    const { execute } = registerTool();
+
+    const start = Date.now();
+    expect(await execute({})).toBe("degraded");
+    expect(Date.now() - start).toBeLessThan(50);
+    const state = getSettleState();
+    expect(state.isSettled()).toBe(true);
+    expect(state.waitCount).toBe(0);
+  });
+
+  it("(h) the settled steady-state path never touches the wait primitives", async () => {
+    setBudget("10");
+    const { agent, execute } = registerTool();
+    resolveDep(agent, "settle_tool", "db_cap");
+
+    const state = getSettleState();
+    expect(state.isSettled()).toBe(true);
+    const waitForSpy = vi.spyOn(state, "waitFor");
+    const awaitPendingSpy = vi.spyOn(state, "awaitPending");
+
+    for (let i = 0; i < 3; i++) {
+      await execute({});
+    }
+
+    expect(waitForSpy).not.toHaveBeenCalled();
+    expect(awaitPendingSpy).not.toHaveBeenCalled();
+    expect(state.waitCount).toBe(0);
+  });
+});
+
+describe("RouteRegistry settle integration", () => {
+  it("declares route deps and resolves them through setDependency", () => {
+    setBudget("10");
+    const registry = RouteRegistry.getInstance();
+    const routeId = registry.registerRoute("POST", "/compute", [
+      { capability: "calculator" },
+    ]);
+
+    const state = getSettleState();
+    expect(state.isSettled()).toBe(false);
+    expect(state.isResolved(`${routeId}:dep_0`)).toBe(false);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registry.setDependency(routeId, 0, {} as any);
+    expect(state.isResolved(`${routeId}:dep_0`)).toBe(true);
+    // Single declared dep resolved → agent settles eagerly.
+    expect(state.isSettled()).toBe(true);
+  });
+
+  it("keeps settle keys aligned when route IDs are remapped", () => {
+    setBudget("10");
+    const registry = RouteRegistry.getInstance();
+    const placeholderId = registry.registerRoute("UNKNOWN", "UNKNOWN", [
+      { capability: "calculator" },
+    ]);
+
+    registry.updateRouteInfo(placeholderId, "POST", "/compute");
+
+    const state = getSettleState();
+    // Resolution arrives under the remapped ID — must still flip the
+    // (renamed) declared key and settle the agent.
+    registry.setDependency("POST:/compute", 0, {} as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    expect(state.isResolved("POST:/compute:dep_0")).toBe(true);
+    expect(state.isSettled()).toBe(true);
+  });
+
+  it("releases a displaced waiter on rename key collision (chains to survivor)", async () => {
+    setBudget("10");
+    const state = getSettleState();
+    state.registerDeclared("old:dep_0");
+    state.registerDeclared("POST:/compute:dep_0");
+
+    // A call is already waiting under the OLD key when the rename lands
+    // on a key that has its own waiter (collision).
+    const displaced = state.waitFor("old:dep_0", "calculator");
+    const survivor = state.waitFor("POST:/compute:dep_0", "calculator");
+    state.renameDeclared("old:dep_0", "POST:/compute:dep_0");
+
+    state.markResolved("POST:/compute:dep_0");
+
+    const winner = await Promise.race([
+      Promise.all([displaced, survivor]).then(() => "released"),
+      new Promise((resolve) => setTimeout(resolve, 1000, "stuck")),
+    ]);
+    expect(winner).toBe("released");
+  });
+
+  it("releases a renamed waiter immediately when the new key already resolved", async () => {
+    setBudget("10");
+    const state = getSettleState();
+    state.registerDeclared("old:dep_0");
+
+    const displaced = state.waitFor("old:dep_0", "calculator");
+    state.markResolved("POST:/compute:dep_0");
+    state.renameDeclared("old:dep_0", "POST:/compute:dep_0");
+
+    const winner = await Promise.race([
+      displaced.then(() => "released"),
+      new Promise((resolve) => setTimeout(resolve, 1000, "stuck")),
+    ]);
+    expect(winner).toBe("released");
+  });
+
+  it("a waiting route call unblocks when the dependency resolves", async () => {
+    setBudget("10");
+    const registry = RouteRegistry.getInstance();
+    const routeId = registry.registerRoute("GET", "/data", [
+      { capability: "store" },
+    ]);
+    const state = getSettleState();
+
+    setTimeout(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => registry.setDependency(routeId, 0, { live: true } as any),
+      150,
+    );
+
+    const start = Date.now();
+    await state.waitFor(`${routeId}:dep_0`, "store");
+    const elapsedMs = Date.now() - start;
+
+    expect(elapsedMs).toBeLessThan(5000);
+    expect(registry.getDependency(routeId, 0)).toEqual({ live: true });
+  });
+});

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -48,6 +48,7 @@ import {
   spliceJobController,
 } from "./inbound-job-dispatch.js";
 import { MeshJobSubmitter } from "./mesh-job-submitter.js";
+import { getSettleState, type PendingSettleDep } from "./settle.js";
 import {
   ClaimDispatcher,
   stopDispatchers,
@@ -562,6 +563,17 @@ export class MeshAgent {
     );
     const depEndpoints = normalizedDeps.map((d) => d.capability);
 
+    // Settling-window grace (#1193): declare this tool's proxy deps with the
+    // process-wide settle state so the agent-level "all declared deps
+    // resolved" latch can flip eagerly. The MeshJob slot is excluded — its
+    // submitter is constructed locally, not resolved by an event.
+    const settleState = getSettleState();
+    normalizedDeps.forEach((_dep, depIndex) => {
+      if (depIndex !== def.meshJobDepIndex) {
+        settleState.registerDeclared(`${toolName}:dep_${depIndex}`);
+      }
+    });
+
     // Capture for closures — these reads must be live at invocation
     // time (e.g. registryUrl/agentId aren't set yet at addTool time).
     const isTaskTool = def.task === true;
@@ -599,6 +611,27 @@ export class MeshAgent {
     const wrappedExecute = async (
       args: z.infer<T>,
     ): Promise<string> => {
+      // Settling-window grace (#1193): while the agent is still settling,
+      // wait — bounded by the remaining settle budget — for any declared
+      // dep this call would inject that is still unresolved. No-op (single
+      // latch check) once settled; the deps array below is built AFTER the
+      // wait so it re-reads the resolution state.
+      if (normalizedDeps.length > 0 && !settleState.isSettled()) {
+        const pendingSettle: PendingSettleDep[] = [];
+        normalizedDeps.forEach((dep, depIndex) => {
+          const depKey = `${toolName}:dep_${depIndex}`;
+          if (
+            depIndex !== meshJobDepIndex &&
+            !this.resolvedDeps.has(depKey)
+          ) {
+            pendingSettle.push({ depKey, capability: dep.capability });
+          }
+        });
+        if (pendingSettle.length > 0) {
+          await settleState.awaitPending(pendingSettle);
+        }
+      }
+
       // Build positional deps array using composite keys (toolName:dep_index)
       // Phase 1 MeshJob substrate (consumer-side): if meshJobDepIndex is
       // set, swap the McpMeshTool proxy at that slot for a
@@ -887,6 +920,24 @@ export class MeshAgent {
     if (isTaskTool) {
       const capability = def.capability ?? toolName;
       const handler: ClaimHandler = async (payload, controller) => {
+        // Settling-window grace (#1193): claim dispatch gets the same
+        // bounded wait as the inbound HTTP path — a claim arriving during
+        // the settling window would otherwise see null deps.
+        if (normalizedDeps.length > 0 && !settleState.isSettled()) {
+          const pendingSettle: PendingSettleDep[] = [];
+          normalizedDeps.forEach((dep, depIndex) => {
+            const depKey = `${toolName}:dep_${depIndex}`;
+            if (
+              depIndex !== meshJobDepIndex &&
+              !this.resolvedDeps.has(depKey)
+            ) {
+              pendingSettle.push({ depKey, capability: dep.capability });
+            }
+          });
+          if (pendingSettle.length > 0) {
+            await settleState.awaitPending(pendingSettle);
+          }
+        }
         const liveDeps: (McpMeshTool | MeshJobSubmitter | null)[] = normalizedDeps.map(
           (dep, depIndex) => {
             if (depIndex === meshJobDepIndex) {
@@ -1806,6 +1857,10 @@ export class MeshAgent {
       const depKey = `${requestingFunction}:dep_${depIndex}`;
       const proxy = createProxy(endpoint, capability, functionName, kwargs);
       this.resolvedDeps.set(depKey, proxy);
+      // Settling-window grace (#1193): wake any settling call waiting on
+      // this dependency AFTER the proxy is stored so the woken call
+      // re-reads a real proxy.
+      getSettleState().markResolved(depKey);
 
       console.log(
         `Dependency available: ${capability} at ${endpoint} (tool: ${requestingFunction}, index: ${depIndex}, agent: ${agentId})`
@@ -1825,6 +1880,7 @@ export class MeshAgent {
           const depKey = `${toolName}:dep_${idx}`;
           const proxy = createProxy(endpoint, capability, functionName, kwargs);
           this.resolvedDeps.set(depKey, proxy);
+          getSettleState().markResolved(depKey);
           matchCount++;
         }
       });
@@ -1906,6 +1962,30 @@ export class MeshAgent {
    */
   getAllDependencies(): Map<string, McpMeshTool> {
     return new Map(this.resolvedDeps);
+  }
+
+  /**
+   * Inject a mock/fake proxy for a capability (the documented mock
+   * contract — see `meshctl man testing --typescript`).
+   *
+   * Fills the dependency slot of every registered tool that declares the
+   * capability and marks those slots resolved with the settle state, so
+   * the settling-window grace (#1193) never waits on a caller-supplied
+   * dependency.
+   */
+  setMockDependency(capability: string, mock: McpMeshTool): void {
+    for (const [toolName, meta] of this.tools.entries()) {
+      if (!meta.dependencies) continue;
+      meta.dependencies.forEach((dep, depIndex) => {
+        if (dep.capability === capability) {
+          const depKey = `${toolName}:dep_${depIndex}`;
+          this.resolvedDeps.set(depKey, mock);
+          // A caller-supplied slot needs no resolution event — count it
+          // as resolved so settling calls never wait on it.
+          getSettleState().markResolved(depKey);
+        }
+      });
+    }
   }
 
   /**

--- a/src/runtime/typescript/src/route.ts
+++ b/src/runtime/typescript/src/route.ts
@@ -33,6 +33,7 @@ import type { Request, Response, NextFunction, RequestHandler } from "express";
 import type { DependencySpec, McpMeshTool, DependencyKwargs, TagSpec } from "./types.js";
 import { normalizeDependency, runWithPropagatedHeaders, runWithTraceContext } from "./proxy.js";
 import { getApiRuntime, introspectExpressRoutes } from "./api-runtime.js";
+import { getSettleState, type PendingSettleDep } from "./settle.js";
 import {
   PROPAGATE_HEADERS,
   matchesPropagateHeader,
@@ -161,6 +162,15 @@ export class RouteRegistry {
       dependencyKwargs,
     });
 
+    // Settling-window grace (#1193): declare this route's deps with the
+    // process-wide settle state so the agent-level "all declared deps
+    // resolved" latch can flip eagerly. Keys are renamed alongside the
+    // route ID in updateRouteInfo().
+    const settleState = getSettleState();
+    normalizedDeps.forEach((_dep, depIndex) => {
+      settleState.registerDeclared(`${routeId}:dep_${depIndex}`);
+    });
+
     return routeId;
   }
 
@@ -197,6 +207,11 @@ export class RouteRegistry {
     const actualId = this.routeIdMapping.get(routeId) || routeId;
     const depKey = `${actualId}:dep_${depIndex}`;
     this.resolvedDeps.set(depKey, proxy);
+    // Settling-window grace (#1193): wake any settling request waiting on
+    // this dependency AFTER the proxy is stored so the woken request
+    // re-reads a real proxy. This is the single funnel for route deps —
+    // both the express runtime and the API runtime land here.
+    getSettleState().markResolved(depKey);
   }
 
   /**
@@ -279,6 +294,9 @@ export class RouteRegistry {
           this.resolvedDeps.set(newKey, dep);
           this.resolvedDeps.delete(oldKey);
         }
+        // Settling-window grace (#1193): keep the settle state's declared/
+        // resolved/waiter keys aligned with the remapped route ID.
+        getSettleState().renameDeclared(oldKey, newKey);
       }
     }
   }
@@ -382,6 +400,28 @@ export function route(
       if (!expressAutoDetected) {
         expressAutoDetected = true;
         performExpressAutoDetection(req);
+      }
+
+      // Settling-window grace (#1193): while the agent is still settling,
+      // wait — bounded by the remaining settle budget — for any declared
+      // dep this request would inject that is still unresolved. No-op
+      // (single latch check) once settled; deps are read AFTER the wait so
+      // they reflect the resolution state.
+      const settleState = getSettleState();
+      if (normalizedDeps.length > 0 && !settleState.isSettled()) {
+        const currentId = registry.resolveRouteId(routeRef.id);
+        const pendingSettle: PendingSettleDep[] = [];
+        normalizedDeps.forEach((dep, depIndex) => {
+          if (registry.getDependency(currentId, depIndex) === null) {
+            pendingSettle.push({
+              depKey: `${currentId}:dep_${depIndex}`,
+              capability: dep.capability,
+            });
+          }
+        });
+        if (pendingSettle.length > 0) {
+          await settleState.awaitPending(pendingSettle);
+        }
       }
 
       // Get resolved dependencies as object (use ref to get current ID after introspection)

--- a/src/runtime/typescript/src/settle.ts
+++ b/src/runtime/typescript/src/settle.ts
@@ -34,6 +34,8 @@
  * diagnostics never interact with the settle window in any way.
  */
 
+import { performance } from "node:perf_hooks";
+
 export const SETTLE_TIMEOUT_DEFAULT_SECONDS = 20;
 
 /**
@@ -91,7 +93,12 @@ export interface PendingSettleDep {
  * `isSettled()` observes window expiry.
  */
 export class SettleState {
-  /** Window anchor — set by the FIRST registerDeclared() call. */
+  /**
+   * Window anchor — set by the FIRST registerDeclared() call. Monotonic
+   * (`performance.now()`) so wall-clock jumps (NTP steps, manual clock
+   * changes) never stretch or collapse the settle window; matches
+   * `time.monotonic()` in Python and `System.nanoTime()` in Java.
+   */
   private startMs: number | null = null;
   private readonly declared = new Set<string>();
   private readonly resolved = new Set<string>();
@@ -115,7 +122,7 @@ export class SettleState {
    */
   registerDeclared(depKey: string): void {
     if (this.startMs === null) {
-      this.startMs = Date.now();
+      this.startMs = performance.now();
     }
     this.declared.add(depKey);
   }
@@ -200,7 +207,7 @@ export class SettleState {
       // window must still open when the first declaration lands.
       return true;
     }
-    if (Date.now() - this.startMs >= timeoutSecs * 1000) {
+    if (performance.now() - this.startMs >= timeoutSecs * 1000) {
       this.settled = true;
       return true;
     }
@@ -214,7 +221,7 @@ export class SettleState {
     }
     return Math.max(
       0,
-      getSettleTimeoutSeconds() * 1000 - (Date.now() - this.startMs),
+      getSettleTimeoutSeconds() * 1000 - (performance.now() - this.startMs),
     );
   }
 

--- a/src/runtime/typescript/src/settle.ts
+++ b/src/runtime/typescript/src/settle.ts
@@ -1,0 +1,303 @@
+/**
+ * Settling-window dependency grace (issue #1193).
+ *
+ * Dependency injection resolves asynchronously: declared dependencies become
+ * available when the first full heartbeat cycle completes and
+ * `dependency_available` events land. A call that fires during that settling
+ * window would otherwise see a declared-but-unresolved dependency as `null`
+ * even though resolution typically lands moments later.
+ *
+ * Process-wide settle state:
+ *
+ * - The settle window is ANCHORED at the first dependency declaration (the
+ *   first `registerDeclared()` call during startup wiring) — not at module
+ *   import — so slow imports or pre-registration work never eat into the
+ *   grace budget. The agent is **unsettled** from that anchor until EITHER
+ *   every declared dependency has resolved at least once OR the settle
+ *   window (`MCP_MESH_SETTLE_TIMEOUT` seconds, default 20) expires.
+ * - While unsettled, invocation paths await — bounded by the REMAINING settle
+ *   budget — a per-dependency promise that the existing
+ *   `handleDependencyAvailable` handling resolves the moment the dependency
+ *   lands. Resolution at 800ms unblocks at 800ms; the budget is a ceiling
+ *   only, never a sleep.
+ * - Once settled — either way — the latch is permanent: calls never touch the
+ *   wait primitives again and fail-fast behavior is byte-identical to the
+ *   pre-grace behavior (unresolved deps inject `null` exactly as before).
+ *
+ * Scope (deliberate): the grace covers the dependency-injection invocation
+ * paths only — the MCP tool execute wrapper, the claim-dispatch handler, and
+ * the `mesh.route` middleware. Module-scope captured deps and `mesh.llm`
+ * provider/filter assembly (registration-time, with its own update mechanism)
+ * are NOT covered.
+ *
+ * This is environmental, not a declaration mistake: strict-DI style
+ * diagnostics never interact with the settle window in any way.
+ */
+
+export const SETTLE_TIMEOUT_DEFAULT_SECONDS = 20;
+
+/**
+ * Cached per-process resolution of MCP_MESH_SETTLE_TIMEOUT — the settle
+ * window is a process-level posture, not a per-call toggle.
+ */
+let cachedTimeoutSecs: number | null = null;
+
+/**
+ * Settle window in seconds. `0` disables the grace entirely.
+ *
+ * Configurable via `MCP_MESH_SETTLE_TIMEOUT` (float seconds, default 20).
+ * Read once per process and cached. Negative or unparseable values fall
+ * back to the default with a warning.
+ */
+export function getSettleTimeoutSeconds(): number {
+  if (cachedTimeoutSecs === null) {
+    const raw = process.env.MCP_MESH_SETTLE_TIMEOUT;
+    if (raw === undefined || raw.trim() === "") {
+      cachedTimeoutSecs = SETTLE_TIMEOUT_DEFAULT_SECONDS;
+    } else {
+      const parsed = Number.parseFloat(raw);
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        console.warn(
+          `MCP_MESH_SETTLE_TIMEOUT must be >= 0 (got '${raw}'); ` +
+            `using default ${SETTLE_TIMEOUT_DEFAULT_SECONDS}s`,
+        );
+        cachedTimeoutSecs = SETTLE_TIMEOUT_DEFAULT_SECONDS;
+      } else {
+        cachedTimeoutSecs = parsed;
+      }
+    }
+  }
+  return cachedTimeoutSecs;
+}
+
+interface DepWaiter {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+/** A declared-but-unresolved dependency an invocation is about to inject. */
+export interface PendingSettleDep {
+  depKey: string;
+  capability: string;
+}
+
+/**
+ * Process-wide settle latch + per-dependency resolution promises.
+ *
+ * Dependencies are tracked at the AGENT level as the union of declared
+ * dependency keys across all tools/routes (the same composite
+ * `"<owner>:dep_<N>"` keys the resolution paths already use). The latch
+ * flips eagerly when the last declared key resolves, or lazily when
+ * `isSettled()` observes window expiry.
+ */
+export class SettleState {
+  /** Window anchor — set by the FIRST registerDeclared() call. */
+  private startMs: number | null = null;
+  private readonly declared = new Set<string>();
+  private readonly resolved = new Set<string>();
+  private readonly waiters = new Map<string, DepWaiter>();
+  /** Capabilities whose first wait was already logged (INFO once). */
+  private readonly loggedWaits = new Set<string>();
+  private settled = false;
+  /**
+   * Diagnostic counter: number of actual bounded waits performed. Used by
+   * tests to prove the settled steady-state path never touches the wait
+   * primitives.
+   */
+  waitCount = 0;
+
+  /**
+   * Record a declared dependency key (registration time).
+   *
+   * The FIRST declaration anchors the settle window — the window measures
+   * topology convergence from the moment the agent starts declaring
+   * dependencies, not from module import.
+   */
+  registerDeclared(depKey: string): void {
+    if (this.startMs === null) {
+      this.startMs = Date.now();
+    }
+    this.declared.add(depKey);
+  }
+
+  /**
+   * Record a resolution and wake any waiter on this key.
+   *
+   * "Resolved at least once" semantics: a later unavailability does NOT
+   * un-resolve the key — the settle window only measures initial topology
+   * convergence.
+   */
+  markResolved(depKey: string): void {
+    this.resolved.add(depKey);
+    const waiter = this.waiters.get(depKey);
+    if (waiter) {
+      waiter.resolve();
+    }
+    if (!this.settled && this.declared.size > 0) {
+      let all = true;
+      for (const key of this.declared) {
+        if (!this.resolved.has(key)) {
+          all = false;
+          break;
+        }
+      }
+      if (all) {
+        // Eager latch: the LAST declared dependency just resolved.
+        this.settled = true;
+      }
+    }
+  }
+
+  /**
+   * Migrate a declared/resolved/waiting key to a new name. Needed by the
+   * Express route registry whose placeholder route IDs are remapped to
+   * `METHOD:path` after introspection.
+   *
+   * A pending waiter on the old key is never dropped unresolved: when the
+   * new key already resolved it is released immediately; on a key
+   * collision (the new key already has its own waiter) the displaced
+   * waiter is chained to the survivor so both resolve together.
+   */
+  renameDeclared(oldKey: string, newKey: string): void {
+    if (this.declared.delete(oldKey)) {
+      this.declared.add(newKey);
+    }
+    if (this.resolved.delete(oldKey)) {
+      this.resolved.add(newKey);
+    }
+    const waiter = this.waiters.get(oldKey);
+    if (waiter) {
+      this.waiters.delete(oldKey);
+      if (this.resolved.has(newKey)) {
+        // The surviving key already resolved — release the migrated waiter.
+        waiter.resolve();
+      } else {
+        const survivor = this.waiters.get(newKey);
+        if (survivor) {
+          // Chain to the survivor: when the surviving key's resolution
+          // lands, the displaced waiter wakes too.
+          void survivor.promise.then(() => waiter.resolve());
+        } else {
+          this.waiters.set(newKey, waiter);
+        }
+      }
+    }
+  }
+
+  /** Permanent latch check; flips on window expiry or timeout=0. */
+  isSettled(): boolean {
+    if (this.settled) {
+      return true;
+    }
+    const timeoutSecs = getSettleTimeoutSeconds();
+    if (timeoutSecs <= 0) {
+      this.settled = true;
+      return true;
+    }
+    if (this.startMs === null) {
+      // Window not yet anchored — no dependency has been declared, so
+      // nothing can be pending. Report settled WITHOUT latching: the
+      // window must still open when the first declaration lands.
+      return true;
+    }
+    if (Date.now() - this.startMs >= timeoutSecs * 1000) {
+      this.settled = true;
+      return true;
+    }
+    return false;
+  }
+
+  /** Remaining settle budget in milliseconds (>= 0). */
+  remainingMs(): number {
+    if (this.startMs === null) {
+      return 0;
+    }
+    return Math.max(
+      0,
+      getSettleTimeoutSeconds() * 1000 - (Date.now() - this.startMs),
+    );
+  }
+
+  isResolved(depKey: string): boolean {
+    return this.resolved.has(depKey);
+  }
+
+  private waiterFor(depKey: string): DepWaiter {
+    let waiter = this.waiters.get(depKey);
+    if (!waiter) {
+      let resolveFn: () => void = () => {};
+      const promise = new Promise<void>((resolve) => {
+        resolveFn = resolve;
+      });
+      waiter = { promise, resolve: resolveFn };
+      this.waiters.set(depKey, waiter);
+    }
+    return waiter;
+  }
+
+  /**
+   * Wait until `depKey` resolves or the remaining settle budget elapses.
+   * Event-driven: the dependency's resolution promise is raced against a
+   * timer bounded by the remaining window — never a fixed sleep.
+   */
+  async waitFor(depKey: string, capability: string): Promise<void> {
+    const remaining = this.remainingMs();
+    if (remaining <= 0 || this.resolved.has(depKey)) {
+      return;
+    }
+    const waiter = this.waiterFor(depKey);
+    const remainingSecs = (remaining / 1000).toFixed(1);
+    const message = `waiting up to ${remainingSecs}s for dependency '${capability}' to settle`;
+    if (!this.loggedWaits.has(capability)) {
+      // One INFO line per capability per process; later waits at DEBUG
+      // (matches the Python/Java log cadence).
+      this.loggedWaits.add(capability);
+      console.log(message);
+    } else {
+      console.debug(message);
+    }
+    this.waitCount++;
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        waiter.promise,
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, remaining);
+          // Never keep the process alive just for a settle timer.
+          timer.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+    }
+    // On timeout we simply proceed — the unresolved dep injects null
+    // exactly as today; the existing unresolved-dep handling covers the
+    // diagnostic (no double-logging here).
+  }
+
+  /**
+   * Await every pending dependency in turn. The per-wait budget is the
+   * REMAINING window, so the total wait is bounded by the settle window
+   * regardless of how many deps are pending.
+   */
+  async awaitPending(pending: PendingSettleDep[]): Promise<void> {
+    for (const { depKey, capability } of pending) {
+      await this.waitFor(depKey, capability);
+    }
+  }
+}
+
+let settleState = new SettleState();
+
+/** Get the process-wide settle state. */
+export function getSettleState(): SettleState {
+  return settleState;
+}
+
+/** Replace the settle state and drop the cached timeout (test support). */
+export function resetSettleStateForTests(): void {
+  settleState = new SettleState();
+  cachedTimeoutSecs = null;
+}


### PR DESCRIPTION
## Summary
Closes #1193 — the settling-window dependency grace, in all three runtimes. Full design rationale recorded on the issue.

- **What it does**: a call arriving while an agent's topology is still settling no longer fails instantly on a declared-but-unresolved dependency. The DI wrapper waits — event-driven, bounded by the remaining settle window — for the `dependency_available` signal, then proceeds with the real proxy; on budget expiry it proceeds with `None`/null **exactly as today**. User code can never observe a pending state: params stay binary (real or None), so the defensive `if dep:` idiom in every shipped example is untouched.
- **Settled latch**: unsettled from the *first dependency declaration* until all declared deps have resolved once OR `MCP_MESH_SETTLE_TIMEOUT` (float seconds, default 20, `0` disables; cached read) expires — then permanently settled: zero steady-state overhead (pinned by spies in all three suites) and byte-identical fail-fast behavior.
- **Mechanics**: Python — per-dep `threading.Event` for sync tools (which run on dedicated threads; a running-loop probe skips the wait rather than ever blocking a loop) and loop-native `asyncio.Event` mirrors woken via `call_soon_threadsafe` for async paths (zero shared-executor usage, cancellable, no shutdown delay). TypeScript — per-dep deferred promises raced with unref'd cleared timers, covering tool, route, and claim-handler paths. Java — per-consumer-slot latches counted down strictly after the slot write (capability-keyed only on the route funnel, where the shared proxy's update precedes the wake), blocking on Spring threads.
- **Caller-supplied deps never wait** (the documented mock contract); settle timeout is environmental and never interacts with `MCP_MESH_STRICT_DI`.
- **Out of scope, documented**: lifespan-hook dep usage, module-scope captured deps, `@mesh.llm` provider/filter assembly.

## Notable extras (review-driven)
- **Pre-existing Java injection corruption fixed**: with a MeshJob-first dependency list, `updateDependency` wrote the job event's proxy into the wrong slot and bounds-dropped the real dep's event. The new declared-index↔slot translation fixes injection to match its own documented declaration-order semantics (regression-pinned).
- **TS `setMockDependency` implemented**: documented in the testing man page for some time but absent from the SDK; now real, with non-stickiness and ordering notes added to both doc surfaces.
- Example bug fixed: `llm_with_deps_agent.py:smart_analyze` referenced undefined params.
- All three test suites default the settle window OFF suite-wide (Python conftest, TS per-file, Java auto-registered JUnit extension with a negative-control test proving the wiring) — graced waits are opted into per test.

## Review Notes
- Two full review rounds + a focused delta review. Round 1 found one blocker (the Python unit suite silently stalling ~20s — measured) and the Java capability-keyed wake that would have defeated the grace in the multi-consumer topology it exists for; both drove redesigns. The delta review verified the race matrix (no lost wakeups; level-triggered primitives + resolved pre-checks under one lock), the #1171 consistent-view rule, and identity-translation safety for existing no-job Java agents. 0 blockers outstanding.
- Test-suite follow-up (per the issue plan): an integration TC pinning the immediate-call cold-start path, then the suite-wide migration to `MCP_MESH_SETTLE_TIMEOUT=60` reliance — the broad DI cold-start regression proof — as separate efforts.

Closes #1193

## Test plan
- [x] Python 1144+ unit tests (suite wall time verified back to normal); 18-test settle matrix incl. loop-native proof, sync-on-thread liveness, strict-DI non-interaction
- [x] TS typecheck + 924 tests (17-test settle spec incl. rename chaining, per-slot mock skip)
- [x] Java 437 tests (16-test settle suite incl. wrong-consumer pin, job-first skew pin, corruption regression; extension negative control)
- [ ] Integration pin TC (immediate call, no dep wait) — follow-up via the integration suite
- [ ] Suite-wide settle-reliance migration with raised window — follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable dependency settling window during agent startup via `MCP_MESH_SETTLE_TIMEOUT` environment variable (default 20 seconds). Agents now wait for declared dependencies to become available before degrading gracefully to null/unavailable states.
  * Enhanced dependency injection to support optional, gracefully-handled missing dependencies.

* **Documentation**
  * Updated dependency-injection guides to clarify settling-window behavior during startup across all runtimes.
  * Added clarification on mock dependency behavior in testing contexts.

* **Improvements**
  * Better event-driven dependency resolution handling during agent initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->