### PR TITLE
fix(java,ts): LLM token-usage telemetry parity with Python (closes #1227, #1228)

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -417,6 +417,13 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
         // Metadata from last call
         private GenerationMeta lastMeta = null;
 
+        // Accumulated LLM token usage across agentic-loop iterations (issue #1227).
+        // Read by generate() to populate lastMeta and published to the consumer
+        // span via TraceContext.setLlmMetadata.
+        private long accumulatedInputTokens = 0;
+        private long accumulatedOutputTokens = 0;
+        private String effectiveModel = null;
+
         // --- Messages ---
 
         @Override
@@ -545,8 +552,13 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
             try {
                 String result = executeAgenticLoop(provider);
                 long latency = System.currentTimeMillis() - startTime;
-                // Update metadata (tokens would come from response if provider returns them)
-                this.lastMeta = new GenerationMeta(0, 0, 0, latency, maxIterations, provider.provider());
+                // Update metadata with the token usage accumulated across the
+                // agentic loop (issue #1227). effectiveModel falls back to the
+                // provider name when the response carried no model field.
+                int in = (int) accumulatedInputTokens;
+                int out = (int) accumulatedOutputTokens;
+                String model = effectiveModel != null ? effectiveModel : provider.provider();
+                this.lastMeta = new GenerationMeta(in, out, in + out, latency, maxIterations, model);
                 return result;
             } finally {
                 clearInvocationContext();
@@ -778,7 +790,12 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
             log.info("Built {} tool definitions for LLM (availableTools={})",
                 toolDefs.size(), availableTools.size());
 
-            // 4. Execute agentic loop
+            // 4. Execute agentic loop. Reset per-call accumulators so a reused
+            // builder doesn't carry stale token totals (issue #1227).
+            accumulatedInputTokens = 0;
+            accumulatedOutputTokens = 0;
+            effectiveModel = null;
+            try {
             int iteration = 0;
             while (iteration < maxIterations) {
                 iteration++;
@@ -818,6 +835,11 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                     log.error("LLM call failed: {}", e.getMessage());
                     throw new RuntimeException("LLM call failed", e);
                 }
+
+                // Accumulate LLM token usage from this iteration's response
+                // (issue #1227). Null/missing-safe: a response without
+                // _mesh_usage contributes nothing.
+                accumulateUsage(response);
 
                 // Check for tool calls
                 List<Map<String, Object>> toolCalls = extractToolCalls(response);
@@ -867,6 +889,35 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
 
             log.warn("Max iterations ({}) reached for LLM agent {}", maxIterations, functionId);
             return extractLastAssistantContent(llmMessages);
+            } finally {
+                // Publish accumulated token usage to the per-thread sink so
+                // ExecutionTracer.endSpan can stamp the CONSUMER span (parity
+                // with Python's set_llm_metadata → end_execution). Only emit
+                // when usage was actually reported, avoiding zero-spam for
+                // providers/tools that report none.
+                if (accumulatedInputTokens > 0 || accumulatedOutputTokens > 0) {
+                    String providerName = provider.provider() != null ? provider.provider() : "";
+                    TraceContext.setLlmMetadata(providerName, effectiveModel,
+                        accumulatedInputTokens, accumulatedOutputTokens);
+                }
+            }
+        }
+
+        /**
+         * Accumulate {@code _mesh_usage} token counts from a provider response into the
+         * per-call running totals (issue #1227). Null/missing-safe.
+         */
+        private void accumulateUsage(Map<String, Object> response) {
+            Map<String, Object> usage = extractUsage(response);
+            if (usage == null) {
+                return;
+            }
+            accumulatedInputTokens += toTokenCount(usage.get("prompt_tokens"));
+            accumulatedOutputTokens += toTokenCount(usage.get("completion_tokens"));
+            Object model = usage.get("model");
+            if (model instanceof String s && !s.isBlank()) {
+                effectiveModel = s;
+            }
         }
 
         private Map<String, Object> buildToolResultMessage(ParsedToolCall parsed) {
@@ -1127,6 +1178,59 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
         }
 
         return List.of();
+    }
+
+    /**
+     * Extract the provider's {@code _mesh_usage} token-usage object from a response.
+     *
+     * <p>The object — {@code {model, prompt_tokens, completion_tokens}} — may appear at
+     * the response top level OR inside the nested {@code content[0].text} JSON envelope
+     * that {@link #extractContent}/{@link #extractToolCalls} already unwrap. Mirrors that
+     * same unwrap path. Returns {@code null} when no usage is present (non-LLM tools or
+     * providers that don't report usage) so callers contribute nothing.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> extractUsage(Map<String, Object> response) {
+        Object topLevel = response.get("_mesh_usage");
+        if (topLevel instanceof Map<?, ?> m) {
+            return (Map<String, Object>) m;
+        }
+
+        Object content = response.get("content");
+        if (content instanceof List<?> contentList && !contentList.isEmpty()) {
+            Object first = contentList.get(0);
+            if (first instanceof Map<?, ?> block) {
+                Object text = block.get("text");
+                if (text instanceof String textStr && textStr.trim().startsWith("{")) {
+                    try {
+                        Map<String, Object> parsed = objectMapper.readValue(textStr, Map.class);
+                        Object nested = parsed.get("_mesh_usage");
+                        if (nested instanceof Map<?, ?> nm) {
+                            return (Map<String, Object>) nm;
+                        }
+                    } catch (JacksonException e) {
+                        log.trace("Failed to parse nested JSON for _mesh_usage: {}", e.getMessage());
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /** Coerce a token-count field (Number or numeric String) to a long; 0 if missing/unparseable. */
+    private static long toTokenCount(Object value) {
+        if (value instanceof Number n) {
+            return n.longValue();
+        }
+        if (value instanceof String s && !s.isBlank()) {
+            try {
+                return Long.parseLong(s.trim());
+            } catch (NumberFormatException ignored) {
+                return 0L;
+            }
+        }
+        return 0L;
     }
 
     private String extractContent(Map<String, Object> response) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -899,6 +899,12 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                     String providerName = provider.provider() != null ? provider.provider() : "";
                     TraceContext.setLlmMetadata(providerName, effectiveModel,
                         accumulatedInputTokens, accumulatedOutputTokens);
+                } else {
+                    // No usage reported: clear the per-thread sink so stale
+                    // llm_* metadata from a prior call on a pooled thread can't
+                    // leak into a later span. Always leave the sink in a known
+                    // state after the loop — set when accumulated, cleared otherwise.
+                    TraceContext.clearLlmMetadata();
                 }
             }
         }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/ExecutionTracer.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/ExecutionTracer.java
@@ -143,6 +143,18 @@ public class ExecutionTracer {
             traceData.putAll(agentContext.getContext());
         }
 
+        // Stamp accumulated LLM token-usage onto THIS (consumer) span. The
+        // MeshLlmAgentProxy agentic loop publishes totals into a per-thread sink
+        // (mirrors Python's _llm_metadata contextvar). Reuse withLlmMeta so the
+        // wire keys (llm_input_tokens/llm_output_tokens/llm_total_tokens/
+        // llm_model/llm_provider) match the dashboard contract exactly.
+        TraceContext.LlmMetadata llmMeta = TraceContext.getLlmMetadata();
+        if (llmMeta != null) {
+            scope.withLlmMeta(llmMeta.provider(), llmMeta.model(),
+                llmMeta.inputTokens(), llmMeta.outputTokens());
+            TraceContext.clearLlmMetadata();
+        }
+
         // Add custom metadata
         if (scope.getMetadata() != null) {
             traceData.putAll(scope.getMetadata());

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TraceContext.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TraceContext.java
@@ -72,6 +72,18 @@ public class TraceContext {
         ThreadLocal.withInitial(Collections::emptyMap);
 
     /**
+     * Thread-local sink for LLM token-usage metadata produced by a {@code @MeshLlm}
+     * agentic loop. Mirrors the Python {@code _llm_metadata} contextvar: the
+     * {@code MeshLlmAgentProxy} accumulates per-iteration usage and writes the totals
+     * here; {@code ExecutionTracer.endSpan} reads and clears it when finalizing the
+     * consumer span so the dashboard can attribute tokens to that span.
+     */
+    private static final ThreadLocal<LlmMetadata> LLM_METADATA = new ThreadLocal<>();
+
+    /** Accumulated LLM token-usage metadata for the active consumer span. */
+    public record LlmMetadata(String provider, String model, long inputTokens, long outputTokens) {}
+
+    /**
      * Thread-local storage for trace context.
      * Use {@link #wrap(Runnable)} or {@link #wrap(Callable)} for async propagation.
      */
@@ -147,6 +159,26 @@ public class TraceContext {
 
     public static void clearPropagatedHeaders() {
         PROPAGATED_HEADERS.set(Collections.emptyMap());
+    }
+
+    /**
+     * Publish accumulated LLM token-usage metadata for the active consumer span.
+     *
+     * <p>Called by {@code MeshLlmAgentProxy} after the agentic loop completes; read and
+     * cleared by {@code ExecutionTracer.endSpan}. Mirrors Python's {@code set_llm_metadata}.
+     */
+    public static void setLlmMetadata(String provider, String model, long inputTokens, long outputTokens) {
+        LLM_METADATA.set(new LlmMetadata(provider, model, inputTokens, outputTokens));
+    }
+
+    /** Get the current LLM token-usage metadata, or null if none was set on this thread. */
+    public static LlmMetadata getLlmMetadata() {
+        return LLM_METADATA.get();
+    }
+
+    /** Clear the current LLM token-usage metadata. */
+    public static void clearLlmMetadata() {
+        LLM_METADATA.remove();
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyTokenTelemetryTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyTokenTelemetryTest.java
@@ -1,0 +1,309 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.core.MeshObjectMappers;
+import io.mcpmesh.spring.tracing.TraceContext;
+import io.mcpmesh.types.MeshLlmAgent.GenerateBuilder;
+import io.mcpmesh.types.MeshLlmAgent.GenerationMeta;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests that a {@code @MeshLlm} agentic loop emits LLM token-usage telemetry into
+ * the per-thread sink that {@code ExecutionTracer.endSpan} stamps onto the CONSUMER
+ * span (issue #1227 — parity with the Python runtime's {@code set_llm_metadata}).
+ *
+ * <p>The provider's {@code _mesh_usage} object — {@code {model, prompt_tokens,
+ * completion_tokens}} — may arrive at the response top level OR inside the nested
+ * {@code content[0].text} JSON envelope. Real mesh-delegated responses use the
+ * envelope form, so both are exercised. We assert on
+ * {@link TraceContext#getLlmMetadata()} (the contract handoff that the tracer reads,
+ * analogous to asserting Python's contextvar) and on the builder's
+ * {@link GenerationMeta}.
+ *
+ * <p>Wiring mirrors {@code MeshLlmAgentProxyModelParamsTest}: a real
+ * {@link McpHttpClient} pointed at a {@link MockWebServer} returning the MCP
+ * tools/call shape the LLM provider produces.
+ */
+@DisplayName("MeshLlmAgentProxy — LLM token-usage telemetry on the consumer span (issue #1227)")
+class MeshLlmAgentProxyTokenTelemetryTest {
+
+    private MockWebServer server;
+    private McpHttpClient client;
+    private ObjectMapper mapper;
+    private MeshLlmAgentProxy proxy;
+
+    @BeforeAll
+    static void initTlsConfig() throws Exception {
+        Constructor<MeshTlsConfig> ctor = MeshTlsConfig.class.getDeclaredConstructor(
+            boolean.class, String.class, String.class, String.class, String.class);
+        ctor.setAccessible(true);
+        MeshTlsConfig disabled = ctor.newInstance(false, "off", null, null, null);
+
+        Field cachedField = MeshTlsConfig.class.getDeclaredField("cached");
+        cachedField.setAccessible(true);
+        cachedField.set(null, disabled);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        mapper = MeshObjectMappers.create();
+        client = new McpHttpClient(mapper);
+
+        proxy = new MeshLlmAgentProxy("test.tokens");
+        proxy.configure(client, null, null, null, "", "ctx", 1, false);
+        proxy.updateProvider(
+            server.url("/").toString().replaceAll("/$", ""),
+            "process_chat",
+            "anthropic"
+        );
+
+        // Clear any stale sink from a previous test on this thread.
+        TraceContext.clearLlmMetadata();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        TraceContext.clearLlmMetadata();
+        if (client != null) client.close();
+        server.shutdown();
+    }
+
+    // -------------------------------------------------------------------------
+    // Mock helpers
+    // -------------------------------------------------------------------------
+
+    /** Build the MCP envelope wrapping a JSON-encoded inner provider payload. */
+    private MockResponse envelope(Map<String, Object> innerPayload) {
+        long id = System.currentTimeMillis();
+        String innerJson;
+        try {
+            innerJson = mapper.writeValueAsString(innerPayload);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        Map<String, Object> envelope = Map.of(
+            "jsonrpc", "2.0",
+            "id", id,
+            "result", Map.of(
+                "content", List.of(Map.of("type", "text", "text", innerJson))
+            )
+        );
+        String body;
+        try {
+            body = mapper.writeValueAsString(envelope);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return new MockResponse()
+            .setBody(body)
+            .setHeader("Content-Type", "application/json");
+    }
+
+    /**
+     * Content response carrying {@code _mesh_usage} in the inner provider payload — the
+     * real mesh-delegated shape the proxy receives (the MCP client unwraps the JSON-RPC
+     * envelope and parses the inner text into the response map).
+     */
+    private MockResponse stubContentWithUsage(String reply, String model, int prompt, int completion) {
+        Map<String, Object> inner = new LinkedHashMap<>();
+        inner.put("role", "assistant");
+        inner.put("content", reply);
+        inner.put("_mesh_usage", Map.of(
+            "model", model,
+            "prompt_tokens", prompt,
+            "completion_tokens", completion
+        ));
+        return envelope(inner);
+    }
+
+    /**
+     * Content response where {@code _mesh_usage} sits at the TOP level of the response
+     * map the proxy receives — i.e. a sibling of {@code role}/{@code content} in the
+     * inner provider payload. (The MCP client unwraps the JSON-RPC envelope and returns
+     * this inner object as the response map, so its top level IS the proxy's top level.)
+     */
+    private MockResponse stubContentWithTopLevelUsage(String reply, String model, int prompt, int completion) {
+        Map<String, Object> inner = new LinkedHashMap<>();
+        inner.put("role", "assistant");
+        inner.put("content", reply);
+        inner.put("_mesh_usage", Map.of(
+            "model", model,
+            "prompt_tokens", prompt,
+            "completion_tokens", completion
+        ));
+        return envelope(inner);
+    }
+
+    /** Tool-call response (no final content) that also carries usage in the inner payload. */
+    private MockResponse stubToolCallWithUsage(String callId, String toolName, Map<String, Object> args,
+                                               String model, int prompt, int completion) {
+        Map<String, Object> toolCall = Map.of(
+            "id", callId,
+            "type", "function",
+            "function", Map.of("name", toolName, "arguments", args)
+        );
+        Map<String, Object> inner = new LinkedHashMap<>();
+        inner.put("role", "assistant");
+        inner.put("content", "");
+        inner.put("tool_calls", List.of(toolCall));
+        inner.put("_mesh_usage", Map.of(
+            "model", model,
+            "prompt_tokens", prompt,
+            "completion_tokens", completion
+        ));
+        return envelope(inner);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("_mesh_usage in mesh-delegated response → consumer-span sink carries accumulated tokens + model")
+    void meshDelegatedUsageStampsSink() {
+        server.enqueue(stubContentWithUsage("done", "claude-sonnet-4-20250514", 120, 45));
+
+        GenerateBuilder builder = proxy.request().user("hi");
+        String result = builder.generate();
+        assertEquals("done", result);
+
+        TraceContext.LlmMetadata meta = TraceContext.getLlmMetadata();
+        assertNotNull(meta, "LLM metadata sink must be populated for the consumer span to stamp");
+        assertEquals(120, meta.inputTokens(), "llm_input_tokens");
+        assertEquals(45, meta.outputTokens(), "llm_output_tokens");
+        assertEquals(165, meta.inputTokens() + meta.outputTokens(), "llm_total_tokens");
+        assertEquals("claude-sonnet-4-20250514", meta.model(), "llm_model");
+        assertEquals("anthropic", meta.provider(), "llm_provider");
+
+        // GenerationMeta exposes the same totals to API callers.
+        GenerationMeta gm = builder.lastMeta();
+        assertNotNull(gm);
+        assertEquals(120, gm.inputTokens());
+        assertEquals(45, gm.outputTokens());
+        assertEquals(165, gm.totalTokens());
+        assertEquals("claude-sonnet-4-20250514", gm.model());
+    }
+
+    @Test
+    @DisplayName("top-level result._mesh_usage → also accumulated (both wire shapes supported)")
+    void topLevelUsageStampsSink() {
+        server.enqueue(stubContentWithTopLevelUsage("done", "gpt-4o", 200, 80));
+
+        String result = proxy.request().user("hi").generate();
+        assertEquals("done", result);
+
+        TraceContext.LlmMetadata meta = TraceContext.getLlmMetadata();
+        assertNotNull(meta);
+        assertEquals(200, meta.inputTokens());
+        assertEquals(80, meta.outputTokens());
+        assertEquals("gpt-4o", meta.model());
+    }
+
+    @Test
+    @DisplayName("multi-iteration agentic loop ACCUMULATES tokens across LLM calls (last model wins)")
+    void multiIterationAccumulatesTokens() {
+        proxy.configure(client, null, null, null, "", "ctx",
+            io.mcpmesh.MeshLlmDefaults.MAX_ITERATIONS, false);
+
+        // Iteration 1: tool_calls response with usage (prompt=100, completion=10).
+        server.enqueue(stubToolCallWithUsage("call_1", "missing_tool", Map.of("q", "x"),
+            "claude-sonnet-4-20250514", 100, 10));
+        // Iteration 2: final content with usage (prompt=150, completion=30), newer model.
+        server.enqueue(stubContentWithUsage("final", "claude-opus-4-20250514", 150, 30));
+
+        String result = proxy.request().user("do it").generate();
+        assertEquals("final", result);
+
+        TraceContext.LlmMetadata meta = TraceContext.getLlmMetadata();
+        assertNotNull(meta);
+        assertEquals(250, meta.inputTokens(), "input tokens accumulate across iterations (100 + 150)");
+        assertEquals(40, meta.outputTokens(), "output tokens accumulate across iterations (10 + 30)");
+        assertEquals(290, meta.inputTokens() + meta.outputTokens(), "total accumulates");
+        assertEquals("claude-opus-4-20250514", meta.model(),
+            "effective model is the last iteration's reported model");
+    }
+
+    @Test
+    @DisplayName("response with NO _mesh_usage → sink stays null (no zero-spam for non-reporting providers)")
+    void noUsageLeavesSinkUntouched() {
+        // Inner payload deliberately carries no _mesh_usage.
+        Map<String, Object> inner = new LinkedHashMap<>();
+        inner.put("role", "assistant");
+        inner.put("content", "ok");
+        server.enqueue(envelope(inner));
+
+        String result = proxy.request().user("hi").generate();
+        assertEquals("ok", result);
+
+        assertNull(TraceContext.getLlmMetadata(),
+            "no _mesh_usage must leave the sink null so the span carries no zero token fields");
+    }
+
+    // -------------------------------------------------------------------------
+    // extractUsage unwrap-path coverage (mirrors extractToolCalls' dual lookup):
+    // top-level key AND nested content[0].text JSON envelope. Invoked reflectively
+    // because the live MCP client collapses text responses before the proxy sees
+    // them, so the nested-envelope branch is only reachable for raw/mixed shapes.
+    // -------------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> invokeExtractUsage(Map<String, Object> response) throws Exception {
+        java.lang.reflect.Method m = MeshLlmAgentProxy.class
+            .getDeclaredMethod("extractUsage", Map.class);
+        m.setAccessible(true);
+        return (Map<String, Object>) m.invoke(proxy, response);
+    }
+
+    @Test
+    @DisplayName("extractUsage reads _mesh_usage from a top-level response key")
+    void extractUsageTopLevelKey() throws Exception {
+        Map<String, Object> response = Map.of(
+            "content", "hi",
+            "_mesh_usage", Map.of("model", "gpt-4o", "prompt_tokens", 10, "completion_tokens", 5)
+        );
+        Map<String, Object> usage = invokeExtractUsage(response);
+        assertNotNull(usage);
+        assertEquals("gpt-4o", usage.get("model"));
+        assertEquals(10, ((Number) usage.get("prompt_tokens")).intValue());
+        assertEquals(5, ((Number) usage.get("completion_tokens")).intValue());
+    }
+
+    @Test
+    @DisplayName("extractUsage reads _mesh_usage from the nested content[0].text JSON envelope")
+    void extractUsageNestedEnvelope() throws Exception {
+        String innerJson = mapper.writeValueAsString(Map.of(
+            "content", "hi",
+            "_mesh_usage", Map.of("model", "claude", "prompt_tokens", 7, "completion_tokens", 3)
+        ));
+        Map<String, Object> response = Map.of(
+            "content", List.of(Map.of("type", "text", "text", innerJson))
+        );
+        Map<String, Object> usage = invokeExtractUsage(response);
+        assertNotNull(usage, "nested content[0].text envelope must be unwrapped like extractToolCalls does");
+        assertEquals("claude", usage.get("model"));
+        assertEquals(7, ((Number) usage.get("prompt_tokens")).intValue());
+        assertEquals(3, ((Number) usage.get("completion_tokens")).intValue());
+    }
+
+    @Test
+    @DisplayName("extractUsage returns null when no _mesh_usage is present")
+    void extractUsageMissingReturnsNull() throws Exception {
+        assertNull(invokeExtractUsage(Map.of("content", "hi")));
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/tracing/ExecutionTracerLlmSpanTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/tracing/ExecutionTracerLlmSpanTest.java
@@ -1,0 +1,105 @@
+package io.mcpmesh.spring.tracing;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tracer-level coverage for the LLM token-telemetry emission path (issue #1227).
+ *
+ * <p>{@link MeshLlmAgentProxyTokenTelemetryTest} asserts that the agentic loop populates
+ * {@link TraceContext#getLlmMetadata()}. This test drives the OTHER half of the contract:
+ * that {@link ExecutionTracer#endSpan} actually DRAINS that per-thread sink into the
+ * published span payload (via {@link SpanScope#withLlmMeta}) so the dashboard fields are
+ * populated — and clears the sink after consumption. A regression that fails to stamp the
+ * span (leaving dashboard fields empty) would be caught here but not by the proxy-level test.
+ *
+ * <p>The real publish path is exercised with a Mockito-mocked {@link TracePublisher} that
+ * captures the trace-data map handed to {@code publish(...)}. Tracing is enabled for the
+ * tracer via the {@code mcp.mesh.distributed-tracing-enabled} system property (the env-var
+ * fallback in {@link ExecutionTracer#isTracingEnabled()} when the Rust core is not loaded).
+ */
+@DisplayName("ExecutionTracer — drains the LLM metadata sink into the published span (issue #1227)")
+class ExecutionTracerLlmSpanTest {
+
+    private String prevTracingProp;
+
+    @BeforeEach
+    void enableTracing() {
+        prevTracingProp = System.getProperty("mcp.mesh.distributed-tracing-enabled");
+        System.setProperty("mcp.mesh.distributed-tracing-enabled", "true");
+        TraceContext.clear();
+        TraceContext.clearLlmMetadata();
+    }
+
+    @AfterEach
+    void restore() {
+        if (prevTracingProp == null) {
+            System.clearProperty("mcp.mesh.distributed-tracing-enabled");
+        } else {
+            System.setProperty("mcp.mesh.distributed-tracing-enabled", prevTracingProp);
+        }
+        TraceContext.clear();
+        TraceContext.clearLlmMetadata();
+    }
+
+    @Test
+    @DisplayName("endSpan stamps llm_* fields onto the published span and clears the sink")
+    @SuppressWarnings("unchecked")
+    void endSpanStampsLlmFieldsOntoPublishedSpan() {
+        TracePublisher publisher = mock(TracePublisher.class);
+        ExecutionTracer tracer = new ExecutionTracer(publisher, null);
+        assertTrue(tracer.isEnabled(),
+            "tracing must be ON for the emission path to run (system property fallback)");
+
+        // The proxy publishes accumulated usage into the per-thread sink before the
+        // consumer span closes; replicate that here.
+        TraceContext.setLlmMetadata("anthropic", "claude-sonnet-4-20250514", 120, 45);
+
+        try (SpanScope span = tracer.startSpan("test.consumer", null)) {
+            span.withResult("done");
+        }
+
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(publisher, times(1)).publish(captor.capture());
+        Map<String, Object> published = captor.getValue();
+
+        assertEquals(120L, ((Number) published.get("llm_input_tokens")).longValue(), "llm_input_tokens");
+        assertEquals(45L, ((Number) published.get("llm_output_tokens")).longValue(), "llm_output_tokens");
+        assertEquals(165L, ((Number) published.get("llm_total_tokens")).longValue(), "llm_total_tokens");
+        assertEquals("claude-sonnet-4-20250514", published.get("llm_model"), "llm_model");
+        assertEquals("anthropic", published.get("llm_provider"), "llm_provider");
+
+        assertNull(TraceContext.getLlmMetadata(),
+            "sink must be cleared after the tracer consumes it (no leak onto a later span)");
+    }
+
+    @Test
+    @DisplayName("endSpan with no sink set publishes a span carrying no llm_* fields")
+    @SuppressWarnings("unchecked")
+    void endSpanWithoutSinkOmitsLlmFields() {
+        TracePublisher publisher = mock(TracePublisher.class);
+        ExecutionTracer tracer = new ExecutionTracer(publisher, null);
+
+        // No TraceContext.setLlmMetadata(...) — e.g. a non-LLM tool span.
+        try (SpanScope span = tracer.startSpan("test.tool", null)) {
+            span.withResult("ok");
+        }
+
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(publisher, times(1)).publish(captor.capture());
+        Map<String, Object> published = captor.getValue();
+
+        assertFalse(published.containsKey("llm_input_tokens"),
+            "no sink → span must not carry zero/stale llm_* fields");
+        assertFalse(published.containsKey("llm_total_tokens"));
+        assertFalse(published.containsKey("llm_model"));
+    }
+}

--- a/src/runtime/typescript/src/__tests__/llm-token-telemetry.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-token-telemetry.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Consumer-span LLM token telemetry — regression test for #1228.
+ *
+ * The dashboard aggregates per-agent / per-model token usage from `mesh:trace`
+ * span fields `llm_input_tokens` / `llm_output_tokens` / `llm_total_tokens` /
+ * `llm_model`. Python already stamps the consumer's own execution span (via the
+ * `set_llm_metadata` contextvar read in ExecutionTracer); this asserts the TS
+ * `@mesh.llm` consumer span reaches parity.
+ *
+ * The mesh-delegated provider is reached through `callMcpTool`, mocked here to
+ * return the canned provider response JSON (incl. `_mesh_usage`). The agentic
+ * loop in MeshLlmAgent parses `_mesh_usage`, accumulates totals across
+ * iterations, finalizes `_meta`, and the `@mesh.llm` consumer span published in
+ * llm.ts stamps the llm_* SpanData fields from it.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
+
+const callMcpToolMock = vi.hoisted(() => vi.fn());
+const publishTraceSpanMock = vi.hoisted(() => vi.fn(async () => true));
+
+// Replace only callMcpTool — keep runWithTraceContext etc. real so the
+// consumer span's trace context propagation behaves normally.
+vi.mock("../proxy.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../proxy.js")>();
+  return { ...actual, callMcpTool: callMcpToolMock };
+});
+
+// Capture published spans; keep everything else real.
+vi.mock("../tracing.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../tracing.js")>();
+  return { ...actual, publishTraceSpan: publishTraceSpanMock };
+});
+
+import { llm, LlmToolRegistry } from "../llm.js";
+import { createLlmToolProxy } from "../llm-agent.js";
+import type { SpanData } from "../tracing.js";
+
+const FUNCTION_ID = "summarize";
+const PROVIDER_ENDPOINT = "http://llm-provider.local:9200";
+
+/** Provider response carrying token usage and (optionally) a tool call. */
+function providerResponse(opts: {
+  content: string;
+  inputTokens: number;
+  outputTokens: number;
+  toolCall?: { id: string; name: string; args: string };
+}): string {
+  return JSON.stringify({
+    role: "assistant",
+    content: opts.content,
+    ...(opts.toolCall
+      ? {
+          tool_calls: [
+            {
+              id: opts.toolCall.id,
+              type: "function",
+              function: { name: opts.toolCall.name, arguments: opts.toolCall.args },
+            },
+          ],
+        }
+      : {}),
+    _mesh_usage: {
+      prompt_tokens: opts.inputTokens,
+      completion_tokens: opts.outputTokens,
+    },
+  });
+}
+
+/** The consumer's own `@mesh.llm` execution span (function_name === FUNCTION_ID). */
+function consumerSpan(): SpanData | undefined {
+  const calls = publishTraceSpanMock.mock.calls as unknown as Array<[SpanData]>;
+  return calls.map((c) => c[0]).find((s) => s.functionName === FUNCTION_ID);
+}
+
+describe("consumer-span LLM token telemetry (#1228)", () => {
+  beforeEach(() => {
+    LlmToolRegistry.reset();
+    callMcpToolMock.mockReset();
+    publishTraceSpanMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("stamps llm_* token fields on the consumer span for a single-iteration call", async () => {
+    const tool = llm({
+      name: FUNCTION_ID,
+      provider: { capability: "llm-service" },
+      parameters: z.object({}),
+      execute: async (_args: unknown, { llm: llmCallable }: { llm: (m: string) => Promise<string> }) => {
+        return llmCallable("Summarize the doc");
+      },
+    });
+
+    LlmToolRegistry.getInstance().setResolvedProvider(FUNCTION_ID, {
+      endpoint: PROVIDER_ENDPOINT,
+      functionName: "process_chat",
+      model: "claude-sonnet-4",
+      agentId: "provider-agent",
+    });
+
+    callMcpToolMock.mockResolvedValue(
+      providerResponse({ content: "A short summary.", inputTokens: 100, outputTokens: 40 })
+    );
+
+    await tool.execute({} as never);
+
+    const span = consumerSpan();
+    expect(span).toBeDefined();
+    expect(span!.llmInputTokens).toBe(100);
+    expect(span!.llmOutputTokens).toBe(40);
+    expect(span!.llmTotalTokens).toBe(140);
+    expect(span!.llmModel).toBe("claude-sonnet-4");
+    expect(span!.llmProvider).toBe(`mesh:${PROVIDER_ENDPOINT}`);
+  });
+
+  it("accumulates token usage across a multi-iteration agentic loop", async () => {
+    const tool = llm({
+      name: FUNCTION_ID,
+      provider: { capability: "llm-service" },
+      parameters: z.object({}),
+      execute: async (_args: unknown, { llm: llmCallable }: { llm: (m: string) => Promise<string> }) => {
+        return llmCallable("Look something up then answer");
+      },
+    });
+
+    LlmToolRegistry.getInstance().setResolvedProvider(FUNCTION_ID, {
+      endpoint: PROVIDER_ENDPOINT,
+      functionName: "process_chat",
+      model: "claude-sonnet-4",
+      agentId: "provider-agent",
+    });
+
+    // Register a resolved tool so the loop has a tool to call on iteration 1.
+    // The proxy routes through the mocked callMcpTool for its result.
+    LlmToolRegistry.getInstance().setResolvedTools(FUNCTION_ID, [
+      createLlmToolProxy(
+        {
+          functionName: "lookup",
+          capability: "lookup",
+          endpoint: "http://tool-agent.local:9300",
+          agentId: "tool-agent",
+        },
+        "Look up a value"
+      ),
+    ]);
+
+    // Iteration 1: provider asks for a tool call (usage 50/20).
+    // Tool result returned by the proxy/callMcpTool.
+    // Iteration 2: provider returns final text (usage 70/30).
+    callMcpToolMock
+      .mockResolvedValueOnce(
+        providerResponse({
+          content: "",
+          inputTokens: 50,
+          outputTokens: 20,
+          toolCall: { id: "call-1", name: "lookup", args: "{}" },
+        })
+      )
+      .mockResolvedValueOnce(JSON.stringify({ value: 42 })) // tool result
+      .mockResolvedValueOnce(
+        providerResponse({ content: "The answer is 42.", inputTokens: 70, outputTokens: 30 })
+      );
+
+    await tool.execute({} as never);
+
+    const span = consumerSpan();
+    expect(span).toBeDefined();
+    // Accumulated across both provider calls: 50+70 input, 20+30 output.
+    expect(span!.llmInputTokens).toBe(120);
+    expect(span!.llmOutputTokens).toBe(50);
+    expect(span!.llmTotalTokens).toBe(170);
+    expect(span!.llmModel).toBe("claude-sonnet-4");
+  });
+
+  it("publishes the consumer span WITHOUT llm_* fields when execute never calls the llm", async () => {
+    const tool = llm({
+      name: FUNCTION_ID,
+      provider: { capability: "llm-service" },
+      parameters: z.object({}),
+      // Non-LLM path through the same wrapper: returns directly, no llm() call.
+      execute: async () => "static result",
+    });
+
+    LlmToolRegistry.getInstance().setResolvedProvider(FUNCTION_ID, {
+      endpoint: PROVIDER_ENDPOINT,
+      functionName: "process_chat",
+      model: "claude-sonnet-4",
+      agentId: "provider-agent",
+    });
+
+    await tool.execute({} as never);
+
+    const span = consumerSpan();
+    expect(span).toBeDefined();
+    expect(span!.llmInputTokens).toBeUndefined();
+    expect(span!.llmOutputTokens).toBeUndefined();
+    expect(span!.llmTotalTokens).toBeUndefined();
+    expect(span!.llmModel).toBeUndefined();
+    expect(span!.llmProvider).toBeUndefined();
+    // callMcpTool must not have been invoked on this non-LLM path.
+    expect(callMcpToolMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/runtime/typescript/src/__tests__/llm-token-telemetry.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-token-telemetry.test.ts
@@ -176,6 +176,44 @@ describe("consumer-span LLM token telemetry (#1228)", () => {
     expect(span!.llmModel).toBe("claude-sonnet-4");
   });
 
+  it("stamps llm_* token fields when the handler throws AFTER an LLM call recorded usage", async () => {
+    const boom = new Error("handler failed after LLM call");
+    const tool = llm({
+      name: FUNCTION_ID,
+      provider: { capability: "llm-service" },
+      parameters: z.object({}),
+      execute: async (_args: unknown, { llm: llmCallable }: { llm: (m: string) => Promise<string> }) => {
+        // Real LLM call records usage, THEN the handler fails.
+        await llmCallable("Summarize the doc");
+        throw boom;
+      },
+    });
+
+    LlmToolRegistry.getInstance().setResolvedProvider(FUNCTION_ID, {
+      endpoint: PROVIDER_ENDPOINT,
+      functionName: "process_chat",
+      model: "claude-sonnet-4",
+      agentId: "provider-agent",
+    });
+
+    callMcpToolMock.mockResolvedValue(
+      providerResponse({ content: "A short summary.", inputTokens: 100, outputTokens: 40 })
+    );
+
+    // The handler's exception must still propagate.
+    await expect(tool.execute({} as never)).rejects.toThrow("handler failed after LLM call");
+
+    const span = consumerSpan();
+    expect(span).toBeDefined();
+    expect(span!.success).toBe(false);
+    // Accumulated usage from the LLM call before the throw is preserved.
+    expect(span!.llmInputTokens).toBe(100);
+    expect(span!.llmOutputTokens).toBe(40);
+    expect(span!.llmTotalTokens).toBe(140);
+    expect(span!.llmModel).toBe("claude-sonnet-4");
+    expect(span!.llmProvider).toBe(`mesh:${PROVIDER_ENDPOINT}`);
+  });
+
   it("publishes the consumer span WITHOUT llm_* fields when execute never calls the llm", async () => {
     const tool = llm({
       name: FUNCTION_ID,

--- a/src/runtime/typescript/src/llm.ts
+++ b/src/runtime/typescript/src/llm.ts
@@ -42,12 +42,13 @@ import type {
   LlmAgent,
   LlmToolProxy,
   LlmOutputMode,
+  LlmMeta,
 } from "./types.js";
 import { MeshLlmAgent, createLlmToolProxy } from "./llm-agent.js";
 import { envMaxIterations } from "./llm-provider.js";
 import { debug } from "./debug.js";
 import { generateTraceId, generateSpanId, publishTraceSpan, matchesPropagateHeader } from "./tracing.js";
-import type { TraceContext } from "./tracing.js";
+import type { TraceContext, SpanData } from "./tracing.js";
 import { runWithTraceContext, runWithPropagatedHeaders } from "./proxy.js";
 
 /**
@@ -315,6 +316,12 @@ export function llm<
     let error: string | null = null;
     let resultType = "string";
 
+    // Issue #1228: LLM token usage from the agentic loop, captured after the
+    // user's execute() runs (which drives agent.run() via the llm callable).
+    // Read into a local so the consumer span below carries the loop totals —
+    // mirrors Python's set_llm_metadata contextvar feeding the consumer span.
+    let llmMeta: LlmMeta | null = null;
+
     try {
       // Run within trace context for propagation to downstream calls
       return await runWithTraceContext(traceContext, async () => {
@@ -354,6 +361,10 @@ export function llm<
             const result = await llmConfig.execute(cleanArgs, { llm: llmCallable as LlmAgent<TResponse extends ZodType ? z.infer<TResponse> : TReturns extends ZodType ? z.infer<TReturns> : string> });
             debug.llm(`Execute completed successfully`);
 
+            // Issue #1228: capture the agentic-loop token usage finalized by
+            // the last llm() call so the consumer span can carry it.
+            llmMeta = llmCallable.meta;
+
             // Convert result to string for MCP
             if (typeof result === "string") {
               return result;
@@ -374,6 +385,24 @@ export function llm<
       const endTime = Date.now() / 1000;
       const durationMs = (endTime - startTime) * 1000;
 
+      // Issue #1228: stamp the consumer span with the agentic-loop token usage
+      // (parity with Python's ExecutionTracer reading set_llm_metadata). Only
+      // set the llm_* fields when a real usage record exists — a tool whose
+      // execute() never calls the llm() callable leaves llmMeta null and the
+      // span carries no llm_* fields.
+      const llmFields: Pick<
+        SpanData,
+        "llmInputTokens" | "llmOutputTokens" | "llmTotalTokens" | "llmModel" | "llmProvider"
+      > = {};
+      if (llmMeta) {
+        const m = llmMeta as LlmMeta;
+        llmFields.llmInputTokens = m.inputTokens;
+        llmFields.llmOutputTokens = m.outputTokens;
+        llmFields.llmTotalTokens = m.totalTokens;
+        if (m.model) llmFields.llmModel = m.model;
+        if (m.provider) llmFields.llmProvider = m.provider;
+      }
+
       publishTraceSpan({
         traceId,
         spanId,
@@ -390,6 +419,7 @@ export function llm<
         dependencies: [],
         injectedDependencies: 0,
         meshPositions: [],
+        ...llmFields,
       }).catch(() => {
         // Silently ignore publish errors
       });

--- a/src/runtime/typescript/src/llm.ts
+++ b/src/runtime/typescript/src/llm.ts
@@ -358,12 +358,17 @@ export function llm<
 
             // Call user's execute handler
             debug.llm(`Calling user execute handler`);
-            const result = await llmConfig.execute(cleanArgs, { llm: llmCallable as LlmAgent<TResponse extends ZodType ? z.infer<TResponse> : TReturns extends ZodType ? z.infer<TReturns> : string> });
-            debug.llm(`Execute completed successfully`);
-
-            // Issue #1228: capture the agentic-loop token usage finalized by
-            // the last llm() call so the consumer span can carry it.
-            llmMeta = llmCallable.meta;
+            let result;
+            try {
+              result = await llmConfig.execute(cleanArgs, { llm: llmCallable as LlmAgent<TResponse extends ZodType ? z.infer<TResponse> : TReturns extends ZodType ? z.infer<TReturns> : string> });
+              debug.llm(`Execute completed successfully`);
+            } finally {
+              // Issue #1228: capture the agentic-loop token usage so the
+              // consumer span can carry it on BOTH success and error. If the
+              // handler throws after it already made LLM calls, the accumulated
+              // usage is preserved before the exception unwinds.
+              llmMeta = llmCallable.meta;
+            }
 
             // Convert result to string for MCP
             if (typeof result === "string") {


### PR DESCRIPTION
## Summary

The dashboard's "Token Usage by Model" + per-agent "Tokens In/Out" were populated only for **Python** LLM consumers — Java and TypeScript consumers showed `0` / "No model data" despite distributed tracing being fully enabled and spans + data-sizes flowing. Token metrics attribute to the **consumer span**, and only Python stamped it. This brings Java and TS to parity. Closes #1227, #1228.

Both runtimes already had the span-emission plumbing wired to the dashboard contract (`llm_input_tokens` / `llm_output_tokens` / `llm_total_tokens` / `llm_model` / `llm_provider`) — it was just **dead/uncalled**. This feeds it.

## Java (#1227)
`MeshLlmAgentProxy.executeAgenticLoop` discarded the provider's `_mesh_usage`. It now extracts it (model + prompt/completion tokens — top-level and the nested `content[0].text` envelope), accumulates across loop iterations, and publishes via a new ThreadLocal `LlmMetadata` sink on `TraceContext` that `ExecutionTracer.endSpan` drains into `SpanScope.withLlmMeta` (previously zero callers). Mirrors Python's `set_llm_metadata` contextvar → `end_execution` model; stamps the consumer span. Null-safe (no `_mesh_usage` → emits nothing). +7 tests.

## TypeScript (#1228)
The TS consumer already extracted + accumulated `_mesh_usage` into its in-memory `LlmMeta` but never published it. The consumer execution span (`llm.ts` — the `@mesh.llm` tool's own span, published once after the agentic loop) now reads the agent's finalized meta and sets the existing `SpanData.llm*` fields. Chosen over the per-iteration `proxy_call_wrapper` span, which would lack the accumulated totals and multiply the per-model call count. Null-safe. +3 tests.

## Consistency
Both runtimes stamp the **single per-invocation consumer span** with the **accumulated loop totals** — matching Python exactly, and avoiding per-iteration double-counting. No new attribute keys; the Go dashboard/correlator side is unchanged (it already reads these keys).

## Verification
Java: 455 tests pass, full Maven reactor build green. TS: 945 tests pass, build clean.

> **End-to-end note:** unit tests prove the published spans carry the `llm_*` attributes. Confirming the dashboard panels actually populate requires a deploy of the patched Java/TS SDKs to a cluster with the observability stack.

## Known limitation (both, pre-existing, out of scope)
The consumer meta is "last-set-wins" (Java ThreadLocal / TS shared `_meta`), matching Python's contextvar semantics. Strict per-invocation isolation under concurrency would need async-local scoping — noted, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM traces now include token usage and model/provider details on consumer spans.
  * Token counts can accumulate across multi-step agent loops, giving a more complete view of total usage.

* **Bug Fixes**
  * Improved handling of token metadata when usage details are returned in different response formats.
  * Prevents token/model metadata from leaking into unrelated spans after a request completes.

* **Tests**
  * Added regression coverage for token telemetry in both Java and TypeScript paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->