### PR TITLE
fix(meshctl): timeout-cut SSE streams error instead of printing keepalive comments

### DIFF
--- a/src/core/cli/call.go
+++ b/src/core/cli/call.go
@@ -712,16 +712,24 @@ const sseProxyTimeoutMarker = ": mesh-proxy-timeout"
 // extractMCPResponseJSON returns the JSON-RPC payload bytes from an /mcp
 // response body, plus whether the body was SSE-shaped. Plain JSON bodies pass
 // through unchanged (fromSSE=false). SSE bodies (FastMCP streamable-HTTP
-// answers tools/call as text/event-stream) have their first non-empty data
-// frame extracted; comment frames (lines starting with ":", e.g.
-// sse-starlette's `: ping - <ts>` keepalives) are ignored per the SSE spec
-// (#1201).
+// answers tools/call as text/event-stream) are scanned for the TERMINAL
+// JSON-RPC response frame — the first data frame carrying a top-level
+// "result" or "error" key. MCP streamable-HTTP may interleave notification
+// frames (progress, logging: method+params, no result/error) on the same
+// stream BEFORE the response; those must be skipped, not returned — a
+// notification unmarshals "successfully" into MCPResponse with nil
+// Result/Error, which would silently surface the wrong payload. Comment
+// frames (lines starting with ":", e.g. sse-starlette's `: ping - <ts>`
+// keepalives) are ignored per the SSE spec (#1201).
 //
-// An SSE stream that ends without ANY data frame is an error, never a result:
-// it means the exchange was cut (typically by the X-Mesh-Timeout budget at
-// the registry proxy) before the agent answered. The error is timeout-shaped
-// when the proxy's terminal marker is present or the elapsed wall time
-// consumed the budget; otherwise it is reported as a protocol error.
+// An SSE stream that ends without a terminal response frame is an error,
+// never a result: it means the exchange was cut (typically by the
+// X-Mesh-Timeout budget at the registry proxy) before the agent answered.
+// The error is timeout-shaped when the proxy's terminal marker is present or
+// the elapsed wall time consumed the budget; otherwise it is reported as a
+// protocol error (noting any notification frames that did arrive). A data
+// frame that does not parse as JSON (cut mid-frame) is returned as-is so the
+// caller's unmarshal failure routes to sseTruncatedFrameError.
 //
 // fromSSE tells the caller whether a downstream JSON parse failure may fall
 // back to the raw body: only non-SSE bodies (legacy plain-text responses)
@@ -738,21 +746,46 @@ func extractMCPResponseJSON(body []byte, contentType string, elapsed time.Durati
 		return body, false, nil
 	}
 
+	var firstUnparseable []byte
+	sawNotifications := false
 	for _, line := range strings.Split(bodyStr, "\n") {
 		line = strings.TrimRight(line, "\r")
 		if strings.HasPrefix(line, ":") {
 			// SSE comment frame — never payload (SSE spec: ignore ":" lines).
 			continue
 		}
-		if strings.HasPrefix(line, "data:") {
-			data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
-			if data != "" {
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "" {
+			continue
+		}
+		var probe map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(data), &probe); err == nil {
+			if _, ok := probe["result"]; ok {
 				return []byte(data), true, nil
 			}
+			if _, ok := probe["error"]; ok {
+				return []byte(data), true, nil
+			}
+			// Valid JSON object without a terminal key — a JSON-RPC
+			// notification (progress/logging). Not the response; keep scanning.
+			sawNotifications = true
+			continue
+		}
+		// Not parseable as a JSON object — likely the response frame cut
+		// mid-payload. Remember the first one; only used if no complete
+		// terminal frame follows.
+		if firstUnparseable == nil {
+			firstUnparseable = []byte(data)
 		}
 	}
 
-	return nil, true, sseStreamEndedError(elapsed, timeoutSeconds, sseBodyProxyTimeoutSignaled(bodyStr))
+	if firstUnparseable != nil {
+		return firstUnparseable, true, nil
+	}
+	return nil, true, sseStreamEndedError(elapsed, timeoutSeconds, sseBodyProxyTimeoutSignaled(bodyStr), sawNotifications)
 }
 
 // sseBodyProxyTimeoutSignaled reports whether the SSE body contains the
@@ -769,20 +802,45 @@ func sseBodyProxyTimeoutSignaled(bodyStr string) bool {
 	return false
 }
 
-// sseStreamEndedError shapes the failure for an SSE response that carried no
-// data frame. proxyTimeoutSignaled means the registry proxy explicitly marked
-// the stream as cut by its timeout cap; without that signal, elapsed wall
-// time consuming the X-Mesh-Timeout budget (with 1s slack for network and
-// scheduling jitter) is treated as a timeout, and anything quicker as a
-// protocol error (the agent or proxy closed the stream early).
-func sseStreamEndedError(elapsed time.Duration, timeoutSeconds int, proxyTimeoutSignaled bool) error {
+// sseElapsedConsumedBudget reports whether the elapsed wall time consumed the
+// X-Mesh-Timeout budget. For budgets above 1s a 1s slack absorbs network and
+// scheduling jitter; for 1s-and-under budgets the slack would swallow the
+// whole budget (any close, however fast, would classify as a timeout), so the
+// comparison is against the full budget instead. Shared by the data-less
+// (sseStreamEndedError) and truncated-frame (sseTruncatedFrameError) paths so
+// the heuristic can't drift between them.
+func sseElapsedConsumedBudget(elapsed time.Duration, timeoutSeconds int) bool {
+	if timeoutSeconds <= 0 {
+		return false
+	}
 	budget := time.Duration(timeoutSeconds) * time.Second
-	if proxyTimeoutSignaled || (timeoutSeconds > 0 && elapsed >= budget-time.Second) {
+	threshold := budget
+	if budget > time.Second {
+		threshold = budget - time.Second
+	}
+	return elapsed >= threshold
+}
+
+// sseStreamEndedError shapes the failure for an SSE response that carried no
+// terminal response frame. proxyTimeoutSignaled means the registry proxy
+// explicitly marked the stream as cut by its timeout cap; without that
+// signal, elapsed wall time consuming the X-Mesh-Timeout budget (see
+// sseElapsedConsumedBudget) is treated as a timeout, and anything quicker as
+// a protocol error (the agent or proxy closed the stream early).
+// sawNotifications enriches the protocol error: the stream carried JSON-RPC
+// notification frames (so the agent was alive and talking) but never the
+// response.
+func sseStreamEndedError(elapsed time.Duration, timeoutSeconds int, proxyTimeoutSignaled, sawNotifications bool) error {
+	if proxyTimeoutSignaled || sseElapsedConsumedBudget(elapsed, timeoutSeconds) {
 		return sseBudgetTimeoutError(elapsed, timeoutSeconds, "expired before the agent sent a response")
 	}
+	detail := ""
+	if sawNotifications {
+		detail = " — the stream carried notification frames but never a terminal result/error frame"
+	}
 	return fmt.Errorf(
-		"agent closed the SSE stream after %s without sending a response (X-Mesh-Timeout budget: %ds)",
-		elapsed.Round(100*time.Millisecond), timeoutSeconds)
+		"agent closed the SSE stream after %s without sending a response%s (X-Mesh-Timeout budget: %ds)",
+		elapsed.Round(100*time.Millisecond), detail, timeoutSeconds)
 }
 
 // sseTruncatedFrameError shapes the failure for an SSE data frame that was
@@ -793,8 +851,7 @@ func sseStreamEndedError(elapsed time.Duration, timeoutSeconds int, proxyTimeout
 // the raw body: that would report the truncated envelope (marker included) as
 // a successful result with exit 0.
 func sseTruncatedFrameError(bodyStr string, elapsed time.Duration, timeoutSeconds int) error {
-	budget := time.Duration(timeoutSeconds) * time.Second
-	if sseBodyProxyTimeoutSignaled(bodyStr) || (timeoutSeconds > 0 && elapsed >= budget-time.Second) {
+	if sseBodyProxyTimeoutSignaled(bodyStr) || sseElapsedConsumedBudget(elapsed, timeoutSeconds) {
 		return sseBudgetTimeoutError(elapsed, timeoutSeconds, "expired mid-response, cutting the result frame short")
 	}
 	return fmt.Errorf(

--- a/src/core/cli/call.go
+++ b/src/core/cli/call.go
@@ -696,6 +696,129 @@ func isIPAddress(s string) bool {
 	return true
 }
 
+// sseProxyTimeoutMarker is the terminal SSE comment frame the registry proxy
+// appends when the upstream exchange is cut by the X-Mesh-Timeout budget
+// mid-stream. Comment frames (":"-prefixed lines) are invisible to conforming
+// SSE clients per the SSE spec, which makes this a spec-compliant in-band
+// signal: meshctl uses it to report a definitive timeout instead of inferring
+// one from elapsed time (#1201).
+// Keep in sync with proxyTimeoutCommentMarker in src/core/registry/ent_handlers.go
+// and SSE_PROXY_TIMEOUT_MARKER in src/runtime/typescript/src/proxy.ts. The
+// literal is pinned by src/core/cli/call_test.go and
+// src/core/registry/proxy_stream_test.go — a drift in either package breaks
+// the partner's tests.
+const sseProxyTimeoutMarker = ": mesh-proxy-timeout"
+
+// extractMCPResponseJSON returns the JSON-RPC payload bytes from an /mcp
+// response body, plus whether the body was SSE-shaped. Plain JSON bodies pass
+// through unchanged (fromSSE=false). SSE bodies (FastMCP streamable-HTTP
+// answers tools/call as text/event-stream) have their first non-empty data
+// frame extracted; comment frames (lines starting with ":", e.g.
+// sse-starlette's `: ping - <ts>` keepalives) are ignored per the SSE spec
+// (#1201).
+//
+// An SSE stream that ends without ANY data frame is an error, never a result:
+// it means the exchange was cut (typically by the X-Mesh-Timeout budget at
+// the registry proxy) before the agent answered. The error is timeout-shaped
+// when the proxy's terminal marker is present or the elapsed wall time
+// consumed the budget; otherwise it is reported as a protocol error.
+//
+// fromSSE tells the caller whether a downstream JSON parse failure may fall
+// back to the raw body: only non-SSE bodies (legacy plain-text responses)
+// qualify. An SSE body is a transport envelope — returning it verbatim would
+// leak keepalive comments and the proxy's timeout marker as a "successful"
+// result (see sseTruncatedFrameError).
+func extractMCPResponseJSON(body []byte, contentType string, elapsed time.Duration, timeoutSeconds int) ([]byte, bool, error) {
+	bodyStr := string(body)
+	isSSE := strings.Contains(contentType, "text/event-stream") ||
+		strings.HasPrefix(bodyStr, "event:") ||
+		strings.HasPrefix(bodyStr, "data:") ||
+		strings.HasPrefix(bodyStr, ":")
+	if !isSSE {
+		return body, false, nil
+	}
+
+	for _, line := range strings.Split(bodyStr, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.HasPrefix(line, ":") {
+			// SSE comment frame — never payload (SSE spec: ignore ":" lines).
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if data != "" {
+				return []byte(data), true, nil
+			}
+		}
+	}
+
+	return nil, true, sseStreamEndedError(elapsed, timeoutSeconds, sseBodyProxyTimeoutSignaled(bodyStr))
+}
+
+// sseBodyProxyTimeoutSignaled reports whether the SSE body contains the
+// registry proxy's terminal timeout marker (a comment frame, so the marker
+// prefix already includes the ":"). Scanned over the whole body because the
+// marker is appended AFTER any partial frame the cut left behind — a
+// first-frames-only scan would miss it on mid-data-frame truncation.
+func sseBodyProxyTimeoutSignaled(bodyStr string) bool {
+	for _, line := range strings.Split(bodyStr, "\n") {
+		if strings.HasPrefix(strings.TrimRight(line, "\r"), sseProxyTimeoutMarker) {
+			return true
+		}
+	}
+	return false
+}
+
+// sseStreamEndedError shapes the failure for an SSE response that carried no
+// data frame. proxyTimeoutSignaled means the registry proxy explicitly marked
+// the stream as cut by its timeout cap; without that signal, elapsed wall
+// time consuming the X-Mesh-Timeout budget (with 1s slack for network and
+// scheduling jitter) is treated as a timeout, and anything quicker as a
+// protocol error (the agent or proxy closed the stream early).
+func sseStreamEndedError(elapsed time.Duration, timeoutSeconds int, proxyTimeoutSignaled bool) error {
+	budget := time.Duration(timeoutSeconds) * time.Second
+	if proxyTimeoutSignaled || (timeoutSeconds > 0 && elapsed >= budget-time.Second) {
+		return sseBudgetTimeoutError(elapsed, timeoutSeconds, "expired before the agent sent a response")
+	}
+	return fmt.Errorf(
+		"agent closed the SSE stream after %s without sending a response (X-Mesh-Timeout budget: %ds)",
+		elapsed.Round(100*time.Millisecond), timeoutSeconds)
+}
+
+// sseTruncatedFrameError shapes the failure for an SSE data frame that was
+// extracted but does not parse as JSON — the stream was cut mid-frame, so the
+// payload is incomplete. Timeout-shaped when the proxy's terminal marker is
+// in the body (it is appended after the partial frame) or the elapsed wall
+// time consumed the budget; otherwise a protocol error. Never falls back to
+// the raw body: that would report the truncated envelope (marker included) as
+// a successful result with exit 0.
+func sseTruncatedFrameError(bodyStr string, elapsed time.Duration, timeoutSeconds int) error {
+	budget := time.Duration(timeoutSeconds) * time.Second
+	if sseBodyProxyTimeoutSignaled(bodyStr) || (timeoutSeconds > 0 && elapsed >= budget-time.Second) {
+		return sseBudgetTimeoutError(elapsed, timeoutSeconds, "expired mid-response, cutting the result frame short")
+	}
+	return fmt.Errorf(
+		"agent sent a truncated or invalid SSE data frame after %s — the stream closed before the JSON payload completed (X-Mesh-Timeout budget: %ds)",
+		elapsed.Round(100*time.Millisecond), timeoutSeconds)
+}
+
+// sseBudgetTimeoutError renders the timeout-shaped error shared by the
+// data-less and truncated-frame SSE failure modes: names the budget, what it
+// cut (the `what` clause), and the --timeout remedy.
+func sseBudgetTimeoutError(elapsed time.Duration, timeoutSeconds int, what string) error {
+	budgetLabel := "the X-Mesh-Timeout budget"
+	if timeoutSeconds > 0 {
+		budgetLabel = fmt.Sprintf("the X-Mesh-Timeout budget (%ds)", timeoutSeconds)
+	}
+	suggested := timeoutSeconds * 2
+	if suggested <= 0 {
+		suggested = 120
+	}
+	return fmt.Errorf(
+		"call timed out after %s: %s %s — retry with a larger --timeout (e.g. --timeout %d)",
+		elapsed.Round(100*time.Millisecond), budgetLabel, what, suggested)
+}
+
 // callMCPToolWithHost makes an MCP tools/call request with a custom Host header (for ingress)
 func callMCPToolWithHost(client *http.Client, endpoint, hostHeader, toolName string, args map[string]interface{}, userHeaders http.Header, traceCtx *TraceContext, timeout int) (*MCPCallResult, error) {
 	// Inject trace context into arguments (for agents that can't access HTTP headers)
@@ -759,6 +882,7 @@ func callMCPToolWithHost(client *http.Client, endpoint, hostHeader, toolName str
 		req.Host = hostHeader
 	}
 
+	start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call agent at %s (Host: %s): %w", mcpURL, hostHeader, err)
@@ -782,26 +906,25 @@ func callMCPToolWithHost(client *http.Client, endpoint, hostHeader, toolName str
 		return nil, fmt.Errorf("agent returned status %d: %s", resp.StatusCode, string(body))
 	}
 
-	// Check if response is SSE format and extract JSON data
-	bodyStr := string(body)
-	jsonData := body
-
-	// SSE format: "event: message\ndata: {json}\n\n"
-	if strings.HasPrefix(bodyStr, "event:") || strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
-		// Extract JSON from SSE data line
-		for _, line := range strings.Split(bodyStr, "\n") {
-			if strings.HasPrefix(line, "data:") {
-				jsonData = []byte(strings.TrimPrefix(line, "data:"))
-				jsonData = []byte(strings.TrimSpace(string(jsonData)))
-				break
-			}
-		}
+	// Extract the JSON payload, SSE-aware (#1201): comment frames are skipped
+	// and a data-less SSE stream surfaces as a timeout/protocol error instead
+	// of leaking keepalive text as the "result".
+	jsonData, fromSSE, err := extractMCPResponseJSON(body, resp.Header.Get("Content-Type"), time.Since(start), timeout)
+	if err != nil {
+		return nil, err
 	}
 
 	// Parse MCP response
 	var mcpResp MCPResponse
 	if err := json.Unmarshal(jsonData, &mcpResp); err != nil {
-		// Return raw body if not valid JSON-RPC
+		if fromSSE {
+			// The extracted SSE data frame is not valid JSON — the stream was
+			// cut mid-frame. Never fall back to the raw body here: it is a
+			// transport envelope (keepalives, the proxy's timeout marker, the
+			// partial frame) and returning it would report garbage as success.
+			return nil, sseTruncatedFrameError(string(body), time.Since(start), timeout)
+		}
+		// Return raw body if not valid JSON-RPC (legacy plain-text responses)
 		return &MCPCallResult{Result: body, TraceID: traceID, SpanID: spanID}, nil
 	}
 
@@ -874,6 +997,7 @@ func callMCPTool(client *http.Client, endpoint, toolName string, args map[string
 		req.Header.Set("X-Trace-ID", traceCtx.TraceID)
 	}
 
+	start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call agent at %s: %w\n\n"+
@@ -902,26 +1026,25 @@ func callMCPTool(client *http.Client, endpoint, toolName string, args map[string
 		return nil, fmt.Errorf("agent returned status %d: %s", resp.StatusCode, string(body))
 	}
 
-	// Check if response is SSE format and extract JSON data
-	bodyStr := string(body)
-	jsonData := body
-
-	// SSE format: "event: message\ndata: {json}\n\n"
-	if strings.HasPrefix(bodyStr, "event:") || strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
-		// Extract JSON from SSE data line
-		for _, line := range strings.Split(bodyStr, "\n") {
-			if strings.HasPrefix(line, "data:") {
-				jsonData = []byte(strings.TrimPrefix(line, "data:"))
-				jsonData = []byte(strings.TrimSpace(string(jsonData)))
-				break
-			}
-		}
+	// Extract the JSON payload, SSE-aware (#1201): comment frames are skipped
+	// and a data-less SSE stream surfaces as a timeout/protocol error instead
+	// of leaking keepalive text as the "result".
+	jsonData, fromSSE, err := extractMCPResponseJSON(body, resp.Header.Get("Content-Type"), time.Since(start), timeout)
+	if err != nil {
+		return nil, err
 	}
 
 	// Parse MCP response
 	var mcpResp MCPResponse
 	if err := json.Unmarshal(jsonData, &mcpResp); err != nil {
-		// Return raw body if not valid JSON-RPC
+		if fromSSE {
+			// The extracted SSE data frame is not valid JSON — the stream was
+			// cut mid-frame. Never fall back to the raw body here: it is a
+			// transport envelope (keepalives, the proxy's timeout marker, the
+			// partial frame) and returning it would report garbage as success.
+			return nil, sseTruncatedFrameError(string(body), time.Since(start), timeout)
+		}
+		// Return raw body if not valid JSON-RPC (legacy plain-text responses)
 		return &MCPCallResult{Result: body, TraceID: traceID, SpanID: spanID}, nil
 	}
 

--- a/src/core/cli/call_test.go
+++ b/src/core/cli/call_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestFormatMCPError_DuplicatesCollapsed covers issue #956 item #11:
@@ -513,6 +514,239 @@ func TestCallMCPToolWithHost_UserHeadersAndFrameworkPrecedence(t *testing.T) {
 	}
 	if got.Get("X-Trace-ID") != "real-framework-trace" {
 		t.Errorf("framework X-Trace-ID should win, got %q", got.Get("X-Trace-ID"))
+	}
+}
+
+// --- extractMCPResponseJSON / SSE extraction (#1201) ---
+
+const sseContentType = "text/event-stream; charset=utf-8"
+
+// TestExtractMCPResponseJSON_CommentOnlyTimeoutShaped covers the #1201
+// repro: the proxy's X-Mesh-Timeout cap cut the stream after only an
+// sse-starlette keepalive comment arrived. The result must be a
+// timeout-shaped error naming the budget and the --timeout remedy — and
+// must NOT contain the raw comment text.
+func TestExtractMCPResponseJSON_CommentOnlyTimeoutShaped(t *testing.T) {
+	body := []byte(": ping - 2026-06-09 12:00:00.000000+00:00\r\n\r\n")
+	_, _, err := extractMCPResponseJSON(body, sseContentType, 30*time.Second, 30)
+	if err == nil {
+		t.Fatal("expected error for comment-only SSE stream, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"timed out", "X-Mesh-Timeout", "30", "--timeout"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("timeout error missing %q:\n%s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "ping") {
+		t.Errorf("raw keepalive comment leaked into the error: %s", msg)
+	}
+}
+
+// TestExtractMCPResponseJSON_QuickEmptyStreamProtocolError distinguishes a
+// stream that ended well within the budget: that's the agent (or proxy)
+// closing early, not a timeout — the error must not claim a timeout.
+func TestExtractMCPResponseJSON_QuickEmptyStreamProtocolError(t *testing.T) {
+	body := []byte("event: message\n\n")
+	_, _, err := extractMCPResponseJSON(body, sseContentType, 2*time.Second, 30)
+	if err == nil {
+		t.Fatal("expected error for data-less SSE stream, got nil")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "timed out") {
+		t.Errorf("quick empty stream must not be reported as a timeout: %s", msg)
+	}
+	if !strings.Contains(msg, "without sending a response") {
+		t.Errorf("protocol error missing explanation: %s", msg)
+	}
+}
+
+// TestExtractMCPResponseJSON_ProxyMarkerForcesTimeout covers the registry
+// proxy's terminal `: mesh-proxy-timeout` comment frame: when present, the
+// error is timeout-shaped even if local elapsed time is below the budget
+// (e.g. the proxy's own MCP_MESH_PROXY_TIMEOUT default fired first).
+func TestExtractMCPResponseJSON_ProxyMarkerForcesTimeout(t *testing.T) {
+	body := []byte(": ping - keepalive\n\n: mesh-proxy-timeout budget=30s\n\n")
+	_, _, err := extractMCPResponseJSON(body, sseContentType, 5*time.Second, 60)
+	if err == nil {
+		t.Fatal("expected error for marker-terminated SSE stream, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("proxy timeout marker must force a timeout-shaped error: %s", err.Error())
+	}
+}
+
+// TestExtractMCPResponseJSON_CommentsInterleavedDataWins: comment frames
+// before/after a real data frame are ignored and the data payload is
+// extracted intact.
+func TestExtractMCPResponseJSON_CommentsInterleavedDataWins(t *testing.T) {
+	body := []byte(": ping - 1\n\nevent: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n\n: ping - 2\n\n")
+	data, _, err := extractMCPResponseJSON(body, sseContentType, 30*time.Second, 30)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var resp MCPResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		t.Fatalf("extracted data is not valid JSON-RPC: %v\ndata: %s", err, data)
+	}
+	if resp.Result == nil {
+		t.Errorf("expected result in extracted payload, got: %s", data)
+	}
+}
+
+// TestExtractMCPResponseJSON_NormalSSEUnchanged: the plain happy path —
+// event + data frame, no comments.
+func TestExtractMCPResponseJSON_NormalSSEUnchanged(t *testing.T) {
+	body := []byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"hi\"}\n\n")
+	data, _, err := extractMCPResponseJSON(body, sseContentType, time.Second, 30)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := `{"jsonrpc":"2.0","id":1,"result":"hi"}`; string(data) != want {
+		t.Errorf("got %q, want %q", data, want)
+	}
+}
+
+// TestExtractMCPResponseJSON_PlainJSONPassthrough: non-SSE bodies are
+// returned untouched regardless of elapsed time.
+func TestExtractMCPResponseJSON_PlainJSONPassthrough(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`)
+	data, _, err := extractMCPResponseJSON(body, "application/json", time.Minute, 30)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != string(body) {
+		t.Errorf("plain JSON body altered: got %q", data)
+	}
+}
+
+// TestExtractMCPResponseJSON_SSEDetectionWithoutContentType: bodies that
+// look like SSE are handled even when Content-Type is missing (some proxies
+// strip it). Includes the comment-first body shape from sse-starlette.
+func TestExtractMCPResponseJSON_SSEDetectionWithoutContentType(t *testing.T) {
+	// data-first body, no content type
+	data, _, err := extractMCPResponseJSON([]byte("data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":1}\n\n"), "", time.Second, 30)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(data), `"result":1`) {
+		t.Errorf("data frame not extracted: %q", data)
+	}
+
+	// comment-only body, no content type — must still error, not pass through
+	_, _, err = extractMCPResponseJSON([]byte(": ping - ts\n\n"), "", 30*time.Second, 30)
+	if err == nil {
+		t.Fatal("comment-only body without Content-Type must error, got nil")
+	}
+}
+
+// TestCallMCPTool_CommentOnlySSEErrors wires the extraction through the full
+// callMCPTool path: an agent answering only a keepalive comment must produce
+// an error, not the comment text as a successful result.
+func TestCallMCPTool_CommentOnlySSEErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(": ping - 2026-06-09 12:00:00+00:00\r\n\r\n"))
+	}))
+	defer srv.Close()
+
+	result, err := callMCPTool(http.DefaultClient, srv.URL, "slow_tool", map[string]interface{}{}, nil, nil, 30)
+	if err == nil {
+		t.Fatalf("expected error for comment-only SSE response, got result: %+v", result)
+	}
+	if strings.Contains(err.Error(), "ping") {
+		t.Errorf("keepalive comment leaked into error: %s", err.Error())
+	}
+}
+
+// TestCallMCPTool_SSEWithCommentsStillSucceeds is the happy-path guard for
+// the full call path: keepalive comments around a real data frame don't
+// disturb the result.
+func TestCallMCPTool_SSEWithCommentsStillSucceeds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(": ping - keepalive\n\nevent: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n\n"))
+	}))
+	defer srv.Close()
+
+	result, err := callMCPTool(http.DefaultClient, srv.URL, "slow_tool", map[string]interface{}{}, nil, nil, 30)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(result.Result), `"ok":true`) {
+		t.Errorf("unexpected result payload: %s", result.Result)
+	}
+}
+
+// TestCallMCPTool_TruncatedDataFrameWithMarkerIsTimeout covers the
+// mid-data-frame cut: the proxy's X-Mesh-Timeout budget fires while the
+// result frame is in flight, leaving a partial `data:` payload followed by
+// the terminal timeout marker. The extracted frame fails to parse — that must
+// be a timeout-shaped error (the marker is in the body), NEVER the raw SSE
+// envelope returned as a successful result with exit 0.
+func TestCallMCPTool_TruncatedDataFrameWithMarkerIsTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"res\n: mesh-proxy-timeout budget=30s\n\n"))
+	}))
+	defer srv.Close()
+
+	result, err := callMCPTool(http.DefaultClient, srv.URL, "slow_tool", map[string]interface{}{}, nil, nil, 30)
+	if err == nil {
+		t.Fatalf("expected error for truncated SSE data frame, got result: %s", result.Result)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "timed out") {
+		t.Errorf("marker in body must force a timeout-shaped error: %s", msg)
+	}
+	if !strings.Contains(msg, "--timeout") {
+		t.Errorf("timeout error missing the --timeout remedy: %s", msg)
+	}
+	if strings.Contains(msg, "mesh-proxy-timeout") || strings.Contains(msg, `"jsonrpc"`) {
+		t.Errorf("raw SSE envelope leaked into the error: %s", msg)
+	}
+}
+
+// TestCallMCPTool_TruncatedDataFrameQuickCloseIsProtocolError: a partial data
+// frame with NO marker and the stream closed well within the budget is the
+// agent (or an intermediary) misbehaving — a protocol error, not a timeout,
+// and never the raw body as success.
+func TestCallMCPTool_TruncatedDataFrameQuickCloseIsProtocolError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"res"))
+	}))
+	defer srv.Close()
+
+	result, err := callMCPTool(http.DefaultClient, srv.URL, "slow_tool", map[string]interface{}{}, nil, nil, 30)
+	if err == nil {
+		t.Fatalf("expected error for truncated SSE data frame, got result: %s", result.Result)
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "timed out") {
+		t.Errorf("quick truncated frame must not be reported as a timeout: %s", msg)
+	}
+	if !strings.Contains(msg, "truncated or invalid SSE data frame") {
+		t.Errorf("protocol error missing truncation explanation: %s", msg)
+	}
+}
+
+// TestCallMCPTool_NonSSEPlainTextFallbackUnchanged: the raw-body fallback for
+// non-JSON-RPC responses survives for non-SSE bodies only (legacy plain-text
+// agents) — those still come back verbatim as a successful result.
+func TestCallMCPTool_NonSSEPlainTextFallbackUnchanged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("hello from a legacy agent"))
+	}))
+	defer srv.Close()
+
+	result, err := callMCPTool(http.DefaultClient, srv.URL, "legacy_tool", map[string]interface{}{}, nil, nil, 30)
+	if err != nil {
+		t.Fatalf("unexpected error for plain-text body: %v", err)
+	}
+	if string(result.Result) != "hello from a legacy agent" {
+		t.Errorf("plain-text fallback altered the body: %q", result.Result)
 	}
 }
 

--- a/src/core/cli/call_test.go
+++ b/src/core/cli/call_test.go
@@ -640,6 +640,140 @@ func TestExtractMCPResponseJSON_SSEDetectionWithoutContentType(t *testing.T) {
 	}
 }
 
+// TestSSEElapsedConsumedBudget pins the timeout-classification heuristic
+// shared by the data-less and truncated-frame paths. The 1s slack only
+// applies to budgets above 1s — for a 1s budget the slack would swallow the
+// whole budget and classify ANY close (however fast) as a timeout.
+func TestSSEElapsedConsumedBudget(t *testing.T) {
+	cases := []struct {
+		name           string
+		elapsed        time.Duration
+		timeoutSeconds int
+		want           bool
+	}{
+		{"1s budget, quick close", 100 * time.Millisecond, 1, false},
+		{"1s budget, just under", 999 * time.Millisecond, 1, false},
+		{"1s budget, fully consumed", time.Second, 1, true},
+		{"30s budget, within slack", 29 * time.Second, 30, true},
+		{"30s budget, quick close", 5 * time.Second, 30, false},
+		{"no budget", time.Hour, 0, false},
+		{"negative budget", time.Hour, -5, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := sseElapsedConsumedBudget(c.elapsed, c.timeoutSeconds); got != c.want {
+				t.Errorf("sseElapsedConsumedBudget(%v, %d) = %v, want %v", c.elapsed, c.timeoutSeconds, got, c.want)
+			}
+		})
+	}
+}
+
+// TestExtractMCPResponseJSON_OneSecondBudgetQuickClose: with a 1s budget, a
+// stream that closes almost immediately is a protocol error, not a timeout —
+// the old budget−1s slack made the threshold zero and misclassified every
+// quick close.
+func TestExtractMCPResponseJSON_OneSecondBudgetQuickClose(t *testing.T) {
+	body := []byte("event: message\n\n")
+	_, _, err := extractMCPResponseJSON(body, sseContentType, 100*time.Millisecond, 1)
+	if err == nil {
+		t.Fatal("expected error for data-less SSE stream, got nil")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "timed out") {
+		t.Errorf("quick close on a 1s budget must not be reported as a timeout: %s", msg)
+	}
+	if !strings.Contains(msg, "without sending a response") {
+		t.Errorf("protocol error missing explanation: %s", msg)
+	}
+}
+
+// TestExtractMCPResponseJSON_NotificationThenResult: MCP streamable-HTTP may
+// emit JSON-RPC notification frames (progress, logging) on the SAME stream
+// before the terminal response. The notification must be skipped — it would
+// unmarshal "successfully" into MCPResponse with nil Result/Error — and the
+// terminal result frame returned.
+func TestExtractMCPResponseJSON_NotificationThenResult(t *testing.T) {
+	body := []byte("event: message\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{\"progressToken\":\"t\",\"message\":\"working...\"}}\n\n" +
+		"event: message\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n\n")
+	data, fromSSE, err := extractMCPResponseJSON(body, sseContentType, time.Second, 30)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fromSSE {
+		t.Error("expected fromSSE=true")
+	}
+	var resp MCPResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		t.Fatalf("extracted data is not valid JSON-RPC: %v\ndata: %s", err, data)
+	}
+	if resp.Result == nil {
+		t.Errorf("expected the terminal result frame, got: %s", data)
+	}
+	if strings.Contains(string(data), "notifications/progress") {
+		t.Errorf("notification frame returned instead of the response: %s", data)
+	}
+}
+
+// TestExtractMCPResponseJSON_NotificationThenError: a terminal frame carrying
+// a top-level "error" key is also the response — returned so the caller
+// surfaces the JSON-RPC error.
+func TestExtractMCPResponseJSON_NotificationThenError(t *testing.T) {
+	body := []byte("data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\",\"params\":{\"level\":\"info\"}}\n\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32000,\"message\":\"boom\"}}\n\n")
+	data, _, err := extractMCPResponseJSON(body, sseContentType, time.Second, 30)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(data), "\"error\"") || strings.Contains(string(data), "notifications/message") {
+		t.Errorf("expected the terminal error frame, got: %s", data)
+	}
+}
+
+// TestExtractMCPResponseJSON_NotificationsOnlyErrors: a stream that carried
+// only notification frames and then closed is still a no-response condition —
+// it must error (mentioning the notifications), never return a notification
+// frame as the "result".
+func TestExtractMCPResponseJSON_NotificationsOnlyErrors(t *testing.T) {
+	body := []byte("event: message\n" +
+		"data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{\"progressToken\":\"t\",\"message\":\"working...\"}}\n\n")
+	_, _, err := extractMCPResponseJSON(body, sseContentType, 2*time.Second, 30)
+	if err == nil {
+		t.Fatal("expected error for notifications-only SSE stream, got nil")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "timed out") {
+		t.Errorf("quick notifications-only close must not be reported as a timeout: %s", msg)
+	}
+	if !strings.Contains(msg, "notification") {
+		t.Errorf("error should mention that notification frames arrived: %s", msg)
+	}
+	if strings.Contains(msg, "working...") {
+		t.Errorf("raw notification payload leaked into the error: %s", msg)
+	}
+}
+
+// TestExtractMCPResponseJSON_NotificationThenTruncatedFrame: a notification
+// followed by a cut-mid-payload response frame must surface the unparseable
+// frame (so the caller routes to sseTruncatedFrameError), not the
+// notification.
+func TestExtractMCPResponseJSON_NotificationThenTruncatedFrame(t *testing.T) {
+	partial := "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"co"
+	body := []byte("data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{}}\n\n" +
+		"data: " + partial + "\n")
+	data, fromSSE, err := extractMCPResponseJSON(body, sseContentType, time.Second, 30)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fromSSE {
+		t.Error("expected fromSSE=true")
+	}
+	if string(data) != partial {
+		t.Errorf("expected the truncated frame back for downstream truncation handling, got: %s", data)
+	}
+}
+
 // TestCallMCPTool_CommentOnlySSEErrors wires the extraction through the full
 // callMCPTool path: an agent answering only a keepalive comment must produce
 // an error, not the comment text as a successful result.

--- a/src/core/cli/list.go
+++ b/src/core/cli/list.go
@@ -2600,16 +2600,11 @@ func getToolDetailsFromAgent(endpoint, toolName, registryURL string) *MCPToolInf
 		return nil
 	}
 
-	// Parse SSE if needed
-	bodyStr := string(body)
-	jsonData := body
-	if strings.HasPrefix(bodyStr, "event:") || strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
-		for _, line := range strings.Split(bodyStr, "\n") {
-			if strings.HasPrefix(line, "data:") {
-				jsonData = []byte(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
-				break
-			}
-		}
+	// Parse SSE if needed (shared comment-frame-aware extraction, #1201).
+	// This lookup is best-effort: a data-less stream just yields nil details.
+	jsonData, _, err := extractMCPResponseJSON(body, resp.Header.Get("Content-Type"), 0, 0)
+	if err != nil {
+		return nil
 	}
 
 	// Parse response

--- a/src/core/registry/ent_handlers.go
+++ b/src/core/registry/ent_handlers.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"mime"
 	"net"
 	"net/http"
 	"os"
@@ -935,8 +936,17 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 	// produced. Flush after every chunk so streamed (SSE) responses aren't
 	// held back by the response writer's buffer; gin's ResponseWriter
 	// implements http.Flusher.
-	isSSE := strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream")
-	relayProxyStream(c.Writer, resp.Body, isSSE, targetURL, proxyTimeout, start)
+	relayProxyStream(c.Writer, resp.Body, isSSEContentType(resp.Header.Get("Content-Type")), targetURL, proxyTimeout, start)
+}
+
+// isSSEContentType reports whether a Content-Type header value denotes an SSE
+// response. Parsed with mime.ParseMediaType (case-insensitive, parameters
+// like `; charset=utf-8` stripped) and matched exactly — a substring check
+// would false-positive on unrelated types that merely embed the string.
+// Unparseable values are treated as non-SSE.
+func isSSEContentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	return err == nil && mediaType == "text/event-stream"
 }
 
 // proxyTimeoutCommentMarker is the terminal SSE comment frame appended by

--- a/src/core/registry/ent_handlers.go
+++ b/src/core/registry/ent_handlers.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -910,6 +911,7 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 		client.Transport = transport
 	}
 
+	start := time.Now()
 	resp, err := client.Do(proxyReq)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, generated.ErrorResponse{
@@ -933,23 +935,89 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 	// produced. Flush after every chunk so streamed (SSE) responses aren't
 	// held back by the response writer's buffer; gin's ResponseWriter
 	// implements http.Flusher.
+	isSSE := strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream")
+	relayProxyStream(c.Writer, resp.Body, isSSE, targetURL, proxyTimeout, start)
+}
+
+// proxyTimeoutCommentMarker is the terminal SSE comment frame appended by
+// relayProxyStream when the upstream exchange is cut by the X-Mesh-Timeout
+// budget mid-stream (#1201).
+// Keep in sync with sseProxyTimeoutMarker in src/core/cli/call.go and
+// SSE_PROXY_TIMEOUT_MARKER in src/runtime/typescript/src/proxy.ts. The
+// emitted literal (`: mesh-proxy-timeout budget=<N>s`) is pinned by
+// src/core/registry/proxy_stream_test.go and matched by the consumer tests in
+// src/core/cli/call_test.go — a drift here breaks the partner's tests.
+const proxyTimeoutCommentMarker = "mesh-proxy-timeout"
+
+// streamFlusher is the slice of gin.ResponseWriter that relayProxyStream
+// needs — an interface so the relay loop is unit-testable without gin.
+type streamFlusher interface {
+	io.Writer
+	Flush()
+}
+
+// relayProxyStream copies the upstream response body to the client, flushing
+// after every chunk (preserves the #1177 streaming behavior: SSE frames reach
+// the client as they are produced and large bodies are never buffered whole).
+//
+// Terminal-signal design for timeout cuts (#1201): when the X-Mesh-Timeout
+// budget expires mid-stream, the headers (200 + chunked) are long gone, so
+// there is no HTTP-level way to report the failure. For SSE responses the
+// only spec-compliant in-band channel is a comment frame — ":"-prefixed lines
+// are ignored by conforming SSE clients, so emitting one cannot break foreign
+// consumers, while mesh clients (meshctl) detect it and report a precise
+// timeout error instead of guessing from elapsed time. HTTP trailers were
+// rejected: they require pre-declaration before the first body byte and are
+// invisible to fetch()/EventSource consumers. For non-SSE bodies no marker is
+// appended (it would corrupt the JSON payload); truncated JSON is already
+// transport-detectable client-side via parse failure.
+func relayProxyStream(w streamFlusher, upstream io.Reader, isSSE bool, targetURL string, budget time.Duration, start time.Time) {
 	buf := make([]byte, 32*1024)
 	for {
-		n, rerr := resp.Body.Read(buf)
+		n, rerr := upstream.Read(buf)
 		if n > 0 {
-			if _, werr := c.Writer.Write(buf[:n]); werr != nil {
+			if _, werr := w.Write(buf[:n]); werr != nil {
 				// Client went away — nothing useful left to do.
 				return
 			}
-			c.Writer.Flush()
+			w.Flush()
 		}
-		if rerr != nil {
-			if rerr != io.EOF {
-				log.Printf("WARNING: proxy stream from %s ended early: %v", targetURL, rerr)
-			}
+		if rerr == nil {
+			continue
+		}
+		if rerr == io.EOF {
 			return
 		}
+		if isProxyTimeoutError(rerr) {
+			log.Printf("WARNING: proxy stream from %s cut by X-Mesh-Timeout budget (%s) after %s: %v",
+				targetURL, budget, time.Since(start).Round(time.Millisecond), rerr)
+			if isSSE {
+				// Leading newline guards against a cut mid-line: it terminates
+				// any partial frame so the comment starts at a line boundary.
+				// %g keeps sub-second budgets meaningful (budget=0.5s, not
+				// budget=0s) while whole seconds stay terse (budget=30s).
+				if _, werr := fmt.Fprintf(w, "\n: %s budget=%gs\n\n", proxyTimeoutCommentMarker, budget.Seconds()); werr == nil {
+					w.Flush()
+				}
+			}
+		} else {
+			log.Printf("WARNING: proxy stream from %s ended early: %v", targetURL, rerr)
+		}
+		return
 	}
+}
+
+// isProxyTimeoutError reports whether a body-read error came from the proxy
+// http.Client's Timeout (the X-Mesh-Timeout cap) rather than a genuine
+// upstream failure. Covers both shapes Go produces: context.DeadlineExceeded
+// (and wrappers) and net.Error timeouts (http's "Client.Timeout exceeded
+// while reading body" error implements net.Error with Timeout() == true).
+func isProxyTimeoutError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var nerr net.Error
+	return errors.As(err, &nerr) && nerr.Timeout()
 }
 
 // proxyTLSCacheEntry holds the cached mTLS transport for the proxy along with

--- a/src/core/registry/proxy_stream_test.go
+++ b/src/core/registry/proxy_stream_test.go
@@ -1,0 +1,189 @@
+package registry
+
+// Tests for relayProxyStream's timeout terminal signal (#1201): when the
+// X-Mesh-Timeout budget cuts an SSE exchange mid-stream, the proxy appends a
+// `: mesh-proxy-timeout` SSE comment frame (spec-compliant — conforming
+// clients ignore ":"-prefixed lines) so mesh clients can distinguish budget
+// expiry from a normal end-of-stream. Non-SSE bodies are never decorated
+// (it would corrupt the JSON payload), and the #1177 flush-per-chunk relay
+// behavior is preserved.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// flushRecorder implements streamFlusher over a buffer and counts flushes.
+type flushRecorder struct {
+	buf       bytes.Buffer
+	flushes   int
+	failWrite bool // when true, all writes fail (models a departed client)
+}
+
+func (f *flushRecorder) Write(p []byte) (int, error) {
+	if f.failWrite {
+		return 0, errors.New("client went away")
+	}
+	return f.buf.Write(p)
+}
+
+func (f *flushRecorder) Flush() { f.flushes++ }
+
+// scriptedReader yields each chunk on its own Read call, then returns the
+// final error (io.EOF for a clean stream end, a timeout error for a cut).
+type scriptedReader struct {
+	chunks []string
+	final  error
+}
+
+func (r *scriptedReader) Read(p []byte) (int, error) {
+	if len(r.chunks) == 0 {
+		return 0, r.final
+	}
+	n := copy(p, r.chunks[0])
+	if n < len(r.chunks[0]) {
+		r.chunks[0] = r.chunks[0][n:]
+	} else {
+		r.chunks = r.chunks[1:]
+	}
+	return n, nil
+}
+
+func TestRelayProxyStream_TimeoutCutSSEAppendsMarker(t *testing.T) {
+	upstream := &scriptedReader{
+		chunks: []string{": ping - 2026-06-09 12:00:00+00:00\r\n\r\n"},
+		final:  context.DeadlineExceeded,
+	}
+	w := &flushRecorder{}
+
+	relayProxyStream(w, upstream, true, "http://agent:8080/mcp", 30*time.Second, time.Now())
+
+	out := w.buf.String()
+	if !strings.HasPrefix(out, ": ping") {
+		t.Errorf("relayed bytes must precede the marker:\n%q", out)
+	}
+	if !strings.Contains(out, ": "+proxyTimeoutCommentMarker+" budget=30s") {
+		t.Errorf("expected terminal timeout comment frame in output:\n%q", out)
+	}
+	if !strings.HasSuffix(out, "\n\n") {
+		t.Errorf("terminal comment frame must end with a blank line:\n%q", out)
+	}
+	if w.flushes < 2 {
+		t.Errorf("expected flush after relay chunk AND after marker, got %d flushes", w.flushes)
+	}
+}
+
+func TestRelayProxyStream_SubSecondBudgetRendersFraction(t *testing.T) {
+	// Sub-second budgets (e.g. MCP_MESH_PROXY_TIMEOUT=500ms) must render as a
+	// fraction, not collapse to the nonsensical "budget=0s".
+	upstream := &scriptedReader{
+		chunks: []string{": ping\n\n"},
+		final:  context.DeadlineExceeded,
+	}
+	w := &flushRecorder{}
+
+	relayProxyStream(w, upstream, true, "http://agent:8080/mcp", 500*time.Millisecond, time.Now())
+
+	out := w.buf.String()
+	if !strings.Contains(out, ": "+proxyTimeoutCommentMarker+" budget=0.5s") {
+		t.Errorf("sub-second budget not rendered as a fraction:\n%q", out)
+	}
+}
+
+func TestRelayProxyStream_TimeoutCutNonSSENoMarker(t *testing.T) {
+	// A JSON body cut by the timeout must NOT be decorated — appending
+	// anything would corrupt the payload; truncation is parse-detectable.
+	upstream := &scriptedReader{
+		chunks: []string{`{"jsonrpc":"2.0","id":1,"result":{"par`},
+		final:  os.ErrDeadlineExceeded, // net.Error with Timeout() == true
+	}
+	w := &flushRecorder{}
+
+	relayProxyStream(w, upstream, false, "http://agent:8080/mcp", 30*time.Second, time.Now())
+
+	out := w.buf.String()
+	if strings.Contains(out, proxyTimeoutCommentMarker) {
+		t.Errorf("non-SSE body must not get the marker appended:\n%q", out)
+	}
+	if out != `{"jsonrpc":"2.0","id":1,"result":{"par` {
+		t.Errorf("relayed bytes altered:\n%q", out)
+	}
+}
+
+func TestRelayProxyStream_CleanEOFRelaysVerbatim(t *testing.T) {
+	body := "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"ok\"}\n\n"
+	upstream := &scriptedReader{
+		chunks: []string{body[:20], body[20:]},
+		final:  io.EOF,
+	}
+	w := &flushRecorder{}
+
+	relayProxyStream(w, upstream, true, "http://agent:8080/mcp", 30*time.Second, time.Now())
+
+	if got := w.buf.String(); got != body {
+		t.Errorf("clean stream altered:\ngot  %q\nwant %q", got, body)
+	}
+	if strings.Contains(w.buf.String(), proxyTimeoutCommentMarker) {
+		t.Errorf("marker must not appear on a clean EOF")
+	}
+	// #1177 behavior: flush after every chunk.
+	if w.flushes != 2 {
+		t.Errorf("expected one flush per chunk (2), got %d", w.flushes)
+	}
+}
+
+func TestRelayProxyStream_NonTimeoutErrorNoMarker(t *testing.T) {
+	upstream := &scriptedReader{
+		chunks: []string{": ping\n\n"},
+		final:  errors.New("connection reset by peer"),
+	}
+	w := &flushRecorder{}
+
+	relayProxyStream(w, upstream, true, "http://agent:8080/mcp", 30*time.Second, time.Now())
+
+	if strings.Contains(w.buf.String(), proxyTimeoutCommentMarker) {
+		t.Errorf("non-timeout upstream error must not emit the timeout marker:\n%q", w.buf.String())
+	}
+}
+
+func TestRelayProxyStream_ClientGoneStopsRelay(t *testing.T) {
+	upstream := &scriptedReader{
+		chunks: []string{"data: chunk1\n\n", "data: chunk2\n\n"},
+		final:  io.EOF,
+	}
+	w := &flushRecorder{failWrite: true}
+
+	// Must return without panicking or spinning; nothing relayed, no flushes.
+	relayProxyStream(w, upstream, true, "http://agent:8080/mcp", 30*time.Second, time.Now())
+
+	if w.buf.Len() != 0 || w.flushes != 0 {
+		t.Errorf("expected no output/flushes after client write failure, got %q / %d flushes", w.buf.String(), w.flushes)
+	}
+}
+
+func TestIsProxyTimeoutError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"context deadline", context.DeadlineExceeded, true},
+		{"wrapped context deadline", errors.Join(errors.New("while reading body"), context.DeadlineExceeded), true},
+		{"net timeout (os deadline)", os.ErrDeadlineExceeded, true},
+		{"plain error", errors.New("connection reset"), false},
+		{"eof", io.EOF, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isProxyTimeoutError(c.err); got != c.want {
+				t.Errorf("isProxyTimeoutError(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}

--- a/src/core/registry/proxy_stream_test.go
+++ b/src/core/registry/proxy_stream_test.go
@@ -167,6 +167,34 @@ func TestRelayProxyStream_ClientGoneStopsRelay(t *testing.T) {
 	}
 }
 
+// TestIsSSEContentType pins the proxy's SSE detection to exact media-type
+// matching: parameterized and case-variant forms of text/event-stream are
+// SSE, while unrelated types that merely embed the string (which a substring
+// check would false-positive on) are not.
+func TestIsSSEContentType(t *testing.T) {
+	cases := []struct {
+		contentType string
+		want        bool
+	}{
+		{"text/event-stream", true},
+		{"text/event-stream; charset=utf-8", true},
+		{"TEXT/EVENT-STREAM", true},
+		{"application/json", false},
+		{"application/json; charset=utf-8", false},
+		{"text/event-stream-json", false},
+		{`application/json; note="text/event-stream"`, false},
+		{"", false},
+		{"not a media type;;;", false},
+	}
+	for _, c := range cases {
+		t.Run(c.contentType, func(t *testing.T) {
+			if got := isSSEContentType(c.contentType); got != c.want {
+				t.Errorf("isSSEContentType(%q) = %v, want %v", c.contentType, got, c.want)
+			}
+		})
+	}
+}
+
 func TestIsProxyTimeoutError(t *testing.T) {
 	cases := []struct {
 		name string

--- a/src/runtime/core/src/mcp_client.rs
+++ b/src/runtime/core/src/mcp_client.rs
@@ -416,6 +416,35 @@ mod tests {
         assert!(result.unwrap_err().contains("No valid JSON"));
     }
 
+    #[test]
+    fn test_parse_sse_comment_only_keepalive_errors() {
+        // #1201: a stream cut by the proxy's X-Mesh-Timeout cap can consist
+        // of nothing but an sse-starlette keepalive comment frame. Comment
+        // frames are not payload — this must error (Python's SSEParser
+        // surfaces it as RuntimeError), never parse as a result.
+        let sse = ": ping - 2026-06-09 12:00:00.000000+00:00\r\n\r\n";
+        assert!(parse_sse_response(sse).is_err());
+    }
+
+    #[test]
+    fn test_parse_sse_event_with_comments_but_no_data_errors() {
+        // Same cut-stream class with SSE markers present: zero data frames
+        // must error, not return empty success.
+        let sse = "event: message\n: ping - keepalive\n\n";
+        let result = parse_sse_response(sse);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("No valid JSON"));
+    }
+
+    #[test]
+    fn test_parse_sse_comments_interleaved_with_data_ignored() {
+        // Keepalive comments around a real data frame don't disturb parsing.
+        let sse = ": ping - 1\n\nevent: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":\"ok\"}\n\n: ping - 2\n\n";
+        let result = parse_sse_response(sse).unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["result"], "ok");
+    }
+
     // =========================================================================
     // extract_content
     // =========================================================================

--- a/src/runtime/typescript/src/__tests__/proxy-sse-no-data.test.ts
+++ b/src/runtime/typescript/src/__tests__/proxy-sse-no-data.test.ts
@@ -137,6 +137,27 @@ describe("callMcpTool SSE no-data EOF handling (#1201)", () => {
     expect(value).toBe("fine");
   });
 
+  it("accepts a data frame without the space after the colon (SSE spec: zero or one space)", async () => {
+    const noSpaceFrame = `event: message\ndata:${JSON.stringify({
+      jsonrpc: "2.0",
+      id: "x",
+      result: { content: [{ type: "text", text: "fine" }] },
+    })}\n\n`;
+    mockFetch(() => rawSseResponse([noSpaceFrame]));
+
+    const value = await callMcpTool(ENDPOINT, TOOL, {}, DEFAULT_CALL_OPTIONS, CAPABILITY);
+    expect(value).toBe("fine");
+  });
+
+  it("skips the [DONE] sentinel in both spacing forms and still extracts the result", async () => {
+    mockFetch(() =>
+      rawSseResponse(["data: [DONE]\n\n", "data:[DONE]\n\n", RESULT_FRAME])
+    );
+
+    const value = await callMcpTool(ENDPOINT, TOOL, {}, DEFAULT_CALL_OPTIONS, CAPABILITY);
+    expect(value).toBe("fine");
+  });
+
   it("proxy timeout marker + no result frame → timeout-classified, not retried", async () => {
     // The registry proxy's terminal `: mesh-proxy-timeout budget=<N>s`
     // comment frame (#1201) marks the X-Mesh-Timeout budget as spent.

--- a/src/runtime/typescript/src/__tests__/proxy-sse-no-data.test.ts
+++ b/src/runtime/typescript/src/__tests__/proxy-sse-no-data.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Unit tests for SSE no-data/comment-only EOF handling in callMcpTool (#1201).
+ *
+ * When a producer holds a response past the proxy's X-Mesh-Timeout budget,
+ * the registry proxy cuts the exchange with a clean EOF whose accumulated
+ * body may be nothing but sse-starlette keepalive comment frames
+ * (`: ping - <ts>`). Per the SSE spec, ":"-prefixed comment frames must be
+ * ignored — and a stream that ends with ZERO result frames is a cut
+ * exchange that must reject, never resolve as an empty-string success
+ * (which would poison LLM tool loops and record success spans).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { callMcpTool, DEFAULT_CALL_OPTIONS } from "../proxy.js";
+
+vi.mock("@mcpmesh/core", () => ({
+  generateTraceId: () => "trace-mock",
+  generateSpanId: () => "span-mock",
+  injectTraceContext: (argsJson: string) => argsJson,
+  publishSpan: vi.fn(async () => false),
+  parseSseResponse: (s: string) => s,
+  parseSseResponseToObject: (s: string) => JSON.parse(s),
+  awaitJobCancel: vi.fn(() => new Promise<void>(() => {})),
+  matchesPropagateHeader: () => false,
+}));
+
+vi.mock("../http-pool.js", () => ({
+  getDispatcher: () => undefined,
+}));
+
+const ENDPOINT = "http://producer.local:9000";
+const TOOL = "slow_tool";
+const CAPABILITY = "slow_capability";
+
+/** Build a Response streaming the given raw SSE chunks verbatim. */
+function rawSseResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  let i = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(encoder.encode(chunks[i]));
+        i += 1;
+      } else {
+        controller.close();
+      }
+    },
+  });
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    body: stream,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "text/event-stream" : null,
+    },
+  } as unknown as Response;
+}
+
+function mockFetch(makeResponse: () => Response): ReturnType<typeof vi.fn> {
+  // Fresh Response per call so retries don't reuse a consumed SSE body.
+  const fetchMock = vi.fn(async () => makeResponse());
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+const RESULT_FRAME = `event: message\ndata: ${JSON.stringify({
+  jsonrpc: "2.0",
+  id: "x",
+  result: { content: [{ type: "text", text: "fine" }] },
+})}\n\n`;
+
+describe("callMcpTool SSE no-data EOF handling (#1201)", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("rejects a comment-only stream (keepalive ping then proxy cut)", async () => {
+    mockFetch(() => rawSseResponse([": ping - 2026-06-09 12:00:00+00:00\r\n\r\n"]));
+
+    await expect(
+      callMcpTool(ENDPOINT, TOOL, {}, DEFAULT_CALL_OPTIONS, CAPABILITY)
+    ).rejects.toThrow("ended without a result frame");
+  });
+
+  it("rejects a fully empty stream (zero bytes before EOF)", async () => {
+    mockFetch(() => rawSseResponse([]));
+
+    await expect(
+      callMcpTool(ENDPOINT, TOOL, {}, DEFAULT_CALL_OPTIONS, CAPABILITY)
+    ).rejects.toThrow("ended without a result frame");
+  });
+
+  it("rejects a notifications-only stream that never delivers the result", async () => {
+    const notification = `event: message\ndata: ${JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/progress",
+      params: { progressToken: "t", message: "working..." },
+    })}\n\n`;
+    mockFetch(() => rawSseResponse([notification]));
+
+    await expect(
+      callMcpTool(ENDPOINT, TOOL, {}, DEFAULT_CALL_OPTIONS, CAPABILITY)
+    ).rejects.toThrow("ended without a result frame");
+  });
+
+  it("ignores comment frames interleaved with a real result frame", async () => {
+    mockFetch(() =>
+      rawSseResponse([": ping - keepalive 1\r\n\r\n", RESULT_FRAME, ": ping - keepalive 2\r\n\r\n"])
+    );
+
+    const value = await callMcpTool(ENDPOINT, TOOL, {}, DEFAULT_CALL_OPTIONS, CAPABILITY);
+    expect(value).toBe("fine");
+  });
+
+  it("still extracts a result frame whose final line lacks a trailing newline", async () => {
+    // A proxy cut can drop the final newline; the leftover-buffer drain must
+    // still parse a complete data line.
+    mockFetch(() => rawSseResponse([RESULT_FRAME.trimEnd()]));
+
+    const value = await callMcpTool(ENDPOINT, TOOL, {}, DEFAULT_CALL_OPTIONS, CAPABILITY);
+    expect(value).toBe("fine");
+  });
+
+  it("normal SSE result path unchanged (sanity)", async () => {
+    mockFetch(() => rawSseResponse([RESULT_FRAME]));
+
+    const value = await callMcpTool(ENDPOINT, TOOL, {}, DEFAULT_CALL_OPTIONS, CAPABILITY);
+    expect(value).toBe("fine");
+  });
+
+  it("proxy timeout marker + no result frame → timeout-classified, not retried", async () => {
+    // The registry proxy's terminal `: mesh-proxy-timeout budget=<N>s`
+    // comment frame (#1201) marks the X-Mesh-Timeout budget as spent.
+    // Classification must match local abort-timeouts: a single attempt even
+    // with retries configured (a retry would burn another full budget), and
+    // a message naming the proxy budget.
+    const fetchMock = mockFetch(() =>
+      rawSseResponse([": ping - keepalive\r\n\r\n", ": mesh-proxy-timeout budget=30s\n\n"])
+    );
+
+    await expect(
+      callMcpTool(ENDPOINT, TOOL, {}, { ...DEFAULT_CALL_OPTIONS, maxAttempts: 2 }, CAPABILITY)
+    ).rejects.toThrow(/timed out: registry proxy X-Mesh-Timeout budget \(30s\)/);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("proxy timeout marker after a complete result frame → data wins", async () => {
+    // A marker can only follow a complete frame on a pathological proxy, but
+    // the contract stays: a delivered result is a success, marker or not.
+    mockFetch(() =>
+      rawSseResponse([RESULT_FRAME, ": mesh-proxy-timeout budget=30s\n\n"])
+    );
+
+    const value = await callMcpTool(ENDPOINT, TOOL, {}, DEFAULT_CALL_OPTIONS, CAPABILITY);
+    expect(value).toBe("fine");
+  });
+
+  it("no marker → generic no-result error stays retryable", async () => {
+    const fetchMock = mockFetch(() => rawSseResponse([": ping - keepalive\r\n\r\n"]));
+
+    await expect(
+      callMcpTool(ENDPOINT, TOOL, {}, { ...DEFAULT_CALL_OPTIONS, maxAttempts: 2, retryDelay: 1 }, CAPABILITY)
+    ).rejects.toThrow("ended without a result frame");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/runtime/typescript/src/__tests__/sse.test.ts
+++ b/src/runtime/typescript/src/__tests__/sse.test.ts
@@ -169,6 +169,20 @@ data: {"step": 3, "complete": true}
     expect(results[2].complete).toBe(true);
   });
 
+  it("should parse data lines without the space after the colon (SSE spec: zero or one space)", () => {
+    const sse = `event: progress
+data:{"step": 1}
+
+event: done
+data: {"step": 2}
+`;
+    const results = parseSSEStream<{ step: number }>(sse);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].step).toBe(1);
+    expect(results[1].step).toBe(2);
+  });
+
   it("should return empty array for non-SSE content", () => {
     const json = '{"result": 42}';
     const results = parseSSEStream(json);

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -929,8 +929,11 @@ async function readSSEResponseToContent(response: Response): Promise<string | Mu
       proxyTimeoutBudget = /budget=([0-9.]+s)/.exec(line)?.[1] ?? null;
       return;
     }
-    if (!line.startsWith("data: ")) return;
-    const data = line.slice(6);
+    if (!line.startsWith("data:")) return;
+    // Per the SSE spec the colon may be followed by zero or one space:
+    // strip the field name, then at most one leading space.
+    let data = line.slice(5);
+    if (data.startsWith(" ")) data = data.slice(1);
     if (data === "[DONE]") return;
 
     let event: unknown;

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -463,10 +463,11 @@ export async function callMcpTool(
           // Mirror the JSON path below: JSON-RPC errors and tool-level errors
           // (CallToolResult.isError) thrown by the SSE reader record an error
           // span instead of a success span. Aborts (timeout or job-cancel
-          // firing mid-read) are deliberately NOT published here — the outer
-          // catch owns abort/timeout accounting, and publishing in both
-          // places would emit two spans with the same spanId.
-          if (!isTimeoutError(sseErr)) {
+          // firing mid-read) and the proxy's in-band timeout marker (#1201)
+          // are deliberately NOT published here — the outer catch owns
+          // timeout accounting, and publishing in both places would emit two
+          // spans with the same spanId.
+          if (!isTimeoutError(sseErr) && !(sseErr instanceof ProxyTimeoutError)) {
             const sseErrMsg = sseErr instanceof Error ? sseErr.message : String(sseErr);
             publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, sseErrMsg, "error", requestBytes, sseResponseBytes);
           }
@@ -514,6 +515,17 @@ export async function callMcpTool(
       if (isTimeoutError(lastError)) {
         publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, "timeout", "error", requestBytes);
         throw new Error(`MCP call timed out after ${effectiveTimeout}ms`);
+      }
+
+      // Don't retry on the proxy's in-band timeout marker either (#1201):
+      // the X-Mesh-Timeout budget is definitively spent, so a retry would
+      // burn another full budget against an exchange the proxy already cut.
+      // Same accounting as the local abort above: one error span, immediate
+      // throw — the message names the proxy budget, matching meshctl's
+      // report of the same cut.
+      if (lastError instanceof ProxyTimeoutError) {
+        publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, lastError.message, "error", requestBytes);
+        throw lastError;
       }
 
       // Retry everything else (network, HTTP, protocol, and tool-level
@@ -857,6 +869,36 @@ function toolErrorMessage(innerResult: unknown): string | null {
 }
 
 /**
+ * Terminal SSE comment frame the registry proxy appends when the upstream
+ * exchange is cut by the X-Mesh-Timeout budget mid-stream (#1201). Emitted as
+ * `: mesh-proxy-timeout budget=<N>s`. Comment frames are invisible to
+ * conforming SSE clients per the SSE spec, which makes this a spec-compliant
+ * in-band timeout signal.
+ * Keep in sync with proxyTimeoutCommentMarker in
+ * src/core/registry/ent_handlers.go and sseProxyTimeoutMarker in
+ * src/core/cli/call.go. The literal is pinned by
+ * src/core/registry/proxy_stream_test.go and the consumer tests in
+ * src/__tests__/proxy-sse-no-data.test.ts — a drift in either package breaks
+ * the partner's tests.
+ */
+const SSE_PROXY_TIMEOUT_MARKER = ": mesh-proxy-timeout";
+
+/**
+ * Thrown when an SSE stream ends without a result frame AND the registry
+ * proxy's timeout marker was seen: the X-Mesh-Timeout budget is definitively
+ * spent. callMcpTool classifies this like its local abort-timeouts — NOT
+ * retried (a retry would burn another full budget against an exchange the
+ * proxy already cut) and exactly one error span via the timeout accounting
+ * path — so the runtime-side report agrees with meshctl's for the same cut.
+ */
+class ProxyTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProxyTimeoutError";
+  }
+}
+
+/**
  * Read an SSE response from the MCP HTTP Streamable transport down to its
  * final content (the JSON-RPC `result`).
  *
@@ -872,6 +914,54 @@ async function readSSEResponseToContent(response: Response): Promise<string | Mu
   const decoder = new TextDecoder();
   let buffer = "";
   let result: string | MultiContentResult = "";
+  let sawResult = false;
+  let proxyTimeoutBudget: string | null = null;
+  let proxyTimeoutSignaled = false;
+
+  // Handle a single SSE line. Comment frames (":"-prefixed, e.g.
+  // sse-starlette's `: ping - <ts>` keepalives) and other non-data lines are
+  // ignored per the SSE spec — only `data:` frames carry payload (#1201) —
+  // except the proxy's terminal timeout marker, which is tracked so a
+  // result-less stream end can be reported as a definitive timeout.
+  const handleLine = (line: string): void => {
+    if (line.startsWith(SSE_PROXY_TIMEOUT_MARKER)) {
+      proxyTimeoutSignaled = true;
+      proxyTimeoutBudget = /budget=([0-9.]+s)/.exec(line)?.[1] ?? null;
+      return;
+    }
+    if (!line.startsWith("data: ")) return;
+    const data = line.slice(6);
+    if (data === "[DONE]") return;
+
+    let event: unknown;
+    try {
+      event = JSON.parse(data);
+    } catch {
+      // Ignore parse errors for non-JSON data events
+      return;
+    }
+
+    // Handle JSON-RPC response — mirror callMcpTool's JSON path exactly so
+    // callers can't distinguish transports: protocol-level error first,
+    // then tool-level isError, then content extraction.
+    const jsonRpcEvent = event as { result?: unknown; error?: { message?: string } };
+    if (jsonRpcEvent.error) {
+      throw new Error(
+        `MCP error: ${jsonRpcEvent.error.message ?? JSON.stringify(jsonRpcEvent.error)}`
+      );
+    }
+    // Key-presence (not truthiness) so legitimately falsy results
+    // (null, "", 0) are extracted just like the JSON path does. Events
+    // without a `result` key (e.g. notifications) are skipped.
+    if (event && typeof event === "object" && "result" in event) {
+      const toolErrMsg = toolErrorMessage(jsonRpcEvent.result);
+      if (toolErrMsg !== null) {
+        throw new Error(`MCP tool error: ${toolErrMsg}`);
+      }
+      sawResult = true;
+      result = extractContent(jsonRpcEvent.result);
+    }
+  };
 
   while (true) {
     const { done, value } = await reader.read();
@@ -884,39 +974,32 @@ async function readSSEResponseToContent(response: Response): Promise<string | Mu
     buffer = lines.pop() ?? ""; // Keep incomplete line
 
     for (const line of lines) {
-      if (line.startsWith("data: ")) {
-        const data = line.slice(6);
-        if (data === "[DONE]") continue;
-
-        let event: unknown;
-        try {
-          event = JSON.parse(data);
-        } catch {
-          // Ignore parse errors for non-JSON data events
-          continue;
-        }
-
-        // Handle JSON-RPC response — mirror callMcpTool's JSON path exactly so
-        // callers can't distinguish transports: protocol-level error first,
-        // then tool-level isError, then content extraction.
-        const jsonRpcEvent = event as { result?: unknown; error?: { message?: string } };
-        if (jsonRpcEvent.error) {
-          throw new Error(
-            `MCP error: ${jsonRpcEvent.error.message ?? JSON.stringify(jsonRpcEvent.error)}`
-          );
-        }
-        // Key-presence (not truthiness) so legitimately falsy results
-        // (null, "", 0) are extracted just like the JSON path does. Events
-        // without a `result` key (e.g. notifications) are skipped.
-        if (event && typeof event === "object" && "result" in event) {
-          const toolErrMsg = toolErrorMessage(jsonRpcEvent.result);
-          if (toolErrMsg !== null) {
-            throw new Error(`MCP tool error: ${toolErrMsg}`);
-          }
-          result = extractContent(jsonRpcEvent.result);
-        }
-      }
+      handleLine(line);
     }
+  }
+
+  // Drain anything left in the decoder and buffer: a stream that ends
+  // without a trailing newline still has its last line pending here.
+  buffer += decoder.decode();
+  for (const line of buffer.split("\n")) {
+    handleLine(line);
+  }
+
+  // A stream that ended without ANY result frame is a cut exchange — e.g.
+  // the registry proxy's X-Mesh-Timeout budget expired mid-stream and only
+  // keepalive comment frames arrived (#1201). That must surface as an error,
+  // never as an empty-string success. When the proxy's terminal marker was
+  // seen, the cut is a definitive timeout (non-retryable); without it, the
+  // generic protocol error below stays retryable.
+  if (!sawResult) {
+    if (proxyTimeoutSignaled) {
+      throw new ProxyTimeoutError(
+        `MCP call timed out: registry proxy X-Mesh-Timeout budget${proxyTimeoutBudget ? ` (${proxyTimeoutBudget})` : ""} expired before the agent sent a response`
+      );
+    }
+    throw new Error(
+      "MCP SSE stream ended without a result frame (connection closed or proxy timeout before the agent responded)"
+    );
   }
 
   return result;

--- a/src/runtime/typescript/src/sse.ts
+++ b/src/runtime/typescript/src/sse.ts
@@ -67,8 +67,10 @@ export function parseSSEStream<T = unknown>(responseText: string): T[] {
   const lines = responseText.split("\n");
 
   for (const line of lines) {
-    if (line.startsWith("data: ")) {
-      const jsonData = line.slice(6);
+    if (line.startsWith("data:")) {
+      // Per the SSE spec the colon may be followed by zero or one space.
+      let jsonData = line.slice(5);
+      if (jsonData.startsWith(" ")) jsonData = jsonData.slice(1);
       if (jsonData.trim()) {
         results.push(JSON.parse(jsonData) as T);
       }


### PR DESCRIPTION
## Summary
Closes #1201 — surfaced by the settle-reliance pilot: a `meshctl call` cut by its `X-Mesh-Timeout` budget mid-SSE printed a bare keepalive comment (`: ping - <ts>`) as the result, exit 0.

- **meshctl**: skips SSE comment frames per spec; a zero-data stream errors structurally — timeout-shaped (naming the budget and the `--timeout` remedy) when the proxy's terminal marker is present or elapsed approached the budget, protocol-shaped for quick closes. The triplicated inline SSE parsing collapsed into one shared helper. A stream cut **mid-data-frame** no longer falls back to dumping the raw body as success — SSE-shaped bodies error (timeout-shaped when the marker landed after the partial frame); the raw fallback survives only for legacy non-SSE plain text.
- **Registry proxy**: logs timeout cuts with budget + elapsed, and appends a `: mesh-proxy-timeout budget=Ns` comment frame to SSE streams it cuts — the only spec-compliant in-band terminal signal once 200+chunked headers are out (trailers need pre-declaration; conforming foreign clients ignore comment frames by spec, so this cannot break anyone). Non-SSE bodies get no marker (truncation there is parse-detectable). Normal relay and the #1177 flush cadence are behavior-identical (test-asserted).
- **TypeScript speaks the marker protocol**: `readSSEResponseToContent` recognizes the marker and throws a dedicated `ProxyTimeoutError` (single span, not retried — without it, every retry attempt would re-wait the full proxy budget); marker-less no-data EOF throws the generic retryable error instead of returning empty success, and the final unterminated line is drained (fixing a latent dropped-result bug).
- **Python verified already safe** via the Rust parser (no-data SSE errors); regression tests added there.
- Marker literal pinned by tests on all three sides with cross-reference comments.

## Review Notes
- Independent review: 0 blockers. Verified the marker can't convert results (a complete data frame always wins; spoofing only changes error wording on an already-failed call), JSON bodies can't false-positive the widened SSE detection, the elapsed/budget comparison shares one value source with the header, and `gin.ResponseWriter` satisfies the extracted relay interface natively.
- Both warnings fixed (truncated-frame leak; TS marker participation). The third (per-attempt + aggregate spans sharing a spanId — a #1170-era pattern this would have made more frequent) is filed as #1202.
- Known pre-existing carried over (documented): multi-line SSE data frames aren't concatenated; meshctl's own client timeout can win the race against the proxy budget in proxy mode, yielding the older raw error shape.

Closes #1201

## Test plan
- [x] `go test ./src/core/... -race` (9 new cli tests incl. truncated-frame matrix; 7 proxy relay tests incl. marker emission + flush cadence)
- [x] TS typecheck + 933 tests (9 new: no-data/comment-only rejection, marker timeout classification + no-retry, data-wins, drain)
- [x] Rust parser regression tests (comment-only, no-data, comments-interleaved)
- [ ] Re-run the settle pilot tests against a rebuilt image post-merge (the original repro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate detection and classification of streaming timeouts vs protocol/truncation errors, preventing leaked raw stream content and improving retry behavior.
  * Better handling of truncated or comment-only event streams so incomplete responses no longer surface as successful results.

* **Refactor**
  * Centralized SSE/stream extraction for consistent behavior across tool calls and proxy relays; proxy now emits an in-band timeout marker for SSE streams.

* **Tests**
  * Expanded end-to-end and unit tests covering SSE parsing, timeout classification, proxy behavior, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->