### PR TITLE
feat(registry): automatic trace retention for the Redis stream and correlator

### DIFF
--- a/docs/07-observability/03-distributed-tracing.md
+++ b/docs/07-observability/03-distributed-tracing.md
@@ -24,22 +24,22 @@ async def generate_report(title: str) -> str:
 
 **Event Types Published:**
 - `span_start`: Operation begins
-- `span_end`: Operation completes successfully  
+- `span_end`: Operation completes successfully
 - `error`: Operation fails with error details
 
 ### 2. Redis Streams (Transport Layer)
 
-**Stream Name**: `mcp-mesh:traces`
+**Stream Name**: `mesh:trace`
 **Consumer Group**: `mcp-mesh-registry-processors`
 
 Events are published asynchronously without blocking agent operations:
 
 ```bash
 # View recent trace events
-redis-cli XREVRANGE mcp-mesh:traces + - COUNT 10
+redis-cli XREVRANGE mesh:trace + - COUNT 10
 
 # Monitor stream length
-redis-cli XLEN mcp-mesh:traces
+redis-cli XLEN mesh:trace
 ```
 
 ### 3. Go Registry (Consumer & Correlator)
@@ -63,6 +63,7 @@ The registry consumes events and correlates them into complete traces:
 | `TRACE_JSON_OUTPUT_DIR` | `/tmp` | JSON export directory |
 | `TRACE_BATCH_SIZE` | `100` | Consumer batch size |
 | `TRACE_TIMEOUT` | `5m` | Trace completion timeout |
+| `MCP_MESH_TRACE_RETENTION` | `24h` | Redis stream retention window (`0` disables trimming) |
 
 ### Enable Tracing
 
@@ -84,7 +85,7 @@ Python agents automatically detect when tracing is enabled and begin publishing 
 ```json
 {
   "trace_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-  "span_id": "x1y2z3w4-a5b6-c789-def0-123456789abc", 
+  "span_id": "x1y2z3w4-a5b6-c789-def0-123456789abc",
   "parent_span": "parent-span-id-if-exists",
   "agent_name": "weather-service",
   "agent_id": "weather-123",
@@ -109,7 +110,7 @@ Python agents automatically detect when tracing is enabled and begin publishing 
   "spans": [
     {
       "span_id": "x1y2z3w4-a5b6-c789-def0-123456789abc",
-      "agent_name": "weather-service", 
+      "agent_name": "weather-service",
       "operation": "tool:get_weather",
       "start_time": "2024-01-01T10:00:00Z",
       "end_time": "2024-01-01T10:00:00.150Z",
@@ -118,7 +119,7 @@ Python agents automatically detect when tracing is enabled and begin publishing 
     }
   ],
   "start_time": "2024-01-01T10:00:00Z",
-  "end_time": "2024-01-01T10:00:00.300Z", 
+  "end_time": "2024-01-01T10:00:00.300Z",
   "duration": "300ms",
   "success": true,
   "span_count": 3,
@@ -167,7 +168,7 @@ export TRACE_PRETTY_OUTPUT=true
 🔗 TRACE a1b2c3d4 (285ms) - SUCCESS (3 spans across 2 agents)
   📍 Agent: weather-service
     ✅ tool:get_weather [get_weather] (150ms)
-  📍 Agent: data-processor  
+  📍 Agent: data-processor
     ✅ tool:process_data [process_data] (100ms)
     ✅ tool:validate_result [validate_result] (35ms)
 ```
@@ -208,7 +209,7 @@ Returns tracing configuration and runtime statistics:
 {
   "enabled": true,
   "consumer": {
-    "stream_name": "mcp-mesh:traces",
+    "stream_name": "mesh:trace",
     "consumer_group": "mcp-mesh-registry-processors",
     "status": "running"
   },
@@ -323,13 +324,13 @@ Trace context automatically flows between agents:
 
 ```python
 # Parent agent
-@mesh.tool(depends_on=["child-agent"])  
+@mesh.tool(depends_on=["child-agent"])
 async def parent_operation():
     # trace_id and span_id automatically propagated
     child = await mesh.get_agent("child-agent")
     return await child.child_operation()
 
-# Child agent  
+# Child agent
 @mesh.tool()
 async def child_operation():
     # Inherits trace context from parent
@@ -369,19 +370,35 @@ User Request → Agent A → Agent B → Agent C
 ### In-Memory Storage
 
 - **Active Traces**: Stored until completion or 5-minute timeout
-- **Completed Traces**: Last 1000 traces kept for querying
+- **Completed Traces**: Last 1000 traces kept for querying, and pruned once
+  older than `MCP_MESH_TRACE_RETENTION`
 - **Automatic Cleanup**: Oldest 20% removed when limit exceeded
 
 ### Redis Stream Retention
 
-```bash
-# Configure Redis stream retention
-redis-cli CONFIG SET stream-node-max-bytes 4096
-redis-cli CONFIG SET stream-node-max-entries 100
+The registry automatically trims the `mesh:trace` stream: entries older than
+`MCP_MESH_TRACE_RETENTION` (default `24h`) are removed when the registry
+connects to Redis and periodically while it runs. Set `0` to disable trimming
+entirely.
 
-# Manual stream cleanup (if needed)
-redis-cli XTRIM mcp-mesh:traces MAXLEN ~ 10000
+```bash
+# Keep span events in Redis for 48 hours instead of the default 24
+export MCP_MESH_TRACE_RETENTION=48h
 ```
+
+The stream is a transport buffer, not a system of record — the registry
+consumes events and forwards them to your telemetry backend, so long-term
+queryable trace history is governed by Tempo's retention settings (configure
+those in Tempo, not here). The stream window only needs to cover how far the
+registry can fall behind, e.g. during an outage; on reconnect, entries older
+than the window are trimmed approximately, in batches (Redis macro-node
+granularity), so a few entries just past the cutoff may briefly survive. Note
+that the dashboard consumer group (`mcp-mesh-ui-dashboard`) reads the same
+stream and is subject to the same window if it lags.
+
+As a disaster floor for extreme cases (registry down for many hours combined
+with high span volume), set a Redis `maxmemory` limit so the stream cannot
+grow without bound before the registry comes back to trim it.
 
 ## Troubleshooting
 
@@ -394,8 +411,8 @@ curl http://localhost:8000/trace/status | jq .enabled
 
 **Verify Redis stream:**
 ```bash
-redis-cli XLEN mcp-mesh:traces
-redis-cli XINFO GROUPS mcp-mesh:traces
+redis-cli XLEN mesh:trace
+redis-cli XINFO GROUPS mesh:trace
 ```
 
 **Check agent connectivity:**
@@ -408,7 +425,7 @@ redis-cli XINFO GROUPS mcp-mesh:traces
 
 **Check for orphaned events:**
 ```bash
-redis-cli XREVRANGE mcp-mesh:traces + - COUNT 20
+redis-cli XREVRANGE mesh:trace + - COUNT 20
 ```
 
 **Monitor correlator status:**
@@ -420,7 +437,7 @@ curl http://localhost:8000/trace/status | jq .correlator
 
 **Monitor consumer lag:**
 ```bash
-redis-cli XINFO GROUPS mcp-mesh:traces
+redis-cli XINFO GROUPS mesh:trace
 # Look for "lag" field in consumer info
 ```
 
@@ -482,7 +499,7 @@ curl -s "http://localhost:8000/trace/search?success=false&limit=10" | \
 ### 1. Monitoring
 
 - Set up alerts on trace export failures
-- Monitor trace completion rates  
+- Monitor trace completion rates
 - Track trace duration trends
 - Alert on error rate spikes
 
@@ -503,7 +520,7 @@ curl -s "http://localhost:8000/trace/search?success=false&limit=10" | \
 ### 4. Production Deployment
 
 - Configure JSON export for trace persistence
-- Set up external metrics collection  
+- Set up external metrics collection
 - Implement trace sampling for high-volume systems
 - Monitor registry resource usage
 
@@ -511,7 +528,7 @@ curl -s "http://localhost:8000/trace/search?success=false&limit=10" | \
 
 - **Throughput**: 10,000+ spans/second sustained
 - **Latency**: <1ms trace event publishing (async)
-- **Memory**: ~1MB per 1000 completed traces  
+- **Memory**: ~1MB per 1000 completed traces
 - **Storage**: Configurable retention in Redis and memory
 - **Correlation**: Real-time span correlation and export
 - **Availability**: Registry failure doesn't impact agents
@@ -521,7 +538,7 @@ curl -s "http://localhost:8000/trace/search?success=false&limit=10" | \
 The distributed tracing system provides comprehensive observability out of the box. Consider extending with:
 
 1. **Custom Exporters**: Implement organization-specific backends
-2. **Trace Sampling**: Add intelligent sampling for high-volume scenarios  
+2. **Trace Sampling**: Add intelligent sampling for high-volume scenarios
 3. **SLA Monitoring**: Extract SLA metrics from trace data
 4. **Automated Alerting**: Set up proactive monitoring based on trace patterns
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -413,6 +413,11 @@ export TRACE_EXPORTER_TYPE=otlp
 export TRACE_BATCH_SIZE=100
 export TRACE_TIMEOUT=5m
 
+# Redis trace stream retention — registry trims mesh:trace entries older
+# than this on connect and periodically. Go duration string. Default: 24h.
+# Set to "0" to disable trimming entirely.
+export MCP_MESH_TRACE_RETENTION=24h
+
 # Trace output options
 export TRACE_PRETTY_OUTPUT=false
 export TRACE_ENABLE_STATS=true

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	entgo.io/ent v0.14.0
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/gin-gonic/gin v1.10.1
@@ -89,6 +90,7 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/zclconf/go-cty v1.8.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
 github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
@@ -172,6 +174,8 @@ github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//J
 github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037/go.mod h1:2bpvgLBZEtENV5scfDFEtB/5+1M4hkQhDQrccEJ/qGw=
 github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=
 github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDe
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
@@ -148,8 +150,6 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
-github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
 github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
@@ -172,8 +172,6 @@ github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//J
 github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037/go.mod h1:2bpvgLBZEtENV5scfDFEtB/5+1M4hkQhDQrccEJ/qGw=
 github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=
 github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
-github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
-github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
@@ -223,6 +221,8 @@ github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgq
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zclconf/go-cty v1.8.0 h1:s4AvqaeQzJIu3ndv4gVIhplVD0krU+bgrcLSVUnaWuA=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/helm/mcp-mesh-core/values.yaml
+++ b/helm/mcp-mesh-core/values.yaml
@@ -177,6 +177,10 @@ mcp-mesh-registry:
     observability:
       distributedTracing:
         enabled: true
+        # mesh:trace Redis stream retention (XTRIM MINID on connect and
+        # periodically); "0" disables trimming. The stream is a transport
+        # buffer — long-term trace history lives in Tempo.
+        retention: "24h"
       telemetryEndpoint: "mcp-core-mcp-mesh-tempo:4317"
 
     # Health check configuration

--- a/helm/mcp-mesh-registry/templates/_helpers.tpl
+++ b/helm/mcp-mesh-registry/templates/_helpers.tpl
@@ -240,6 +240,10 @@ them — so a values file carrying one would silently no-op while the user
 expects effect. Fail loudly with migration guidance instead. Invoked
 unconditionally from the configmap.
 
+The only consumed keys under distributedTracing are 'enabled' and
+'retention' (rendered as MCP_MESH_DISTRIBUTED_TRACING_ENABLED and
+MCP_MESH_TRACE_RETENTION); both are allowlisted below.
+
 Carve-out: the v2.4.0 mcp-mesh-core umbrella SHIPPED these keys as defaults
 (nine distributedTracing.* keys including redisUrl, and a 17-entry
 registry.environment map — see `git show v2.4.0:helm/mcp-mesh-core/values.yaml`).
@@ -273,9 +277,9 @@ DIVERGING value — user intent that would silently no-op — fails.
       "streamName" "mesh:trace"
       "consumerGroup" "mcp-mesh-registry-processors" -}}
 {{- range $key, $val := (dig "observability" "distributedTracing" (dict) .Values.registry) | default dict -}}
-{{- if eq $key "enabled" -}}
+{{- if or (eq $key "enabled") (eq $key "retention") -}}
 {{- else if not (hasKey $oldTracingDefaults $key) -}}
-{{- fail (printf "registry.observability.distributedTracing.%s was never consumed and has been removed; only 'enabled' lives under distributedTracing (telemetryEndpoint and exporterType sit directly under registry.observability). Stream tuning is set via the top-level env list: TRACE_BATCH_SIZE, TRACE_TIMEOUT, TRACE_PRETTY_OUTPUT, TRACE_ENABLE_STATS, TELEMETRY_PROTOCOL" $key) -}}
+{{- fail (printf "registry.observability.distributedTracing.%s was never consumed and has been removed; only 'enabled' and 'retention' live under distributedTracing (telemetryEndpoint and exporterType sit directly under registry.observability). Stream tuning is set via the top-level env list: TRACE_BATCH_SIZE, TRACE_TIMEOUT, TRACE_PRETTY_OUTPUT, TRACE_ENABLE_STATS, TELEMETRY_PROTOCOL" $key) -}}
 {{- else if ne (toString $val) (get $oldTracingDefaults $key) -}}
 {{- if eq $key "redisUrl" -}}
 {{- fail (printf "registry.observability.distributedTracing.redisUrl was never consumed and has been removed (set to %q, diverging from the old shipped default, so it would silently no-op); configure registry.redis.{host,port,password,tls} instead — the trace stream shares that endpoint" (toString $val)) -}}

--- a/helm/mcp-mesh-registry/templates/configmap.yaml
+++ b/helm/mcp-mesh-registry/templates/configmap.yaml
@@ -52,7 +52,12 @@ data:
   REGISTRY_NAME: {{ .Values.registry.name | default "mcp-mesh-registry" | quote }}
 
   # Observability configuration - matches Docker setup
-  MCP_MESH_DISTRIBUTED_TRACING_ENABLED: {{ .Values.registry.observability.distributedTracing.enabled | default "true" | quote }}
+  {{- /* hasKey instead of `default`: Sprig `default` treats false and 0 as
+         unset, so `enabled: false` would render "true" and `retention: 0`
+         (unquoted) would render "24h". */}}
+  {{- $dt := ((.Values.registry.observability).distributedTracing) | default dict }}
+  MCP_MESH_DISTRIBUTED_TRACING_ENABLED: {{ hasKey $dt "enabled" | ternary $dt.enabled true | toString | quote }}
+  MCP_MESH_TRACE_RETENTION: {{ hasKey $dt "retention" | ternary $dt.retention "24h" | toString | quote }}
   TELEMETRY_ENDPOINT: {{ .Values.registry.observability.telemetryEndpoint | default "tempo:4317" | quote }}
   # Exporter type: console (default), otlp (for Tempo/Jaeger), json
   TRACE_EXPORTER_TYPE: {{ .Values.registry.observability.exporterType | default "otlp" | quote }}

--- a/helm/mcp-mesh-registry/values.yaml
+++ b/helm/mcp-mesh-registry/values.yaml
@@ -271,6 +271,11 @@ registry:
   observability:
     distributedTracing:
       enabled: true
+      # How long span events stay in the mesh:trace Redis stream before the
+      # registry trims them (XTRIM MINID on connect and every 5m). The stream
+      # is a transport buffer — long-term trace history lives in Tempo. Go
+      # duration string; "0" disables trimming entirely.
+      retention: "24h"
     telemetryEndpoint: "mcp-core-mcp-mesh-tempo:4317"
     # Exporter type: console (default), otlp (for Tempo/Jaeger), json
     exporterType: "otlp"

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -325,6 +325,10 @@ export TELEMETRY_PROTOCOL=grpc                  # OTLP protocol: grpc or http
 # Trace exporter type: otlp, console, json (default: otlp)
 export TRACE_EXPORTER_TYPE=otlp
 
+# Redis trace stream retention — registry trims mesh:trace entries older
+# than this on connect and periodically (default: 24h; 0 disables trimming)
+export MCP_MESH_TRACE_RETENTION=24h
+
 # Header propagation across agents (comma-separated prefixes)
 export MCP_MESH_PROPAGATE_HEADERS=x-request-id,x-trace
 

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -100,6 +100,7 @@ Default credentials: `admin` / `admin`
 | `TELEMETRY_ENDPOINT`                   | OTLP endpoint   | `localhost:4317`        |
 | `TELEMETRY_PROTOCOL`                   | Protocol        | `grpc`                  |
 | `TEMPO_URL`                            | Tempo query URL | `http://localhost:3200` |
+| `MCP_MESH_TRACE_RETENTION`             | Redis trace stream retention (`0` = no trimming) | `24h` |
 
 ## Troubleshooting
 

--- a/src/core/registry/tracing/consumer.go
+++ b/src/core/registry/tracing/consumer.go
@@ -54,6 +54,7 @@ type StreamConsumer struct {
 	logger       *log.Logger
 	batchSize    int64
 	blockTimeout time.Duration
+	retention    time.Duration // trace stream retention window (0 = trimming disabled)
 	processor    TraceEventProcessor
 	ctx          context.Context
 	cancel       context.CancelFunc
@@ -116,6 +117,10 @@ type StreamConsumerConfig struct {
 	BatchSize     int64
 	BlockTimeout  time.Duration
 	Enabled       bool
+	// Retention bounds how long entries stay in the stream; entries older
+	// than this are removed via XTRIM MINID on (re)connect and periodically
+	// by the tracing manager. 0 disables trimming.
+	Retention time.Duration
 }
 
 // NewStreamConsumer creates a new Redis Streams consumer for trace events
@@ -159,6 +164,7 @@ func NewStreamConsumer(config *StreamConsumerConfig, processor TraceEventProcess
 		logger:          logger,
 		batchSize:       config.BatchSize,
 		blockTimeout:    config.BlockTimeout,
+		retention:       config.Retention,
 		processor:       processor,
 		ctx:             ctx,
 		cancel:          cancel,
@@ -311,6 +317,54 @@ func (sc *StreamConsumer) attemptConnection() {
 		sc.logger.Printf("Warning: Failed to create consumer group: %v (will retry)", err)
 		// Don't disconnect - the group might already exist or stream not created yet
 	}
+
+	// Recovery cleanup: drop entries already past the retention window
+	// before consumption resumes. After a registry outage the stream holds
+	// the full backlog; anything older than retention is no longer worth
+	// processing and would otherwise sit in Redis until the next periodic
+	// trim. Runs on every (re)connect.
+	if _, err := sc.TrimStream(); err != nil {
+		sc.logger.Printf("Warning: startup stream trim failed: %v (periodic trim will retry)", err)
+	}
+}
+
+// TrimStream removes entries older than the configured retention window from
+// the trace stream. Stream entry IDs are millisecond timestamps, so
+// XTRIM MINID <now - retention> yields time-based trimming; the approximate
+// flag (~) lets Redis trim in whole-macro-node steps, which is cheaper and
+// more than precise enough at trace volumes. Returns the number of entries
+// removed.
+//
+// No-ops (0, nil) when trimming is disabled (retention <= 0) or the consumer
+// is not currently connected — the next periodic tick or reconnect retries.
+func (sc *StreamConsumer) TrimStream() (int64, error) {
+	if !sc.enabled || sc.retention <= 0 {
+		return 0, nil
+	}
+
+	sc.mu.RLock()
+	client := sc.client
+	state := sc.connectionState
+	sc.mu.RUnlock()
+
+	if client == nil || state != StateConnected {
+		return 0, nil
+	}
+
+	minID := strconv.FormatInt(time.Now().Add(-sc.retention).UnixMilli(), 10)
+
+	ctx, cancel := context.WithTimeout(sc.ctx, 10*time.Second)
+	defer cancel()
+
+	removed, err := client.XTrimMinIDApprox(ctx, sc.streamName, minID, 0).Result()
+	if err != nil {
+		return 0, fmt.Errorf("failed to trim stream %s: %w", sc.streamName, err)
+	}
+	if removed > 0 {
+		sc.logger.Printf("Trimmed %d entries older than %s from stream %s (XTRIM MINID ~ %s)",
+			removed, sc.retention, sc.streamName, minID)
+	}
+	return removed, nil
 }
 
 // handleConnectionError records connection failure and updates state

--- a/src/core/registry/tracing/correlator.go
+++ b/src/core/registry/tracing/correlator.go
@@ -20,6 +20,7 @@ type SpanCorrelator struct {
 	logger          *log.Logger
 	exporter        TraceExporter
 	traceTimeout    time.Duration
+	retention       time.Duration // age bound for stored completed traces (0 = count cap only)
 	maxStoredTraces int
 	cleanupTicker   *time.Ticker
 	ctx             context.Context
@@ -80,8 +81,12 @@ type SpanExporter interface {
 	ExportCompleteSpan(event *TraceEvent) error  // For single execution trace events
 }
 
-// NewSpanCorrelator creates a new span correlator
-func NewSpanCorrelator(exporter TraceExporter, traceTimeout time.Duration) *SpanCorrelator {
+// NewSpanCorrelator creates a new span correlator.
+//
+// retention bounds how long completed traces (full span payloads) stay in the
+// in-memory store; entries older than retention are pruned on the cleanup
+// ticker. 0 keeps the count cap (maxStoredTraces) as the only bound.
+func NewSpanCorrelator(exporter TraceExporter, traceTimeout, retention time.Duration) *SpanCorrelator {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	correlator := &SpanCorrelator{
@@ -90,6 +95,7 @@ func NewSpanCorrelator(exporter TraceExporter, traceTimeout time.Duration) *Span
 		logger:          log.New(os.Stdout, "[TRACE-CORRELATOR] ", log.LstdFlags),
 		exporter:        exporter,
 		traceTimeout:    traceTimeout,
+		retention:       retention,
 		maxStoredTraces: 1000, // Store last 1000 completed traces for querying
 		cleanupTicker:   time.NewTicker(1 * time.Minute), // Cleanup every minute
 		ctx:             ctx,
@@ -372,7 +378,36 @@ func (sc *SpanCorrelator) cleanupLoop() {
 			return
 		case <-sc.cleanupTicker.C:
 			sc.cleanupOldTraces()
+			sc.pruneExpiredCompletedTraces()
 		}
+	}
+}
+
+// pruneExpiredCompletedTraces removes completed traces older than the
+// retention window from the in-memory store. The count cap in
+// storeCompletedTrace bounds peak size; this bounds age, so full span
+// payloads don't linger indefinitely in a quiet mesh. No-op when
+// retention <= 0.
+func (sc *SpanCorrelator) pruneExpiredCompletedTraces() {
+	if sc.retention <= 0 {
+		return
+	}
+
+	cutoff := time.Now().Add(-sc.retention)
+
+	sc.completedMutex.Lock()
+	defer sc.completedMutex.Unlock()
+
+	removed := 0
+	for traceID, trace := range sc.completedTraces {
+		if trace.EndTime.Before(cutoff) {
+			delete(sc.completedTraces, traceID)
+			removed++
+		}
+	}
+
+	if removed > 0 {
+		sc.logger.Printf("🧹 Pruned %d completed traces older than %s", removed, sc.retention)
 	}
 }
 

--- a/src/core/registry/tracing/manager.go
+++ b/src/core/registry/tracing/manager.go
@@ -9,7 +9,24 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
+)
+
+// Trace stream retention tunables.
+//
+// defaultTraceRetention bounds how long span events stay in the mesh:trace
+// Redis stream. The stream is a transport buffer, not a system of record —
+// the registry consumes and ACKs entries, but ACK never deletes them, so
+// without trimming the stream grows forever. Operators override via
+// MCP_MESH_TRACE_RETENTION (Go duration string; "0" disables trimming).
+//
+// trimTickInterval is how often the periodic trim runs. It mirrors the
+// registry sweep job's 5-minute interval convention; trims are a single
+// O(log N) XTRIM MINID call, so the cost per tick is negligible.
+const (
+	defaultTraceRetention = 24 * time.Hour
+	trimTickInterval      = 5 * time.Minute
 )
 
 // TracingManager manages the entire distributed tracing pipeline
@@ -23,6 +40,11 @@ type TracingManager struct {
 	logger            *log.Logger
 	enabled           bool
 	streamThroughMode bool
+
+	// Periodic stream-trim loop (only runs when tracing is enabled and
+	// TraceRetention > 0).
+	trimStop chan struct{}
+	trimWg   sync.WaitGroup
 }
 
 // TracingConfig holds configuration for distributed tracing
@@ -35,6 +57,7 @@ type TracingConfig struct {
 	BatchSize            int64         `json:"batch_size"`
 	BlockTimeout         time.Duration `json:"block_timeout"`
 	TraceTimeout         time.Duration `json:"trace_timeout"`
+	TraceRetention       time.Duration `json:"trace_retention"`
 	ExporterType         string        `json:"exporter_type"`
 	PrettyConsoleOutput  bool          `json:"pretty_console_output"`
 	JSONOutputDirectory  string        `json:"json_output_directory,omitempty"`
@@ -111,7 +134,7 @@ func NewTracingManager(config *TracingConfig) (*TracingManager, error) {
 		}
 
 		// Create correlator for non-Jaeger exporters
-		correlator := NewSpanCorrelator(exporter, config.TraceTimeout)
+		correlator := NewSpanCorrelator(exporter, config.TraceTimeout, config.TraceRetention)
 		manager.processor = correlator
 	}
 
@@ -124,6 +147,7 @@ func NewTracingManager(config *TracingConfig) (*TracingManager, error) {
 		BatchSize:     config.BatchSize,
 		BlockTimeout:  config.BlockTimeout,
 		Enabled:       config.Enabled,
+		Retention:     config.TraceRetention,
 	}
 
 	consumer, err := NewStreamConsumer(consumerConfig, manager.processor)
@@ -133,6 +157,12 @@ func NewTracingManager(config *TracingConfig) (*TracingManager, error) {
 	manager.consumer = consumer
 
 	manager.logger.Printf("Distributed tracing: enabled, exporter=%s, mode=%s, endpoint=%s", config.ExporterType, mode, config.TelemetryEndpoint)
+	if config.TraceRetention > 0 {
+		manager.logger.Printf("Trace stream retention: %s (XTRIM MINID on connect and every %s; override via MCP_MESH_TRACE_RETENTION)",
+			config.TraceRetention, trimTickInterval)
+	} else {
+		manager.logger.Printf("Trace stream retention disabled (MCP_MESH_TRACE_RETENTION=0); stream %s is never trimmed", config.StreamName)
+	}
 	return manager, nil
 }
 
@@ -150,7 +180,36 @@ func (tm *TracingManager) Start() error {
 		return fmt.Errorf("failed to start consumer: %w", err)
 	}
 
+	// Periodic stream trim. The startup/recovery trim happens in the
+	// consumer when its Redis connection is (re)established; this loop keeps
+	// the stream near the retention bound while the registry stays up.
+	if tm.config.TraceRetention > 0 {
+		tm.trimStop = make(chan struct{})
+		tm.trimWg.Add(1)
+		go tm.trimLoop()
+	}
+
 	return nil
+}
+
+// trimLoop periodically trims the trace stream to the retention window.
+// Errors are logged by the consumer and retried on the next tick.
+func (tm *TracingManager) trimLoop() {
+	defer tm.trimWg.Done()
+
+	ticker := time.NewTicker(trimTickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-tm.trimStop:
+			return
+		case <-ticker.C:
+			if _, err := tm.consumer.TrimStream(); err != nil {
+				tm.logger.Printf("Warning: periodic stream trim failed: %v (will retry in %s)", err, trimTickInterval)
+			}
+		}
+	}
 }
 
 // Stop stops the tracing manager. The consumer is stopped first so that
@@ -161,6 +220,14 @@ func (tm *TracingManager) Stop() error {
 	}
 
 	var errors []string
+
+	// Stop the trim loop before the consumer so TrimStream never races a
+	// closing Redis client.
+	if tm.trimStop != nil {
+		close(tm.trimStop)
+		tm.trimWg.Wait()
+		tm.trimStop = nil
+	}
 
 	// Stop consumer first to drain in-flight spans before the accumulator shuts down
 	if tm.consumer != nil {
@@ -444,6 +511,8 @@ func DefaultTracingConfig() *TracingConfig {
 		}
 	}
 
+	traceRetention := parseTraceRetentionFromEnv()
+
 	exporterType := os.Getenv("TRACE_EXPORTER_TYPE")
 	if exporterType == "" {
 		exporterType = "otlp"
@@ -478,6 +547,7 @@ func DefaultTracingConfig() *TracingConfig {
 		BatchSize:           batchSize,
 		BlockTimeout:        5 * time.Second,
 		TraceTimeout:        traceTimeout,
+		TraceRetention:      traceRetention,
 		ExporterType:        exporterType,
 		PrettyConsoleOutput: prettyOutput,
 		JSONOutputDirectory: os.Getenv("TRACE_JSON_OUTPUT_DIR"),
@@ -486,6 +556,33 @@ func DefaultTracingConfig() *TracingConfig {
 		TelemetryProtocol:   telemetryProtocol,
 		TempoQueryURL:       tempoQueryURL,
 	}
+}
+
+// parseTraceRetentionFromEnv parses MCP_MESH_TRACE_RETENTION following the
+// same conventions as MCP_MESH_RETENTION (registry sweep):
+//   - unset / empty: defaults to 24h
+//   - any positive time.ParseDuration value (e.g. "48h", "30m"): use that value
+//   - "0" / "0s": disables stream trimming entirely
+//   - negative: warn and fall back to default (0 is the documented disable)
+//   - invalid: warn and fall back to default
+//
+// Uses the stdlib log package because it can run before the manager's
+// logger exists (mirrors readSweepIntervalFromEnv in the registry package).
+func parseTraceRetentionFromEnv() time.Duration {
+	raw := os.Getenv("MCP_MESH_TRACE_RETENTION")
+	if raw == "" {
+		return defaultTraceRetention
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		log.Printf("[TRACE-MANAGER] Invalid MCP_MESH_TRACE_RETENTION %q, using default %s: %v", raw, defaultTraceRetention, err)
+		return defaultTraceRetention
+	}
+	if d < 0 {
+		log.Printf("[TRACE-MANAGER] Invalid MCP_MESH_TRACE_RETENTION %q: negative durations are not allowed (use 0 to disable); using default %s", raw, defaultTraceRetention)
+		return defaultTraceRetention
+	}
+	return d
 }
 
 // LoadTracingConfigFromEnv loads tracing configuration from environment variables

--- a/src/core/registry/tracing/retention_test.go
+++ b/src/core/registry/tracing/retention_test.go
@@ -1,0 +1,362 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+// --- helpers ---
+
+type noopProcessor struct{}
+
+func (noopProcessor) ProcessTraceEvent(*TraceEvent) error { return nil }
+
+type noopExporter struct{}
+
+func (noopExporter) ExportTrace(*CompletedTrace) error { return nil }
+
+// seedStreamEntry adds an entry with an explicit millisecond-timestamp ID
+// (the same ID shape producers generate via XADD *).
+func seedStreamEntry(t *testing.T, client *redis.Client, stream string, ts time.Time, seq int) string {
+	t.Helper()
+	id := fmt.Sprintf("%d-%d", ts.UnixMilli(), seq)
+	if err := client.XAdd(context.Background(), &redis.XAddArgs{
+		Stream: stream,
+		ID:     id,
+		Values: map[string]interface{}{"trace_id": "t", "span_id": "s"},
+	}).Err(); err != nil {
+		t.Fatalf("failed to seed stream entry %s: %v", id, err)
+	}
+	return id
+}
+
+func newTestConsumer(client *redis.Client, stream string, retention time.Duration) *StreamConsumer {
+	return &StreamConsumer{
+		enabled:         true,
+		client:          client,
+		connectionState: StateConnected,
+		streamName:      stream,
+		retention:       retention,
+		logger:          log.New(io.Discard, "", 0),
+		ctx:             context.Background(),
+	}
+}
+
+// --- env parsing (mirrors the MCP_MESH_RETENTION conventions) ---
+
+func TestParseTraceRetentionFromEnv(t *testing.T) {
+	t.Run("unset defaults to 24h", func(t *testing.T) {
+		t.Setenv("MCP_MESH_TRACE_RETENTION", "")
+		if got := parseTraceRetentionFromEnv(); got != defaultTraceRetention {
+			t.Errorf("expected default %s, got %s", defaultTraceRetention, got)
+		}
+	})
+
+	t.Run("valid duration is used", func(t *testing.T) {
+		t.Setenv("MCP_MESH_TRACE_RETENTION", "48h")
+		if got := parseTraceRetentionFromEnv(); got != 48*time.Hour {
+			t.Errorf("expected 48h, got %s", got)
+		}
+	})
+
+	t.Run("zero disables", func(t *testing.T) {
+		t.Setenv("MCP_MESH_TRACE_RETENTION", "0")
+		if got := parseTraceRetentionFromEnv(); got != 0 {
+			t.Errorf("expected 0 (disabled), got %s", got)
+		}
+	})
+
+	t.Run("negative falls back to default", func(t *testing.T) {
+		t.Setenv("MCP_MESH_TRACE_RETENTION", "-1h")
+		if got := parseTraceRetentionFromEnv(); got != defaultTraceRetention {
+			t.Errorf("expected default %s, got %s", defaultTraceRetention, got)
+		}
+	})
+
+	t.Run("invalid falls back to default", func(t *testing.T) {
+		t.Setenv("MCP_MESH_TRACE_RETENTION", "not-a-duration")
+		if got := parseTraceRetentionFromEnv(); got != defaultTraceRetention {
+			t.Errorf("expected default %s, got %s", defaultTraceRetention, got)
+		}
+	})
+}
+
+// --- stream trimming ---
+//
+// TrimStream uses XTRIM MINID ~ (XTrimMinIDApprox). miniredis treats `~` as
+// exact, so the exact-count assertions below hold; real Redis approximate
+// trimming may retain entries past the cutoff until a macro-node boundary.
+// If these tests ever move to testcontainers/real Redis, relax the equalities
+// to "at most N remaining / at least M removed".
+
+func TestTrimStreamRemovesOnlyEntriesOlderThanRetention(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	const stream = "mesh:trace"
+	now := time.Now()
+
+	// Two entries past the 1h retention window, two within it.
+	seedStreamEntry(t, client, stream, now.Add(-3*time.Hour), 0)
+	seedStreamEntry(t, client, stream, now.Add(-2*time.Hour), 0)
+	keep1 := seedStreamEntry(t, client, stream, now.Add(-30*time.Minute), 0)
+	keep2 := seedStreamEntry(t, client, stream, now.Add(-time.Minute), 0)
+
+	sc := newTestConsumer(client, stream, time.Hour)
+
+	removed, err := sc.TrimStream()
+	if err != nil {
+		t.Fatalf("TrimStream failed: %v", err)
+	}
+	if removed != 2 {
+		t.Errorf("expected 2 entries removed, got %d", removed)
+	}
+
+	entries, err := client.XRange(context.Background(), stream, "-", "+").Result()
+	if err != nil {
+		t.Fatalf("XRange failed: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries remaining, got %d", len(entries))
+	}
+	if entries[0].ID != keep1 || entries[1].ID != keep2 {
+		t.Errorf("expected remaining entries [%s %s], got [%s %s]", keep1, keep2, entries[0].ID, entries[1].ID)
+	}
+}
+
+func TestTrimStreamDisabledWithZeroRetention(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	const stream = "mesh:trace"
+	seedStreamEntry(t, client, stream, time.Now().Add(-48*time.Hour), 0)
+	seedStreamEntry(t, client, stream, time.Now().Add(-36*time.Hour), 0)
+
+	sc := newTestConsumer(client, stream, 0)
+
+	removed, err := sc.TrimStream()
+	if err != nil {
+		t.Fatalf("TrimStream failed: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("expected no entries removed with retention=0, got %d", removed)
+	}
+
+	length, err := client.XLen(context.Background(), stream).Result()
+	if err != nil {
+		t.Fatalf("XLen failed: %v", err)
+	}
+	if length != 2 {
+		t.Errorf("expected stream untouched (2 entries), got %d", length)
+	}
+}
+
+func TestTrimStreamNoopWhenDisconnected(t *testing.T) {
+	sc := &StreamConsumer{
+		enabled:         true,
+		connectionState: StateDisconnected,
+		streamName:      "mesh:trace",
+		retention:       time.Hour,
+		logger:          log.New(io.Discard, "", 0),
+		ctx:             context.Background(),
+	}
+
+	removed, err := sc.TrimStream()
+	if err != nil {
+		t.Fatalf("TrimStream should no-op when disconnected, got error: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("expected 0 removed when disconnected, got %d", removed)
+	}
+}
+
+// TestStartupTrimRunsOnConnect exercises the full consumer connect path:
+// the recovery trim must fire as part of (re)connection, before any periodic
+// tick — this is the cleanup path after a registry outage.
+func TestStartupTrimRunsOnConnect(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	const stream = "mesh:trace"
+	now := time.Now()
+	seedStreamEntry(t, client, stream, now.Add(-3*time.Hour), 0)
+	seedStreamEntry(t, client, stream, now.Add(-2*time.Hour), 0)
+	seedStreamEntry(t, client, stream, now.Add(-time.Minute), 0)
+
+	consumer, err := NewStreamConsumer(&StreamConsumerConfig{
+		RedisURL:      "redis://" + mr.Addr(),
+		StreamName:    stream,
+		ConsumerGroup: "test-group",
+		ConsumerName:  "test-consumer",
+		BatchSize:     10,
+		BlockTimeout:  100 * time.Millisecond,
+		Enabled:       true,
+		Retention:     time.Hour,
+	}, noopProcessor{})
+	if err != nil {
+		t.Fatalf("NewStreamConsumer failed: %v", err)
+	}
+	consumer.logger = log.New(io.Discard, "", 0)
+
+	if err := consumer.Start(); err != nil {
+		t.Fatalf("consumer Start failed: %v", err)
+	}
+	defer consumer.Stop()
+
+	// XACK never deletes entries, so the consumer reading the stream cannot
+	// shrink it — only the startup trim can.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		length, err := client.XLen(context.Background(), stream).Result()
+		if err == nil && length == 1 {
+			return // startup trim removed the two expired entries
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("startup trim did not run: stream length=%d (want 1)", length)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func TestStartupTrimSkippedWhenRetentionDisabled(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	const stream = "mesh:trace"
+	seedStreamEntry(t, client, stream, time.Now().Add(-48*time.Hour), 0)
+	seedStreamEntry(t, client, stream, time.Now().Add(-36*time.Hour), 0)
+
+	consumer, err := NewStreamConsumer(&StreamConsumerConfig{
+		RedisURL:      "redis://" + mr.Addr(),
+		StreamName:    stream,
+		ConsumerGroup: "test-group",
+		ConsumerName:  "test-consumer",
+		BatchSize:     10,
+		BlockTimeout:  100 * time.Millisecond,
+		Enabled:       true,
+		Retention:     0,
+	}, noopProcessor{})
+	if err != nil {
+		t.Fatalf("NewStreamConsumer failed: %v", err)
+	}
+	consumer.logger = log.New(io.Discard, "", 0)
+
+	if err := consumer.Start(); err != nil {
+		t.Fatalf("consumer Start failed: %v", err)
+	}
+	defer consumer.Stop()
+
+	// Wait until connected (and therefore past the point where the startup
+	// trim would have run), then verify the stream is untouched.
+	deadline := time.Now().Add(5 * time.Second)
+	for !consumer.IsConnected() {
+		if time.Now().After(deadline) {
+			t.Fatal("consumer never connected")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	// Small grace so a (buggy) trim issued right after connect would land.
+	time.Sleep(200 * time.Millisecond)
+
+	length, err := client.XLen(context.Background(), stream).Result()
+	if err != nil {
+		t.Fatalf("XLen failed: %v", err)
+	}
+	if length != 2 {
+		t.Errorf("expected stream untouched with retention=0 (2 entries), got %d", length)
+	}
+}
+
+// --- correlator completed-trace store bounds ---
+
+func newQuietCorrelator(t *testing.T, retention time.Duration) *SpanCorrelator {
+	t.Helper()
+	sc := NewSpanCorrelator(noopExporter{}, 5*time.Minute, retention)
+	sc.logger = log.New(io.Discard, "", 0)
+	t.Cleanup(func() { _ = sc.Stop() })
+	return sc
+}
+
+func makeCompletedTrace(id string, endTime time.Time) *CompletedTrace {
+	return &CompletedTrace{
+		TraceID:   id,
+		StartTime: endTime.Add(-time.Second),
+		EndTime:   endTime,
+		Duration:  time.Second,
+		Success:   true,
+		SpanCount: 1,
+	}
+}
+
+func TestCorrelatorCompletedTraceCountCap(t *testing.T) {
+	sc := newQuietCorrelator(t, 0)
+	sc.maxStoredTraces = 30
+
+	base := time.Now().Add(-time.Hour)
+	for i := 0; i < 31; i++ {
+		sc.storeCompletedTrace(makeCompletedTrace(fmt.Sprintf("trace-%03d", i), base.Add(time.Duration(i)*time.Second)))
+	}
+
+	if count := sc.GetTraceCount(); count > sc.maxStoredTraces {
+		t.Errorf("store exceeded cap: %d > %d", count, sc.maxStoredTraces)
+	}
+
+	// Oldest entries are evicted first (cleanup removes at least 10).
+	for i := 0; i < 10; i++ {
+		id := fmt.Sprintf("trace-%03d", i)
+		if _, ok := sc.GetTrace(id); ok {
+			t.Errorf("expected oldest trace %s to be evicted", id)
+		}
+	}
+
+	// Newest entry stays queryable.
+	if _, ok := sc.GetTrace("trace-030"); !ok {
+		t.Error("expected newest trace trace-030 to remain queryable")
+	}
+}
+
+func TestCorrelatorCompletedTraceAgePruning(t *testing.T) {
+	sc := newQuietCorrelator(t, time.Hour)
+
+	now := time.Now()
+	sc.storeCompletedTrace(makeCompletedTrace("expired-1", now.Add(-3*time.Hour)))
+	sc.storeCompletedTrace(makeCompletedTrace("expired-2", now.Add(-2*time.Hour)))
+	sc.storeCompletedTrace(makeCompletedTrace("recent", now.Add(-5*time.Minute)))
+
+	sc.pruneExpiredCompletedTraces()
+
+	if _, ok := sc.GetTrace("expired-1"); ok {
+		t.Error("expected expired-1 to be pruned")
+	}
+	if _, ok := sc.GetTrace("expired-2"); ok {
+		t.Error("expected expired-2 to be pruned")
+	}
+	if _, ok := sc.GetTrace("recent"); !ok {
+		t.Error("expected recent trace to remain queryable")
+	}
+	if count := sc.GetTraceCount(); count != 1 {
+		t.Errorf("expected 1 trace after pruning, got %d", count)
+	}
+}
+
+func TestCorrelatorAgePruningDisabledWithZeroRetention(t *testing.T) {
+	sc := newQuietCorrelator(t, 0)
+
+	sc.storeCompletedTrace(makeCompletedTrace("old", time.Now().Add(-100*time.Hour)))
+	sc.pruneExpiredCompletedTraces()
+
+	if _, ok := sc.GetTrace("old"); !ok {
+		t.Error("expected age pruning to be disabled with retention=0")
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1215 — the release-gate item: the `mesh:trace` Redis stream grew unboundedly (consumer ACKs never delete entries; the docs told operators to run manual `XTRIM`), and prod deployments were hand-deleting old traces.

- **Registry-only retention, agents stay policy-free**: `MCP_MESH_TRACE_RETENTION` (duration, default `24h`, `0` disables) drives `XTRIM MINID ~` — stream IDs are ms timestamps, so the trim is time-based. Trim runs on **every consumer (re)connect** — a registry returning from any outage immediately shears the backlog, which is the agreed recovery model — and every 5 minutes thereafter. The stream is a transport buffer: long-term queryable history is Tempo's retention (configured there); the extreme-outage disaster floor (registry down many hours + high span volume) is documented as Redis `maxmemory` guidance, operator-level.
- **Correlation-mode memory fix**: `completedTraces` was count-capped (1000) but never age-bounded — full span payloads lingered indefinitely on quiet meshes; it now TTL-prunes on its existing cleanup ticker with the same retention duration (count cap preserved; retention `0` disables age pruning only).
- **Helm**: `registry.observability.distributedTracing.retention` exposed (the #1190 removed-keys guard allowlists the new consumed key; tolerance matrix re-verified). Review caught a Sprig falsy-`default` bug — unquoted `retention: 0` rendered `"24h"`, silently *inverting* the disable intent — fixed with hasKey-based rendering, **including the identical pre-existing bug on `distributedTracing.enabled`** (`enabled: false` used to render `"true"`). Full render matrix in the work log.
- **Docs**: manual-XTRIM advice replaced by the knob; approximate-trim semantics stated honestly (macro-node granularity); the dashboard consumer group noted as a second reader subject to the window; and **eight references to a nonexistent stream name** (`mcp-mesh:traces` vs the real `mesh:trace`) fixed — the documented inspection commands silently returned nothing.

## Review Notes
- Independent review: 0 blockers. Verified the MINID ms-arithmetic and ID format, retention=0 provably no-trims on both hooks, trimmed-entry behavior for lagging consumer groups (XREADGROUP `>` skips silently; nothing wedges; no PEL re-read exists to fetch tombstones), reconnect-hook concurrency with the ticker (no shared mutable state), and the correlator lock discipline.
- Pre-existing hygiene gap noted for someday (not this PR): crash-orphaned PEL entries are never reclaimed (no XAutoClaim) — trimming adds one more way to orphan them, harmlessly.
- miniredis is the package's first Redis test dep; the exact-count assertions carry a comment noting they rely on miniredis treating `~` as exact.

## Behavior change — release-note visibility
- Trace stream entries older than 24h are trimmed by default starting this release; set `retention: "0"` to keep today's keep-forever behavior.
- `distributedTracing.enabled: false` in values files now actually renders `"false"` (previously silently inverted to `"true"` by the falsy-default bug).

Closes #1215

## Test plan
- [x] `go test ./src/core/... -race` (9 new retention tests: env matrix, trim only-old/disabled/disconnected, (re)connect trim, correlator cap + age pruning)
- [x] helm lint + the full render matrix (defaults / enabled=false / retention 0 in four YAML forms / 48h / umbrella pass-through / #1190 guard regression)
- [ ] Prod-profile soak: confirm stream length plateaus after 24h on a busy mesh (post-merge observation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable distributed trace retention with new `MCP_MESH_TRACE_RETENTION` environment variable (default: 24 hours; set to `0` to disable trimming).
  * Implemented automatic Redis stream cleanup to remove expired trace entries.

* **Documentation**
  * Updated distributed tracing documentation with standardized Redis stream naming and retention behavior.
  * Added environment variable documentation for trace retention configuration.
  * Updated Helm values and templates to support trace retention settings.

* **Tests**
  * Added comprehensive test coverage for trace retention functionality and stream trimming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->