### PR TITLE
fix(python): build SSE route endpoints at decoration time — settle grace holds on streaming paths

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/settle.py
+++ b/src/runtime/python/_mcp_mesh/engine/settle.py
@@ -179,6 +179,37 @@ class SettleState:
                 # nothing left to wake.
                 pass
 
+    def retire_declared(self, dep_key: str) -> None:
+        """Remove a declared key that no update path will ever resolve.
+
+        Used by route-wrapper convergence in the dual-import scenario
+        (``python main.py`` + ``from main import X``): each decoration pass
+        created its own DI wrapper and declared its own func_id-scoped keys,
+        but after convergence only the preferred instance receives heartbeat
+        updates. Leaving the abandoned instance's keys declared would pin
+        the eager latch open for the full window — every graced call would
+        then wait out the budget even after all live dependencies resolved.
+
+        Any waiter already parked on the retired key (a call that collected
+        its pending set just before convergence) is woken so it proceeds
+        immediately instead of dead-waiting a key that can never resolve.
+        """
+        with self._lock:
+            self._declared.discard(dep_key)
+            event = self._events.get(dep_key)
+            async_waiters = list(self._async_waiters.get(dep_key, ()))
+            if self._declared and self._declared <= self._resolved:
+                # Eager latch: the retired key was the last unresolved one.
+                self._settled = True
+        if event is not None:
+            event.set()
+        for loop, async_event in async_waiters:
+            try:
+                loop.call_soon_threadsafe(async_event.set)
+            except RuntimeError:
+                # The waiter's loop already closed (shutdown mid-wait).
+                pass
+
     def is_settled(self) -> bool:
         """Permanent latch check; flips on window expiry or timeout=0."""
         if self._settled:

--- a/src/runtime/python/_mcp_mesh/engine/settle.py
+++ b/src/runtime/python/_mcp_mesh/engine/settle.py
@@ -121,6 +121,12 @@ class SettleState:
         self._lock = threading.Lock()
         self._declared: set[str] = set()
         self._resolved: set[str] = set()
+        # Terminal-but-NOT-resolved keys (see retire_declared): retired by
+        # route-wrapper convergence because no update path will ever resolve
+        # them. Semantically distinct from _resolved — no proxy ever landed —
+        # but both mean "stop waiting": late waits short-circuit on retired
+        # keys exactly like resolved ones.
+        self._retired: set[str] = set()
         self._events: dict[str, threading.Event] = {}
         # Loop-native mirrors for async waiters: dep_key -> [(loop, event)].
         # Set via loop.call_soon_threadsafe from the resolution funnel so
@@ -193,16 +199,31 @@ class SettleState:
         Any waiter already parked on the retired key (a call that collected
         its pending set just before convergence) is woken so it proceeds
         immediately instead of dead-waiting a key that can never resolve.
+
+        Retired keys are TERMINAL: the key joins ``_retired`` and its
+        per-key event is created-and-set, so a LATE wait — the abandoned
+        twin wrapper remains callable after convergence (direct invocation,
+        or uvicorn serving the copy whose endpoint was converged away) —
+        short-circuits on both the sync and async paths instead of parking
+        for the remaining budget. Retired ≠ resolved (no proxy ever
+        landed), but both mean "stop waiting".
         """
         with self._lock:
             self._declared.discard(dep_key)
+            self._retired.add(dep_key)
             event = self._events.get(dep_key)
+            if event is None:
+                event = threading.Event()
+                self._events[dep_key] = event
             async_waiters = list(self._async_waiters.get(dep_key, ()))
-            if self._declared and self._declared <= self._resolved:
-                # Eager latch: the retired key was the last unresolved one.
+            if self._start is not None and self._declared <= self._resolved:
+                # Eager latch: the retired key was the last unresolved one —
+                # including retire-to-empty, where nothing declared remains
+                # to converge. Guarded on the window being anchored so a
+                # spurious retire before any declaration can never latch
+                # the grace shut for later declarations.
                 self._settled = True
-        if event is not None:
-            event.set()
+        event.set()
         for loop, async_event in async_waiters:
             try:
                 loop.call_soon_threadsafe(async_event.set)
@@ -300,7 +321,7 @@ class SettleState:
         loop = asyncio.get_running_loop()
         async_event = asyncio.Event()
         with self._lock:
-            if dep_key in self._resolved:
+            if dep_key in self._resolved or dep_key in self._retired:
                 return
             self._async_waiters.setdefault(dep_key, []).append(
                 (loop, async_event)

--- a/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
@@ -2,6 +2,7 @@ import functools
 import inspect
 import json
 import logging
+import os
 from typing import Any
 
 from ...engine.decorator_registry import DecoratorRegistry
@@ -41,6 +42,83 @@ def _frame_chunk_as_sse(chunk: str) -> str:
     return "".join(f"data: {line}\n" for line in lines) + "\n"
 
 
+def _converge_to_preferred_wrapper(wrapper: Any) -> Any:
+    """Multi-wrapper convergence for the dual-import scenario.
+
+    ``python main.py`` plus a sibling ``from main import X`` evaluates the
+    entry script twice as distinct modules (``__main__`` and ``main``), so
+    @mesh.route decoration fires twice and registers two independent DI
+    wrapper instances in the injector's function registry — one under
+    ``__main__.<qualname>``, one under ``<module>.<qualname>``. Heartbeat
+    dependency updates land on only one of them, so route integration must
+    serve/register the instance updates actually reach. This preserves the
+    preference the legacy "CRITICAL FIX" convergence applied: among multiple
+    instances of the same source function, prefer the non-``__main__`` one.
+
+    Matching is conservative (mirrors ``dual_module_detection``): a candidate
+    counts only when its original function has the SAME qualname and the SAME
+    code location (file + first line) — i.e., it is literally the same source
+    function evaluated under another module name.
+
+    Side effect: any abandoned ``__main__`` instance has its settle keys
+    retired. Both decoration passes declared func_id-scoped settle keys, but
+    no update path targets the abandoned instance — leaving its keys declared
+    would pin the eager settle latch open for the full window (#1193).
+
+    Returns the preferred wrapper (possibly ``wrapper`` itself, unchanged).
+    """
+    from ...engine.settle import get_settle_state
+
+    injector = get_global_injector()
+    original = getattr(wrapper, "_mesh_original_func", wrapper)
+    qualname = getattr(original, "__qualname__", "") or ""
+    code = getattr(original, "__code__", None)
+    if not qualname or code is None:
+        return wrapper
+    is_main_instance = getattr(original, "__module__", "") == "__main__"
+    source_location = (os.path.abspath(code.co_filename), code.co_firstlineno)
+
+    def _same_source(candidate: Any) -> bool:
+        cand_orig = getattr(candidate, "_mesh_original_func", candidate)
+        if getattr(cand_orig, "__qualname__", "") != qualname:
+            return False
+        cand_code = getattr(cand_orig, "__code__", None)
+        if cand_code is None:
+            return False
+        return (
+            os.path.abspath(cand_code.co_filename),
+            cand_code.co_firstlineno,
+        ) == source_location
+
+    preferred = wrapper
+    abandoned: list[Any] = []
+    for func_id, candidate in list(injector._function_registry.items()):
+        if candidate is wrapper or not _same_source(candidate):
+            continue
+        if func_id.startswith("__main__."):
+            # A __main__-registered twin that heartbeat updates will never
+            # target once registration converges on the named-module form.
+            abandoned.append(candidate)
+        elif is_main_instance and preferred is wrapper:
+            preferred = candidate
+
+    if preferred is not wrapper:
+        abandoned.append(wrapper)
+        logger.info(
+            f"🔀 Converging route wrapper for '{qualname}' from its __main__ "
+            f"instance to the preferred module instance — heartbeat "
+            f"dependency updates land on the latter"
+        )
+
+    settle_state = get_settle_state()
+    for instance in abandoned:
+        for key in getattr(instance, "_mesh_settle_keys", None) or []:
+            if key is not None:
+                settle_state.retire_declared(key)
+
+    return preferred
+
+
 def _build_sse_endpoint(wrapped_handler: Any, user_func: Any) -> Any:
     """Wrap a streaming route handler so FastAPI emits Server-Sent Events.
 
@@ -67,16 +145,28 @@ def _build_sse_endpoint(wrapped_handler: Any, user_func: Any) -> Any:
     )
 
     injector = get_global_injector()
-    mesh_positions = list(getattr(wrapped_handler, "_mesh_positions", []) or [])
-    dependencies = list(getattr(wrapped_handler, "_mesh_dependencies", []) or [])
-    injected_deps = getattr(
-        wrapped_handler, "_mesh_injected_deps", [None] * len(dependencies)
-    )
-    settle_keys = getattr(wrapped_handler, "_mesh_settle_keys", None)
-    settle_params = getattr(wrapped_handler, "_mesh_settle_params", None)
 
     @functools.wraps(user_func)
     async def sse_endpoint(*args, **kwargs):
+        # Resolve the inner DI wrapper DYNAMICALLY through the endpoint's own
+        # ``_mesh_inner_wrapper`` attribute rather than the decoration-time
+        # closure. In the dual-import scenario (``python main.py`` + a sibling
+        # ``from main import X``) decoration fires twice, producing two wrapper
+        # instances — and the route-integration step converges heartbeat
+        # registration onto the preferred (non-__main__) one by re-pointing
+        # this attribute. A closure-captured wrapper would keep reading the
+        # abandoned copy's dependency arrays (which heartbeats never update)
+        # forever: the served endpoint would eat the full settle budget per
+        # request and then inject None.
+        inner = getattr(sse_endpoint, "_mesh_inner_wrapper", wrapped_handler)
+        mesh_positions = list(getattr(inner, "_mesh_positions", []) or [])
+        dependencies = list(getattr(inner, "_mesh_dependencies", []) or [])
+        injected_deps = getattr(
+            inner, "_mesh_injected_deps", [None] * len(dependencies)
+        )
+        settle_keys = getattr(inner, "_mesh_settle_keys", None)
+        settle_params = getattr(inner, "_mesh_settle_params", None)
+
         if mesh_positions:
             # Settling-window grace (#1193): same bounded wait the inner
             # DI wrapper applies — this endpoint bypasses that wrapper and
@@ -360,6 +450,66 @@ class RouteIntegrationStep(PipelineStep):
             f"with dependencies: {dependency_names}"
         )
 
+        # Issue #1206: streaming routes decorated by @mesh.route have their
+        # SSE endpoint built at DECORATION time — FastAPI registered the
+        # correct streaming endpoint at @app.post() time, so there is no
+        # handler to swap (and no window between server bind and pipeline
+        # execution where a request — possibly HELD by the #1193 settling
+        # grace — lands in the plain DI wrapper and 500s on its raw
+        # async-generator return). All that remains here is registering the
+        # INNER DI wrapper for heartbeat dependency updates: the SSE endpoint
+        # resolves that wrapper dynamically through its own
+        # ``_mesh_inner_wrapper`` attribute at call time, so re-pointing the
+        # attribute below converges the served endpoint and the heartbeat
+        # funnel onto the same instance.
+        if getattr(original_handler, "_mesh_is_sse_endpoint", False):
+            inner_wrapper = getattr(original_handler, "_mesh_inner_wrapper", None)
+            if inner_wrapper is None:
+                # Defensive only — _build_sse_endpoint always sets the
+                # attribute. Registering the SSE endpoint itself keeps the
+                # route entry present, but the endpoint has no
+                # _mesh_update_dependency, so the heartbeat funnel will
+                # silently skip it: dependencies will NEVER resolve for this
+                # route.
+                self.logger.warning(
+                    f"⚠️ SSE route {methods} {path} -> {endpoint_name}() is "
+                    f"missing its inner DI wrapper; registering the SSE "
+                    f"endpoint itself, which lacks _mesh_update_dependency — "
+                    f"heartbeat updates will silently skip this route and its "
+                    f"mesh dependencies will never resolve"
+                )
+                inner_wrapper = original_handler
+            else:
+                # Dual-import convergence: if decoration fired twice
+                # (__main__ + named module), heartbeat updates land on the
+                # preferred non-__main__ wrapper — re-point the endpoint's
+                # dynamic inner-wrapper reference and register THAT instance,
+                # so the served endpoint and the update funnel agree.
+                converged = _converge_to_preferred_wrapper(inner_wrapper)
+                if converged is not inner_wrapper:
+                    original_handler._mesh_inner_wrapper = converged
+                    inner_wrapper = converged
+            for method in methods:
+                DecoratorRegistry.register_route_wrapper(
+                    method=method,
+                    path=path,
+                    wrapper=inner_wrapper,
+                    dependencies=dependency_names,
+                )
+            self.logger.info(
+                f"📡 Route {methods} {path} -> {endpoint_name}() already "
+                f"SSE-wrapped at decoration time; registered for dependency "
+                f"updates"
+            )
+            return {
+                "status": "integrated",
+                "dependency_count": len(dependency_names),
+                "dependencies": dependency_names,
+                "original_handler": original_handler,
+                "wrapped_handler": original_handler,
+                "sse": True,
+            }
+
         user_func = _resolve_user_function(original_handler)
         try:
             stream_type = detect_stream_type(user_func)
@@ -431,32 +581,11 @@ class RouteIntegrationStep(PipelineStep):
             # Streaming route with no mesh dependencies — SSE wrapping only.
             wrapped_handler = original_handler
 
-        # CRITICAL FIX: Check if there are multiple wrapper instances for this function
-        # If so, use the one that actually receives dependency updates
-        from ...engine.dependency_injector import get_global_injector
-
-        injector = get_global_injector()
-
-        # Find all functions that depend on the first dependency of this route
+        # Multi-wrapper convergence (dual-import scenario): if decoration
+        # fired under both __main__ and the named module, prefer the wrapper
+        # instance that actually receives dependency updates.
         if dependency_names:
-            first_dep = dependency_names[
-                0
-            ]  # Use first dependency to find all instances
-            affected_functions = injector._dependency_mapping.get(first_dep, set())
-
-            # Check if there are multiple instances and if so, prefer the one that's NOT __main__
-            if len(affected_functions) > 1:
-                non_main_functions = [
-                    f for f in affected_functions if not f.startswith("__main__.")
-                ]
-                if non_main_functions:
-                    # Found a non-main instance, try to get that wrapper instead
-                    preferred_func_id = non_main_functions[0]  # Take first non-main
-                    preferred_wrapper = injector._function_registry.get(
-                        preferred_func_id
-                    )
-                    if preferred_wrapper:
-                        wrapped_handler = preferred_wrapper
+            wrapped_handler = _converge_to_preferred_wrapper(wrapped_handler)
 
         # Register the route wrapper in DecoratorRegistry for path-based dependency resolution
         # This creates a mapping from METHOD:path -> wrapper function

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -1776,19 +1776,63 @@ def route(
             # Also store a flag on the wrapper itself so route integration can detect it
             wrapped._mesh_is_injection_wrapper = True
 
-            # FastAPI inspects the endpoint's return annotation (via get_type_hints
-            # following __wrapped__) to build a Pydantic response_field. An
-            # AsyncIterator[str] / Stream[str] return is not a valid Pydantic field
-            # and crashes registration. The route integration step later detects the
-            # stream annotation on the underlying _mesh_original_func and installs an
-            # SSE-emitting endpoint, so the wrapper itself does not need to expose
-            # the streaming return type to FastAPI.
+            # Streaming routes: build the SSE endpoint at DECORATION time so
+            # FastAPI registers the correct streaming endpoint at @app.post()
+            # time (issue #1206). The route-integration pipeline step runs
+            # debounced AFTER uvicorn may already be serving — with only the
+            # post-registration endpoint swap, a request arriving in that
+            # window (or HELD across it by the #1193 settling-window grace)
+            # completed inside the plain DI wrapper, whose raw async-generator
+            # return value FastAPI cannot serialize → 500. Registering the
+            # SSE endpoint from the start removes the window entirely; the
+            # integration step detects ``_mesh_is_sse_endpoint`` and only
+            # registers the inner wrapper for heartbeat dependency updates.
             try:
                 from _mcp_mesh.engine.stream_introspection import (
                     detect_stream_type,
                 )
 
-                if detect_stream_type(target) == "text":
+                is_stream_route = detect_stream_type(target) == "text"
+            except Exception as e:
+                logger.debug(
+                    f"Stream-route detection skipped for {target.__name__}: {e}"
+                )
+                is_stream_route = False
+
+            if is_stream_route:
+                try:
+                    from _mcp_mesh.pipeline.api_startup.route_integration import (
+                        _build_sse_endpoint,
+                    )
+
+                    sse_endpoint = _build_sse_endpoint(wrapped, target)
+                    logger.debug(
+                        f"📡 Built SSE endpoint for streaming route "
+                        f"'{target.__name__}' at decoration time"
+                    )
+                    _trigger_debounced_processing()
+                    return sse_endpoint
+                except Exception as e:
+                    # Graceful degradation: fall back to the pre-#1206 flow
+                    # (annotation strip below + integration-time SSE swap).
+                    logger.warning(
+                        f"Decoration-time SSE endpoint build failed for route "
+                        f"'{target.__name__}' ({e}); falling back to the "
+                        f"integration-time endpoint swap — the pre-#1206 "
+                        f"startup race window applies to this route (a "
+                        f"request arriving before route integration runs may "
+                        f"hit the plain DI wrapper and fail with a 500)"
+                    )
+
+                # FastAPI inspects the endpoint's return annotation (via
+                # get_type_hints following __wrapped__) to build a Pydantic
+                # response_field. An AsyncIterator[str] / Stream[str] return
+                # is not a valid Pydantic field and crashes registration. The
+                # route integration step later detects the stream annotation
+                # on the underlying _mesh_original_func and installs an
+                # SSE-emitting endpoint, so the wrapper itself does not need
+                # to expose the streaming return type to FastAPI.
+                try:
                     import inspect as _inspect
 
                     from _mcp_mesh.engine.dependency_injector import (
@@ -1825,10 +1869,11 @@ def route(
                             parameters=cleaned_params,
                             return_annotation=_inspect.Signature.empty,
                         )
-            except Exception as e:
-                logger.debug(
-                    f"Stream-route annotation strip skipped for {target.__name__}: {e}"
-                )
+                except Exception as e:
+                    logger.debug(
+                        f"Stream-route annotation strip skipped for "
+                        f"{target.__name__}: {e}"
+                    )
 
             # Return the wrapped function - FastAPI will register this wrapper when it runs
             logger.debug(

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -1729,6 +1729,27 @@ def route(
             **kwargs,
         }
 
+        # Detect the streaming return annotation UP FRONT so an unsupported
+        # stream element type (e.g. Stream[bytes]) fails decoration with a
+        # clear error instead of silently becoming a non-streaming route
+        # (the handler's chunks would be accumulated and serialized — the
+        # opposite of what the annotation asks for). detect_stream_type only
+        # raises for genuine async-iterator annotations over a non-str type;
+        # benign non-stream outcomes (no async-iterator return, unresolvable
+        # string hints, unparameterized iterators) report None and stay on
+        # the plain-route path. Raising HERE — before the DecoratorRegistry
+        # registration and the graceful-degradation try block below — keeps
+        # the failure loud (mirrors the @mesh.tool decoration-time contract)
+        # and leaves no half-registered route behind.
+        from _mcp_mesh.engine.stream_introspection import detect_stream_type
+
+        try:
+            is_stream_route = detect_stream_type(target) == "text"
+        except ValueError as e:
+            raise ValueError(
+                f"@mesh.route '{getattr(target, '__name__', '?')}': {e}"
+            ) from None
+
         # Store metadata on function
         target._mesh_route_metadata = metadata
 
@@ -1787,18 +1808,8 @@ def route(
             # SSE endpoint from the start removes the window entirely; the
             # integration step detects ``_mesh_is_sse_endpoint`` and only
             # registers the inner wrapper for heartbeat dependency updates.
-            try:
-                from _mcp_mesh.engine.stream_introspection import (
-                    detect_stream_type,
-                )
-
-                is_stream_route = detect_stream_type(target) == "text"
-            except Exception as e:
-                logger.debug(
-                    f"Stream-route detection skipped for {target.__name__}: {e}"
-                )
-                is_stream_route = False
-
+            # (``is_stream_route`` was detected — fail-fast on unsupported
+            # stream element types — before registration, above.)
             if is_stream_route:
                 try:
                     from _mcp_mesh.pipeline.api_startup.route_integration import (

--- a/src/runtime/python/tests/unit/test_stream_settle.py
+++ b/src/runtime/python/tests/unit/test_stream_settle.py
@@ -1,0 +1,506 @@
+"""Settling-window grace on the streaming invocation paths (issue #1206).
+
+The #1193 grace already covered the non-streaming DI wrappers; these tests
+pin the same matrix on BOTH streaming wrapper shapes:
+
+* the decorator stream wrapper (``_make_stream_wrapper`` — async-generator
+  ``@mesh.tool`` functions, e.g. the multi-hop passthrough agent), and
+* the ``@mesh.route`` SSE endpoint (``_build_sse_endpoint``).
+
+Matrix per shape (mirrors ``test_settle_window.py``):
+
+(a) resolution mid-wait → the stream proceeds with the REAL proxy;
+(b) window timeout → today's behavior (the user's defensive branch runs:
+    ``yield "degraded"`` for tools, a clean ``HTTPException(503)`` for the
+    canonical two-function route shape — never a raw 500);
+(c) settled → zero wait (steady state never touches the wait primitives).
+
+Plus the #1206 root-cause regression: ``@mesh.route`` streaming handlers get
+their SSE endpoint built at DECORATION time, so FastAPI registers the correct
+streaming endpoint at ``@app.post()`` time. Before the fix, the SSE swap only
+happened in the debounced route-integration pipeline step — a request
+arriving before that step (or HELD across it by the settle grace) completed
+inside the plain DI wrapper, whose raw async-generator return value FastAPI
+cannot serialize → gateway 500.
+"""
+
+import asyncio
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
+from fastapi.testclient import TestClient
+
+import mesh
+from _mcp_mesh.engine import settle
+from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+from _mcp_mesh.engine.dependency_injector import DependencyInjector
+from _mcp_mesh.engine.settle import get_settle_state
+from _mcp_mesh.pipeline.api_startup import route_integration
+from _mcp_mesh.pipeline.api_startup.route_integration import (
+    RouteIntegrationStep,
+    _build_sse_endpoint,
+)
+
+
+@pytest.fixture(autouse=True)
+def fresh_state(monkeypatch):
+    """Isolate every test: fresh settle state + clean DecoratorRegistry."""
+    monkeypatch.delenv("MCP_MESH_SETTLE_TIMEOUT", raising=False)
+    settle._reset_settle_state_for_tests()
+    DecoratorRegistry.clear_all()
+    yield
+    settle._reset_settle_state_for_tests()
+    DecoratorRegistry.clear_all()
+
+
+def _set_budget(monkeypatch, value: str) -> None:
+    monkeypatch.setenv("MCP_MESH_SETTLE_TIMEOUT", value)
+    settle._reset_settle_state_for_tests()
+
+
+class FakeStreamingDep:
+    """Stand-in for an injected McpMeshTool whose remote tool streams."""
+
+    def __init__(self, chunks):
+        self.chunks = chunks
+
+    async def stream(self, **kwargs):
+        for c in self.chunks:
+            yield c
+
+
+def _make_stream_tool_wrapper(injector):
+    """Async-generator @mesh.tool shape (the multi-hop passthrough agent)."""
+
+    async def passthrough(prompt: str, chat: mesh.McpMeshTool = None) -> mesh.Stream[str]:
+        # Defensive user idiom — must keep working unchanged on timeout.
+        if chat is None:
+            yield "degraded"
+            return
+        async for chunk in chat.stream(prompt=prompt):
+            yield chunk
+
+    return injector.create_injection_wrapper(passthrough, ["chat_cap"])
+
+
+def _make_canonical_route_handler():
+    """The canonical two-function @mesh.route streaming shape (gateway)."""
+
+    async def _stream(prompt, chat):
+        async for chunk in chat.stream(prompt=prompt):
+            yield chunk
+
+    async def chat_endpoint(
+        prompt: str, chat: mesh.McpMeshTool = None
+    ) -> mesh.Stream[str]:
+        if chat is None:
+            raise HTTPException(
+                status_code=503, detail="chat capability unavailable"
+            )
+        return _stream(prompt, chat)
+
+    return chat_endpoint
+
+
+async def _drain(streaming_response: StreamingResponse) -> str:
+    chunks: list[str] = []
+    async for piece in streaming_response.body_iterator:
+        if isinstance(piece, bytes):
+            piece = piece.decode("utf-8")
+        chunks.append(piece)
+    return "".join(chunks)
+
+
+# ---------------------------------------------------------------------------
+# Shape 1: decorator stream wrapper (_make_stream_wrapper)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamToolWrapperSettle:
+    @pytest.mark.asyncio
+    async def test_resolution_mid_wait_streams_with_real_proxy(self, monkeypatch):
+        """(a) Event arriving mid-wait → the stream proceeds with the proxy."""
+        _set_budget(monkeypatch, "10")
+        injector = DependencyInjector()
+        wrapper = _make_stream_tool_wrapper(injector)
+        dep = FakeStreamingDep(["alpha", " beta"])
+
+        async def resolve_later():
+            await asyncio.sleep(0.2)
+            wrapper._mesh_update_dependency(0, dep)
+
+        resolver = asyncio.create_task(resolve_later())
+        start = time.monotonic()
+        result = await wrapper(prompt="hi")
+        elapsed = time.monotonic() - start
+        await resolver
+
+        assert result == "alpha beta"  # real proxy, chunks accumulated
+        assert elapsed < 5.0  # woken by the event, not the budget ceiling
+        assert get_settle_state().wait_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_runs_defensive_branch(self, monkeypatch):
+        """(b) No event → proceeds at budget with None; the user's
+        defensive ``if chat is None`` branch runs (today-behavior)."""
+        _set_budget(monkeypatch, "0.3")
+        injector = DependencyInjector()
+        wrapper = _make_stream_tool_wrapper(injector)
+
+        start = time.monotonic()
+        result = await wrapper(prompt="hi")
+        elapsed = time.monotonic() - start
+
+        assert result == "degraded"
+        assert elapsed >= 0.2  # actually waited toward the budget
+
+    @pytest.mark.asyncio
+    async def test_settled_streams_with_zero_wait(self, monkeypatch):
+        """(c) Dep resolved before the call → no wait primitives touched."""
+        _set_budget(monkeypatch, "10")
+        injector = DependencyInjector()
+        wrapper = _make_stream_tool_wrapper(injector)
+        wrapper._mesh_update_dependency(0, FakeStreamingDep(["x"]))
+
+        state = get_settle_state()
+        assert state.is_settled()
+
+        with patch.object(
+            state, "wait_for_async", wraps=state.wait_for_async
+        ) as wait_spy:
+            start = time.monotonic()
+            result = await wrapper(prompt="hi")
+            elapsed = time.monotonic() - start
+
+        assert result == "x"
+        assert elapsed < 0.5
+        wait_spy.assert_not_called()
+        assert state.wait_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Shape 2: @mesh.route SSE endpoint (_build_sse_endpoint)
+# ---------------------------------------------------------------------------
+
+
+class TestSseEndpointSettle:
+    def _build(self, injector):
+        handler = _make_canonical_route_handler()
+        wrapper = injector.create_injection_wrapper(handler, ["chat_cap"])
+        return wrapper, _build_sse_endpoint(wrapper, handler)
+
+    @pytest.mark.asyncio
+    async def test_resolution_mid_wait_streams_with_real_proxy(self, monkeypatch):
+        """(a) Event arriving mid-wait → SSE stream proceeds with the proxy."""
+        _set_budget(monkeypatch, "10")
+        injector = DependencyInjector()
+        wrapper, endpoint = self._build(injector)
+        dep = FakeStreamingDep(["alpha", "beta"])
+
+        async def resolve_later():
+            await asyncio.sleep(0.2)
+            wrapper._mesh_update_dependency(0, dep)
+
+        resolver = asyncio.create_task(resolve_later())
+        start = time.monotonic()
+        response = await endpoint(prompt="hi")
+        elapsed = time.monotonic() - start
+        await resolver
+
+        assert isinstance(response, StreamingResponse)
+        body = await _drain(response)
+        assert body == "data: alpha\n\ndata: beta\n\ndata: [DONE]\n\n"
+        assert elapsed < 5.0
+        assert get_settle_state().wait_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises_users_clean_503(self, monkeypatch):
+        """(b) No event → None injected at budget; the canonical shape's
+        defensive branch raises a clean HTTPException(503) — the degraded
+        contract — NOT a raw 500."""
+        _set_budget(monkeypatch, "0.3")
+        injector = DependencyInjector()
+        _, endpoint = self._build(injector)
+
+        start = time.monotonic()
+        with pytest.raises(HTTPException) as exc_info:
+            await endpoint(prompt="hi")
+        elapsed = time.monotonic() - start
+
+        assert exc_info.value.status_code == 503
+        assert elapsed >= 0.2
+
+    @pytest.mark.asyncio
+    async def test_settled_streams_with_zero_wait(self, monkeypatch):
+        """(c) Dep resolved before the call → no wait primitives touched."""
+        _set_budget(monkeypatch, "10")
+        injector = DependencyInjector()
+        wrapper, endpoint = self._build(injector)
+        wrapper._mesh_update_dependency(0, FakeStreamingDep(["x"]))
+
+        state = get_settle_state()
+        assert state.is_settled()
+
+        start = time.monotonic()
+        response = await endpoint(prompt="hi")
+        body = await _drain(response)
+        elapsed = time.monotonic() - start
+
+        assert body == "data: x\n\ndata: [DONE]\n\n"
+        assert elapsed < 0.5
+        assert state.wait_count == 0
+
+    @pytest.mark.asyncio
+    async def test_caller_supplied_dep_never_waits(self, monkeypatch):
+        """Mock contract: a caller-supplied slot skips the wait entirely."""
+        _set_budget(monkeypatch, "5")
+        injector = DependencyInjector()
+        _, endpoint = self._build(injector)
+        assert not get_settle_state().is_settled()
+
+        start = time.monotonic()
+        response = await endpoint(prompt="hi", chat=FakeStreamingDep(["m"]))
+        body = await _drain(response)
+        elapsed = time.monotonic() - start
+
+        assert body == "data: m\n\ndata: [DONE]\n\n"
+        assert elapsed < 0.5
+        assert get_settle_state().wait_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #1206 root cause: decoration-time SSE endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestDecorationTimeSseEndpoint:
+    def test_route_decorator_returns_sse_endpoint_for_stream_routes(self):
+        handler = _make_canonical_route_handler()
+        decorated = mesh.route(dependencies=["chat"])(handler)
+
+        assert getattr(decorated, "_mesh_is_sse_endpoint", False) is True
+        inner = decorated._mesh_inner_wrapper
+        assert callable(getattr(inner, "_mesh_update_dependency", None))
+        assert decorated._mesh_original_func is handler
+
+    def test_non_stream_route_unaffected(self):
+        async def plain(payload: dict, db: mesh.McpMeshTool = None) -> dict:
+            return {"ok": db is not None}
+
+        decorated = mesh.route(dependencies=["db"])(plain)
+        assert not getattr(decorated, "_mesh_is_sse_endpoint", False)
+
+    def test_pre_integration_request_streams_instead_of_500(self):
+        """THE #1206 regression: a request served BEFORE the route-integration
+        pipeline step runs must hit the SSE endpoint (registered at
+        @app.post() time), not the plain DI wrapper whose raw
+        async-generator return FastAPI cannot serialize (the observed
+        gateway 500)."""
+        handler = _make_canonical_route_handler()
+        decorated = mesh.route(dependencies=["chat"])(handler)
+
+        app = FastAPI()
+        app.post("/api/chat")(decorated)
+
+        # Resolve the dependency, but deliberately do NOT run
+        # RouteIntegrationStep — this is the pre-integration window.
+        decorated._mesh_inner_wrapper._mesh_update_dependency(
+            0, FakeStreamingDep(["alpha", "beta"])
+        )
+
+        client = TestClient(app)
+        with client.stream("POST", "/api/chat?prompt=hi") as response:
+            assert response.status_code == 200
+            assert response.headers["content-type"].startswith(
+                "text/event-stream"
+            )
+            body = response.read().decode("utf-8")
+
+        assert body == "data: alpha\n\ndata: beta\n\ndata: [DONE]\n\n"
+
+    def test_pre_integration_request_held_then_streams(self, monkeypatch):
+        """The full failure shape from the uc18 migration: a request that
+        arrives during settling is HELD by the grace and must complete in
+        the SSE endpoint once the dependency resolves mid-wait."""
+        _set_budget(monkeypatch, "10")
+        handler = _make_canonical_route_handler()
+        decorated = mesh.route(dependencies=["chat"])(handler)
+
+        app = FastAPI()
+        app.post("/api/chat")(decorated)
+
+        assert not get_settle_state().is_settled()
+
+        # Resolution arrives from a foreign thread while the request is
+        # held — the real heartbeat shape.
+        timer = threading.Timer(
+            0.3,
+            lambda: decorated._mesh_inner_wrapper._mesh_update_dependency(
+                0, FakeStreamingDep(["held", "ok"])
+            ),
+        )
+        timer.start()
+
+        client = TestClient(app)
+        start = time.monotonic()
+        with client.stream("POST", "/api/chat?prompt=hi") as response:
+            assert response.status_code == 200
+            body = response.read().decode("utf-8")
+        elapsed = time.monotonic() - start
+        timer.join()
+
+        assert body == "data: held\n\ndata: ok\n\ndata: [DONE]\n\n"
+        assert elapsed < 5.0  # woken by the event, not the 10s ceiling
+        assert get_settle_state().wait_count >= 1
+
+    def test_unresolved_after_window_returns_clean_503(self, monkeypatch):
+        """Degraded contract preserved: window expired + dep unresolved →
+        the user's defensive branch produces a clean 503 over HTTP."""
+        _set_budget(monkeypatch, "0.05")
+        handler = _make_canonical_route_handler()
+        decorated = mesh.route(dependencies=["chat"])(handler)
+
+        app = FastAPI()
+        app.post("/api/chat")(decorated)
+        time.sleep(0.1)  # let the window expire
+
+        client = TestClient(app)
+        response = client.post("/api/chat?prompt=hi")
+        assert response.status_code == 503
+        assert "chat capability unavailable" in response.text
+
+    def test_integration_step_keeps_decorator_built_endpoint(self):
+        """RouteIntegrationStep must not re-wrap a decoration-built SSE
+        endpoint — it only registers the inner wrapper for heartbeat
+        dependency updates."""
+        handler = _make_canonical_route_handler()
+        decorated = mesh.route(dependencies=["chat"])(handler)
+
+        app = FastAPI()
+        app.post("/api/chat")(decorated)
+
+        step = RouteIntegrationStep()
+        route_info = {
+            "endpoint": decorated,
+            "endpoint_name": decorated.__name__,
+            "path": "/api/chat",
+            "methods": ["POST"],
+            "dependencies": [{"capability": "chat"}],
+        }
+        result = step._integrate_single_route(app, route_info, None)
+
+        assert result["status"] == "integrated"
+        assert result["sse"] is True
+
+        # Endpoint identity unchanged on the app route.
+        endpoint = next(
+            r.endpoint
+            for r in app.router.routes
+            if getattr(r, "path", "") == "/api/chat"
+        )
+        assert endpoint is decorated
+
+        # Heartbeat updates target the INNER wrapper (whose injected-deps
+        # array the SSE endpoint reads by reference).
+        registered = DecoratorRegistry.get_route_wrapper("POST:/api/chat")
+        assert registered is not None
+        assert registered["wrapper"] is decorated._mesh_inner_wrapper
+
+    def test_dual_import_convergence_repoints_sse_endpoint(self, monkeypatch):
+        """Dual-import scenario (``python main.py`` + ``from main import X``):
+        decoration fires twice, producing TWO DI wrapper instances. The SSE
+        endpoint is closure-built against wrapper A (the __main__ instance),
+        but heartbeat updates land on wrapper B (the named-module instance,
+        last-write-wins under the METHOD:path registry key). Integration must
+        converge: re-point the endpoint's dynamic ``_mesh_inner_wrapper`` to
+        B and register B — so an update on B is visible to the SERVED
+        endpoint. Wrapper A's orphaned settle keys must be retired so the
+        eager settle latch still flips (no per-request budget-long holds)."""
+        _set_budget(monkeypatch, "10")
+        injector = DependencyInjector()
+        monkeypatch.setattr(
+            route_integration, "get_global_injector", lambda: injector
+        )
+
+        # Two evaluations of the same source function under different
+        # module names — same qualname, same code location.
+        handler_a = _make_canonical_route_handler()
+        handler_a.__module__ = "__main__"
+        handler_b = _make_canonical_route_handler()
+        handler_b.__module__ = "chat_agent"
+        wrapper_a = injector.create_injection_wrapper(handler_a, ["chat_cap"])
+        wrapper_b = injector.create_injection_wrapper(handler_b, ["chat_cap"])
+
+        # uvicorn serves the endpoint bound (at decoration time) to A.
+        endpoint = _build_sse_endpoint(wrapper_a, handler_a)
+        assert endpoint._mesh_inner_wrapper is wrapper_a
+
+        app = FastAPI()
+        app.post("/api/chat")(endpoint)
+
+        step = RouteIntegrationStep()
+        route_info = {
+            "endpoint": endpoint,
+            "endpoint_name": endpoint.__name__,
+            "path": "/api/chat",
+            "methods": ["POST"],
+            "dependencies": [{"capability": "chat_cap"}],
+        }
+        result = step._integrate_single_route(app, route_info, None)
+        assert result["status"] == "integrated"
+        assert result["sse"] is True
+
+        # Convergence: endpoint re-pointed to B; B registered for heartbeats.
+        assert endpoint._mesh_inner_wrapper is wrapper_b
+        registered = DecoratorRegistry.get_route_wrapper("POST:/api/chat")
+        assert registered is not None
+        assert registered["wrapper"] is wrapper_b
+
+        # Heartbeat resolves the dep on B (the registered wrapper)...
+        registered["wrapper"]._mesh_update_dependency(
+            0, FakeStreamingDep(["converged"])
+        )
+
+        # ...and A's orphaned declared key was retired, so resolving B's
+        # last key flips the eager latch — the window doesn't stay pinned
+        # open until timeout.
+        state = get_settle_state()
+        assert state.is_settled()
+
+        # The SERVED endpoint (built against A) reads the dep through its
+        # dynamic inner-wrapper reference — and with the latch settled it
+        # never touches the wait primitives.
+        client = TestClient(app)
+        with client.stream("POST", "/api/chat?prompt=hi") as response:
+            assert response.status_code == 200
+            body = response.read().decode("utf-8")
+        assert body == "data: converged\n\ndata: [DONE]\n\n"
+        assert state.wait_count == 0
+
+    def test_sse_build_failure_falls_back_to_integration_time_wrapping(
+        self, monkeypatch
+    ):
+        """Graceful degradation: when the decoration-time SSE build fails,
+        @mesh.route returns the DI wrapper with the streaming return
+        annotation stripped (the pre-#1206 flow) so FastAPI registration
+        still succeeds and the integration step can do the SSE swap."""
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("synthetic SSE build failure")
+
+        monkeypatch.setattr(route_integration, "_build_sse_endpoint", _boom)
+
+        handler = _make_canonical_route_handler()
+        decorated = mesh.route(dependencies=["chat"])(handler)
+
+        assert not getattr(decorated, "_mesh_is_sse_endpoint", False)
+        assert getattr(decorated, "_mesh_is_injection_wrapper", False) is True
+        assert "return" not in (getattr(decorated, "__annotations__", {}) or {})
+
+        # Registration must not crash (no Stream[str] response_field).
+        app = FastAPI()
+        app.post("/api/chat")(decorated)

--- a/src/runtime/python/tests/unit/test_stream_settle.py
+++ b/src/runtime/python/tests/unit/test_stream_settle.py
@@ -410,6 +410,23 @@ class TestDecorationTimeSseEndpoint:
         assert registered is not None
         assert registered["wrapper"] is decorated._mesh_inner_wrapper
 
+        # Re-entrancy: a second integration pass (the pipeline step is
+        # debounced and can re-run) must be a no-op with identical
+        # outcomes — same status/sse verdict, same served endpoint object,
+        # same registered inner wrapper.
+        result2 = step._integrate_single_route(app, route_info, None)
+        assert result2["status"] == "integrated"
+        assert result2["sse"] is True
+        endpoint2 = next(
+            r.endpoint
+            for r in app.router.routes
+            if getattr(r, "path", "") == "/api/chat"
+        )
+        assert endpoint2 is decorated
+        registered2 = DecoratorRegistry.get_route_wrapper("POST:/api/chat")
+        assert registered2 is not None
+        assert registered2["wrapper"] is decorated._mesh_inner_wrapper
+
     def test_dual_import_convergence_repoints_sse_endpoint(self, monkeypatch):
         """Dual-import scenario (``python main.py`` + ``from main import X``):
         decoration fires twice, producing TWO DI wrapper instances. The SSE
@@ -504,3 +521,126 @@ class TestDecorationTimeSseEndpoint:
         # Registration must not crash (no Stream[str] response_field).
         app = FastAPI()
         app.post("/api/chat")(decorated)
+
+
+# ---------------------------------------------------------------------------
+# Fail-fast on unsupported stream annotations (PR #1212 review)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamAnnotationFailFast:
+    def test_stream_bytes_route_fails_at_decoration(self):
+        """An async-iterator return over a non-str type is a STREAM
+        annotation the runtime cannot fulfil — it must fail decoration with
+        a descriptive error, never silently degrade to a non-stream route
+        that accumulates-and-serializes the chunks."""
+
+        async def bad_route(
+            prompt: str, chat: mesh.McpMeshTool = None
+        ) -> mesh.Stream[bytes]:
+            yield b"chunk"
+
+        with pytest.raises(ValueError) as exc_info:
+            mesh.route(dependencies=["chat"])(bad_route)
+
+        message = str(exc_info.value)
+        assert "@mesh.route 'bad_route'" in message
+        assert "Stream[bytes]" in message
+        assert "str" in message
+
+    def test_failed_decoration_leaves_no_half_registered_route(self):
+        """The raise happens BEFORE DecoratorRegistry registration — no
+        half-registered route survives the failure."""
+
+        async def bad_route(prompt: str) -> mesh.Stream[bytes]:
+            yield b"chunk"
+
+        with pytest.raises(ValueError):
+            mesh.route(dependencies=[])(bad_route)
+
+        assert "bad_route" not in DecoratorRegistry.get_all_by_type(
+            "mesh_route"
+        )
+
+    def test_unresolvable_hint_on_non_stream_route_stays_quiet(self):
+        """Benign hint-resolution failure (forward ref to a name that does
+        not exist) on a NON-stream route keeps the current quiet path —
+        decorates fine, no SSE."""
+
+        async def plain(payload: dict) -> "NoSuchTypeAnywhere":  # noqa: F821
+            return payload
+
+        decorated = mesh.route(dependencies=[])(plain)
+        assert not getattr(decorated, "_mesh_is_sse_endpoint", False)
+
+
+# ---------------------------------------------------------------------------
+# Retired settle keys are terminal (PR #1212 review)
+# ---------------------------------------------------------------------------
+
+
+class TestRetiredKeyTerminal:
+    def test_late_sync_wait_on_retired_key_returns_immediately(
+        self, monkeypatch
+    ):
+        """A wait_for that STARTS after the key was retired must
+        short-circuit — the abandoned twin wrapper remains callable after
+        convergence, and its keys can never resolve."""
+        _set_budget(monkeypatch, "10")
+        state = get_settle_state()
+        state.register_declared("twin:dep_0")
+        state.register_declared("live:dep_0")  # keeps the latch open
+        state.retire_declared("twin:dep_0")
+        assert not state.is_settled()
+
+        import logging
+
+        start = time.monotonic()
+        state.wait_for("twin:dep_0", "chat_cap", logging.getLogger(__name__))
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.5
+
+    @pytest.mark.asyncio
+    async def test_late_async_wait_on_retired_key_returns_immediately(
+        self, monkeypatch
+    ):
+        _set_budget(monkeypatch, "10")
+        state = get_settle_state()
+        state.register_declared("twin:dep_0")
+        state.register_declared("live:dep_0")  # keeps the latch open
+        state.retire_declared("twin:dep_0")
+        assert not state.is_settled()
+
+        import logging
+
+        start = time.monotonic()
+        await state.wait_for_async(
+            "twin:dep_0", "chat_cap", logging.getLogger(__name__)
+        )
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.5
+        assert state.wait_count == 0  # short-circuited before parking
+
+    def test_retire_to_empty_flips_the_latch(self, monkeypatch):
+        """Retiring the LAST declared key (nothing left to converge) settles
+        the agent eagerly — the window does not stay pinned open until
+        timeout."""
+        _set_budget(monkeypatch, "10")
+        state = get_settle_state()
+        state.register_declared("twin:dep_0")
+        assert not state.is_settled()
+        state.retire_declared("twin:dep_0")
+        assert state.is_settled()
+
+    def test_retire_with_unresolved_keys_left_keeps_latch_open(
+        self, monkeypatch
+    ):
+        _set_budget(monkeypatch, "10")
+        state = get_settle_state()
+        state.register_declared("twin:dep_0")
+        state.register_declared("live:dep_0")
+        state.retire_declared("twin:dep_0")
+        assert not state.is_settled()
+        # ...and resolving the remaining live key then flips it eagerly.
+        state.mark_resolved("live:dep_0")
+        assert state.is_settled()

--- a/tests/integration/suites/uc18_streaming/tc01_single_hop_sse/test.yaml
+++ b/tests/integration/suites/uc18_streaming/tc01_single_hop_sse/test.yaml
@@ -48,7 +48,7 @@ test:
   - name: "Start gateway-agent (port 9172)"
     handler: shell
     workdir: /workspace
-    command: "meshctl start streaming/gateway-agent/main.py -d"
+    command: "meshctl start streaming/gateway-agent/main.py --env MCP_MESH_SETTLE_TIMEOUT=60 -d"
     capture: start_gateway
 
   # NOTE: gateway-agent registers as "api-<hash>" (mesh.route-only services do not
@@ -89,12 +89,28 @@ test:
     capture: wait_output
     timeout: 150
 
-  # Small additional sleep to let the gateway's `chat` dep resolve before
-  # curl tests fire. End-to-end SSE assertions below will fail loudly if it
-  # didn't, so this just avoids a flaky first-call race.
-  - name: "Brief settle for gateway chat dep resolution"
-    handler: wait
-    seconds: 5
+  # Liveness gate (NOT dependency resolution): the gateway registers as
+  # "api-<hash>" so the named-agent wait above never covers it — poll its
+  # plain-JSON health route until uvicorn has bound. Dependency resolution
+  # itself needs no wait: the settling-window grace
+  # (MCP_MESH_SETTLE_TIMEOUT=60 on the gateway) holds the first SSE request
+  # until the `chat` dep resolves (issue #1206).
+  - name: "Wait for gateway HTTP server up"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 30); do
+        CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9172/api/health 2>/dev/null || true)
+        if [ "$CODE" = "200" ]; then
+          echo "gateway HTTP up after $i attempt(s)"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: gateway /api/health not responding within 30s (last code: $CODE)"
+      exit 1
+    capture: gateway_up
+    timeout: 45
 
   - name: "Curl POST /api/chat (capture full SSE stream body)"
     handler: shell

--- a/tests/integration/suites/uc18_streaming/tc02_multi_hop_passthrough/test.yaml
+++ b/tests/integration/suites/uc18_streaming/tc02_multi_hop_passthrough/test.yaml
@@ -44,13 +44,13 @@ test:
   - name: "Start passthrough-agent (port 9171, depends on 'chat')"
     handler: shell
     workdir: /workspace
-    command: "meshctl start streaming/passthrough-agent/main.py -d"
+    command: "meshctl start streaming/passthrough-agent/main.py --env MCP_MESH_SETTLE_TIMEOUT=60 -d"
     capture: start_passthrough
 
   - name: "Start gateway-agent (port 9172, depends on 'chat' AND 'chat_passthrough')"
     handler: shell
     workdir: /workspace
-    command: "meshctl start streaming/gateway-agent/main.py -d"
+    command: "meshctl start streaming/gateway-agent/main.py --env MCP_MESH_SETTLE_TIMEOUT=60 -d"
     capture: start_gateway
 
   # NOTE: gateway-agent registers as "api-<hash>" (mesh.route-only services do
@@ -88,12 +88,28 @@ test:
     capture: wait_output
     timeout: 150
 
-  # Small additional sleep to let the gateway's `chat` and `chat_passthrough`
-  # deps resolve before the multi-hop curl fires. The per-chunk SSE assertions
-  # below will fail loudly if resolution didn't complete.
-  - name: "Brief settle for gateway dep resolution"
-    handler: wait
-    seconds: 5
+  # Liveness gate (NOT dependency resolution): the gateway registers as
+  # "api-<hash>" so the named-agent wait above never covers it — poll its
+  # plain-JSON health route until uvicorn has bound. Dependency resolution
+  # itself needs no wait: the settling-window grace
+  # (MCP_MESH_SETTLE_TIMEOUT=60 on gateway + passthrough) holds the multi-hop
+  # SSE request at each hop until its dep resolves (issue #1206).
+  - name: "Wait for gateway HTTP server up"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 30); do
+        CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9172/api/health 2>/dev/null || true)
+        if [ "$CODE" = "200" ]; then
+          echo "gateway HTTP up after $i attempt(s)"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: gateway /api/health not responding within 30s (last code: $CODE)"
+      exit 1
+    capture: gateway_up
+    timeout: 45
 
   - name: "Curl POST /api/chat-multihop (capture full multi-hop SSE stream body)"
     handler: shell


### PR DESCRIPTION
## Summary
Closes #1206 — the last real gap from the settle-grace rollout, and with it the last dependency-resolution sleeps in the entire integration suite.

- **Root cause (traced via live repro; all three working hypotheses disproven)**: a startup-ordering race the settle hold widened into near-certainty. `@mesh.route` registered the *plain* DI wrapper with FastAPI at import; the SSE endpoint was only swapped in by the debounced route-integration step ~1–2s after uvicorn started serving. Pre-settle, a request in that window failed fast on the unresolved dep; post-settle it was *held across the swap*, resolved, and the plain wrapper returned a raw async generator FastAPI can't serialize → 500. The reported multi-hop `.stream()` shape was misattribution — the stream wrapper's hold was verified correct all along.
- **Fix**: streaming routes build their SSE endpoint at decoration time, exactly like non-streaming routes always did — eliminating the window and the post-registration-swap FastAPI traps on the primary path. The endpoint resolves its inner DI wrapper *dynamically* (own-attribute read at call time), and the integration step converges it to the preferred wrapper instance in the double-import (`__main__` + named module) scenario, registering that instance for the heartbeat funnel. The old swap survives only as a loudly-logged fallback (consequence stated) if the build fails.
- **Two latent bugs fixed en route**: the integration step re-wrapped SSE endpoints on a second pipeline run (re-entrancy); and the old path's "CRITICAL FIX" convergence block was **dead code** — it queried the dependency mapping with the wrong key shape, so `affected_functions` was always empty. The extracted helper implements the intended semantics against the real keying (conservative: same source qualname+location, converge away from `__main__` only) — making convergence functional for non-SSE routes for the first time (flagged as an intended semantic activation, not just refactoring).
- **Settle-state addition**: `retire_declared` — an abandoned twin's orphaned declared keys would otherwise pin the eager latch open for the full window; retirement re-checks the latch and wakes parked waiters.
- **Contract preserved**: settle timeout → None → the user's defensive branch (a clean 503 in the canonical shape); no stream-chunk buffering — the hold completes before streaming begins.
- **uc18 tc01/tc02 re-migrated sleep-free** (closing the final #1209 exclusion), with a bounded gateway `/api/health` poll covering the bind-liveness gap the deleted sleep had been incidentally masking (the gateway registers as `api-<hash>`, so named-agent polls never covered it).

## Review Notes
- Independent review verified all six documented streaming-trap risk areas: decoration-time inputs all stamped before the build, the old annotation-strip's three jobs subsumed by the rebuilt signature, the by-reference dep-array chain mutation-only, fallback triggers environmental-only, re-entrancy idempotent, non-streaming routes byte-identical.
- Its warning (SSE branch bypassing multi-instance convergence — permanent heartbeat disconnect in the double-import scenario) drove the dynamic-resolution + convergence + key-retirement round, pinned by a dual-import test that exercises the full chain through a real FastAPI TestClient.

Closes #1206

## Test plan
- [x] Full Python unit suite: 1163 passed (15 new stream-settle tests incl. the pre-integration-500 regression pin and the dual-import convergence chain)
- [x] End-to-end repro replay: previously-500 single-hop → held 5.5s, streamed 9/9 chunks, HTTP 200; multi-hop both-hops-settling → 200
- [x] uc18 tc01/tc02 sleep-free on the cluster: 4 rounds green (plus a post-convergence rerun)
- [x] src-tests image rebuild green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming routes may build SSE endpoints at decoration time for faster, more reliable startup.
  * Decoration-time validation now fails fast for unsupported stream element types.

* **Bug Fixes**
  * Improved convergence so heartbeat updates target the correct wrapper in dual-import scenarios.
  * Settle logic now retires unresolved dependencies cleanly and avoids lingering waits.
  * Integration tests use health polling and extended settle timeout for robust startup checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->