### PR TITLE
fix(ts): callMcpTool publishes one span per call, not per attempt

### DIFF
--- a/src/runtime/typescript/src/__tests__/proxy-tool-error.test.ts
+++ b/src/runtime/typescript/src/__tests__/proxy-tool-error.test.ts
@@ -238,12 +238,11 @@ describe("callMcpTool abort mid-SSE-read span accounting", () => {
     });
   });
 
-  it("still publishes the SSE-reader error span for genuine tool errors", async () => {
+  it("still publishes exactly one error span for genuine SSE tool errors", async () => {
     // Counterpart guard: the abort fix must not stop non-abort SSE-reader
-    // errors from publishing their error span. The first published span
-    // carries the precise tool-error message, and nothing is mislabeled
-    // "timeout". (A generic post-loop span on exhausted retries is
-    // pre-existing JSON-path behavior, deliberately not asserted on.)
+    // errors from being accounted. Since #1202, the post-loop aggregate is
+    // the single publisher: one span, carrying the precise tool-error
+    // message, nothing mislabeled "timeout".
     mockFetch(() => sseResponse([{ result: TOOL_ERROR_RESULT }]));
 
     await expect(
@@ -253,11 +252,193 @@ describe("callMcpTool abort mid-SSE-read span accounting", () => {
     ).rejects.toThrow("MCP tool error: boom: division by zero");
 
     const calls = vi.mocked(publishTraceSpan).mock.calls;
-    expect(calls.length).toBeGreaterThanOrEqual(1);
+    expect(calls.length).toBe(1);
     expect(calls[0][0]).toMatchObject({
       success: false,
       error: "MCP tool error: boom: division by zero",
     });
     expect(calls.some((c) => c[0].error === "timeout")).toBe(false);
+  });
+});
+
+describe("callMcpTool per-call span accounting (#1202)", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    vi.mocked(publishTraceSpan).mockClear();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("single failed call (maxAttempts=1) publishes exactly ONE error span", async () => {
+    // Regression: the JSON-RPC error branch used to publish a per-attempt
+    // error span AND the post-loop aggregate published a second one — two
+    // span records sharing one spanId for a single failed call.
+    mockFetch(() => jsonResponse({ error: { code: -32603, message: "internal failure" } }));
+
+    await expect(
+      runWithTraceContext({ traceId: "trace-1202-a", parentSpanId: null }, () =>
+        callMcpTool(ENDPOINT, TOOL, { a: 1 }, DEFAULT_CALL_OPTIONS, CAPABILITY)
+      )
+    ).rejects.toThrow("MCP error: internal failure");
+
+    expect(publishTraceSpan).toHaveBeenCalledTimes(1);
+    const span = vi.mocked(publishTraceSpan).mock.calls[0][0];
+    expect(span).toMatchObject({
+      spanId: "span-mock",
+      success: false,
+      error: "MCP error: internal failure",
+    });
+    // Single-attempt spans don't carry attempts info
+    expect(span.callAttempts).toBeUndefined();
+    // The response body size (formerly only on the per-attempt span) is
+    // folded into the aggregate.
+    expect(span.responseBytes).toBeGreaterThan(0);
+  });
+
+  it("exhausted retries (maxAttempts=3) publish exactly ONE error span carrying attempts info", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ result: TOOL_ERROR_RESULT }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      runWithTraceContext({ traceId: "trace-1202-b", parentSpanId: null }, () =>
+        callMcpTool(
+          ENDPOINT,
+          TOOL,
+          { a: 1 },
+          { ...DEFAULT_CALL_OPTIONS, maxAttempts: 3, retryDelay: 1 },
+          CAPABILITY
+        )
+      )
+    ).rejects.toThrow("MCP tool error: boom: division by zero");
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(publishTraceSpan).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(publishTraceSpan).mock.calls[0][0]).toMatchObject({
+      success: false,
+      error: "MCP tool error: boom: division by zero",
+      callAttempts: 3,
+    });
+  });
+
+  it("success after retry publishes exactly ONE success span (attempts noted, no error spans)", async () => {
+    let call = 0;
+    const fetchMock = vi.fn(async () => {
+      call += 1;
+      return call === 1
+        ? jsonResponse({ error: { code: -32603, message: "transient failure" } })
+        : jsonResponse({ result: { content: [{ type: "text", text: "fine" }] } });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const value = await runWithTraceContext(
+      { traceId: "trace-1202-c", parentSpanId: null },
+      () =>
+        callMcpTool(
+          ENDPOINT,
+          TOOL,
+          { a: 1 },
+          { ...DEFAULT_CALL_OPTIONS, maxAttempts: 2, retryDelay: 1 },
+          CAPABILITY
+        )
+    );
+
+    expect(value).toBe("fine");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(publishTraceSpan).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(publishTraceSpan).mock.calls[0][0]).toMatchObject({
+      success: true,
+      error: null,
+      callAttempts: 2,
+    });
+  });
+
+  it("first-attempt success publishes one success span without attempts info", async () => {
+    mockFetch(() => jsonResponse({ result: { content: [{ type: "text", text: "fine" }] } }));
+
+    const value = await runWithTraceContext(
+      { traceId: "trace-1202-d", parentSpanId: null },
+      () => callMcpTool(ENDPOINT, TOOL, { a: 1 }, DEFAULT_CALL_OPTIONS, CAPABILITY)
+    );
+
+    expect(value).toBe("fine");
+    expect(publishTraceSpan).toHaveBeenCalledTimes(1);
+    const span = vi.mocked(publishTraceSpan).mock.calls[0][0];
+    expect(span).toMatchObject({ success: true, error: null });
+    expect(span.callAttempts).toBeUndefined();
+  });
+
+  it("timeout on attempt 2 (after a retried generic failure) publishes ONE timeout span with callAttempts: 2", async () => {
+    // The abort/timeout path is non-retryable and publishes immediately from
+    // the catch — but when it strikes on a later attempt, its span must still
+    // carry the total attempts the call burned, not look like a first-try
+    // timeout.
+    let call = 0;
+    const fetchMock = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return jsonResponse({ error: { code: -32603, message: "transient failure" } });
+      }
+      throw new DOMException("This operation was aborted", "AbortError");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      runWithTraceContext({ traceId: "trace-1202-e", parentSpanId: null }, () =>
+        callMcpTool(
+          ENDPOINT,
+          TOOL,
+          { a: 1 },
+          { ...DEFAULT_CALL_OPTIONS, maxAttempts: 3, retryDelay: 1 },
+          CAPABILITY
+        )
+      )
+    ).rejects.toThrow(`MCP call timed out after ${DEFAULT_CALL_OPTIONS.timeout}ms`);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(publishTraceSpan).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(publishTraceSpan).mock.calls[0][0]).toMatchObject({
+      success: false,
+      error: "timeout",
+      callAttempts: 2,
+    });
+  });
+
+  it("SSE success after retry publishes exactly ONE success span with callAttempts: 2", async () => {
+    // The SSE success branch has its own publish site; it must carry the
+    // same attempts accounting as the JSON branch.
+    let call = 0;
+    const fetchMock = vi.fn(async () => {
+      call += 1;
+      return call === 1
+        ? jsonResponse({ error: { code: -32603, message: "transient failure" } })
+        : sseResponse([{ result: { content: [{ type: "text", text: "fine" }] } }]);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const value = await runWithTraceContext(
+      { traceId: "trace-1202-f", parentSpanId: null },
+      () =>
+        callMcpTool(
+          ENDPOINT,
+          TOOL,
+          { a: 1 },
+          { ...DEFAULT_CALL_OPTIONS, maxAttempts: 2, retryDelay: 1 },
+          CAPABILITY
+        )
+    );
+
+    expect(value).toBe("fine");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(publishTraceSpan).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(publishTraceSpan).mock.calls[0][0]).toMatchObject({
+      success: true,
+      error: null,
+      callAttempts: 2,
+    });
   });
 });

--- a/src/runtime/typescript/src/debug.ts
+++ b/src/runtime/typescript/src/debug.ts
@@ -15,7 +15,7 @@
  * ```
  */
 
-type DebugCategory = "llm" | "llm-provider" | "sse" | "template" | "agent" | "registry" | "provider-handler-registry" | "provider-handler" | "claude-handler" | "openai-handler" | "gemini-handler" | "media-resolver";
+type DebugCategory = "llm" | "llm-provider" | "sse" | "template" | "agent" | "registry" | "proxy" | "provider-handler-registry" | "provider-handler" | "claude-handler" | "openai-handler" | "gemini-handler" | "media-resolver";
 
 /** Log levels in order of severity */
 const LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] as const;

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -19,6 +19,9 @@ import { isTimeoutError } from "./timeout-utils.js";
 import { getDispatcher } from "./http-pool.js";
 import { currentJob } from "./job-context.js";
 import { awaitJobCancel } from "@mcpmesh/core";
+import { createDebug } from "./debug.js";
+
+const debugProxy = createDebug("proxy");
 
 /** Options for callMcpTool, derived from DependencyKwargs. */
 export interface CallOptions {
@@ -405,6 +408,10 @@ export async function callMcpTool(
   } = buildMcpRequest(endpoint, toolName, args, options, extraHeaders, DEFAULT_CALL_OPTIONS.timeout);
 
   let lastError: Error | null = null;
+  // Response size of the most recent attempt that got far enough to read a
+  // body — carried onto the post-loop aggregate error span so a failed call's
+  // span still reports payload size (per-attempt spans used to carry it).
+  let lastResponseBytes: number | undefined;
 
   for (let attempt = 0; attempt < options.maxAttempts; attempt++) {
     // Abort timer covers the WHOLE attempt — connect, headers, AND body
@@ -452,35 +459,28 @@ export async function callMcpTool(
 
       const contentType = response.headers.get("content-type") ?? "";
 
-      // Handle SSE streaming response
+      // Handle SSE streaming response.
+      //
+      // Span accounting (#1202): spans are per-call, not per-attempt. Error
+      // paths in this loop body throw WITHOUT publishing — the outer catch
+      // owns the non-retryable single-span paths (abort/timeout,
+      // ProxyTimeoutError) and the post-loop aggregate owns retried-then-
+      // exhausted errors. Publishing here too would emit multiple spans
+      // sharing one spanId.
       if (contentType.includes("text/event-stream")) {
         // Estimate response size from content-length header (exact size not available for SSE)
         const sseResponseBytes = contentLength > 0 ? contentLength : undefined;
-        let sseResult: string | MultiContentResult;
-        try {
-          sseResult = await readSSEResponseToContent(response);
-        } catch (sseErr) {
-          // Mirror the JSON path below: JSON-RPC errors and tool-level errors
-          // (CallToolResult.isError) thrown by the SSE reader record an error
-          // span instead of a success span. Aborts (timeout or job-cancel
-          // firing mid-read) and the proxy's in-band timeout marker (#1201)
-          // are deliberately NOT published here — the outer catch owns
-          // timeout accounting, and publishing in both places would emit two
-          // spans with the same spanId.
-          if (!isTimeoutError(sseErr) && !(sseErr instanceof ProxyTimeoutError)) {
-            const sseErrMsg = sseErr instanceof Error ? sseErr.message : String(sseErr);
-            publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, sseErrMsg, "error", requestBytes, sseResponseBytes);
-          }
-          throw sseErr;
-        }
+        lastResponseBytes = sseResponseBytes;
+        const sseResult = await readSSEResponseToContent(response);
         // Publish success span
-        publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, true, null, typeof sseResult, requestBytes, sseResponseBytes);
+        publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, true, null, typeof sseResult, requestBytes, sseResponseBytes, attempt + 1);
         return sseResult;
       }
 
       // Handle JSON response — read as text to measure byte size
       const responseText = await response.text();
       const responseBytes = Buffer.byteLength(responseText, "utf8");
+      lastResponseBytes = responseBytes;
       const result = JSON.parse(responseText) as {
         error?: { message?: string };
         result?: unknown;
@@ -488,8 +488,6 @@ export async function callMcpTool(
 
       if (result.error) {
         const errorMsg = result.error.message ?? JSON.stringify(result.error);
-        // Publish error span
-        publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, errorMsg, "error", requestBytes, responseBytes);
         throw new Error(`MCP error: ${errorMsg}`);
       }
 
@@ -499,21 +497,20 @@ export async function callMcpTool(
       // re-wrap it instead of returning the error text as a successful result.
       const toolErrMsg = toolErrorMessage(result.result);
       if (toolErrMsg !== null) {
-        publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, toolErrMsg, "error", requestBytes, responseBytes);
         throw new Error(`MCP tool error: ${toolErrMsg}`);
       }
 
       // Extract content from result
       const content = extractContent(result.result);
       // Publish success span
-      publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, true, null, typeof content, requestBytes, responseBytes);
+      publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, true, null, typeof content, requestBytes, responseBytes, attempt + 1);
       return content;
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
 
       // Don't retry on abort (timeout)
       if (isTimeoutError(lastError)) {
-        publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, "timeout", "error", requestBytes);
+        publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, "timeout", "error", requestBytes, undefined, attempt + 1);
         throw new Error(`MCP call timed out after ${effectiveTimeout}ms`);
       }
 
@@ -524,13 +521,17 @@ export async function callMcpTool(
       // throw — the message names the proxy budget, matching meshctl's
       // report of the same cut.
       if (lastError instanceof ProxyTimeoutError) {
-        publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, lastError.message, "error", requestBytes);
+        publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, lastError.message, "error", requestBytes, undefined, attempt + 1);
         throw lastError;
       }
 
       // Retry everything else (network, HTTP, protocol, and tool-level
       // errors) until attempts are exhausted; only the abort/timeout case
-      // above is non-retryable.
+      // above is non-retryable. No span here (#1202) — the post-loop
+      // aggregate publishes once for the whole call.
+      debugProxy(
+        `attempt ${attempt + 1}/${options.maxAttempts} failed for ${toolName} at ${endpoint}: ${lastError.message}`
+      );
       if (attempt < options.maxAttempts - 1) {
         await sleep(options.retryDelay * Math.pow(options.retryBackoff, attempt));
         continue;
@@ -540,8 +541,10 @@ export async function callMcpTool(
     }
   }
 
-  // All retries failed
-  publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, lastError?.message ?? "unknown", "error", requestBytes);
+  // All retries failed — the single aggregate error span for this call
+  // (#1202): carries the last attempt's error and response size, plus the
+  // attempts count when retries were configured.
+  publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, lastError?.message ?? "unknown", "error", requestBytes, lastResponseBytes, options.maxAttempts);
   throw lastError ?? new Error("MCP call failed");
 }
 
@@ -765,6 +768,10 @@ function generateProgressToken(): string {
 
 /**
  * Helper to publish a proxy call span (fire and forget).
+ *
+ * `attempts` is the number of call attempts this span aggregates; it is
+ * recorded on the span only when greater than 1 (i.e. retries actually
+ * happened), keeping single-attempt spans unchanged.
  */
 function publishProxySpan(
   traceCtx: TraceContext | null,
@@ -778,6 +785,7 @@ function publishProxySpan(
   resultType: string,
   requestBytes?: number,
   responseBytes?: number,
+  attempts?: number,
 ): void {
   if (!traceCtx || !spanId) return;
 
@@ -803,6 +811,7 @@ function publishProxySpan(
     meshPositions: [],
     requestBytes,
     responseBytes,
+    ...(attempts !== undefined && attempts > 1 ? { callAttempts: attempts } : {}),
   }).catch(() => {
     // Silently ignore publish errors
   });

--- a/src/runtime/typescript/src/tracing.ts
+++ b/src/runtime/typescript/src/tracing.ts
@@ -255,6 +255,12 @@ export interface SpanData {
   requestBytes?: number;
   responseBytes?: number;
 
+  // Number of call attempts this span aggregates (only set when > 1).
+  // Spans are per-call, not per-attempt (#1202): a retried call publishes
+  // exactly one span and notes how many attempts it took here (total
+  // attempts, not retries: 3 means the call was tried three times).
+  callAttempts?: number;
+
   // LLM token metadata
   llmInputTokens?: number;
   llmOutputTokens?: number;
@@ -307,6 +313,9 @@ export async function publishTraceSpan(span: SpanData): Promise<boolean> {
     }
     if (span.responseBytes !== undefined) {
       spanMap.response_bytes = String(span.responseBytes);
+    }
+    if (span.callAttempts !== undefined) {
+      spanMap.call_attempts = String(span.callAttempts);
     }
     if (span.llmInputTokens !== undefined) {
       spanMap.llm_input_tokens = String(span.llmInputTokens);


### PR DESCRIPTION
## Summary
Closes #1202 — the last #1170-era span-accounting leftover.

- `callMcpTool` published an error span **per attempt** plus a post-exhaustion aggregate — N+1 spans sharing one spanId, double-publishing even at the default single attempt, and a retried-then-succeeded call published an error span before its success span. Spans are now **per-call, single-owner**: the post-loop aggregate is the only error publisher; the #1201 single-span paths (abort/timeout, `ProxyTimeoutError`) are behavior-identical; success-after-retry publishes exactly one success span.
- Per-attempt failures get debug-logged (`[mesh.proxy] attempt N/M failed…`) — which also gives network/HTTP failures a per-attempt record they never had. The SSE inner try/catch is gone entirely (it existed only to publish; every error class it handled was traced to its outer-catch destination — none lost observability, none changed retry classification).
- The aggregate keeps the per-attempt spans' `responseBytes` and gains **`call_attempts`** (total attempts, emitted only when >1 — single-attempt spans are byte-identical to before). Named `call_attempts` rather than `retry_attempts` deliberately: 3 means three attempts, not three retries, and the rename was free while the field has zero consumers.
- `streamMcpTool` audited: already single-owner, untouched.

## Review Notes
- Independent review traced every former inner-catch error class to its new destination (table in the work log): one span each, retry classification bit-for-bit unchanged. Exactly-one test assertions verified to count all publisher calls.
- Its warning — `call_attempts` is currently write-only (the Go trace ingestion whitelist-parses fields and drops it) — is filed as #1213 (Go parsing + storage + UI + Python/Java emit parity); the naming info drove the rename; the two untested arithmetic paths got tests.
- Known trade-off (labeled in code): an aggregate span can pair the last attempt's error with an earlier attempt's byte count when the final attempt fails pre-body.

Closes #1202

## Test plan
- [x] `npm run typecheck:all` clean; `npx vitest run` — 67 files, 942 tests
- [x] Span matrix: maxAttempts=1 error → 1 span; exhausted ×3 → 1 span with `callAttempts: 3`; success-after-retry → 1 success span with `callAttempts: 2`; timeout-on-attempt-2 → 1 timeout span with `callAttempts: 2`; abort path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
