### PR TITLE
test: harden three integration-suite timing flakes

### DIFF
--- a/tests/integration/suites/uc05_meshctl/tc40_repeated_start_stop_lifecycle/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc40_repeated_start_stop_lifecycle/test.yaml
@@ -61,6 +61,7 @@ test:
       done
       echo "LOOP_COMPLETED=true"
     capture: loop_output
+    timeout: 200
 
   - name: "Verify meshctl still responsive after loop"
     handler: shell

--- a/tests/integration/suites/uc07_example_simple/tc03_fastapi_integration/test.yaml
+++ b/tests/integration/suites/uc07_example_simple/tc03_fastapi_integration/test.yaml
@@ -95,6 +95,20 @@ test:
     workdir: /workspace
     capture: health_result
 
+  - name: "Wait for FastAPI route dependencies to settle"
+    handler: shell
+    command: |
+      for i in $(seq 1 70); do
+        RESULT=$(curl -s --max-time 5 http://localhost:8080/api/v1/time 2>/dev/null || true)
+        if echo "$RESULT" | grep -q 'time'; then
+          echo "time_service resolved after ${i}s"; exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: time_service not resolved within ~70s"; exit 1
+    workdir: /workspace
+    timeout: 90
+
   - name: "Test time endpoint (uses time_service dependency)"
     handler: shell
     command: "curl -s --max-time 10 http://localhost:8080/api/v1/time"

--- a/tests/integration/suites/uc20_tutorial/tc04_day04_tiers/test.yaml
+++ b/tests/integration/suites/uc20_tutorial/tc04_day04_tiers/test.yaml
@@ -198,6 +198,13 @@ test:
     capture: deregister_output
     timeout: 60
 
+  # Give the planner's in-process MeshLlmAgent proxy time to re-resolve from
+  # claude to openai. Registry-list removal != proxy re-resolution; that needs
+  # a heartbeat cycle (~5s) to propagate. 15s = 3x heartbeat interval.
+  - name: "Wait for planner to re-resolve LLM provider to openai"
+    handler: wait
+    seconds: 15
+
   # Call plan_trip again — should auto-route to OpenAI
   - name: "Call plan_trip with failover to OpenAI"
     handler: shell


### PR DESCRIPTION
## Summary

Three integration tests fail intermittently on timing/readiness, independent of any product behavior. These surfaced during the gate run for #1219 (confirmed unrelated to that change — no provider resolution is involved in two of them, and the third fails on a connection to an already-dead provider, not a resolution tie).

## Fixes

- **`uc05_meshctl/tc40_repeated_start_stop_lifecycle`** — the 20-iteration start/stop loop (~7s/iter ≈ 134s) exceeds the inherited 120s step timeout and is killed mid-loop (exit 124) after ~18 clean iterations. Set an explicit `timeout: 200`. Pure slow-test timeout; every iteration that runs succeeds.

- **`uc07_example_simple/tc03_fastapi_integration`** — the `@mesh.route` handler blocks on the DI settle window while `time_service` resolves, so a fixed `--max-time 10` curl can fire mid-settle (curl exit 28). Add a readiness poll on the dependency-backed endpoint before the assertion-bearing requests, so they run only after settle completes.

- **`uc20_tutorial/tc04_day04_tiers`** — the failover call fires as soon as `claude-provider` leaves `meshctl list`, but the planner's in-process LLM provider proxy is only re-resolved on the next heartbeat (~5s). Add a 15s wait so re-resolution to the OpenAI provider propagates before the call. (Failover itself works once the heartbeat lands — this is purely a propagation wait, not a product fix.)

All three are test-config (YAML) changes only; no source or runtime behavior is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
