### PR TITLE
test: harden fixable flake sources from the migration gate analysis

### DIFF
--- a/tests/integration/suites/uc08_llm_prompt_templates/tc06_py_mesh_openai/test.yaml
+++ b/tests/integration/suites/uc08_llm_prompt_templates/tc06_py_mesh_openai/test.yaml
@@ -11,7 +11,7 @@ tags:
   - context-param
   - python
   - openai
-timeout: 120
+timeout: 180 # headroom for the bounded provider-registration poll (worst case 45s)
 
 pre_run:
   - routine: global.setup_for_python_agent
@@ -45,10 +45,26 @@ test:
     workdir: /workspace
     capture: provider_start_output
 
-  # Wait for provider to register
+  # Liveness only: poll until the provider is registered (replaces a
+  # fixed 10s wait that could give up while the freshly auto-started
+  # registry was still coming up). Bounded with diagnostics per the
+  # migration conventions; LLM tool assembly is covered by the fixed
+  # wait after the consumer start below (outside settle scope).
   - name: "Wait for provider to register"
-    handler: wait
-    seconds: 10
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 45); do
+        if meshctl list 2>/dev/null | grep -q "openai-provider"; then
+          echo "openai-provider registered after ~${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: openai-provider not registered within 45s"
+      meshctl list 2>/dev/null || true
+      exit 1
+    timeout: 90
 
   # Verify provider is running
   - name: "Verify provider is running"

--- a/tests/integration/suites/uc21_meshjob/fixtures/long-task-consumer/main.py
+++ b/tests/integration/suites/uc21_meshjob/fixtures/long-task-consumer/main.py
@@ -290,6 +290,7 @@ async def commission_downstream(
 # the agent startup pipeline) and POSTs ``/jobs/{id}/events``.
 
 import asyncio  # noqa: E402  (event-injection helpers below need asyncio.sleep)
+import time  # noqa: E402  (claim-gate deadline in commission_cancel_via_event)
 
 
 @app.tool()
@@ -378,7 +379,34 @@ async def commission_cancel_via_event(
     if run_until_cancel is None:
         return {"error": "run_until_cancel submitter not injected"}
     proxy = await run_until_cancel.submit(ctx={}, max_duration=60)
-    await asyncio.sleep(2.0)
+    # Deterministic claim gate (was a fixed 2s sleep): wait until a
+    # producer replica has CLAIMED the job before posting 'work' and
+    # cancelling below. Pull-mode rows are created with
+    # owner_instance_id = NULL; the registry sets it on /jobs/claim.
+    # The producer's idle claim poll backs off to a 5s cap, so the old
+    # fixed 2s (+1s pre-cancel) budget could fire the cancel BEFORE the
+    # claim — the producer then never ran run_until_cancel and the
+    # synthetic 'cancelled' event went unobserved (issue #1207). Events
+    # posted after the claim are safe: a fresh JobController's
+    # recv_event replays from the first event in the job's event log.
+    claim_deadline = time.monotonic() + 30.0
+    while True:
+        try:
+            claim_status = await proxy.status()
+        except Exception:
+            # Transient status-read failures (registry hiccup) are
+            # tolerated within the budget — keep polling.
+            claim_status = None
+        owner = (claim_status or {}).get("owner_instance_id")
+        if owner:
+            break
+        if time.monotonic() >= claim_deadline:
+            return {
+                "error": "job never claimed within 30s — cannot exercise cancel-via-event",
+                "job_id": proxy.job_id,
+                "last_status": claim_status,
+            }
+        await asyncio.sleep(0.3)
     work_receipt = await mesh.jobs.post_event(
         job_id=proxy.job_id,
         event_type="work",

--- a/tests/integration/suites/uc21_meshjob/tc26_cancel_posts_synthetic_event/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc26_cancel_posts_synthetic_event/test.yaml
@@ -6,9 +6,13 @@
 # ["work", "cancelled"], ...)``. Consumer:
 #
 #   1. submits the job
-#   2. posts a 'work' event with payload ``{"item": 1}``
-#   3. sleeps so producer consumes it
-#   4. calls ``proxy.cancel(reason="external_stop_requested")``
+#   2. polls proxy.status() until owner_instance_id is set — i.e. a
+#      producer replica has CLAIMED the job (deterministic gate; a
+#      fixed 2s sleep here used to race the producer's claim poll,
+#      whose idle backoff caps at 5s — issue #1207)
+#   3. posts a 'work' event with payload ``{"item": 1}``
+#   4. sleeps so producer consumes it
+#   5. calls ``proxy.cancel(reason="external_stop_requested")``
 #
 # Inside the registry's ``CancelJob`` handler the row transitions to
 # ``status=cancelled`` AND the handler then posts a synthetic
@@ -69,18 +73,35 @@ test:
     workdir: /workspace
     command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
 
-  - name: "Wait for provider registration"
-    handler: wait
-    seconds: 12
-
   - name: "Start consumer (port 9101)"
     handler: shell
     workdir: /workspace
-    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
 
-  - name: "Wait for consumer + DI resolution"
-    handler: wait
-    seconds: 18
+  # Liveness only: wait for both agents to REGISTER (meshctl call routes via
+  # the registry). Dependency resolution is covered by the settle window —
+  # no fixed dep-resolution sleep needed. (This migration was reverted once
+  # in #1209 because the fixture's fixed 2s pre-cancel wait raced the
+  # producer's claim tick — #1207; the fixture now gates on
+  # owner_instance_id, so the warm-up sleeps are safe to drop.)
+  - name: "Wait for both agents to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for both agents to register..."
+      for i in $(seq 1 60); do
+        AGENTS=$(meshctl list 2>/dev/null || true)
+        if echo "$AGENTS" | grep -q "long-task-provider" && echo "$AGENTS" | grep -q "long-task-consumer"; then
+          echo "Both agents registered after ~${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: agents did not register within 60s"
+      meshctl list 2>/dev/null || true
+      exit 1
+    capture: wait_registration
+    timeout: 90
 
   - name: "Call commission_cancel_via_event — submit, post work, cancel"
     handler: shell

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/src/index.ts
@@ -545,7 +545,43 @@ agent.addTool({
     }
     const proxy = await runUntilCancel.submit({}, { maxDuration: 60 });
     const jobId = (proxy as { jobId?: string }).jobId ?? "";
-    await sleepMs(2000);
+    if (!proxy.status) {
+      return { error: "submitter returned a proxy without .status()" };
+    }
+    // Deterministic claim gate (was a fixed 2s sleep): wait until a
+    // producer replica has CLAIMED the job before posting 'work' and
+    // cancelling below. Pull-mode rows are created with
+    // owner_instance_id = NULL; the registry sets it on /jobs/claim.
+    // The producer's idle claim poll backs off to a 5s cap, so the old
+    // fixed 2s (+1s pre-cancel) budget could fire the cancel BEFORE the
+    // claim — the producer then never ran run_until_cancel and the
+    // synthetic 'cancelled' event went unobserved (issue #1207). Events
+    // posted after the claim are safe: a fresh JobController's
+    // recvEvent replays from the first event in the job's event log.
+    const claimDeadline = Date.now() + 30_000;
+    for (;;) {
+      let claimStatus: Record<string, unknown> | null = null;
+      try {
+        claimStatus = (await proxy.status()) as Record<string, unknown>;
+      } catch {
+        // Transient status-read failures (registry hiccup) are
+        // tolerated within the budget — keep polling.
+        claimStatus = null;
+      }
+      const owner = claimStatus?.owner_instance_id;
+      if (owner !== null && owner !== undefined && owner !== "") {
+        break;
+      }
+      if (Date.now() >= claimDeadline) {
+        return {
+          error:
+            "job never claimed within 30s — cannot exercise cancel-via-event",
+          job_id: jobId,
+          last_status: claimStatus,
+        };
+      }
+      await sleepMs(300);
+    }
     const workReceipt = await mesh.jobs.postEvent(jobId, "work", { item: 1 });
     // Give the producer a moment to consume the 'work' event before we
     // fire the cancel. This makes the two events strictly ordered in

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
@@ -609,7 +609,36 @@ public class LongTaskConsumerApplication {
             new LinkedHashMap<>(), null, 60, null, null);
         try (JobProxy proxy = submitter.submit(opts).get()) {
             String jobId = proxy.jobId();
-            Thread.sleep(2000);
+            // Deterministic claim gate (was a fixed 2s sleep): wait until a
+            // producer replica has CLAIMED the job before posting 'work'
+            // and cancelling below. Pull-mode rows are created with
+            // owner_instance_id = NULL; the registry sets it on
+            // /jobs/claim. The producer's idle claim poll backs off to a
+            // 5s cap, so the old fixed 2s (+1s pre-cancel) budget could
+            // fire the cancel BEFORE the claim — the producer then never
+            // ran runUntilCancel and the synthetic 'cancelled' event went
+            // unobserved (same race class as uc21's Python fixture,
+            // issue #1207). Events posted after the claim are safe: a
+            // fresh JobController's recvEvent replays from the first
+            // event in the job's event log.
+            long claimDeadline = System.currentTimeMillis() + 30_000L;
+            while (true) {
+                Map<String, Object> claimStatus = proxy.status();
+                Object owner = claimStatus != null
+                    ? claimStatus.get("owner_instance_id") : null;
+                if (owner != null && !owner.toString().isEmpty()) {
+                    break;
+                }
+                if (System.currentTimeMillis() >= claimDeadline) {
+                    Map<String, Object> err = new LinkedHashMap<>();
+                    err.put("error",
+                        "job never claimed within 30s — cannot exercise cancel-via-event");
+                    err.put("job_id", jobId);
+                    err.put("last_status", claimStatus);
+                    return err;
+                }
+                Thread.sleep(300);
+            }
             Map<String, Object> workPayload = new LinkedHashMap<>();
             workPayload.put("item", 1);
             Map<String, Object> workReceipt = MeshJobs.postEvent(jobId, "work", workPayload);

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
@@ -623,7 +623,14 @@ public class LongTaskConsumerApplication {
             // event in the job's event log.
             long claimDeadline = System.currentTimeMillis() + 30_000L;
             while (true) {
-                Map<String, Object> claimStatus = proxy.status();
+                Map<String, Object> claimStatus;
+                try {
+                    claimStatus = proxy.status();
+                } catch (RuntimeException e) {
+                    // Transient status-read failures (registry hiccup) are
+                    // tolerated within the budget — keep polling.
+                    claimStatus = null;
+                }
                 Object owner = claimStatus != null
                     ? claimStatus.get("owner_instance_id") : null;
                 if (owner != null && !owner.toString().isEmpty()) {

--- a/tests/integration/suites/uc23_meshjob_java/tc16_third_party_can_read_status_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc16_third_party_can_read_status_java/test.yaml
@@ -131,9 +131,39 @@ test:
     capture: submit_resp
     timeout: 30
 
-  - name: "Wait for completion"
-    handler: wait
-    seconds: 8
+  # Deterministic completion gate: poll job status until terminal
+  # (replaces a fixed 8s wait — the bystander reads below assert
+  # 'completed', and under CI load the job sometimes outlived the fixed
+  # wait, so the bystander observed status=working). Polls via the
+  # CONSUMER's __mesh_job_status helper so the bystander reads below
+  # remain the first third-party observations. Same transform as
+  # uc21/tc09's pre-cancel status gate (#1209).
+  - name: "Wait for job completion (status gate)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .id')
+      echo "AGENT=${AGENT} JOB=${JOB_ID}"
+      STATUS=""
+      for i in $(seq 1 45); do
+        STATUS=$(meshctl call "${AGENT}:__mesh_job_status" "{\"job_id\":\"${JOB_ID}\"}" --raw 2>/dev/null \
+          | jq -r '.content[0].text | fromjson | .status' 2>/dev/null || true)
+        if [ "$STATUS" = "completed" ]; then
+          echo "job completed after ~${i}s"
+          exit 0
+        fi
+        case "$STATUS" in
+          failed|cancelled)
+            echo "ERROR: job reached terminal status=$STATUS (expected completed)"
+            exit 1
+            ;;
+        esac
+        sleep 1
+      done
+      echo "ERROR: job not completed within 45s (last status=$STATUS)"
+      exit 1
+    timeout: 90
 
   - name: "Bystander X reads status"
     handler: shell

--- a/tests/integration/suites/uc23_meshjob_java/tc16_third_party_can_read_status_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc16_third_party_can_read_status_java/test.yaml
@@ -156,12 +156,16 @@ test:
         case "$STATUS" in
           failed|cancelled)
             echo "ERROR: job reached terminal status=$STATUS (expected completed)"
+            echo "=== full status JSON ==="
+            meshctl call "${AGENT}:__mesh_job_status" "{\"job_id\":\"${JOB_ID}\"}" --raw 2>&1 || true
             exit 1
             ;;
         esac
         sleep 1
       done
       echo "ERROR: job not completed within 45s (last status=$STATUS)"
+      echo "=== full status JSON ==="
+      meshctl call "${AGENT}:__mesh_job_status" "{\"job_id\":\"${JOB_ID}\"}" --raw 2>&1 || true
       exit 1
     timeout: 90
 

--- a/tests/integration/suites/uc23_meshjob_java/tc26_cancel_posts_synthetic_event_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc26_cancel_posts_synthetic_event_java/test.yaml
@@ -6,9 +6,13 @@
 # List.of("work","cancelled"), Duration.ofSeconds(15))`. Consumer:
 #
 #   1. submits the job
-#   2. posts a 'work' event with payload `{item: 1}`
-#   3. sleeps so producer consumes it
-#   4. calls `proxy.cancel("external_stop_requested")`
+#   2. polls proxy.status() until owner_instance_id is set — i.e. a
+#      producer replica has CLAIMED the job (deterministic gate; a
+#      fixed 2s sleep here used to race the producer's claim poll,
+#      whose idle backoff caps at 5s — same race class as #1207)
+#   3. posts a 'work' event with payload `{item: 1}`
+#   4. sleeps so producer consumes it
+#   5. calls `proxy.cancel("external_stop_requested")`
 #
 # Inside the registry's CancelJob handler the row transitions to
 # status=cancelled AND the handler then posts a synthetic

--- a/tests/lib-tests/suites/uc04_build_image/tc01_build_base/artifacts/Dockerfile
+++ b/tests/lib-tests/suites/uc04_build_image/tc01_build_base/artifacts/Dockerfile
@@ -15,6 +15,9 @@ RUN if [ -z "$VERSION" ]; then echo "VERSION build arg is required" && exit 1; f
     if [ -z "$PIP_VERSION" ]; then echo "PIP_VERSION build arg is required" && exit 1; fi
 
 # Install system dependencies, tini (init), and Node.js 22
+# (apt pinning is brittle for a test image; --no-install-recommends bloat is
+# acceptable here; pipefail predates this change)
+# hadolint ignore=DL3008,DL3015,DL4006
 RUN apt-get update && apt-get install -y \
     curl \
     jq \
@@ -28,6 +31,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Eclipse Temurin JDK 17 (architecture-aware)
+# (pipefail predates this change)
+# hadolint ignore=DL4006
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) JAVA_ARCH="x64" ;; \
@@ -43,13 +48,31 @@ ENV JAVA_HOME=/opt/java
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Install Maven 3.9.6
+# (pipefail predates this change)
+# hadolint ignore=DL4006
 RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz | tar -xzf - -C /opt && \
     ln -s /opt/apache-maven-3.9.6 /opt/maven && \
     ln -s /opt/maven/bin/mvn /usr/local/bin/mvn
 ENV MAVEN_HOME=/opt/maven
 ENV PATH="${MAVEN_HOME}/bin:${PATH}"
 
+# Harden npm against registry transients (intermittent ETIMEDOUT / spurious
+# "notarget" from registry.npmjs.org on fresh test containers). Baking this
+# into the global npmrc means every npm invocation in test containers —
+# including those via the framework `npm-install` handler — retries fetches
+# automatically; no per-test config needed. npm's defaults (2 retries,
+# 10s min backoff) give up too easily; 5 retries starting at 2s recovers
+# faster from blips and survives longer ones. Mirrors the src-tests
+# tc06_build_local_image Dockerfile.
+RUN npm config set --location=global \
+      fetch-retries=5 \
+      fetch-retry-mintimeout=2000 \
+      fetch-retry-maxtimeout=30000 && \
+    npm config get fetch-retries
+
 # Verify Node.js, Java, and Maven installation
+# (pipefail predates this change)
+# hadolint ignore=DL4006
 RUN node --version && npm --version && java -version && mvn --version | head -1
 
 # Install Tempo for distributed tracing (architecture-aware)
@@ -61,7 +84,9 @@ RUN ARCH=$(dpkg --print-architecture) && \
 COPY tempo.yaml /etc/tempo/tempo.yaml
 RUN mkdir -p /var/tempo && chown -R root:root /var/tempo
 
-# Pre-install MCP Mesh Java SDK from Maven Central
+# Pre-install MCP Mesh Java SDK from Maven Central (cd is scoped to this RUN;
+# the directory is removed at the end, so WORKDIR would be wrong here)
+# hadolint ignore=DL3003
 RUN mkdir -p /tmp/java-sdk-install && \
     printf '<?xml version="1.0" encoding="UTF-8"?>\n\
 <project xmlns="http://maven.apache.org/POM/4.0.0"\n\
@@ -103,6 +128,8 @@ RUN echo "Installing pip package mcp-mesh==${PIP_VERSION}..." && \
 RUN python -c "import mesh; print('mesh module imported successfully')"
 
 # Install tsuite dependencies for running tests inside container
+# (pip pinning is brittle for a test image; separate RUN predates this change)
+# hadolint ignore=DL3013,DL3059
 RUN pip install --no-cache-dir click rich pyyaml jsonpath-ng requests flask docker
 
 # Create mcp-mesh user for security (matching official runtime images)

--- a/tests/src-tests/suites/build/tc01b_build_meshui/test.yaml
+++ b/tests/src-tests/suites/build/tc01b_build_meshui/test.yaml
@@ -55,7 +55,12 @@ test:
       echo "Building meshui inside container (SPA + Go binary)..."
       # meshui needs: go.mod, go.sum, cmd/mcp-mesh-ui/, src/core/, src/ui/
       # Steps: 1) npm install + build SPA, 2) copy dist/ to embed dir, 3) go build
+      # NPM_CONFIG_FETCH_*: harden against registry.npmjs.org transients
+      # (npm defaults to 2 retries with 10s min backoff — too fragile).
       docker run --rm \
+        -e NPM_CONFIG_FETCH_RETRIES=5 \
+        -e NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=2000 \
+        -e NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=30000 \
         -v "$SOURCE_ABS:/src-host:ro" \
         -v "$OUTPUT_ABS:/out" \
         ${config.build.image} \

--- a/tests/src-tests/suites/build/tc02a_build_rust_core_nodejs/test.yaml
+++ b/tests/src-tests/suites/build/tc02a_build_rust_core_nodejs/test.yaml
@@ -61,9 +61,14 @@ test:
       # CARGO_HTTP_MULTIPLEXING=false + CARGO_NET_RETRY: crates.io downloads
       # from this host intermittently die mid-transfer; disabling HTTP/2
       # multiplexing is the canonical cargo remedy (see tc04a for history).
+      # NPM_CONFIG_FETCH_*: same treatment for registry.npmjs.org transients
+      # (npm defaults to 2 retries with 10s min backoff — too fragile).
       docker run --rm \
         -e CARGO_HTTP_MULTIPLEXING=false \
         -e CARGO_NET_RETRY=10 \
+        -e NPM_CONFIG_FETCH_RETRIES=5 \
+        -e NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=2000 \
+        -e NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=30000 \
         -v "$SOURCE_ABS:/src-host:ro" \
         -v "$OUTPUT_ABS:/out" \
         ${config.build.image} \
@@ -116,7 +121,12 @@ test:
       CORE_PKG=$(ls "${run_path}/${config.output.packages}"/*core*.tgz 2>/dev/null | head -1)
 
       echo "Testing @mcpmesh/core installation inside container..."
+      # NPM_CONFIG_FETCH_*: harden against registry.npmjs.org transients
+      # (transitive deps still resolve from the registry).
       docker run --rm \
+        -e NPM_CONFIG_FETCH_RETRIES=5 \
+        -e NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=2000 \
+        -e NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=30000 \
         -v "$OUTPUT_ABS:/out:ro" \
         ${config.build.image} \
         bash -c "cd /tmp && npm init -y > /dev/null 2>&1 && \

--- a/tests/src-tests/suites/build/tc04_build_typescript_sdk/test.yaml
+++ b/tests/src-tests/suites/build/tc04_build_typescript_sdk/test.yaml
@@ -58,7 +58,12 @@ test:
       # tc02a already built it and produced an npm tarball. We extract that
       # tarball into the expected location so npm install resolves the file:
       # ref to a ready-to-use package — pure TypeScript build, no Rust here.
+      # NPM_CONFIG_FETCH_*: harden against registry.npmjs.org transients
+      # (npm defaults to 2 retries with 10s min backoff — too fragile).
       docker run --rm \
+        -e NPM_CONFIG_FETCH_RETRIES=5 \
+        -e NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=2000 \
+        -e NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=30000 \
         -v "$SOURCE_ABS:/src-host:ro" \
         -v "$OUTPUT_ABS:/out" \
         ${config.build.image} \

--- a/tests/src-tests/suites/build/tc06_build_local_image/artifacts/Dockerfile
+++ b/tests/src-tests/suites/build/tc06_build_local_image/artifacts/Dockerfile
@@ -7,6 +7,8 @@
 FROM python:3.11-slim
 
 # Install system dependencies, tini (init), and Node.js 22
+# (apt pinning is brittle for a test image; pipefail predates this change)
+# hadolint ignore=DL3008,DL3015,DL4006
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     wget \
@@ -20,6 +22,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Eclipse Temurin JDK 17 (architecture-aware)
+# (pipefail predates this change)
+# hadolint ignore=DL4006
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) JAVA_ARCH="x64" ;; \
@@ -35,6 +39,8 @@ ENV JAVA_HOME=/opt/java
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Install Maven
+# (pipefail predates this change)
+# hadolint ignore=DL4006
 RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz | tar -xzf - -C /opt && \
     ln -s /opt/apache-maven-3.9.6 /opt/maven && \
     ln -s /opt/maven/bin/mvn /usr/local/bin/mvn
@@ -64,6 +70,19 @@ RUN mkdir -p /root/.m2 && \
       '</settings>' \
       > /root/.m2/settings.xml
 
+# Harden npm against registry transients (intermittent ETIMEDOUT / spurious
+# "notarget" from registry.npmjs.org on fresh test containers). Baking this
+# into the global npmrc means every npm invocation in test containers —
+# including those via the framework `npm-install` handler — retries fetches
+# automatically; no per-test config needed. npm's defaults (2 retries,
+# 10s min backoff) give up too easily; 5 retries starting at 2s recovers
+# faster from blips and survives longer ones.
+RUN npm config set --location=global \
+      fetch-retries=5 \
+      fetch-retry-mintimeout=2000 \
+      fetch-retry-maxtimeout=30000 && \
+    npm config get fetch-retries
+
 # Install Tempo for distributed tracing (architecture-aware)
 RUN ARCH=$(dpkg --print-architecture) && \
     curl -fsSL "https://github.com/grafana/tempo/releases/download/v2.7.1/tempo_2.7.1_linux_${ARCH}.deb" -o /tmp/tempo.deb && \
@@ -74,6 +93,8 @@ COPY tempo.yaml /etc/tempo/tempo.yaml
 RUN mkdir -p /var/tempo && chown -R root:root /var/tempo
 
 # Install HashiCorp Vault for PKI credential provider tests (architecture-aware)
+# (apt pinning of transient unzip is brittle for a test image)
+# hadolint ignore=DL3008
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) VAULT_ARCH="amd64" ;; \
@@ -113,6 +134,8 @@ RUN ARCH=$(dpkg --print-architecture) && \
     chmod +x /usr/local/bin/mc
 
 # Verify Node.js and Java installation
+# (pipefail predates this change)
+# hadolint ignore=DL4006
 RUN node --version && npm --version && java -version && mvn --version | head -1 && vault --version && spire-server --version && spire-agent --version && minio --version && mc --version
 
 # Create directories for local packages
@@ -145,6 +168,8 @@ RUN chmod +x /usr/local/bin/select-runner /usr/local/bin/tsuite-runner-linux-* 2
 RUN pip install --no-cache-dir /wheels/mcp_mesh_core-*.whl /wheels/mcp_mesh-*.whl
 
 # Verify mesh module installation
+# (separate RUN keeps install/verify layers distinct; predates this change)
+# hadolint ignore=DL3059
 RUN python -c "import mesh; print('mesh module imported successfully')"
 
 # Install meshctl CLI from local tarball (if exists) or use binary
@@ -158,9 +183,12 @@ RUN if ls /packages/mcpmesh-cli-*.tgz 1> /dev/null 2>&1; then \
 RUN meshctl --version
 
 # Install TypeScript core bindings globally (SDK depends on this)
+# (separate RUNs keep per-package layers cacheable; predates this change)
+# hadolint ignore=DL3059
 RUN npm install -g /packages/mcpmesh-core-*.tgz
 
 # Install TypeScript SDK globally from local tarball
+# hadolint ignore=DL3059
 RUN npm install -g /packages/mcpmesh-sdk-*.tgz
 
 # Verify Java SDK installation (installed via m2-repo copy above)
@@ -176,6 +204,8 @@ RUN if [ -d "/root/.m2/repository/io/mcp-mesh" ]; then \
 ENV MESH_NATIVE_LIB_PATH=/native-libs
 
 # Install tsuite dependencies for running tests inside container
+# (pip pinning is brittle for a test image)
+# hadolint ignore=DL3013
 RUN pip install --no-cache-dir click rich pyyaml jsonpath-ng requests flask docker boto3
 
 # Create mcp-mesh user for security (matching official runtime images)


### PR DESCRIPTION
## Summary
Closes #1210 — follow-up to the #1209 migration gate analysis: of 12 first-run flakes (zero migration-caused), 7 were fixable rather than random.

- **npm registry transients (5 flakes)**: all 182 integration installs flow through tsuite's precompiled `npm-install` handler, so the retry config is baked into the `tsuite-mesh` image npmrc — one edit, total coverage, following the image's existing Maven-mirror precedent (`fetch-retries=5`, 2s→30s backoff vs npm's default 2×10s). `NPM_CONFIG_*` env mirrors on the src-tests build containers (incl. the meshui SPA build — same exposure) per the #1209 cargo treatment; the lib-tests base image gets parity. Takes effect at the next image build.
- **uc23 java fixed-budget waits (2 flakes, red in pre-migration baselines too)**: tc16 now polls for completed status before the bystander read — the old 8s wait was under-budgeted *even on green runs* (job completes ~10s). tc26's Java fixture had the #1207 claim-tick race baked in (correcting that issue's "Java doesn't share the race" note — comment posted there): the pre-cancel wait now polls job status for non-null `owner_instance_id` — the cleanest claim marker, since rows are created owner-NULL and jobs have no pending status — with event-replay safety verified against the Rust core. The same transform is the recommended fix for #1207's Python fixture.
- **uc08/tc06 (1 flake)**: the fixed 10s provider wait (settle-excluded UC, untouched by #1209) became a bounded 45s liveness-only poll; the original failure showed the registry 12s old when the old wait expired.
- Pre-existing hadolint findings in the touched test-image Dockerfiles carry targeted inline ignores per the #1188 precedent (the new lines themselves are hadolint-clean).

## Verification
- Deterministic fixes: 3 iterations × {uc23 tc16, uc23 tc26, uc08 tc06} = 9/9 green on the k8s cluster.
- npm-heavy tests (uc11 tc02/tc05) regression-clean on the current image; the retry config itself is unprovable against a transient by nature.
- Remaining 5 of the original 12 (LLM-vendor noise, watch flake) deliberately untouched.

Closes #1210

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced OpenAI provider startup reliability with extended timeout windows and deterministic polling-based verification
  * Improved job completion detection with status polling instead of fixed delays
  * Strengthened npm package installation resilience against transient network failures during builds and tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Round 2 (review-driven): the cancel-claim race fixed across ALL THREE runtimes
The review caught that the Java-only fixture fix covered one of three runtimes for an explicitly cross-runtime race — and found the latent TS sibling. Now: Python and TS fixtures gate on the same non-null `owner_instance_id` claim marker (transient status() failures tolerated within the budget in all three), **uc21/tc26 is re-migrated to settle reliance** (undoing the #1209 revert that was parked on #1207), and tc16's failure paths dump full status JSON.

Verification round 2: 3 iterations × {uc21/tc26 py, uc22/tc26 ts, uc23/tc26 java, uc23/tc16} = **12/12 green** on the cluster.

Closes #1207