### PR TITLE
feat(java): LLM model override + model_params passthrough (Wave 2a parity)

### DIFF
--- a/src/core/cli/man/content/llm_java.md
+++ b/src/core/cli/man/content/llm_java.md
@@ -4,66 +4,16 @@
 
 ## Overview
 
-MCP Mesh provides first-class LLM support for Java/Spring Boot agents through the `@MeshLlm` annotation. Two modes are available:
-
-| Mode              | Annotation                          | API Key Location | Use Case                         |
-| ----------------- | ----------------------------------- | ---------------- | -------------------------------- |
-| **Direct**        | `@MeshLlm(provider = "claude")`     | Local agent      | Single agent, simpler setup      |
-| **Mesh Delegate** | `@MeshLlm(providerSelector = @...)` | Provider agent   | Shared LLM, centralized key mgmt |
+MCP Mesh provides first-class LLM support for Java/Spring Boot agents through the `@MeshLlm` annotation. Every LLM call is routed to a provider agent in the mesh — the consumer never holds a vendor API key. Use `providerSelector` to pick which provider serves the request.
 
 ## Architecture
-
-### Direct Mode
-
-```
-User -> Agent -> Spring AI -> Claude API (direct)
-                 (local API key)
-```
-
-### Mesh Delegation Mode
 
 ```
 User -> Agent -> Mesh -> LLM Provider Agent -> Claude API
                          (API key here only)
 ```
 
-## Direct LLM (@MeshLlm with provider)
-
-Use `provider = "claude"` or `provider = "openai"` for direct API calls. Requires the API key set locally.
-
-```java
-import io.mcpmesh.*;
-import io.mcpmesh.types.MeshLlmAgent;
-
-@MeshLlm(
-    provider = "claude",
-    maxIterations = 1,
-    systemPrompt = "You are a helpful, friendly assistant. Keep responses concise.",
-    maxTokens = 1024,
-    temperature = 0.7
-)
-@MeshTool(
-    capability = "chat",
-    description = "Interactive chat with Claude",
-    tags = {"chat", "llm", "java", "direct"}
-)
-public ChatResponse chat(
-    @Param(value = "message", description = "User message") String message,
-    MeshLlmAgent llm
-) {
-    if (llm != null && llm.isAvailable()) {
-        String response = llm.generate(message);
-        return new ChatResponse(message, response, "direct:claude");
-    }
-    return new ChatResponse(message, "LLM unavailable", "fallback");
-}
-```
-
-```bash
-export ANTHROPIC_API_KEY=sk-ant-...
-# or
-export OPENAI_API_KEY=sk-...
-```
+The API key lives only on the provider agent. Consumers select a provider by capability and tags; the mesh resolves the binding and forwards the call.
 
 ## Mesh Delegation (@MeshLlm with providerSelector)
 
@@ -97,6 +47,46 @@ public AnalysisResult analyze(
         .generate(AnalysisResult.class);
 }
 ```
+
+## Model Override
+
+Override the provider's default model per consumer tool with `model`:
+
+```java
+@MeshLlm(
+    providerSelector = @Selector(capability = "llm", tags = {"+claude"}),
+    model = "anthropic/claude-haiku"   // override provider default for this tool
+)
+@MeshTool(capability = "fast-assist")
+public String fastAssist(@Param("message") String message, MeshLlmAgent llm) {
+    return llm.request().user(message).generate();
+}
+```
+
+The override is honored when its vendor matches the provider's vendor. A vendor mismatch (e.g. requesting an OpenAI model from a Claude provider) logs a warning and falls back to the provider default. When `model` is unset, the provider uses the model declared on its own `@MeshLlmProvider`.
+
+A per-call override via the proxy escape hatch (`request().modelParams(Map.of("model", "..."))`) takes precedence over the annotation value.
+
+## Model Tuning
+
+Set `maxTokens`/`temperature` on `@MeshLlm`, or use the fluent builder (`maxTokens()`, `temperature()`, `topP()`, `stop()`) for per-call values. These serialize into the `model_params` wire shape and the provider applies them to the vendor call:
+
+```java
+@MeshLlm(
+    providerSelector = @Selector(capability = "llm", tags = {"+claude"}),
+    maxTokens = 4096,
+    temperature = 0.3
+)
+@MeshTool(capability = "summarize")
+public String summarize(@Param("text") String text, MeshLlmAgent llm) {
+    return llm.request()
+        .user(text)
+        .topP(0.9)
+        .generate();
+}
+```
+
+When a value is unset, the provider's own default applies — nothing is sent on the wire for that key.
 
 ## Fluent Builder API
 

--- a/src/core/cli/man/content/streaming.md
+++ b/src/core/cli/man/content/streaming.md
@@ -41,7 +41,7 @@ async def passthrough(prompt: str, chat: mesh.McpMeshTool = None) -> mesh.Stream
 
 This bridges incoming `notifications/progress` messages into an `AsyncIterator[str]`. Multi-hop streaming composes by re-yielding chunks at each layer.
 
-> Note: TypeScript and Java SDKs do not yet expose `proxy.stream()`. Wire-level streaming still works (a TS or Java client receives the buffered final result), but per-chunk delivery requires Python on the consumer side. Cross-runtime parity is on the roadmap.
+> Note: The Java consumer SDK exposes per-chunk streaming via `proxy.stream(List<Message>)` and `MeshLlmAgentProxy.streamGenerate()`, returning a `Flow.Publisher<String>` of chunks. TypeScript does not yet expose `proxy.stream()` (a TS client receives the buffered final result). Producing a stream is not yet supported on the Java side — there is no streaming `@MeshTool` or streaming `@MeshLlmProvider`, so a Java agent can consume streams but cannot yet originate them.
 
 ## Browser via `mesh.route` auto-SSE
 
@@ -83,7 +83,7 @@ Server ← {result: {content: [{type: "text", text: "Hello world"}]}}
 - **`MeshLlmAgent.stream()` is `str`-output only.** Mesh-delegated streaming is the default and only mode in v2.x. The constraint is on the return type: `MeshLlmAgent.stream()` supports `output_type=str` (token-by-token text chunks). For typed structured output, use `MeshLlmAgent.__call__()` with a Pydantic return type — typed structured streaming raises `NotImplementedError` by design.
 - **`Stream[str]` only** — typed Pydantic streaming is intentionally unsupported (consumer needs complete JSON for schema validation).
 - **Final iteration only** — in agentic loops, only the LAST iteration (text-only, no tool calls) streams. Intermediate tool-calling iterations are buffered.
-- **Python only for `proxy.stream()`** — TS/Java consumer parity pending.
+- **Consumer streaming: Python and Java** — `proxy.stream()` (Python) and `proxy.stream()` / `streamGenerate()` (Java) deliver per-chunk; TypeScript consumer parity is pending. Producing a stream is Python-only — a streaming `@MeshTool`/`@MeshLlmProvider` is not yet supported on the Java producer side.
 - **Short responses may not appear streamed** — Anthropic batches small responses, so a 1-token answer can land in a single SSE event.
 
 See `meshctl man llm` for `MeshLlmAgent` details. See the [streaming concept doc](https://github.com/dhyansraj/mcp-mesh/blob/main/docs/concepts/streaming.md) for design rationale and the full wire-protocol walkthrough.

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlm.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlm.java
@@ -125,6 +125,25 @@ public @interface MeshLlm {
     FilterMode filterMode() default FilterMode.ALL;
 
     /**
+     * Optional per-tool model override.
+     *
+     * <p>When set (non-empty), this model string (e.g.
+     * {@code "anthropic/claude-3-5-sonnet-latest"}) is sent to the provider via
+     * {@code model_params.model}. The provider honors it when the override's
+     * vendor matches its own vendor, otherwise it logs a warning and falls back
+     * to the provider's default model — mirroring Python's vendor-checked
+     * behavior.
+     *
+     * <p>A per-call override supplied via the proxy's {@code modelParams(Map)}
+     * escape hatch (key {@code "model"}) takes precedence over this annotation
+     * value.
+     *
+     * <p>If unset (empty string), no {@code model} is sent on the wire and the
+     * provider uses the model declared on its own {@code @MeshLlmProvider}.
+     */
+    String model() default "";
+
+    /**
      * Maximum tokens for LLM response.
      *
      * <p>If unset ({@code -1}), the provider's own default is used — no

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AClient.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/a2a/A2AClient.java
@@ -20,14 +20,20 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * Thin A2A v1.0 client — sync {@code tasks/send} + poll until terminal.
+ * A2A v1.0 client — synchronous send/poll plus async submit/subscribe (SSE).
  *
- * <p>Phase 1 surface (issue #916): one synchronous {@link #send} call
- * that POSTs a JSON-RPC {@code tasks/send} request, then polls
- * {@code tasks/get} with exponential backoff (capped at
- * {@code pollIntervalMaxMs}) until the task reaches a terminal state
- * ({@code completed} / {@code failed} / {@code canceled}, case-insensitive
- * for the US/UK spelling) or the user-supplied timeout elapses.
+ * <p>Two call styles are supported:
+ * <ul>
+ *   <li><b>Synchronous</b> {@link #send} — POSTs a JSON-RPC {@code tasks/send}
+ *       request, then polls {@code tasks/get} with exponential backoff (capped
+ *       at {@code pollIntervalMaxMs}) until the task reaches a terminal state
+ *       ({@code completed} / {@code failed} / {@code canceled}, case-insensitive
+ *       for the US/UK spelling) or the user-supplied timeout elapses.</li>
+ *   <li><b>Asynchronous</b> {@link #submit} — POSTs {@code tasks/send} and
+ *       returns an {@link A2AJob} handle without blocking; {@link #subscribe}
+ *       opens a {@code tasks/sendSubscribe} SSE stream and returns an
+ *       {@link A2AStream} of task events.</li>
+ * </ul>
  *
  * <p>One instance per (url, skillId, auth) tuple — a typical Spring
  * agent constructs one per {@code @MeshTool} method (with {@code static}
@@ -35,8 +41,7 @@ import java.util.UUID;
  * amortized across calls.
  *
  * <p>Mirrors {@code mesh._a2a_consumer.A2AClient} from the Python
- * runtime. Phase 3 ({@code submit} / {@code subscribe} / SSE) is
- * deferred to a follow-up PR.
+ * runtime, including the {@code submit} / {@code subscribe} / SSE surface.
  *
  * <p><b>Lifecycle on JDK 17:</b> This class implements {@link AutoCloseable}
  * for forward-compatibility, but the underlying {@link java.net.http.HttpClient}

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/MeshLlmProviderProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/MeshLlmProviderProcessor.java
@@ -406,7 +406,7 @@ public class MeshLlmProviderProcessor implements BeanPostProcessor, ApplicationC
                     response.put("tool_calls", List.of());
                     usageMeta = llmResponse.usage();
                 } else {
-                    String content = llmProvider.generateWithMessages(config.provider(), messages);
+                    String content = llmProvider.generateWithMessages(config.provider(), messages, handlerOptions);
                     // Note: generateWithMessages() doesn't return token usage metadata.
                     // usageMeta remains null — this is expected for non-structured paths.
                     response.put("content", content);

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/MeshLlmProviderProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/MeshLlmProviderProcessor.java
@@ -354,6 +354,15 @@ public class MeshLlmProviderProcessor implements BeanPostProcessor, ApplicationC
             if (om != null && !String.valueOf(om).isEmpty()) {
                 handlerOptions.put(LlmProviderHandler.OPTION_OUTPUT_MODE, String.valueOf(om));
             }
+            // C2: thread the numeric/model generation params through to the
+            // vendor handlers so they apply onto the per-vendor ChatOptions.
+            // Keys absent here are simply not forwarded → handler keeps the
+            // Spring AI default (no force-set nulls). The model override is
+            // vendor-checked inside each handler (resolveModelOverride).
+            copyOption(modelParams, handlerOptions, LlmProviderHandler.OPTION_MODEL);
+            copyOption(modelParams, handlerOptions, LlmProviderHandler.OPTION_MAX_TOKENS);
+            copyOption(modelParams, handlerOptions, LlmProviderHandler.OPTION_TEMPERATURE);
+            copyOption(modelParams, handlerOptions, LlmProviderHandler.OPTION_TOP_P);
         }
         if (parallelToolCalls) {
             log.info("Provider parallel tool calls enabled — tools will execute concurrently via CompletableFuture");
@@ -852,6 +861,18 @@ public class MeshLlmProviderProcessor implements BeanPostProcessor, ApplicationC
         spec.put("parameters", parameters);
 
         return spec;
+    }
+
+    /**
+     * Copy a present, non-null {@code model_params} entry into the handler
+     * options map. Absent keys are not copied so the handler keeps the Spring AI
+     * default (C2: don't force-set nulls).
+     */
+    private static void copyOption(Map<String, Object> modelParams, Map<String, Object> handlerOptions, String key) {
+        Object v = modelParams.get(key);
+        if (v != null) {
+            handlerOptions.put(key, v);
+        }
     }
 
     private LlmProviderConfig findProvider(String capability) {

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/AnthropicHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/AnthropicHandler.java
@@ -234,10 +234,40 @@ public class AnthropicHandler implements LlmProviderHandler {
 
         if (executeTools) {
             // Auto-execution mode: Use ChatClient which handles tool execution automatically
-            return generateWithToolsAutoExecute(model, springMessages, tools, toolExecutor, formattedSystemPrompt, enforcedSchema, hintSchema, hintTools);
+            return generateWithToolsAutoExecute(model, springMessages, tools, toolExecutor, formattedSystemPrompt, enforcedSchema, hintSchema, hintTools, options);
         } else {
             // No-execution mode: Use model.call with internalToolExecutionEnabled(false)
-            return generateWithToolsNoExecute(model, springMessages, tools, formattedSystemPrompt, enforcedSchema, hintSchema, hintTools);
+            return generateWithToolsNoExecute(model, springMessages, tools, formattedSystemPrompt, enforcedSchema, hintSchema, hintTools, options);
+        }
+    }
+
+    /**
+     * Apply the consumer-supplied {@code model_params} (max_tokens, temperature,
+     * top_p, and a vendor-matched model override) onto an Anthropic options
+     * builder. Absent keys are left untouched so Spring AI's own defaults apply.
+     *
+     * <p>The {@code model} override is honored only when its declared vendor
+     * matches {@code anthropic}/{@code claude}; on mismatch
+     * {@link LlmProviderHandler#resolveModelOverride} logs a warning and returns
+     * null, leaving the provider's default model in place.
+     */
+    private void applyModelParams(AnthropicChatOptions.Builder builder, Map<String, Object> options) {
+        Integer maxTokens = LlmProviderHandler.maxTokensOption(options);
+        if (maxTokens != null) {
+            builder.maxTokens(maxTokens);
+        }
+        Double temperature = LlmProviderHandler.temperatureOption(options);
+        if (temperature != null) {
+            builder.temperature(temperature);
+        }
+        Double topP = LlmProviderHandler.topPOption(options);
+        if (topP != null) {
+            builder.topP(topP);
+        }
+        String modelOverride = LlmProviderHandler.resolveModelOverride(options, getVendor(), getAliases());
+        if (modelOverride != null) {
+            builder.model(modelOverride);
+            log.debug("AnthropicHandler: applied model override '{}'", modelOverride);
         }
     }
 
@@ -252,7 +282,8 @@ public class AnthropicHandler implements LlmProviderHandler {
             String formattedSystemPrompt,
             OutputSchema outputSchema,
             OutputSchema hintSchema,
-            List<ToolDefinition> hintTools) {
+            List<ToolDefinition> hintTools,
+            Map<String, Object> options) {
 
         // Convert tools to Spring AI ToolCallback objects
         List<ToolCallback> toolCallbacks = new ArrayList<>();
@@ -284,20 +315,28 @@ public class AnthropicHandler implements LlmProviderHandler {
             requestSpec.toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]));
         }
 
-        // Apply native output_format when outputSchema is present
-        if (outputSchema != null) {
+        // Apply native output_format when outputSchema is present, plus any
+        // consumer-supplied model_params (max_tokens/temperature/top_p/model).
+        // Build options whenever EITHER a schema OR model_params are present so
+        // the numeric/model overrides reach the wire even without a schema.
+        boolean hasModelParams = LlmProviderHandler.hasAnyModelParam(options);
+        if (outputSchema != null || hasModelParams) {
             try {
-                Map<String, Object> sanitizedSchema = outputSchema.sanitize();
-                String schemaJson = TOOL_CALLBACK_MAPPER.writeValueAsString(sanitizedSchema);
+                AnthropicChatOptions.Builder optionsBuilder = AnthropicChatOptions.builder();
+                if (outputSchema != null) {
+                    Map<String, Object> sanitizedSchema = outputSchema.sanitize();
+                    String schemaJson = TOOL_CALLBACK_MAPPER.writeValueAsString(sanitizedSchema);
+                    optionsBuilder.outputSchema(schemaJson);
+                }
+                applyModelParams(optionsBuilder, options);
 
-                AnthropicChatOptions chatOptions = AnthropicChatOptions.builder()
-                    .outputSchema(schemaJson)
-                    .build();
-
-                requestSpec.options(chatOptions);
-                log.debug("Applied Anthropic output_format with schema: {}", outputSchema.name());
+                requestSpec.options(optionsBuilder.build());
+                if (outputSchema != null) {
+                    log.debug("Applied Anthropic output_format with schema: {}", outputSchema.name());
+                }
             } catch (Exception e) {
-                log.warn("Failed to apply output_format for {}: {}", outputSchema.name(), e.getMessage());
+                log.warn("Failed to apply Anthropic options (schema={}): {}",
+                    outputSchema != null ? outputSchema.name() : "none", e.getMessage());
             }
         }
 
@@ -351,7 +390,8 @@ public class AnthropicHandler implements LlmProviderHandler {
             String formattedSystemPrompt,
             OutputSchema outputSchema,
             OutputSchema hintSchema,
-            List<ToolDefinition> hintTools) {
+            List<ToolDefinition> hintTools,
+            Map<String, Object> options) {
 
         // Replace system message with formatted one
         List<Message> messagesWithFormattedSystem = replaceSystemMessage(springMessages, formattedSystemPrompt);
@@ -362,38 +402,39 @@ public class AnthropicHandler implements LlmProviderHandler {
         // Build prompt with chat options
         org.springframework.ai.chat.prompt.Prompt prompt;
 
-        // Apply native output_format when outputSchema is present
+        // Apply native output_format when outputSchema is present. AnthropicChatOptions
+        // also carries the consumer-supplied model_params (max_tokens/temperature/
+        // top_p/model). When there's no schema we still build AnthropicChatOptions
+        // (instead of the generic ToolCallingChatOptions) so model_params apply.
         if (outputSchema != null) {
             try {
                 Map<String, Object> sanitizedSchema = outputSchema.sanitize();
                 String schemaJson = TOOL_CALLBACK_MAPPER.writeValueAsString(sanitizedSchema);
 
-                AnthropicChatOptions chatOptions = AnthropicChatOptions.builder()
+                AnthropicChatOptions.Builder optionsBuilder = AnthropicChatOptions.builder()
                     .toolCallbacks(toolCallbacks)
                     .internalToolExecutionEnabled(false)
-                    .outputSchema(schemaJson)
-                    .build();
+                    .outputSchema(schemaJson);
+                applyModelParams(optionsBuilder, options);
 
-                prompt = new org.springframework.ai.chat.prompt.Prompt(messagesWithFormattedSystem, chatOptions);
+                prompt = new org.springframework.ai.chat.prompt.Prompt(messagesWithFormattedSystem, optionsBuilder.build());
                 log.debug("Applied Anthropic output_format with schema: {}", outputSchema.name());
             } catch (Exception e) {
                 log.warn("Failed to apply output_format for {}: {}, falling back to basic options",
                     outputSchema.name(), e.getMessage());
-                org.springframework.ai.model.tool.ToolCallingChatOptions chatOptions =
-                    org.springframework.ai.model.tool.ToolCallingChatOptions.builder()
-                        .toolCallbacks(toolCallbacks)
-                        .internalToolExecutionEnabled(false)
-                        .build();
-                prompt = new org.springframework.ai.chat.prompt.Prompt(messagesWithFormattedSystem, chatOptions);
+                AnthropicChatOptions.Builder optionsBuilder = AnthropicChatOptions.builder()
+                    .toolCallbacks(toolCallbacks)
+                    .internalToolExecutionEnabled(false);
+                applyModelParams(optionsBuilder, options);
+                prompt = new org.springframework.ai.chat.prompt.Prompt(messagesWithFormattedSystem, optionsBuilder.build());
             }
         } else {
-            // No structured output needed
-            org.springframework.ai.model.tool.ToolCallingChatOptions chatOptions =
-                org.springframework.ai.model.tool.ToolCallingChatOptions.builder()
-                    .toolCallbacks(toolCallbacks)
-                    .internalToolExecutionEnabled(false)
-                    .build();
-            prompt = new org.springframework.ai.chat.prompt.Prompt(messagesWithFormattedSystem, chatOptions);
+            // No structured output needed — still apply model_params via AnthropicChatOptions.
+            AnthropicChatOptions.Builder optionsBuilder = AnthropicChatOptions.builder()
+                .toolCallbacks(toolCallbacks)
+                .internalToolExecutionEnabled(false);
+            applyModelParams(optionsBuilder, options);
+            prompt = new org.springframework.ai.chat.prompt.Prompt(messagesWithFormattedSystem, optionsBuilder.build());
         }
 
         log.debug("Calling Claude with {} tools (execution disabled)", tools != null ? tools.size() : 0);

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/AnthropicHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/AnthropicHandler.java
@@ -174,7 +174,17 @@ public class AnthropicHandler implements LlmProviderHandler {
         log.debug("AnthropicHandler: Processing {} messages", messages.size());
 
         List<Message> springMessages = convertMessages(messages);
-        Prompt prompt = new Prompt(springMessages);
+        // Plain-text generation: apply consumer-supplied model_params
+        // (max_tokens/temperature/top_p/vendor-matched model) when present so the
+        // no-tools/no-schema path honors them like the tools path does.
+        Prompt prompt;
+        if (LlmProviderHandler.hasAnyModelParam(options)) {
+            AnthropicChatOptions.Builder optionsBuilder = AnthropicChatOptions.builder();
+            applyModelParams(optionsBuilder, options);
+            prompt = new Prompt(springMessages, optionsBuilder.build());
+        } else {
+            prompt = new Prompt(springMessages);
+        }
         ChatResponse response = model.call(prompt);
 
         String content = response.getResult() != null && response.getResult().getOutput() != null
@@ -361,7 +371,13 @@ public class AnthropicHandler implements LlmProviderHandler {
                 if (!toolCallbacks.isEmpty()) {
                     retrySpec.toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]));
                 }
-                // No output_format applied — rely on HINT instructions
+                // No output_format applied — rely on HINT instructions. Still
+                // re-apply consumer-supplied model_params (max_tokens/temperature/
+                // top_p/model) so the retry matches the initial request minus
+                // the rejected output_format.
+                AnthropicChatOptions.Builder retryOptions = AnthropicChatOptions.builder();
+                applyModelParams(retryOptions, options);
+                retrySpec.options(retryOptions.build());
                 chatResponse = retrySpec.call().chatResponse();
             } else {
                 throw e;
@@ -461,13 +477,15 @@ public class AnthropicHandler implements LlmProviderHandler {
                     }
                 }
 
-                // Rebuild prompt without outputFormat
-                org.springframework.ai.model.tool.ToolCallingChatOptions hintOptions =
-                    org.springframework.ai.model.tool.ToolCallingChatOptions.builder()
-                        .toolCallbacks(toolCallbacks)
-                        .internalToolExecutionEnabled(false)
-                        .build();
-                prompt = new org.springframework.ai.chat.prompt.Prompt(hintMessages, hintOptions);
+                // Rebuild prompt without outputFormat. Use AnthropicChatOptions
+                // (not the generic ToolCallingChatOptions) and re-apply the
+                // consumer-supplied model_params so the retry matches the initial
+                // request minus the rejected output_format.
+                AnthropicChatOptions.Builder hintBuilder = AnthropicChatOptions.builder()
+                    .toolCallbacks(toolCallbacks)
+                    .internalToolExecutionEnabled(false);
+                applyModelParams(hintBuilder, options);
+                prompt = new org.springframework.ai.chat.prompt.Prompt(hintMessages, hintBuilder.build());
 
                 response = model.call(prompt);
             } else {

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/GeminiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/GeminiHandler.java
@@ -52,6 +52,20 @@ public class GeminiHandler implements LlmProviderHandler {
         return new String[]{"google"};
     }
 
+    /**
+     * Vendor aliases accepted specifically for {@code model_params.model} override
+     * resolution. Superset of {@link #getAliases()}: mesh delegation routes both
+     * Google AI Studio ({@code gemini/...}) and Vertex AI ({@code vertex_ai/...})
+     * model strings through this single {@code GeminiHandler}, so a
+     * {@code vertex_ai/}-qualified override is same-provider and must be accepted
+     * on BOTH the Vertex and GenAI option branches. Kept separate from the public
+     * {@link #getAliases()} (which other surfaces assert returns exactly
+     * {@code ["google"]}) so widening override-matching doesn't change that
+     * contract. A genuinely cross-vendor override (e.g. {@code openai/...}) is
+     * still rejected by {@link LlmProviderHandler#resolveModelOverride}.
+     */
+    private static final String[] MODEL_OVERRIDE_ALIASES = {"google", "vertex_ai", "vertex"};
+
     /** Gemini uses a shorter previous-turn prefix than the Anthropic/OpenAI default. */
     @Override
     public String previousResponsePrefix() {
@@ -99,7 +113,14 @@ public class GeminiHandler implements LlmProviderHandler {
         log.debug("GeminiHandler: Processing {} messages", messages.size());
 
         List<Message> springMessages = convertMessages(messages);
-        Prompt prompt = new Prompt(springMessages);
+        // Plain-text generation: apply consumer-supplied model_params
+        // (max_tokens→maxOutputTokens/temperature/top_p/vendor-matched model) when
+        // present. buildModelParamOptions branches Vertex vs GenAI to match the
+        // underlying chat model and returns null when no params are present.
+        ChatOptions paramOptions = buildModelParamOptions(model, options);
+        Prompt prompt = paramOptions != null
+            ? new Prompt(springMessages, paramOptions)
+            : new Prompt(springMessages);
         ChatResponse response = model.call(prompt);
 
         String content = response.getResult() != null && response.getResult().getOutput() != null
@@ -417,7 +438,7 @@ public class GeminiHandler implements LlmProviderHandler {
         if (topP != null) {
             builder.topP(topP);
         }
-        String modelOverride = LlmProviderHandler.resolveModelOverride(options, getVendor(), getAliases());
+        String modelOverride = LlmProviderHandler.resolveModelOverride(options, getVendor(), MODEL_OVERRIDE_ALIASES);
         if (modelOverride != null) {
             builder.model(modelOverride);
             log.debug("GeminiHandler: applied model override '{}'", modelOverride);
@@ -459,7 +480,7 @@ public class GeminiHandler implements LlmProviderHandler {
         if (topP != null) {
             builder.topP(topP);
         }
-        String modelOverride = LlmProviderHandler.resolveModelOverride(options, getVendor(), getAliases());
+        String modelOverride = LlmProviderHandler.resolveModelOverride(options, getVendor(), MODEL_OVERRIDE_ALIASES);
         if (modelOverride != null) {
             builder.model(modelOverride);
             log.debug("GeminiHandler (vertex): applied model override '{}'", modelOverride);

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/GeminiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/GeminiHandler.java
@@ -160,10 +160,10 @@ public class GeminiHandler implements LlmProviderHandler {
 
         if (executeTools) {
             // Auto-execution mode: Use ChatClient which handles tool execution automatically
-            return generateWithToolsAutoExecute(model, springMessages, tools, toolExecutor, formattedSystemPrompt, outputSchema);
+            return generateWithToolsAutoExecute(model, springMessages, tools, toolExecutor, formattedSystemPrompt, outputSchema, options);
         } else {
             // No-execution mode: Use model.call with internalToolExecutionEnabled(false)
-            return generateWithToolsNoExecute(model, springMessages, tools, formattedSystemPrompt, outputSchema);
+            return generateWithToolsNoExecute(model, springMessages, tools, formattedSystemPrompt, outputSchema, options);
         }
     }
 
@@ -176,7 +176,8 @@ public class GeminiHandler implements LlmProviderHandler {
             List<ToolDefinition> tools,
             ToolExecutorCallback toolExecutor,
             String formattedSystemPrompt,
-            OutputSchema outputSchema) {
+            OutputSchema outputSchema,
+            Map<String, Object> options) {
 
         // Convert tools to Spring AI ToolCallback objects
         List<ToolCallback> toolCallbacks = new ArrayList<>();
@@ -211,6 +212,16 @@ public class GeminiHandler implements LlmProviderHandler {
         // Don't use applyResponseFormat - Spring AI has issues with Gemini responseSchema
         // Structured output is handled via prompt-based hints in formatSystemPrompt()
 
+        // Apply consumer-supplied model_params (max_tokens/temperature/top_p/model)
+        // onto a vendor-correct Gemini options object when present. The concrete
+        // options class must match the underlying chat model (see buildModelParamOptions).
+        if (LlmProviderHandler.hasAnyModelParam(options)) {
+            ChatOptions paramOptions = buildModelParamOptions(model, options);
+            if (paramOptions != null) {
+                requestSpec.options(paramOptions);
+            }
+        }
+
         // Execute the request
         ChatResponse chatResponse = requestSpec.call().chatResponse();
         String content = chatResponse.getResult() != null && chatResponse.getResult().getOutput() != null
@@ -234,7 +245,8 @@ public class GeminiHandler implements LlmProviderHandler {
             List<Message> springMessages,
             List<ToolDefinition> tools,
             String formattedSystemPrompt,
-            OutputSchema outputSchema) {
+            OutputSchema outputSchema,
+            Map<String, Object> options) {
 
         // Replace system message with formatted one
         List<Message> messagesWithFormattedSystem = replaceSystemMessage(springMessages, formattedSystemPrompt);
@@ -250,7 +262,7 @@ public class GeminiHandler implements LlmProviderHandler {
         // Structured output is handled via prompt-based hints in formatSystemPrompt()
         log.debug("Using prompt-based JSON hints for structured output (not responseSchema)");
 
-        ChatOptions chatOptions = buildToolNoExecuteOptions(model, toolCallbacks);
+        ChatOptions chatOptions = buildToolNoExecuteOptions(model, toolCallbacks, options);
 
         // Create prompt with options
         org.springframework.ai.chat.prompt.Prompt prompt =
@@ -344,13 +356,72 @@ public class GeminiHandler implements LlmProviderHandler {
      * <p>Package-private for testability.
      */
     ChatOptions buildToolNoExecuteOptions(ChatModel chatModel, List<ToolCallback> toolCallbacks) {
+        return buildToolNoExecuteOptions(chatModel, toolCallbacks, null);
+    }
+
+    /**
+     * Build provider-specific {@link ChatOptions} for the no-tool-execution path,
+     * applying any consumer-supplied {@code model_params}
+     * (max_tokens→maxOutputTokens, temperature, top_p, vendor-matched model).
+     */
+    ChatOptions buildToolNoExecuteOptions(ChatModel chatModel, List<ToolCallback> toolCallbacks,
+                                          Map<String, Object> options) {
         if (VERTEX_CHAT_MODEL_CLASS != null && VERTEX_CHAT_MODEL_CLASS.isInstance(chatModel)) {
-            return buildVertexOptions(toolCallbacks);
+            return buildVertexOptions(toolCallbacks, options);
         }
-        return GoogleGenAiChatOptions.builder()
+        GoogleGenAiChatOptions.Builder builder = GoogleGenAiChatOptions.builder()
             .toolCallbacks(toolCallbacks)
-            .internalToolExecutionEnabled(false)
-            .build();
+            .internalToolExecutionEnabled(false);
+        applyGoogleGenAiModelParams(builder, options);
+        return builder.build();
+    }
+
+    /**
+     * Build a vendor-correct Gemini options object carrying ONLY the
+     * consumer-supplied {@code model_params} (no tool callbacks) for the
+     * auto-execute (ChatClient) path, where tools are attached via the request
+     * spec rather than the options object.
+     *
+     * @return the options object, or {@code null} if no params are present
+     */
+    private ChatOptions buildModelParamOptions(ChatModel chatModel, Map<String, Object> options) {
+        if (!LlmProviderHandler.hasAnyModelParam(options)) {
+            return null;
+        }
+        if (VERTEX_CHAT_MODEL_CLASS != null && VERTEX_CHAT_MODEL_CLASS.isInstance(chatModel)) {
+            VertexAiGeminiChatOptions.Builder builder = VertexAiGeminiChatOptions.builder();
+            applyVertexModelParams(builder, options);
+            return builder.build();
+        }
+        GoogleGenAiChatOptions.Builder builder = GoogleGenAiChatOptions.builder();
+        applyGoogleGenAiModelParams(builder, options);
+        return builder.build();
+    }
+
+    /**
+     * Apply {@code model_params} to a Google AI Studio (GenAI) options builder.
+     * Gemini maps {@code max_tokens} → {@code maxOutputTokens}. The {@code model}
+     * override is honored only when its declared vendor matches
+     * {@code gemini}/{@code google}.
+     */
+    private void applyGoogleGenAiModelParams(GoogleGenAiChatOptions.Builder builder, Map<String, Object> options) {
+        Integer maxTokens = LlmProviderHandler.maxTokensOption(options);
+        if (maxTokens != null) {
+            builder.maxOutputTokens(maxTokens);
+        }
+        Double temperature = LlmProviderHandler.temperatureOption(options);
+        if (temperature != null) {
+            builder.temperature(temperature);
+        }
+        Double topP = LlmProviderHandler.topPOption(options);
+        if (topP != null) {
+            builder.topP(topP);
+        }
+        String modelOverride = LlmProviderHandler.resolveModelOverride(options, getVendor(), getAliases());
+        if (modelOverride != null) {
+            builder.model(modelOverride);
+            log.debug("GeminiHandler: applied model override '{}'", modelOverride);
+        }
     }
 
     /**
@@ -362,11 +433,37 @@ public class GeminiHandler implements LlmProviderHandler {
      * body is first executed is guaranteed to succeed -- the class IS on the
      * classpath by the time we get here.
      */
-    private ChatOptions buildVertexOptions(List<ToolCallback> toolCallbacks) {
-        return VertexAiGeminiChatOptions.builder()
+    private ChatOptions buildVertexOptions(List<ToolCallback> toolCallbacks, Map<String, Object> options) {
+        VertexAiGeminiChatOptions.Builder builder = VertexAiGeminiChatOptions.builder()
             .toolCallbacks(toolCallbacks)
-            .internalToolExecutionEnabled(false)
-            .build();
+            .internalToolExecutionEnabled(false);
+        applyVertexModelParams(builder, options);
+        return builder.build();
+    }
+
+    /**
+     * Apply {@code model_params} to a Vertex AI Gemini options builder. Mirrors
+     * {@link #applyGoogleGenAiModelParams} but on the Vertex builder type (the
+     * concrete class differs and the chat model does an explicit checkcast).
+     */
+    private void applyVertexModelParams(VertexAiGeminiChatOptions.Builder builder, Map<String, Object> options) {
+        Integer maxTokens = LlmProviderHandler.maxTokensOption(options);
+        if (maxTokens != null) {
+            builder.maxOutputTokens(maxTokens);
+        }
+        Double temperature = LlmProviderHandler.temperatureOption(options);
+        if (temperature != null) {
+            builder.temperature(temperature);
+        }
+        Double topP = LlmProviderHandler.topPOption(options);
+        if (topP != null) {
+            builder.topP(topP);
+        }
+        String modelOverride = LlmProviderHandler.resolveModelOverride(options, getVendor(), getAliases());
+        if (modelOverride != null) {
+            builder.model(modelOverride);
+            log.debug("GeminiHandler (vertex): applied model override '{}'", modelOverride);
+        }
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/LlmProviderHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/LlmProviderHandler.java
@@ -62,6 +62,22 @@ public interface LlmProviderHandler {
     String OPTION_OUTPUT_MODE = "output_mode";
 
     // =========================================================================
+    // model_params → ChatOptions keys (C2: provider applies model_params)
+    // =========================================================================
+
+    /** Key under which a consumer-supplied per-tool/per-call model override travels (e.g. "anthropic/claude-..."). */
+    String OPTION_MODEL = "model";
+
+    /** Key under which a consumer-supplied {@code max_tokens} travels in the options map. */
+    String OPTION_MAX_TOKENS = "max_tokens";
+
+    /** Key under which a consumer-supplied {@code temperature} travels in the options map. */
+    String OPTION_TEMPERATURE = "temperature";
+
+    /** Key under which a consumer-supplied {@code top_p} travels in the options map. */
+    String OPTION_TOP_P = "top_p";
+
+    // =========================================================================
     // Core Methods
     // =========================================================================
 
@@ -307,6 +323,163 @@ public interface LlmProviderHandler {
         }
         Object v = options.get(OPTION_OUTPUT_MODE);
         return v != null ? v.toString() : OUTPUT_MODE_UNSET;
+    }
+
+    // =========================================================================
+    // model_params extraction (C2: provider applies model_params)
+    // =========================================================================
+
+    /**
+     * Read the consumer-supplied {@code max_tokens} from the options map.
+     *
+     * @param options the generation options (may be null)
+     * @return the value as an Integer, or {@code null} if absent/unparseable
+     */
+    static Integer maxTokensOption(Map<String, Object> options) {
+        return intOption(options, OPTION_MAX_TOKENS);
+    }
+
+    /**
+     * Read the consumer-supplied {@code temperature} from the options map.
+     *
+     * @param options the generation options (may be null)
+     * @return the value as a Double, or {@code null} if absent/unparseable/NaN
+     */
+    static Double temperatureOption(Map<String, Object> options) {
+        return doubleOption(options, OPTION_TEMPERATURE);
+    }
+
+    /**
+     * Read the consumer-supplied {@code top_p} from the options map.
+     *
+     * @param options the generation options (may be null)
+     * @return the value as a Double, or {@code null} if absent/unparseable/NaN
+     */
+    static Double topPOption(Map<String, Object> options) {
+        return doubleOption(options, OPTION_TOP_P);
+    }
+
+    private static Integer intOption(Map<String, Object> options, String key) {
+        if (options == null) {
+            return null;
+        }
+        Object v = options.get(key);
+        if (v instanceof Number n) {
+            return n.intValue();
+        }
+        if (v instanceof String s && !s.isBlank()) {
+            try {
+                return Integer.valueOf(s.trim());
+            } catch (NumberFormatException ignored) {
+                // fall through
+            }
+        }
+        return null;
+    }
+
+    private static Double doubleOption(Map<String, Object> options, String key) {
+        if (options == null) {
+            return null;
+        }
+        Object v = options.get(key);
+        if (v instanceof Number n) {
+            double d = n.doubleValue();
+            return Double.isNaN(d) ? null : d;
+        }
+        if (v instanceof String s && !s.isBlank()) {
+            try {
+                double d = Double.parseDouble(s.trim());
+                return Double.isNaN(d) ? null : d;
+            } catch (NumberFormatException ignored) {
+                // fall through
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolve a consumer-supplied {@code model} override against this handler's
+     * vendor, mirroring Python's vendor-checked model-override behavior.
+     *
+     * <p>The override travels as a fully-qualified model string of the form
+     * {@code "<vendor>/<model-name>"} (e.g. {@code "anthropic/claude-3-5-sonnet-latest"}).
+     * Only the vendor-qualified model name is returned, and only when the
+     * declared vendor matches {@code expectedVendor} (case-insensitive, with the
+     * handler's {@link #getAliases()} also accepted). On a vendor mismatch a
+     * warning is logged and {@code null} is returned so the caller keeps the
+     * provider's own default model (Spring AI default).
+     *
+     * <p>A bare model string with no {@code vendor/} prefix is treated as
+     * matching (returned verbatim) — the consumer simply named a model without a
+     * vendor qualifier and we assume it targets this provider.
+     *
+     * @param options        the generation options (may be null)
+     * @param expectedVendor this handler's vendor (e.g. "anthropic")
+     * @param aliases        accepted vendor aliases (e.g. {"claude"}); may be null
+     * @return the bare model name to apply, or {@code null} to keep the default
+     */
+    static String resolveModelOverride(Map<String, Object> options, String expectedVendor, String[] aliases) {
+        if (options == null) {
+            return null;
+        }
+        Object v = options.get(OPTION_MODEL);
+        if (!(v instanceof String raw) || raw.isBlank()) {
+            return null;
+        }
+        String value = raw.trim();
+        int slash = value.indexOf('/');
+        if (slash < 0) {
+            // Bare model name (no vendor prefix) — assume it targets this provider.
+            return value;
+        }
+        String declaredVendor = value.substring(0, slash);
+        String modelName = value.substring(slash + 1);
+        if (modelName.isBlank()) {
+            return null;
+        }
+        if (vendorMatches(declaredVendor, expectedVendor, aliases)) {
+            return modelName;
+        }
+        LoggerFactory.getLogger(LlmProviderHandler.class).warn(
+            "Ignoring cross-vendor model override '{}' (declared vendor '{}' does not match provider vendor '{}'); "
+            + "falling back to the provider's default model.", value, declaredVendor, expectedVendor);
+        return null;
+    }
+
+    /**
+     * Whether the options map carries any of the C2 generation params
+     * ({@code model}, {@code max_tokens}, {@code temperature}, {@code top_p}).
+     * Used by handlers to decide whether to build a vendor options object at all
+     * when no structured-output schema is present.
+     *
+     * @param options the generation options (may be null)
+     * @return true if at least one of the four keys is present and non-null
+     */
+    static boolean hasAnyModelParam(Map<String, Object> options) {
+        if (options == null) {
+            return false;
+        }
+        return options.get(OPTION_MODEL) != null
+            || options.get(OPTION_MAX_TOKENS) != null
+            || options.get(OPTION_TEMPERATURE) != null
+            || options.get(OPTION_TOP_P) != null;
+    }
+
+    private static boolean vendorMatches(String declared, String expectedVendor, String[] aliases) {
+        if (declared == null) {
+            return false;
+        }
+        if (declared.equalsIgnoreCase(expectedVendor)) {
+            return true;
+        }
+        if (aliases != null) {
+            for (String alias : aliases) {
+                if (declared.equalsIgnoreCase(alias)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     // =========================================================================

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
@@ -134,10 +134,38 @@ public class OpenAiHandler implements LlmProviderHandler {
 
         if (executeTools) {
             // Auto-execution mode: Use ChatClient which handles tool execution automatically
-            return generateWithToolsAutoExecute(model, springMessages, tools, toolExecutor, formattedSystemPrompt, enforcedSchema, messages);
+            return generateWithToolsAutoExecute(model, springMessages, tools, toolExecutor, formattedSystemPrompt, enforcedSchema, messages, options);
         } else {
             // No-execution mode: Use model.call with internalToolExecutionEnabled(false)
-            return generateWithToolsNoExecute(model, springMessages, tools, formattedSystemPrompt, enforcedSchema);
+            return generateWithToolsNoExecute(model, springMessages, tools, formattedSystemPrompt, enforcedSchema, options);
+        }
+    }
+
+    /**
+     * Apply the consumer-supplied {@code model_params} (max_tokens, temperature,
+     * top_p, and a vendor-matched model override) onto an OpenAI options builder.
+     * Absent keys are left untouched so Spring AI's own defaults apply. The
+     * {@code model} override is honored only when its declared vendor matches
+     * {@code openai}/{@code gpt}; on mismatch a warning is logged and the
+     * provider's default model is kept.
+     */
+    private void applyModelParams(OpenAiChatOptions.Builder builder, Map<String, Object> options) {
+        Integer maxTokens = LlmProviderHandler.maxTokensOption(options);
+        if (maxTokens != null) {
+            builder.maxTokens(maxTokens);
+        }
+        Double temperature = LlmProviderHandler.temperatureOption(options);
+        if (temperature != null) {
+            builder.temperature(temperature);
+        }
+        Double topP = LlmProviderHandler.topPOption(options);
+        if (topP != null) {
+            builder.topP(topP);
+        }
+        String modelOverride = LlmProviderHandler.resolveModelOverride(options, getVendor(), getAliases());
+        if (modelOverride != null) {
+            builder.model(modelOverride);
+            log.debug("OpenAiHandler: applied model override '{}'", modelOverride);
         }
     }
 
@@ -151,7 +179,8 @@ public class OpenAiHandler implements LlmProviderHandler {
             ToolExecutorCallback toolExecutor,
             String formattedSystemPrompt,
             OutputSchema outputSchema,
-            List<Map<String, Object>> originalMessages) {
+            List<Map<String, Object>> originalMessages,
+            Map<String, Object> options) {
 
         // Convert tools to Spring AI ToolCallback objects
         List<ToolCallback> toolCallbacks = new ArrayList<>();
@@ -183,29 +212,37 @@ public class OpenAiHandler implements LlmProviderHandler {
             requestSpec.toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]));
         }
 
-        // Apply response_format immediately when outputSchema is present (like Python)
-        if (outputSchema != null) {
+        // Apply response_format immediately when outputSchema is present (like Python),
+        // plus any consumer-supplied model_params (max_tokens/temperature/top_p/model).
+        // Build options whenever EITHER a schema OR model_params are present so the
+        // numeric/model overrides reach the wire even without a schema.
+        boolean hasModelParams = LlmProviderHandler.hasAnyModelParam(options);
+        if (outputSchema != null || hasModelParams) {
             try {
-                // Make schema strict (add additionalProperties: false, all properties required)
-                Map<String, Object> strictSchema = outputSchema.makeStrict(true);
+                OpenAiChatOptions.Builder optionsBuilder = OpenAiChatOptions.builder();
+                if (outputSchema != null) {
+                    // Make schema strict (add additionalProperties: false, all properties required)
+                    Map<String, Object> strictSchema = outputSchema.makeStrict(true);
 
-                ResponseFormat responseFormat = ResponseFormat.builder()
-                    .type(Type.JSON_SCHEMA)
-                    .jsonSchema(ResponseFormat.JsonSchema.builder()
-                        .name(outputSchema.name())
-                        .schema(strictSchema)
-                        .strict(true)
-                        .build())
-                    .build();
+                    ResponseFormat responseFormat = ResponseFormat.builder()
+                        .type(Type.JSON_SCHEMA)
+                        .jsonSchema(ResponseFormat.JsonSchema.builder()
+                            .name(outputSchema.name())
+                            .schema(strictSchema)
+                            .strict(true)
+                            .build())
+                        .build();
+                    optionsBuilder.responseFormat(responseFormat);
+                }
+                applyModelParams(optionsBuilder, options);
 
-                OpenAiChatOptions chatOptions = OpenAiChatOptions.builder()
-                    .responseFormat(responseFormat)
-                    .build();
-
-                requestSpec.options(chatOptions);
-                log.debug("Applied OpenAI response_format with schema: {}", outputSchema.name());
+                requestSpec.options(optionsBuilder.build());
+                if (outputSchema != null) {
+                    log.debug("Applied OpenAI response_format with schema: {}", outputSchema.name());
+                }
             } catch (Exception e) {
-                log.warn("Failed to apply response_format for {}: {}", outputSchema.name(), e.getMessage());
+                log.warn("Failed to apply OpenAI options (schema={}): {}",
+                    outputSchema != null ? outputSchema.name() : "none", e.getMessage());
             }
         }
 
@@ -232,7 +269,8 @@ public class OpenAiHandler implements LlmProviderHandler {
             List<Message> springMessages,
             List<ToolDefinition> tools,
             String formattedSystemPrompt,
-            OutputSchema outputSchema) {
+            OutputSchema outputSchema,
+            Map<String, Object> options) {
 
         // Replace system message with formatted one
         List<Message> messagesWithFormattedSystem = replaceSystemMessage(springMessages, formattedSystemPrompt);
@@ -243,7 +281,10 @@ public class OpenAiHandler implements LlmProviderHandler {
         // Build prompt with chat options
         Prompt prompt;
 
-        // Apply response_format immediately when outputSchema is present (like Python)
+        // Apply response_format immediately when outputSchema is present (like Python),
+        // plus any consumer-supplied model_params (max_tokens/temperature/top_p/model).
+        // Always build OpenAiChatOptions (not the generic ToolCallingChatOptions) so
+        // model_params apply even without a schema.
         if (outputSchema != null) {
             try {
                 // Make schema strict (add additionalProperties: false, all properties required)
@@ -259,33 +300,31 @@ public class OpenAiHandler implements LlmProviderHandler {
                     .build();
 
                 // Use OpenAiChatOptions which supports both tools and response_format
-                OpenAiChatOptions chatOptions = OpenAiChatOptions.builder()
+                OpenAiChatOptions.Builder optionsBuilder = OpenAiChatOptions.builder()
                     .toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]))
                     .internalToolExecutionEnabled(false)
-                    .responseFormat(responseFormat)
-                    .build();
+                    .responseFormat(responseFormat);
+                applyModelParams(optionsBuilder, options);
 
-                prompt = new Prompt(messagesWithFormattedSystem, chatOptions);
+                prompt = new Prompt(messagesWithFormattedSystem, optionsBuilder.build());
                 log.debug("Applied OpenAI response_format with schema: {}", outputSchema.name());
             } catch (Exception e) {
                 log.warn("Failed to apply response_format for {}: {}, falling back to basic options",
                     outputSchema.name(), e.getMessage());
-                // Fallback to basic options without response_format
-                org.springframework.ai.model.tool.ToolCallingChatOptions chatOptions =
-                    org.springframework.ai.model.tool.ToolCallingChatOptions.builder()
-                        .toolCallbacks(toolCallbacks)
-                        .internalToolExecutionEnabled(false)
-                        .build();
-                prompt = new Prompt(messagesWithFormattedSystem, chatOptions);
+                // Fallback to OpenAiChatOptions without response_format (still apply model_params)
+                OpenAiChatOptions.Builder optionsBuilder = OpenAiChatOptions.builder()
+                    .toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]))
+                    .internalToolExecutionEnabled(false);
+                applyModelParams(optionsBuilder, options);
+                prompt = new Prompt(messagesWithFormattedSystem, optionsBuilder.build());
             }
         } else {
-            // No structured output needed
-            org.springframework.ai.model.tool.ToolCallingChatOptions chatOptions =
-                org.springframework.ai.model.tool.ToolCallingChatOptions.builder()
-                    .toolCallbacks(toolCallbacks)
-                    .internalToolExecutionEnabled(false)
-                    .build();
-            prompt = new Prompt(messagesWithFormattedSystem, chatOptions);
+            // No structured output needed — still apply model_params via OpenAiChatOptions.
+            OpenAiChatOptions.Builder optionsBuilder = OpenAiChatOptions.builder()
+                .toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]))
+                .internalToolExecutionEnabled(false);
+            applyModelParams(optionsBuilder, options);
+            prompt = new Prompt(messagesWithFormattedSystem, optionsBuilder.build());
         }
 
         log.debug("Calling OpenAI with {} tools (execution disabled)", tools != null ? tools.size() : 0);

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
@@ -79,7 +79,17 @@ public class OpenAiHandler implements LlmProviderHandler {
         log.debug("OpenAiHandler: Processing {} messages", messages.size());
 
         List<Message> springMessages = convertMessages(messages);
-        Prompt prompt = new Prompt(springMessages);
+        // Plain-text generation: apply consumer-supplied model_params
+        // (max_tokens/temperature/top_p/vendor-matched model) when present so the
+        // no-tools/no-schema path honors them like the tools path does.
+        Prompt prompt;
+        if (LlmProviderHandler.hasAnyModelParam(options)) {
+            OpenAiChatOptions.Builder optionsBuilder = OpenAiChatOptions.builder();
+            applyModelParams(optionsBuilder, options);
+            prompt = new Prompt(springMessages, optionsBuilder.build());
+        } else {
+            prompt = new Prompt(springMessages);
+        }
         ChatResponse response = model.call(prompt);
 
         String content = response.getResult() != null && response.getResult().getOutput() != null

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderModelParamsTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderModelParamsTest.java
@@ -1,0 +1,267 @@
+package io.mcpmesh.ai.handlers;
+
+import io.mcpmesh.ai.handlers.LlmProviderHandler.OutputSchema;
+import io.mcpmesh.ai.handlers.LlmProviderHandler.ToolDefinition;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+import org.springframework.ai.anthropic.AnthropicChatOptions;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatOptions;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Provider-side application of {@code model_params} onto the per-vendor Spring AI
+ * {@code *ChatOptions} (GAP C2).
+ *
+ * <p>The Java consumer already puts {@code max_tokens}/{@code temperature}/
+ * {@code top_p}/{@code model} on the wire; this verifies the PROVIDER reads those
+ * keys from the incoming {@code model_params} (threaded through the handler
+ * {@code options} map) and applies them to the vendor ChatOptions, INCLUDING the
+ * vendor-match guard for the {@code model} override (cross-vendor → fall back to
+ * the provider default).
+ *
+ * <p>Exercises the no-execution path ({@code toolExecutor == null}) so the handler
+ * builds a vendor options object and calls {@code model.call(prompt)} — we capture
+ * the {@link Prompt} and inspect {@code prompt.getOptions()}.
+ */
+@DisplayName("provider applies model_params → ChatOptions (GAP C2)")
+class ProviderModelParamsTest {
+
+    @BeforeAll
+    static void installNativeStub() {
+        FormatSystemPromptStub.install();
+    }
+
+    @AfterAll
+    static void uninstallNativeStub() {
+        FormatSystemPromptStub.uninstall();
+    }
+
+    /** A mock ChatModel that returns a trivial text response and captures the Prompt. */
+    private static ChatModel mockModel(ArgumentCaptor<Prompt> captor) {
+        ChatModel model = mock(ChatModel.class);
+        ChatResponse response = new ChatResponse(
+            List.of(new Generation(new AssistantMessage("done"))));
+        when(model.call(captor.capture())).thenReturn(response);
+        return model;
+    }
+
+    private static List<Map<String, Object>> userMessages() {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("role", "user");
+        m.put("content", "hi");
+        return List.of(m);
+    }
+
+    @Nested
+    @DisplayName("OpenAI")
+    class OpenAi {
+
+        private final OpenAiHandler handler = new OpenAiHandler();
+
+        @Test
+        @DisplayName("max_tokens/temperature/top_p flow onto OpenAiChatOptions")
+        void numericParamsApplied() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            Map<String, Object> options = new LinkedHashMap<>();
+            options.put(LlmProviderHandler.OPTION_MAX_TOKENS, 1234);
+            options.put(LlmProviderHandler.OPTION_TEMPERATURE, 0.42);
+            options.put(LlmProviderHandler.OPTION_TOP_P, 0.9);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null, options);
+
+            ChatOptions opts = captor.getValue().getOptions();
+            assertInstanceOf(OpenAiChatOptions.class, opts);
+            assertEquals(1234, opts.getMaxTokens());
+            assertEquals(0.42, opts.getTemperature(), 1e-9);
+            assertEquals(0.9, opts.getTopP(), 1e-9);
+        }
+
+        @Test
+        @DisplayName("same-vendor model override is applied (openai/gpt-4o → gpt-4o)")
+        void sameVendorModelApplied() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null,
+                Map.of(LlmProviderHandler.OPTION_MODEL, "openai/gpt-4o"));
+
+            ChatOptions opts = captor.getValue().getOptions();
+            assertEquals("gpt-4o", opts.getModel(),
+                "same-vendor model override must be applied (vendor-stripped)");
+        }
+
+        @Test
+        @DisplayName("cross-vendor model override is rejected → provider default (model stays null)")
+        void crossVendorModelRejected() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null,
+                Map.of(LlmProviderHandler.OPTION_MODEL, "anthropic/claude-3-5-sonnet-latest"));
+
+            ChatOptions opts = captor.getValue().getOptions();
+            assertNull(opts.getModel(),
+                "cross-vendor model override must be ignored — provider keeps its own default model");
+        }
+
+        @Test
+        @DisplayName("absent params leave the options defaults untouched (no force-set nulls)")
+        void absentParamsUntouched() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null, Map.of());
+
+            ChatOptions opts = captor.getValue().getOptions();
+            assertNull(opts.getMaxTokens(), "absent max_tokens must not be force-set");
+            assertNull(opts.getTemperature(), "absent temperature must not be force-set");
+            assertNull(opts.getTopP(), "absent top_p must not be force-set");
+            assertNull(opts.getModel(), "absent model must not be force-set");
+        }
+    }
+
+    @Nested
+    @DisplayName("Anthropic")
+    class Anthropic {
+
+        private final AnthropicHandler handler = new AnthropicHandler();
+
+        @Test
+        @DisplayName("max_tokens/temperature/top_p flow onto AnthropicChatOptions")
+        void numericParamsApplied() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            Map<String, Object> options = new LinkedHashMap<>();
+            options.put(LlmProviderHandler.OPTION_MAX_TOKENS, 2048);
+            options.put(LlmProviderHandler.OPTION_TEMPERATURE, 0.15);
+            options.put(LlmProviderHandler.OPTION_TOP_P, 0.8);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null, options);
+
+            ChatOptions opts = captor.getValue().getOptions();
+            assertInstanceOf(AnthropicChatOptions.class, opts);
+            assertEquals(2048, opts.getMaxTokens());
+            assertEquals(0.15, opts.getTemperature(), 1e-9);
+            assertEquals(0.8, opts.getTopP(), 1e-9);
+        }
+
+        @Test
+        @DisplayName("same-vendor model override is applied (alias 'claude' also matches)")
+        void sameVendorModelApplied() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null,
+                Map.of(LlmProviderHandler.OPTION_MODEL, "claude/claude-3-5-sonnet-latest"));
+
+            ChatOptions opts = captor.getValue().getOptions();
+            assertEquals("claude-3-5-sonnet-latest", opts.getModel(),
+                "the 'claude' alias must match the anthropic vendor and apply the model");
+        }
+
+        @Test
+        @DisplayName("cross-vendor model override is rejected → provider default (model stays null)")
+        void crossVendorModelRejected() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null,
+                Map.of(LlmProviderHandler.OPTION_MODEL, "openai/gpt-4o"));
+
+            ChatOptions opts = captor.getValue().getOptions();
+            assertNull(opts.getModel(),
+                "cross-vendor model override must be ignored — Anthropic keeps its own default model");
+        }
+    }
+
+    @Nested
+    @DisplayName("resolveModelOverride (vendor-match guard)")
+    class ResolveModelOverride {
+
+        @Test
+        @DisplayName("matching vendor returns the bare model name")
+        void matchReturnsBareName() {
+            assertEquals("gpt-4o",
+                LlmProviderHandler.resolveModelOverride(
+                    Map.of("model", "openai/gpt-4o"), "openai", new String[]{"gpt"}));
+        }
+
+        @Test
+        @DisplayName("alias match returns the bare model name")
+        void aliasMatchReturnsBareName() {
+            assertEquals("claude-3-5-sonnet-latest",
+                LlmProviderHandler.resolveModelOverride(
+                    Map.of("model", "claude/claude-3-5-sonnet-latest"), "anthropic", new String[]{"claude"}));
+        }
+
+        @Test
+        @DisplayName("cross-vendor returns null (fall back to default)")
+        void crossVendorReturnsNull() {
+            assertNull(LlmProviderHandler.resolveModelOverride(
+                Map.of("model", "anthropic/claude-3-5-sonnet-latest"), "openai", new String[]{"gpt"}));
+        }
+
+        @Test
+        @DisplayName("bare model name (no vendor prefix) is assumed to target this provider")
+        void bareNameAssumedMatch() {
+            assertEquals("gpt-4o",
+                LlmProviderHandler.resolveModelOverride(
+                    Map.of("model", "gpt-4o"), "openai", new String[]{"gpt"}));
+        }
+
+        @Test
+        @DisplayName("absent / null / blank model returns null")
+        void absentReturnsNull() {
+            assertNull(LlmProviderHandler.resolveModelOverride(null, "openai", null));
+            assertNull(LlmProviderHandler.resolveModelOverride(Map.of(), "openai", null));
+            assertNull(LlmProviderHandler.resolveModelOverride(
+                Map.of("model", "  "), "openai", null));
+        }
+    }
+
+    @Nested
+    @DisplayName("numeric option extractors")
+    class NumericExtractors {
+
+        @Test
+        @DisplayName("max_tokens parses Number and numeric String")
+        void maxTokens() {
+            assertEquals(100, LlmProviderHandler.maxTokensOption(Map.of("max_tokens", 100)));
+            assertEquals(100, LlmProviderHandler.maxTokensOption(Map.of("max_tokens", "100")));
+            assertNull(LlmProviderHandler.maxTokensOption(Map.of()));
+            assertNull(LlmProviderHandler.maxTokensOption(null));
+        }
+
+        @Test
+        @DisplayName("temperature parses Number, ignores NaN")
+        void temperature() {
+            assertEquals(0.3, LlmProviderHandler.temperatureOption(Map.of("temperature", 0.3)), 1e-9);
+            assertEquals(0.3, LlmProviderHandler.temperatureOption(Map.of("temperature", "0.3")), 1e-9);
+            assertNull(LlmProviderHandler.temperatureOption(Map.of("temperature", Double.NaN)));
+            assertNull(LlmProviderHandler.temperatureOption(Map.of()));
+        }
+
+        @Test
+        @DisplayName("hasAnyModelParam detects presence of any C2 key")
+        void hasAnyModelParam() {
+            assertFalse(LlmProviderHandler.hasAnyModelParam(null));
+            assertFalse(LlmProviderHandler.hasAnyModelParam(Map.of()));
+            assertTrue(LlmProviderHandler.hasAnyModelParam(Map.of("max_tokens", 1)));
+            assertTrue(LlmProviderHandler.hasAnyModelParam(Map.of("model", "openai/gpt-4o")));
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderModelParamsTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderModelParamsTest.java
@@ -12,6 +12,7 @@ import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 
 import java.util.*;
 
@@ -185,6 +186,115 @@ class ProviderModelParamsTest {
             ChatOptions opts = captor.getValue().getOptions();
             assertNull(opts.getModel(),
                 "cross-vendor model override must be ignored — Anthropic keeps its own default model");
+        }
+    }
+
+    @Nested
+    @DisplayName("Gemini")
+    class Gemini {
+
+        private final GeminiHandler handler = new GeminiHandler();
+
+        // A plain mock(ChatModel.class) is NOT a VertexAiGeminiChatModel, so the
+        // handler takes the Google AI Studio (GenAI) branch and produces
+        // GoogleGenAiChatOptions. The Vertex branch needs the concrete
+        // VertexAiGeminiChatModel and is out of scope for this unit harness.
+
+        @Test
+        @DisplayName("max_tokens→maxOutputTokens/temperature/top_p flow onto GoogleGenAiChatOptions")
+        void numericParamsApplied() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            Map<String, Object> options = new LinkedHashMap<>();
+            options.put(LlmProviderHandler.OPTION_MAX_TOKENS, 777);
+            options.put(LlmProviderHandler.OPTION_TEMPERATURE, 0.33);
+            options.put(LlmProviderHandler.OPTION_TOP_P, 0.7);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null, options);
+
+            ChatOptions opts = captor.getValue().getOptions();
+            assertInstanceOf(GoogleGenAiChatOptions.class, opts);
+            GoogleGenAiChatOptions g = (GoogleGenAiChatOptions) opts;
+            assertEquals(777, g.getMaxOutputTokens(), "max_tokens maps to maxOutputTokens");
+            assertEquals(0.33, g.getTemperature(), 1e-9);
+            assertEquals(0.7, g.getTopP(), 1e-9);
+        }
+
+        @Test
+        @DisplayName("same-vendor model override is applied (gemini/... and google/...)")
+        void sameVendorModelApplied() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null,
+                Map.of(LlmProviderHandler.OPTION_MODEL, "gemini/gemini-2.0-flash"));
+
+            assertEquals("gemini-2.0-flash", captor.getValue().getOptions().getModel(),
+                "same-vendor 'gemini/' override must be applied (vendor-stripped)");
+
+            ArgumentCaptor<Prompt> captor2 = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model2 = mockModel(captor2);
+            handler.generateWithTools(model2, userMessages(), List.of(), null, null,
+                Map.of(LlmProviderHandler.OPTION_MODEL, "google/gemini-2.0-flash"));
+            assertEquals("gemini-2.0-flash", captor2.getValue().getOptions().getModel(),
+                "the 'google' alias must match the gemini vendor and apply the model");
+        }
+
+        @Test
+        @DisplayName("vertex_ai/... override is accepted on the GenAI branch (FIX 2)")
+        void vertexQualifiedOverrideAccepted() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null,
+                Map.of(LlmProviderHandler.OPTION_MODEL, "vertex_ai/gemini-1.5-pro"));
+
+            assertEquals("gemini-1.5-pro", captor.getValue().getOptions().getModel(),
+                "a vertex_ai-qualified override routes through GeminiHandler and must be accepted");
+        }
+
+        @Test
+        @DisplayName("cross-vendor model override is rejected → provider default (model stays null)")
+        void crossVendorModelRejected() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null,
+                Map.of(LlmProviderHandler.OPTION_MODEL, "openai/gpt-4o"));
+
+            assertNull(captor.getValue().getOptions().getModel(),
+                "cross-vendor model override must be ignored — Gemini keeps its own default model");
+        }
+
+        @Test
+        @DisplayName("plain-text generateWithMessages applies model_params (FIX 3)")
+        void plainTextPathAppliesParams() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            Map<String, Object> options = new LinkedHashMap<>();
+            options.put(LlmProviderHandler.OPTION_MAX_TOKENS, 512);
+            options.put(LlmProviderHandler.OPTION_MODEL, "gemini/gemini-2.0-flash");
+
+            handler.generateWithMessages(model, userMessages(), options);
+
+            ChatOptions opts = captor.getValue().getOptions();
+            assertInstanceOf(GoogleGenAiChatOptions.class, opts);
+            assertEquals(512, ((GoogleGenAiChatOptions) opts).getMaxOutputTokens());
+            assertEquals("gemini-2.0-flash", opts.getModel());
+        }
+
+        @Test
+        @DisplayName("plain-text generateWithMessages with no params builds a no-options prompt")
+        void plainTextPathNoParams() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithMessages(model, userMessages(), Map.of());
+
+            assertNull(captor.getValue().getOptions(),
+                "no model_params → plain Prompt(messages) with no ChatOptions");
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
@@ -335,8 +335,9 @@ public class MeshEventProcessor implements SmartLifecycle {
             int maxTokens = config != null ? config.maxTokens() : MeshLlmDefaults.MAX_TOKENS_UNSET;
             double temperature = config != null ? config.temperature() : MeshLlmDefaults.TEMPERATURE_UNSET;
             String outputMode = config != null ? config.outputMode() : MeshLlmDefaults.OUTPUT_MODE_UNSET;
+            String modelOverride = config != null ? config.model() : "";
 
-            proxy.configure(mcpClient, proxyFactory, toolInvoker, injector, systemPrompt, contextParam, maxIterations, parallelToolCalls, maxTokens, temperature, outputMode);
+            proxy.configure(mcpClient, proxyFactory, toolInvoker, injector, systemPrompt, contextParam, maxIterations, parallelToolCalls, maxTokens, temperature, outputMode, modelOverride);
 
             // Wire MediaStore for multimodal support
             wireMediaStore(proxy);
@@ -517,8 +518,9 @@ public class MeshEventProcessor implements SmartLifecycle {
             int maxTokens = config != null ? config.maxTokens() : MeshLlmDefaults.MAX_TOKENS_UNSET;
             double temperature = config != null ? config.temperature() : MeshLlmDefaults.TEMPERATURE_UNSET;
             String outputMode = config != null ? config.outputMode() : MeshLlmDefaults.OUTPUT_MODE_UNSET;
+            String modelOverride = config != null ? config.model() : "";
 
-            proxy.configure(mcpClient, proxyFactory, toolInvoker, injector, systemPrompt, contextParam, maxIterations, parallelToolCalls, maxTokens, temperature, outputMode);
+            proxy.configure(mcpClient, proxyFactory, toolInvoker, injector, systemPrompt, contextParam, maxIterations, parallelToolCalls, maxTokens, temperature, outputMode, modelOverride);
 
             // Wire MediaStore for multimodal support
             wireMediaStore(proxy);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -90,6 +90,7 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
     private volatile double defaultTemperature = MeshLlmDefaults.TEMPERATURE_UNSET;
     private volatile boolean parallelToolCalls = false;
     private volatile String defaultOutputMode = MeshLlmDefaults.OUTPUT_MODE_UNSET;
+    private volatile String defaultModel = "";
 
     private McpHttpClient mcpClient;
     private McpMeshToolProxyFactory proxyFactory;
@@ -198,6 +199,33 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
         this.defaultOutputMode = outputMode != null ? outputMode : MeshLlmDefaults.OUTPUT_MODE_UNSET;
         if (!this.defaultOutputMode.isEmpty()) {
             log.info("@MeshLlm outputMode for {}: {}", functionId, this.defaultOutputMode);
+        }
+    }
+
+    /**
+     * Configure the proxy with dependencies, parallel tool calls option,
+     * {@code maxTokens}/{@code temperature} defaults, the {@code @MeshLlm}
+     * {@code outputMode}, and the optional {@code @MeshLlm} {@code model}
+     * per-tool override.
+     *
+     * <p>Wires the annotation's {@code model} through to the wire
+     * {@code model_params.model} so the consumer can request a specific model per
+     * tool. The provider honors it when the override's vendor matches its own,
+     * else falls back to the provider's default model (vendor-checked, mirroring
+     * Python). When {@code model} is left unset (empty/blank), no {@code model}
+     * key is injected and the provider uses its own declared model. A per-call
+     * {@code modelParams(Map.of("model", ...))} override takes precedence over
+     * this annotation value.
+     */
+    public void configure(McpHttpClient mcpClient, McpMeshToolProxyFactory proxyFactory,
+                          ToolInvoker toolInvoker, MeshDependencyInjector dependencyInjector,
+                          String systemPrompt, String contextParamName, int maxIterations,
+                          boolean parallelToolCalls, int maxTokens, double temperature,
+                          String outputMode, String model) {
+        configure(mcpClient, proxyFactory, toolInvoker, dependencyInjector, systemPrompt, contextParamName, maxIterations, parallelToolCalls, maxTokens, temperature, outputMode);
+        this.defaultModel = (model != null && !model.isBlank()) ? model : "";
+        if (!this.defaultModel.isEmpty()) {
+            log.info("@MeshLlm model override for {}: {}", functionId, this.defaultModel);
         }
     }
 
@@ -702,6 +730,14 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
             if (defaultOutputMode != null && !defaultOutputMode.isEmpty()
                     && !modelParams.containsKey("output_mode")) {
                 modelParams.put("output_mode", defaultOutputMode);
+            }
+            // model (@MeshLlm(model=...)): inject the annotation's per-tool model
+            // override only when set AND the escape-hatch modelParams did not
+            // already supply a "model" (a per-call .modelParams(Map.of("model", ...))
+            // wins). Unset → key omitted → provider uses its own declared model.
+            if (defaultModel != null && !defaultModel.isEmpty()
+                    && !modelParams.containsKey("model")) {
+                modelParams.put("model", defaultModel);
             }
             return modelParams;
         }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmRegistry.java
@@ -36,7 +36,8 @@ public class MeshLlmRegistry {
         int maxTokens,
         double temperature,
         boolean parallelToolCalls,
-        String outputMode
+        String outputMode,
+        String model
     ) {}
 
     // Registry: functionId -> LlmConfig
@@ -83,7 +84,8 @@ public class MeshLlmRegistry {
             annotation.maxTokens(),
             annotation.temperature(),
             annotation.parallelToolCalls(),
-            resolveOutputMode(annotation.outputMode(), functionId)
+            resolveOutputMode(annotation.outputMode(), functionId),
+            annotation.model() != null ? annotation.model() : ""
         );
 
         configsByFunctionId.put(functionId, config);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyModelParamsTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyModelParamsTest.java
@@ -378,6 +378,64 @@ class MeshLlmAgentProxyModelParamsTest {
     }
 
     @Test
+    @DisplayName("@MeshLlm(model=...) per-tool override flows into the wire model_params.model (GAP C3)")
+    void meshLlmModelOverrideFlowsToWire() throws Exception {
+        // C3: @MeshLlm(model="anthropic/claude-3-5-sonnet-latest") must surface as
+        // model_params.model on the wire so the provider can honor it (same-vendor).
+        server.enqueue(stubLlmResponse("ok"));
+
+        // 12-arg configure overload simulates @MeshLlm(model="anthropic/claude-3-5-sonnet-latest").
+        proxy.configure(client, null, null, null, "", "ctx", 1, false,
+            io.mcpmesh.MeshLlmDefaults.MAX_TOKENS_UNSET, io.mcpmesh.MeshLlmDefaults.TEMPERATURE_UNSET,
+            io.mcpmesh.MeshLlmDefaults.OUTPUT_MODE_UNSET, "anthropic/claude-3-5-sonnet-latest");
+
+        proxy.request().user("hi").generate();
+
+        RecordedRequest req = server.takeRequest();
+        JsonNode modelParams = readModelParams(req);
+
+        assertEquals("anthropic/claude-3-5-sonnet-latest", modelParams.get("model").asText(),
+            "@MeshLlm(model=...) must reach the wire as model_params.model");
+    }
+
+    @Test
+    @DisplayName("per-call .modelParams(model) wins over @MeshLlm(model=...) annotation (GAP C3)")
+    void perCallModelOverridesAnnotation() throws Exception {
+        server.enqueue(stubLlmResponse("ok"));
+
+        // Annotation says one model; the per-call escape hatch supplies another.
+        proxy.configure(client, null, null, null, "", "ctx", 1, false,
+            io.mcpmesh.MeshLlmDefaults.MAX_TOKENS_UNSET, io.mcpmesh.MeshLlmDefaults.TEMPERATURE_UNSET,
+            io.mcpmesh.MeshLlmDefaults.OUTPUT_MODE_UNSET, "anthropic/claude-3-5-sonnet-latest");
+
+        proxy.request()
+            .user("hi")
+            .modelParams(Map.of("model", "anthropic/claude-3-5-haiku-latest"))
+            .generate();
+
+        RecordedRequest req = server.takeRequest();
+        JsonNode modelParams = readModelParams(req);
+
+        assertEquals("anthropic/claude-3-5-haiku-latest", modelParams.get("model").asText(),
+            "a per-call .modelParams(Map.of(\"model\", ...)) must win over the @MeshLlm(model=...) annotation");
+    }
+
+    @Test
+    @DisplayName("unset @MeshLlm model → no model key on the wire (provider uses its own model)")
+    void unsetModelOmitsKey() throws Exception {
+        server.enqueue(stubLlmResponse("ok"));
+
+        // Default 8-arg configure leaves the model override empty.
+        proxy.request().user("hi").generate();
+
+        RecordedRequest req = server.takeRequest();
+        JsonNode modelParams = readModelParams(req);
+
+        assertFalse(modelParams.has("model"),
+            "with no @MeshLlm(model=...) and no per-call override, model_params.model must be absent");
+    }
+
+    @Test
     @DisplayName("parallelToolCalls annotation honors user modelParams override (issue #1026)")
     void parallelToolCallsHonorsUserModelParamsOverride() throws Exception {
         // Issue #1026: previously `if (parallelToolCalls) modelParams.put("parallel_tool_calls", true)`

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyStreamTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyStreamTest.java
@@ -325,7 +325,8 @@ class MeshLlmAgentProxyStreamTest {
             4096,                                 // maxTokens
             0.7,                                  // temperature
             false,                                // parallelToolCalls
-            ""                                    // outputMode (unset)
+            "",                                   // outputMode (unset)
+            ""                                    // model (unset)
         );
 
         assertNotNull(config.providerSelector());


### PR DESCRIPTION
## Summary

Closes the contained Java LLM parity gaps vs Python — model selection and tuning params that the consumer already put on the wire but the Java (Spring AI) provider dropped. **Wave 2a** of the Java parity effort; streaming producer support (D/C1) is **deferred to 2.7** (it needs a parallel inbound transport — the stateless MCP server can't emit `notifications/progress` — and warrants a deliberate design, not a rush).

## Gaps closed

**C3 — consumer per-tool / per-call model override.**
Adds `model()` to `@MeshLlm`. When set, the consumer sends it via `model_params.model`; the provider honors it **only when the vendor matches** its own (warn + fall back to the provider default otherwise), mirroring Python's vendor-checked override. A per-call `modelParams(Map.of("model", ...))` still wins over the annotation. Threaded through `MeshLlmRegistry` → `MeshEventProcessor` → `MeshLlmAgentProxy`.

**C2 — provider applies `model_params` to the vendor call.**
Previously the consumer put `max_tokens`/`temperature`/`top_p`/`model` on the wire but the Spring AI provider only read `parallel_tool_calls`/`output_mode` and dropped the rest. `MeshLlmProviderProcessor` now forwards them, and the Anthropic/OpenAI/Gemini handlers apply them to their per-vendor `*ChatOptions` (Gemini maps `max_tokens → maxOutputTokens`). Absent keys leave Spring AI defaults untouched. Thinking/reasoning config continues to flow via the existing `modelParams(...)` escape hatch (no uniform Spring AI surface).

## Docs
- `llm_java.md`: removed the teaching of the v2-**removed** Direct-LLM mode (`@MeshLlm(provider="...")` + local API key — the runtime now throws on it); documented the new `model()` override and the `model_params` tuning the provider now honors.
- `streaming.md`: corrected the Java notes — the consumer stream API ships (`proxy.stream()`/`streamGenerate()`), but Java cannot yet **produce** a stream (deferred to 2.7); stated as not-yet-supported, not parity.
- `A2AClient.java`: javadoc claimed submit/subscribe/SSE were "deferred to a follow-up PR" though both ship — corrected to the actual surface.

## Tests
- Consumer: `@MeshLlm(model=...)` reaches `model_params.model`; per-call override wins; unset → key absent.
- Provider: `max_tokens`/`temperature`/`top_p`/`model` applied to each vendor's `ChatOptions`; **cross-vendor model override rejected** → falls back to default (guard fires in logs).
- Full Maven reactor build green; **711 tests pass** (6 modules).

## Reviewer note
The OpenAI/Anthropic no-execute paths now always build the vendor `*ChatOptions` (instead of the generic `ToolCallingChatOptions`) so `model_params` apply even without a structured-output schema. Behavior-preserving for the no-params case (vendor options are a superset), but worth a glance since it touches the structured-output branches.

## Follow-up
Streaming producer (core `@MeshTool` `Stream` + `@MeshLlmProvider` streaming tool) tracked separately for 2.7 — the scoping (wire-format spec + transport blocker + the two viable approaches) is captured in that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-tool model overrides and tuning options, including max tokens, temperature, and top-p.
  * Expanded streaming and A2A documentation to better reflect current cross-SDK behavior.
  * Improved configuration support so model selection can be set at annotation, request, or provider level.

* **Bug Fixes**
  * Ensured model settings are consistently applied across tool-enabled and non-tool flows.
  * Added safeguards so invalid or mismatched model overrides fall back to the default provider model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->