### PR TITLE
fix(test): calculator fixtures publish the capabilities consumers declare

### DIFF
--- a/tests/integration/suites/uc02_tools/artifacts/py-calculator-agent/main.py
+++ b/tests/integration/suites/uc02_tools/artifacts/py-calculator-agent/main.py
@@ -17,7 +17,7 @@ app = FastMCP("py-calculator-agent")
 
 @app.tool()
 @mesh.tool(
-    capability="calculator",
+    capability="calc_add",
     description="Add two numbers",
     tags=["math", "calculator"],
 )
@@ -28,7 +28,7 @@ def calc_add(a: int, b: int) -> int:
 
 @app.tool()
 @mesh.tool(
-    capability="calculator",
+    capability="calc_multiply",
     description="Multiply two numbers",
     tags=["math", "calculator"],
 )

--- a/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/src/index.ts
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/src/index.ts
@@ -24,7 +24,7 @@ const agent = mesh(server, {
 
 agent.addTool({
   name: "calc_add",
-  capability: "calculator",
+  capability: "calc_add",
   description: "Add two numbers",
   tags: ["math", "calculator"],
   parameters: z.object({
@@ -38,7 +38,7 @@ agent.addTool({
 
 agent.addTool({
   name: "calc_multiply",
-  capability: "calculator",
+  capability: "calc_multiply",
   description: "Multiply two numbers",
   tags: ["math", "calculator"],
   parameters: z.object({

--- a/tests/integration/suites/uc02_tools/tc04_cross_agent_call/test.yaml
+++ b/tests/integration/suites/uc02_tools/tc04_cross_agent_call/test.yaml
@@ -2,9 +2,13 @@
 # Tests that Agent A can call Agent B's tools via dependency injection.
 #
 # Scenario:
-#   - py-calculator-agent provides calc_add and calc_multiply tools
-#   - py-report-agent depends on "calculator" capability
+#   - py-calculator-agent provides calc_add and calc_multiply capabilities
+#   - py-report-agent depends on "calc_add" / "calc_multiply"
 #   - Calling sum_report triggers cross-agent calls to calc_add
+#
+# The report agent appends "(local)" to its output when it falls back to
+# local computation, so the assertions below verify the result came from
+# the mesh-injected dependency, not the local fallback.
 #
 # Uses UC-level artifacts from /uc-artifacts
 
@@ -78,8 +82,8 @@ test:
       meshctl status
       echo "=== Checking dependencies ==="
       STATUS=$(meshctl status 2>&1)
-      if echo "$STATUS" | grep -q "calculator"; then
-        echo "PASS: Dependency on calculator visible"
+      if echo "$STATUS" | grep -q "calc_add"; then
+        echo "PASS: Dependency on calc_add visible"
       else
         echo "INFO: Dependency might be implicit"
         echo "PASS: Status check complete"
@@ -94,9 +98,15 @@ test:
       echo "=== Calling sum_report ==="
       RESULT=$(meshctl call sum_report '{"numbers": [1, 2, 3, 4, 5]}' 2>&1)
       echo "Result: $RESULT"
+      # The agent appends "(local)" when calc_add is NOT injected - that
+      # means the cross-agent call never happened, even if the sum is right.
+      if echo "$RESULT" | grep -q "(local)"; then
+        echo "FAIL: sum_report used local fallback - calc_add was not injected"
+        exit 1
+      fi
       # Sum of 1+2+3+4+5 = 15
       if echo "$RESULT" | grep -q "15"; then
-        echo "PASS: sum_report cross-agent call worked"
+        echo "PASS: sum_report cross-agent call worked (mesh-injected calc_add)"
       else
         echo "FAIL: Expected sum of 15"
         exit 1
@@ -111,9 +121,14 @@ test:
       echo "=== Calling product_report ==="
       RESULT=$(meshctl call product_report '{"numbers": [2, 3, 4]}' 2>&1)
       echo "Result: $RESULT"
+      # "(local)" marks the local fallback - the cross-agent call did not happen.
+      if echo "$RESULT" | grep -q "(local)"; then
+        echo "FAIL: product_report used local fallback - calc_multiply was not injected"
+        exit 1
+      fi
       # Product of 2*3*4 = 24
       if echo "$RESULT" | grep -q "24"; then
-        echo "PASS: product_report cross-agent call worked"
+        echo "PASS: product_report cross-agent call worked (mesh-injected calc_multiply)"
       else
         echo "FAIL: Expected product of 24"
         exit 1
@@ -128,8 +143,14 @@ assertions:
   - expr: "${captured.sum_report_call} contains 'PASS'"
     message: "sum_report should call calculator and return correct sum"
 
+  - expr: "${captured.sum_report_call} not contains '(local)'"
+    message: "sum_report must use the mesh-injected calc_add, not the local fallback"
+
   - expr: "${captured.product_report_call} contains 'PASS'"
     message: "product_report should call calculator and return correct product"
+
+  - expr: "${captured.product_report_call} not contains '(local)'"
+    message: "product_report must use the mesh-injected calc_multiply, not the local fallback"
 
 post_run:
   - handler: shell

--- a/tests/integration/suites/uc02_tools/tc05_graceful_degradation/test.yaml
+++ b/tests/integration/suites/uc02_tools/tc05_graceful_degradation/test.yaml
@@ -108,31 +108,41 @@ test:
     workdir: /workspace
     capture: list_with_dep
 
-  # Check calculator is now available
+  # Check calculator is now available - hard requirement.
+  # The provider is up and registered, so the consumer MUST rewire.
+  # Retry to allow for heartbeat/topology propagation, then fail hard.
   - name: "Check calculator is now available"
     handler: shell
     command: |
-      RESULT=$(meshctl call check_calculator 2>&1)
-      echo "check_calculator: $RESULT"
-      if echo "$RESULT" | grep -q "available"; then
-        echo "PASS: Calculator now available"
-      else
-        echo "INFO: Calculator might need rewiring"
-        echo "PASS: Check complete"
-      fi
+      for i in $(seq 1 10); do
+        RESULT=$(meshctl call check_calculator 2>&1)
+        echo "check_calculator (attempt $i): $RESULT"
+        if echo "$RESULT" | grep -q "Calculator is available"; then
+          echo "PASS: Calculator now available (dependency rewired)"
+          exit 0
+        fi
+        sleep 3
+      done
+      echo "FAIL: Calculator never became available after provider startup"
+      exit 1
     workdir: /workspace
     capture: check_with_dep
+    timeout: 60
 
-  # Call smart_add - should now use calculator
+  # Call smart_add - must now use the calculator, not the local fallback
   - name: "Call smart_add with calculator"
     handler: shell
     command: |
       RESULT=$(meshctl call smart_add '{"a": 10, "b": 7}' 2>&1)
       echo "smart_add(10,7) with calculator: $RESULT"
-      if echo "$RESULT" | grep -q "17"; then
-        echo "PASS: Calculation returned correct result"
+      if echo "$RESULT" | grep -q "Local result"; then
+        echo "FAIL: smart_add used local fallback - calc_add was not injected"
+        exit 1
+      fi
+      if echo "$RESULT" | grep -q "Calculator result" && echo "$RESULT" | grep -q "17"; then
+        echo "PASS: smart_add used the injected calculator and returned 17"
       else
-        echo "FAIL: Expected result 17"
+        echo "FAIL: Expected 'Calculator result' with 17"
         exit 1
       fi
     workdir: /workspace
@@ -146,12 +156,18 @@ assertions:
   - expr: "${captured.call_without_dep} contains 'PASS'"
     message: "Agent should gracefully degrade to local calculation"
 
-  # Phase 2: With dependency
+  # Phase 2: With dependency (recovered phase - hard requirements)
   - expr: "${captured.list_with_dep} contains 'PASS'"
     message: "Calculator should be registered after starting"
 
+  - expr: "${captured.check_with_dep} contains 'Calculator is available'"
+    message: "check_calculator must report the dependency as wired after provider startup"
+
   - expr: "${captured.call_with_dep} contains 'PASS'"
-    message: "Agent should return correct result (with or without calculator)"
+    message: "Agent should use the injected calculator and return 17"
+
+  - expr: "${captured.call_with_dep} contains 'Calculator result'"
+    message: "smart_add must use the mesh-injected calc_add, not the local fallback"
 
 post_run:
   - handler: shell

--- a/tests/integration/suites/uc02_tools/tc08_ts_cross_agent_call/test.yaml
+++ b/tests/integration/suites/uc02_tools/tc08_ts_cross_agent_call/test.yaml
@@ -2,9 +2,13 @@
 # Tests that TypeScript Agent A can call Agent B's tools via dependency injection.
 #
 # Scenario:
-#   - ts-calculator-agent provides calc_add and calc_multiply tools
-#   - ts-report-agent depends on "calculator" capability
+#   - ts-calculator-agent provides calc_add and calc_multiply capabilities
+#   - ts-report-agent depends on "calc_add" / "calc_multiply"
 #   - Calling sum_report triggers cross-agent calls to calc_add
+#
+# The report agent appends "(local)" to its output when it falls back to
+# local computation, so the assertions below verify the result came from
+# the mesh-injected dependency, not the local fallback.
 #
 # Uses UC-level artifacts from /uc-artifacts
 
@@ -115,9 +119,15 @@ assertions:
   - expr: "${captured.sum_report_call} contains '15'"
     message: "sum_report should return sum of 15"
 
+  - expr: "${captured.sum_report_call} not contains '(local)'"
+    message: "sum_report must use the mesh-injected calc_add, not the local fallback"
+
   # Product of 2*3*4 = 24
   - expr: "${captured.product_report_call} contains '24'"
     message: "product_report should return product of 24"
+
+  - expr: "${captured.product_report_call} not contains '(local)'"
+    message: "product_report must use the mesh-injected calc_multiply, not the local fallback"
 
 post_run:
   - handler: shell

--- a/tests/integration/suites/uc02_tools/tc09_ts_graceful_degradation/test.yaml
+++ b/tests/integration/suites/uc02_tools/tc09_ts_graceful_degradation/test.yaml
@@ -93,12 +93,26 @@ test:
     workdir: /workspace
     capture: list_with_dep
 
-  # Check calculator is now available
+  # Check calculator is now available - hard requirement.
+  # The provider is up and registered, so the consumer MUST rewire.
+  # Retry to allow for heartbeat/topology propagation, then fail hard.
   - name: "Check calculator is now available"
     handler: shell
-    command: "meshctl call check_calculator"
+    command: |
+      for i in $(seq 1 10); do
+        RESULT=$(meshctl call check_calculator 2>&1)
+        echo "check_calculator (attempt $i): $RESULT"
+        if echo "$RESULT" | grep -q "Calculator is available"; then
+          echo "PASS: Calculator now available (dependency rewired)"
+          exit 0
+        fi
+        sleep 3
+      done
+      echo "FAIL: Calculator never became available after provider startup"
+      exit 1
     workdir: /workspace
     capture: check_with_dep
+    timeout: 60
 
   # Call smart_add - should now use calculator
   - name: "Call smart_add with calculator"
@@ -121,9 +135,15 @@ assertions:
   - expr: "${captured.call_without_dep} contains '8'"
     message: "Local fallback should return correct result (5+3=8)"
 
-  # Phase 2: With dependency
+  # Phase 2: With dependency (recovered phase - hard requirements)
   - expr: "${captured.list_with_dep} contains 'ts-calculator-agent'"
     message: "Calculator should be registered after starting"
+
+  - expr: "${captured.check_with_dep} contains 'Calculator is available'"
+    message: "check_calculator must report the dependency as wired after provider startup"
+
+  - expr: "${captured.call_with_dep} contains 'Calculator result'"
+    message: "smart_add must use the mesh-injected calc_add, not the local fallback"
 
   - expr: "${captured.call_with_dep} contains '17'"
     message: "Agent should return correct result 17 (10+7)"

--- a/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/py-calculator-agent/main.py
+++ b/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/py-calculator-agent/main.py
@@ -18,7 +18,7 @@ app = FastMCP("py-calculator-agent")
 
 @app.tool()
 @mesh.tool(
-    capability="calculator",
+    capability="calc_add",
     description="Add two numbers",
     tags=["math", "calculator"],
 )
@@ -29,7 +29,7 @@ def calc_add(a: int, b: int) -> int:
 
 @app.tool()
 @mesh.tool(
-    capability="calculator",
+    capability="calc_multiply",
     description="Multiply two numbers",
     tags=["math", "calculator"],
 )
@@ -95,7 +95,7 @@ async def calculate(
         "a": a,
         "b": b,
         "operator": operator,
-        "resuglt": None,
+        "result": None,
         "source": None,
         "error": None,
     }

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-calculator-agent/src/index.ts
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-calculator-agent/src/index.ts
@@ -26,7 +26,7 @@ const agent = mesh(server, {
 
 agent.addTool({
   name: "calc_add",
-  capability: "calculator",
+  capability: "calc_add",
   description: "Add two numbers",
   tags: ["math", "calculator"],
   parameters: z.object({
@@ -40,7 +40,7 @@ agent.addTool({
 
 agent.addTool({
   name: "calc_multiply",
-  capability: "calculator",
+  capability: "calc_multiply",
   description: "Multiply two numbers",
   tags: ["math", "calculator"],
   parameters: z.object({

--- a/tests/integration/suites/uc05_meshctl/artifacts/py-calculator-agent/main.py
+++ b/tests/integration/suites/uc05_meshctl/artifacts/py-calculator-agent/main.py
@@ -18,7 +18,7 @@ app = FastMCP("py-calculator-agent")
 
 @app.tool()
 @mesh.tool(
-    capability="calculator",
+    capability="calc_add",
     description="Add two numbers",
     tags=["math", "calculator"],
 )
@@ -29,7 +29,7 @@ def calc_add(a: int, b: int) -> int:
 
 @app.tool()
 @mesh.tool(
-    capability="calculator",
+    capability="calc_multiply",
     description="Multiply two numbers",
     tags=["math", "calculator"],
 )

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/src/index.ts
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/src/index.ts
@@ -26,7 +26,7 @@ const agent = mesh(server, {
 
 agent.addTool({
   name: "calc_add",
-  capability: "calculator",
+  capability: "calc_add",
   description: "Add two numbers",
   tags: ["math", "calculator"],
   parameters: z.object({
@@ -40,7 +40,7 @@ agent.addTool({
 
 agent.addTool({
   name: "calc_multiply",
-  capability: "calculator",
+  capability: "calc_multiply",
   description: "Multiply two numbers",
   tags: ["math", "calculator"],
   parameters: z.object({


### PR DESCRIPTION
## Summary
Closes #1204 — prerequisite 2 of the settle-reliance migration (#1193 follow-up), surfaced by the pilot.

- The shared calculator fixtures (py + TS twins across uc02/uc03/uc05) published `capability="calculator"` while consumers declared `["calc_add"]`/`["calc_multiply"]` — permanently unresolvable, masked by value-only assertions the local fallback also satisfied. **`tc04 "Cross-Agent Call"` never tested a cross-agent call.** Providers now publish the per-tool capabilities consumers declare (the `calculate` tool keeps `calculator`; repo-wide survey confirms nothing depends on that string).
- Assertions are fallback-proof: hard-fail on the `(local)` marker (verified verbatim in the fixture fallback paths), source-based checks, and the graceful-degradation tests' recovered phase hardened from soft INFO to a retry loop + hard assertion (degraded-phase semantics byte-for-byte untouched).
- Survey: the Java, uc06, and uc04-LLM fixture families are internally consistent — this mismatch class is now extinct in the suites. A latent `"resuglt"` dict-key typo in the tc11 fixture fixed en route (verified non-load-bearing).

## Review Notes
- Independent review: 0 blockers, 0 warnings. Verified exact provider↔consumer alignment, flake-safety of the retry budgets under the established step-timeout conventions, marker-text grounding, and that sibling tests invoking the fixtures by tool name are unaffected.

Closes #1204

## Test plan
- [x] All 10 affected/adjacent tests run 2× via `--tc-file`: 10/10 both rounds (80.2s each)
- [x] tc04's hardened check proven load-bearing: it fails against the pre-fix fixtures
- [ ] Rides into the full-suite settle migration verification next

🤖 Generated with [Claude Code](https://claude.com/claude-code)
