### PR TITLE
fix: stale down agents persist in registry and false-alarm in meshctl list

### DIFF
--- a/src/core/cli/list.go
+++ b/src/core/cli/list.go
@@ -1030,7 +1030,7 @@ func outputEnhancedJSON(output ListOutput) error {
 // row annotations, --all dimming, and the footer (issue #1195).
 func outputDockerComposeStyle(output ListOutput, headerView, view supersessionView, summary listDefaultSummary, showAll, verbose, noDeps, wide bool) error {
 	// Show registry status first
-	showRegistryStatus(output.Registry, headerView.total)
+	showRegistryStatus(output.Registry, headerView.total, len(headerView.blocking))
 
 	if len(output.Agents) == 0 {
 		fmt.Println("No agents found")
@@ -1087,8 +1087,11 @@ func outputDockerComposeStyle(output ListOutput, headerView, view supersessionVi
 	return nil
 }
 
-// showRegistryStatus displays registry status with proper formatting
-func showRegistryStatus(registry RegistryStatus, supersededCount int) {
+// showRegistryStatus displays registry status with proper formatting.
+// supersededCount and blockingCount come from the headerView computed over the
+// full agent set so the count breakdown can route only the genuinely-blocking
+// down instances to the red "unhealthy" alarm (issue #1198).
+func showRegistryStatus(registry RegistryStatus, supersededCount, blockingCount int) {
 	statusColor := getStatusColor(registry.Status)
 	fmt.Printf("Registry: %s%s%s", statusColor, registry.Status, colorReset)
 
@@ -1098,7 +1101,7 @@ func showRegistryStatus(registry RegistryStatus, supersededCount int) {
 
 	if registry.Status == "running" {
 		// Show healthy/unhealthy/superseded breakdown (issue #1195)
-		fmt.Printf(" - %s", formatRegistryAgentCounts(registry.HealthyCount, registry.UnhealthyCount, supersededCount))
+		fmt.Printf(" - %s", formatRegistryAgentCounts(registry.HealthyCount, registry.UnhealthyCount, supersededCount, blockingCount))
 	}
 
 	if registry.Uptime != "" {
@@ -1110,20 +1113,38 @@ func showRegistryStatus(registry RegistryStatus, supersededCount int) {
 }
 
 // formatRegistryAgentCounts renders the agent count breakdown for the registry
-// status line. Superseded instances are split out of the unhealthy count and
-// rendered dim so they don't read as alarming; the remaining (genuinely
-// unhealthy) count is the alarm surface and renders red (issue #1195).
-func formatRegistryAgentCounts(healthy, unhealthy, superseded int) string {
+// status line. The down (unhealthy) total is split three ways so only the
+// genuinely-alarming portion reads red (issues #1195, #1198):
+//
+//   - superseded — a healthy newer instance of the same name exists; rendered
+//     gray since it blocks nothing.
+//   - blocking — down AND declares a capability some live agent depends on but
+//     hasn't resolved; this is the real alarm and renders red as "unhealthy".
+//   - inactive — orphaned non-blocking down instances (no healthy replacement,
+//     yet blocking nothing); rendered gray as "inactive" because they're just
+//     stale instances pending the retention purge, not a live problem.
+//
+// blocking is the count of genuinely-blocking down instances (len of the
+// header supersession view's blocking set); the remaining down instances are
+// the inactive disclosure.
+func formatRegistryAgentCounts(healthy, unhealthy, superseded, blocking int) string {
 	// The counts come from two separate registry fetches; clamp so a
-	// momentary skew can't produce a negative unhealthy count.
+	// momentary skew can't produce a negative count.
 	if superseded > unhealthy {
 		superseded = unhealthy
 	}
 	genuine := unhealthy - superseded
+	if blocking > genuine {
+		blocking = genuine
+	}
+	inactive := genuine - blocking
 
 	s := fmt.Sprintf("%s%d healthy%s", colorGreen, healthy, colorReset)
-	if genuine > 0 {
-		s += fmt.Sprintf(", %s%d unhealthy%s", colorRed, genuine, colorReset)
+	if blocking > 0 {
+		s += fmt.Sprintf(", %s%d unhealthy%s", colorRed, blocking, colorReset)
+	}
+	if inactive > 0 {
+		s += fmt.Sprintf(", %s%d inactive%s", colorGray, inactive, colorReset)
 	}
 	if superseded > 0 {
 		s += fmt.Sprintf(", %s%d superseded%s", colorGray, superseded, colorReset)
@@ -1141,16 +1162,20 @@ func formatSupersededAnnotation(count int) string {
 }
 
 // formatListFooter renders the summary line printed after the default table,
-// e.g. "3 agents (3 healthy) - 1 agent down (use --all) - 2 superseded hidden".
+// e.g. "3 agents (3 healthy) - 1 inactive instance hidden (use --all) - 2 superseded hidden".
 // displayed and healthy count distinct declared agent names among the rendered
-// rows. Down agents hidden from the table are reported namelessly in red; the
-// superseded clause is gray, and "(use --all)" rides on whichever hidden
-// clause appears first. Clauses are omitted when zero.
+// rows. The hidden down agents counted here are orphaned non-blocking instances
+// (a genuinely blocking down instance is promoted to a visible red row by
+// collapseDefaultView and never reaches this count), so they block nothing and
+// are disclosed in neutral gray as "inactive" pending retention purge rather
+// than as a red "agent down" alarm. The superseded clause is likewise gray, and
+// "(use --all)" rides on whichever hidden clause appears first. Clauses are
+// omitted when zero.
 func formatListFooter(displayed, healthy int, summary listDefaultSummary) string {
 	footer := fmt.Sprintf("%d agent%s (%d healthy)", displayed, pluralS(displayed), healthy)
 	if summary.hiddenDownAgents > 0 {
-		footer += fmt.Sprintf(" - %s%d agent%s down (use --all)%s",
-			colorRed, summary.hiddenDownAgents, pluralS(summary.hiddenDownAgents), colorReset)
+		footer += fmt.Sprintf(" - %s%d inactive instance%s hidden (use --all)%s",
+			colorGray, summary.hiddenDownAgents, pluralS(summary.hiddenDownAgents), colorReset)
 	}
 	if summary.hiddenSuperseded > 0 {
 		clause := fmt.Sprintf("%d superseded hidden", summary.hiddenSuperseded)

--- a/src/core/cli/list_test.go
+++ b/src/core/cli/list_test.go
@@ -238,6 +238,57 @@ func TestComputeSupersessionView_ResolvedDepsAllowDimming(t *testing.T) {
 	assert.Equal(t, 1, view.total)
 }
 
+// TestRegistryCountsDiscloseDownBuckets is an end-to-end guard over issue #1198:
+// the header count surface must route a blocking down instance to the red
+// "unhealthy" alarm while an orphaned non-blocking down instance is disclosed in
+// gray as "inactive" — never red. It mirrors how outputDockerComposeStyle feeds
+// the headerView into the count formatter (headerView.total superseded,
+// len(headerView.blocking) blocking).
+func TestRegistryCountsDiscloseDownBuckets(t *testing.T) {
+	base := time.Now().Add(-1 * time.Hour)
+
+	// provider-solo is down AND explains consumer-1's unresolved dependency:
+	// genuine blocking alarm.
+	provider := testAgent("provider-solo", "provider", "unhealthy", base, nil)
+	provider.Tools = []ToolInfo{{Name: "date_service", Capability: "date_service"}}
+	consumer := testAgent("consumer-1", "consumer", "healthy", base, nil)
+	consumer.DependencyResolutions = []DependencyResolution{
+		{Capability: "date_service", Status: "unresolved"},
+	}
+	// stale-solo is down, has no healthy replacement and blocks nothing: an
+	// orphaned non-blocking down instance.
+	stale := testAgent("stale-solo", "stale", "unhealthy", base, nil)
+
+	agents := []EnhancedAgent{provider, consumer, stale}
+	view := computeSupersessionView(agents)
+
+	require.True(t, view.blocking["provider-solo"], "provider-solo must be the blocking down instance")
+	require.False(t, view.blocking["stale-solo"], "stale-solo blocks nothing")
+	require.False(t, view.superseded["stale-solo"], "stale-solo has no healthy replacement, so it is not superseded")
+	require.Equal(t, 0, view.total, "no superseded instances in this fixture")
+
+	// Registry reports 1 healthy (consumer) and 2 unhealthy (provider + stale).
+	// The header derives superseded from view.total and blocking from
+	// len(view.blocking), exactly as showRegistryStatus does.
+	s := formatRegistryAgentCounts(1, 2, view.total, len(view.blocking))
+
+	assert.Contains(t, s, colorRed+"1 unhealthy",
+		"the blocking down instance is the genuine alarm and renders red")
+	assert.Contains(t, s, colorGray+"1 inactive",
+		"the orphaned non-blocking down instance is a muted gray 'inactive' disclosure, not red")
+	assert.NotContains(t, s, "2 unhealthy",
+		"a down instance that blocks nothing must not inflate the red unhealthy count")
+
+	// And the footer (orphaned down hidden, blocking promoted to a row).
+	_, summary := collapseDefaultView(agents, view)
+	require.Equal(t, 1, summary.hiddenDownAgents, "only the orphaned down instance is hidden")
+	footer := formatListFooter(2, 1, summary)
+	assert.Contains(t, footer, colorGray+"1 inactive instance hidden",
+		"the hidden orphan is disclosed as gray inactive in the footer, not red 'agent down'")
+	assert.NotContains(t, footer, colorRed,
+		"nothing in the footer is a genuine alarm: the blocking instance is a visible red row, not a footer count")
+}
+
 func TestCollapseDefaultView(t *testing.T) {
 	base := time.Now().Add(-1 * time.Hour)
 
@@ -327,58 +378,100 @@ func TestFormatListFooter(t *testing.T) {
 		assert.Equal(t, "7 agents (7 healthy)", footer)
 	})
 
-	t.Run("down and superseded clauses", func(t *testing.T) {
+	t.Run("inactive and superseded clauses", func(t *testing.T) {
 		footer := formatListFooter(3, 3, listDefaultSummary{hiddenSuperseded: 2, hiddenDownAgents: 1})
 		assert.Contains(t, footer, "3 agents (3 healthy)")
-		assert.Contains(t, footer, "1 agent down (use --all)")
+		assert.Contains(t, footer, "1 inactive instance hidden (use --all)")
 		assert.Contains(t, footer, "2 superseded hidden")
-		assert.Contains(t, footer, colorRed+"1 agent down",
-			"the down clause is the alarm surface and renders red")
+		// Orphaned non-blocking down instances block nothing, so they are a
+		// muted gray "inactive" disclosure rather than a red "agent down"
+		// alarm (issue #1198).
+		assert.Contains(t, footer, colorGray+"1 inactive instance hidden",
+			"a hidden non-blocking down instance is a neutral gray disclosure, not a red alarm")
+		assert.NotContains(t, footer, colorRed,
+			"no clause in this footer is a genuine alarm, so nothing renders red")
+		assert.NotContains(t, footer, "agent down",
+			"the alarming 'agent down' wording is reserved; hidden orphans read as 'inactive'")
 		assert.Contains(t, footer, colorGray+"2 superseded hidden",
 			"the superseded clause is neutral gray")
 		assert.NotContains(t, footer, "superseded hidden (use --all)",
-			"--all hint is not repeated when the down clause already carries it")
+			"--all hint is not repeated when the inactive clause already carries it")
 	})
 
 	t.Run("superseded-only clause carries the --all hint", func(t *testing.T) {
 		footer := formatListFooter(7, 7, listDefaultSummary{hiddenSuperseded: 8})
 		assert.Contains(t, footer, "8 superseded hidden (use --all)")
-		assert.NotContains(t, footer, "down")
+		assert.NotContains(t, footer, "inactive")
 	})
 
-	t.Run("plural down clause", func(t *testing.T) {
+	t.Run("plural inactive clause", func(t *testing.T) {
 		footer := formatListFooter(1, 1, listDefaultSummary{hiddenDownAgents: 2})
 		assert.Contains(t, footer, "1 agent (1 healthy)")
-		assert.Contains(t, footer, "2 agents down (use --all)")
+		assert.Contains(t, footer, "2 inactive instances hidden (use --all)")
+		assert.NotContains(t, footer, colorRed)
 	})
 }
 
 func TestFormatRegistryAgentCounts(t *testing.T) {
-	t.Run("splits superseded out of unhealthy", func(t *testing.T) {
-		s := formatRegistryAgentCounts(7, 9, 8)
+	t.Run("blocking down is red unhealthy, superseded is gray", func(t *testing.T) {
+		// 9 down total: 8 superseded, of the remaining 1 genuine all 1 blocks.
+		s := formatRegistryAgentCounts(7, 9, 8, 1)
 		assert.Contains(t, s, "7 healthy")
-		assert.Contains(t, s, "1 unhealthy", "genuine unhealthy = unhealthy - superseded")
+		assert.Contains(t, s, "1 unhealthy", "blocking down instances are the red alarm")
 		assert.Contains(t, s, "8 superseded")
-		// Genuine unhealthy is the alarm surface (red); superseded is neutral (gray).
+		// Only the genuinely-blocking down count is the alarm surface (red);
+		// superseded is neutral (gray).
 		assert.Contains(t, s, colorRed+"1 unhealthy")
 		assert.Contains(t, s, colorGray+"8 superseded")
+		assert.NotContains(t, s, "inactive")
 	})
 
-	t.Run("all superseded omits unhealthy clause", func(t *testing.T) {
-		s := formatRegistryAgentCounts(7, 8, 8)
+	t.Run("orphaned non-blocking down is gray inactive, not red", func(t *testing.T) {
+		// 3 down total: 0 superseded, 0 blocking -> all 3 orphaned/inactive.
+		s := formatRegistryAgentCounts(5, 3, 0, 0)
+		assert.Contains(t, s, "5 healthy")
+		assert.Contains(t, s, "3 inactive",
+			"orphaned non-blocking down instances disclose as gray 'inactive', not red 'unhealthy'")
+		assert.Contains(t, s, colorGray+"3 inactive")
+		assert.NotContains(t, s, "unhealthy",
+			"a down instance that blocks nothing must not inflate the red unhealthy count (issue #1198)")
+		assert.NotContains(t, s, colorRed)
+	})
+
+	t.Run("splits down into red blocking and gray inactive", func(t *testing.T) {
+		// 5 down total: 1 superseded, of the remaining 4 genuine 1 blocks and
+		// 3 are inactive orphans.
+		s := formatRegistryAgentCounts(2, 5, 1, 1)
+		assert.Contains(t, s, colorRed+"1 unhealthy", "only the blocking down instance is red")
+		assert.Contains(t, s, colorGray+"3 inactive", "non-blocking orphans are gray inactive")
+		assert.Contains(t, s, colorGray+"1 superseded")
+	})
+
+	t.Run("all superseded omits unhealthy and inactive clauses", func(t *testing.T) {
+		s := formatRegistryAgentCounts(7, 8, 8, 0)
 		assert.NotContains(t, s, "unhealthy")
+		assert.NotContains(t, s, "inactive")
 		assert.Contains(t, s, "8 superseded")
 	})
 
 	t.Run("no unhealthy at all", func(t *testing.T) {
-		s := formatRegistryAgentCounts(3, 0, 0)
+		s := formatRegistryAgentCounts(3, 0, 0, 0)
 		assert.Equal(t, fmt.Sprintf("%s3 healthy%s", colorGreen, colorReset), s)
 	})
 
 	t.Run("clamps superseded to unhealthy on fetch skew", func(t *testing.T) {
-		s := formatRegistryAgentCounts(3, 2, 5)
+		s := formatRegistryAgentCounts(3, 2, 5, 0)
 		assert.Contains(t, s, "2 superseded")
 		assert.NotContains(t, s, "unhealthy")
+		assert.NotContains(t, s, "inactive")
+	})
+
+	t.Run("clamps blocking to genuine down on skew", func(t *testing.T) {
+		// blocking reported higher than the genuine down count must not
+		// produce a negative inactive count.
+		s := formatRegistryAgentCounts(3, 2, 1, 5)
+		assert.Contains(t, s, colorRed+"1 unhealthy")
+		assert.NotContains(t, s, "inactive")
 	})
 }
 

--- a/src/core/registry/ent_service.go
+++ b/src/core/registry/ent_service.go
@@ -2083,12 +2083,21 @@ func (s *EntService) unregisterAgentAttempt(ctx context.Context, agentID string)
 		}
 	}
 
-	// Update agent status to unhealthy and update timestamp (like RegisterAgent does)
+	// Flip status to unhealthy but deliberately PRESERVE updated_at (do not bump
+	// it to `now`). updated_at is the agent's last-heartbeat timestamp from the
+	// sweep job's perspective (purgeStaleAgents filters on
+	// UpdatedAtLT(now-retention)). Bumping it on a graceful shutdown would
+	// restart the retention clock on every unregister, so a gracefully-shut-down
+	// agent in a watch-driven dev loop (repeated re-register/unregister) would
+	// keep refreshing its timestamp and never age past retention to be purged.
+	// Leaving it untouched lets the sweep purge the agent once it has actually
+	// been silent for Retention. This matches the down-transition invariant
+	// upheld by health_monitor.markAgentUnhealthyIfUnchanged and
+	// markAgentStaleAttempt, which also preserve updated_at.
 	agentUpdated, err := tx.Agent.
 		Update().
 		Where(agent.IDEQ(agentID)).
 		SetStatus(agent.StatusUnhealthy).
-		SetUpdatedAt(now). // Update timestamp like RegisterAgent does
 		Save(ctx)
 
 	if err != nil {

--- a/src/core/registry/sweep_test.go
+++ b/src/core/registry/sweep_test.go
@@ -831,3 +831,55 @@ func TestSweep_PurgeOrphanSchemaEntries_SkipsReferencedAcrossLargeBatch(t *testi
 		}
 	}
 }
+
+// TestUnregisterPreservesUpdatedAtSoSweepCanPurge verifies the retention-clock
+// invariant for graceful shutdown: UnregisterAgent flips an agent to unhealthy
+// but MUST NOT bump updated_at (the last-heartbeat timestamp the sweep filters
+// on). If it bumped updated_at to now, the retention clock would restart on
+// every unregister and a long-silent, gracefully-shut-down agent could never
+// age past Retention to be purged. This asserts updated_at is preserved and
+// that a subsequent sweep with elapsed Retention then purges the agent.
+func TestUnregisterPreservesUpdatedAtSoSweepCanPurge(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, service, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Agent last heartbeated well outside the retention window. Seed it as
+	// healthy so the unregister is what performs the down-transition.
+	lastHeartbeat := now.Add(-3 * time.Hour)
+	seedAgent(t, client, "graceful-1", agent.StatusHealthy, lastHeartbeat)
+
+	if err := service.UnregisterAgent(ctx, "graceful-1"); err != nil {
+		t.Fatalf("UnregisterAgent: %v", err)
+	}
+
+	got, err := client.Agent.Get(ctx, "graceful-1")
+	if err != nil {
+		t.Fatalf("reload agent: %v", err)
+	}
+	if got.Status != agent.StatusUnhealthy {
+		t.Errorf("expected status=unhealthy after unregister, got %s", got.Status)
+	}
+	// The crux: updated_at must still be the pre-unregister heartbeat time, NOT
+	// advanced toward now. Tolerate sub-second storage rounding only.
+	if got.UpdatedAt.Sub(lastHeartbeat).Abs() > time.Second {
+		t.Fatalf("expected updated_at preserved at %v after unregister, got %v (advanced — retention clock would restart)",
+			lastHeartbeat, got.UpdatedAt)
+	}
+
+	// Because updated_at was preserved at -3h and Retention is 1h, the sweep
+	// must now purge the agent.
+	res, err := job.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.agentsPurged != 1 {
+		t.Errorf("expected 1 agent purged, got %d", res.agentsPurged)
+	}
+	if _, err := client.Agent.Get(ctx, "graceful-1"); !ent.IsNotFound(err) {
+		t.Errorf("expected agent purged from table, got err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary

App users (and agents) were alarmed by `meshctl list` showing old unhealthy instances and a red "N agent down". Two root causes, both fixed here.

### 1. Registry never purged gracefully-shut-down agents (the real bug)

`unregisterAgentAttempt` stamped `SetUpdatedAt(now)` when flipping an agent to `unhealthy` on graceful shutdown. The retention sweep purges `status IN (unhealthy,unknown) AND updated_at < now − Retention` — so bumping `updated_at` **restarted the retention clock on every shutdown**. In watch-driven dev loops (repeated re-register/unregister), a down instance's `updated_at` kept refreshing and it **never aged past `Retention`** — hence unhealthy instances 2+ days old persisting with `LAST SEEN ~46m` (`updated_at` is the "last seen" field), and the deep superseded/down pile in `meshctl list`.

**Fix:** drop the `SetUpdatedAt(now)` on the down-transition so unregister preserves the true last-heartbeat timestamp — matching the invariant `health_monitor.markAgentUnhealthyIfUnchanged` and `markAgentStaleAttempt` already uphold (both deliberately preserve `updated_at` on down-transitions; this path was the lone outlier with a copy-pasted "like RegisterAgent does" comment). Now a gracefully-stopped agent purges once it's actually been silent for `Retention`. Regression test added.

### 2. `meshctl list` red-alarmed on harmless down agents (UX)

#1198's "only surface a down agent if it blocks an unresolved dep" rule was applied to the red-row promotion but **not** the header/footer counts — so an orphaned down agent that blocks nothing still showed red `1 unhealthy` + red `1 agent down (use --all)`, reading as an alarm.

**Fix:** red is now reserved for the genuine alarm (blocking down agents, promoted to rows). Non-blocking orphaned-down instances render **gray**: the header splits into red `N unhealthy` (blocking only) + gray `N inactive`, and the footer reads gray `N inactive instance(s) hidden (use --all)`. Classification, blocking row promotion, `--all`, the grep contract, and `--json` are all unchanged. Tests updated + a bucket-disclosure test added.

## Net effect
Stale instances now actually purge (no more days-old accumulation), and during the brief retention window a harmless orphan is a muted gray disclosure rather than a red alarm. The red alarm now means what it should: a down agent is blocking a live dependency.

Reported via app `meshctl list` output showing 14 superseded + a persistent `1 agent down` for an orphaned spike agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
