### PR TITLE
feat(registry): resolve to highest satisfying version among matching providers

### DIFF
--- a/src/core/cli/audit_test.go
+++ b/src/core/cli/audit_test.go
@@ -75,7 +75,7 @@ func makeFlippedEvent() AuditEvent {
 				"stage":  "tiebreaker",
 				"kept":   []interface{}{"hr-v2", "legacy-emp"},
 				"chosen": "hr-v2",
-				"reason": "HighestScoreFirst",
+				"reason": "HighestScoreThenVersion",
 			},
 		},
 		"chosen": map[string]interface{}{

--- a/src/core/cli/man/content/audit.md
+++ b/src/core/cli/man/content/audit.md
@@ -13,9 +13,9 @@ When a consumer asks the registry to resolve a dependency, candidates flow throu
 1. **`health`** — drop unhealthy or deregistering candidates first. Running this stage first keeps the downstream stage tables clean (no stale agents listed in the tag-eviction trace).
 2. **`capability_match`** — survivors from the indexed query for `capability=X`. This stage records the universe the rest of the pipeline operates on.
 3. **`tags`** — apply required / preferred / excluded tag filters and compute scores. See `meshctl man tags`.
-4. **`version`** — apply semver constraint (`>=2.0.0`, `^1.4`, etc.).
+4. **`version`** — apply semver constraint (bare `4.6.0` = exact; `>=2.0.0`, `^1.4`, etc.).
 5. **`schema`** — apply the opt-in schema check (issue #547). When the consumer didn't ask for schema matching, this stage is a pass-through and `spec.schema_mode` reads `"none"`. See `meshctl man schema-matching`.
-6. **`tiebreaker`** — pick the winner from the surviving set. Currently `HighestScoreFirst` (highest tag-match score, first encountered if tied).
+6. **`tiebreaker`** — pick the winner from the surviving set: highest tag-match score first, then **highest version**, then agent ID for determinism (the newest satisfying version wins).
 
 Each stage records `kept` (survivors) and `evicted` (with a typed reason). The chosen producer is recorded on the `tiebreaker` stage and at the top level of the trace.
 
@@ -88,7 +88,7 @@ Each event's `data` field is an `AuditTrace`:
     },
     { "stage": "schema",     "kept": ["hr-v2:lookup"] },
     { "stage": "tiebreaker", "kept": ["hr-v2:lookup"],
-      "chosen": "hr-v2:lookup", "reason": "HighestScoreFirst" }
+      "chosen": "hr-v2:lookup", "reason": "HighestScoreThenVersion" }
   ],
   "chosen": {
     "agent_id":      "hr-v2",
@@ -136,7 +136,7 @@ Reasons are typed (not freeform strings) so audit consumers can pattern-match. T
 
 ## Tiebreaker
 
-After all filter stages, the surviving candidates are ordered by tag-match score (descending) and the first one wins. The audit records this as `reason: "HighestScoreFirst"` on the tiebreaker stage.
+After all filter stages, the surviving candidates are ordered by tag-match score (descending), then by version (highest first), then by agent ID for determinism — the first one wins. So among providers of the same capability and tags, the newest satisfying version is chosen. The audit records this as `reason: "HighestScoreThenVersion"` on the tiebreaker stage.
 
 Configurable tiebreakers (round-robin, latency-aware, etc.) are out of scope for v1 — the audit trail is forward-compatible: future tiebreakers will record their own name in the same `reason` field.
 

--- a/src/core/cli/man/content/capabilities.md
+++ b/src/core/cli/man/content/capabilities.md
@@ -16,7 +16,7 @@ MCP Mesh uses a unified syntax for selecting capabilities throughout the framewo
 | ------------ | -------- | ---------------------------------------------------------------- |
 | `capability` | Yes\*    | Capability name to match                                         |
 | `tags`       | No       | Tag filters. Optional `+` (preferred) / `-` (excluded) operators |
-| `version`    | No       | Semantic version constraint (e.g., `>=2.0.0`)                    |
+| `version`    | No       | Semver constraint (bare `4.6.0` = exact; `>=2.0.0`, `^1.4`, ...) |
 
 \*When filtering by tags only (e.g., LLM tool filter), `capability` can be omitted.
 
@@ -105,9 +105,11 @@ def get_weather(city: str) -> dict:
 When an agent requests a dependency, the registry resolves it by:
 
 1. **Name matching**: Find agents providing the requested capability
-2. **Tag filtering**: Apply tag constraints (if specified)
-3. **Version constraints**: Check semantic version compatibility
-4. **Load balancing**: Select from multiple matching providers
+2. **Tag filtering**: Apply tag constraints (if specified) and compute a tag-match score
+3. **Version constraints**: Drop providers whose version doesn't satisfy the semver constraint
+4. **Selection**: Among the survivors, pick the best match — highest tag-match score first, then **highest version**, then agent ID for determinism
+
+So when several providers share the same capability and tags, the one with the **newest version wins**.
 
 ## Multiple Implementations
 
@@ -174,7 +176,7 @@ def my_tool(date: mesh.McpMeshTool = None, weather: mesh.McpMeshTool = None):
 
 ## Versioning
 
-Capabilities support semantic versioning:
+Providers declare a concrete version on `@mesh.tool` / `@mesh.llm_provider` (default `"1.0.0"` if unset):
 
 ```python
 @mesh.tool(
@@ -184,11 +186,21 @@ Capabilities support semantic versioning:
 def api_v2(): ...
 ```
 
-Consumers can specify version constraints:
+Consumers specify a **semver constraint** (Masterminds/semver syntax) in the dependency selector. The constraint is a hard filter applied before selection; among the providers that satisfy it, the registry picks the **highest version**:
 
 ```python
 dependencies=[{"capability": "api_client", "version": ">=2.0.0"}]
 ```
+
+| Constraint     | Matches                          | Selected                          |
+| -------------- | -------------------------------- | --------------------------------- |
+| `"4.6.0"`      | exactly `4.6.0`                  | `4.6.0`                           |
+| `">=4.6.0"`    | any version ≥ `4.6.0`            | highest available (may cross major) |
+| `"^4.6.0"`     | `>=4.6.0 <5.0.0` (same major)    | highest within major `4`          |
+| `"~4.6.0"`     | `>=4.6.0 <4.7.0` (same minor)    | highest within minor `4.6`        |
+| omitted        | any version                      | highest available                 |
+
+A **bare** version like `"4.6.0"` means an **exact** match, consistent with `capability=` and `tags=` being exact matches. A provider with no/empty version cannot satisfy a non-empty constraint.
 
 Beyond name + tags + version, dependencies can opt into schema-based resolution via `expected_type` (Python) / `expectedSchema` (TypeScript) / `expectedType` (Java). The registry then matches producers by the canonical shape of their `outputSchema`, evicting candidates whose response shape doesn't satisfy the consumer's expectation. See `meshctl man schema-matching` for the full opt-in mechanism, modes (`subset` vs `strict`), and verdict tiers.
 

--- a/src/core/cli/man/content/capabilities_java.md
+++ b/src/core/cli/man/content/capabilities_java.md
@@ -33,7 +33,7 @@ MCP Mesh uses the `@Selector` annotation for selecting capabilities. This same p
 | ------------ | -------- | --------------------------------------------- |
 | `capability` | Yes\*    | Capability name to match                      |
 | `tags`       | No       | Tag filters. Optional `+` (preferred) / `-` (excluded) operators |
-| `version`    | No       | Semantic version constraint (e.g., `>=2.0.0`) |
+| `version`    | No       | Semver constraint (bare `4.6.0` = exact; `>=2.0.0`, `^1.4`, ...) |
 
 \*When filtering by tags only (e.g., LLM tool filter), `capability` can be omitted.
 
@@ -144,9 +144,11 @@ public ForecastResponse getForecast(
 When an agent requests a dependency, the registry resolves it by:
 
 1. **Name matching**: Find agents providing the requested capability
-2. **Tag filtering**: Apply tag constraints (if specified)
-3. **Version constraints**: Check semantic version compatibility
-4. **Load balancing**: Select from multiple matching providers
+2. **Tag filtering**: Apply tag constraints (if specified) and compute a tag-match score
+3. **Version constraints**: Drop providers whose version doesn't satisfy the semver constraint
+4. **Selection**: Among the survivors, pick the best match — highest tag-match score first, then **highest version**, then agent ID for determinism
+
+So when several providers share the same capability and tags, the one with the **newest version wins**.
 
 ## Capability Naming Conventions
 
@@ -159,7 +161,7 @@ When an agent requests a dependency, the registry resolves it by:
 
 ## Versioning
 
-Capabilities support semantic versioning:
+Providers declare a concrete version (default `"1.0.0"` if unset):
 
 ```java
 @MeshTool(capability = "api_client", version = "2.1.0",
@@ -170,11 +172,21 @@ public ApiResponse callApi(
 }
 ```
 
-Consumers can specify version constraints:
+Consumers specify a **semver constraint** in the dependency selector. The constraint is a hard filter applied before selection; among the providers that satisfy it, the registry picks the **highest version**:
 
 ```java
 dependencies = @Selector(capability = "api_client", version = ">=2.0.0")
 ```
+
+| Constraint   | Matches                       | Selected                            |
+| ------------ | ----------------------------- | ----------------------------------- |
+| `"4.6.0"`    | exactly `4.6.0`               | `4.6.0`                             |
+| `">=4.6.0"`  | any version ≥ `4.6.0`         | highest available (may cross major) |
+| `"^4.6.0"`   | `>=4.6.0 <5.0.0` (same major) | highest within major `4`            |
+| `"~4.6.0"`   | `>=4.6.0 <4.7.0` (same minor) | highest within minor `4.6`          |
+| omitted      | any version                   | highest available                   |
+
+A **bare** version like `"4.6.0"` means an **exact** match, consistent with `capability` and `tags` being exact matches. A provider with no/empty version cannot satisfy a non-empty constraint.
 
 ## See Also
 

--- a/src/core/cli/man/content/capabilities_typescript.md
+++ b/src/core/cli/man/content/capabilities_typescript.md
@@ -16,7 +16,7 @@ MCP Mesh uses a unified syntax for selecting capabilities throughout the framewo
 | ------------ | -------- | --------------------------------------------- |
 | `capability` | Yes\*    | Capability name to match                      |
 | `tags`       | No       | Tag filters. Optional `+` (preferred) / `-` (excluded) operators |
-| `version`    | No       | Semantic version constraint (e.g., `>=2.0.0`) |
+| `version`    | No       | Semver constraint (bare `4.6.0` = exact; `>=2.0.0`, `^1.4`, ...) |
 
 \*When filtering by tags only (e.g., LLM tool filter), `capability` can be omitted.
 
@@ -111,9 +111,11 @@ agent.addTool({
 When an agent requests a dependency, the registry resolves it by:
 
 1. **Name matching**: Find agents providing the requested capability
-2. **Tag filtering**: Apply tag constraints (if specified)
-3. **Version constraints**: Check semantic version compatibility
-4. **Load balancing**: Select from multiple matching providers
+2. **Tag filtering**: Apply tag constraints (if specified) and compute a tag-match score
+3. **Version constraints**: Drop providers whose version doesn't satisfy the semver constraint
+4. **Selection**: Among the survivors, pick the best match — highest tag-match score first, then **highest version**, then agent ID for determinism
+
+So when several providers share the same capability and tags, the one with the **newest version wins**.
 
 ## Multiple Implementations
 
@@ -204,7 +206,7 @@ agent.addTool({
 
 ## Versioning
 
-Capabilities support semantic versioning:
+Providers declare a concrete version (default `"1.0.0"` if unset):
 
 ```typescript
 agent.addTool({
@@ -215,11 +217,21 @@ agent.addTool({
 });
 ```
 
-Consumers can specify version constraints:
+Consumers specify a **semver constraint** in the dependency selector. The constraint is a hard filter applied before selection; among the providers that satisfy it, the registry picks the **highest version**:
 
 ```typescript
 dependencies: [{ capability: "api_client", version: ">=2.0.0" }];
 ```
+
+| Constraint   | Matches                       | Selected                            |
+| ------------ | ----------------------------- | ----------------------------------- |
+| `"4.6.0"`    | exactly `4.6.0`               | `4.6.0`                             |
+| `">=4.6.0"`  | any version ≥ `4.6.0`         | highest available (may cross major) |
+| `"^4.6.0"`   | `>=4.6.0 <5.0.0` (same major) | highest within major `4`            |
+| `"~4.6.0"`   | `>=4.6.0 <4.7.0` (same minor) | highest within minor `4.6`          |
+| omitted      | any version                   | highest available                   |
+
+A **bare** version like `"4.6.0"` means an **exact** match, consistent with `capability` and `tags` being exact matches. A provider with no/empty version cannot satisfy a non-empty constraint.
 
 ## See Also
 

--- a/src/core/cli/man/content/dependency-injection.md
+++ b/src/core/cli/man/content/dependency-injection.md
@@ -29,9 +29,9 @@ health → capability_match → tags → version → schema → tiebreaker
 | `health`           | Drops unhealthy / deregistering candidates first                            |
 | `capability_match` | Indexed query on the capability name                                        |
 | `tags`             | Required / preferred / excluded tag filter (with scoring)                   |
-| `version`          | Semver constraint (`>=2.0.0`, `^1.4`, ...)                                  |
+| `version`          | Semver constraint (bare `4.6.0` = exact; `>=2.0.0`, `^1.4`, ...)            |
 | `schema`           | Opt-in schema check (issue #547) — see below                                |
-| `tiebreaker`       | `HighestScoreFirst` from the surviving set                                  |
+| `tiebreaker`       | Highest tag-match score, then **highest version**, then agent ID            |
 
 Every decision the registry makes is recorded as a `dependency_resolved` (or `dependency_unresolved`) event. Use `meshctl audit <agent>` to read them back — see `meshctl man audit`.
 

--- a/src/core/cli/man/content/dependency-injection_java.md
+++ b/src/core/cli/man/content/dependency-injection_java.md
@@ -27,9 +27,9 @@ health → capability_match → tags → version → schema → tiebreaker
 | `health`           | Drops unhealthy / deregistering candidates first                            |
 | `capability_match` | Indexed query on the capability name                                        |
 | `tags`             | Required / preferred / excluded tag filter (with scoring)                   |
-| `version`          | Semver constraint (`>=2.0.0`, `^1.4`, ...)                                  |
+| `version`          | Semver constraint (bare `4.6.0` = exact; `>=2.0.0`, `^1.4`, ...)            |
 | `schema`           | Opt-in schema check (issue #547) — see below                                |
-| `tiebreaker`       | `HighestScoreFirst` from the surviving set                                  |
+| `tiebreaker`       | Highest tag-match score, then **highest version**, then agent ID            |
 
 Every decision the registry makes is recorded as a `dependency_resolved` (or `dependency_unresolved`) event. Use `meshctl audit <agent>` to read them back — see `meshctl man audit`.
 

--- a/src/core/cli/man/content/dependency-injection_typescript.md
+++ b/src/core/cli/man/content/dependency-injection_typescript.md
@@ -27,9 +27,9 @@ health → capability_match → tags → version → schema → tiebreaker
 | `health`           | Drops unhealthy / deregistering candidates first                            |
 | `capability_match` | Indexed query on the capability name                                        |
 | `tags`             | Required / preferred / excluded tag filter (with scoring)                   |
-| `version`          | Semver constraint (`>=2.0.0`, `^1.4`, ...)                                  |
+| `version`          | Semver constraint (bare `4.6.0` = exact; `>=2.0.0`, `^1.4`, ...)            |
 | `schema`           | Opt-in schema check (issue #547) — see below                                |
-| `tiebreaker`       | `HighestScoreFirst` from the surviving set                                  |
+| `tiebreaker`       | Highest tag-match score, then **highest version**, then agent ID            |
 
 Every decision the registry makes is recorded as a `dependency_resolved` (or `dependency_unresolved`) event. Use `meshctl audit <agent>` to read them back — see `meshctl man audit`.
 

--- a/src/core/cli/man/content/registry.md
+++ b/src/core/cli/man/content/registry.md
@@ -82,9 +82,10 @@ export MCP_MESH_DEBUG_MODE=false
 When an agent requests dependencies, the registry:
 
 1. **Finds providers**: Agents with matching capability
-2. **Applies filters**: Tag and version constraints
+2. **Applies filters**: Tag and version constraints (the `version` field is a semver constraint; bare `4.6.0` = exact match)
 3. **Scores matches**: Preferred tags add points
-4. **Returns topology**: Selected providers for each dependency
+4. **Selects winner**: Among matches, highest tag-match score first, then **highest version**, then agent ID for determinism — the newest satisfying version wins
+5. **Returns topology**: Selected providers for each dependency
 
 ### Resolution Request
 

--- a/src/core/registry/audit_resolver_test.go
+++ b/src/core/registry/audit_resolver_test.go
@@ -202,7 +202,7 @@ func TestAudit_FourCandidatesMixed(t *testing.T) {
 	// tr.Chosen.FunctionName.
 	tieb := tr.Stages[5]
 	assert.NotEmpty(t, tieb.Chosen)
-	assert.Equal(t, TiebreakerHighestScoreFirst, tieb.Reason)
+	assert.Equal(t, TiebreakerScoreThenVersion, tieb.Reason)
 	assert.Equal(t, tr.Chosen.AgentID+":"+tr.Chosen.FunctionName, tieb.Chosen)
 }
 
@@ -416,7 +416,7 @@ func TestAuditTrace_RoundTrip(t *testing.T) {
 				Stage:  StageTiebreaker,
 				Kept:   []string{"a", "b"},
 				Chosen: "a",
-				Reason: TiebreakerHighestScoreFirst,
+				Reason: TiebreakerScoreThenVersion,
 			},
 		},
 		Chosen: &AuditChosen{
@@ -521,7 +521,7 @@ func makeBaseTrace() AuditTrace {
 				Stage:  StageTiebreaker,
 				Kept:   []string{"hr-v2:do_thing", "legacy-emp:do_thing"},
 				Chosen: "hr-v2:do_thing",
-				Reason: TiebreakerHighestScoreFirst,
+				Reason: TiebreakerScoreThenVersion,
 			},
 		},
 		Chosen: &AuditChosen{

--- a/src/core/registry/audit_trace.go
+++ b/src/core/registry/audit_trace.go
@@ -39,11 +39,12 @@ const (
 	StageTiebreaker      = "tiebreaker"
 )
 
-// TiebreakerHighestScoreFirst names the current resolver's tiebreaker logic:
-// candidates are sorted by tag-match score (descending) and the first is picked.
+// TiebreakerScoreThenVersion names the current resolver's tiebreaker logic:
+// candidates are sorted by tag-match score (descending), then by highest semver
+// version (descending), then by agent ID (ascending) for determinism.
 // Documenting this in the audit makes it explicit; configurable tiebreakers
 // are out of scope for v1.
-const TiebreakerHighestScoreFirst = "HighestScoreFirst"
+const TiebreakerScoreThenVersion = "HighestScoreThenVersion"
 
 // AuditTrace is the JSON payload stored in RegistryEvent.data for
 // dependency_resolved / dependency_unresolved events.
@@ -79,7 +80,7 @@ type AuditStage struct {
 	Kept    []string       `json:"kept"`
 	Evicted []AuditEvicted `json:"evicted,omitempty"`
 	Chosen  string         `json:"chosen,omitempty"` // only set on the tiebreaker stage; format "<agent_id>:<function_name>"
-	Reason  string         `json:"reason,omitempty"` // only set on the tiebreaker stage (e.g., "HighestScoreFirst")
+	Reason  string         `json:"reason,omitempty"` // only set on the tiebreaker stage (e.g., "HighestScoreThenVersion")
 }
 
 // AuditEvicted records a single dropped candidate with a typed reason and

--- a/src/core/registry/llm_provider_resolver.go
+++ b/src/core/registry/llm_provider_resolver.go
@@ -101,9 +101,23 @@ func filterProviderByEnhancedTags(caps []*ent.Capability, requestedTags interfac
 		}
 	}
 
-	// Sort by score descending (highest score first)
-	sort.Slice(scored, func(i, j int) bool {
-		return scored[i].score > scored[j].score
+	// Sort by score DESC, then highest semver version DESC, then agent ID ASC
+	// for determinism. Mirrors the mesh.tool tiebreaker so the highest-version
+	// provider wins within an equal-score family.
+	agentIDOf := func(c *ent.Capability) string {
+		if c.Edges.Agent == nil {
+			return ""
+		}
+		return c.Edges.Agent.ID
+	}
+	sort.SliceStable(scored, func(i, j int) bool {
+		if scored[i].score != scored[j].score {
+			return scored[i].score > scored[j].score
+		}
+		if vc := compareVersion(scored[i].cap.Version, scored[j].cap.Version); vc != 0 {
+			return vc > 0
+		}
+		return agentIDOf(scored[i].cap) < agentIDOf(scored[j].cap)
 	})
 
 	// Extract capabilities in score order

--- a/src/core/registry/matcher.go
+++ b/src/core/registry/matcher.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"strings"
+
 	"github.com/Masterminds/semver/v3"
 	"mcp-mesh/src/core/logger"
 )
@@ -87,6 +89,27 @@ func (m *Matcher) MatchVersion(version, constraint string) bool {
 
 	// Check if version satisfies constraint
 	return c.Check(v)
+}
+
+// CompareVersion orders two version strings for "highest wins" selection.
+// Returns >0 if a is newer than b, <0 if older, 0 if equal.
+// Valid semver always ranks above unparseable/empty; two unparseable
+// versions fall back to deterministic string comparison so selection is
+// never nondeterministic.
+func (m *Matcher) CompareVersion(a, b string) int {
+	va, errA := semver.NewVersion(a)
+	vb, errB := semver.NewVersion(b)
+
+	switch {
+	case errA == nil && errB == nil:
+		return va.Compare(vb)
+	case errA == nil:
+		return 1
+	case errB == nil:
+		return -1
+	default:
+		return strings.Compare(a, b)
+	}
 }
 
 // MatchTags implements enhanced tag matching with +/- operators and OR alternatives.
@@ -245,6 +268,12 @@ func hasAllTags(available, required []string) bool {
 // Used by llm_filtering.go and llm_provider_resolver.go.
 func matchesVersion(version, constraint string) bool {
 	return (&Matcher{}).MatchVersion(version, constraint)
+}
+
+// compareVersion is a package-level convenience function for version ordering.
+// Used by llm_provider_resolver.go for highest-version selection.
+func compareVersion(a, b string) int {
+	return (&Matcher{}).CompareVersion(a, b)
 }
 
 // matchesEnhancedTags is a package-level convenience function for tag matching.

--- a/src/core/registry/matcher_version_select_test.go
+++ b/src/core/registry/matcher_version_select_test.go
@@ -1,0 +1,90 @@
+package registry
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCompareVersion verifies the "highest wins" ordering helper: valid semver
+// compares numerically, valid always beats unparseable/empty, and two
+// unparseable versions fall back to deterministic string comparison.
+func TestCompareVersion(t *testing.T) {
+	m := &Matcher{}
+
+	assert.Positive(t, m.CompareVersion("2.0.0", "1.0.0"), "2.0.0 > 1.0.0")
+	assert.Zero(t, m.CompareVersion("1.0.0", "1.0.0"), "1.0.0 == 1.0.0")
+	// Numeric, not lexical: 1.2.0 < 1.10.0
+	assert.Negative(t, m.CompareVersion("1.2.0", "1.10.0"), "1.2.0 < 1.10.0 numerically")
+	assert.Negative(t, m.CompareVersion("", "1.0.0"), "empty ranks below valid semver")
+	assert.Negative(t, m.CompareVersion("garbage", "1.0.0"), "unparseable ranks below valid semver")
+	assert.Positive(t, m.CompareVersion("1.0.0", "garbage"), "valid semver ranks above unparseable")
+
+	// Two unparseable versions: deterministic strings.Compare sign.
+	want := strings.Compare("garbage", "other")
+	got := m.CompareVersion("garbage", "other")
+	assert.Equal(t, want, got, "two unparseable versions fall back to strings.Compare")
+
+	// Package-level convenience mirrors the method.
+	assert.Equal(t, m.CompareVersion("2.0.0", "1.0.0"), compareVersion("2.0.0", "1.0.0"))
+}
+
+// sortScored applies the exact tiebreaker ordering used by the resolver
+// (score DESC, version DESC, agentID ASC) so selection can be asserted in
+// isolation from the DB pipeline.
+func sortScored(xs []scoredCandidateWithHealth) {
+	m := &Matcher{}
+	sort.SliceStable(xs, func(i, j int) bool {
+		if xs[i].Score != xs[j].Score {
+			return xs[i].Score > xs[j].Score
+		}
+		if vc := m.CompareVersion(xs[i].Version, xs[j].Version); vc != 0 {
+			return vc > 0
+		}
+		return xs[i].AgentID < xs[j].AgentID
+	})
+}
+
+func scored(agentID, version string, score int) scoredCandidateWithHealth {
+	return scoredCandidateWithHealth{
+		candidateWithHealth: candidateWithHealth{
+			Candidate: Candidate{AgentID: agentID, Version: version},
+		},
+		Score: score,
+	}
+}
+
+// TestTiebreakerSelection verifies the resolver's selection ordering: tag score
+// is primary; among equal scores the highest version wins; identical
+// score+version is broken by agent ID for determinism.
+func TestTiebreakerSelection(t *testing.T) {
+	t.Run("HighestVersionWinsAmongEqualScore", func(t *testing.T) {
+		xs := []scoredCandidateWithHealth{
+			scored("a", "4.6.0", 5),
+			scored("b", "4.7.0", 5),
+			scored("c", "5.0.0", 5),
+		}
+		sortScored(xs)
+		assert.Equal(t, "c", xs[0].AgentID, "5.0.0 wins")
+	})
+
+	t.Run("HigherScoreBeatsHigherVersion", func(t *testing.T) {
+		xs := []scoredCandidateWithHealth{
+			scored("high-version", "9.9.9", 5),
+			scored("preferred", "1.0.0", 10),
+		}
+		sortScored(xs)
+		assert.Equal(t, "preferred", xs[0].AgentID, "tag score is primary")
+	})
+
+	t.Run("AgentIDBreaksScoreAndVersionTie", func(t *testing.T) {
+		xs := []scoredCandidateWithHealth{
+			scored("zeta", "1.0.0", 5),
+			scored("alpha", "1.0.0", 5),
+		}
+		sortScored(xs)
+		assert.Equal(t, "alpha", xs[0].AgentID, "lexicographically smallest agent ID wins ties")
+	})
+}

--- a/src/core/registry/resolver.go
+++ b/src/core/registry/resolver.go
@@ -448,17 +448,26 @@ func (s *EntService) findHealthyProviderWithTrace(dep Dependency) (*DependencyRe
 		return nil, trace
 	}
 
-	// Stage 6: tiebreaker — sort by score DESC then take the head. Document
-	// the algorithm name in the audit so changes are visible.
+	// Stage 6: tiebreaker — sort by tag score DESC, then highest semver version
+	// DESC, then agent ID ASC for determinism. Tag score stays primary (a
+	// +preferred tag still beats a higher version); version picks the newest
+	// within an equal-score family. Document the algorithm name in the audit so
+	// changes are visible.
 	sort.SliceStable(afterSchema, func(i, j int) bool {
-		return afterSchema[i].Score > afterSchema[j].Score
+		if afterSchema[i].Score != afterSchema[j].Score {
+			return afterSchema[i].Score > afterSchema[j].Score
+		}
+		if vc := s.matcher.CompareVersion(afterSchema[i].Version, afterSchema[j].Version); vc != 0 {
+			return vc > 0
+		}
+		return afterSchema[i].AgentID < afterSchema[j].AgentID
 	})
 	winner := afterSchema[0]
 	trace.Stages = append(trace.Stages, AuditStage{
 		Stage:  StageTiebreaker,
 		Kept:   idsFromScored(afterSchema),
 		Chosen: candidateID(winner.AgentID, winner.FunctionName),
-		Reason: TiebreakerHighestScoreFirst,
+		Reason: TiebreakerScoreThenVersion,
 	})
 
 	endpoint := "stdio://" + winner.AgentID

--- a/src/core/registry/version_selection_pipeline_test.go
+++ b/src/core/registry/version_selection_pipeline_test.go
@@ -1,0 +1,238 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"mcp-mesh/src/core/ent"
+	"mcp-mesh/src/core/ent/enttest"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// seedVersionedLLMProvider creates a healthy LLM provider agent + capability at
+// the given version, sharing the same capability name and tags as its siblings.
+// The agent ID is keyed off the version so the resolved winner is unambiguous.
+func seedVersionedLLMProvider(t *testing.T, ctx context.Context, client *ent.Client, version string, httpPort int) {
+	t.Helper()
+	a, err := client.Agent.Create().
+		SetID("llm-provider-" + version).
+		SetName("LLM Provider " + version).
+		SetNamespace("default").
+		SetHTTPHost("localhost").
+		SetHTTPPort(httpPort).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = client.Capability.Create().
+		SetFunctionName("process_chat").
+		SetCapability("llm").
+		SetDescription("Claude Sonnet LLM provider " + version).
+		SetTags([]string{"claude", "sonnet"}).
+		SetVersion(version).
+		SetInputSchema(map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"messages": map[string]interface{}{"type": "array"},
+			},
+		}).
+		SetAgent(a).
+		Save(ctx)
+	require.NoError(t, err)
+}
+
+// TestResolveProvider_SelectsHighestSatisfyingVersion proves that the LLM
+// provider resolver, driven through the real ent DB query + scoring pipeline,
+// selects the HIGHEST satisfying version for a given constraint — not the
+// first-registered or first-queried capability.
+//
+// All three providers share capability="llm" and tags=["claude","sonnet"], so
+// tag score ties; the (version DESC, agentID ASC) tiebreaker is the only thing
+// that can decide the winner. To prove the test exercises version ranking and
+// not insertion luck, the providers are seeded in an order that would pick the
+// WRONG answer for the omitted-version case if selection fell back to insertion
+// order: 5.0.0 first, then 4.7.0, then 4.6.0 LAST. With agentID-ASC as the
+// final tiebreaker (agent IDs sort 4.6.0 < 4.7.0 < 5.0.0), insertion order is
+// irrelevant — only the version comparator can lift 5.0.0 to the top.
+func TestResolveProvider_SelectsHighestSatisfyingVersion(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Seed in an order designed to defeat insertion-order shortcuts:
+	// the eventual winner for the omitted-version case (5.0.0) is inserted
+	// FIRST and the bare/tilde winner (4.6.0) is inserted LAST.
+	seedVersionedLLMProvider(t, ctx, client, "5.0.0", 9050)
+	seedVersionedLLMProvider(t, ctx, client, "4.7.0", 9047)
+	seedVersionedLLMProvider(t, ctx, client, "4.6.0", 9046)
+
+	tests := []struct {
+		name            string
+		version         string // provider spec "version"; empty = omitted
+		expectedVersion string
+		expectedAgentID string
+	}{
+		{
+			name:            "omitted_version_picks_highest",
+			version:         "",
+			expectedVersion: "5.0.0",
+			expectedAgentID: "llm-provider-5.0.0",
+		},
+		{
+			name:            "caret_picks_highest_in_major",
+			version:         "^4.6.0", // >=4.6.0 <5.0.0 -> 4.7.0
+			expectedVersion: "4.7.0",
+			expectedAgentID: "llm-provider-4.7.0",
+		},
+		{
+			name:            "gte_picks_highest_overall",
+			version:         ">=4.6.0", // -> 5.0.0
+			expectedVersion: "5.0.0",
+			expectedAgentID: "llm-provider-5.0.0",
+		},
+		{
+			name:            "bare_is_exact",
+			version:         "4.6.0", // bare = exact match, by design
+			expectedVersion: "4.6.0",
+			expectedAgentID: "llm-provider-4.6.0",
+		},
+		{
+			name:            "tilde_only_patch_present",
+			version:         "~4.6.0", // >=4.6.0 <4.7.0 -> only 4.6.0 qualifies
+			expectedVersion: "4.6.0",
+			expectedAgentID: "llm-provider-4.6.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := map[string]interface{}{
+				"capability": "llm",
+				"tags":       []interface{}{"claude", "sonnet"},
+			}
+			if tt.version != "" {
+				spec["version"] = tt.version
+			}
+
+			provider, err := ResolveProvider(ctx, client, spec)
+			require.NoError(t, err)
+			require.NotNil(t, provider, "expected a matching provider")
+			require.NotNil(t, provider.Version, "resolved provider must carry a version")
+
+			assert.Equal(t, tt.expectedVersion, *provider.Version,
+				"resolver must select the highest satisfying version")
+			assert.Equal(t, tt.expectedAgentID, provider.AgentId,
+				"winning agent must correspond to the highest satisfying version")
+		})
+	}
+}
+
+// TestDependencyResolution_SelectsHighestSatisfyingVersion proves the same
+// "highest satisfying version wins" behavior for the @mesh.tool dependency
+// path, driven through the real RegisterAgent -> ResolveAllDependencies
+// pipeline against a seeded ent DB.
+//
+// Three provider agents publish the SAME capability ("database_service") with
+// the SAME tags (["data"]) at versions 4.6.0 / 4.7.0 / 5.0.0, each keyed to a
+// distinct agent ID so the resolved winner is unambiguous from dep.AgentID.
+// Providers are registered with 4.6.0 LAST so the test proves version ranking
+// rather than registration order.
+func TestDependencyResolution_SelectsHighestSatisfyingVersion(t *testing.T) {
+	type providerSeed struct {
+		agentID string
+		version string
+		host    string
+		port    float64
+	}
+	// Registration order intentionally scrambled (highest first, lowest last).
+	// Agent IDs use hyphens only (RegisterAgent validation forbids dots) but
+	// still sort in version order so agentID-ASC cannot mask a comparator bug.
+	providers := []providerSeed{
+		{"db-provider-v5-0-0", "5.0.0", "db-5", 8050},
+		{"db-provider-v4-7-0", "4.7.0", "db-47", 8047},
+		{"db-provider-v4-6-0", "4.6.0", "db-46", 8046},
+	}
+
+	tests := []struct {
+		name            string
+		constraint      string // dependency version constraint; empty = omitted
+		expectedAgentID string
+	}{
+		{"omitted_version_picks_highest", "", "db-provider-v5-0-0"},
+		{"caret_picks_highest_in_major", "^4.6.0", "db-provider-v4-7-0"},
+		{"gte_picks_highest_overall", ">=4.6.0", "db-provider-v5-0-0"},
+		{"bare_is_exact", "4.6.0", "db-provider-v4-6-0"},
+		{"tilde_only_patch_present", "~4.6.0", "db-provider-v4-6-0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := setupTestService(t)
+
+			for _, p := range providers {
+				req := &AgentRegistrationRequest{
+					AgentID: p.agentID,
+					Metadata: map[string]interface{}{
+						"agent_type": "mcp_agent",
+						"name":       p.agentID,
+						"version":    p.version,
+						"http_host":  p.host,
+						"http_port":  p.port,
+						"tools": []interface{}{
+							map[string]interface{}{
+								"function_name": "query_db",
+								"capability":    "database_service",
+								"version":       p.version,
+								"tags":          []string{"data"},
+								"description":   "Query database",
+							},
+						},
+					},
+				}
+				_, err := service.RegisterAgent(req)
+				require.NoError(t, err, "provider %s registration should succeed", p.agentID)
+			}
+
+			dep := map[string]interface{}{
+				"capability": "database_service",
+				"tags":       []string{"data"},
+			}
+			if tt.constraint != "" {
+				dep["version"] = tt.constraint
+			}
+
+			consumerReq := &AgentRegistrationRequest{
+				AgentID: "db-consumer",
+				Metadata: map[string]interface{}{
+					"agent_type": "mcp_agent",
+					"name":       "db-consumer",
+					"version":    "1.0.0",
+					"http_host":  "consumer",
+					"http_port":  float64(9000),
+					"tools": []interface{}{
+						map[string]interface{}{
+							"function_name": "use_db",
+							"capability":    "app_service",
+							"version":       "1.0.0",
+							"dependencies":  []interface{}{dep},
+							"description":   "Uses the database service",
+						},
+					},
+				},
+			}
+
+			response, err := service.RegisterAgent(consumerReq)
+			require.NoError(t, err, "consumer registration should succeed")
+
+			deps := response.DependenciesResolved["use_db"]
+			require.Len(t, deps, 1, "expected exactly one resolved dependency")
+			assert.Equal(t, "available", deps[0].Status, "dependency should resolve")
+			assert.Equal(t, tt.expectedAgentID, deps[0].AgentID,
+				"resolver must select the agent providing the highest satisfying version")
+		})
+	}
+}

--- a/tests/integration/suites/uc06_observability/artifacts/py-calculator/main.py
+++ b/tests/integration/suites/uc06_observability/artifacts/py-calculator/main.py
@@ -23,7 +23,7 @@ app = FastMCP("PyCalculator Service")
     description="Multiply two numbers using both repeated addition and direct multiplication",
     tags=["calculator", "math"],
     dependencies=[
-        {"capability": "add", "tags": ["+math"]},
+        {"capability": "add", "tags": ["+math", "+add"]},
         {"capability": "multiply", "tags": ["+math"]},
     ],
 )


### PR DESCRIPTION
## Summary

Dependency and `@mesh.llm` provider resolution selected a winner by **tag-match score only** — the `version` constraint was applied as a hard filter but never influenced selection. Ties fell to registration/input order (effectively undefined), so a consumer asking for `>=4.6.0` (or omitting a version) could resolve to *any* satisfying provider, not the newest.

This makes version a **deterministic secondary sort key**. Selection is now:

```
(tag score DESC, semver version DESC, agent ID ASC)
```

Among providers matching capability + tags, the **highest satisfying version wins**; agent ID is the final tiebreaker for determinism.

## Constraint semantics (filtering unchanged; now also drives selection)

| Consumer `version` | Matches | Selected |
| --- | --- | --- |
| omitted | any | highest available |
| `"4.6.0"` (bare) | exactly 4.6.0 | 4.6.0 |
| `">=4.6.0"` | ≥ 4.6.0 | highest (may cross major) |
| `"^4.6.0"` | ≥4.6.0 <5.0.0 | highest within major |
| `"~4.6.0"` | ≥4.6.0 <4.7.0 | highest within minor |

Bare `version` is **exact**, consistent with how `capability` and `tags` match; `^`/`~`/`>=` opt into bounded floating (Masterminds/semver).

## Changes
- `matcher.go`: `CompareVersion` helper (semver-aware; empty/invalid sort last; deterministic).
- `resolver.go` (`@mesh.tool` path) and `llm_provider_resolver.go` (`@mesh.llm` provider path): version as secondary sort key after tag score, agent ID final.
- Audit tiebreaker reason → `HighestScoreThenVersion`.
- Man pages (capabilities, registry, dependency-injection, audit + `_typescript`/`_java`) document highest-satisfying selection and the operator semantics.

## Tests
- `matcher_version_select_test.go`: comparator units.
- `version_selection_pipeline_test.go`: DB-backed selection through the real resolver, **both paths**, covering omitted / exact / `^` / `~` / `>=`. Agent IDs are keyed so the cases only pass if version-ranking actively wins (not insertion luck).
- One tracing fixture (uc06) that relied on the previously-undefined tie order is disambiguated here (`+add`) so it resolves by score.

## Notes
- Behavior change: resolutions that (unknowingly) relied on registration-order ties now resolve deterministically to the highest version — more predictable, worth a release note.
- Unrelated integration-suite flake-hardening that surfaced in the same gate run will follow as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency and capability resolution tie-breaking logic to prioritize highest version selection and deterministic agent ordering, ensuring consistent results across restarts.

* **Documentation**
  * Updated documentation for resolver, capability selection, and dependency injection to clarify version-based tie-breaking behavior and semver constraint semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->